### PR TITLE
Say what actually happened: h2 flow control, WebSocket parking, and the ack that arrived before the act

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Install dependencies
         run: shards install
       - name: Run tests
-        run: crystal spec
+        run: stdbuf -oL -eL crystal spec --verbose
 # No `build-docker` job here. It used to build docker/Dockerfile for amd64 and
 # arm64 on every PR, and those two builds — each compiling a static Crystal
 # binary from source, the arm64 one on a native runner because QEMU is far too

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Install dependencies
         run: shards install
       - name: Run tests
-        run: stdbuf -oL -eL crystal spec --verbose
+        run: crystal spec
 # No `build-docker` job here. It used to build docker/Dockerfile for amd64 and
 # arm64 on every PR, and those two builds — each compiling a static Crystal
 # binary from source, the arm64 one on a native runner because QEMU is far too

--- a/spec/cli/run/repeater_headers_spec.cr
+++ b/spec/cli/run/repeater_headers_spec.cr
@@ -161,6 +161,83 @@ describe "gori run repeater — head terminators survive an edit" do
   end
 end
 
+# The OPERATOR half of `PlanOptions#evidence?`.
+#
+# `Repeater::Plan` no longer expands anything on a flow replay, because it cannot tell the
+# capture's bytes from the operator's once they are one merged wire — a project defining an
+# ordinary name (`filter`, `top`, `where`) rewrote the STORED request and re-framed its
+# Content-Length to match. So expansion moved to the merge itself, which is the last point
+# where the two are still distinguishable. These pin that it really happens here, since the
+# builder will not do it any more: without them the `-H`/`-b`/`--target` values would ship
+# with their `$KEY` characters on the wire and the origin's 401 would look like a target
+# verdict rather than an unexpanded variable (#519's failure, one seam over).
+#
+# The refusal for an UNRESOLVED token in the same three flags is `refuse_unresolved_overrides`
+# and runs before this, so nothing that reaches `Env.expand` here can be left literal — except
+# a DECLARED session binding, which `Env.expand` leaves for `Env.expand_bindings` at the send.
+private def with_vars(pairs : Array({String, String}), &)
+  saved = Gori::Settings.env_vars
+  saved_p = Gori::Settings.project_env_vars
+  saved_x = Gori::Settings.env_prefix
+  Gori::Settings.env_vars = pairs
+  Gori::Settings.project_env_vars = [] of {String, String}
+  Gori::Settings.env_prefix = "$"
+  yield
+ensure
+  Gori::Settings.env_vars = saved || [] of {String, String}
+  Gori::Settings.project_env_vars = saved_p || [] of {String, String}
+  Gori::Settings.env_prefix = saved_x || "$"
+end
+
+describe "gori run repeater — operator overrides expand at the merge seam" do
+  it "expands a $KEY in a -H VALUE" do
+    with_vars([{"TOK", "s3cr3t"}]) do
+      build(["Authorization: Bearer $TOK"]).should contain("Authorization: Bearer s3cr3t")
+    end
+  end
+
+  it "expands a $KEY in -b AND frames Content-Length over the EXPANDED body" do
+    with_vars([{"TOK", "s3cr3t"}]) do
+      out = build([] of String, body_override: "tok=$TOK")
+      out.should end_with("tok=s3cr3t")
+      # 10 bytes, not the 9 of the pre-expansion `tok=$TOK`: the resync that used to happen
+      # in `Repeater::Plan` after a whole-wire expansion now has nothing left to correct.
+      out.should contain("Content-Length: 10\r\n")
+    end
+  end
+
+  it "expands a $KEY in --target before deriving the Host: header from it" do
+    with_vars([{"HOSTV", "api.test:8443"}]) do
+      build([] of String, target: "http://$HOSTV").should contain("Host: api.test:8443\r\n")
+    end
+  end
+
+  # The complement of every case above: the CAPTURED bytes are next to the merged overrides
+  # in the same wire, and none of this may touch them.
+  it "leaves a colliding $KEY in the CAPTURED head and body untouched" do
+    with_vars([{"Dup", "PWNED"}, {"TOK", "s3cr3t"}]) do
+      head = "POST /t HTTP/1.1\r\nHost: h\r\nX-Dup: $Dup\r\nContent-Length: 8\r\n\r\n"
+      wire, _ = Gori::CLI::Run.build_single_flow_request_for_spec(
+        head.to_slice, "b=$Dup\r\n".to_slice, ["Authorization: Bearer $TOK"], nil, nil,
+        [] of String)
+      out = String.new(wire)
+      out.should contain("X-Dup: $Dup\r\n")              # capture: literal
+      out.should end_with("b=$Dup\r\n")                  # capture: literal
+      out.should contain("Content-Length: 8\r\n")        # capture: not re-framed
+      out.should contain("Authorization: Bearer s3cr3t") # override: expanded
+      out.should_not contain("PWNED")
+    end
+  end
+
+  # A `$` in a header NAME can only ever be a typo — `$` is not a tchar — and folding it into
+  # the dedup key would make `-H '$H: a' -H 'X: b'` collide the moment `$H` resolved to `X`.
+  it "does not expand a $KEY in a header NAME" do
+    with_vars([{"H", "X-Dup"}]) do
+      build(["$H: v"]).should contain("$H: v\r\n")
+    end
+  end
+end
+
 # `gori run repeater h2 --fields FILE` accepts two shapes, and the BARE ARRAY is the one the
 # help text advertises first. Reading the optional body keys off `doc` unconditionally CRASHED
 # on it — `JSON::Any#[]?(String)` raises on an array rather than returning nil — so the

--- a/spec/discover/engine_spec.cr
+++ b/spec/discover/engine_spec.cr
@@ -265,6 +265,69 @@ describe Gori::Discover::Engine do
     stats.sent.should be <= 5
   end
 
+  # …and SAYS it stopped short. Fuzz and mine let a consumer derive this (`sent < total`,
+  # `names_done < names_total`); discover's only denominator is `est_total`, a moving estimate
+  # that RISES as the crawl proceeds, so nothing downstream could tell a capped run from a
+  # complete one — `status:"done", job_complete:true, has_more:false` came back with 275 of
+  # 283 wordlist tasks unsent, and both the CLI and an agent read that as a finished sweep.
+  describe "budget_exhausted" do
+    it "is set when the cap left queued work behind" do
+      cfg = D::Config.new(spider: false, bruteforce: true, max_requests: 5_i64, calibrate_probes: 2,
+        concurrency: 1, retries: 0)
+      words = (1..50).map { |i| "path#{i}" }
+      done = nil.as(D::DoneEvent?)
+      D::Engine.new("http://t/", words, RouteBackend.new(->(_t : String) { notfound }), cfg)
+        .run { |ev| done = ev if ev.is_a?(D::DoneEvent) }
+      d = done.not_nil!
+      d.budget_exhausted.should be_true
+      d.progress.queued.should be > 0
+    end
+
+    # The complement, and the reason this is not just `cap_reached?`: a run with NO cap, and a
+    # run whose cap was never binding, both finished — saying "budget exhausted" there would
+    # send the operator after a flag that was not the reason for anything.
+    it "is NOT set for an uncapped run, nor for a cap the run never reached" do
+      words = ["admin", "login"]
+      {nil.as(Int64?), 500_i64}.each do |cap|
+        cfg = D::Config.new(spider: false, bruteforce: true, max_requests: cap, calibrate_probes: 1,
+          concurrency: 1, retries: 0)
+        done = nil.as(D::DoneEvent?)
+        D::Engine.new("http://t/", words, RouteBackend.new(->(_t : String) { notfound }), cfg)
+          .run { |ev| done = ev if ev.is_a?(D::DoneEvent) }
+        done.not_nil!.budget_exhausted.should be_false
+        done.not_nil!.progress.queued.should eq(0)
+      end
+    end
+  end
+
+  # Mine's `mine_all_refused?` backstop, brought over. A target that accepts TCP and then
+  # answers nothing, under a budget small enough that only CALIBRATION probes ever ran,
+  # reported `done · 0 found · 9 sent · 0 errors` and exit 0: nine requests went out, nine got
+  # no response, and `handle_calibrate` — unlike `handle_probe`/`handle_crawl` — never recorded
+  # a reason, so `wholly_refused_reason` had nothing to name.
+  it "names the reason when the whole budget went on failing CALIBRATION probes" do
+    cfg = D::Config.new(spider: false, bruteforce: true, max_requests: 3_i64, calibrate_probes: 3,
+      concurrency: 1, retries: 2)
+    dead = R.new(Bytes.new(0), nil, nil, 0_i64, "no response from t:80")
+    engine = D::Engine.new("http://t/", ["admin", "login"], RouteBackend.new(->(_t : String) { dead }), cfg)
+    kinds, messages = terminal_of(engine)
+    kinds.should eq([:error]) # terminal — no Done for a consumer to settle "0 found" over
+    messages.first.should contain("no response from t:80")
+  end
+
+  # The complement of `successful_sends == 0`: a target that ANSWERED is not a failed run even
+  # when it held nothing, so a stray later error must not turn "found nothing" into an error.
+  it "still ends Done when the target answered but nothing was found" do
+    cfg = D::Config.new(spider: false, bruteforce: true, calibrate_probes: 1, concurrency: 1, retries: 0)
+    seen = 0
+    backend = RouteBackend.new(->(_t : String) do
+      seen += 1
+      seen > 3 ? R.new(Bytes.new(0), nil, nil, 0_i64, "no response from t:80") : notfound
+    end)
+    kinds, _ = terminal_of(D::Engine.new("http://t/", ["admin", "login"], backend, cfg))
+    kinds.last.should eq(:done)
+  end
+
   it "survives a backend that raises without hanging (worker rescue keeps @pending balanced)" do
     cfg = D::Config.new(spider: true, bruteforce: true, concurrency: 2, retries: 0, calibrate_probes: 1)
     engine = D::Engine.new("http://t/", ["admin"], RaisingBackend.new, cfg)

--- a/spec/discover/headers_spec.cr
+++ b/spec/discover/headers_spec.cr
@@ -20,6 +20,61 @@ describe Gori::Discover::Headers do
     it "drops a value carrying CR/LF (header-injection guard)" do
       H.parse_lines(["X-Inject: a\r\nEvil: y"]).should be_empty
     end
+
+    # Refusing is right; refusing SILENTLY is not. The header this drops is `Authorization`,
+    # and the crawl then ran unauthenticated and reported "found nothing" over the whole
+    # authenticated surface — clean exit, nothing on stderr, and no way to tell that case from
+    # a genuinely empty target except by sniffing. The count of drops was not returned, so no
+    # caller COULD report it.
+    it "reports every rejected line through the out-collector, verbatim" do
+      rejected = [] of String
+      H.parse_lines(["nope", "X-Ok: y", "Bad Name: v", "X-Inject: a\r\nEvil: y"], rejected)
+        .should eq([{"X-Ok", "y"}])
+      rejected.should eq(["nope", "Bad Name: v", "X-Inject: a\r\nEvil: y"])
+    end
+
+    # A blank line is not a header anyone asked for — the TUI overlay parses an editor
+    # buffer, which is full of them — so it is neither parsed nor reported.
+    it "ignores blank lines entirely rather than reporting them as rejects" do
+      rejected = [] of String
+      H.parse_lines(["", "   ", "X-Ok: y"], rejected).should eq([{"X-Ok", "y"}])
+      rejected.should be_empty
+    end
+
+    it "leaves the collector empty when every line is fine (the complement)" do
+      rejected = [] of String
+      H.parse_lines(["Authorization: Bearer t", "X-Time: 10:30:00"], rejected).size.should eq(2)
+      rejected.should be_empty
+    end
+  end
+
+  # The realistic half of the same failure: the line the operator typed is fine and the ENV
+  # VAR is not — a token read from a file that kept its trailing newline. `expand` still drops
+  # such a value at send time (it must: it is the last look before the wire), but a backstop
+  # that fires silently on every probe is not a report, and by then the crawl is running. This
+  # is the QUERY a surface asks BEFORE any traffic.
+  describe ".unsafe_expanded" do
+    it "names a header whose value only becomes unsafe after $VAR expansion" do
+      saved = Gori::Settings.env_vars
+      saved_p = Gori::Settings.project_env_vars
+      saved_x = Gori::Settings.env_prefix
+      begin
+        Gori::Settings.env_prefix = "$"
+        Gori::Settings.project_env_vars = [] of {String, String}
+        Gori::Settings.env_vars = [{"TOKEN", "abc\ndef"}, {"CLEAN", "abc"}]
+        H.unsafe_expanded([{"Authorization", "Bearer $TOKEN"}]).should eq(["Authorization"])
+        # The complement, three ways: a clean var, a literal value, and an UNRESOLVED token
+        # (which `Env.expand` leaves as the harmless characters `$NOPE` — the unresolved
+        # refusal is a different check and owns that case).
+        H.unsafe_expanded([{"Authorization", "Bearer $CLEAN"},
+                           {"X-Lit", "plain"},
+                           {"X-Un", "Bearer $NOPE"}]).should be_empty
+      ensure
+        Gori::Settings.env_vars = saved || [] of {String, String}
+        Gori::Settings.project_env_vars = saved_p || [] of {String, String}
+        Gori::Settings.env_prefix = saved_x || "$"
+      end
+    end
   end
 
   describe ".merge" do

--- a/spec/discover/plan_spec.cr
+++ b/spec/discover/plan_spec.cr
@@ -389,6 +389,13 @@ describe Gori::Discover::Plan do
       # `Headers.parse_lines` refuses a hand-typed CRLF, but it only ever saw `$TOKEN`.
       # Without a second guard after expansion, an env var's value would splice extra
       # headers into every probe the crawl sends.
+      #
+      # This is the BACKSTOP, not the report. Dropping silently here is what made an
+      # authenticated sweep run unauthenticated and answer "found nothing" over the whole
+      # authenticated surface — so the surface now REFUSES the run up front, by name, off
+      # `Headers.unsafe_expanded` (see spec/discover/headers_spec.cr and
+      # `gori run discover`). The drop stays because this is the last look before the wire
+      # and a binding can resolve later than plan-build; it just is no longer the only look.
       Gori::Settings.env_vars = [{"TOKEN", "a\r\nX-Injected: 1"}]
       config = one_shot_config(D::Headers.parse_lines(["X-Auth: $TOKEN"]))
       _findings, seen = run_one do |port|

--- a/spec/env_unresolved_spec.cr
+++ b/spec/env_unresolved_spec.cr
@@ -164,6 +164,45 @@ describe "plan builders refuse an unresolved env token (#519)" do
     end
   end
 
+  # …and the complement, which is what those three were missing. "Send this capture to the
+  # fuzzer / miner / sequencer" is the MAIN consumer of a captured flow, and the refusal above
+  # made every OData / Mongo / SSTI capture unsweepable while `gori run repeater <same-flow>`
+  # replayed it fine. Same `evidence?` flag, same meaning and same two policies as
+  # `Repeater::PlanOptions#evidence?` — see spec/repeater/evidence_provenance_spec.cr.
+  it "Fuzz::Plan.build does NOT refuse, and does not substitute, on EVIDENCE" do
+    with_vars([{"filter", "PWNED"}]) do
+      options = Gori::Fuzz::PlanOptions.new(
+        "GET /a?$filter=§x§&$top=10 HTTP/1.1\r\nHost: t.test\r\nAuth: Bearer $SESSION\r\n\r\n",
+        evidence: true, target: "http://t.test",
+        sources: [Gori::Fuzz::InlineList.new(["p"])] of Gori::Fuzz::PayloadSource)
+      plan = Gori::Fuzz::Plan.build(options, ungated)
+      wire = String.new(plan.generator.baseline_request)
+      wire.should contain("$filter=")
+      wire.should contain("$top=10")
+      wire.should contain("Bearer $SESSION")
+      wire.should_not contain("PWNED")
+    end
+  end
+
+  it "Miner::Plan.build does NOT refuse, and keeps a bare-LF head, on EVIDENCE" do
+    with_vars([{"where", "XX"}]) do
+      raw = "POST /a HTTP/1.1\nHost: t.test\nContent-Length: 9\n\n{\"$where\"}"
+      options = Gori::Miner::PlanOptions.new(raw, evidence: true, target: "http://t.test")
+      String.new(Gori::Miner::Plan.build(options, ungated).request).should eq(raw)
+    end
+  end
+
+  it "Sequencer::Plan.build does NOT refuse, and keeps a bare-LF head, on EVIDENCE" do
+    with_vars([{"top", "9"}]) do
+      raw = "GET /a?$top=10 HTTP/1.1\nHost: t.test\nAuth: $SESSION\n\n"
+      loc = Gori::Sequencer::TokenLoc.new(kind: Gori::Sequencer::ExtractKind::Cookie, selector: "sid")
+      config = Gori::Sequencer::Config.new(mode: Gori::Sequencer::Mode::LiveReplay, token_loc: loc, goal: 10)
+      options = Gori::Sequencer::PlanOptions.new(raw.to_slice, evidence: true,
+        target: "http://t.test", config: config)
+      String.new(Gori::Sequencer::Plan.build(options, ungated).request).should eq(raw)
+    end
+  end
+
   it "Discover::Plan.build refuses an unresolved SEED and names the token" do
     with_vars([] of {String, String}) do
       options = Gori::Discover::PlanOptions.new("$SEED/api")

--- a/spec/fuzz/plan_spec.cr
+++ b/spec/fuzz/plan_spec.cr
@@ -272,4 +272,56 @@ describe Gori::Fuzz::Plan do
       ex.reason.should eq(F::PlanError::Reason::NoTarget)
     end
   end
+
+  # The Content-Length knob `Fuzz::Config` has always carried and no surface ever wrote.
+  #
+  # A fuzz template's framing headers are operator-authored evidence, not a draft to be
+  # tidied (P7 / "malformed input IS the payload" names the fuzz path explicitly): a
+  # `Content-Length: 5` over a ten-byte body IS the CL-desync probe. With the resync welded
+  # on, every variation went out with the header corrected, the run reported `0 errors`, and
+  # the desync class was unreachable from the Fuzzer on all three surfaces — while the
+  # Repeater right next to it has `--verbatim` and Intercept documents the same switch as
+  # "the desync switch, and the reason to hold a request at all".
+  describe "update_content_length" do
+    desync_tpl = "POST /x?p=\u00A7S\u00A7 HTTP/1.1\r\nHost: t.test\r\nContent-Length: 5\r\n\r\nAAAAAAAAAA"
+
+    it "sends the operator's declared Content-Length when the knob is off" do
+      plan = F::Plan.build(F::PlanOptions.new(desync_tpl, target: "http://t.test",
+        sources: [F::InlineList.new(["aa"])] of F::PayloadSource,
+        config: F::Config.new(update_content_length: false)), ungated)
+      String.new(plan.generator.baseline_request).should contain("Content-Length: 5\r\n")
+    end
+
+    it "still recomputes it by default (the knob is opt-OUT, not a behaviour change)" do
+      plan = F::Plan.build(F::PlanOptions.new(desync_tpl, target: "http://t.test",
+        sources: [F::InlineList.new(["aa"])] of F::PayloadSource), ungated)
+      String.new(plan.generator.baseline_request).should contain("Content-Length: 10\r\n")
+    end
+
+    # …and when it is about to rewrite framing the operator authored, the surface has to say
+    # so. `rewrites_content_length?` is that fact, computed ONCE at plan-build rather than
+    # discovered per request, so a surface can name the flag before the sweep starts.
+    it "flags a template whose declared CL already disagrees with its own body" do
+      F::Plan.build(F::PlanOptions.new(desync_tpl, target: "http://t.test",
+        sources: [F::InlineList.new(["aa"])] of F::PayloadSource), ungated)
+        .rewrites_content_length?.should be_true
+    end
+
+    it "does NOT flag a template whose CL is correct, one with no body, or one under --verbatim" do
+      correct = "POST /y HTTP/1.1\r\nHost: t.test\r\nContent-Length: 1\r\n\r\n\u00A7S\u00A7"
+      bodiless = "GET /z?q=\u00A7S\u00A7 HTTP/1.1\r\nHost: t.test\r\n\r\n"
+      # `Transfer-Encoding` present: `ContentLength.sync` bails, so nothing is rewritten and
+      # there is nothing to warn about — the one shape that was already verbatim.
+      chunked = "POST /c HTTP/1.1\r\nHost: t.test\r\nTransfer-Encoding: chunked\r\n" \
+                "Content-Length: 99\r\n\r\n1\r\n\u00A7S\u00A7\r\n0\r\n\r\n"
+      src = [F::InlineList.new(["a"])] of F::PayloadSource
+      {correct, bodiless, chunked}.each do |tpl|
+        F::Plan.build(F::PlanOptions.new(tpl, target: "http://t.test", sources: src), ungated)
+          .rewrites_content_length?.should be_false
+      end
+      F::Plan.build(F::PlanOptions.new(desync_tpl, target: "http://t.test", sources: src,
+        config: F::Config.new(update_content_length: false)), ungated)
+        .rewrites_content_length?.should be_false
+    end
+  end
 end

--- a/spec/fuzz_spec.cr
+++ b/spec/fuzz_spec.cr
@@ -517,6 +517,32 @@ describe F::Engine do
     backend.sent.should eq(4)
     done.as(F::DoneEvent).progress.matched.should eq(4)
     done.as(F::DoneEvent).stopped.should be_false
+    # With no retries and no redirects the two counters agree, which is why nobody noticed
+    # them diverging (see the next example).
+    done.as(F::DoneEvent).progress.sent.should eq(4_i64)
+    done.as(F::DoneEvent).progress.requests.should eq(4_i64)
+  end
+
+  # `progress.sent` counts PAYLOADS — the numerator against `total`, so it must not run past
+  # it — and a retry or a redirect hop costs none of it. A 3-payload sweep with
+  # `--follow-redirects` against a redirect chain therefore reported "3 sent" for 18 real
+  # requests, and `--retries 2` reported 2 for 6: understatements of 6x and 3x of the load
+  # gori put on the target, on the one number a tester working inside an agreed request budget
+  # is actually watching. `CappedBackend#sent` was already the true count — it is what
+  # `max_requests` is enforced against — and miner/discover already publish it.
+  it "publishes the TRUE wire count as `requests`, separately from the payload count" do
+    set = F::PayloadSet.new(F::InlineList.new(["a", "b"]))
+    cfg = F::Config.new(mode: F::Mode::Sniper, concurrency: 1, retries: 2,
+      retry_pause: Time::Span.zero)
+    gen = F::Generator.new(base, [set], cfg)
+    backend = FakeBackend.new(F::Origin.new("http", "h", 80)) do |_b|
+      Gori::Repeater::Result.new(Bytes.new(0), nil, nil, 0_i64, "no response from h:80")
+    end
+    _, done = drain(F::Engine.new(gen, F::Matcher.new, backend, cfg))
+    d = done.as(F::DoneEvent)
+    d.progress.sent.should eq(2_i64)     # payloads
+    d.progress.requests.should eq(6_i64) # 1 attempt + 2 retries each
+    backend.sent.should eq(6)            # …and that is what the origin really received
   end
 
   it "auto-calibration end-to-end: calibrate_baseline's synthetic sends capture EVERY shape " \

--- a/spec/interceptor_spec.cr
+++ b/spec/interceptor_spec.cr
@@ -454,4 +454,130 @@ describe "Interceptor scope gates over an ABSOLUTE-FORM target" do
       end
     end
   end
+  # R2-F5. The ack for a forward/drop/edit is the agent's and the script's ONLY receipt for an
+  # irreversible action on a held message, and one expression composed it for every kind:
+  # `"#{method} #{host}#{target}"`. `Item#target` is deliberately overloaded per kind, so a
+  # proxied h1 request doubled its authority and a held response welded the host to the status
+  # line — `POST 127.0.0.1200 OK`, which reads as HTTP status 1200.
+  describe "Item#label" do
+    it "does not double the authority of an absolute-form (forward-proxy) request target" do
+      with_store do |store|
+        ic = Gori::Interceptor.new(Gori::Scope.load(store))
+        ic.toggle
+        item = ic.enqueue_request("x".to_slice, method: "POST",
+          target: "http://127.0.0.1:19201/held", host: "127.0.0.1", port: 19201,
+          scheme: "http").not_nil!
+        item.label.should eq("POST 127.0.0.1/held")
+      end
+    end
+
+    it "leaves an origin-form request target alone (the case that always read correctly)" do
+      with_store do |store|
+        ic = Gori::Interceptor.new(Gori::Scope.load(store))
+        ic.toggle
+        item = ic.enqueue_request("x".to_slice, method: "POST", target: "/held",
+          host: "127.0.0.1", port: 19201, scheme: "http").not_nil!
+        item.label.should eq("POST 127.0.0.1/held")
+      end
+    end
+
+    it "separates a response's status line from the host" do
+      with_store do |store|
+        ic = Gori::Interceptor.new(Gori::Scope.load(store))
+        ic.toggle
+        h1 = ic.enqueue_response("x".to_slice, flow_id: 1_i64, method: "POST", target: "200 OK",
+          host: "127.0.0.1", port: 19201, scheme: "http").not_nil!
+        h1.label.should eq("POST 127.0.0.1 -> 200 OK")
+        h1.label.should_not contain("127.0.0.1200")
+        # h2 has no reason phrase (RFC 9113 §8.3.2), so its response target is the bare code.
+        h2 = ic.enqueue_response("x".to_slice, flow_id: 2_i64, method: "GET", target: "200",
+          host: "api.test", port: 443, scheme: "https").not_nil!
+        h2.label.should eq("GET api.test -> 200")
+      end
+    end
+
+    it "identifies WHICH message on a socket, since every row on it shares the handshake" do
+      with_store do |store|
+        ic = Gori::Interceptor.new(Gori::Scope.load(store))
+        ic.toggle
+        out = ic.enqueue_ws("hello".to_slice, to_server: true, method: "GET", target: "/ws",
+          host: "acme.test", port: 443, scheme: "https", flow_id: 9_i64, binary: false).not_nil!
+        out.label.should eq("acme.test/ws client->server 5B")
+        back = ic.enqueue_ws(Bytes[0xFF, 0xFE], to_server: false, method: "GET", target: "/ws",
+          host: "acme.test", port: 443, scheme: "https", flow_id: 9_i64, binary: true).not_nil!
+        back.label.should eq("acme.test/ws server->client 2B")
+      end
+    end
+  end
+
+  # The head/body boundary an intercept edit is split on. Shared with `H2::StreamGate`, which
+  # encodes the head half, so the surface that acks the edit and the gate that applies it
+  # cannot disagree about whether an edit added a body.
+  describe ".split_edit" do
+    it "takes the EARLIEST blank line in either spelling" do
+      head, body = Gori::Interceptor.split_edit("GET / HTTP/2\r\nHost: h\r\n\r\nBODY".to_slice)
+      String.new(head).should eq("GET / HTTP/2\r\nHost: h\r\n\r\n")
+      body.should be_true
+      # LF-joined head (what the intercept editor's TextArea produces) whose BODY carries a
+      # CRLFCRLF: preferring the CRLF form took the boundary INSIDE the body.
+      head, body = Gori::Interceptor.split_edit("GET / HTTP/2\nHost: h\n\nA\r\n\r\nB".to_slice)
+      String.new(head).should eq("GET / HTTP/2\nHost: h\n\n")
+      body.should be_true
+    end
+
+    it "reports no body for a head-only edit, in either spelling" do
+      Gori::Interceptor.split_edit("GET / HTTP/2\r\nHost: h\r\n\r\n".to_slice)[1].should be_false
+      Gori::Interceptor.split_edit("GET / HTTP/2\nHost: h\n\n".to_slice)[1].should be_false
+      # No blank line at all: the whole thing is the head.
+      Gori::Interceptor.split_edit("GET / HTTP/2".to_slice)[1].should be_false
+    end
+  end
+  # R3-F1/F2, the surface half. `refuse_edit` is what every surface that offers an edit asks
+  # BEFORE it decides, because the settle side can only discard — and discarding after an ack
+  # is how "edited: GET 127.0.0.1/unf3" came to mean "the original went on the wire".
+  describe "Item#refuse_edit" do
+    it "refuses every edit to a message gori cannot apply one to, and says why" do
+      with_store do |store|
+        ic = Gori::Interceptor.new(Gori::Scope.load(store))
+        ic.toggle
+        item = ic.enqueue_request("GET /unf3 HTTP/2\r\nHost: h\r\n\r\n".to_slice, method: "GET",
+          target: "/unf3", host: "h", port: 443, scheme: "https", head_only: true,
+          edit_refusal: "the value of \"x-evil\" carries a CR or LF").not_nil!
+        item.refuse_edit("GET /OPERATOR-EDIT HTTP/2\r\nHost: h\r\n\r\n".to_slice)
+          .not_nil!.should contain("x-evil")
+        # ...including one that changes nothing structural: the refusal is about the MESSAGE.
+        item.refuse_edit(item.raw).not_nil!.should contain("x-evil")
+      end
+    end
+
+    it "refuses a body added to a head-only (h2) hold, and allows a head-only edit" do
+      with_store do |store|
+        ic = Gori::Interceptor.new(Gori::Scope.load(store))
+        ic.toggle
+        item = ic.enqueue_request("GET /p HTTP/2\r\nHost: h\r\n\r\n".to_slice, method: "GET",
+          target: "/p", host: "h", port: 443, scheme: "https", head_only: true).not_nil!
+        item.refuse_edit("GET /edited HTTP/2\r\nHost: h\r\n\r\nOPERATORBODY".to_slice)
+          .not_nil!.should contain("HEAD only")
+        # Complement: the same edit without a body is applied.
+        item.refuse_edit("GET /edited HTTP/2\r\nHost: h\r\n\r\n".to_slice).should be_nil
+        # ...and so is one that only declares a content-length. That value is the operator's
+        # RFC 9113 §8.1.1 probe, not a body.
+        item.refuse_edit("POST /edited HTTP/2\r\nHost: h\r\ncontent-length: 3\r\n\r\n".to_slice)
+          .should be_nil
+      end
+    end
+
+    it "leaves an h1 hold (head AND body) free to carry a body, as it always has" do
+      with_store do |store|
+        ic = Gori::Interceptor.new(Gori::Scope.load(store))
+        ic.toggle
+        item = ic.enqueue_request("POST /p HTTP/1.1\r\nHost: h\r\n\r\nab".to_slice, method: "POST",
+          target: "/p", host: "h", port: 80, scheme: "http").not_nil!
+        item.head_only?.should be_false
+        item.edit_refusal.should be_nil
+        item.refuse_edit("POST /p HTTP/1.1\r\nHost: h\r\nContent-Length: 1\r\n\r\nZZZZ".to_slice)
+          .should be_nil
+      end
+    end
+  end
 end

--- a/spec/mcp_agent_surface_spec.cr
+++ b/spec/mcp_agent_surface_spec.cr
@@ -498,6 +498,52 @@ describe "MCP network-error classification" do
       Gori::MCP::Tools.network_error_kind(s).should eq("other")
     end
   end
+
+  # RFC 9113 §8.1 lets an origin answer while the request body is still going out — the 413
+  # every upload / body-size probe is looking for. The send comes back with a REAL response
+  # (status 413, full head and body) and `ok:false`; only the REQUEST is partial. Reported as
+  # a network error it was `retryable:true`, which tells an agent to re-send the whole body to
+  # a server that already rejected it.
+  #
+  # The engine's sentence is pinned here AS DATA, not produced by a live origin, so this holds
+  # whatever order the h2 change and this one land in.
+  it "does not tell an agent to retry a body the origin already rejected" do
+    truncated = "the request body was truncated at 4096 of 20000 bytes (the origin ended the " \
+                "stream before the body finished, which RFC 9113 §8.1 permits). " \
+                "The request was NOT fully sent."
+    Gori::MCP::Tools.network_error_kind(truncated).should eq("truncated_request")
+    Gori::MCP::Tools.send_error_code("truncated_request").should eq("REQUEST_TRUNCATED")
+
+    # The two siblings that must keep the verdict they already earn. The flow-control stall is
+    # the reason this cannot key on "NOT fully sent": that sentence ALREADY ends with it, and
+    # it is a genuine stall with no response at all.
+    stall = "h2 flow control: only 16384 of 70000 request body bytes could be sent — the " \
+            "origin never granted flow-control window for the rest (RFC 9113 §6.9): its " \
+            "connection window is 0 and its stream window 0. The request was NOT fully sent."
+    Gori::MCP::Tools.network_error_kind(stall).should eq("protocol")
+
+    # A GOAWAY/RST_STREAM reason APPENDS the truncation clause rather than replacing it, so
+    # each keeps the verdict its own error code earns: REFUSED_STREAM stays retryable, CANCEL
+    # stays a protocol verdict — the clause must not capture either.
+    refused = "h2 RST_STREAM REFUSED_STREAM on stream 1 from a.example:443 — #{truncated}"
+    Gori::MCP::Tools.network_error_kind(refused).should eq("other")
+    cancel = "h2 RST_STREAM CANCEL on stream 1 from a.example:443 — #{truncated}"
+    Gori::MCP::Tools.network_error_kind(cancel).should eq("protocol")
+    goaway = "h2 GOAWAY INTERNAL_ERROR from a.example:443 — #{truncated}"
+    Gori::MCP::Tools.network_error_kind(goaway).should eq("protocol")
+  end
+
+  # `retryable` is the field a caller branches on, so no kind may reach it by accident.
+  it "keeps exactly the transient kinds retryable" do
+    retryable = {"connect", "timeout", "no_response", "other", nil}
+    final = {"protocol", "truncated_request"}
+    retryable.each do |k|
+      Gori::MCP::Tools.send_error_code(k).should eq("NETWORK_ERROR")
+    end
+    final.each do |k|
+      Gori::MCP::Tools.send_error_code(k).should_not eq("NETWORK_ERROR")
+    end
+  end
 end
 
 describe "MCP WebSocket and gRPC projections in get_flow" do

--- a/spec/mcp_bool_args_spec.cr
+++ b/spec/mcp_bool_args_spec.cr
@@ -1,0 +1,493 @@
+require "./spec_helper"
+require "socket"
+
+# Every MCP boolean argument, driven with the SEVEN forms a client can send:
+#   true / false      — the two legal ones
+#   "true" / "false"  — the lenient string forms clients and LLMs actually emit
+#   1 / 0 / "yes"     — unintelligible: must be REFUSED BY NAME, never coerced
+#   absent            — must keep the tool's documented default, which for
+#                       auto_content_length / spider / bruteforce / keep_alive is ON
+#
+# `bool(h, key) || false` collapsed the last two rows together, so `probe_scan{active:1}`
+# ran a passive scan and reported a clean active one, and `create_repeater{auto_content_length:1}`
+# stored the OPPOSITE of the absent-default. See `Tools#bool_value`.
+
+private def with_store(&)
+  path = File.tempname("gori-mcp-bools", ".db")
+  store = Gori::Store.open(path)
+  begin
+    yield store
+  ensure
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+private def bool_tools(store) : Gori::MCP::Tools
+  Gori::MCP::Tools.new(store, allow_actions: true, verify_upstream: false)
+end
+
+private def bool_json(tools : Gori::MCP::Tools, name : String, args : String) : JSON::Any
+  r = tools.call(name, JSON.parse(args))
+  fail "tool #{name}#{args} errored: #{r.text}" if r.is_error
+  JSON.parse(r.text)
+end
+
+# The three forms that must now be refused, and the assertion that the refusal NAMES the
+# argument (an unnamed "invalid arguments" would be no better than the silent coercion).
+private def refuses_garbage(tools : Gori::MCP::Tools, name : String, field : String,
+                            args : Proc(String, String))
+  {"1", "0", %("yes")}.each do |bad|
+    r = tools.call(name, JSON.parse(args.call(bad)))
+    unless r.is_error
+      fail "#{name}{#{field}: #{bad}} was accepted (#{r.text[0, 200]})"
+    end
+    r.text.should contain("'#{field}'")
+    r.text.should contain("expected true or false")
+  end
+end
+
+private def seed_bool_flow(store, target = "/x", host = "acme.test") : Int64
+  store.insert_flow(Gori::Store::CapturedRequest.new(
+    created_at: 1_i64, scheme: "http", host: host, port: 80,
+    method: "GET", target: target, http_version: "HTTP/1.1",
+    head: "GET #{target} HTTP/1.1\r\nHost: #{host}\r\n\r\n".to_slice, body: nil))
+end
+
+private def repeater_row(store, id : Int64)
+  store.get_repeater(id).not_nil!
+end
+
+describe "MCP boolean arguments — refused by name, never silently substituted" do
+  it "create_repeater refuses 1/0/\"yes\" on every boolean, naming the field" do
+    with_store do |store|
+      tools = bool_tools(store)
+      base = %("target":"http://acme.test","request":"GET / HTTP/1.1\\r\\nHost: acme.test\\r\\n\\r\\n")
+      {"http2", "auto_content_length", "ws_keep_key", "keep_request_line"}.each do |field|
+        refuses_garbage(tools, "create_repeater", field, ->(bad : String) {
+          %({#{base},"#{field}":#{bad}})
+        })
+      end
+    end
+  end
+
+  it "create_repeater keeps auto_content_length ON when the field is absent, and honours both legal forms" do
+    with_store do |store|
+      tools = bool_tools(store)
+      base = %("target":"http://acme.test","request":"GET / HTTP/1.1\\r\\nHost: acme.test\\r\\n\\r\\n")
+
+      # The trap: the absent-default is ON. `auto_content_length: 1` used to store 0.
+      absent = bool_json(tools, "create_repeater", %({#{base}}))["id"].as_i64
+      repeater_row(store, absent).auto_content_length?.should be_true
+
+      on = bool_json(tools, "create_repeater", %({#{base},"auto_content_length":true}))["id"].as_i64
+      repeater_row(store, on).auto_content_length?.should be_true
+
+      off = bool_json(tools, "create_repeater", %({#{base},"auto_content_length":false}))["id"].as_i64
+      repeater_row(store, off).auto_content_length?.should be_false
+
+      # The lenient string forms still work — leniency was never the problem.
+      s_on = bool_json(tools, "create_repeater", %({#{base},"auto_content_length":"true"}))["id"].as_i64
+      repeater_row(store, s_on).auto_content_length?.should be_true
+      s_off = bool_json(tools, "create_repeater", %({#{base},"auto_content_length":"FALSE"}))["id"].as_i64
+      repeater_row(store, s_off).auto_content_length?.should be_false
+    end
+  end
+
+  it "create_repeater stores http2 / ws_keep_key exactly as asked, both ways, default off" do
+    with_store do |store|
+      tools = bool_tools(store)
+      base = %("target":"http://acme.test","request":"GET / HTTP/1.1\\r\\nHost: acme.test\\r\\n\\r\\n")
+
+      d = bool_json(tools, "create_repeater", %({#{base}}))["id"].as_i64
+      repeater_row(store, d).http2?.should be_false
+      repeater_row(store, d).ws_keep_key?.should be_false
+
+      on = bool_json(tools, "create_repeater", %({#{base},"http2":true,"ws_keep_key":true}))["id"].as_i64
+      repeater_row(store, on).http2?.should be_true
+      repeater_row(store, on).ws_keep_key?.should be_true
+
+      off = bool_json(tools, "create_repeater", %({#{base},"http2":false,"ws_keep_key":false}))["id"].as_i64
+      repeater_row(store, off).http2?.should be_false
+      repeater_row(store, off).ws_keep_key?.should be_false
+    end
+  end
+
+  it "update_repeater refuses garbage by name and keeps the stored value when the field is absent" do
+    with_store do |store|
+      id = store.insert_repeater("http://acme.test/", "GET / HTTP/1.1\r\nHost: acme.test\r\n\r\n".to_slice,
+        true, true, nil, 0, nil, true)
+      tools = bool_tools(store)
+      {"http2", "auto_content_length", "ws_keep_key"}.each do |field|
+        refuses_garbage(tools, "update_repeater", field, ->(bad : String) {
+          %({"id":#{id},"#{field}":#{bad}})
+        })
+      end
+      # Absent → the row is unchanged (all three were seeded ON).
+      bool_json(tools, "update_repeater", %({"id":#{id},"name":"n"}))
+      rec = repeater_row(store, id)
+      rec.http2?.should be_true
+      rec.auto_content_length?.should be_true
+      rec.ws_keep_key?.should be_true
+      # …and an explicit false still turns each one off.
+      bool_json(tools, "update_repeater", %({"id":#{id},"http2":false,"auto_content_length":false,"ws_keep_key":false}))
+      rec2 = repeater_row(store, id)
+      rec2.http2?.should be_false
+      rec2.auto_content_length?.should be_false
+      rec2.ws_keep_key?.should be_false
+    end
+  end
+
+  it "probe_scan refuses active/unsafe/aggressive garbage by name — a silent passive scan is a false negative" do
+    with_store do |store|
+      seed_bool_flow(store)
+      tools = bool_tools(store)
+      {"active", "unsafe", "aggressive"}.each do |field|
+        refuses_garbage(tools, "probe_scan", field, ->(bad : String) { %({"#{field}":#{bad}}) })
+      end
+      # The control the finding leaned on: allow_unscoped in the SAME call already refused.
+      refuses_garbage(tools, "probe_scan", "allow_unscoped", ->(bad : String) { %({"allow_unscoped":#{bad}}) })
+      # Absent still means a passive scan, echoed as active:false.
+      bool_json(tools, "probe_scan", "{}")["active"].as_bool.should be_false
+      # And active:true still reaches the scope gate rather than reporting a clean scan.
+      r = tools.call("probe_scan", JSON.parse(%({"active":true})))
+      r.is_error.should be_true
+      r.text.should contain("scope")
+    end
+  end
+
+  it "discover_start refuses spider/bruteforce garbage instead of crawling — and keeps both defaults ON" do
+    with_store do |store|
+      tools = bool_tools(store)
+      seed = %("url":"http://127.0.0.1:1/")
+      {"spider", "bruteforce", "keep_alive", "allow_unscoped"}.each do |field|
+        refuses_garbage(tools, "discover_start", field, ->(bad : String) {
+          %({#{seed},"#{field}":#{bad}})
+        })
+      end
+      # `spider:false, bruteforce:false` still trips the technique guard…
+      both_off = tools.call("discover_start", JSON.parse(%({#{seed},"spider":false,"bruteforce":false,"allow_unscoped":true})))
+      both_off.is_error.should be_true
+      both_off.text.should contain("at least one of spider/bruteforce")
+      # …and `spider:0` no longer slips past it by never becoming false at all.
+      zero = tools.call("discover_start", JSON.parse(%({#{seed},"spider":0,"bruteforce":false,"allow_unscoped":true})))
+      zero.is_error.should be_true
+      zero.text.should contain("'spider'")
+      # One technique off is fine (the complement of the guard) — both default ON when absent,
+      # so this reaches the scope gate, not the technique guard.
+      one_off = tools.call("discover_start", JSON.parse(%({#{seed},"spider":false})))
+      one_off.text.should_not contain("at least one of spider/bruteforce")
+    end
+  end
+
+  it "validates 'insecure' even when the server already runs with TLS verification off" do
+    with_store do |store|
+      # `verify && @verify_upstream` short-circuited past the argument whenever the server was
+      # started with --insecure, so the SAME call validated the flag or not depending on a
+      # server-level setting the caller cannot see. The read comes first now.
+      {true, false}.each do |verify_upstream|
+        tools = Gori::MCP::Tools.new(store, allow_actions: true, verify_upstream: verify_upstream)
+        refuses_garbage(tools, "discover_start", "insecure", ->(bad : String) {
+          %({"url":"http://127.0.0.1:1/","insecure":#{bad}})
+        })
+        refuses_garbage(tools, "send_request", "insecure", ->(bad : String) {
+          %({"url":"http://127.0.0.1:1/","insecure":#{bad},"allow_unscoped":true})
+        })
+      end
+    end
+  end
+
+  it "minimize_repeater refuses apply/verbatim garbage BEFORE it sends anything" do
+    with_store do |store|
+      id = store.insert_repeater("http://127.0.0.1:1/", "GET / HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n".to_slice,
+        false, true, nil, 0)
+      tools = bool_tools(store)
+      {"apply", "verbatim", "allow_unscoped"}.each do |field|
+        refuses_garbage(tools, "minimize_repeater", field, ->(bad : String) {
+          %({"repeater_id":#{id},"#{field}":#{bad}})
+        })
+      end
+    end
+  end
+
+  it "list_sitemap / decode / clear_history / get_flow refuse garbage by name" do
+    with_store do |store|
+      seed_bool_flow(store)
+      tools = bool_tools(store)
+      refuses_garbage(tools, "list_sitemap", "collapse_transport", ->(bad : String) { %({"collapse_transport":#{bad}}) })
+      refuses_garbage(tools, "decode", "input_base64", ->(bad : String) { %({"input":"aGk=","spec":"hex","input_base64":#{bad}}) })
+      refuses_garbage(tools, "clear_history", "confirm", ->(bad : String) { %({"confirm":#{bad}}) })
+      refuses_garbage(tools, "get_flow", "include_sensitive", ->(bad : String) { %({"id":1,"include_sensitive":#{bad}}) })
+      # Complement: the legal forms still do what they say.
+      bool_json(tools, "decode", %({"input":"aGk=","spec":"hex","input_base64":true}))
+      bool_json(tools, "decode", %({"input":"aGk=","spec":"hex","input_base64":false}))
+      bool_json(tools, "list_sitemap", %({"collapse_transport":true}))
+      bool_json(tools, "list_sitemap", %({"collapse_transport":false}))
+      # clear_history without confirm still refuses with CONFIRM_REQUIRED, not an arg error.
+      r = tools.call("clear_history", JSON.parse("{}"))
+      r.is_error.should be_true
+      r.text.should contain("confirm:true")
+    end
+  end
+
+  it "the three-state 'enabled' flags refuse garbage by name and still refuse a MISSING value" do
+    with_store do |store|
+      tools = bool_tools(store)
+      rule = store.insert_rule(Gori::Store::RuleTarget::Request, Gori::Store::RulePart::Head, "old", "")
+      refuses_garbage(tools, "set_rule_enabled", "enabled", ->(bad : String) { %({"id":#{rule},"enabled":#{bad}}) })
+      refuses_garbage(tools, "set_scope_enabled", "enabled", ->(bad : String) { %({"enabled":#{bad}}) })
+      refuses_garbage(tools, "set_sandbox", "enabled", ->(bad : String) { %({"enabled":#{bad}}) })
+      refuses_garbage(tools, "intercept_toggle", "enable", ->(bad : String) { %({"enable":#{bad}}) })
+      # Absent is a DIFFERENT refusal — "missing", not "invalid" — and must stay that way.
+      miss = tools.call("set_scope_enabled", JSON.parse("{}"))
+      miss.is_error.should be_true
+      miss.text.should contain("missing required 'enabled'")
+      # Both legal values still commit.
+      bool_json(tools, "set_scope_enabled", %({"enabled":false}))
+      Gori::Scope.load(store).enabled?.should be_false
+      bool_json(tools, "set_scope_enabled", %({"enabled":true}))
+      Gori::Scope.load(store).enabled?.should be_true
+    end
+  end
+end
+
+# --- R2-F3: the absolute-form request line ---------------------------------------
+
+# A flow whose stored request line is ABSOLUTE-form — how a proxy client writes it, and how
+# a routing / cache-poisoning / SSRF probe recorded from a direct send is written.
+private def seed_absolute_form_flow(store, host = "evil.example") : Int64
+  store.insert_flow(Gori::Store::CapturedRequest.new(
+    created_at: 1_i64, scheme: "http", host: host, port: 80,
+    method: "GET", target: "http://#{host}/abs", http_version: "HTTP/1.1",
+    head: "GET http://#{host}/abs HTTP/1.1\r\nHost: #{host}\r\n\r\n".to_slice, body: nil))
+end
+
+describe "MCP create_repeater / send_request keep_request_line" do
+  it "create_repeater reports the rewrite and keep_request_line stores the captured line" do
+    with_store do |store|
+      flow = seed_absolute_form_flow(store)
+      tools = bool_tools(store)
+
+      rewritten = bool_json(tools, "create_repeater", %({"flow_id":#{flow}}))
+      rewritten["request_line_rewritten"].as_bool.should be_true
+      String.new(repeater_row(store, rewritten["id"].as_i64).request)
+        .should start_with("GET /abs HTTP/1.1")
+
+      kept = bool_json(tools, "create_repeater", %({"flow_id":#{flow},"keep_request_line":true}))
+      kept.as_h.has_key?("request_line_rewritten").should be_false
+      String.new(repeater_row(store, kept["id"].as_i64).request)
+        .should start_with("GET http://evil.example/abs HTTP/1.1")
+    end
+  end
+
+  it "does not claim a rewrite on an ORIGIN-form capture, or on an explicit request argument" do
+    with_store do |store|
+      origin_form = seed_bool_flow(store, "/plain")
+      tools = bool_tools(store)
+      # Complement 1: nothing to rewrite → no field, with and without the flag.
+      bool_json(tools, "create_repeater", %({"flow_id":#{origin_form}}))
+        .as_h.has_key?("request_line_rewritten").should be_false
+      bool_json(tools, "create_repeater", %({"flow_id":#{origin_form},"keep_request_line":true}))
+        .as_h.has_key?("request_line_rewritten").should be_false
+      # Complement 2: an explicit `request` wins over the seed, so nothing of the caller's
+      # was rewritten even though the flow's own line is absolute-form.
+      abs = seed_absolute_form_flow(store, "other.example")
+      res = bool_json(tools, "create_repeater",
+        %({"flow_id":#{abs},"request":"GET http://other.example/abs HTTP/1.1\\r\\nHost: other.example\\r\\n\\r\\n"}))
+      res.as_h.has_key?("request_line_rewritten").should be_false
+      String.new(repeater_row(store, res["id"].as_i64).request)
+        .should start_with("GET http://other.example/abs HTTP/1.1")
+    end
+  end
+
+  it "send_request{flow_id} puts the stored absolute-form line on the wire under keep_request_line, and says so when it rewrites" do
+    sink = Channel(Bytes).new(2)
+    port = start_bool_recording_origin(sink, 2)
+    with_store do |store|
+      flow = store.insert_flow(Gori::Store::CapturedRequest.new(
+        created_at: 1_i64, scheme: "http", host: "127.0.0.1", port: port,
+        method: "GET", target: "http://127.0.0.1:#{port}/abs", http_version: "HTTP/1.1",
+        head: "GET http://127.0.0.1:#{port}/abs HTTP/1.1\r\nHost: 127.0.0.1:#{port}\r\n\r\n".to_slice,
+        body: nil))
+      tools = bool_tools(store)
+
+      rewritten = bool_json(tools, "send_request",
+        %({"flow_id":#{flow},"allow_unscoped":true,"record_history":false}))
+      rewritten["request_line_rewritten"].as_bool.should be_true
+      rewritten["effective_request"]["target"].as_s.should eq("/abs")
+      String.new(sink.receive).should start_with("GET /abs HTTP/1.1\r\n")
+
+      kept = bool_json(tools, "send_request",
+        %({"flow_id":#{flow},"keep_request_line":true,"allow_unscoped":true,"record_history":false}))
+      kept.as_h.has_key?("request_line_rewritten").should be_false
+      kept["effective_request"]["target"].as_s.should eq("http://127.0.0.1:#{port}/abs")
+      String.new(sink.receive).should start_with("GET http://127.0.0.1:#{port}/abs HTTP/1.1\r\n")
+    end
+  end
+
+  it "send_request refuses keep_request_line garbage by name" do
+    with_store do |store|
+      flow = seed_absolute_form_flow(store)
+      tools = bool_tools(store)
+      refuses_garbage(tools, "send_request", "keep_request_line", ->(bad : String) {
+        %({"flow_id":#{flow},"keep_request_line":#{bad},"allow_unscoped":true})
+      })
+    end
+  end
+end
+
+# Records the raw request bytes of the next `count` connections into `sink`, answering 204.
+private def start_bool_recording_origin(sink : Channel(Bytes), count : Int32) : Int32
+  origin = TCPServer.new("127.0.0.1", 0)
+  port = origin.local_address.port
+  spawn do
+    count.times do
+      break unless conn = origin.accept?
+      buf = IO::Memory.new
+      begin
+        conn.read_timeout = 300.milliseconds
+        tmp = Bytes.new(4096)
+        while (n = conn.read(tmp)) > 0
+          buf.write(tmp[0, n])
+        end
+      rescue
+        # idle — everything the client meant to send has arrived
+      end
+      sink.send(buf.to_slice)
+      conn << "HTTP/1.1 204 No Content\r\n\r\n" rescue nil
+      conn.flush rescue nil
+      conn.close rescue nil
+    end
+    origin.close
+  rescue
+    origin.close rescue nil
+  end
+  port
+end
+
+# --- R2-F6: minimize on a session that holds evidence ---------------------------
+
+describe "MCP minimize_repeater verbatim" do
+  it "no longer refuses a CAPTURED $KEY in the request head, while a draft minimize still does" do
+    with_store do |store|
+      # `$top` is stored OData, not an unresolved template variable.
+      req = "GET /api?$filter=name&$top=10 HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n"
+      id = store.insert_repeater("http://127.0.0.1:1/", req.to_slice, false, true, nil, 0)
+      tools = bool_tools(store)
+
+      draft = tools.call("minimize_repeater", JSON.parse(%({"repeater_id":#{id},"allow_unscoped":true})))
+      draft.is_error.should be_true
+      draft.text.should contain("$top")
+
+      # verbatim: the token is evidence, so the refusal must not fire. The search then runs
+      # and aborts on an unreachable baseline (the dead port) — which is the proof that it got
+      # PAST the draft-time gate and actually tried to send.
+      verbatim = tools.call("minimize_repeater",
+        JSON.parse(%({"repeater_id":#{id},"verbatim":true,"allow_unscoped":true})))
+      verbatim.is_error.should be_false
+      verbatim.text.should_not contain("unresolved env")
+      payload = JSON.parse(verbatim.text)
+      payload["aborted"].as_bool.should be_true
+      payload["sends"].as_i.should be > 0
+      # And the request it reports is the stored one, token intact.
+      payload["minimized_request"].as_s.should contain("$top=10")
+    end
+  end
+
+  it "still refuses an unresolved token in the operator-typed TARGET under verbatim" do
+    with_store do |store|
+      # The target is not evidence — the operator typed it — so verbatim must not cover it.
+      id = store.insert_repeater("http://$NOPE/", "GET / HTTP/1.1\r\nHost: h\r\n\r\n".to_slice,
+        false, true, nil, 0)
+      tools = bool_tools(store)
+      r = tools.call("minimize_repeater",
+        JSON.parse(%({"repeater_id":#{id},"verbatim":true,"allow_unscoped":true})))
+      r.is_error.should be_true
+      r.text.should contain("$NOPE")
+    end
+  end
+end
+
+# --- R4-F2: a budget-capped discover is not a finished one ----------------------
+
+# Answers 200 to everything, so the brute-force pass keeps finding work to queue.
+private def start_bool_always200_origin : Int32
+  origin = TCPServer.new("127.0.0.1", 0)
+  port = origin.local_address.port
+  spawn do
+    loop do
+      break unless conn = origin.accept?
+      spawn do
+        conn.read_timeout = 2.seconds
+        loop do
+          break unless Gori::Proxy::Codec::Http1.read_head(conn)
+          conn << "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: 2\r\n\r\nhi"
+          conn.flush
+        end
+      rescue
+      ensure
+        conn.close rescue nil
+      end
+    end
+  rescue
+    origin.close rescue nil
+  end
+  port
+end
+
+describe "MCP discover_status / discover_results incomplete_reason" do
+  it "reports budget_exhausted with tasks still queued instead of a clean done" do
+    port = start_bool_always200_origin
+    with_store do |store|
+      Gori::Scope.load(store).add("include", "host", "127.0.0.1")
+      tools = bool_tools(store)
+      job = bool_json(tools, "discover_start",
+        %({"url":"http://127.0.0.1:#{port}/","spider":false,"max_requests":4,"concurrency":1}))
+      id = job["job_id"].as_s
+
+      status = nil.as(JSON::Any?)
+      120.times do
+        status = bool_json(tools, "discover_status", %({"job_id":"#{id}"}))
+        break if status["job_complete"].as_bool
+        sleep 100.milliseconds
+      end
+      s = status.not_nil!
+      s["job_complete"].as_bool.should be_true
+      s["queued"].as_i.should be > 0
+      s["status"].as_s.should eq("budget_exhausted")
+      s["incomplete_reason"].as_s.should eq("budget_exhausted")
+
+      results = bool_json(tools, "discover_results", %({"job_id":"#{id}"}))
+      results["job_complete"].as_bool.should be_true
+      results["incomplete_reason"].as_s.should eq("budget_exhausted")
+      results["queued"].as_i.should be > 0
+    end
+  end
+
+  it "a run that empties its frontier is still a clean done with a null incomplete_reason" do
+    port = start_bool_always200_origin
+    with_store do |store|
+      Gori::Scope.load(store).add("include", "host", "127.0.0.1")
+      tools = bool_tools(store)
+      # The complement: no brute-force wordlist and no crawl depth to spend, so the frontier
+      # drains. A budget high enough that max_requests cannot be what stops it.
+      job = bool_json(tools, "discover_start",
+        %({"url":"http://127.0.0.1:#{port}/","bruteforce":false,"max_depth":1,"max_requests":500,"concurrency":1}))
+      id = job["job_id"].as_s
+
+      status = nil.as(JSON::Any?)
+      200.times do
+        status = bool_json(tools, "discover_status", %({"job_id":"#{id}"}))
+        break if status["job_complete"].as_bool
+        sleep 100.milliseconds
+      end
+      s = status.not_nil!
+      s["job_complete"].as_bool.should be_true
+      s["queued"].as_i.should eq(0)
+      s["status"].as_s.should eq("done")
+      s["incomplete_reason"].raw.should be_nil
+    end
+  end
+end

--- a/spec/miner/engine_spec.cr
+++ b/spec/miner/engine_spec.cr
@@ -243,4 +243,39 @@ describe Gori::Miner::Engine do
       engine.successful_sends.should be > 0
     end
   end
+
+  # Names the wordlist supplied that a location cannot carry. Dropping them is CORRECT — a
+  # header/cookie name must be an RFC 7230 token, and `Content-Length`/`Host` would break
+  # framing — but `total_names` sums the FILTERED sizes, so the drop surfaced nowhere: the
+  # operator's only signal was that one wordlist produced "444 names" against the query and
+  # "435 names" against headers, and only if they ran both and compared. `probe` publishes a
+  # `skipped` count for exactly this reason.
+  describe "#skipped_names" do
+    wl_names = ["normalname", "my param", "x=y", "arr[]", "Content-Length", "semi;colon"]
+
+    it "reports how many names each location cannot carry, and the pre-filter denominator" do
+      c = cfg
+      c.locations = [M::Location::Headers]
+      base = "GET /api?a=1 HTTP/1.1\r\nHost: h\r\n\r\n".to_slice
+      engine = M::Engine.new(base, http2: false, names: wl_names,
+        backend: HiddenParamBackend.new(F::Origin.new("http", "h", 80), reflect: [] of String),
+        config: c)
+      engine.candidate_names.should eq(6)
+      engine.skipped_names.should eq([{M::Location::Headers, 5}])
+      engine.total_names.should eq(1_i64) # and the headline count agrees with the difference
+    end
+
+    # The complement: the query location accepts every one of those names (Inject
+    # percent-encodes what needs it), so there is nothing to report and nothing is printed.
+    it "reports nothing for a location that can carry every name" do
+      c = cfg
+      c.locations = [M::Location::Query]
+      base = "GET /api?a=1 HTTP/1.1\r\nHost: h\r\n\r\n".to_slice
+      engine = M::Engine.new(base, http2: false, names: wl_names,
+        backend: HiddenParamBackend.new(F::Origin.new("http", "h", 80), reflect: [] of String),
+        config: c)
+      engine.skipped_names.should be_empty
+      engine.total_names.should eq(6_i64)
+    end
+  end
 end

--- a/spec/proxy/h2/assembler_spec.cr
+++ b/spec/proxy/h2/assembler_spec.cr
@@ -245,6 +245,37 @@ describe Gori::Proxy::H2::Assembler do
     String.new(sink.responses.first.head).should_not contain("X-Gori-Trailers")
   end
 
+  # R3-F5. The request side got the merge and not the marker, so `x-req-trailer` read exactly
+  # like a header the client sent in its head — a gRPC client-streaming call or a `TE: trailers`
+  # probe is the same test on this side as `grpc-status` is on the other.
+  it "names REQUEST trailers in the stored request head, as it already did for the response" do
+    sink = RecSink.new
+    assembler = Gori::Proxy::H2::Assembler.new(sink, "grpc.test", 443, 1_i64)
+    assembler.feed("out", headers_frame(1_u32, Frame::END_HEADERS,
+      hexb("828684418cf1e3c2e5f23a6ba0ab90f4ff")))
+    assembler.feed("out", data_frame(1_u32, 0_u8, "body"))
+    trailer = IO::Memory.new
+    trailer.write_byte(0x00_u8)
+    trailer.write_byte(0x0d_u8)
+    trailer << "x-req-trailer"
+    trailer.write_byte(0x03_u8)
+    trailer << "yes"
+    assembler.feed("out", headers_frame(1_u32, Frame::END_HEADERS | Frame::END_STREAM, trailer.to_slice))
+
+    head = String.new(sink.requests.first.head)
+    head.should contain("x-req-trailer: yes")
+    head.should contain("X-Gori-Trailers: x-req-trailer")
+  end
+
+  # Complement: the same request WITHOUT a trailing block must be byte-identical to before.
+  it "does not name a trailer on a request that had no trailing HEADERS block" do
+    sink = RecSink.new
+    assembler = Gori::Proxy::H2::Assembler.new(sink, "grpc.test", 443, 1_i64)
+    assembler.feed("out", headers_frame(1_u32, Frame::END_HEADERS | Frame::END_STREAM,
+      hexb("828684418cf1e3c2e5f23a6ba0ab90f4ff")))
+    String.new(sink.requests.first.head).should_not contain("X-Gori-Trailers")
+  end
+
   it "captures a server push (PUSH_PROMISE → promised-stream flow + response)" do
     sink = RecSink.new
     assembler = Gori::Proxy::H2::Assembler.new(sink, "example.com", 443, 1_i64)
@@ -267,6 +298,57 @@ describe Gori::Proxy::H2::Assembler do
     sink.responses.size.should eq(1)
     sink.responses.first.status.should eq(200)
     String.new(sink.responses.first.body.not_nil!).should eq("pushed body")
+
+    # R3-F4. A promise is the ORIGIN inventing a request. Projected as an ordinary flow it was
+    # indistinguishable in History / QL / the Sitemap from one the client made — rows the
+    # origin authored, inside the evidence an operator came to read.
+    String.new(req.head).should contain("X-Gori-Pushed: server push promised on stream 1")
+  end
+
+  # Complement: a request the client actually sent carries no push marker.
+  it "does not mark an ordinary client request as pushed" do
+    sink = RecSink.new
+    assembler = Gori::Proxy::H2::Assembler.new(sink, "example.com", 443, 1_i64)
+    assembler.feed("out", headers_frame(1_u32, Frame::END_HEADERS | Frame::END_STREAM,
+      hexb("828684418cf1e3c2e5f23a6ba0ab90f4ff")))
+    String.new(sink.requests.first.head).should_not contain("X-Gori-Pushed")
+  end
+
+  # R5-F4. gori relays an RFC 8441 extended CONNECT byte-for-byte (it also relays the origin's
+  # SETTINGS verbatim, so a client facing an 8441 origin is entitled to send one) — but it
+  # decodes nothing on it: the WS transcript, the message gate, intercept and Match&Replace all
+  # live on the h1 Upgrade path. The flow used to end as a bare "h2 connection closed", which
+  # describes the symptom and not the fact.
+  it "names RFC 8441 extended CONNECT on the flow instead of only the symptom" do
+    sink = RecSink.new
+    assembler = Gori::Proxy::H2::Assembler.new(sink, "ws.test", 443, 1_i64)
+    block = IO::Memory.new
+    [{":method", "CONNECT"}, {":scheme", "https"}, {":authority", "ws.test"},
+     {":path", "/chat"}, {":protocol", "websocket"}].each do |(n, v)|
+      block.write_byte(0x00_u8)
+      block.write_byte(n.bytesize.to_u8)
+      block << n
+      block.write_byte(v.bytesize.to_u8)
+      block << v
+    end
+    assembler.feed("out", headers_frame(1_u32, Frame::END_HEADERS, block.to_slice))
+    assembler.finalize_all("h2 connection closed")
+
+    err = sink.responses.first.error.not_nil!
+    err.should contain("h2 connection closed")
+    err.should contain("RFC 8441 extended CONNECT")
+    err.should contain("websocket")
+    err.should contain("HTTP/1.1 Upgrade path")
+  end
+
+  # Complement: an ordinary stream torn down the same way keeps the bare reason.
+  it "leaves an ordinary aborted stream's reason alone" do
+    sink = RecSink.new
+    assembler = Gori::Proxy::H2::Assembler.new(sink, "example.com", 443, 1_i64)
+    assembler.feed("out", headers_frame(1_u32, Frame::END_HEADERS,
+      hexb("828684418cf1e3c2e5f23a6ba0ab90f4ff")))
+    assembler.finalize_all("h2 connection closed")
+    sink.responses.first.error.should eq("h2 connection closed")
   end
 
   # #409: a CONTINUATION frame with no preceding un-terminated HEADERS is a protocol violation

--- a/spec/proxy/h2/head_codec_spec.cr
+++ b/spec/proxy/h2/head_codec_spec.cr
@@ -387,5 +387,86 @@ describe Gori::Proxy::H2::HeadCodec do
       rewritten = [f(":method", "GET"), f("content-length", "5")]
       tuples(HeadCodec.restore_content_length(rewritten, original)).should eq([{":method", "GET"}])
     end
+
+    # R3-F2. The restore used to `reject` then `concat`, so the field moved to the END of the
+    # list — a header REORDER gori made on the wire, silently, in the one ordering a
+    # header-order probe is about.
+    it "restores the value in place rather than moving the field to the end" do
+      original = [f(":method", "POST"), f("content-length", "12"), f("x-probe", "a")]
+      rewritten = [f(":method", "POST"), f("content-length", "3"), f("x-probe", "cl-mismatch")]
+      tuples(HeadCodec.restore_content_length(rewritten, original))
+        .should eq([{":method", "POST"}, {"content-length", "12"}, {"x-probe", "cl-mismatch"}])
+    end
+
+    # The complement of the in-place case: the peer sent a content-length the rewritten head
+    # dropped, so there is no position left to restore it to and it goes back at the end.
+    it "appends a content-length the rewrite removed, since it has no position to keep" do
+      original = [f(":method", "POST"), f("content-length", "12")]
+      rewritten = [f(":method", "POST"), f("x-added", "1")]
+      tuples(HeadCodec.restore_content_length(rewritten, original))
+        .should eq([{":method", "POST"}, {"x-added", "1"}, {"content-length", "12"}])
+    end
+  end
+
+  # R3-F1. The refusal was correct and invisible: "no HTTP/1.1 text form" is a CLASS, and the
+  # operator who induced it (probe a CRLF sink, watch the origin reflect `%0d%0a` back) needs
+  # the FIELD to connect the two.
+  describe "h1_unfaithful_reason" do
+    it "is nil for a head the h1 text can carry" do
+      HeadCodec.h1_unfaithful_reason(req_fields, true).should be_nil
+      HeadCodec.h1_unfaithful_reason([f(":status", "200"), f("x-tag", "a")], false).should be_nil
+    end
+
+    it "names the field and the CR/LF for a value the h1 text would split in two" do
+      fields = req_fields + [f("x-evil", "a\r\nx-injected: yes"), f("x-tail", "z")]
+      reason = HeadCodec.h1_unfaithful_reason(fields, true).not_nil!
+      reason.should contain("x-evil")
+      reason.should contain("CR or LF")
+      # The innocent neighbour is not blamed.
+      reason.should_not contain("x-tail")
+    end
+
+    it "names an uppercase field name, a duplicate pseudo and a padded :status" do
+      HeadCodec.h1_unfaithful_reason(req_fields + [f("X-Upper", "1")], true)
+        .not_nil!.should contain("X-Upper")
+      HeadCodec.h1_unfaithful_reason(req_fields + [f(":path", "/again")], true)
+        .not_nil!.should contain("more than once")
+      HeadCodec.h1_unfaithful_reason([f(":status", "0200")], false)
+        .not_nil!.should contain(":status")
+    end
+
+    it "names the response direction's CRLF too — the origin's value, the dangerous one" do
+      fields = [f(":status", "200"), f("x-evil", "a\r\nx-injected: yes")]
+      HeadCodec.h1_unfaithful_reason(fields, false).not_nil!.should contain("x-evil")
+      # Complement: strip the injected bytes back out and the same shape is carried fine.
+      HeadCodec.h1_unfaithful_reason([f(":status", "200"), f("x-evil", "a")], false).should be_nil
+    end
+
+    it "agrees with h1_faithful? on every corpus entry" do
+      CORPUS.each do |entry|
+        HeadCodec.h1_unfaithful_reason(entry.fields, entry.request).nil?.should eq(entry.faithful)
+      end
+    end
+  end
+
+  # R3-F5 / R3-F4. Both markers are capture-projection only; the rewrite path passes neither,
+  # so neither can reach an h2 wire.
+  describe "synth_request markers" do
+    it "names request trailers, exactly as synth_response already named response ones" do
+      fields = [{":method", "POST"}, {":path", "/trail"}, {"x-req-trailer", "yes"}]
+      head = String.new(HeadCodec.synth_request(fields, "h:1", ["x-req-trailer"]))
+      head.should contain("X-Gori-Trailers: x-req-trailer\r\n")
+      # Complement: no trailers, no line — an ordinary request head is byte-identical to before.
+      String.new(HeadCodec.synth_request(fields, "h:1")).should_not contain("X-Gori-Trailers")
+      String.new(HeadCodec.synth_request(fields, "h:1", [] of String)).should_not contain("X-Gori-Trailers")
+    end
+
+    it "marks a request the ORIGIN invented via PUSH_PROMISE" do
+      fields = [{":method", "GET"}, {":path", "/pushed"}]
+      String.new(HeadCodec.synth_request(fields, "evil.test", nil, 3_u32))
+        .should contain("X-Gori-Pushed: server push promised on stream 3\r\n")
+      # Complement: a request the client actually sent carries no marker.
+      String.new(HeadCodec.synth_request(fields, "evil.test")).should_not contain("X-Gori-Pushed")
+    end
   end
 end

--- a/spec/proxy/h2/head_rewrite_spec.cr
+++ b/spec/proxy/h2/head_rewrite_spec.cr
@@ -1,4 +1,5 @@
 require "../../spec_helper"
+require "log/spec"
 
 private alias Frame = Gori::Proxy::H2::Frame
 private alias HPACK = Gori::Proxy::H2::HPACK
@@ -532,6 +533,70 @@ describe Gori::Proxy::H2::HeadRewrite do
         headers(1_u32, Bytes.empty), Bytes.empty, false)
       edited = pipe.encode_edited(fine, "HTTP/2 200\r\nx-echo: edited\r\n\r\n".to_slice).not_nil!
       edited.fields.map(&.to_tuple).should eq([{":status", "200"}, {"x-echo", "edited"}])
+    end
+
+    # R3-F3. `finish` snapshots the buffer and calls `reset` up front — deliberately, it closes
+    # a whole class of leak — and `reset` zeroes `@block_stream`. Every warning below that point
+    # then named "stream 0", a stream that cannot exist (stream 0 is the connection). An
+    # operator who did go looking could not map the warning to a flow.
+    it "names the REAL stream in the rule-path warning, not the zeroed @block_stream" do
+      pipe, assembler, _ = pipeline(SubRewriter.new("/two", "/twoLONGER"), direction: "out")
+      evil = [{":method", "GET"}, {":scheme", "https"}, {":authority", "a.test"},
+              {":path", "/two"}, {"x-reflected", "a\r\nx-injected: 1"}]
+      block = HPACK::Encoder.new.encode(evil)
+      Log.capture do |logs|
+        pipe.accept(headers(3_u32, block)) { |f, pre| assembler.feed("out", f, pre) }
+        entry = logs.check(:warn, /no HTTP\/1\.1 text form/).entry
+        entry.message.should contain("stream 3")
+        entry.message.should_not contain("stream 0")
+        # ...and it names the offending FIELD, which is what connects the warning to the probe
+        # that induced it.
+        entry.message.should contain("x-reflected")
+      end
+    end
+
+    # The complement: the SAME connection, the same rule, a head the text CAN carry — the rule
+    # fires and nothing is warned about.
+    it "fires the rule normally on a head that has an h1 text form" do
+      pipe, assembler, sink = pipeline(SubRewriter.new("/two", "/twoLONGER"), direction: "out")
+      ok = [{":method", "GET"}, {":scheme", "https"}, {":authority", "a.test"}, {":path", "/two"}]
+      emitted = [] of Frame::Header
+      pipe.accept(headers(1_u32, HPACK::Encoder.new.encode(ok))) do |f, pre|
+        emitted << f
+        assembler.feed("out", f, pre)
+      end
+      HPACK::Decoder.new.decode(emitted.first.payload)
+        .find { |(n, _)| n == ":path" }.not_nil![1].should eq("/twoLONGER")
+      sink.requests.first.target.should eq("/twoLONGER")
+    end
+
+    # R3-F2. `restore_length` is provenance: an editor that recomputed Content-Length against a
+    # body h2 will not send gets the peer's value back; an operator who DECLARED one keeps it,
+    # exactly as h1 forwards the identical edit byte-exact.
+    it "honours a declared content-length on an edit, and reverts a synced one" do
+      sink = RecSink.new
+      assembler = Gori::Proxy::H2::Assembler.new(sink, "a.test", 443, 1_i64)
+      pipe = Gori::Proxy::H2::HeadRewrite.new("out", nil, assembler, "a.test")
+      fields = [HPACK::Field.new(":method", "POST"), HPACK::Field.new(":scheme", "https"),
+                HPACK::Field.new(":authority", "a.test"), HPACK::Field.new(":path", "/cl"),
+                HPACK::Field.new("content-length", "10")]
+      block = Gori::Proxy::H2::HeadRewrite::Block.new(
+        [] of Frame::Header, HeadBlock.new(fields.map(&.to_tuple)), fields,
+        "POST /cl HTTP/2\r\nHost: a.test\r\ncontent-length: 10\r\n\r\n".to_slice,
+        headers(1_u32, Bytes.empty), Bytes.empty, true)
+      edit = "POST /cl HTTP/2\r\nHost: a.test\r\ncontent-length: 3\r\nx-probe: cl\r\n\r\n".to_slice
+
+      declared = pipe.encode_edited(block, edit, false).not_nil!
+      declared.fields.map(&.to_tuple).should eq([
+        {":method", "POST"}, {":scheme", "https"}, {":authority", "a.test"}, {":path", "/cl"},
+        {"content-length", "3"}, {"x-probe", "cl"},
+      ])
+
+      synced = pipe.encode_edited(block, edit).not_nil!
+      synced.fields.map(&.to_tuple).should eq([
+        {":method", "POST"}, {":scheme", "https"}, {":authority", "a.test"}, {":path", "/cl"},
+        {"content-length", "10"}, {"x-probe", "cl"},
+      ])
     end
 
     it "still adds two headers for a CRLF the OPERATOR wrote — those are their bytes (P7)" do

--- a/spec/proxy/h2/stream_gate_spec.cr
+++ b/spec/proxy/h2/stream_gate_spec.cr
@@ -91,6 +91,17 @@ private def headers(stream : UInt32, block : Bytes, flags = Frame::END_HEADERS |
   Frame::Header.new(Frame::Type::Headers.value, flags, stream, block)
 end
 
+# RFC 9113 §6.6: the payload is the promised stream id (R + 31 bits) followed by the header
+# block fragment carrying the request the SERVER invented.
+private def push_promise(stream : UInt32, promised : UInt32, block : Bytes) : Frame::Header
+  payload = IO::Memory.new
+  id = Bytes.new(4)
+  IO::ByteFormat::BigEndian.encode(promised, id)
+  payload.write(id)
+  payload.write(block)
+  Frame::Header.new(Frame::Type::PushPromise.value, Frame::END_HEADERS, stream, payload.to_slice)
+end
+
 private def data(stream : UInt32, body : String, flags = 0_u8) : Frame::Header
   Frame::Header.new(Frame::Type::Data.value, flags, stream, body.to_slice)
 end
@@ -352,6 +363,97 @@ describe Gori::Proxy::H2::StreamGate do
       head.find { |(n, _)| n == ":method" }.not_nil![1].should eq("POST") # the head edit lands
       head.any? { |(n, _)| n == "content-length" }.should be_false        # DATA is untouched, so CL is not the operator's to set
       rig.to_origin.any? { |f| f.frame_type == Frame::Type::Data }.should be_false
+    end
+  end
+
+  # ---- R3-F1/F2: what the surface is told BEFORE it acks an edit ---------------
+  #
+  # The refusal itself (#517) is correct: the h1 text is lossy for these heads, so re-parsing
+  # an operator's edit would apply it to a DIFFERENT message. What cost a live test is that it
+  # ran on the wait fiber, after the CLI/MCP/TUI had already reported the edit applied. It is a
+  # pure function of the decoded block, so the item carries it from the moment it is held.
+
+  it "marks a held request whose head has no h1 text form as uneditable, naming the field" do
+    with_ic do |ic|
+      rig = Rig.new(ic)
+      fields = request("/unf") + [{"x-evil", "a\r\nx-injected: yes"}, {"x-tail", "z"}]
+      rig.c2s.accept(headers(1_u32, rig.enc_out.encode(fields)))
+      settle
+      item = ic.pending.first
+      item.edit_refusal.not_nil!.should contain("x-evil")
+      item.edit_refusal.not_nil!.should contain("CR or LF")
+      item.head_only?.should be_true
+    end
+  end
+
+  # The complement, and the one that matters most: an ordinary head must stay editable, or the
+  # fix would have turned a silent discard into a blanket refusal.
+  it "leaves an ordinary held request editable" do
+    with_ic do |ic|
+      rig = Rig.new(ic)
+      rig.c2s.accept(headers(1_u32, rig.enc_out.encode(request("/ok"))))
+      settle
+      ic.pending.first.edit_refusal.should be_nil
+    end
+  end
+
+  it "marks a held RESPONSE the same way — the direction a CRLF-injection probe reflects on" do
+    with_ic do |ic|
+      ic.set_direction(Gori::Interceptor::Direction::ResponseOnly)
+      rig = Rig.new(ic)
+      rig.c2s.accept(headers(1_u32, rig.enc_out.encode(request("/x")), Frame::END_HEADERS))
+      rig.s2c.accept(headers(1_u32, rig.enc_in.encode(response("200") + [{"x-evil", "a\r\nx-injected: 1"}]),
+        Frame::END_HEADERS))
+      settle
+      ic.pending.first.edit_refusal.not_nil!.should contain("x-evil")
+
+      # Complement, same direction, same run shape: a clean response head stays editable.
+      rig.c2s.accept(headers(3_u32, rig.enc_out.encode(request("/y")), Frame::END_HEADERS))
+      rig.s2c.accept(headers(3_u32, rig.enc_in.encode(response("200")), Frame::END_HEADERS))
+      settle
+      ic.pending.find { |it| it.id != 1 }.not_nil!.edit_refusal.should be_nil
+    end
+  end
+
+  # R3-F2. h1 forwards the identical edit byte-exact and its comment says why: "the proxy must
+  # not rewrite bytes the human chose to send (e.g. a deliberately CL-mismatched smuggling
+  # probe)". On h2 that probe is the RFC 9113 §8.1.1 one, and it was unexpressible.
+  it "honours a content-length the operator DECLARED (no editor synced it)" do
+    with_ic do |ic|
+      rig = Rig.new(ic)
+      fields = post("/cl") + [{"content-length", "10"}]
+      rig.c2s.accept(headers(1_u32, rig.enc_out.encode(fields), Frame::END_HEADERS))
+      settle
+      item = ic.pending.first
+      ic.forward(item.id,
+        "POST /cl HTTP/2\r\nHost: api.example.com\r\ncontent-length: 3\r\nx-probe: cl-mismatch\r\n\r\n".to_slice)
+      settle
+
+      head = head_of(rig.to_origin, 1_u32).not_nil!
+      head.find { |(n, _)| n == "content-length" }.not_nil![1].should eq("3")
+      head.find { |(n, _)| n == "x-probe" }.not_nil![1].should eq("cl-mismatch")
+      # ...and in the position the operator wrote it, not moved to the end of the list.
+      head.map(&.[0]).should eq([":method", ":scheme", ":authority", ":path", "content-length", "x-probe"])
+    end
+  end
+
+  # The complement: a content-length that AGREES with the (absent) body of the edit, which is
+  # exactly what every "update Content-Length" affordance produces on a head-only hold — the
+  # TUI's `^L`, the MCP tool's default, `gori run intercept edit`. Those get the peer's back.
+  it "puts the peer's content-length back when the surface synced it against a body h2 will not send" do
+    with_ic do |ic|
+      rig = Rig.new(ic)
+      fields = post("/cl") + [{"content-length", "10"}]
+      rig.c2s.accept(headers(1_u32, rig.enc_out.encode(fields), Frame::END_HEADERS))
+      settle
+      item = ic.pending.first
+      ic.forward(item.id,
+        "POST /cl HTTP/2\r\nHost: api.example.com\r\ncontent-length: 0\r\nx-probe: edited\r\n\r\n".to_slice)
+      settle
+
+      head = head_of(rig.to_origin, 1_u32).not_nil!
+      head.find { |(n, _)| n == "content-length" }.not_nil![1].should eq("10")
+      head.find { |(n, _)| n == "x-probe" }.not_nil![1].should eq("edited")
     end
   end
 
@@ -658,6 +760,73 @@ describe Gori::Proxy::H2::StreamGate do
       allowed = request("/api/ok") + [{"x-token", "abc"}]
       rig.c2s.accept(headers(3_u32, rig.enc_out.encode(allowed), Frame::END_HEADERS))
       head_of(rig.to_origin, 3_u32).should eq(allowed)
+    end
+  end
+
+  # ---- R3-F4: server push, the request the ORIGIN invented ---------------------
+  #
+  # `sandbox_refuses_locked` could not reach a PUSH_PROMISE: it arrives on the RESPONSE leg
+  # (where `@ordered` is false) and `head_text` returns nil for it, so `block.head` is nil too.
+  # A promise therefore named any authority it liked and got a History row, on the same
+  # connection that refuses the identical authority on a real request.
+
+  it "refuses a PUSH_PROMISE for an out-of-scope authority and cancels the promised stream" do
+    with_ic(intercept: false) do |ic, scope|
+      scope.add("include", "string", "https://api.example.com/api/")
+      scope.enable_sandbox
+      rig = Rig.new(ic)
+
+      # A real, in-scope request first, so the connection is an ordinary one.
+      rig.c2s.accept(headers(1_u32, rig.enc_out.encode(request("/api/ok"))))
+      rig.to_origin.map(&.stream_id).should eq([1_u32])
+
+      rig.s2c.accept(push_promise(1_u32, 2_u32,
+        rig.enc_in.encode(request("/pushed", "evil.test"))))
+
+      # The client never learns the promise exists...
+      rig.to_client.any? { |f| f.frame_type == Frame::Type::PushPromise }.should be_false
+      # ...and the ORIGIN is told to cancel the promised stream, which is a client's own §8.4
+      # way of declining a push.
+      rst = rig.to_origin.select { |f| f.frame_type == Frame::Type::RstStream }
+      rst.map(&.stream_id).should eq([2_u32])
+      IO::ByteFormat::BigEndian.decode(UInt32, rst.first.payload).should eq(Gate::CANCEL)
+
+      # Visible in History under the same string a refused request gets, and marked as pushed.
+      pushed = rig.sink.requests.find { |r| r.host == "evil.test" }.not_nil!
+      String.new(pushed.head).should contain("X-Gori-Pushed")
+      rig.sink.responses.map(&.error).should contain(Gate::SANDBOX_REASON)
+
+      # A pushed response already in flight is swallowed rather than written to a client that
+      # never learned the stream exists.
+      rig.s2c.accept(headers(2_u32, rig.enc_in.encode(response("200")), Frame::END_HEADERS))
+      rig.to_client.any? { |f| f.stream_id == 2_u32 }.should be_false
+    end
+  end
+
+  it "relays a PUSH_PROMISE whose promised URL IS in scope" do
+    with_ic(intercept: false) do |ic, scope|
+      scope.add("include", "string", "https://api.example.com/api/")
+      scope.enable_sandbox
+      rig = Rig.new(ic)
+      rig.c2s.accept(headers(1_u32, rig.enc_out.encode(request("/api/ok"))))
+      rig.s2c.accept(push_promise(1_u32, 2_u32, rig.enc_in.encode(request("/api/sub"))))
+
+      rig.to_client.any? { |f| f.frame_type == Frame::Type::PushPromise }.should be_true
+      rig.to_origin.any? { |f| f.frame_type == Frame::Type::RstStream }.should be_false
+    end
+  end
+
+  it "relays an out-of-scope PUSH_PROMISE when the sandbox is OFF (the scope is a lens then)" do
+    with_ic(intercept: false) do |ic, scope|
+      scope.add("include", "string", "https://api.example.com/api/")
+      # Sandbox NOT enabled.
+      rig = Rig.new(ic)
+      rig.c2s.accept(headers(1_u32, rig.enc_out.encode(request("/api/ok"))))
+      rig.s2c.accept(push_promise(1_u32, 2_u32, rig.enc_in.encode(request("/pushed", "evil.test"))))
+
+      rig.to_client.any? { |f| f.frame_type == Frame::Type::PushPromise }.should be_true
+      rig.to_origin.any? { |f| f.frame_type == Frame::Type::RstStream }.should be_false
+      rig.heads_in.engaged?.should be_false # and the direction stays byte-exact
     end
   end
 

--- a/spec/proxy/tls/h2_offer_reason_spec.cr
+++ b/spec/proxy/tls/h2_offer_reason_spec.cr
@@ -1,0 +1,152 @@
+require "../../spec_helper"
+require "socket"
+require "openssl"
+require "file_utils"
+
+include Gori::Proxy
+include Gori::Proxy::Tls
+
+# R5-F3. An h2/gRPC client whose preface lands on the HTTP/1.1 path is refused, and the refusal
+# used to hard-code two causes ("settings network.http2 is \"off\" or a Match&Replace body rule
+# is live") and point at a `gori.log` line that names which. Two things went stale under that
+# reasoning: `h2_candidate?` has FOUR downgrade branches now, and — decisively — the common case
+# is NONE of them. The tunnel offered h2, the ORIGIN answered `http/1.1` at ALPN,
+# `notice_downgrade` never ran, and `gori.log` stayed 0 bytes. The operator was told to change a
+# setting that was already correct and to read a line that did not exist.
+
+private class ErrSink < FlowSink
+  getter requests = [] of Gori::Store::CapturedRequest
+  getter responses = [] of Gori::Store::CapturedResponse
+
+  def initialize(@done : Channel(Nil))
+    @next_id = 0_i64
+  end
+
+  def on_request(req : Gori::Store::CapturedRequest) : Int64
+    @requests << req
+    @next_id += 1
+  end
+
+  def on_response(resp : Gori::Store::CapturedResponse) : Nil
+    @responses << resp
+    @done.send(nil)
+  end
+
+  def on_ws_message(flow_id : Int64, direction : String, opcode : Int32, payload : Bytes,
+                    shape : Gori::Proxy::WS::Shape = Gori::Proxy::WS::Shape::DEFAULT) : Nil
+  end
+end
+
+# A TLS origin that does or does not advertise h2 at ALPN. `advertise_h2: false` is the whole
+# point of the primary example: gori's probe completes, the origin says `http/1.1`, and gori
+# therefore does not offer h2 to the client either (there is no h2 <-> h1 bridge).
+private def start_origin(advertise_h2 : Bool) : Int32
+  cert, key = CertBuilder.build_root("origin.test")
+  ctx = ContextFactory.server_context(cert, key, advertise_h2: advertise_h2)
+  server = TCPServer.new("127.0.0.1", 0)
+  port = server.local_address.port
+  spawn do
+    while raw = server.accept?
+      begin
+        ssl = OpenSSL::SSL::Socket::Server.new(raw, ctx, sync_close: true)
+        Codec::Http1.read_head(ssl)
+        ssl.close
+      rescue
+      end
+    end
+  end
+  port
+end
+
+private def h2_offering_client(raw : TCPSocket, ca_dir : String) : OpenSSL::SSL::Socket::Client
+  ctx = OpenSSL::SSL::Context::Client.new
+  ctx.alpn_protocol = "h2"
+  ca_cert = Cert.read_pem(File.join(ca_dir, "root.crt.pem"))
+  store = LibSSL.ssl_ctx_get_cert_store(ctx.to_unsafe)
+  LibCrypto.x509_store_add_cert(store, ca_cert.handle)
+  OpenSSL::SSL::Socket::Client.new(raw, context: ctx, sync_close: true, hostname: "localhost")
+end
+
+# CONNECT through gori, offer h2, then speak the HTTP/2 client preface regardless of what ALPN
+# came back — a hand-rolled gRPC client's exact behaviour. Returns the recorded flow error.
+private def preface_refusal(origin_port : Int32, dir : String) : String
+  done = Channel(Nil).new(1)
+  sink = ErrSink.new(done)
+  proxy = Server.new("127.0.0.1", 0, sink, tls: Tunnel.new(CertAuthority.load_or_create(dir), verify_upstream: false))
+  proxy.start
+  begin
+    raw = TCPSocket.new("127.0.0.1", proxy.port)
+    raw << "CONNECT localhost:#{origin_port} HTTP/1.1\r\nHost: localhost:#{origin_port}\r\n\r\n"
+    raw.flush
+    Codec::Http1.read_head(raw).not_nil!
+    tls = h2_offering_client(raw, dir)
+    tls << "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"
+    tls.flush
+    tls.close rescue nil
+    done.receive
+    sink.responses.first.error.not_nil!
+  ensure
+    proxy.stop
+  end
+end
+
+describe "the reason an h2 preface is refused on the HTTP/1.1 path" do
+  it "names the ORIGIN's ALPN, not a setting that is already correct" do
+    dir = File.tempname("gori-ca-h2offer")
+    begin
+      Gori::Settings.http2 = "auto"
+      err = preface_refusal(start_origin(advertise_h2: false), dir)
+
+      err.should contain("rejected h2/gRPC client preface")
+      err.should contain("the ORIGIN did not negotiate HTTP/2")
+      # The two things the old sentence got wrong: it blamed a setting that is on "auto", and
+      # it pointed at a gori.log line this path never writes.
+      err.should_not contain("network.http2")
+      err.should_not contain("Match&Replace")
+      err.should_not contain("gori.log")
+    ensure
+      Gori::Settings.http2 = Gori::Settings::DEFAULT_HTTP2
+      FileUtils.rm_rf(dir) if Dir.exists?(dir)
+    end
+  end
+
+  # The complement: the branch that IS the setting's still names it, and still points at the
+  # gori.log line, because `notice_downgrade` really does write one there.
+  it "still names the setting — and gori.log — when the setting really is the cause" do
+    dir = File.tempname("gori-ca-h2off")
+    begin
+      Gori::Settings.http2 = "off"
+      err = preface_refusal(start_origin(advertise_h2: true), dir)
+
+      err.should contain("HTTP/2 is switched off")
+      err.should contain("network.http2")
+      err.should contain("gori.log")
+    ensure
+      Gori::Settings.http2 = Gori::Settings::DEFAULT_HTTP2
+      FileUtils.rm_rf(dir) if Dir.exists?(dir)
+    end
+  end
+
+  # The unit half: every member says something different, and only the branches that write to
+  # gori.log mention it.
+  describe Gori::Proxy::H2Offer do
+    it "gives each cause its own sentence" do
+      reasons = Gori::Proxy::H2Offer.values.map(&.refusal_reason)
+      reasons.uniq.size.should eq(reasons.size)
+      reasons.each { |r| r.should_not be_empty }
+    end
+
+    it "mentions gori.log only where a line was actually written" do
+      writes = [Gori::Proxy::H2Offer::DisabledBySetting, Gori::Proxy::H2Offer::BodyRule,
+                Gori::Proxy::H2Offer::ShortCircuitRule, Gori::Proxy::H2Offer::ExtractRule]
+      Gori::Proxy::H2Offer.values.each do |offer|
+        offer.refusal_reason.includes?("gori.log").should eq(writes.includes?(offer))
+      end
+    end
+
+    it "asserts no cause at all when nothing stamped one" do
+      Gori::Proxy::H2Offer::Unknown.refusal_reason
+        .should eq("HTTP/2 was not negotiated on this connection")
+    end
+  end
+end

--- a/spec/proxy/tls/h2_offer_reason_spec.cr
+++ b/spec/proxy/tls/h2_offer_reason_spec.cr
@@ -76,14 +76,35 @@ private def preface_refusal(origin_port : Int32, dir : String) : String
   proxy.start
   begin
     raw = TCPSocket.new("127.0.0.1", proxy.port)
+    raw.read_timeout = 10.seconds
     raw << "CONNECT localhost:#{origin_port} HTTP/1.1\r\nHost: localhost:#{origin_port}\r\n\r\n"
     raw.flush
     Codec::Http1.read_head(raw).not_nil!
     tls = h2_offering_client(raw, dir)
     tls << "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"
     tls.flush
+    # Drain to EOF before closing, the way a real client does. Closing straight after the write
+    # raced the proxy on Linux: the peer's close was observed first, the connection was torn
+    # down before the refusal was written and recorded, and no response ever reached the sink.
+    # macOS timing hid it, so the suite passed locally and hung in CI.
+    begin
+      buf = Bytes.new(4096)
+      while (n = tls.read(buf)) > 0
+      end
+    rescue
+    end
     tls.close rescue nil
-    done.receive
+    # NEVER a bare `receive` here. This example drives a real proxy over a real socket, so
+    # "the response was not captured" is a plausible outcome of a platform difference — and a
+    # bare receive turns that into a suite that hangs with no output instead of one example
+    # that says what happened. It cost a CI run to learn: `crystal spec` block-buffers its
+    # dots under Actions, so a hang leaves nothing behind to read.
+    select
+    when done.receive
+      # captured
+    when timeout(20.seconds)
+      raise "no response was captured within 20s — the proxy never completed the flow"
+    end
     sink.responses.first.error.not_nil!
   ensure
     proxy.stop

--- a/spec/proxy/ws_hold_spec.cr
+++ b/spec/proxy/ws_hold_spec.cr
@@ -397,6 +397,96 @@ describe Gori::Proxy::WS::MessageGate do
     r.shutdown
   end
 
+  # #554's control-frame parking turned a DELIVERED keepalive into a lost one. `TEXT fin=0
+  # "SECRET"` / `PING` / a socket that ends with NO close frame is a half-sent-secret test,
+  # and both the byte-exact pump and the rewrite-only pump put both frames on the wire. On a
+  # GATED socket neither left: `AssemblingPump#run`'s `ensure` skipped the flush whenever a
+  # gate was armed, so `@parked` and `@buffer` were discarded — while capture still carried
+  # the arrival row for the PING that never went out and NO row for the fragment that did.
+  # The evidence was exactly inverted, and losing a keepalive on a gated socket is the very
+  # liveness failure `MAX_PARKED_CONTROLS` and this class's header exist to prevent.
+  #
+  # The condition here matches NOTHING, which is the worst case and the way an operator arms
+  # this by accident: they caught the socket for something else entirely.
+  it "delivers a parked control frame and the fragment it sat inside when a gated socket ends with no CLOSE" do
+    first = masked(WS::OP_TEXT, "SECRET".to_slice, fin: false)
+    ping = masked(WS::OP_PING, "zz".to_slice)
+    r = rig
+    sink = HoldSink.new
+    with_interceptor("proto:ws body:never-matches-this") do |ic|
+      spawn { WS::Relay.run(r.client, r.upstream, 60_i64, sink, nil, HOLD_CTX, ic) }
+      r.cs_w.write(first)
+      r.cs_w.write(ping)
+      # The arrival row proves the PING has been read and parked; only then is the teardown
+      # racing the thing under test.
+      wait_until("the PING to be parked") { sink.messages.size == 1 }
+      r.cs_w.close # the client vanishes mid-message: no CLOSE frame, no FIN
+
+      r.ts_r.as(IO::FileDescriptor).read_timeout = 3.seconds
+      r.ts_r.gets_to_end.to_slice.should eq(first + ping) # was: nothing at all
+      # ... and the capture now says what the wire says, in the same order.
+      sink.messages.should eq([{"out", 9, "zz"}, {"out", 1, "SECRET"}])
+      ic.pending_count.should eq(0)
+    end
+    r.shutdown
+  end
+
+  # The complement: the same frames on the same gated socket, ended by a real CLOSE. That
+  # path already flushed (via `forward_control`'s close branch) and must not now flush twice
+  # — the teardown pass is idempotent, and the CLOSE still comes last (§5.5.1).
+  it "still delivers the parked frame exactly once when the gated socket ends WITH a CLOSE" do
+    first = masked(WS::OP_TEXT, "SECRET".to_slice, fin: false)
+    ping = masked(WS::OP_PING, "zz".to_slice)
+    bye = masked(WS::OP_CLOSE, Bytes[0x03, 0xe8])
+    r = rig
+    sink = HoldSink.new
+    with_interceptor("proto:ws body:never-matches-this") do |ic|
+      spawn { WS::Relay.run(r.client, r.upstream, 61_i64, sink, nil, HOLD_CTX, ic) }
+      r.cs_w.write(first)
+      r.cs_w.write(ping)
+      r.cs_w.write(bye)
+
+      # Bounded read, not `gets_to_end`: a CLOSE is a CLEAN end, so `Relay.run` gives the
+      # other direction its CLOSE_TIMEOUT window before it closes this writer.
+      want = first + ping + bye
+      got = Bytes.new(want.size)
+      r.ts_r.as(IO::FileDescriptor).read_timeout = 3.seconds
+      r.ts_r.read_fully(got)
+      got.should eq(want)
+      sink.messages[0, 2].should eq([{"out", 9, "zz"}, {"out", 1, "SECRET"}])
+      sink.messages.size.should eq(3) # ... and the CLOSE, once
+    end
+    r.shutdown
+  end
+
+  # Ordering across the two teardown resolutions: a message a human really owns is released
+  # by `settle` FIRST, and the half-assembled fragments the pump is withholding — which
+  # arrived after it — follow. Getting this backwards would put later bytes on the wire ahead
+  # of earlier ones on the one socket where order is the whole guarantee.
+  it "releases a genuinely held message before the fragments still assembling behind it" do
+    tail = masked(WS::OP_TEXT, "TAIL".to_slice, fin: false)
+    ping = masked(WS::OP_PING, "zz".to_slice)
+    r = rig
+    sink = HoldSink.new
+    with_interceptor("proto:ws") do |ic|
+      ic.set_direction(Gori::Interceptor::Direction::RequestOnly)
+      spawn { WS::Relay.run(r.client, r.upstream, 62_i64, sink, nil, HOLD_CTX, ic) }
+      r.cs_w.write(masked(WS::OP_TEXT, "HELD".to_slice))
+      wait_until("the hold") { ic.pending_count == 1 }
+      # A second message starts behind the hold and never FINs, with a PING inside it.
+      r.cs_w.write(tail)
+      r.cs_w.write(ping)
+      wait_until("the PING to be parked") { sink.messages.size == 1 }
+      r.cs_w.close
+
+      r.ts_r.as(IO::FileDescriptor).read_timeout = 3.seconds
+      got = r.ts_r.gets_to_end.to_slice
+      got.should eq(masked(WS::OP_TEXT, "HELD".to_slice) + tail + ping)
+      sink.messages.should eq([{"out", 9, "zz"}, {"out", 1, "HELD"}, {"out", 1, "TAIL"}])
+    end
+    r.shutdown
+  end
+
   it "forwards a still-held message at teardown instead of destroying it" do
     # The socket ends while the operator still owns the message. `MessageGate#close` runs
     # from the pump's `ensure`, which is only reached AFTER `Relay.run` has closed both

--- a/spec/proxy/ws_spec.cr
+++ b/spec/proxy/ws_spec.cr
@@ -652,6 +652,123 @@ describe Gori::Proxy::WS do
     # fragmentation is gone and there is no position left to hold the control frame at — so it
     # goes out AHEAD, which is what keeps the peer's ping timer answered. Both dispositions in
     # one place, because the boundary between them is the whole design.
+    # The parking ceiling (`MAX_PARKED_CONTROLS`) is a REORDER gori performs on the wire, and
+    # until now it told only `gori.log` — "which reaches only an operator who knew to tail it",
+    # the exact argument #518 used to move the `Sec-WebSocket-Extensions` advisory onto the
+    # flow's own `ws_messages` stream. Control rows are recorded at ARRIVAL and message rows at
+    # EMIT, so with the interleave preserved and with it given up the capture reads identically
+    # — History, `gori run show`, MCP `get_flow` and an export could not tell the two apart.
+    # Both sides of the ceiling are asserted here, because that is the only thing that makes
+    # the marker mean anything.
+    it "records the parking-ceiling reorder as a [gori] row, above the ceiling only" do
+      lead = masked_op_frame(Gori::Proxy::WS::OP_TEXT, "AAA".to_slice, fin: false)
+      tail = masked_op_frame(Gori::Proxy::WS::OP_CONT, "BBB".to_slice)
+      pings = (0...9).map do |i|
+        masked_op_frame(Gori::Proxy::WS::OP_PING, Bytes[0x70_u8, (0x30 + i).to_u8])
+      end
+      cs_r, cs_w = IO.pipe
+      ts_r, ts_w = IO.pipe
+      ss_r, ss_w = IO.pipe
+      tc_r, tc_w = IO.pipe
+      client = IO::Stapled.new(cs_r, tc_w)
+      upstream = IO::Stapled.new(ss_r, ts_w)
+
+      cs_w.write(lead)
+      pings.each { |p| cs_w.write(p) }
+      cs_w.write(tail)
+      cs_w.close
+      ss_w.close
+
+      sink = WsSink.new
+      # A rule that matches nothing: the message itself is still forwarded as the peer's own
+      # frames, so the ONLY thing gori changed about this socket is where the PINGs sit.
+      Gori::Proxy::WS::Relay.run(client, upstream, 7_i64, sink,
+        WsRewriter.new(to_server: {"absent", "x"}), WS_CTX)
+
+      ts_w.close
+      # The documented hoist: the ninth PING trips the ceiling, everything parked goes out
+      # ahead of the fragments, and the message follows byte-exact.
+      ts_r.gets_to_end.to_slice.should eq(pings.reduce(Bytes.empty) { |a, p| a + p } + lead + tail)
+
+      notices = sink.messages.select { |(_, _, text)| text.starts_with?("[gori] ") }
+      notices.size.should eq(1) # once per direction per socket, like the warn
+      notices.first[0].should eq("out")
+      notices.first[2].should contain("more than 8 control frames arrived between the fragments")
+      # Its POSITION is what names the message: right where gori gave up, after the eight it
+      # had parked and before the one that broke the ceiling.
+      sink.messages.index(notices.first).should eq(8)
+      sink.messages.last.should eq({"out", 1, "AAABBB"})
+      _ = tc_r
+    end
+
+    # The complement, one frame BELOW the ceiling: eight parked controls still ride out inside
+    # the message at the offsets they arrived at, and nothing claims a reorder that did not
+    # happen. A marker that fires on both sides of a boundary carries no information.
+    it "keeps the interleave and writes no [gori] row one frame below the parking ceiling" do
+      lead = masked_op_frame(Gori::Proxy::WS::OP_TEXT, "AAA".to_slice, fin: false)
+      tail = masked_op_frame(Gori::Proxy::WS::OP_CONT, "BBB".to_slice)
+      pings = (0...8).map do |i|
+        masked_op_frame(Gori::Proxy::WS::OP_PING, Bytes[0x70_u8, (0x30 + i).to_u8])
+      end
+      cs_r, cs_w = IO.pipe
+      ts_r, ts_w = IO.pipe
+      ss_r, ss_w = IO.pipe
+      tc_r, tc_w = IO.pipe
+      client = IO::Stapled.new(cs_r, tc_w)
+      upstream = IO::Stapled.new(ss_r, ts_w)
+
+      cs_w.write(lead)
+      pings.each { |p| cs_w.write(p) }
+      cs_w.write(tail)
+      cs_w.close
+      ss_w.close
+
+      sink = WsSink.new
+      Gori::Proxy::WS::Relay.run(client, upstream, 7_i64, sink,
+        WsRewriter.new(to_server: {"absent", "x"}), WS_CTX)
+
+      ts_w.close
+      ts_r.gets_to_end.to_slice
+        .should eq(lead + pings.reduce(Bytes.empty) { |a, p| a + p } + tail)
+      sink.messages.count { |(_, _, text)| text.starts_with?("[gori] ") }.should eq(0)
+      sink.messages.last.should eq({"out", 1, "AAABBB"})
+      _ = tc_r
+    end
+
+    # The same "a parked control frame must never be silently dropped" rule, at the other
+    # place it was broken: a LEADING FRAGMENT MAY BE EMPTY. `TEXT fin=0 ""` puts bytes in the
+    # raw accumulator and none in the payload buffer, so a PING parked inside that message sat
+    # in a message `start_message`'s `@buffer.size > 0` test called "not there" — and the
+    # `reset_raw` right after it discarded the PING with no wire write and no way to tell.
+    # `MessageShape#frames`' own comment names this hazard ("the payload buffer cannot answer
+    # it, because a leading fragment may be empty").
+    it "does not swallow a control frame parked inside a message whose leading fragment is empty" do
+      lead = masked_op_frame(Gori::Proxy::WS::OP_TEXT, Bytes.empty, fin: false)
+      ping = masked_op_frame(Gori::Proxy::WS::OP_PING, "pi".to_slice)
+      # A new data message while the previous one never FIN'd (RFC 6455 §5.4) — the exit that
+      # dropped it.
+      second = masked_op_frame(Gori::Proxy::WS::OP_TEXT, "second".to_slice)
+      cs_r, cs_w = IO.pipe
+      ts_r, ts_w = IO.pipe
+      ss_r, ss_w = IO.pipe
+      tc_r, tc_w = IO.pipe
+      client = IO::Stapled.new(cs_r, tc_w)
+      upstream = IO::Stapled.new(ss_r, ts_w)
+
+      cs_w.write(lead); cs_w.write(ping); cs_w.write(second); cs_w.close
+      ss_w.close
+
+      sink = WsSink.new
+      Gori::Proxy::WS::Relay.run(client, upstream, 7_i64, sink,
+        WsRewriter.new(to_server: {"absent", "x"}), WS_CTX)
+
+      ts_w.close
+      # The PING reaches the origin ahead of the message that displaced the one it was parked
+      # inside — was: never written at all.
+      ts_r.gets_to_end.to_slice.should eq(ping + second)
+      _ = tc_r
+    end
+
     it "hoists an interleaved PING only when the message is actually re-framed" do
       cs_r, cs_w = IO.pipe
       ts_r, ts_w = IO.pipe

--- a/spec/repeater/evidence_provenance_spec.cr
+++ b/spec/repeater/evidence_provenance_spec.cr
@@ -79,15 +79,57 @@ describe "Gori::Repeater::PlanOptions#evidence?" do
           auto_content_length: false)).should eq("POST /lf HTTP/1.1\r\nHost: h\r\nContent-Length: 5\r\n\r\nhello")
       end
     end
+  end
 
-    # Expansion is a SEPARATE knob: a surface may have merged operator-typed `-H` overrides
-    # into the evidence bytes, and those still have to expand.
-    it "still expands a resolvable $KEY in evidence bytes, without re-terminating the head" do
-      raw = "GET /a HTTP/1.1\nHost: h\nAuthorization: Bearer $TOK\n\n"
+  # The third draft-time policy, and the one round 2 left running: `$KEY` SUBSTITUTION.
+  #
+  # This block used to assert the opposite ("still expands a resolvable $KEY in evidence
+  # bytes"), on the theory that a surface might have merged operator-typed overrides into
+  # these bytes and those still had to expand. The theory was right and the seam was wrong:
+  # by the time the builder sees one merged wire, nothing can tell the operator's bytes from
+  # the capture's — so the expansion also ran over the CAPTURE, and a project that happened
+  # to define an ordinary name (`filter`, `top`, `where`, `token`, `user`) rewrote the stored
+  # request and re-framed its Content-Length to match, silently. Meanwhile MCP's flow path
+  # reached the intended end state by a DIFFERENT mechanism (`expand_request: false`) and did
+  # not, so the two headless surfaces sent different requests from the same flow id.
+  #
+  # A surface that merges overrides now expands them at ITS OWN merge seam, where it still
+  # knows whose bytes are whose — see `spec/cli/run/repeater_headers_spec.cr`.
+  describe "$KEY substitution" do
+    it "does not substitute a project value into evidence, even when the name resolves" do
+      raw = "GET /api?$filter=name%20eq%20x&$top=10 HTTP/1.1\r\nHost: h\r\n\r\n"
+      with_env_vars([{"filter", "PWNED"}, {"top", "9"}]) do
+        wire_of(R::PlanOptions.new([raw.to_slice], target: "http://h",
+          auto_content_length: false, evidence: true)).should eq(raw)
+      end
+    end
+
+    it "does not re-frame a captured Content-Length over a body it did not change" do
+      raw = "POST /bk HTTP/1.1\r\nHost: h\r\nContent-Length: 22\r\n\r\n{\"q\":\"$where 1==1 ab\"}\n"
+      with_env_vars([{"where", "XX"}]) do
+        wire_of(R::PlanOptions.new([raw.to_slice], target: "http://h",
+          auto_content_length: false, resync_cl_after_expansion: true, evidence: true)).should eq(raw)
+      end
+    end
+
+    it "still substitutes in a DRAFT, which is the whole point of the syntax there" do
+      raw = "GET /a HTTP/1.1\r\nHost: h\r\nAuthorization: Bearer $TOK\r\n\r\n"
       with_env_vars([{"TOK", "s3cr3t"}]) do
         wire_of(R::PlanOptions.new([raw.to_slice], target: "http://h",
+          auto_content_length: false))
+          .should eq("GET /a HTTP/1.1\r\nHost: h\r\nAuthorization: Bearer s3cr3t\r\n\r\n")
+      end
+    end
+
+    # `expand_request?` is still consulted for the version-line downgrade, which is NOT a
+    # draft policy — a captured h2 flow replayed down an h1 socket must not put `HTTP/2` on
+    # the request line whatever its provenance, and `evidence?` must not silently disable it.
+    it "still downgrades an h2 version line on evidence bytes" do
+      raw = "GET /a HTTP/2\r\nHost: h\r\n\r\n"
+      with_env_vars([] of {String, String}) do
+        wire_of(R::PlanOptions.new([raw.to_slice], target: "http://h",
           auto_content_length: false, evidence: true))
-          .should eq("GET /a HTTP/1.1\nHost: h\nAuthorization: Bearer s3cr3t\n\n")
+          .should eq("GET /a HTTP/1.1\r\nHost: h\r\n\r\n")
       end
     end
   end

--- a/spec/repeater/h2_engine_spec.cr
+++ b/spec/repeater/h2_engine_spec.cr
@@ -377,6 +377,168 @@ private def start_h2_origin_window(init_window : Int32, grant : Bool, seen : Cha
   port
 end
 
+# An origin that ANSWERS WHILE THE REQUEST BODY IS STILL GOING OUT — the 413 every upload /
+# body-size probe exists to find, and explicitly permitted by RFC 9113 §8.1. It advertises
+# `init_window`, never replenishes it, and once `after` body bytes have arrived replies
+# `status` either as HEADERS+DATA/END_STREAM (`with_body: true` — the ORDINARY shape of an
+# error response) or as a bodiless HEADERS/END_STREAM. Both are needed: END_HEADERS is a
+# HEADERS/CONTINUATION flag, so a detector that tests for it can only ever fire on the
+# bodiless one. Reports the body bytes it received.
+private def start_h2_origin_early_response(init_window : Int32, after : Int32, status : Int32,
+                                           with_body : Bool, seen : Channel(Int32)) : Int32
+  origin = TCPServer.new("127.0.0.1", 0)
+  port = origin.local_address.port
+  spawn do
+    next unless conn = origin.accept?
+    conn.read_timeout = 5.seconds
+    Frame.read_preface(conn)
+    settings = IO::Memory.new
+    settings.write_bytes(0x4_u16, IO::ByteFormat::BigEndian) # SETTINGS_INITIAL_WINDOW_SIZE
+    settings.write_bytes(init_window.to_u32, IO::ByteFormat::BigEndian)
+    send_server_preface(conn, settings.to_slice)
+
+    got = 0
+    begin
+      until got >= after
+        f = Frame.read(conn)
+        break if f.nil?
+        next unless f.frame_type == Frame::Type::Data && f.stream_id == 1
+        got += f.payload.size
+        break if f.end_stream?
+      end
+      sb = HPACK::Encoder.new.encode([{":status", status.to_s}, {"content-length", with_body ? "17" : "0"}])
+      flags = Frame::END_HEADERS | (with_body ? 0_u8 : Frame::END_STREAM)
+      conn.write(Frame::Header.new(Frame::Type::Headers.value, flags, 1_u32, sb).to_bytes)
+      if with_body
+        conn.write(Frame::Header.new(Frame::Type::Data.value, Frame::END_STREAM, 1_u32,
+          "request too large".to_slice).to_bytes)
+      end
+      conn.flush
+      sleep 0.3.seconds # hold the socket open: a stall must be distinguishable from a hangup
+    rescue
+    end
+    seen.send(got)
+    conn.close
+  end
+  port
+end
+
+# An origin whose FIRST frame is NOT SETTINGS — a PING or a connection WINDOW_UPDATE — with
+# its real SETTINGS (`init_window`) arriving `delay` later. RFC 9113 §3.4 says SETTINGS comes
+# first, but a client that reads exactly ONE frame draws the wrong conclusion from any other
+# opener and writes against the 65535-byte default. Enforces the advertised window and
+# answers an overrun with GOAWAY(FLOW_CONTROL_ERROR), reporting body bytes or -1 on overrun.
+private def start_h2_origin_late_settings(init_window : Int32, first : Symbol, delay : Time::Span,
+                                          seen : Channel(Int32)) : Int32
+  origin = TCPServer.new("127.0.0.1", 0)
+  port = origin.local_address.port
+  spawn do
+    next unless conn = origin.accept?
+    conn.read_timeout = 10.seconds
+    Frame.read_preface(conn)
+    if first == :ping
+      conn.write(Frame::Header.new(Frame::Type::Ping.value, 0_u8, 0_u32, Bytes.new(8)).to_bytes)
+    else
+      inc = Bytes.new(4)
+      IO::ByteFormat::BigEndian.encode(1_u32, inc)
+      conn.write(Frame::Header.new(Frame::Type::WindowUpdate.value, 0_u8, 0_u32, inc).to_bytes)
+    end
+    conn.flush
+    spawn do
+      sleep delay
+      settings = IO::Memory.new
+      settings.write_bytes(0x4_u16, IO::ByteFormat::BigEndian)
+      settings.write_bytes(init_window.to_u32, IO::ByteFormat::BigEndian)
+      send_server_preface(conn, settings.to_slice) rescue nil
+    end
+
+    win = init_window
+    got = 0
+    overran = false
+    begin
+      loop do
+        f = Frame.read(conn)
+        break if f.nil?
+        next unless f.frame_type == Frame::Type::Data && f.stream_id == 1
+        if f.payload.size > win
+          overran = true
+          break
+        end
+        win -= f.payload.size
+        got += f.payload.size
+        break if f.end_stream?
+      end
+    rescue
+    end
+    seen.send(overran ? -1 : got)
+    if overran
+      payload = IO::Memory.new
+      payload.write_bytes(1_u32, IO::ByteFormat::BigEndian) # last-stream-id
+      payload.write_bytes(3_u32, IO::ByteFormat::BigEndian) # FLOW_CONTROL_ERROR
+      conn.write(Frame::Header.new(Frame::Type::Goaway.value, 0_u8, 0_u32, payload.to_slice).to_bytes)
+      conn.flush rescue nil
+    else
+      sleep 2.seconds
+    end
+    conn.close
+  end
+  port
+end
+
+# An origin that advertises `init_window`, NEVER grants more, and keeps the socket busy —
+# either with keepalive PINGs or with the RFC 9113 §6.9.1-illegal `WINDOW_UPDATE +0`. Both
+# reset the per-read idle timer without ever reopening the send window, which is how the
+# "bounded wait" turned out to be bounded by frame COUNT (MAX_FRAMES: ~55 hours at a 2 s
+# ping cadence) rather than by any wall clock. Reports the body bytes it received.
+private def start_h2_origin_busy_stall(init_window : Int32, filler : Symbol,
+                                       interval : Time::Span, seen : Channel(Int32)) : Int32
+  origin = TCPServer.new("127.0.0.1", 0)
+  port = origin.local_address.port
+  spawn do
+    next unless conn = origin.accept?
+    conn.read_timeout = 30.seconds
+    Frame.read_preface(conn)
+    settings = IO::Memory.new
+    settings.write_bytes(0x4_u16, IO::ByteFormat::BigEndian)
+    settings.write_bytes(init_window.to_u32, IO::ByteFormat::BigEndian)
+    send_server_preface(conn, settings.to_slice)
+
+    stop = false
+    spawn do
+      until stop
+        sleep interval
+        break if stop
+        begin
+          if filler == :ping
+            conn.write(Frame::Header.new(Frame::Type::Ping.value, 0_u8, 0_u32, Bytes.new(8)).to_bytes)
+          else
+            conn.write(Frame::Header.new(Frame::Type::WindowUpdate.value, 0_u8, 1_u32, Bytes.new(4)).to_bytes)
+          end
+          conn.flush
+        rescue
+          break
+        end
+      end
+    end
+
+    got = 0
+    begin
+      loop do
+        f = Frame.read(conn)
+        break if f.nil?
+        next unless f.frame_type == Frame::Type::Data && f.stream_id == 1
+        got += f.payload.size
+        break if f.end_stream?
+      end
+    rescue
+    end
+    stop = true
+    seen.send(got)
+    conn.close rescue nil
+  end
+  port
+end
+
 # A cleartext-h2 origin that answers with RST_STREAM(`code`) on stream 1 — optionally after
 # a complete response head and a partial body, which is how a server aborts a response it
 # already began (CANCEL / INTERNAL_ERROR) and the case where the cause used to vanish.
@@ -945,6 +1107,189 @@ describe Gori::Repeater::H2Engine do
       error.should contain("only 65535 of 200000 request body bytes")
       error.should contain("never granted flow-control window")
       error.should contain("NOT fully sent")
+    end
+
+    # R1-F1. An origin that answers WHILE the body is still going out — the 413 every upload /
+    # body-size probe is looking for — was never detected. The early-stop test was
+    # `end_stream? && end_headers?`, but END_HEADERS is a HEADERS/CONTINUATION flag (on a DATA
+    # frame that bit means PADDED), so it could only fire for a response with NO body. With a
+    # body gori waited out the whole io_timeout and then RAISED from `write_data`, and the
+    # raise unwound before `read_response` ran — destroying the complete 413 that had been
+    # sitting in `flow.pending` the entire time.
+    #
+    # Both shapes are asserted here on purpose: the bodiless one is what round 2's fixer
+    # tested, and it is the ONLY one the old condition could satisfy.
+    describe "an origin that answers before the request body finishes (RFC 9113 §8.1)" do
+      it "reports the response WITH a body, and says the request body was cut short" do
+        seen = Channel(Int32).new(1)
+        port = start_h2_origin_early_response(4096, after: 4096, status: 413,
+          with_body: true, seen: seen)
+        body = ("A" * 20_000).to_slice
+        started = Time.instant
+        result = Gori::Repeater::H2Engine.send_fields(
+          [{":method", "POST"}, {":path", "/big"}, {":scheme", "http"}, {":authority", "h"},
+           {"content-length", body.size.to_s}], body,
+          scheme: "http", host: "127.0.0.1", port: port, verify_upstream: false,
+          timeout: 3.seconds)
+
+        seen.receive.should eq(4096)
+        # The response ARRIVED — it must survive the writer's disposition.
+        result.response.try(&.status).should eq(413)
+        String.new(result.head).should contain("413")
+        String.new(result.body || Bytes.empty).should eq("request too large")
+        # …and the send must not be reported as clean.
+        error = result.error.should_not be_nil
+        error.should contain("truncated at 4096 of 20000 bytes")
+        error.should contain("NOT fully sent")
+        # It must not spend the io_timeout: the answer was already on the socket.
+        (Time.instant - started).should be < 3.seconds
+      end
+
+      it "reports the same truncation for a BODILESS response, which used to come back clean" do
+        seen = Channel(Int32).new(1)
+        port = start_h2_origin_early_response(4096, after: 4096, status: 413,
+          with_body: false, seen: seen)
+        body = ("B" * 20_000).to_slice
+        result = Gori::Repeater::H2Engine.send_fields(
+          [{":method", "POST"}, {":path", "/big"}, {":scheme", "http"}, {":authority", "h"},
+           {"content-length", body.size.to_s}], body,
+          scheme: "http", host: "127.0.0.1", port: port, verify_upstream: false,
+          timeout: 3.seconds)
+
+        seen.receive.should eq(4096)
+        result.response.try(&.status).should eq(413)
+        error = result.error.should_not be_nil # was `ok:true, error:null`
+        error.should contain("truncated at 4096 of 20000 bytes")
+      end
+
+      it "leaves a body that DID go out whole reporting clean" do
+        # The complement of the two above: same origin, a body that fits the window. Nothing
+        # was truncated, so nothing may be said about truncation.
+        seen = Channel(Int32).new(1)
+        port = start_h2_origin_early_response(65_535, after: 500, status: 200,
+          with_body: true, seen: seen)
+        body = ("C" * 500).to_slice
+        result = Gori::Repeater::H2Engine.send_fields(
+          [{":method", "POST"}, {":path", "/small"}, {":scheme", "http"}, {":authority", "h"},
+           {"content-length", body.size.to_s}], body,
+          scheme: "http", host: "127.0.0.1", port: port, verify_upstream: false,
+          timeout: 3.seconds)
+
+        seen.receive.should eq(500)
+        result.response.try(&.status).should eq(200)
+        result.error.should be_nil
+      end
+    end
+
+    # R1-F2. `await_settings` read exactly ONE frame. `pump_once` ACKs a PING, credits a
+    # WINDOW_UPDATE and falls straight through a SETTINGS **ACK** without setting
+    # `settings_seen`, so an origin whose opening frame is any of those got the whole body
+    # written against the RFC default 65535-byte window — and the GOAWAY(FLOW_CONTROL_ERROR)
+    # it drew was reported as the ORIGIN misbehaving, the exact misattribution the send-side
+    # flow control was added to remove.
+    describe "an origin whose first frame is not SETTINGS" do
+      {:ping, :window_update}.each do |first|
+        it "waits for the real SETTINGS when the opener is a #{first}" do
+          seen = Channel(Int32).new(1)
+          port = start_h2_origin_late_settings(4096, first, 300.milliseconds, seen)
+          body = ("D" * 20_000).to_slice
+          result = Gori::Repeater::H2Engine.send_fields(
+            [{":method", "POST"}, {":path", "/late"}, {":scheme", "http"}, {":authority", "h"},
+             {"content-length", body.size.to_s}], body,
+            scheme: "http", host: "127.0.0.1", port: port, verify_upstream: false,
+            timeout: 2.seconds)
+
+          seen.receive.should eq(4096) # -1 = gori overran the window it was told about
+          # No window was ever granted, so this stalls — but on gori's OWN accounting, with
+          # no GOAWAY drawn and the origin never blamed.
+          error = result.error.should_not be_nil
+          error.should contain("h2 flow control")
+          error.should contain("only 4096 of 20000 request body bytes")
+          error.should_not contain("GOAWAY")
+        end
+      end
+
+      it "names gori's own overrun when it did proceed on the RFC defaults" do
+        # The complement: an origin that sends a non-SETTINGS opener and then NO SETTINGS at
+        # all within the budget. gori legitimately falls back to the §6.9.2 default — and the
+        # GOAWAY that follows must be attributed to gori, not handed over as the origin's fault.
+        seen = Channel(Int32).new(1)
+        port = start_h2_origin_late_settings(4096, :ping, 30.seconds, seen)
+        body = ("E" * 20_000).to_slice
+        result = Gori::Repeater::H2Engine.send_fields(
+          [{":method", "POST"}, {":path", "/never"}, {":scheme", "http"}, {":authority", "h"},
+           {"content-length", body.size.to_s}], body,
+          scheme: "http", host: "127.0.0.1", port: port, verify_upstream: false,
+          timeout: 2.seconds)
+
+        seen.receive.should eq(-1) # gori overran, as the RFC default entitles it to
+        error = result.error.should_not be_nil
+        error.should contain("FLOW_CONTROL_ERROR")
+        error.should contain("gori's own accounting")
+        error.should contain("the origin's SETTINGS had not arrived")
+      end
+    end
+
+    # R1-F3. The stall's only exits were `flow.available > 0`, `flow.closed?` and a
+    # `pump_once` that returned false — which happens on an IDLE read, an EOF, or
+    # MAX_FRAMES. Any frame at all resets the idle timer, so a keepalive PING under the
+    # timeout left MAX_FRAMES (a COUNT) as the only ceiling: ~55 hours at 2 s, ~17 days at a
+    # 15 s gRPC keepalive. `WsEngine::DRAIN_DEADLINE` is the wall clock this loop was missing.
+    describe "a stall kept alive by frames that grant no window" do
+      it "gives up on the wall clock when the origin sends keepalive PINGs" do
+        seen = Channel(Int32).new(1)
+        port = start_h2_origin_busy_stall(1024, :ping, 150.milliseconds, seen)
+        body = ("F" * 20_000).to_slice
+        started = Time.instant
+        result = Gori::Repeater::H2Engine.send_fields(
+          [{":method", "POST"}, {":path", "/ping"}, {":scheme", "http"}, {":authority", "h"},
+           {"content-length", body.size.to_s}], body,
+          scheme: "http", host: "127.0.0.1", port: port, verify_upstream: false,
+          timeout: 1.second)
+        elapsed = Time.instant - started
+
+        seen.receive.should eq(1024)
+        elapsed.should be < 10.seconds # unbounded before: the PINGs reset the idle timer
+        error = result.error.should_not be_nil
+        error.should contain("only 1024 of 20000 request body bytes")
+        error.should contain("never granted flow-control window")
+      end
+
+      it "names the §6.9.1 violation when the filler is WINDOW_UPDATE +0" do
+        seen = Channel(Int32).new(1)
+        port = start_h2_origin_busy_stall(1024, :window_update, 50.milliseconds, seen)
+        body = ("G" * 20_000).to_slice
+        result = Gori::Repeater::H2Engine.send_fields(
+          [{":method", "POST"}, {":path", "/wuzero"}, {":scheme", "http"}, {":authority", "h"},
+           {"content-length", body.size.to_s}], body,
+          scheme: "http", host: "127.0.0.1", port: port, verify_upstream: false,
+          timeout: 1.second)
+
+        seen.receive.should eq(1024)
+        error = result.error.should_not be_nil
+        error.should contain("WINDOW_UPDATE with a 0 increment")
+        error.should contain("§6.9.1")
+      end
+
+      it "still fails in ONE idle timeout when the origin sends nothing at all" do
+        # The complement of both: total silence. The deadline must not double the wall clock
+        # for the commonest failure — an origin that simply never grants window.
+        seen = Channel(Int32).new(1)
+        port = start_h2_origin_window(65_535, grant: false, seen: seen)
+        body = ("H" * 200_000).to_slice
+        started = Time.instant
+        result = Gori::Repeater::H2Engine.send_fields(
+          [{":method", "POST"}, {":path", "/silent"}, {":scheme", "http"}, {":authority", "h"}], body,
+          scheme: "http", host: "127.0.0.1", port: port, verify_upstream: false,
+          timeout: 700.milliseconds)
+        elapsed = Time.instant - started
+
+        seen.receive.should eq(65_535)
+        result.error.should_not be_nil
+        # One patience budget, not two: the write stall must not be followed by a full
+        # response-read timeout on a socket that produced no frames.
+        elapsed.should be < 1600.milliseconds
+      end
     end
   end
 

--- a/spec/repeater/h2_engine_spec.cr
+++ b/spec/repeater/h2_engine_spec.cr
@@ -423,6 +423,58 @@ private def start_h2_origin_early_response(init_window : Int32, after : Int32, s
   port
 end
 
+# An origin that answers a tight window with an INTERIM 1xx and then expects the rest of the
+# body — the complement of `start_h2_origin_early_response`, and the shape that decides
+# whether "a header block on stream 1" may be read as "stop writing". It advertises
+# `init_window`, sends `100 Continue` (HEADERS, END_HEADERS, NO END_STREAM) once the window is
+# spent, then replenishes until the whole body has arrived and answers 200. A client that
+# stops writing at the 1xx starves here. Reports the body bytes it received.
+private def start_h2_origin_interim(init_window : Int32, total : Int32, seen : Channel(Int32)) : Int32
+  origin = TCPServer.new("127.0.0.1", 0)
+  port = origin.local_address.port
+  spawn do
+    next unless conn = origin.accept?
+    conn.read_timeout = 5.seconds
+    Frame.read_preface(conn)
+    settings = IO::Memory.new
+    settings.write_bytes(0x4_u16, IO::ByteFormat::BigEndian)
+    settings.write_bytes(init_window.to_u32, IO::ByteFormat::BigEndian)
+    send_server_preface(conn, settings.to_slice)
+
+    got = 0
+    sent_interim = false
+    begin
+      until got >= total
+        f = Frame.read(conn)
+        break if f.nil?
+        next unless f.frame_type == Frame::Type::Data && f.stream_id == 1
+        got += f.payload.size
+        break if f.end_stream?
+        unless sent_interim
+          sent_interim = true
+          ib = HPACK::Encoder.new.encode([{":status", "100"}])
+          conn.write(Frame::Header.new(Frame::Type::Headers.value, Frame::END_HEADERS, 1_u32, ib).to_bytes)
+        end
+        inc = Bytes.new(4)
+        IO::ByteFormat::BigEndian.encode(init_window.to_u32, inc)
+        {0_u32, 1_u32}.each do |sid|
+          conn.write(Frame::Header.new(Frame::Type::WindowUpdate.value, 0_u8, sid, inc).to_bytes)
+        end
+        conn.flush
+      end
+      sb = HPACK::Encoder.new.encode([{":status", "200"}])
+      conn.write(Frame::Header.new(Frame::Type::Headers.value, Frame::END_HEADERS, 1_u32, sb).to_bytes)
+      conn.write(Frame::Header.new(Frame::Type::Data.value, Frame::END_STREAM, 1_u32, "ok".to_slice).to_bytes)
+      conn.flush
+      sleep 0.2.seconds
+    rescue
+    end
+    seen.send(got)
+    conn.close
+  end
+  port
+end
+
 # An origin whose FIRST frame is NOT SETTINGS — a PING or a connection WINDOW_UPDATE — with
 # its real SETTINGS (`init_window`) arriving `delay` later. RFC 9113 §3.4 says SETTINGS comes
 # first, but a client that reads exactly ONE frame draws the wrong conclusion from any other
@@ -1178,6 +1230,25 @@ describe Gori::Repeater::H2Engine do
         seen.receive.should eq(500)
         result.response.try(&.status).should eq(200)
         result.error.should be_nil
+      end
+
+      it "keeps writing the body through an interim 1xx on the same stream" do
+        # The complement that constrains the fix's SHAPE. "A header block arrived on stream 1"
+        # is NOT the end-of-write condition, because a 100 Continue is one — and an
+        # `Expect: 100-continue` origin sends it precisely to ask for the body. END_STREAM is,
+        # and it excludes the interim for free: a 1xx cannot end the stream.
+        seen = Channel(Int32).new(1)
+        port = start_h2_origin_interim(4096, 20_000, seen)
+        body = ("I" * 20_000).to_slice
+        result = Gori::Repeater::H2Engine.send_fields(
+          [{":method", "POST"}, {":path", "/expect"}, {":scheme", "http"}, {":authority", "h"},
+           {"expect", "100-continue"}, {"content-length", body.size.to_s}], body,
+          scheme: "http", host: "127.0.0.1", port: port, verify_upstream: false,
+          timeout: 3.seconds)
+
+        seen.receive.should eq(20_000)               # the whole body, not 4096
+        result.response.try(&.status).should eq(200) # the FINAL status, not the 100
+        result.error.should be_nil                   # nothing was truncated
       end
     end
 

--- a/spec/repeater/minimize_spec.cr
+++ b/spec/repeater/minimize_spec.cr
@@ -268,3 +268,71 @@ describe Gori::Repeater::Minimize do
     capped.sent.should eq(3)
   end
 end
+
+# `gori run repeater minimize --verbatim`'s resolver.
+#
+# `repeater send` grew `--verbatim` precisely because a session can hold EVIDENCE; minimize
+# is a search over that same request and had no such knob, so a session seeded from a capture
+# was either refused outright (an OData `$top` in the head) or minimized against bytes that
+# differ from what `repeater send --verbatim` puts on the wire ($where substituted, the CL
+# re-framed 22 → 19). The resolver is the whole difference, so it is asserted directly.
+#
+# The catch this exists to pin: `Minimize.run` hands its `resolve` proc the request
+# LF-NORMALIZED (its text helpers are written against that form) and restores the operator's
+# terminator only on the REPORT — so a resolver that simply took the bytes put a CRLF-stored
+# session on the wire bare-LF, inventing the very desync primitive the flag preserves, and one
+# that blindly re-CRLF'd produced `\r\r\n` on the report call.
+module Gori::CLI::Run
+  def self.restore_head_crlf_for_spec(text : String) : Bytes
+    restore_head_crlf(text)
+  end
+
+  def self.mixed_line_endings_for_spec?(text : String) : Bool
+    mixed_line_endings?(text)
+  end
+end
+
+describe "gori run repeater minimize --verbatim — the resolver" do
+  it "puts CRLF back on the HEAD and leaves the body byte-exact" do
+    lf = "POST /bk HTTP/1.1\nHost: h\nContent-Length: 22\n\n{\"q\":\"$where 1==1 ab\"}\n"
+    String.new(Gori::CLI::Run.restore_head_crlf_for_spec(lf)).should eq(
+      "POST /bk HTTP/1.1\r\nHost: h\r\nContent-Length: 22\r\n\r\n{\"q\":\"$where 1==1 ab\"}\n")
+  end
+
+  it "is idempotent, so the already-restored report text does not become \\r\\r\\n" do
+    crlf = "POST /bk HTTP/1.1\r\nHost: h\r\nContent-Length: 2\r\n\r\nhi"
+    String.new(Gori::CLI::Run.restore_head_crlf_for_spec(crlf)).should eq(crlf)
+  end
+
+  it "does not substitute a $KEY, and does not re-frame the Content-Length" do
+    saved = Gori::Settings.env_vars
+    saved_x = Gori::Settings.env_prefix
+    begin
+      Gori::Settings.env_prefix = "$"
+      Gori::Settings.env_vars = [{"where", "XX"}]
+      out = String.new(Gori::CLI::Run.restore_head_crlf_for_spec(
+        "POST /bk HTTP/1.1\nHost: h\nContent-Length: 22\n\n{\"q\":\"$where 1==1 ab\"}\n"))
+      out.should contain("$where 1==1 ab")     # the capture, not the project's value
+      out.should contain("Content-Length: 22") # over a 23-byte body: the CL-desync evidence
+    ensure
+      Gori::Settings.env_vars = saved || [] of {String, String}
+      Gori::Settings.env_prefix = saved_x || "$"
+    end
+  end
+
+  describe "the mixed-terminator notice" do
+    it "fires only when the HEAD really mixes CRLF and bare LF" do
+      Gori::CLI::Run.mixed_line_endings_for_spec?(
+        "POST /m HTTP/1.1\r\nHost: h\nX: 1\r\n\r\nhi").should be_true
+    end
+
+    it "does not fire for an all-CRLF head, an all-LF head, or a body full of LFs" do
+      Gori::CLI::Run.mixed_line_endings_for_spec?("GET / HTTP/1.1\r\nHost: h\r\n\r\n").should be_false
+      Gori::CLI::Run.mixed_line_endings_for_spec?("GET / HTTP/1.1\nHost: h\n\n").should be_false
+      # A raw 0x0A in a BODY is a byte, not a line ending — judging the whole request would
+      # flag every binary upload.
+      Gori::CLI::Run.mixed_line_endings_for_spec?(
+        "POST / HTTP/1.1\r\nHost: h\r\n\r\nline1\nline2\n").should be_false
+    end
+  end
+end

--- a/spec/sequencer/engine_spec.cr
+++ b/spec/sequencer/engine_spec.cr
@@ -122,6 +122,28 @@ describe Gori::Sequencer::Engine do
       done = ev if ev.is_a?(Q::DoneEvent)
     end
     done.not_nil!.collected.should eq(10) # lands exactly on the goal, no overshoot
+    # …and with no retries, the two send counters agree.
+    done.not_nil!.sent.should eq(10)
+    done.not_nil!.requests.should eq(10_i64)
+  end
+
+  # `sent` counts REPLAYS — the numerator against `goal` — and a retry costs none of it. So a
+  # collection against a dead origin with `--retries 2` reported "6 sent" for 18 real
+  # requests: a 3x understatement of the load gori put on the target, and `sent` is the number
+  # that matters to a tester working inside an agreed request budget on a client's production
+  # system. `Fuzz::CappedBackend#sent` was already the true count, already what `max_requests`
+  # is enforced against, and already published by miner and discover as their own `sent`.
+  it "publishes the TRUE wire count separately from the replay count under --retries" do
+    backend = BlockedBackend.new(F::Origin.new("http", "h", 80), "no response from h:80")
+    config = Q::Config.new(token_loc: Q::TokenLoc.cookie("SID"), goal: 2, concurrency: 1, retries: 2)
+    req = "GET / HTTP/1.1\r\nHost: h\r\n\r\n".to_slice
+    done = nil.as(Q::DoneEvent?)
+    Q::Engine.new(req, http2: false, backend: backend, config: config).run do |ev|
+      done = ev if ev.is_a?(Q::DoneEvent)
+    end
+    d = done.not_nil!
+    d.requests.should eq((d.sent * 3).to_i64) # 1 attempt + 2 retries per replay
+    d.requests.should be > d.sent.to_i64
   end
 
   # A run that collects nothing because every replay was REFUSED is a failure, not a clean

--- a/spec/sequencer/plan_spec.cr
+++ b/spec/sequencer/plan_spec.cr
@@ -201,6 +201,20 @@ describe Gori::Sequencer::Plan do
       # Head normalized, BODY left byte-for-byte (a body's LFs are payload, not framing).
       String.new(plan.request).should eq("GET /p HTTP/1.1\r\nHost: t.test\r\n\r\nbody\nkeeps\nLF")
     end
+
+    # …for a DRAFT. The example above is the editor case its title names — a line buffer whose
+    # fresh lines end in LF owes the wire a CRLF — and it does NOT generalise to a capture,
+    # whose head is already exact wire bytes. A bare-LF terminator is a front-end/back-end
+    # desync primitive gori stores byte-exact and `gori run repeater <flow-id>` replays
+    # byte-exact; sending the same flow to the sequencer used to quietly un-desync it and then
+    # report a clean collection. See `PlanOptions#evidence?`.
+    it "leaves a CAPTURED bare-LF head exactly as captured" do
+      raw = "GET /p HTTP/1.1\nHost: t.test\n\nbody\nkeeps\nLF"
+      plan = Q::Plan.build(Q::PlanOptions.new(raw.to_slice, evidence: true,
+        target: "http://t.test",
+        config: live_config(Q::TokenLoc.cookie("SID"), 5), verify: false), ungated)
+      String.new(plan.request).should eq(raw)
+    end
   end
 
   describe "analyse-only (manual) plans" do

--- a/spec/tui/fuzzer_view_spec.cr
+++ b/spec/tui/fuzzer_view_spec.cr
@@ -16,6 +16,38 @@ private def loaded_fuzzer : FuzzerView
   view
 end
 
+# A row the run's keep_bodies dropped: no head, no body, no request — the TUI default
+# (:matched) leaves EVERY non-matching row in this shape.
+private def unretained_result(idx : Int32, payloads : Array(String)) : Gori::Fuzz::Result
+  Gori::Fuzz::Result.new(idx.to_i64, payloads, nil, 404, 12_i64, 2, 1, 1000_i64,
+    nil, false, false, nil)
+end
+
+private def with_fuzz_store(&)
+  path = File.tempname("gori-fuzzview", ".db")
+  store = Gori::Store.open(path)
+  begin
+    yield store
+  ensure
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+# Byte offset just past the head/body separator, or 0. Byte-level on purpose: the seed
+# text under test is deliberately not valid UTF-8.
+private def body_start(s : String) : Int32
+  b = s.to_slice
+  i = 0
+  while i + 3 < b.size
+    return i + 4 if b[i] == 0x0d && b[i + 1] == 0x0a && b[i + 2] == 0x0d && b[i + 3] == 0x0a
+    i += 1
+  end
+  0
+end
+
 describe Gori::Tui::FuzzerView do
   describe "a failed send's reason" do
     # Fuzz::Engine returns a scope/sandbox refusal as a Result whose `error` carries the
@@ -470,8 +502,206 @@ describe Gori::Tui::FuzzerView do
       view.append_result(fuzz_result(0, 404, 12)) # keep_bodies dropped head/body/request
       r = view.selected_result.not_nil!
       # The marked position takes the row's payload, so the row still reads as its own
-      # request. The editor holds LF text; the Repeater seed re-expands to CRLF on send.
-      String.new(view.result_request_bytes(r)).should eq("GET /?x=p0 HTTP/1.1\nHost: h\n\n")
+      # request. WIRE form, not the LF projection: the template is a message, and the
+      # fallback must reproduce what the socket would have carried (R5-F1).
+      String.new(view.result_request_bytes(r)).should eq("GET /?x=p0 HTTP/1.1\r\nHost: h\r\n\r\n")
+    end
+  end
+
+  # ── R5-F1 / R5-F2 ──────────────────────────────────────────────────────────────────
+  #
+  # A captured body carrying a CRLF is the whole point of these: 0x0D 0x0A inside a BODY is
+  # data (a CL/TE desync probe, a multipart delimiter, part content, a CRLF-injection test),
+  # never a line ending the fuzzer may re-encode. The TUI Fuzzer read `TextArea#text` — the
+  # LF projection — on the send path, the persistence path AND every § marking helper, so the
+  # capture went out one byte shorter per line with `ContentLength.sync` quietly resyncing the
+  # header DOWN to match. Nothing errored. `gori run fuzz` given the same bytes is byte-exact,
+  # and so is the Repeater replaying the same flow in the same session.
+  describe "byte-exact captured template (R5-F1)" do
+    # POST with a deliberate CRLF inside the JSON body. Body is exactly 12 bytes.
+    captured = "POST /h1t HTTP/1.1\r\nHost: h\r\nContent-Type: application/json\r\n" \
+               "Content-Length: 12\r\n\r\n{\"k\":\"v\r\nx\"}"
+    # The same request an operator TYPED — every terminator LF, body has no CR at all.
+    # This is the complement: the fix must not go the other way and inject CRLF into a body.
+    typed = "POST /h1t HTTP/1.1\nHost: h\nContent-Type: application/json\n" \
+            "Content-Length: 11\n\n{\"k\":\"v\nx\"}"
+
+    # Put the caret on the body's `v` (line 5, col 6) — the finding's own repro chord.
+    caret_on_body_v = ->(view : FuzzerView) do
+      view.focus_pane(:template)
+      view.template_move(5, 6)
+    end
+
+    it "keeps the body's CRLF through ^K mark word — the chord the repro uses" do
+      view = FuzzerView.new
+      view.load_request("http://h", captured, false, "")
+      caret_on_body_v.call(view)
+      view.mark_word.should eq("marked position")
+      # The § landed around the body's `v`, and the CRLF that followed it is still a CRLF.
+      view.template_text.should eq("POST /h1t HTTP/1.1\r\nHost: h\r\nContent-Type: application/json\r\n" \
+                                   "Content-Length: 12\r\n\r\n{\"k\":\"§v§\r\nx\"}")
+    end
+
+    it "keeps a hand-typed body's bare LF through ^K — the complement" do
+      view = FuzzerView.new
+      view.load_request("http://h", typed, false, "")
+      caret_on_body_v.call(view)
+      view.mark_word.should eq("marked position")
+      view.template_text.should eq("POST /h1t HTTP/1.1\nHost: h\nContent-Type: application/json\n" \
+                                   "Content-Length: 11\n\n{\"k\":\"§v§\nx\"}")
+    end
+
+    it "keeps the body's CRLF through ^A auto-mark and Clear markers" do
+      view = FuzzerView.new
+      view.load_request("http://h", captured, false, "")
+      view.auto_mark.should contain("auto-marked")
+      # auto-mark wraps the whole JSON string value, so the CRLF sits INSIDE the marker —
+      # a position whose default spans a line break, which is exactly the shape that the
+      # LF projection destroyed (`§v\nx§`, one byte short).
+      view.template_text.should contain("{\"k\":\"§v\r\nx§\"}")
+
+      view.clear_marks
+      view.template_text.should eq(captured) # …and a full round-trip is the identity
+    end
+
+    it "persists the template in wire form and round-trips it across a restart" do
+      view = FuzzerView.new
+      view.load_request("http://h", captured, false, "")
+      caret_on_body_v.call(view)
+      view.mark_word
+      stored = view.template_text # exactly what insert/update_fuzz_session writes
+
+      reopened = FuzzerView.new
+      reopened.restore(Gori::Store::FuzzSessionRecord.new(1_i64, "http://h", stored, false, nil,
+        "", nil, 0, nil))
+      reopened.template_text.should eq(stored)
+      # …and the reconcile poll must see them as equal, or it slams the caret every tick.
+      reopened.session_side_matches?(Gori::Store::FuzzSessionRecord.new(1_i64, "http://h", stored,
+        false, nil, "", nil, 0, nil)).should be_true
+    end
+
+    it "puts the captured body on the wire byte-exact, CL and all, end to end" do
+      with_fuzz_store do |store|
+        scope = Gori::Scope.load(store)
+        view = FuzzerView.new
+        view.load_request("http://127.0.0.1:1/h1t", captured, false, "")
+        caret_on_body_v.call(view)
+        view.mark_word
+        view.apply_set(nil, Gori::Tui::SetSpec.new(:list, "a,bbbbbbbbbb"))
+
+        engine, err = view.build_engine(false, scope, nil)
+        err.should be_nil
+        engine.should_not be_nil
+        view.begin_run(2_i64)
+
+        # Row 0, payload "a": same length as the default, so the CL is unchanged at 12 —
+        # and the body's CRLF is still two bytes. The old code sent 11 with a bare LF.
+        view.append_result(unretained_result(0, ["a"]))
+        String.new(view.result_request(view.selected_result.not_nil!).bytes)
+          .should eq("POST /h1t HTTP/1.1\r\nHost: h\r\nContent-Type: application/json\r\n" \
+                     "Content-Length: 12\r\n\r\n{\"k\":\"a\r\nx\"}")
+
+        # Row 1, payload "bbbbbbbbbb": the CL MOVES (12 → 21). 21, not the 20 a flattened
+        # body produces — the complement that proves the CRLF is counted as two bytes.
+        view.append_result(unretained_result(1, ["bbbbbbbbbb"]))
+        view.select_result_row(1)
+        String.new(view.result_request(view.selected_result.not_nil!).bytes)
+          .should eq("POST /h1t HTTP/1.1\r\nHost: h\r\nContent-Type: application/json\r\n" \
+                     "Content-Length: 21\r\n\r\n{\"k\":\"bbbbbbbbbb\r\nx\"}")
+      end
+    end
+  end
+
+  # R5-F2: `Result#request` is nil for every row the run's keep_bodies dropped — and the TUI
+  # default is :matched, so that is EVERY non-matching row. The fallback re-rendered the raw
+  # template: no Content-Length sync, no per-position chain transform, and no mark saying it
+  # was a reconstruction — while the response pane beside it DOES name its own retention,
+  # which implies by contrast that the request pane is evidence.
+  describe "reconstruction provenance (R5-F2)" do
+    marked = "POST /p HTTP/1.1\r\nHost: h\r\nContent-Length: 3\r\n\r\nv=§x§"
+
+    it "syncs Content-Length on the reconstruction instead of showing an impossible pair" do
+      view = FuzzerView.new
+      view.load_request("http://h", marked, false, "")
+      view.append_result(unretained_result(0, ["ccccccccccccccccccccc"])) # 21 bytes
+      req = view.result_request(view.selected_result.not_nil!)
+      req.reconstructed.should be_true
+      # body is "v=" + 21 = 23. The old fallback left the template's "Content-Length: 3"
+      # beside a 23-byte body — a pair no socket ever carried.
+      String.new(req.bytes).should eq("POST /p HTTP/1.1\r\nHost: h\r\nContent-Length: 23\r\n\r\nv=ccccccccccccccccccccc")
+    end
+
+    it "applies the position's ¦chain, as the generator did" do
+      view = FuzzerView.new
+      view.load_request("http://h", "POST /p HTTP/1.1\r\nHost: h\r\nContent-Length: 3\r\n\r\nv=§x¦b64§", false, "")
+      view.append_result(unretained_result(0, ["bbbbbbbbbb"]))
+      body = String.new(view.result_request(view.selected_result.not_nil!).bytes).split("\r\n\r\n", 2)[1]
+      body.should eq("v=YmJiYmJiYmJiYg==") # base64("bbbbbbbbbb") — the ¦b64 chain ran
+    end
+
+    it "labels the reconstruction in the detail pane, and does NOT label retained bytes" do
+      view = FuzzerView.new
+      view.load_request("http://h", marked, false, "")
+      view.focus_pane(:results)
+      view.append_result(unretained_result(0, ["yyy"]))
+      view.open_detail
+      view.detail_step_pane(-1) # :response → :request
+      lines = view.detail_plain_lines
+      lines.first.should contain("reconstructed from the template")
+      lines.first.should contain("keep_bodies: matched")
+      # It reads as a sibling of the response pane's own retention note, not as a new dialect.
+      view.detail_step_pane(1)
+      view.detail_plain_lines.first.should contain("response not retained")
+
+      # Complement: a row whose request WAS retained carries no note, and no rewriting.
+      sent = "POST /p HTTP/1.1\r\nHost: h\r\nContent-Length: 99\r\n\r\nv=yyy"
+      view2 = FuzzerView.new
+      view2.load_request("http://h", marked, false, "")
+      view2.focus_pane(:results)
+      view2.append_result(Gori::Fuzz::Result.new(0_i64, ["yyy"], nil, 200, 5_i64, 1, 1, 10_i64,
+        nil, true, false, nil, "HTTP/1.1 200 OK\r\n\r\n".to_slice, Bytes.empty, sent.to_slice))
+      view2.open_detail
+      view2.detail_step_pane(-1)
+      view2.detail_plain_lines.first.should eq("POST /p HTTP/1.1")
+      view2.result_request_note(view2.selected_result.not_nil!).should be_nil
+      # …and the operator's deliberate CL/body desync is handed back untouched.
+      String.new(view2.result_request(view2.selected_result.not_nil!).bytes).should eq(sent)
+    end
+
+    it "carries the caveat into the Repeater seed, and keeps the bytes exact" do
+      view = FuzzerView.new
+      view.load_request("http://h:80", marked, false, "")
+      view.focus_pane(:results)
+      view.append_result(unretained_result(0, ["yyy"]))
+      seed = FuzzerController.repeater_seed_for(view, view.selected_result.not_nil!)
+      seed.note.should_not be_nil
+      seed.note.not_nil!.should contain("reconstructed from the template")
+      seed.label.should contain("reconstructed")
+      # The head keeps its CRLFs — the seed used to collapse them to LF on the premise
+      # "Repeater editors store LF text", which the @eols work made false.
+      seed.request_text.should contain("POST /p HTTP/1.1\r\nHost: h\r\n")
+
+      # Complement: a retained row seeds with no note and an untouched label.
+      view.append_result(Gori::Fuzz::Result.new(1_i64, ["zzz"], nil, 200, 5_i64, 1, 1, 10_i64,
+        nil, true, false, nil, "HTTP/1.1 200 OK\r\n\r\n".to_slice, Bytes.empty,
+        "POST /p HTTP/1.1\r\n\r\nv=zzz".to_slice))
+      view.select_result_row(1)
+      seed2 = FuzzerController.repeater_seed_for(view, view.selected_result.not_nil!)
+      seed2.note.should be_nil
+      seed2.label.should eq("#1 zzz")
+    end
+
+    it "hands a non-UTF-8 payload byte to the Repeater verbatim instead of U+FFFD" do
+      view = FuzzerView.new
+      view.load_request("http://h:80", marked, false, "")
+      view.focus_pane(:results)
+      raw = String.new(Bytes[0xff_u8, 0xfe_u8]) # not valid UTF-8 — a hex/binary payload set
+      view.append_result(unretained_result(0, [raw]))
+      seed = FuzzerController.repeater_seed_for(view, view.selected_result.not_nil!)
+      body = seed.request_text.to_slice[body_start(seed.request_text)..]
+      body.should eq(Bytes[0x76_u8, 0x3d_u8, 0xff_u8, 0xfe_u8]) # "v=" + the two raw bytes
+      # `.scrub` would have replaced each with U+FFFD (3 bytes each) and lied about the length.
+      seed.request_text.should contain("Content-Length: 4")
     end
   end
 
@@ -692,7 +922,9 @@ describe "FuzzerView#template_click_to_cursor / #target_click_to_cursor" do
     # The template card sits below the 3-row target band; row 1 is the "Host: h" line.
     view.template_click_to_cursor(rect, 90, 5) # mx past end → clamps to end of that line
     view.template_insert('X')
-    view.template_text.split('\n')[1].should eq("Host: hX")
+    # `template_text` is wire form (R5-F1) — the captured CRLFs are still there, so split
+    # on the terminator the request actually carries.
+    view.template_text.split("\r\n")[1].should eq("Host: hX")
   end
 
   it "places the target caret at the clicked column" do

--- a/src/gori/cli/run/discover.cr
+++ b/src/gori/cli/run/discover.cr
@@ -39,7 +39,7 @@ module Gori
           p.on("--no-bruteforce", "Disable directory brute-forcing (crawl only)") { bruteforce = false }
           p.on("--wordlist=PATH", "Extra path wordlist (merged with the built-in list)") { |v| wordlist = v }
           p.on("--extensions=LIST", "Also probe these extensions (e.g. php,json,bak)") { |v| extensions = parse_extensions(v) }
-          p.on("-HHEADER", "--header=HEADER", "Custom request header on every probe, e.g. \"Authorization: Bearer …\" (repeatable)") { |v| headers << v }
+          p.on("-HHEADER", "--header=HEADER", "Custom request header on every probe, e.g. \"Authorization: Bearer …\" (repeatable). Host and Connection are owned by the crawler and ignored; a value carrying CR/LF is refused, not dropped") { |v| headers << v }
           p.on("--containment=MODE", "same-origin | scope-aware (default) | host+subdomains") { |v| containment = parse_containment(v) }
           p.on("--concurrency=N", "Parallel requests (default 20)") { |v| concurrency = parse_count(v, "--concurrency") }
           p.on("--rate=RPS", "Cap requests/sec (0 = unlimited)") { |v| rate = parse_rate(v) }
@@ -69,12 +69,25 @@ module Gori
         abort "gori run discover: #{discover_reason_error(Discover::PlanError::Reason::NoTechnique)}" unless spider || bruteforce
         abort "gori run discover: #{discover_reason_error(Discover::PlanError::Reason::NoTarget)}" if target_override.to_s.strip.empty?
 
+        # A `-H` gori will not send is a REFUSAL, and it aborts the run rather than quietly
+        # crawling without it. `Fuzz::Plan.build#refuse_unresolved` is the model: same class
+        # of problem (the operator asked for bytes gori will not put on the wire), opposite
+        # treatment until now. The stakes here are higher, not lower — the header this drops
+        # is `Authorization`, and the sweep then reports "found nothing" over the entire
+        # authenticated surface it never reached.
+        rejected = [] of String
+        parsed_headers = Discover::Headers.parse_lines(headers, rejected)
+        unless rejected.empty?
+          abort "gori run discover: header #{rejected.first.inspect} rejected — a header value may " \
+                "not contain CR or LF, and a header name must be an RFC 7230 token " \
+                "(#{rejected.size} of #{headers.size} -H arguments rejected)"
+        end
         config = Discover::Config.new(
           concurrency: concurrency, rps: rate, throttle_ms: throttle, timeout: timeout,
           retries: retries, max_requests: max_requests, keep_alive: keep_alive,
           spider: spider, bruteforce: bruteforce,
           max_depth: max_depth, user_wordlist: wordlist, extensions: extensions,
-          containment: containment, headers: Discover::Headers.parse_lines(headers))
+          containment: containment, headers: parsed_headers)
 
         project = resolve_discover_project(project_name, db_path)
         store = open_store(project)
@@ -82,6 +95,17 @@ module Gori
           # The store stays open for the whole run (findings are written through it), so the
           # Outbound does NOT take ownership of it — the ensure below is what closes it.
           outbound = Gori::Outbound.cli(Scope.load(store), allow_unscoped)
+          # The second half of the header check, and the realistic one: the line the operator
+          # typed is fine and the ENV VAR is not (`-H 'Authorization: Bearer $TOKEN'` where
+          # TOKEN was read from a file and kept its trailing newline). It has to run here
+          # rather than beside the parse above, because `open_store` is what hydrates the
+          # project's env — and before any traffic, because `Headers.expand`'s send-time
+          # backstop drops the header on every probe without a word.
+          unsafe = Discover::Headers.unsafe_expanded(config.headers)
+          unless unsafe.empty?
+            abort "gori run discover: header #{unsafe.first.inspect} rejected — its value contains " \
+                  "CR or LF after $VAR expansion, which would splice extra headers into every probe"
+          end
           # `.to_s` rather than `|| ""`: an OptionParser-closured var never narrows out of String?.
           options = Discover::PlanOptions.new(target_override.to_s, config: config,
             verify: !insecure, overrides: Gori::HostOverrides.load(store))
@@ -266,6 +290,14 @@ module Gori
         STDERR.puts "done · #{s.found} found · #{s.sent} sent · #{ev.progress.errors} errors" \
                     " · calibrated-out #{s.calibrated_out} · dedup #{s.dedup_suppressed}" \
                     " · template #{s.template_suppressed} · cluster #{s.cluster_suppressed}#{ev.stopped ? " (stopped)" : ""}"
+        # A sweep that stopped on its budget must never read like one that finished: with
+        # `--max-requests 8` against a 283-candidate wordlist this line said `5 found` and
+        # exited 0, and 275 of those candidates were never sent. `queued` is what is still
+        # sitting in the frontier — the number that says how much of the target was not looked at.
+        if ev.budget_exhausted
+          STDERR.puts "budget exhausted · #{ev.progress.queued} queued unexplored " \
+                      "— raise or drop --max-requests to finish the sweep"
+        end
         # Handshakes actually paid for — the one thing the request counts above cannot show.
         # `dialed ≈ sent` means the origin closed after every response, which is the usual
         # explanation for a run that took far longer than its request count suggests.

--- a/src/gori/cli/run/fuzz.cr
+++ b/src/gori/cli/run/fuzz.cr
@@ -277,6 +277,17 @@ module Gori
         STDERR.flush
       end
 
+      # A cap that HALTED the run is not the same run as one that finished — say which, and
+      # how much was left untried. Keyed on the TRUE wire count (`requests`, what the cap is
+      # enforced against), and only claimed when payloads really were left: a sweep that
+      # happened to land exactly on its budget with nothing remaining is complete.
+      private def self.warn_fuzz_budget(p : Fuzz::Progress, max_requests : Int64?) : Nil
+        return unless (cap = max_requests) && p.requests >= cap
+        return unless (total = p.total) && p.sent < total
+        STDERR.puts "budget exhausted · stopped at --max-requests #{cap} with " \
+                    "#{total - p.sent} of #{total} payloads untried"
+      end
+
       private def self.fuzz_done(ev : Fuzz::DoneEvent, emitted : Int32, pool : Fuzz::ConnPool?,
                                  max_requests : Int64? = nil) : Nil
         STDERR.print "\r" if STDERR.tty? # clear the in-place meter (none was drawn when piped)
@@ -286,10 +297,7 @@ module Gori
         p = ev.progress
         extra = p.requests > p.sent ? " · #{p.requests} requests on the wire" : ""
         STDERR.puts "done · #{p.sent} sent#{extra} · #{emitted} shown · #{p.errors} errors#{ev.stopped ? " (stopped)" : ""}"
-        # A cap that HALTED the run is not the same run as one that finished — say which.
-        if (cap = max_requests) && p.requests >= cap && (t = p.total) && p.sent < t
-          STDERR.puts "budget exhausted · stopped at --max-requests #{cap} with #{t - p.sent} of #{t} payloads untried"
-        end
+        warn_fuzz_budget(p, max_requests)
         # Sends stopped BEFORE the socket (Sandbox, an exclude rule, an unbound binding). They
         # already appear as per-row errors, but a run that is 100% refused reads as "the
         # target is down" unless the gate is named once, with its remedy.

--- a/src/gori/cli/run/fuzz.cr
+++ b/src/gori/cli/run/fuzz.cr
@@ -25,8 +25,10 @@ module Gori
         throttle : Int32? = nil
         timeout : Time::Span? = nil
         retries = 0
+        max_requests : Int64? = nil
         follow = false
         keep_alive = true
+        update_cl = true
         auto_cal = false
         format = :text
         force = false
@@ -65,8 +67,16 @@ module Gori
           p.on("--throttle=MS", "Fixed delay between requests (ms)") { |v| throttle = parse_nonneg(v, "--throttle") }
           p.on("--timeout=SEC", "Per-request connect + idle timeout (seconds)") { |v| timeout = parse_count(v, "--timeout").seconds }
           p.on("--retries=N", "Retries on a network error") { |v| retries = parse_nonneg(v, "--retries") }
+          # Counted against REAL sends, not payloads: retries, redirect hops and baseline
+          # calibration all charge it (Fuzz::CappedBackend), matching mine/discover/sequence
+          # and MCP's `max_requests`, which honoured this knob while the CLI had no way to set it.
+          p.on("--max-requests=N", "Hard cap on total requests sent (retries and redirect hops count)") { |v| max_requests = parse_count(v, "--max-requests").to_i64 }
           p.on("--follow-redirects", "Follow same-origin redirects") { follow = true }
           p.on("--no-keep-alive", "Dial a fresh connection for every request (default: reuse)") { keep_alive = false }
+          # The Repeater's `--verbatim` and Intercept's `update_content_length:false` by the
+          # same name and for the same reason: a CL/CL-TE desync template is the payload, and
+          # recomputing its Content-Length swept a different request than the one written.
+          p.on("--verbatim", "Send the template's Content-Length as written — no auto-resync after payload substitution (for CL / CL-TE desync payloads)") { update_cl = false }
           p.on("--mc=SPEC", "Match status (e.g. 200,302,500-599,2xx)") { |v| matcher.match_status = v }
           p.on("--fc=SPEC", "Filter out status") { |v| matcher.filter_status = v }
           p.on("--ms=SPEC", "Match response size (e.g. 1500,>1000)") { |v| matcher.match_size = v }
@@ -95,16 +105,20 @@ module Gori
         flow_id ||= positional.first?.try { |s| parse_flow_id(s, "gori run fuzz") }
 
         hydrate_project_env(project_name, db_path) if (project_name || db_path) && flow_id.nil?
-        text, default_target, src_h2 = fuzz_source(flow_id, request_file, project_name, db_path)
+        text, default_target, src_h2, evidence = fuzz_source(flow_id, request_file, project_name, db_path)
         http2 = force_h2 || src_h2
 
         options = Fuzz::PlanOptions.new(text,
+          # A `--flow` template is a CAPTURED request; --request/stdin is a draft the operator
+          # authored. See `Fuzz::PlanOptions#evidence?`.
+          evidence: evidence,
           default_target: default_target, target: target_override,
           auto_mark: auto, marks: marks, http2: http2,
           sources: sources, processors: processors,
           config: Fuzz::Config.new(mode: mode, concurrency: concurrency, rps: rate, throttle_ms: throttle,
             retries: retries, timeout: timeout, follow_redirects: follow, auto_calibrate: auto_cal,
-            keep_bodies: :none, keep_alive: keep_alive),
+            keep_bodies: :none, keep_alive: keep_alive, max_requests: max_requests,
+            update_content_length: update_cl),
           matcher: matcher, verify: !insecure, sni: sni,
           overrides: cli_host_overrides(project_name, db_path, flow_id))
         # Gate outbound traffic through the ONE seam every surface shares (Gori::Outbound):
@@ -120,6 +134,7 @@ module Gori
           abort "gori run fuzz: #{fuzz_plan_error(ex)}"
         end
         warn_fuzz_marks(plan)
+        warn_fuzz_content_length(plan)
         origin = plan.origin
         unless origin.scheme.in?("http", "https")
           outbound.close
@@ -134,7 +149,8 @@ module Gori
           (fid = bind_from) && seed_bindings(fid, project_name, db_path, outbound, insecure, "gori run fuzz")
           preflight_bindings(text, bind_from, "gori run fuzz")
           plan.engine.calibrate_baseline if auto_cal
-          run_fuzz_stream(plan.engine, mode, origin.scheme, origin.host, origin.port, format, force, fail_if_no_matches, plan.pool)
+          run_fuzz_stream(plan.engine, mode, origin.scheme, origin.host, origin.port, format, force,
+            fail_if_no_matches, plan.pool, max_requests)
         ensure
           outbound.close
         end
@@ -167,12 +183,25 @@ module Gori
         end
       end
 
-      # {template text, default target (nil for file/stdin), http2} from the chosen source.
+      # The template declares a Content-Length that disagrees with its own body BEFORE any
+      # payload is substituted — so the auto-resync is about to rewrite framing the operator
+      # authored deliberately, on every variation, and the sweep would report a clean
+      # CL-desync run that never put a CL desync on the wire. Once, up front, naming the flag.
+      private def self.warn_fuzz_content_length(plan : Fuzz::Plan) : Nil
+        return unless plan.rewrites_content_length?
+        STDERR.puts "gori run fuzz: note: the template's Content-Length disagrees with its own body " \
+                    "and is being recomputed on every request — pass --verbatim to send it as written"
+      end
+
+      # {template text, default target (nil for file/stdin), http2, is-evidence} from the
+      # chosen source. The last element is PROVENANCE, not a knob: only the `--flow` branch
+      # hands back captured bytes, and only that branch may therefore skip the draft-time
+      # passes (see `Fuzz::PlanOptions#evidence?`).
       private def self.fuzz_source(flow_id : Int64?, request_file : String?,
-                                   project_name : String?, db_path : String?) : {String, String?, Bool}
+                                   project_name : String?, db_path : String?) : {String, String?, Bool, Bool}
         if file = request_file
           abort "gori run fuzz: not a readable file: #{file}" unless File.exists?(file) && !File.directory?(file)
-          {File.read(file), nil, false}
+          {File.read(file), nil, false, false}
         elsif id = flow_id
           store = open_store(resolve_read_project(project_name, db_path))
           detail = begin
@@ -182,9 +211,15 @@ module Gori
           end
           abort "gori run fuzz: no flow ##{id}" unless detail
           built = Repeater::FlowRequest.build(detail)
-          {String.new(built.bytes).scrub, built.target, built.http2}
+          # The sweep runs against a request line gori changed, so say so — see
+          # `warn_request_line_rewrite`. No flag here: unlike the repeater there is no
+          # single request to keep verbatim, and a fuzz template that dials one origin
+          # while its line names another needs its own design, not a boolean.
+          warn_request_line_rewrite(built, "gori run fuzz",
+            "replay it with `gori run repeater #{id} --keep-request-line` to keep it")
+          {String.new(built.bytes).scrub, built.target, built.http2, true}
         elsif !STDIN.tty?
-          {STDIN.gets_to_end, nil, false}
+          {STDIN.gets_to_end, nil, false, false}
         else
           abort "gori run fuzz: no source — give a <flow-id>, --request FILE, or pipe a request on stdin"
         end
@@ -192,7 +227,8 @@ module Gori
 
       private def self.run_fuzz_stream(engine : Fuzz::Engine, mode : Fuzz::Mode, scheme : String,
                                        host : String, port : Int32, format : Symbol, force : Bool,
-                                       fail_if_no_matches : Bool, pool : Fuzz::ConnPool? = nil) : Nil
+                                       fail_if_no_matches : Bool, pool : Fuzz::ConnPool? = nil,
+                                       max_requests : Int64? = nil) : Nil
         total = fuzz_preflight(engine, mode, scheme, host, port, force)
         matched = 0
         errored = 0
@@ -206,7 +242,7 @@ module Gori
             if emit_fuzz_result(r, format, buffer)
               r.matched? ? (matched += 1) : (errored += 1)
             end
-          when Fuzz::DoneEvent  then fuzz_done(ev, matched + errored, pool)
+          when Fuzz::DoneEvent  then fuzz_done(ev, matched + errored, pool, max_requests)
           when Fuzz::ErrorEvent then had_error = true; STDERR.puts "fuzz error: #{ev.message}"
           end
         end
@@ -241,9 +277,19 @@ module Gori
         STDERR.flush
       end
 
-      private def self.fuzz_done(ev : Fuzz::DoneEvent, emitted : Int32, pool : Fuzz::ConnPool?) : Nil
+      private def self.fuzz_done(ev : Fuzz::DoneEvent, emitted : Int32, pool : Fuzz::ConnPool?,
+                                 max_requests : Int64? = nil) : Nil
         STDERR.print "\r" if STDERR.tty? # clear the in-place meter (none was drawn when piped)
-        STDERR.puts "done · #{ev.progress.sent} sent · #{emitted} shown · #{ev.progress.errors} errors#{ev.stopped ? " (stopped)" : ""}"
+        # `requests` only when it DIFFERS from the payload count — retries and redirect hops
+        # are the two things that make them diverge, and a run with neither should not grow a
+        # second number that says the same thing twice. See `Fuzz::Progress#requests`.
+        p = ev.progress
+        extra = p.requests > p.sent ? " · #{p.requests} requests on the wire" : ""
+        STDERR.puts "done · #{p.sent} sent#{extra} · #{emitted} shown · #{p.errors} errors#{ev.stopped ? " (stopped)" : ""}"
+        # A cap that HALTED the run is not the same run as one that finished — say which.
+        if (cap = max_requests) && p.requests >= cap && (t = p.total) && p.sent < t
+          STDERR.puts "budget exhausted · stopped at --max-requests #{cap} with #{t - p.sent} of #{t} payloads untried"
+        end
         # Sends stopped BEFORE the socket (Sandbox, an exclude rule, an unbound binding). They
         # already appear as per-row errors, but a run that is 100% refused reads as "the
         # target is down" unless the gate is named once, with its remedy.

--- a/src/gori/cli/run/mine.cr
+++ b/src/gori/cli/run/mine.cr
@@ -65,7 +65,7 @@ module Gori
         # Explicit, as in cmd_fuzz: it used to fall out of cli_host_overrides opening a
         # store, and that helper ends in `rescue; nil`.
         hydrate_project_env(project_name, db_path) if (project_name || db_path) && flow_id.nil?
-        text, default_target, src_h2 = mine_source(flow_id, request_file, project_name, db_path)
+        text, default_target, src_h2, evidence = mine_source(flow_id, request_file, project_name, db_path)
 
         config = Miner::Config.new
         config.concurrency = concurrency
@@ -81,6 +81,9 @@ module Gori
           abort "gori run mine: --locations was empty — name at least one of query|form|multipart|json|headers|cookies (or omit it to auto-detect)"
         end
         options = Miner::PlanOptions.new(text,
+          # A `--flow` request is CAPTURED; --request/stdin is a draft the operator authored.
+          # See `Miner::PlanOptions#evidence?`.
+          evidence: evidence,
           default_target: default_target, target: target_override,
           http2: force_h2 || src_h2, bucket: bucket,
           # No --locations at all ⇒ nil, so the builder auto-detects what applies to this
@@ -144,12 +147,14 @@ module Gori
       end
 
       # {raw request text (byte-exact, BEFORE Env expansion — Miner::Plan owns that),
-      # default target, http2} from the chosen source.
+      # default target, http2, is-evidence} from the chosen source. The last element is
+      # PROVENANCE, not a knob: only the `--flow` branch hands back captured bytes, and only
+      # that branch may therefore skip the draft-time passes (see `Miner::PlanOptions#evidence?`).
       private def self.mine_source(flow_id : Int64?, request_file : String?,
-                                   project_name : String?, db_path : String?) : {String, String?, Bool}
+                                   project_name : String?, db_path : String?) : {String, String?, Bool, Bool}
         if file = request_file
           abort "gori run mine: not a readable file: #{file}" unless File.exists?(file) && !File.directory?(file)
-          {File.read(file), nil, false}
+          {File.read(file), nil, false, false}
         elsif id = flow_id
           store = open_store(resolve_read_project(project_name, db_path))
           detail = begin
@@ -159,9 +164,13 @@ module Gori
           end
           abort "gori run mine: no flow ##{id}" unless detail
           built = Repeater::FlowRequest.build(detail)
-          {String.new(built.bytes), built.target, built.http2}
+          # Every probe of the run carries a request line gori changed — see
+          # `warn_request_line_rewrite`.
+          warn_request_line_rewrite(built, "gori run mine",
+            "replay it with `gori run repeater #{id} --keep-request-line` to keep it")
+          {String.new(built.bytes), built.target, built.http2, true}
         elsif !STDIN.tty?
-          {STDIN.gets_to_end, nil, false}
+          {STDIN.gets_to_end, nil, false, false}
         else
           abort "gori run mine: no source — give a <flow-id>, --request FILE, or pipe a request on stdin"
         end
@@ -178,6 +187,14 @@ module Gori
                                        port : Int32, config : Miner::Config, format : Symbol) : Nil
         total = engine.total_names
         STDERR.puts "mining #{scheme}://#{host}:#{port} · #{config.locations.map(&.label).join("/")} · #{total} names"
+        # Names the wordlist supplied that this location cannot carry. Dropping them is
+        # correct; dropping them silently made the headline count differ between two runs of
+        # the same wordlist with no explanation anywhere. See `Miner::Engine#skipped_names`.
+        engine.skipped_names.each do |(loc, n)|
+          STDERR.puts "gori run mine: #{n} of #{engine.candidate_names} names are not valid at " \
+                      "#{loc.label} and were skipped (a name there must be an RFC 7230 token, " \
+                      "and framing headers are never injected)"
+        end
         findings = [] of Miner::Finding
         had_error = false
         engine.run do |ev|
@@ -185,7 +202,7 @@ module Gori
           when Miner::BaselineEvent then mine_baseline(ev)
           when Miner::FindingEvent  then findings << ev.finding; emit_mine_finding(ev.finding, format)
           when Miner::ProgressEvent then mine_progress(ev, total)
-          when Miner::DoneEvent     then mine_done(ev, findings.size)
+          when Miner::DoneEvent     then mine_done(ev, findings.size, config)
           when Miner::ErrorEvent    then had_error = true; STDERR.puts "mine error: #{ev.message}"
           end
         end
@@ -235,9 +252,24 @@ module Gori
         STDERR.flush
       end
 
-      private def self.mine_done(ev : Miner::DoneEvent, found : Int32) : Nil
+      private def self.mine_done(ev : Miner::DoneEvent, found : Int32, config : Miner::Config) : Nil
         STDERR.print "\r" if STDERR.tty? # clear the in-place meter (none was drawn when piped)
-        STDERR.puts "done · #{found} found · #{ev.progress.sent} sent · #{ev.progress.errors} errors#{ev.stopped ? " (stopped)" : ""}"
+        p = ev.progress
+        STDERR.puts "done · #{p.names_done}/#{p.names_total} names · #{found} found · " \
+                    "#{p.sent} sent · #{p.errors} errors#{ev.stopped ? " (stopped)" : ""}"
+        # A run that stopped on its budget must never read like one that finished. The engine
+        # has always known — `Progress` carries both counters and MCP `mine_status` prints
+        # `budget_exhausted` off them — but the terminal line showed neither, so
+        # `--max-requests 4` over 434 names ended in "done · 0 found" and exit 0, which reads
+        # as "there are no hidden parameters here". The \r meter that DID show them is
+        # `STDERR.tty?`-gated, so in CI or a pipe there was no counter anywhere.
+        return if ev.stopped || p.names_done >= p.names_total
+        left = p.names_total - p.names_done
+        # Name the CAP only when there is one: the same shortfall with no --max-requests set
+        # means the run ended some other way (a dead target), and pointing at a flag the
+        # operator never passed would send them after the wrong thing.
+        why = config.max_requests ? "budget exhausted — raise or drop --max-requests" : "incomplete"
+        STDERR.puts "#{why} · #{left} of #{p.names_total} names never tested"
       end
     end
   end

--- a/src/gori/cli/run/repeater.cr
+++ b/src/gori/cli/run/repeater.cr
@@ -213,6 +213,7 @@ module Gori
         flow_id : Int64? = nil
         sni : String? = nil
         ws_keep_key = false
+        keep_request_line = false
 
         parser = OptionParser.new do |p|
           p.banner = "Usage: gori run repeater create [options]"
@@ -231,6 +232,7 @@ module Gori
           p.on("--no-http2", "Alias for --http1") { http2 = false; http2_given = true }
           p.on("--no-auto-cl", "Do not auto-calculate Content-Length header") { auto_cl = false }
           p.on("--flow=ID", "Optional original flow ID this repeater stems from") { |v| flow_id = parse_flow_id(v, "gori run repeater create") }
+          p.on("--keep-request-line", "With --flow: store the flow's request line as-is — do not rewrite an absolute-form line (\"GET http://h/p\") to origin-form") { keep_request_line = true }
           p.on("--sni=HOST", "TLS SNI override") { |v| sni = v }
           p.on("--ws-keep-key", "WebSocket: send the request's own Sec-WebSocket-Key instead of a fresh one (lets an absent/short/duplicate/non-base64 key be tested)") { ws_keep_key = true }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
@@ -262,7 +264,13 @@ module Gori
           if fid = flow_id
             detail = store.get_flow(fid)
             abort "gori run repeater create: no flow ##{fid} to clone" unless detail
-            built = Repeater::FlowRequest.build(detail)
+            # The rewrite is PERSISTED here, so this is the one door where it cannot be
+            # undone later: `repeater send --verbatim` sends the stored row, and by then the
+            # absolute-form line is gone. `gori run repeater <flow-id>` grew
+            # `--keep-request-line` for the direct replay; this is the same flag on the
+            # workbench door, and the rewrite is reported either way (see `Built`).
+            built = Repeater::FlowRequest.build(detail, rewrite_absolute_form: !keep_request_line)
+            warn_request_line_rewrite(built, "gori run repeater create")
             # Only seed the request from the flow when the user didn't hand one in: --flow
             # doubles as provenance (the flow_id column) for a custom --request-raw/-file,
             # so an explicit request must NOT be silently overwritten by the flow's bytes.
@@ -771,10 +779,21 @@ module Gori
       # post-expansion resync overwrites it (parity with `repeater create --no-auto-cl` + `send`,
       # the only other path that could do this before).
       #
-      # Returns the PRE-expansion wire plus whether an explicit CL was pinned. Env expansion and
-      # the post-expansion Content-Length resync are `Repeater::Plan`'s job — `explicit_cl` is
-      # exactly the session store's `auto_content_length` toggle inverted, so both ways of
-      # pinning a CL reach the builder as one knob instead of two open-coded branches.
+      # `$KEY` EXPANSION HAPPENS HERE, on the operator's overrides ALONE. `Repeater::Plan`
+      # used to run it over the whole merged wire, which meant a project var whose name
+      # collided with a token in the CAPTURE (`$filter`, `$top`, `$where`, `$token`, `$user`
+      # — ordinary names) rewrote the stored request and re-framed its Content-Length to
+      # match, silently. The captured bytes are evidence and are now passed through untouched
+      # (`PlanOptions#evidence?`), so the only place left that still knows which bytes the
+      # operator typed is this merge — hence the expansion moved here with them. An
+      # UNRESOLVED token in an override is refused before this runs
+      # (`refuse_unresolved_overrides`), so nothing reaches `Env.expand` that it would leave
+      # literal — except a DECLARED session binding, which `Env.expand` deliberately leaves
+      # for `Env.expand_bindings` at the send seam.
+      #
+      # Returns the wire plus whether an explicit CL was pinned. `explicit_cl` is exactly the
+      # session store's `auto_content_length` toggle inverted, so both ways of pinning a CL
+      # reach the builder as one knob instead of two open-coded branches.
       private def self.build_single_flow_request(head_bytes : Bytes, body_bytes : Bytes,
                                                  headers : Array(String), body_override : String?,
                                                  target_override : String?,
@@ -822,7 +841,10 @@ module Gori
           next if name.strip.empty?
           lname = name.strip.downcase
           custom_order << {lname, name} unless custom_headers.has_key?(lname)
-          (custom_headers[lname] ||= [] of String) << val
+          # The VALUE is the operator's draft, so it expands; the NAME is not (a `$` is not
+          # a tchar, so a token there could only ever be a typo, and folding it into the
+          # dedup key would make `-H '$H: a' -H 'X: b'` collide once `$H` resolved to `X`).
+          (custom_headers[lname] ||= [] of String) << Env.expand(val)
         end
         # --rm-header: drop every line with this name. Distinct from `-H "X:"`, which sends
         # X with an EMPTY value — both are real tests and neither can express the other.
@@ -860,8 +882,11 @@ module Gori
           custom_headers[lname].each { |v| new_lines << {"#{orig}:#{v}", request_eol} }
         end
 
+        # `-b` is a draft too, and it expands BEFORE the Content-Length below is framed over
+        # it — which is why `Repeater::Plan`'s post-expansion resync is now a no-op on this
+        # path rather than the thing that quietly re-lengthed the CAPTURED body.
         final_body = if b_over = body_override
-                       b_over.to_slice
+                       Env.expand(b_over).to_slice
                      else
                        body_bytes
                      end
@@ -905,7 +930,10 @@ module Gori
         # host-header-confusion / vhost test deliberately pairs --target (where to connect)
         # with a different claimed Host, so that override must win.
         if (override = target_override) && !custom_headers.has_key?("host") && !dropped.includes?("host")
-          scheme_part, host_part, port_part = Repeater::FlowRequest.parse_target(override)
+          # Expanded, like every other override here: `Repeater::Plan` expands `--target` for
+          # the DIAL, so a `$HOST` left literal in the derived `Host:` header would send a
+          # request whose claimed authority disagreed with the socket it went down.
+          scheme_part, host_part, port_part = Repeater::FlowRequest.parse_target(Env.expand(override))
           # FlowRequest.authority, not a local formula: the two it replaced were both wrong.
           # This one omitted `wss` from the default-port test, so a `wss://h` target — which
           # parse_target resolves to port 443 — got `Host: h:443` while the TUI wrote `Host: h`
@@ -975,6 +1003,27 @@ module Gori
         abort "gori run repeater: unresolved env #{Env.token_list(names)} in -H/-b/--target/--sni — " \
               "set it with `gori run project env set KEY value`, or remove the token. " \
               "(Tokens in the CAPTURED bytes are replayed literally; only your overrides are checked.)"
+      end
+
+      # Say that `FlowRequest.build` turned the capture's absolute-form request line into
+      # origin-form. ONE line, because on a plaintext-HTTP capture it fires on EVERY use of
+      # that flow (a proxy client always sends absolute-form) and a paragraph there is noise
+      # the operator learns to skip. It still has to be said: the same rewrite silently
+      # defuses a routing / cache-poisoning / SSRF probe recorded from a DIRECT send, and
+      # nothing on the row tells the two apart.
+      #
+      # Shared because `Built#rewrote_request_line` was computed at all thirteen call sites
+      # and read at exactly one — the classic "a guard wired at one call site" shape. Every
+      # `gori run` command that seeds itself from a flow now reports it; `--keep-request-line`
+      # exists on the two doors where the stored line is the whole message (`gori run repeater
+      # <flow-id>` and `repeater create`, which persists the rewrite into the session row so
+      # no later flag can recover it).
+      protected def self.warn_request_line_rewrite(built : Repeater::FlowRequest::Built,
+                                                   prefix : String,
+                                                   remedy : String = "--keep-request-line keeps it") : Nil
+        return unless built.rewrote_request_line
+        STDERR.puts "#{prefix}: request line rewritten to origin-form " \
+                    "(absolute-form is a proxy artifact; #{remedy})"
       end
 
       private def self.combine_head_body(head : Bytes, body : Bytes) : Bytes
@@ -1106,14 +1155,7 @@ module Gori
         rescue ex : Repeater::FlowRequest::PseudoHeaderHead
           abort "gori run repeater: flow ##{id} cannot be replayed over HTTP/1.1 — #{ex.message}"
         end
-        if built.rewrote_request_line
-          # One line, because on a plaintext-HTTP capture this fires on EVERY replay (a proxy
-          # client always sends absolute-form) and a paragraph there is noise the operator
-          # learns to skip. It still has to be said: the same rewrite silently defuses a
-          # routing / cache-poisoning / SSRF probe recorded from a direct send.
-          STDERR.puts "gori run repeater: request line rewritten to origin-form " \
-                      "(absolute-form is a proxy artifact; --keep-request-line keeps it)"
-        end
+        warn_request_line_rewrite(built, "gori run repeater")
 
         raw_bytes = built.bytes
         # `Env.head_body_boundary`, not a hand-rolled CRLFCRLF scan: a captured head may be
@@ -1145,6 +1187,9 @@ module Gori
             http2: use_http2, sni: sni_override.presence || built.sni,
             auto_content_length: false, resync_cl_after_expansion: !explicit_cl,
             # These bytes are stored EVIDENCE, not a draft — see `PlanOptions#evidence?`.
+            # That now includes `$KEY` expansion: `build_single_flow_request` expanded the
+            # operator's OWN `-H`/`-b`/`--target` above, so nothing downstream needs to (and
+            # nothing downstream can still tell the operator's bytes from the capture's).
             evidence: true,
             verify: !insecure, overrides: host_overrides), outbound)
         rescue ex : Repeater::PlanError

--- a/src/gori/cli/run/repeater_minimize.cr
+++ b/src/gori/cli/run/repeater_minimize.cr
@@ -10,6 +10,7 @@ module Gori
         project_name : String? = nil
         insecure = false
         apply = false
+        verbatim = false
         format = :text
         allow_unscoped = false
         positional = [] of String
@@ -23,6 +24,7 @@ module Gori
           p.on("--project=NAME", "Project to read (default: most-recently-active)") { |v| project_name = v }
           p.on("--db=PATH", "Explicit SQLite db file to read") { |v| db_path = v }
           p.on("--apply", "Write the minimized request back into the repeater session") { apply = true }
+          p.on("--verbatim", "Send the stored bytes as-is: no $VAR expansion, no Content-Length resync (same meaning as `repeater send --verbatim`; body params stop being candidates because their framing could not be kept honest)") { verbatim = true }
           p.on("-k", "--insecure", "Do not verify the upstream TLS certificate") { insecure = true }
           p.on("--allow-unscoped", "Minimize even if the target is outside the project scope (Sandbox/exclude still apply)") { allow_unscoped = true }
           p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
@@ -50,13 +52,40 @@ module Gori
         outbound = project_outbound(project_name, db_path, allow_unscoped)
 
         text = String.new(rec.request)
-        scheme, host, port = minimize_target_or_abort(id, rec, text, outbound)
-        auto_cl = rec.auto_content_length?
+        scheme, host, port = minimize_target_or_abort(id, rec, text, outbound, verbatim)
+        # `--verbatim` means exactly what it means on `repeater send`: the stored bytes ARE
+        # the message. So the resolver stops expanding AND stops re-framing, and `auto_cl`
+        # goes off with it — which also takes body params out of the candidate set, because
+        # removing one without re-lengthing the body would put a request on the wire whose
+        # Content-Length disagreed with it for a reason the operator did not choose.
+        # (`session_plan_options` folds the same two flags together the same way.)
+        auto_cl = !verbatim && rec.auto_content_length?
         # Mirrors the TUI's resolve: env-expand, then Content-Length resync only when the
         # session has Auto-CL on (the same gate that lets body params be removed at all).
+        # `Minimize.run` hands its `resolve` the request LF-normalized (its text helpers are
+        # written against that form) and restores the operator's terminator only on the
+        # REPORT. `Env.expand_wire` re-terminates the head with CRLF, so the non-verbatim path
+        # never noticed; a verbatim resolver that just took the bytes would have put a
+        # CRLF-stored session on the wire bare-LF — inventing the very desync primitive this
+        # flag exists to preserve. So restore the terminator here, by the same rule
+        # `Minimize#restore_eol` uses, and the wire and the printed report agree.
+        stored_crlf = text.includes?("\r\n")
+        # …with the one case that rule cannot carry: a head whose lines DISAGREE (some CRLF,
+        # some bare LF) is itself a smuggling shape, and minimize's LF round-trip flattens it
+        # to all-CRLF. Nothing here can undo that — the algorithm rebuilds the head — so say
+        # it rather than let `--verbatim` imply a byte-exactness it is not delivering.
+        if verbatim && stored_crlf && mixed_line_endings?(text)
+          STDERR.puts "gori run repeater minimize: session ##{id}'s head mixes CRLF and bare-LF " \
+                      "line endings; minimize rebuilds the head, so every line is sent CRLF-terminated. " \
+                      "Use `gori run repeater send #{id} --verbatim` for a byte-exact replay."
+        end
         resolve = ->(t : String) do
-          raw = Env.expand_wire(t)
-          auto_cl ? Repeater::FlowRequest.resync_content_length(raw) : raw
+          if verbatim
+            stored_crlf ? restore_head_crlf(t) : t.to_slice
+          else
+            raw = Env.expand_wire(t)
+            auto_cl ? Repeater::FlowRequest.resync_content_length(raw) : raw
+          end
         end
         # Fuzz::Sender applies the Outbound gate (Sandbox / exclude) at the socket seam;
         # CappedBackend bounds total sends. Same stack the TUI builds.
@@ -85,14 +114,60 @@ module Gori
             w.close
           end
         end
-        report_repeater_minimize(id, report, format, apply)
+        # The report is rendered through the SAME resolver the search used, so the request
+        # shown is the request that was tested. It used to print `minimized_text` raw — the
+        # SOURCE form — which on a session holding a captured `$where`/CL-22 body printed a
+        # 2-byte body under a Content-Length of 22: neither what went on the wire during the
+        # search nor what a later `repeater send` would produce. `--apply` still stores the
+        # source form (that is what the session row holds, and re-resolving it on every send
+        # is the point of storing it).
+        report_repeater_minimize(id, report, format, apply, resolve)
         exit 1 if report.aborted
+      end
+
+      # Put CRLF terminators back on the HEAD of a `Minimize` working text, leaving the body
+      # byte-exact. The same split, and the same reason, as `Env.expand_wire`'s: in the head a
+      # 0x0A is a line ending, in the body it is a byte.
+      #
+      # Needed because `Minimize` hands its `resolve` proc two different forms — the
+      # LF-normalized working text during the search, and `restore_eol`'s already-CRLF text in
+      # the report — so the step has to be idempotent (LF-normalize first, or the second call
+      # produces `\r\r\n`). Restoring the head ALONE also undoes, for the bytes this command
+      # sends and prints, `restore_eol`'s blanket `gsub("\n", "\r\n")` over the BODY: a
+      # captured body ending in a bare LF under a deliberately-short Content-Length came back
+      # one byte longer, which is the CL-desync evidence `--verbatim` exists to preserve.
+      private def self.restore_head_crlf(text : String) : Bytes
+        bytes = text.gsub("\r\n", "\n").to_slice
+        boundary = Env.head_body_boundary(bytes)
+        head = Env.normalize_crlf(bytes[0...boundary])
+        return head if boundary >= bytes.size
+        body = bytes[boundary..]
+        io = IO::Memory.new(head.size + body.size)
+        io.write(head)
+        io.write(body)
+        io.to_slice
+      end
+
+      # Does the HEAD carry both CRLF- and bare-LF-terminated lines? Head only: a raw 0x0A in
+      # a body is a byte, not a line ending (`Env.expand_wire` splits on the same boundary and
+      # for the same reason), and judging the whole request would flag every binary body.
+      private def self.mixed_line_endings?(text : String) : Bool
+        head = String.new(text.to_slice[0...Env.head_body_boundary(text.to_slice)])
+        crlf = false
+        lf = false
+        pos = 0
+        while nl = head.index('\n', pos)
+          (nl > 0 && head[nl - 1] == '\r') ? (crlf = true) : (lf = true)
+          pos = nl + 1
+        end
+        crlf && lf
       end
 
       # The validated {scheme, host, port} to minimize against, or an abort. Split out of
       # cmd_repeater_minimize to keep it under the cyclomatic-complexity bar.
       private def self.minimize_target_or_abort(id : Int64, rec : Store::RepeaterRecord,
-                                                text : String, outbound : Gori::Outbound) : {String, String, Int32}
+                                                text : String, outbound : Gori::Outbound,
+                                                verbatim : Bool = false) : {String, String, Int32}
         if Repeater::WsEngine.upgrade_request?(text)
           abort "gori run repeater minimize: session ##{id} is a WebSocket upgrade — minimize works on plain HTTP requests"
         end
@@ -114,7 +189,15 @@ module Gori
         # body is a byte, and a whole-request check refuses nearly every binary-body session —
         # but whole-string on the target and SNI, which are short operator-typed fields with no
         # body to exclude. The MCP and TUI minimize paths carry the same three checks.
-        names = Env.unresolved_wire(text) | Env.unresolved(rec.target) |
+        #
+        # Under `--verbatim` the REQUEST drops out of that check, exactly as it does on
+        # `repeater send --verbatim`: the operator has said the bytes are the message, so a
+        # literal `$user.name` / `$IFS` / OData `$top` is the payload and refusing it makes
+        # the flag unable to minimize its own advertised content. The TARGET and SNI are
+        # still checked — those are short operator-typed fields that `Env.expand` resolves
+        # below either way, and an unresolved `$HOST` there is a dial address, not a payload.
+        names = (verbatim ? [] of String : Env.unresolved_wire(text)) |
+                Env.unresolved(rec.target) |
                 (rec.sni.try { |s| Env.unresolved(s) } || [] of String)
         unless names.empty?
           abort "gori run repeater minimize: " +
@@ -137,8 +220,12 @@ module Gori
         {scheme, host, port}
       end
 
+      # `resolve` is the SAME proc the search sent through, so `minimized_request` is the
+      # request that was actually tested rather than the pre-resolution source text.
       private def self.report_repeater_minimize(id : Int64, report : Repeater::Minimize::Report,
-                                                format : Symbol, applied : Bool) : Nil
+                                                format : Symbol, applied : Bool,
+                                                resolve : Proc(String, Bytes)) : Nil
+        wire = resolve.call(report.minimized_text)
         if format == :json
           puts(JSON.build do |j|
             j.object do
@@ -155,7 +242,17 @@ module Gori
               end
               j.field "removed_count", report.removed.size
               j.field "applied", applied && !report.aborted && !report.removed.empty?
-              j.field "minimized_request", report.minimized_text
+              # The RESOLVED wire, plus the source form the session stores, because they are
+              # different questions and the operator needs both: the first is what was sent,
+              # the second is what `--apply` writes back and what a later send re-resolves.
+              # `scrub` for the same reason the repeater's `head` field does it — a minimized
+              # request can carry a binary body, and JSON cannot hold an 8-bit octet.
+              j.field "minimized_request", String.new(wire).scrub
+              unless String.new(wire).valid_encoding?
+                j.field "minimized_request_lossy", true
+                j.field "minimized_request_base64", Base64.strict_encode(wire)
+              end
+              j.field "minimized_source", report.minimized_text
             end
           end)
           return
@@ -163,7 +260,8 @@ module Gori
         STDERR.puts "#{report.note} · #{report.sends} send#{report.sends == 1 ? "" : "s"}"
         report.removed.each { |r| STDERR.puts "  - [#{r.kind.to_s.downcase}] #{r.label}" }
         STDERR.puts "saved back to session ##{id}" if applied && !report.aborted && !report.removed.empty?
-        puts report.minimized_text
+        STDOUT.write(wire)
+        STDOUT.puts unless wire.empty? || wire[-1] == 0x0A_u8
       end
     end
   end

--- a/src/gori/cli/run/repeater_minimize.cr
+++ b/src/gori/cli/run/repeater_minimize.cr
@@ -60,33 +60,7 @@ module Gori
         # Content-Length disagreed with it for a reason the operator did not choose.
         # (`session_plan_options` folds the same two flags together the same way.)
         auto_cl = !verbatim && rec.auto_content_length?
-        # Mirrors the TUI's resolve: env-expand, then Content-Length resync only when the
-        # session has Auto-CL on (the same gate that lets body params be removed at all).
-        # `Minimize.run` hands its `resolve` the request LF-normalized (its text helpers are
-        # written against that form) and restores the operator's terminator only on the
-        # REPORT. `Env.expand_wire` re-terminates the head with CRLF, so the non-verbatim path
-        # never noticed; a verbatim resolver that just took the bytes would have put a
-        # CRLF-stored session on the wire bare-LF — inventing the very desync primitive this
-        # flag exists to preserve. So restore the terminator here, by the same rule
-        # `Minimize#restore_eol` uses, and the wire and the printed report agree.
-        stored_crlf = text.includes?("\r\n")
-        # …with the one case that rule cannot carry: a head whose lines DISAGREE (some CRLF,
-        # some bare LF) is itself a smuggling shape, and minimize's LF round-trip flattens it
-        # to all-CRLF. Nothing here can undo that — the algorithm rebuilds the head — so say
-        # it rather than let `--verbatim` imply a byte-exactness it is not delivering.
-        if verbatim && stored_crlf && mixed_line_endings?(text)
-          STDERR.puts "gori run repeater minimize: session ##{id}'s head mixes CRLF and bare-LF " \
-                      "line endings; minimize rebuilds the head, so every line is sent CRLF-terminated. " \
-                      "Use `gori run repeater send #{id} --verbatim` for a byte-exact replay."
-        end
-        resolve = ->(t : String) do
-          if verbatim
-            stored_crlf ? restore_head_crlf(t) : t.to_slice
-          else
-            raw = Env.expand_wire(t)
-            auto_cl ? Repeater::FlowRequest.resync_content_length(raw) : raw
-          end
-        end
+        resolve = minimize_resolver(id, text, verbatim, auto_cl)
         # Fuzz::Sender applies the Outbound gate (Sandbox / exclude) at the socket seam;
         # CappedBackend bounds total sends. Same stack the TUI builds.
         backend = Fuzz::CappedBackend.new(
@@ -123,6 +97,43 @@ module Gori
         # is the point of storing it).
         report_repeater_minimize(id, report, format, apply, resolve)
         exit 1 if report.aborted
+      end
+
+      # The editor-text → wire-bytes step `Minimize` sends through, and the ONE thing
+      # `--verbatim` changes about this command.
+      #
+      # Draft (default): mirrors the TUI's resolve — env-expand, then a Content-Length resync
+      # only when the session has Auto-CL on (the same gate that lets body params be removed
+      # at all). VERBATIM: neither, because the operator has said the stored bytes ARE the
+      # message — `repeater send --verbatim` means exactly this, and without it a session
+      # holding a capture was either refused outright or minimized against bytes that differ
+      # from what a later send would put on the wire.
+      #
+      # `Minimize.run` hands this proc the request LF-NORMALIZED (its text helpers are written
+      # against that form) and restores the operator's terminator only on the REPORT.
+      # `Env.expand_wire` re-terminates the head with CRLF, so the draft path never noticed; a
+      # verbatim resolver that simply took the bytes would have put a CRLF-stored session on
+      # the wire bare-LF, inventing the very desync primitive the flag exists to preserve.
+      private def self.minimize_resolver(id : Int64, text : String, verbatim : Bool,
+                                         auto_cl : Bool) : Proc(String, Bytes)
+        stored_crlf = text.includes?("\r\n")
+        # The one case that restore cannot carry: a head whose lines DISAGREE (some CRLF, some
+        # bare LF) is itself a smuggling shape, and minimize's LF round-trip flattens it to
+        # all-CRLF. Nothing here can undo that — the algorithm rebuilds the head — so say it
+        # rather than let `--verbatim` imply a byte-exactness it is not delivering.
+        if verbatim && stored_crlf && mixed_line_endings?(text)
+          STDERR.puts "gori run repeater minimize: session ##{id}'s head mixes CRLF and bare-LF " \
+                      "line endings; minimize rebuilds the head, so every line is sent CRLF-terminated. " \
+                      "Use `gori run repeater send #{id} --verbatim` for a byte-exact replay."
+        end
+        ->(t : String) do
+          if verbatim
+            stored_crlf ? restore_head_crlf(t) : t.to_slice
+          else
+            raw = Env.expand_wire(t)
+            auto_cl ? Repeater::FlowRequest.resync_content_length(raw) : raw
+          end
+        end
       end
 
       # Put CRLF terminators back on the HEAD of a `Minimize` working text, leaving the body

--- a/src/gori/cli/run/sequence.cr
+++ b/src/gori/cli/run/sequence.cr
@@ -87,7 +87,7 @@ module Gori
         # literally. Explicit and identical to cmd_fuzz, rather than relying on the store that
         # `cli_host_overrides` happens to open below (see run.cr's open_store).
         hydrate_project_env(project_name, db_path) if (project_name || db_path) && flow_id.nil?
-        bytes, default_target, src_h2 = sequence_source(flow_id, request_file, project_name, db_path)
+        bytes, default_target, src_h2, evidence = sequence_source(flow_id, request_file, project_name, db_path)
         token_loc = build_token_loc(k, selector)
 
         config = Sequencer::Config.new(mode: Sequencer::Mode::LiveReplay, token_loc: token_loc, goal: count, concurrency: concurrency)
@@ -96,7 +96,10 @@ module Gori
         config.timeout = timeout
         config.retries = retries
         config.max_requests = max_requests
-        options = Sequencer::PlanOptions.new(bytes, default_target: default_target,
+        options = Sequencer::PlanOptions.new(bytes,
+          # A `--flow` request is CAPTURED; --request/stdin is a draft the operator authored.
+          # See `Sequencer::PlanOptions#evidence?`.
+          evidence: evidence, default_target: default_target,
           target: target_override, http2: force_h2 || src_h2, config: config,
           verify: !insecure, sni: sni,
           overrides: cli_host_overrides(project_name, db_path, flow_id))
@@ -168,14 +171,17 @@ module Gori
         end
       end
 
-      # {raw request bytes, the seeding flow's target, http2} from the chosen source.
-      # Deliberately UNEXPANDED: `Sequencer::Plan.build` owns `Env.expand`, and expanding
-      # here as well would resolve a var whose value itself contains a `$TOKEN` twice.
+      # {raw request bytes, the seeding flow's target, http2, is-evidence} from the chosen
+      # source. Deliberately UNEXPANDED: `Sequencer::Plan.build` owns `Env.expand`, and
+      # expanding here as well would resolve a var whose value itself contains a `$TOKEN`
+      # twice. The last element is PROVENANCE, not a knob: only the `--flow` branch hands back
+      # captured bytes, and only that branch may skip the draft-time passes (see
+      # `Sequencer::PlanOptions#evidence?`).
       private def self.sequence_source(flow_id : Int64?, request_file : String?,
-                                       project_name : String?, db_path : String?) : {Bytes, String?, Bool}
+                                       project_name : String?, db_path : String?) : {Bytes, String?, Bool, Bool}
         if file = request_file
           abort "gori run sequence: not a readable file: #{file}" unless File.exists?(file) && !File.directory?(file)
-          {File.read(file).to_slice, nil, false}
+          {File.read(file).to_slice, nil, false, false}
         elsif id = flow_id
           store = open_store(resolve_read_project(project_name, db_path))
           detail = begin
@@ -185,9 +191,13 @@ module Gori
           end
           abort "gori run sequence: no flow ##{id}" unless detail
           built = Repeater::FlowRequest.build(detail)
-          {built.bytes, built.target, built.http2}
+          # Every replay in the collection carries a request line gori changed — see
+          # `warn_request_line_rewrite`.
+          warn_request_line_rewrite(built, "gori run sequence",
+            "replay it with `gori run repeater #{id} --keep-request-line` to keep it")
+          {built.bytes, built.target, built.http2, true}
         elsif !STDIN.tty?
-          {STDIN.gets_to_end.to_slice, nil, false}
+          {STDIN.gets_to_end.to_slice, nil, false, false}
         else
           abort "gori run sequence: no source — give a <flow-id>, --request FILE, or pipe a request on stdin"
         end
@@ -229,7 +239,11 @@ module Gori
 
       private def self.sequence_done(ev : Sequencer::DoneEvent, collected : Int32) : Nil
         STDERR.print "\r" if STDERR.tty?
-        STDERR.puts "done · #{collected} collected · #{ev.sent} sent#{ev.stopped ? " (stopped)" : ""}"
+        # `requests` only when it DIFFERS from the replay count — `--retries` is what makes
+        # them diverge, and a run without one should not grow a second number that says the
+        # same thing twice. See `Sequencer::ProgressEvent#requests`.
+        extra = ev.requests > ev.sent ? " · #{ev.requests} requests on the wire" : ""
+        STDERR.puts "done · #{collected} collected · #{ev.sent} sent#{extra}#{ev.stopped ? " (stopped)" : ""}"
       end
 
       # In jsonl mode the samples already streamed, so append the final report as a JSON

--- a/src/gori/discover/engine.cr
+++ b/src/gori/discover/engine.cr
@@ -249,12 +249,20 @@ module Gori::Discover
     def initialize(@inner : Backend, @cap : Int64?)
     end
 
+    # Fetches the cap DENIED. Distinct from `cap_reached?`, which is also true for a run that
+    # happened to finish exactly on its budget: a non-zero count here is proof that work the
+    # run wanted to do did not happen. See `Engine#budget_exhausted?`.
+    getter refused : Int64 = 0_i64
+
     def cap_reached? : Bool
       (c = @cap) && c > 0 ? @sent >= c : false
     end
 
     def fetch(scheme : String, host : String, port : Int32, target : String) : Repeater::Result
-      return Repeater::Result.new(Bytes.new(0), nil, nil, 0_i64, CAP_ERROR) if cap_reached?
+      if cap_reached?
+        @refused += 1
+        return Repeater::Result.new(Bytes.new(0), nil, nil, 0_i64, CAP_ERROR)
+      end
       @sent += 1
       @inner.fetch(scheme, host, port, target)
     end
@@ -364,6 +372,11 @@ module Gori::Discover
     # consumer reads this and decides. ONE string, not a list — every send in a wholly-blocked
     # run fails for the same reason and the point is to name it, not to tally it.
     getter first_error : String? = nil
+    # Sends that reached an origin and came back without an error. `@capped.sent` cannot
+    # answer that — it is a BUDGET counter that charges an attempt before the fetch, so a run
+    # whose every send failed still has `sent > 0`. Same counter, same name and same purpose
+    # as `Miner::Engine#successful_sends`; see `wholly_refused_reason`.
+    getter successful_sends : Int64 = 0_i64
     @pages : Int32
     @crawl_enqueued : Int32
     @calibrated_out : Int32
@@ -541,7 +554,8 @@ module Gori::Discover
       if refusal
         @events.send(ErrorEvent.new(refusal))
       else
-        @events.send(DoneEvent.new(progress_snapshot, run_stats, @state == State::Stopped))
+        @events.send(DoneEvent.new(progress_snapshot, run_stats, @state == State::Stopped,
+          budget_exhausted?))
       end
       @events.close
     rescue ex
@@ -650,12 +664,31 @@ module Gori::Discover
       end
     end
 
-    # The reason this run produced nothing, or nil when it produced something. "Nothing" is
-    # deliberately `@found == 0 && @pages == 0`: a run that recorded a page or a finding got
-    # an answer from an origin, however many later sends were refused, and turning that into
-    # a terminal error would hide the results it did get.
+    # The run stopped SHORT of its work because `max_requests` ran out — not merely reached
+    # its cap on the last thing it had to do, which is an ordinary complete run. Both halves
+    # are needed and neither alone is right:
+    #   * `@frontier` non-empty — the orchestrator's `break if @capped.cap_reached?` leaves
+    #     every un-dispatched task sitting there (the 275-of-283 case);
+    #   * `@capped.refused > 0` — a Calibrate task whose bogus probes were all denied
+    #     consumed no frontier entry at all, so the frontier can drain while real work was
+    #     skipped.
+    private def budget_exhausted? : Bool
+      @capped.cap_reached? && (!@frontier.empty? || @capped.refused > 0)
+    end
+
+    # The reason this run produced nothing, or nil when it produced something.
+    #
+    # "Produced nothing" is `@found == 0 && @pages == 0` AND nothing got through
+    # (`@successful_sends == 0`) — the second clause is `Miner::Engine`'s predicate, added
+    # here for its reason and against the same failure: a target that accepts TCP and then
+    # answers nothing, under a budget small enough that only CALIBRATION probes ever ran,
+    # reported `done · 0 found · 9 sent · 0 errors` and exit 0. Nine requests went out, nine
+    # got no response. Calibration failures now reach `@first_error` too (see
+    # `send_with_retries`), which is what makes that run nameable at all; `successful_sends`
+    # is what stops the wider check from turning a target that answered fine but held nothing
+    # into a spurious terminal error.
     private def wholly_refused_reason : String?
-      return nil unless @found == 0 && @pages == 0
+      return nil unless @found == 0 && @pages == 0 && @successful_sends == 0
       @first_error.presence
     end
 
@@ -1106,6 +1139,17 @@ module Gori::Discover
           attempts += 1
           sleep @config.retry_pause
           next
+        end
+        # Book the outcome HERE — the one line every send passes — rather than in the two
+        # `handle_*` methods that used to do it. `handle_calibrate` never did, so a run whose
+        # whole budget went on CALIBRATION probes against a dead-silent origin recorded no
+        # error at all and reported `0 errors` on a run where nothing answered. The error
+        # COUNT stays in the handlers (a calibration miss is not a probe result and must not
+        # inflate it); only the "what went wrong / did anything work" facts move here.
+        if err = raw.error
+          @first_error ||= err.presence unless benign_error?(err)
+        else
+          @successful_sends += 1
         end
         return raw
       end

--- a/src/gori/discover/headers.cr
+++ b/src/gori/discover/headers.cr
@@ -32,18 +32,44 @@ module Gori::Discover
     # Parse raw "Name: Value" lines (CLI `-H`, the TUI editor) into pairs, dropping
     # anything malformed or unsafe: a value may not contain CR/LF (header injection),
     # and a name must be a non-empty RFC 7230 token.
-    def self.parse_lines(lines : Array(String)) : Array({String, String})
+    #
+    # Pass `rejected` to learn WHICH lines were dropped. Refusing a CR/LF-carrying value is
+    # right — this is an automated crawler, not the repeater, and the value is spliced
+    # straight into every probe's header block — but refusing it SILENTLY is not: the drop
+    # took `Authorization` with it, so an authenticated sweep ran unauthenticated and reported
+    # "found nothing" over the whole authenticated surface, with a clean exit and nothing on
+    # stderr. An out-collector rather than a changed return type, so the three surfaces that
+    # call this can adopt the report one at a time.
+    def self.parse_lines(lines : Array(String),
+                         rejected : Array(String)? = nil) : Array({String, String})
       out = [] of {String, String}
       lines.each do |line|
+        # A BLANK line is not a header anyone asked for — the TUI overlay parses an editor
+        # buffer, which is full of them — so it is neither parsed nor reported. Everything
+        # else the operator typed is one or the other, never silently neither.
+        next if line.blank?
         name, sep, value = line.partition(':')
-        next if sep.empty?
         name = name.strip
         value = value.strip
-        next if name.empty? || !valid_name?(name)
-        next unless safe_value?(value)
+        if sep.empty? || name.empty? || !valid_name?(name) || !safe_value?(value)
+          rejected.try(&.<<(line))
+          next
+        end
         out << {name, value}
       end
       out
+    end
+
+    # The NAMES of already-parsed headers whose value stops being safe once `$VAR` is
+    # resolved — the realistic half of the same failure: the header the operator typed is
+    # fine, and `TOKEN` holds a value read from a file with a trailing newline in it.
+    #
+    # A QUERY, so a surface can refuse the run BEFORE any traffic. `expand` (below) still
+    # drops such a value at send time, and must: it is the last line before the wire and a
+    # binding can resolve later than plan-build. But a backstop that fires silently on every
+    # probe is not a report, and by then the crawl is already running.
+    def self.unsafe_expanded(pairs : Array({String, String})) : Array(String)
+      pairs.compact_map { |(name, value)| safe_value?(Env.expand(value).strip) ? nil : name }
     end
 
     # Headers reused from a captured History flow: parse the stored request head and

--- a/src/gori/discover/types.cr
+++ b/src/gori/discover/types.cr
@@ -121,7 +121,15 @@ module Gori
     record BaselineEvent, dir : String, kind : String, note : String?
     record FindingEvent, finding : Finding
     record ProgressEvent, progress : Progress
-    record DoneEvent, progress : Progress, stats : RunStats, stopped : Bool
+    # `budget_exhausted` — the run STOPPED SHORT because `max_requests` ran out, as opposed to
+    # having simply reached its cap on the last thing it had to do. Fuzz and mine let a
+    # consumer derive this (`sent < total`, `names_done < names_total`); discover has no
+    # stable denominator to derive it from — `est_total` is a moving estimate — so the engine
+    # has to say it. Without it, `status:"done", job_complete:true, has_more:false` came back
+    # with 275 of 283 wordlist tasks unsent, and both the CLI and an agent read that as a
+    # finished directory sweep.
+    record DoneEvent, progress : Progress, stats : RunStats, stopped : Bool,
+      budget_exhausted : Bool = false
     record ErrorEvent, message : String
 
     alias Event = BaselineEvent | FindingEvent | ProgressEvent | DoneEvent | ErrorEvent

--- a/src/gori/fuzz/engine.cr
+++ b/src/gori/fuzz/engine.cr
@@ -251,7 +251,10 @@ module Gori::Fuzz
 
     getter events : Channel(Event)
 
-    @backend : Backend
+    # The CAP WRAPPER, not the raw Backend the caller passed: the engine always wraps (a nil
+    # cap is a pass-through), and typing it as the wrapper is what lets `snapshot` publish
+    # `CappedBackend#sent` — the true wire count — without a runtime `is_a?` at every read.
+    @backend : CappedBackend
     @concurrency : Int32
     @state : State
     @wake : Channel(Nil)
@@ -372,7 +375,7 @@ module Gori::Fuzz
         # Soft job-count check (cheap) plus the hard real-send ceiling: retries/redirects
         # can exhaust CappedBackend mid-run while @dispatched is still under cap.
         raise Halt.new if (cap = @config.max_requests) && cap > 0 && @dispatched >= cap
-        raise Halt.new if (b = @backend).is_a?(CappedBackend) && b.cap_reached?
+        raise Halt.new if @backend.cap_reached?
         pace(interval)
         @jobs.send(job)
         @dispatched += 1
@@ -543,7 +546,8 @@ module Gori::Fuzz
     end
 
     private def snapshot : Progress
-      Progress.new(@sent, total, @matched, @errors, @backend.blocked, @backend.blocked_reason)
+      Progress.new(@sent, total, @matched, @errors, @backend.blocked, @backend.blocked_reason,
+        @backend.sent)
     end
   end
 end

--- a/src/gori/fuzz/generator.cr
+++ b/src/gori/fuzz/generator.cr
@@ -58,8 +58,16 @@ module Gori::Fuzz
     # The unmodified base request (all positions = their defaults), CL-synced — used
     # to seed the matcher baseline for anomaly diffing.
     def baseline_request : Bytes
-      raw = @template.render(chained(@template.default_payloads))
+      raw = baseline_raw
       @config.update_content_length? ? ContentLength.sync(raw, @config.add_content_length_when_missing?) : raw
+    end
+
+    # The same request WITHOUT the Content-Length pass. Split out so a surface can ask
+    # whether the resync is about to REWRITE framing the operator authored — a template
+    # declaring `Content-Length: 5` over a ten-byte body is the CL-desync probe itself, and
+    # a sweep that silently corrects it tests something else and reports success.
+    def baseline_raw : Bytes
+      @template.render(chained(@template.default_payloads))
     end
 
     # `n` synthetic requests for auto-calibration (Engine#calibrate_baseline): each

--- a/src/gori/fuzz/plan.cr
+++ b/src/gori/fuzz/plan.cr
@@ -58,6 +58,24 @@ module Gori::Fuzz
     # Raw template text, BEFORE `Env.expand` — the builder owns the expansion so it happens
     # exactly once (see `Plan.build`).
     property template : String
+    # PROVENANCE: this template is a CAPTURED FLOW's stored bytes, not a request the operator
+    # typed or edited. Identical in meaning and consequence to `Repeater::PlanOptions#evidence?`,
+    # and it exists for the same reason that one does: "send this capture to the fuzzer" is
+    # the main consumer of a captured flow, and the draft-time passes the replay path stopped
+    # running were still running here. Concretely, with it OFF a capture was
+    #
+    #   * REFUSED outright when its head carried a `$` nobody typed — OData `$filter`/`$top`,
+    #     Mongo `$where`, an `$IFS` shell probe, `$user.name` SSTI — and the refusal's own
+    #     remedy ("set the variable") would have SUBSTITUTED a value and swept a different
+    #     request; and
+    #   * silently un-desynced when its head was bare-LF terminated, because `expand_wire`
+    #     re-terminates a head with CRLF. `gori run repeater 3` replays that capture
+    #     byte-exact; `gori run fuzz 3` promoted it and reported a clean run.
+    #
+    # A `--request FILE` / stdin / TUI-editor template keeps the draft behaviour: those bytes
+    # ARE a draft, the editor's fresh lines really do end in LF, and a `$KEY` there is a
+    # variable reference the operator meant.
+    property? evidence : Bool
     # The origin the seeding flow implies, when there is one (nil for --request/stdin).
     property default_target : String?
     # An explicit target, which wins over `default_target` when non-blank.
@@ -88,6 +106,7 @@ module Gori::Fuzz
 
     def initialize(@template : String = "",
                    *,
+                   @evidence : Bool = false,
                    @default_target : String? = nil,
                    @target : String? = nil,
                    @auto_mark : Bool = false,
@@ -134,11 +153,18 @@ module Gori::Fuzz
     # {token, occurrence count} per `--mark`, in the order the marks were applied — the
     # CLI warns when one token silently matched several spots (including in headers).
     getter mark_matches : Array({String, Int32})
+    # The `update_content_length` pass will REWRITE a Content-Length the operator authored —
+    # i.e. the template's declared CL already disagrees with its own body BEFORE any payload
+    # is substituted, which only happens on purpose. Computed here rather than discovered per
+    # request so a surface can say it ONCE, up front, and name the flag that turns it off.
+    # False when the knob is already off, or when the declared length was correct anyway.
+    getter? rewrites_content_length : Bool
 
     def initialize(@engine : Engine, @generator : Generator, @matcher : Matcher,
                    @config : Config, @origin : Origin, @template : Template,
                    @http2 : Bool, @request_target : String,
-                   @mark_matches : Array({String, Int32}), @pool : ConnPool? = nil)
+                   @mark_matches : Array({String, Int32}), @pool : ConnPool? = nil,
+                   @rewrites_content_length : Bool = false)
     end
 
     # Candidate request count, or nil when unknown / Int64-overflowing. Reads the payload
@@ -159,8 +185,18 @@ module Gori::Fuzz
       # in the same session, sent CRLF. A bare LF is itself a front-end/back-end desync
       # primitive, so it does not merely look untidy — it confounds every result the sweep
       # produces. The body is left byte-exact either way; `expand_wire` only touches the head.
-      refuse_unresolved(Env.unresolved_wire(options.template))
-      text = String.new(Env.expand_wire(options.template))
+      #
+      # BOTH steps are skipped for EVIDENCE (`PlanOptions#evidence?`): a captured head's `$`
+      # was not typed by anyone, and its terminators are already exact wire bytes. The
+      # marking, template parse and payload splice below are unchanged either way — a
+      # position is a position whether the operator marked it in an editor or `--auto`
+      # found it in a capture.
+      text = if options.evidence?
+               options.template
+             else
+               refuse_unresolved(Env.unresolved_wire(options.template))
+               String.new(Env.expand_wire(options.template))
+             end
       text = Template.auto_mark(text) if options.auto_mark?
       marker = Template::MARKER
       mark_matches = options.marks.map do |tok|
@@ -204,7 +240,9 @@ module Gori::Fuzz
       new(engine: Engine.new(generator, matcher, sender, config), generator: generator,
         matcher: matcher, config: config, origin: origin, template: template,
         http2: options.http2?, request_target: request_target, mark_matches: mark_matches,
-        pool: sender.pool)
+        pool: sender.pool,
+        rewrites_content_length: config.update_content_length? &&
+                                 generator.baseline_request != generator.baseline_raw)
     end
 
     # The explicit target when it has one, else the seeding flow's. Blank counts as absent

--- a/src/gori/fuzz/types.cr
+++ b/src/gori/fuzz/types.cr
@@ -83,6 +83,8 @@ module Gori
     # Live counters. `total` is nil when the run size is unknown (cluster bomb / brute
     # force overflowing Int64).
     record Progress,
+      # PAYLOADS completed — one per generated variation, and therefore the numerator that
+      # belongs against `total`. NOT the number of requests: see `requests`.
       sent : Int64,
       total : Int64?,
       matched : Int64,
@@ -92,7 +94,17 @@ module Gori
       # on the Backend because the surfaces that must not render a fully-refused run as
       # "0 matches" only ever see events. See `Fuzz::Backend#blocked`.
       blocked : Int64 = 0_i64,
-      blocked_reason : String? = nil
+      blocked_reason : String? = nil,
+      # REQUESTS actually put on the wire — `CappedBackend#sent`, the counter `max_requests`
+      # is enforced against. Retries and redirect hops each cost one here and NONE in `sent`,
+      # so the two diverge by up to `(retries + 1) * (max_redirects + 1)`: a 3-payload sweep
+      # with `--follow-redirects` against a redirect chain reported "3 sent" for 18 real
+      # requests. For a tester working inside an agreed request budget on a client's
+      # production system — or against anything that rate-limits or alerts on volume — this
+      # is the number that matters, and mine/discover have always published it as their own
+      # `sent`. Kept as a SECOND field rather than replacing `sent`, because `sent/total` is
+      # the progress meter's fraction and would otherwise run past 100%.
+      requests : Int64 = 0_i64
 
     # Engine → consumer events. A union (not a class hierarchy) so `Channel(Event)`
     # carries them without boxing surprises. Progress is droppable (latest wins);

--- a/src/gori/interceptor.cr
+++ b/src/gori/interceptor.cr
@@ -78,12 +78,101 @@ module Gori
       # `.to_slice`, which is lossy on non-UTF-8 — a pre-existing sharp edge on an HTTP body
       # that WS makes the DEFAULT case, since opcode 2 is protobuf/msgpack/CBOR.
       getter? binary : Bool
+      # Why an EDIT to this message cannot be applied, or nil when it can.
+      #
+      # Known at hold time and not a moment later: on HTTP/2 the answer is
+      # `HeadCodec.h1_unfaithful_reason`, a pure function of the block's decoded fields, and
+      # the refusal it describes used to run on the gate's wait fiber — AFTER the surface had
+      # already acked the edit as applied. A CR/LF reflected into one header value (the shape
+      # a CRLF-injection probe INDUCES) made gori accept every subsequent edit to that message
+      # and apply none. Reading it here lets the surface refuse before the operator writes one.
+      # nil on h1, where the decision bytes are forwarded byte-exact.
+      getter edit_refusal : String?
+      # This hold covers the HEAD only, so a body typed into an edit has nowhere to go: the h2
+      # relay streams DATA past the gate untouched (#492 step 3, D2). h1 holds head+body and
+      # leaves this false.
+      getter? head_only : Bool
 
       def initialize(@id, @kind, @method, @host, @target, @port, @scheme, @raw, @held_at,
-                     @flow_id = nil, @binary = false)
+                     @flow_id = nil, @binary = false, @edit_refusal = nil, @head_only = false)
         @reply = Channel(Decision).new(1)
         @held_at_ms = Time.utc.to_unix_ms
       end
+
+      # Why gori will not apply THESE edited bytes to this message, or nil when it will.
+      #
+      # Asked by every surface that offers an edit, BEFORE it decides — because the settle side
+      # can only discard, and discarding after an ack is how "edited: GET 127.0.0.1/unf3" came
+      # to mean "the original request went on the wire byte for byte". Both facts are already
+      # known: `edit_refusal` was computed when the message was held, and the head/body split
+      # is `Interceptor.split_edit`, the same one the h2 gate encodes against.
+      #
+      # A refusal leaves the message HELD. Nothing was decided, so the operator can still
+      # forward it, drop it, or write a different edit.
+      def refuse_edit(bytes : Bytes) : String?
+        if reason = @edit_refusal
+          return reason
+        end
+        return nil unless head_only? && Interceptor.split_edit(bytes)[1]
+        "this HTTP/2 hold covers the HEAD only, so the body in this edit has nowhere to go — " \
+        "DATA frames stream past the intercept gate untouched (#492 step 3) and gori will not " \
+        "report having sent bytes it dropped. Edit the head, or replay the whole message from " \
+        "the Repeater"
+      end
+
+      # How this queue row is NAMED to a human or an agent — the ack for an irreversible
+      # forward/drop/edit, and the only record either gets of which message it just acted on.
+      #
+      # `target` is deliberately overloaded per kind (an h1 request's is the ABSOLUTE-form
+      # proxy request line, a response's is its status line, a WS message's is the handshake's),
+      # so the one expression `"#{method} #{host}#{target}"` produced
+      # `POST 127.0.0.1http://127.0.0.1:19201/held` for a proxied h1 request and
+      # `POST 127.0.0.1200 OK` for a held response — which reads as HTTP status 1200. Composing
+      # per kind is what `Tui::InterceptView#row_label`, `CLI::Output` and `Links` already do
+      # separately; this is the copy the settle paths use so they cannot drift again.
+      def label : String
+        case kind
+        in .request?  then "#{method} #{host}#{origin_form(target)}"
+        in .response? then "#{method} #{host} -> #{target}"
+        in .ws_out?   then "#{host}#{origin_form(target)} client->server #{raw.size}B"
+        in .ws_in?    then "#{host}#{origin_form(target)} server->client #{raw.size}B"
+        end
+      end
+
+      # A plaintext forward-proxy request is captured absolute-form (the wire truth, P7), and
+      # gluing the host onto one doubles the authority. Same rule as `Tui::Url.origin_path`,
+      # kept here because `Interceptor` is core and that helper is TUI-scoped.
+      private def origin_form(t : String) : String
+        return t unless t.starts_with?("http://") || t.starts_with?("https://")
+        scheme_end = t.index("://")
+        return t unless scheme_end
+        slash = t.index('/', scheme_end + 3)
+        slash ? t[slash..] : "/"
+      end
+    end
+
+    # Where the HEAD of a held message ends, and whether anything followed it.
+    #
+    # The EARLIEST blank line, in either spelling — `Rules#split_message`'s rule and for the
+    # same reason. `||` preferred the CRLF form wherever it appeared, so an operator whose
+    # edited head is LF-joined (the intercept editor's `TextArea#text` is) and whose BODY
+    # carries a CRLFCRLF got the boundary taken inside the body.
+    #
+    # Lives here rather than in `H2::StreamGate` because two callers need the same answer: the
+    # gate splits the bytes it is about to encode, and the settle surface has to know whether an
+    # edit added a body to a head-only hold BEFORE it acks the edit as applied.
+    def self.split_edit(bytes : Bytes) : {Bytes, Bool}
+      text = String.new(bytes)
+      crlf = text.index("\r\n\r\n")
+      lf = text.index("\n\n")
+      idx =
+        if crlf && (lf.nil? || crlf < lf)
+          crlf + 4
+        elsif lf
+          lf + 2
+        end
+      return {bytes, false} unless idx
+      {bytes[0, idx], idx < bytes.size}
     end
 
     @direction : Direction
@@ -328,14 +417,20 @@ module Gori
     # human cannot be the one reading frames (#492 step 3, D1) — it enqueues here and blocks
     # on `Item#reply` elsewhere. `hold_request`/`hold_response` are this plus the receive, so
     # the two paths cannot drift.
+    # `edit_refusal` / `head_only` are the h2 gate's — see `Item`. h1 leaves both at their
+    # defaults, which is what "an h1 decision is forwarded byte-exact" means.
     def enqueue_request(raw : Bytes, *, method : String, target : String,
-                        host : String, port : Int32, scheme : String) : Item?
-      enqueue(Kind::Request, raw, method, target, host, port, scheme, nil)
+                        host : String, port : Int32, scheme : String,
+                        edit_refusal : String? = nil, head_only : Bool = false) : Item?
+      enqueue(Kind::Request, raw, method, target, host, port, scheme, nil,
+        edit_refusal: edit_refusal, head_only: head_only)
     end
 
     def enqueue_response(raw : Bytes, *, flow_id : Int64?, method : String, target : String,
-                         host : String, port : Int32, scheme : String) : Item?
-      enqueue(Kind::Response, raw, method, target, host, port, scheme, flow_id)
+                         host : String, port : Int32, scheme : String,
+                         edit_refusal : String? = nil, head_only : Bool = false) : Item?
+      enqueue(Kind::Response, raw, method, target, host, port, scheme, flow_id,
+        edit_refusal: edit_refusal, head_only: head_only)
     end
 
     # Queue one reassembled WebSocket message (#500 step 2). `raw` is the payload as it would
@@ -354,12 +449,14 @@ module Gori
     end
 
     private def enqueue(kind, raw, method, target, host, port, scheme, flow_id,
-                        binary = false) : Item?
+                        binary = false, edit_refusal : String? = nil,
+                        head_only : Bool = false) : Item?
       return nil unless intercepts_host?(host)
       item = @mutex.synchronize do
         return nil if @shutting_down || !@enabled
         id = (@next_id += 1)
-        it = Item.new(id, kind, method, host, target, port, scheme, raw, Time.instant, flow_id, binary)
+        it = Item.new(id, kind, method, host, target, port, scheme, raw, Time.instant, flow_id,
+          binary, edit_refusal, head_only)
         @items[id] = it
         it
       end

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -1113,7 +1113,11 @@ module Gori
               "always includes `effective_request` (the scheme/host/port/method/target/" \
               "http_version actually sent). " \
               "Host + Content-Length are auto-added when omitted on the url path. " \
-              "Match & Replace rules are NOT applied unless apply_rules:true." do |s|
+              "Match & Replace rules are NOT applied unless apply_rules:true. " \
+              "On a failed send, branch on `retryable`: PROTOCOL_ERROR (gori proved the message " \
+              "malformed) and REQUEST_TRUNCATED (the origin answered — status/head/body are all " \
+              "here — before the request body finished, which RFC 9113 §8.1 permits) are both " \
+              "final; re-sending a truncated body puts the whole body back on the wire." do |s|
               s.field "flow_id", intprop("resend a captured flow by id (no url needed; like the TUI Repeater)")
               s.field "keep_request_line", boolprop("flow_id only: send the STORED request line as captured instead of rewriting an absolute-form line (GET http://h/p) to origin-form (GET /p). Default false, because a proxy capture's absolute form is a proxy artifact — but on a flow recorded from a direct send it is the routing / cache-poisoning / SSRF payload. `request_line_rewritten:true` comes back whenever the rewrite fired")
               s.field "repeater_id", intprop("execute a saved HTTP repeater by id (no url needed; respects its target/http2/sni/auto-Content-Length)")

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -1115,6 +1115,7 @@ module Gori
               "Host + Content-Length are auto-added when omitted on the url path. " \
               "Match & Replace rules are NOT applied unless apply_rules:true." do |s|
               s.field "flow_id", intprop("resend a captured flow by id (no url needed; like the TUI Repeater)")
+              s.field "keep_request_line", boolprop("flow_id only: send the STORED request line as captured instead of rewriting an absolute-form line (GET http://h/p) to origin-form (GET /p). Default false, because a proxy capture's absolute form is a proxy artifact — but on a flow recorded from a direct send it is the routing / cache-poisoning / SSRF payload. `request_line_rewritten:true` comes back whenever the rewrite fired")
               s.field "repeater_id", intprop("execute a saved HTTP repeater by id (no url needed; respects its target/http2/sni/auto-Content-Length)")
               s.field "url", strprop("absolute URL incl. scheme+host, e.g. https://api.example.com/v1/x (required unless flow_id/repeater_id is given)")
               s.field "method", strprop("HTTP method (default GET)")
@@ -1160,6 +1161,7 @@ module Gori
               s.field "http2", boolprop("use HTTP/2 (default false)")
               s.field "auto_content_length", boolprop("auto-calculate Content-Length header (default true)")
               s.field "flow_id", intprop("optional original flow id this repeater stems from")
+              s.field "keep_request_line", boolprop("flow_id/issue_id seeding only: store the captured request line as-is instead of rewriting an absolute-form line (GET http://h/p) to origin-form (GET /p). Default false. The rewrite is PERMANENT once stored — not even send_request --verbatim can recover the line — so pass true when the absolute form is the payload. `request_line_rewritten:true` comes back whenever it fired")
               s.field "issue_id", intprop("optional issue id to populate target/request/messages from")
               s.field "position", intprop("tab position order index (optional, defaults to appending at end)")
               s.field "sni", strprop("optional TLS Server Name Indication override")
@@ -1342,6 +1344,7 @@ module Gori
               s.field "repeater_id", intprop("repeater database id (`id` is accepted as an alias — the sibling repeater tools spell it that way)"), required: true
               s.field "id", intprop("alias for repeater_id")
               s.field "apply", boolprop("write the minimized request back into the session (default false)")
+              s.field "verbatim", boolprop("search with the stored bytes EXACTLY, as send_request/--verbatim would send them: no $VAR expansion, no bare-LF→CRLF promotion, no Content-Length resync (so body params stop being removal candidates). Use it for a session seeded from a capture, where an unresolved $filter/$top/$where is stored evidence rather than a typo — without it such a session is either refused by name or minimized against substituted bytes. Default false")
               s.field "allow_unscoped", boolprop("minimize even when the target host is outside — or without — a configured scope (default false)")
             end
 
@@ -1554,13 +1557,16 @@ module Gori
               s.field "allow_unscoped", boolprop("run even when the target host is outside the project's configured scope — REQUIRED for an out-of-scope target, or when no scope is configured")
             end
 
-            tool j, "discover_status", "Counts + state of a discover job (running|done|stopped|error), " \
-                                       "including the FP/FN figures (calibrated_out / *_suppressed)." do |s|
+            tool j, "discover_status", "Counts + state of a discover job (running|done|budget_exhausted|stopped|error), " \
+                                       "including the FP/FN figures (calibrated_out / *_suppressed). " \
+                                       "budget_exhausted means max_requests halted the run with tasks still queued — a " \
+                                       "partial sweep, NOT an exhaustive one; see incomplete_reason and queued." do |s|
               s.field "job_id", strprop("id from discover_start"), required: true
             end
 
             tool j, "discover_results",
-              "Paged discovered endpoints for a discover job (url, method, status, length, content_type, source, depth, confidence)." do |s|
+              "Paged discovered endpoints for a discover job (url, method, status, length, content_type, source, depth, confidence). " \
+              "has_more is about THIS page; incomplete_reason says whether the RUN covered everything it queued." do |s|
               s.field "job_id", strprop("id from discover_start"), required: true
               s.field "offset", intprop("start row (default 0)")
               s.field "limit", intprop("max rows (default 100, max 1000)")
@@ -1634,7 +1640,7 @@ module Gori
       # bury the outbound ones it exists to surface.
       private def agent_action?(name : String, h) : Bool
         return true if AGENT_ACTION_TOOLS.includes?(name)
-        name == "probe_scan" && (bool(h, "active") || false)
+        name == "probe_scan" && bool_arg(h, "active", false)
       end
 
       # #124 — record a completed agent mutation/send into the store event feed so the AI's
@@ -2143,8 +2149,19 @@ module Gori
         value.clamp(min, max)
       end
 
-      private def bool(h, key : String) : Bool?
-        v = h[key]?
+      # Coerce ONE already-looked-up JSON value to a boolean, or nil when it is neither.
+      #
+      # This deliberately takes the VALUE and not `(h, key)`. The old `(h, key)` form invited
+      # `bool(h, "x") || false`, which collapses "absent" and "unintelligible" into the same
+      # answer — so `probe_scan{active: 1}` ran a PASSIVE scan and reported it as a clean
+      # active one, `create_repeater{auto_content_length: 1}` stored the OPPOSITE of the
+      # absent-default, and `discover_start{spider: 0}` crawled anyway while slipping past the
+      # "at least one technique" guard `spider: false` correctly trips. That shape was fixed
+      # twice on three flags and survived on fifteen others, so the shape itself is gone:
+      # there is no longer any `(h, key)` boolean reader that can silently fall back.
+      # `bool_arg` (absent → a stated default) and `optional_bool_arg` (absent → nil) are the
+      # only two, and both NAME the argument when the value is unintelligible.
+      private def bool_value(v : JSON::Any?) : Bool?
         return nil unless v
         return v.as_bool? unless v.as_bool?.nil?
         # Clients/LLMs often serialize tool args as strings (the schema's "boolean" is
@@ -2157,12 +2174,24 @@ module Gori
         end
       end
 
+      # The boolean argument, or `default` when the caller did not pass it. Raises on a value
+      # that is neither a JSON boolean nor "true"/"false" — a lenient coercion is fine, a
+      # SILENT one is not, and the alternative is running a different test than the one asked
+      # for. Mirrors `bounded_int_arg`'s contract for integers.
       private def bool_arg(h, key : String, default : Bool) : Bool
-        value = bool(h, key)
+        value = optional_bool_arg(h, key)
+        value.nil? ? default : value
+      end
+
+      # The boolean argument as a THREE-state answer: true / false / nil for absent, for the
+      # tools where "not passed" is a distinct outcome (keep the stored value, refuse as a
+      # missing required arg, inherit from the seed flow). Unintelligible still raises.
+      private def optional_bool_arg(h, key : String) : Bool?
+        value = bool_value(h[key]?)
         if present?(h, key) && value.nil?
           raise Gori::Error.new("invalid '#{key}' (expected true or false)")
         end
-        value.nil? ? default : value
+        value
       end
 
       private def clamp(n : Int64?, default : Int32, max : Int32) : Int32

--- a/src/gori/mcp/tools/context.cr
+++ b/src/gori/mcp/tools/context.cr
@@ -118,12 +118,8 @@ module Gori
         ui = parse_ui_state
         repeater_id = int(h, "id")
         return Result.new(id_error(h, "id"), is_error: true) if repeater_id.nil? && present?(h, "id")
-        include_content = bool(h, "include_content")
-        if include_content.nil? && present?(h, "include_content")
-          return Result.new("invalid 'include_content' (expected true or false)", is_error: true)
-        end
-        include_content = include_content || false
-        include_sensitive = bool(h, "include_sensitive") || false
+        include_content = bool_arg(h, "include_content", false)
+        include_sensitive = bool_arg(h, "include_sensitive", false)
         req_lim = int(h, "limit")
         req_off = int(h, "offset")
         limit = clamp(req_lim, 50, 500)

--- a/src/gori/mcp/tools/decode.cr
+++ b/src/gori/mcp/tools/decode.cr
@@ -20,7 +20,7 @@ module Gori
         return Result.new("missing required 'input'", is_error: true) if raw.nil?
 
         input =
-          if bool(h, "input_base64")
+          if bool_arg(h, "input_base64", false)
             begin
               Base64.decode(raw)
             rescue

--- a/src/gori/mcp/tools/discover.cr
+++ b/src/gori/mcp/tools/discover.cr
@@ -42,7 +42,7 @@ module Gori
       # builder's. Raises FuzzArgError (clean message) on any malformed input.
       private def build_discover_plan(h, ob : Outbound) : Discover::Plan
         options = Discover::PlanOptions.new(str(h, "url") || "", config: discover_config(h),
-          verify: @verify_upstream && !bool_arg(h, "insecure", false),
+          verify: !bool_arg(h, "insecure", false) && @verify_upstream,
           overrides: HostOverrides.load(store))
         Discover::Plan.build(options, ob)
       rescue ex : Discover::PlanError
@@ -53,10 +53,6 @@ module Gori
       # able to ask for an unbounded crawl). `user_wordlist` lives on the Config like every
       # other knob — the builder reads it from there on all three surfaces.
       private def discover_config(h) : Discover::Config
-        spider = bool(h, "spider")
-        bruteforce = bool(h, "bruteforce")
-        spider = true if spider.nil?
-        bruteforce = true if bruteforce.nil?
         cap = int(h, "max_requests")
         Discover::Config.new(
           concurrency: clamp(int(h, "concurrency"), 20, DISCOVER_MAX_CONCURRENCY),
@@ -68,7 +64,11 @@ module Gori
           retries: (int(h, "retries") || 1_i64).clamp(0_i64, 1000_i64).to_i,
           max_requests: cap ? {cap, DISCOVER_MAX_REQUESTS}.min : DISCOVER_MAX_REQUESTS,
           keep_alive: bool_arg(h, "keep_alive", true),
-          spider: spider, bruteforce: bruteforce,
+          # Both default ON, and both must be readable as a NAMED refusal when the value is
+          # unintelligible: `spider: 0` used to come back as nil → `true`, so the crawl ran
+          # after the caller asked for it off AND slipped past the "at least one technique"
+          # guard that `spider: false` correctly trips.
+          spider: bool_arg(h, "spider", true), bruteforce: bool_arg(h, "bruteforce", true),
           max_depth: clamp(int(h, "max_depth"), 4, DISCOVER_MAX_DEPTH),
           user_wordlist: str(h, "wordlist").presence,
           extensions: discover_extensions(h), containment: discover_containment(h),
@@ -148,8 +148,18 @@ module Gori
           djob.sent = p.sent; djob.found = p.found; djob.errors = p.errors; djob.queued = p.queued
         when Discover::DoneEvent
           djob.sent = ev.progress.sent; djob.found = ev.progress.found; djob.errors = ev.progress.errors
+          # Read the FINAL queue depth off the Done event rather than leaving whatever the
+          # last ProgressEvent happened to carry — it is the number the status below reports.
+          djob.queued = ev.progress.queued
           djob.stats = ev.stats
-          djob.status = ev.stopped ? :stopped : :done
+          # Discover has no fixed candidate total (a live crawl's denominator moves), so the
+          # shortfall is read the other way round: tasks still QUEUED when the run ended mean
+          # max_requests halted it, exactly the :budget_exhausted fuzz and mine derive from
+          # `done_count < total`. Without this a budget-capped sweep that never sent 275 of
+          # 283 tasks reported `status:"done", job_complete:true, has_more:false` — an agent
+          # reads that as an exhaustive directory sweep and stops looking.
+          djob.status = terminal_status(djob.status, ev.stopped, 0_i64,
+            djob.queued > 0 ? djob.queued.to_i64 : nil)
           djob.ended_at_ms = Time.utc.to_unix_ms
         when Discover::ErrorEvent
           djob.status = :error
@@ -188,6 +198,9 @@ module Gori
             j.field "errors", djob.errors
             j.field "queued", djob.queued
             j.field "job_complete", djob.status != :running
+            # Parity with fuzz_status/mine_status: `job_complete` says the job ENDED, this
+            # says whether it ended having covered everything it queued.
+            j.field "incomplete_reason", incomplete_reason(djob.status)
             j.field "results_truncated", djob.truncated?
             j.field "error", djob.error_msg
             if s
@@ -216,7 +229,11 @@ module Gori
             j.field "offset", offset
             j.field "total_available", djob.results.size
             j.field "job_complete", djob.status != :running
+            # `has_more` is about this PAGE. A budget-capped run has no more stored findings
+            # and still is not an exhaustive answer — that is what incomplete_reason says.
             j.field "has_more", offset + page.size < djob.results.size
+            j.field "incomplete_reason", incomplete_reason(djob.status)
+            j.field "queued", djob.queued
             j.field "results_truncated", djob.truncated?
           end
         end)

--- a/src/gori/mcp/tools/flows.cr
+++ b/src/gori/mcp/tools/flows.cr
@@ -67,7 +67,7 @@ module Gori
         # A WebSocket flow (101) carries a separate message log; fetch it so get_flow
         # surfaces the frames (parity with `gori run show`). Non-WS flows skip the query.
         ws_msgs = detail.row.status == 101 ? store.ws_messages(id) : [] of Store::WsMessage
-        include_sensitive = bool(h, "include_sensitive") || false
+        include_sensitive = bool_arg(h, "include_sensitive", false)
         cap, omit = body_return_opts(h)
         Result.new(Serialize.flow_detail_json(detail, ws_msgs, include_sensitive, cap, omit))
       end
@@ -187,7 +187,7 @@ module Gori
       # mis-issued call cannot silently empty a capture session.
       private def clear_history(h) : Result
         n = store.count
-        unless bool(h, "confirm")
+        unless bool_arg(h, "confirm", false)
           return err("refusing to delete #{n} flow#{n == 1 ? "" : "s"} without confirm:true — this cannot be undone",
             "CONFIRM_REQUIRED", field: "confirm",
             details: JSON.parse({"flows" => n}.to_json))

--- a/src/gori/mcp/tools/fuzz.cr
+++ b/src/gori/mcp/tools/fuzz.cr
@@ -234,17 +234,17 @@ module Gori
       # tool args. Raises FuzzArgError (clean message) on any malformed input.
       private def build_fuzz_job(h, ob : Outbound) : {Fuzz::Engine, Fuzz::Origin, Int64?, Bool}
         text, default_target, src_h2 = fuzz_template_source(h)
-        use_h2 = (bool(h, "http2") || false) || src_h2
+        use_h2 = bool_arg(h, "http2", false) || src_h2
         mode = fuzz_mode(h)
         options = Fuzz::PlanOptions.new(text,
           default_target: default_target, target: str(h, "url"),
-          auto_mark: bool(h, "auto") || false, marks: fuzz_marks(h), http2: use_h2,
+          auto_mark: bool_arg(h, "auto", false), marks: fuzz_marks(h), http2: use_h2,
           sources: fuzz_sources(h), processors: fuzz_processors(h),
           config: fuzz_config(h, mode), matcher: fuzz_matcher(h),
           # Defense-in-depth alongside the job-start Layer-1 check: that check only covers
           # the origin once, not a path a template mutates per-request. The Outbound re-reads
           # the scope periodically, so a mid-run EXCLUDE / Sandbox toggle stops the sweep.
-          verify: @verify_upstream && !bool_arg(h, "insecure", false),
+          verify: !bool_arg(h, "insecure", false) && @verify_upstream,
           # SNI independent of the Host header is the vhost-confusion / domain-fronting test.
           # `Fuzz::PlanOptions` and the CLI have always carried it; MCP's only route to it was
           # create_repeater{sni} → send_request{repeater_id}, i.e. not a sweep at all.

--- a/src/gori/mcp/tools/intercept.cr
+++ b/src/gori/mcp/tools/intercept.cr
@@ -149,7 +149,7 @@ module Gori
       end
 
       private def intercept_toggle(h) : Result
-        want = bool(h, "enable")
+        want = optional_bool_arg(h, "enable")
         return err("missing required 'enable' (true or false)", "INVALID_ARGUMENT", field: "enable") if want.nil?
         enqueue_intercept("toggle", arg: want ? "true" : "false")
       end

--- a/src/gori/mcp/tools/jobs.cr
+++ b/src/gori/mcp/tools/jobs.cr
@@ -102,7 +102,7 @@ module Gori
           return mismatch
         end
         job.stop
-        wait = bool(h, "wait") || false
+        wait = bool_arg(h, "wait", false)
         waited_out = false
         if wait
           budget = int(h, "wait_timeout_ms").try(&.clamp(1_i64, 60_000_i64)) || 10_000_i64

--- a/src/gori/mcp/tools/mine.cr
+++ b/src/gori/mcp/tools/mine.cr
@@ -163,12 +163,12 @@ module Gori
         int(h, "throttle_ms").try { |v| config.throttle_ms = v.clamp(0_i64, 600_000_i64).to_i }
         options = Miner::PlanOptions.new(text,
           default_target: default_target, target: str(h, "url"),
-          http2: (bool(h, "http2") || false) || src_h2,
+          http2: bool_arg(h, "http2", false) || src_h2,
           locations: mine_locations(h), bucket: mine_bucket(h), config: config,
           # Defense-in-depth alongside the job-start Layer-1 check: that check only covers the
           # origin once, not a path mining mutates per-request. The Outbound re-reads the scope
           # periodically, so a mid-run EXCLUDE / Sandbox toggle stops the sweep.
-          verify: @verify_upstream && !bool_arg(h, "insecure", false),
+          verify: !bool_arg(h, "insecure", false) && @verify_upstream,
           # SNI independent of the Host header is the vhost-confusion / domain-fronting test.
           # `Miner::PlanOptions` and `gori run mine --sni` have always carried it; MCP had no
           # route to it at all, so a param-mine against a vhost whose SNI must differ from the

--- a/src/gori/mcp/tools/minimize.cr
+++ b/src/gori/mcp/tools/minimize.cr
@@ -31,15 +31,35 @@ module Gori
 
         text = String.new(rec.request)
         ob = outbound(bool_arg(h, "allow_unscoped", false))
-        target = minimize_target(id, rec, text, ob)
+        # `send_repeater --verbatim` exists because a session can hold EVIDENCE (seeded from a
+        # capture). Minimize is a search over that same request, so it needs the same knob:
+        # without it the one flag that makes such a session sendable made it un-minimizable —
+        # a captured `$top` was refused outright, and a captured `$where` was minimized against
+        # substituted bytes with a reframed Content-Length, i.e. against a request that a later
+        # `--verbatim` send would never put on the wire.
+        verbatim = bool_arg(h, "verbatim", false)
+        # Read BEFORE the search, not after: `apply` used to be parsed once the sends were
+        # already spent, so an unintelligible value would refuse a run that had put up to 250
+        # real requests on the wire.
+        apply = bool_arg(h, "apply", false)
+        target = minimize_target(id, rec, text, ob, verbatim)
         return target if target.is_a?(Result)
         scheme, host, port = target
 
-        auto_cl = rec.auto_content_length?
-        # Mirrors the TUI/CLI resolve: env-expand, then Content-Length resync only when the
-        # session has Auto-CL on (the same gate that lets body params be removed at all).
+        # The SEARCH's Auto-CL, not the session's — `send_repeater --verbatim` reads
+        # `auto_content_length: !verbatim && rec.auto_content_length?`, and this has to agree
+        # with it or the minimized request is not the request a verbatim send would produce.
+        # Under verbatim a body param stops being a removal candidate, which is the honest
+        # consequence: removing one requires reframing Content-Length, and verbatim is the
+        # operator saying do not reframe. The session's own stored setting is untouched (the
+        # apply-back below still writes `rec.auto_content_length?`).
+        auto_cl = !verbatim && rec.auto_content_length?
+        # Mirrors the TUI/CLI resolve: env-expand, then Content-Length resync only when
+        # Auto-CL is on (the same gate that lets body params be removed at all). `verbatim`
+        # drops the whole draft pass — no `$VAR` substitution and no bare-LF→CRLF promotion —
+        # exactly as `--verbatim`/`expand_request: false` does on the send path.
         resolve = ->(t : String) do
-          raw = Env.expand_wire(t)
+          raw = verbatim ? t.to_slice : Env.expand_wire(t)
           auto_cl ? Repeater::FlowRequest.resync_content_length(raw) : raw
         end
         # Minimize dials Fuzz::Sender directly (many capped probe sends) rather than through
@@ -55,10 +75,10 @@ module Gori
         report = Repeater::Minimize.run(text, auto_cl: auto_cl, resolve: resolve, backend: backend) { }
 
         applied = false
-        if (bool(h, "apply") || false) && !report.aborted && !report.removed.empty?
+        if apply && !report.aborted && !report.removed.empty?
           applied = store.update_repeater(id: id, target: rec.target,
             request: report.minimized_text.to_slice, http2: rec.http2?,
-            auto_cl: auto_cl, sni: rec.sni)
+            auto_cl: rec.auto_content_length?, sni: rec.sni)
         end
 
         Result.new(JSON.build do |j|
@@ -84,7 +104,7 @@ module Gori
       # The validated {scheme, host, port} to minimize against, or a refusal Result. Split out
       # of minimize_repeater to keep it under the cyclomatic-complexity bar.
       private def minimize_target(id : Int64, rec : Store::RepeaterRecord, text : String,
-                                  ob : Outbound) : {String, String, Int32} | Result
+                                  ob : Outbound, verbatim : Bool = false) : {String, String, Int32} | Result
         if Repeater::WsEngine.upgrade_request?(text)
           return err("repeater #{id} is a WebSocket upgrade — minimize works on plain HTTP requests",
             "INVALID_ARGUMENT", field: "repeater_id")
@@ -107,7 +127,12 @@ module Gori
         # body is a byte, and a whole-request check refuses nearly every binary-body session —
         # but whole-string on the target and SNI, which are short operator-typed fields with no
         # body to exclude. The CLI and TUI minimize paths carry the same three checks.
-        names = Env.unresolved_wire(text) | Env.unresolved(rec.target) |
+        #
+        # `verbatim` drops the REQUEST half of that check, on the provenance axis: those bytes
+        # are evidence the operator did not author (a captured `$filter`/`$top`/`$where`), and
+        # nothing will expand them, so there is no unresolved token to refuse. The target and
+        # SNI checks stay — those ARE operator-typed and they ARE still expanded below.
+        names = (verbatim ? [] of String : Env.unresolved_wire(text)) | Env.unresolved(rec.target) |
                 (rec.sni.try { |s| Env.unresolved(s) } || [] of String)
         unless names.empty?
           return err(env_unresolved_error(Env.token_list(names)), "INVALID_ARGUMENT", field: "repeater_id")

--- a/src/gori/mcp/tools/oast_providers.cr
+++ b/src/gori/mcp/tools/oast_providers.cr
@@ -13,6 +13,7 @@ module Gori
       # inline every time — including the token, on every call.
       private def list_oast_providers(h) : Result
         configs = Oast.provider_configs(store)
+        include_sensitive = bool_arg(h, "include_sensitive", false)
         Result.new(JSON.build do |j|
           j.object do
             j.field("providers") do
@@ -26,8 +27,8 @@ module Gori
                     j.field "scope", c.scope
                     j.field "enabled", c.enabled
                     # A provider token is an auth credential — same treatment as list_env.
-                    j.field "token", c.token.nil? ? nil : "[REDACTED]" unless bool(h, "include_sensitive")
-                    j.field "token", c.token if bool(h, "include_sensitive")
+                    j.field "token", c.token.nil? ? nil : "[REDACTED]" unless include_sensitive
+                    j.field "token", c.token if include_sensitive
                   end
                 end
               end
@@ -72,8 +73,7 @@ module Gori
                 else
                   existing.token
                 end
-        enabled = bool(h, "enabled")
-        enabled = existing.enabled? if enabled.nil?
+        enabled = bool_arg(h, "enabled", existing.enabled?)
 
         return busy("provider NOT updated (store busy or unwritable); it is unchanged") unless store.update_oast_provider(row, name, kind.label, host, token, enabled)
         Result.new({"id" => "p_#{row}", "name" => name, "kind" => kind.label}.to_json)
@@ -82,7 +82,7 @@ module Gori
       private def set_oast_provider_enabled(h) : Result
         row = oast_provider_row(h)
         return row if row.is_a?(Result)
-        enabled = bool(h, "enabled")
+        enabled = optional_bool_arg(h, "enabled")
         return err("missing required 'enabled'", "INVALID_ARGUMENT", field: "enabled") if enabled.nil?
         return busy("enable/disable NOT applied (store busy or unwritable); the provider is unchanged") unless store.set_oast_provider_enabled(row, enabled)
         Result.new({"id" => "p_#{row}", "enabled" => enabled}.to_json)
@@ -123,8 +123,7 @@ module Gori
         host = str(h, "host").try(&.strip).presence ||
                Oast::Presets.all.find { |p| p.kind == kind }.try(&.host)
         return err("'host' is required for #{kind.label} (it has no default preset)", "INVALID_ARGUMENT", field: "host") unless host
-        enabled = bool(h, "enabled")
-        {name, kind.label, host, str(h, "token").try(&.strip).presence, enabled.nil? ? true : enabled}
+        {name, kind.label, host, str(h, "token").try(&.strip).presence, bool_arg(h, "enabled", true)}
       end
     end
   end

--- a/src/gori/mcp/tools/probe.cr
+++ b/src/gori/mcp/tools/probe.cr
@@ -26,11 +26,11 @@ module Gori
         category = probe_scan_category(h)
         return category if category.is_a?(Result)
 
-        active = bool(h, "active") || false
+        active = bool_arg(h, "active", false)
         allow_unscoped = bool_arg(h, "allow_unscoped", false)
         # --aggressive implies unsafe (it also raises caps + widens bypass sets).
-        aggressive = bool(h, "aggressive") || false
-        unsafe = (bool(h, "unsafe") || false) || aggressive
+        aggressive = bool_arg(h, "aggressive", false)
+        unsafe = bool_arg(h, "unsafe", false) || aggressive
         gate = probe_active_gate(active, allow_unscoped)
         return gate if gate.is_a?(Result)
         scope, scope_configured = gate
@@ -49,7 +49,7 @@ module Gori
         # `insecure` is the ACTIVE path's `gori run probe -k`: a lab / staging origin with a
         # self-signed certificate is the ordinary case for a scan, and without this the active
         # checks simply failed there with a TLS error that named nothing actionable.
-        verify_upstream = @verify_upstream && !bool_arg(h, "insecure", false)
+        verify_upstream = !bool_arg(h, "insecure", false) && @verify_upstream
         dets, repeater_n = Probe::Scan.scan_all(store, ids, active: active, verify_upstream: verify_upstream,
           scope: scope, allow_unscoped: allow_unscoped, opts: opts, active_budget: budget,
           on_error: ->(_where : String, _ex : Exception) { scan_errors += 1; nil })
@@ -75,7 +75,7 @@ module Gori
         category = probe_scan_category(h)
         return category if category.is_a?(Result)
 
-        include_closed = bool(h, "include_closed") || false
+        include_closed = bool_arg(h, "include_closed", false)
         all = store.probe_issues(category.as(String?), str(h, "host").try(&.strip).presence,
           severity_from(str(h, "severity")))
         all = all.select(&.status.open?) unless include_closed
@@ -162,7 +162,7 @@ module Gori
       private def probe_delete(h) : Result
         id = int(h, "id")
         return Result.new(id_error(h, "id"), is_error: true) if id.nil? && present?(h, "id")
-        all = bool(h, "all") || false
+        all = bool_arg(h, "all", false)
         # Reject the ambiguous combination rather than silently letting `all` win — an agent
         # that sets `all` defensively alongside a specific `id` would lose the whole table.
         # (The CLI refuses the same input.)
@@ -172,7 +172,7 @@ module Gori
         end
         if all
           n = store.count_probe_issues
-          unless bool(h, "confirm")
+          unless bool_arg(h, "confirm", false)
             return err("refusing to delete #{n} finding#{n == 1 ? "" : "s"} without confirm:true — this also clears every hard-delete suppression, so a rescan re-discovers them",
               "CONFIRM_REQUIRED", field: "confirm", details: JSON.parse({"findings" => n}.to_json))
           end
@@ -213,7 +213,7 @@ module Gori
       private def set_probe_rule_enabled(h) : Result
         id = str(h, "id").try(&.strip).presence
         return err("missing required 'id' (see list_probe_rules)", "INVALID_ARGUMENT", field: "id") unless id
-        enabled = bool(h, "enabled")
+        enabled = optional_bool_arg(h, "enabled")
         return err("missing required 'enabled'", "INVALID_ARGUMENT", field: "enabled") if enabled.nil?
 
         entry = Probe::RuleCatalog.load(store).find { |e| e.id == id }

--- a/src/gori/mcp/tools/ql.cr
+++ b/src/gori/mcp/tools/ql.cr
@@ -15,7 +15,7 @@ module Gori
         return ql_error(query) if QL.reject_empty?(query, filter)
         bad = QL.invalid_regex_terms(query)
         return ql_invalid_regex_error(query, bad) unless bad.empty?
-        if bool(h, "strict") || false
+        if bool_arg(h, "strict", false)
           analysis = QL.analyze(query)
           return ql_strict_error(analysis) unless analysis.clean?
         end

--- a/src/gori/mcp/tools/repeater.cr
+++ b/src/gori/mcp/tools/repeater.cr
@@ -28,11 +28,18 @@ module Gori
           end
         end
 
-        http2_val = bool(h, "http2")
+        # Three-state on purpose: `http2` absent means "inherit from the seed flow" (below),
+        # which is not the same as `http2:false`. `auto_content_length` has no seed to inherit
+        # from, so it is a plain default-on flag.
+        http2_val = optional_bool_arg(h, "http2")
         http2 = http2_val || false
-        auto_cl_val = bool(h, "auto_content_length")
-        auto_cl = (auto_cl_val.nil? && !present?(h, "auto_content_length")) ? true : !!auto_cl_val
+        auto_cl = bool_arg(h, "auto_content_length", true)
+        # Read here rather than at its one use below, so an unintelligible value is refused on
+        # EVERY call and not only on the flow-seeded ones — an argument that is validated in
+        # one branch and ignored in another is the same silent-substitution trap one level up.
+        keep_request_line = bool_arg(h, "keep_request_line", false)
         ws_messages_override = nil.as(Array(Store::WsOutMessage)?)
+        rewrote_request_line = false
 
         if flow_id
           flow = store.get_flow(flow_id)
@@ -52,10 +59,23 @@ module Gori
           #     verbatim to an origin that expects origin-form.
           #   * `build_target` — this was a third hand-rolled copy of the authority formula,
           #     without the ws/wss default-port fold or IPv6 re-bracketing the shared one has.
-          built = Repeater::FlowRequest.build(flow)
+          #
+          # `origin_form_bytes` is also the one of the three that is not always housekeeping:
+          # on a flow gori recorded from a DIRECT send the absolute-form line is the routing /
+          # cache-poisoning / SSRF payload, and baking the rewrite in here made the loss
+          # PERMANENT — the stored session no longer holds the line, so not even
+          # `send_repeater --verbatim` can recover it. `keep_request_line` turns it off and
+          # `request_line_rewritten` reports it when it fires, matching
+          # `gori run repeater --keep-request-line` and `send_request`.
+          built = Repeater::FlowRequest.build(flow, rewrite_absolute_form: !keep_request_line)
 
           target = built.target if target.nil? || target.empty?
-          request = String.new(built.bytes) if request.nil? || request.empty?
+          if request.nil? || request.empty?
+            request = String.new(built.bytes)
+            # Only when the SEEDED bytes are the ones being stored: an explicit `request`
+            # argument was never rewritten.
+            rewrote_request_line = built.rewrote_request_line
+          end
           http2 = built.http2 if http2_val.nil?
           # `built.sni` is deliberately NOT seeded here: `gori run repeater create --flow`
           # takes SNI from the operator's flag alone, and this tool is its MCP twin.
@@ -109,7 +129,7 @@ module Gori
           flow_id: flow_id,
           position: position.to_i32,
           sni: masked_sni,
-          ws_keep_key: bool(h, "ws_keep_key") || false
+          ws_keep_key: bool_arg(h, "ws_keep_key", false)
         )
 
         return busy("failed to persist repeater (store busy or unwritable)") if id == 0
@@ -144,6 +164,10 @@ module Gori
             j.field "target", masked_target
             j.field "summary", summary
             j.field "position", position
+            # Only when it FIRED, and it is worth more here than on `send_request`: the stored
+            # session no longer carries the absolute-form line, so this is the only record
+            # that it was ever there.
+            j.field "request_line_rewritten", true if rewrote_request_line
             # How many frames were actually stored, so an agent authoring a multi-frame
             # sequence can assert on it rather than take the count on trust.
             j.field "ws_out_message_count", ws_count if ws_count
@@ -298,20 +322,11 @@ module Gori
         return Result.new("target must not be empty", is_error: true) if target.empty?
         return Result.new("request must not be empty", is_error: true) if request.empty?
 
-        http2 = if present?(h, "http2")
-                  bool(h, "http2") || false
-                else
-                  existing.http2?
-                end
-
-        auto_cl = if present?(h, "auto_content_length")
-                    bool(h, "auto_content_length") || false
-                  else
-                    existing.auto_content_length?
-                  end
+        http2 = bool_arg(h, "http2", existing.http2?)
+        auto_cl = bool_arg(h, "auto_content_length", existing.auto_content_length?)
 
         sni = present?(h, "sni") ? str(h, "sni") : existing.sni
-        ws_keep_key = present?(h, "ws_keep_key") ? (bool(h, "ws_keep_key") || false) : existing.ws_keep_key?
+        ws_keep_key = bool_arg(h, "ws_keep_key", existing.ws_keep_key?)
 
         masked_target = Env.mask_secrets(target)
         masked_request = Env.mask_secrets(request)

--- a/src/gori/mcp/tools/rules.cr
+++ b/src/gori/mcp/tools/rules.cr
@@ -256,7 +256,7 @@ module Gori
       private def set_rule_enabled(h) : Result
         id = int(h, "id")
         return Result.new(id_error(h, "id"), is_error: true) unless id
-        enabled = bool(h, "enabled")
+        enabled = optional_bool_arg(h, "enabled")
         return Result.new("missing required 'enabled' (true|false)", is_error: true) if enabled.nil?
         return not_found("no rule with id #{id}") unless rule_exists?(id)
         return busy("enable/disable NOT applied (store busy or unwritable); the rule is unchanged and may still be rewriting live traffic") unless store.set_rule_enabled(id, enabled)
@@ -455,7 +455,7 @@ module Gori
       private def set_extract_rule_enabled(h) : Result
         id = int(h, "id")
         return Result.new(id_error(h, "id"), is_error: true) unless id
-        enabled = bool(h, "enabled")
+        enabled = optional_bool_arg(h, "enabled")
         return Result.new("missing required 'enabled' (true|false)", is_error: true) if enabled.nil?
         return not_found("no extract rule with id #{id}") unless store.extract_rules.any?(&.id.==(id))
         return busy("enable/disable NOT applied (store busy or unwritable); the extract rule is unchanged") unless store.set_extract_rule_enabled(id, enabled)

--- a/src/gori/mcp/tools/scope.cr
+++ b/src/gori/mcp/tools/scope.cr
@@ -98,7 +98,7 @@ module Gori
       end
 
       private def set_scope_enabled(h) : Result
-        enabled = bool(h, "enabled")
+        enabled = optional_bool_arg(h, "enabled")
         return err("missing required 'enabled' (true or false)", "INVALID_ARGUMENT", field: "enabled") if enabled.nil?
         scope = Scope.load(store)
         committed = enabled ? scope.enable : scope.disable
@@ -112,7 +112,7 @@ module Gori
       # scope does not allow — with no include rule it blocks ALL captured traffic
       # (reported as blocks_all).
       private def set_sandbox(h) : Result
-        enabled = bool(h, "enabled")
+        enabled = optional_bool_arg(h, "enabled")
         return err("missing required 'enabled' (true or false)", "INVALID_ARGUMENT", field: "enabled") if enabled.nil?
         scope = Scope.load(store)
         # Scope's sandbox setters persist through the SAME settings write the TUI uses but

--- a/src/gori/mcp/tools/send.cr
+++ b/src/gori/mcp/tools/send.cr
@@ -31,8 +31,9 @@ module Gori
         # builder must never pick it, or MCP's strict "no scope ⇒ refuse" default would
         # silently become whichever policy got hard-coded there (DESIGN.md §7).
         ob = outbound(bool_arg(h, "allow_unscoped", false))
-        plan = build_send_plan(h, ob)
-        return plan if plan.is_a?(Result)
+        built_plan = build_send_plan(h, ob)
+        return built_plan if built_plan.is_a?(Result)
+        plan, request_line_rewritten = built_plan
         # OPT-IN Match&Replace parity (before the scope gate + History write so the
         # recorded/effective request == the wire); byte-exact by default.
         plan, applied_rules = maybe_apply_request_rules(h, plan)
@@ -63,7 +64,8 @@ module Gori
 
         body_cap, body_omit = body_return_opts(h)
         Result.new(send_result_json(result, recorded_flow_id, repeater_id,
-          include_sensitive_headers, sc, built, wire, http2, flow_precedence_ignored(h), body_cap, body_omit, applied_rules, plan.h2_fields),
+          include_sensitive_headers, sc, built, wire, http2, flow_precedence_ignored(h), body_cap, body_omit, applied_rules, plan.h2_fields,
+          request_line_rewritten),
           is_error: !result.ok?)
       rescue ex : Gori::Error
         # Bad input (missing/invalid url, illegal header, …) — return a clean
@@ -444,12 +446,17 @@ module Gori
                                    http2 : Bool,
                                    ignored : Array(String), body_cap : Int32, body_omit : Bool,
                                    applied_rules : Bool = false,
-                                   h2_fields : Array({String, String})? = nil) : String
+                                   h2_fields : Array({String, String})? = nil,
+                                   request_line_rewritten : Bool = false) : String
         JSON.build do |j|
           j.object do
             emit_scope(j, sc)
             emit_effective_request(j, built, wire, http2, h2_fields)
             emit_sent_h2_fields(j, h2_fields)
+            # Only when it FIRED: gori changed the operator's stored bytes, so the surface
+            # that reports the send has to say so (`effective_request.target` then shows the
+            # origin-form line that actually went out). Absent means nothing was rewritten.
+            j.field "request_line_rewritten", true if request_line_rewritten
             j.field "match_replace_applied", true if applied_rules
             unless ignored.empty?
               j.field("ignored_fields") { j.array { ignored.each { |f| j.string f } } }
@@ -574,7 +581,11 @@ module Gori
 
         # Scope gate before the outbound handshake (same policy as send_request).
         ob = outbound(bool_arg(h, "allow_unscoped", false))
-        verify = @verify_upstream && !bool_arg(h, "insecure", false)
+        verify = !bool_arg(h, "insecure", false) && @verify_upstream
+        # The session's stored setting, overridable per call — a handshake test wants to run
+        # it both ways against the same session without editing the session. Read up here with
+        # the other flags so an unintelligible value refuses before the issue link is written.
+        keep_key = bool_arg(h, "keep_sec_websocket_key", repeater.ws_keep_key?)
         plan = begin
           Repeater::Plan.build(Repeater::PlanOptions.new([repeater.request],
             default_target: repeater.target, sni: repeater.sni, verify: verify,
@@ -597,9 +608,6 @@ module Gori
           store.add_link(Store::LinkOwnerKind::Issue, issue_id,
             Store::LinkRefKind::Repeater, repeater_id)
         end
-        # The session's stored setting, overridable per call — a handshake test wants to run
-        # it both ways against the same session without editing the session.
-        keep_key = present?(h, "keep_sec_websocket_key") ? (bool(h, "keep_sec_websocket_key") || false) : repeater.ws_keep_key?
         result = plan.send_ws(out_messages, idle, keep_key)
 
         store.update_repeater_response(repeater_id, result.handshake_head, Bytes.empty,
@@ -691,9 +699,9 @@ module Gori
       # `Repeater::Plan` owns the assembly (env expansion, the Content-Length policy, target
       # parsing, SNI, host overrides, the gated dialer); everything left here is MCP's own
       # argument parsing.
-      private def build_send_plan(h, ob : Outbound) : Repeater::Plan | Result
-        opts = present?(h, "h2_fields") ? field_native_plan_options(h) : send_plan_options(h)
-        Repeater::Plan.build(opts, ob)
+      private def build_send_plan(h, ob : Outbound) : {Repeater::Plan, Bool} | Result
+        opts, rewrote = present?(h, "h2_fields") ? {field_native_plan_options(h), false} : send_plan_options(h)
+        {Repeater::Plan.build(opts, ob), rewrote}
       rescue ex : Repeater::PlanError
         send_plan_error(ex, "url")
       end
@@ -768,16 +776,22 @@ module Gori
         Repeater::PlanOptions.new(
           h2_fields: fields, h2_body: h2_body_arg(h),
           origin: Repeater::Origin.new(scheme, host, port),
-          http2: true, verify: @verify_upstream && !bool_arg(h, "insecure", false),
+          http2: true, verify: !bool_arg(h, "insecure", false) && @verify_upstream,
           timeout: send_timeout(h), overrides: HostOverrides.load(store))
       end
 
-      private def send_plan_options(h) : Repeater::PlanOptions
+      # The option set plus "did gori rewrite the stored request line?" — the second half is
+      # not derivable from `PlanOptions`, and `send_request` has to report it (see the
+      # `flow_id` branch below).
+      private def send_plan_options(h) : {Repeater::PlanOptions, Bool}
         if present?(h, "flow_id") && present?(h, "repeater_id")
           raise Gori::Error.new("pass only one of flow_id or repeater_id")
         end
-        verify = @verify_upstream && !bool_arg(h, "insecure", false)
+        verify = !bool_arg(h, "insecure", false) && @verify_upstream
         timeout = send_timeout(h)
+        # Read up front, not inside the `flow_id` branch that uses it: an argument validated in
+        # one branch and ignored in another is the same silent-substitution trap one level up.
+        keep_request_line = bool_arg(h, "keep_request_line", false)
         # Honor the project's host overrides on the direct-dial path (parity with the live
         # proxy). nil/empty is behaviorally identical to no override.
         overrides = HostOverrides.load(store)
@@ -792,17 +806,25 @@ module Gori
           end
           # Respect the repeater's auto-Content-Length setting (the TUI Repeater does):
           # only recompute CL when it's on, so a deliberately hand-set CL is preserved.
-          return Repeater::PlanOptions.new([rec.request], default_target: rec.target,
+          return {Repeater::PlanOptions.new([rec.request], default_target: rec.target,
             http2: bool_arg(h, "http2", rec.http2?), sni: rec.sni,
             auto_content_length: rec.auto_content_length?, verify: verify,
-            timeout: timeout, overrides: overrides)
+            timeout: timeout, overrides: overrides), false}
         end
         if present?(h, "flow_id")
           id = int(h, "flow_id")
           raise Gori::Error.new(id_error(h, "flow_id")) unless id
           detail = store.get_flow(id)
           raise Gori::Error.new("no flow with id #{id}") unless detail
-          flow = Repeater::FlowRequest.build(detail)
+          # A stored ABSOLUTE-form request line is a proxy artifact on a proxy capture and the
+          # PAYLOAD on a flow gori recorded from a direct send — routing / cache-poisoning /
+          # SSRF probes are written that way, and MCP's own `send_request{raw, verbatim}` can
+          # produce one. So the rewrite stays the default (every plaintext-HTTP capture needs
+          # it), but it is now REPORTED (`request_line_rewritten`) and `keep_request_line`
+          # turns it off — the same pair `gori run repeater --keep-request-line` has. Without
+          # it an agent had no route to the probe at all: the rewrite was silent and there was
+          # no argument to prevent it.
+          flow = Repeater::FlowRequest.build(detail, rewrite_absolute_form: !keep_request_line)
           # Default to how the flow was captured, but honor an EXPLICIT http2 either way —
           # `bool_arg` returns `flow.http2` only when the arg is absent, so `http2:false`
           # can now downgrade an h2 capture to h1 (it used to be silently ignored because
@@ -831,11 +853,11 @@ module Gori
           # With expansion off there is no expansion to resync a Content-Length after, so
           # `resync_cl_after_expansion` goes with it: the stored framing ships exactly as
           # captured, which is what a CL/TE desync capture is for.
-          Repeater::PlanOptions.new([flow.bytes], default_target: flow.target,
+          {Repeater::PlanOptions.new([flow.bytes], default_target: flow.target,
             expand_request: false, refuse_unresolved_env: false,
             auto_content_length: false,
             http2: bool_arg(h, "http2", flow.http2), sni: flow.sni, verify: verify,
-            timeout: timeout, overrides: overrides)
+            timeout: timeout, overrides: overrides), flow.rewrote_request_line}
         else
           # `RequestBuilder` already expanded, framed and range-checked this one, with
           # sharper messages than a re-parse could give — so the origin is handed over
@@ -847,7 +869,7 @@ module Gori
           # Reading `verbatim` again through `bool_arg` here let the builder and this gate
           # disagree about the same call.
           verbatim = RequestBuilder.verbatim?(h)
-          Repeater::PlanOptions.new([built.bytes], expand_request: false,
+          {Repeater::PlanOptions.new([built.bytes], expand_request: false,
             auto_content_length: false,
             # `verbatim:true` means the operator's bytes ARE the message (RequestBuilder
             # already skipped expansion for it), so a leftover `$user.name` / `$IFS` is the
@@ -860,7 +882,7 @@ module Gori
             preserve_field_case: verbatim,
             origin: Repeater::Origin.new(built.scheme, built.host, built.port),
             http2: bool_arg(h, "http2", false), verify: verify,
-            timeout: timeout, overrides: overrides)
+            timeout: timeout, overrides: overrides), false}
         end
       end
 

--- a/src/gori/mcp/tools/send.cr
+++ b/src/gori/mcp/tools/send.cr
@@ -245,6 +245,22 @@ module Gori
       # verdict means gori can PROVE the message malformed; silence is not that.
       NO_RESPONSE_PHRASES = {"no h2 response", "no response"}
 
+      # RFC 9113 §8.1 lets an origin answer while the request body is still going out — a 413
+      # after N bytes is exactly what an upload / body-size probe is looking for. The send has
+      # a REAL response (status, head, body); what it does not have is the whole request. That
+      # is neither a network fault nor gori proving the message malformed:
+      #   * retrying re-sends the entire body to a server that already rejected it, which for a
+      #     body-size probe is the wrong move and, at scale, is the probe becoming the attack;
+      #   * `PROTOCOL_ERROR` would blame someone for behaviour the RFC explicitly permits.
+      # So it gets its own kind and its own non-retryable code.
+      #
+      # Keyed on "truncated at" and NOT on "NOT fully sent", deliberately: the flow-control
+      # stall sentence (`H2Engine.flow_stalled`) ALREADY ends with "The request was NOT fully
+      # sent." and is a genuine stall that must stay `protocol`. The two conditions differ in
+      # whether a response arrived, and only the truncation sentence counts bytes with
+      # "truncated at".
+      TRUNCATED_REQUEST_PHRASE = "truncated at"
+
       # Coarse category for a send's network error, from the engine's error text
       # (gori's own controlled strings). "connect" (the dialer collapses DNS /
       # refused / connect-timeout / TLS-verify into one failure — finer split would
@@ -268,18 +284,39 @@ module Gori
         return "other" if RETRYABLE_H2_PHRASES.any? { |p| m.includes?(p) }
         return "no_response" if NO_RESPONSE_PHRASES.any? { |p| m.includes?(p) }
         return "protocol" if PROTOCOL_ERROR_PHRASES.any? { |p| m.includes?(p) }
+        # AFTER the three lists above, on purpose. A GOAWAY/RST_STREAM reason APPENDS the
+        # truncation clause rather than replacing it, so those sentences must keep the verdict
+        # their error code already earns them (REFUSED_STREAM stays retryable, CANCEL stays
+        # protocol) — every one of them says "h2 " and is matched strictly earlier.
+        return "truncated_request" if m.includes?(TRUNCATED_REQUEST_PHRASE)
         return "no_response" if m.includes?("closed")
         "other"
       end
 
-      # The structured-error pair for a failed send. A "protocol" kind is gori refusing a
-      # message it can prove is malformed, so it is NOT retryable and is not a network fault:
-      # retrying reproduces it exactly, and the refusal itself is the finding. Everything else
-      # keeps the transient NETWORK_ERROR contract callers already apply policy against.
+      # The structured-error pair for a failed send.
+      #
+      # "protocol" is gori refusing a message it can prove is malformed: NOT retryable and not
+      # a network fault — retrying reproduces it exactly, and the refusal itself is the
+      # finding. "truncated_request" is the origin answering early (RFC 9113 §8.1): also not
+      # retryable, but for the opposite reason — the answer is real and complete, it is the
+      # REQUEST that is partial, and re-sending would put the whole body back on the wire.
+      # Everything else keeps the transient NETWORK_ERROR contract callers already apply
+      # policy against. `retryable` is the field to branch on; the code names the cause.
       private def emit_send_error_code(j : JSON::Builder, kind : String?) : Nil
-        protocol = kind == "protocol"
-        j.field "error_code", protocol ? "PROTOCOL_ERROR" : "NETWORK_ERROR"
-        j.field "retryable", !protocol
+        code = Tools.send_error_code(kind)
+        j.field "error_code", code
+        j.field "retryable", code == "NETWORK_ERROR"
+      end
+
+      # Split out and `self.` for the same reason `network_error_kind` is: the retry policy an
+      # agent applies hangs off this mapping, and pinning it in a spec is what stops a new kind
+      # from silently landing in the retryable bucket by falling through the `else`.
+      def self.send_error_code(kind : String?) : String
+        case kind
+        when "protocol"          then "PROTOCOL_ERROR"
+        when "truncated_request" then "REQUEST_TRUNCATED"
+        else                          "NETWORK_ERROR"
+        end
       end
 
       private def persist_send_repeater(h, save : Bool, built : RequestBuilder::Built,

--- a/src/gori/mcp/tools/sequence.cr
+++ b/src/gori/mcp/tools/sequence.cr
@@ -157,8 +157,8 @@ module Gori
         # The builder's sender carries the Outbound decision, so Sandbox / EXCLUDE hard-block
         # a collection run per send — sequence_start used to have only the job-start check.
         options = Sequencer::PlanOptions.new(bytes, default_target: default_target,
-          target: str(h, "url"), http2: (bool(h, "http2") || false) || src_h2, config: config,
-          verify: @verify_upstream && !bool_arg(h, "insecure", false),
+          target: str(h, "url"), http2: bool_arg(h, "http2", false) || src_h2, config: config,
+          verify: !bool_arg(h, "insecure", false) && @verify_upstream,
           # SNI independent of the Host header is the vhost-confusion / domain-fronting test,
           # and a token-randomness sweep against such a vhost had NO route through MCP at all
           # (`send_request` at least has create_repeater{sni} → send_request{repeater_id}).

--- a/src/gori/mcp/tools/sitemap.cr
+++ b/src/gori/mcp/tools/sitemap.cr
@@ -14,7 +14,7 @@ module Gori
         # Same reason as list_history: a `body:` query reads the off-commit trigram index
         # (Store V4), and an agent can't distinguish "absent" from "not indexed yet".
         store.index_pending! if filter.uses_fts?
-        return collapsed_sitemap(filter, limit) if bool(h, "collapse_transport") || false
+        return collapsed_sitemap(filter, limit) if bool_arg(h, "collapse_transport", false)
         entries = store.sitemap_entries_detailed(filter, limit)
         tags = store.sitemap_tags
         Result.new(JSON.build do |j|

--- a/src/gori/miner/engine.cr
+++ b/src/gori/miner/engine.cr
@@ -367,6 +367,28 @@ module Gori::Miner
       end
     end
 
+    # {location, how many wordlist names it cannot carry}, for the locations this run
+    # actually mines and only where something WAS dropped.
+    #
+    # The rejection itself is right — a header/cookie name must be an RFC 7230 token, and
+    # `Content-Length`/`Host` would break framing — but it was invisible: `total_names` sums
+    # the FILTERED sizes, so the operator's only signal was that the same wordlist produced
+    # "444 names" against the query and "435 names" against headers, and only if they ran
+    # both and compared. Coverage was incomplete and the run reported clean. `probe` already
+    # publishes a `skipped` count for exactly this reason; this is the same fact.
+    def skipped_names : Array({Location, Int32})
+      @config.locations.compact_map do |loc|
+        n = @names.size - valid_names_for(loc).size
+        n > 0 ? {loc, n} : nil
+      end
+    end
+
+    # The wordlist size BEFORE any per-location filtering — the denominator a `skipped`
+    # count is only meaningful against.
+    def candidate_names : Int32
+      @names.size
+    end
+
     # ── counters / events ───────────────────────────────────────────────────────────
 
     private def report : Baseline::Report

--- a/src/gori/miner/plan.cr
+++ b/src/gori/miner/plan.cr
@@ -59,6 +59,13 @@ module Gori::Miner
     # `Env.expand` is byte-safe: a captured flow's binary body survives the round trip
     # unchanged (see its doc comment), so `String.new(bytes)` here loses nothing.
     property request : String
+    # PROVENANCE: this request is a CAPTURED FLOW's stored bytes, not one the operator typed.
+    # Same flag, same meaning and same consequences as `Fuzz::PlanOptions#evidence?` and
+    # `Repeater::PlanOptions#evidence?` — with it off, seeding the miner from a capture
+    # refused any head carrying an OData/Mongo `$token` and promoted a bare-LF head to CRLF
+    # on every one of the run's probes, while `gori run repeater <same-flow>` replayed it
+    # byte-exact. `--request FILE` / stdin / the TUI editor keep the draft behaviour.
+    property? evidence : Bool
     # The origin the seeding flow implies, when there is one (nil for --request/stdin).
     property default_target : String?
     # An explicit target, which wins over `default_target` when non-blank.
@@ -88,6 +95,7 @@ module Gori::Miner
 
     def initialize(@request : String = "",
                    *,
+                   @evidence : Bool = false,
                    @default_target : String? = nil,
                    @target : String? = nil,
                    @http2 : Bool = false,
@@ -168,8 +176,13 @@ module Gori::Miner
     def self.build(options : PlanOptions, outbound : Gori::Outbound) : Plan
       # ONE `Env.expand_wire` over the request, before anything reads it — and first, a
       # refusal when a token in the HEAD resolves to nothing (see `refuse_unresolved`).
-      refuse_unresolved(Env.unresolved_wire(options.request))
-      request = Env.expand_wire(options.request)
+      # Both are DRAFT-time passes and are skipped for EVIDENCE — see `PlanOptions#evidence?`.
+      request = if options.evidence?
+                  options.request.to_slice
+                else
+                  refuse_unresolved(Env.unresolved_wire(options.request))
+                  Env.expand_wire(options.request)
+                end
       request_target = Gori::Outbound.request_target(request)
       origin = resolve_origin(options)
 

--- a/src/gori/proxy/conn/client_conn.cr
+++ b/src/gori/proxy/conn/client_conn.cr
@@ -20,6 +20,59 @@ require "../../flow_mapper"
 require "./self_page"
 
 module Gori::Proxy
+  # Why this connection is speaking HTTP/1.1 rather than HTTP/2 — the OBSERVED reason, stamped
+  # by whoever made the decision, rather than re-derived afterwards by whoever needs to explain
+  # it. `ClientConn` reads exactly one of these back when an h2/gRPC client's preface lands on
+  # the h1 path.
+  #
+  # It exists because re-deriving was wrong. The old message hard-coded two causes ("settings
+  # network.http2 is \"off\" or a Match&Replace body rule is live") and pointed at a
+  # `gori.log` line that names which — but `Tls::Tunnel#h2_candidate?` has FOUR such branches
+  # now, and the common case is none of them: the tunnel offered h2, the ORIGIN answered
+  # `http/1.1` at ALPN, `notice_downgrade` never ran, and nothing was ever written to
+  # `gori.log`. So the operator was told to change a setting that was already correct and to
+  # read a line that did not exist. A refusal that names the wrong reason costs more time than
+  # one that names none.
+  enum H2Offer
+    # No tunnel made this decision (the plaintext listener, a blind CONNECT). Says nothing
+    # about a cause, on purpose.
+    Unknown
+    # h2 was offered to the client and the client did not select it at ALPN (curl --http1.1,
+    # an old browser). Nothing is wrong; the client chose.
+    Offered
+    # A cleartext origin. ALPN lives inside a TLS handshake, so there was nothing to reflect
+    # and gori has no h2c of its own to offer.
+    Cleartext
+    # The four `h2_candidate?` downgrades. Each one DID write a `gori.log` line, so each one
+    # may point at it.
+    DisabledBySetting
+    BodyRule
+    ShortCircuitRule
+    ExtractRule
+    # The origin completed a TLS handshake and chose HTTP/1.1 at ALPN, so gori did not offer
+    # h2 to the client either (there is no h2↔h1 bridge — see `reflect_origin_h2`).
+    UpstreamDeclined
+    # The h2 ALPN probe to the origin never completed (unreachable, or a TLS/verify refusal),
+    # so gori could not learn what it speaks and kept the client on h1.
+    UpstreamUnreachable
+
+    # The sentence recorded on a flow when an h2/gRPC preface is refused on the h1 path. Only
+    # the branches that actually write to `gori.log` mention it.
+    def refusal_reason : String
+      case self
+      in Unknown             then "HTTP/2 was not negotiated on this connection"
+      in Offered             then "HTTP/2 was offered to this client and it selected HTTP/1.1 at ALPN, then spoke the HTTP/2 preface anyway"
+      in Cleartext           then "this origin is cleartext, and ALPN — the only way gori offers HTTP/2 — exists inside a TLS handshake; gori does not serve h2c prior-knowledge here"
+      in DisabledBySetting   then "HTTP/2 is switched off (settings network.http2; set it back to \"auto\" to keep h2) — gori.log has the matching \"h2 downgrade: <host> ...\" line"
+      in BodyRule            then "a Match&Replace BODY rule is live for this host and body rewriting on HTTP/2 is not implemented yet — gori.log has the matching \"h2 downgrade: <host> ...\" line"
+      in ShortCircuitRule    then "a Match&Replace short-circuit rule is live for this host and the h2 relay cannot answer a request locally — gori.log has the matching \"h2 downgrade: <host> ...\" line"
+      in ExtractRule         then "a session-binding extract rule reads the response BODY for this host and body extraction on HTTP/2 is not implemented yet — gori.log has the matching \"h2 downgrade: <host> ...\" line"
+      in UpstreamDeclined    then "the ORIGIN did not negotiate HTTP/2 (it chose HTTP/1.1 at ALPN), so gori did not offer h2 to this client either — gori does not translate between h2 and h1. Nothing on this proxy needs changing"
+      in UpstreamUnreachable then "gori's HTTP/2 ALPN probe to the origin did not complete (unreachable, or the upstream TLS handshake was refused), so it could not learn whether the origin speaks h2 and kept this client on HTTP/1.1"
+      end
+    end
+  end
+
   # Handles one client connection over an `IO` (a plaintext TCPSocket, or — after
   # the CONNECT/TLS handoff — a decrypted TLS socket; the same loop serves both,
   # which is why it is written against `IO`). Reads requests in a keep-alive
@@ -76,7 +129,8 @@ module Gori::Proxy
                    @default_port : Int32? = nil,
                    @origin_dst : {String, Int32}? = nil,
                    @rewrite_fixed_host : Bool = false,
-                   @extractor : ResponseExtract? = nil)
+                   @extractor : ResponseExtract? = nil,
+                   @h2_offer : H2Offer = H2Offer::Unknown)
       # Per-connection upstream reuse (see `acquire_upstream`). One live origin
       # connection kept across this client's keep-alive requests.
       @upstream = nil.as(IO?)
@@ -207,13 +261,13 @@ module Gori::Proxy
       #
       # The recorded reason names the SETTINGS to change rather than a private method the
       # operator cannot see (#492 step 4b, the same fix `Outbound#sweep_block` got in #491).
-      # It cannot name WHICH of the two applies — that decision was made per host in the
-      # Tunnel, before this connection existed — so it points at the gori.log line that can.
+      # It no longer GUESSES which cause applies: the Tunnel stamps what it observed on this
+      # connection (`H2Offer`), so the sentence is the true one and only the branches that
+      # write to gori.log point at it. See `H2Offer` for what went stale under the old
+      # "it cannot name which, so it points at the log" reasoning.
       if Codec::Http1.h2_preface?(req)
         record_error(req, @scheme, @fixed_host || req.host? || "", @fixed_port, created_at,
-          "rejected h2/gRPC client preface on the HTTP/1.1 path: HTTP/2 was not offered for " \
-          "this host, because settings network.http2 is \"off\" or a Match&Replace body rule " \
-          "is live — gori.log names which (\"h2 downgrade: <host> ...\")")
+          "rejected h2/gRPC client preface on the HTTP/1.1 path: #{@h2_offer.refusal_reason}")
         return false
       end
 

--- a/src/gori/proxy/h2/assembler.cr
+++ b/src/gori/proxy/h2/assembler.cr
@@ -81,6 +81,11 @@ module Gori::Proxy::H2
       # response HEADERS/DATA frame (time-to-first-byte).
       getter started_at : Time::Instant = Time.instant
       property resp_first_at : Time::Instant? = nil
+      # The stream whose PUSH_PROMISE invented this request, when the client never sent it.
+      # A pushed flow was indistinguishable in History / QL / the Sitemap from one the client
+      # made — the origin authoring rows in an operator's evidence — so the projection says so
+      # (`HeadCodec::PUSHED_MARKER`).
+      property pushed_by : UInt32? = nil
     end
 
     def initialize(@sink : FlowSink, @host : String, @port : Int32, @created_at : Int64,
@@ -316,6 +321,7 @@ module Gori::Proxy::H2
       # Same rule as finish_header_block: `pre` means the block is already decoded.
       promised.req.headers = pre ? (pre.fields || raise Gori::Error.new("h2 push block failed to decode")) : decoder.decode(block)
       promised.req.ended = true
+      promised.pushed_by = frame.stream_id
       emit_request(promised_id, promised)
     end
 
@@ -388,7 +394,7 @@ module Gori::Proxy::H2
       cap = stream.req.body
       body = cap.total == 0 ? nil : cap.to_slice
 
-      head = synth_request_head(headers, authority)
+      head = synth_request_head(headers, authority, stream.req.trailer_names, stream.pushed_by)
       captured = Store::CapturedRequest.new(
         created_at: @created_at, scheme: scheme, host: host, port: port,
         method: method, target: path, http_version: "HTTP/2", head: head, body: body,
@@ -428,6 +434,7 @@ module Gori::Proxy::H2
       emit_request(stream_id, stream) if stream.req.headers && stream.flow_id.nil?
       flow_id = stream.flow_id
       return unless flow_id # never saw request headers — nothing to project
+      reason = extended_connect_note(stream, reason)
       if stream.resp.headers
         if stream.resp.ended
           emit_response(stream) # response fully received; only the request never cleanly closed
@@ -438,6 +445,30 @@ module Gori::Proxy::H2
         duration_us = (Time.instant - stream.started_at).total_microseconds.to_i64
         @sink.on_response(FlowMapper.aborted_response(flow_id, reason, duration_us: duration_us))
       end
+    end
+
+    # RFC 8441 extended CONNECT — `:method CONNECT` plus a `:protocol` pseudo-header, which is
+    # how a WebSocket is opened over HTTP/2. Such a stream ends as an abort ("h2 connection
+    # closed", "stream reset"), and that reason describes the SYMPTOM: what the operator needs
+    # to know is that gori carried the stream but read nothing on it.
+    #
+    # Deliberately an advisory and NOT a refusal. gori relays the ORIGIN's SETTINGS frame
+    # verbatim (`StreamGate#write` / `Relay#emit` on stream 0), so a client facing an origin
+    # that advertises SETTINGS_ENABLE_CONNECT_PROTOCOL sees that advertisement and is entitled
+    # to use it — and the CONNECT stream's DATA frames then relay byte-for-byte like any
+    # others. RST-ing it (RFC 9113 §8.5 would allow that for a setting gori itself never sent)
+    # would break a path that works end to end. What does NOT work is everything gori adds:
+    # the WS message transcript, the message gate, intercept and Match&Replace all live on the
+    # HTTP/1.1 Upgrade path, so those frames are opaque DATA here. Say that, on the flow.
+    private def extended_connect_note(stream : Stream, reason : String) : String
+      headers = stream.req.headers
+      return reason unless headers
+      protocol = pseudo(headers, ":protocol")
+      return reason if protocol.nil? || protocol.empty?
+      "#{reason} — this is an RFC 8441 extended CONNECT stream (:protocol #{protocol.inspect}). " \
+      "gori relayed it byte-for-byte but did not decode it: WebSocket messages are read on the " \
+      "HTTP/1.1 Upgrade path only, so this socket has no message transcript, no message " \
+      "intercept and no Match&Replace"
     end
 
     # Called by the relay when the connection closes, to flush any streams still in
@@ -470,8 +501,16 @@ module Gori::Proxy::H2
     # produce the SAME bytes to run rules against — that is what makes the Rewriter tab's
     # preview (`rules.cr:331-345`, which reads exactly this head off a stored flow) agree
     # with what the live proxy does to an h2 head. Two copies would drift; there is one.
-    private def synth_request_head(headers : Array({String, String}), authority : String) : Bytes
-      HeadCodec.synth_request(headers, authority)
+    #
+    # `trailers` is the same CAPTURE-only extra `synth_response_head` passes, and it was
+    # one-sided by omission: a request trailer block is merged into `headers` by
+    # `finish_header_block` exactly as a response one is, so after the merge `x-req-trailer`
+    # read like a header the client sent in its head. `Side#trailer_names` was already being
+    # recorded for both sides.
+    private def synth_request_head(headers : Array({String, String}), authority : String,
+                                   trailers : Array(String)? = nil,
+                                   pushed_by : UInt32? = nil) : Bytes
+      HeadCodec.synth_request(headers, authority, trailers, pushed_by)
     end
 
     # `trailers` is the CAPTURE projection's extra: only the stored head names which fields

--- a/src/gori/proxy/h2/head_codec.cr
+++ b/src/gori/proxy/h2/head_codec.cr
@@ -39,16 +39,40 @@ module Gori::Proxy::H2
     # host at all, breaking `gori run show` / MCP get_flow / QL `header:host`. Emitted only
     # when the fields carry no explicit (non-pseudo) `host`, which is what makes the
     # mapping reversible: see `parse_request`.
-    def synth_request(fields : Array({String, String}), authority : String) : Bytes
+    #
+    # `trailers` is `synth_response`'s argument, and it is here for the reason `TRAILER_MARKER`
+    # exists at all: a REQUEST trailer block (a gRPC client-streaming call, a `TE: trailers`
+    # probe) is merged into the request head by `Assembler#finish_header_block` exactly as a
+    # response trailer is, and after the merge it reads like a header the client sent in its
+    # head. Whether a target/CDN/WAF treats a trailer as a header is the test the operator came
+    # to run, and that question is no less real on the request side. Passed ONLY by the capture
+    # projection; the rewrite path re-synthesizes from the live fields and passes nothing, so
+    # the fabricated line can never reach an h2 wire.
+    #
+    # `pushed_by` is the same kind of capture-only line for a request the CLIENT NEVER SENT: a
+    # PUSH_PROMISE is the origin inventing a request, and `Assembler#handle_push_promise`
+    # projects it as an ordinary flow, so History / QL / the Sitemap handed an operator reading
+    # for evidence a row the origin authored, with nothing saying so.
+    def synth_request(fields : Array({String, String}), authority : String,
+                      trailers : Array(String)? = nil, pushed_by : UInt32? = nil) : Bytes
       method = pseudo(fields, ":method") || "GET"
       path = pseudo(fields, ":path") || "/"
       String.build do |io|
         io << line_safe(method) << ' ' << line_safe(path) << " HTTP/2\r\n"
         io << "Host: " << line_safe(authority) << "\r\n" if !authority.empty? && !explicit_host?(fields)
         regular(fields) { |n, v| io << line_safe(n) << ": " << line_safe(v) << "\r\n" }
+        if trailers && !trailers.empty?
+          io << TRAILER_MARKER << ": " << line_safe(trailers.join(", ")) << "\r\n"
+        end
+        pushed_by.try { |sid| io << PUSHED_MARKER << ": server push promised on stream " << sid << "\r\n" }
         io << "\r\n"
       end.to_slice
     end
+
+    # See `synth_request`'s `pushed_by`. Same discipline as `TRAILER_MARKER`: additive, on the
+    # stored projection only, so nothing that reads a field off the head changes behaviour and
+    # the line can never reach an h2 wire (the rewrite path re-synthesizes from live fields).
+    PUSHED_MARKER = "X-Gori-Pushed"
 
     # The marker line that names which fields of a synthesized h2 response head arrived in a
     # TRAILING HEADERS block rather than the response head (`Assembler` merges the two — that
@@ -70,6 +94,8 @@ module Gori::Proxy::H2
     # `trailers` names the fields that came from a trailing HEADERS block; it is passed ONLY
     # by the capture projection (`Assembler`). The rewrite path re-synthesizes from the live
     # fields and passes nothing, so this fabricated line can never reach an h2 wire.
+    #
+    # `synth_request` takes the same argument for the same reason — see its own comment.
     def synth_response(fields : Array({String, String}), trailers : Array(String)? = nil) : Bytes
       status = (pseudo(fields, ":status") || "0").to_i? || 0
       String.build do |io|
@@ -225,12 +251,46 @@ module Gori::Proxy::H2
     # §8.1.1), so a rule-changed value would RST the stream instead of rewriting anything.
     # The h1 path restores framing headers after a head rewrite for the same reason (#403,
     # `client_conn.cr:1367`); h2 has no Transfer-Encoding to restore alongside it.
+    #
+    # ## Only for bytes gori produced, never for bytes the operator authored
+    #
+    # That argument is a RULE's. It is not an intercept edit's: on h1 the same edit is
+    # forwarded byte-exact and the comment there says why — "the proxy must not rewrite bytes
+    # the human chose to send (e.g. a deliberately CL-mismatched smuggling probe)"
+    # (`client_conn.cr`). Whether a given origin/CDN/WAF/gRPC gateway actually enforces §8.1.1
+    # is PRECISELY the probe an operator opens the intercept editor to run, and reverting their
+    # value made it unexpressible on the live h2 path — silently, with the surface reporting
+    # success. So the caller decides: `HeadRewrite#rewrite` restores, `#encode_edited` restores
+    # only when the surface that produced the bytes recomputed the value itself (the TUI
+    # editor's `^L`), which on a head-only hold would otherwise declare `content-length: 0`
+    # beside DATA gori is still going to relay.
+    #
+    # Restored IN PLACE. Rejecting and re-appending moved `content-length` to the END of the
+    # field list, so a rule that touched an unrelated header silently reordered the head on the
+    # wire — a change gori made, that nothing displayed, in the one field order a header-order
+    # probe is about.
     def restore_content_length(fields : Array(HPACK::Field),
                                original : Array(HPACK::Field)) : Array(HPACK::Field)
       orig = original.select { |f| f.name == "content-length" }
       return fields if orig.map(&.value) == fields.select { |f| f.name == "content-length" }.map(&.value)
-      fields_out = fields.reject { |f| f.name == "content-length" }
-      fields_out.concat(orig)
+      fields_out = [] of HPACK::Field
+      taken = 0
+      fields.each do |f|
+        if f.name == "content-length"
+          # Positional replacement while the original has one left to give; a rule that ADDED
+          # a `content-length` the peer never sent has its extra occurrences dropped, which is
+          # the same disposition the old reject-then-append had.
+          if o = orig[taken]?
+            fields_out << o
+            taken += 1
+          end
+        else
+          fields_out << f
+        end
+      end
+      # The peer sent more than the rewritten head kept (a rule removed the line). Those go
+      # back at the end — there is no position left to restore them to.
+      fields_out.concat(orig[taken..]) if taken < orig.size
       fields_out
     end
 
@@ -260,6 +320,22 @@ module Gori::Proxy::H2
     # directions, though only `request_pseudo` drops every duplicate while `parse_response`
     # drops only a second `:status`. Duplicate pseudo-headers are malformed either way.
     def h1_faithful?(fields : Array(HPACK::Field), request : Bool) : Bool
+      h1_unfaithful_reason(fields, request).nil?
+    end
+
+    # `h1_faithful?`, but it says WHICH field and WHY — nil when the round trip is sound.
+    #
+    # The refusal above is correct and deliberate; what cost an operator a live test was that it
+    # was invisible. An intercept edit on such a message was accepted by the surface and thrown
+    # away here, and "gori will not apply an edit to this message" is a fact known the moment
+    # the head is decoded, so it can be told BEFORE the operator writes one. A refusal has to
+    # name its real cause, and "the peer's head has no HTTP/1.1 text form" names a class, not a
+    # cause — the operator needs to read `x-evil` and `CR/LF` to connect it to the injection
+    # sink they just probed.
+    #
+    # First offender wins: with a CRLF reflected into three headers the operator fixes the same
+    # thing three times either way, and one field name is a sentence a CLI ack can carry.
+    def h1_unfaithful_reason(fields : Array(HPACK::Field), request : Bool) : String?
       seen = Set(String).new
       regular = false
       fields.each do |f|
@@ -267,14 +343,21 @@ module Gori::Proxy::H2
           # §8.3 puts the pseudo-headers first and `parse_*` re-emits them there, so a peer
           # that sent one AFTER a regular field would get its order corrected. A duplicate is
           # dropped outright by the `seen` guard in `request_pseudo`.
-          return false if regular || !seen.add?(f.name)
-          return false unless pseudo_faithful?(f, fields, request)
+          return "the pseudo-header #{f.name} arrives after a regular field, and the h1 text " \
+                 "form would silently move it back in front (RFC 9113 §8.3)" if regular
+          return "the pseudo-header #{f.name} appears more than once, and the h1 text form " \
+                 "carries only one of them" unless seen.add?(f.name)
+          if reason = pseudo_reason(f, fields, request)
+            return reason
+          end
         else
           regular = true
-          return false unless regular_faithful?(f)
+          if reason = regular_reason(f)
+            return reason
+          end
         end
       end
-      request ? request_shape?(fields, seen) : seen.includes?(":status")
+      request ? request_shape_reason(fields, seen) : shape_reason(seen.includes?(":status"), ":status")
     end
 
     # A regular field survives iff the text can hold it: `header_lines` cuts the line at its
@@ -285,56 +368,86 @@ module Gori::Proxy::H2
     # CRLF truncates the head and drops every field after it, and a lone CR/LF survives here
     # today only because the synthesized EOL happens to be CRLF — the same byte still ends
     # the head early for `StreamGate#split_edit`'s `\n\n` scan on an intercept edit.
-    private def regular_faithful?(f : HPACK::Field) : Bool
+    private def regular_reason(f : HPACK::Field) : String?
       name = f.name
-      !name.empty? && !name.includes?(':') && !line_broken?(name) &&
-        name == name.strip.downcase &&
-        !line_broken?(f.value) && !f.value.starts_with?(' ')
+      return "a header field has an empty name" if name.empty?
+      return "the field name #{name.inspect} contains a colon, and the h1 text form cuts a " \
+             "line at its first colon — it would come back as a different field" if name.includes?(':')
+      return "the field name #{name.inspect} carries a CR or LF, and the h1 text form would " \
+             "read it back as two fields" if line_broken?(name)
+      return "the field name #{name.inspect} is not lowercase and trimmed, and the h1 round " \
+             "trip normalizes it — a different name would go on the wire" unless name == name.strip.downcase
+      return "the value of #{name.inspect} carries a CR or LF, so the h1 text form would read " \
+             "it back as two fields (a header-injection primitive — the raw frames are " \
+             "untouched and the stored head escapes it)" if line_broken?(f.value)
+      return "the value of #{name.inspect} starts with a space, which the h1 round trip eats" if f.value.starts_with?(' ')
+      nil
     end
 
     # A pseudo-header survives iff the start line (or the synthetic `Host:` line) can hold it.
     # A pseudo belonging to the OTHER direction — a `:status` on a request, a `:method` on a
     # response — is copied straight off `original`, exactly like `:scheme` and an unknown one,
     # and so cannot be damaged.
-    private def pseudo_faithful?(f : HPACK::Field, fields : Array(HPACK::Field), request : Bool) : Bool
-      request ? request_pseudo_faithful?(f, fields) : response_pseudo_faithful?(f)
+    private def pseudo_reason(f : HPACK::Field, fields : Array(HPACK::Field), request : Bool) : String?
+      request ? request_pseudo_reason(f, fields) : response_pseudo_reason(f)
     end
 
-    private def request_pseudo_faithful?(f : HPACK::Field, fields : Array(HPACK::Field)) : Bool
-      value = f.value
+    private def request_pseudo_reason(f : HPACK::Field, fields : Array(HPACK::Field)) : String?
       case f.name
-      when ":method"
-        # `request_line` splits the start line on its FIRST space: a method carrying one comes
-        # back with its tail moved into `:path`.
-        !value.empty? && !value.includes?(' ') && !line_broken?(value)
-      when ":path"
-        # A CRLF here splits the START line — the injected field lands ahead of every real one.
-        !value.empty? && !line_broken?(value)
-      when ":authority"
-        # Only the SYNTHETIC `Host:` line can damage it; with an explicit `host` field
-        # `resolve_authority` preserves `:authority` off the original instead.
-        return true if host_carrier?(fields)
-        !value.empty? && !value.starts_with?(' ') && !line_broken?(value)
-      else
-        true
+      when ":method"    then method_reason(f.value)
+      when ":path"      then path_reason(f.value)
+      when ":authority" then host_carrier?(fields) ? nil : authority_reason(f.value)
       end
+    end
+
+    # `request_line` splits the start line on its FIRST space: a method carrying one comes back
+    # with its tail moved into `:path`.
+    private def method_reason(value : String) : String?
+      return ":method is empty, and the h1 text form has no way to say so" if value.empty?
+      return ":method #{value.inspect} contains a space, and the h1 start line splits on its " \
+             "first one — the tail would move into :path" if value.includes?(' ')
+      ":method #{value.inspect} carries a CR or LF, which would split the start line" if line_broken?(value)
+    end
+
+    # A CRLF here splits the START line — the injected field lands ahead of every real one.
+    private def path_reason(value : String) : String?
+      return ":path is empty, and the h1 text form would come back with \"/\" invented" if value.empty?
+      ":path #{value.inspect} carries a CR or LF, which splits the START line — the injected " \
+      "field would land ahead of every real one" if line_broken?(value)
+    end
+
+    # Only the SYNTHETIC `Host:` line can damage `:authority`; with an explicit `host` field
+    # `resolve_authority` preserves it off the original instead, so the caller skips this.
+    private def authority_reason(value : String) : String?
+      return ":authority is empty, and the h1 text form has no way to say so" if value.empty?
+      return ":authority #{value.inspect} starts with a space, which the Host: round trip eats" if value.starts_with?(' ')
+      ":authority #{value.inspect} carries a CR or LF, which the Host: line cannot hold" if line_broken?(value)
     end
 
     # `synth_response` normalizes the code through `to_i` so a stored head does not vary with a
     # peer's padding — which also turns a `:status` of `0200` (§8.3.2 requires exactly three
     # digits, so a conformant client rejects it) into an accepted `200`.
-    private def response_pseudo_faithful?(f : HPACK::Field) : Bool
-      return true unless f.name == ":status"
-      (f.value.to_i? || 0).to_s == f.value
+    private def response_pseudo_reason(f : HPACK::Field) : String?
+      return nil unless f.name == ":status"
+      return nil if (f.value.to_i? || 0).to_s == f.value
+      ":status #{f.value.inspect} is not the normalized form of its code, and the h1 status " \
+      "line would launder it into one a client accepts (RFC 9113 §8.3.2 wants exactly three digits)"
     end
 
     # `synth_request` defaults a missing `:method`/`:path` and `resolve_authority` maps the
     # `Host:` line back to `:authority`, so a request missing any of the three comes back
     # with it INVENTED — §8.3.1 requires all three, so that is another malformed head made
     # acceptable. (`:authority` may legitimately be absent when a `host` field carries it.)
-    private def request_shape?(fields : Array(HPACK::Field), seen : Set(String)) : Bool
-      seen.includes?(":method") && seen.includes?(":path") &&
-        (seen.includes?(":authority") || host_carrier?(fields))
+    private def request_shape_reason(fields : Array(HPACK::Field), seen : Set(String)) : String?
+      shape_reason(seen.includes?(":method"), ":method") ||
+        shape_reason(seen.includes?(":path"), ":path") ||
+        shape_reason(seen.includes?(":authority") || host_carrier?(fields), ":authority")
+    end
+
+    private def shape_reason(present : Bool, name : String) : String?
+      return nil if present
+      "the head carries no #{name}, and the h1 text form would come back with one invented " \
+      "(RFC 9113 §8.3 requires it)"
     end
 
     private def line_broken?(s : String) : Bool

--- a/src/gori/proxy/h2/head_rewrite.cr
+++ b/src/gori/proxy/h2/head_rewrite.cr
@@ -160,12 +160,24 @@ module Gori::Proxy::H2
     # intercept is a stage inside this pipeline, not a second pipeline beside it. nil when the
     # edited bytes are no longer a head: the caller then forwards the block as it stood, which
     # is what an unparseable RULE result already does.
-    def encode_edited(block : Block, head : Bytes) : Block?
+    #
+    # `restore_length` is PROVENANCE, not policy (#513 / R3-F2). Reverting the operator's
+    # `content-length` is right when the surface computed it FOR them — the TUI intercept
+    # editor's `^L` recomputes it from the editor's body, and an h2 hold is the head only, so
+    # on a dirty edit that lands as `content-length: 0` beside DATA gori still relays. It is
+    # wrong when the operator DECLARED it: a content-length that disagrees with the DATA is
+    # RFC 9113 §8.1.1-malformed, and whether a given origin/CDN/WAF/gRPC gateway enforces that
+    # is exactly the probe they opened the editor to run. h1 forwards the identical edit
+    # byte-exact and says so (`client_conn.cr`); h2 reverted it and reported success.
+    def encode_edited(block : Block, head : Bytes, restore_length : Bool = true) : Block?
       # The head shown to the operator is a lossy rendering of what the peer sent, so re-parsing
       # their edit would apply it to a DIFFERENT message (#517). Refuse the edit rather than
       # send that; the caller keeps the block as it stood.
-      unless HeadCodec.h1_faithful?(block.fields, block.request)
-        warn_unfaithful(block.stream_id, block.request)
+      #
+      # `StreamGate` now asks `HeadCodec.h1_unfaithful_reason` at HOLD time and refuses the edit
+      # at the surface that asked for it, so this is the backstop rather than the only stop.
+      if reason = HeadCodec.h1_unfaithful_reason(block.fields, block.request)
+        warn_unfaithful(block.stream_id, block.request, reason)
         return nil
       end
       parsed = block.request ? HeadCodec.parse_request(head, block.fields) : HeadCodec.parse_response(head, block.fields)
@@ -173,7 +185,7 @@ module Gori::Proxy::H2
         warn_unparseable(block.stream_id, "an intercept edit")
         return nil
       end
-      fields = HeadCodec.restore_content_length(parsed, block.fields)
+      fields = restore_length ? HeadCodec.restore_content_length(parsed, block.fields) : parsed
       @engaged = true
       Block.new(reframe(block.first, block.prefix, @encoder.encode(fields)),
         Assembler::HeadBlock.new(pairs(fields)), fields, head, block.first, block.prefix, block.request)
@@ -322,13 +334,19 @@ module Gori::Proxy::H2
       return unreadable(first, snapshot) if fields.nil?
 
       request = @direction == "out"
+      # `first.stream_id`, NOT `@block_stream`: `reset` above zeroed it (deliberately — it
+      # closes the buffered-block leak class), so every warning below `finish` named "stream 0",
+      # a stream that cannot exist. `encode_edited` was never affected because it reads
+      # `block.stream_id`, which is why the intercept-path warnings said the right thing while
+      # the rule-path ones did not.
+      stream_id = first.stream_id
       head = head_text(fields, first, request)
       # Before the rewrite, and NOT from inside it: what this announces is a seam the relay
       # cannot reach at all, which is true whether or not a head rule is live. Running it from
       # `rewrite` put it behind `rw.active?`, so an operator whose only rule is a session-binding
       # extract descriptor — the case #536 is about — got nothing.
       notice_coalesced(fields) if request && head
-      rewritten = head ? rewrite(fields, head, request) : nil
+      rewritten = head ? rewrite(fields, head, request, stream_id) : nil
       emit_fields = rewritten || fields
       built = if rewritten.nil? && !@engaged
                 # Unchanged, and this direction has never re-encoded: byte-exact passthrough,
@@ -380,14 +398,17 @@ module Gori::Proxy::H2
 
     # Run the Match&Replace rules over this block's h1-equivalent head. nil = unchanged
     # (which is also what a block the rules do not apply to returns).
-    private def rewrite(fields : Array(HPACK::Field), head : Bytes, request : Bool) : Array(HPACK::Field)?
+    private def rewrite(fields : Array(HPACK::Field), head : Bytes, request : Bool,
+                        stream_id : UInt32) : Array(HPACK::Field)?
       rw = @rewriter
       return nil unless rw && rw.active?
       # The peer's own head has no faithful h1-text form, so the round trip that runs the
       # rules would hand the far side a DIFFERENT message — see `HeadCodec.h1_faithful?`.
       # `parse_*` refuses it anyway; checking here keeps the rules from running for nothing
       # and, more to the point, keeps the log from blaming a rule for the peer's bytes.
-      return warn_unfaithful(@block_stream, request) unless HeadCodec.h1_faithful?(fields, request)
+      if reason = HeadCodec.h1_unfaithful_reason(fields, request)
+        return warn_unfaithful(stream_id, request, reason)
+      end
       # The BARE host, because that is what a rule's host glob is written against and what
       # every other host-scoping site in this pipeline passes (`notice_coalesced` below,
       # `H2::Extract`, `StreamGate`'s three gates). `:authority` may carry a port, and
@@ -400,7 +421,7 @@ module Gori::Proxy::H2
 
       parsed = request ? HeadCodec.parse_request(rewritten_head, fields) : HeadCodec.parse_response(rewritten_head, fields)
       if parsed.nil?
-        warn_unparseable(@block_stream, "a Match&Replace rule")
+        warn_unparseable(stream_id, "a Match&Replace rule")
         return nil
       end
       restored = HeadCodec.restore_content_length(parsed, fields)
@@ -436,13 +457,17 @@ module Gori::Proxy::H2
     # (#517). Not a rule's doing and not the operator's, so it gets its own line — and its own
     # flag, or whichever of the two happened first would silence the other. Always nil, so
     # `rewrite` can return it directly: nothing is rewritten and the original fields go out.
-    private def warn_unfaithful(stream_id : UInt32, request : Bool) : Nil
+    #
+    # `reason` names the offending field. "No HTTP/1.1 text form" is a class, not a cause, and
+    # the operator who induced it — probe a CRLF sink, watch the origin reflect `%0d%0a` back —
+    # needs to read the field name to connect the two.
+    private def warn_unfaithful(stream_id : UInt32, request : Bool, reason : String) : Nil
       return if @warned_unfaithful
       @warned_unfaithful = true
       ::Log.warn do
         "h2 #{@direction}: the peer sent a #{request ? "request" : "response"} head that has no " \
-        "HTTP/1.1 text form (stream #{stream_id}) — Match&Replace and intercept edits are " \
-        "not applied to it, the fields go out exactly as they arrived"
+        "HTTP/1.1 text form (stream #{stream_id}): #{reason}. Match&Replace and intercept edits " \
+        "are not applied to it, the fields go out exactly as they arrived"
       end
     end
 

--- a/src/gori/proxy/h2/stream_gate.cr
+++ b/src/gori/proxy/h2/stream_gate.cr
@@ -170,6 +170,7 @@ module Gori::Proxy::H2
       @deferred_cross = [] of UInt32
       @closed = false
       @warned_body = false
+      @warned_length = false
       @warned_scope = false
       @warned_overflow = false
       # Connection-level flow-control credit owed back to the SENDER for DATA this gate
@@ -235,6 +236,7 @@ module Gori::Proxy::H2
       # refused stream is never held: there is no decision to offer a human about a request
       # that is not going anywhere.
       return true if sandbox_refuses_locked(block)
+      return true if push_refuses_locked(block)
       item = start_hold(block)
       queued = @ordered && !block.head.nil? && !@opens.empty?
       return false unless item || queued
@@ -464,6 +466,64 @@ module Gori::Proxy::H2
       true
     end
 
+    # The same containment gate for a request the ORIGIN invented (RFC 9113 §8.4 server push).
+    #
+    # `sandbox_refuses_locked` cannot reach it: PUSH_PROMISE arrives on the RESPONSE leg, where
+    # `@ordered` is false, and `HeadRewrite#head_text` returns nil for it (rules are correctly
+    # never run over a promised head), so `block.head` is nil too. A promised request therefore
+    # walked past a gate that refuses the identical authority on a real request, and
+    # `Assembler#handle_push_promise` projected it into History as an ordinary row — a flow the
+    # origin authored, indistinguishable from one the client made, inside the evidence the
+    # operator came to read. "Hard containment" is what the sandbox advertises.
+    #
+    # Refusing a promise means three things, and they are the client's own §8.4 disposition:
+    #   * the PUSH_PROMISE never reaches the client (suppressed, hence `@heads.latch` — the
+    #     third route into the §6.2.1 HPACK asymmetry, exactly as `refuse_locked` describes);
+    #   * RST_STREAM(CANCEL) goes to the ORIGIN on the PROMISED id, which is how a client
+    #     declines a push, so the origin stops before it sends the pushed response;
+    #   * the promised id joins `@refused` on THIS leg, so a pushed response already in flight
+    #     is swallowed rather than written to a client that never learned the stream exists.
+    #
+    # Both URLs are tested for the reason `sandbox_refuses_locked` gives: the promised
+    # `:authority` may be any origin the certificate covers (§9.1.1), which is the whole point
+    # of the finding — an origin that names `evil.test` in a promise.
+    private def push_refuses_locked(block : HeadRewrite::Block) : Bool
+      return false if @ordered # promises are server-initiated; the request leg never sees one
+      return false unless block.first.frame_type == Frame::Type::PushPromise
+      return false unless @interceptor.sandbox_enabled?
+      promised = promised_stream_id(block)
+      return false if promised == 0 || promised.odd? # §5.1.1 — the assembler rejects these too
+      fields = block.fields
+      authority = HeadCodec.pseudo_of(fields, ":authority") || @host
+      host, _ = Upstream.split_host_port(authority, @port)
+      scheme = HeadCodec.pseudo_of(fields, ":scheme") || "https"
+      target = HeadCodec.pseudo_of(fields, ":path") || "/"
+      blocked = @interceptor.sandbox_blocks?(scheme, host, target) ||
+                (host != @host && @interceptor.sandbox_blocks?(scheme, @host, target))
+      return false unless blocked
+      ::Log.warn do
+        "h2 in: refused a server PUSH_PROMISE for #{scheme}://#{host}#{target} (promised " \
+        "stream #{promised}, promised on stream #{block.stream_id}) — the sandbox does not " \
+        "allow that URL, and a promise is the origin's request, not the client's"
+      end
+      @heads.latch
+      project(block)
+      @assembler.drop_stream(promised, SANDBOX_REASON)
+      remember_refused(promised)
+      @deferred_cross << promised
+      true
+    end
+
+    # The promised stream id out of a PUSH_PROMISE's carried-over prefix (R + 31 bits), which
+    # `HeadRewrite#split_block` preserved verbatim for exactly this frame type. 0 when the
+    # prefix is not there — a malformed promise the caller then leaves alone.
+    private def promised_stream_id(block : HeadRewrite::Block) : UInt32
+      prefix = block.prefix
+      return 0_u32 if prefix.size < 4
+      ((prefix[0].to_u32 & 0x7f) << 24) | (prefix[1].to_u32 << 16) |
+        (prefix[2].to_u32 << 8) | prefix[3].to_u32
+    end
+
     # Refuse one stream. The head never goes on the wire, so it is fed to the assembler for the
     # PROJECTION ONLY — `write` is what logs a frame, and P7 logs what gori actually wrote — and
     # the flow is finalized with h1's own sandbox reason, so a blocked attempt stays visible in
@@ -543,7 +603,8 @@ module Gori::Proxy::H2
       return nil unless @interceptor.intercepts_request?(
                           method: method, host: host, target: target, scheme: scheme)
       @interceptor.enqueue_request(head, method: method, target: target,
-        host: host, port: port, scheme: scheme)
+        host: host, port: port, scheme: scheme,
+        edit_refusal: edit_refusal(block), head_only: true)
     end
 
     private def hold_response(block : HeadRewrite::Block, head : Bytes) : Gori::Interceptor::Item?
@@ -567,7 +628,22 @@ module Gori::Proxy::H2
                           scheme: ref.scheme, status: status)
       # h1's response Item carries "<status> <reason>"; h2 has no reason phrase (§8.3.2).
       @interceptor.enqueue_response(head, flow_id: @assembler.flow_id_of(block.stream_id),
-        method: ref.method, target: status.to_s, host: host, port: port, scheme: ref.scheme)
+        method: ref.method, target: status.to_s, host: host, port: port, scheme: ref.scheme,
+        edit_refusal: edit_refusal(block), head_only: true)
+    end
+
+    # Why an edit to this held head cannot be applied, or nil. Asked HERE — at hold time, on
+    # the pump fiber — because `h1_faithful?` is a pure function of the block's decoded fields,
+    # so the answer is already knowable and the surface can refuse before the operator writes
+    # the edit. It used to be discovered on the wait fiber, inside `HeadRewrite#encode_edited`,
+    # whose `|| block` fallback in `edited` silently threw the edit away long after the CLI /
+    # MCP / TUI had reported it applied.
+    private def edit_refusal(block : HeadRewrite::Block) : String?
+      reason = HeadCodec.h1_unfaithful_reason(block.fields, block.request)
+      return nil unless reason
+      "gori will not apply an edit to this HTTP/2 message: #{reason}. The h1 text form shown " \
+      "here is lossy for it, so an edit would be applied to a different message than the one " \
+      "the peer sent (#517) — the fields go out exactly as they arrived"
     end
 
     private def wait_for(item : Gori::Interceptor::Item, block : HeadRewrite::Block) : Nil
@@ -595,46 +671,76 @@ module Gori::Proxy::H2
       if decision.action.drop?
         slot.dropped = true
       else
-        slot.decided = decision.bytes == block.head ? block : edited(block, decision.bytes)
+        slot.decided = decision.bytes == block.head ? block : edited(block, decision)
       end
       slot.ready = true
       drain_locked
     end
 
     # The operator's bytes, back through the same pipeline a rule takes.
-    private def edited(block : HeadRewrite::Block, bytes : Bytes) : HeadRewrite::Block
-      head, body = split_edit(bytes)
+    private def edited(block : HeadRewrite::Block,
+                       decision : Gori::Interceptor::Decision) : HeadRewrite::Block
+      head, body = Gori::Interceptor.split_edit(decision.bytes)
       # h2 holds the HEAD only (#492 step 3, D2) — DATA streams past untouched, so a body typed
-      # into the editor has nowhere to go. Ignoring it silently is the failure class this epic
-      # exists to remove, so say it once. (`content-length` needs no equivalent warning: the
-      # editor's own automatic `Content-Length:` on a dirty edit is reverted by
-      # `HeadCodec.restore_content_length`, which is required anyway because DATA is untouched.)
+      # into the editor has nowhere to go. `Item#head_only?` lets the surface refuse the edit
+      # outright now, so reaching here means a caller that did not check; say it once anyway.
       if body && !@warned_body
         @warned_body = true
         ::Log.warn { "h2 #{@direction}: an intercept edit added a body (stream #{block.stream_id}) — h2 holds the head only, the body was ignored" }
       end
-      @heads.encode_edited(block, head) || block
+      restore = length_synced?(head, decision.bytes.size - head.size)
+      warn_length_restored(block.stream_id) if restore && declares_length?(head)
+      @heads.encode_edited(block, head, restore) || block
     end
 
-    # {head incl. its terminating blank line, whether anything followed it}.
+    # Whether the edit's `content-length` was computed FOR the operator rather than declared BY
+    # them — the one thing that decides whether `HeadCodec.restore_content_length` runs over
+    # their bytes (R3-F2).
     #
-    # The EARLIEST blank line, in either spelling — `Rules#split_message`'s rule and for the
-    # same reason. `||` preferred the CRLF form wherever it appeared, so an operator whose
-    # edited head is LF-joined (the intercept editor's `TextArea#text` is) and whose BODY
-    # carries a CRLFCRLF got the boundary taken inside the body: the "head" handed to the
-    # codec would then include body bytes.
-    private def split_edit(bytes : Bytes) : {Bytes, Bool}
-      text = String.new(bytes)
-      crlf = text.index("\r\n\r\n")
-      lf = text.index("\n\n")
-      idx =
-        if crlf && (lf.nil? || crlf < lf)
-          crlf + 4
-        elsif lf
-          lf + 2
-        end
-      return {bytes, false} unless idx
-      {bytes[0, idx], idx < bytes.size}
+    # Derived from the bytes, not asserted by the caller, because the caller does not reliably
+    # know: `gori run intercept edit` runs `ContentLength.sync` over `--raw-file` unconditionally,
+    # the MCP tool runs it unless `update_content_length:false`, and the TUI editor runs it
+    # unless `^L` is off. What every one of those affordances PRODUCES is a `content-length`
+    # that agrees with the body the edit carries, and an h2 hold carries no body — so a value
+    # that DISAGREES cannot have come from any of them. That is the operator declaring one,
+    # which on h2 is the RFC 9113 §8.1.1 probe (does this origin/CDN/WAF/gRPC gateway enforce
+    # content-length against DATA?) and on h1 is already forwarded byte-exact.
+    #
+    # Its stated limit: a deliberate `content-length: 0` on a head-only hold is
+    # INDISTINGUISHABLE from a sync of the same empty body, so it still gets the peer's value
+    # back. That case is unreachable by construction, not by choice.
+    private def length_synced?(head : Bytes, body_size : Int32) : Bool
+      declared = declared_lengths(head)
+      declared.empty? || declared.all? { |v| v == body_size.to_s }
+    end
+
+    private def declares_length?(head : Bytes) : Bool
+      !declared_lengths(head).empty?
+    end
+
+    private def declared_lengths(head : Bytes) : Array(String)
+      values = [] of String
+      String.new(head).each_line do |line|
+        stripped = line.rstrip('\r')
+        break if stripped.empty?
+        next unless pair = HeadCodec.header_field(stripped)
+        values << pair[1] if pair[0].compare("content-length", case_insensitive: true) == 0
+      end
+      values
+    end
+
+    # The restore is a rewrite of the operator's own bytes, so it does not get to be silent —
+    # the reasoning `warned_body` already had, applied to the other thing this path changes.
+    private def warn_length_restored(stream_id : UInt32) : Nil
+      return if @warned_length
+      @warned_length = true
+      ::Log.warn do
+        "h2 #{@direction}: an intercept edit's content-length agreed with the body the edit " \
+        "carried, which is what an \"update Content-Length\" affordance produces — the peer's " \
+        "original value was put back (stream #{stream_id}), because h2 holds the head only and " \
+        "the DATA frames are unchanged. To send a content-length that disagrees with the DATA " \
+        "(the RFC 9113 §8.1.1 probe), declare it with the editor's Content-Length sync OFF"
+      end
     end
 
     # --- release -------------------------------------------------------------

--- a/src/gori/proxy/tls/tunnel.cr
+++ b/src/gori/proxy/tls/tunnel.cr
@@ -119,7 +119,12 @@ module Gori::Proxy::Tls
       # Skipped entirely for a CLEARTEXT origin: reflection is an ALPN probe, and ALPN only
       # exists inside a TLS handshake. gori has no h2c support to reflect instead, so the
       # client is kept on h1 — which is what the nil path already means.
-      upstream = tls_upstream ? reflect_origin_h2(host, port, dial_addr) : nil
+      #
+      # `offer` is the OBSERVED outcome, carried into `ClientConn` rather than re-derived
+      # there. See `Proxy::H2Offer`: an h2/gRPC client whose preface lands on the h1 path used
+      # to be told the two causes this method knows nothing about, and pointed at a `gori.log`
+      # line the common path never writes.
+      upstream, offer = tls_upstream ? reflect_origin_h2(host, port, dial_addr) : {nil, Proxy::H2Offer::Cleartext}
 
       server_ctx = @ca.context_for(host, advertise_h2: !upstream.nil?)
       # sync_close: true is REQUIRED, not cosmetic. The h2/ws relays tear down by
@@ -165,6 +170,7 @@ module Gori::Proxy::Tls
           # listener — without it the setting was honoured or ignored depending on whether
           # the client happened to speak TLS, which is not a distinction the operator made.
           rewrite_fixed_host: rewrite_host,
+          h2_offer: offer,
         ).run
       end
     rescue
@@ -198,22 +204,31 @@ module Gori::Proxy::Tls
     # about the machine that answered: the same name reached at two different pinned addresses
     # is two origins, and sharing one entry between them would deny h2 to the second on
     # evidence gathered from the first.
+    #
+    # Returns the socket AND the observed reason, because the reason is the thing this method
+    # is uniquely able to know and every later surface was reduced to guessing at (`H2Offer`).
     private def reflect_origin_h2(host : String, port : Int32,
-                                  dial_addr : String? = nil) : OpenSSL::SSL::Socket::Client?
-      return nil unless h2_candidate?(host)
-      return nil if @h1_only_origins.includes?({host, port, dial_addr}) # known h1-only: skip the probe
+                                  dial_addr : String? = nil) : {OpenSSL::SSL::Socket::Client?, Proxy::H2Offer}
+      if downgrade = h2_downgrade_reason(host)
+        return {nil, downgrade}
+      end
+      # A cached h1-only origin is the same OBSERVATION as one made on this connection — it was
+      # made by a real handshake, just an earlier one — so it reports the same reason.
+      return {nil, Proxy::H2Offer::UpstreamDeclined} if @h1_only_origins.includes?({host, port, dial_addr})
       # Cap the connect wait so an unreachable origin doesn't burn the full timeout here before
       # the h1 fallback re-dials and waits again (never longer than the configured timeout).
       timeout = {Gori::Settings.connect_timeout, H2_PROBE_CONNECT_TIMEOUT}.min
       upstream = Proxy::Upstream.dial_tls(host, port, verify: @verify_upstream, alpn: "h2",
         connect_timeout: timeout, overrides: @host_overrides, pin: dial_addr)
-      return upstream if upstream && upstream.alpn_protocol == "h2"
+      return {upstream, Proxy::H2Offer::Offered} if upstream && upstream.alpn_protocol == "h2"
       # Remember a DEFINITIVE h1 negotiation (handshake completed, ALPN != h2) so repeat visits
       # skip the probe. Never cache a nil dial — that's a transient reach/verify failure, not a
       # statement about the origin's ALPN; caching it would wrongly pin a briefly-down origin.
-      @h1_only_origins << {host, port, dial_addr} if upstream && @h1_only_origins.size < H1_ONLY_CACHE_MAX
+      # The same distinction is what separates the two reasons below.
+      declined = !upstream.nil?
+      @h1_only_origins << {host, port, dial_addr} if declined && @h1_only_origins.size < H1_ONLY_CACHE_MAX
       upstream.try(&.close) rescue nil
-      nil
+      {nil, declined ? Proxy::H2Offer::UpstreamDeclined : Proxy::H2Offer::UpstreamUnreachable}
     end
 
     # Whether this host may take the fast h2 relay at all. FALSE — forcing HTTP/1.1, the
@@ -276,16 +291,20 @@ module Gori::Proxy::Tls
     # hand-rolled peer — but it is not impossible, so it is not left silent: `H2::HeadRewrite`
     # already computes the per-stream authority for rule scoping and logs once per connection
     # when a stream's authority differs from this host AND a body/stub rule matches it.
-    private def h2_candidate?(host : String) : Bool
+    #
+    # Returns the REASON (an `H2Offer` member) rather than a Bool, and nil for a candidate:
+    # every one of these branches writes a `gori.log` line, and `ClientConn` has to be able to
+    # say which one applied without re-deriving it from a rule table that has since changed.
+    private def h2_downgrade_reason(host : String) : Proxy::H2Offer?
       if Gori::Settings.http2_disabled?
         notice_downgrade(host, "HTTP/2 is switched off (settings network.http2; set it back to " \
                                "\"auto\" to keep h2)")
-        return false
+        return Proxy::H2Offer::DisabledBySetting
       end
       if @rewriter.try(&.rewrites_body_for_host?(host))
         notice_downgrade(host, "a Match&Replace BODY rule is live and body rewriting on HTTP/2 " \
                                "is not implemented yet (disable the body rule to keep h2)")
-        return false
+        return Proxy::H2Offer::BodyRule
       end
       # A SHORT-CIRCUIT rule (#511) earns the downgrade for the same reason a body rule does:
       # `HeadRewriter#short_circuit` is consulted in `ClientConn#handle_request`, and the h2
@@ -297,7 +316,7 @@ module Gori::Proxy::Tls
       if @rewriter.try(&.short_circuits_for_host?(host))
         notice_downgrade(host, "a Match&Replace short-circuit rule is live and the h2 relay " \
                                "cannot answer a request locally (disable the stub rule to keep h2)")
-        return false
+        return Proxy::H2Offer::ShortCircuitRule
       end
       # A BODY-scoped session-binding extract rule (#501 slice 2) earns the downgrade for
       # exactly the reason a body rewrite rule does: it needs the response ENTITY, and DATA
@@ -313,9 +332,9 @@ module Gori::Proxy::Tls
         notice_downgrade(host, "a session-binding extract rule reads the response BODY and body " \
                                "extraction on HTTP/2 is not implemented yet (a cookie / header " \
                                "descriptor works on h2 and costs nothing)")
-        return false
+        return Proxy::H2Offer::ExtractRule
       end
-      true
+      nil
     end
 
     # One gori.log line per host per reason, the discipline `Settings::PASSTHROUGH_NOTICE_MAX`

--- a/src/gori/proxy/ws/relay.cr
+++ b/src/gori/proxy/ws/relay.cr
@@ -130,12 +130,18 @@ module Gori::Proxy::WS
       # the upstream leg.
       out_gate = ws_gate(interceptor, upstream, flow_id, sink, ctx, "out", mask: true)
       in_gate = ws_gate(interceptor, client, flow_id, sink, ctx, "in", mask: false)
+      # Built HERE and not inside the pump fiber, for the same reason `settle` is called from
+      # this method: what a pump is WITHHOLDING can only reach the peer while the sockets are
+      # still open, and on a gated socket the pump's own `ensure` is reached only AFTER the
+      # two `close` calls below. See `AssemblingPump#flush_at_teardown`.
+      out_pump = assembling_pump(client, upstream, "out", flow_id, sink, out_rw, ctx, out_gate, mask: true)
+      in_pump = assembling_pump(upstream, client, "in", flow_id, sink, in_rw, ctx, in_gate, mask: false)
 
       done = Channel(Bool).new(2) # each pump's payload: did it end by relaying a CLOSE frame?
       # client→server: RFC 6455 §5.3 requires every such frame to be masked, so a re-emitted
       # one carries a fresh key of gori's.
-      spawn { done.send(direction_pump(client, upstream, "out", flow_id, sink, out_rw, ctx, out_gate, mask: true)) }
-      spawn { done.send(direction_pump(upstream, client, "in", flow_id, sink, in_rw, ctx, in_gate, mask: false)) }
+      spawn { done.send(run_direction(client, upstream, "out", flow_id, sink, out_pump, out_gate)) }
+      spawn { done.send(run_direction(upstream, client, "in", flow_id, sink, in_pump, in_gate)) }
 
       # The first direction to end tells us how to tear down:
       #   - abnormal end (EOF / reset / truncated frame): the peer is gone — close both
@@ -165,6 +171,12 @@ module Gori::Proxy::WS
       # is the one moment at which a held message can still reach its peer.
       out_gate.try(&.settle("the socket is closing"))
       in_gate.try(&.settle("the socket is closing"))
+      # ... and the same moment, for the same reason, is the last one at which a HALF-assembled
+      # message and the control frames parked between its fragments can still reach the peer.
+      # The gates above resolve what a HUMAN still owns; this resolves what the pump itself is
+      # withholding, and it goes second because those bytes arrived after everything queued.
+      out_pump.try(&.flush_at_teardown)
+      in_pump.try(&.flush_at_teardown)
       client.close rescue nil
       upstream.close rescue nil
       # Every path above consumes exactly one of the two `done` sends before this point
@@ -217,14 +229,31 @@ module Gori::Proxy::WS
       MessageGate.new(direction, dst, flow_id, sink, ic, ctx, mask: mask)
     end
 
-    # One direction's loop. `pump` — the pre-existing byte-exact one — unless this direction
-    # has a rewriter or a hold gate to run, which is what keeps an unconfigured socket on the
-    # path it has always taken.
-    private def self.direction_pump(src : IO, dst : IO, direction : String, flow_id : Int64,
-                                    sink : FlowSink, rewriter : HeadRewriter?, ctx : Context,
-                                    gate : MessageGate?, mask : Bool) : Bool
-      return pump(src, dst, direction, flow_id, sink) unless rewriter || gate
-      pump_assembling(src, dst, direction, flow_id, sink, rewriter, ctx, gate, mask: mask)
+    # This direction's assembling pump, or nil when neither a `part: ws` rule nor a hold is
+    # live on it — `pump`, the pre-existing byte-exact loop, is what every other socket runs
+    # and it carries no state across frames, so it needs no object.
+    private def self.assembling_pump(src : IO, dst : IO, direction : String, flow_id : Int64,
+                                     sink : FlowSink, rewriter : HeadRewriter?, ctx : Context,
+                                     gate : MessageGate?, mask : Bool) : AssemblingPump?
+      return nil unless rewriter || gate
+      AssemblingPump.new(src, dst, direction, flow_id, sink, rewriter, ctx, gate, mask)
+    end
+
+    # One direction's loop, on whichever pump `assembling_pump` chose.
+    private def self.run_direction(src : IO, dst : IO, direction : String, flow_id : Int64,
+                                   sink : FlowSink, assembling : AssemblingPump?,
+                                   gate : MessageGate?) : Bool
+      return pump(src, dst, direction, flow_id, sink) unless assembling
+      begin
+        assembling.run
+      ensure
+        # The direction ended (cleanly or not). Hand every still-held message back to the
+        # Interceptor so no ghost queue row survives the socket and no wait fiber leaks —
+        # `H2::StreamGate#close`'s contract. This is also where the CLOSE_TIMEOUT ceiling
+        # lands: when the PEER closes the other direction, `run` gives this one 5 s and then
+        # closes the sockets, which unblocks the read here and reaps whatever was still held.
+        gate.try(&.close)
+      end
     end
 
     # Chunk size for streaming an oversized frame's payload (see stream_payload).
@@ -342,25 +371,14 @@ module Gori::Proxy::WS
       n
     end
 
-    # The assembling pump for ONE direction (#500). Only reached when a `part: ws` rule can
-    # match this socket's host on this side, or when the catch condition arms a hold there;
-    # `pump` above is what every other socket runs, unchanged.
-    private def self.pump_assembling(src : IO, dst : IO, direction : String, flow_id : Int64,
-                                     sink : FlowSink, rewriter : HeadRewriter?, ctx : Context,
-                                     gate : MessageGate?, mask : Bool) : Bool
-      AssemblingPump.new(src, dst, direction, flow_id, sink, rewriter, ctx, gate, mask).run
-    ensure
-      # The direction ended (cleanly or not). Hand every still-held message back to the
-      # Interceptor so no ghost queue row survives the socket and no wait fiber leaks —
-      # `H2::StreamGate#close`'s contract. This is also where the CLOSE_TIMEOUT ceiling lands:
-      # when the PEER closes the other direction, `run` gives this one 5 s and then closes the
-      # sockets, which unblocks the read here and reaps whatever was still held.
-      gate.try(&.close)
-    end
-
-    # One direction's assembling pump. An object rather than a method because it carries
-    # per-message state across frames (the assembly buffer, the message opcode, whether the
-    # message has fallen back to byte-exact forwarding). One instance per pump fiber, so
+    # One direction's assembling pump (#500). Only reached when a `part: ws` rule can match
+    # this socket's host on this side, or when the catch condition arms a hold there; `pump`
+    # above is what every other socket runs, unchanged.
+    #
+    # An object rather than a method because it carries per-message state across frames (the
+    # assembly buffer, the message opcode, whether the message has fallen back to byte-exact
+    # forwarding) — and because `Relay.run` has to reach that state at teardown, while the
+    # sockets are still open (`flush_at_teardown`). One instance per pump fiber, so
     # nothing here is shared and nothing is locked — the GATE owns the only shared state,
     # because a wait fiber writes through it.
     #
@@ -396,7 +414,8 @@ module Gori::Proxy::WS
       # hands them to the gate the moment a hold actually parks the message.
       @parked = [] of {Int32, Bytes}
       @parked_overflowed = false
-      @in_bypass = false # the gate's lock is already held, so writes must not re-take it
+      @in_bypass = false  # the gate's lock is already held, so writes must not re-take it
+      @torn_down = false  # `flush_at_teardown` has run; there is nothing left to owe the wire
       @scratch : Bytes
       # The V7 frame-shape accumulator and this direction's ping/pong capture budget. Both
       # pumps have to record identical facts about identical bytes, or an operator's finding
@@ -438,14 +457,34 @@ module Gori::Proxy::WS
         # The abnormal exits (EOF, a truncated frame, a reset) are withholding the same bytes
         # a CLOSE would have been, and the byte-exact pump would already have forwarded them —
         # so dropping them silently is a difference between the two pumps that should not
-        # exist. Best-effort: this path is usually taken BECAUSE a peer went away.
-        #
-        # GATED sockets are deliberately excluded. `Relay.run` closes both sockets to unblock
-        # this pump's read, so by the time this `ensure` runs on a gated socket the write has
-        # nowhere to go — and `flush_withheld` also writes a `ws_messages` row, which would
-        # then claim a delivery that did not happen. `run` has already given the gate its one
-        # real chance (`MessageGate#settle`, while the sockets were still open).
-        (flush_withheld rescue nil) if @gate.nil?
+        # exist. Reached FIRST for the direction that ends on its own (the sockets are still
+        # open — `Relay.run` is parked on `done.receive`); a no-op for the other one, which
+        # `run` has already flushed. Either way `flush_at_teardown` runs exactly once.
+        flush_at_teardown
+      end
+
+      # Everything this pump is still WITHHOLDING — a half-assembled message's fragments and
+      # any control frame parked between them — put on the wire in arrival order, and into
+      # capture. Idempotent, and best-effort: it is normally reached BECAUSE a peer went away.
+      #
+      # It cannot be left to the `ensure` above on a GATED socket. That `ensure` is reached
+      # there only because `Relay.run` closed both sockets to unblock this pump's read, so the
+      # write would have nowhere to go — which is exactly why the flush used to be skipped
+      # (`if @gate.nil?`). That exclusion was harmless until #554 started PARKING control
+      # frames: before it, a control frame was on the wire the instant it arrived, so there
+      # was nothing in `@parked` to lose. After it, a gated socket that ended without a CLOSE
+      # delivered neither the parked PING nor the fragment it was parked inside — while the
+      # arrival-time `capture_control` row still claimed the PING had gone out. Losing a
+      # keepalive on a gated socket is the liveness failure `MAX_PARKED_CONTROLS` and
+      # `MessageGate`'s header exist to prevent, so the answer is to write the frames, not to
+      # stop recording them. `Relay.run` calls this while both sockets are still open, right
+      # after `settle` — the same moment, and for the same reason.
+      def flush_at_teardown : Nil
+        return if @torn_down
+        @torn_down = true
+        bypass("the socket is closing") { flush_withheld }
+      rescue
+        nil
       end
 
       # A control frame (ping/pong/close) never takes part in a rewrite or a hold, and it is
@@ -567,14 +606,32 @@ module Gori::Proxy::WS
         io.to_slice
       end
 
+      # The ceiling tripped, so gori is about to put this message's parked control frames on
+      # the wire AHEAD of the fragments they arrived between: the §5.4 interleave the peer
+      # reads off this socket is no longer the one the peer sent.
+      #
+      # That is a fact about the wire, so it goes on the flow's own `ws_messages` stream and
+      # not only into `gori.log` — #518's argument for the `Sec-WebSocket-Extensions`
+      # advisory, and the `[gori] …` convention `capture_control`'s ping-flood marker and
+      # `forward_oversized_frame`'s already use. Without the row nothing downstream can tell
+      # the two dispositions apart: control frames are recorded at ARRIVAL and message rows at
+      # EMIT either way, so History, `gori run show`, MCP `get_flow` and an export show the
+      # same "controls, then the message" ordering whether the interleave was preserved or
+      # given up. Once per direction per socket, like the warn and like `MAX_CONTROL_CAPTURE`'s
+      # marker — its POSITION in the stream is what names the message it applies to.
       private def warn_parking_ceiling : Nil
         return if @parked_overflowed
         @parked_overflowed = true
-        ::Log.warn do
-          "ws #{@direction}: more than #{MAX_PARKED_CONTROLS} control frames arrived between " \
-          "the fragments of one message — forwarding them ahead of it so the peer's ping " \
-          "timer still sees a reply. The frames are byte-exact; their position relative to " \
-          "this message's fragments is not"
+        note = "more than #{MAX_PARKED_CONTROLS} control frames arrived between the fragments " \
+               "of one message; they were forwarded ahead of it so the peer's ping timer still " \
+               "sees a reply. The frames are byte-exact; their position relative to this " \
+               "message's fragments is not"
+        ::Log.warn { "ws #{@direction}: #{note}" }
+        begin
+          @sink.on_ws_message(@flow_id, @direction, OP_TEXT.to_i, "#{NOTICE_PREFIX}#{note}".to_slice)
+        rescue
+          # Capture is best-effort here exactly as it is in `record_notice`: a row that fails
+          # to write must never stop the relay from forwarding.
         end
       end
 
@@ -599,7 +656,14 @@ module Gori::Proxy::WS
         # passthrough and TEXT is not, so `BIN fin=0 "LEAK"` then `TEXT fin=1 "second"` put
         # `LEAKSECOND` on the wire as one TEXT frame. Its bytes need no flush (they were
         # already written frame by frame) but they must not stay in the buffer.
-        bypass("a message arrived before the previous one sent its FIN") { flush_withheld } if @buffer.size > 0
+        #
+        # `@parked` is asked about separately because a LEADING FRAGMENT MAY BE EMPTY: an
+        # empty `TEXT fin=0` puts bytes in `@raw` and none in `@buffer`, so a control frame
+        # can be parked inside a message the buffer test calls "not there" — and `reset_raw`
+        # below would then discard it silently. Same rule `flush_withheld` already states.
+        if @buffer.size > 0 || !@parked.empty?
+          bypass("a message arrived before the previous one sent its FIN") { flush_withheld }
+        end
         @opcode = opcode
         @rewritable = opcode == OP_TEXT && !@rewriter.nil?
         @passthrough = !@rewritable && @gate.nil?
@@ -740,7 +804,14 @@ module Gori::Proxy::WS
       # cap) is the prefix re-framed, as a NON-final frame carrying the message opcode rather
       # than OP_CONT: this is reached at most once per message, so it is always the leading one.
       private def flush_buffered : Nil
-        return if @buffer.size == 0
+        if @buffer.size == 0
+          # Nothing is owed for the payload, but a control frame parked between fragments
+          # still is — a leading fragment may be empty, and every caller here goes on to
+          # `reset_raw`, which drops `@parked` on the floor. `flush_withheld` states the same
+          # rule for the same reason.
+          flush_parked
+          return
+        end
         if @raw_kept && @raw.size > 0
           write_direct(interleaved_raw) # the peer's frames, control-frame interleave and all
           @parked.clear

--- a/src/gori/proxy/ws/relay.cr
+++ b/src/gori/proxy/ws/relay.cr
@@ -414,8 +414,8 @@ module Gori::Proxy::WS
       # hands them to the gate the moment a hold actually parks the message.
       @parked = [] of {Int32, Bytes}
       @parked_overflowed = false
-      @in_bypass = false  # the gate's lock is already held, so writes must not re-take it
-      @torn_down = false  # `flush_at_teardown` has run; there is nothing left to owe the wire
+      @in_bypass = false # the gate's lock is already held, so writes must not re-take it
+      @torn_down = false # `flush_at_teardown` has run; there is nothing left to owe the wire
       @scratch : Bytes
       # The V7 frame-shape accumulator and this direction's ping/pong capture budget. Both
       # pumps have to record identical facts about identical bytes, or an operator's finding

--- a/src/gori/repeater/h2_engine.cr
+++ b/src/gori/repeater/h2_engine.cr
@@ -452,7 +452,7 @@ module Gori
         else            return
         end
         if flow.conn > MAX_WINDOW || flow.stream > MAX_WINDOW
-          flow.violation ||= "the origin's WINDOW_UPDATEs drove a flow-control window past " \
+          flow.violation ||= "the origin's WINDOW_UPDATE frames drove a flow-control window past " \
                              "2^31-1, which RFC 9113 §6.9.1 makes a FLOW_CONTROL_ERROR " \
                              "(connection #{flow.conn}, stream #{flow.stream})"
         end

--- a/src/gori/repeater/h2_engine.cr
+++ b/src/gori/repeater/h2_engine.cr
@@ -36,6 +36,17 @@ module Gori
       # per-op io_timeout only fires on IDLE, so bytes-always-arriving pins the fiber. This
       # bounds the loop the way the h1 engine's MAX_INTERIM does (RFC-hostile-origin guard).
       MAX_FRAMES = 100_000
+      # RFC 9113 §6.9.1: a flow-control window may never exceed 2^31-1, and a WINDOW_UPDATE
+      # increment of 0 is a PROTOCOL_ERROR. Both are plausible real-world server bugs and
+      # both used to be absorbed in silence — see `credit`.
+      MAX_WINDOW = 2_147_483_647_i64
+      # Frames read while waiting for the peer's SETTINGS. §3.4 makes SETTINGS the server's
+      # FIRST frame, but a peer that opens with a PING or a connection WINDOW_UPDATE still
+      # sends it moments later, and reading exactly one frame meant gori wrote the body
+      # against the RFC default window and then blamed the ORIGIN for the GOAWAY it drew.
+      # Two or three covers every real stack (a SETTINGS ACK plus a WINDOW_UPDATE); eight
+      # leaves room for a chatty one without letting a SETTINGS-less peer hold the write.
+      AWAIT_SETTINGS_FRAMES = 8
 
       private alias Frame = Proxy::H2::Frame
       private alias HPACK = Proxy::H2::HPACK
@@ -67,6 +78,26 @@ module Gori
         property? eof = false
         property goaway : String? = nil
         property rst : String? = nil
+        # Wall-clock budget for ONE contiguous wait — for send-window credit, and for any
+        # progress at all on stream 1. The per-read io_timeout fires only on IDLE, so ANY
+        # frame (a keepalive PING, a SETTINGS, a `WINDOW_UPDATE +0`) resets it and the only
+        # remaining ceiling was MAX_FRAMES, a COUNT: ~55 hours at a 2 s ping cadence, ~17
+        # days at a 15 s gRPC keepalive. Same value as the idle timeout, so "the origin sent
+        # nothing" and "the origin sent everything except window" bound alike — the one
+        # number an operator already expects. (`WsEngine::DRAIN_DEADLINE` is the sibling.)
+        property patience : Time::Span = Settings.io_timeout
+        # Request-body accounting, so a send gori cut short can never be reported as a clean
+        # one. `total_body` is 0 when there was no body to send.
+        property sent_body = 0
+        property total_body = 0
+        # Why the body stopped short of the peer's window. RECORDED rather than raised: a
+        # raise unwinds out of `write_request` before `read_response` runs, destroying a
+        # response the peer had already finished sending.
+        property stall : String? = nil
+        # The FIRST RFC 9113 §6.9.1 WINDOW_UPDATE violation observed. Reported as a clause on
+        # a failure, never as a failure itself: an illegal frame from the origin does not
+        # invalidate a response that nonetheless arrived intact.
+        property violation : String? = nil
         getter pending = [] of Frame::Header
         # Shared with `read_response` so the MAX_FRAMES hostile-origin ceiling counts the
         # frames absorbed during the write too.
@@ -104,7 +135,7 @@ module Gori
         return failure(connect_error(scheme, host, port, verify_upstream), started) unless upstream
         begin
           headers, body = parse_request(request, scheme, host, port, preserve_field_case)
-          exchange(upstream, headers, body, host, port, started)
+          exchange(upstream, headers, body, host, port, started, timeout)
         rescue ex
           failure(ex.message || "h2 repeater error", started)
         ensure
@@ -135,7 +166,7 @@ module Gori
         upstream = open(scheme, host, port, verify_upstream, sni, timeout, overrides)
         return failure(connect_error(scheme, host, port, verify_upstream), started) unless upstream
         begin
-          exchange(upstream, fields, body, host, port, started)
+          exchange(upstream, fields, body, host, port, started, timeout)
         rescue ex
           failure(ex.message || "h2 repeater error", started)
         ensure
@@ -147,22 +178,84 @@ module Gori
       # from `send` so the h1-text path and the field-native `send_fields` path share the exact
       # same exchange — the fields differ, the framing and reassembly do not.
       private def self.exchange(upstream : IO, headers : Array({String, String}), body : Bytes?,
-                                host : String, port : Int32, started : Time::Instant) : Result
+                                host : String, port : Int32, started : Time::Instant,
+                                timeout : Time::Span? = nil) : Result
         flow = SendFlow.new
+        # The caller's per-operation timeout IS the socket's idle bound (`open` passes it to
+        # the dialer), so the stall/no-progress ceilings must use the same number or a spec
+        # (and an operator) that dialled with a short timeout would still wait out the global
+        # default.
+        flow.patience = timeout || Settings.io_timeout
         write_request(upstream, headers, body, flow)
         reply = read_response(upstream, flow)
-        return failure(no_response(reply, host, port), started) if reply.status == 0 && reply.headers.empty?
+        return failure(no_response(reply, flow, host, port), started) if reply.status == 0 && reply.headers.empty?
         head = synth_head(reply)
         resp = Proxy::Codec::Http1.parse_response_head(head)
         # A stream the peer RESET or a connection it sent GOAWAY on still produced bytes here,
         # and the cause must not be dropped just because a partial response arrived: a
         # RST_STREAM(CANCEL) after a 200 + half a body used to render as
         # "incomplete — origin closed before the framed body finished", which names the wrong
-        # event entirely. The head and body stay on the Result; the reason rides alongside.
-        reason = reply.rst || reply.goaway
+        # event entirely. The head and body stay on the Result; the reason rides alongside —
+        # and so does the send-side accounting, because a 413 that the origin returned WHILE
+        # the body was still going out is a real response to a request gori did not finish.
         Result.new(head, reply.body, resp, elapsed(started),
-          error: reason ? "#{reason} from #{host}:#{port}" : nil,
+          error: send_side_reason(reply, flow, host, port),
           incomplete: !reply.clean_eos, delivered: true)
+      end
+
+      # Everything gori has to say about how an exchange went, or nil when it went cleanly:
+      # the peer's own stated reason (RST_STREAM / GOAWAY, re-attributed when the overrun was
+      # gori's own), gori's send-side accounting when the request body did NOT go out whole,
+      # and any §6.9.1 WINDOW_UPDATE violation observed on the way.
+      #
+      # A response that arrived keeps its head and body regardless — this rides alongside it,
+      # it does not replace it. The §6.9.1 violation is only ever a clause on something that
+      # already went wrong: an origin whose illegal WINDOW_UPDATE cost nothing (a body that
+      # completed anyway) must not have its 200 turned into a failure.
+      private def self.send_side_reason(reply : Reply, flow : SendFlow,
+                                        host : String, port : Int32) : String?
+        parts = [] of String
+        if reason = reply.rst || reply.goaway
+          parts << attribute(reason, host, port, flow)
+        end
+        if stall = flow.stall
+          parts << stall
+        elsif cut = truncated(flow)
+          parts << cut
+        end
+        if violation = flow.violation
+          parts << violation unless parts.empty?
+        end
+        parts.empty? ? nil : parts.join(" — ")
+      end
+
+      # A GOAWAY(FLOW_CONTROL_ERROR) drawn while gori had NOT yet seen the peer's SETTINGS is
+      # gori's OWN overrun: it wrote against the §6.9.2 default because the peer's real window
+      # had not arrived yet. Handing the operator the origin's address for that is the exact
+      # misattribution the send-side flow control was added to remove, and one non-SETTINGS
+      # opening frame was enough to reach it again.
+      private def self.attribute(reason : String, host : String, port : Int32,
+                                 flow : SendFlow) : String
+        base = "#{reason} from #{host}:#{port}"
+        return base if flow.settings_seen? || !reason.includes?("FLOW_CONTROL_ERROR")
+        "#{base} — gori wrote #{flow.sent_body} request body bytes against the RFC 9113 §6.9.2 " \
+        "default #{DEFAULT_WINDOW}-byte window because the origin's SETTINGS had not arrived. " \
+        "The overrun is gori's own accounting, not a fault of the origin."
+      end
+
+      # The request body was cut short because the PEER ended stream 1 first — the 413/431 an
+      # upload or body-size probe exists to find (RFC 9113 §8.1 explicitly permits answering
+      # before the request body is complete), or a RST_STREAM/GOAWAY mid-body. nil when the
+      # body went out whole, or when there was no body at all.
+      #
+      # Reporting this is half the fix: the one early-response shape that DID work returned
+      # `ok:true, error:null` for a request gori had truncated at 4096 of 20 000 bytes, so no
+      # status read off it was a verdict on the payload the operator meant to send.
+      private def self.truncated(flow : SendFlow) : String?
+        return nil if flow.total_body == 0 || flow.sent_body >= flow.total_body
+        "the request body was truncated at #{flow.sent_body} of #{flow.total_body} bytes " \
+        "(the origin ended the stream before the body finished, which RFC 9113 §8.1 permits). " \
+        "The request was NOT fully sent."
       end
 
       # The one sentence that names why an h2 exchange produced no response.
@@ -174,14 +267,23 @@ module Gori
       # connection" instruction (RFC 9113 §8.7) that was being reported as a flat refusal.
       # RST_STREAM is preferred over GOAWAY: it is about OUR stream, the GOAWAY that usually
       # follows is about the connection.
-      private def self.no_response(reply : Reply, host : String, port : Int32) : String
-        if reason = reply.rst || reply.goaway
-          return "#{reason} from #{host}:#{port}"
+      private def self.no_response(reply : Reply, flow : SendFlow, host : String, port : Int32) : String
+        # A body that never went out whole is the FINDING; a missing response is its
+        # consequence. `send_side_reason` states it in gori's own accounting.
+        if reason = send_side_reason(reply, flow, host, port)
+          return reason
         end
         # "sent nothing before the read timed out" is the genuinely retryable outcome and
         # "closed" is not; they had the same wording, so no consumer could tell them apart.
-        return "no h2 response from #{host}:#{port} — the origin sent nothing before the read timed out" if reply.timed_out
-        "no h2 response from #{host}:#{port} — the connection closed before a response frame arrived"
+        base = if reply.timed_out
+                 "no h2 response from #{host}:#{port} — the origin sent nothing before the read timed out"
+               else
+                 "no h2 response from #{host}:#{port} — the connection closed before a response frame arrived"
+               end
+        # With nothing else to attach it to, a §6.9.1 violation is still the most specific
+        # thing gori saw: an origin that answered every window request with an illegal
+        # `WINDOW_UPDATE +0` and then hung up is not a plain silent origin.
+        (v = flow.violation) ? "#{base} — #{v}" : base
       end
 
       private def self.open(scheme : String, host : String, port : Int32, verify : Bool,
@@ -230,12 +332,24 @@ module Gori
       # window — the request was already over the limit before the first WINDOW_UPDATE could
       # have mattered, so no amount of blocking later would have helped.
       #
-      # Exactly ONE frame, and every failure is tolerated: a peer that opens with something
-      # else has told us it will not send SETTINGS first, and a peer that sends nothing at all
-      # costs one idle timeout that the response read was going to spend anyway. Neither is a
-      # reason to fail a send — the RFC defaults still apply.
+      # Reads up to AWAIT_SETTINGS_FRAMES frames, and every failure is tolerated: a peer that
+      # sends nothing at all costs one idle timeout that the response read was going to spend
+      # anyway, and that is not a reason to fail a send — the RFC defaults still apply.
+      #
+      # It used to read exactly ONE frame, on the reasoning that "a peer that opens with
+      # something else has told us it will not send SETTINGS first". It has told us no such
+      # thing: `pump_once` ACKs a PING, credits a WINDOW_UPDATE and falls straight through a
+      # SETTINGS **ACK** without setting `settings_seen`, so an origin whose opening frame is
+      # any of those — then its real SETTINGS a moment later — got the whole body written
+      # against the 65535-byte default and answered GOAWAY(FLOW_CONTROL_ERROR), which gori
+      # then reported as the ORIGIN misbehaving. `flow.settings_seen?` stays false when the
+      # budget runs out, and `attribute` names gori's own accounting if a GOAWAY follows.
       private def self.await_settings(io : IO, flow : SendFlow) : Nil
-        pump_once(io, flow) unless flow.settings_seen?
+        budget = AWAIT_SETTINGS_FRAMES
+        while !flow.settings_seen? && !flow.closed? && budget > 0
+          budget -= 1
+          break unless pump_once(io, flow)
+        end
       end
 
       # Read and dispatch ONE frame from the peer while the request is still being written.
@@ -278,10 +392,20 @@ module Gori
             flow.closed = true
           end
           flow.pending << frame
-        else
+        when Frame::Type::Data, Frame::Type::Headers
           # The peer answered before we finished the body (a 413/431 rejection, say). The
           # stream is over: stop writing at it and go read what it said.
-          flow.closed = true if frame.stream_id == 1 && frame.end_stream? && frame.end_headers?
+          #
+          # The test used to be `end_stream? && end_headers?`. END_HEADERS (0x4) is a
+          # HEADERS/CONTINUATION flag — on a DATA frame that bit means PADDED — so the
+          # conjunction could only ever hold for a response with NO BODY, and the ordinary
+          # shape (HEADERS then DATA/END_STREAM) fell through to a 30 s stall that then threw
+          # the finished response away. END_STREAM alone is both necessary and sufficient
+          # here, and it excludes an interim 1xx for free: a 1xx cannot end the stream, so an
+          # `Expect: 100-continue` origin still gets the body it asked to see.
+          flow.closed = true if frame.stream_id == 1 && frame.end_stream?
+          flow.pending << frame
+        else
           flow.pending << frame
         end
         true
@@ -308,12 +432,29 @@ module Gori
       # Credit an inbound WINDOW_UPDATE to the connection (stream 0) or our stream (1). The
       # read loop dispatched this frame type only to DISCARD it, which is why the send window
       # could never reopen.
+      #
+      # Both halves of §6.9.1 are NAMED rather than absorbed. A 0-increment WINDOW_UPDATE is a
+      # PROTOCOL_ERROR and a plausible real-world server bug; crediting it silently left the
+      # stall loop reporting a flat timeout for a violation gori had watched the origin commit
+      # 1200 times. Neither half REJECTS the frame — gori is the tester here, and a window that
+      # overflows into an Int64 is harmless — but the operator gets told what was on the wire.
       private def self.credit(frame : Frame::Header, flow : SendFlow) : Nil
         return if frame.payload.size < 4
         inc = (IO::ByteFormat::BigEndian.decode(UInt32, frame.payload[0, 4]) & 0x7fffffff_u32).to_i64
+        if inc == 0
+          flow.violation ||= "the origin sent WINDOW_UPDATE with a 0 increment on stream " \
+                             "#{frame.stream_id}, which RFC 9113 §6.9.1 makes a PROTOCOL_ERROR"
+          return
+        end
         case frame.stream_id
         when 0_u32 then flow.conn += inc
         when 1_u32 then flow.stream += inc
+        else            return
+        end
+        if flow.conn > MAX_WINDOW || flow.stream > MAX_WINDOW
+          flow.violation ||= "the origin's WINDOW_UPDATEs drove a flow-control window past " \
+                             "2^31-1, which RFC 9113 §6.9.1 makes a FLOW_CONTROL_ERROR " \
+                             "(connection #{flow.conn}, stream #{flow.stream})"
         end
       end
 
@@ -345,17 +486,35 @@ module Gori
 
       # The request body as DATA frames, never exceeding the peer's send window (§6.9.1).
       # When the window is exhausted the writer blocks reading frames until a WINDOW_UPDATE
-      # reopens it; the bound is the socket's own idle timeout, after which the stall is
-      # reported for what it is rather than left to the origin's GOAWAY.
+      # reopens it, bounded by `flow.patience` in WALL CLOCK, after which the stall is
+      # recorded for what it is rather than left to the origin's GOAWAY.
+      #
+      # Two things this loop must never do again, both of them ways of lying about the send:
+      # RAISE (it unwound out of `write_request` before `read_response` could drain the
+      # complete response already sitting in `flow.pending`), and `break` in silence (a body
+      # cut at 4096 of 20 000 bytes came back `ok:true, error:null`). Every exit records the
+      # byte counts; `truncated`/`flow_stalled` turn them into the sentence.
       private def self.write_data(io : IO, body : Bytes, flow : SendFlow) : Nil
         offset = 0
+        flow.total_body = body.size
         while offset < body.size
-          while flow.available <= 0 && !flow.closed?
-            io.flush # the peer cannot grant window for frames still sitting in our buffer
-            break unless pump_once(io, flow)
+          if flow.available <= 0 && !flow.closed?
+            # The wall clock, not the frame count. The per-read io_timeout fires only on
+            # IDLE, so a keepalive PING every 2 s kept this loop alive under MAX_FRAMES for
+            # ~55 hours at 0.1 % CPU — no busy-spin, but no bound an operator can reason
+            # about either. The deadline restarts on every DATA frame written below, so an
+            # origin that drips window is never cut short: it bounds only a stall that makes
+            # no progress. One blocking `Frame.read` may already be in flight when it
+            # expires, so the true ceiling is `patience` plus that read's own idle bound.
+            deadline = Time.instant + flow.patience
+            while flow.available <= 0 && !flow.closed?
+              io.flush # the peer cannot grant window for frames still sitting in our buffer
+              break if Time.instant >= deadline
+              break unless pump_once(io, flow)
+            end
           end
           break if flow.closed?
-          raise Gori::Error.new(flow_stalled(offset, body.size, flow)) if flow.available <= 0
+          break if flow.available <= 0
           n = Math.min(Math.min(MAX_FRAME.to_i64, (body.size - offset).to_i64), flow.available).to_i
           last = offset + n >= body.size
           flags = last ? Frame::END_STREAM : 0_u8
@@ -364,14 +523,18 @@ module Gori
           flow.stream -= n
           offset += n
         end
+        flow.sent_body = offset
+        # `closed?` means the PEER ended the stream first — that is `truncated`'s sentence,
+        # not a stall. Only a window that never reopened lands here.
+        flow.stall = flow_stalled(flow) if offset < body.size && !flow.closed?
       end
 
       # Why the body could not be finished. Names the flow-control window — gori's own
       # accounting — rather than blaming the origin for a refusal it never made, and says
       # plainly that the request did NOT go out whole, so no status is read as a verdict on
       # the payload the operator meant to send.
-      private def self.flow_stalled(sent : Int32, total : Int32, flow : SendFlow) : String
-        base = "h2 flow control: only #{sent} of #{total} request body bytes could be sent"
+      private def self.flow_stalled(flow : SendFlow) : String
+        base = "h2 flow control: only #{flow.sent_body} of #{flow.total_body} request body bytes could be sent"
         if flow.eof?
           "#{base} — the origin closed the connection before granting window for the rest " \
           "(RFC 9113 §6.9). The request was NOT fully sent."
@@ -392,6 +555,15 @@ module Gori
       # socket while waiting for flow-control window. They arrived before anything read here
       # and must be processed in that order.
       private def self.read_response(io : IO, flow : SendFlow) : Reply
+        # A stall that produced NO frames at all has already spent the whole patience budget
+        # on this socket; going back to it would only spend a second idle timeout to learn
+        # the same thing, doubling the operator's wall clock for the commonest failure
+        # (an origin that simply never grants window). When frames DID arrive the read runs
+        # and drains them below — a response that arrived must never be destroyed by the
+        # writer's disposition, which is exactly what the old `raise` did.
+        if flow.stall && flow.pending.empty?
+          return Reply.new(0, [] of {String, String}, nil, false, flow.goaway, flow.rst, nil, !flow.eof?)
+        end
         decoder = HPACK::Decoder.new
         header_buf = IO::Memory.new
         body = IO::Memory.new
@@ -407,12 +579,22 @@ module Gori
         timed_out = false          # the read ended on an idle timeout, not on a closed socket
         pending = flow.pending
         at = 0
+        progress = Time.instant # last time stream 1 actually moved
 
         until done
           if at < pending.size
             frame = pending[at]
             at += 1
           else
+            # The same wall-clock ceiling `write_data` uses, for the same reason: MAX_FRAMES
+            # below is a COUNT, and the per-read io_timeout fires only on IDLE, so an origin
+            # trickling PING/SETTINGS/WINDOW_UPDATE under the idle gap without ever advancing
+            # stream 1 pinned this read for hours. Reset by every frame that DOES advance
+            # stream 1, so a legitimately slow but progressing response is never cut short.
+            if Time.instant - progress >= flow.patience
+              timed_out = true
+              break
+            end
             # An IO error mid-response (connection reset — e.g. an origin that closed
             # right after a non-END_STREAM DATA) is end-of-data, not a hard failure:
             # treat it like a clean EOF and return what arrived, flagged incomplete
@@ -456,6 +638,7 @@ module Gori
             end
           when Frame::Type::Headers
             next unless frame.stream_id == 1
+            progress = Time.instant
             chunk = header_block(frame)
             break if header_buf.bytesize + chunk.size > MAX_HEADER_BLOCK # flood — abort
             header_buf.write(chunk)
@@ -473,6 +656,7 @@ module Gori
             end
           when Frame::Type::Continuation
             next unless frame.stream_id == 1
+            progress = Time.instant
             break if header_buf.bytesize + frame.payload.size > MAX_HEADER_BLOCK # flood — abort
             header_buf.write(frame.payload)
             if frame.end_headers?
@@ -484,6 +668,7 @@ module Gori
             end
           when Frame::Type::Data
             next unless frame.stream_id == 1
+            progress = Time.instant
             consumed = frame.payload.size # flow control counts the WHOLE DATA payload (incl. padding)
             body.write(data_block(frame)) if body.bytesize < MAX_BODY
             done = clean_eos = true if frame.end_stream?

--- a/src/gori/repeater/plan.cr
+++ b/src/gori/repeater/plan.cr
@@ -112,10 +112,19 @@ module Gori::Repeater
     #     exact wire bytes, so normalizing can only CHANGE them — promoting a bare-LF
     #     terminator (a front-end/back-end desync primitive gori stores byte-exact) into an
     #     ordinary conformant request.
+    #   * `$KEY` SUBSTITUTION ITSELF. This one was left running, and it is the same argument
+    #     one step further: a project that happens to define `filter` (or `top`, `where`,
+    #     `token`, `user` — ordinary names) rewrote `GET /api?$filter=…` into
+    #     `GET /api?PWNED=…` on the wire and then re-framed Content-Length so the corrupted
+    #     request looked self-consistent, while MCP's flow path — which reaches the same
+    #     end state through `expand_request: false` — sent the stored bytes. Two surfaces,
+    #     one flow id, different requests. A capture is replayed as recorded or not at all.
     #
-    # Env expansion itself still runs (`expand_request?`), because a surface may have merged
-    # operator-typed overrides into these bytes; `expand_request: false` remains the separate
-    # "already final, do not expand" knob.
+    # A surface that merges OPERATOR-TYPED overrides into evidence bytes (`gori run
+    # repeater <flow-id>`'s `-H`/`-b`) must therefore expand those at ITS OWN merge seam,
+    # where it still knows which bytes are the operator's. `expand_request: false` remains
+    # the separate "already final, do not expand" knob for a surface whose bytes are a
+    # DRAFT it expanded itself (MCP's `RequestBuilder`, the TUI editor's byte modes).
     property? evidence : Bool
 
     # Whether an unresolved `$VAR` left in the request is a refusal. ON everywhere by
@@ -287,7 +296,8 @@ module Gori::Repeater
       scheme, host, port = resolve_origin(options)
 
       raise PlanError.new(PlanError::Reason::NoRequest, "no request to send") if options.requests.empty?
-      # The two DRAFT-TIME policies, both off for evidence — see `PlanOptions#evidence?`.
+      # The DRAFT-TIME policies — unresolved-`$KEY` refusal, head CRLF normalization, and
+      # `$KEY` substitution itself — all off for evidence. See `PlanOptions#evidence?`.
       draft = !options.evidence?
       # Checked on `options.requests` REGARDLESS of `expand_request?`, and that is the
       # point: when it is false the surface expanded already (MCP's `RequestBuilder`, the
@@ -307,7 +317,10 @@ module Gori::Repeater
         if options.auto_content_length?
           wires = wires.map { |b| FlowRequest.resync_content_length(b) }
         elsif options.resync_cl_after_expansion?
-          # Flow replay: byte-exact unless a `$KEY` in the body just changed its length.
+          # Byte-exact unless expansion just changed the body's length. A no-op whenever
+          # nothing expanded (`evidence?`, or `expand_request: false`), which is now every
+          # flow-replay caller — it stays wired because the flag means "the CL is not pinned",
+          # and a surface that DOES expand a merged draft body still needs it.
           # See `FlowRequest.resync_content_length_if_body_changed`.
           wires = wires.map_with_index { |b, i| FlowRequest.resync_content_length_if_body_changed(options.requests[i], b) }
         end
@@ -356,19 +369,21 @@ module Gori::Repeater
 
     # The request wires with `$KEY` expansion applied, or the originals when the surface says
     # it already expanded (`expand_request: false` — MCP's pre-expanded `raw`, the TUI's byte
-    # modes, `--verbatim`).
+    # modes, `--verbatim`) — or when the bytes are EVIDENCE, which is never expanded at all.
     #
-    # `expand_wire` for a DRAFT, plain `expand` for EVIDENCE. The only difference between them
-    # is that `expand_wire` re-terminates the HEAD with CRLF, which a line-buffer editor owes
-    # the wire and a stored capture does not: promoting a captured bare-LF terminator destroys
-    # a front-end/back-end desync primitive gori stores byte-exact. See `PlanOptions#evidence?`.
+    # `expand_wire` is the DRAFT pass and there is no evidence pass: a stored head is full of
+    # `$` nobody typed (OData `$filter`/`$top`, Mongo `$where`, `$IFS`, `$user.name`), and
+    # substituting a project value into one sends a request the operator never captured. This
+    # USED to run plain `Env.expand` for evidence, on the theory that only the head's CRLF
+    # promotion was a draft policy — but expansion is one too, and it was the one that could
+    # silently change the request line. See `PlanOptions#evidence?`.
+    #
+    # Left INSIDE `evidence?` rather than left to each surface to remember (via
+    # `expand_request: false`) precisely because that is how the two headless surfaces drifted:
+    # MCP turned expansion off and `gori run repeater` did not, and nothing compared them.
     private def self.expand_requests(options : PlanOptions, draft : Bool) : Array(Bytes)
-      return options.requests unless options.expand_request?
-      if draft
-        options.requests.map { |b| Env.expand_wire(String.new(b)) }
-      else
-        options.requests.map { |b| Env.expand(String.new(b)).to_slice }
-      end
+      return options.requests unless options.expand_request? && draft
+      options.requests.map { |b| Env.expand_wire(String.new(b)) }
     end
 
     # A field-native h2 send: dial origin + SNI resolution, then a `Sender` whose `send` will

--- a/src/gori/sequencer/engine.cr
+++ b/src/gori/sequencer/engine.cr
@@ -109,10 +109,10 @@ module Gori::Sequencer
       in Mode::Manual     then run_manual
       in Mode::LiveReplay then run_live
       end
-      @events.send(DoneEvent.new(@collected, @sent, @state.stopped?))
+      @events.send(DoneEvent.new(@collected, @sent, @state.stopped?, wire_requests))
     rescue ex
       @events.send(ErrorEvent.new(ex.message || "sequencer error"))
-      @events.send(DoneEvent.new(@collected, @sent, @state.stopped?))
+      @events.send(DoneEvent.new(@collected, @sent, @state.stopped?, wire_requests))
     ensure
       @events.close
     end
@@ -236,8 +236,14 @@ module Gori::Sequencer
 
     # ── counters / pacing ───────────────────────────────────────────────────────────
 
+    # Requests actually put on the wire, retries included — see `ProgressEvent#requests`.
+    # 0 on an analyse-only plan, which has no backend and opens no socket.
+    private def wire_requests : Int64
+      @backend.try(&.sent) || 0_i64
+    end
+
     private def emit_progress : Nil
-      ev = ProgressEvent.new(@collected, @sent, total, @errors)
+      ev = ProgressEvent.new(@collected, @sent, total, @errors, wire_requests)
       select
       when @events.send(ev)
       else

--- a/src/gori/sequencer/plan.cr
+++ b/src/gori/sequencer/plan.cr
@@ -55,6 +55,13 @@ module Gori::Sequencer
     # The raw request to replay, BEFORE `Env.expand_wire` — the builder owns the expansion
     # so it happens exactly once (see `Plan.build`). Empty for a manual (analyse-only) run.
     property request : Bytes
+    # PROVENANCE: this request is a CAPTURED FLOW's stored bytes, not one the operator typed.
+    # Same flag, same meaning and same consequences as `Fuzz::PlanOptions#evidence?` and
+    # `Repeater::PlanOptions#evidence?` — with it off, sequencing a capture refused any head
+    # carrying an OData/Mongo `$token` and promoted a bare-LF head to CRLF on every replay in
+    # the collection, while `gori run repeater <same-flow>` sent it byte-exact.
+    # `--request FILE` / stdin / the TUI editor keep the draft behaviour.
+    property? evidence : Bool
     # The origin the seeding flow implies, when there is one (nil for --request/stdin).
     property default_target : String?
     # An explicit target, which wins over `default_target` when non-blank.
@@ -75,6 +82,7 @@ module Gori::Sequencer
 
     def initialize(@request : Bytes = Bytes.empty,
                    *,
+                   @evidence : Bool = false,
                    @default_target : String? = nil,
                    @target : String? = nil,
                    @http2 : Bool = false,
@@ -155,8 +163,13 @@ module Gori::Sequencer
       # their source reader, and doing it there AND here would resolve a var whose value
       # itself contains a `$TOKEN` twice. A token in the HEAD that resolves to nothing
       # refuses the run first (see `refuse_unresolved`).
-      refuse_unresolved(Env.unresolved_wire(String.new(options.request)))
-      request = Env.expand_wire(String.new(options.request))
+      # Both are DRAFT-time passes and are skipped for EVIDENCE — see `PlanOptions#evidence?`.
+      request = if options.evidence?
+                  options.request
+                else
+                  refuse_unresolved(Env.unresolved_wire(String.new(options.request)))
+                  Env.expand_wire(String.new(options.request))
+                end
       sender = Fuzz::Sender.new(origin, outbound, http2: options.http2?, verify: options.verify?,
         sni: options.sni, timeout: config.timeout, overrides: options.overrides)
       new(engine: Engine.new(request, options.http2?, sender, config), config: config,

--- a/src/gori/sequencer/types.cr
+++ b/src/gori/sequencer/types.cr
@@ -51,9 +51,16 @@ module Gori
 
     # Live counters. `collected` counts successful extractions (the goal is met by
     # these); `sent` is the real request count (always ≥ collected — misses + retries).
-    record ProgressEvent, collected : Int32, sent : Int32, goal : Int32, errors : Int32
+    # `sent` is REPLAYS completed — one per collected sample slot, and the numerator that
+    # belongs against `goal`. `requests` is what actually went on the wire
+    # (`Fuzz::CappedBackend#sent`, the counter `max_requests` is enforced against): a retry
+    # costs one there and none in `sent`, so a `--retries 2` collection against a dead origin
+    # reported "6 sent" for 18 real requests. Both are published because they answer
+    # different questions — progress, and the load the run put on the target.
+    record ProgressEvent, collected : Int32, sent : Int32, goal : Int32, errors : Int32,
+      requests : Int64 = 0_i64
     record SampleEvent, sample : Sample
-    record DoneEvent, collected : Int32, sent : Int32, stopped : Bool
+    record DoneEvent, collected : Int32, sent : Int32, stopped : Bool, requests : Int64 = 0_i64
     record ErrorEvent, message : String
 
     # Engine → consumer events. A union of records (matches Fuzz/Miner so a

--- a/src/gori/tui/controllers/fuzzer_controller.cr
+++ b/src/gori/tui/controllers/fuzzer_controller.cr
@@ -937,7 +937,8 @@ module Gori::Tui
       request_text : String,
       http2 : Bool,
       sni : String?,
-      label : String # sub-tab chip + toast ("#index payload")
+      label : String,  # sub-tab chip + toast ("#index payload")
+      note : String? = nil # provenance when request_text is NOT the retained wire bytes
 
     # True when the focused session has a result row under the cursor (gates space →
     # Send to Repeater): no run yet, or a filter that hides every row, means no request
@@ -950,12 +951,31 @@ module Gori::Tui
     def selected_repeater_seed : RepeaterSeed?
       return nil unless v = current_view
       return nil unless r = v.selected_result
-      # Repeater editors store LF text; send expands back to CRLF (RepeaterView#expanded_text_to_bytes).
-      # Same LF shape as History→Repeater (origin_form_text) and the Miner path.
-      text = String.new(v.result_request_bytes(r)).scrub.gsub("\r\n", "\n")
+      FuzzerController.repeater_seed_for(v, r)
+    end
+
+    # The seed for one {session, result} pair. A class method because it reads no shell
+    # state: `selected_repeater_seed` above only picks the pair, so a spec can drive the
+    # REAL byte handling below without standing up a Host.
+    def self.repeater_seed_for(v : FuzzerView, r : Fuzz::Result) : RepeaterSeed
+      req = v.result_request(r)
+      # `String.new`, NOT `.scrub`, and NO CRLF→LF collapse. Both used to be justified by
+      # "Repeater editors store LF text", which the @eols work made false — `TextArea#set_text`
+      # now round-trips each line's own terminator and the send path reads `wire_text`, so
+      # collapsing here is exactly the loss F1 fixed one tab over. `.scrub` was worse than
+      # cosmetic: a payload byte that is not valid UTF-8 (a hex/binary set, a decoder chain
+      # emitting raw bytes) became U+FFFD in bytes this record calls the request that was sent.
+      # `String.new(Bytes)` copies them through verbatim.
+      text = String.new(req.bytes)
       payload = r.payloads.join(", ")
       payload = "#{payload[0, 23]}…" if payload.size > 24
-      RepeaterSeed.new(v.target_origin, text, v.http2?, v.sni_override, "##{r.index} #{payload}".rstrip)
+      label = "##{r.index} #{payload}".rstrip
+      note = v.result_request_note(r)
+      # The chip/toast label carries the caveat too, not just `note`: the label is the only
+      # field that reaches the operator through every consumer of this seed, and a tab holding
+      # a reconstruction should keep saying so after the toast has gone.
+      label = "#{label} · reconstructed" if note
+      RepeaterSeed.new(v.target_origin, text, v.http2?, v.sni_override, label, note)
     end
 
     # ⇧I from History (or Issues evidence): open a captured flow as a fuzz session.

--- a/src/gori/tui/controllers/fuzzer_controller.cr
+++ b/src/gori/tui/controllers/fuzzer_controller.cr
@@ -937,7 +937,7 @@ module Gori::Tui
       request_text : String,
       http2 : Bool,
       sni : String?,
-      label : String,  # sub-tab chip + toast ("#index payload")
+      label : String,      # sub-tab chip + toast ("#index payload")
       note : String? = nil # provenance when request_text is NOT the retained wire bytes
 
     # True when the focused session has a result row under the cursor (gates space →

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -102,6 +102,12 @@ module Gori::Tui
       # which the user may have edited (adding/removing §…§ markers) since the run.
       @run_template = nil.as(Fuzz::Template?)
       @pending_template = nil.as(Fuzz::Template?)
+      # {update_content_length?, add_content_length_when_missing?, keep_bodies} as of the run
+      # that produced @results — frozen alongside @run_template for the same reason: the
+      # reconstruction and the note that names the retention policy must describe THAT run,
+      # not whatever the CONFIG pane says now.
+      @run_policy = nil.as({Bool, Bool, Symbol}?)
+      @pending_policy = nil.as({Bool, Bool, Symbol}?)
       @sel = 0
       @scroll = 0
       @sort = :index
@@ -245,11 +251,12 @@ module Gori::Tui
       @tcx = @target.size
       @http2 = rec.http2?
       @sni = rec.sni || ""
-      # Normalized compare for the same reason as session_side_matches? below: set_text zeroes
-      # the caret/scroll and clears undo, so it must only run on a REAL text change. No writer
-      # puts CRLF in fuzz_sessions.template today (only the fuzzer controller writes it, always
-      # from @editor.text, already LF) — kept consistent so it can't rot if one ever does.
-      @editor.set_text(rec.template) if @editor.text != TextArea.normalize_lf(rec.template)
+      # set_text zeroes the caret/scroll and clears undo, so it must only run on a REAL text
+      # change. The compare is EXACT (`wire_text` is set_text's byte-for-byte inverse), the
+      # same test RepeaterView#apply_request_fields makes: the template is persisted in wire
+      # form now, so a normalized compare would be blind to a pure line-ending edit — which
+      # is a real edit on a message — while an exact one is never falsely unequal.
+      @editor.set_text(rec.template) if @editor.wire_text != rec.template
       @name = rec.name
       apply_config_json(rec.config)
       @last_synced_config = rec.config
@@ -258,10 +265,11 @@ module Gori::Tui
     end
 
     # True when the live view matches a store row's request-side fields (reconcile skip).
-    # Template compare normalizes CRLF→LF (TextArea stores LF; the store may hold wire CRLF).
+    # The template compare is EXACT — see apply_peer_session above; `template_text` is wire
+    # form and is exactly what `update_fuzz_session` wrote, so the two can never disagree.
     def session_side_matches?(rec : Store::FuzzSessionRecord) : Bool
       @target == rec.target &&
-        template_text == TextArea.normalize_lf(rec.template) &&
+        template_text == rec.template &&
         @http2 == rec.http2? &&
         (sni_override || "") == (rec.sni || "") &&
         (@name || "") == (rec.name || "") &&
@@ -285,8 +293,13 @@ module Gori::Tui
     end
 
     # --- persistence accessors ----------------------------------------------
+    # `wire_text`, NOT `text`: this is what gets written to `fuzz_sessions.template`, so
+    # persisting the LF projection would make the loss of a captured body's CRLFs SURVIVE a
+    # restart — the run would then be wrong even after the send path was fixed. Wire form
+    # round-trips exactly (`set_text` is `wire_text`'s inverse), and it is also what
+    # `duplicate_from` and the reconstruction in `result_request` read.
     def template_text : String
-      @editor.text
+      @editor.wire_text
     end
 
     def sni_override : String?
@@ -483,7 +496,7 @@ module Gori::Tui
       # anchor — restoring the raw cursor could land inside a now-longer hidden chain.
       anchor = Fuzz::Template.marker_start_at(@editor.text, @chain_marker_cursor) || @chain_marker_cursor
       if updated = Fuzz::Template.set_chain(@editor.text, @chain_marker_cursor, @chain_pane.value)
-        @editor.set_text(updated)
+        @editor.set_text(restore_wire_eols(updated))
         @editor.place_at_offset(anchor) # back into the marker (set_text reset it) → tooltip stays up
         @dirty = true
       end
@@ -521,6 +534,32 @@ module Gori::Tui
     end
 
     # --- marking -------------------------------------------------------------
+    # Re-attach the buffer's ORIGINAL line terminators to the result of a marking transform.
+    #
+    # The § / ¦ helpers (auto_mark, mark_word, clear_markers, set_chain) all take the LF
+    # projection, because every offset they are given — `@editor.cursor_offset`, the cached
+    # `marked_spans` — indexes THAT string; handing them wire text would shift every offset by
+    # one per CRLF line and mark the wrong span. But they only ever insert or delete `§`/`¦`
+    # WITHIN a line, never a newline, so the line count is invariant and the terminators can
+    # simply be put back. Without this, `set_text(transformed)` stores the LF projection and a
+    # captured body's CRLFs are gone before the run even starts — which is how ^K (the marking
+    # chord the status line names on every fuzz session open) defeated a byte-exact send path.
+    #
+    # Falls back to `lf_text` unchanged when the line count did move: better a template that
+    # lost its CRLFs than one whose terminators were reattached to the wrong lines.
+    private def restore_wire_eols(lf_text : String) : String
+      wl = @editor.wire_lines
+      parts = lf_text.split('\n')
+      return lf_text unless parts.size == wl.size
+      return lf_text if wl.all? { |(_, eol)| eol == "\n" || eol.empty? } # nothing to restore
+      String.build do |io|
+        parts.each_with_index do |p, i|
+          io << p
+          io << wl[i][1]
+        end
+      end
+    end
+
     def auto_mark : String
       before = @editor.text
       text = Fuzz::Template.auto_mark(before)
@@ -532,7 +571,7 @@ module Gori::Tui
         n = Fuzz::Template.parse(before).position_count
         return n.zero? ? "nothing to auto-mark — no query, cookie or body values found" : "already marked (#{n} position#{n == 1 ? "" : "s"}) — Clear markers first to re-derive"
       end
-      @editor.set_text(text)
+      @editor.set_text(restore_wire_eols(text))
       @dirty = true
       n = Fuzz::Template.parse(text).position_count
       "auto-marked #{n} position#{n == 1 ? "" : "s"}"
@@ -553,17 +592,32 @@ module Gori::Tui
       @http2
     end
 
+    # Reformat the template's BODY. Reads `wire_text` and splices the head back verbatim: a
+    # pretty-print is an explicit request to rewrite the body, but it is not a licence to
+    # re-encode the head's terminators — this is the one marking-adjacent transform whose line
+    # count moves, so restore_wire_eols cannot cover it.
     def pretty_print_template : String?
-      text = @editor.text
-      env_sep = text.index("\n\n")
-      return "no request body" unless env_sep
+      text = @editor.wire_text
+      crlf = text.index("\r\n\r\n")
+      lf = text.index("\n\n")
+      # First blank line wins, whichever form it is (an LF head whose BODY holds a CRLFCRLF
+      # must not be split at the body's) — same rule as Fuzz::ContentLength.boundary.
+      sep, sep_w = if crlf && (lf.nil? || crlf <= lf)
+                     {crlf, 4}
+                   elsif lf
+                     {lf, 2}
+                   else
+                     {nil, 0}
+                   end
+      return "no request body" unless sep
 
-      head = text[0, env_sep]
-      body = text[env_sep + 2..]
+      head = text[0, sep]
+      eol = sep_w == 4 ? "\r\n" : "\n"
+      body = text[sep + sep_w..]
       return "request body is empty" if body.strip.empty?
 
       if formatted_body = Pretty.format_request(head, body)
-        new_text = "#{head}\n\n#{formatted_body}"
+        new_text = "#{head}#{eol}#{eol}#{formatted_body}"
         @editor.set_text(new_text)
         @dirty = true
         nil # success
@@ -577,7 +631,7 @@ module Gori::Tui
       before = @editor.text
       after = Fuzz::Template.mark_word(before, @editor.cursor_offset)
       return "no word at the cursor — place it on a token (or ^A to auto-mark)" if after == before
-      @editor.set_text(after)
+      @editor.set_text(restore_wire_eols(after))
       @dirty = true
       Fuzz::Template.parse(after).position_count < Fuzz::Template.parse(before).position_count ? "unmarked position" : "marked position"
     end
@@ -603,7 +657,7 @@ module Gori::Tui
     def clear_marks : String
       # clear_markers renders the defaults inline — drops both the § delimiters AND any
       # ¦chain (a naive gsub("§","") would leave a stray value¦chain behind).
-      @editor.set_text(Fuzz::Template.clear_markers(@editor.text))
+      @editor.set_text(restore_wire_eols(Fuzz::Template.clear_markers(@editor.text)))
       @dirty = true
       "cleared all § markers"
     end
@@ -670,6 +724,7 @@ module Gori::Tui
     def begin_run(total : Int64?) : Nil
       @results.clear
       @run_template = @pending_template # freeze the template these results are rendered against
+      @run_policy = @pending_policy     # ...and the CL knobs + retention its generator ran under
       @results_rev += 1
       # A fresh run reuses result indices from 0, so drop the {pane, index}-keyed detail
       # cache — otherwise an old row's lines could survive under a colliding new index.
@@ -947,11 +1002,27 @@ module Gori::Tui
       if err = regex_error
         return {nil, err} # don't silently run match-everything on a bad pattern
       end
-      options = Fuzz::PlanOptions.new(@editor.text, target: @target, http2: @http2,
+      # `wire_text`, NOT `text` — the same distinction the Repeater's send path draws
+      # (`RepeaterView#expanded_editor_bytes`) and for the same reason. `text` is the LF
+      # projection: it flattens every CRLF the capture carried, and since `ContentLength.sync`
+      # then resyncs the header DOWN to the shortened body, a captured request goes out one
+      # byte shorter per line with nothing erroring and nothing warning. A 0x0D 0x0A inside a
+      # BODY is data — a CL/TE desync probe, a multipart delimiter, part content, a
+      # CRLF-injection test — never a line ending the fuzzer may re-encode, and a sweep whose
+      # baseline is not the captured request produces results that mean nothing.
+      # `Plan.build`'s `Env.expand_wire` still promotes the HEAD to CRLF, and it is idempotent
+      # on a head that already carries CRLF (`Env.normalize_crlf` only inserts a CR before an
+      # LF that has none), so a wire-form template changes nothing downstream.
+      options = Fuzz::PlanOptions.new(@editor.wire_text, target: @target, http2: @http2,
         sources: @sets.map { |s| build_source(s) }, config: @config, matcher: @matcher,
         verify: verify, sni: sni_override, overrides: overrides)
       plan = Fuzz::Plan.build(options, Gori::Outbound.interactive(scope))
-      @pending_template = plan.template # committed to @run_template in begin_run (see result_request_bytes)
+      @pending_template = plan.template # committed to @run_template in begin_run (see result_request)
+      # Freeze the CL knobs + retention policy the same way: the reconstruction in
+      # `result_request` has to reproduce what THIS run's generator did, and its note has to
+      # name the retention THIS run used — not what the CONFIG pane says after a post-run edit.
+      @pending_policy = {@config.update_content_length?, @config.add_content_length_when_missing?,
+                         @matcher.keep_bodies}
       {plan.engine, nil}
     rescue ex : Fuzz::PlanError
       {nil, fuzz_plan_error(ex)}
@@ -1271,7 +1342,9 @@ module Gori::Tui
     # the freed value's end. One undoable edit, so prior edits stay undoable. Dirties the tab.
     def strip_marker_span(span : {Int32, Int32}) : Nil
       new_text, caret = Fuzz::Template.strip_marker(@editor.text, span)
-      @editor.replace_all(new_text, caret)
+      # `caret` is an offset into the LF projection, which is what `replace_all` →
+      # `place_at_offset` walks (@lines is CR-free), so restoring the terminators is caret-safe.
+      @editor.replace_all(restore_wire_eols(new_text), caret)
       @dirty = true
     end
 
@@ -2153,27 +2226,74 @@ module Gori::Tui
       styled
     end
 
-    # The wire request for a result — what the detail pane shows and what "Send to
-    # Repeater" hands over (see FuzzerController#selected_repeater_seed), so the two can
-    # never disagree. Public because the controller needs it for a row the operator
-    # picked in the results table, not just for the open detail.
+    # The wire request for a result, WITH its provenance — what the detail pane shows and
+    # what "Send to Repeater" hands over (see FuzzerController#selected_repeater_seed), so
+    # the two can never disagree, and neither can pass a reconstruction off as evidence.
     #
-    # `Result#request` is the byte-exact request the engine sent (Job#bytes: payload
-    # chains applied, Content-Length synced), retained under the run's keep_bodies
-    # policy. When it wasn't retained (:none, or :matched and this row missed) fall back
-    # to re-rendering the run's frozen template — env-expanded as sent, so a post-run
-    # edit to the live buffer can't truncate/garble it — which reproduces everything but
-    # the per-position chain transform and the CL sync.
-    def result_request_bytes(r : Fuzz::Result) : Bytes
+    # `reconstructed: false` means `bytes` is the exact octets the engine put on the socket
+    # (`Result#request` = `Job#bytes`), retained under the run's keep_bodies policy.
+    # `reconstructed: true` means nothing kept them and they were re-derived here.
+    record ResultRequest, bytes : Bytes, reconstructed : Bool
+
+    # The one sentence every surface uses for a reconstruction — kept next to the record so
+    # the detail pane, the copy buffer and the Repeater seed cannot word it differently, and
+    # deliberately shaped like the response pane's "(response not retained — …)" note, which
+    # sits beside it and would otherwise imply by contrast that the request pane is real.
+    def self.reconstruction_note(keep_bodies : Symbol) : String
+      "(reconstructed from the template — this row's request was not retained; keep_bodies: #{keep_bodies})"
+    end
+
+    # `Result#request` is the byte-exact request the engine sent. When it wasn't retained
+    # (:none, or :matched and this row missed — the TUI default, so this is EVERY
+    # non-matching row) re-render the run's frozen template: env-expanded as sent, so a
+    # post-run edit to the live buffer can't truncate/garble it, and now through the SAME
+    # two steps the generator applied — the per-position `¦chain` transform and the
+    # Content-Length sync (`Fuzz::Generator#emit`). Without those the pane showed a 31-byte
+    # body under the template's `Content-Length: 12`, a combination no socket ever carried
+    # and the single most consequential header to get wrong on a fuzzing surface.
+    #
+    # It is still a reconstruction, not evidence: a payload the engine sent through a set
+    # processor, a run whose template the buffer no longer matches, or anything the frozen
+    # template does not capture can still differ. Hence the flag — closeness is the
+    # consolation, saying so is the fix.
+    def result_request(r : Fuzz::Result) : ResultRequest
       if sent = r.request
-        return sent
+        return ResultRequest.new(sent, false)
       end
-      tmpl = @run_template || Fuzz::Template.parse(Env.expand(@editor.text), @http2)
-      tmpl.render(r.payloads)
+      tmpl = @run_template || Fuzz::Template.parse(String.new(Env.expand_wire(@editor.wire_text)), @http2)
+      payloads = tmpl.apply_chains(r.payloads, Decoder.shared_registry)
+      raw = tmpl.render(payloads)
+      sync, add, _ = run_policy
+      raw = Fuzz::ContentLength.sync(raw, add) if sync
+      ResultRequest.new(raw, true)
+    end
+
+    # The frozen {update_cl, add_cl_when_missing, keep_bodies} of the run that produced
+    # @results, falling back to the live config for a view whose results predate the freeze.
+    private def run_policy : {Bool, Bool, Symbol}
+      @run_policy || {@config.update_content_length?, @config.add_content_length_when_missing?,
+                      @matcher.keep_bodies}
+    end
+
+    # The provenance note for `r`, or nil when its request is retained evidence. Public: the
+    # controller stamps it on the Repeater seed so "Send to Repeater" carries the same caveat
+    # the detail pane shows.
+    def result_request_note(r : Fuzz::Result) : String?
+      return nil unless r.request.nil?
+      FuzzerView.reconstruction_note(run_policy[2])
+    end
+
+    # Bytes only — for callers that have already accounted for provenance (the decode strip,
+    # which only needs a shape to parse). Never use this where the bytes are shown or resent.
+    def result_request_bytes(r : Fuzz::Result) : Bytes
+      result_request(r).bytes
     end
 
     private def detail_request_lines(r : Fuzz::Result) : Array(String)
-      String.new(result_request_bytes(r)).scrub.split('\n').map(&.rstrip('\r'))
+      req = result_request(r)
+      lines = String.new(req.bytes).scrub.split('\n').map(&.rstrip('\r'))
+      lines.unshift(FuzzerView.reconstruction_note(run_policy[2])) if req.reconstructed
+      lines
     end
 
     private def detail_response_lines(r : Fuzz::Result) : Array(String)

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -616,7 +616,12 @@ module Gori::Tui
           store.ack_intercept_command(cmd.id, "no_such_item", "item #{item_id} is no longer held")
           return false
         end
-        desc = "#{item.method} #{item.host}#{item.target}"
+        # `Item#label` composes per kind. The one expression that used to live here glued
+        # `host` onto `target`, and `target` is overloaded per kind — so a held response acked
+        # as `POST 127.0.0.1200 OK` (reads as HTTP status 1200) and a proxied h1 request as
+        # `POST 127.0.0.1http://127.0.0.1:19201/held`. This string is the agent's only receipt
+        # for an irreversible action.
+        desc = item.label
         case cmd.verb
         when "forward"
           # The store's ack is the agent's only record, so it reports what actually happened:
@@ -637,6 +642,20 @@ module Gori::Tui
           bytes = cmd.bytes
           unless bytes
             store.ack_intercept_command(cmd.id, "error", "forward_edit missing bytes"); return false
+          end
+          # An edit gori will not apply is REFUSED HERE, at the surface that asked for it, and
+          # the item stays held so the operator can forward it, drop it, or edit it again.
+          #
+          # Both refusals are decided by the settle side (`H2::StreamGate` / `HeadRewrite`) and
+          # used to be discovered there, on the gate's wait fiber, with no path back — the ack
+          # two lines below had already gone out saying "edited". On an h2 message whose head
+          # has no HTTP/1.1 text form that meant gori accepted every edit and applied none,
+          # which is exactly the state a CRLF-injection probe INDUCES. Both facts are pure
+          # functions of the held block, so they are known at hold time and readable here.
+          if refusal = item.refuse_edit(bytes)
+            store.ack_intercept_command(cmd.id, "error", "edit refused (#{desc} is still held) — #{refusal}")
+            push_agent_note(:warn, "intercept edit REFUSED, still held: #{desc}", item)
+            return false
           end
           # Forward the AGENT's edited bytes DIRECTLY — never through view.forward_bytes, which
           # would pull the human editor buffer and re-expand $VARS (wrong bytes + secret leak).
@@ -711,7 +730,7 @@ module Gori::Tui
         next unless ic.forward(it.id)
         secs = @intercept_max_hold_ms // 1000
         goto = (fid = it.flow_id) ? Jobs::Goto.new(:history, fid) : nil
-        @notifications.push(:warn, "auto-forwarded held #{it.method} #{it.host}#{it.target} (no decision after #{secs}s)", goto, source: "app")
+        @notifications.push(:warn, "auto-forwarded held #{it.label} (no decision after #{secs}s)", goto, source: "app")
         reaped = true
       end
       reaped


### PR DESCRIPTION
A third audit round over the TUI / `gori run` / MCP send paths. Two arms: an **adversarial regression sweep of PR #554's own changes**, and a first pass over three areas no round had reached — the live MITM HTTP/2 path, the four job engines end to end, and the TUI paths round 2 ran out of budget for.

26 defects, every one reproduced against a running binary before it was fixed. **Four were regressions PR #554 introduced**, and they shipped with a green suite — which is what the regression arm existed to catch.

## The regressions, and why the specs missed them

- **An h2 origin that answers while the request body is still going out** — the 413 every upload probe is looking for, and permitted by RFC 9113 §8.1 — was never detected. The early-stop test read `end_stream? && end_headers?`, but END_HEADERS is a HEADERS/CONTINUATION flag; on a DATA frame that bit means PADDED, so the condition could only fire for a **bodiless** response. gori then stalled 30 s and destroyed the complete 413 it was already holding. The fix removes one conjunct: END_STREAM alone is necessary and sufficient, and it excludes an interim 1xx for free. 30.00 s → 0.89 s, with the response and an honest `truncated at N of M bytes` clause.
- **`await_settings` read exactly one frame.** An origin whose first frame is a PING or WINDOW_UPDATE left gori writing against the RFC default window and drawing a `GOAWAY FLOW_CONTROL_ERROR` — reported as the origin misbehaving, which is precisely the misattribution #554 set out to remove.
- **The new WebSocket control-frame parking lost a delivered PING.** On a gated socket that ends without a CLOSE, nothing flushed: the origin got neither the parked ping nor the fragment it sat inside, while the capture kept a row for the ping that never left and none for the fragment that did.
- **Two surfaces "reached the same end state" by different mechanisms and nobody byte-compared them.** `gori run repeater <flow-id>` still ran env expansion over the captured bytes, so a project variable whose name collides with a token in the capture (`$filter`, `$top`, `$where` — ordinary OData/Mongo) silently rewrote the evidence and resynced Content-Length to match.

## Provenance reached one consumer; now it reaches all of them

`evidence?` was wired into `gori run repeater <flow-id>` alone. Every other consumer of a captured or operator-authored request still applied draft-time policy: `fuzz`/`mine`/`sequence` seeded from a flow refused an OData capture outright and promoted a captured bare-LF head to CRLF; `repeater create --flow` baked the absolute-form rewrite in permanently; `minimize` searched against bytes a `--verbatim` send would never produce; and the Fuzzer rewrote the operator's Content-Length on every variation with no way to turn it off, putting the CL-desync probe class out of reach on all three surfaces.

## The ack arrived before the act

On the live h2 path, an intercept edit was acked the moment it was queued — the code that could refuse it ran later on another fiber with no way back. So an edit to any message whose head has no HTTP/1.1 text form was silently discarded while the CLI, the TUI and MCP all reported success. That is exactly the input a tester induces: probe a CRLF-injection sink, the origin reflects `%0d%0a` into a header, and from that message on gori accepts every edit and applies none. The refusal itself is correct (#517) — its invisibility was the defect. Edits are now refused at hold time, by name, with the message left held.

## Also

- h2 `content-length` on an intercept edit was silently reverted and an edited body silently dropped, so the RFC 9113 §8.1.1 desync probe was unexpressible on the live path.
- A Match&Replace head rule that could not fire warned to STDERR only, naming `stream 0` — a stream that cannot exist.
- A server PUSH_PROMISE minted a History flow for any authority the origin named, past a sandbox that refused the same authority on a real request.
- `sent` under-reported actual wire volume by up to 6× under redirects and retries; a budget-capped `mine`/`discover` read as a completed run; discover silently dropped a header whose value carried CR/LF, so an authenticated sweep ran unauthenticated and reported "found nothing".
- Fifteen MCP boolean arguments still coerced silently — `probe_scan{active: 1}` sent zero requests and reported a successful scan. `bool(h, key)` no longer exists: the reader now takes the value, so the silent-fallback shape does not compile.
- The TUI Fuzzer treated the template as an LF document end to end, flattening a captured body's CRLFs and resyncing Content-Length down to match; and a non-matching result was displayed — and seeded to the Repeater — as a request that was never sent.

## Verification

Every fix reproduces the defect first, adds a spec, and control-runs that spec against unfixed source. This round additionally required each fixer to **test the complement of the condition it keyed on** — with a body and without, early and late, above the ceiling and below, first frame and second. That requirement found two defects inside the fixes themselves, falsified one fixer's first approach, and showed another that the proposed one-line seam was six.

```
crystal spec                 5988 examples, 0 failures, 0 errors, 0 pending   (was 5870)
crystal build --no-codegen   exit 0
```

## Known gaps, deliberately left

Six MCP/CLI wirings that only compile once these branches are together (`evidence: true` on the MCP flow seeds, discover's `incomplete_reason`, `fuzz_start{update_content_length}`, `mine_status{skipped}`, MCP discover's header refusal, CLI `intercept --no-update-content-length`). WebSocket over HTTP/2 relays byte-for-byte but is not decoded — the flow now says so rather than leaving the operator to guess.