### PR TITLE
Finish what one consumer started: provenance on every seed, and three facts gori could not record

### DIFF
--- a/spec/cli/run/history_spec.cr
+++ b/spec/cli/run/history_spec.cr
@@ -65,6 +65,31 @@ describe "gori run history — CLI::Output rows" do
     rel.should contain("api.test/a")
   end
 
+  # R4. `target.starts_with?("http")` is not the absolute-form test — RFC 3986 §3.1 makes a
+  # URI scheme case-insensitive, and gori captures the request line the client wrote. Driven
+  # live through the proxy: `GET HTTP://127.0.0.1:19594/upper HTTP/1.1` printed as
+  # `127.0.0.1HTTP://127.0.0.1:19594/upper`, the doubling `FlowRow.absolute_form?` exists to
+  # stop. `Gori::Url.location` is the one spelling now.
+  it "does not double the authority when the captured scheme is UPPERCASE" do
+    txt = Gori::CLI::Output.flow_row_text(flow_row(
+      target: "HTTP://127.0.0.1:19594/upper", host: "127.0.0.1", status: 200,
+      state: Gori::Store::FlowState::Complete))
+    txt.should contain("HTTP://127.0.0.1:19594/upper")
+    txt.should_not contain("127.0.0.1HTTP://")
+  end
+
+  # R4. `[!]` is the scannable pointer, exactly like `[stub]` beside it: a text-mode reader
+  # must be able to see that gori has something to SAY about a row without opening it.
+  it "chips a row gori has an advisory about, and leaves an ordinary row unmarked" do
+    plain = flow_row(target: "/a", host: "h", status: 200, state: Gori::Store::FlowState::Complete)
+    Gori::CLI::Output.flow_row_text(plain).should_not contain("[!]")
+    noted = Gori::Store::FlowRow.new(
+      id: 1_i64, created_at: 0_i64, scheme: "https", method: "GET", host: "h", port: 443,
+      target: "/a", status: 200, size: 0_i64, state: Gori::Store::FlowState::Complete,
+      advisory: "Match&Replace was NOT applied to this request head")
+    Gori::CLI::Output.flow_row_text(noted).should contain("[!]")
+  end
+
   it "marks a pending flow with a dash status and a state tag" do
     txt = Gori::CLI::Output.flow_row_text(flow_row(target: "/p", host: "h", status: nil, state: Gori::Store::FlowState::Pending))
     txt.should contain("—")
@@ -144,6 +169,23 @@ describe "gori run history — CLI::Output rows" do
     cli.should contain("time")               # CLI names it `time`
     mcp.should contain("created_at_iso")     # MCP names it `created_at_iso`
     cli.should_not contain("created_at_iso") # …and neither carries both
+  end
+
+  # The same lockstep for the field this round added, since a conditional field is exactly
+  # the kind that gets added to one serializer and forgotten in the other.
+  it "keeps `advisory` in lockstep too, and omits it on an ordinary row" do
+    noted = Gori::Store::FlowRow.new(
+      id: 1_i64, created_at: 0_i64, scheme: "https", method: "GET", host: "h", port: 443,
+      target: "/a", status: 200, size: 0_i64, state: Gori::Store::FlowState::Complete,
+      advisory: "line one\nline two")
+    cli = JSON.parse(Gori::CLI::Output.flow_row_json(noted))
+    mcp = JSON.parse(JSON.build { |j| Gori::MCP::Serialize.flow_row(j, noted) })
+    cli["advisory"].as_a.map(&.as_s).should eq(["line one", "line two"])
+    mcp["advisory"].as_a.map(&.as_s).should eq(["line one", "line two"])
+
+    plain = flow_row(target: "/a", host: "h", status: 200, state: Gori::Store::FlowState::Complete)
+    JSON.parse(Gori::CLI::Output.flow_row_json(plain)).as_h.has_key?("advisory").should be_false
+    JSON.parse(JSON.build { |j| Gori::MCP::Serialize.flow_row(j, plain) }).as_h.has_key?("advisory").should be_false
   end
 
   it "humanises sizes and durations" do

--- a/spec/cli/run/intercept_spec.cr
+++ b/spec/cli/run/intercept_spec.cr
@@ -66,3 +66,45 @@ describe "Gori::CLI::Run.intercept_row_where" do
       .should eq("http://127.0.0.1:19501/held")
   end
 end
+
+# R4. The refusal is decided when the message is HELD, and it reached no read surface: the
+# operator (or the agent) composed an edit against a message described as ordinarily editable
+# and learned otherwise from the ack. Both projections say so up front now.
+private def refusing_row(refusal : String? = nil, head_only : Bool = false) : Gori::Store::HeldRow
+  Gori::Store::HeldRow.new(
+    session_token: "t", item_id: 1_i64, kind: "request", method: "GET", host: "h",
+    port: 443, scheme: "https", target: "/a",
+    raw: "GET /a HTTP/2\r\nHost: h\r\n\r\n".to_slice, held_at_ms: 0_i64,
+    edit_refusal: refusal, head_only: head_only)
+end
+
+describe "held-item edit refusal on the read surfaces" do
+  it "emits the reason and the head-only hold in the MCP list and detail projections" do
+    row = refusing_row("the value of \"x-evil\" carries a CR or LF", head_only: true)
+    listed = JSON.parse(JSON.build { |j| Gori::MCP::Serialize.intercept_item_row(j, row, false, 0_i64) })
+    listed["edit_refusal"].as_s.should contain("x-evil")
+    listed["head_only"].as_bool.should be_true
+    detail = JSON.parse(JSON.build { |j| Gori::MCP::Serialize.intercept_item_detail(j, row, false, 0_i64) })
+    detail["edit_refusal"].as_s.should contain("x-evil")
+  end
+
+  # A head-only hold with NO refusal is still editable — only a BODY has nowhere to go — so
+  # the warning has to say that and not "edits are refused".
+  it "warns about a head-only hold without claiming the message is uneditable" do
+    row = refusing_row(nil, head_only: true)
+    row.edit_warning.not_nil!.should contain("HEAD only")
+    row.edit_warning.not_nil!.should_not contain("CR or LF")
+    JSON.parse(JSON.build { |j| Gori::MCP::Serialize.intercept_item_row(j, row, false, 0_i64) })["head_only"]
+      .as_bool.should be_true
+  end
+
+  # The complement: an h1 hold covers head+body and forwards byte-exact, so neither field is
+  # emitted and a client keying off field presence sees exactly the shape it saw before.
+  it "says nothing at all about an ordinary h1 hold" do
+    row = refusing_row
+    row.edit_warning.should be_nil
+    obj = JSON.parse(JSON.build { |j| Gori::MCP::Serialize.intercept_item_row(j, row, false, 0_i64) }).as_h
+    obj.has_key?("edit_refusal").should be_false
+    obj.has_key?("head_only").should be_false
+  end
+end

--- a/spec/cli/run/intercept_spec.cr
+++ b/spec/cli/run/intercept_spec.cr
@@ -88,23 +88,28 @@ describe "held-item edit refusal on the read surfaces" do
     detail["edit_refusal"].as_s.should contain("x-evil")
   end
 
-  # A head-only hold with NO refusal is still editable — only a BODY has nowhere to go — so
-  # the warning has to say that and not "edits are refused".
-  it "warns about a head-only hold without claiming the message is uneditable" do
+  # EVERY h2 hold is head-only (`H2::StreamGate` passes `head_only: true` on both legs), so
+  # folding that into `edit_refusal` would mark every held HTTP/2 message uneditable — head
+  # edits DO apply, only a body has nowhere to go. Two statements, two fields.
+  it "does not report a head-only hold as a refusal" do
     row = refusing_row(nil, head_only: true)
-    row.edit_warning.not_nil!.should contain("HEAD only")
-    row.edit_warning.not_nil!.should_not contain("CR or LF")
-    JSON.parse(JSON.build { |j| Gori::MCP::Serialize.intercept_item_row(j, row, false, 0_i64) })["head_only"]
-      .as_bool.should be_true
+    row.edit_refusal.should be_nil
+    row.head_only_note.not_nil!.should contain("HEAD only")
+    obj = JSON.parse(JSON.build { |j| Gori::MCP::Serialize.intercept_item_row(j, row, false, 0_i64) }).as_h
+    obj["head_only"].as_bool.should be_true
+    obj["head_only_note"].as_s.should contain("ADDS A BODY")
+    obj.has_key?("edit_refusal").should be_false
   end
 
-  # The complement: an h1 hold covers head+body and forwards byte-exact, so neither field is
+  # The complement: an h1 hold covers head+body and forwards byte-exact, so no field is
   # emitted and a client keying off field presence sees exactly the shape it saw before.
   it "says nothing at all about an ordinary h1 hold" do
     row = refusing_row
-    row.edit_warning.should be_nil
+    row.edit_refusal.should be_nil
+    row.head_only_note.should be_nil
     obj = JSON.parse(JSON.build { |j| Gori::MCP::Serialize.intercept_item_row(j, row, false, 0_i64) }).as_h
     obj.has_key?("edit_refusal").should be_false
     obj.has_key?("head_only").should be_false
+    obj.has_key?("head_only_note").should be_false
   end
 end

--- a/spec/cli/run/intercept_spec.cr
+++ b/spec/cli/run/intercept_spec.cr
@@ -34,6 +34,37 @@ describe "Gori::CLI::Run.normalize_head_crlf" do
   end
 end
 
+# MCP has carried `intercept_forward_edit{update_content_length}` since the desync switch was
+# made a declared argument; the CLI resynced unconditionally, so the whole CL-desync probe
+# class (CL shorter than the body, CL longer than the body, CL alongside Transfer-Encoding —
+# the RFC 9113 §8.1.1 shape) was unreachable from `gori run intercept edit`, even though the
+# gate on the other end already honours a value the caller declared. `--raw-file` advertised
+# itself as the byte-exact channel while being the one path that could not hold a length.
+describe "Gori::CLI::Run.intercept_edit_bytes" do
+  it "resyncs Content-Length to the edited body by default" do
+    raw = "POST /h HTTP/1.1\r\nHost: h\r\nContent-Length: 3\r\n\r\nlonger-body"
+    String.new(Gori::CLI::Run.intercept_edit_bytes(raw, true))
+      .should eq("POST /h HTTP/1.1\r\nHost: h\r\nContent-Length: 11\r\n\r\nlonger-body")
+  end
+
+  it "forwards a DELIBERATELY short Content-Length untouched with the resync off" do
+    raw = "POST /h HTTP/1.1\r\nHost: h\r\nContent-Length: 3\r\n\r\nlonger-body"
+    String.new(Gori::CLI::Run.intercept_edit_bytes(raw, false)).should eq(raw)
+  end
+
+  it "keeps Content-Length ALONGSIDE Transfer-Encoding — the CL.TE smuggling pair" do
+    raw = "POST /h HTTP/1.1\r\nHost: h\r\nContent-Length: 6\r\n" \
+          "Transfer-Encoding: chunked\r\n\r\n0\r\n\r\n"
+    String.new(Gori::CLI::Run.intercept_edit_bytes(raw, false)).should eq(raw)
+  end
+
+  it "still CRLF-terminates the head with the resync off, and adds no Content-Length" do
+    raw = "POST /h HTTP/1.1\nHost: h\n\nalpha\ngamma"
+    String.new(Gori::CLI::Run.intercept_edit_bytes(raw, false))
+      .should eq("POST /h HTTP/1.1\r\nHost: h\r\n\r\nalpha\ngamma")
+  end
+end
+
 # `HeldRow#target` carries TWO different things depending on `kind`: a request's target, or a
 # RESPONSE's status reason. The row builder never branched on it, so a held response rendered
 # as `http://127.0.0.1200 OK` — a string that looks like a URL, is not one, drops the port,

--- a/spec/export/har_spec.cr
+++ b/spec/export/har_spec.cr
@@ -369,6 +369,28 @@ describe Gori::Export::Har do
     end
   end
 
+  # R4. An exported entry has to carry what gori has to SAY about the exchange — HAR 1.2
+  # gives `entry.comment` for exactly this. The pushed case matters most: a HAR reader has no
+  # other way to tell a request the ORIGIN invented from one the client sent.
+  it "carries the flow advisory as the entry comment, and omits it otherwise" do
+    with_store do |store|
+      id = store.insert_flow(Gori::Store::CapturedRequest.new(
+        created_at: 1_i64, scheme: "https", host: "shop.test", port: 443, method: "GET",
+        target: "/pushed", http_version: "HTTP/2",
+        head: "GET /pushed HTTP/2\r\nHost: shop.test\r\n\r\n".to_slice,
+        advisory: "server push: this request was invented by the origin"))
+      store.update_response(Gori::Store::CapturedResponse.new(
+        flow_id: id, status: 200, head: "HTTP/2 200\r\nContent-Length: 0\r\n\r\n".to_slice,
+        advisory: "server push: this request was invented by the origin"))
+      har, _ = export([store.get_flow(id).not_nil!])
+      entry = JSON.parse(har)["log"]["entries"][0]
+      entry["comment"].as_s.should contain("invented by the origin")
+
+      plain, _ = export([capture_flow(store)])
+      JSON.parse(plain)["log"]["entries"][0].as_h.has_key?("comment").should be_false
+    end
+  end
+
   describe "flows with no HAR representation" do
     it "skips a WebSocket flow and says so, rather than emitting the handshake alone" do
       with_store do |store|

--- a/spec/fuzz_spec.cr
+++ b/spec/fuzz_spec.cr
@@ -635,7 +635,7 @@ describe F::Engine do
     gen = F::Generator.new(base, [set], cfg)
     backend = FakeBackend.new(F::Origin.new("http", "h", 80)) do |_b|
       started.send(nil)
-      gate.receive
+      receive_within(gate)
       ok_result(200, "ok")
     end
     engine = F::Engine.new(gen, F::Matcher.new, backend, cfg)
@@ -643,11 +643,11 @@ describe F::Engine do
     done = Channel(Nil).new
     spawn { engine.run { |_ev| }; done.send(nil) }
 
-    2.times { started.receive } # both workers are inside send() (in-flight)
-    10.times { Fiber.yield }    # let the dispatcher fill the buffered @jobs channel
+    2.times { receive_within(started) } # both workers are inside send() (in-flight)
+    10.times { Fiber.yield }            # let the dispatcher fill the buffered @jobs channel
     engine.stop
     spawn { loop { gate.send(nil) } } # release: in-flight finish, buffered must be skipped
-    done.receive
+    receive_within(done)
 
     # concurrency (2) buffered on top of concurrency (2) in-flight = 4 previously fired
     # after stop; now only the in-flight batch does.
@@ -679,7 +679,7 @@ describe F::Engine do
 
     results.size.should eq(2)
     results.all? { |r| r.status == 200 && r.length == 4 }.should be_true
-    got = [seen.receive, seen.receive].sort
+    got = [receive_within(seen), receive_within(seen)].sort
     got.should contain("GET /?q=one HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n")
     got.should contain("GET /?q=two HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n")
     origin.close

--- a/spec/fuzz_template_bytes_spec.cr
+++ b/spec/fuzz_template_bytes_spec.cr
@@ -1,0 +1,70 @@
+require "./spec_helper"
+
+private alias T = Gori::Fuzz::Template
+
+# `Template.parse` iterated `marked.chars`, and Crystal's char iteration substitutes U+FFFD
+# for every byte that is not valid UTF-8. So the template layer — which every fuzz run passes
+# through, on every surface, whether or not anything is marked — silently rewrote any request
+# body carrying raw 0x80-0xFF: a protobuf/gRPC frame, a gzip'd or otherwise binary POST, a
+# latin-1 form field. Each such byte became the THREE bytes of the replacement character, so
+# every request the sweep sent differed in length from the one it was seeded with, under a
+# Content-Length recomputed to match the corruption, and nothing anywhere said so.
+#
+# `gori run fuzz --request FILE` and a piped stdin reach this with no scrub in front of them,
+# so it is directly reachable, not only via a capture.
+describe "Gori::Fuzz::Template — byte fidelity" do
+  it "round-trips a body with invalid UTF-8 through parse → render unchanged" do
+    raw = "POST /u HTTP/1.1\r\nHost: h\r\nContent-Length: 5\r\n\r\n" +
+          String.new(Bytes[0x80, 0xFE, 0x00, 0xFF, 0xC0])
+    tmpl = T.parse(raw)
+    tmpl.position_count.should eq(0)
+    tmpl.render([] of String).to_a.should eq(raw.to_slice.to_a)
+  end
+
+  it "splices a payload into a marked position while the binary body around it survives" do
+    prefix = "POST /u?id=".to_slice
+    marked = String.new(prefix) + "§1§" + " HTTP/1.1\r\nHost: h\r\n\r\n" +
+             String.new(Bytes[0xC3, 0x28, 0x9F, 0x0A])
+    tmpl = T.parse(marked)
+    tmpl.position_count.should eq(1)
+    rendered = tmpl.render(["99"])
+    String.new(rendered).should start_with("POST /u?id=99 HTTP/1.1")
+    rendered[-4..].to_a.should eq([0xC3, 0x28, 0x9F, 0x0A])
+  end
+
+  it "keeps a lone 0xA7 byte — the second half of §'s encoding — as itself" do
+    # 0xA7 alone is not §; only the C2 A7 pair is. A char scan turned the bare byte into
+    # U+FFFD; a byte scan that matched on 0xA7 alone would instead open a bogus position.
+    raw = "POST /x HTTP/1.1\r\n\r\n" + String.new(Bytes[0xA7, 0x41, 0xC2])
+    tmpl = T.parse(raw)
+    tmpl.position_count.should eq(0)
+    tmpl.render([] of String).to_a.should eq(raw.to_slice.to_a)
+  end
+
+  it "still honours §§ escapes, ¦chains and an unbalanced trailing § over bytes" do
+    tmpl = T.parse("A§§B§v¦b64§C§tail")
+    tmpl.position_count.should eq(1)
+    tmpl.positions[0].default.should eq("v")
+    tmpl.positions[0].chain.should eq("b64")
+    # `A§B` literal, the position, then the unbalanced trailing § folded back as text.
+    String.new(tmpl.render(["X"])).should eq("A§BXC§tail")
+  end
+
+  it "keeps a ¦¦ escape and a second bare ¦ literal inside the chain" do
+    tmpl = T.parse("§a¦¦b¦c¦d§")
+    tmpl.positions[0].default.should eq("a¦b")
+    tmpl.positions[0].chain.should eq("c¦d")
+  end
+
+  it "renders the defaults back to the original bytes when nothing is substituted" do
+    src = "GET /p?a=§1§&b=§two§ HTTP/1.1\r\nHost: h\r\n\r\n"
+    tmpl = T.parse(src)
+    String.new(tmpl.render(tmpl.default_payloads)).should eq("GET /p?a=1&b=two HTTP/1.1\r\nHost: h\r\n\r\n")
+  end
+
+  it "does not lose the byte count on a body that is entirely high bytes" do
+    body = Bytes.new(256) { |i| i.to_u8 }
+    raw = "POST /b HTTP/1.1\r\nContent-Length: 256\r\n\r\n" + String.new(body)
+    T.parse(raw).render([] of String).size.should eq(raw.to_slice.size)
+  end
+end

--- a/spec/interceptor_spec.cr
+++ b/spec/interceptor_spec.cr
@@ -508,6 +508,30 @@ describe "Interceptor scope gates over an ABSOLUTE-FORM target" do
         back.label.should eq("acme.test/ws server->client 2B")
       end
     end
+
+    # R4. The composition is ONE definition now: `InterceptView#row_label` and
+    # `InterceptController#intercept_label` had their own per-kind branches and call this
+    # instead, passing the EDITED method/target so a queue row and a forward toast name the
+    # message about to be sent rather than the hold-time metadata. Same rule either way —
+    # which is the point, since three separate branches is how `POST 127.0.0.1200 OK` shipped.
+    it "composes an OVERRIDDEN method/target by exactly the same rule" do
+      with_store do |store|
+        ic = Gori::Interceptor.new(Gori::Scope.load(store))
+        ic.toggle
+        req = ic.enqueue_request("x".to_slice, method: "GET", target: "/held",
+          host: "127.0.0.1", port: 19201, scheme: "http").not_nil!
+        # A GET the operator edited into a PUT against another path, absolute-form and all.
+        req.label("PUT", "http://127.0.0.1:19201/edited").should eq("PUT 127.0.0.1/edited")
+        # An unedited call is the no-argument one.
+        req.label(req.method, req.target).should eq(req.label)
+
+        resp = ic.enqueue_response("x".to_slice, flow_id: 1_i64, method: "POST", target: "200 OK",
+          host: "127.0.0.1", port: 19201, scheme: "http").not_nil!
+        # A 200→201 status edit, which is what the editor's first line gives back.
+        resp.label("POST", "201 CREATED").should eq("POST 127.0.0.1 -> 201 CREATED")
+        resp.label("POST", "201 CREATED").should_not contain("127.0.0.1201")
+      end
+    end
   end
 
   # The head/body boundary an intercept edit is split on. Shared with `H2::StreamGate`, which

--- a/spec/interceptor_spec.cr
+++ b/spec/interceptor_spec.cr
@@ -43,7 +43,7 @@ describe Gori::Interceptor do
       item.host.should eq("acme.test")
 
       ic.forward(item.id, "GET /edited HTTP/1.1\r\nHost: acme.test\r\n\r\n".to_slice)
-      d = result.receive
+      d = receive_within(result)
       d.action.should eq(Gori::Interceptor::Action::Forward)
       String.new(d.bytes).should contain("/edited")
       ic.pending_count.should eq(0)
@@ -65,7 +65,7 @@ describe Gori::Interceptor do
 
       r2 = ic.revision
       ic.forward(ic.pending.first.id)
-      result.receive
+      receive_within(result)
       (ic.revision > r2).should be_true # forward bumped
     end
   end
@@ -78,7 +78,7 @@ describe Gori::Interceptor do
       spawn { result.send(req(ic, "GET / HTTP/1.1\r\n\r\n")) }
       Fiber.yield
       ic.drop(ic.pending.first.id)
-      result.receive.action.should eq(Gori::Interceptor::Action::Drop)
+      receive_within(result).action.should eq(Gori::Interceptor::Action::Drop)
     end
   end
 
@@ -94,7 +94,7 @@ describe Gori::Interceptor do
       item.held_at_ms.should be > 0                                  # wall-clock captured once at hold
       ic.get(item.id).not_nil!.held_at_ms.should eq(item.held_at_ms) # never re-stamped
       ic.forward(item.id)
-      result.receive
+      receive_within(result)
       ic.get(item.id).should be_nil # gone after forward
     end
   end
@@ -108,7 +108,7 @@ describe Gori::Interceptor do
       Fiber.yield
       ic.pending_count.should eq(1)
       ic.toggle # off → release held
-      result.receive.action.should eq(Gori::Interceptor::Action::Forward)
+      receive_within(result).action.should eq(Gori::Interceptor::Action::Forward)
       ic.pending_count.should eq(0)
     end
   end
@@ -122,7 +122,7 @@ describe Gori::Interceptor do
       Fiber.yield
       ic.pending_count.should eq(2)
       ic.release_all
-      2.times { done.receive }
+      2.times { receive_within(done) }
       ic.pending_count.should eq(0)
     end
   end
@@ -150,7 +150,7 @@ describe Gori::Interceptor do
       item.method.should eq("GET")
 
       ic.forward(item.id) # no override → the ORIGINAL bytes, byte-exact
-      d = result.receive
+      d = receive_within(result)
       d.action.should eq(Gori::Interceptor::Action::Forward)
       String.new(d.bytes).should eq("GET /a HTTP/1.1\r\nHost: acme.test\r\n\r\n")
       ic.pending_count.should eq(0)

--- a/spec/links_spec.cr
+++ b/spec/links_spec.cr
@@ -73,13 +73,27 @@ describe Gori::Links do
       end
     end
 
-    it "treats a schemeless 'http'-prefixed target as verbatim (best-effort location)" do
-      # flow_location checks starts_with?("http") loosely; a schemeless host that
-      # begins with "http" is passed through as-is. Documented as best-effort.
+    # R4. `flow_location` used `starts_with?("http")`, which is not the absolute-form test:
+    # it MISSED `HTTP://host/x` (RFC 3986 §3.1 — schemes are case-insensitive) and CAUGHT a
+    # schemeless `httpbin.org/x`. `Gori::Url.location` is the strict test now, so this target
+    # — which carries no authority of its own — takes the host prefix every other non-absolute
+    # target takes, and `label` finally agrees with `url` (which has used `absolute_form?` all
+    # along and read `http://a.testhttpbin.org/x` while the label read `httpbin.org/x`).
+    it "prefixes the host on a schemeless 'http'-prefixed target, agreeing with #url" do
       with_store do |store|
         fid = insert_flow_row(store, host: "a.test", target: "httpbin.org/x")
         r = Gori::Links.resolve(store, link_for(Gori::Store::LinkRefKind::Flow, fid))
-        r.label.should eq("GET httpbin.org/x")
+        r.label.should eq("GET a.testhttpbin.org/x")
+        r.url.should eq("http://a.testhttpbin.org/x")
+      end
+    end
+
+    it "uses an UPPERCASE-scheme absolute-form target verbatim, without doubling the host" do
+      with_store do |store|
+        fid = insert_flow_row(store, host: "a.test", target: "HTTP://a.test:8080/abs")
+        r = Gori::Links.resolve(store, link_for(Gori::Store::LinkRefKind::Flow, fid))
+        r.label.should eq("GET HTTP://a.test:8080/abs")
+        r.label.should_not contain("a.testHTTP://")
       end
     end
 

--- a/spec/mcp_agent_surface_spec.cr
+++ b/spec/mcp_agent_surface_spec.cr
@@ -185,7 +185,7 @@ describe "MCP WebSocket frame object form" do
         verify_upstream: false)[0]
       resp["result"]["isError"].as_bool.should be_false
 
-      frames = decode_frames(seen.receive)
+      frames = decode_frames(receive_within(seen))
       frames.map(&.opcode).first(5).should eq([9, 0, 10, 8, 1])
       frames[3].payload.should eq(Bytes[0x03, 0xe9])
       frames[4].payload.should eq(Bytes[0xff, 0xfe])
@@ -333,7 +333,7 @@ describe "MCP boolean arguments" do
         %({"url":"http://127.0.0.1:#{port}/x",) +
         %("raw":"GET /lf HTTP/1.1\\nHost: h\\n\\n","verbatim":"TRUE","allow_unscoped":"true"})))[0]
       resp["result"]["isError"].as_bool.should be_false
-      String.new(seen.receive).should eq("GET /lf HTTP/1.1\nHost: h\n\n")
+      String.new(receive_within(seen)).should eq("GET /lf HTTP/1.1\nHost: h\n\n")
     end
   end
 end
@@ -348,7 +348,7 @@ describe "MCP effective_request" do
       resp = drive(store, call_line("send_request",
         %({"url":"http://127.0.0.1:#{port}/09","raw":"GET /old09\\r\\n\\r\\n",) +
         %("verbatim":true,"allow_unscoped":true})))[0]
-      String.new(seen.receive).should eq("GET /old09\r\n\r\n")
+      String.new(receive_within(seen)).should eq("GET /old09\r\n\r\n")
       payload(resp)["effective_request"]["http_version"].raw.should be_nil
     end
   end
@@ -372,7 +372,7 @@ describe "MCP flow replay" do
         resp = drive(store, call_line("send_request",
           %({"flow_id":#{id},"allow_unscoped":true,"record_history":false})))[0]
         resp["result"]["isError"].as_bool.should be_false
-        String.new(seen.receive).should eq(text)
+        String.new(receive_within(seen)).should eq(text)
       end
     end
   end
@@ -392,7 +392,7 @@ describe "MCP field-native h2 evidence" do
         %({"url":"http://127.0.0.1:#{port}/api/v1/user","h2_fields":#{fields},) +
         %("body":"{\\"a\\":1}","allow_unscoped":true,"save_as_repeater":true})))[0]
       body = payload(resp)
-      seen.receive # the h2 attempt itself
+      receive_within(seen) # the h2 attempt itself
 
       body["sent_h2_fields"].as_a.map(&.as_a.first.as_s)
         .should eq([":method", ":path", ":scheme", ":authority", "cookie"])
@@ -407,7 +407,7 @@ describe "MCP field-native h2 evidence" do
       saved = body["saved_repeater_id"].as_i64
       drive(store, call_line("send_request",
         %({"repeater_id":#{saved},"http2":false,"allow_unscoped":true,"record_history":false})))
-      String.new(seen.receive).lines.first.should eq("POST /api/v1/user?id=1 HTTP/1.1")
+      String.new(receive_within(seen)).lines.first.should eq("POST /api/v1/user?id=1 HTTP/1.1")
     end
   end
 end

--- a/spec/mcp_discover_wiring_spec.cr
+++ b/spec/mcp_discover_wiring_spec.cr
@@ -1,0 +1,199 @@
+require "./spec_helper"
+require "socket"
+
+# The MCP half of round 3's wiring, discover's share of it. Kept in its own file: the
+# fuzz/mine/sequence examples in mcp_wiring_spec.cr leave engine fibers behind them, and a
+# discover run sharing a process with those took twenty times as long as it does alone.
+#
+# Helpers are file-local — Crystal's top-level `private def` is file-scoped, so this file
+# does not depend on mcp_wiring_spec.cr's or mcp_fuzz_spec.cr's.
+
+private def with_store(&)
+  path = File.tempname("gori-mcpwire", ".db")
+  store = Gori::Store.open(path)
+  begin
+    yield store
+  ensure
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+private def tools_for(store) : Gori::MCP::Tools
+  Gori::MCP::Tools.new(store, allow_actions: true, verify_upstream: false)
+end
+
+private def call_raw(tools, name, args : String) : {String, Bool}
+  r = tools.call(name, JSON.parse(args))
+  {r.text, r.is_error}
+end
+
+private def call_json(tools, name, args : String) : JSON::Any
+  text, err = call_raw(tools, name, args)
+  fail "tool #{name} errored: #{text}" if err
+  JSON.parse(text)
+end
+
+private def poll_until_done(tools, status_tool : String, job_id : String, seconds = 20) : JSON::Any
+  deadline = Time.instant + seconds.seconds
+  loop do
+    st = call_json(tools, status_tool, %({"job_id":#{job_id.to_json}}))
+    return st unless st["status"].as_s == "running"
+    fail "#{status_tool} #{job_id} never left :running within #{seconds}s" if Time.instant > deadline
+    sleep 0.02.seconds
+  end
+end
+
+# A plain HTML origin with no links on the page. Keep-alive capable (several requests per
+# connection, no `Connection: close`) on purpose: discover pools its sockets, and an origin
+# that hangs up after every response turns each probe into a re-dial plus a retry.
+#
+# Used even by the examples that only care whether an argument was ACCEPTED. A job started
+# against a dead port keeps retrying for the rest of the file, which showed up as unrelated
+# later examples taking twenty seconds each.
+private def html_origin : Int32
+  server = TCPServer.new("127.0.0.1", 0)
+  port = server.local_address.port
+  spawn do
+    while conn = server.accept?
+      spawn do
+        begin
+          conn.read_timeout = 2.seconds
+          body = "<html><body>no links here</body></html>"
+          while Gori::Proxy::Codec::Http1.read_head(conn)
+            conn << "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n" \
+                    "Content-Length: #{body.bytesize}\r\n\r\n" << body
+            conn.flush
+          end
+        rescue
+        end
+        conn.close rescue nil
+      end
+    end
+  end
+  port
+end
+
+# ONE listener for the whole file: each `html_origin` leaks a listening socket plus an
+# accept-loop fiber, and a dozen of them made unrelated later examples take twenty seconds.
+private HTML_ORIGIN_PORT = html_origin
+
+# ── 5. discover adopts the header refusal ─────────────────────────────────────────────────
+#
+# `Discover::Headers.parse_lines` drops a CR/LF-carrying value and a non-token name — right,
+# since this is an automated crawler splicing the value into every probe's header block — but
+# it dropped them SILENTLY. The drop takes `Authorization` with it, so an agent's
+# authenticated sweep ran unauthenticated over the whole authenticated surface and reported
+# "found nothing", with no error anywhere. `gori run discover` aborts by name; MCP is the
+# surface where nobody is watching stderr.
+describe "MCP discover_start refuses a header it will not send" do
+  it "names the header whose value carries CR/LF instead of crawling without it" do
+    port = HTML_ORIGIN_PORT
+    with_store do |store|
+      tools = tools_for(store)
+      text, err = call_raw(tools, "discover_start",
+        {"url"            => "http://127.0.0.1:#{port}/",
+         "headers"        => {"Authorization" => "Bearer t\r\nX-Injected: 1"},
+         "allow_unscoped" => true}.to_json)
+      err.should be_true
+      text.should contain("Authorization")
+      text.should_not contain("Bearer t") # never echo the value back — it is the credential
+    end
+  end
+
+  it "names a header that only becomes unsafe after $VAR expansion" do
+    port = HTML_ORIGIN_PORT
+    with_store do |store|
+      saved = Gori::Settings.env_vars
+      saved_prefix = Gori::Settings.env_prefix
+      begin
+        # Built BEFORE the vars are set: constructing Tools runs `Env.load_project(store)`,
+        # which would otherwise reset them from the (empty) project.
+        tools = tools_for(store)
+        Gori::Settings.env_prefix = "$"
+        # The header the caller passed is fine; the VALUE bound to TOKEN is not. (A purely
+        # TRAILING newline is not this case: both `unsafe_expanded` and `Headers.expand`
+        # strip, so it cannot splice anything. An interior CRLF can, and does.)
+        Gori::Settings.env_vars = [{"TOKEN", "abc\r\nX-Injected: 1"}]
+        text, err = call_raw(tools, "discover_start",
+          {"url"            => "http://127.0.0.1:#{port}/",
+           "headers"        => {"Authorization" => "Bearer $TOKEN"},
+           "allow_unscoped" => true}.to_json)
+        err.should be_true
+        text.should contain("Authorization")
+        text.should contain("$VAR expansion")
+      ensure
+        Gori::Settings.env_vars = saved || [] of {String, String}
+        Gori::Settings.env_prefix = saved_prefix || "$"
+      end
+    end
+  end
+
+  it "still accepts an ordinary header" do
+    port = HTML_ORIGIN_PORT
+    with_store do |store|
+      tools = tools_for(store)
+      text, err = call_raw(tools, "discover_start",
+        {"url" => "http://127.0.0.1:#{port}/",
+         "headers" => {"Authorization" => "Bearer plain"},
+         "max_requests" => 1, "bruteforce" => false, "allow_unscoped" => true}.to_json)
+      fail "discover_start refused an ordinary header: #{text}" if err
+      poll_until_done(tools, "discover_status", JSON.parse(text)["job_id"].as_s)
+    end
+  end
+end
+
+# ── 2. discover's incomplete_reason comes from the ENGINE ─────────────────────────────────
+#
+# Two round-3 fixes met here from opposite sides: one added `queued` + `incomplete_reason` to
+# the MCP discover envelopes, the other added `Discover::DoneEvent#budget_exhausted`. MCP was
+# left INFERRING the reason from `queued > 0`, and the engine's own predicate is
+# `cap_reached? && (frontier non-empty || refused > 0)` — deliberately two clauses, because a
+# Calibrate task whose probes were all refused consumes no frontier entry. So a sweep that
+# spent its whole budget before a single wordlist candidate was tried drained the frontier to
+# EMPTY and came back `status:"done", job_complete:true, has_more:false`, which an agent reads
+# as an exhaustive directory sweep and stops looking.
+describe "MCP discover reports a budget-capped sweep as incomplete" do
+  it "says budget_exhausted even when the frontier drained to EMPTY" do
+    port = HTML_ORIGIN_PORT
+    with_store do |store|
+      tools = tools_for(store)
+      start = call_json(tools, "discover_start",
+        {"url" => "http://127.0.0.1:#{port}/", "max_requests" => 2,
+         "allow_unscoped" => true}.to_json)
+      job_id = start["job_id"].as_s
+      st = poll_until_done(tools, "discover_status", job_id, 45)
+
+      st["sent"].as_i.should be > 0 # not the "nothing reached the wire" terminal error
+      # The shape that made the inference wrong: nothing is left QUEUED, and the run is still
+      # nowhere near exhaustive — the budget went on calibration, so no wordlist candidate
+      # was ever tried.
+      st["queued"].as_i.should eq(0)
+      st["status"].as_s.should eq("budget_exhausted")
+      st["incomplete_reason"].as_s.should eq("budget_exhausted")
+
+      # discover_results carries the same verdict: `has_more` is about the PAGE, so on its own
+      # it says "you have seen everything" about a sweep that saw almost nothing.
+      res = call_json(tools, "discover_results", %({"job_id":#{job_id.to_json}}))
+      res["job_complete"].as_bool.should be_true
+      res["has_more"].as_bool.should be_false
+      res["incomplete_reason"].as_s.should eq("budget_exhausted")
+    end
+  end
+
+  it "still reports a spider-only run that finished as a clean done" do
+    port = HTML_ORIGIN_PORT
+    with_store do |store|
+      tools = tools_for(store)
+      start = call_json(tools, "discover_start",
+        {"url" => "http://127.0.0.1:#{port}/", "bruteforce" => false, "keep_alive" => false,
+         "concurrency" => 4, "timeout_ms" => 800, "retries" => 0,
+         "max_requests" => 200, "allow_unscoped" => true}.to_json)
+      st = poll_until_done(tools, "discover_status", start["job_id"].as_s, 45)
+      st["status"].as_s.should eq("done")
+      st["incomplete_reason"].raw.should be_nil
+    end
+  end
+end

--- a/spec/mcp_wiring_spec.cr
+++ b/spec/mcp_wiring_spec.cr
@@ -1,0 +1,279 @@
+require "./spec_helper"
+require "socket"
+
+# The MCP half of round 3's wiring: several fixes produced an API on the engine side of a
+# file-ownership boundary with no consumer on the MCP side, so an agent could not reach a
+# capability `gori run …` already had. Each case here is one such gap, driven through a real
+# `Gori::MCP::Tools` (the IO::Memory server harness never yields to a job fiber).
+#
+# Helpers are file-local — Crystal's top-level `private def` is file-scoped, so this file
+# does not depend on mcp_fuzz_spec.cr's.
+
+private def with_store(&)
+  path = File.tempname("gori-mcpwire", ".db")
+  store = Gori::Store.open(path)
+  begin
+    yield store
+  ensure
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+private def tools_for(store) : Gori::MCP::Tools
+  Gori::MCP::Tools.new(store, allow_actions: true, verify_upstream: false)
+end
+
+private def call_raw(tools, name, args : String) : {String, Bool}
+  r = tools.call(name, JSON.parse(args))
+  {r.text, r.is_error}
+end
+
+private def call_json(tools, name, args : String) : JSON::Any
+  text, err = call_raw(tools, name, args)
+  fail "tool #{name} errored: #{text}" if err
+  JSON.parse(text)
+end
+
+# A recording origin that keeps the EXACT bytes of each request it is handed, answers a
+# canned 200, and publishes them on a channel.
+private def recording_origin(conns = 1) : {Int32, Channel(Bytes)}
+  server = TCPServer.new("127.0.0.1", 0)
+  port = server.local_address.port
+  seen = Channel(Bytes).new(conns)
+  spawn do
+    conns.times do
+      break unless conn = server.accept?
+      spawn do
+        buf = IO::Memory.new
+        begin
+          conn.read_timeout = 400.milliseconds
+          slice = Bytes.new(65536)
+          loop do
+            n = conn.read(slice)
+            break if n == 0
+            buf.write(slice[0, n])
+          end
+        rescue
+        end
+        begin
+          conn << "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok"
+          conn.flush
+        rescue
+        end
+        seen.send(buf.to_slice)
+        conn.close rescue nil
+      end
+    end
+  ensure
+    server.close rescue nil
+  end
+  {port, seen}
+end
+
+private def poll_until_done(tools, status_tool : String, job_id : String, seconds = 20) : JSON::Any
+  deadline = Time.instant + seconds.seconds
+  loop do
+    st = call_json(tools, status_tool, %({"job_id":#{job_id.to_json}}))
+    return st unless st["status"].as_s == "running"
+    fail "#{status_tool} #{job_id} never left :running within #{seconds}s" if Time.instant > deadline
+    sleep 0.02.seconds
+  end
+end
+
+# A plain HTML origin with no links on the page. Keep-alive capable (several requests per
+# connection, no `Connection: close`) on purpose: discover pools its sockets, and an origin
+# that hangs up after every response turns each probe into a re-dial plus a retry.
+#
+# Used even by the examples that only care whether an argument was ACCEPTED. A job started
+# against a dead port keeps retrying for the rest of the file, which showed up as unrelated
+# later examples taking twenty seconds each.
+private def html_origin : Int32
+  server = TCPServer.new("127.0.0.1", 0)
+  port = server.local_address.port
+  spawn do
+    while conn = server.accept?
+      spawn do
+        begin
+          conn.read_timeout = 2.seconds
+          body = "<html><body>no links here</body></html>"
+          while Gori::Proxy::Codec::Http1.read_head(conn)
+            conn << "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n" \
+                    "Content-Length: #{body.bytesize}\r\n\r\n" << body
+            conn.flush
+          end
+        rescue
+        end
+        conn.close rescue nil
+      end
+    end
+  end
+  port
+end
+
+# ONE listener for the whole file: each `html_origin` leaks a listening socket plus an
+# accept-loop fiber, and a dozen of them made unrelated later examples take twenty seconds.
+private HTML_ORIGIN_PORT = html_origin
+
+private def insert_flow(store, port : Int32, head : String) : Int64
+  store.insert_flow(Gori::Store::CapturedRequest.new(
+    created_at: 1_i64, scheme: "http", host: "127.0.0.1", port: port,
+    method: "GET", target: "/", http_version: "HTTP/1.1", head: head.to_slice))
+end
+
+# ── 1. flow seeds are EVIDENCE ────────────────────────────────────────────────────────────
+#
+# `Fuzz`/`Miner`/`Sequencer::PlanOptions#evidence?` is the provenance bit: a captured flow's
+# bytes are not a draft the operator typed, so the draft-time passes (the unresolved-`$KEY`
+# refusal, the head's bare-LF → CRLF promotion) must not run over them. `gori run fuzz|mine|
+# sequence --flow` set it; MCP's three `flow_id` seeds did not. An agent seeding a sweep from
+# an OData capture (`$filter`, `$top`) therefore had the whole run REFUSED for a variable
+# nobody typed — and the refusal's own remedy, "set the variable", would have SUBSTITUTED a
+# value and swept a different request than the one it was told to sweep.
+private ODATA_HEAD = "GET /api?$filter=name%20eq%20x&$top=10 HTTP/1.1\r\n" \
+                     "X-Cmd: ;cat$IFS/etc/passwd\r\n"
+
+describe "MCP flow seeds carry PROVENANCE" do
+  it "fuzz_start does not refuse a captured $filter/$top head" do
+    port = HTML_ORIGIN_PORT
+    with_store do |store|
+      tools = tools_for(store)
+      id = insert_flow(store, port, ODATA_HEAD + "Host: 127.0.0.1:#{port}\r\n\r\n")
+      text, err = call_raw(tools, "fuzz_start",
+        {"flow_id" => id, "auto" => true, "max_requests" => 1,
+         "payloads" => [{"list" => ["a"]}], "allow_unscoped" => true}.to_json)
+      fail "fuzz_start refused a capture: #{text}" if err
+      job_id = JSON.parse(text)["job_id"].as_s
+      job_id.should start_with("fz_")
+      # The point here is that the plan BUILT. Stop the job rather than let it outlive the
+      # example: an engine fiber still running competes with every example after it.
+      call_json(tools, "fuzz_stop", %({"job_id":#{job_id.to_json}}))
+    end
+  end
+
+  it "mine_start does not refuse a captured $filter/$top head" do
+    port = HTML_ORIGIN_PORT
+    with_store do |store|
+      tools = tools_for(store)
+      id = insert_flow(store, port, ODATA_HEAD + "Host: 127.0.0.1:#{port}\r\n\r\n")
+      text, err = call_raw(tools, "mine_start",
+        {"flow_id" => id, "max_requests" => 1, "allow_unscoped" => true}.to_json)
+      fail "mine_start refused a capture: #{text}" if err
+      call_json(tools, "mine_stop", %({"job_id":#{JSON.parse(text)["job_id"].as_s.to_json}}))
+    end
+  end
+
+  it "sequence_start does not refuse a captured $filter/$top head" do
+    port = HTML_ORIGIN_PORT
+    with_store do |store|
+      tools = tools_for(store)
+      id = insert_flow(store, port, ODATA_HEAD + "Host: 127.0.0.1:#{port}\r\n\r\n")
+      text, err = call_raw(tools, "sequence_start",
+        {"flow_id" => id, "cookie" => "sid", "count" => 1, "max_requests" => 1,
+         "allow_unscoped" => true}.to_json)
+      fail "sequence_start refused a capture: #{text}" if err
+      call_json(tools, "sequence_stop", %({"job_id":#{JSON.parse(text)["job_id"].as_s.to_json}}))
+    end
+  end
+
+  # The other half of the same bit, and the one that silently changes what a whole sweep
+  # measures: `expand_wire` re-terminates a head with CRLF. A bare LF between header lines is
+  # itself a front-end/back-end desync primitive, so promoting it does not merely tidy the
+  # bytes — it confounds every result the run produces, and the run reports clean.
+  it "fuzz_start puts a captured bare-LF head on the wire bare-LF" do
+    port, seen = recording_origin(1)
+    with_store do |store|
+      tools = tools_for(store)
+      bare = "GET /lf?q=1 HTTP/1.1\nHost: 127.0.0.1:#{port}\nX-Probe: keep\n\n"
+      id = insert_flow(store, port, bare)
+      start = call_json(tools, "fuzz_start",
+        {"flow_id" => id, "auto" => true, "max_requests" => 1,
+         "payloads" => [{"list" => ["Z"]}], "keep_alive" => false,
+         "allow_unscoped" => true}.to_json)
+      poll_until_done(tools, "fuzz_status", start["job_id"].as_s)
+      wire = String.new(receive_within(seen))
+      wire.should_not contain("\r\n")
+      wire.should start_with("GET /lf?q=Z HTTP/1.1\nHost:")
+    end
+  end
+end
+
+# ── 3. fuzz_start{update_content_length} ──────────────────────────────────────────────────
+#
+# `Fuzz::Config#update_content_length` is wired to `gori run fuzz --verbatim` and to
+# `intercept_forward_edit{update_content_length:false}`. fuzz_start could not reach it, so
+# every payload was re-framed to fit before it left and the whole CL-desync probe class was
+# unreachable for an agent — the sweep silently repaired the exact property it was measuring.
+private CL_TEMPLATE = "POST /d HTTP/1.1\r\nHost: 127.0.0.1\r\n" \
+                      "Content-Length: 4\r\n\r\nq=§x§"
+
+describe "MCP fuzz_start{update_content_length}" do
+  it "sends the template's DECLARED Content-Length when it is false" do
+    port, seen = recording_origin(1)
+    with_store do |store|
+      tools = tools_for(store)
+      start = call_json(tools, "fuzz_start",
+        {"template" => CL_TEMPLATE, "url" => "http://127.0.0.1:#{port}",
+         "payloads" => [{"list" => ["a-long-payload"]}], "keep_alive" => false,
+         "update_content_length" => false, "allow_unscoped" => true}.to_json)
+      poll_until_done(tools, "fuzz_status", start["job_id"].as_s)
+      wire = String.new(receive_within(seen))
+      wire.should contain("Content-Length: 4\r\n")
+      wire.should end_with("q=a-long-payload")
+    end
+  end
+
+  it "still resyncs by default" do
+    port, seen = recording_origin(1)
+    with_store do |store|
+      tools = tools_for(store)
+      start = call_json(tools, "fuzz_start",
+        {"template" => CL_TEMPLATE, "url" => "http://127.0.0.1:#{port}",
+         "payloads" => [{"list" => ["a-long-payload"]}], "keep_alive" => false,
+         "allow_unscoped" => true}.to_json)
+      poll_until_done(tools, "fuzz_status", start["job_id"].as_s)
+      String.new(receive_within(seen)).should contain("Content-Length: 16\r\n")
+    end
+  end
+end
+
+# ── 4. mine_status{skipped} ───────────────────────────────────────────────────────────────
+#
+# `names_total` counts only the names that SURVIVED per-location filtering, so the same
+# wordlist reported a different headline count at the query and at headers with nothing
+# anywhere to say why. `Miner::Engine#skipped_names` is the fact; `gori run mine` prints it
+# and MCP did not carry it, so an agent read an incomplete sweep as a clean one.
+describe "MCP mine_status{skipped}" do
+  it "reports the names a location cannot carry, against the wordlist's own size" do
+    port = HTML_ORIGIN_PORT
+    with_store do |store|
+      wl = File.tempname("gori-mine-wl", ".txt")
+      # Three names a header cannot carry (a separator, whitespace, and a framing header)
+      # against two that it can.
+      File.write(wl, "good_one\nbad(name)\nbad name\ncontent-length\nalso_good\n")
+      begin
+        tools = tools_for(store)
+        start = call_json(tools, "mine_start",
+          {"template" => "GET /m HTTP/1.1\r\nHost: 127.0.0.1:#{port}\r\n\r\n",
+           "url" => "http://127.0.0.1:#{port}", "locations" => "headers",
+           "wordlist" => wl, "max_requests" => 1,
+           "concurrency" => 1, "allow_unscoped" => true}.to_json)
+        st = call_json(tools, "mine_status", %({"job_id":#{start["job_id"].as_s.to_json}}))
+        st["candidate_names"].as_i.should be > st["names_total"].as_i
+        skipped = st["skipped"].as_a
+        skipped.size.should eq(1)
+        skipped[0]["location"].as_s.should eq("headers")
+        # At least the three this wordlist contributes; it is MERGED with the built-in list,
+        # which carries header-invalid names of its own, so this is a floor and not a total.
+        skipped[0]["names"].as_i.should be >= 3
+        # ...and the count really is the denominator's shortfall, not an unrelated number.
+        skipped[0]["names"].as_i.should eq(st["candidate_names"].as_i - st["names_total"].as_i)
+        call_json(tools, "mine_stop", %({"job_id":#{start["job_id"].as_s.to_json}}))
+      ensure
+        File.delete?(wl)
+      end
+    end
+  end
+end

--- a/spec/proxy/h2/assembler_spec.cr
+++ b/spec/proxy/h2/assembler_spec.cr
@@ -303,6 +303,13 @@ describe Gori::Proxy::H2::Assembler do
     # indistinguishable in History / QL / the Sitemap from one the client made — rows the
     # origin authored, inside the evidence an operator came to read.
     String.new(req.head).should contain("X-Gori-Pushed: server push promised on stream 1")
+    # R4: and as DATA on the row, not only as a line inside the head TEXT. History, QL, the
+    # Sitemap, MCP `get_flow` and a HAR export all read the row, and none of them parses a
+    # stored head looking for a marker.
+    req.advisory.not_nil!.should contain("server push")
+    req.advisory.not_nil!.should contain("PUSH_PROMISE on stream 1")
+    # The response half must not drop it: `update_one` writes the column outright.
+    sink.responses.first.advisory.not_nil!.should contain("server push")
   end
 
   # Complement: a request the client actually sent carries no push marker.
@@ -312,6 +319,32 @@ describe Gori::Proxy::H2::Assembler do
     assembler.feed("out", headers_frame(1_u32, Frame::END_HEADERS | Frame::END_STREAM,
       hexb("828684418cf1e3c2e5f23a6ba0ab90f4ff")))
     String.new(sink.requests.first.head).should_not contain("X-Gori-Pushed")
+    sink.requests.first.advisory.should be_nil
+  end
+
+  # `HeadRewrite` runs BEFORE the frame reaches `feed`, so an advisory can arrive for a stream
+  # this assembler has never seen. It has to open the entry the way `feed_locked` does, or the
+  # statement is dropped for exactly the messages it is about.
+  it "records an advisory that arrives BEFORE the stream's first frame" do
+    sink = RecSink.new
+    assembler = Gori::Proxy::H2::Assembler.new(sink, "example.com", 443, 1_i64)
+    assembler.note_advisory(1_u32, "a rule could not run here")
+    assembler.note_advisory(1_u32, "a rule could not run here") # deduped, not doubled
+    assembler.feed("out", headers_frame(1_u32, Frame::END_HEADERS | Frame::END_STREAM,
+      hexb("828684418cf1e3c2e5f23a6ba0ab90f4ff")))
+    sink.requests.first.advisory.should eq("a rule could not run here")
+  end
+
+  # The complement of "opens the entry": stream 0 is the CONNECTION, never a message, so an
+  # advisory keyed to it must not mint a phantom stream (`feed` already treats 0 as
+  # not-a-stream, and a Slot keyed 0 is the freeze D1 rule 1 forbids).
+  it "ignores an advisory for stream 0" do
+    sink = RecSink.new
+    assembler = Gori::Proxy::H2::Assembler.new(sink, "example.com", 443, 1_i64)
+    assembler.note_advisory(0_u32, "not about any message")
+    assembler.feed("out", headers_frame(1_u32, Frame::END_HEADERS | Frame::END_STREAM,
+      hexb("828684418cf1e3c2e5f23a6ba0ab90f4ff")))
+    sink.requests.first.advisory.should be_nil
   end
 
   # R5-F4. gori relays an RFC 8441 extended CONNECT byte-for-byte (it also relays the origin's

--- a/spec/proxy/h2/head_rewrite_spec.cr
+++ b/spec/proxy/h2/head_rewrite_spec.cr
@@ -555,6 +555,70 @@ describe Gori::Proxy::H2::HeadRewrite do
       end
     end
 
+    # R4. The stream id was right after R3-F3 and the statement still reached nobody: one WARN
+    # per direction per connection on `gori run capture`'s STDERR, correlated with no flow. The
+    # skip is a PER-MESSAGE fact ("did my rule run on THIS request?"), so it goes on the flow
+    # row — `Store::FlowRow#advisory`, the HTTP twin of the `[gori] …` rows a WebSocket flow
+    # has carried since #518.
+    it "records the skip on the FLOW, not only in the log" do
+      pipe, assembler, sink = pipeline(SubRewriter.new("/two", "/twoLONGER"), direction: "out")
+      evil = [{":method", "GET"}, {":scheme", "https"}, {":authority", "a.test"},
+              {":path", "/two"}, {"x-reflected", "a\r\nx-injected: 1"}]
+      pipe.accept(headers(3_u32, HPACK::Encoder.new.encode(evil))) { |f, pre| assembler.feed("out", f, pre) }
+
+      advisory = sink.requests.first.advisory.not_nil!
+      advisory.should contain("Match&Replace was NOT applied to this request head")
+      advisory.should contain("x-reflected") # the FIELD, which is what names the probe that induced it
+      advisory.should contain("no HTTP/1.1 text form")
+    end
+
+    # The complement of the fix condition: two messages on ONE connection, only the second
+    # unfaithful. The log line is once per connection; the advisory must be per MESSAGE, so the
+    # faithful flow must carry none and the unfaithful one must carry its own.
+    it "leaves a faithful head's flow with no advisory on the same connection" do
+      pipe, assembler, sink = pipeline(SubRewriter.new("/two", "/twoLONGER"), direction: "out")
+      ok = [{":method", "GET"}, {":scheme", "https"}, {":authority", "a.test"}, {":path", "/two"}]
+      evil = [{":method", "GET"}, {":scheme", "https"}, {":authority", "a.test"},
+              {":path", "/two"}, {"x-reflected", "a\r\nx-injected: 1"}]
+      enc = HPACK::Encoder.new
+      pipe.accept(headers(1_u32, enc.encode(ok))) { |f, pre| assembler.feed("out", f, pre) }
+      pipe.accept(headers(3_u32, enc.encode(evil))) { |f, pre| assembler.feed("out", f, pre) }
+
+      sink.requests.size.should eq(2)
+      sink.requests[0].advisory.should be_nil
+      sink.requests[1].advisory.not_nil!.should contain("x-reflected")
+    end
+
+    # The other complement: no rule live means nothing failed to fire, so there is nothing to
+    # report. An advisory on every CRLF-carrying head would be noise about a rule table that
+    # is empty.
+    it "says nothing when no head rule is live" do
+      pipe, assembler, sink = pipeline(SubRewriter.new("/two", "/twoLONGER", on: false), direction: "out")
+      evil = [{":method", "GET"}, {":scheme", "https"}, {":authority", "a.test"},
+              {":path", "/two"}, {"x-reflected", "a\r\nx-injected: 1"}]
+      pipe.accept(headers(3_u32, HPACK::Encoder.new.encode(evil))) { |f, pre| assembler.feed("out", f, pre) }
+      sink.requests.first.advisory.should be_nil
+    end
+
+    # The RESPONSE direction reaches the same seam through `emit_response`, and it must not
+    # erase what the request side already stored — `update_one` writes the column outright.
+    it "carries a response-direction advisory without dropping the request-direction one" do
+      sink = RecSink.new
+      assembler = Gori::Proxy::H2::Assembler.new(sink, "a.test", 443, 1_i64)
+      out_pipe = Gori::Proxy::H2::HeadRewrite.new("out", SubRewriter.new("/two", "/twoLONGER"), assembler, "a.test")
+      in_pipe = Gori::Proxy::H2::HeadRewrite.new("in", SubRewriter.new("x-tag: a", "x-tag: b"), assembler, "a.test")
+      evil_req = [{":method", "GET"}, {":scheme", "https"}, {":authority", "a.test"},
+                  {":path", "/two"}, {"x-reflected", "a\r\nx-injected: 1"}]
+      evil_resp = [{":status", "200"}, {"x-echo", "safe\r\nset-cookie: injected=1"}]
+      out_pipe.accept(headers(1_u32, HPACK::Encoder.new.encode(evil_req))) { |f, pre| assembler.feed("out", f, pre) }
+      in_pipe.accept(headers(1_u32, HPACK::Encoder.new.encode(evil_resp))) { |f, pre| assembler.feed("in", f, pre) }
+
+      resp = sink.responses.first.advisory.not_nil!
+      resp.should contain("request head") # the request-direction line survived
+      resp.should contain("response head")
+      resp.lines.size.should eq(2)
+    end
+
     # The complement: the SAME connection, the same rule, a head the text CAN carry — the rule
     # fires and nothing is warned about.
     it "fires the rule normally on a head that has an h1 text form" do

--- a/spec/proxy/ws_spec.cr
+++ b/spec/proxy/ws_spec.cr
@@ -359,7 +359,7 @@ describe Gori::Proxy::WS do
 
       sink = WsSink.new
       Gori::Proxy::WS::Relay.run(relay_client, relay_upstream, 9_i64, sink)
-      drain.receive
+      receive_within(drain)
       client_side.close rescue nil
 
       fwd = forwarded.to_slice
@@ -407,7 +407,7 @@ describe Gori::Proxy::WS do
 
       sink = WsSink.new
       Gori::Proxy::WS::Relay.run(relay_client, relay_upstream, 11_i64, sink)
-      drain.receive
+      receive_within(drain)
       client_side.close rescue nil
 
       # The leading "abc" fragment reaches the sink (not silently discarded because the
@@ -1028,8 +1028,8 @@ describe "WebSocket through the proxy (end-to-end)" do
     echoed = Gori::Proxy::WS.read_frame(client).not_nil!
     String.new(echoed.payload).should eq("ping") # round-tripped through gori
 
-    ws_chan.receive # out
-    ws_chan.receive # in
+    receive_within(ws_chan) # out
+    receive_within(ws_chan) # in
     client.close
     proxy.stop
 
@@ -1073,7 +1073,7 @@ describe "WebSocket through the proxy (end-to-end)" do
               "User-Agent: probe\r\n\r\n"
     client.flush
 
-    origin_head = seen.receive
+    origin_head = receive_within(seen)
     origin_head.downcase.should_not contain("sec-websocket-extensions")
     origin_head.should contain("Sec-WebSocket-Key: dGhlIHNhbXBsZQ==") # everything else survives
     origin_head.should contain("User-Agent: probe")
@@ -1084,8 +1084,8 @@ describe "WebSocket through the proxy (end-to-end)" do
     client.write(masked_frame("hello"))
     client.flush
     Gori::Proxy::WS.read_frame(client).not_nil!
-    ws_chan.receive # out
-    ws_chan.receive # in
+    receive_within(ws_chan) # out
+    receive_within(ws_chan) # in
     client.close
     proxy.stop
 
@@ -1132,7 +1132,7 @@ describe "WebSocket through the proxy (end-to-end)" do
               "Sec-WebSocket-Extensions: permessage-deflate\r\n\r\n"
     client.flush
 
-    seen.receive.downcase.should_not contain("sec-websocket-extensions") # the offer, as before
+    receive_within(seen).downcase.should_not contain("sec-websocket-extensions") # the offer, as before
     resp_head = String.new(Gori::Proxy::Codec::Http1.read_head(client).not_nil!)
     resp_head.should contain("101")
     # ... and now the acceptance too, so the client never turns permessage-deflate on.
@@ -1184,7 +1184,7 @@ describe "WebSocket through the proxy (end-to-end)" do
               "Sec-WebSocket-Key: dGhlIHNhbXBsZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n"
     client.flush
 
-    seen.receive
+    receive_within(seen)
     resp_head = String.new(Gori::Proxy::Codec::Http1.read_head(client).not_nil!)
     resp_head.should contain("Sec-WebSocket-Extensions: permessage-deflate") # P7: untouched
     expect_ws_rows(ws_chan, 1)                                               # the notice row
@@ -1220,7 +1220,7 @@ describe "WebSocket through the proxy (end-to-end)" do
               "Sec-WebSocket-Extensions: permessage-deflate\r\n\r\n"
     client.flush
 
-    seen.receive.should contain("Sec-WebSocket-Extensions: permessage-deflate")
+    receive_within(seen).should contain("Sec-WebSocket-Extensions: permessage-deflate")
     Gori::Proxy::Codec::Http1.read_head(client)
     client.close
     proxy.stop

--- a/spec/repeater/h2_engine_spec.cr
+++ b/spec/repeater/h2_engine_spec.cr
@@ -704,7 +704,7 @@ describe Gori::Repeater::H2Engine do
     request = "GET /api/thing HTTP/2\r\nx-repeater: yes\r\n\r\n".to_slice
     result = Gori::Repeater::H2Engine.send(request, scheme: "http", host: "127.0.0.1", port: port, verify_upstream: false)
 
-    seen.receive.should eq("GET /api/thing body=") # origin saw the HPACK-encoded request
+    receive_within(seen).should eq("GET /api/thing body=") # origin saw the HPACK-encoded request
     result.ok?.should be_true
     result.response.not_nil!.status.should eq(200)
     String.new(result.head).should contain("HTTP/2 200")
@@ -765,7 +765,7 @@ describe Gori::Repeater::H2Engine do
     result = Gori::Repeater::H2Engine.send(request, scheme: "http", host: "127.0.0.1",
       port: port, verify_upstream: false)
 
-    seen.receive.should eq("GET /f body=")
+    receive_within(seen).should eq("GET /f body=")
     result.ok?.should be_true
   end
 
@@ -788,7 +788,7 @@ describe Gori::Repeater::H2Engine do
     request = "POST /submit HTTP/2\r\ncontent-type: text/plain\r\n\r\nhello-h2-body".to_slice
     result = Gori::Repeater::H2Engine.send(request, scheme: "http", host: "127.0.0.1", port: port, verify_upstream: false)
 
-    seen.receive.should eq("POST /submit body=hello-h2-body")
+    receive_within(seen).should eq("POST /submit body=hello-h2-body")
     result.response.not_nil!.status.should eq(201)
     String.new(result.body.not_nil!).should eq("created")
   end
@@ -811,7 +811,7 @@ describe Gori::Repeater::H2Engine do
     request = "GET / HTTP/2\r\nHost: victim.internal\r\n\r\n".to_slice
     result = Gori::Repeater::H2Engine.send(request, scheme: "http", host: "127.0.0.1", port: port, verify_upstream: false)
 
-    seen.receive.should eq("victim.internal")
+    receive_within(seen).should eq("victim.internal")
     result.ok?.should be_true
   end
 
@@ -822,7 +822,7 @@ describe Gori::Repeater::H2Engine do
     result = Gori::Repeater::H2Engine.send("GET / HTTP/2\r\n\r\n".to_slice,
       scheme: "http", host: "127.0.0.1", port: port, verify_upstream: false)
 
-    seen.receive.should eq("127.0.0.1:#{port}")
+    receive_within(seen).should eq("127.0.0.1:#{port}")
     result.ok?.should be_true
   end
 
@@ -848,7 +848,7 @@ describe Gori::Repeater::H2Engine do
     result = Gori::Repeater::H2Engine.send(request, scheme: "http", host: "127.0.0.1",
       port: port, verify_upstream: false)
 
-    fields, _ = seen.receive
+    fields, _ = receive_within(seen)
     fields.should contain({"transfer-encoding", "chunked"})
     fields.should contain({"connection", "keep-alive"})
     fields.should contain({"upgrade", "h2c"})
@@ -870,7 +870,7 @@ describe Gori::Repeater::H2Engine do
     Gori::Repeater::H2Engine.send(request, scheme: "http", host: "127.0.0.1",
       port: port, verify_upstream: false)
 
-    fields, _ = seen.receive
+    fields, _ = receive_within(seen)
     fields.should contain({"x-pad", "trailing   "})
   end
 
@@ -884,7 +884,7 @@ describe Gori::Repeater::H2Engine do
     Gori::Repeater::H2Engine.send("GET / HTTP/2\r\nx-lead:    lead\r\n\r\n".to_slice,
       scheme: "http", host: "127.0.0.1", port: port, verify_upstream: false)
 
-    fields, _ = seen.receive
+    fields, _ = receive_within(seen)
     fields.should contain({"x-lead", "lead"})
   end
 
@@ -895,7 +895,7 @@ describe Gori::Repeater::H2Engine do
     Gori::Repeater::H2Engine.send("GET / HTTP/2\r\nX-MiXeD-Case: KeepMe\r\n\r\n".to_slice,
       scheme: "http", host: "127.0.0.1", port: port, verify_upstream: false)
 
-    fields, _ = seen.receive
+    fields, _ = receive_within(seen)
     fields.should contain({"x-mixed-case", "KeepMe"}) # name folded, VALUE untouched
   end
 
@@ -911,7 +911,7 @@ describe Gori::Repeater::H2Engine do
       scheme: "http", host: "127.0.0.1", port: port, verify_upstream: false,
       preserve_field_case: true)
 
-    fields, _ = seen.receive
+    fields, _ = receive_within(seen)
     fields.should contain({"X-MiXeD-Case", "KeepMe"})
   end
 
@@ -927,7 +927,7 @@ describe Gori::Repeater::H2Engine do
     result = Gori::Repeater::H2Engine.send("GET /noversion\r\nx-case: a\r\n\r\n".to_slice,
       scheme: "http", host: "127.0.0.1", port: port, verify_upstream: false)
 
-    seen.receive.should eq("GET /noversion body=")
+    receive_within(seen).should eq("GET /noversion body=")
     result.ok?.should be_true
   end
 
@@ -945,7 +945,7 @@ describe Gori::Repeater::H2Engine do
     result = Gori::Repeater::H2Engine.send(request, scheme: "http", host: "127.0.0.1",
       port: port, verify_upstream: false)
 
-    fields, shape = seen.receive
+    fields, shape = receive_within(seen)
     shape.size.should be > 1
     shape.first[0].should eq("Headers")
     shape[1..].each { |(type, _)| type.should eq("Continuation") }
@@ -1051,7 +1051,7 @@ describe Gori::Repeater::H2Engine do
       result = Gori::Repeater::H2Engine.send_fields(fields, nil,
         scheme: "http", host: "127.0.0.1", port: port, verify_upstream: false)
 
-      got, _ = seen.receive
+      got, _ = receive_within(seen)
       got.should eq(fields) # nothing dropped, reordered, deduped, folded or stripped
       result.ok?.should be_true
     end
@@ -1064,7 +1064,7 @@ describe Gori::Repeater::H2Engine do
       result = Gori::Repeater::H2Engine.send_fields(fields, "payload".to_slice,
         scheme: "http", host: "127.0.0.1", port: port, verify_upstream: false)
 
-      seen.receive.should eq("POST /upload body=payload")
+      receive_within(seen).should eq("POST /upload body=payload")
       result.response.not_nil!.status.should eq(201)
     end
 
@@ -1079,7 +1079,7 @@ describe Gori::Repeater::H2Engine do
       Gori::Repeater::H2Engine.send_fields(fields, nil,
         scheme: "http", host: "127.0.0.1", port: port, verify_upstream: false)
 
-      got, shape = seen.receive
+      got, shape = receive_within(seen)
       shape.size.should be > 1
       shape.first[0].should eq("Headers")
       shape[1..].each { |(type, _)| type.should eq("Continuation") }
@@ -1124,7 +1124,7 @@ describe Gori::Repeater::H2Engine do
         scheme: "http", host: "127.0.0.1", port: port, verify_upstream: false,
         timeout: 5.seconds)
 
-      seen.receive.should eq(200_000) # -1 would mean gori overran the window
+      receive_within(seen).should eq(200_000) # -1 would mean gori overran the window
       result.error.should be_nil
       result.response.try(&.status).should eq(200)
     end
@@ -1140,7 +1140,7 @@ describe Gori::Repeater::H2Engine do
         scheme: "http", host: "127.0.0.1", port: port, verify_upstream: false,
         timeout: 5.seconds)
 
-      seen.receive.should eq(20_000)
+      receive_within(seen).should eq(20_000)
       result.error.should be_nil
     end
 
@@ -1153,7 +1153,7 @@ describe Gori::Repeater::H2Engine do
         scheme: "http", host: "127.0.0.1", port: port, verify_upstream: false,
         timeout: 500.milliseconds)
 
-      seen.receive.should eq(65_535) # exactly the window, not a byte more
+      receive_within(seen).should eq(65_535) # exactly the window, not a byte more
       error = result.error.should_not be_nil
       error.should contain("h2 flow control")
       error.should contain("only 65535 of 200000 request body bytes")
@@ -1184,7 +1184,7 @@ describe Gori::Repeater::H2Engine do
           scheme: "http", host: "127.0.0.1", port: port, verify_upstream: false,
           timeout: 3.seconds)
 
-        seen.receive.should eq(4096)
+        receive_within(seen).should eq(4096)
         # The response ARRIVED — it must survive the writer's disposition.
         result.response.try(&.status).should eq(413)
         String.new(result.head).should contain("413")
@@ -1208,7 +1208,7 @@ describe Gori::Repeater::H2Engine do
           scheme: "http", host: "127.0.0.1", port: port, verify_upstream: false,
           timeout: 3.seconds)
 
-        seen.receive.should eq(4096)
+        receive_within(seen).should eq(4096)
         result.response.try(&.status).should eq(413)
         error = result.error.should_not be_nil # was `ok:true, error:null`
         error.should contain("truncated at 4096 of 20000 bytes")
@@ -1227,7 +1227,7 @@ describe Gori::Repeater::H2Engine do
           scheme: "http", host: "127.0.0.1", port: port, verify_upstream: false,
           timeout: 3.seconds)
 
-        seen.receive.should eq(500)
+        receive_within(seen).should eq(500)
         result.response.try(&.status).should eq(200)
         result.error.should be_nil
       end
@@ -1246,7 +1246,7 @@ describe Gori::Repeater::H2Engine do
           scheme: "http", host: "127.0.0.1", port: port, verify_upstream: false,
           timeout: 3.seconds)
 
-        seen.receive.should eq(20_000)               # the whole body, not 4096
+        receive_within(seen).should eq(20_000)       # the whole body, not 4096
         result.response.try(&.status).should eq(200) # the FINAL status, not the 100
         result.error.should be_nil                   # nothing was truncated
       end
@@ -1270,7 +1270,7 @@ describe Gori::Repeater::H2Engine do
             scheme: "http", host: "127.0.0.1", port: port, verify_upstream: false,
             timeout: 2.seconds)
 
-          seen.receive.should eq(4096) # -1 = gori overran the window it was told about
+          receive_within(seen).should eq(4096) # -1 = gori overran the window it was told about
           # No window was ever granted, so this stalls — but on gori's OWN accounting, with
           # no GOAWAY drawn and the origin never blamed.
           error = result.error.should_not be_nil
@@ -1293,7 +1293,7 @@ describe Gori::Repeater::H2Engine do
           scheme: "http", host: "127.0.0.1", port: port, verify_upstream: false,
           timeout: 2.seconds)
 
-        seen.receive.should eq(-1) # gori overran, as the RFC default entitles it to
+        receive_within(seen).should eq(-1) # gori overran, as the RFC default entitles it to
         error = result.error.should_not be_nil
         error.should contain("FLOW_CONTROL_ERROR")
         error.should contain("gori's own accounting")
@@ -1319,7 +1319,7 @@ describe Gori::Repeater::H2Engine do
           timeout: 1.second)
         elapsed = Time.instant - started
 
-        seen.receive.should eq(1024)
+        receive_within(seen).should eq(1024)
         elapsed.should be < 10.seconds # unbounded before: the PINGs reset the idle timer
         error = result.error.should_not be_nil
         error.should contain("only 1024 of 20000 request body bytes")
@@ -1336,7 +1336,7 @@ describe Gori::Repeater::H2Engine do
           scheme: "http", host: "127.0.0.1", port: port, verify_upstream: false,
           timeout: 1.second)
 
-        seen.receive.should eq(1024)
+        receive_within(seen).should eq(1024)
         error = result.error.should_not be_nil
         error.should contain("WINDOW_UPDATE with a 0 increment")
         error.should contain("§6.9.1")
@@ -1355,7 +1355,7 @@ describe Gori::Repeater::H2Engine do
           timeout: 700.milliseconds)
         elapsed = Time.instant - started
 
-        seen.receive.should eq(65_535)
+        receive_within(seen).should eq(65_535)
         result.error.should_not be_nil
         # One patience budget, not two: the write stall must not be followed by a full
         # response-read timeout on a socket that produced no frames.
@@ -1462,7 +1462,7 @@ describe Gori::Repeater::H2Engine do
       Gori::Repeater::H2Engine.send(
         "GET /dup HTTP/2\r\nHost: first.example\r\nHost: second.example\r\nX-A: 1\r\n\r\n".to_slice,
         scheme: "http", host: "127.0.0.1", port: port, verify_upstream: false, timeout: 5.seconds)
-      fields, _ = seen.receive
+      fields, _ = receive_within(seen)
       fields.should contain({":authority", "first.example"})
       fields.should contain({"host", "second.example"})
     end
@@ -1473,7 +1473,7 @@ describe Gori::Repeater::H2Engine do
       Gori::Repeater::H2Engine.send(
         "GET /e HTTP/2\r\nHost: \r\nX-A: 1\r\n\r\n".to_slice,
         scheme: "http", host: "127.0.0.1", port: port, verify_upstream: false, timeout: 5.seconds)
-      fields, _ = seen.receive
+      fields, _ = receive_within(seen)
       fields.should contain({":authority", ""})
       fields.map(&.[1]).should_not contain("127.0.0.1:#{port}")
     end

--- a/spec/repeater/minimize_spec.cr
+++ b/spec/repeater/minimize_spec.cr
@@ -336,3 +336,54 @@ describe "gori run repeater minimize --verbatim — the resolver" do
     end
   end
 end
+
+# The REPORT is the third form (after "what was sent" and "what was printed"), and it is the
+# one that is kept: `gori run repeater minimize --apply` and `minimize_repeater{apply:true}`
+# both store `minimized_text` back over the session, and `minimized_source` /
+# `minimized_request` print it.
+#
+# `Minimize` used to LF-normalize the whole request on the way in and blanket
+# `gsub("\n", "\r\n")` it on the way out. Both halves corrupt a BODY: the way in flattened a
+# multipart body's own CRLF boundaries, the way out promoted a body's bare LF, so a captured
+# body ending in one came back a byte longer under a Content-Length that no longer described
+# it. In a head a 0x0A is a line ending; in a body it is a byte — head-only is the rule every
+# other site on this branch follows (`Env.expand_wire`, `gori run intercept edit`).
+describe "Gori::Repeater::Minimize — body bytes on the round trip" do
+  it "keeps a body's trailing bare LF out of the report — the CL-desync evidence" do
+    text = "POST /bk HTTP/1.1\r\nHost: h\r\nUser-Agent: Mozilla/5.0\r\n" \
+           "Content-Length: 22\r\n\r\n{\"q\":\"$where 1==1 ab\"}\n"
+    report = minimize(StaticOrigin.new, text)
+    body = report.minimized_text.split("\r\n\r\n", 2)[1]
+    body.should eq("{\"q\":\"$where 1==1 ab\"}\n") # 23 bytes, exactly as handed in
+    body.should_not contain("\r\n")
+    # The head is still restored to the terminator the caller used.
+    report.minimized_text.should start_with("POST /bk HTTP/1.1\r\nHost: h\r\n")
+    # ...and the cosmetic header really was removed, so this is the minimize path, not a
+    # short-circuit through the "nothing removable" branch.
+    report.removed.map(&.label).should contain("User-Agent")
+  end
+
+  it "keeps a multipart body's OWN CRLF boundaries intact" do
+    body = "--B\r\nContent-Disposition: form-data; name=\"f\"\r\n\r\nv\r\n--B--\r\n"
+    text = "POST /up HTTP/1.1\r\nHost: h\r\nUser-Agent: Mozilla/5.0\r\n" \
+           "Content-Type: multipart/form-data; boundary=B\r\n" \
+           "Content-Length: #{body.bytesize}\r\n\r\n#{body}"
+    report = minimize(StaticOrigin.new, text)
+    report.minimized_text.split("\r\n\r\n", 2)[1].should eq(body)
+  end
+
+  it "leaves a binary body byte-for-byte, including a lone CR and a NUL" do
+    body = String.new(Bytes[0x0A, 0x00, 0x0D, 0xEF, 0x0A])
+    text = "POST /b HTTP/1.1\r\nHost: h\r\nAccept: */*\r\nContent-Length: 5\r\n\r\n#{body}"
+    report = minimize(StaticOrigin.new, text)
+    report.minimized_text.to_slice[-5..].to_a.should eq([0x0A, 0x00, 0x0D, 0xEF, 0x0A])
+  end
+
+  it "asks about the HEAD's terminators, not a CRLF that only appears in the body" do
+    text = "POST /b HTTP/1.1\nHost: h\nAccept: */*\n\nline1\r\nline2"
+    report = minimize(StaticOrigin.new, text)
+    # An LF head stays an LF head even though the body carries a CRLF pair.
+    report.minimized_text.split("\n\n", 2)[0].should_not contain('\r')
+    report.minimized_text.should end_with("line1\r\nline2")
+  end
+end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -31,3 +31,23 @@ Spec.after_suite { FileUtils.rm_rf(GORI_TEST_HOME) }
 def ungated_outbound : Gori::Outbound
   Gori::Outbound.waived(nil, Gori::Outbound::Reason::NoProject)
 end
+
+# NEVER a bare `Channel#receive` in a spec driven by real sockets — use this instead.
+#
+# PR #555 hung CI for 24 minutes on exactly that. The suite was green on macOS; on Linux a
+# client close was observed before the proxy had recorded its response, so nothing was ever
+# sent on the channel and the receive blocked forever. `crystal spec` block-buffers its dots
+# under Actions, so the hang left no output at all — not even how far it got.
+#
+# A timeout turns "it never arrived" into ONE failing example that says so, which is the
+# difference between a five-second diagnosis and a rerun. The default is deliberately long:
+# this is a deadlock guard, not a latency assertion, and a slow CI runner must not fail an
+# example that would have passed. Pass `what` to name what was expected.
+def receive_within(chan : Channel(T), seconds : Int32 = 20, what : String = "a value") : T forall T
+  select
+  when got = chan.receive
+    got
+  when timeout(seconds.seconds)
+    raise "nothing arrived on the channel within #{seconds}s (expected #{what})"
+  end
+end

--- a/spec/store/store_spec.cr
+++ b/spec/store/store_spec.cr
@@ -119,6 +119,75 @@ describe Gori::Store do
     end
   end
 
+  # R4. `Interceptor::Item` has known why an edit cannot be applied since R3-F1, and the
+  # bridge dropped it — so `gori run intercept get`/`list` and MCP `intercept_get` described a
+  # CRLF-carrying HTTP/2 message as ordinarily editable, and the operator (or the agent)
+  # learned otherwise only from the ack of an edit that was never applied.
+  it "carries the edit refusal and the head-only hold across the intercept bridge" do
+    with_store do |store|
+      tok = "sess-refuse"
+      raw = "GET /a HTTP/2\r\nHost: x.test\r\n\r\n".to_slice
+      reason = "gori will not apply an edit: the value of \"x-evil\" carries a CR or LF"
+      store.publish_intercept_held(tok, [
+        Gori::Store::HeldRow.new(tok, 1_i64, "request", "GET", "x.test", 443, "https", "/a",
+          raw, 1_000_i64, nil, false, 0_i64, reason, true),
+        # head_only alone, with no refusal — an editable h2 hold, which still cannot take a BODY.
+        Gori::Store::HeldRow.new(tok, 2_i64, "request", "GET", "x.test", 443, "https", "/b",
+          raw, 1_000_i64, nil, false, 0_i64, nil, true),
+        # h1: head+body held and forwarded byte-exact, so neither flag is set.
+        Gori::Store::HeldRow.new(tok, 3_i64, "request", "GET", "x.test", 80, "http", "/c",
+          raw, 1_000_i64, nil, false),
+      ])
+      held = store.intercept_held(tok)
+      held.map(&.edit_refusal).should eq([reason, nil, nil])
+      held.map(&.head_only?).should eq([true, true, false])
+      held[0].edit_warning.should eq(reason)
+      held[1].edit_warning.not_nil!.should contain("HEAD only")
+      held[2].edit_warning.should be_nil
+    end
+  end
+
+  # R4. The two producers that had nowhere to put a flow-level statement (a Match&Replace rule
+  # that could not run, a server-pushed request) write here. `error` is the neighbouring shape;
+  # this one does not mean the flow failed.
+  it "persists a flow advisory and lets the response side add to it without erasing it" do
+    with_store do |store|
+      req = Gori::Store::CapturedRequest.new(
+        created_at: 1_i64, scheme: "https", host: "a.test", port: 443, method: "GET",
+        target: "/x", http_version: "HTTP/2", head: "GET /x HTTP/2\r\n\r\n".to_slice,
+        advisory: "request-side line")
+      id = store.insert_flow(req)
+      store.flow_row(id).not_nil!.advisory.should eq("request-side line")
+
+      # The h2 assembler re-sends the FULL accumulated set on the response, because this write
+      # replaces the column. Both lines must survive, and `advisories` must split them.
+      store.update_response(Gori::Store::CapturedResponse.new(
+        flow_id: id, status: 200, head: "HTTP/2 200\r\n\r\n".to_slice,
+        advisory: "request-side line\nresponse-side line"))
+      row = store.flow_row(id).not_nil!
+      row.advisories.should eq(["request-side line", "response-side line"])
+      store.get_flow(id).not_nil!.row.advisories.size.should eq(2)
+
+      # A response that carries NO advisory must leave the stored one alone (COALESCE) —
+      # every ordinary flow takes this path, and a bare `advisory = ?` would blank the column.
+      store.update_response(Gori::Store::CapturedResponse.new(
+        flow_id: id, status: 200, head: "HTTP/2 200\r\n\r\n".to_slice))
+      store.flow_row(id).not_nil!.advisories.size.should eq(2)
+    end
+  end
+
+  # The complement: an ordinary flow stores NULL, and every advisory reader answers empty.
+  it "leaves an ordinary flow's advisory null" do
+    with_store do |store|
+      id = store.insert_flow(sample_request)
+      store.update_response(Gori::Store::CapturedResponse.new(
+        flow_id: id, status: 200, head: "HTTP/1.1 200 OK\r\n\r\n".to_slice))
+      row = store.flow_row(id).not_nil!
+      row.advisory.should be_nil
+      row.advisories.should be_empty
+    end
+  end
+
   it "never reuses an intercept_commands id after a delete (AUTOINCREMENT watermark safety)" do
     with_store do |store|
       a = store.enqueue_intercept_command("t", "forward", item_id: 1_i64)

--- a/spec/store/store_spec.cr
+++ b/spec/store/store_spec.cr
@@ -141,9 +141,12 @@ describe Gori::Store do
       held = store.intercept_held(tok)
       held.map(&.edit_refusal).should eq([reason, nil, nil])
       held.map(&.head_only?).should eq([true, true, false])
-      held[0].edit_warning.should eq(reason)
-      held[1].edit_warning.not_nil!.should contain("HEAD only")
-      held[2].edit_warning.should be_nil
+      held[0].edit_refusal.should eq(reason)
+      # head_only is a CAVEAT, not a refusal: it holds for every h2 message and a head edit
+      # still applies, so it must never read as "this message cannot be edited".
+      held[1].edit_refusal.should be_nil
+      held[1].head_only_note.not_nil!.should contain("HEAD only")
+      held[2].head_only_note.should be_nil
     end
   end
 

--- a/spec/tui/engine_tab_provenance_spec.cr
+++ b/spec/tui/engine_tab_provenance_spec.cr
@@ -1,0 +1,623 @@
+require "../spec_helper"
+require "../support/memory_backend"
+require "../support/overlay_harness"
+require "socket"
+
+# The four engine TUI tabs' PROVENANCE and REPORTING contracts.
+#
+# `Fuzz/Miner/Sequencer::PlanOptions#evidence?` existed and was passed by `gori run` at
+# three call sites out of nine: the TUI Fuzzer/Miner/Sequencer views passed none of them.
+# So a captured OData request (`?$filter=…&$top=10`) was REFUSED outright by all three
+# tabs — zero requests sent — while `gori run fuzz --flow 1` swept it correctly, and once
+# the operator followed the refusal's own advice and defined `filter`/`top`, every probe
+# went out with its PARAMETER NAMES rewritten (`?PWNED=aa&99=10`) under a green
+# `6 hits / 6 sent`. Builder-level coverage lives in spec/env_unresolved_spec.cr; what can
+# only be checked HERE is that each view actually HANDS the builder its provenance.
+#
+# Every wire assertion reads the bytes a recording origin received, not the plan object:
+# the whole class of defect here is a surface that assembles a plausible plan and then
+# sends something else.
+include Gori::Tui
+
+private def with_vars(vars : Array({String, String}), &)
+  Gori::Settings.env_prefix = "$"
+  Gori::Settings.env_vars = vars
+  Gori::Settings.project_env_vars = [] of {String, String}
+  yield
+ensure
+  Gori::Settings.env_vars = [] of {String, String}
+  Gori::Settings.project_env_vars = [] of {String, String}
+  Gori::Settings.env_prefix = "$"
+end
+
+private def with_scope(&)
+  path = File.tempname("gori-engine-tabs", ".db")
+  store = Gori::Store.open(path)
+  begin
+    yield Gori::Scope.load(store)
+  ensure
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+# A recording origin. Serves `reply` to every request and appends the EXACT head+body bytes
+# it read to a shared array. `stop` closes the listener; the spec reads `requests` after
+# the engine has finished, so there is no cross-fiber handshake to block on — the rule
+# about a bare `Channel#receive` in a socket-driven spec is why this is an array and a
+# server close rather than a rendezvous.
+private class RecordingOrigin
+  getter port : Int32
+  getter requests = [] of String
+
+  def initialize(@reply : String = "HTTP/1.1 200 OK\r\nSet-Cookie: SID=tok1; Path=/\r\nContent-Length: 2\r\n\r\nhi")
+    @server = TCPServer.new("127.0.0.1", 0)
+    @port = @server.local_address.port
+    @mutex = Mutex.new
+    spawn(name: "rec-origin") { accept_loop }
+  end
+
+  def close : Nil
+    @server.close rescue nil
+  end
+
+  # Request lines only — the common assertion, and the one the marker rewrites land in.
+  def lines : Array(String)
+    @mutex.synchronize { @requests.map { |r| r.lines.first? || "" } }
+  end
+
+  def bodies : Array(String)
+    @mutex.synchronize do
+      @requests.map { |r| (i = r.index("\r\n\r\n")) ? r[(i + 4)..] : "" }
+    end
+  end
+
+  def heads : Array(String)
+    @mutex.synchronize { @requests.map { |r| (i = r.index("\r\n\r\n")) ? r[0, i] : r } }
+  end
+
+  def count : Int32
+    @mutex.synchronize { @requests.size }
+  end
+
+  private def accept_loop : Nil
+    while conn = @server.accept?
+      spawn(name: "rec-conn") { serve(conn) }
+    end
+  rescue
+    # listener closed — expected at teardown
+  end
+
+  private def serve(conn : TCPSocket) : Nil
+    loop do
+      head = read_head(conn)
+      break unless head
+      cl = content_length(head)
+      body = cl > 0 ? read_exact(conn, cl) : ""
+      @mutex.synchronize { @requests << "#{head}\r\n\r\n#{body}" }
+      conn << @reply
+      conn.flush
+    end
+  rescue
+    # client closed / teardown
+  ensure
+    conn.close rescue nil
+  end
+
+  private def read_head(conn : TCPSocket) : String?
+    buf = String::Builder.new
+    seen = ""
+    loop do
+      b = conn.read_byte
+      return nil unless b
+      seen = "#{seen}#{b.unsafe_chr}"[-4..]? || seen + b.unsafe_chr
+      buf << b.unsafe_chr
+      break if seen == "\r\n\r\n"
+    end
+    s = buf.to_s
+    s[0, s.size - 4]
+  end
+
+  private def read_exact(conn : TCPSocket, n : Int32) : String
+    slice = Bytes.new(n)
+    conn.read_fully(slice)
+    String.new(slice)
+  end
+
+  private def content_length(head : String) : Int32
+    head.each_line do |line|
+      name, sep, value = line.partition(':')
+      next if sep.empty?
+      return value.strip.to_i? || 0 if name.strip.compare("content-length", case_insensitive: true) == 0
+    end
+    0
+  end
+end
+
+private def flow_seeded_fuzzer(target : String, template : String) : FuzzerView
+  view = FuzzerView.new
+  # The ⇧I path assigns from a Store::FlowDetail; `restore` with a non-nil flow_id is the
+  # same provenance through the persistence seam, and is what a reopened tab goes through.
+  view.restore(Gori::Store::FuzzSessionRecord.new(
+    id: 1, target: target, template: template, http2: false, sni: nil,
+    config: "", flow_id: 7_i64, position: 0, name: nil))
+  view
+end
+
+private def drafted_fuzzer(target : String, template : String) : FuzzerView
+  view = FuzzerView.new
+  view.load_request(target, template, false, "")
+  view
+end
+
+private def run_fuzz(view : FuzzerView, scope : Gori::Scope) : String?
+  engine, err = view.build_engine(false, scope, nil)
+  return err unless engine
+  engine.run { |_| }
+  nil
+end
+
+describe "engine tabs — provenance (T1)" do
+  it "the Fuzzer sends a CAPTURED head's own `$tokens` verbatim, and a DRAFT's expanded" do
+    origin = RecordingOrigin.new
+    begin
+      with_vars([{"filter", "PWNED"}, {"top", "99"}]) do
+        with_scope do |scope|
+          tmpl = "GET /odata?$filter=§Price§&$top=10&id=7 HTTP/1.1\r\n" \
+                 "Host: 127.0.0.1:#{origin.port}\r\nConnection: close\r\n\r\n"
+          target = "http://127.0.0.1:#{origin.port}"
+
+          view = flow_seeded_fuzzer(target, tmpl)
+          view.evidence?.should be_true
+          view.apply_set(nil, SetSpec.new(:list, "aa"))
+          run_fuzz(view, scope).should be_nil
+
+          # …and the complement, over the SAME bytes and the SAME vars: a template the
+          # operator typed keeps the draft reading, where `$filter` IS a variable.
+          draft = drafted_fuzzer(target, tmpl)
+          draft.evidence?.should be_false
+          draft.apply_set(nil, SetSpec.new(:list, "aa"))
+          run_fuzz(draft, scope).should be_nil
+        end
+      end
+      origin.lines.size.should eq(2)
+      origin.lines[0].should eq("GET /odata?$filter=aa&$top=10&id=7 HTTP/1.1")
+      origin.lines[1].should eq("GET /odata?PWNED=aa&99=10&id=7 HTTP/1.1")
+    ensure
+      origin.close
+    end
+  end
+
+  it "the Fuzzer leaves a CAPTURED BODY's `$token` alone — the head-only refusal never saw it" do
+    # `Env.expand_wire` expands the WHOLE text while `Env.unresolved_wire` scans the head
+    # alone, so a `$where` in a captured body was substituted with no refusal at all and
+    # Content-Length was silently resynced to the corrupted body (37 → 39). Provenance is
+    # what closes it: on evidence neither pass runs.
+    origin = RecordingOrigin.new
+    begin
+      with_vars([{"where", "INJECTED"}]) do
+        with_scope do |scope|
+          body = %({"q":{"$where":"1==1"},"note":"ab"})
+          tmpl = "POST /api/find?id=§3§ HTTP/1.1\r\nHost: 127.0.0.1:#{origin.port}\r\n" \
+                 "Content-Type: application/json\r\nContent-Length: #{body.bytesize}\r\n" \
+                 "Connection: close\r\n\r\n#{body}"
+          view = flow_seeded_fuzzer("http://127.0.0.1:#{origin.port}", tmpl)
+          view.apply_set(nil, SetSpec.new(:list, "ZZ"))
+          run_fuzz(view, scope).should be_nil
+        end
+      end
+      origin.bodies.size.should eq(1)
+      origin.bodies[0].should contain(%("$where"))
+      origin.bodies[0].should_not contain("INJECTED")
+      origin.heads[0].should contain("Content-Length: 35") # the ORIGINAL body's length, unchanged
+    ensure
+      origin.close
+    end
+  end
+
+  it "a capture whose `$token` has NO value runs instead of being refused; a draft is still refused" do
+    with_vars([] of {String, String}) do
+      with_scope do |scope|
+        tmpl = "GET /odata?$filter=§Price§&$top=10 HTTP/1.1\r\nHost: t.test\r\n\r\n"
+        seeded = flow_seeded_fuzzer("http://t.test", tmpl)
+        seeded.apply_set(nil, SetSpec.new(:list, "aa"))
+        engine, err = seeded.build_engine(false, scope, nil)
+        err.should be_nil
+        engine.should_not be_nil
+
+        draft = drafted_fuzzer("http://t.test", tmpl)
+        draft.apply_set(nil, SetSpec.new(:list, "aa"))
+        engine, err = draft.build_engine(false, scope, nil)
+        engine.should be_nil
+        err.should eq("unresolved env $filter, $top — add it in the Project tab's ENV pane")
+      end
+    end
+  end
+
+  it "an EVIDENCE template still leaves the head CRLF-terminated after an editor edit" do
+    # `evidence?` also switches OFF `expand_wire`'s LF→CRLF promotion, and `TextArea`
+    # documents that promotion as what fixes up a line the user typed (`insert_newline`
+    # gives it DEFAULT_EOL = "\n"). Without the view's own head normalization, adding one
+    # header to a seeded capture would put a BARE LF in the head — a desync primitive, i.e.
+    # a different test than the one on screen. The body stays byte-exact either way.
+    origin = RecordingOrigin.new
+    begin
+      with_scope do |scope|
+        tmpl = "GET /a?x=§1§ HTTP/1.1\r\nHost: 127.0.0.1:#{origin.port}\r\n" \
+               "X-Typed: fresh\nConnection: close\r\n\r\n"
+        view = flow_seeded_fuzzer("http://127.0.0.1:#{origin.port}", tmpl)
+        view.apply_set(nil, SetSpec.new(:list, "p"))
+        run_fuzz(view, scope).should be_nil
+      end
+      origin.heads.size.should eq(1)
+      origin.heads[0].should contain("\r\nX-Typed: fresh\r\n")
+      origin.heads[0].should_not contain("fresh\nConnection")
+    ensure
+      origin.close
+    end
+  end
+
+  it "the Miner hands the builder its seed's provenance (no editor exists to re-derive it)" do
+    with_vars([] of {String, String}) do
+      with_scope do |scope|
+        req = "GET /odata?$filter=x&$top=10 HTTP/1.1\r\nHost: t.test\r\n\r\n".to_slice
+        cfg = Gori::Miner::Config.new(locations: [Gori::Miner::Location::Query])
+
+        seeded = MinerView.new
+        seeded.load("http://t.test", req, false, nil, cfg, evidence: true)
+        seeded.evidence?.should be_true
+        engine, err = seeded.build_engine(false, scope, nil)
+        err.should be_nil
+        engine.should_not be_nil
+
+        draft = MinerView.new
+        draft.load("http://t.test", req, false, nil,
+          Gori::Miner::Config.new(locations: [Gori::Miner::Location::Query]))
+        draft.evidence?.should be_false
+        engine, err = draft.build_engine(false, scope, nil)
+        engine.should be_nil
+        err.should eq("unresolved env $filter, $top — add it in the Project tab's ENV pane")
+      end
+    end
+  end
+
+  it "the Sequencer hands the builder its seed's provenance" do
+    with_vars([] of {String, String}) do
+      with_scope do |scope|
+        req = "GET /login?$filter=x HTTP/1.1\r\nHost: t.test\r\n\r\n".to_slice
+        loc = Gori::Sequencer::TokenLoc.cookie("SID")
+
+        seeded = SequencerView.new
+        seeded.load("http://t.test", req, false, nil,
+          Gori::Sequencer::Config.new(mode: Gori::Sequencer::Mode::LiveReplay, token_loc: loc, goal: 1),
+          evidence: true)
+        engine, err = seeded.build_engine(false, scope, nil)
+        err.should be_nil
+        engine.should_not be_nil
+
+        draft = SequencerView.new
+        draft.load("http://t.test", req, false, nil,
+          Gori::Sequencer::Config.new(mode: Gori::Sequencer::Mode::LiveReplay, token_loc: loc, goal: 1))
+        engine, err = draft.build_engine(false, scope, nil)
+        engine.should be_nil
+        err.should eq("unresolved env $filter — add it in the Project tab's ENV pane")
+      end
+    end
+  end
+
+  it "provenance survives persistence, and a Repeater-sourced session never acquires it" do
+    # `flow_id` is the carrier every one of the three session tables already had; nothing
+    # but a flow seed ever sets it. Without this, a reopened capture silently reverted to a
+    # draft on the next restart.
+    rec = ->(flow_id : Int64?) do
+      Gori::Store::FuzzSessionRecord.new(id: 1, target: "http://t.test",
+        template: "GET / HTTP/1.1\r\nHost: t.test\r\n\r\n", http2: false, sni: nil,
+        config: "", flow_id: flow_id, position: 0, name: nil)
+    end
+    from_flow = FuzzerView.new
+    from_flow.restore(rec.call(7_i64))
+    from_flow.evidence?.should be_true
+    from_flow.apply_peer_session(rec.call(7_i64))
+    from_flow.evidence?.should be_true
+
+    from_repeater = FuzzerView.new
+    from_repeater.restore(rec.call(nil))
+    from_repeater.evidence?.should be_false
+
+    mrec = ->(flow_id : Int64?) do
+      Gori::Store::MinerSessionRecord.new(id: 1, target: "http://t.test",
+        request: Bytes.empty, http2: false, sni: nil, config: "",
+        flow_id: flow_id, position: 0, name: nil)
+    end
+    m = MinerView.new
+    m.restore(mrec.call(3_i64))
+    m.evidence?.should be_true
+    m.restore(mrec.call(nil))
+    m.evidence?.should be_false
+
+    srec = ->(flow_id : Int64?) do
+      Gori::Store::SequencerSessionRecord.new(id: 1, target: "http://t.test",
+        request: Bytes.empty, http2: false, sni: nil, config: "",
+        flow_id: flow_id, position: 0, name: nil)
+    end
+    s = SequencerView.new
+    s.restore(srec.call(3_i64))
+    s.evidence?.should be_true
+    s.restore(srec.call(nil))
+    s.evidence?.should be_false
+  end
+
+  it "a duplicated fuzz session carries the same provenance as the bytes it copied" do
+    src = flow_seeded_fuzzer("http://t.test", "GET / HTTP/1.1\r\nHost: t.test\r\n\r\n")
+    dup = FuzzerView.new
+    dup.duplicate_from(src)
+    dup.evidence?.should be_true
+
+    draft = drafted_fuzzer("http://t.test", "GET / HTTP/1.1\r\nHost: t.test\r\n\r\n")
+    dup2 = FuzzerView.new
+    dup2.duplicate_from(draft)
+    dup2.evidence?.should be_false
+  end
+end
+
+describe "Fuzzer tab — Content-Length (T2)" do
+  it "sends the template's Content-Length as written once Auto Content-Length is off" do
+    origin = RecordingOrigin.new
+    begin
+      with_scope do |scope|
+        body = %({"q":"1==1"})
+        tmpl = "POST /api?id=§3§ HTTP/1.1\r\nHost: 127.0.0.1:#{origin.port}\r\n" \
+               "Content-Length: 5\r\nConnection: close\r\n\r\n#{body}"
+
+        on = drafted_fuzzer("http://127.0.0.1:#{origin.port}", tmpl)
+        on.apply_set(nil, SetSpec.new(:list, "ZZ"))
+        run_fuzz(on, scope).should be_nil
+        on.rewrites_content_length?.should be_true # and it SAYS so, which is the half an
+        #                                            operator who does not want the switch still needs
+
+        off = drafted_fuzzer("http://127.0.0.1:#{origin.port}", tmpl)
+        snap = off.advanced_snapshot
+        off.apply_advanced(AdvancedSnapshot.new(
+          conc: snap.conc, rate: snap.rate, timeout: snap.timeout, retries: snap.retries,
+          max_requests: snap.max_requests, follow: snap.follow, calibrate: snap.calibrate,
+          keep_alive: snap.keep_alive, update_cl: false,
+          m_status: snap.m_status, m_size: snap.m_size, m_words: snap.m_words, m_regex: snap.m_regex,
+          f_status: snap.f_status, f_size: snap.f_size, f_words: snap.f_words, f_regex: snap.f_regex))
+        off.apply_set(nil, SetSpec.new(:list, "ZZ"))
+        run_fuzz(off, scope).should be_nil
+        off.rewrites_content_length?.should be_false # the knob is off, so nothing is rewritten
+      end
+      origin.heads.size.should eq(2)
+      origin.heads[0].should contain("Content-Length: #{%({"q":"1==1"}).bytesize}")
+      origin.heads[1].should contain("Content-Length: 5")
+    ensure
+      origin.close
+    end
+  end
+
+  it "retracts the CL claim when the template is edited, rather than leaving a stale one" do
+    with_scope do |scope|
+      tmpl = "POST /a?id=§3§ HTTP/1.1\r\nHost: t.test\r\nContent-Length: 5\r\n\r\nlonger-body"
+      view = drafted_fuzzer("http://t.test", tmpl)
+      view.apply_set(nil, SetSpec.new(:list, "ZZ"))
+      view.build_engine(false, scope, nil)[0].should_not be_nil
+      view.rewrites_content_length?.should be_true
+      view.toggle_http2 # any edit to the buffer bumps TextArea#edits
+      view.rewrites_content_length?.should be_false
+    end
+  end
+
+  it "round-trips the toggle and the cap through the snapshot and through config JSON" do
+    view = drafted_fuzzer("http://t.test", "GET /?x=1 HTTP/1.1\r\nHost: t.test\r\n\r\n")
+    snap = view.advanced_snapshot
+    snap.update_cl.should be_true # the ctor default, and the right one for an ordinary sweep
+    snap.max_requests.should eq("")
+    view.apply_advanced(AdvancedSnapshot.new(
+      conc: snap.conc, rate: snap.rate, timeout: snap.timeout, retries: snap.retries,
+      max_requests: "250", follow: snap.follow, calibrate: snap.calibrate,
+      keep_alive: snap.keep_alive, update_cl: false,
+      m_status: snap.m_status, m_size: snap.m_size, m_words: snap.m_words, m_regex: snap.m_regex,
+      f_status: snap.f_status, f_size: snap.f_size, f_words: snap.f_words, f_regex: snap.f_regex))
+    view.advanced_snapshot.max_requests.should eq("250")
+    view.config_json # the numeric buffers fold into @config at build/persist time
+    view.config.max_requests.should eq(250_i64)
+    view.config.update_content_length?.should be_false
+
+    restored = FuzzerView.new
+    restored.duplicate_from(view) # goes through config_json → apply_config_json
+    restored.config.max_requests.should eq(250_i64)
+    restored.config.update_content_length?.should be_false
+    restored.advanced_snapshot.max_requests.should eq("250")
+
+    # A session persisted BEFORE either key existed must keep the ctor defaults, not read
+    # a missing key as "off" — the same nil-vs-false trap keep_alive already documents.
+    old = FuzzerView.new
+    old.restore(Gori::Store::FuzzSessionRecord.new(id: 1, target: "http://t.test",
+      template: "GET / HTTP/1.1\r\nHost: t.test\r\n\r\n", http2: false, sni: nil,
+      config: %({"mode":"Sniper","concurrency":20}), flow_id: nil, position: 0, name: nil))
+    old.config.update_content_length?.should be_true
+    old.config.max_requests.should be_nil
+  end
+end
+
+describe "Fuzzer tab — the requests it actually put on the wire (T3)" do
+  it "shows `requests` only when retries/redirect hops made it exceed the payload count" do
+    view = drafted_fuzzer("http://t.test", "GET /?x=§1§ HTTP/1.1\r\nHost: t.test\r\n\r\n")
+    view.begin_run(3_i64)
+    3.times do |i|
+      view.append_result(Gori::Fuzz::Result.new(i.to_i64, ["p#{i}"], nil, 200, 10_i64, 1, 1,
+        100_i64, nil, false, false, nil))
+    end
+    view.finish_run
+
+    # sent == requests: one number, not the same number twice.
+    view.apply_progress(Gori::Fuzz::Progress.new(3_i64, 3_i64, 0_i64, 0_i64, requests: 3_i64))
+    view.results_count_label.should eq("3 sent · 0 hit")
+
+    # …and the case the tab used to hide entirely: 3 payloads, 18 requests at the origin.
+    view.apply_progress(Gori::Fuzz::Progress.new(3_i64, 3_i64, 0_i64, 0_i64, requests: 18_i64))
+    view.results_count_label.should eq("3 sent · 18 requests · 0 hit")
+  end
+
+  it "renders the wire count while the run is still streaming" do
+    view = drafted_fuzzer("http://t.test", "GET /?x=§1§ HTTP/1.1\r\nHost: t.test\r\n\r\n")
+    view.begin_run(3_i64)
+    view.apply_progress(Gori::Fuzz::Progress.new(1_i64, 3_i64, 0_i64, 0_i64, requests: 6_i64))
+    view.results_count_label.should eq("running 1/3 · 6 req · 0 hit")
+    view.apply_progress(Gori::Fuzz::Progress.new(1_i64, 3_i64, 0_i64, 0_i64, requests: 1_i64))
+    view.results_count_label.should eq("running 1/3 · 0 hit")
+  end
+end
+
+describe "Discover custom headers — a refusal, not a drop (T4)" do
+  it "refuses to close on a line it will not send, and names it" do
+    ov = DiscoverHeadersOverlay.new([] of {String, String})
+    h = OverlayHarness.new(ov)
+    h.type("X Bad: value").should eq(:open) # a name with a space is not an RFC 7230 token
+    ov.rejected_lines.should eq(["X Bad: value"])
+    h.press(Termisu::Input::Key::Escape).should eq(:open) # esc must NOT save-and-close
+    h.commits.should eq(0)
+    h.rendered?("will not be sent").should be_true
+    h.rendered?("X Bad").should be_true
+  end
+
+  it "closes once the line is fixed, and the refusal does not outlive it" do
+    ov = DiscoverHeadersOverlay.new([] of {String, String})
+    h = OverlayHarness.new(ov)
+    h.type("X Bad: value")
+    h.press(Termisu::Input::Key::Escape).should eq(:open)
+    6.times { h.press(Termisu::Input::Key::Backspace) } # "X Bad: value" → "X Bad:"
+    h.rendered?("will not be sent").should be_false     # an edit retracts the standing refusal
+    5.times { h.press(Termisu::Input::Key::Backspace) } # → "X"
+    h.type("-Ok: fine")
+    h.press(Termisu::Input::Key::Escape).should eq(:closed)
+    ov.headers.should eq([{"X-Ok", "fine"}])
+  end
+
+  it "a click away is a refusal too — it is the same commit path" do
+    ov = DiscoverHeadersOverlay.new([] of {String, String})
+    h = OverlayHarness.new(ov)
+    h.type("X Bad: value")
+    h.click(0, 0).should eq(:open)
+    h.commits.should eq(0)
+  end
+
+  it "still accepts a clean header, and a blank line is not a rejection" do
+    ov = DiscoverHeadersOverlay.new([] of {String, String})
+    h = OverlayHarness.new(ov)
+    h.type("Authorization: Bearer $TOKEN")
+    h.press(Termisu::Input::Key::Enter)
+    h.press(Termisu::Input::Key::Enter) # a blank line in the buffer
+    h.type("X-Ok: fine")
+    ov.rejected_lines.should be_empty
+    h.press(Termisu::Input::Key::Escape).should eq(:closed)
+    ov.headers.should eq([{"Authorization", "Bearer $TOKEN"}, {"X-Ok", "fine"}])
+  end
+end
+
+describe "engine tabs — budget (T5)" do
+  it "every config overlay can cap a run, and starts uncapped" do
+    mine = MineConfigOverlay.new(MineSeed.new(
+      target: "http://t.test", request: "GET / HTTP/1.1\r\nHost: t.test\r\n\r\n".to_slice,
+      http2: false, sni: nil, flow_id: nil, summary: "GET /",
+      applicable: [Gori::Miner::Location::Query], default: [Gori::Miner::Location::Query]))
+    mine.build_config.max_requests.should be_nil
+    mine.set_selected(1) # max requests row
+    mine.adjust(1)
+    mine.build_config.max_requests.should eq(100_i64)
+
+    seq = SequenceConfigOverlay.new(SequenceSeed.new(
+      target: "http://t.test", request: "GET / HTTP/1.1\r\nHost: t.test\r\n\r\n".to_slice,
+      http2: false, sni: nil, flow_id: nil, summary: "GET /",
+      mode: Gori::Sequencer::Mode::LiveReplay,
+      suggested_loc: Gori::Sequencer::TokenLoc.cookie("SID"),
+      candidate_cookies: [] of String, candidate_headers: [] of String))
+    seq.build_config.max_requests.should be_nil
+    seq.set_selected(SequenceConfigOverlay::MAXREQ_ROW)
+    seq.adjust(1)
+    seq.build_config.max_requests.should eq(100_i64)
+
+    disc = DiscoverConfigOverlay.new(DiscoverSeed.new(
+      choices: [{"/", "http://t.test/"}], base_label: "t.test"))
+    disc.build_config.max_requests.should be_nil
+    disc.set_selected(DiscoverConfigOverlay::ROW_MAXREQ)
+    disc.adjust(1)
+    disc.build_config.max_requests.should eq(100_i64)
+  end
+
+  it "a mine that ran out of budget says so instead of `no hidden parameters found`" do
+    view = MinerView.new
+    view.load("http://t.test", "GET /?a=1 HTTP/1.1\r\nHost: t.test\r\n\r\n".to_slice, false, nil,
+      Gori::Miner::Config.new(locations: [Gori::Miner::Location::Query], max_requests: 4_i64))
+    view.begin_run
+    view.apply_progress(Gori::Miner::Progress.new(434_i64, 0_i64, 4_i64, 0, 0_i64))
+    view.budget_exhausted?.should be_false # still RUNNING — not a verdict yet
+    view.finish_run
+    view.budget_exhausted?.should be_true
+    view.budget_note.should contain("434 of 434 names untested")
+
+    # Complements: a COMPLETE run, and an uncapped run that was stopped by hand, must not
+    # be relabelled as budget hits.
+    done = MinerView.new
+    done.load("http://t.test", "GET /?a=1 HTTP/1.1\r\nHost: t.test\r\n\r\n".to_slice, false, nil,
+      Gori::Miner::Config.new(locations: [Gori::Miner::Location::Query], max_requests: 4_i64))
+    done.begin_run
+    done.apply_progress(Gori::Miner::Progress.new(434_i64, 434_i64, 9_i64, 0, 0_i64))
+    done.finish_run
+    done.budget_exhausted?.should be_false
+
+    uncapped = MinerView.new
+    uncapped.load("http://t.test", "GET /?a=1 HTTP/1.1\r\nHost: t.test\r\n\r\n".to_slice, false, nil,
+      Gori::Miner::Config.new(locations: [Gori::Miner::Location::Query]))
+    uncapped.begin_run
+    uncapped.apply_progress(Gori::Miner::Progress.new(434_i64, 10_i64, 9_i64, 0, 0_i64))
+    uncapped.finish_run
+    uncapped.budget_exhausted?.should be_false
+  end
+
+  it "a collection that ran out of budget flags the sample its verdict rests on" do
+    cfg = Gori::Sequencer::Config.new(mode: Gori::Sequencer::Mode::LiveReplay,
+      token_loc: Gori::Sequencer::TokenLoc.cookie("SID"), goal: 500)
+    cfg.max_requests = 50_i64
+    view = SequencerView.new
+    view.load("http://t.test", "GET / HTTP/1.1\r\nHost: t.test\r\n\r\n".to_slice, false, nil, cfg)
+    view.begin_run
+    view.apply_progress(40, 50, 500, 0, 50_i64)
+    view.budget_exhausted?.should be_false # running
+    view.finish_run
+    view.budget_exhausted?.should be_true
+    view.budget_note.should contain("40 of 500 tokens")
+
+    full = SequencerView.new
+    full.load("http://t.test", "GET / HTTP/1.1\r\nHost: t.test\r\n\r\n".to_slice, false, nil, cfg)
+    full.begin_run
+    full.apply_progress(500, 500, 500, 0, 500_i64)
+    full.finish_run
+    full.budget_exhausted?.should be_false
+  end
+
+  it "a budget-halted crawl is its own state, never `done`" do
+    run = DiscoverRun.new("http://t.test/", Gori::Discover::Config.new(max_requests: 8_i64))
+    run.status = :done
+    run.budget_exhausted?.should be_false
+    run.status = :budget_exhausted
+    run.budget_exhausted?.should be_true
+    run.running?.should be_false
+
+    # And the pane says what was NOT looked at rather than "no endpoints found".
+    run.sent = 8_i64
+    run.queued = 275
+    screen = Screen.new(MemoryBackend.new(120, 24))
+    run.status = :budget_exhausted
+    view = DiscoverView.new
+    view.add(run)
+    backend = MemoryBackend.new(120, 24)
+    view.render(Screen.new(backend), Rect.new(0, 0, 120, 24), true)
+    backend.contains?("budget exhausted").should be_true
+    backend.contains?("275").should be_true
+    backend.contains?("no endpoints found").should be_false
+    screen.should_not be_nil
+  end
+end

--- a/spec/tui/fuzz_advanced_overlay_spec.cr
+++ b/spec/tui/fuzz_advanced_overlay_spec.cr
@@ -10,8 +10,8 @@ end
 
 private def blank_snapshot : Gori::Tui::AdvancedSnapshot
   Gori::Tui::AdvancedSnapshot.new(
-    conc: "20", rate: "", timeout: "", retries: "0",
-    follow: false, calibrate: false, keep_alive: true,
+    conc: "20", rate: "", timeout: "", retries: "0", max_requests: "",
+    follow: false, calibrate: false, keep_alive: true, update_cl: true,
     m_status: "", m_size: "", m_words: "", m_regex: "",
     f_status: "", f_size: "", f_words: "", f_regex: "")
 end
@@ -26,7 +26,7 @@ describe Gori::Tui::FuzzAdvancedOverlay do
 
   it "toggles a boolean row with space (←/→ on text rows never toggles it)" do
     ov = FuzzAdvancedOverlay.new(blank_snapshot)
-    4.times { ov.handle_key(akey(Termisu::Input::Key::Down)) } # → Follow redirects (row 4)
+    5.times { ov.handle_key(akey(Termisu::Input::Key::Down)) } # → Follow redirects (row 5, past Max requests)
     ov.handle_key(akey(Termisu::Input::Key::Space))
     ov.snapshot.follow.should be_true
   end
@@ -93,7 +93,7 @@ describe Gori::Tui::FuzzAdvancedOverlay do
   it "a click inside focuses the row under the pointer and stays open" do
     ov = FuzzAdvancedOverlay.new(blank_snapshot)
     h = OverlayHarness.new(ov)
-    h.click_in_box(2, 5).should eq(:open) # rows start at box.y + 1 → row index 4 (Follow redirects)
+    h.click_in_box(2, 6).should eq(:open) # rows start at box.y + 1 → row index 5 (Follow redirects)
     h.commits.should eq(0)
     h.press(Termisu::Input::Key::Space)
     ov.snapshot.follow.should be_true
@@ -102,7 +102,7 @@ describe Gori::Tui::FuzzAdvancedOverlay do
   it "the wheel moves the selected row (base handle_wheel delegates to move)" do
     ov = FuzzAdvancedOverlay.new(blank_snapshot)
     h = OverlayHarness.new(ov)
-    h.wheel(5) # → Calibrate (row 5)
+    h.wheel(6) # → Calibrate (row 6)
     h.press(Termisu::Input::Key::Space)
     ov.snapshot.calibrate.should be_true
     ov.snapshot.follow.should be_false
@@ -133,11 +133,12 @@ describe Gori::Tui::FuzzAdvancedOverlay do
   it "toggles keep-alive, which starts on" do
     ov = FuzzAdvancedOverlay.new(blank_snapshot)
     ov.snapshot.keep_alive.should be_true
-    6.times { ov.handle_key(akey(Termisu::Input::Key::Down)) } # → Keep-alive (row 6)
+    7.times { ov.handle_key(akey(Termisu::Input::Key::Down)) } # → Keep-alive (row 7)
     ov.handle_key(akey(Termisu::Input::Key::Space))
     ov.snapshot.keep_alive.should be_false
-    ov.snapshot.calibrate.should be_false # the neighbouring toggle is untouched
+    ov.snapshot.calibrate.should be_false # the neighbouring toggles are untouched
     ov.snapshot.follow.should be_false
+    ov.snapshot.update_cl.should be_true
   end
 
   it "offsets a click by the scroll position once the list has scrolled" do

--- a/spec/tui/fuzzer_view_spec.cr
+++ b/spec/tui/fuzzer_view_spec.cr
@@ -259,7 +259,8 @@ describe Gori::Tui::FuzzerView do
       snap = view.advanced_snapshot
       edited = Gori::Tui::AdvancedSnapshot.new(
         conc: "50", rate: snap.rate, timeout: snap.timeout, retries: snap.retries,
-        follow: true, calibrate: snap.calibrate, keep_alive: false,
+        max_requests: snap.max_requests,
+        follow: true, calibrate: snap.calibrate, keep_alive: false, update_cl: snap.update_cl,
         m_status: "200,500", m_size: snap.m_size, m_words: snap.m_words, m_regex: snap.m_regex,
         f_status: snap.f_status, f_size: snap.f_size, f_words: snap.f_words, f_regex: snap.f_regex)
       view.apply_advanced(edited)
@@ -275,7 +276,9 @@ describe Gori::Tui::FuzzerView do
       snap = src.advanced_snapshot
       src.apply_advanced(Gori::Tui::AdvancedSnapshot.new(
         conc: snap.conc, rate: snap.rate, timeout: snap.timeout, retries: snap.retries,
+        max_requests: snap.max_requests,
         follow: snap.follow, calibrate: snap.calibrate, keep_alive: snap.keep_alive,
+        update_cl: snap.update_cl,
         m_status: snap.m_status, m_size: snap.m_size, m_words: "42", m_regex: snap.m_regex,
         f_status: snap.f_status, f_size: snap.f_size, f_words: "7", f_regex: snap.f_regex))
       dst = FuzzerView.new

--- a/spec/tui/intercept_view_spec.cr
+++ b/spec/tui/intercept_view_spec.cr
@@ -565,6 +565,59 @@ describe "Intercept verbs (P1)" do
     keymap.lookup(Gori::Verb::Chord.new("3"), Gori::Verb::Scope::Body).should eq("nav.pos3")
   end
 
+  # R4. `Item#refuse_edit` is asked by the CLI/MCP drain (`Runner#apply_intercept_command`)
+  # and was NOT asked here, so a human editing an h2 message whose head has no HTTP/1.1 text
+  # form got `forwarded …` in the status bar while the settle side discarded the edit and the
+  # ORIGINAL message went on the wire. Verified live: the TUI said forwarded, the origin
+  # logged the untouched request.
+  it "reports why a pending edit would be refused, so the forward can refuse instead" do
+    tmp_interceptor do |ic|
+      item = ic.enqueue_request("GET /unf HTTP/2\r\nHost: h\r\nx-evil: a\\r\\nx: 1\r\n\r\n".to_slice,
+        method: "GET", target: "/unf", host: "h", port: 443, scheme: "https",
+        edit_refusal: "the value of \"x-evil\" carries a CR or LF", head_only: true).not_nil!
+      view = InterceptView.new
+      view.reload(ic)
+      # Clean editor: nothing is being edited, so nothing can be refused — merely LOOKING at
+      # a held message must never make it unforwardable.
+      view.refused_edit.should be_nil
+
+      view.toggle_edit
+      view.replace_editor("GET /EDITED HTTP/2\r\nHost: h\r\n\r\n")
+      refusal = view.refused_edit.not_nil!
+      refusal[0].id.should eq(item.id)
+      refusal[1].should contain("x-evil")
+    end
+  end
+
+  # The complement: the same head-only hold with NO refusal recorded. A head edit applies;
+  # only an edit that adds a BODY has nowhere to go on h2.
+  it "refuses an edit that adds a body to a head-only hold, and allows a head-only edit" do
+    tmp_interceptor do |ic|
+      ic.enqueue_request("GET /h HTTP/2\r\nHost: h\r\n\r\n".to_slice, method: "GET",
+        target: "/h", host: "h", port: 443, scheme: "https", head_only: true).not_nil!
+      view = InterceptView.new
+      view.reload(ic)
+      view.toggle_edit
+      view.replace_editor("GET /EDITED HTTP/2\r\nHost: h\r\n\r\n")
+      view.refused_edit.should be_nil
+
+      view.replace_editor("GET /EDITED HTTP/2\r\nHost: h\r\n\r\nOPERATORBODY")
+      view.refused_edit.not_nil![1].should contain("HEAD only")
+    end
+  end
+
+  # And the h1 complement: head+body held, forwarded byte-exact, nothing ever refused.
+  it "never refuses an edit on an h1 hold" do
+    tmp_interceptor do |ic|
+      hold_req(ic, "acme.test", "/p", "POST /p HTTP/1.1\r\nHost: acme.test\r\n\r\nab")
+      view = InterceptView.new
+      view.reload(ic)
+      view.toggle_edit
+      view.replace_editor("POST /p HTTP/1.1\r\nHost: acme.test\r\n\r\nZZZZ")
+      view.refused_edit.should be_nil
+    end
+  end
+
   describe "a held WebSocket message (#500 step 2)" do
     it "renders a WS badge, the socket, and the payload's first line" do
       tmp_interceptor do |ic|

--- a/spec/tui/mine_config_overlay_spec.cr
+++ b/spec/tui/mine_config_overlay_spec.cr
@@ -30,9 +30,13 @@ describe Gori::Tui::MineConfigOverlay do
     ov.build_config.locations.should eq([Gori::Miner::Location::Query, Gori::Miner::Location::Headers])
   end
 
-  it "cycles concurrency and notification on their rows and reports the Start row" do
+  it "cycles max-requests, concurrency and notification on their rows and reports the Start row" do
     ov = MineConfigOverlay.new(seed([Gori::Miner::Location::Query], [Gori::Miner::Location::Query]))
-    # rows: [0]=query, [1]=concurrency, [2]=notification, [3]=start
+    # rows: [0]=query, [1]=max requests, [2]=concurrency, [3]=notification, [4]=start
+    ov.build_config.max_requests.should be_nil # uncapped is the first choice, and the default
+    ov.move(1)                                 # max requests row
+    ov.adjust(1)
+    ov.build_config.max_requests.should eq(100_i64)
     ov.move(1) # concurrency row
     ov.adjust(1)
     ov.build_config.concurrency.should eq(20) # default 10 → next choice

--- a/spec/tui/overlay_dispatch_spec.cr
+++ b/spec/tui/overlay_dispatch_spec.cr
@@ -357,9 +357,9 @@ describe "Overlay seam — SequenceConfigOverlay (hard case: 2 open-sites, no fl
     reconf_h = OverlayHarness.new(SequenceConfigOverlay.new(seed))
     reconf_h.on_commit { log << "reconfigure_current"; true }
 
-    # Drive each to Start (row 5) and commit through the generic shell dispatch.
+    # Drive each to Start (row 6) and commit through the generic shell dispatch.
     [new_h, reconf_h].each do |h|
-      4.times { h.press(Termisu::Input::Key::Down) } # selector → … → Start
+      5.times { h.press(Termisu::Input::Key::Down) } # selector → … → Start
       h.overlay.as(SequenceConfigOverlay).on_start_row?.should be_true
       h.press(Termisu::Input::Key::Enter).should eq(:closed)
     end
@@ -372,14 +372,14 @@ describe "Overlay seam — SequenceConfigOverlay (hard case: 2 open-sites, no fl
     ov.valid?.should be_false
     h = OverlayHarness.new(ov)
     h.on_commit { ov.valid? } # real open-site gate: reject + keep open, mirroring Runner#commit_sequence
-    ov.set_selected(5)        # Start row
+    ov.set_selected(6)        # Start row
     h.press(Termisu::Input::Key::Enter).should eq(:open)
   end
 
   it "click on Start commits; a click outside dismisses" do
     h = OverlayHarness.new(SequenceConfigOverlay.new(seed))
-    # Start is row index 5; its screen row is box.y + 3 + 5.
-    h.click_in_box(3, 8).should eq(:closed)
+    # Start is row index 6; its screen row is box.y + 3 + 6.
+    h.click_in_box(3, 9).should eq(:closed)
     h.commits.should eq(1)
 
     away = OverlayHarness.new(SequenceConfigOverlay.new(seed))
@@ -422,8 +422,8 @@ describe "Overlay seam — MineConfigOverlay (laggard: keys were shell-owned; cl
   it "commits from the Start row through the generic dispatch" do
     ov = MineConfigOverlay.new(mseed)
     h = OverlayHarness.new(ov)
-    # rows: [Query, Json, concurrency, notify, Start] → 4 downs to Start.
-    4.times { h.press(Termisu::Input::Key::Down) }
+    # rows: [Query, Json, max requests, concurrency, notify, Start] → 5 downs to Start.
+    5.times { h.press(Termisu::Input::Key::Down) }
     ov.on_start_row?.should be_true
     h.press(Termisu::Input::Key::Enter).should eq(:closed)
     h.commits.should eq(1)
@@ -432,7 +432,7 @@ describe "Overlay seam — MineConfigOverlay (laggard: keys were shell-owned; cl
   it "keeps the form open when the commit closure rejects (no location selected)" do
     ov = MineConfigOverlay.new(mseed)
     h = OverlayHarness.new(ov, commit: false) # e.g. any_checked? was false
-    ov.set_selected(4)                        # Start row
+    ov.set_selected(5)                        # Start row
     h.press(Termisu::Input::Key::Enter).should eq(:open)
   end
 
@@ -447,8 +447,8 @@ describe "Overlay seam — MineConfigOverlay (laggard: keys were shell-owned; cl
 
   it "click on Start commits; a click outside dismisses" do
     h = OverlayHarness.new(MineConfigOverlay.new(mseed))
-    # Start is row index 4; its screen row is box.y + 3 + 4.
-    h.click_in_box(3, 7).should eq(:closed)
+    # Start is row index 5; its screen row is box.y + 3 + 5.
+    h.click_in_box(3, 8).should eq(:closed)
     h.commits.should eq(1)
 
     away = OverlayHarness.new(MineConfigOverlay.new(mseed))

--- a/spec/tui/url_spec.cr
+++ b/spec/tui/url_spec.cr
@@ -59,8 +59,13 @@ describe Gori::Tui::Url do
       Gori::Tui::Url.origin_path("https://example.com/secure").should eq("/secure")
     end
 
-    it "is case-sensitive on the scheme (uppercase passes through)" do
-      Gori::Tui::Url.origin_path("HTTP://example.com/x").should eq("HTTP://example.com/x")
+    # Was "case-sensitive on the scheme (uppercase passes through) — asserting actual". It is
+    # `Gori::Url.origin_path` now, shared with `Interceptor::Item`, `CLI::Output` and `Links`,
+    # and it uses `absolute_form?`'s case-insensitive test: RFC 3986 §3.1 makes a URI scheme
+    # case-insensitive, and letting `HTTP://` through is how `127.0.0.1HTTP://127.0.0.1/x`
+    # reached `gori run history`.
+    it "is case-INSENSITIVE on the scheme (RFC 3986 §3.1)" do
+      Gori::Tui::Url.origin_path("HTTP://example.com/x").should eq("/x")
     end
 
     it "passes through a scheme-relative URL (no scheme prefix)" do

--- a/spec/url_spec.cr
+++ b/spec/url_spec.cr
@@ -1,0 +1,84 @@
+require "./spec_helper"
+
+# `Gori::Url` is the ONE definition of "how a request target is written down when a surface
+# has to say where a message went". Four copies of it existed: `Store::FlowRow.absolute_form?`
+# (careful, byte-level, case-insensitive), `Tui::Url.origin_path` (case-SENSITIVE),
+# `CLI::Output.flow_row_text` and `Links.flow_location` (`target.starts_with?("http")`, which
+# is neither). The disagreement is not academic — see the uppercase-scheme examples below.
+describe Gori::Url do
+  describe ".absolute_form?" do
+    it "recognises an absolute-form target in either scheme and either case" do
+      Gori::Url.absolute_form?("http://h/x").should be_true
+      Gori::Url.absolute_form?("https://h/x").should be_true
+      Gori::Url.absolute_form?("HTTP://h/x").should be_true
+      Gori::Url.absolute_form?("HttPs://h/x").should be_true
+    end
+
+    it "rejects an origin-form target, a near-miss scheme and a status line" do
+      Gori::Url.absolute_form?("/x").should be_false
+      Gori::Url.absolute_form?("http:/x").should be_false
+      Gori::Url.absolute_form?("httpx://h/x").should be_false
+      Gori::Url.absolute_form?("405 Method Not Allowed").should be_false
+      Gori::Url.absolute_form?("").should be_false
+    end
+
+    it "does not raise on a target that is not valid UTF-8" do
+      # A target is bytes a peer or an operator put on the wire. PCRE2 RAISES on an invalid
+      # byte rather than not matching, which is why this check is byte-level.
+      Gori::Url.absolute_form?(String.new(Bytes[0x48, 0x54, 0x54, 0x50, 0x3a, 0x2f, 0x2f, 0x80]))
+        .should be_true
+    end
+  end
+
+  describe ".origin_path" do
+    it "projects an absolute-form target to origin form" do
+      Gori::Url.origin_path("http://example.com/a/b?q=1#f").should eq("/a/b?q=1#f")
+      Gori::Url.origin_path("https://host:8443/x").should eq("/x")
+      Gori::Url.origin_path("http://example.com").should eq("/")
+    end
+
+    it "leaves a non-absolute target alone" do
+      Gori::Url.origin_path("/foo/bar").should eq("/foo/bar")
+      Gori::Url.origin_path("405 Method Not Allowed").should eq("405 Method Not Allowed")
+      Gori::Url.origin_path("httpx://h/p").should eq("httpx://h/p")
+    end
+
+    # The behaviour that changed when the four copies collapsed onto one. `Tui::Url` was
+    # case-sensitive and its spec asserted "actual"; `absolute_form?`'s own comment says an
+    # uppercase scheme is exactly what must NOT slip past, because RFC 3986 §3.1 makes a URI
+    # scheme case-insensitive and gori captures whatever the client wrote.
+    it "projects an UPPERCASE scheme too" do
+      Gori::Url.origin_path("HTTP://example.com/x").should eq("/x")
+      Gori::Url.origin_path("HTTPS://example.com/x").should eq("/x")
+    end
+  end
+
+  describe ".location" do
+    it "returns an absolute-form target verbatim rather than gluing the host onto it" do
+      Gori::Url.location("127.0.0.1", "http://127.0.0.1:19594/upper")
+        .should eq("http://127.0.0.1:19594/upper")
+    end
+
+    # THE regression. Captured live through the proxy from `GET HTTP://127.0.0.1:19594/upper
+    # HTTP/1.1`, `gori run history` printed `127.0.0.1HTTP://127.0.0.1:19594/upper` — a string
+    # that is not a URL, and the exact doubling `FlowRow.absolute_form?` was written to stop.
+    it "does not double the authority on an UPPERCASE absolute-form target" do
+      out = Gori::Url.location("127.0.0.1", "HTTP://127.0.0.1:19594/upper")
+      out.should eq("HTTP://127.0.0.1:19594/upper")
+      out.should_not eq("127.0.0.1HTTP://127.0.0.1:19594/upper")
+    end
+
+    it "prefixes the host on an origin-form target" do
+      Gori::Url.location("acme.test", "/api/users").should eq("acme.test/api/users")
+    end
+  end
+
+  # The delegating names kept for their existing call sites must answer identically, or the
+  # consolidation only moved the drift somewhere else.
+  it "answers the same through every name that survived" do
+    %w(http://h/x HTTP://h/x /x httpx://h/x 405\ Nope).each do |t|
+      Gori::Tui::Url.origin_path(t).should eq(Gori::Url.origin_path(t))
+      Gori::Store::FlowRow.absolute_form?(t).should eq(Gori::Url.absolute_form?(t))
+    end
+  end
+end

--- a/src/gori/cli/output.cr
+++ b/src/gori/cli/output.cr
@@ -1,5 +1,6 @@
 require "json"
 require "../store"
+require "../url"
 require "../fuzz"
 require "../miner"
 require "../sequencer"
@@ -42,6 +43,15 @@ module Gori
           # the two key sets against each other): a consumer of either feed has no other way
           # to tell a gori-authored stub response from one the origin actually sent (#511).
           j.field "short_circuited", row.short_circuited?
+          # What gori has to say about this flow that its bytes cannot (`FlowRow#advisory`):
+          # a rule that structurally could not run on it, a request the ORIGIN invented in a
+          # PUSH_PROMISE. Emitted only when there is one, so a script keying off field
+          # presence is not broken by a field it never asked for — the same discipline
+          # `emit_ws_shape_json` uses.
+          advisories = row.advisories
+          unless advisories.empty?
+            j.field("advisory") { j.array { advisories.each { |l| j.string(term_safe(l)) } } }
+          end
         end
       end
 
@@ -117,9 +127,12 @@ module Gori
       # Columns are padded for scannability; status/state make capture progress legible.
       def self.flow_row_text(row : Store::FlowRow) : String
         status = row.status.try(&.to_s) || "—"
-        # HTTP proxied requests store an absolute-form target ("http://host/path")
-        # that already carries the host; only origin-form targets need host prefixed.
-        loc = term_safe(row.target.starts_with?("http") ? row.target : "#{row.host}#{row.target}")
+        # HTTP proxied requests store an absolute-form target ("http://host/path") that
+        # already carries the host; only origin-form targets need the host prefixed.
+        # `Gori::Url.location`, not the `target.starts_with?("http")` spelled out here before:
+        # that is not the absolute-form test (RFC 3986 §3.1 — schemes are case-insensitive),
+        # so a captured `GET HTTP://host/x` printed as `127.0.0.1HTTP://127.0.0.1:19594/upper`.
+        loc = term_safe(Gori::Url.location(row.host, row.target))
         dur = row.duration_us.try { |us| " #{human_us(us)}" } || ""
         String.build do |io|
           io << '#' << row.id.to_s.ljust(6)
@@ -132,6 +145,10 @@ module Gori
           # Never silently: a text-mode reader scanning this list would otherwise take a
           # stub for traffic the server produced.
           io << "  [stub]" if row.short_circuited?
+          # Same reasoning as [stub] one line up: a text-mode reader scanning a list must be
+          # able to SEE that gori has something to say about a row. The chip is a pointer —
+          # `gori run show <id>` prints the sentences.
+          io << "  [!]" unless row.advisories.empty?
           io << "  [" << row.state << ']' unless row.state.complete?
         end
       end

--- a/src/gori/cli/run/history.cr
+++ b/src/gori/cli/run/history.cr
@@ -290,6 +290,16 @@ module Gori
 
       private def self.show_text(detail : Store::FlowDetail, req : Bool, resp : Bool,
                                  ws_msgs : Array(Store::WsMessage)) : Nil
+        # FIRST, above the bytes it is about: what gori DID to this exchange that the bytes
+        # cannot show — a Match&Replace rule it could not run, a request the origin invented.
+        # The WebSocket half of this has been readable here since #518 (`[gori] …` rows in the
+        # message list); an HTTP flow now carries the same statement on the row itself.
+        advisories = detail.row.advisories
+        unless advisories.empty?
+          puts "=== GORI ADVISORY ==="
+          advisories.each { |a| puts "! #{CLI::Output.term_safe_multiline(a)}" }
+          puts ""
+        end
         if req
           puts "=== REQUEST (#{detail.http_version}) ==="
           print_message_text(detail.request_head, display_body(detail.request_head, detail.request_body), detail.request_body)

--- a/src/gori/cli/run/intercept.cr
+++ b/src/gori/cli/run/intercept.cr
@@ -175,10 +175,22 @@ module Gori
               # any ANSI/OSC/CSI escapes before they hit the live terminal (see its doc
               # comment; same discipline as flow_row_text/print_message_text).
               method = CLI::Output.term_safe(r.method.ljust(6))
-              puts "##{r.item_id}  [#{r.kind}]  #{method} #{CLI::Output.term_safe(intercept_row_where(r))}  (#{body.size}b body)"
+              # `[no-edit]` marks a message an edit cannot be applied to, so the state is
+              # scannable down a queue listing the way `[stub]` is in History. The sentence
+              # itself is `intercept get`'s; a list row has no space for it.
+              chip = r.edit_warning ? "  [no-edit]" : ""
+              puts "##{r.item_id}  [#{r.kind}]  #{method} #{CLI::Output.term_safe(intercept_row_where(r))}  (#{body.size}b body)#{chip}"
             end
           end
         end
+      end
+
+      # "gori will not apply an edit to this message, and here is why" — printed before the
+      # head so the operator reads it before writing one. Silent when the message is editable.
+      private def self.emit_edit_warning(r : Store::HeldRow) : Nil
+        return unless warning = r.edit_warning
+        STDERR.puts "! edits cannot be applied to this message: #{CLI::Output.term_safe(warning)}"
+        STDERR.puts "! it stays held — forward it as it is, drop it, or replay it from the Repeater."
       end
 
       # WHERE a held item is, for one text row. The escape-neutralizing wrap is the caller's;
@@ -245,6 +257,11 @@ module Gori
           else
             head, body = MCP::Serialize.head_and_body(row.raw)
             redacted = MCP::Serialize.redact_head(head, include_sensitive)
+            # ABOVE the head, because this is the reason not to start typing one: an edit gori
+            # will not apply is decided when the message is HELD, and until it was carried on
+            # the row this command printed an ordinary editable message and let the operator
+            # find out from `intercept edit`'s exit code.
+            emit_edit_warning(row)
             puts CLI::Output.term_safe_multiline(redacted).rstrip
             unless body.empty?
               puts ""

--- a/src/gori/cli/run/intercept.cr
+++ b/src/gori/cli/run/intercept.cr
@@ -69,6 +69,7 @@ module Gori
           gori run intercept get 3 --format json
           gori run intercept forward 3
           gori run intercept edit 3 --raw-file edited.txt
+          gori run intercept edit 3 --raw-file desync.txt --no-update-content-length
           gori run intercept direction request
 
         See 'gori run intercept <subcommand> --help' for more.
@@ -342,6 +343,7 @@ module Gori
         format = :text
         raw : String? = nil
         raw_file : String? = nil
+        update_cl = true
         positional = [] of String
 
         parser = OptionParser.new do |p|
@@ -349,11 +351,13 @@ module Gori
                      "Forward a held item with EDITED bytes: the full replacement wire message\n" \
                      "(whichever leg — request or response — is held). The BODY is forwarded\n" \
                      "VERBATIM (no $KEY expansion, no line-ending rewrite); header lines are\n" \
-                     "CRLF-terminated and Content-Length is resynced to the new body."
+                     "CRLF-terminated and Content-Length is resynced to the new body unless\n" \
+                     "--no-update-content-length holds the value you declared."
           p.on("--project=NAME", "Project to update (default: most-recently-active)") { |v| project_name = v }
           p.on("--db=PATH", "Explicit SQLite db file to update") { |v| db_path = v }
           p.on("--raw=RAW", "Verbatim replacement wire message") { |v| raw = v }
           p.on("--raw-file=PATH", "Read the replacement wire message from FILE") { |v| raw_file = v }
+          p.on("--no-update-content-length", "Forward the Content-Length you declared instead of resyncing it to the body (the CL-desync / CL+TE smuggling primitive; mirrors MCP intercept_forward_edit{update_content_length:false})") { update_cl = false }
           p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
           p.unknown_args { |rest, _| positional = rest }
@@ -381,13 +385,29 @@ module Gori
         # the BODY is a byte (binary data, or a bare LF the operator deliberately wrote), and
         # rewriting it contradicted this subcommand's own "forwarded VERBATIM" contract —
         # `--raw-file` is its only byte-exact channel, and an `alpha\rbeta\ngamma` body came
-        # out a byte longer with the LF promoted.
-        #
-        # Byte-level, not `.gsub(/\r?\n/, "\r\n")`: content may be an arbitrary binary body
-        # read from --raw-file (invalid UTF-8), which a Regex subject cannot accept.
-        bytes = Fuzz::ContentLength.sync(normalize_head_crlf(content.to_slice), add_when_missing: true)
+        # out a byte longer with the LF promoted. (That split, and the Content-Length choice
+        # beside it, live in `intercept_edit_bytes` so a spec can pin the exact bytes.)
+        bytes = intercept_edit_bytes(content, update_cl)
         status, detail = enqueue_intercept(project_name, db_path, "forward_edit", item_id: item_id, bytes: bytes)
         emit_intercept_ack(status, detail, format)
+      end
+
+      # The exact bytes `edit` enqueues, from the replacement message and the CL choice.
+      # Public and pure so a spec can pin them without a live capturing instance.
+      #
+      # Byte-level, not `.gsub(/\r?\n/, "\r\n")`: content may be an arbitrary binary body read
+      # from --raw-file (invalid UTF-8), which a Regex subject cannot accept.
+      #
+      # The Content-Length resync is a DECLARED choice, default on, mirroring MCP's
+      # `intercept_forward_edit{update_content_length}`. It used to be unconditional here,
+      # which made a CL desync (CL shorter than the body, CL longer than the body, CL+TE) —
+      # *the* canonical reason to hold a request in the first place, and the RFC 9113 §8.1.1
+      # probe — unexpressible from the CLI, and made `--raw-file`'s advertised byte-exact
+      # channel not byte-exact. The gate on the other end already honours a declared value.
+      def self.intercept_edit_bytes(content : String, update_content_length : Bool) : Bytes
+        head_normalized = normalize_head_crlf(content.to_slice)
+        return head_normalized unless update_content_length
+        Fuzz::ContentLength.sync(head_normalized, add_when_missing: true)
       end
 
       # `Env.normalize_crlf` over the HEAD only — through and including the blank-line

--- a/src/gori/cli/run/intercept.cr
+++ b/src/gori/cli/run/intercept.cr
@@ -178,7 +178,9 @@ module Gori
               # `[no-edit]` marks a message an edit cannot be applied to, so the state is
               # scannable down a queue listing the way `[stub]` is in History. The sentence
               # itself is `intercept get`'s; a list row has no space for it.
-              chip = r.edit_warning ? "  [no-edit]" : ""
+              # `edit_refusal` ONLY, never `head_only`: the gate holds the head of every h2
+              # message, so chipping on that would mark every held HTTP/2 row uneditable.
+              chip = r.edit_refusal ? "  [no-edit]" : ""
               puts "##{r.item_id}  [#{r.kind}]  #{method} #{CLI::Output.term_safe(intercept_row_where(r))}  (#{body.size}b body)#{chip}"
             end
           end
@@ -188,9 +190,14 @@ module Gori
       # "gori will not apply an edit to this message, and here is why" — printed before the
       # head so the operator reads it before writing one. Silent when the message is editable.
       private def self.emit_edit_warning(r : Store::HeldRow) : Nil
-        return unless warning = r.edit_warning
-        STDERR.puts "! edits cannot be applied to this message: #{CLI::Output.term_safe(warning)}"
-        STDERR.puts "! it stays held — forward it as it is, drop it, or replay it from the Repeater."
+        if refusal = r.edit_refusal
+          STDERR.puts "! edits cannot be applied to this message: #{CLI::Output.term_safe(refusal)}"
+          STDERR.puts "! it stays held — forward it as it is, drop it, or replay it from the Repeater."
+          return
+        end
+        # Not a refusal: the head IS editable. Said anyway, because the surface that offers an
+        # edit is the one that has to name what the edit cannot carry.
+        r.head_only_note.try { |n| STDERR.puts "! #{CLI::Output.term_safe(n)}" }
       end
 
       # WHERE a held item is, for one text row. The escape-neutralizing wrap is the caller's;

--- a/src/gori/cli/run/repeater_minimize.cr
+++ b/src/gori/cli/run/repeater_minimize.cr
@@ -116,7 +116,10 @@ module Gori
       # the wire bare-LF, inventing the very desync primitive the flag exists to preserve.
       private def self.minimize_resolver(id : Int64, text : String, verbatim : Bool,
                                          auto_cl : Bool) : Proc(String, Bytes)
-        stored_crlf = text.includes?("\r\n")
+        # HEAD only, and the same question `Minimize.run` asks: a CRLF pair inside a multipart
+        # body says nothing about how the operator terminated their header lines, and reading
+        # it as if it did would re-terminate an LF-headed session on the way out.
+        stored_crlf = Repeater::Minimize.head_crlf?(text)
         # The one case that restore cannot carry: a head whose lines DISAGREE (some CRLF, some
         # bare LF) is itself a smuggling shape, and minimize's LF round-trip flattens it to
         # all-CRLF. Nothing here can undo that — the algorithm rebuilds the head — so say it
@@ -141,22 +144,16 @@ module Gori
       # 0x0A is a line ending, in the body it is a byte.
       #
       # Needed because `Minimize` hands its `resolve` proc two different forms — the
-      # LF-normalized working text during the search, and `restore_eol`'s already-CRLF text in
-      # the report — so the step has to be idempotent (LF-normalize first, or the second call
-      # produces `\r\r\n`). Restoring the head ALONE also undoes, for the bytes this command
-      # sends and prints, `restore_eol`'s blanket `gsub("\n", "\r\n")` over the BODY: a
-      # captured body ending in a bare LF under a deliberately-short Content-Length came back
-      # one byte longer, which is the CL-desync evidence `--verbatim` exists to preserve.
+      # head-LF-normalized working text during the search, and `restore_eol`'s already-CRLF
+      # text in the report — so the step has to be idempotent. It is: `Env.normalize_crlf`
+      # never emits `\r\r\n`, which is why `Minimize.restore_eol` can be reused verbatim here.
+      #
+      # It used to whole-string `gsub("\r\n", "\n")` first, to undo `restore_eol`'s blanket
+      # `gsub("\n", "\r\n")` over the BODY. `Minimize` no longer touches the body at all, so
+      # that pre-pass is not merely unnecessary — it would now flatten a multipart body's own
+      # CRLF boundaries on the way to the wire.
       private def self.restore_head_crlf(text : String) : Bytes
-        bytes = text.gsub("\r\n", "\n").to_slice
-        boundary = Env.head_body_boundary(bytes)
-        head = Env.normalize_crlf(bytes[0...boundary])
-        return head if boundary >= bytes.size
-        body = bytes[boundary..]
-        io = IO::Memory.new(head.size + body.size)
-        io.write(head)
-        io.write(body)
-        io.to_slice
+        Repeater::Minimize.restore_eol(text, true).to_slice
       end
 
       # Does the HEAD carry both CRLF- and bare-LF-terminated lines? Head only: a raw 0x0A in

--- a/src/gori/export/har.cr
+++ b/src/gori/export/har.cr
@@ -215,6 +215,14 @@ module Gori
               j.field "comment", TIMINGS_NOTE
             end
           end
+          # HAR 1.2 §entry allows a `comment`, and this is what it is for: something the
+          # tool has to say about the exchange that the recorded request/response cannot.
+          # An exported flow keeps "Match&Replace was not applied to this head" and "the
+          # ORIGIN invented this request in a PUSH_PROMISE" — the second especially, since
+          # a HAR reader has no other way to tell a pushed entry from one the client sent.
+          # See `Store::FlowRow#advisory`.
+          advisories = row.advisories
+          j.field "comment", advisories.join("\n") unless advisories.empty?
         end
       end
 

--- a/src/gori/fuzz/template.cr
+++ b/src/gori/fuzz/template.cr
@@ -9,15 +9,29 @@ module Gori::Fuzz
   # Sniper, and as the seed the user edits over).
   #
   # The template keeps wire-form CRLF line endings so `render` produces a sendable
-  # request byte-for-byte (only the payload spans differ between variations). Binary
-  # request bodies can't be carried as text — the same limit the Repeater editor has;
-  # the byte-exact path remains `gori run repeater` / export.
+  # request byte-for-byte (only the payload spans differ between variations).
+  #
+  # `parse` and `render` are BYTE-oriented, so a request body that is not valid UTF-8
+  # survives them intact. They used to iterate `marked.chars`, and Crystal's char iteration
+  # substitutes U+FFFD for every invalid byte — so a captured body carrying a raw 0x80-0xFF
+  # run (a protobuf/gRPC frame, a gzip'd or otherwise binary POST, a latin-1 form field) came
+  # out of `render` with each of those bytes replaced by a THREE-byte replacement character.
+  # Every request the sweep sent was a different length from the one the operator seeded it
+  # with, under a Content-Length recomputed to match the corruption, and nothing said so.
+  # Scrubbing at load time only moves that corruption earlier; this is where it has to stop.
   struct Template
     MARKER = '§'
     # Value|chain delimiter inside a marker: `§value¦chain§`. NOT '|' — the Decoder
     # chain syntax already uses '|'/','/'>'  as step separators, so the boundary must
     # be a char the chain never contains. `¦¦` escapes a literal `¦`, mirroring `§§`.
     CHAIN_SEP = '¦'
+
+    # UTF-8 encodings of the two delimiters, for the byte scan. Matching these two-byte
+    # sequences is exactly as precise as matching the chars was: UTF-8 is self-synchronizing
+    # and 0xC2 is a LEAD byte, never a continuation (continuations are 0x80..0xBF), so
+    # `C2 A7` inside well-formed text can only ever be `§`.
+    MARKER_BYTES    = Bytes[0xC2_u8, 0xA7_u8]
+    CHAIN_SEP_BYTES = Bytes[0xC2_u8, 0xA6_u8]
 
     record Position, index : Int32, default : String, chain : String = ""
 
@@ -31,75 +45,92 @@ module Gori::Fuzz
     # The result of scanning one marker's interior (see scan_interior): the decoded
     # {default, chain}, whether a chain part was opened (a bare `¦` seen — needed to
     # rebuild an unbalanced marker faithfully), whether the closing § was found, and the
-    # index just past the closing § (or n when unbalanced).
+    # BYTE index just past the closing § (or n when unbalanced).
     private record InteriorScan, default : String, chain : String,
       chained : Bool, closed : Bool, next_i : Int32
 
+    # Branch-for-branch the scan it has always been — escaped `§§`, the `¦` value|chain
+    # split, the unbalanced-trailing-`§` tail-fold — over BYTES rather than chars, so a
+    # non-UTF-8 body passes through untouched. Every offset here is a byte offset; the
+    # CHARACTER offsets the TUI highlight needs stay in `marked_spans`, which reads the
+    # editor's (already well-formed) text.
     def self.parse(marked : String, http2 : Bool = false) : Template
       segs = [] of String
       defs = [] of {String, String} # {default, chain}
       lit = IO::Memory.new
-      chars = marked.chars
-      n = chars.size
+      bytes = marked.to_slice
+      n = bytes.size
       i = 0
       while i < n
-        c = chars[i]
-        if c != MARKER
-          lit << c
+        if !marker_at?(bytes, i)
+          lit.write_byte(bytes[i])
           i += 1
-        elsif chars[i + 1]? == MARKER # escaped literal §
-          lit << MARKER
-          i += 2
+        elsif marker_at?(bytes, i + 2) # escaped literal §
+          lit.write(MARKER_BYTES)
+          i += 4
         else
-          s = scan_interior(chars, i, n)
+          s = scan_interior(bytes, i, n)
           if s.closed
-            segs << lit.to_s
+            segs << String.new(lit.to_slice)
             lit = IO::Memory.new
             defs << {s.default, s.chain}
           else # unbalanced trailing § → literal text, opens no position (no truncation:
             # the § + interior fold into `lit` so render's positions.size+1 segments keep it)
-            lit << MARKER << s.default
-            lit << CHAIN_SEP << s.chain if s.chained
+            lit.write(MARKER_BYTES)
+            lit << s.default
+            if s.chained
+              lit.write(CHAIN_SEP_BYTES)
+              lit << s.chain
+            end
           end
           i = s.next_i
         end
       end
-      segs << lit.to_s
+      segs << String.new(lit.to_slice)
       positions = defs.map_with_index { |(d, ch), k| Position.new(k, d, ch) }
       new(segs, positions, http2)
     end
 
-    # Scan from the opening § at `open` to the matching close, decoding `§§`→§ and
-    # `¦¦`→¦; the first bare `¦` splits the interior into value|chain. Returns the decoded
+    # Is the two-byte `§` encoding at byte offset `i`? Bounds-checked, so it answers false
+    # rather than raising at the end of the slice (the `chars[i + 1]?` this replaced).
+    private def self.marker_at?(bytes : Bytes, i : Int32) : Bool
+      i >= 0 && i + 1 < bytes.size && bytes[i] == 0xC2_u8 && bytes[i + 1] == 0xA7_u8
+    end
+
+    private def self.chain_sep_at?(bytes : Bytes, i : Int32) : Bool
+      i >= 0 && i + 1 < bytes.size && bytes[i] == 0xC2_u8 && bytes[i + 1] == 0xA6_u8
+    end
+
+    # Scan from the opening § at byte offset `open` to the matching close, decoding `§§`→§
+    # and `¦¦`→¦; the first bare `¦` splits the interior into value|chain. Returns the decoded
     # parts even when unbalanced (closed: false), so parse can fold them back as literal.
-    private def self.scan_interior(chars : Array(Char), open : Int32, n : Int32) : InteriorScan
-      j = open + 1
+    private def self.scan_interior(bytes : Bytes, open : Int32, n : Int32) : InteriorScan
+      j = open + 2
       val = IO::Memory.new
       chn = IO::Memory.new
       in_chain = false
       while j < n
-        cj = chars[j]
-        if cj == MARKER
-          if chars[j + 1]? == MARKER # §§ inside a marker → literal §
-            (in_chain ? chn : val) << MARKER
-            j += 2
+        if marker_at?(bytes, j)
+          if marker_at?(bytes, j + 2) # §§ inside a marker → literal §
+            (in_chain ? chn : val).write(MARKER_BYTES)
+            j += 4
             next
           end
-          return InteriorScan.new(val.to_s, chn.to_s, in_chain, true, j + 1)
-        elsif cj == CHAIN_SEP
-          if chars[j + 1]? == CHAIN_SEP # ¦¦ inside a marker → literal ¦
-            (in_chain ? chn : val) << CHAIN_SEP
-            j += 2
+          return InteriorScan.new(String.new(val.to_slice), String.new(chn.to_slice), in_chain, true, j + 2)
+        elsif chain_sep_at?(bytes, j)
+          if chain_sep_at?(bytes, j + 2) # ¦¦ inside a marker → literal ¦
+            (in_chain ? chn : val).write(CHAIN_SEP_BYTES)
+            j += 4
             next
           end
-          in_chain ? (chn << CHAIN_SEP) : (in_chain = true) # 1st bare ¦ splits value|chain; a 2nd is literal
-          j += 1
+          in_chain ? chn.write(CHAIN_SEP_BYTES) : (in_chain = true) # 1st bare ¦ splits value|chain; a 2nd is literal
+          j += 2
           next
         end
-        (in_chain ? chn : val) << cj
+        (in_chain ? chn : val).write_byte(bytes[j])
         j += 1
       end
-      InteriorScan.new(val.to_s, chn.to_s, in_chain, false, n)
+      InteriorScan.new(String.new(val.to_slice), String.new(chn.to_slice), in_chain, false, n)
     end
 
     def position_count : Int32

--- a/src/gori/interceptor.cr
+++ b/src/gori/interceptor.cr
@@ -1,5 +1,6 @@
 require "./scope"
 require "./intercept_filter"
+require "./url"
 
 module Gori
   # The Intercept lens (P4 — the human decides): when enabled, an in-flight HTTP
@@ -128,26 +129,24 @@ module Gori
       # so the one expression `"#{method} #{host}#{target}"` produced
       # `POST 127.0.0.1http://127.0.0.1:19201/held` for a proxied h1 request and
       # `POST 127.0.0.1200 OK` for a held response — which reads as HTTP status 1200. Composing
-      # per kind is what `Tui::InterceptView#row_label`, `CLI::Output` and `Links` already do
-      # separately; this is the copy the settle paths use so they cannot drift again.
-      def label : String
+      # per kind is what `Tui::InterceptView#row_label` and `InterceptController` render, so
+      # they call THIS with the values they display and the composition lives once.
+      #
+      # `m`/`t` default to the Item's own immutable metadata. The TUI passes the EDITED
+      # method/target instead (`InterceptView#effective_method_target`), so a queue row and a
+      # forward toast name the message the operator is actually about to send — the one
+      # reason a surface ever needs different values here.
+      #
+      # `Gori::Url.origin_path` is the shared spelling of the absolute-form rule; it used to
+      # be copied into this file because `Interceptor` is core and the only other copy was
+      # `Tui::Url`'s.
+      def label(m : String = method, t : String = target) : String
         case kind
-        in .request?  then "#{method} #{host}#{origin_form(target)}"
-        in .response? then "#{method} #{host} -> #{target}"
-        in .ws_out?   then "#{host}#{origin_form(target)} client->server #{raw.size}B"
-        in .ws_in?    then "#{host}#{origin_form(target)} server->client #{raw.size}B"
+        in .request?  then "#{m} #{host}#{Gori::Url.origin_path(t)}"
+        in .response? then "#{m} #{host} -> #{t}"
+        in .ws_out?   then "#{host}#{Gori::Url.origin_path(t)} client->server #{raw.size}B"
+        in .ws_in?    then "#{host}#{Gori::Url.origin_path(t)} server->client #{raw.size}B"
         end
-      end
-
-      # A plaintext forward-proxy request is captured absolute-form (the wire truth, P7), and
-      # gluing the host onto one doubles the authority. Same rule as `Tui::Url.origin_path`,
-      # kept here because `Interceptor` is core and that helper is TUI-scoped.
-      private def origin_form(t : String) : String
-        return t unless t.starts_with?("http://") || t.starts_with?("https://")
-        scheme_end = t.index("://")
-        return t unless scheme_end
-        slash = t.index('/', scheme_end + 3)
-        slash ? t[slash..] : "/"
       end
     end
 

--- a/src/gori/links.cr
+++ b/src/gori/links.cr
@@ -1,4 +1,5 @@
 require "./store"
+require "./url"
 
 module Gori
   # Resolves `entity_links` rows into human-readable labels/URLs for the TUI and export.
@@ -74,8 +75,12 @@ module Gori
       end
     end
 
+    # `Gori::Url.location`, not the `target.starts_with?("http")` this used to spell out: that
+    # predicate is not the absolute-form test (RFC 3986 §3.1 makes a scheme case-insensitive),
+    # so a captured `GET HTTP://host/x` was glued into `hostHTTP://host/x` — the exact doubling
+    # `Store::FlowRow.absolute_form?`'s comment says the check exists to prevent.
     private def self.flow_location(f : Store::FlowRow) : String
-      f.target.starts_with?("http") ? f.target : "#{f.host}#{f.target}"
+      Gori::Url.location(f.host, f.target)
     end
 
     private def self.first_line(s : String) : String?

--- a/src/gori/mcp/serialize.cr
+++ b/src/gori/mcp/serialize.cr
@@ -96,6 +96,14 @@ module Gori
           # feed has no other way to tell a fabricated response from a real one, and an absent
           # field reads as "not applicable" rather than "false".
           j.field "short_circuited", row.short_circuited?
+          # What gori has to say about this flow that its bytes cannot — a rule it could not
+          # apply, a request the ORIGIN invented in a PUSH_PROMISE (`FlowRow#advisory`). An
+          # array, and only when non-empty: a model has no reason to reason about `null` on
+          # every ordinary row, and the absent field reads as "nothing to report".
+          advisories = row.advisories
+          unless advisories.empty?
+            j.field("advisory") { j.array { advisories.each { |a| j.string text(a) } } }
+          end
         end
       end
 
@@ -157,9 +165,22 @@ module Gori
           j.field "held_at_iso", unix_micros_iso(row.held_at_ms * 1000)
           j.field "age_seconds", ((now_ms - row.held_at_ms) // 1000)
           j.field "edited", row.edited
+          emit_edit_warning(j, row)
           j.field "body_size", body.size
           j.field "head_preview", preview
         end
+      end
+
+      # Why an EDIT to this held message would be refused, and whether the hold covers the
+      # head only — BEFORE the agent composes one. Both are decided when the message is held
+      # (`HeadCodec.h1_unfaithful_reason` is a pure function of the h2 block's fields), and
+      # without them here `intercept_get` described an ordinary editable message: the agent
+      # wrote an edit, called `intercept_forward_edit`, and only then got the refusal. That is
+      # the state a CRLF-injection probe INDUCES, so it is the normal case for the test an
+      # agent is most likely to be running. Emitted only when there is something to say.
+      def self.emit_edit_warning(j : JSON::Builder, row : Store::HeldRow) : Nil
+        j.field "head_only", true if row.head_only?
+        row.edit_warning.try { |w| j.field "edit_refusal", text(w) }
       end
 
       # Detail projection: full redacted head + body size. The FULL raw message base64 (for
@@ -181,6 +202,7 @@ module Gori
           j.field "held_at_ms", row.held_at_ms
           j.field "age_seconds", ((now_ms - row.held_at_ms) // 1000)
           j.field "edited", row.edited
+          emit_edit_warning(j, row)
           j.field "head", redact_head(head, include_sensitive)
           j.field "body_size", body.size
           j.field "raw_size", row.raw.size
@@ -251,6 +273,14 @@ module Gori
           # "`stub:false` is what you want before treating History as evidence"; the list
           # projection said so and the detail one dropped it.
           j.field "short_circuited", row.short_circuited?
+          # See `flow_row`. On the detail projection this is the one the agent reading BYTES
+          # as evidence needs: "Match&Replace was not applied to this head" and "the origin
+          # invented this request" are both statements about how much the bytes below can be
+          # trusted to be the operator's test case.
+          detail_advisories = row.advisories
+          unless detail_advisories.empty?
+            j.field("advisory") { j.array { detail_advisories.each { |a| j.string text(a) } } }
+          end
           j.field "error", text(detail.error)
           j.field "request_head", redact_head_opt(head_text(detail.request_head), include_sensitive)
           emit_head_base64(j, "request_head", detail.request_head, include_sensitive)

--- a/src/gori/mcp/serialize.cr
+++ b/src/gori/mcp/serialize.cr
@@ -178,9 +178,15 @@ module Gori
       # wrote an edit, called `intercept_forward_edit`, and only then got the refusal. That is
       # the state a CRLF-injection probe INDUCES, so it is the normal case for the test an
       # agent is most likely to be running. Emitted only when there is something to say.
+      # `edit_refusal` is the HARD one — gori will apply no edit to this message at all.
+      # `head_only` is the caveat: it is true for EVERY h2 hold (the gate holds the head), a
+      # head edit applies normally, and only a body has nowhere to go. Reporting the caveat as
+      # a refusal would mark every held HTTP/2 message uneditable, so they stay separate
+      # fields and an agent can act on each.
       def self.emit_edit_warning(j : JSON::Builder, row : Store::HeldRow) : Nil
         j.field "head_only", true if row.head_only?
-        row.edit_warning.try { |w| j.field "edit_refusal", text(w) }
+        row.head_only_note.try { |n| j.field "head_only_note", text(n) }
+        row.edit_refusal.try { |r| j.field "edit_refusal", text(r) }
       end
 
       # Detail projection: full redacted head + body size. The FULL raw message base64 (for

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -391,6 +391,10 @@ module Gori
         getter audit : JobAudit
 
         getter db_path : String?
+        # The run's engine. Exposed for its two PURE reporting queries (`skipped_names` /
+        # `candidate_names`), which are derived from the loaded wordlist and the config's
+        # locations and so are safe to read from the status fiber while the run is live.
+        getter engine
 
         def initialize(@id : String, @total : Int64, @engine : Miner::Engine, @audit : JobAudit,
                        @db_path : String? = nil)
@@ -1426,6 +1430,7 @@ module Gori
               s.field "max_requests", intprop("caller cap on total requests")
               s.field "allow_unscoped", boolprop("run even when the target host is outside the project's configured scope — REQUIRED to run against an out-of-scope target, or when no scope is configured at all (active requests are refused by default without a matching scope)")
               s.field "record_history", strprop("none (default) | matched | all — record each sent request+response as a History flow for audit/evidence; matched results carry the flow_id in fuzz_results (fetch full detail with get_flow). 'all' is capped at #{FUZZ_HISTORY_MAX} flows.")
+              s.field "update_content_length", boolprop("recompute Content-Length after each payload is spliced into the body (default true). Set FALSE to send your template's declared value verbatim — a Content-Length shorter or longer than the body, or Content-Length alongside Transfer-Encoding, is the canonical request-smuggling primitive, and with the default on every payload is silently re-framed to fit before it leaves. Mirrors CLI `gori run fuzz --verbatim` and intercept_forward_edit{update_content_length:false}.")
             end
 
             tool j, "fuzz_status", "Counts + state of a fuzz job (running|done|budget_exhausted|stopped|error). " \
@@ -1474,7 +1479,11 @@ module Gori
             end
 
             tool j, "mine_status", "Counts + state of a mine job (running|done|budget_exhausted|stopped|error). " \
-                                   "budget_exhausted means max_requests halted the run before every name was tried; see incomplete_reason." do |s|
+                                   "budget_exhausted means max_requests halted the run before every name was tried; see incomplete_reason. " \
+                                   "`skipped` lists wordlist names a location cannot carry (a header/cookie name must be an RFC 7230 " \
+                                   "token, and framing headers are never injected) against `candidate_names`, the wordlist's own size — " \
+                                   "names_total counts only the names that survived that filter, so without `skipped` an incomplete " \
+                                   "sweep reads as a clean one." do |s|
               s.field "job_id", strprop("id from mine_start"), required: true
             end
 
@@ -1961,14 +1970,24 @@ module Gori
         job.ended_at_ms ||= Time.utc.to_unix_ms
       end
 
-      # Terminal status for a finished fuzz/mine job. A non-stopped Done whose
+      # Terminal status for a finished fuzz/mine/discover job. A non-stopped Done whose
       # processed count fell short of the known candidate `total` means the request
       # budget (max_requests) halted the run early — reported as :budget_exhausted
       # so a partial "0 found" is not read as an exhaustive result. A prior :error
       # is preserved (a generation ErrorEvent then a Done must stay failed).
-      private def terminal_status(current : Symbol, stopped : Bool, done_count : Int64, total : Int64?) : Symbol
+      #
+      # `declared` is for an engine that says so ITSELF rather than letting a consumer derive
+      # it. Discover is that engine: it has no stable candidate denominator (`est_total` is a
+      # moving estimate of a live crawl), so `Discover::DoneEvent#budget_exhausted` is the
+      # authority and MCP must not re-infer the answer. It used to infer `queued > 0`, which
+      # misses the half the engine's own predicate exists for — a Calibrate task whose probes
+      # were ALL refused consumes no frontier entry, so the frontier drains to empty with real
+      # work skipped and the run came back `status:"done", job_complete:true, has_more:false`.
+      private def terminal_status(current : Symbol, stopped : Bool, done_count : Int64, total : Int64?,
+                                  declared : Bool = false) : Symbol
         return :error if current == :error
         return :stopped if stopped
+        return :budget_exhausted if declared
         (total && done_count < total) ? :budget_exhausted : :done
       end
 

--- a/src/gori/mcp/tools/discover.cr
+++ b/src/gori/mcp/tools/discover.cr
@@ -41,7 +41,19 @@ module Gori
       # ceilings); seed normalization, wordlist load, scope policy and sender wiring are the
       # builder's. Raises FuzzArgError (clean message) on any malformed input.
       private def build_discover_plan(h, ob : Outbound) : Discover::Plan
-        options = Discover::PlanOptions.new(str(h, "url") || "", config: discover_config(h),
+        config = discover_config(h)
+        # The second half of the header refusal, and the realistic one: the header the caller
+        # passed is fine and the ENV VAR is not (`{"Authorization": "Bearer $TOKEN"}` where
+        # TOKEN was read from a file and kept its trailing newline). A QUERY, run before any
+        # traffic — `Discover::Headers.expand`'s send-time backstop drops such a value on
+        # every probe without a word, and by then the crawl is already running. `gori run
+        # discover` aborts here; MCP crawled on unauthenticated and reported "found nothing".
+        unsafe = Discover::Headers.unsafe_expanded(config.headers)
+        unless unsafe.empty?
+          raise FuzzArgError.new("header #{unsafe.first.inspect} rejected — its value contains CR or LF " \
+                                 "after $VAR expansion, which would splice extra headers into every probe")
+        end
+        options = Discover::PlanOptions.new(str(h, "url") || "", config: config,
           verify: !bool_arg(h, "insecure", false) && @verify_upstream,
           overrides: HostOverrides.load(store))
         Discover::Plan.build(options, ob)
@@ -72,7 +84,30 @@ module Gori
           max_depth: clamp(int(h, "max_depth"), 4, DISCOVER_MAX_DEPTH),
           user_wordlist: str(h, "wordlist").presence,
           extensions: discover_extensions(h), containment: discover_containment(h),
-          headers: Discover::Headers.parse_lines(discover_header_lines(h)))
+          headers: discover_headers(h))
+      end
+
+      # The caller's `headers` map, REFUSING by name anything gori will not put on the wire.
+      # `parse_lines` drops a CR/LF-carrying value and a non-token name — right, since this is
+      # an automated crawler splicing the value into every probe's header block — but dropping
+      # it SILENTLY is not: the drop takes `Authorization` with it, so an agent's authenticated
+      # sweep ran unauthenticated over the whole authenticated surface and reported "found
+      # nothing" with no error anywhere. `gori run discover` aborts on exactly this (#556);
+      # MCP is the surface where nobody is watching stderr, so it matters more here.
+      #
+      # Only the header NAME is echoed back, never the rejected line: the value is the thing
+      # most likely to be a credential.
+      private def discover_headers(h) : Array({String, String})
+        rejected = [] of String
+        lines = discover_header_lines(h)
+        parsed = Discover::Headers.parse_lines(lines, rejected)
+        unless rejected.empty?
+          name = rejected.first.partition(':')[0].strip
+          raise FuzzArgError.new("header #{name.inspect} rejected — a header value may not contain " \
+                                 "CR or LF, and a header name must be an RFC 7230 token " \
+                                 "(#{rejected.size} of #{lines.size} headers rejected)")
+        end
+        parsed
       end
 
       private def discover_containment(h) : Discover::Containment
@@ -153,13 +188,17 @@ module Gori
           djob.queued = ev.progress.queued
           djob.stats = ev.stats
           # Discover has no fixed candidate total (a live crawl's denominator moves), so the
-          # shortfall is read the other way round: tasks still QUEUED when the run ended mean
-          # max_requests halted it, exactly the :budget_exhausted fuzz and mine derive from
-          # `done_count < total`. Without this a budget-capped sweep that never sent 275 of
-          # 283 tasks reported `status:"done", job_complete:true, has_more:false` — an agent
-          # reads that as an exhaustive directory sweep and stops looking.
-          djob.status = terminal_status(djob.status, ev.stopped, 0_i64,
-            djob.queued > 0 ? djob.queued.to_i64 : nil)
+          # shortfall cannot be derived the way fuzz and mine derive it from `done_count <
+          # total`. The ENGINE says it: `DoneEvent#budget_exhausted` is `cap_reached? &&
+          # (frontier non-empty || refused > 0)`. Reading `queued > 0` instead — which is what
+          # this line did — agrees on the 275-of-283 case and silently misses the other half:
+          # a Calibrate task whose probes were all REFUSED consumes no frontier entry, so the
+          # frontier drains to empty while real work was skipped, and the run came back
+          # `status:"done", job_complete:true, has_more:false`. An agent reads that as an
+          # exhaustive directory sweep and stops looking. `queued` is still reported below —
+          # it is how MUCH was left, not WHETHER anything was.
+          djob.status = terminal_status(djob.status, ev.stopped, 0_i64, nil,
+            declared: ev.budget_exhausted)
           djob.ended_at_ms = Time.utc.to_unix_ms
         when Discover::ErrorEvent
           djob.status = :error

--- a/src/gori/mcp/tools/fuzz.cr
+++ b/src/gori/mcp/tools/fuzz.cr
@@ -233,10 +233,13 @@ module Gori
       # Build a ready-to-run engine + its origin + total + effective http2 from the
       # tool args. Raises FuzzArgError (clean message) on any malformed input.
       private def build_fuzz_job(h, ob : Outbound) : {Fuzz::Engine, Fuzz::Origin, Int64?, Bool}
-        text, default_target, src_h2 = fuzz_template_source(h)
+        text, default_target, src_h2, evidence = fuzz_template_source(h)
         use_h2 = bool_arg(h, "http2", false) || src_h2
         mode = fuzz_mode(h)
         options = Fuzz::PlanOptions.new(text,
+          # A `flow_id` template is CAPTURED evidence; a `template` string is the caller's
+          # draft. See `Fuzz::PlanOptions#evidence?`.
+          evidence: evidence,
           default_target: default_target, target: str(h, "url"),
           auto_mark: bool_arg(h, "auto", false), marks: fuzz_marks(h), http2: use_h2,
           sources: fuzz_sources(h), processors: fuzz_processors(h),
@@ -286,15 +289,22 @@ module Gori
         end
       end
 
-      private def fuzz_template_source(h) : {String, String?, Bool}
+      # {template text, the seeding flow's target, http2, EVIDENCE?}. The last element is the
+      # provenance bit `Fuzz::PlanOptions#evidence?` documents: a `flow_id` template is a
+      # CAPTURE, a `template` string is a draft the caller typed. `gori run fuzz` has carried
+      # it at its own `--flow` seed since #556; MCP did not, so an agent seeding a sweep from
+      # an OData capture (`$filter`, `$top`) had the run REFUSED for an unbound variable
+      # nobody typed, and a captured bare-LF head was silently promoted to CRLF — the one
+      # thing that makes every desync result from the sweep unreadable.
+      private def fuzz_template_source(h) : {String, String?, Bool, Bool}
         if t = str(h, "template")
-          return {t, nil, false} unless t.strip.empty?
+          return {t, nil, false, false} unless t.strip.empty?
         end
         if id = int(h, "flow_id")
           detail = store.get_flow(id)
           raise FuzzArgError.new("no flow with id #{id}") unless detail
           built = Repeater::FlowRequest.build(detail)
-          return {String.new(built.bytes).scrub, built.target, built.http2}
+          return {String.new(built.bytes).scrub, built.target, built.http2, true}
         end
         raise FuzzArgError.new("provide a 'template' (raw request with §…§) or a 'flow_id'")
       end
@@ -596,6 +606,12 @@ module Gori
         int(h, "max_redirects").try { |v| cfg.max_redirects = v.clamp(0_i64, 50_i64).to_i }
         cfg.auto_calibrate = bool_arg(h, "auto_calibrate", cfg.auto_calibrate?)
         int(h, "throttle_ms").try { |v| cfg.throttle_ms = v.clamp(0_i64, 600_000_i64).to_i }
+        # `gori run fuzz --verbatim` and `intercept_forward_edit{update_content_length:false}`
+        # both reach this knob; fuzz_start could not, so the whole CL-desync probe class (a
+        # Content-Length shorter or longer than the substituted body, or CL alongside
+        # Transfer-Encoding) was unreachable for an agent — every payload was re-framed to fit
+        # before it went out, which is precisely the observation such a sweep is looking for.
+        cfg.update_content_length = bool_arg(h, "update_content_length", cfg.update_content_length?)
         cfg
       end
     end

--- a/src/gori/mcp/tools/mine.cr
+++ b/src/gori/mcp/tools/mine.cr
@@ -94,9 +94,33 @@ module Gori
             j.field "job_complete", mjob.status != :running
             j.field "incomplete_reason", incomplete_reason(mjob.status)
             j.field "error", mjob.error_msg
+            emit_mine_skipped(j, mjob)
             emit_audit(j, mjob.audit, mjob.ended_at_ms)
           end
         end)
+      end
+
+      # Wordlist names this run's locations CANNOT carry, per location, against the wordlist's
+      # own size. The rejection is right (a header/cookie name must be an RFC 7230 token, and
+      # `Content-Length`/`Host` would break framing) but `names_total` sums the FILTERED sizes,
+      # so without this the same wordlist mined "444 names" at the query and "435" at headers
+      # with nothing anywhere to say the other nine were dropped: coverage was incomplete and
+      # the job reported clean. `gori run mine` prints this on stderr; the agent had no route
+      # to the fact at all. Emitted as an ARRAY (empty when nothing was dropped) so a caller
+      # never has to distinguish "no skips" from "this field does not exist".
+      private def emit_mine_skipped(j : JSON::Builder, mjob : MineJob) : Nil
+        engine = mjob.engine
+        j.field "candidate_names", engine.candidate_names
+        j.field "skipped" do
+          j.array do
+            engine.skipped_names.each do |(loc, n)|
+              j.object do
+                j.field "location", loc.label
+                j.field "names", n
+              end
+            end
+          end
+        end
       end
 
       private def mine_results(h) : Result
@@ -151,7 +175,7 @@ module Gori
       # Build a ready-to-run mining engine + its origin + name count. Raises FuzzArgError
       # (clean message) on malformed input. Reuses the fuzz timeout helper.
       private def build_mine_job(h, ob : Outbound) : {Miner::Engine, Fuzz::Origin, Int64}
-        text, default_target, src_h2 = mine_template_source(h)
+        text, default_target, src_h2, evidence = mine_template_source(h)
         config = Miner::Config.new
         config.concurrency = clamp(int(h, "concurrency"), 10, MINE_MAX_CONCURRENCY)
         config.rps = int(h, "rate").try(&.to_f64)
@@ -162,6 +186,9 @@ module Gori
         config.user_wordlist = str(h, "wordlist").presence
         int(h, "throttle_ms").try { |v| config.throttle_ms = v.clamp(0_i64, 600_000_i64).to_i }
         options = Miner::PlanOptions.new(text,
+          # A `flow_id` template is CAPTURED evidence; a `template` string is the caller's
+          # draft. See `Miner::PlanOptions#evidence?`.
+          evidence: evidence,
           default_target: default_target, target: str(h, "url"),
           http2: bool_arg(h, "http2", false) || src_h2,
           locations: mine_locations(h), bucket: mine_bucket(h), config: config,
@@ -204,15 +231,19 @@ module Gori
       # http2}. The target is handed over raw too: expanding it here as well as in the plan
       # builder was a double pass, so a var whose value contained a token resolved one level
       # deeper on MCP than on the CLI.
-      private def mine_template_source(h) : {String, String?, Bool}
+      # The 4th element is PROVENANCE (`Miner::PlanOptions#evidence?`): a `flow_id` template is
+      # a CAPTURE, a `template` string is a draft. `gori run mine --flow` has carried it since
+      # #556 and MCP did not, so an agent mining a captured OData request had the run refused
+      # for a `$filter` nobody typed, and a bare-LF captured head was promoted to CRLF.
+      private def mine_template_source(h) : {String, String?, Bool, Bool}
         if t = str(h, "template")
-          return {t, nil, false} unless t.strip.empty?
+          return {t, nil, false, false} unless t.strip.empty?
         end
         if id = int(h, "flow_id")
           detail = store.get_flow(id)
           raise FuzzArgError.new("no flow with id #{id}") unless detail
           built = Repeater::FlowRequest.build(detail)
-          return {String.new(built.bytes), built.target, built.http2}
+          return {String.new(built.bytes), built.target, built.http2, true}
         end
         raise FuzzArgError.new("provide a 'template' (raw request) or a 'flow_id'")
       end

--- a/src/gori/mcp/tools/minimize.cr
+++ b/src/gori/mcp/tools/minimize.cr
@@ -56,10 +56,23 @@ module Gori
         auto_cl = !verbatim && rec.auto_content_length?
         # Mirrors the TUI/CLI resolve: env-expand, then Content-Length resync only when
         # Auto-CL is on (the same gate that lets body params be removed at all). `verbatim`
-        # drops the whole draft pass — no `$VAR` substitution and no bare-LF→CRLF promotion —
-        # exactly as `--verbatim`/`expand_request: false` does on the send path.
+        # drops the whole draft pass — no `$VAR` substitution and no `$`-refusal — exactly as
+        # `--verbatim`/`expand_request: false` does on the send path.
+        #
+        # It does NOT drop the head's line terminators, which is what `t.to_slice` used to do:
+        # `Minimize.run` hands this proc its head-LF working form, so a CRLF-stored session
+        # went on the wire bare-LF — verbatim INVENTING the very desync primitive the flag
+        # exists to preserve. `gori run repeater minimize --verbatim` fixed this on its side
+        # in #556; this is the same restore, through the engine's own (idempotent) helper, so
+        # the report's already-CRLF text round-trips through it unchanged. The BODY is byte
+        # for byte either way — `restore_eol` is head-only.
+        stored_crlf = Repeater::Minimize.head_crlf?(text)
         resolve = ->(t : String) do
-          raw = verbatim ? t.to_slice : Env.expand_wire(t)
+          raw = if verbatim
+                  stored_crlf ? Repeater::Minimize.restore_eol(t, true).to_slice : t.to_slice
+                else
+                  Env.expand_wire(t)
+                end
           auto_cl ? Repeater::FlowRequest.resync_content_length(raw) : raw
         end
         # Minimize dials Fuzz::Sender directly (many capped probe sends) rather than through

--- a/src/gori/mcp/tools/sequence.cr
+++ b/src/gori/mcp/tools/sequence.cr
@@ -144,7 +144,7 @@ module Gori
       # Normalize the tool args into `Sequencer::PlanOptions` and let the shared builder
       # assemble the run. Raises FuzzArgError (clean message) on any malformed input.
       private def build_sequence_plan(h, ob : Outbound) : Sequencer::Plan
-        bytes, default_target, src_h2 = sequence_request_source(h)
+        bytes, default_target, src_h2, evidence = sequence_request_source(h)
         config = Sequencer::Config.new(mode: Sequencer::Mode::LiveReplay,
           token_loc: sequence_token_loc(h), goal: clamp(int(h, "count"), 500, SEQUENCE_MAX_GOAL),
           concurrency: clamp(int(h, "concurrency"), 1, SEQUENCE_MAX_CONCURRENCY))
@@ -157,6 +157,9 @@ module Gori
         # The builder's sender carries the Outbound decision, so Sandbox / EXCLUDE hard-block
         # a collection run per send — sequence_start used to have only the job-start check.
         options = Sequencer::PlanOptions.new(bytes, default_target: default_target,
+          # A `flow_id` request is CAPTURED evidence; a `template` string is the caller's
+          # draft. See `Sequencer::PlanOptions#evidence?`.
+          evidence: evidence,
           target: str(h, "url"), http2: bool_arg(h, "http2", false) || src_h2, config: config,
           verify: !bool_arg(h, "insecure", false) && @verify_upstream,
           # SNI independent of the Host header is the vhost-confusion / domain-fronting test,
@@ -191,15 +194,19 @@ module Gori
       # {raw request bytes, the seeding flow's target, http2} for a collection. Deliberately
       # UNEXPANDED — `Sequencer::Plan.build` owns `Env.expand`, and expanding here as well
       # would resolve a var whose value itself contains a `$TOKEN` twice.
-      private def sequence_request_source(h) : {Bytes, String?, Bool}
+      # The 4th element is PROVENANCE (`Sequencer::PlanOptions#evidence?`): a `flow_id` request
+      # is a CAPTURE, a `template` string is a draft. `gori run sequence --flow` has carried it
+      # since #556 and MCP did not, so a token-randomness sweep seeded from a captured login
+      # was refused for a `$` in the capture, or ran against a head silently re-terminated.
+      private def sequence_request_source(h) : {Bytes, String?, Bool, Bool}
         if t = str(h, "template")
-          return {t.to_slice, nil, false} unless t.strip.empty?
+          return {t.to_slice, nil, false, false} unless t.strip.empty?
         end
         if id = int(h, "flow_id")
           detail = store.get_flow(id)
           raise FuzzArgError.new("no flow with id #{id}") unless detail
           built = Repeater::FlowRequest.build(detail)
-          return {built.bytes, built.target, built.http2}
+          return {built.bytes, built.target, built.http2, true}
         end
         raise FuzzArgError.new("provide a 'template' (raw request) or a 'flow_id'")
       end

--- a/src/gori/proxy/h2/assembler.cr
+++ b/src/gori/proxy/h2/assembler.cr
@@ -84,8 +84,15 @@ module Gori::Proxy::H2
       # The stream whose PUSH_PROMISE invented this request, when the client never sent it.
       # A pushed flow was indistinguishable in History / QL / the Sitemap from one the client
       # made — the origin authoring rows in an operator's evidence — so the projection says so
-      # (`HeadCodec::PUSHED_MARKER`).
+      # (`HeadCodec::PUSHED_MARKER`, plus the `advisory` below, which is the half a reader who
+      # is NOT looking at the head text can see).
       property pushed_by : UInt32? = nil
+      # What gori has to say about this exchange that its bytes cannot — see
+      # `Store::FlowRow#advisory`. Accumulated here rather than passed straight through
+      # because the producers run at different moments (a request-direction advisory before
+      # `emit_request`, a response-direction one before `emit_response`) and the stream is
+      # the only thing that spans both.
+      getter advisories = [] of String
     end
 
     def initialize(@sink : FlowSink, @host : String, @port : Int32, @created_at : Int64,
@@ -129,6 +136,29 @@ module Gori::Proxy::H2
     # `Int64?`.
     def flow_id_of(stream_id : UInt32) : Int64?
       @mutex.synchronize { @streams[stream_id]?.try(&.flow_id) }
+    end
+
+    # Record one advisory against `stream_id`'s flow — something gori DID to this message (or
+    # structurally could not do to it) that neither the stored bytes nor `flows.error` can
+    # show. See `Store::FlowRow#advisory`.
+    #
+    # Called from `HeadRewrite`, which runs BEFORE the frame reaches `feed`, so the stream may
+    # not be tracked yet: this opens the entry the way `feed_locked` does, under the same
+    # MAX_LIVE_STREAMS ceiling (past it nothing is tracked and the advisory is dropped along
+    # with the projection it would have annotated — the raw frame log stays the truth, P7).
+    # De-duplicated because a per-message fact must not repeat when a message's head block is
+    # revisited, while it MUST still be recorded for every message — unlike the once-per-
+    # connection `::Log.warn` beside it, which is why they are separate statements.
+    def note_advisory(stream_id : UInt32, text : String) : Nil
+      return if stream_id == 0 || text.empty?
+      @mutex.synchronize do
+        stream = @streams[stream_id]?
+        if stream.nil?
+          next if @streams.size >= MAX_LIVE_STREAMS
+          stream = @streams[stream_id] = Stream.new
+        end
+        stream.advisories << text unless stream.advisories.includes?(text)
+      end
     end
 
     # A stream the operator DROPPED at the intercept gate, or one abandoned while held. Its
@@ -322,6 +352,11 @@ module Gori::Proxy::H2
       promised.req.headers = pre ? (pre.fields || raise Gori::Error.new("h2 push block failed to decode")) : decoder.decode(block)
       promised.req.ended = true
       promised.pushed_by = frame.stream_id
+      # As DATA on the flow row, not only as the `X-Gori-Pushed` line inside the projected
+      # head: History, QL, the Sitemap and every JSON feed read the row, and a row the ORIGIN
+      # authored must not be indistinguishable there from one the client sent.
+      promised.advisories << "server push: this request was invented by the origin in a " \
+                             "PUSH_PROMISE on stream #{frame.stream_id} — the client never sent it"
       emit_request(promised_id, promised)
     end
 
@@ -399,7 +434,8 @@ module Gori::Proxy::H2
         created_at: @created_at, scheme: scheme, host: host, port: port,
         method: method, target: path, http_version: "HTTP/2", head: head, body: body,
         body_truncated: cap.truncated?, body_size: cap.total,
-        h2_conn_id: @conn_id, h2_stream_id: stream_id.to_i64)
+        h2_conn_id: @conn_id, h2_stream_id: stream_id.to_i64,
+        advisory: advisory_of(stream))
       stream.flow_id = @sink.on_request(captured)
     end
 
@@ -421,7 +457,16 @@ module Gori::Proxy::H2
         flow_id: flow_id, status: status, head: head, body: body,
         body_truncated: cap.truncated?, body_size: cap.total,
         content_type: content_type, content_encoding: content_encoding, state: state, error: error,
-        ttfb_us: ttfb_us, duration_us: duration_us))
+        ttfb_us: ttfb_us, duration_us: duration_us, advisory: advisory_of(stream)))
+    end
+
+    # The stream's advisories as one newline-joined column value, or nil when there are none.
+    #
+    # The FULL accumulated set every time, request-side entries included: `update_one` writes
+    # the column outright (nil leaves it alone), so a response-direction advisory that carried
+    # only its own line would erase what `emit_request` already stored.
+    private def advisory_of(stream : Stream) : String?
+      stream.advisories.empty? ? nil : stream.advisories.join('\n')
     end
 
     # Flush a stream that ended abnormally (RST_STREAM or the connection closed at a

--- a/src/gori/proxy/h2/head_rewrite.cr
+++ b/src/gori/proxy/h2/head_rewrite.cr
@@ -407,6 +407,7 @@ module Gori::Proxy::H2
       # `parse_*` refuses it anyway; checking here keeps the rules from running for nothing
       # and, more to the point, keeps the log from blaming a rule for the peer's bytes.
       if reason = HeadCodec.h1_unfaithful_reason(fields, request)
+        note_skipped(stream_id, reason)
         return warn_unfaithful(stream_id, request, reason)
       end
       # The BARE host, because that is what a rule's host glob is written against and what
@@ -451,6 +452,20 @@ module Gori::Proxy::H2
         "h2 #{@direction}: #{source} produced a head that is no longer parseable " \
         "(stream #{stream_id}) — forwarded the original head unchanged"
       end
+    end
+
+    # The same refusal as `warn_unfaithful`, recorded AGAINST THE FLOW instead of only in the
+    # log — `Store::FlowRow#advisory`, the HTTP twin of the `[gori] …` rows a WebSocket flow
+    # gets. The log line is once per direction per connection (a flood would be useless); this
+    # is once per MESSAGE, because "did my rule run on THIS request?" is a per-message
+    # question and the operator asking it is reading History, not tailing `gori.log`. Reached
+    # only with a head rule live, which is what makes the skip a fact worth recording; with no
+    # rules there is nothing that failed to fire.
+    private def note_skipped(stream_id : UInt32, reason : String) : Nil
+      @assembler.note_advisory(stream_id,
+        "Match&Replace was NOT applied to this #{@direction == "out" ? "request" : "response"} " \
+        "head: it has no HTTP/1.1 text form (#{reason}). The fields went out exactly as they " \
+        "arrived, and an intercept edit to it would be refused for the same reason (#517)")
     end
 
     # The mirror of `warn_unparseable` for a head the PEER sent that the h1 text cannot carry

--- a/src/gori/repeater/minimize.cr
+++ b/src/gori/repeater/minimize.cr
@@ -1,5 +1,6 @@
 require "json"
 require "./engine"
+require "../env"
 require "../fuzz/engine"
 require "../fuzz/matcher"
 require "../miner/inject"
@@ -104,8 +105,17 @@ module Gori::Repeater
       # enumerated. The same session minimized further from the TUI than from `gori run
       # repeater minimize` on identical bytes. Normalise once here so the file's stated
       # assumption is actually true, and put the operator's line endings back on the way out.
-      crlf = base_text.includes?("\r\n")
-      base_text = base_text.gsub("\r\n", "\n") if crlf
+      #
+      # HEAD ONLY, both ways. In a header block a 0x0A is a line ending; in a BODY it is a
+      # byte, and the round-trip used to run over the whole request: `\r\n`→`\n` on the way in
+      # flattened a multipart body's CRLF boundaries, and `restore_eol`'s blanket `\n`→`\r\n`
+      # on the way out promoted a body's bare LF, so a captured body ending in one came back
+      # a byte longer in `minimized_text` — i.e. in `minimized_request`, in `minimized_source`,
+      # and in what `--apply` STORES over the session. The CLI's send path patched that for
+      # the bytes it sent and printed; leaving the body untouched end to end fixes the stored
+      # form too, and is the rule every other site on this branch now follows.
+      crlf = head_crlf?(base_text)
+      base_text = normalize_head_lf(base_text) if crlf
       candidates = candidates_for(base_text, auto_cl: auto_cl)
       return Report.new(restore_eol(base_text, crlf), [] of Removed, 0, false, "already minimal — nothing removable") if candidates.empty?
 
@@ -150,10 +160,47 @@ module Gori::Repeater
       Report.new(restore_eol(working, crlf), removed, sends, false, summary_note(removed, sends))
     end
 
-    # Put CRLF back on a report built from LF-normalised text. After the normalisation above
-    # there is no lone CR left, so this is exact.
-    private def self.restore_eol(text : String, crlf : Bool) : String
-      crlf ? text.gsub("\n", "\r\n") : text
+    # Put CRLF back on the HEAD of a report built from head-LF-normalised text, leaving the
+    # BODY byte for byte as it arrived. Split on `Env.head_body_boundary` — the same boundary,
+    # and for the same reason, as `Env.expand_wire` and `gori run intercept edit`.
+    #
+    # Public, and IDEMPOTENT (`Env.normalize_crlf` never produces `\r\r\n`), because a
+    # `--verbatim` resolver has to apply the same restoration to the two different forms
+    # `run` hands it: the LF-headed working text during the search, and this method's own
+    # already-CRLF output when a surface re-resolves the finished report.
+    def self.restore_eol(text : String, crlf : Bool) : String
+      return text unless crlf
+      bytes = text.to_slice
+      boundary = Env.head_body_boundary(bytes)
+      head = Env.normalize_crlf(bytes[0, boundary])
+      return String.new(head) if boundary >= bytes.size
+      body = bytes[boundary..]
+      io = IO::Memory.new(head.size + body.size)
+      io.write(head)
+      io.write(body)
+      String.new(io.to_slice)
+    end
+
+    # Does the HEAD carry CRLF terminators? Head only, for `restore_eol`'s reason: a lone
+    # 0x0D 0x0A inside a multipart body says nothing about how the header lines were written,
+    # and treating it as if it did would re-terminate an LF head the operator wrote. Public
+    # so a surface's `--verbatim` resolver asks the SAME question `run` asked.
+    def self.head_crlf?(text : String) : Bool
+      bytes = text.to_slice
+      String.new(bytes[0, Env.head_body_boundary(bytes)]).includes?("\r\n")
+    end
+
+    # `\r\n` → `\n` over the HEAD alone, body copied through byte for byte.
+    private def self.normalize_head_lf(text : String) : String
+      bytes = text.to_slice
+      boundary = Env.head_body_boundary(bytes)
+      head = String.new(bytes[0, boundary]).gsub("\r\n", "\n")
+      return head if boundary >= bytes.size
+      body = bytes[boundary..]
+      io = IO::Memory.new(head.bytesize + body.size)
+      io << head
+      io.write(body)
+      String.new(io.to_slice)
     end
 
     # ── candidate enumeration ──────────────────────────────────────────────────────────

--- a/src/gori/store.cr
+++ b/src/gori/store.cr
@@ -749,15 +749,15 @@ module Gori
         INSERT INTO flows
           (created_at, scheme, host, port, method, target, http_version,
            sni, alpn, tls_version, request_head, request_body, request_size, state,
-           h2_conn_id, h2_stream_id, request_body_truncated, unsent, short_circuited, fts_dirty)
-        VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,1)
+           h2_conn_id, h2_stream_id, request_body_truncated, unsent, short_circuited, advisory, fts_dirty)
+        VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,1)
         SQL
         req.created_at, req.scheme, req.host, req.port, req.method, req.target,
         req.http_version, req.sni, req.alpn, req.tls_version,
         req.head, req.body,
         req.head.size.to_i64 + body_size,
         FlowState::Pending.value, req.h2_conn_id, req.h2_stream_id,
-        req.body_truncated? ? 1 : 0, unsent ? 1 : 0, req.short_circuited? ? 1 : 0)
+        req.body_truncated? ? 1 : 0, unsent ? 1 : 0, req.short_circuited? ? 1 : 0, req.advisory)
       # The INSERT's own result carries the rowid — no separate `SELECT last_insert_rowid()`.
       # No flows_fts write here: `fts_dirty = 1` hands the trigram work to the off-commit
       # indexer, so a capture commit no longer pays for tokenization (see V4 / await_op).
@@ -776,13 +776,17 @@ module Gori
           response_head = ?, response_body = ?, status = ?, reason = ?,
           content_type = ?, response_size = ?, state = ?,
           ttfb_us = ?, duration_us = ?, error = ?, response_body_truncated = ?,
+          -- nil means "the response side has nothing to add", NOT "clear it": the request
+          -- side may already have written an advisory on this row and a bare `advisory = ?`
+          -- would erase it. COALESCE keeps whatever is stored when the DTO carries nothing.
+          advisory = COALESCE(?, advisory),
           fts_dirty = 1
         WHERE id = ?
         SQL
         resp.head, resp.body, resp.status, resp.reason, resp.content_type,
         response_size,
         resp.state.value, resp.ttfb_us, resp.duration_us, resp.error,
-        resp.body_truncated? ? 1 : 0, resp.flow_id)
+        resp.body_truncated? ? 1 : 0, resp.advisory, resp.flow_id)
       # `fts_dirty = 1` again: the response side just appeared (or changed), so whatever the
       # indexer wrote for this row is stale. Re-dirtying an already-dirty row is a no-op, so
       # the common case — response landing before the indexer ever reached the row — is
@@ -969,9 +973,10 @@ module Gori
       duration_us = rs.read(Int64?)
       content_type = rs.read(String?)
       short_circuited = rs.read(Int32) != 0
+      advisory = rs.read(String?)
       FlowRow.new(id, created_at, scheme, method, host, port, target,
         status, req_size + (resp_size || 0_i64), state, resp_size, duration_us, content_type,
-        short_circuited)
+        short_circuited, advisory)
     end
 
     # Column order MUST match EVENT_COLS.

--- a/src/gori/store/intercept_bridge.cr
+++ b/src/gori/store/intercept_bridge.cr
@@ -22,8 +22,9 @@ module Gori
           placeholders = Array.new(rows.size, "?").join(",")
           c.exec("DELETE FROM intercept_held WHERE session_token = ? AND item_id NOT IN (#{placeholders})", args: keep)
           rows.each do |r|
-            c.exec("INSERT OR IGNORE INTO intercept_held (session_token, item_id, kind, method, host, port, scheme, target, flow_id, raw, held_at_ms, edited) VALUES (?,?,?,?,?,?,?,?,?,?,?,?)",
-              token, r.item_id, r.kind, r.method, r.host, r.port, r.scheme, r.target, r.flow_id, r.raw, r.held_at_ms, r.edited ? 1 : 0)
+            c.exec("INSERT OR IGNORE INTO intercept_held (session_token, item_id, kind, method, host, port, scheme, target, flow_id, raw, held_at_ms, edited, edit_refusal, head_only) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+              token, r.item_id, r.kind, r.method, r.host, r.port, r.scheme, r.target, r.flow_id, r.raw, r.held_at_ms, r.edited ? 1 : 0,
+              r.edit_refusal, r.head_only? ? 1 : 0)
           end
         end
         nil
@@ -32,7 +33,7 @@ module Gori
 
     def intercept_held(token : String) : Array(HeldRow)
       rows = [] of HeldRow
-      @db.query("SELECT session_token, item_id, kind, method, host, port, scheme, target, flow_id, raw, held_at_ms, edited, viewed_ms FROM intercept_held WHERE session_token = ? ORDER BY item_id", token) do |rs|
+      @db.query("SELECT session_token, item_id, kind, method, host, port, scheme, target, flow_id, raw, held_at_ms, edited, viewed_ms, edit_refusal, head_only FROM intercept_held WHERE session_token = ? ORDER BY item_id", token) do |rs|
         rs.each { rows << read_held(rs) }
       end
       rows
@@ -57,7 +58,9 @@ module Gori
       scheme = rs.read(String); target = rs.read(String); flow_id = rs.read(Int64?)
       raw = rs.read(Bytes); held_at_ms = rs.read(Int64); edited = rs.read(Int32) != 0
       viewed_ms = rs.read(Int64)
-      HeldRow.new(token, item_id, kind, method, host, port, scheme, target, raw, held_at_ms, flow_id, edited, viewed_ms)
+      edit_refusal = rs.read(String?); head_only = rs.read(Int32) != 0
+      HeldRow.new(token, item_id, kind, method, host, port, scheme, target, raw, held_at_ms, flow_id, edited, viewed_ms,
+        edit_refusal, head_only)
     end
 
     # Append one MCP->TUI intercept command. Returns last_insert_rowid (0 on a dropped write —

--- a/src/gori/store/models.cr
+++ b/src/gori/store/models.cr
@@ -930,16 +930,17 @@ module Gori
                      @edit_refusal = nil, @head_only = false)
       end
 
-      # Why an EDIT to this held message will be refused, or nil when it will be applied.
-      # The read-side twin of `Interceptor::Item#refuse_edit`, minus the bytes: a surface
-      # asks this to warn BEFORE the operator writes an edit, and `Item#refuse_edit` is what
-      # actually decides when the edited bytes exist.
-      def edit_warning : String?
-        return @edit_refusal if @edit_refusal
+      # The head-only CAVEAT, and deliberately NOT folded into `edit_refusal`.
+      #
+      # Every h2 hold is head-only (`H2::StreamGate` passes `head_only: true` on both legs),
+      # so treating it as a refusal would mark every held HTTP/2 message uneditable — and head
+      # edits DO apply. Only a body has nowhere to go. Two different statements, so two
+      # accessors: a surface that chips "cannot be edited" must key on `edit_refusal` alone.
+      # nil when the hold covers head+body (h1), where an edit is forwarded byte-exact.
+      def head_only_note : String?
         return nil unless @head_only
-        "this HTTP/2 hold covers the HEAD only — a body added by an edit has nowhere to go " \
-        "(DATA frames stream past the intercept gate untouched), so an edit that adds one " \
-        "will be refused"
+        "this HTTP/2 hold covers the HEAD only — an edit that ADDS A BODY will be refused " \
+        "(DATA frames stream past the intercept gate untouched); a head edit applies normally"
       end
     end
 

--- a/src/gori/store/models.cr
+++ b/src/gori/store/models.cr
@@ -1,4 +1,5 @@
 require "../ascii_bytes"
+require "../url"
 require "../token_extract"
 require "../proxy/ws/frame"
 
@@ -37,12 +38,15 @@ module Gori
       # dialed (#511). Carried on the request DTO because the proxy decides it before the
       # response exists; `Store#insert_one` persists it to `flows.short_circuited`.
       getter? short_circuited : Bool
+      # What gori has to SAY about this flow that its bytes cannot — see `FlowRow#advisory`.
+      getter advisory : String?
 
       def initialize(@created_at, @scheme, @host, @port, @method, @target,
                      @http_version, @head, @body = nil,
                      @sni = nil, @alpn = nil, @tls_version = nil,
                      @body_truncated = false, @body_size = nil,
-                     @h2_conn_id = nil, @h2_stream_id = nil, @short_circuited = false)
+                     @h2_conn_id = nil, @h2_stream_id = nil, @short_circuited = false,
+                     @advisory = nil)
       end
     end
 
@@ -64,11 +68,16 @@ module Gori
       getter duration_us : Int64?
       getter state : FlowState
       getter error : String?
+      # See `FlowRow#advisory`. nil means "nothing new to say", which is NOT the same as ""
+      # — a response-side advisory has to be able to leave the request side's alone, so
+      # `Store#update_one` only writes the column when this is non-nil.
+      getter advisory : String?
 
       def initialize(@flow_id, @status, @head, @body = nil, @reason = nil,
                      @content_type = nil, @ttfb_us = nil, @duration_us = nil,
                      @state = FlowState::Complete, @error = nil,
-                     @body_truncated = false, @body_size = nil, @content_encoding = nil)
+                     @body_truncated = false, @body_size = nil, @content_encoding = nil,
+                     @advisory = nil)
       end
     end
 
@@ -92,10 +101,35 @@ module Gori
       # dialed (#511). In the LIST projection, not just the detail, because the whole point
       # is that a fabricated response must not look like an ordinary row while scrolling.
       getter? short_circuited : Bool
+      # What gori has to say about this flow that neither its bytes nor its `error` can.
+      #
+      # A WebSocket flow has had this since #518: `WS::Relay` writes `[gori] …` rows into
+      # `ws_messages`, so "the handshake's `Sec-WebSocket-Extensions` was stripped" or "the
+      # §5.4 interleave was given up" travels with the flow into History, `gori run show`,
+      # MCP `get_flow` and an export. An HTTP flow had nowhere to put the same kind of
+      # statement, so two facts gori KNOWS ended up as a `gori.log`/STDERR line correlated
+      # with nothing (a Match&Replace rule that structurally could not run on this message)
+      # or as a header synthesized into the stored request head (a server PUSH_PROMISE).
+      #
+      # A COLUMN and not a rows table, unlike the WebSocket case, because the two differ in
+      # what the record is about: a `ws_messages` advisory is positioned IN a stream of
+      # messages and its position names the frames it applies to, while an HTTP advisory is
+      # a property of the exchange as a whole. A join on every History page for a value that
+      # is NULL on all but a handful of rows buys nothing; `error` is the same shape and the
+      # surfaces already know how to read a nullable flow-level string.
+      #
+      # Newline-separated when more than one applies (request- and response-direction
+      # advisories can land on one flow). NULL — not "" — when there is nothing to say.
+      getter advisory : String?
 
       def initialize(@id, @created_at, @scheme, @method, @host, @port, @target,
                      @status, @size, @state, @response_size = nil, @duration_us = nil,
-                     @content_type = nil, @short_circuited = false)
+                     @content_type = nil, @short_circuited = false, @advisory = nil)
+      end
+
+      # The advisory as a list of statements, empty when there is none.
+      def advisories : Array(String)
+        @advisory.try { |a| a.split('\n').reject(&.empty?) } || [] of String
       end
 
       # True when `target` already carries its own scheme+authority — an ABSOLUTE-FORM
@@ -111,13 +145,15 @@ module Gori
       # raise reached `Outbound.scope_url` inside a worker fiber and killed the whole sweep,
       # unhandled, the first time a payload carried a high byte. A URI scheme is ASCII by
       # definition, so nothing about the check needed a Regex.
+      # The rule itself moved to core `Gori::Url` (three other surfaces spell it out and one
+      # of them, `Interceptor::Item`, cannot require the store); this stays as the name its
+      # existing callers — `Scope.request_url`, `Outbound`, `CLI::Output` — already use.
       def self.absolute_form?(target : String) : Bool
-        b = target.to_slice
-        AsciiBytes.starts_with_ci?(b, HTTP_PREFIX) || AsciiBytes.starts_with_ci?(b, HTTPS_PREFIX)
+        Gori::Url.absolute_form?(target)
       end
 
-      HTTP_PREFIX  = "http://".to_slice
-      HTTPS_PREFIX = "https://".to_slice
+      HTTP_PREFIX  = Gori::Url::HTTP_PREFIX
+      HTTPS_PREFIX = Gori::Url::HTTPS_PREFIX
 
       # The full absolute URL of the request. Plaintext forward-proxy requests are captured
       # ABSOLUTE-form (`http://host:port/path` — the wire truth, P7), so `target` already
@@ -877,9 +913,33 @@ module Gori
       # Wall-clock of the last MCP intercept_list/get that returned this item — the agent's
       # "I'm still watching" signal for the auto-forward reaper (0 = never viewed by an agent).
       getter viewed_ms : Int64
+      # Mirrors `Interceptor::Item#edit_refusal` / `#head_only?` across the process boundary.
+      #
+      # Both are known the moment the message is HELD (on HTTP/2 the answer is
+      # `HeadCodec.h1_unfaithful_reason`, a pure function of the block's decoded fields), and
+      # without them on this row `gori run intercept get`/`list` and MCP `intercept_get`
+      # showed an ordinary editable message. An operator — or an agent — then composed an
+      # edit, submitted it, and only THEN learned it could never be applied. That is the
+      # state a CRLF-injection probe INDUCES: reflect `%0d%0a` into one header value and
+      # every later message on that stream is in it.
+      getter edit_refusal : String?
+      getter? head_only : Bool
 
       def initialize(@session_token, @item_id, @kind, @method, @host, @port, @scheme,
-                     @target, @raw, @held_at_ms, @flow_id = nil, @edited = false, @viewed_ms = 0_i64)
+                     @target, @raw, @held_at_ms, @flow_id = nil, @edited = false, @viewed_ms = 0_i64,
+                     @edit_refusal = nil, @head_only = false)
+      end
+
+      # Why an EDIT to this held message will be refused, or nil when it will be applied.
+      # The read-side twin of `Interceptor::Item#refuse_edit`, minus the bytes: a surface
+      # asks this to warn BEFORE the operator writes an edit, and `Item#refuse_edit` is what
+      # actually decides when the edited bytes exist.
+      def edit_warning : String?
+        return @edit_refusal if @edit_refusal
+        return nil unless @head_only
+        "this HTTP/2 hold covers the HEAD only — a body added by an edit has nowhere to go " \
+        "(DATA frames stream past the intercept gate untouched), so an edit that adds one " \
+        "will be refused"
       end
     end
 

--- a/src/gori/store/reads.cr
+++ b/src/gori/store/reads.cr
@@ -7,7 +7,7 @@ module Gori
     SELECT_ROW = <<-SQL
       SELECT id, created_at, scheme, method, host, port, target, status,
              request_size, response_size, state, duration_us, content_type,
-             short_circuited
+             short_circuited, advisory
       FROM flows
       SQL
 
@@ -136,7 +136,7 @@ module Gori
         @db.query(<<-SQL, max, max, id) do |rs|
           SELECT id, created_at, scheme, method, host, port, target, status,
                  request_size, response_size, state, duration_us, content_type,
-                 short_circuited,
+                 short_circuited, advisory,
                  http_version, request_head,
                  CASE WHEN request_body IS NULL THEN NULL ELSE substr(request_body, 1, ?) END,
                  response_head,
@@ -151,7 +151,7 @@ module Gori
         @db.query(<<-SQL, id) do |rs|
           SELECT id, created_at, scheme, method, host, port, target, status,
                  request_size, response_size, state, duration_us, content_type,
-                 short_circuited,
+                 short_circuited, advisory,
                  http_version, request_head, request_body, response_head, response_body,
                  h2_conn_id, h2_stream_id, request_body_truncated, response_body_truncated, error,
                  sni

--- a/src/gori/store/schema.cr
+++ b/src/gori/store/schema.cr
@@ -686,7 +686,34 @@ module Gori
         "ALTER TABLE repeaters ADD COLUMN ws_keep_key INTEGER NOT NULL DEFAULT 0",
       ]
 
-      MIGRATIONS = [V1, V2, V3, V4, V5, V6, V7]
+      # Two facts gori knew and could not SAY as data.
+      #
+      # `flows.advisory` — see `Store::FlowRow#advisory` for what it is and why it is a
+      # column rather than a rows table. It gives an HTTP flow what a WebSocket flow has had
+      # since #518 (the `[gori] …` rows `WS::Relay` writes into `ws_messages`): somewhere to
+      # record what gori did to a message that the message's own bytes cannot show. Its two
+      # first tenants both used to escape as a log line or a fabricated header — a
+      # Match&Replace head rule that structurally could not run on an h2 message with no
+      # HTTP/1.1 text form (a WARN on `gori run capture`'s STDERR, correlated with no flow),
+      # and a server PUSH_PROMISE (a synthesized `X-Gori-Pushed` line readable only by
+      # someone already looking at the head text). NULL on every existing row, which is the
+      # truth for them: gori recorded no advisory before this migration.
+      #
+      # `intercept_held.edit_refusal` / `.head_only` mirror the two facts
+      # `Interceptor::Item` has carried since #517/R3-F1 across the #123 bridge, so the MCP
+      # process and `gori run intercept get`/`list` can say "edits cannot be applied to this
+      # message: …" BEFORE the operator writes one. `intercept_held` is a per-session
+      # snapshot mirror that `clear_intercept_state!` wipes, so nothing has to be
+      # back-filled — but it is a released table, so the columns still arrive as a
+      # migration. `head_only` defaults 0: an h1 hold covers head+body, and every row a
+      # pre-V8 gori wrote came from a build whose h2 gate had not been written yet.
+      V8 = [
+        "ALTER TABLE flows ADD COLUMN advisory TEXT",
+        "ALTER TABLE intercept_held ADD COLUMN edit_refusal TEXT",
+        "ALTER TABLE intercept_held ADD COLUMN head_only INTEGER NOT NULL DEFAULT 0",
+      ]
+
+      MIGRATIONS = [V1, V2, V3, V4, V5, V6, V7, V8]
 
       def self.migrate!(db : DB::Database) : Nil
         db.using_connection do |conn|

--- a/src/gori/tui/controllers/discover_controller.cr
+++ b/src/gori/tui/controllers/discover_controller.cr
@@ -196,6 +196,17 @@ module Gori::Tui
     # dial the real DNS answer while `gori run discover` pinned it.
     private def build_engine(run : DiscoverRun) : {Discover::Engine?, String?}
       session = @host.session
+      # The realistic half of the header check, and the one the overlay cannot make: the
+      # line the operator typed is fine and the ENV VAR is not (`Authorization: Bearer
+      # $TOKEN` where TOKEN was read from a file and kept its trailing newline). It has to
+      # run HERE — after the project's env is hydrated, before any traffic — because
+      # `Headers.expand`'s send-time backstop drops the header on every probe without a
+      # word, and by then the crawl is already running. `Headers.unsafe_expanded` had
+      # exactly one caller in the tree (`gori run discover`); this is the second.
+      if unsafe = Discover::Headers.unsafe_expanded(run.config.headers).first?
+        return {nil, "header #{unsafe.inspect} rejected — its value contains CR or LF after " \
+                     "$VAR expansion, which would splice extra headers into every probe"}
+      end
       options = Discover::PlanOptions.new(run.target, config: run.config,
         verify: !session.config.insecure_upstream?, overrides: session.host_overrides)
       {Discover::Plan.build(options, Gori::Outbound.interactive(session.scope)).engine, nil}
@@ -265,8 +276,19 @@ module Gori::Tui
         run.sent = ev.progress.sent
         run.found = ev.progress.found
         run.errors = ev.progress.errors
+        run.queued = ev.progress.queued
         run.stats = ev.stats
-        run.status = ev.stopped ? :stopped : :done
+        # A sweep that stopped on its BUDGET is not the same sweep as one that finished, and
+        # `:done` over an unfinished crawl reads as "that is the whole surface". The engine
+        # already says which (`Discover::DoneEvent#budget_exhausted` — discover has no stable
+        # denominator a consumer could derive it from); this was the one consumer ignoring it.
+        run.status = if ev.stopped
+                       :stopped
+                     elsif ev.budget_exhausted
+                       :budget_exhausted
+                     else
+                       :done
+                     end
         finish_job(run, ev)
       when Discover::ErrorEvent
         run.status = :error
@@ -282,7 +304,14 @@ module Gori::Tui
     private def finish_job(run : DiscoverRun, ev : Discover::DoneEvent) : Nil
       n = run.findings.size
       @host.jobs.finish(run.job_id, :done, "#{n} found")
-      msg = "Discover: #{n} endpoint#{n == 1 ? "" : "s"} on #{run.target}#{ev.stopped ? " (stopped)" : ""}"
+      tail = if ev.stopped
+               " (stopped)"
+             elsif ev.budget_exhausted
+               " — budget exhausted, #{ev.progress.queued} queued unexplored (raise max requests to finish)"
+             else
+               ""
+             end
+      msg = "Discover: #{n} endpoint#{n == 1 ? "" : "s"} on #{run.target}#{tail}"
       level = n > 0 ? :success : :info
       log_event(run, level, msg)
       push_notification(run, level, msg)

--- a/src/gori/tui/controllers/fuzzer_controller.cr
+++ b/src/gori/tui/controllers/fuzzer_controller.cr
@@ -774,6 +774,10 @@ module Gori::Tui
         v.append_result(ev.result)
         probe_scan_fuzz_result(ev.result, v)
       when Fuzz::DoneEvent
+        # The terminal progress is the only one carrying the run's FINAL wire count, and
+        # ProgressEvent is droppable (latest wins) — so without this the header could keep
+        # rendering a mid-run snapshot forever. See `Fuzz::Progress#requests`.
+        v.apply_progress(ev.progress)
         v.finish_run
         finish_job(v, ev)
       when Fuzz::ErrorEvent
@@ -813,7 +817,14 @@ module Gori::Tui
       n = v.matched_count
       @host.jobs.finish(v.job_id, :done, "#{n} hit")
       level = n > 0 ? :success : :info
-      msg = "Fuzzer: #{n} hit#{n == 1 ? "" : "s"} / #{v.result_count} sent on #{v.summary}#{ev.stopped ? " (stopped)" : ""}"
+      # `requests` only when it DIFFERS from the payload count — retries and redirect hops
+      # are the two things that make them diverge, and a run with neither should not grow a
+      # second number saying the same thing twice. This is what the CLI's done line does,
+      # and the number a tester inside an agreed request budget actually needs: a 3-payload
+      # sweep down a redirect chain put 18 requests on the target and said "3 sent".
+      p = ev.progress
+      wire = p.requests > p.sent ? " / #{p.requests} requests" : ""
+      msg = "Fuzzer: #{n} hit#{n == 1 ? "" : "s"} / #{v.result_count} sent#{wire} on #{v.summary}#{ev.stopped ? " (stopped)" : ""}"
       log_event(v, level, msg)
       @host.notifications.push(level, msg, goto_for(v), source: "fuzzer")
       @host.status(msg) if Settings.notify_toast?
@@ -904,7 +915,12 @@ module Gori::Tui
       ensure
         v.finish_run # backstop — the drain's Done also clears it + shows the summary
       end
-      @host.status("fuzzing #{v.target_origin} — ^X stop")
+      # The CL note rides the run-start line, the way `gori run fuzz` prints it on stderr
+      # before the first send: once, up front, naming the switch that turns it off. Silent
+      # rewriting is the half that bites even an operator who does not want the switch —
+      # they typed `Content-Length: 5`, the pane still says 5, and the wire carried 37.
+      note = v.rewrites_content_length? ? " · note: #{FuzzerView::CL_REWRITE_NOTE}" : ""
+      @host.status("fuzzing #{v.target_origin} — ^X stop#{note}")
     end
 
     def fuzz_stop : Nil

--- a/src/gori/tui/controllers/intercept_controller.cr
+++ b/src/gori/tui/controllers/intercept_controller.cr
@@ -342,6 +342,7 @@ module Gori::Tui
       ids = @intercept.target_ids
       return if ids.empty?
       return if refuse_unresolved_env?
+      return if refuse_unappliable_edit?
       ic = @host.session.interceptor
       edit = @intercept.pending_edit
       label = batch_label(ids) # built BEFORE the decisions go out — the items are gone after
@@ -398,9 +399,30 @@ module Gori::Tui
       true
     end
 
+    # Refuse a forward whose pending edit gori would never apply, and say why.
+    #
+    # The CLI/MCP drain has asked `Item#refuse_edit` since R3-F1; this path had not, so the
+    # human got the older behaviour it was written to end — `forwarded GET …` in the status
+    # bar while the settle side (`H2::StreamGate#edited` → `encode_edited || block`) threw the
+    # edit away and the ORIGINAL message went on the wire. Verified against a live h2 origin:
+    # the status bar said forwarded and the origin logged the untouched request.
+    #
+    # The message stays HELD, exactly as it does for the agent path: nothing was decided, so
+    # the operator can forward it as it is, drop it, or write a different edit. And the WHOLE
+    # batch is refused for the same reason `refuse_unresolved_env?` refuses it — reporting
+    # "forwarded 4 held messages" for a set that went out as 3 is the lie being removed.
+    private def refuse_unappliable_edit? : Bool
+      refusal = @intercept.refused_edit
+      return false unless refusal
+      item, reason = refusal
+      @host.status("edit NOT applied to #{item.label} — #{reason}")
+      true
+    end
+
     def intercept_forward_all : Nil
       n = @host.session.interceptor.pending_count
       return if refuse_unresolved_env?
+      return if refuse_unappliable_edit?
       # Carry the currently-loaded item's in-progress edit into the bulk forward, so
       # "forward all" doesn't send its stale original bytes (single-forward already does).
       overrides = @intercept.pending_edit.try { |e| {e[0] => e[1]} }
@@ -487,10 +509,9 @@ module Gori::Tui
     private def intercept_label(it : Interceptor::Item) : String
       method, target = @intercept.effective_method_target(it)
       case it.kind
-      in .request?  then "#{method} #{Url.origin_path(target)}"
-      in .response? then target
-      in .ws_out?   then "WS message → #{it.host}"
-      in .ws_in?    then "WS message ← #{it.host}"
+      in .request?, .response? then it.label(method, target)
+      in .ws_out?              then "WS message → #{it.host}"
+      in .ws_in?               then "WS message ← #{it.host}"
       end
     end
   end

--- a/src/gori/tui/controllers/miner_controller.cr
+++ b/src/gori/tui/controllers/miner_controller.cr
@@ -346,7 +346,12 @@ module Gori::Tui
     # --- start a session (called by the Runner after the config overlay confirms) ---
     def start_session(seed : MineSeed, config : Miner::Config) : Nil
       view = MinerView.new
-      view.load(seed.target, seed.request, seed.http2, seed.sni, config)
+      # `flow_id != nil` IS the provenance test: `build_seed_from_flow` is the only
+      # constructor that sets it, and its bytes come straight from `FlowRequest.build`.
+      # `build_seed_from_request` (the Repeater path) leaves it nil and its bytes are
+      # editor text. Same one-line test `gori run mine` makes on `--flow`.
+      view.load(seed.target, seed.request, seed.http2, seed.sni, config,
+        evidence: !seed.flow_id.nil?)
       open_session(view, seed.flow_id) # NB: NO goto_tab — the job runs in the background
       start_run(view)
     end
@@ -497,7 +502,14 @@ module Gori::Tui
       #                                         engine's trailing DoneEvent must not log/notify success
       n = v.found_count
       @host.jobs.finish(v.job_id, :done, "#{n} found")
-      msg = "Miner: #{n} param#{n == 1 ? "" : "s"} found on #{v.summary}#{ev.stopped ? " (stopped)" : ""}"
+      tail = if ev.stopped
+               " (stopped)"
+             elsif v.budget_exhausted?
+               " — #{v.budget_note}"
+             else
+               ""
+             end
+      msg = "Miner: #{n} param#{n == 1 ? "" : "s"} found on #{v.summary}#{tail}"
       level = n > 0 ? :success : :info
       log_event(v, level, msg)
       push_mine_notification(v, level, msg, found: n)

--- a/src/gori/tui/controllers/sequencer_controller.cr
+++ b/src/gori/tui/controllers/sequencer_controller.cr
@@ -412,7 +412,11 @@ module Gori::Tui
     # --- start / reconfigure sessions (called by the Runner after the overlay confirms) ---
     def start_session(seed : SequenceSeed, config : Sequencer::Config) : Nil
       view = SequencerView.new
-      view.load(seed.target, seed.request, seed.http2, seed.sni, config)
+      # `flow_id != nil` IS the provenance test: `build_seed_from_flow` is the only
+      # constructor that sets it, and its bytes come straight from `FlowRequest.build`.
+      # Same one-line test `gori run sequence` makes on `--flow`.
+      view.load(seed.target, seed.request, seed.http2, seed.sni, config,
+        evidence: !seed.flow_id.nil?)
       open_session(view, seed.flow_id) # NB: NO goto_tab — the collection runs in the background
       start_run(view)
     end
@@ -522,10 +526,15 @@ module Gori::Tui
       case ev
       when Sequencer::SampleEvent then v.append_sample(ev.sample)
       when Sequencer::ProgressEvent
-        v.apply_progress(ev.collected, ev.sent, ev.goal, ev.errors)
+        v.apply_progress(ev.collected, ev.sent, ev.goal, ev.errors, ev.requests)
         denom = ev.goal <= 0 ? ev.collected : ev.goal
         @host.jobs.progress(v.job_id, ev.collected, denom, "#{ev.collected} tokens")
       when Sequencer::DoneEvent
+        # The terminal event carries the run's FINAL counts and ProgressEvent is droppable,
+        # so without this the pane could keep showing a mid-run snapshot. `goal` is not on
+        # DoneEvent — the config's is the one the run was given, and it is what
+        # `budget_exhausted?` compares against.
+        v.apply_progress(ev.collected, ev.sent, v.config.goal, v.errors_count, ev.requests)
         v.finish_run
         finish_job(v, ev)
       when Sequencer::ErrorEvent
@@ -544,7 +553,14 @@ module Gori::Tui
       rep = v.report
       n = rep.usable_count
       @host.jobs.finish(v.job_id, :done, "#{n} · #{rep.rating.label.downcase}")
-      msg = "Sequencer: #{n} token#{n == 1 ? "" : "s"} on #{v.summary} — #{rep.rating.label}#{ev.stopped ? " (stopped)" : ""}"
+      tail = if ev.stopped
+               " (stopped)"
+             elsif v.budget_exhausted?
+               " — #{v.budget_note}"
+             else
+               ""
+             end
+      msg = "Sequencer: #{n} token#{n == 1 ? "" : "s"} on #{v.summary} — #{rep.rating.label}#{tail}"
       level = rep.rating.value <= Sequencer::Stats::Rating::Weak.value ? :warning : :success
       log_event(v, level, msg)
       push_notification(v, level, msg, collected: n)

--- a/src/gori/tui/discover_config_overlay.cr
+++ b/src/gori/tui/discover_config_overlay.cr
@@ -24,17 +24,26 @@ module Gori::Tui
     CONTAINMENTS = [Discover::Containment::ScopeAware, Discover::Containment::SameOrigin, Discover::Containment::HostAndSubdomains]
     COMMON_EXT   = %w(php asp aspx jsp html json txt bak zip)
 
+    # Hard ceiling on REQUESTS the run may put on the target (retries and redirect hops
+    # each charge it — `Fuzz::CappedBackend`, the same counter `--max-requests` and MCP's
+    # `max_requests` are enforced against). nil = uncapped, which is what every TUI run
+    # used to be: there was no way to cap one from the primary surface at all, while
+    # `gori run` and MCP both had the knob. A cycler, not a text field, because this
+    # overlay deliberately has none (no IME plumbing).
+    MAX_REQ_CHOICES = [nil, 100, 250, 500, 1000, 2500, 5000, 10000] of Int32?
+
     ROW_TARGET  =  0
     ROW_SPIDER  =  1
     ROW_BRUTE   =  2
     ROW_DEPTH   =  3
     ROW_CONTAIN =  4
-    ROW_CONC    =  5
-    ROW_EXT     =  6
-    ROW_KEEP    =  7
-    ROW_HEADERS =  8
-    ROW_START   =  9
-    ROWS        = 10
+    ROW_MAXREQ  =  5
+    ROW_CONC    =  6
+    ROW_EXT     =  7
+    ROW_KEEP    =  8
+    ROW_HEADERS =  9
+    ROW_START   = 10
+    ROWS        = 11
 
     getter seed : DiscoverSeed
     # Custom request headers ({name, value}) prefilled from a History flow and/or
@@ -53,6 +62,7 @@ module Gori::Tui
       @depth_idx = DEPTHS.index(4) || 3
       @contain_idx = 0
       @conc_idx = CONCS.index(20) || 1
+      @maxreq_idx = 0
       @ext = false
       @keep_alive = true
       @selected = 0
@@ -162,17 +172,18 @@ module Gori::Tui
       when ROW_TARGET  then @target_idx = (@target_idx + d) % @seed.choices.size
       when ROW_DEPTH   then @depth_idx = (@depth_idx + d) % DEPTHS.size
       when ROW_CONTAIN then @contain_idx = (@contain_idx + d) % CONTAINMENTS.size
+      when ROW_MAXREQ  then @maxreq_idx = (@maxreq_idx + d) % MAX_REQ_CHOICES.size
       when ROW_CONC    then @conc_idx = (@conc_idx + d) % CONCS.size
       end
     end
 
     def toggle : Nil
       case @selected
-      when ROW_SPIDER                                   then @spider = !@spider
-      when ROW_BRUTE                                    then @bruteforce = !@bruteforce
-      when ROW_EXT                                      then @ext = !@ext
-      when ROW_KEEP                                     then @keep_alive = !@keep_alive
-      when ROW_TARGET, ROW_DEPTH, ROW_CONTAIN, ROW_CONC then adjust(1)
+      when ROW_SPIDER                                               then @spider = !@spider
+      when ROW_BRUTE                                                then @bruteforce = !@bruteforce
+      when ROW_EXT                                                  then @ext = !@ext
+      when ROW_KEEP                                                 then @keep_alive = !@keep_alive
+      when ROW_TARGET, ROW_DEPTH, ROW_CONTAIN, ROW_CONC, ROW_MAXREQ then adjust(1)
       end
     end
 
@@ -184,6 +195,7 @@ module Gori::Tui
       Discover::Config.new(
         spider: @spider, bruteforce: @bruteforce,
         max_depth: DEPTHS[@depth_idx], concurrency: CONCS[@conc_idx],
+        max_requests: MAX_REQ_CHOICES[@maxreq_idx].try(&.to_i64),
         containment: CONTAINMENTS[@contain_idx],
         extensions: @ext ? COMMON_EXT.dup : [] of String,
         keep_alive: @keep_alive,
@@ -228,6 +240,7 @@ module Gori::Tui
       when ROW_DEPTH   then cyc(screen, x, py, bg, sel, "max depth:", DEPTHS[@depth_idx].to_s)
       when ROW_CONTAIN then cyc(screen, x, py, bg, sel, "scope:", CONTAINMENTS[@contain_idx].label)
       when ROW_CONC    then cyc(screen, x, py, bg, sel, "concurrency:", CONCS[@conc_idx].to_s)
+      when ROW_MAXREQ  then cyc(screen, x, py, bg, sel, "max requests:", MAX_REQ_CHOICES[@maxreq_idx].try(&.to_s) || "uncapped")
       when ROW_HEADERS then headers_row(screen, x, py, bg, sel)
       else                  start_row(screen, x, py, bg)
       end

--- a/src/gori/tui/discover_headers_overlay.cr
+++ b/src/gori/tui/discover_headers_overlay.cr
@@ -8,22 +8,54 @@ require "../discover"
 module Gori::Tui
   # The custom-headers editor for a Discover run: a plain multi-line text editor,
   # one "Name: Value" per line. Opened from the Discover config popup's headers row;
-  # esc saves (parsing the lines, dropping malformed ones) and returns to the popup.
+  # esc saves the parsed headers and returns to the popup.
   # Host/Connection are always emitted by the engine, so entering them here is a
   # no-op (dropped on parse).
   #
   # A SUB-EDITOR on the Overlay seam (see overlay.cr): it has no cancel path at all, so
   # both esc and click-away commit, and the injected closure writes the parsed headers
   # back onto the Discover popup and re-opens it.
+  #
+  # A line gori will NOT send is a refusal, not a drop. `Headers.parse_lines` used to be
+  # called here with its `rejected` out-collector omitted, so a value carrying CR/LF — a
+  # request-splitting primitive, correctly refused — vanished with no word: the overlay
+  # said `custom headers: 1 set`, 284 probes went out with ZERO carrying `Authorization`,
+  # and the run reported `1 endpoint`. An authenticated sweep that runs unauthenticated
+  # and reports "found nothing" over the whole authenticated surface is the worst way this
+  # can fail, so esc now REFUSES to close while a line is unusable and names it. There is
+  # no trap: deleting or fixing the line always resolves it, and a blank line is not a
+  # header anyone asked for (parse_lines skips those without reporting them).
   class DiscoverHeadersOverlay < Overlay
     def initialize(headers : Array({String, String}))
       text = headers.map { |name, value| "#{name}: #{value}" }.join("\n")
       @editor = TextArea.new(text)
+      @refused = nil.as(String?)
     end
 
-    # Current headers parsed from the editor buffer (invalid/forced lines dropped).
+    # Current headers parsed from the editor buffer.
     def headers : Array({String, String})
       Discover::Headers.parse_lines(@editor.text.split('\n'))
+    end
+
+    # The lines `parse_lines` will not turn into headers, in buffer order.
+    def rejected_lines : Array(String)
+      # NB: not `out` — that is a Crystal keyword and a bare `out` argument is parsed as
+      # an out-parameter declaration, not as this local.
+      rejected = [] of String
+      Discover::Headers.parse_lines(@editor.text.split('\n'), rejected)
+      rejected
+    end
+
+    # The refusal to render, or nil when every non-blank line is a usable header.
+    # Recomputed on every commit attempt, so fixing the line clears it.
+    def refusal : String?
+      first = rejected_lines.first?
+      return nil unless first
+      name = first.partition(':')[0].strip
+      name = first.strip if name.empty?
+      name = "#{name[0, 39]}…" if name.size > 40
+      "#{name.inspect} will not be sent — a header value may not contain CR or LF, " \
+      "and a name must be an RFC 7230 token. Fix or delete the line."
     end
 
     # --- Overlay contract (see overlay.cr) ---
@@ -43,14 +75,14 @@ module Gori::Tui
     # click outside the card saves exactly like esc, which is what the shell did before.
     def handle_click(area : Rect, mx : Int32, my : Int32) : Symbol
       box = overlay_box(area)
-      (box.nil? || !box.contains?(mx, my)) ? :commit : :stay
+      (box.nil? || !box.contains?(mx, my)) ? try_commit : :stay
     end
 
     # esc = save & close (:commit); every other key edits the buffer (:stay).
     def handle_key(ev : Termisu::Event::Key) : Symbol
       key = ev.key
       case
-      when key.escape? then return :commit
+      when key.escape? then return try_commit
       when key.up?     then @editor.move(-1, 0)
       when key.down?   then @editor.move(1, 0)
       else                  edit(ev)
@@ -58,8 +90,18 @@ module Gori::Tui
       :stay
     end
 
+    # Close only when every non-blank line is a header gori will actually put on the wire;
+    # otherwise stay open with the refusal on the hint row.
+    private def try_commit : Symbol
+      @refused = refusal
+      @refused ? :stay : :commit
+    end
+
     # ⏎ inserts a new header line; the rest are the usual TextArea editing/caret keys.
+    # Any edit retracts a standing refusal — it is re-derived on the next commit attempt,
+    # so the red line can never outlive the line it was about.
     private def edit(ev : Termisu::Event::Key) : Nil
+      @refused = nil
       key = ev.key
       case
       when key.enter?     then @editor.insert_newline
@@ -104,7 +146,11 @@ module Gori::Tui
       else
         @editor.render(screen, editor, cursor: true)
       end
-      screen.text(box.x + 2, hintline, "one per line · Host/Connection ignored · esc saves & closes", Theme.muted, Theme.bg, width: box.w - 4)
+      if refused = @refused
+        screen.text(box.x + 2, hintline, refused, Theme.red, Theme.bg, width: box.w - 4)
+      else
+        screen.text(box.x + 2, hintline, "one per line · Host/Connection ignored · esc saves & closes", Theme.muted, Theme.bg, width: box.w - 4)
+      end
     end
   end
 end

--- a/src/gori/tui/discover_view.cr
+++ b/src/gori/tui/discover_view.cr
@@ -12,7 +12,12 @@ module Gori::Tui
     getter config : Discover::Config
     property id : Int32 = 0
     property job_id : Int32 = 0
-    property status : Symbol = :idle # :idle | :running | :paused | :done | :stopped | :error
+    # :idle | :running | :paused | :done | :budget_exhausted | :stopped | :error.
+    # `:budget_exhausted` is its own state, not a flavour of :done: a crawl that ran out of
+    # `max_requests` left `queued` candidates it never looked at, and rendering that as
+    # "done" is what let `5 found` stand for a 283-candidate wordlist of which 275 were
+    # never sent.
+    property status : Symbol = :idle
     getter findings = [] of Discover::Finding
     property stats : Discover::RunStats? = nil
     property sent = 0_i64
@@ -30,6 +35,11 @@ module Gori::Tui
 
     def running? : Bool
       @status == :running || @status == :paused
+    end
+
+    # True when a cap halted the crawl with candidates still in the frontier.
+    def budget_exhausted? : Bool
+      @status == :budget_exhausted
     end
 
     def paused? : Bool
@@ -181,12 +191,17 @@ module Gori::Tui
       screen.text(x, y, hdr, Theme.text_bright, Theme.bg, Attribute::Bold, width: rect.w - 4)
       y += 1
       if y < rect.bottom - 1
-        screen.text(x, y, "#{r.techniques} · #{r.config.containment.label} · depth #{r.config.max_depth}",
+        cap = r.config.max_requests.try { |m| " · cap #{m}" } || ""
+        screen.text(x, y, "#{r.techniques} · #{r.config.containment.label} · depth #{r.config.max_depth}#{cap}",
           Theme.muted, Theme.bg, width: rect.w - 4)
       end
       y += 1
       if y < rect.bottom - 1
-        st = r.status == :error ? "error: #{r.error_msg}" : r.status.to_s
+        st = case r.status
+             when :error            then "error: #{r.error_msg}"
+             when :budget_exhausted then "budget exhausted · #{r.queued} queued unexplored — raise max requests to finish"
+             else                        r.status.to_s
+             end
         screen.text(x, y, st, status_hue(r.status), Theme.bg, width: rect.w - 4)
       end
       y += 1
@@ -203,11 +218,12 @@ module Gori::Tui
 
     private def status_hue(s : Symbol) : Color
       case s
-      when :running then Theme.accent
-      when :paused  then Theme.yellow
-      when :error   then Theme.red
-      when :stopped then Theme.muted
-      else               Theme.green
+      when :running          then Theme.accent
+      when :paused           then Theme.yellow
+      when :error            then Theme.red
+      when :budget_exhausted then Theme.yellow
+      when :stopped          then Theme.muted
+      else                        Theme.green
       end
     end
 
@@ -218,7 +234,17 @@ module Gori::Tui
       inner = rect.inset(1, 1)
       return unless r
       if r.findings.empty?
-        msg = r.running? ? "discovering… endpoints appear here" : (r.stats ? "no endpoints found" : "no run yet — ^R to run")
+        # "no endpoints found" over a crawl that stopped on its budget is the claim this
+        # tab must never make — it did not look.
+        msg = if r.running?
+                "discovering… endpoints appear here"
+              elsif r.budget_exhausted?
+                "none found in the #{r.sent} requests the budget allowed — #{r.queued} candidates unexplored"
+              elsif r.stats
+                "no endpoints found"
+              else
+                "no run yet — ^R to run"
+              end
         screen.text(inner.x + 1, inner.y, msg, Theme.muted, Theme.bg)
         return
       end

--- a/src/gori/tui/fuzz_advanced_overlay.cr
+++ b/src/gori/tui/fuzz_advanced_overlay.cr
@@ -11,7 +11,8 @@ module Gori::Tui
   # strings (compiled by the view's commit_buffers at build/persist time, unchanged).
   record AdvancedSnapshot,
     conc : String, rate : String, timeout : String, retries : String,
-    follow : Bool, calibrate : Bool, keep_alive : Bool,
+    max_requests : String,
+    follow : Bool, calibrate : Bool, keep_alive : Bool, update_cl : Bool,
     m_status : String, m_size : String, m_words : String, m_regex : String,
     f_status : String, f_size : String, f_words : String, f_regex : String
 
@@ -29,9 +30,19 @@ module Gori::Tui
       {:rate, "Rate (rps)", :text},
       {:timeout, "Timeout (s)", :text},
       {:retries, "Retries", :text},
+      # The TRUE wire count is what this caps (retries + redirect hops each charge it) —
+      # `Fuzz::CappedBackend`, the same counter `--max-requests` and MCP's `max_requests`
+      # are enforced against. Blank = no cap, which is what every TUI run used to be.
+      {:max_requests, "Max requests", :text},
       {:follow, "Follow redirects", :toggle},
       {:calibrate, "Auto-calibrate", :toggle},
       {:keep_alive, "Keep-alive", :toggle},
+      # The Repeater's ^L / `--verbatim` and Intercept's `update_content_length:false` by
+      # the same name and for the same reason: a CL / CL-TE desync template IS the payload,
+      # and recomputing its Content-Length sweeps a different request than the one written.
+      # ON is the old (and right) default for an ordinary sweep whose payload changed the
+      # body length; OFF sends the header exactly as the template declares it.
+      {:update_cl, "Auto Content-Length", :toggle},
       {:m_status, "Match status", :text},
       {:m_size, "Match size", :text},
       {:m_words, "Match words", :text},
@@ -41,7 +52,7 @@ module Gori::Tui
       {:f_words, "Filter words", :text},
       {:f_regex, "Filter regex", :text},
     ]
-    LABEL_W = 18 # value column offset (widest label "Follow redirects" + padding)
+    LABEL_W = 21 # value column offset (widest label "Auto Content-Length" + padding)
 
     def initialize(snap : AdvancedSnapshot)
       @sel = 0
@@ -49,19 +60,21 @@ module Gori::Tui
       @follow = snap.follow
       @calibrate = snap.calibrate
       @keep_alive = snap.keep_alive
+      @update_cl = snap.update_cl
       @fields = {
-        :conc     => TextField.new(snap.conc),
-        :rate     => TextField.new(snap.rate),
-        :timeout  => TextField.new(snap.timeout),
-        :retries  => TextField.new(snap.retries),
-        :m_status => TextField.new(snap.m_status),
-        :m_size   => TextField.new(snap.m_size),
-        :m_words  => TextField.new(snap.m_words),
-        :m_regex  => TextField.new(snap.m_regex),
-        :f_status => TextField.new(snap.f_status),
-        :f_size   => TextField.new(snap.f_size),
-        :f_words  => TextField.new(snap.f_words),
-        :f_regex  => TextField.new(snap.f_regex),
+        :conc         => TextField.new(snap.conc),
+        :rate         => TextField.new(snap.rate),
+        :timeout      => TextField.new(snap.timeout),
+        :retries      => TextField.new(snap.retries),
+        :max_requests => TextField.new(snap.max_requests),
+        :m_status     => TextField.new(snap.m_status),
+        :m_size       => TextField.new(snap.m_size),
+        :m_words      => TextField.new(snap.m_words),
+        :m_regex      => TextField.new(snap.m_regex),
+        :f_status     => TextField.new(snap.f_status),
+        :f_size       => TextField.new(snap.f_size),
+        :f_words      => TextField.new(snap.f_words),
+        :f_regex      => TextField.new(snap.f_regex),
       }
     end
 
@@ -126,6 +139,7 @@ module Gori::Tui
       when :follow     then @follow = !@follow
       when :calibrate  then @calibrate = !@calibrate
       when :keep_alive then @keep_alive = !@keep_alive
+      when :update_cl  then @update_cl = !@update_cl
       end
     end
 
@@ -143,7 +157,9 @@ module Gori::Tui
       AdvancedSnapshot.new(
         conc: @fields[:conc].value, rate: @fields[:rate].value,
         timeout: @fields[:timeout].value, retries: @fields[:retries].value,
+        max_requests: @fields[:max_requests].value,
         follow: @follow, calibrate: @calibrate, keep_alive: @keep_alive,
+        update_cl: @update_cl,
         m_status: @fields[:m_status].value, m_size: @fields[:m_size].value,
         m_words: @fields[:m_words].value, m_regex: @fields[:m_regex].value,
         f_status: @fields[:f_status].value, f_size: @fields[:f_size].value,
@@ -152,7 +168,7 @@ module Gori::Tui
 
     # --- rendering ----------------------------------------------------------
     def overlay_box(area : Rect) : Rect?
-      w = {area.w - 6, 56}.min
+      w = {area.w - 6, 60}.min
       h = {area.h - 4, ROWS.size + 4}.min
       return nil if w < 30 || h < 8
       Rect.new(area.x + (area.w - w) // 2, area.y + (area.h - h) // 2, w, h)
@@ -189,6 +205,7 @@ module Gori::Tui
         on = case key
              when :follow     then @follow
              when :keep_alive then @keep_alive
+             when :update_cl  then @update_cl
              else                  @calibrate
              end
         screen.text(vx, y, on ? "‹ on ›" : "‹ off ›", foc ? Theme.text_bright : Theme.text, bg)

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -58,6 +58,11 @@ module Gori::Tui
     getter? loaded : Bool
     getter? dirty : Bool
     getter? running : Bool
+    # PROVENANCE: this template's bytes came out of a CAPTURED FLOW (⇧I from History /
+    # Sitemap / Issues evidence), not a request the operator drafted here. Feeds
+    # `Fuzz::PlanOptions#evidence?` — see `evidence_template` for what it turns off and
+    # why an operator edit does NOT clear it.
+    getter? evidence : Bool
     property name : String?
     property job_id : Int32 # bottom-bar/notification job handle (0 = no active job)
     getter config : Fuzz::Config
@@ -71,6 +76,7 @@ module Gori::Tui
       @tcx = 0
       @sni = ""
       @http2 = false
+      @evidence = false
       @editor = TextArea.new
       @editor.gutter = true
       @editor.follow_x = true     # long lines (headers, URLs, §-marked params) scroll horizontally to keep the cursor visible
@@ -89,6 +95,7 @@ module Gori::Tui
       @s_rate = ""   # buffers, committed to @config at build/persist time (so a field can be cleared)
       @s_timeout = ""
       @s_retries = "0"
+      @s_max_req = ""
       @s_m_regex = "" # regex fields buffered as source strings, compiled on commit
       @s_f_regex = ""
       # Memoized "Run · N requests" count, recomputed only when the config signature
@@ -108,6 +115,11 @@ module Gori::Tui
       # not whatever the CONFIG pane says now.
       @run_policy = nil.as({Bool, Bool, Symbol}?)
       @pending_policy = nil.as({Bool, Bool, Symbol}?)
+      # `Fuzz::Plan#rewrites_content_length?` as of the last plan build, plus the
+      # `@editor.edits` revision it was computed at — an edit to the template invalidates
+      # the answer, and a stale "your CL is being rewritten" is worse than none.
+      @cl_rewrite = false
+      @cl_rewrite_rev = -1
       @sel = 0
       @scroll = 0
       @sort = :index
@@ -198,12 +210,15 @@ module Gori::Tui
     end
 
     # --- loading -------------------------------------------------------------
+    # ⇧I: a CAPTURED flow becomes this session's template. `evidence` is set here and
+    # nowhere else, because this is the only loader whose bytes came off the wire.
     def load(detail : Store::FlowDetail) : Nil
       built = Repeater::FlowRequest.build(detail)
       @http2 = built.http2
       @target = built.target
       @tcx = @target.size
       @editor.set_text(String.new(built.bytes).scrub)
+      @evidence = true
       @focus = :template
       @loaded = true
       @dirty = false
@@ -215,6 +230,9 @@ module Gori::Tui
       @http2 = http2
       @sni = sni
       @editor.set_text(request_text)
+      # A Repeater/reconstruction seed and ^N are DRAFTS: the operator authored (or gori
+      # rebuilt) those bytes, so a `$KEY` in them is a variable reference they meant.
+      @evidence = false
       @focus = :template
       @loaded = true
       @dirty = false
@@ -235,6 +253,11 @@ module Gori::Tui
       @http2 = rec.http2?
       @sni = rec.sni || ""
       @editor.set_text(rec.template)
+      # Provenance has to survive a restart, or a reopened capture silently becomes a
+      # draft again. `flow_id` is what `insert_fuzz_session` already stored for the ⇧I
+      # path and nothing else sets it — the same one-line test the CLI's `fuzz_source`
+      # makes on `--flow`.
+      @evidence = !rec.flow_id.nil?
       @name = rec.name
       apply_config_json(rec.config)
       @last_synced_config = rec.config
@@ -257,6 +280,7 @@ module Gori::Tui
       # form now, so a normalized compare would be blind to a pure line-ending edit — which
       # is a real edit on a message — while an exact one is never falsely unequal.
       @editor.set_text(rec.template) if @editor.wire_text != rec.template
+      @evidence = !rec.flow_id.nil? # see restore
       @name = rec.name
       apply_config_json(rec.config)
       @last_synced_config = rec.config
@@ -280,6 +304,11 @@ module Gori::Tui
     # Does not copy run results, job state, or source flow linkage.
     def duplicate_from(src : FuzzerView) : Nil
       load_request(src.target, src.template_text, src.http2?, src.sni_override || "")
+      # `load_request` cleared it; a content clone carries the SAME bytes, so it carries
+      # the same provenance. (The clone has no `flow_id` row of its own, so `restore`
+      # will read it back as a draft after a restart — that is the store's linkage, not
+      # a claim about these bytes, and erring toward "draft" for a copy is the safe way.)
+      @evidence = src.evidence?
       apply_config_json(src.config_json)
       @name = SubtabClone.copy_name(src.name)
       @dirty = true
@@ -860,8 +889,9 @@ module Gori::Tui
     def advanced_snapshot : AdvancedSnapshot
       AdvancedSnapshot.new(
         conc: @s_conc, rate: @s_rate, timeout: @s_timeout, retries: @s_retries,
+        max_requests: @s_max_req,
         follow: @config.follow_redirects?, calibrate: @config.auto_calibrate?,
-        keep_alive: @config.keep_alive?,
+        keep_alive: @config.keep_alive?, update_cl: @config.update_content_length?,
         m_status: @matcher.match_status || "", m_size: @matcher.match_size || "",
         m_words: @matcher.match_words || "", m_regex: @s_m_regex,
         f_status: @matcher.filter_status || "", f_size: @matcher.filter_size || "",
@@ -875,10 +905,12 @@ module Gori::Tui
       @s_rate = s.rate
       @s_timeout = s.timeout
       @s_retries = s.retries
+      @s_max_req = s.max_requests
       @config.follow_redirects = s.follow
       @config.auto_calibrate = s.calibrate
       @matcher.auto_calibrate = s.calibrate
       @config.keep_alive = s.keep_alive
+      @config.update_content_length = s.update_cl
       @matcher.match_status = blank_nil(s.m_status)
       @matcher.match_size = blank_nil(s.m_size)
       @matcher.match_words = blank_nil(s.m_words)
@@ -966,6 +998,9 @@ module Gori::Tui
       @config.rps = @s_rate.to_f?.try { |r| r > 0 ? r : nil }
       @config.timeout = @s_timeout.to_i?.try { |t| t > 0 ? t.seconds : nil }
       @config.retries = (@s_retries.to_i? || 0).clamp(0, 1000)
+      # Blank / unparsable / <= 0 all mean "no cap" — the same reading `--max-requests`
+      # and MCP give an absent key, so clearing the field really does remove the ceiling.
+      @config.max_requests = @s_max_req.to_i64?.try { |n| n > 0 ? n : nil }
       @matcher.match_regex = @s_m_regex.empty? ? nil : (Regex.new(@s_m_regex) rescue nil)
       @matcher.filter_regex = @s_f_regex.empty? ? nil : (Regex.new(@s_f_regex) rescue nil)
     end
@@ -975,6 +1010,7 @@ module Gori::Tui
       @s_rate = @config.rps.try(&.to_s) || ""
       @s_timeout = @config.timeout.try(&.total_seconds.to_i.to_s) || ""
       @s_retries = @config.retries.to_s
+      @s_max_req = @config.max_requests.try(&.to_s) || ""
       @s_m_regex = @matcher.match_regex.try(&.source) || ""
       @s_f_regex = @matcher.filter_regex.try(&.source) || ""
     end
@@ -1013,7 +1049,8 @@ module Gori::Tui
       # `Plan.build`'s `Env.expand_wire` still promotes the HEAD to CRLF, and it is idempotent
       # on a head that already carries CRLF (`Env.normalize_crlf` only inserts a CR before an
       # LF that has none), so a wire-form template changes nothing downstream.
-      options = Fuzz::PlanOptions.new(@editor.wire_text, target: @target, http2: @http2,
+      options = Fuzz::PlanOptions.new(evidence_template, evidence: @evidence,
+        target: @target, http2: @http2,
         sources: @sets.map { |s| build_source(s) }, config: @config, matcher: @matcher,
         verify: verify, sni: sni_override, overrides: overrides)
       plan = Fuzz::Plan.build(options, Gori::Outbound.interactive(scope))
@@ -1023,11 +1060,62 @@ module Gori::Tui
       # name the retention THIS run used — not what the CONFIG pane says after a post-run edit.
       @pending_policy = {@config.update_content_length?, @config.add_content_length_when_missing?,
                          @matcher.keep_bodies}
+      # The template declares a Content-Length that disagrees with its own body BEFORE any
+      # payload is substituted — so the auto-resync is about to rewrite framing the operator
+      # authored deliberately, on every variation, and the sweep would report a clean
+      # CL-desync run that never put a CL desync on the wire. `gori run fuzz` says this once
+      # up front and names `--verbatim`; this is the same fact pointed at the toggle.
+      @cl_rewrite = plan.rewrites_content_length?
+      @cl_rewrite_rev = @editor.edits
       {plan.engine, nil}
     rescue ex : Fuzz::PlanError
       {nil, fuzz_plan_error(ex)}
     rescue ex
       {nil, "config error: #{ex.message}"}
+    end
+
+    # The template bytes handed to `Plan.build`, with ONE editor-owed fixup applied for an
+    # EVIDENCE session.
+    #
+    # `Fuzz::PlanOptions#evidence?` turns off two draft-time passes at once, and only one of
+    # them is right for a tab that has an editor in it:
+    #
+    #   * the unresolved-`$KEY` refusal and `$KEY` SUBSTITUTION — off, and that is the whole
+    #     point. A capture's `$filter`/`$top`/`$where`/`$IFS`/`$user.name` are bytes the
+    #     origin sent, not variables anybody typed. With them on, a captured OData request
+    #     was refused outright, and the refusal's own remedy ("set the variable") rewrote the
+    #     PARAMETER NAMES on the wire (`?PWNED=aa&99=10`) while the TEMPLATE pane still read
+    #     `$filter=§…§` and the screen said `6 hits / 6 sent`.
+    #   * the head's LF→CRLF promotion — which `expand_wire` did, and which this editor still
+    #     OWES the wire. `TextArea#insert_newline` gives a line the user typed `DEFAULT_EOL`
+    #     ("\n") and documents `expand_wire` as what promotes it back; without that, adding
+    #     one header to a seeded capture would put a bare LF in the head — itself a
+    #     front-end/back-end desync primitive, i.e. a different test than the one on screen.
+    #     So the view runs the head-only normalization itself. It is idempotent on a head
+    #     that already carries CRLF (`Env.normalize_crlf` only inserts a CR before an LF that
+    #     has none), the body is copied through byte-for-byte, and no `$` is touched.
+    #
+    # Provenance is about where the bytes CAME FROM, so an operator edit does not clear it:
+    # ^A/^K only insert §/¦ within a line (`restore_wire_eols` keeps every terminator), and
+    # dropping evidence on the first keystroke would put the substitution back on the most
+    # common workflow there is — seed a capture, tweak a header, mark, run.
+    #
+    # The one thing given up: an IMPORTED flow whose head is bare-LF terminated is promoted
+    # here rather than replayed. gori's proxy refuses to capture such a head at all (P7), so
+    # it is not reachable through the proxy; `gori run repeater --verbatim` is the byte-exact
+    # route for one.
+    private def evidence_template : String
+      text = @editor.wire_text
+      return text unless @evidence
+      bytes = text.to_slice
+      boundary = Env.head_body_boundary(bytes)
+      head = Env.normalize_crlf(bytes[0...boundary])
+      return String.new(head) if boundary >= bytes.size
+      body = bytes[boundary..]
+      buf = IO::Memory.new(head.size + body.size)
+      buf.write(head)
+      buf.write(body)
+      String.new(buf.to_slice)
     end
 
     # The Fuzzer tab's wording for a plan this view's state can't produce. The builder
@@ -1044,6 +1132,20 @@ module Gori::Tui
         "unresolved env #{ex.detail} — add it in the Project tab's ENV pane"
       end
     end
+
+    # True when the LAST plan built off this exact template buffer was going to recompute a
+    # Content-Length the operator wrote by hand. Scoped to `@editor.edits` so a template
+    # edit retracts the claim rather than leaving a stale one on screen.
+    def rewrites_content_length? : Bool
+      @cl_rewrite && @editor.edits == @cl_rewrite_rev
+    end
+
+    # `gori run fuzz`'s sentence for the same fact, with this surface's remedy in place of
+    # `--verbatim`. A constant so the controller's run-start line and any future consumer
+    # cannot drift from each other about what the run is doing.
+    CL_REWRITE_NOTE = "the template's Content-Length disagrees with its own body and is " \
+                      "being recomputed on every request — turn off ^O ▸ Advanced ▸ " \
+                      "Auto Content-Length to send it as written"
 
     # Whether the run targets HTTP/2 — for Probe's synthetic RepeaterRecord (see
     # FuzzerController#probe_scan_fuzz_result), which needs to know the protocol
@@ -1460,9 +1562,11 @@ module Gori::Tui
           j.field "throttle_ms", @config.throttle_ms
           j.field "timeout_s", @config.timeout.try(&.total_seconds.to_i)
           j.field "retries", @config.retries
+          j.field "max_requests", @config.max_requests
           j.field "follow", @config.follow_redirects?
           j.field "calibrate", @config.auto_calibrate?
           j.field "keep_alive", @config.keep_alive?
+          j.field "update_cl", @config.update_content_length?
           j.field("sets") { j.array { @sets.each { |s| j.object { j.field "kind", s.kind.to_s; j.field "value", s.value } } } }
           j.field "match_status", @matcher.match_status
           j.field "filter_status", @matcher.filter_status
@@ -1488,11 +1592,15 @@ module Gori::Tui
       @config.throttle_ms = obj["throttle_ms"]?.try(&.as_i?)
       obj["timeout_s"]?.try(&.as_i?).try { |s| @config.timeout = s.seconds }
       obj["retries"]?.try(&.as_i?).try { |n| @config.retries = n }
+      @config.max_requests = obj["max_requests"]?.try(&.as_i64?)
       @config.follow_redirects = obj["follow"]?.try(&.as_bool?) || false
       @config.auto_calibrate = obj["calibrate"]?.try(&.as_bool?) || false
       # A session persisted before this key existed reads as nil ⇒ keep the ctor default
       # (on). `|| false` here would silently turn keep-alive off for every saved tab.
       @config.keep_alive = obj["keep_alive"]?.try(&.as_bool?) != false
+      # Same nil-means-default reading as keep_alive above: a session saved before this
+      # key existed must keep the ctor default (on), not silently start sending desyncs.
+      @config.update_content_length = obj["update_cl"]?.try(&.as_bool?) != false
       apply_sets_json(obj["sets"]?)
       @matcher.match_status = obj["match_status"]?.try(&.as_s?)
       @matcher.filter_status = obj["filter_status"]?.try(&.as_s?)
@@ -1843,8 +1951,16 @@ module Gori::Tui
         else
           "↳ run size unknown"
         end
+      # The two things a run's SIZE now depends on besides the payload sets: the wire cap
+      # (retries + redirect hops charge it, so it is not the same number as the estimate
+      # above) and whether the framing the operator authored is about to be rewritten.
+      cl = rewrites_content_length?
+      if cap = @config.max_requests
+        text += "#{text.empty? ? "↳" : " ·"} cap #{Fmt.count(cap)}"
+      end
+      text += "#{text.empty? ? "↳" : " ·"} CL recomputed" if cl
       return if text.empty?
-      screen.text(inner.x, y, text, Theme.muted, Theme.bg, width: {inner.w, 1}.max)
+      screen.text(inner.x, y, text, cl ? Theme.yellow : Theme.muted, Theme.bg, width: {inner.w, 1}.max)
     end
 
     # One Sets row. In per-position modes (pp) it carries a marker-coloured swatch + →N
@@ -1882,17 +1998,37 @@ module Gori::Tui
       end
     end
 
+    # The RESULTS border's live count. ONE definition because `results_chrome_hit` has to
+    # measure exactly the string `render_results` drew, or the badge hit-boxes shift.
+    #
+    # `requests` — the TRUE number of requests this run put on the target — is shown only
+    # when it exceeds the payload count, which is precisely when retries or redirect hops
+    # made them diverge. It used to be absent entirely: the header read the number of
+    # RESULT ROWS, so a 3-payload sweep with `Follow redirects` on against a redirect chain
+    # said `3 sent` for 18 requests at the origin, and `Retries 2` against a dead host said
+    # `2 sent` for 3. For a tester inside an agreed request budget, or against anything that
+    # rate-limits or alerts on volume, that is the number that matters, and the engine has
+    # always published it (`Fuzz::Progress#requests`).
+    # Public so a spec can assert on the exact string the border draws — the whole defect
+    # was a header reporting a different number from the one on the wire.
+    def results_count_label : String
+      p = @progress
+      req = p ? p.requests : 0_i64
+      if @running
+        extra = req > (p ? p.sent : 0_i64) ? " · #{req} req" : ""
+        "running #{p ? p.sent : 0}/#{@run_total || "?"}#{extra} · #{matched_count} hit"
+      else
+        extra = req > result_count ? " · #{req} requests" : ""
+        "#{result_count} sent#{extra} · #{matched_count} hit"
+      end
+    end
+
     private def render_results(screen : Screen, rect : Rect, focused : Bool) : Nil
       return if rect.w < 2 || rect.h < 2
       Frame.card(screen, rect, "RESULTS", bg: Theme.bg, border: Frame.pane_border(focused))
       # Left: the live count. Right: keyed toggle badges (sort value · matched · dist) so
       # each results toggle's shortcut rides the border, not just the bottom hint bar.
-      count = if @running
-                p = @progress
-                "running #{p ? p.sent : 0}/#{@run_total || "?"} · #{matched_count} hit"
-              else
-                "#{result_count} sent · #{matched_count} hit"
-              end
+      count = results_count_label
       screen.text(rect.x + 11, rect.y, count, Theme.muted, Theme.bg) # +11 clears the " RESULTS " title
       min_x = rect.x + 11 + count.size + 1                           # badges never overwrite the count
       rx = Frame.toggle_badge(screen, rect.right - 1, rect.y, min_x, "v", "DIST", @show_dist)
@@ -2419,13 +2555,7 @@ module Gori::Tui
     def results_chrome_hit(rect : Rect, mx : Int32, my : Int32) : Symbol?
       return nil unless pane = results_rect(rect)
       return nil if pane.w < 2 || my != pane.y
-      count = if @running
-                p = @progress
-                "running #{p ? p.sent : 0}/#{@run_total || "?"} · #{matched_count} hit"
-              else
-                "#{result_count} sent · #{matched_count} hit"
-              end
-      min_x = pane.x + 11 + count.size + 1
+      min_x = pane.x + 11 + results_count_label.size + 1
       Frame.right_badge_hit(mx, my, pane.y, pane.right - 1, min_x, [
         {:dist, "v", "DIST"},
         {:match, "m", "MATCH"},

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -2170,6 +2170,17 @@ module Gori::Tui
         trailer << Highlight::Line.new
         trailer << [Highlight::Span.new("— body truncated at capture limit (#{Settings.effective_capture_max_mib} MiB); full size in the list —", Theme.yellow)]
       end
+      # What gori has to say about this exchange that its bytes cannot (`FlowRow#advisory`).
+      # In the TRAILER, beside the truncation notice, and not spliced into the head: this is
+      # gori's sentence, and the panes above it are the wire's bytes (P7). Only on the
+      # REQUEST pane — an advisory is a property of the exchange, so printing it under both
+      # would read as two different findings.
+      if request
+        detail.row.advisories.each do |a|
+          trailer << Highlight::Line.new
+          trailer << [Highlight::Span.new("! #{a}", Theme.yellow)]
+        end
+      end
 
       # gRPC: bounded framed hex view — style eagerly into `head`. Flagged binary so the
       # reveal-whitespace path is gated off (like any other binary body): a gRPC body is

--- a/src/gori/tui/intercept_view.cr
+++ b/src/gori/tui/intercept_view.cr
@@ -435,6 +435,26 @@ module Gori::Tui
       {id, Fuzz::ContentLength.sync(raw, add_when_missing: true)}
     end
 
+    # Why gori would REFUSE the current pending edit, or nil when it would apply it.
+    #
+    # A QUERY beside `pending_edit`, the same shape as `unresolved_env` and for the same
+    # reason: the editor keeps showing what the operator typed, and only the FORWARD consults
+    # this. `Item#refuse_edit` is the single definition of the answer — the CLI/MCP drain
+    # (`Runner#apply_intercept_command`) has asked it since R3-F1, and this path did not, so a
+    # human editing an h2 message whose head has no HTTP/1.1 text form got `forwarded …` in
+    # the status bar while the ORIGINAL request went on the wire byte for byte.
+    #
+    # Nil when the editor is clean: an unedited forward is byte-exact, so there is no edit to
+    # refuse — inspecting a held message must never make it unforwardable.
+    def refused_edit : {Interceptor::Item, String}?
+      edit = pending_edit
+      return nil unless edit
+      item = item_by_id(edit[0])
+      return nil unless item
+      reason = item.refuse_edit(edit[1])
+      reason ? {item, reason} : nil
+    end
+
     # Whether a forward recomputes `Content-Length` from the edited body (Burp's "Update
     # Content-Length"; default on).
     #
@@ -891,13 +911,17 @@ module Gori::Tui
     # item); a WebSocket message shows the socket it rides on plus a preview of the payload,
     # because the handshake identity is shared by every message on that socket and the
     # payload is the only thing that tells two rows apart.
+    # `Item#label` composes the HTTP kinds — the ONE definition of "host + an overloaded
+    # target", which as three separate copies produced `POST 127.0.0.1200 OK` (reads as HTTP
+    # status 1200) on the ack path. It takes the EDITED method/target so a row still tracks
+    # what is about to be sent. A WebSocket row keeps its own tail: `Item#label` ends a WS
+    # message with its byte count, and here the PAYLOAD PREVIEW is the only thing that tells
+    # two messages on one socket apart.
     private def row_label(it : Interceptor::Item) : String
       method, raw_target = effective_method_target(it) # edited values for the loaded item
-      target = Url.origin_path(raw_target)             # strip scheme+authority for plaintext forward-proxy targets
       case it.kind
-      in .request?         then "#{method} #{it.host}#{target}"
-      in .response?        then "#{it.host} #{target}"
-      in .ws_out?, .ws_in? then "#{it.host}#{target}  #{ws_preview(it)}"
+      in .request?, .response? then it.label(method, raw_target)
+      in .ws_out?, .ws_in?     then "#{it.host}#{Url.origin_path(raw_target)}  #{ws_preview(it)}"
       end
     end
 

--- a/src/gori/tui/mine_config_overlay.cr
+++ b/src/gori/tui/mine_config_overlay.cr
@@ -28,6 +28,14 @@ module Gori::Tui
     CONC_CHOICES   = [5, 10, 20, 40]
     NOTIFY_CHOICES = Miner::NotifyMode.values
 
+    # Hard ceiling on REQUESTS the run may put on the target (retries and redirect hops
+    # each charge it — `Fuzz::CappedBackend`, the same counter `--max-requests` and MCP's
+    # `max_requests` are enforced against). nil = uncapped, which is what every TUI run
+    # used to be: there was no way to cap one from the primary surface at all, while
+    # `gori run` and MCP both had the knob. A cycler, not a text field, because this
+    # overlay deliberately has none (no IME plumbing).
+    MAX_REQ_CHOICES = [nil, 100, 250, 500, 1000, 2500, 5000, 10000] of Int32?
+
     getter seed : MineSeed
     # Additional flows this one config starts a session for — History's multi-select (#442).
     # The CHECKBOXES come from `seed` (the first target), because locations are per-request;
@@ -40,6 +48,7 @@ module Gori::Tui
       @seed.applicable.each { |l| @checked[l] = @seed.default.includes?(l) }
       @conc_idx = CONC_CHOICES.index(10) || 1
       @notify_idx = NOTIFY_CHOICES.index(Miner::NotifyMode::WhenFound) || 0
+      @maxreq_idx = 0
       @selected = 0
       restore_saved_prefs
     end
@@ -65,21 +74,26 @@ module Gori::Tui
       end
     end
 
-    # Rows: one per applicable location, then concurrency + notification cyclers, then Start.
+    # Rows: one per applicable location, then max-requests + concurrency + notification
+    # cyclers, then Start.
     private def row_count : Int32
-      @seed.applicable.size + 3
+      @seed.applicable.size + 4
     end
 
-    private def conc_row : Int32
+    private def maxreq_row : Int32
       @seed.applicable.size
     end
 
-    private def notify_row : Int32
+    private def conc_row : Int32
       @seed.applicable.size + 1
     end
 
-    private def start_row : Int32
+    private def notify_row : Int32
       @seed.applicable.size + 2
+    end
+
+    private def start_row : Int32
+      @seed.applicable.size + 3
     end
 
     def on_start_row? : Bool
@@ -143,6 +157,7 @@ module Gori::Tui
 
     def adjust(d : Int32) : Nil
       case @selected
+      when maxreq_row then @maxreq_idx = (@maxreq_idx + d) % MAX_REQ_CHOICES.size
       when conc_row   then @conc_idx = (@conc_idx + d) % CONC_CHOICES.size
       when notify_row then @notify_idx = (@notify_idx + d) % NOTIFY_CHOICES.size
       end
@@ -153,7 +168,7 @@ module Gori::Tui
       if @selected < @seed.applicable.size
         loc = @seed.applicable[@selected]
         @checked[loc] = !(@checked[loc]? || false)
-      elsif @selected == conc_row || @selected == notify_row
+      elsif @selected == maxreq_row || @selected == conc_row || @selected == notify_row
         adjust(1)
       end
     end
@@ -163,6 +178,7 @@ module Gori::Tui
       c.locations = @seed.applicable.select { |l| @checked[l]? }
       c.concurrency = CONC_CHOICES[@conc_idx]
       c.notify = NOTIFY_CHOICES[@notify_idx]
+      c.max_requests = MAX_REQ_CHOICES[@maxreq_idx].try(&.to_i64)
       c
     end
 
@@ -222,16 +238,27 @@ module Gori::Tui
         on = @checked[loc]? || false
         screen.text(x, py, on ? "[x]" : "[ ]", on ? Theme.green : Theme.muted, bg)
         screen.text(x + 4, py, "#{loc.label} mining", sel ? Theme.text_bright : Theme.text, bg)
-      elsif i == conc_row
-        screen.text(x, py, "concurrency:", Theme.muted, bg)
-        screen.text(x + 13, py, "#{CONC_CHOICES[@conc_idx]}  ‹/›", sel ? Theme.text_bright : Theme.text, bg)
-      elsif i == notify_row
-        screen.text(x, py, "notification:", Theme.muted, bg)
-        screen.text(x + 14, py, "#{NOTIFY_CHOICES[@notify_idx].label}  ‹/›", sel ? Theme.text_bright : Theme.text, bg)
-      else
+      elsif i == start_row
         label = any_checked? ? "[ Start mining ]" : "[ select a location ]"
         screen.text(x, py, label, any_checked? ? Theme.accent : Theme.muted, bg, Attribute::Bold)
+      else
+        draw_cycler(screen, x, py, bg, sel, i)
       end
+    end
+
+    # The three ←/›-cycled rows, split out of draw_row so adding a knob does not keep
+    # growing one branch chain.
+    private def draw_cycler(screen : Screen, x : Int32, py : Int32, bg : Color, sel : Bool, i : Int32) : Nil
+      label, value =
+        if i == maxreq_row
+          {"max requests:", MAX_REQ_CHOICES[@maxreq_idx].try(&.to_s) || "uncapped"}
+        elsif i == conc_row
+          {"concurrency:", CONC_CHOICES[@conc_idx].to_s}
+        else
+          {"notification:", NOTIFY_CHOICES[@notify_idx].label}
+        end
+      screen.text(x, py, label, Theme.muted, bg)
+      screen.text(x + label.size + 1, py, "#{value}  ‹/›", sel ? Theme.text_bright : Theme.text, bg)
     end
 
     def row_at(box : Rect, mx : Int32, my : Int32) : Int32?

--- a/src/gori/tui/miner_view.cr
+++ b/src/gori/tui/miner_view.cr
@@ -22,12 +22,19 @@ module Gori::Tui
     getter focus : Symbol
     getter config : Miner::Config
     property job_id : Int32
+    # PROVENANCE: `@request` is a CAPTURED FLOW's stored bytes (a History/Sitemap/Issues
+    # seed), not something the operator drafted. This view has NO editor at all —
+    # `@request` is only ever assigned from a seed or from the store — so the flag is
+    # decided once, at load, and there is no draft interpretation to fall back to.
+    # See `Miner::PlanOptions#evidence?`.
+    getter? evidence : Bool
 
     def initialize
       @target = ""
       @request = Bytes.empty
       @http2 = false
       @sni = ""
+      @evidence = false
       @config = Miner::Config.new
       @last_synced_config = "" # last store config blob applied (reconcile equality)
       @name = nil.as(String?)
@@ -47,13 +54,17 @@ module Gori::Tui
       @job_id = 0
     end
 
-    # Seed a fresh session from the config overlay.
-    def load(target : String, request : Bytes, http2 : Bool, sni : String?, config : Miner::Config) : Nil
+    # Seed a fresh session from the config overlay. `evidence` is the seed's `flow_id`
+    # having been non-nil (a History/Sitemap/Issues flow); a Repeater-sourced seed is
+    # editor text the operator authored and stays a draft.
+    def load(target : String, request : Bytes, http2 : Bool, sni : String?,
+             config : Miner::Config, evidence : Bool = false) : Nil
       @target = target
       @request = request
       @http2 = http2
       @sni = sni || ""
       @config = config
+      @evidence = evidence
       @dirty = true
     end
 
@@ -62,6 +73,9 @@ module Gori::Tui
       @request = rec.request
       @http2 = rec.http2?
       @sni = rec.sni || ""
+      # Provenance survives a restart: `flow_id` is what `insert_miner_session` already
+      # stored for a flow-seeded session and nothing else sets it.
+      @evidence = !rec.flow_id.nil?
       @name = rec.name
       apply_config_json(rec.config)
       @last_synced_config = rec.config
@@ -75,6 +89,7 @@ module Gori::Tui
       @request = rec.request
       @http2 = rec.http2?
       @sni = rec.sni || ""
+      @evidence = !rec.flow_id.nil? # see restore
       @name = rec.name
       apply_config_json(rec.config)
       @last_synced_config = rec.config
@@ -96,6 +111,7 @@ module Gori::Tui
       @request = src.@request.dup
       @http2 = src.@http2
       @sni = src.@sni
+      @evidence = src.evidence? # the same bytes carry the same provenance
       apply_config_json(src.config_json)
       @name = SubtabClone.copy_name(src.name)
       @dirty = true
@@ -264,6 +280,23 @@ module Gori::Tui
       @progress = p
     end
 
+    # A FINISHED mine that left candidate names untested because the request cap ran out.
+    # Derived rather than carried, the way `gori run mine` and MCP derive it: the engine
+    # already publishes both halves on `Miner::Progress`. Guarded on `max_requests` being
+    # set so a run STOPPED by hand (^X) is not relabelled as a budget hit.
+    def budget_exhausted? : Bool
+      return false if @running
+      return false unless @config.max_requests
+      @progress.names_total > 0 && @progress.names_done < @progress.names_total
+    end
+
+    # "N of M names untested" — what a budget-halted mine actually did, for the surfaces
+    # that would otherwise say "0 found" over a wordlist it never opened.
+    def budget_note : String
+      "budget exhausted · #{@progress.names_total - @progress.names_done} of " \
+      "#{@progress.names_total} names untested — raise max requests to finish"
+    end
+
     def apply_baseline(ev : Miner::BaselineEvent) : Nil
       @baseline_stable = ev.stable
       @baseline_warning = ev.warning
@@ -293,8 +326,13 @@ module Gori::Tui
     def build_engine(verify : Bool, scope : Gori::Scope,
                      overrides : Gori::HostOverrides?) : {Miner::Engine?, String?}
       # @request / @target keep their `$VAR` tokens (that is what gets persisted and what
-      # the operator sees); Miner::Plan expands both exactly once, at build time.
-      options = Miner::PlanOptions.new(String.new(@request), target: @target, http2: @http2,
+      # the operator sees); Miner::Plan expands both exactly once, at build time — unless
+      # these bytes are EVIDENCE, in which case it expands neither and refuses neither.
+      # A flow-seeded mine of `?$filter=…&$top=10` was refused outright ("unresolved env
+      # $filter, $top"), and once the operator followed that advice every probe went out
+      # with the PARAMETER NAMES rewritten. `gori run mine --flow N` never did either.
+      options = Miner::PlanOptions.new(String.new(@request), evidence: @evidence,
+        target: @target, http2: @http2,
         locations: @config.locations, config: @config, verify: verify, sni: sni_override,
         overrides: overrides)
       plan = Miner::Plan.build(options, Gori::Outbound.interactive(scope))
@@ -330,6 +368,7 @@ module Gori::Tui
             j.array { @config.locations.each { |l| j.string l.label } }
           end
           j.field "concurrency", @config.concurrency
+          j.field "max_requests", @config.max_requests
           j.field "notify", @config.notify.token
           j.field "stability_rounds", @config.stability_rounds
           j.field "confirm_rounds", @config.confirm_rounds
@@ -351,6 +390,8 @@ module Gori::Tui
         @config.locations = parsed unless parsed.empty?
       end
       any["concurrency"]?.try(&.as_i?).try { |n| @config.concurrency = n }
+      # Absent (an older row) reads as nil ⇒ uncapped, which is what those runs were.
+      @config.max_requests = any["max_requests"]?.try(&.as_i64?)
       any["notify"]?.try(&.as_s?).try { |s| Miner::NotifyMode.parse?(s) }.try { |m| @config.notify = m }
       any["stability_rounds"]?.try(&.as_i?).try { |n| @config.stability_rounds = n }
       any["confirm_rounds"]?.try(&.as_i?).try { |n| @config.confirm_rounds = n }
@@ -403,6 +444,10 @@ module Gori::Tui
         screen.text(x, y, line, Theme.muted, Theme.bg, width: rect.w - 4)
       end
       y += 1
+      if budget_exhausted? && y < rect.bottom - 1
+        screen.text(x, y, budget_note, Theme.yellow, Theme.bg, width: rect.w - 4)
+        y += 1
+      end
       if (w = @baseline_warning) && y < rect.bottom - 1
         screen.text(x, y, "⚠ #{w}", Theme.yellow, Theme.bg, width: rect.w - 4)
       end
@@ -421,8 +466,12 @@ module Gori::Tui
       if @results.empty?
         # Distinguish never-run from a completed run that found nothing, using the
         # same signal the status line does (names_total > 0 ⇒ a run happened).
+        # "no hidden parameters found" over a wordlist the budget never opened is the one
+        # claim this pane must not make — it did not look.
         msg = if @running
                 "mining… discovered parameters appear here"
+              elsif budget_exhausted?
+                "none found in the #{@progress.names_done} of #{@progress.names_total} names the budget allowed"
               elsif @progress.names_total > 0
                 "no hidden parameters found"
               else

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -573,8 +573,13 @@ module Gori::Tui
     private def publish_intercept_snapshot(ic : Interceptor) : Nil
       token = @session.intercept_token
       rows = ic.pending.map do |it|
+        # `edit_refusal`/`head_only` ride along so the MCP process and `gori run intercept
+        # get`/`list` can say "edits cannot be applied to this message" BEFORE one is written.
+        # They are known at hold time and were dropped here, which is why every cross-process
+        # surface described a CRLF-carrying h2 message as ordinarily editable.
         Store::HeldRow.new(token, it.id, it.kind.to_s.downcase, it.method, it.host, it.port,
-          it.scheme, it.target, it.raw, it.held_at_ms, it.flow_id, false)
+          it.scheme, it.target, it.raw, it.held_at_ms, it.flow_id, false, 0_i64,
+          it.edit_refusal, it.head_only?)
       end
       @session.store.publish_intercept_held(token, rows)
     end

--- a/src/gori/tui/sequence_config_overlay.cr
+++ b/src/gori/tui/sequence_config_overlay.cr
@@ -39,13 +39,22 @@ module Gori::Tui
     CONC_CHOICES   = [1, 2, 5, 10]
     NOTIFY_CHOICES = Sequencer::NotifyMode.values
 
+    # Hard ceiling on REQUESTS the run may put on the target (retries and redirect hops
+    # each charge it — `Fuzz::CappedBackend`, the same counter `--max-requests` and MCP's
+    # `max_requests` are enforced against). nil = uncapped, which is what every TUI run
+    # used to be: there was no way to cap one from the primary surface at all, while
+    # `gori run` and MCP both had the knob. A cycler, not a text field, because this
+    # overlay deliberately has none (no IME plumbing).
+    MAX_REQ_CHOICES = [nil, 100, 250, 500, 1000, 2500, 5000, 10000] of Int32?
+
     KIND_ROW     = 0
     SELECTOR_ROW = 1
     GOAL_ROW     = 2
-    CONC_ROW     = 3
-    NOTIFY_ROW   = 4
-    START_ROW    = 5
-    ROW_COUNT    = 6
+    MAXREQ_ROW   = 3
+    CONC_ROW     = 4
+    NOTIFY_ROW   = 5
+    START_ROW    = 6
+    ROW_COUNT    = 7
 
     getter seed : SequenceSeed
 
@@ -55,6 +64,7 @@ module Gori::Tui
       init = loc ? (loc.kind.position? ? "#{loc.pos_start}:#{loc.pos_end}" : loc.selector) : ""
       @selector = TextField.new(init)
       @goal_idx = GOAL_CHOICES.index(500) || 2
+      @maxreq_idx = 0
       @conc_idx = 0
       @notify_idx = NOTIFY_CHOICES.index(Sequencer::NotifyMode::WhenDone) || 0
       @selected = SELECTOR_ROW
@@ -150,6 +160,7 @@ module Gori::Tui
         @kind_idx = (@kind_idx + d) % KINDS.size
         prefill_for_kind
       when GOAL_ROW   then @goal_idx = (@goal_idx + d) % GOAL_CHOICES.size
+      when MAXREQ_ROW then @maxreq_idx = (@maxreq_idx + d) % MAX_REQ_CHOICES.size
       when CONC_ROW   then @conc_idx = (@conc_idx + d) % CONC_CHOICES.size
       when NOTIFY_ROW then @notify_idx = (@notify_idx + d) % NOTIFY_CHOICES.size
       end
@@ -157,7 +168,8 @@ module Gori::Tui
 
     # Space/Enter on a cycler advances it; on the kind row it also re-prefills.
     def toggle_or_advance : Nil
-      adjust(1) if @selected == KIND_ROW || @selected == GOAL_ROW || @selected == CONC_ROW || @selected == NOTIFY_ROW
+      adjust(1) if @selected == KIND_ROW || @selected == GOAL_ROW || @selected == MAXREQ_ROW ||
+                   @selected == CONC_ROW || @selected == NOTIFY_ROW
     end
 
     # When the kind flips to Cookie/Header and the field is blank, offer the first
@@ -186,6 +198,7 @@ module Gori::Tui
                       Sequencer::TokenLoc.new(kind, sel)
                     end
       c.goal = GOAL_CHOICES[@goal_idx]
+      c.max_requests = MAX_REQ_CHOICES[@maxreq_idx].try(&.to_i64)
       c.concurrency = CONC_CHOICES[@conc_idx]
       c.notify = NOTIFY_CHOICES[@notify_idx]
       c
@@ -239,19 +252,27 @@ module Gori::Tui
       when SELECTOR_ROW
         screen.text(x, py, selector_label, Theme.muted, bg)
         @selector.render(screen, vx, py, vw, sel, sel ? Theme.text_bright : Theme.text, bg)
-      when GOAL_ROW
-        screen.text(x, py, "samples:", Theme.muted, bg)
-        screen.text(vx, py, "#{GOAL_CHOICES[@goal_idx]}  ‹/›", sel ? Theme.text_bright : Theme.text, bg)
-      when CONC_ROW
-        screen.text(x, py, "concurrency:", Theme.muted, bg)
-        screen.text(vx, py, "#{CONC_CHOICES[@conc_idx]}  ‹/›", sel ? Theme.text_bright : Theme.text, bg)
-      when NOTIFY_ROW
-        screen.text(x, py, "notify:", Theme.muted, bg)
-        screen.text(vx, py, "#{NOTIFY_CHOICES[@notify_idx].label}  ‹/›", sel ? Theme.text_bright : Theme.text, bg)
-      else
+      when START_ROW
         label = valid? ? "[ Start collecting ]" : "[ set a token location ]"
         screen.text(x, py, label, valid? ? Theme.accent : Theme.muted, bg, Attribute::Bold)
+      else
+        draw_cycler(screen, x, vx, py, bg, sel, i)
       end
+    end
+
+    # The four ←/›-cycled rows, split out of draw_row so adding a knob does not keep
+    # growing one branch chain.
+    private def draw_cycler(screen : Screen, x : Int32, vx : Int32, py : Int32,
+                            bg : Color, sel : Bool, i : Int32) : Nil
+      label, value =
+        case i
+        when GOAL_ROW   then {"samples:", GOAL_CHOICES[@goal_idx].to_s}
+        when MAXREQ_ROW then {"max requests:", MAX_REQ_CHOICES[@maxreq_idx].try(&.to_s) || "uncapped"}
+        when CONC_ROW   then {"concurrency:", CONC_CHOICES[@conc_idx].to_s}
+        else                 {"notify:", NOTIFY_CHOICES[@notify_idx].label}
+        end
+      screen.text(x, py, label, Theme.muted, bg)
+      screen.text(vx, py, "#{value}  ‹/›", sel ? Theme.text_bright : Theme.text, bg)
     end
 
     def row_at(box : Rect, mx : Int32, my : Int32) : Int32?

--- a/src/gori/tui/sequencer_view.cr
+++ b/src/gori/tui/sequencer_view.cr
@@ -24,12 +24,18 @@ module Gori::Tui
     getter focus : Symbol
     getter config : Sequencer::Config
     property job_id : Int32
+    # PROVENANCE: `@request` is a CAPTURED FLOW's stored bytes, not a request the operator
+    # drafted. Like MinerView this session has NO editor — `@request` is only ever assigned
+    # from a seed or from the store — so the flag is decided once, at load, and there is no
+    # draft interpretation to fall back to. See `Sequencer::PlanOptions#evidence?`.
+    getter? evidence : Bool
 
     def initialize
       @target = ""
       @request = Bytes.empty
       @http2 = false
       @sni = ""
+      @evidence = false
       @config = Sequencer::Config.new
       @last_synced_config = ""
       @name = nil.as(String?)
@@ -39,6 +45,7 @@ module Gori::Tui
       @stop_requested = false
       @collected = 0
       @sent = 0
+      @requests = 0_i64
       @errors = 0
       @goal_display = 0
       @samples = [] of Sequencer::Sample
@@ -58,12 +65,16 @@ module Gori::Tui
     end
 
     # --- seed / restore ---
-    def load(target : String, request : Bytes, http2 : Bool, sni : String?, config : Sequencer::Config) : Nil
+    # `evidence` is the seed's `flow_id` having been non-nil (a History/Sitemap/Issues
+    # flow); a Repeater-sourced or current-session seed is a draft.
+    def load(target : String, request : Bytes, http2 : Bool, sni : String?,
+             config : Sequencer::Config, evidence : Bool = false) : Nil
       @target = target
       @request = request
       @http2 = http2
       @sni = sni || ""
       @config = config
+      @evidence = evidence
       @dirty = true
     end
 
@@ -85,6 +96,9 @@ module Gori::Tui
       @request = rec.request
       @http2 = rec.http2?
       @sni = rec.sni || ""
+      # Provenance survives a restart: `flow_id` is what `insert_sequencer_session`
+      # already stored for a flow-seeded session and nothing else sets it.
+      @evidence = !rec.flow_id.nil?
       @name = rec.name
       apply_config_json(rec.config)
       @last_synced_config = rec.config
@@ -96,6 +110,7 @@ module Gori::Tui
       @request = rec.request
       @http2 = rec.http2?
       @sni = rec.sni || ""
+      @evidence = !rec.flow_id.nil? # see restore
       @name = rec.name
       apply_config_json(rec.config)
       @last_synced_config = rec.config
@@ -287,11 +302,36 @@ module Gori::Tui
       @samples_rev += 1
     end
 
-    def apply_progress(collected : Int32, sent : Int32, goal : Int32, errors : Int32) : Nil
+    # `requests` is the TRUE wire count (`Fuzz::CappedBackend#sent`, what `max_requests` is
+    # enforced against); `sent` counts collection attempts, and a retry charges only the
+    # former. Both are shown, and only when they differ — see `results_count_label` in
+    # FuzzerView for the same rule.
+    def apply_progress(collected : Int32, sent : Int32, goal : Int32, errors : Int32,
+                       requests : Int64 = 0_i64) : Nil
       @collected = collected
       @sent = sent
       @goal_display = goal
       @errors = errors
+      @requests = requests
+    end
+
+    # Errored sends so far — `DoneEvent` does not carry an error count, so the terminal
+    # apply reuses the last one the progress stream reported.
+    def errors_count : Int32
+      @errors
+    end
+
+    # A FINISHED collection that fell short of its goal because the request cap ran out.
+    # Guarded on `max_requests` so a hand-stopped (^X) or error-ended run is not relabelled.
+    def budget_exhausted? : Bool
+      return false if @running
+      return false unless @config.max_requests
+      @goal_display > 0 && @collected < @goal_display
+    end
+
+    def budget_note : String
+      "budget exhausted · #{@collected} of #{@goal_display} tokens collected — " \
+      "raise max requests to finish (the verdict below rests on this sample)"
     end
 
     def collected_count : Int32
@@ -334,7 +374,12 @@ module Gori::Tui
     # so a caller has to say what it means rather than inherit that bug back.
     def build_engine(verify : Bool, scope : Gori::Scope,
                      overrides : Gori::HostOverrides?) : {Sequencer::Engine?, String?}
-      options = Sequencer::PlanOptions.new(@request, target: @target, http2: @http2,
+      # `evidence` skips the draft-time passes for a captured seed: with it off, sequencing
+      # a capture whose head carried `$filter`/`$top` was refused outright, and setting the
+      # variables the refusal named rewrote the request on the wire. `gori run sequence
+      # --flow N` never did either.
+      options = Sequencer::PlanOptions.new(@request, evidence: @evidence,
+        target: @target, http2: @http2,
         config: @config, verify: verify, sni: sni_override, overrides: overrides)
       {Sequencer::Plan.build(options, Gori::Outbound.interactive(scope)).engine, nil}
     rescue ex : Sequencer::PlanError
@@ -369,6 +414,7 @@ module Gori::Tui
           j.field "pos_start", loc.pos_start
           j.field "pos_end", loc.pos_end
           j.field "goal", @config.goal
+          j.field "max_requests", @config.max_requests
           j.field "concurrency", @config.concurrency
           j.field "notify", @config.notify.token
         end
@@ -385,6 +431,8 @@ module Gori::Tui
       pend = any["pos_end"]?.try(&.as_i?) || 0
       @config.token_loc = Sequencer::TokenLoc.new(kind, selector, pstart, pend)
       any["goal"]?.try(&.as_i?).try { |n| @config.goal = n }
+      # Absent (an older row) reads as nil => uncapped, which is what those runs were.
+      @config.max_requests = any["max_requests"]?.try(&.as_i64?)
       any["concurrency"]?.try(&.as_i?).try { |n| @config.concurrency = n }
       any["notify"]?.try(&.as_s?).try { |t| Sequencer::NotifyMode.parse?(t) }.try { |m| @config.notify = m }
     rescue
@@ -440,8 +488,13 @@ module Gori::Tui
       end
       y += 1
       if y < rect.bottom - 1
-        line = "#{@collected}/#{@goal_display <= 0 ? "?" : @goal_display.to_s} collected · #{@sent} sent · #{@errors} err"
+        wire = @requests > @sent ? " · #{@requests} requests" : ""
+        line = "#{@collected}/#{@goal_display <= 0 ? "?" : @goal_display.to_s} collected · #{@sent} sent#{wire} · #{@errors} err"
         screen.text(x, y, line, Theme.muted, Theme.bg, width: rect.w - 4)
+      end
+      y += 1
+      if budget_exhausted? && y < rect.bottom - 1
+        screen.text(x, y, budget_note, Theme.yellow, Theme.bg, width: rect.w - 4)
       end
     end
 

--- a/src/gori/tui/url.cr
+++ b/src/gori/tui/url.cr
@@ -1,3 +1,5 @@
+require "../url"
+
 module Gori::Tui
   # Small URL display helpers shared across views (History list, Intercept queue …).
   module Url
@@ -6,12 +8,13 @@ module Gori::Tui
     # scheme+authority so a path column / queue label reads like the HTTPS (origin-form)
     # rows instead of gluing the host onto a full URL ("example.comhttp://example.com/x").
     # Non-URL targets (e.g. a response's "405 Method Not Allowed") pass through unchanged.
+    #
+    # The rule itself now lives in core `Gori::Url` — `Interceptor::Item` is core and needed
+    # the same answer, and the two `target.starts_with?("http")` copies in `CLI::Output` and
+    # `Links` were a THIRD spelling that disagreed with this one on an uppercase scheme. This
+    # stays as the TUI's name for it so the eight call sites in `tui/` read unchanged.
     def self.origin_path(target : String) : String
-      return target unless target.starts_with?("http://") || target.starts_with?("https://")
-      scheme_end = target.index("://")
-      return target unless scheme_end
-      slash = target.index('/', scheme_end + 3)
-      slash ? target[slash..] : "/"
+      Gori::Url.origin_path(target)
     end
   end
 end

--- a/src/gori/url.cr
+++ b/src/gori/url.cr
@@ -1,0 +1,51 @@
+require "./ascii_bytes"
+
+module Gori
+  # How a request TARGET is written down when a surface has to say WHERE a message went.
+  #
+  # There is exactly one rule and it has now been written four times: a plaintext
+  # forward-proxy request is captured in ABSOLUTE form (`http://host:port/path` — the wire
+  # truth, P7) while a CONNECT-tunnelled or HTTP/2 request is captured origin-form (`/path`),
+  # so a surface that glues the host onto every target doubles the authority on half of them.
+  # `Store::FlowRow.absolute_form?` had the careful version, `Tui::Url.origin_path` had a
+  # second, `CLI::Output.flow_row_text` and `Links.flow_location` each had a
+  # `target.starts_with?("http")` third — which is not the same predicate: it misses the
+  # case-insensitivity RFC 3986 §3.1 requires, so a captured `GET HTTP://host/x` printed as
+  # `127.0.0.1HTTP://127.0.0.1:19594/upper`, exactly the doubling `absolute_form?`'s own
+  # comment says it exists to prevent.
+  #
+  # Byte-level and Regex-free for the reason `absolute_form?` states: a target is bytes an
+  # operator or a peer put on the wire and need not be valid UTF-8, and PCRE2 RAISES on an
+  # invalid byte rather than not matching.
+  module Url
+    HTTP_PREFIX  = "http://".to_slice
+    HTTPS_PREFIX = "https://".to_slice
+
+    # True when `target` already carries its own scheme+authority. Case-insensitive
+    # (RFC 3986 §3.1: URI schemes are case-insensitive).
+    def self.absolute_form?(target : String) : Bool
+      b = target.to_slice
+      AsciiBytes.starts_with_ci?(b, HTTP_PREFIX) || AsciiBytes.starts_with_ci?(b, HTTPS_PREFIX)
+    end
+
+    # The target in ORIGIN form for display: an absolute-form target loses its
+    # scheme+authority so a path column reads like the origin-form rows beside it, and
+    # anything that is not absolute-form (a bare `/path`, or a held response's
+    # "405 Method Not Allowed") passes through unchanged.
+    def self.origin_path(target : String) : String
+      return target unless absolute_form?(target)
+      # "://" is ASCII-punctuation only, so this index is unaffected by the scheme's case.
+      scheme_end = target.index("://")
+      return target unless scheme_end
+      slash = target.index('/', scheme_end + 3)
+      slash ? target[slash..] : "/"
+    end
+
+    # "where this message went", as one string: the absolute-form target verbatim, else the
+    # host with the origin-form target appended. The composition `CLI::Output.flow_row_text`
+    # and `Links.flow_location` both spell out.
+    def self.location(host : String, target : String) : String
+      absolute_form?(target) ? target : "#{host}#{target}"
+    end
+  end
+end


### PR DESCRIPTION
Round 4, first half. Four hunters swept ground no round had reached — the four engine TUI tabs, the engines over TLS and HTTP/2, export/import round-trips, and an adversarial pass over round 3's own changes — and found 22 defects. This PR lands the 17 that were ready; the rest are dispatched next.

## The provenance axis was fixed at one consumer out of ten

`PlanOptions#evidence?` exists so a captured flow stops being treated as the operator's draft. PR #555 wired it into the CLI. It was still missing from the three MCP job tools and the three engine TUI tabs — so a captured OData request (`?$filter=…&$top=10`) was refused outright there, 0 requests sent, while `gori run fuzz --flow 1` ran it correctly.

Following the refusal's own remedy was worse than the refusal. With `filter=PWNED` set, the TEMPLATE pane still showed `$filter=§…§` while the origin received `?PWNED=aa&99=10` — parameter *names* rewritten — and the screen reported `✓ 6 hits / 6 sent`. A separate half of the same defect substituted a `$token` in the **body** with no refusal at all, because `Env.expand_wire` expands the whole text while `Env.unresolved_wire` scans only the head.

An operator edit deliberately does **not** clear evidence: the editor preserves every line terminator now, and dropping provenance on the first keystroke would put the substitution straight back on the commonest workflow.

## Three facts gori knew and could not say as data

- **An intercept edit gori will not apply** — an HTTP/2 head with no HTTP/1.1 text form — was only revealed when the operator submitted one. The TUI was worse than the CLI: it printed `forwarded …` and sent the original byte-for-byte. The refusal now rides on the held row, so every surface says so before an edit is written. A complement test caught the design error on the way: *every* h2 hold is head-only, so folding that into the refusal would have chipped every held h2 row as uneditable when head edits do apply — it is a caveat, not a refusal.
- **A Match&Replace rule skipped on a message**, and **a request that was server-pushed**, existed only as a `WARN` on capture's STDERR and as a synthesised header. Both now land in a `flows.advisory` column that History, `gori run show`, MCP and a HAR export all read. A column rather than a rows table: a WebSocket advisory is *positioned* in a stream of frames and its position names what it applies to; an HTTP advisory is a property of the exchange.

## Silent narrowing, closed at the remaining callers

- `Discover::Headers`' rejection collector had **one** caller and `unsafe_expanded` had **one in the whole tree**, so the TUI and MCP still dropped a header whose value carries CR/LF — including one that only becomes unsafe after `$VAR` expansion. A TUI sweep sent 284 probes, none carrying `Authorization`, and reported `1 endpoint`.
- A TUI run could not be capped at all: one discover put **3338** requests on the hunter's origin. Every overlay now has a budget, and `budget_exhausted` is rendered instead of an empty findings pane claiming nothing was found.
- The Fuzzer tab's `N sent` was the payload count, not wire requests — `3 sent` for 18 requests on a redirect chain.
- Discover's MCP `incomplete_reason` was inferred from `queued > 0`; a sweep that spends its whole budget on calibration drains the frontier to empty and so reported `job_complete: true`.

## Two corruptions found while wiring

- `Fuzz::Template.parse` iterated `marked.chars`, so **every** fuzz run corrupted a binary body — marked or not. A 297-byte request rendered as 553. It now scans bytes; UTF-8 is self-synchronising, so precision is unchanged.
- `Repeater::Minimize` needed both halves, not one: the inbound whole-request `\r\n`→`\n` was flattening multipart CRLF boundaries, and the outbound blanket `\n`→`\r\n` was hiding it. A binary body's `0A 00 0D EF 0A` came back as `EF BF BD 0D 0A`.

## And the thing that hung CI last time

57 bare `Channel#receive` calls in socket-driven specs are now wrapped in a shared `receive_within` helper. A bare receive is what hung PR #555's CI for 24 minutes: green on macOS, and on Linux a client close was observed before the proxy recorded its response. `crystal spec` block-buffers its dots under Actions, so the hang left no output at all. No assertion changed — only how each example waits.

## Verification

Every fix reproduces the defect first, adds a spec, control-runs it against unfixed source, and re-runs the finding's own repro against a freshly built binary. The TUI package asserts on the bytes a recording origin received under a real tmux-driven TUI, not on plan objects.

```
crystal spec                 6073 examples, 8 failures   (the 8 are capture_status/project_registry
crystal build --no-codegen   exit 0                       against a gori already listening on :8070)
```

Schema V8 adds `flows.advisory`, `intercept_held.edit_refusal`, `intercept_held.head_only`; a V7 database opens and migrates.

## Still open, dispatched next

The same provenance mechanism has three more call sites — a fuzz payload containing `$TOKEN` is replaced by the live session token on the wire, and both `repeater/sender.cr`'s send seam and the TUI Repeater's `expanded_text_to_bytes` bypass `evidence?`. Also open: an h2 patience deadline that restarts on every DATA frame and so bounds nothing (`timeout_ms: 2000` measured at 5.5 hours), a keep-alive pool that re-sends a non-idempotent POST the origin had already read, a `[gori]` advisory row that leaks into a WebSocket repeater seed and goes out on the wire, and four HAR export/import defects.