### PR TITLE
feat(sitemap): put the cursor row in scope, from the tree that shows it

### DIFF
--- a/spec/support/fake_context.cr
+++ b/spec/support/fake_context.cr
@@ -515,6 +515,10 @@ class FakeExecContext < Gori::Verb::ExecContext
     rec(:sitemap_open_flow)
   end
 
+  def sitemap_scope_add : Nil
+    rec(:sitemap_scope_add)
+  end
+
   def sitemap_mark_toggle : Nil
     rec(:sitemap_mark_toggle)
   end

--- a/spec/tui/sitemap_view_spec.cr
+++ b/spec/tui/sitemap_view_spec.cr
@@ -398,6 +398,47 @@ describe Gori::Tui::SitemapView do
     end
   end
 
+  it "seeds a scope rule from the cursor: host row -> host rule, path row -> host+path string" do
+    tmp_store do |store|
+      capture(store, "acme.test", "GET", "/api/users")
+
+      view = SitemapView.new
+      view.reload(store)
+
+      # Row 0 is the host: the whole site, so the precise `host` type (subdomain/glob aware).
+      seed = view.selected_scope_seed.should_not be_nil
+      seed[:match_type].should eq("host")
+      seed[:pattern].should eq("acme.test")
+
+      # Any path row narrows to a substring of scheme://host/target — Scope has no path type.
+      view.move(1) # /api
+      seed = view.selected_scope_seed.should_not be_nil
+      seed[:match_type].should eq("string")
+      seed[:pattern].should eq("acme.test/api")
+
+      view.move(1) # /api/users
+      view.selected_scope_seed.not_nil![:pattern].should eq("acme.test/api/users")
+    end
+  end
+
+  it "seeds a fold's scope rule from its CONTAINER, not one folded child" do
+    tmp_store do |store|
+      capture(store, "acme.test", "GET", "/users/3f2a8b1c-1234-5678-9abc-def012345678")
+      capture(store, "acme.test", "GET", "/users/a1b2c3d4-5566-7788-99aa-bbccddeeff00")
+
+      view = SitemapView.new
+      view.reload(store)
+      view.move(1)
+      view.move(1) # the {uuid} fold
+
+      seed = view.selected_scope_seed.should_not be_nil
+      # A rule pinned to one uuid would scope out every OTHER user — and `{uuid}` is not a
+      # real path, so it could never match at all.
+      seed[:match_type].should eq("string")
+      seed[:pattern].should eq("acme.test/users")
+    end
+  end
+
   it "refuses to tag a template fold" do
     tmp_store do |store|
       capture(store, "acme.test", "GET", "/users/3f2a8b1c-1234-5678-9abc-def012345678")

--- a/spec/verb/registry_spec.cr
+++ b/spec/verb/registry_spec.cr
@@ -472,6 +472,10 @@ private class FakeContext < ExecContext
     @calls << :sitemap_open_flow
   end
 
+  def sitemap_scope_add : Nil
+    @calls << :sitemap_scope_add
+  end
+
   def sitemap_mark_toggle : Nil
     @calls << :sitemap_mark_toggle
   end

--- a/spec/verbs/sitemap_spec.cr
+++ b/spec/verbs/sitemap_spec.cr
@@ -30,7 +30,22 @@ describe "Gori::Verbs.register_sitemap" do
      "sitemap.discover"        => :sitemap_discover,
      "sitemap.repeater"        => :sitemap_repeater,
      "sitemap.open-flow"       => :sitemap_open_flow,
+     "sitemap.scope-add"       => :sitemap_scope_add,
     }.each { |id, intent| verb_intents(r, id).should eq([intent]) }
+  end
+
+  # The tree is where you SEE what is worth scoping, but the rule editor lived only in the
+  # Project tab — so scoping a host you just found meant retyping it there.
+  it "adds the cursor row to the scope on `a`, the same chord the Project scope pane uses" do
+    verb = r["sitemap.scope-add"]
+    verb.chords.should eq([Gori::Verb::Chord.new("a")])
+    verb.hidden?.should be_false # else it reaches neither the space menu nor Help
+    verb.menu_key.should eq('a')
+    # Same gesture as the popup's other door, so `a` means "add a scope rule" in both places.
+    r["scope.add-rule"].chords.should eq([Gori::Verb::Chord.new("a")])
+    # 's' still belongs to the LENS toggle here — adding a rule and filtering by it are
+    # distinct actions, and the toast after a save points at 's'.
+    r["sitemap.scope-toggle"].menu_key.should eq('s')
   end
 
   # #539: the action existed nowhere — no chord, no registry entry — so the space menu could

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -4396,14 +4396,23 @@ module Gori::Tui
     # Host: open the Project SCOPE rule popup (nil edit_id = add a new rule). The apply is
     # injected as the overlay's commit closure (Overlay seam): it persists via the Project
     # controller and returns whether to close (false = invalid pattern → keep the form up).
-    def open_scope_rule_editor(edit_id : Int64?, kind : String, match_type : String, pattern : String) : Nil
+    #
+    # `on_applied` runs only on a SUCCESSFUL write, for a caller that opened this form from
+    # somewhere the new rule is immediately visible (the Sitemap's `a`, whose tree carries
+    # scope markers and — with the lens on — is filtered by the rule just added).
+    def open_scope_rule_editor(edit_id : Int64?, kind : String, match_type : String, pattern : String,
+                               on_applied : Proc(Nil)? = nil) : Nil
       ov =
         if id = edit_id
           ScopeRuleOverlay.editing(id, kind, match_type, pattern)
         else
           ScopeRuleOverlay.new(kind: kind, match_type: match_type, pattern: pattern)
         end
-      ov.on_commit = -> { project_controller.apply_scope_rule(ov.edit_id, ov.kind, ov.match_type, ov.pattern) }
+      ov.on_commit = -> {
+        ok = project_controller.apply_scope_rule(ov.edit_id, ov.kind, ov.match_type, ov.pattern)
+        on_applied.try(&.call) if ok
+        ok
+      }
       open_overlay(ov)
     end
 
@@ -4672,9 +4681,10 @@ module Gori::Tui
     # Sitemap verbs that stay SINGLE-target even with marks set, and say so in their menu
     # hint. Discover is single by design (one config popup scans one start target under one
     # host — see the multi-host refusal in runner/discover.cr), the Sequencer collects one
-    # endpoint's token, and a detail overlay shows one flow; the rest (query / fold /
-    # scope-lens) are selection-independent, so a cursor note there would be noise.
-    SITEMAP_CURSOR_ONLY = {"sitemap.discover", "sitemap.sequence", "sitemap.open-flow"}
+    # endpoint's token, a detail overlay shows one flow, and the scope form edits one
+    # pattern; the rest (query / fold / scope-lens) are selection-independent, so a cursor
+    # note there would be noise.
+    SITEMAP_CURSOR_ONLY = {"sitemap.discover", "sitemap.sequence", "sitemap.open-flow", "sitemap.scope-add"}
 
     # Retitle the Sitemap's menu entries while marks are set, so the menu says what will
     # actually happen — "Tag 3 paths". MUST return nil when nothing is marked, so every

--- a/src/gori/tui/runner/sitemap.cr
+++ b/src/gori/tui/runner/sitemap.cr
@@ -63,6 +63,26 @@ class Gori::Tui::Runner < Gori::Verb::ExecContext
     end
   end
 
+  # `a` — put the cursor row into the project scope, through the SAME popup the Project
+  # tab's `a` opens, pre-filled from where the cursor sits: a host row seeds a `host` rule,
+  # a path row seeds a "host/path" `string` rule (see SitemapView#selected_scope_seed).
+  # Pre-filled, not written blind: the form is where you widen "/api/v1" to "/api", flip
+  # include→exclude, or bail — and it is the one place scope patterns are validated.
+  #
+  # Cursor-only even with marks set (SITEMAP_CURSOR_ONLY): the form edits ONE pattern, so
+  # a marked set has nothing to mean here.
+  def sitemap_scope_add : Nil
+    seed = sitemap_controller.view.selected_scope_seed
+    unless seed
+      @toast = "select a host or path to scope"
+      return
+    end
+    # Reload on success: the tree shows a scope marker per host whenever rules EXIST (lens or
+    # not), and with the lens on the rule also re-filters the rows under the cursor.
+    open_scope_rule_editor(nil, "include", seed[:match_type], seed[:pattern],
+      on_applied: -> { sitemap_controller.reload })
+  end
+
   # Open the bytes behind the cursor row. CROSS-TAB mediator: resolves the tree node through
   # the store, then drives the History controller + detail overlay — exactly the hop
   # issue_open_flow (runner/issues.cr) makes from an issue to its evidence.

--- a/src/gori/tui/sitemap_view.cr
+++ b/src/gori/tui/sitemap_view.cr
@@ -564,6 +564,26 @@ module Gori::Tui
       endpoint_of(node, host)
     end
 
+    # The cursor row's scope-rule seed — what "add THIS to the scope" means at this depth:
+    #   host row (depth 0) → a `host` rule for the whole site
+    #   path row           → a `string` rule on "host/path", because Scope has no path type.
+    #                        A string rule is a substring of the same `scheme://host/target`
+    #                        the SQL lens builds (QL::URL_EXPR, port-free), so "example.com/api"
+    #                        covers the subtree under /api on any port.
+    # A fold resolves to its CONTAINER ("/users", not one uuid child) — the same reading
+    # `selected_endpoint(:container)` gives Discover, and the only one a scope prefix can mean.
+    def selected_scope_seed : {match_type: String, pattern: String}?
+      return nil unless row = visible_rows[@selected]?
+      node = row.node
+      return {match_type: "host", pattern: row.host} if row.depth == 0
+      path = node.grouped ? node.fold_parent : node.path
+      return nil unless path
+      # A fold sitting directly under the host root has no container path to prefix with —
+      # scoping it is scoping the host.
+      return {match_type: "host", pattern: row.host} if path.empty?
+      {match_type: "string", pattern: "#{row.host}#{path}"}
+    end
+
     # One node's {host, method, target}, GET-preferred. A node with no captured method of
     # its own (an intermediate folder, a host row) still yields a tuple — it just resolves
     # to no flow at the store, which is the same "no captured request for this path" the

--- a/src/gori/verb/context/sitemap.cr
+++ b/src/gori/verb/context/sitemap.cr
@@ -11,6 +11,7 @@ abstract class Gori::Verb::ExecContext
   abstract def sitemap_toggle_grouping : Nil # fold/unfold numeric path-param sequences
   abstract def sitemap_repeater : Nil        # send the selected/marked endpoints to Repeater
   abstract def sitemap_open_flow : Nil       # open the selected endpoint's captured flow in History
+  abstract def sitemap_scope_add : Nil       # seed the scope-rule popup from the cursor row (host, or host+path)
   # multi-select marks: the batch verbs above act on the marks if any are set, else the cursor row
   abstract def sitemap_mark_toggle : Nil                # flip the cursor row's mark, then step down
   abstract def sitemap_mark_clear : Nil                 # drop every mark

--- a/src/gori/verbs/sitemap.cr
+++ b/src/gori/verbs/sitemap.cr
@@ -88,6 +88,14 @@ module Gori
         "sitemap.scope-toggle", "Toggle scope lens", "Filter the tree to in-scope endpoints on/off",
         Verb::Scope::Sitemap, [Verb::Chord.new("s", shift: true)], mnemonic: 's') { |ctx| ctx.scope_toggle_lens; nil }
 
+      # `a` — add the cursor row to the project scope, pre-filling the SAME popup the Project
+      # tab's `a` opens (hence the same chord): a host row seeds a `host` rule, a path row a
+      # "host/path" `string` rule. The tree is where you SEE what is worth scoping, so the
+      # rule is authored there instead of retyping the host in the Project tab.
+      r.register Verb::Definition.new(
+        "sitemap.scope-add", "Add to scope", "Add the selected host — or host + path — to the scope rules",
+        Verb::Scope::Sitemap, [Verb::Chord.new("a")], mnemonic: 'a') { |ctx| ctx.sitemap_scope_add; nil }
+
       # `d` — spider + brute-force the selected host/path (opens the Discover config popup).
       r.register Verb::Definition.new(
         "sitemap.discover", "Discover here", "Spider + brute-force the selected host or path subtree",


### PR DESCRIPTION
## What

Sitemap tree에서 커서 위치를 그대로 scope 규칙으로 등록합니다. `a` 단축키 + space 메뉴의 `a Add to scope`.

| 커서 행 | kind | type | pattern |
|---|---|---|---|
| host row (depth 0) | include | host | `example.com` |
| path row | include | string | `example.com/api` |
| `{uuid}` fold | include | string | `example.com/users` (컨테이너) |

Project 탭의 `a`가 여는 것과 **같은** `ScopeRuleOverlay`를 미리 채워서 띄웁니다 — 그래서 같은 chord입니다. 바로 쓰지 않고 폼을 여는 이유: `/api/v1`을 `/api`로 넓히거나, include를 exclude로 뒤집거나, 취소하는 자리가 거기이고, scope 패턴 검증도 그 폼이 유일한 창구이기 때문입니다.

## Why the type flip

`Scope::TYPES`는 `host | string | regex`뿐이고 path 타입이 없습니다. 그래서 path 행은 SQL 렌즈가 쓰는 것과 동일한 `scheme://host/target`(`QL::URL_EXPR`, 포트 없음)의 부분 문자열 규칙이 됩니다 — `example.com/api`가 포트와 무관하게 `/api` 서브트리를 덮습니다.

fold는 Discover와 같은 읽기로 **컨테이너**(`/users`)에 해당합니다. uuid 하나에 규칙을 박으면 나머지 사용자가 전부 scope 밖으로 나가고, 애초에 `{uuid}`는 실제 경로가 아니라 아무것도 매치하지 못합니다.

marks가 있어도 cursor-only(`SITEMAP_CURSOR_ONLY`)입니다 — 폼은 패턴 하나를 편집하니까요.

`open_scope_rule_editor`에 `on_applied` 훅을 추가했고, **쓰기 성공 시에만** 실행됩니다. 트리는 호스트마다 scope 마커를 그리고, 렌즈가 켜져 있으면 방금 추가한 규칙으로 행 자체가 다시 필터되기 때문입니다.

## Verification

- `crystal spec` — 6202 examples, 0 failures. 신규 스펙 3개는 구현을 일부러 깨뜨린 control-run으로 실제 red가 되는 것까지 확인.
- `crystal tool format --check` 통과. ameba는 해당 파일 baseline 31건 그대로 (신규 0).
- tmux로 실제 TUI 확인: 메뉴 노출 → host 행 `include/host/example.com`, `/api` 행 `include/string/example.com/api`(`string`이 선택 상태) → 저장 후 Project SCOPE 페인에 반영 → host 규칙 삭제 후 렌즈 ON 시 트리가 `/api` 서브트리만 남는 것까지.

## Note (pre-existing)

string/regex 규칙만 있는 상태에서는 모든 host 행에 in-scope `◆` 마커가 붙습니다. `Scope#host_in_scope?`가 경로 단위 패턴으로는 호스트를 배제할 수 없어 보수적으로 판정하는 기존 동작이며, 트리 필터링 자체는 정상입니다. 이 PR에서 건드리지 않았습니다.