### PR TITLE
feat(tui): show every discovery run, not just the newest

### DIFF
--- a/spec/support/fake_context.cr
+++ b/spec/support/fake_context.cr
@@ -551,6 +551,10 @@ class FakeExecContext < Gori::Verb::ExecContext
     rec(:discover_toggle_pause)
   end
 
+  def discover_dismiss : Nil
+    rec(:discover_dismiss)
+  end
+
   def goto_discover : Nil
     rec(:goto_discover)
   end

--- a/spec/tui/discover_runs_pane_spec.cr
+++ b/spec/tui/discover_runs_pane_spec.cr
@@ -1,0 +1,159 @@
+require "../spec_helper"
+require "../support/memory_backend"
+
+# The Discover pane's RUNS list. Discovery is a BACKGROUND job and several can be in flight
+# at once, but the pane used to draw one summary card for the selected run: a second
+# "Discover here" moved the selection to the new run and the first one — still crawling —
+# had no row, no status, and no reachable ^X. Every example here is about a run OTHER than
+# the newest staying visible and selectable.
+include Gori::Tui
+
+private def discover_run(target : String, status : Symbol = :running,
+                         config : Gori::Discover::Config? = nil) : DiscoverRun
+  run = DiscoverRun.new(target, config || Gori::Discover::Config.new)
+  run.status = status
+  run
+end
+
+private def render_runs(view : DiscoverView, w = 120, h = 24) : MemoryBackend
+  backend = MemoryBackend.new(w, h)
+  view.render(Screen.new(backend), Rect.new(0, 0, w, h), true)
+  backend
+end
+
+# The screen row the target's own row landed on, so the click hit-test is checked against
+# what the renderer actually drew rather than against a hand-copied offset.
+private def row_of(backend : MemoryBackend, text : String, h = 24) : Int32
+  (0...h).each { |y| return y if backend.row(y).includes?(text) }
+  -1
+end
+
+describe "Discover RUNS list" do
+  it "keeps every launched run on screen, not just the newest" do
+    view = DiscoverView.new
+    view.add(discover_run("http://a.test/", :running))
+    view.add(discover_run("http://b.test/", :paused))
+    view.add(discover_run("http://c.test/", :running))
+    backend = render_runs(view)
+
+    backend.contains?("http://a.test/").should be_true
+    backend.contains?("http://b.test/").should be_true
+    backend.contains?("http://c.test/").should be_true
+    backend.contains?("RUNS (3)").should be_true
+    # Each row carries its own status, so "which one is still sending" is readable at a glance.
+    row_of(backend, "http://b.test/").should_not eq(-1)
+    backend.row(row_of(backend, "http://b.test/")).should contain("paused")
+    backend.row(row_of(backend, "http://a.test/")).should contain("running")
+  end
+
+  it "selects an earlier run with ↑/↓ so ^X/p have something to act on" do
+    view = DiscoverView.new
+    view.add(discover_run("http://a.test/"))
+    view.add(discover_run("http://b.test/"))
+    view.current.try(&.target).should eq("http://b.test/") # a launch selects the new run
+    view.runs_at_bottom?.should be_true
+
+    view.move_run(-1)
+    view.current.try(&.target).should eq("http://a.test/")
+    view.runs_at_top?.should be_true
+    view.move_run(-1) # clamped: the controller turns this into "leave for the sub-tab strip"
+    view.current.try(&.target).should eq("http://a.test/")
+  end
+
+  it "selects the run whose row was clicked" do
+    view = DiscoverView.new
+    view.add(discover_run("http://a.test/"))
+    view.add(discover_run("http://b.test/"))
+    view.add(discover_run("http://c.test/"))
+    rect = Rect.new(0, 0, 120, 24)
+    backend = MemoryBackend.new(120, 24)
+    view.render(Screen.new(backend), rect, true)
+
+    y = row_of(backend, "http://a.test/")
+    y.should_not eq(-1)
+    view.click(rect, 10, y)
+    view.focus.should eq(:runs)
+    view.current.try(&.target).should eq("http://a.test/")
+  end
+
+  it "scrolls the list rather than dropping rows when runs outgrow the card" do
+    view = DiscoverView.new
+    20.times { |i| view.add(discover_run("http://h#{i}.test/")) }
+    backend = render_runs(view)
+    # The newest run is selected, so the window must have followed the selection down.
+    backend.contains?("http://h19.test/").should be_true
+    backend.contains?("RUNS (20)").should be_true
+
+    view.move_run(-19) # back to the first run
+    top = render_runs(view)
+    top.contains?("http://h0.test/").should be_true
+  end
+
+  it "reports the SELECTED run's cost in the detail band, not the newest run's" do
+    stopped = discover_run("http://a.test/", :budget_exhausted,
+      Gori::Discover::Config.new(max_requests: 8_i64))
+    stopped.sent = 8_i64
+    stopped.queued = 275
+    view = DiscoverView.new
+    view.add(stopped)
+    view.add(discover_run("http://b.test/", :running))
+    render_runs(view).contains?("budget exhausted").should be_false # b is selected
+
+    view.move_run(-1)
+    back = render_runs(view)
+    back.contains?("budget exhausted").should be_true
+    back.contains?("275").should be_true
+  end
+
+  it "dismisses a finished run's row and keeps the selection in range" do
+    view = DiscoverView.new
+    view.add(discover_run("http://a.test/", :done))
+    view.add(discover_run("http://b.test/", :stopped))
+    b = view.current.not_nil!
+
+    view.dismiss(b).should be_true
+    view.count.should eq(1)
+    view.current.try(&.target).should eq("http://a.test/") # the selection never dangles past the end
+    render_runs(view).contains?("http://b.test/").should be_false
+
+    view.dismiss(b).should be_false # already gone
+    view.dismiss(view.current.not_nil!).should be_true
+    view.empty?.should be_true
+    render_runs(view).contains?("no runs").should be_true
+  end
+
+  it "refuses to dismiss a run that is still crawling" do
+    view = DiscoverView.new
+    running = discover_run("http://a.test/", :running)
+    paused = discover_run("http://b.test/", :paused)
+    view.add(running)
+    view.add(paused)
+
+    # Both count as live (DiscoverRun#running? covers :paused): the engine fiber outlives the
+    # row and drain_events drops events for a run that left the list, so dropping either would
+    # orphan a crawl that is still sending.
+    view.dismiss(running).should be_false
+    view.dismiss(paused).should be_false
+    view.count.should eq(2)
+  end
+
+  it "steps between the RUNS list and the FINDINGS table" do
+    view = DiscoverView.new
+    view.add(discover_run("http://a.test/"))
+    view.focus.should eq(:runs)
+    view.pane_advance(1).should be_true
+    view.focus.should eq(:findings)
+    view.pane_advance(1).should be_false # off the last pane → the ring returns to the tab bar
+    view.pane_advance(-1).should be_true
+    view.focus.should eq(:runs)
+    view.pane_advance(-1).should be_false
+  end
+
+  it "keeps the target and status columns at a narrow body width" do
+    view = DiscoverView.new
+    view.add(discover_run("http://narrow.test/", :running))
+    backend = render_runs(view, 40, 16)
+    backend.contains?("narrow.test").should be_true
+    (0...16).any? { |y| backend.row(y).includes?("running") }.should be_true
+  end
+end

--- a/spec/verb/registry_spec.cr
+++ b/spec/verb/registry_spec.cr
@@ -508,6 +508,10 @@ private class FakeContext < ExecContext
     @calls << :discover_toggle_pause
   end
 
+  def discover_dismiss : Nil
+    @calls << :discover_dismiss
+  end
+
   def oast_listen : Nil
     @calls << :oast_listen
   end

--- a/src/gori/tui/controllers/discover_controller.cr
+++ b/src/gori/tui/controllers/discover_controller.cr
@@ -14,6 +14,10 @@ module Gori::Tui
   # MinerController (start_run / drain_events / apply_event + the drain-before-rebind race
   # fix). Composed by TargetController, so it exposes frameless render_content /
   # handle_click_content seams instead of owning the tab frame.
+  #
+  # The body is two panes (RUNS list ↹ FINDINGS table): every launched run keeps a row, and
+  # ^R/^X/p act on the SELECTED row, so a crawl started before the current one is still
+  # reachable — see DiscoverView's note on what the single-card version cost.
   class DiscoverController < TabController
     DRAIN_CAP = 512
 
@@ -45,7 +49,11 @@ module Gori::Tui
 
     def body_hint(focus : Symbol) : String
       return "start from Sitemap/History (space → \"Discover here\")" if @view.empty?
-      "↑/↓ nav · [ / ] runs · ^R run · ^X stop · p pause · space cmds · esc tabs"
+      if @view.focus == :runs
+        "↑/↓ runs · tab findings · ^R run · ^X stop · p pause · d dismiss · space cmds · esc tabs"
+      else
+        "↑/↓ nav · tab runs · [ / ] runs · ^R run · ^X stop · p pause · d dismiss · esc tabs"
+      end
     end
 
     # --- rendering (frameless seam for TargetController) ---
@@ -59,6 +67,7 @@ module Gori::Tui
 
     def handle_click_content(content : Rect, mx : Int32, my : Int32) : Bool
       @host.focus_body
+      @view.click(content, mx, my)
       true
     end
 
@@ -68,40 +77,78 @@ module Gori::Tui
 
     # --- input ---
     def handle_body_key(ev : Termisu::Event::Key) : Bool
-      key = ev.key
-      if @view.empty?
-        if key.escape? || key.up? || key.lower_k?
-          @host.request_focus(:subtabs) # pop to Target's Sitemap|Discover strip (self-downgrades to :menu with no strip)
-          return true
-        end
-        return false
-      end
-      if key.space? && !ev.ctrl? && !ev.alt?
+      return handle_empty_key(ev) if @view.empty?
+      if ev.key.space? && !ev.ctrl? && !ev.alt?
         @host.open_space_menu
         return true
       end
-      return false if (ev.ctrl? || ev.alt?) && !key.escape? # ^R/^X/^P fall through to the verb keymap
-      c = ev.char || key.to_char
+      return false if (ev.ctrl? || ev.alt?) && !ev.key.escape? # ^R/^X/^P fall through to the verb keymap
+      return true if handle_pane_chord(ev)
+      @view.focus == :runs ? handle_runs_key(ev) : handle_findings_key(ev)
+    end
+
+    private def handle_empty_key(ev : Termisu::Event::Key) : Bool
+      key = ev.key
+      return false unless key.escape? || key.up? || key.lower_k?
+      @host.request_focus(:subtabs) # pop to Target's Sitemap|Discover strip (self-downgrades to :menu with no strip)
+      true
+    end
+
+    # Keys that mean the same thing in either pane.
+    private def handle_pane_chord(ev : Termisu::Event::Key) : Bool
+      c = ev.char || ev.key.to_char
       case
-      when key.escape?             then @host.request_focus(:subtabs)
-      when key.up?, key.lower_k?   then @view.at_top? ? @host.request_focus(:subtabs) : @view.move(-1)
+      when ev.key.escape? then @host.request_focus(:subtabs)
+      when c == '['       then @view.move_run(-1) # cycling still works from either pane
+      when c == ']'       then @view.move_run(1)
+      when c == 'p'       then discover_toggle_pause
+      else                     return false
+      end
+      true
+    end
+
+    # RUNS list: ↑/↓ walk the runs (which is what ^R/^X/p then act on), stepping off the
+    # bottom into the findings table and off the top to the Sitemap|Discover strip.
+    private def handle_runs_key(ev : Termisu::Event::Key) : Bool
+      key = ev.key
+      case
+      when key.up?, key.lower_k?   then @view.runs_at_top? ? @host.request_focus(:subtabs) : @view.move_run(-1)
+      when key.down?, key.lower_j? then @view.runs_at_bottom? ? @view.focus_pane(:findings) : @view.move_run(1)
+      else                              return false
+      end
+      true
+    end
+
+    private def handle_findings_key(ev : Termisu::Event::Key) : Bool
+      key = ev.key
+      case
+      when key.up?, key.lower_k?   then @view.findings_at_top? ? @view.focus_pane(:runs) : @view.move(-1)
       when key.down?, key.lower_j? then @view.move(1)
-      when c == '['                then @view.switch(-1)
-      when c == ']'                then @view.switch(1)
-      when c == 'p'                then discover_toggle_pause
       else                              return false
       end
       true
     end
 
     def body_scroll(delta : Int32) : Bool
-      @view.move(delta)
-      true
+      handle_wheel(delta)
     end
 
     def handle_wheel(step : Int32) : Bool
-      @view.move(step)
+      @view.focus == :runs ? @view.move_run(step) : @view.move(step)
       true
+    end
+
+    # --- focus ring ---
+    def pane_advance(dir : Int32) : Bool
+      @view.empty? ? false : @view.pane_advance(dir)
+    end
+
+    def focus_first : Nil
+      @view.focus_first
+    end
+
+    def focus_last : Nil
+      @view.focus_last
     end
 
     # --- verbs (delegated by the Runner's ExecContext) ---
@@ -119,20 +166,49 @@ module Gori::Tui
       start_run(run)
     end
 
+    # Stops the SELECTED run, not "the" run — with several crawls in flight the operator has
+    # to be told which row ^X landed on, and told when it landed on a finished one instead of
+    # silently doing nothing while another run keeps sending.
     def discover_stop : Nil
-      return unless (run = @view.current) && run.running?
+      run = @view.current
+      unless run && run.running?
+        @host.status(@view.any_running? ? "selected run is not running — ↑/↓ to the running row, then ^X" : "no run to stop")
+        return
+      end
       run.request_stop
-      @host.status("stopping…")
+      @host.status("stopping #{run.label(40)}…")
+    end
+
+    # Remove the selected run's row — the manual half of retention, since the list is append-
+    # only for the session (a long dogfood run otherwise scrolls through dozens of finished
+    # crawls). Refused while it is running or paused: the engine fiber outlives the row and
+    # `drain_events` drops events for a run that left the list, so this would orphan a crawl
+    # that is still sending. Findings already reached the Sitemap via the persist batch, so the
+    # row is the only thing lost.
+    def discover_dismiss : Nil
+      run = @view.current
+      unless run
+        @host.status("no run selected")
+        return
+      end
+      label = run.label(40)
+      unless @view.dismiss(run)
+        @host.status("#{label} is still going — ^X to stop it first")
+        return
+      end
+      @host.status(@view.empty? ? "dismissed #{label} — no runs left" : "dismissed #{label}")
     end
 
     def discover_toggle_pause : Nil
       return unless run = @view.current
       if run.paused?
         run.resume
-        @host.status("resumed")
+        @host.status("resumed #{run.label(40)}")
       elsif run.running?
         run.pause
-        @host.status("paused — p to resume")
+        @host.status("paused #{run.label(40)} — p to resume")
+      else
+        @host.status("selected run is #{run.status} — nothing to pause")
       end
     end
 

--- a/src/gori/tui/discover_view.cr
+++ b/src/gori/tui/discover_view.cr
@@ -1,6 +1,7 @@
 require "./screen"
 require "./theme"
 require "./frame"
+require "./fmt"
 require "../discover"
 
 module Gori::Tui
@@ -96,15 +97,35 @@ module Gori::Tui
     end
   end
 
-  # The Discover sub-tab body: a summary/control card + a live findings table for the
-  # SELECTED run (multiple runs cycle with [ / ]). Read-only — runs are launched from the
-  # config overlay (Sitemap/History space menu or ^R here).
+  # The Discover sub-tab body: a RUNS list over every session launched this run of the TUI
+  # (in flight AND finished) + a live findings table for the SELECTED run. Runs are launched
+  # from the config overlay (Sitemap/History space menu, or ^R here to re-run the selected
+  # one); ^X/p act on the SELECTED row.
+  #
+  # Every run stays on screen because every action here is per-run. The pane used to draw a
+  # single summary card for `current` and cycle with [ / ]: launching a second `Discover
+  # here` moved the selection to the new run and left the first one — still crawling — with
+  # no visible row, no status, and no reachable ^X.
   class DiscoverView
+    PANE_ORDER = [:runs, :findings]
+
+    # Run-row column widths. The blocks are laid out from the right edge and DROP when the
+    # body is narrow (counts first, then techniques) so a run's target and its status —
+    # the two things an action needs — survive at any width.
+    RUN_STATUS_W   =  9
+    RUN_TECH_W     = 13
+    RUN_COUNT_W    = 20
+    RUN_TARGET_MIN = 16
+
+    getter focus : Symbol
+
     def initialize
       @runs = [] of DiscoverRun
       @sel = 0
       @fsel = 0
       @scroll = 0
+      @rscroll = 0
+      @focus = :runs
     end
 
     def empty? : Bool
@@ -139,9 +160,7 @@ module Gori::Tui
 
     def select_run_by_id(id : Int32) : Nil
       if idx = @runs.index { |r| r.id == id }
-        @sel = idx
-        @fsel = 0
-        @scroll = 0
+        select_run(idx)
       end
     end
 
@@ -149,7 +168,58 @@ module Gori::Tui
       @runs.any?(&.running?)
     end
 
+    # Drop a finished run's row (the list is otherwise append-only for the whole session).
+    # REFUSES a live one — `DiscoverController#drain_events` skips events whose run is no
+    # longer in `@runs`, so removing a crawling run would leave its engine fiber sending with
+    # nothing on screen to stop it. Returns false when it refused or the run was already gone,
+    # so the caller can say why. The guard lives here, next to the array it protects, rather
+    # than only at the one call site that reports it.
+    def dismiss(run : DiscoverRun) : Bool
+      return false if run.running?
+      idx = @runs.index(&.same?(run))
+      return false unless idx
+      @runs.delete_at(idx)
+      @sel = @sel.clamp(0, {@runs.size - 1, 0}.max)
+      @fsel = 0
+      @scroll = 0
+      @rscroll = 0
+      true
+    end
+
+    # --- focus ring (RUNS list ↹ FINDINGS table) ---
+    def focus_pane(pane : Symbol) : Nil
+      @focus = pane if PANE_ORDER.includes?(pane)
+    end
+
+    def focus_first : Nil
+      @focus = :runs
+    end
+
+    def focus_last : Nil
+      @focus = :findings
+    end
+
+    def pane_advance(dir : Int32) : Bool
+      idx = PANE_ORDER.index(@focus) || 0
+      nidx = idx + dir
+      return false unless 0 <= nidx < PANE_ORDER.size
+      @focus = PANE_ORDER[nidx]
+      true
+    end
+
     # --- nav ---
+    def move_run(d : Int32) : Nil
+      switch(d)
+    end
+
+    def runs_at_top? : Bool
+      @sel <= 0
+    end
+
+    def runs_at_bottom? : Bool
+      @sel >= @runs.size - 1
+    end
+
     def move(d : Int32) : Nil
       return unless r = current
       return if r.findings.empty?
@@ -160,60 +230,160 @@ module Gori::Tui
       current.try(&.findings[@fsel]?)
     end
 
-    def at_top? : Bool
+    def findings_at_top? : Bool
       @fsel == 0
     end
 
     # --- rendering ---
     def render(screen : Screen, rect : Rect, focused : Bool) : Nil
-      sum_h = {rect.h // 3, 7}.min
-      sum_h = rect.h - 3 if sum_h > rect.h - 3
-      sum_rect = Rect.new(rect.x, rect.y, rect.w, {sum_h, 1}.max)
-      res_rect = Rect.new(rect.x, rect.y + sum_rect.h, rect.w, {rect.h - sum_rect.h, 1}.max)
-      render_summary(screen, sum_rect, focused)
-      render_findings(screen, res_rect, focused)
+      runs_rect = Rect.new(rect.x, rect.y, rect.w, runs_pane_height(rect))
+      res_rect = Rect.new(rect.x, rect.y + runs_rect.h, rect.w, {rect.h - runs_rect.h, 1}.max)
+      render_runs(screen, runs_rect, focused && @focus == :runs)
+      render_findings(screen, res_rect, focused && @focus == :findings)
     end
 
-    private def render_summary(screen : Screen, rect : Rect, focused : Bool) : Nil
-      Frame.card(screen, rect, "DISCOVER", border: focused ? Theme.focus_gold : Theme.border, bg: Theme.bg)
+    # The RUNS card grows a row per run so a second and third crawl are VISIBLE rather than
+    # cycled to. It stops growing once the findings table is down to its last six rows (the
+    # list scrolls from there), and on a body too short for even that the card is clamped to
+    # `rect.h - 3` so the findings card is never squeezed out of existence.
+    private def runs_pane_height(rect : Rect) : Int32
+      # borders(2) + column header(1) + one row per run + divider(1) + detail(2)
+      h = {@runs.size + 6, {rect.h - 6, 7}.max}.min
+      h = rect.h - 3 if h > rect.h - 3
+      {h, 1}.max
+    end
+
+    # {rows_y, rows_cap, detail_y} for the RUNS card's interior — the row band and the
+    # selected-run detail band. Shared by render and the click hit-test so a click can't
+    # land on a row the renderer put somewhere else. `detail_y` is -1 when the card is too
+    # short for the detail band (it is the first thing to go).
+    private def run_bands(card : Rect) : {Int32, Int32, Int32}
+      inner = card.inset(1, 1)
+      return {inner.y, 0, -1} if inner.h <= 0
+      detail_h = inner.h >= 5 ? 3 : 0
+      list_h = inner.h - detail_h
+      hdr = list_h >= 2 ? 1 : 0
+      {inner.y + hdr, {list_h - hdr, 1}.max, detail_h > 0 ? inner.y + list_h : -1}
+    end
+
+    private def render_runs(screen : Screen, rect : Rect, focused : Bool) : Nil
+      title = "RUNS (#{@runs.size})"
+      Frame.card(screen, rect, title, border: Frame.pane_border(focused), bg: Theme.bg)
+      inner = rect.inset(1, 1)
+      return if inner.h <= 0 || inner.w <= 0
       r = current
       unless r
-        screen.text(rect.x + 2, rect.y + 1,
-          "no runs — from Sitemap/History press space → \"Discover here\"", Theme.muted, Theme.bg, width: rect.w - 4)
+        screen.text(inner.x + 1, inner.y,
+          "no runs — from Sitemap/History press space → \"Discover here\"", Theme.muted, Theme.bg, width: inner.w - 1)
         return
       end
-      running = r.running?
-      chord, name = running ? {"^X", "STOP"} : {"^R", "RUN"}
-      Frame.toggle_badge(screen, rect.right - 1, rect.y, rect.x + "DISCOVER".size + 4, chord, name, running)
-      x = rect.x + 2
-      y = rect.y + 1
-      hdr = @runs.size > 1 ? "run #{@sel + 1}/#{@runs.size}  #{r.label(rect.w - 20)}" : r.label(rect.w - 6)
-      screen.text(x, y, hdr, Theme.text_bright, Theme.bg, Attribute::Bold, width: rect.w - 4)
-      y += 1
-      if y < rect.bottom - 1
-        cap = r.config.max_requests.try { |m| " · cap #{m}" } || ""
-        screen.text(x, y, "#{r.techniques} · #{r.config.containment.label} · depth #{r.config.max_depth}#{cap}",
-          Theme.muted, Theme.bg, width: rect.w - 4)
+      # The badge tracks the SELECTED row, which is what ^R/^X act on — so a stopped run
+      # selected while another still crawls offers RUN, not STOP.
+      chord, name = r.running? ? {"^X", "STOP"} : {"^R", "RUN"}
+      Frame.toggle_badge(screen, rect.right - 1, rect.y, rect.x + title.size + 4, chord, name, r.running?)
+
+      rows_y, rows_cap, detail_y = run_bands(rect)
+      runs_header_row(screen, inner) if rows_y > inner.y
+      ensure_run_visible(rows_cap)
+      rows_cap.times do |i|
+        idx = @rscroll + i
+        break if idx >= @runs.size
+        draw_run_row(screen, inner, @runs[idx], idx, rows_y + i, focused)
       end
-      y += 1
-      if y < rect.bottom - 1
-        st = case r.status
-             when :error            then "error: #{r.error_msg}"
-             when :budget_exhausted then "budget exhausted · #{r.queued} queued unexplored — raise max requests to finish"
-             else                        r.status.to_s
-             end
-        screen.text(x, y, st, status_hue(r.status), Theme.bg, width: rect.w - 4)
+      Frame.scroll_gauge(screen, Rect.new(inner.x, rows_y, inner.w, rows_cap), @runs.size, @rscroll, focused)
+      return if detail_y < 0
+      Frame.inner_divider(screen, inner, detail_y, Theme.bg, Frame.pane_border(focused))
+      render_run_detail(screen, inner, detail_y + 1, r)
+    end
+
+    # Column x-offsets for one run row: {target_w, tech_x, status_x, counts_x}, where a
+    # negative x means the block does not fit and is not drawn.
+    private def run_layout(inner : Rect) : {Int32, Int32, Int32, Int32}
+      x = inner.x + 2
+      edge = inner.right
+      counts_x = -1
+      if edge - x >= RUN_TARGET_MIN + RUN_TECH_W + RUN_STATUS_W + RUN_COUNT_W
+        counts_x = edge - RUN_COUNT_W
+        edge = counts_x
       end
-      y += 1
-      if y < rect.bottom - 1
-        screen.text(x, y, "found #{r.found} · #{r.sent} sent · #{r.queued} queued · #{r.errors} err",
-          Theme.muted, Theme.bg, width: rect.w - 4)
+      status_x = edge - RUN_STATUS_W
+      status_x = -1 if status_x < x + 8
+      tech_x = -1
+      tech_x = status_x - RUN_TECH_W if status_x >= 0 && status_x - x >= RUN_TARGET_MIN + RUN_TECH_W
+      right_block = tech_x >= 0 ? tech_x : (status_x >= 0 ? status_x : edge)
+      target_w = {right_block - x - 1, 4}.max
+      {target_w, tech_x, status_x, counts_x}
+    end
+
+    private def runs_header_row(screen : Screen, inner : Rect) : Nil
+      target_w, tech_x, status_x, counts_x = run_layout(inner)
+      screen.text(inner.x + 2, inner.y, "TARGET", Theme.muted, Theme.bg, width: target_w)
+      screen.text(tech_x, inner.y, "HOW", Theme.muted, Theme.bg, width: RUN_TECH_W - 1) if tech_x >= 0
+      screen.text(status_x, inner.y, "STATUS", Theme.muted, Theme.bg, width: RUN_STATUS_W - 1) if status_x >= 0
+      screen.text(counts_x, inner.y, "FOUND·SENT·QUEUE", Theme.muted, Theme.bg, width: RUN_COUNT_W) if counts_x >= 0
+    end
+
+    private def draw_run_row(screen : Screen, inner : Rect, r : DiscoverRun, idx : Int32,
+                             py : Int32, focused : Bool) : Nil
+      sel = idx == @sel
+      bg = sel ? (focused ? Theme.accent_bg : Theme.selection_dim) : Theme.bg
+      screen.fill(Rect.new(inner.x, py, inner.w, 1), bg)
+      screen.cell(inner.x, py, sel ? '▎' : ' ', Theme.accent, bg)
+      target_w, tech_x, status_x, counts_x = run_layout(inner)
+      screen.text(inner.x + 2, py, r.target, sel ? Theme.text_bright : Theme.text, bg, width: target_w)
+      screen.text(tech_x, py, r.techniques, Theme.accent, bg, width: RUN_TECH_W - 1) if tech_x >= 0
+      screen.text(status_x, py, short_status(r), status_hue(r.status), bg, width: RUN_STATUS_W - 1) if status_x >= 0
+      screen.text(counts_x, py, run_counts(r), Theme.muted, bg, width: RUN_COUNT_W) if counts_x >= 0
+    end
+
+    # `:budget_exhausted` shortened for the fixed column — the detail band below spells out
+    # what it cost. Not "done": the crawl left candidates it never looked at.
+    private def short_status(r : DiscoverRun) : String
+      r.status == :budget_exhausted ? "budget" : r.status.to_s
+    end
+
+    # Rounded (`Fmt.count`) so the column stays fixed-width on a long crawl; the detail band
+    # carries the exact figures for the selected run.
+    private def run_counts(r : DiscoverRun) : String
+      "#{Fmt.count(r.found.to_i64)}f · #{Fmt.count(r.sent)}s · #{Fmt.count(r.queued.to_i64)}q"
+    end
+
+    private def render_run_detail(screen : Screen, inner : Rect, y : Int32, r : DiscoverRun) : Nil
+      w = {inner.w - 1, 1}.max
+      cap = r.config.max_requests.try { |m| " · cap #{m}" } || ""
+      screen.text(inner.x + 1, y, "#{r.techniques} · #{r.config.containment.label} · depth #{r.config.max_depth}#{cap}",
+        Theme.muted, Theme.bg, width: w)
+      return if y + 1 >= inner.bottom
+      screen.text(inner.x + 1, y + 1, run_detail_note(r), detail_hue(r.status), Theme.bg, width: w)
+    end
+
+    # What the selected row's status COST the operator: an error's message, a budget stop's
+    # unexplored remainder (never rendered as "done" — see DiscoverRun#status), else the
+    # suppression breakdown once the engine reported stats.
+    private def run_detail_note(r : DiscoverRun) : String
+      case r.status
+      when :error
+        "error: #{r.error_msg}"
+      when :budget_exhausted
+        "budget exhausted · #{r.queued} queued unexplored — raise max requests to finish"
+      else
+        if s = r.stats
+          "fp-cut #{s.calibrated_out} · dedup #{s.dedup_suppressed} · tmpl #{s.template_suppressed} · clust #{s.cluster_suppressed}"
+        else
+          "found #{r.found} · #{r.sent} sent · #{r.queued} queued · #{r.errors} err"
+        end
       end
-      y += 1
-      if (s = r.stats) && y < rect.bottom - 1
-        screen.text(x, y, "fp-cut #{s.calibrated_out} · dedup #{s.dedup_suppressed} · tmpl #{s.template_suppressed} · clust #{s.cluster_suppressed}",
-          Theme.muted, Theme.bg, width: rect.w - 4)
-      end
+    end
+
+    private def detail_hue(s : Symbol) : Color
+      s == :error || s == :budget_exhausted ? status_hue(s) : Theme.muted
+    end
+
+    private def ensure_run_visible(cap : Int32) : Nil
+      return if cap <= 0
+      @rscroll = @sel if @sel < @rscroll
+      @rscroll = @sel - cap + 1 if @sel >= @rscroll + cap
+      @rscroll = 0 if @rscroll < 0
     end
 
     private def status_hue(s : Symbol) : Color
@@ -297,7 +467,30 @@ module Gori::Tui
 
     # --- click hit-test ---
     def pane_at(rect : Rect, mx : Int32, my : Int32) : Symbol?
-      rect.contains?(mx, my) ? :findings : nil
+      return nil unless rect.contains?(mx, my)
+      my < rect.y + runs_pane_height(rect) ? :runs : :findings
+    end
+
+    # Focus the clicked pane, and on a RUNS row select that run — clicking a row is the
+    # discoverable way to reach an earlier crawl before pressing ^X on it.
+    def click(rect : Rect, mx : Int32, my : Int32) : Nil
+      return unless pane = pane_at(rect, mx, my)
+      focus_pane(pane)
+      return unless pane == :runs
+      card = Rect.new(rect.x, rect.y, rect.w, runs_pane_height(rect))
+      rows_y, rows_cap, _ = run_bands(card)
+      row = my - rows_y
+      return unless 0 <= row < rows_cap
+      idx = @rscroll + row
+      return unless 0 <= idx < @runs.size
+      select_run(idx)
+    end
+
+    private def select_run(idx : Int32) : Nil
+      return if idx == @sel
+      @sel = idx
+      @fsel = 0
+      @scroll = 0
     end
   end
 end

--- a/src/gori/tui/runner/discover.cr
+++ b/src/gori/tui/runner/discover.cr
@@ -73,6 +73,10 @@ class Gori::Tui::Runner < Gori::Verb::ExecContext
     discover_controller.discover_toggle_pause
   end
 
+  def discover_dismiss : Nil
+    discover_controller.discover_dismiss
+  end
+
   def goto_discover : Nil
     focus_tab(:target)
     target_controller.select_discover

--- a/src/gori/verb/context/discover.cr
+++ b/src/gori/verb/context/discover.cr
@@ -6,5 +6,6 @@ abstract class Gori::Verb::ExecContext
   abstract def discover_run : Nil          # start / re-run the current Discover run
   abstract def discover_stop : Nil         # stop the running Discover run
   abstract def discover_toggle_pause : Nil # pause / resume the running Discover run
+  abstract def discover_dismiss : Nil      # drop the selected FINISHED run's row from the list
   abstract def goto_discover : Nil         # focus the Target tab's Discover sub-tab
 end

--- a/src/gori/verbs/discover.cr
+++ b/src/gori/verbs/discover.cr
@@ -10,7 +10,7 @@ module Gori
         Verb::Scope::Discover, [Verb::Chord.new("r", ctrl: true)], mnemonic: 'r') { |ctx| ctx.discover_run; nil }
 
       r.register Verb::Definition.new(
-        "discover.stop", "Stop", "Stop the running discovery (in-flight requests finish)",
+        "discover.stop", "Stop", "Stop the selected discovery run (in-flight requests finish)",
         Verb::Scope::Discover, [Verb::Chord.new("x", ctrl: true)], mnemonic: 'x') { |ctx| ctx.discover_stop; nil }
 
       # Plain `p` toggles pause in the body (handled by the controller); the space menu
@@ -18,6 +18,12 @@ module Gori
       r.register Verb::Definition.new(
         "discover.pause", "Pause / resume", "Pause or resume the running discovery",
         Verb::Scope::Discover, [] of Verb::Chord, mnemonic: 'p') { |ctx| ctx.discover_toggle_pause; nil }
+
+      # `d` clears a finished row from the RUNS list, which is append-only for the session.
+      # Never a running one — the controller refuses and says to stop it first.
+      r.register Verb::Definition.new(
+        "discover.dismiss", "Dismiss run", "Remove the selected finished run from the RUNS list",
+        Verb::Scope::Discover, [Verb::Chord.new("d")], mnemonic: 'd') { |ctx| ctx.discover_dismiss; nil }
 
       r.register Verb::Definition.new(
         "discover.to-menu", "Back to sub-tabs", "Move focus up to the Sitemap/Discover strip", Verb::Scope::Discover,


### PR DESCRIPTION
## Why

Discover launches **background** jobs and several can crawl at once, but the pane drew one summary card for the selected run and cycled with `[ / ]`. Starting a second "Discover here" moved the selection to the new run, so the first one — still sending — had no row, no status, and no reachable `^X`. The only way back was a chord nothing on screen mentioned.

## What

The body is now two panes.

```
╭─ RUNS (3) ────────────────────────────────────────────────────────── ^X:STOP ╮
│  TARGET                              HOW          STATUS   FOUND·SENT·QUEUE  │
│  https://127.0.0.1/                  spider+brute done     0f · 562s · 0q    │
│▎ https://127.0.0.1/a/                spider+brute stopped  0f · 338s · 105q  │
│  https://127.0.0.1/c/                spider+brute running  0f · 228s · 175q  │
├──────────────────────────────────────────────────────────────────────────────┤
│ spider+brute · scope-aware · depth 4                                         │
│ fp-cut 0 · dedup 0 · tmpl 0 · clust 0                                        │
╰──────────────────────────────────────────────────────────────────────────────╯
╭─ FINDINGS (0) ─ … the selected run's table, unchanged ───────────────────────╯
```

- **RUNS** lists every run launched this session (in flight and finished): target, techniques, status, found·sent·queued. It grows a row per run until the findings table is down to its last rows, then scrolls with a gauge and follows the selection. Columns drop right-to-left on a narrow body so target + status always survive.
- Below a divider, two lines carry the **selected** run's config and what its status cost — an error's message, a budget stop's unexplored remainder, else the suppression breakdown.
- `^R`/`^X`/`p` act on the **selected** row, so an earlier crawl is reachable: `↑/↓` walk the list (off the bottom into findings, off the top to the sub-tab strip), `Tab` steps the panes, `[ / ]` still cycles, and a click selects the row it landed on. `^X`/`p` now name the run they hit and say when the selected row is already finished instead of no-opping while another run keeps sending.
- `d` (and the space menu's "Dismiss run") drops a finished row, since the list is otherwise append-only for the session.

## Why dismissing a live run is refused

The engine fiber outlives the row and `drain_events` discards events for a run that left the list, so dismissing a crawling one would orphan it — still sending, with nothing on screen to stop it. The guard sits in `DiscoverView#dismiss` next to the array it protects (`:paused` counts as live too); the controller only reports why. Findings already reached the Sitemap through the persist batch, so the row is all that is lost.

## Verification

- **Live TUI** (tmux, isolated `GORI_HOME`, slow local origin): three concurrent runs visible at once; `^X` stopped the run selected two rows up (`stopped`, 105 queued left) while the newest kept crawling; `d` refused the live row (`… is still going — ^X to stop it first`) then cleared the stopped one; `^R` re-ran the selected earlier row; mouse click selected a row; space menu shows `d Dismiss run`.
- `spec/tui/discover_runs_pane_spec.cr` (9 examples): all runs rendered, earlier-run selection, click hit-test against the row the renderer drew, scrolling past the card cap, narrow-width column fallback, the budget detail following the selection, dismiss + selection clamp, dismiss refused while running/paused, pane ring.
- Full suite green (6211 examples, 0 failures) on the rebased tree; touched files clean under `crystal tool format --check` and ameba.