### PR TITLE
One seam downstream, again: a credential on the redirect hop, a POST sweep half-sent, and four records that did not match what happened

### DIFF
--- a/spec/bindings_proxy_extract_spec.cr
+++ b/spec/bindings_proxy_extract_spec.cr
@@ -201,6 +201,137 @@ describe "Gori::Bindings — the proxy response seam (#501 slice 2)" do
       end
     end
 
+    # One origin response, five descriptors, ONE value. `decoded_text` used to `#scrub` the
+    # whole body before `regex`, `position` and `jsonpath` touched it, so an invalid UTF-8 byte
+    # became U+FFFD and every `position` offset past it slid by two — a cookie rule returned the
+    # origin's `41 42 FF 43 44` and a `position` rule asking for the same five bytes returned
+    # five different ones. `bindings.cr` states the rule that breaks: "the same `TokenLoc` on
+    # the same response has to mean one thing", and its own comment says "`Position` has no
+    # text-only reading at all".
+    describe "a body that is not valid UTF-8" do
+      # `AB\xffCD` in the cookie, the header and the body — mint.py's `/login?m=nonutf8` shape.
+      nonutf8_body = String.new(Bytes[0x7b, 0x22, 0x74, 0x22, 0x3a, 0x22, 0x41, 0x42, 0xff,
+        0x43, 0x44, 0x22, 0x7d, 0x54, 0x4f, 0x4b, 0x45, 0x4e, 0x3d, 0x41, 0x42, 0xff, 0x43,
+        0x44, 0x3b]) # {"t":"AB\xffCD"}TOKEN=AB\xffCD;
+      head = "HTTP/1.1 200 OK\r\nSet-Cookie: sid=" + String.new(Bytes[0x41, 0x42, 0xff, 0x43, 0x44]) +
+             "\r\n\r\n"
+
+      it "gives a position descriptor the origin's bytes, not a repaired reading" do
+        with_store do |store|
+          b = Gori::Bindings.load(store)
+          b.add("CTOK", "", Gori::ExtractKind::Cookie, "sid").should be_nil
+          # bytes 6..10 of the body are exactly `AB\xffCD` — the same five the cookie carries.
+          b.add("QTOK", "", Gori::ExtractKind::Position, "", 6, 11).should be_nil
+          observe(b, head, nonutf8_body.to_slice)
+          origin = Bytes[0x41, 0x42, 0xff, 0x43, 0x44]
+          b.values["QTOK"].to_slice.should eq origin
+          # The whole point: the two descriptors agree, byte for byte.
+          b.values["QTOK"].should eq b.values["CTOK"]
+        end
+      end
+
+      it "does not slide a range that starts past the invalid byte" do
+        with_store do |store|
+          b = Gori::Bindings.load(store)
+          # `TOKEN` — five bytes at 13..17, all AFTER the 0xff at offset 8. Under the scrubbed
+          # reading this came back as `EN=AB` (the U+FFFD had pushed everything two along).
+          b.add("PTOK", "", Gori::ExtractKind::Position, "", 13, 18).should be_nil
+          observe(b, head, nonutf8_body.to_slice)
+          b.values["PTOK"].should eq "TOKEN"
+        end
+      end
+
+      it "is unaffected by an invalid byte AFTER the requested range" do
+        with_store do |store|
+          b = Gori::Bindings.load(store)
+          # bytes 0..5 are `{"t":"`, entirely before the 0xff at 8.
+          b.add("PTOK", "", Gori::ExtractKind::Position, "", 0, 6).should be_nil
+          observe(b, head, nonutf8_body.to_slice)
+          b.values["PTOK"].should eq %({"t":")
+        end
+      end
+
+      it "returns the invalid byte itself when the range ends exactly on it" do
+        with_store do |store|
+          b = Gori::Bindings.load(store)
+          b.add("PTOK", "", Gori::ExtractKind::Position, "", 6, 9).should be_nil
+          observe(b, head, nonutf8_body.to_slice)
+          b.values["PTOK"].to_slice.should eq Bytes[0x41, 0x42, 0xff]
+        end
+      end
+
+      # `Regex` and `JsonPath` genuinely need a valid subject — Crystal's `Regex` raises
+      # `ArgumentError` otherwise — so the scrub STAYS there. What must not stay is it being
+      # silent: binding bytes that are not the origin's without saying so is the one option
+      # ruled out. Refusing outright was rejected: a page in a legacy encoding with a CSRF
+      # token in it is an ordinary target and refusing would break a case that works today.
+      it "binds a regex descriptor but says the body was repaired" do
+        with_store do |store|
+          b = Gori::Bindings.load(store)
+          b.add("RTOK", "", Gori::ExtractKind::Regex, "TOKEN=([\\s\\S]*?);").should be_nil
+          observe(b, head, nonutf8_body.to_slice)
+          b.bound?("RTOK").should be_true
+          ev = store.events_after(0, 50).find { |e| e.kind == "extract_scrubbed" }.not_nil!
+          ev.level.should eq("warn")
+          ev.message.should contain("$RTOK")
+          ev.message.should contain("not valid UTF-8")
+          ev.message.should contain("U+FFFD")
+        end
+      end
+
+      # Once per rule per rule revision, the same key `extract_no_body` uses: this is a
+      # structural fact about the target's body, so it is news when the operator edits the
+      # rule and noise on every subsequent response.
+      it "says it once per rule, not once per response" do
+        with_store do |store|
+          b = Gori::Bindings.load(store)
+          b.add("RTOK", "", Gori::ExtractKind::Regex, "TOKEN=([\\s\\S]*?);").should be_nil
+          5.times { observe(b, head, nonutf8_body.to_slice) }
+          store.events_after(0, 50).count { |e| e.kind == "extract_scrubbed" }.should eq 1
+        end
+      end
+
+      # The COMPLEMENT of the condition the advisory keys on, in both directions.
+      it "says nothing for a valid-UTF-8 body, and nothing for a byte-scoped descriptor" do
+        with_store do |store|
+          b = Gori::Bindings.load(store)
+          b.add("RTOK", "", Gori::ExtractKind::Regex, "tok=(\\w+)").should be_nil
+          observe(b, "HTTP/1.1 200 OK\r\n\r\n", "tok=swordfish".to_slice)
+          b.values["RTOK"].should eq "swordfish"
+          store.events_after(0, 50).any? { |e| e.kind == "extract_scrubbed" }.should be_false
+        end
+        with_store do |store|
+          b = Gori::Bindings.load(store)
+          # `position` reads bytes, so an invalid body costs it nothing and says nothing.
+          b.add("PTOK", "", Gori::ExtractKind::Position, "", 6, 11).should be_nil
+          b.add("CTOK", "", Gori::ExtractKind::Cookie, "sid").should be_nil
+          observe(b, head, nonutf8_body.to_slice)
+          store.events_after(0, 50).any? { |e| e.kind == "extract_scrubbed" }.should be_false
+        end
+      end
+
+      # A gzip body is the case `Position`'s own comment names — "forty bytes of DEFLATE" —
+      # so the range must land on the DECODED entity and be byte-exact there too.
+      it "slices the decoded entity of a gzipped body, byte-exact" do
+        with_store do |store|
+          b = Gori::Bindings.load(store)
+          b.add("PTOK", "", Gori::ExtractKind::Position, "", 6, 11).should be_nil
+          observe(b, "HTTP/1.1 200 OK\r\nContent-Encoding: gzip\r\n\r\n", gzip(nonutf8_body))
+          b.values["PTOK"].to_slice.should eq Bytes[0x41, 0x42, 0xff, 0x43, 0x44]
+        end
+      end
+
+      it "slices the de-chunked entity of a chunked body, byte-exact" do
+        with_store do |store|
+          b = Gori::Bindings.load(store)
+          b.add("PTOK", "", Gori::ExtractKind::Position, "", 6, 11).should be_nil
+          observe(b, "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n",
+            chunked(nonutf8_body[0, 4], nonutf8_body[4..]))
+          b.values["PTOK"].to_slice.should eq Bytes[0x41, 0x42, 0xff, 0x43, 0x44]
+        end
+      end
+    end
+
     it "keeps the previous value when the extractor finds nothing" do
       with_store do |store|
         b = Gori::Bindings.load(store)

--- a/spec/bindings_spec.cr
+++ b/spec/bindings_spec.cr
@@ -187,6 +187,153 @@ describe Gori::Bindings do
       end
     end
 
+    # The refusal above is right and it was SILENT: no header on the wire, no event, no log
+    # line, no advisory, no status. `substitute` had two nil-returns meaning opposite things
+    # and one reporter that only understood the first — `report_unbound` computes
+    # `Env.unbound(replacement)` and returns when it is empty, and a BOUND name is by
+    # definition not unbound. So an origin minting a cookie with a stray CR in it disarmed
+    # every head-scoped injection rule the operator had configured, invisibly, and every
+    # later request went out unauthenticated while gori reported clean sends.
+    describe "the boundary refusal names itself" do
+      # One helper, three byte classes: the guard is CR/LF/NUL and each has to be named on
+      # its own, because "invalid" is not something an operator can act on.
+      {"\\r" => "CR", "\\n" => "LF", "\\u0000" => "NUL"}.each do |escape, byte_class|
+        it "writes a named event when the value carries #{byte_class}" do
+          with_store do |store|
+            b = Gori::Bindings.load(store)
+            b.add("SESSION", "", Gori::ExtractKind::JsonPath, "$.token").should be_nil
+            b.observe(response_result("HTTP/1.1 200 OK\r\n\r\n", %({"token":"a#{escape}b"})),
+              subject).should eq(["SESSION"])
+            with_layer(b) do
+              rules = Gori::Rules.new(store, store.match_rules)
+              rules.add(Gori::Store::RuleTarget::Request, Gori::Store::RulePart::Head, "X-Auth",
+                "$SESSION", Gori::Store::RuleOp::SetHeader, Gori::Store::MatchKind::Literal,
+                "inject", "", "")
+              req = "GET /a HTTP/1.1\r\nHost: acme.test\r\n\r\n".to_slice
+              rules.rewrite_request(req, "acme.test")
+
+              ev = store.events_after(0, 50).find { |e| e.kind == "boundary_refused" }
+              ev.should_not be_nil
+              ev = ev.not_nil!
+              ev.level.should eq("warn")
+              # It names the RULE, the BINDING and the byte class — and never the value.
+              ev.message.should contain(%("inject"))
+              ev.message.should contain("$SESSION")
+              ev.message.should contain(byte_class)
+              ev.message.should contain("forge a message boundary")
+              # And the VALUE never reaches the feed, not even the byte that triggered it.
+              ev.message.each_byte.none? { |x| x == 0x0d_u8 || x == 0x0a_u8 || x == 0x00_u8 }
+                .should be_true
+              # The rule still did not apply. A named refusal is not a licence to send.
+              String.new(rules.rewrite_request(req, "acme.test")).should_not contain("X-Auth:")
+            end
+          end
+        end
+      end
+
+      # The COMPLEMENT of the guard's own condition. A horizontal tab is a legal header-value
+      # byte and forges nothing, so it must pass byte-exact and say nothing at all — an
+      # over-wide guard here would be the same silent disarming with a different trigger.
+      it "does not fire for a TAB, which the guard deliberately allows" do
+        with_store do |store|
+          b = Gori::Bindings.load(store)
+          b.add("SESSION", "", Gori::ExtractKind::JsonPath, "$.token").should be_nil
+          b.observe(response_result("HTTP/1.1 200 OK\r\n\r\n", %({"token":"a\\tb"})),
+            subject).should eq(["SESSION"])
+          with_layer(b) do
+            rules = Gori::Rules.new(store, store.match_rules)
+            rules.add(Gori::Store::RuleTarget::Request, Gori::Store::RulePart::Head, "X-Auth",
+              "$SESSION", Gori::Store::RuleOp::SetHeader, Gori::Store::MatchKind::Literal,
+              "inject", "", "")
+            out = String.new(rules.rewrite_request("GET /a HTTP/1.1\r\nHost: acme.test\r\n\r\n".to_slice,
+              "acme.test"))
+            out.should contain("X-Auth: a\tb")
+            store.events_after(0, 50).any? { |e| e.kind == "boundary_refused" }.should be_false
+          end
+        end
+      end
+
+      # The other complement, and the reason the guard is at the injection site rather than at
+      # extraction: the SAME value through a BODY rule forges nothing and is the designed case.
+      it "does not fire for a body-scoped rule carrying the same value" do
+        with_store do |store|
+          b = Gori::Bindings.load(store)
+          b.add("SESSION", "", Gori::ExtractKind::JsonPath, "$.token").should be_nil
+          b.observe(response_result("HTTP/1.1 200 OK\r\n\r\n", %({"token":"a\\r\\nb"})),
+            subject).should eq(["SESSION"])
+          with_layer(b) do
+            rules = Gori::Rules.new(store, store.match_rules)
+            rules.add(Gori::Store::RuleTarget::Request, Gori::Store::RulePart::Body, "MARK",
+              "$SESSION", Gori::Store::RuleOp::Replace, Gori::Store::MatchKind::Literal,
+              "inject-body", "", "")
+            String.new(rules.rewrite_request_body("x=MARK".to_slice, "acme.test"))
+              .should eq("x=a\r\nb")
+            store.events_after(0, 50).any? { |e| e.kind == "boundary_refused" }.should be_false
+          end
+        end
+      end
+
+      # The THIRD branch of `head_scoped?`, and the one the finding left uncovered: a WebSocket
+      # frame is all payload, there is no head in it for a CR/LF to forge a line into, and
+      # `Env.expand_bindings(String)` maps `part: Ws` to `guard_boundary: false` for exactly
+      # that reason. So the value must reach the frame intact and say nothing.
+      it "does not fire for a ws-scoped rule carrying the same value" do
+        with_store do |store|
+          b = Gori::Bindings.load(store)
+          b.add("SESSION", "", Gori::ExtractKind::JsonPath, "$.token").should be_nil
+          b.observe(response_result("HTTP/1.1 200 OK\r\n\r\n", %({"token":"a\\r\\nb"})),
+            subject).should eq(["SESSION"])
+          with_layer(b) do
+            rules = Gori::Rules.new(store, store.match_rules)
+            rules.add(Gori::Store::RuleTarget::Request, Gori::Store::RulePart::Ws, "MARK",
+              "$SESSION", Gori::Store::RuleOp::Replace, Gori::Store::MatchKind::Literal,
+              "inject-ws", "", "")
+            String.new(rules.rewrite_ws_out("x=MARK".to_slice, "acme.test")).should eq("x=a\r\nb")
+            store.events_after(0, 50).any? { |e| e.kind == "boundary_refused" }.should be_false
+          end
+        end
+      end
+
+      # The refusal the reporter DID understand must keep its exact sentence — it is the one
+      # every surface already reads, and the two now share a reporter.
+      it "leaves the unbound sentence alone" do
+        with_store do |store|
+          b = Gori::Bindings.load(store)
+          b.add("SESSION", "", Gori::ExtractKind::Cookie, "sid").should be_nil
+          with_layer(b) do
+            rules = Gori::Rules.new(store, store.match_rules)
+            rules.add(Gori::Store::RuleTarget::Request, Gori::Store::RulePart::Head, "X-Auth",
+              "$SESSION", Gori::Store::RuleOp::SetHeader, Gori::Store::MatchKind::Literal,
+              "inject", "", "")
+            rules.rewrite_request("GET /a HTTP/1.1\r\nHost: acme.test\r\n\r\n".to_slice, "acme.test")
+            events = store.events_after(0, 50)
+            events.any? { |e| e.kind == "boundary_refused" }.should be_false
+            ev = events.find { |e| e.kind == "unbound" }.not_nil!
+            ev.message.should eq(%(rewrite rule "inject" not applied: $SESSION is not bound yet))
+          end
+        end
+      end
+
+      # Same dedupe as the unbound half: one row per (rule, binding revision), or a rule
+      # injecting into every proxied request writes one store row per message.
+      it "says it once per rule per binding revision, not once per message" do
+        with_store do |store|
+          b = Gori::Bindings.load(store)
+          b.add("SESSION", "", Gori::ExtractKind::JsonPath, "$.token").should be_nil
+          b.observe(response_result("HTTP/1.1 200 OK\r\n\r\n", %({"token":"a\\r\\nb"})), subject)
+          with_layer(b) do
+            rules = Gori::Rules.new(store, store.match_rules)
+            rules.add(Gori::Store::RuleTarget::Request, Gori::Store::RulePart::Head, "X-Auth",
+              "$SESSION", Gori::Store::RuleOp::SetHeader, Gori::Store::MatchKind::Literal,
+              "inject", "", "")
+            req = "GET /a HTTP/1.1\r\nHost: acme.test\r\n\r\n".to_slice
+            5.times { rules.rewrite_request(req, "acme.test") }
+            store.events_after(0, 50).count { |e| e.kind == "boundary_refused" }.should eq 1
+          end
+        end
+      end
+    end
+
     # Binding values resolve at SEND time, after every plan builder has already framed the
     # request. Without this the declared length described the UNEXPANDED body: on a pipelined
     # send-group the origin read the declared prefix and the remainder became the front of the
@@ -279,7 +426,7 @@ describe Gori::Bindings do
           wire = "POST /a HTTP/1.1\r\nContent-Length: 2\r\nTransfer-Encoding: chunked\r\n\r\n2\r\n$T\r\n0\r\n\r\n"
           out = String.new(Gori::Env.expand_bindings(wire.to_slice))
           out.should contain("Content-Length: 2\r\n") # untouched
-          out.should contain("2\r\n0123456789\r\n")    # the body still substituted
+          out.should contain("2\r\n0123456789\r\n")   # the body still substituted
         end
       end
     end

--- a/spec/decoder_spec.cr
+++ b/spec/decoder_spec.cr
@@ -480,6 +480,123 @@ describe Gori::Decoder do
       end
     end
 
+    # ── ordering independence ─────────────────────────────────────────────────────
+    #
+    # `register_all` used to flatten and register in ONE loop, so `flatten`'s `r[tok]?` probe
+    # read a registry the loop was mutating: by entry i, entries 0..i-1 answered it and every
+    # BACKWARD reference stayed a run-time nested call instead of being spliced. Only forward
+    # references were spliced, so only forward references were counted against MAX_TOKENS —
+    # and the ordinary authoring order (save the helper, THEN save the chain that calls it) is
+    # entirely backward references, which left the guard dead on the path it exists for.
+    #
+    # Every example below states the same library TWICE, helper-first and helper-last, because
+    # the defect was invisible in one ordering and only in one.
+    it "refuses an over-MAX_TOKENS library in EITHER definition order" do
+      # Depth 9 of `x(n) = x(n-1) > x(n-1)` is 512 flattened steps — past MAX_TOKENS (256).
+      # Written helper-LAST this was already refused; written helper-FIRST it registered fine
+      # and one `run` burned 2^9 applications, growing to 73 seconds of CPU at depth 25.
+      deep = [{"z0", "upper"}]
+      (1..9).each { |i| deep << {"z#{i}", "z#{i - 1} > z#{i - 1}"} }
+
+      with_library(deep) do |reg| # helper FIRST (what ^S produces)
+        res = Gori::Decoder.run(reg, "hi".to_slice, "z9")
+        res.steps[0].state.should eq Gori::Decoder::StepState::Failed
+        res.steps[0].error.not_nil!.should contain "expands past 256 steps"
+      end
+      with_library(deep.reverse) do |reg| # helper LAST
+        res = Gori::Decoder.run(reg, "hi".to_slice, "z9")
+        res.steps[0].state.should eq Gori::Decoder::StepState::Failed
+        res.steps[0].error.not_nil!.should contain "expands past 256 steps"
+      end
+    end
+
+    it "keeps an UNDER-MAX_TOKENS library usable in either order (the complement)" do
+      # The same shape one level shallower — 256 steps, at the ceiling and not past it. If the
+      # fix refused this it would have turned a working library into a broken one.
+      ok = [{"z0", "upper"}]
+      (1..8).each { |i| ok << {"z#{i}", "z#{i - 1} > z#{i - 1}"} }
+      [ok, ok.reverse].each do |entries|
+        with_library(entries) do |reg|
+          String.new(Gori::Decoder.run(reg, "hi".to_slice, "z8").output.not_nil!).should eq "HI"
+        end
+      end
+    end
+
+    it "reports the SAME failing built-in at the same depth in either order" do
+      # The ordering also decided the error TEXT from a two-entry library: helper-first left
+      # `inner` as a run-time call and reported "outer: step 1 'inner': inner: step 1
+      # 'base64-decode': …", helper-last spliced it and reported "outer: step 1
+      # 'base64-decode': …". One library, one meaning.
+      pair = [{"inner", "base64-decode"}, {"outer", "inner > upper"}]
+      msgs = [pair, pair.reverse].map do |entries|
+        with_library(entries) do |reg|
+          Gori::Decoder.run(reg, "!!!!".to_slice, "outer").steps[0].error.not_nil!
+        end
+      end
+      msgs[0].should eq msgs[1]
+      msgs[0].should contain "base64-decode"
+    end
+
+    it "detects a cycle in either order, and does not memoize a false one" do
+      cyc = [{"cyc-a", "cyc-b"}, {"cyc-b", "cyc-a"}]
+      [cyc, cyc.reverse].each do |entries|
+        with_library(entries) do |reg|
+          ["cyc-a", "cyc-b"].each do |name|
+            res = Gori::Decoder.run(reg, "x".to_slice, name)
+            res.steps[0].state.should eq Gori::Decoder::StepState::Failed
+            res.steps[0].error.not_nil!.should contain "recursive"
+          end
+        end
+      end
+      # Self-reference, both orders (there is only one entry, but the DIAMOND below is the
+      # case a naive "don't memoize failures" fix regresses).
+      with_library([{"selfref", "selfref > upper"}]) do |reg|
+        Gori::Decoder.run(reg, "x".to_slice, "selfref").steps[0].error.not_nil!
+          .should contain "recursive"
+      end
+      # A DIAMOND is not a cycle: `top` reaches `leaf` by two routes. Flattening must succeed
+      # in either order — the memo has to be reused, not mistaken for a stack hit.
+      dia = [{"leaf", "upper"}, {"l", "leaf"}, {"r", "leaf"}, {"top", "l > r"}]
+      [dia, dia.reverse].each do |entries|
+        with_library(entries) do |reg|
+          String.new(Gori::Decoder.run(reg, "hi".to_slice, "top").output.not_nil!).should eq "HI"
+        end
+      end
+    end
+
+    it "leaves a dangling reference dangling in either order" do
+      dang = [{"outer", "nosuch > upper"}]
+      [dang, dang.reverse].each do |entries|
+        with_library(entries) do |reg|
+          res = Gori::Decoder.run(reg, "x".to_slice, "outer")
+          res.steps[0].state.should eq Gori::Decoder::StepState::Failed
+          res.steps[0].error.not_nil!.should contain "nosuch"
+        end
+      end
+    end
+
+    it "still lets a built-in win over a saved name that shadows it, in either order" do
+      # The two-pass split changes WHAT `r` holds while flattening, so the "a built-in wins"
+      # filter is worth re-stating on both sides of it.
+      shadow = [{"hexer", "hex-encode"}, {"hex", "upper"}]
+      [shadow, shadow.reverse].each do |entries|
+        with_library(entries) do |reg|
+          String.new(Gori::Decoder.run(reg, "a".to_slice, "hex").output.not_nil!).should eq "61"
+          String.new(Gori::Decoder.run(reg, "a".to_slice, "hexer").output.not_nil!).should eq "61"
+        end
+      end
+    end
+
+    # ── the flag a caller reads instead of running the converter ──────────────────
+    it "marks an unusable saved chain `unusable` and a working one nil" do
+      with_library([{"good", "upper"}, {"selfref", "selfref > upper"}]) do |reg|
+        reg["good"].unusable.should be_nil
+        reg["selfref"].unusable.not_nil!.should contain "recursive"
+        # A built-in is never unusable.
+        reg["upper"].unusable.should be_nil
+      end
+    end
+
     it "publishes through the Settings setter, so every surface sees the same library" do
       before = Gori::Settings.decoder_chains
       begin

--- a/spec/fuzz/chain_refusal_spec.cr
+++ b/spec/fuzz/chain_refusal_spec.cr
@@ -1,0 +1,169 @@
+require "../spec_helper"
+
+private alias F = Gori::Fuzz
+
+# `§value¦chain§` naming a converter the run cannot apply must refuse the PLAN, not quietly
+# put the raw payload on the wire.
+#
+# `Template#apply_chains` returns the payload verbatim when its chain does not run, arguing
+# that a streaming fuzz run has nowhere to surface a per-position error. That was written when
+# the only way to reach it was a typo. The saved-chain library added a class that is not a
+# typo: a name the operator saved, that the `^Y` autocomplete offers and `gori run decoder
+# list` prints as an ordinary converter, and that the library registered as an always-raising
+# step precisely so the failure would be VISIBLE. Reproduced on the wire: five marked
+# positions, three naming such a chain, all three carrying the plaintext payload under
+# `1 sent · 0 errors`, `"error":null`, `"matched":true`, while `gori run decoder` named the
+# identical refusal off the identical registry.
+
+private def with_library(entries : Array({String, String}), &)
+  before = Gori::Decoder.library
+  Gori::Decoder.library = entries
+  begin
+    yield
+  ensure
+    Gori::Decoder.library = before
+  end
+end
+
+private def ungated : Gori::Outbound
+  Gori::Outbound.waived(nil, Gori::Outbound::Reason::NoProject)
+end
+
+private def plan_for(template : String, payload : String = "ff00") : F::Plan
+  F::Plan.build(F::PlanOptions.new(template,
+    target: "http://t.test",
+    sources: [F::InlineList.new([payload])] of F::PayloadSource,
+    config: F::Config.new(mode: F::Mode::BatteringRam)), ungated)
+end
+
+private def first_request(plan : F::Plan) : String
+  out = ""
+  # `next`, not `break`: Generator#each takes a CAPTURED block.
+  plan.generator.each { |j| out = String.new(j.bytes) if out.empty? }
+  out
+end
+
+private CHAINS = [
+  {"myenc", "base64-encode > upper"},
+  {"selfref", "selfref > upper"},
+  {"cyc-a", "cyc-b"},
+  {"cyc-b", "cyc-a"},
+]
+
+describe "Fuzz::Plan chain refusal" do
+  it "refuses a plan whose position names a self-referential saved chain" do
+    with_library(CHAINS) do
+      ex = expect_raises(F::ChainError) do
+        plan_for("GET /q?a=§P¦selfref§ HTTP/1.1\r\nHost: t.test\r\n\r\n")
+      end
+      ex.message.not_nil!.should contain "selfref"
+      ex.message.not_nil!.should contain "recursive"
+      # It says what would otherwise have happened, and where to look.
+      ex.message.not_nil!.should contain "untransformed"
+      ex.message.not_nil!.should contain "gori run decoder list"
+    end
+  end
+
+  it "refuses a plan whose position names a CYCLIC saved chain (either leg)" do
+    with_library(CHAINS) do
+      ["cyc-a", "cyc-b"].each do |name|
+        ex = expect_raises(F::ChainError) do
+          plan_for("GET /q?a=§P¦#{name}§ HTTP/1.1\r\nHost: t.test\r\n\r\n")
+        end
+        ex.message.not_nil!.should contain "recursive"
+      end
+    end
+  end
+
+  it "refuses a plan whose position names an over-MAX_TOKENS saved chain" do
+    deep = [{"z0", "upper"}]
+    (1..9).each { |i| deep << {"z#{i}", "z#{i - 1} > z#{i - 1}"} }
+    with_library(deep) do
+      ex = expect_raises(F::ChainError) do
+        plan_for("GET /q?a=§P¦z9§ HTTP/1.1\r\nHost: t.test\r\n\r\n")
+      end
+      ex.message.not_nil!.should contain "expands past 256 steps"
+    end
+  end
+
+  it "refuses a plan whose position names an UNKNOWN converter" do
+    with_library(CHAINS) do
+      ex = expect_raises(F::ChainError) do
+        plan_for("GET /q?a=§P¦nosuchconv§ HTTP/1.1\r\nHost: t.test\r\n\r\n")
+      end
+      ex.message.not_nil!.should contain "nosuchconv: unknown converter"
+    end
+  end
+
+  it "names EVERY bad token in the template, not only the first" do
+    with_library(CHAINS) do
+      ex = expect_raises(F::ChainError) do
+        plan_for("GET /q?a=§P¦selfref§&b=§P¦nosuchconv§&c=§P¦myenc§ HTTP/1.1\r\nHost: t.test\r\n\r\n")
+      end
+      msg = ex.message.not_nil!
+      msg.should contain "selfref"
+      msg.should contain "nosuchconv"
+      msg.should_not contain "myenc" # the one that works is not blamed
+    end
+  end
+
+  it "refuses on a bad token ANYWHERE in a multi-step chain, not just the first step" do
+    with_library(CHAINS) do
+      expect_raises(F::ChainError, /nosuchconv/) do
+        plan_for("GET /q?a=§P¦upper > nosuchconv§ HTTP/1.1\r\nHost: t.test\r\n\r\n")
+      end
+    end
+  end
+
+  # ── the complements: everything that must STILL build and still transform ───────────
+  it "builds, and TRANSFORMS, a chain that works" do
+    with_library(CHAINS) do
+      plan = plan_for("GET /q?a=§P¦myenc§ HTTP/1.1\r\nHost: t.test\r\n\r\n")
+      # base64("ff00") = ZmYwMA== , uppercased.
+      first_request(plan).should contain("a=ZMYWMA==")
+    end
+  end
+
+  it "builds a chain naming only BUILT-INS" do
+    with_library(CHAINS) do
+      plan = plan_for("GET /q?a=§P¦upper§ HTTP/1.1\r\nHost: t.test\r\n\r\n", "ffab")
+      first_request(plan).should contain("a=FFAB")
+    end
+  end
+
+  it "builds a template with NO chains at all" do
+    with_library(CHAINS) do
+      first_request(plan_for("GET /q?a=§P§ HTTP/1.1\r\nHost: t.test\r\n\r\n")).should contain("a=ff00")
+    end
+  end
+
+  it "does NOT refuse a usable chain that merely fails on THIS payload" do
+    # The line the refusal must not cross. `base64-decode` is a perfectly good converter and
+    # `!!!!` is not base64 — that is a property of the payload, not of the template, and the
+    # next payload in the same set may well succeed. There is nothing to refuse up front, so
+    # `apply_chains`' documented per-payload passthrough still owns it.
+    with_library(CHAINS) do
+      plan = plan_for("GET /q?a=§P¦base64-decode§ HTTP/1.1\r\nHost: t.test\r\n\r\n", "!!!!")
+      first_request(plan).should contain("a=!!!!")
+    end
+  end
+
+  it "does not refuse when an unusable chain is merely SAVED and no position names it" do
+    # The library still registers `selfref`/`cyc-a` so their names resolve and their reason is
+    # visible in the Decoder tab. Having them in the library must not refuse unrelated runs.
+    with_library(CHAINS) do
+      first_request(plan_for("GET /q?a=§P§ HTTP/1.1\r\nHost: t.test\r\n\r\n")).should contain("a=ff00")
+    end
+  end
+
+  it "refuses BEFORE the no-positions / no-payloads checks stop mattering" do
+    # Ordering guard: the chain check reads `template.positions`, so it must sit after the
+    # parse. A template with no positions still reports NoPositions, not a chain error.
+    with_library(CHAINS) do
+      ex = expect_raises(F::PlanError) do
+        plan_for("GET /q?a=1 HTTP/1.1\r\nHost: t.test\r\n\r\n")
+      end
+      ex.reason.should eq F::PlanError::Reason::NoPositions
+    end
+  end
+end

--- a/spec/fuzz/conn_pool_spec.cr
+++ b/spec/fuzz/conn_pool_spec.cr
@@ -270,7 +270,7 @@ describe F::ConnPool do
       origin.close
     end
 
-    it "re-sends on a fresh connection when the origin had closed the parked one" do
+    it "sends on a fresh connection when the origin had closed the parked one" do
       # The origin serves one request per connection and hangs up WITHOUT saying so, so
       # every checkout after the first finds a dead socket — the classic idle-timeout
       # race. No result may be lost to it.
@@ -287,8 +287,13 @@ describe F::ConnPool do
       results.size.should eq(6)
       results.all? { |r| r.status == 200 && r.error.nil? }.should be_true
       pool = sender.pool.should_not be_nil
-      pool.stale_retries.should be > 0
-      # …and it stops paying for the wasted redial rather than doing it 6 times.
+      # The dead socket IS detected. WHERE it is detected decides what the send costs: the
+      # checkout probe sees the FIN before a byte goes out, so the request is written ONCE, on
+      # a fresh connection. `stale_retries` — a request that went out TWICE — is now the
+      # narrower fallback for a FIN that lands between the probe and the write.
+      (pool.stale_checkouts + pool.stale_retries).should be > 0
+      results.count(&.retried?).should eq(pool.stale_retries)
+      # …and it stops paying for the wasted probe-and-redial rather than doing it 6 times.
       pool.pooling?.should be_false
       origin.close
     end
@@ -333,7 +338,7 @@ describe F::ConnPool do
       # A body longer than its Content-Length: gori reads the framed 4 bytes and the rest sits
       # in the receive buffer. Parking it would hand the NEXT request that leftover response —
       # a 200 attributed to the wrong payload, silently. `reusable_response?` sees only the
-      # head, so the checkout-time `drained?` is what has to catch this.
+      # head, so the checkout-time `checkout_state` is what has to catch this.
       #
       # The poison is the FIRST payload deliberately: this origin is a same-process fiber, and
       # on a REUSED socket the scheduler can interleave its write past gori's checkout so the
@@ -399,7 +404,12 @@ describe F::ConnPool do
       results.none?(&.retried?).should be_true
       pool = sender.pool.should_not be_nil
       pool.stale_retries.should eq(0)
-      pool.unsafe_stale.should eq(2)
+      # R5: ONE, not two. An unsafe stale is a LOST payload, not a wasted redial, so the pool
+      # now stops pooling on the first one instead of waiting for STALE_GIVE_UP. The second
+      # error above is the origin dropping a request on a connection gori dialed fresh —
+      # which `--no-keep-alive` reports identically, and which is the point of the next example.
+      pool.unsafe_stale.should eq(1)
+      pool.pooling?.should be_false
       sender.close
       origin.close
     end
@@ -443,10 +453,10 @@ describe F::ConnPool do
       origin.close
     end
 
-    it "still re-sends a GET after a genuine keep-alive idle close (the pool's whole point)" do
+    it "still delivers a GET after a genuine keep-alive idle close (the pool's whole point)" do
       # The complement of the drop case: the origin ANSWERS and then hangs up, so the next
-      # checkout finds a socket the application never saw a request on. That retry must
-      # survive, or pooling is worse than not pooling.
+      # checkout finds a socket the application never saw a request on. Every payload must
+      # still reach the origin, or pooling is worse than not pooling.
       origin = KeepAliveOrigin.new(close_after: 1)
       tmpl = F::Template.parse("GET /?q=§a§ HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n")
       set = F::PayloadSet.new(F::InlineList.new((1..6).map(&.to_s)))
@@ -459,8 +469,9 @@ describe F::ConnPool do
 
       results.size.should eq(6)
       results.all? { |r| r.status == 200 && r.error.nil? }.should be_true
+      origin.requests.should eq(6) # once each — the redial does not duplicate the request
       pool = sender.pool.should_not be_nil
-      pool.stale_retries.should be > 0
+      (pool.stale_checkouts + pool.stale_retries).should be > 0
       pool.unsafe_stale.should eq(0)
       sender.close
       origin.close
@@ -487,6 +498,146 @@ describe F::ConnPool do
         {results.count { |r| r.error }, n}
       end
       counts[0].should eq(counts[1])
+    end
+  end
+
+  # R5-F2. The checkout probe PROVED the parked socket dead — `MSG_PEEK` returned 0 before a
+  # byte of the next request was written — and handed it back as "drained" anyway, on the
+  # (then true) reasoning that the stale-retry path would re-send it. Round 4's idempotency
+  # gate made that reasoning false for POST/PUT/PATCH/DELETE, so the two correct changes
+  # jointly DROPPED the request: gori wrote the POST onto a dead socket, the read failed with
+  # `Connection reset by peer`, and the gate then declined to replay a delivery it could no
+  # longer disprove — one call too late.
+  #
+  # Measured against an out-of-process origin that answers and hangs up: a 4-payload POST
+  # sweep put TWO POSTs at the origin, at a steady 50% loss for the whole run (the interleaved
+  # successes reset `@consecutive_stale`, so STALE_GIVE_UP never tripped), and reported the
+  # missing ones as `read (#<TCPSocket:0x102e5cc80>): Connection reset by peer`.
+  describe "a parked socket the origin closed BEFORE the next request was written" do
+    it "sends the POST once, on a fresh connection, and loses nothing" do
+      origin = KeepAliveOrigin.new(close_after: 1)
+      body = "op=charge&amt=1"
+      tmpl = F::Template.parse("POST /pay HTTP/1.1\r\nHost: 127.0.0.1\r\n" \
+                               "Content-Length: #{body.bytesize}\r\n\r\nop=charge&amt=§1§")
+      set = F::PayloadSet.new(F::InlineList.new((1..4).map(&.to_s)))
+      cfg = F::Config.new(mode: F::Mode::Sniper, concurrency: 1)
+      sender = F::Sender.new(F::Origin.new("http", "127.0.0.1", origin.port), ungated_outbound,
+        http2: false, verify: false, keep_alive: true, idle_conns: 1)
+      engine = F::Engine.new(F::Generator.new(tmpl, [set], cfg), F::Matcher.new, sender, cfg)
+      results = [] of F::Result
+      engine.run { |ev| results << ev.result if ev.is_a?(F::ResultEvent) }
+
+      results.size.should eq(4)
+      # Every payload reached the origin, exactly once, and every row is a real answer.
+      origin.requests.should eq(4)
+      results.all? { |r| r.status == 200 && r.error.nil? }.should be_true
+      pool = sender.pool.should_not be_nil
+      # A FIRST send on a fresh connection, not a replay: nothing had been written, so no row
+      # may claim its request went out twice and no re-send may be charged.
+      results.none?(&.retried?).should be_true
+      pool.stale_retries.should eq(0)
+      pool.unsafe_stale.should eq(0)
+      pool.stale_checkouts.should be > 0
+      sender.close
+      origin.close
+    end
+
+    it "agrees with --no-keep-alive, which is the whole point" do
+      # The pooled and unpooled runs of the same POST sweep must reach the same verdict. With
+      # the socket handed back dead they did not: pooled lost half the payloads and blamed the
+      # origin for it; unpooled sent all four.
+      counts = [true, false].map do |keep_alive|
+        origin = KeepAliveOrigin.new(close_after: 1)
+        body = "op=charge&amt=1"
+        tmpl = F::Template.parse("POST /pay HTTP/1.1\r\nHost: 127.0.0.1\r\n" \
+                                 "Content-Length: #{body.bytesize}\r\n\r\nop=charge&amt=§1§")
+        set = F::PayloadSet.new(F::InlineList.new((1..4).map(&.to_s)))
+        cfg = F::Config.new(mode: F::Mode::Sniper, concurrency: 1, keep_alive: keep_alive)
+        sender = F::Sender.new(F::Origin.new("http", "127.0.0.1", origin.port), ungated_outbound,
+          http2: false, verify: false, keep_alive: cfg.keep_alive?, idle_conns: 1)
+        engine = F::Engine.new(F::Generator.new(tmpl, [set], cfg), F::Matcher.new, sender, cfg)
+        results = [] of F::Result
+        engine.run { |ev| results << ev.result if ev.is_a?(F::ResultEvent) }
+        sender.close
+        n = origin.requests
+        origin.close
+        {results.count { |r| r.error }, n}
+      end
+      counts[0].should eq(counts[1])
+      counts[0].should eq({0, 4})
+    end
+
+    # `--concurrency > 1` is deliberately NOT driven here. `KeepAliveOrigin` is an in-process
+    # fiber, and above about six connections it starts leaving requests unread on sockets gori
+    # dialed FRESH — errors with `unsafe_stale == 0`, i.e. nothing to do with the pool. It was
+    # measured out-of-process instead, against an origin that answers and closes immediately:
+    # `--concurrency 4`, 12 POST payloads, 9 of 12 delivered before this fix and 12 of 12
+    # after. Recording it so nobody re-adds a spec that reproduces the harness, not the code.
+    it "retires a socket carrying RESIDUE without charging it as a closed one" do
+      # The complement of the condition the fix keys on. Unread bytes from the PREVIOUS
+      # exchange are a response-desync, not an idle close: the socket is retired either way,
+      # but only a proven FIN licenses treating the redial as a first send, and only a FIN
+      # says "parking this origin's sockets is pointless".
+      origin = PoisonOrigin.new(poison_tail: "EXTRA")
+      pool = F::ConnPool.new("http", "127.0.0.1", origin.port, false, nil, nil, nil, 4)
+      %w[EXTRA B02 B03].each do |p|
+        pool.send(req("GET /f/#{p} HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n"))
+      end
+      pool.stale_checkouts.should eq(0)
+      pool.stale_retries.should eq(0)
+      pool.pooling?.should be_true # a poisoned socket is not a reason to stop pooling
+      pool.close_all
+      origin.close
+    end
+  end
+
+  # The third harm in R5-F2, and the one that survives the fix: a FIN that lands BETWEEN the
+  # checkout probe and the write is genuinely ambiguous, so the request is NOT replayed — but
+  # the row for it was `Engine.exchange`'s raw exception message. `read (#<TCPSocket:0x…>):
+  # Connection reset by peer` reads as "this payload provoked a reset" (a false positive in a
+  # sweep), blames the ORIGIN for a socket gori wrote onto after the origin had closed it, and
+  # puts a heap pointer in the terminal, in `--format json` and in MCP `fuzz_results`.
+  describe "the row for a non-idempotent request that died on a parked socket" do
+    it "says what gori knows, keeps the transport's words, and leaks no object address" do
+      origin = KeepAliveOrigin.new(drop_every: 2)
+      body = "op=charge&amt=1"
+      tmpl = F::Template.parse("POST /pay HTTP/1.1\r\nHost: 127.0.0.1\r\n" \
+                               "Content-Length: #{body.bytesize}\r\n\r\nop=charge&amt=§1§")
+      set = F::PayloadSet.new(F::InlineList.new((1..4).map(&.to_s)))
+      cfg = F::Config.new(mode: F::Mode::Sniper, concurrency: 1)
+      sender = F::Sender.new(F::Origin.new("http", "127.0.0.1", origin.port), ungated_outbound,
+        http2: false, verify: false, keep_alive: true, idle_conns: 1)
+      engine = F::Engine.new(F::Generator.new(tmpl, [set], cfg), F::Matcher.new, sender, cfg)
+      results = [] of F::Result
+      engine.run { |ev| results << ev.result if ev.is_a?(F::ResultEvent) }
+
+      pool = sender.pool.should_not be_nil
+      pool.unsafe_stale.should eq(1)
+      pooled = results.compact_map(&.error).select(&.includes?("parked keep-alive"))
+      pooled.size.should eq(1)
+      msg = pooled.first
+      msg.should contain("parked keep-alive connection to 127.0.0.1:#{origin.port}")
+      msg.should contain("POST is not idempotent")
+      msg.should contain("NOT re-send")
+      # gori does not know whether the origin read it, and must not claim either way.
+      msg.should contain("may or may not have reached the origin")
+      # No `#<TCPSocket:0x…>` — the pointer is the tell.
+      msg.should_not match(/0x[0-9a-f]{6,}/)
+      msg.should_not match(/#<\w+:/)
+      sender.close
+      origin.close
+    end
+
+    it "keeps the transport's own words and drops only the object address" do
+      # `transport_detail` is pure, so the shape can be pinned without a socket — the exact
+      # string a real reset produced is the DATA here.
+      raw = "read (#<TCPSocket:0x102e5cc80>): Connection reset by peer"
+      cleaned = F::ConnPool.transport_detail(raw).should_not be_nil
+      cleaned.should eq("read: Connection reset by peer")
+      # Complements: nothing to strip, nothing at all, and a message that is ONLY an address.
+      F::ConnPool.transport_detail("Broken pipe").should eq("Broken pipe")
+      F::ConnPool.transport_detail(nil).should be_nil
+      F::ConnPool.transport_detail(" (#<IO::FileDescriptor:0xdeadbeef>)").should be_nil
     end
   end
 end

--- a/spec/fuzz/redirect_hop_spec.cr
+++ b/spec/fuzz/redirect_hop_spec.cr
@@ -1,0 +1,384 @@
+require "../spec_helper"
+require "socket"
+
+private alias F = Gori::Fuzz
+
+# What `Fuzz::Engine#follow_redirects` does to the two facts the hop must carry.
+#
+# The follower is twenty-four lines that round 4 never touched while both of the things it
+# handles changed underneath it, and it got both wrong in the same way — by calling a
+# neighbouring API positionally:
+#
+#   1. It called the ONE-argument `Backend#send`, i.e. "no verbatim exclusions", so round 4's
+#      payload-span exclusion was dropped at the hop. Against an origin that reflects a query
+#      parameter into `Location` — an ordinary login/redirect endpoint, and exactly what an
+#      open-redirect probe aims at — `--payloads '$TOKEN'` put the live session credential in
+#      the target's query string and access log while every surface still showed `$TOKEN`.
+#   2. It rebuilt `Repeater::Result` with eight POSITIONAL arguments, so `retried` landed in
+#      `timed_out`: every keep-alive re-send in a redirect-following sweep lost its row marker
+#      and gained a `timed_out` nothing had observed.
+#
+# Both are asserted here on the ONE thing that settles them — the bytes an origin received,
+# and the fields a surface reads — with the no-redirect control beside each.
+
+private def with_clean_env(&)
+  Gori::Settings.env_prefix = "$"
+  Gori::Settings.env_vars = [] of {String, String}
+  Gori::Settings.project_env_vars = [] of {String, String}
+  yield
+ensure
+  Gori::Settings.env_vars = [] of {String, String}
+  Gori::Settings.project_env_vars = [] of {String, String}
+  Gori::Settings.env_prefix = "$"
+end
+
+private def with_hop_store(&)
+  path = File.tempname("gori-redirect-hop", ".db")
+  store = Gori::Store.open(path)
+  begin
+    with_clean_env { yield store }
+  ensure
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+private def with_layer(layer : Gori::Env::Layer?, &)
+  previous = Gori::Env.layer
+  Gori::Env.layer = layer
+  begin
+    yield
+  ensure
+    Gori::Env.layer = previous
+  end
+end
+
+# `name` DECLARED and BOUND to `value`, reached the only way a real session reaches it: by
+# observing a response. A hand-poked hash would not prove the send path consults the same one.
+private def bound(store : Gori::Store, name : String, value : String) : Gori::Bindings
+  b = Gori::Bindings.load(store)
+  b.add(name, "", Gori::ExtractKind::Cookie, "sid").should be_nil
+  head = "HTTP/1.1 200 OK\r\nSet-Cookie: sid=#{value}; Path=/\r\nContent-Length: 0\r\n\r\n"
+  parsed = Gori::Proxy::Codec::Http1.parse_response_head(head.to_slice)
+  b.observe(Gori::Repeater::Result.new(head.to_slice, Bytes.empty, parsed, 1_i64, nil),
+    Gori::InterceptFilter::Subject.new(method: "GET", host: "acme.test", target: "/login",
+      scheme: "https", status: 200))
+  b.values[name]?.should eq(value)
+  b
+end
+
+# An origin that REFLECTS the request's query string into its `Location`, which is the whole
+# mechanism: it is how the operator's payload bytes reappear inside a request gori synthesised
+# rather than one it was given. `redirects` says how many hops to answer before the 200.
+private class ReflectingOrigin
+  getter port : Int32
+  getter requests = [] of String
+
+  def initialize(@redirects : Int32 = 1, @server : TCPServer = TCPServer.new("127.0.0.1", 0))
+    @port = @server.local_address.port
+  end
+
+  def serve : Nil
+    spawn do
+      hop = 0
+      while conn = @server.accept?
+        conn.read_timeout = 5.seconds
+        head = Gori::Proxy::Codec::Http1.read_head(conn)
+        break unless head
+        text = String.new(head)
+        @requests << text
+        line = text.split("\r\n", 2)[0]
+        target = line.split(' ')[1]? || "/"
+        query = target.includes?('?') ? target.split('?', 2)[1] : ""
+        conn << if hop < @redirects
+          "HTTP/1.1 302 Found\r\nLocation: /hop#{hop + 1}?#{query}\r\n" \
+          "Content-Length: 0\r\nConnection: close\r\n\r\n"
+        else
+          "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok"
+        end
+        conn.flush
+        conn.close
+        hop += 1
+      end
+    rescue
+    ensure
+      @server.close rescue nil
+    end
+  end
+
+  def close : Nil
+    @server.close rescue nil
+  end
+end
+
+private def outbound_any : Gori::Outbound
+  Gori::Outbound.cli(nil, false)
+end
+
+# One single-payload run through the real Sender against `origin`.
+private def run_against(origin : ReflectingOrigin, template : String, payload : String,
+                        follow : Bool = true) : Array(F::Result)
+  tpl = F::Template.parse(template.gsub("{PORT}", origin.port))
+  cfg = F::Config.new(mode: F::Mode::Sniper, concurrency: 1, follow_redirects: follow,
+    max_redirects: 3, timeout: 2.seconds)
+  gen = F::Generator.new(tpl, [F::PayloadSet.new(F::InlineList.new([payload]))], cfg)
+  backend = F::Sender.new(F::Origin.new("http", "127.0.0.1", origin.port), outbound_any,
+    http2: false, verify: false)
+  results = [] of F::Result
+  F::Engine.new(gen, F::Matcher.new, backend, cfg).run do |ev|
+    results << ev.result if ev.is_a?(F::ResultEvent)
+  end
+  results
+end
+
+# ─── the retried/timed_out half: a Backend double, so the two flags are set exactly ───
+
+# Returns a canned Result per call, so an example can put `retried` (or `timed_out`) on any
+# hop of the chain and read back what the collapsed Result carries.
+private class ScriptedBackend < F::Backend
+  getter sent = [] of Bytes
+  getter verbatim = [] of Array({Int32, Int32})?
+
+  def initialize(@replies : Array(Gori::Repeater::Result))
+  end
+
+  def origin : F::Origin
+    F::Origin.new("http", "127.0.0.1", 9)
+  end
+
+  def send(bytes : Bytes) : Gori::Repeater::Result
+    send(bytes, nil)
+  end
+
+  def send(bytes : Bytes, verbatim : Array({Int32, Int32})?) : Gori::Repeater::Result
+    @sent << bytes.dup
+    @verbatim << verbatim
+    @replies[@sent.size - 1]? || @replies.last
+  end
+end
+
+private def reply(status : Int32, location : String? = nil, retried : Bool = false,
+                  timed_out : Bool = false) : Gori::Repeater::Result
+  head = String.build do |io|
+    io << "HTTP/1.1 " << status << (status == 302 ? " Found" : " OK") << "\r\n"
+    io << "Location: " << location << "\r\n" if location
+    io << "Content-Length: 2\r\n\r\n"
+  end
+  Gori::Repeater::Result.new(head.to_slice, "ok".to_slice,
+    Gori::Proxy::Codec::Http1.parse_response_head(head.to_slice), 100_i64,
+    retried: retried, timed_out: timed_out)
+end
+
+private def follow(replies : Array(Gori::Repeater::Result),
+                   template : String = "GET /start?q=§a§ HTTP/1.1\r\nHost: h\r\n\r\n",
+                   follow : Bool = true) : {F::Result, ScriptedBackend}
+  tpl = F::Template.parse(template)
+  cfg = F::Config.new(mode: F::Mode::Sniper, concurrency: 1, follow_redirects: follow,
+    max_redirects: 3)
+  gen = F::Generator.new(tpl, [F::PayloadSet.new(F::InlineList.new(["one"]))], cfg)
+  backend = ScriptedBackend.new(replies)
+  out = [] of F::Result
+  F::Engine.new(gen, F::Matcher.new, backend, cfg).run do |ev|
+    out << ev.result if ev.is_a?(F::ResultEvent)
+  end
+  {out.first, backend}
+end
+
+# ─────────────────────────────────────────────────────────────────────────────────────
+
+describe "Fuzz::Engine#follow_redirects — the hop's provenance" do
+  it "does not resolve a session binding into a hop the ORIGIN's Location chose" do
+    with_hop_store do |store|
+      origin = ReflectingOrigin.new(redirects: 1)
+      origin.serve
+      with_layer(bound(store, "TOKEN", "SECRETTOKEN123")) do
+        results = run_against(origin,
+          "GET /redir?q=§X§ HTTP/1.1\r\nHost: 127.0.0.1:{PORT}\r\nAuthorization: Bearer $TOKEN\r\n\r\n",
+          "$TOKEN")
+        results.size.should eq(1)
+        results[0].error.should be_nil
+        origin.requests.size.should eq(2) # the hop really was followed
+
+        # Hop 1 — round 4's fix, and the control that a binding IS live in this run: the
+        # TEMPLATE's `$TOKEN` resolves, the PAYLOAD's does not.
+        origin.requests[0].should contain("/redir?q=$TOKEN")
+        origin.requests[0].should contain("Bearer SECRETTOKEN123")
+        origin.requests[0].should_not contain("q=SECRETTOKEN123")
+
+        # Hop 2 — gori assembled it from the origin's `Location`, which reflected the payload
+        # straight back. Nothing in it is a `$NAME` anybody typed, so nothing in it resolves.
+        origin.requests[1].should contain("/hop1?q=$TOKEN")
+        origin.requests[1].should_not contain("SECRETTOKEN123")
+      end
+      origin.close
+    end
+  end
+
+  it "keeps every hop of a MULTI-hop chain verbatim, not only the first" do
+    with_hop_store do |store|
+      origin = ReflectingOrigin.new(redirects: 3)
+      origin.serve
+      with_layer(bound(store, "TOKEN", "SECRETTOKEN123")) do
+        results = run_against(origin,
+          "GET /redir?q=§X§ HTTP/1.1\r\nHost: 127.0.0.1:{PORT}\r\n\r\n", "$TOKEN")
+        results.size.should eq(1)
+        # 1 original + max_redirects(3) hops.
+        origin.requests.size.should eq(4)
+        origin.requests.each { |r| r.should_not contain("SECRETTOKEN123") }
+        origin.requests[3].should contain("/hop3?q=$TOKEN")
+      end
+      origin.close
+    end
+  end
+
+  it "leaves a payload at offset 0 and one at the very end of the query verbatim on the hop" do
+    with_hop_store do |store|
+      origin = ReflectingOrigin.new(redirects: 1)
+      origin.serve
+      with_layer(bound(store, "TOKEN", "SECRETTOKEN123")) do
+        # BatteringRam so both positions carry the same payload; the first span opens the
+        # query, the second closes the request-target.
+        tpl = F::Template.parse(
+          "GET /redir?§A§=1&z=§B§ HTTP/1.1\r\nHost: 127.0.0.1:#{origin.port}\r\n\r\n")
+        cfg = F::Config.new(mode: F::Mode::BatteringRam, concurrency: 1,
+          follow_redirects: true, max_redirects: 3, timeout: 2.seconds)
+        gen = F::Generator.new(tpl, [F::PayloadSet.new(F::InlineList.new(["$TOKEN"]))], cfg)
+        backend = F::Sender.new(F::Origin.new("http", "127.0.0.1", origin.port), outbound_any,
+          http2: false, verify: false)
+        F::Engine.new(gen, F::Matcher.new, backend, cfg).run { }
+        origin.requests.size.should eq(2)
+        origin.requests[1].should contain("$TOKEN=1&z=$TOKEN")
+        origin.requests.each { |r| r.should_not contain("SECRETTOKEN123") }
+      end
+      origin.close
+    end
+  end
+
+  it "still follows the hop when the payload is ZERO-LENGTH (a zero-width span)" do
+    with_hop_store do |store|
+      origin = ReflectingOrigin.new(redirects: 1)
+      origin.serve
+      with_layer(bound(store, "TOKEN", "SECRETTOKEN123")) do
+        # An empty payload renders a zero-width span, which `Env.clip_spans` drops entirely —
+        # the edge where a spans-based exclusion degenerates to "no exclusions". The hop must
+        # still be taken and the run must still finish; the template's own `$TOKEN` (outside
+        # every span) must still resolve, exactly as it does with no exclusion in play.
+        results = run_against(origin,
+          "GET /redir?e=§d§&t=$TOKEN HTTP/1.1\r\nHost: 127.0.0.1:{PORT}\r\n\r\n", "")
+        results.size.should eq(1)
+        results[0].error.should be_nil
+        origin.requests.size.should eq(2)
+        origin.requests[0].should contain("/redir?e=&t=SECRETTOKEN123")
+        origin.requests[1].should contain("/hop1?e=&t=SECRETTOKEN123")
+      end
+      origin.close
+    end
+  end
+
+  it "keeps two payloads verbatim across a Content-Length resync, and on the hop after it" do
+    with_hop_store do |store|
+      origin = ReflectingOrigin.new(redirects: 1)
+      origin.serve
+      with_layer(bound(store, "TOKEN", "SECRETTOKEN123")) do
+        tpl = F::Template.parse(
+          "POST /redir?q=§A§ HTTP/1.1\r\nHost: 127.0.0.1:#{origin.port}\r\n" \
+          "Content-Length: 1\r\n\r\nzz=§B§")
+        cfg = F::Config.new(mode: F::Mode::BatteringRam, concurrency: 1, follow_redirects: true,
+          max_redirects: 3, timeout: 2.seconds, update_content_length: true)
+        gen = F::Generator.new(tpl, [F::PayloadSet.new(F::InlineList.new(["$TOKEN"]))], cfg)
+        backend = F::Sender.new(F::Origin.new("http", "127.0.0.1", origin.port), outbound_any,
+          http2: false, verify: false)
+        F::Engine.new(gen, F::Matcher.new, backend, cfg).run { }
+        origin.requests.size.should eq(2)
+        origin.requests[0].should contain("Content-Length: 9") # resynced over `zz=$TOKEN`
+        origin.requests[1].should contain("/hop1?q=$TOKEN")
+        origin.requests.each { |r| r.should_not contain("SECRETTOKEN123") }
+      end
+      origin.close
+    end
+  end
+
+  it "still resolves a template binding when NO redirect is followed (the control)" do
+    with_hop_store do |store|
+      origin = ReflectingOrigin.new(redirects: 0)
+      origin.serve
+      with_layer(bound(store, "TOKEN", "SECRETTOKEN123")) do
+        run_against(origin,
+          "GET /plain?q=§X§ HTTP/1.1\r\nHost: 127.0.0.1:{PORT}\r\nAuthorization: Bearer $TOKEN\r\n\r\n",
+          "$TOKEN")
+        origin.requests.size.should eq(1)
+        origin.requests[0].should contain("q=$TOKEN")
+        origin.requests[0].should contain("Bearer SECRETTOKEN123")
+      end
+      origin.close
+    end
+  end
+
+  it "takes no hop at all with follow_redirects OFF (the other control)" do
+    with_hop_store do |store|
+      origin = ReflectingOrigin.new(redirects: 1)
+      origin.serve
+      with_layer(bound(store, "TOKEN", "SECRETTOKEN123")) do
+        results = run_against(origin,
+          "GET /redir?q=§X§ HTTP/1.1\r\nHost: 127.0.0.1:{PORT}\r\n\r\n", "$TOKEN", follow: false)
+        results[0].status.should eq(302)
+        origin.requests.size.should eq(1)
+      end
+      origin.close
+    end
+  end
+
+  it "hands the hop a NON-NIL exclusion — the one thing the 1-argument overload could not" do
+    # The mechanism, pinned directly: the first send gets the job's spans, the hop gets a
+    # whole-message exclusion. A future edit that reverts either to `nil` fails here even if
+    # no binding happens to be live in that run.
+    _, backend = follow([reply(302, "/next"), reply(200)])
+    backend.sent.size.should eq(2)
+    backend.verbatim[0].should eq([{13, 16}]) # the §a§ payload's span in the rendered request
+    backend.verbatim[1].should eq([{0, backend.sent[1].size}])
+  end
+end
+
+describe "Fuzz::Engine#follow_redirects — the collapsed Result's fields" do
+  it "carries `retried` from the ORIGINAL send through the redirect chain" do
+    # The defect: `retried` was the 8th positional argument, and the 8th parameter is
+    # `timed_out`. The row said nothing was re-sent and (silently) that it timed out.
+    res, _ = follow([reply(302, "/next", retried: true), reply(200)])
+    res.retried?.should be_true
+  end
+
+  it "carries `retried` when a LATER hop is the one that was re-sent" do
+    res, _ = follow([reply(302, "/next"), reply(200, retried: true)])
+    res.retried?.should be_true
+  end
+
+  it "reports retried == false when no hop was re-sent (the complement)" do
+    res, _ = follow([reply(302, "/next"), reply(200)])
+    res.retried?.should be_false
+  end
+
+  it "does not invent a timed_out from a retried send" do
+    # `Fuzz::Result` has no `timed_out` field to leak it to a surface today, so this asserts
+    # on the Repeater::Result the follower builds, through the field that DOES reach a row.
+    r = Gori::Repeater::Result.new(Bytes.empty, nil, nil, 1_i64, nil, false, retried: true)
+    r.retried?.should be_true
+    r.timed_out?.should be_false
+    r.delivered?.should be_false
+  end
+
+  it "preserves a genuine timed_out on the last hop" do
+    r = Gori::Repeater::Result.new(Bytes.empty, nil, nil, 1_i64, nil, false,
+      delivered: true, timed_out: true, retried: false)
+    r.timed_out?.should be_true
+    r.delivered?.should be_true
+    r.retried?.should be_false
+  end
+
+  it "leaves a single-hop (no redirect) Result untouched, retried included" do
+    res, backend = follow([reply(200, retried: true)])
+    backend.sent.size.should eq(1)
+    res.retried?.should be_true
+  end
+end

--- a/spec/mcp_delivered_retry_spec.cr
+++ b/spec/mcp_delivered_retry_spec.cr
@@ -1,0 +1,172 @@
+require "./spec_helper"
+
+# `Repeater::Result#delivered?` is the one bit that separates "safe to send again" from "the
+# origin already has this request and has acted on it". Both engines compute it; until this
+# spec it reached NO surface (`grep -rn '"delivered"' src/` was empty), so MCP answered
+# `retryable: true` for exactly the failures the engines flag as delivered — and an agent
+# driving a POST doubled the side effect.
+#
+# The complements matter as much as the cases: a plain silent origin and a plain connect
+# refusal MUST stay retryable, or the fix has traded one wrong answer for another.
+
+private def with_store(&)
+  path = File.tempname("gori-delivered", ".db")
+  store = Gori::Store.open(path)
+  begin
+    yield store
+  ensure
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+private def drive(store, *lines) : Array(JSON::Any)
+  input = IO::Memory.new(lines.join('\n') + "\n")
+  output = IO::Memory.new
+  Gori::MCP::Server.new(store, allow_actions: true, verify_upstream: false,
+    input: input, output: output).run
+  output.to_s.each_line.reject(&.strip.empty?).map { |l| JSON.parse(l) }.to_a
+end
+
+private def tool_payload(resp : JSON::Any) : JSON::Any
+  JSON.parse(resp["result"]["content"][0]["text"].as_s)
+end
+
+# An h1 origin that reads a request head and then either answers `100 Continue` and holds the
+# socket open, or holds it open saying nothing at all. `hold` keeps the socket from closing —
+# a close would take the "upstream closed after interim 1xx" branch instead of the timeout one
+# this exercises. `done` lets the example stop the fiber without a bare `Channel#receive`.
+private def start_holding_origin(interim : Bool, done : Channel(Nil)) : Int32
+  origin = TCPServer.new("127.0.0.1", 0)
+  port = origin.local_address.port
+  spawn do
+    conn = origin.accept?
+    if conn
+      conn.read_timeout = 5.seconds
+      begin
+        Gori::Proxy::Codec::Http1.read_head(conn)
+      rescue
+        # a body may follow; the head is all this origin needs
+      end
+      if interim
+        conn.write("HTTP/1.1 100 Continue\r\n\r\n".to_slice)
+        conn.flush
+      end
+    end
+    select
+    when done.receive?
+    when timeout(6.seconds)
+    end
+    conn.try(&.close) rescue nil
+    origin.close rescue nil
+  rescue
+    origin.close rescue nil
+  end
+  port
+end
+
+private def send_call(port : Int32, method : String = "POST") : String
+  %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"send_request","arguments":) +
+    %({"url":"http://127.0.0.1:#{port}/x","method":"#{method}","body":"charge=1",) +
+    %("timeout_ms":400,"allow_unscoped":true}}})
+end
+
+describe "MCP send_request delivered/retryable" do
+  # The pure function, both terms, so a later `error_kind` addition cannot land in the
+  # retryable bucket by accident and a delivered failure cannot become retryable by reword.
+  describe "Tools.send_retryable?" do
+    it "is retryable only for an undelivered NETWORK_ERROR" do
+      Gori::MCP::Tools.send_retryable?("NETWORK_ERROR", false).should be_true
+      Gori::MCP::Tools.send_retryable?("NETWORK_ERROR", true).should be_false
+      Gori::MCP::Tools.send_retryable?("PROTOCOL_ERROR", false).should be_false
+      Gori::MCP::Tools.send_retryable?("REQUEST_TRUNCATED", false).should be_false
+    end
+  end
+
+  it "reports an h1 failure AFTER an interim 1xx as delivered and NOT retryable, naming the origin" do
+    with_store do |store|
+      done = Channel(Nil).new
+      port = start_holding_origin(true, done)
+      payload = tool_payload(drive(store, send_call(port))[0])
+      done.close
+      err = payload["error"].as_s
+      # The bare `"Read timed out"` this used to be named neither the origin nor the one
+      # fact that decides what a caller may do next. Its h2 twin (`H2Engine.no_response`)
+      # has said all of it since round 4; these two are siblings now.
+      err.should contain("no response from 127.0.0.1:#{port}")
+      err.should contain("interim 100")
+      err.should contain("read timed out")
+      err.should contain("RFC 9110 §15.2")
+      payload["error_kind"].as_s.should eq("timeout")
+      payload["error_code"].as_s.should eq("NETWORK_ERROR")
+      payload["delivered"].as_bool.should be_true
+      payload["retryable"].as_bool.should be_false
+    end
+  end
+
+  # COMPLEMENT of the interim: the same silence, the same timeout, the same error_kind —
+  # and nothing was delivered, so this one must still be retryable. Without it the fix
+  # would read as "a timeout is never retryable", which is a different (and wrong) rule.
+  it "keeps a silent origin with NO interim retryable" do
+    with_store do |store|
+      done = Channel(Nil).new
+      port = start_holding_origin(false, done)
+      payload = tool_payload(drive(store, send_call(port))[0])
+      done.close
+      payload["error_kind"].as_s.should eq("timeout")
+      payload["error_code"].as_s.should eq("NETWORK_ERROR")
+      payload["delivered"].as_bool.should be_false
+      payload["retryable"].as_bool.should be_true
+      # No interim, so no sentence is invented: gori knows nothing here `ex.message` does not.
+      payload["error"].as_s.should_not contain("RFC 9110")
+    end
+  end
+
+  # COMPLEMENT: a genuine network error, nothing delivered, must stay retryable.
+  it "keeps a refused connection retryable and marks it undelivered" do
+    with_store do |store|
+      closed = TCPServer.new("127.0.0.1", 0)
+      port = closed.local_address.port
+      closed.close
+      payload = tool_payload(drive(store, send_call(port))[0])
+      payload["error_kind"].as_s.should eq("connect")
+      payload["error_code"].as_s.should eq("NETWORK_ERROR")
+      payload["delivered"].as_bool.should be_false
+      payload["retryable"].as_bool.should be_true
+    end
+  end
+
+  # The engine half, straight on `Engine.exchange`, so the h1 sentence is pinned where it is
+  # written rather than only through MCP's kind table.
+  describe "Repeater::Engine.exchange" do
+    it "marks an interim-then-timeout delivered, and an immediate timeout not" do
+      done = Channel(Nil).new
+      port = start_holding_origin(true, done)
+      sock = TCPSocket.new("127.0.0.1", port)
+      sock.read_timeout = 400.milliseconds
+      sock.write_timeout = 400.milliseconds
+      r = Gori::Repeater::Engine.exchange(sock,
+        "POST /x HTTP/1.1\r\nHost: 127.0.0.1:#{port}\r\nContent-Length: 0\r\n\r\n".to_slice,
+        "127.0.0.1", port, Time.instant)
+      sock.close rescue nil
+      done.close
+      r.delivered?.should be_true
+      r.error.not_nil!.should contain("interim 100")
+
+      done2 = Channel(Nil).new
+      port2 = start_holding_origin(false, done2)
+      sock2 = TCPSocket.new("127.0.0.1", port2)
+      sock2.read_timeout = 400.milliseconds
+      sock2.write_timeout = 400.milliseconds
+      r2 = Gori::Repeater::Engine.exchange(sock2,
+        "POST /x HTTP/1.1\r\nHost: 127.0.0.1:#{port2}\r\nContent-Length: 0\r\n\r\n".to_slice,
+        "127.0.0.1", port2, Time.instant)
+      sock2.close rescue nil
+      done2.close
+      r2.delivered?.should be_false
+      r2.error.not_nil!.should_not contain("interim")
+    end
+  end
+end

--- a/spec/mcp_repeater_draft_provenance_spec.cr
+++ b/spec/mcp_repeater_draft_provenance_spec.cr
@@ -1,0 +1,163 @@
+require "./spec_helper"
+
+# MCP used to run `Env.mask_secrets` over the request bytes it PERSISTS, so an author who
+# typed a value gori can recognise — a project env var, or a LIVE session-binding value —
+# had gori rewrite it to `$NAME` in the stored repeater row. No other writer does that: the
+# TUI editor and `gori run repeater` store what the author typed.
+#
+# The consequence was not cosmetic. `update_repeater` leaves `flow_id` alone, the TUI reads
+# `flow_id` as `RepeaterView#evidence?`, and an evidence tab deliberately does NOT expand
+# `$NAME` (a capture's `$filter` is a byte the origin saw, not a reference). So one stored row
+# put `Authorization: Bearer $CTOK` on the wire from the TUI and the real value from MCP and
+# the CLI — three surfaces, two different requests, `✓ sent → 200` on all of them.
+#
+# The fix is at the write: store the author's bytes, mask only on the way out. `masking_vars`
+# is one table (`Env.effective_vars` + `Bindings#held_values`), so an env var and a bound
+# session value take the identical path through `mask_secrets`; these drive the env-var half
+# because a live binding value exists only in the process that observed it and the MCP server
+# rebinds `Env.layer` from the store at bind time (`Tools#bind_binding_layer`).
+
+private def with_store(&)
+  path = File.tempname("gori-draftprov", ".db")
+  store = Gori::Store.open(path)
+  prev_env = Gori::Settings.project_env_vars
+  begin
+    yield store
+  ensure
+    Gori::Settings.project_env_vars = prev_env
+    Gori::Env.bump_highlight_rev
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+private def drive(store, *lines) : Array(JSON::Any)
+  input = IO::Memory.new(lines.join('\n') + "\n")
+  output = IO::Memory.new
+  Gori::MCP::Server.new(store, allow_actions: true, verify_upstream: false,
+    input: input, output: output).run
+  output.to_s.each_line.reject(&.strip.empty?).map { |l| JSON.parse(l) }.to_a
+end
+
+private def tool_payload(resp : JSON::Any) : JSON::Any
+  JSON.parse(resp["result"]["content"][0]["text"].as_s)
+end
+
+SECRET = "MCPSECRET4242"
+
+private def set_secret_call : String
+  %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"set_env_var","arguments":) +
+    %({"key":"CTOK","value":"#{SECRET}"}}})
+end
+
+private def create_call(request : String, flow_id : Int64? = nil, id : Int32 = 2) : String
+  args = %({"target":"http://127.0.0.1:1","request":#{request.to_json})
+  args += %(,"flow_id":#{flow_id}) if flow_id
+  %({"jsonrpc":"2.0","id":#{id},"method":"tools/call","params":{"name":"create_repeater","arguments":#{args}}}})
+end
+
+private def update_call(rid : Int64, request : String, id : Int32 = 3) : String
+  %({"jsonrpc":"2.0","id":#{id},"method":"tools/call","params":{"name":"update_repeater","arguments":) +
+    %({"id":#{rid},"request":#{request.to_json}}}})
+end
+
+private def seed_flow(store) : Int64
+  store.insert_flow(Gori::Store::CapturedRequest.new(
+    created_at: 1_i64, scheme: "http", host: "h", port: 80,
+    method: "GET", target: "/seed", http_version: "HTTP/1.1",
+    head: "GET /seed HTTP/1.1\r\nHost: h\r\n\r\n".to_slice, body: nil))
+end
+
+describe "MCP repeater drafts keep the author's bytes" do
+  it "stores create_repeater's request verbatim when it carries a recognisable secret" do
+    with_store do |store|
+      req = "GET /a HTTP/1.1\r\nHost: h\r\nAuthorization: Bearer #{SECRET}\r\n\r\n"
+      res = drive(store, set_secret_call, create_call(req))
+      payload = tool_payload(res[1])
+      stored = String.new(store.get_repeater(payload["id"].as_i64).not_nil!.request)
+      stored.should eq(req)
+      stored.should_not contain("$CTOK")
+      # …and the report SAYS gori recognised one, which the silent rewrite never did.
+      payload["secrets_masked"].as_a.map(&.as_s).should eq(["CTOK"])
+      payload["secrets_masked_note"].as_s.should contain("$CTOK")
+    end
+  end
+
+  it "stores update_repeater's replacement verbatim, and says the flow link no longer means byte identity" do
+    with_store do |store|
+      flow = seed_flow(store)
+      seed = "GET /seed HTTP/1.1\r\nHost: h\r\n\r\n"
+      req = "GET /afterupdate HTTP/1.1\r\nHost: h\r\nAuthorization: Bearer #{SECRET}\r\n\r\n"
+      rid = tool_payload(drive(store, set_secret_call, create_call(seed, flow))[1])["id"].as_i64
+      payload = tool_payload(drive(store, update_call(rid, req))[0])
+
+      String.new(store.get_repeater(rid).not_nil!.request).should eq(req)
+      payload["secrets_masked"].as_a.map(&.as_s).should eq(["CTOK"])
+      # The row still advertises `flow_id`, which is the flag the TUI turns into
+      # `evidence?`. Clearing the column needs a store change; until then it is STATED.
+      payload["flow_id"].as_i64.should eq(flow)
+      payload["derived_from_flow_note"].as_s.should contain("no longer holds that flow's bytes")
+    end
+  end
+
+  # COMPLEMENT 1: a request with NO recognisable value must be byte-identical either way, and
+  # must not grow a `secrets_masked` field — an "only when it FIRED" report that fires on
+  # every call is noise an agent learns to ignore.
+  it "leaves a request with no secret in it alone and reports nothing" do
+    with_store do |store|
+      req = "GET /clean HTTP/1.1\r\nHost: h\r\n\r\n"
+      payload = tool_payload(drive(store, set_secret_call, create_call(req))[1])
+      String.new(store.get_repeater(payload["id"].as_i64).not_nil!.request).should eq(req)
+      payload.as_h.has_key?("secrets_masked").should be_false
+      payload.as_h.has_key?("secrets_masked_note").should be_false
+    end
+  end
+
+  # COMPLEMENT 2: an UNCHANGED request under update_repeater keeps its flow link meaning what
+  # it says, so the note must not fire. It keys on "the bytes were replaced", not on
+  # "update_repeater was called".
+  it "does not claim a flow link is stale when the request was not replaced" do
+    with_store do |store|
+      flow = seed_flow(store)
+      req = "GET /seed HTTP/1.1\r\nHost: h\r\n\r\n"
+      rid = tool_payload(drive(store, create_call(req, flow))[0])["id"].as_i64
+      # Rename only — `request` is absent, so it round-trips from the stored row.
+      payload = tool_payload(drive(store,
+        %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"update_repeater","arguments":) +
+        %({"id":#{rid},"name":"renamed"}}}))[0])
+      payload.as_h.has_key?("derived_from_flow_note").should be_false
+    end
+  end
+
+  # COMPLEMENT 3: with NO env var and no binding at all the two paths are identical, so this
+  # cannot be a behaviour difference for the overwhelmingly common call.
+  it "is a no-op when nothing is set" do
+    with_store do |store|
+      req = "GET /x HTTP/1.1\r\nHost: h\r\nAuthorization: Bearer #{SECRET}\r\n\r\n"
+      payload = tool_payload(drive(store, create_call(req))[0])
+      String.new(store.get_repeater(payload["id"].as_i64).not_nil!.request).should eq(req)
+      payload.as_h.has_key?("secrets_masked").should be_false
+    end
+  end
+
+  # The whole point: one stored row, one set of bytes, whoever sends it. The TUI's evidence
+  # path applies `Env.normalize_wire` and nothing else; the CLI/MCP path applies
+  # `Env.expand_wire` + `Env.expand_bindings` — and with the author's own bytes stored, both
+  # produce the SAME request. Round 3's headline regression existed because nobody compared
+  # the three surfaces against each other.
+  it "gives the TUI evidence path and the CLI/MCP path the same wire bytes" do
+    with_store do |store|
+      req = "GET /a HTTP/1.1\r\nHost: h\r\nAuthorization: Bearer #{SECRET}\r\n\r\n"
+      res = drive(store, set_secret_call, create_call(req))
+      rid = tool_payload(res[1])["id"].as_i64
+      stored = String.new(store.get_repeater(rid).not_nil!.request)
+      Gori::Env.load_project(store)                                         # what every surface does on open
+      evidence_wire = Gori::Env.normalize_wire(stored)                      # TUI, evidence tab
+      draft_wire = Gori::Env.expand_bindings(Gori::Env.expand_wire(stored)) # CLI / MCP
+      evidence_wire.should eq(draft_wire)
+      String.new(evidence_wire).should contain("Bearer #{SECRET}")
+    end
+  end
+end

--- a/spec/proto_spec.cr
+++ b/spec/proto_spec.cr
@@ -27,18 +27,56 @@ describe Gori::Proto do
   end
 
   describe Gori::Proto::Kind do
-    it "labels WS/GRPC/SSE for the PROTO column" do
-      Gori::Proto::Kind::Ws.label.should eq("WS")
-      Gori::Proto::Kind::Grpc.label.should eq("GRPC")
-      Gori::Proto::Kind::Sse.label.should eq("SSE")
+    # The tag used to REPLACE the scheme for WS/GRPC/SSE, so a `ws://` row and a `wss://` row
+    # were pixel-identical in History — same METHOD, same PROTO, same HOST (the column carries
+    # no port) — for exactly the three protocols where "the app opened a CLEARTEXT WebSocket
+    # and put a session token in the first frame" is the finding. The Http member kept the
+    # HTTP/HTTPS pair the whole time; the others now carry the same signal the same way.
+    it "labels the transport as well as the protocol, for every member" do
+      Gori::Proto::Kind::Http.label("http").should eq("HTTP")
+      Gori::Proto::Kind::Http.label("https").should eq("HTTPS")
+      Gori::Proto::Kind::Ws.label("http").should eq("WS")
+      Gori::Proto::Kind::Ws.label("https").should eq("WSS")
+      Gori::Proto::Kind::Grpc.label("http").should eq("GRPC")
+      Gori::Proto::Kind::Grpc.label("https").should eq("GRPCS")
+      Gori::Proto::Kind::Sse.label("http").should eq("SSE")
+      Gori::Proto::Kind::Sse.label("https").should eq("SSES")
     end
 
+    # A WebSocket flow is stored with the HTTP scheme of the tunnel it ran in, so `https` is
+    # what a `wss://` row actually carries; `wss` is accepted for a caller holding a URL.
+    it "reads the transport off a flow's stored scheme" do
+      Gori::Proto.secure?("https").should be_true
+      Gori::Proto.secure?("wss").should be_true
+      Gori::Proto.secure?("http").should be_false
+      Gori::Proto.secure?("ws").should be_false
+      Gori::Proto.secure?("").should be_false
+    end
+
+    # Every string `label` can print has to be a value the `proto:` filter accepts, or the
+    # column and the QL drift — which is the invariant the module doc claims.
+    it "splits the transport spelling the PROTO column prints off the protocol" do
+      Gori::Proto.split_transport("wss").should eq({"ws", true})
+      Gori::Proto.split_transport("grpcs").should eq({"grpc", true})
+      Gori::Proto.split_transport("sses").should eq({"sse", true})
+      Gori::Proto.split_transport("HTTPS").should eq({"http", true})
+      # No transport named — "either", not "cleartext".
+      Gori::Proto.split_transport("ws").should eq({"ws", nil})
+      Gori::Proto.split_transport("websocket").should eq({"websocket", nil})
+      Gori::Proto.split_transport("nope").should eq({"nope", nil})
+    end
+
+    # `Kind.parse?` deliberately does NOT absorb the TLS spellings: `InterceptFilter.fold`
+    # canonicalizes through it, has one field per leaf, and cannot carry a transport term —
+    # folding `wss` to `ws` there would silently widen an operator's catch condition to
+    # cleartext sockets.
     it "parses QL proto: values (websocket is an alias for ws) and rejects unknowns" do
       Gori::Proto::Kind.parse?("ws").should eq(Gori::Proto::Kind::Ws)
       Gori::Proto::Kind.parse?("websocket").should eq(Gori::Proto::Kind::Ws)
       Gori::Proto::Kind.parse?("GRPC").should eq(Gori::Proto::Kind::Grpc)
       Gori::Proto::Kind.parse?("http").should eq(Gori::Proto::Kind::Http)
       Gori::Proto::Kind.parse?("nope").should be_nil
+      Gori::Proto::Kind.parse?("wss").should be_nil
     end
   end
 end

--- a/spec/proxy/h2/assembler_spec.cr
+++ b/spec/proxy/h2/assembler_spec.cr
@@ -15,6 +15,24 @@ private def data_frame(stream : UInt32, flags : UInt8, body : String) : Frame::H
   Frame::Header.new(Frame::Type::Data.value, flags, stream, body.to_slice)
 end
 
+# An RFC 8441 extended CONNECT head — `:method CONNECT` with a `:protocol` pseudo-header,
+# which is how a WebSocket is opened over HTTP/2. Encoded rather than hard-coded because
+# `:protocol` is not in the HPACK static table.
+private def connect_block : Bytes
+  Gori::Proxy::H2::HPACK::Encoder.new.encode([
+    {":method", "CONNECT"}, {":protocol", "websocket"}, {":scheme", "https"},
+    {":path", "/chat"}, {":authority", "ws.example.com"},
+    {"sec-websocket-version", "13"},
+  ])
+end
+
+# The same shape WITHOUT `:protocol`: an ordinary CONNECT tunnel.
+private def plain_connect_block : Bytes
+  Gori::Proxy::H2::HPACK::Encoder.new.encode([
+    {":method", "CONNECT"}, {":authority", "tunnel.example.com:443"},
+  ])
+end
+
 # Records emitted flows (decoded projection) without a DB.
 private class RecSink < Gori::Proxy::FlowSink
   getter requests = [] of Gori::Store::CapturedRequest
@@ -436,5 +454,79 @@ describe Gori::Proxy::H2::Assembler do
       hexb("828684418cf1e3c2e5f23a6ba0ab90f4ff")))
     sink.requests.size.should eq(1)
     sink.requests.first.method.should eq("GET")
+  end
+  # --- RFC 8441 extended CONNECT (a WebSocket over h2) ----------------------------------
+  #
+  # The relay works end to end, and that is exactly the problem these cover: the flow it
+  # leaves behind said nothing. `extended_connect_note` hung off `finalize_stream`, which is
+  # reached only when a stream ABORTS — so the normal teardown (a WebSocket Close handshake
+  # and END_STREAM, what every conforming client does) completed through `emit_ready` with
+  # `error` NULL and `advisory` NULL, and `synth_request`'s pseudo filter dropped `:protocol`
+  # from the stored head. Nothing on disk — History, the QL, `run show`, HAR, MCP `get_flow` —
+  # could identify the flow as a WebSocket that ran with no transcript, no message intercept
+  # and no Match&Replace.
+  it "advises on a CLEANLY closed extended CONNECT stream, not only on an aborted one" do
+    sink = RecSink.new
+    assembler = Gori::Proxy::H2::Assembler.new(sink, "example.com", 443, 1_i64)
+    assembler.feed("out", headers_frame(1_u32, Frame::END_HEADERS, connect_block))
+    # The origin accepts, relays frames, and both halves END_STREAM: state Complete.
+    assembler.feed("in", headers_frame(1_u32, Frame::END_HEADERS, Bytes[0x88_u8]))
+    assembler.feed("in", data_frame(1_u32, Frame::END_STREAM, "\x81\x03one"))
+    assembler.feed("out", data_frame(1_u32, Frame::END_STREAM, "\x88\x02\x03\xe8"))
+
+    sink.requests.size.should eq(1)
+    sink.responses.size.should eq(1)
+    resp = sink.responses.first
+    resp.state.should eq(Gori::Store::FlowState::Complete)
+    resp.error.should be_nil # the stream really did complete — this is not a failure
+    # `advisory_of` joins the accumulated set onto BOTH halves, so it survives to the request
+    # row and the response row alike (`update_one` writes the column outright).
+    sink.requests.first.advisory.not_nil!.should contain("RFC 8441 extended CONNECT")
+    sink.requests.first.advisory.not_nil!.should contain(":protocol \"websocket\"")
+    resp.advisory.not_nil!.should contain("no message transcript")
+    # ... and the head names the stream shape, which the pseudo filter dropped entirely.
+    String.new(sink.requests.first.head).should contain("X-Gori-Protocol: websocket")
+  end
+
+  # The same stream ABORTED: the reason on `flows.error` still explains itself (that path is
+  # what an operator reads first), and the advisory is there too rather than instead.
+  it "keeps the aborted extended CONNECT reason AND writes the advisory" do
+    sink = RecSink.new
+    assembler = Gori::Proxy::H2::Assembler.new(sink, "example.com", 443, 1_i64)
+    assembler.feed("out", headers_frame(1_u32, Frame::END_HEADERS, connect_block))
+    assembler.feed("in", headers_frame(1_u32, Frame::END_HEADERS, Bytes[0x88_u8]))
+    assembler.finalize_all("h2 connection closed")
+
+    resp = sink.responses.first
+    resp.state.should eq(Gori::Store::FlowState::Aborted)
+    resp.error.not_nil!.should contain("h2 connection closed")
+    resp.error.not_nil!.should contain("RFC 8441 extended CONNECT")
+    resp.advisory.not_nil!.should contain("RFC 8441 extended CONNECT")
+  end
+
+  # The complement that decides whether either of the above means anything: an ordinary
+  # CONNECT tunnel — no `:protocol` pseudo — must get NO advisory and NO head marker, or the
+  # signal is on every CONNECT and says nothing.
+  it "leaves an ordinary CONNECT tunnel unannotated" do
+    sink = RecSink.new
+    assembler = Gori::Proxy::H2::Assembler.new(sink, "example.com", 443, 1_i64)
+    assembler.feed("out", headers_frame(1_u32, Frame::END_HEADERS, plain_connect_block))
+    assembler.feed("in", headers_frame(1_u32, Frame::END_HEADERS, Bytes[0x88_u8]))
+    assembler.feed("in", data_frame(1_u32, Frame::END_STREAM, "bytes"))
+    assembler.feed("out", data_frame(1_u32, Frame::END_STREAM, "bytes"))
+
+    sink.requests.first.advisory.should be_nil
+    sink.responses.first.advisory.should be_nil
+    String.new(sink.requests.first.head).should_not contain("X-Gori-Protocol")
+  end
+
+  # ... and neither does an ordinary GET, which is what every other flow on the connection is.
+  it "leaves an ordinary request unannotated" do
+    sink = RecSink.new
+    assembler = Gori::Proxy::H2::Assembler.new(sink, "example.com", 443, 1_i64)
+    assembler.feed("out", headers_frame(1_u32, Frame::END_HEADERS | Frame::END_STREAM,
+      hexb("828684418cf1e3c2e5f23a6ba0ab90f4ff")))
+    sink.requests.first.advisory.should be_nil
+    String.new(sink.requests.first.head).should_not contain("X-Gori-Protocol")
   end
 end

--- a/spec/proxy/h2/head_codec_spec.cr
+++ b/spec/proxy/h2/head_codec_spec.cr
@@ -145,6 +145,22 @@ describe Gori::Proxy::H2::HeadCodec do
       head.should contain("host: other.example.com")
     end
 
+    # The `:protocol` pseudo-header (RFC 8441) is what says a WebSocket is running on a
+    # CONNECT stream, and the pseudo filter above dropped it — so the stored head read as an
+    # ordinary tunnel. Additive and CAPTURE-ONLY, exactly like `X-Gori-Pushed`: passed by the
+    # projection alone, so the line can never reach an h2 wire through the rewrite path.
+    it "names the RFC 8441 :protocol only when the capture projection passes it" do
+      fields = [f(":method", "CONNECT"), f(":protocol", "websocket"),
+                f(":scheme", "https"), f(":path", "/chat"), f(":authority", "ws.test")]
+      bare = String.new(HeadCodec.synth_request(tuples(fields), "ws.test"))
+      bare.should_not contain("X-Gori-Protocol") # the rewrite path passes nothing
+      named = String.new(HeadCodec.synth_request(tuples(fields), "ws.test", protocol: "websocket"))
+      named.should contain("X-Gori-Protocol: websocket")
+      # It is the LAST line, like the other markers: nothing that reads a field off the head
+      # by position changes behaviour.
+      named.should end_with("X-Gori-Protocol: websocket\r\n\r\n")
+    end
+
     it "renders a response status line with no reason phrase (h2 has none)" do
       head = String.new(HeadCodec.synth_response(tuples([f(":status", "200"), f("content-type", "text/html")])))
       head.should eq("HTTP/2 200\r\ncontent-type: text/html\r\n\r\n")

--- a/spec/proxy/upstream_spec.cr
+++ b/spec/proxy/upstream_spec.cr
@@ -521,7 +521,12 @@ describe Gori::Proxy::Upstream do
         _, err = Gori::Proxy::Upstream.dial_tls_result("127.0.0.1", port, verify: true,
           io_timeout: 3.seconds)
         cause = err.try(&.cause).to_s
-        cause.should_not be_empty
+        # NOT asserted non-empty. Whether the TLS library has words for a connection reset
+        # mid-handshake is platform-dependent — macOS yields an IO error carrying a message,
+        # Linux yields one without. That a cause is PRESENT when the library has a verdict is
+        # pinned by the untrusted-certificate example above, which reports `certificate verify
+        # failed` everywhere. This example is about the SHAPE of whatever comes back, and an
+        # absent cause is trivially storable.
         # Crystal decorates an IO failure with the object's inspect
         # ("write (#<TCPSocket:0x104245c80>): Broken pipe"); a heap address in a string the
         # DB keeps and HAR/MCP export makes two identical failures compare unequal.

--- a/spec/proxy/upstream_spec.cr
+++ b/spec/proxy/upstream_spec.cr
@@ -405,7 +405,7 @@ describe Gori::Proxy::Upstream do
       err.try(&.kind).should eq(Gori::Proxy::Upstream::DialErrorKind::Connect)
     end
 
-    it "classifies an untrusted-cert origin as a Tls failure under verify, and succeeds with verify off" do
+    it "classifies an untrusted-cert origin as a TlsVerify failure under verify, and succeeds with verify off" do
       # A leaf for "localhost" signed by a CA the client does NOT trust: the origin is REACHED
       # (so not a Connect failure) but the chain doesn't verify — exactly the #323 shape.
       ca_cert, ca_key = Gori::Proxy::Tls::CertBuilder.build_root("gori-spec Untrusted CA")
@@ -430,7 +430,12 @@ describe Gori::Proxy::Upstream do
         # Dial 127.0.0.1 explicitly (no localhost→::1 resolution race), verify the "localhost" cert via SNI.
         sock, err = Gori::Proxy::Upstream.dial_tls_result("127.0.0.1", port, verify: true, sni: "localhost")
         sock.should be_nil
-        err.try(&.kind).should eq(Gori::Proxy::Upstream::DialErrorKind::Tls)
+        err.try(&.kind).should eq(Gori::Proxy::Upstream::DialErrorKind::TlsVerify)
+        # …and still the TLS leg for anything that only asks which layer broke.
+        err.try(&.tls?).should be_true
+        # OpenSSL's own verdict is kept, not thrown away — it is the ONLY evidence that
+        # separates this from a plaintext port or an origin that never answered.
+        err.try(&.cause).to_s.should contain("certificate verify failed")
 
         # verify OFF: the same origin dials fine — a live socket, no error.
         sock2, err2 = Gori::Proxy::Upstream.dial_tls_result("127.0.0.1", port, verify: false, sni: "localhost")
@@ -440,6 +445,117 @@ describe Gori::Proxy::Upstream do
       ensure
         origin.close rescue nil
       end
+    end
+
+    # Round 5 / Part 2 §2.1. The rescue here used to be bare: it threw the exception away and
+    # called EVERY outcome `Tls`, so a socket that accepts the TCP connection and then never
+    # speaks — a silent firewall drop, a wedged origin, an inline IPS — arrived at the operator
+    # as "origin certificate not trusted; retry with --insecure-upstream or set SSL_CERT_FILE".
+    # No certificate is exchanged in that conversation and both remedies are useless.
+    it "classifies an origin that accepts and then says nothing as Timeout, not a TLS verdict" do
+      origin = TCPServer.new("127.0.0.1", 0)
+      port = origin.local_address.port
+      held = [] of TCPSocket
+      spawn do
+        while sock = origin.accept?
+          held << sock # accepted, and deliberately never written to
+        end
+      end
+
+      begin
+        [true, false].each do |verify| # -k must not change the answer
+          sock, err = Gori::Proxy::Upstream.dial_tls_result("127.0.0.1", port, verify: verify,
+            io_timeout: 300.milliseconds)
+          sock.should be_nil
+          err.try(&.kind).should eq(Gori::Proxy::Upstream::DialErrorKind::Timeout)
+          # Not the TLS leg at all: nothing came back to judge, so no surface may offer a
+          # certificate remedy — and -k must not change the answer, because verification
+          # never ran either way.
+          err.try(&.tls?).should be_false
+          # The stall was invisible before (a failed dial records no duration), so the wait
+          # itself is the evidence.
+          err.try(&.cause).to_s.should contain("0.3s")
+        end
+      ensure
+        origin.close rescue nil
+        held.each { |s| s.close rescue nil }
+      end
+    end
+
+    it "classifies a plaintext port spoken to as TLS by what OpenSSL said, not as a cert failure" do
+      origin = TCPServer.new("127.0.0.1", 0)
+      port = origin.local_address.port
+      spawn do
+        while sock = origin.accept?
+          # Answers immediately, so OpenSSL parses the reply as a TLS record and refuses —
+          # the complement of the silent case above, which times out instead.
+          sock.write("HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\n\r\n".to_slice) rescue nil
+          sock.close rescue nil
+        end
+      end
+
+      begin
+        sock, err = Gori::Proxy::Upstream.dial_tls_result("127.0.0.1", port, verify: true,
+          io_timeout: 3.seconds)
+        sock.should be_nil
+        err.try(&.kind).should eq(Gori::Proxy::Upstream::DialErrorKind::Tls)
+        # Under verify-on this used to be indistinguishable from an untrusted certificate.
+        err.try(&.kind).should_not eq(Gori::Proxy::Upstream::DialErrorKind::TlsVerify)
+        err.try(&.cause).to_s.downcase.should contain("version")
+      ensure
+        origin.close rescue nil
+      end
+    end
+
+    it "keeps a library verdict storable: no heap address, no control bytes" do
+      origin = TCPServer.new("127.0.0.1", 0)
+      port = origin.local_address.port
+      spawn do
+        while sock = origin.accept?
+          sock.linger = 0 # RST rather than FIN, so the failure is an IO error, not a TLS alert
+          sock.close rescue nil
+        end
+      end
+
+      begin
+        _, err = Gori::Proxy::Upstream.dial_tls_result("127.0.0.1", port, verify: true,
+          io_timeout: 3.seconds)
+        cause = err.try(&.cause).to_s
+        cause.should_not be_empty
+        # Crystal decorates an IO failure with the object's inspect
+        # ("write (#<TCPSocket:0x104245c80>): Broken pipe"); a heap address in a string the
+        # DB keeps and HAR/MCP export makes two identical failures compare unequal.
+        cause.should_not contain("#<")
+        cause.should_not contain("\r")
+        cause.should_not contain("\n")
+      ensure
+        origin.close rescue nil
+      end
+    end
+
+    it "classifies a name that does not resolve as Dns — nothing was dialed" do
+      _, err = Gori::Proxy::Upstream.dial_result("gori-spec-does-not-exist.invalid", 443,
+        connect_timeout: 3.seconds, io_timeout: 3.seconds)
+      err.try(&.kind).should eq(Gori::Proxy::Upstream::DialErrorKind::Dns)
+      err.try(&.detail).should be_nil # the caller words this one itself
+    end
+
+    it "still reports a refused port as Connect, not as the new DNS kind" do
+      srv = TCPServer.new("127.0.0.1", 0)
+      port = srv.local_address.port
+      srv.close
+      _, err = Gori::Proxy::Upstream.dial_result("127.0.0.1", port)
+      err.try(&.kind).should eq(Gori::Proxy::Upstream::DialErrorKind::Connect)
+    end
+  end
+
+  describe "DialError#because" do
+    it "is empty when there is nothing the library added, and parenthesised when there is" do
+      Gori::Proxy::Upstream::DialError::ORIGIN_UNREACHABLE.because.should eq("")
+      Gori::Proxy::Upstream::DialError.new(Gori::Proxy::Upstream::DialErrorKind::Tls, cause: "")
+        .because.should eq("")
+      Gori::Proxy::Upstream::DialError.new(Gori::Proxy::Upstream::DialErrorKind::Tls,
+        cause: "wrong version number").because.should eq(" (wrong version number)")
     end
   end
 end

--- a/spec/proxy/ws_hold_spec.cr
+++ b/spec/proxy/ws_hold_spec.cr
@@ -92,6 +92,18 @@ private def masked(opcode : UInt8, payload : Bytes, fin : Bool = true) : Bytes
 end
 
 # Read one whole frame off `io` as {opcode, payload}.
+# A gate's own `[gori] …` rows, and everything that is not one. Both accountings the gate
+# keeps — a held message forwarded involuntarily, dropped, stranded, or written to a peer that
+# had already gone — now reach the flow's `ws_messages` stream rather than only `gori.log`,
+# which under `gori tui` reaches neither the notification centre nor stderr.
+private def notice_rows(sink) : Array({String, Int32, String})
+  sink.messages.select { |(_, _, text)| text.starts_with?("[gori] ") }
+end
+
+private def data_rows(sink) : Array({String, Int32, String})
+  sink.messages.reject { |(_, _, text)| text.starts_with?("[gori] ") }
+end
+
 private def read_message(io : IO) : {UInt8, String}
   h = WS.read_header(io).not_nil!
   f = WS.read_body(io, h).not_nil!
@@ -482,7 +494,14 @@ describe Gori::Proxy::WS::MessageGate do
       r.ts_r.as(IO::FileDescriptor).read_timeout = 3.seconds
       got = r.ts_r.gets_to_end.to_slice
       got.should eq(masked(WS::OP_TEXT, "HELD".to_slice) + tail + ping)
-      sink.messages.should eq([{"out", 9, "zz"}, {"out", 1, "HELD"}, {"out", 1, "TAIL"}])
+      data_rows(sink).should eq([{"out", 9, "zz"}, {"out", 1, "HELD"}, {"out", 1, "TAIL"}])
+      # The upstream leg is still live here (only the CLIENT went), so the release is a real
+      # delivery and the row is a true claim — but the operator's decision window closed
+      # involuntarily, and that is now said where they will meet it.
+      notice_rows(sink).map(&.[](2)).should eq(
+        ["[gori] client→server: the socket is closing — forwarding 1 held message(s) " \
+         "unedited, in arrival order. WebSocket has no application-level flow control, so " \
+         "nothing throttles the sender while a hold is out"])
     end
     r.shutdown
   end
@@ -613,12 +632,16 @@ describe Gori::Proxy::WS::MessageGate do
 
       r.ts_r.as(IO::FileDescriptor).read_timeout = 3.seconds
       r.ts_r.gets_to_end.to_slice.should eq(masked(WS::OP_TEXT, "HELD".to_slice) + lead + ping)
-      sink.messages.should eq([{"out", 9, "zz"}, {"out", 1, "HELD"}])
+      data_rows(sink).should eq([{"out", 9, "zz"}, {"out", 1, "HELD"}])
+      notice_rows(sink).map(&.[](2)).should eq(
+        ["[gori] client→server: the socket is closing — forwarding 1 held message(s) " \
+         "unedited, in arrival order. WebSocket has no application-level flow control, so " \
+         "nothing throttles the sender while a hold is out"])
     end
     r.shutdown
   end
 
-  it "forwards a still-held message at teardown instead of destroying it" do
+  it "forwards a still-held message at teardown without CLAIMING the dead peer received it" do
     # The socket ends while the operator still owns the message. `MessageGate#close` runs
     # from the pump's `ensure`, which is only reached AFTER `Relay.run` has closed both
     # sockets to unblock the pump's read — so releasing there writes to a dead socket. It
@@ -627,6 +650,14 @@ describe Gori::Proxy::WS::MessageGate do
     # `ws_messages` row, under a log line calling them "released". `Relay.run` settles both
     # gates while the sockets are still open; fail-open is the disposition every other
     # involuntary release in this class already takes.
+    #
+    # And the DESTINATION here is already gone: the `in` pump EOF'd, which is the upstream
+    # leg this gate writes to. `write_message` decided "did the peer see it?" by whether the
+    # write RAISED, and a write to a socket whose peer has sent FIN succeeds into the kernel
+    # buffer — so this used to record a `ws_messages` row byte-identical to the one a message
+    # that really arrived gets, while `@lost` stayed 0 and the teardown accounting had nothing
+    # to say. The bytes are still written (a genuine half-close delivers them, and gori cannot
+    # tell that from a full close); the CLAIM is what is withdrawn.
     r = rig
     sink = HoldSink.new
     with_interceptor("proto:ws") do |ic|
@@ -638,7 +669,64 @@ describe Gori::Proxy::WS::MessageGate do
       r.ss_w.close # the origin goes away with the decision still outstanding
       read_message(r.ts_r).should eq({WS::OP_TEXT, "CLIENT-HELD"})
       wait_until("the queue row to be given back") { ic.pending_count == 0 }
-      sink.messages.should eq([{"out", 1, "CLIENT-HELD"}])
+      # Was: `[{"out", 1, "CLIENT-HELD"}]` — indistinguishable, in `run show` and in the
+      # table, from the delivered case asserted by the complement below.
+      data_rows(sink).should eq([] of {String, Int32, String})
+      wait_until("the teardown accounting") { notice_rows(sink).size == 2 }
+      texts = notice_rows(sink).map(&.[](2))
+      texts[0].should contain("the peer had already ended this direction without a CLOSE frame")
+      texts[0].should contain("no ws_messages row is recorded for them")
+      texts[1].should contain("1 written after the peer had already ended this direction")
+      # A diagnostic is not traffic: never on the direction a WebSocket repeater seeds from.
+      notice_rows(sink).map(&.[](0)).uniq.should eq(["in"])
+    end
+    r.shutdown
+  end
+
+  # The complement that decides whether the row above means anything: the SAME hold, the same
+  # involuntary teardown release, on a socket whose destination is still alive. Here the write
+  # is a real delivery, so the `ws_messages` row is a true claim and must still be written —
+  # the operator is only told that their decision window closed.
+  it "still records a held message released at teardown when the destination is alive" do
+    r = rig
+    sink = HoldSink.new
+    with_interceptor("proto:ws") do |ic|
+      ic.set_direction(Gori::Interceptor::Direction::RequestOnly)
+      spawn { WS::Relay.run(r.client, r.upstream, 37_i64, sink, nil, HOLD_CTX, ic) }
+      r.cs_w.write(masked(WS::OP_TEXT, "CLIENT-HELD".to_slice))
+      wait_until("the hold") { ic.pending_count == 1 }
+
+      r.cs_w.close # only the CLIENT goes; the upstream leg this gate writes to is untouched
+      read_message(r.ts_r).should eq({WS::OP_TEXT, "CLIENT-HELD"})
+      wait_until("the queue row to be given back") { ic.pending_count == 0 }
+      data_rows(sink).should eq([{"out", 1, "CLIENT-HELD"}])
+      notice_rows(sink).map(&.[](2)).should eq(
+        ["[gori] client→server: the socket is closing — forwarding 1 held message(s) " \
+         "unedited, in arrival order. WebSocket has no application-level flow control, so " \
+         "nothing throttles the sender while a hold is out"])
+    end
+    r.shutdown
+  end
+
+  # The DOCUMENTED decision window, which must not regress: a peer that sends a CLOSE frame is
+  # closing on purpose and is still reading, so `Relay::CLOSE_TIMEOUT` expires, the held
+  # message is forwarded unedited, it DOES arrive — and the row is therefore correct.
+  it "keeps the capture row when the peer ends with a CLOSE frame instead of vanishing" do
+    r = rig
+    sink = HoldSink.new
+    with_interceptor("proto:ws") do |ic|
+      ic.set_direction(Gori::Interceptor::Direction::RequestOnly)
+      spawn { WS::Relay.run(r.client, r.upstream, 38_i64, sink, nil, HOLD_CTX, ic) }
+      r.cs_w.write(masked(WS::OP_TEXT, "CLIENT-HELD".to_slice))
+      wait_until("the hold") { ic.pending_count == 1 }
+
+      # The origin closes the RFC 6455 way. `in` ends CLEAN, so the upstream leg is not dead.
+      r.ss_w.write(WS.encode(WS::OP_CLOSE, Bytes[0x03, 0xe8], mask: false))
+      read_message(r.ts_r).should eq({WS::OP_TEXT, "CLIENT-HELD"})
+      wait_until("the row") { data_rows(sink).any? { |(_, _, t)| t == "CLIENT-HELD" } }
+      data_rows(sink).should contain({"out", 1, "CLIENT-HELD"})
+      # ... and no reset notice: the peer closed on purpose.
+      notice_rows(sink).each { |(_, _, t)| t.should_not contain("RESET") }
     end
     r.shutdown
   end
@@ -657,8 +745,38 @@ describe Gori::Proxy::WS::MessageGate do
       gate.close
       dst.size.should_not eq(0) # was: zero bytes, and no capture row either
       read_message(IO::Memory.new(dst.to_slice)).should eq({WS::OP_TEXT, "held"})
-      sink.messages.should eq([{"out", 1, "held"}])
+      data_rows(sink).should eq([{"out", 1, "held"}])
+      # `close` never saw a `settle`, so nothing knows the destination is dead — the release
+      # is claimed, and the involuntary release is still named.
+      notice_rows(sink).map(&.[](2)).should eq(
+        ["[gori] client→server: the socket closed with the message still held — forwarding " \
+         "1 held message(s) unedited, in arrival order. WebSocket has no application-level " \
+         "flow control, so nothing throttles the sender while a hold is out"])
       ic.pending_count.should eq(0)
+    end
+  end
+
+  # The `@dropped` half of the same accounting, which was equally silent: an operator who
+  # dropped a message watched the queue row leave and nothing downstream — History, the WS
+  # pane, an export — had any record of the attempt.
+  it "says on the flow that a dropped message left no trace, rather than only in gori.log" do
+    dst = IO::Memory.new
+    sink = HoldSink.new
+    with_interceptor("proto:ws") do |ic|
+      gate = WS::MessageGate.new("out", dst, 39_i64, sink, ic, HOLD_CTX, mask: true)
+      gate.submit(WS::OP_TEXT, "secret".to_slice, nil)
+      wait_until("the hold") { ic.pending_count == 1 }
+      ic.drop(ic.pending.first.id)
+      # The gate's own queue, not the interceptor's: `drop` only puts the decision on the
+      # channel, and a `close` that overtakes the wait fiber counts the slot as STRANDED.
+      wait_until("the drop to reach the gate") { !gate.pending? }
+      gate.close
+      dst.size.should eq(0) # nothing on the wire, which is the whole point of a drop
+      data_rows(sink).should eq([] of {String, Int32, String})
+      notice_rows(sink).map(&.[](2)).should eq(
+        ["[gori] client→server: held message(s) at teardown — 1 dropped by the operator. " \
+         "None of these left a ws_messages row and neither endpoint can see the gap: a " \
+         "WebSocket message has no identity for a peer to miss"])
     end
   end
 

--- a/spec/proxy/ws_spec.cr
+++ b/spec/proxy/ws_spec.cr
@@ -1552,6 +1552,112 @@ describe "Gori::Proxy::WS::Relay frame shape capture (V7)" do
   end
 end
 
+# An IO whose READ RAISES where a pipe would report end of stream — a transport reset, the
+# other of the two ways a WebSocket ends without a CLOSE frame. gori distinguishes them
+# (a FIN is `read_fully?` → nil, a reset raises) and used to throw the difference away, so an
+# operator staring at a `101 / complete / empty transcript` flow could not tell "the peer hung
+# up normally" from "something killed this socket".
+private class ResettingIO < IO
+  def initialize(@src : IO, @dst : IO)
+  end
+
+  def read(slice : Bytes) : Int32
+    n = @src.read(slice)
+    raise IO::Error.new("Connection reset by peer") if n == 0
+    n
+  end
+
+  def write(slice : Bytes) : Nil
+    @dst.write(slice)
+  end
+
+  def flush : Nil
+    @dst.flush
+  end
+
+  def close : Nil
+    @src.close rescue nil
+    @dst.close rescue nil
+  end
+end
+
+describe "Gori::Proxy::WS::Relay teardown, FIN vs RST" do
+  # A frame, then the origin's socket RESET. The frame's own row is untouched (it really did
+  # arrive); what is added is the sentence saying HOW the socket ended, on the flow's own
+  # `ws_messages` stream so `gori run show`, the WS pane, MCP `get_flow` and an export all
+  # carry it.
+  it "names a peer that RESET the socket instead of closing it" do
+    ss_r, ss_w = IO.pipe
+    ts_r, ts_w = IO.pipe
+    cs_r, cs_w = IO.pipe
+    tc_r, tc_w = IO.pipe
+    client = IO::Stapled.new(cs_r, tc_w, sync_close: true)
+    upstream = ResettingIO.new(ss_r, ts_w)
+
+    # The CLIENT stays live throughout, so the reset is the FIRST ending `run` observes —
+    # exactly the shape of the case an operator asks about, a socket killed under a peer that
+    # is still there. (`run` closes both legs on an abnormal end, which reaps the other pump.)
+    ss_w.write(Gori::Proxy::WS.encode(Gori::Proxy::WS::OP_TEXT, "from-server".to_slice, mask: false))
+    ss_w.close # ResettingIO turns this end of stream into a raise
+
+    sink = WsSink.new
+    Gori::Proxy::WS::Relay.run(client, upstream, 9_i64, sink, nil, WS_CTX)
+    cs_w.close
+
+    notices = sink.messages.select { |(_, _, t)| t.starts_with?("[gori] ") }
+    notices.size.should eq(1)
+    # A diagnostic is not traffic: NOTICE_DIRECTION, never the direction a repeater seeds from.
+    notices.first[0].should eq("in")
+    notices.first[2].should contain("the server ended this WebSocket with a transport-level RESET")
+    notices.first[2].should contain("leaves no row here")   # so its ABSENCE is readable
+    sink.messages.first.should eq({"in", 1, "from-server"}) # the frame's own row is untouched
+    _ = {ts_r, tc_r}
+  end
+
+  # The complement, and the reason the sentence above says what absence means: the SAME
+  # transcript ended by a plain FIN gets no row. A WebSocket dying on a FIN with no CLOSE is
+  # how one ordinarily dies in the field, and a `[gori]` row on a large fraction of every
+  # capture saying "nothing unusual happened" is how the anomalous row stops being noticed.
+  it "writes no teardown row when the peer merely closed (FIN)" do
+    ss_r, ss_w = IO.pipe
+    ts_r, ts_w = IO.pipe
+    cs_r, cs_w = IO.pipe
+    tc_r, tc_w = IO.pipe
+    client = IO::Stapled.new(cs_r, tc_w, sync_close: true)
+    upstream = IO::Stapled.new(ss_r, ts_w)
+
+    ss_w.write(Gori::Proxy::WS.encode(Gori::Proxy::WS::OP_TEXT, "from-server".to_slice, mask: false))
+    ss_w.close # a plain end of stream: the peer's FIN
+
+    sink = WsSink.new
+    Gori::Proxy::WS::Relay.run(client, upstream, 10_i64, sink, nil, WS_CTX)
+    cs_w.close
+    sink.messages.should eq([{"in", 1, "from-server"}])
+    _ = {ts_r, tc_r}
+  end
+
+  # ... and a proper closing handshake gets none either, even though gori's own teardown then
+  # unblocks the surviving pump's read: only endings observed BEFORE `run` closes the sockets
+  # are the peers', or the diagnostic would report gori's own reap as a peer's reset.
+  it "writes no teardown row when the peer sent a CLOSE frame" do
+    ss_r, ss_w = IO.pipe
+    ts_r, ts_w = IO.pipe
+    cs_r, cs_w = IO.pipe
+    tc_r, tc_w = IO.pipe
+    client = IO::Stapled.new(cs_r, tc_w, sync_close: true)
+    upstream = ResettingIO.new(ss_r, ts_w)
+
+    ss_w.write(Gori::Proxy::WS.encode(Gori::Proxy::WS::OP_CLOSE, Bytes[0x03, 0xE8], mask: false))
+    cs_w.close # both directions end at once; neither ending is a reset
+
+    sink = WsSink.new
+    Gori::Proxy::WS::Relay.run(client, upstream, 11_i64, sink, nil, WS_CTX)
+    sink.messages.count { |(_, _, t)| t.starts_with?("[gori] ") }.should eq(0)
+    ss_w.close
+    _ = {ts_r, tc_r}
+  end
+end
+
 describe "Gori::Proxy::WS.encode frame shapes" do
   # Every one of these was inexpressible: `encode` had no `rsv`, no explicit mask key and no
   # way to decouple the length header from the payload, and nothing above it plumbed `fin`.

--- a/spec/ql_spec.cr
+++ b/spec/ql_spec.cr
@@ -283,6 +283,21 @@ describe Gori::QL do
     # Mirrors a bad status: — a typo like proto:htttp must not silently match all flows.
     Gori::QL.parse("proto:htttp").sql.should eq("1")
   end
+
+  # The History PROTO column prints WSS/GRPCS/SSES/HTTPS, so those spellings have to be
+  # typeable here — and they have to MEAN the transport they name. An alias that quietly
+  # returned the cleartext rows too would drop exactly the signal the column was changed to
+  # keep, on the query an operator writes BECAUSE they saw it in the column.
+  it "compiles the transport spellings the PROTO column prints as protocol AND scheme" do
+    Gori::QL.parse("proto:wss").sql.should eq("((status = 101) AND scheme = 'https')")
+    Gori::QL.parse("proto:grpcs").sql.should eq(
+      "(((content_type IS NOT NULL AND lower(content_type) LIKE 'application/grpc%')) " \
+      "AND scheme = 'https')")
+    Gori::QL.parse("proto:sses").sql.should eq(
+      "(((content_type IS NOT NULL AND lower(content_type) LIKE 'text/event-stream%')) " \
+      "AND scheme = 'https')")
+    Gori::QL.parse("proto:wss").args.should be_empty
+  end
 end
 
 describe "Gori::Store#search (QL)" do
@@ -359,6 +374,33 @@ describe "Gori::Store#search (QL)" do
       def_ids.call("proto:http").should eq([html, pending].sort)
       # Negation is NULL-safe too: -proto:grpc keeps the pending (NULL content_type) flow.
       def_ids.call("-proto:grpc").includes?(pending).should be_true
+    end
+  end
+
+  # H3-F3's other half, over real rows: the same protocol on the two transports, listed
+  # together the way an operator triages them. `proto:ws` still means "a WebSocket"; the
+  # spelling the PROTO column shows for each row selects that row and only that row.
+  it "separates ws:// from wss:// on proto:, the way the PROTO column now spells them" do
+    tmp_store do |store|
+      cleartext = store.insert_flow(Gori::Store::CapturedRequest.new(
+        created_at: 1_i64, scheme: "http", host: "acme.test", port: 80,
+        method: "GET", target: "/chat", http_version: "HTTP/1.1",
+        head: "GET /chat HTTP/1.1\r\nHost: acme.test\r\n\r\n".to_slice))
+      store.update_response(Gori::Store::CapturedResponse.new(flow_id: cleartext, status: 101,
+        head: "HTTP/1.1 101 Switching Protocols\r\n\r\n".to_slice))
+      tls = store.insert_flow(Gori::Store::CapturedRequest.new(
+        created_at: 2_i64, scheme: "https", host: "acme.test", port: 443,
+        method: "GET", target: "/chat", http_version: "HTTP/1.1",
+        head: "GET /chat HTTP/1.1\r\nHost: acme.test\r\n\r\n".to_slice))
+      store.update_response(Gori::Store::CapturedResponse.new(flow_id: tls, status: 101,
+        head: "HTTP/1.1 101 Switching Protocols\r\n\r\n".to_slice))
+
+      ids = ->(q : String) { store.search(Gori::QL.parse(q), 50).map(&.id).sort }
+      ids.call("proto:ws").should eq([cleartext, tls].sort)
+      ids.call("proto:wss").should eq([tls])
+      # ... and the composed form an operator could always write means the same thing.
+      ids.call("proto:ws scheme:https").should eq([tls])
+      ids.call("proto:ws scheme:http").should eq([cleartext])
     end
   end
 

--- a/spec/repeater/connect_error_spec.cr
+++ b/spec/repeater/connect_error_spec.cr
@@ -16,27 +16,75 @@ require "../spec_helper"
 private alias U = Gori::Proxy::Upstream
 private alias E = Gori::Repeater::Engine
 
-private def tls_error : U::DialError
-  U::DialError.new(U::DialErrorKind::Tls)
+private def verify_error : U::DialError
+  U::DialError.new(U::DialErrorKind::TlsVerify, cause: "SSL_connect: error:0A000086:SSL routines::certificate verify failed")
+end
+
+private def handshake_error : U::DialError
+  U::DialError.new(U::DialErrorKind::Tls, cause: "SSL_connect: error:0A00010B:SSL routines::wrong version number")
+end
+
+private def blackhole_error : U::DialError
+  U::DialError.new(U::DialErrorKind::Timeout, cause: "no TLS response within 3.0s")
+end
+
+private def dns_error : U::DialError
+  U::DialError.new(U::DialErrorKind::Dns, cause: "Hostname lookup for h.test failed: No address found")
 end
 
 describe "Gori::Repeater::Engine.connect_error" do
-  it "names a certificate rejection, with the remedy, under verify-on" do
-    msg = E.connect_error("https", "h.test", 443, true, tls_error)
+  it "names a certificate rejection, with the remedy, and quotes OpenSSL" do
+    msg = E.connect_error("https", "h.test", 443, true, verify_error)
     msg.should contain("TLS verification failed: h.test:443")
     msg.should contain("certificate is not trusted")
     msg.should contain("SSL_CERT_FILE")
+    msg.should contain("certificate verify failed")
     # Not the reachability sentence — that is the whole defect.
     msg.should_not contain("host unreachable")
   end
 
-  it "names a HANDSHAKE failure under -k, where verification is not the explanation" do
-    msg = E.connect_error("https", "h.test", 443, false, tls_error)
+  it "names a HANDSHAKE failure where verification is not the explanation" do
+    msg = E.connect_error("https", "h.test", 443, false, handshake_error)
     msg.should contain("TLS handshake failed: h.test:443")
     msg.should contain("may not be TLS")
     msg.should_not contain("host unreachable")
     # …and it must not offer -k to someone who already passed it.
     msg.should_not contain("SSL_CERT_FILE")
+    # The guess is checkable rather than believed.
+    msg.should contain("wrong version number")
+  end
+
+  # Round 5 / Part 2 §2.1. The dial kind, not the `verify` flag, decides the sentence. Keying
+  # on the flag is what made a black hole and a plaintext port read as an untrusted cert.
+  it "does not offer a certificate remedy for a plaintext port just because verify is on" do
+    msg = E.connect_error("https", "h.test", 443, true, handshake_error)
+    msg.should contain("TLS handshake failed: h.test:443")
+    msg.should_not contain("SSL_CERT_FILE")
+    msg.should_not contain("certificate")
+  end
+
+  it "names a black hole as a timeout and says the two TLS remedies cannot help" do
+    [true, false].each do |verify| # -k changes nothing: verification never ran
+      msg = E.connect_error("https", "h.test", 443, verify, blackhole_error)
+      msg.should contain("TLS handshake timed out: h.test:443")
+      msg.should contain("sent nothing")
+      msg.should contain("cannot help")
+      msg.should contain("no TLS response within 3.0s")
+      # The two remedies that were offered before, and are useless here: nothing may read as
+      # "add a CA file" when no certificate was ever exchanged.
+      msg.should_not contain("not trusted")
+      msg.should_not contain("retry with")
+      msg.should_not contain("host unreachable")
+    end
+  end
+
+  it "separates a name that never resolved from a port that refused" do
+    dns = E.connect_error("https", "h.test", 443, true, dns_error)
+    dns.should contain("the name did not resolve")
+    dns.should contain("nothing was dialed")
+    tcp = E.connect_error("https", "h.test", 443, true, U::DialError::ORIGIN_UNREACHABLE)
+    tcp.should_not contain("did not resolve")
+    dns.should_not eq(tcp)
   end
 
   it "keeps the reachability sentence for a TCP failure, WITHOUT the TLS clause" do
@@ -62,10 +110,14 @@ describe "Gori::Repeater::Engine.connect_error" do
       .should eq("connect failed: h.test:443 — host unreachable (DNS/refused/timeout)")
   end
 
-  it "gives the three failures three DIFFERENT sentences" do
-    cert = E.connect_error("https", "h.test", 443, true, tls_error)
-    shake = E.connect_error("https", "h.test", 443, false, tls_error)
-    tcp = E.connect_error("https", "h.test", 443, true, U::DialError::ORIGIN_UNREACHABLE)
-    [cert, shake, tcp].uniq.size.should eq(3)
+  it "gives the five dial failures five DIFFERENT sentences" do
+    all = [
+      E.connect_error("https", "h.test", 443, true, verify_error),
+      E.connect_error("https", "h.test", 443, true, handshake_error),
+      E.connect_error("https", "h.test", 443, true, blackhole_error),
+      E.connect_error("https", "h.test", 443, true, dns_error),
+      E.connect_error("https", "h.test", 443, true, U::DialError::ORIGIN_UNREACHABLE),
+    ]
+    all.uniq.size.should eq(5)
   end
 end

--- a/spec/repeater/h2_engine_spec.cr
+++ b/spec/repeater/h2_engine_spec.cr
@@ -1853,10 +1853,16 @@ describe Gori::Repeater::H2Engine do
     # examples on literals would mean an h1-side improvement lands as an h2-side spec failure,
     # which is how the two drifted apart in the first place.
     {
-      {"a TCP connect that never came up", -> { s = TCPServer.new("127.0.0.1", 0); p = s.local_address.port; s.close; p }, false},
-      {"a certificate the client does not trust", -> { start_tls_origin(advertise_h2: true) }, true},
-      {"a plaintext port addressed as https", -> { start_quiet_origin }, false},
-    }.each do |(label, open_port, verify)|
+      # `exact` is false for the plaintext port ALONE, and that is a property of the case, not a
+      # weakened assertion. A port that is not TLS answers the ClientHello when it happens to be
+      # reading and stays silent when it does not, so OpenSSL reports `wrong version number` on
+      # one connection and the handshake times out on the next — and the two sends below are two
+      # connections. Both readings are true, and neither is a certificate claim, which is the
+      # thing this example exists to pin. Demanding one string here would pin the race instead.
+      {"a TCP connect that never came up", -> { s = TCPServer.new("127.0.0.1", 0); p = s.local_address.port; s.close; p }, false, true},
+      {"a certificate the client does not trust", -> { start_tls_origin(advertise_h2: true) }, true, true},
+      {"a plaintext port addressed as https", -> { start_quiet_origin }, false, false},
+    }.each do |(label, open_port, verify, exact)|
       it "says exactly what the h1 engine says about #{label}" do
         port = open_port.call
         args = {"GET /x HTTP/2\r\nHost: h\r\n\r\n".to_slice}
@@ -1866,7 +1872,20 @@ describe Gori::Repeater::H2Engine do
           port: port, verify_upstream: verify, timeout: 3.seconds)
 
         error = h2.error.should_not be_nil
-        error.should eq(h1.error)
+        h1_error = h1.error.should_not be_nil
+        if exact
+          error.should eq(h1_error)
+        else
+          # Same layer, and — the point of the example — neither engine BLAMES a certificate.
+          # Note the timeout sentence mentions one on purpose ("no certificate was exchanged, so
+          # -k and SSL_CERT_FILE cannot help"), which is the opposite of a certificate claim, so
+          # the assertion is on the verdict and its remedy rather than on the word.
+          {error, h1_error}.each do |e|
+            e.should start_with("TLS handshake")
+            e.should_not contain("certificate is not trusted")
+            e.should_not contain("retry with -k")
+          end
+        end
         # …and none of the three carries the collapsed sentence's guesses.
         error.should_not contain("no h2 negotiated")
         error.should_not contain("doesn't offer HTTP/2")

--- a/spec/repeater/h2_engine_spec.cr
+++ b/spec/repeater/h2_engine_spec.cr
@@ -28,6 +28,36 @@ private def start_quiet_origin : Int32
   port
 end
 
+# A real TLS listener presenting a leaf minted by a throwaway gori CA — self-signed as far as
+# this process is concerned, so `verify_upstream: true` fails verification against it. It never
+# answers: every example using it is about what happens BEFORE a request goes out.
+#
+# `advertise_h2: false` makes `context_for` offer only `http/1.1` over ALPN, which is the
+# "handshake fine, this origin has no h2" case — a lab or legacy origin, and the one dial
+# failure gori can state without hedging.
+private def start_tls_origin(advertise_h2 : Bool) : Int32
+  dir = File.tempname("gori-h2ca")
+  ca = Gori::Proxy::Tls::CertAuthority.load_or_create(dir)
+  ctx = ca.context_for("127.0.0.1", advertise_h2: advertise_h2)
+  origin = TCPServer.new("127.0.0.1", 0)
+  port = origin.local_address.port
+  spawn do
+    while conn = origin.accept?
+      spawn do
+        ssl = OpenSSL::SSL::Socket::Server.new(conn, ctx, sync_close: true)
+        sleep 2.seconds
+        ssl.close
+      rescue
+        conn.close rescue nil
+      end
+    end
+  rescue
+  ensure
+    FileUtils.rm_rf(dir) if Dir.exists?(dir)
+  end
+  port
+end
+
 # A minimal cleartext-h2 origin: reads the preface + request, records the decoded
 # request line and body, then replies HEADERS(:status) + DATA.
 private def start_h2_origin(status : Int32, body : String, seen : Channel(String)) : Int32
@@ -797,6 +827,63 @@ private def start_h2_origin_interim_then(status : Int32, final_after : Time::Spa
       else
         sleep 10.seconds # hold the socket OPEN: "the origin closed" must stay falsifiable
       end
+    rescue
+    end
+    conn.close rescue nil
+  end
+  port
+end
+
+# An origin that answers with a COMPLETE final response and then sends a header block AFTER it.
+# What that block is decides what gori must do with it:
+#
+#   `late: :interim`    — `HEADERS(:status 103, link)`. An RFC 9110 §15.2 violation: a 1xx
+#                         precedes the final response, it is not one. This is what an h2
+#                         response-splitting / header-injection probe produces and what a
+#                         buggy gateway or an h1→h2 translating proxy emits.
+#   `late: :trailers`   — a real trailers block (no `:status`). Must stay trailers.
+#   `late: :interim_x2` — two late 1xx blocks, so the drop cannot accumulate.
+#
+# `end_stream_on_late` puts END_STREAM on the late block itself instead of on a following DATA
+# frame; before the fix that variant failed DIFFERENTLY (the 1xx's field was MERGED into the
+# final head rather than replacing it), so both shapes are driven.
+private def start_h2_origin_late_block(late : Symbol, end_stream_on_late : Bool = false) : Int32
+  origin = TCPServer.new("127.0.0.1", 0)
+  port = origin.local_address.port
+  spawn do
+    next unless conn = origin.accept?
+    conn.read_timeout = 30.seconds
+    Frame.read_preface(conn)
+    send_server_preface(conn)
+    begin
+      loop do
+        f = Frame.read(conn)
+        break if f.nil?
+        break if f.frame_type.in?(Frame::Type::Headers, Frame::Type::Data) && f.end_stream?
+      end
+      body = "REALBODY"
+      enc = HPACK::Encoder.new # ONE encoder: the dynamic table spans every block on the stream
+      final = enc.encode([{":status", "200"}, {"content-type", "text/plain"},
+                          {"x-final", "yes"}, {"content-length", body.bytesize.to_s}])
+      conn.write(Frame::Header.new(Frame::Type::Headers.value, Frame::END_HEADERS, 1_u32, final).to_bytes)
+      conn.flush
+      blocks = case late
+               when :trailers then [[{"x-checksum", "deadbeef"}]]
+               when :interim_x2 then [[{":status", "103"}, {"link", "</a.css>; rel=preload"}],
+                                      [{":status", "103"}, {"link", "</b.css>; rel=preload"}]]
+               else [[{":status", "103"}, {"link", "</late.css>; rel=preload"}]]
+               end
+      blocks.each_with_index do |fields, i|
+        last = i == blocks.size - 1
+        flags = Frame::END_HEADERS | ((end_stream_on_late && last) ? Frame::END_STREAM : 0_u8)
+        conn.write(Frame::Header.new(Frame::Type::Headers.value, flags, 1_u32, enc.encode(fields)).to_bytes)
+        conn.flush
+      end
+      unless end_stream_on_late
+        conn.write(Frame::Header.new(Frame::Type::Data.value, Frame::END_STREAM, 1_u32, body.to_slice).to_bytes)
+        conn.flush
+      end
+      sleep 0.3.seconds
     rescue
     end
     conn.close rescue nil
@@ -1642,6 +1729,7 @@ describe Gori::Repeater::H2Engine do
     end
 
     it "still succeeds when the final response merely arrives LATE" do
+      # (see below for the AFTER-the-final-response case — the mirror of this one)
       # The complement: an interim is not a failure, it is a PRELUDE. The fix must key on
       # "did a final response arrive", never on "was an interim seen".
       result = Gori::Repeater::H2Engine.send(
@@ -1655,6 +1743,184 @@ describe Gori::Repeater::H2Engine do
       String.new(result.body || Bytes.empty).should eq("late")
       String.new(result.head).should_not contain("100")
       result.timed_out?.should be_false
+    end
+  end
+
+  # R5-F3. The mirror of the block above, and the case its rework walked straight past. A 1xx
+  # header block arriving AFTER the final response used to overwrite the status, append its
+  # fields, file them as trailers, and then `headers.clear` everything the FINAL block had
+  # contributed — the guard was `interim?(status)` with no `!final_seen` term. A
+  # `200 + content-type + content-length + x-final` followed by `103 link:` and the body was
+  # reported, and STORED, as a clean `status: 103` with NO headers and no error. That is the
+  # output of an h2 response-splitting probe reported as a benign informational response.
+  describe "an interim 1xx that arrives AFTER the final response (RFC 9110 §15.2 violation)" do
+    it "keeps the final response's status, headers and body, and names the late 1xx" do
+      result = Gori::Repeater::H2Engine.send(
+        "GET /x HTTP/2\r\nHost: h\r\n\r\n".to_slice,
+        scheme: "http", host: "127.0.0.1",
+        port: start_h2_origin_late_block(:interim),
+        verify_upstream: false, timeout: 3.seconds)
+
+      # The real answer survives, intact.
+      result.response.try(&.status).should eq(200)
+      head = String.new(result.head)
+      head.should contain("HTTP/2 200")
+      head.should contain("content-type: text/plain")
+      head.should contain("x-final: yes")
+      head.should contain("content-length: 8")
+      String.new(result.body || Bytes.empty).should eq("REALBODY")
+      # The interloper reaches NEITHER the head nor the trailers marker.
+      head.should_not contain("103")
+      head.should_not contain("late.css")
+      head.should_not contain("X-Gori-Trailers")
+      # …and it is not swallowed either: gori exists to reveal exactly this.
+      error = result.error.should_not be_nil
+      error.should contain("interim 103")
+      error.should contain("AFTER its final response")
+      error.should contain("RFC 9110 §15.2")
+      # A response DID arrive, so this is a clause on it, not a failed send.
+      result.delivered?.should be_true
+      result.incomplete?.should be_false
+    end
+
+    it "does the same when END_STREAM rides on the late 1xx itself" do
+      # This variant failed DIFFERENTLY before the fix — `headers.clear` was gated on
+      # `!end_stream_pending`, so the 1xx's `link` was MERGED into the final head instead of
+      # replacing it, and the status was still 103. Both shapes have to end up right.
+      result = Gori::Repeater::H2Engine.send(
+        "GET /x HTTP/2\r\nHost: h\r\n\r\n".to_slice,
+        scheme: "http", host: "127.0.0.1",
+        port: start_h2_origin_late_block(:interim, end_stream_on_late: true),
+        verify_upstream: false, timeout: 3.seconds)
+
+      result.response.try(&.status).should eq(200)
+      head = String.new(result.head)
+      head.should contain("HTTP/2 200")
+      head.should contain("x-final: yes")
+      head.should_not contain("late.css")
+      head.should_not contain("X-Gori-Trailers")
+      result.error.should_not be_nil
+      result.error.not_nil!.should contain("interim 103")
+    end
+
+    it "drops only what EACH late block added, however many arrive" do
+      result = Gori::Repeater::H2Engine.send(
+        "GET /x HTTP/2\r\nHost: h\r\n\r\n".to_slice,
+        scheme: "http", host: "127.0.0.1",
+        port: start_h2_origin_late_block(:interim_x2),
+        verify_upstream: false, timeout: 3.seconds)
+
+      result.response.try(&.status).should eq(200)
+      head = String.new(result.head)
+      head.should contain("x-final: yes")
+      head.should contain("content-length: 8")
+      head.should_not contain("a.css")
+      head.should_not contain("b.css")
+      String.new(result.body || Bytes.empty).should eq("REALBODY")
+    end
+
+    it "still files a REAL trailing block as trailers" do
+      # The complement of the condition the fix keys on. `note_trailers` must keep firing for
+      # a block after the final response that is NOT an interim — a gRPC trailers response, and
+      # whether a gateway promotes a trailer into a header, is a first-class test.
+      result = Gori::Repeater::H2Engine.send(
+        "GET /x HTTP/2\r\nHost: h\r\n\r\n".to_slice,
+        scheme: "http", host: "127.0.0.1",
+        port: start_h2_origin_late_block(:trailers),
+        verify_upstream: false, timeout: 3.seconds)
+
+      result.response.try(&.status).should eq(200)
+      head = String.new(result.head)
+      head.should contain("HTTP/2 200")
+      head.should contain("x-checksum: deadbeef")
+      head.should contain("X-Gori-Trailers: x-checksum")
+      String.new(result.body || Bytes.empty).should eq("REALBODY")
+      result.error.should be_nil # a trailers block is not a violation
+    end
+  end
+
+  # R5 / H3-F1. Four dial failures with four different fixes arrived as ONE sentence — "host
+  # unreachable, the origin doesn't offer HTTP/2 via ALPN, or its TLS certificate failed
+  # verification" — while the SAME operator one `^V` away got the h1 engine's named refusals for
+  # three of them. Two causes: `H2Engine.connect_error` took no `DialError` and built its string
+  # from `scheme`/`verify` alone, and `open` called the nil-returning `Upstream.dial_tls`, which
+  # discards `DialErrorKind` before any caller can ask.
+  describe "why an h2 dial produced no connection" do
+    # The three transport failures are h1's to word — a refused TCP connect and a rejected
+    # certificate fail identically whatever runs on top — so the invariant asserted here is
+    # PARITY, not any particular phrase. `Repeater::Engine.connect_error` is where the wording
+    # (and `DialErrorKind`'s split, and its remedies) is decided and re-decided; keying these
+    # examples on literals would mean an h1-side improvement lands as an h2-side spec failure,
+    # which is how the two drifted apart in the first place.
+    {
+      {"a TCP connect that never came up", -> { s = TCPServer.new("127.0.0.1", 0); p = s.local_address.port; s.close; p }, false},
+      {"a certificate the client does not trust", -> { start_tls_origin(advertise_h2: true) }, true},
+      {"a plaintext port addressed as https", -> { start_quiet_origin }, false},
+    }.each do |(label, open_port, verify)|
+      it "says exactly what the h1 engine says about #{label}" do
+        port = open_port.call
+        args = {"GET /x HTTP/2\r\nHost: h\r\n\r\n".to_slice}
+        h2 = Gori::Repeater::H2Engine.send(*args, scheme: "https", host: "127.0.0.1",
+          port: port, verify_upstream: verify, timeout: 3.seconds)
+        h1 = Gori::Repeater::Engine.send(*args, scheme: "https", host: "127.0.0.1",
+          port: port, verify_upstream: verify, timeout: 3.seconds)
+
+        error = h2.error.should_not be_nil
+        error.should eq(h1.error)
+        # …and none of the three carries the collapsed sentence's guesses.
+        error.should_not contain("no h2 negotiated")
+        error.should_not contain("doesn't offer HTTP/2")
+      end
+    end
+
+    it "names an origin whose ALPN is http/1.1 — the one case gori OBSERVED" do
+      # The handshake COMPLETED and the origin named its protocol, so this is the only one of
+      # the four that needs no hedging. It was buried third in a list of three guesses.
+      port = start_tls_origin(advertise_h2: false)
+
+      result = Gori::Repeater::H2Engine.send(
+        "GET /x HTTP/2\r\nHost: h\r\n\r\n".to_slice,
+        scheme: "https", host: "127.0.0.1", port: port,
+        verify_upstream: false, timeout: 3.seconds)
+
+      error = result.error.should_not be_nil
+      error.should contain("h2 not negotiated")
+      error.should contain("completed the TLS handshake")
+      # gori offers `h2` alone, so an http/1.1-only origin has nothing to select and the
+      # negotiated protocol is EMPTY. Naming that is the point — the old sentence's "the
+      # origin doesn't offer HTTP/2 via ALPN" was one guess of three, applied to all four.
+      error.should contain("did not accept `h2` over ALPN")
+      error.should contain("HTTP/1.1 instead")
+      # Not blamed on reachability or on the certificate — both are demonstrably fine.
+      error.should_not contain("host unreachable")
+      error.should_not contain("certificate")
+      # This one is h2's ALONE: the h1 engine reaches the same origin without complaint, which
+      # is precisely the advice the sentence gives. It is also why it cannot be delegated.
+      h1 = Gori::Repeater::Engine.send(
+        "GET /x HTTP/1.1\r\nHost: h\r\n\r\n".to_slice,
+        scheme: "https", host: "127.0.0.1", port: port,
+        verify_upstream: false, timeout: 3.seconds)
+      h1.error.should_not eq(error)
+    end
+
+    it "gives the four failures four DIFFERENT sentences" do
+      # The defect was not any one wording, it was that all four were byte-identical.
+      closed = TCPServer.new("127.0.0.1", 0)
+      dead = closed.local_address.port
+      closed.close
+      cases = {
+        {dead, false},
+        {start_tls_origin(advertise_h2: true), true},
+        {start_quiet_origin, false},
+        {start_tls_origin(advertise_h2: false), false},
+      }
+      errors = cases.map do |(port, verify)|
+        Gori::Repeater::H2Engine.send(
+          "GET /x HTTP/2\r\nHost: h\r\n\r\n".to_slice,
+          scheme: "https", host: "127.0.0.1", port: port,
+          verify_upstream: verify, timeout: 3.seconds).error.to_s.sub(port.to_s, "PORT")
+      end
+      errors.to_a.uniq.size.should eq(4)
     end
   end
 
@@ -1715,14 +1981,19 @@ describe Gori::Repeater::H2Engine do
   # F5. The guard was `scheme == "https" && verify`, so `-k` / MCP `insecure:true` routed an
   # https target into the h2c branch and reported a cleartext prior-knowledge diagnosis for a
   # failed ALPN negotiation — on the branch operators hit most against a lab origin.
-  it "reports the ALPN diagnosis for an https target even with verification off" do
+  #
+  # R5 / H3-F1 kept both negative assertions and replaced the positive one: this origin is a
+  # PLAINTEXT port, so "the origin doesn't offer HTTP/2 via ALPN" was itself one of the three
+  # guesses the sentence was collapsing. The h2 engine now says which layer broke, in the h1
+  # engine's own words — see "why an h2 dial produced no connection" above.
+  it "does not diagnose h2c, or invent a certificate clause, for an https target with -k" do
     port = start_quiet_origin # accepts TCP, never completes a TLS handshake
     result = Gori::Repeater::H2Engine.send(
       "GET /x HTTP/2\r\nHost: h\r\n\r\n".to_slice,
       scheme: "https", host: "127.0.0.1", port: port, verify_upstream: false,
       timeout: 2.seconds)
     error = result.error.should_not be_nil
-    error.should contain("doesn't offer HTTP/2 via ALPN")
+    error.should contain("TLS handshake failed")
     error.should_not contain("h2c")
     error.should_not contain("certificate") # verification was off — don't invent a clause
   end

--- a/spec/repeater/h2_engine_spec.cr
+++ b/spec/repeater/h2_engine_spec.cr
@@ -21,9 +21,16 @@ end
 private def start_quiet_origin : Int32
   origin = TCPServer.new("127.0.0.1", 0)
   port = origin.local_address.port
+  # Closes each connection immediately — "this port is not TLS" — but accepts REPEATEDLY.
+  # The one-shot version served only the first dial, so an example that dials twice (the
+  # h1-vs-h2 comparison does, once per engine) got the intended verdict on the first connection
+  # and whatever a vanished listener produces on the second. That read as the two engines
+  # disagreeing when it was the harness running out.
   spawn do
-    conn = origin.accept?
-    conn.try(&.close) rescue nil
+    while conn = origin.accept?
+      conn.close rescue nil
+    end
+  rescue
   end
   port
 end
@@ -45,7 +52,11 @@ private def start_tls_origin(advertise_h2 : Bool) : Int32
     while conn = origin.accept?
       spawn do
         ssl = OpenSSL::SSL::Socket::Server.new(conn, ctx, sync_close: true)
-        sleep 2.seconds
+        # Longer than any example's own timeout. At 2s a second connection on a loaded runner
+        # could start its handshake after this fiber had closed, and the example then compared
+        # a verification verdict against a reset — a harness race that read as a real divergence
+        # between the h1 and h2 engines.
+        sleep 30.seconds
         ssl.close
       rescue
         conn.close rescue nil
@@ -1853,39 +1864,33 @@ describe Gori::Repeater::H2Engine do
     # examples on literals would mean an h1-side improvement lands as an h2-side spec failure,
     # which is how the two drifted apart in the first place.
     {
-      # `exact` is false for the plaintext port ALONE, and that is a property of the case, not a
-      # weakened assertion. A port that is not TLS answers the ClientHello when it happens to be
-      # reading and stays silent when it does not, so OpenSSL reports `wrong version number` on
-      # one connection and the handshake times out on the next — and the two sends below are two
-      # connections. Both readings are true, and neither is a certificate claim, which is the
-      # thing this example exists to pin. Demanding one string here would pin the race instead.
-      {"a TCP connect that never came up", -> { s = TCPServer.new("127.0.0.1", 0); p = s.local_address.port; s.close; p }, false, true},
-      {"a certificate the client does not trust", -> { start_tls_origin(advertise_h2: true) }, true, true},
-      {"a plaintext port addressed as https", -> { start_quiet_origin }, false, false},
-    }.each do |(label, open_port, verify, exact)|
+      # Both origins hold every connection open for far longer than these timeouts, on purpose:
+      # each example below dials TWICE (once per engine), and a one-shot or short-lived listener
+      # made the second dial fail differently from the first — which read as the two engines
+      # disagreeing when it was the harness running out.
+      {"a TCP connect that never came up", -> { s = TCPServer.new("127.0.0.1", 0); p = s.local_address.port; s.close; p }, false},
+      {"a certificate the client does not trust", -> { start_tls_origin(advertise_h2: true) }, true},
+      {"a plaintext port addressed as https", -> { start_quiet_origin }, false},
+    }.each do |(label, open_port, verify)|
       it "says exactly what the h1 engine says about #{label}" do
-        port = open_port.call
+        # A FRESH origin per engine. Sharing one made each engine's dial a different connection
+        # to the same listener, and the second connection is not the case under test: it saw a
+        # listener mid-teardown and reported a reset rather than the verdict the first got. Each
+        # engine now gets a first connection, which is what the example is actually about.
         args = {"GET /x HTTP/2\r\nHost: h\r\n\r\n".to_slice}
         h2 = Gori::Repeater::H2Engine.send(*args, scheme: "https", host: "127.0.0.1",
-          port: port, verify_upstream: verify, timeout: 3.seconds)
+          port: open_port.call, verify_upstream: verify, timeout: 3.seconds)
         h1 = Gori::Repeater::Engine.send(*args, scheme: "https", host: "127.0.0.1",
-          port: port, verify_upstream: verify, timeout: 3.seconds)
+          port: open_port.call, verify_upstream: verify, timeout: 3.seconds)
 
+        # Compared WITHOUT the trailing `(cause)` and without the port. The cause is the TLS
+        # library's own words about the syscall that observed the failure, and two connections
+        # legitimately differ there ("Unexpected EOF while reading" vs "Connection reset by
+        # peer") for one verdict. What must match is the verdict, the layer and the remedy —
+        # which is the whole of what the h2 engine used to collapse.
+        verdict = ->(s : String?) { s.to_s.sub(/ \([^)]*\)\z/, "").sub(/:\d+ /, " ") }
         error = h2.error.should_not be_nil
-        h1_error = h1.error.should_not be_nil
-        if exact
-          error.should eq(h1_error)
-        else
-          # Same layer, and — the point of the example — neither engine BLAMES a certificate.
-          # Note the timeout sentence mentions one on purpose ("no certificate was exchanged, so
-          # -k and SSL_CERT_FILE cannot help"), which is the opposite of a certificate claim, so
-          # the assertion is on the verdict and its remedy rather than on the word.
-          {error, h1_error}.each do |e|
-            e.should start_with("TLS handshake")
-            e.should_not contain("certificate is not trusted")
-            e.should_not contain("retry with -k")
-          end
-        end
+        verdict.call(error).should eq(verdict.call(h1.error))
         # …and none of the three carries the collapsed sentence's guesses.
         error.should_not contain("no h2 negotiated")
         error.should_not contain("doesn't offer HTTP/2")

--- a/spec/support/fake_context.cr
+++ b/spec/support/fake_context.cr
@@ -318,6 +318,10 @@ class FakeExecContext < Gori::Verb::ExecContext
     rec(:fuzz_toggle_http2)
   end
 
+  def fuzz_toggle_sni : Nil
+    rec(:fuzz_toggle_sni)
+  end
+
   def repeater_auto_mark : Nil
     rec(:repeater_auto_mark)
   end

--- a/spec/tui/fuzzer_sni_spec.cr
+++ b/spec/tui/fuzzer_sni_spec.cr
@@ -1,0 +1,149 @@
+require "../spec_helper"
+require "../support/memory_backend"
+
+include Gori::Tui
+
+# `FuzzerView` has carried `@sni` since the tab shipped: it is persisted with the session,
+# restored, compared by the cross-session reconcile, cloned by Duplicate and handed to
+# `build_engine`. What it never had was an AFFORDANCE — no chord, no menu entry — so a fuzz
+# session seeded from History (⇧I) could never set one and an https vhost sweep always
+# presented the dialed IP. The single working route was Repeater ^S ▸ space ▸ Send to Fuzzer.
+#
+# These pin the affordance and, just as importantly, the complements: SNI unset must leave the
+# card at its old height and `sni_override` nil, and every focus change must leave the sub-field.
+
+private def sni_view(sni : String = "") : FuzzerView
+  view = FuzzerView.new
+  view.load_request("https://1.2.3.4", "GET / HTTP/1.1\r\nHost: vhost.test\r\n\r\n", false, sni)
+  view.focus_pane(:target)
+  view
+end
+
+private def type(view : FuzzerView, text : String) : Nil
+  text.each_char { |c| view.target_insert(c) }
+end
+
+describe "FuzzerView SNI override" do
+  it "^S opens the SNI field and typing lands there, not in the URL" do
+    view = sni_view
+    view.editing_sni?.should be_false
+    view.sni_override.should be_nil
+
+    view.toggle_sni_field
+    view.editing_sni?.should be_true
+    type(view, "vhost.test")
+
+    view.sni_override.should eq("vhost.test")
+    view.target.should eq("https://1.2.3.4") # the dialed host is untouched
+    view.dirty?.should be_true
+  end
+
+  it "^S again (and exit_sni_field) returns to the URL keeping the value" do
+    view = sni_view
+    view.toggle_sni_field
+    type(view, "a.test")
+    view.toggle_sni_field
+    view.editing_sni?.should be_false
+    view.sni_override.should eq("a.test")
+    type(view, "/x")
+    view.target.should eq("https://1.2.3.4/x")
+    view.sni_override.should eq("a.test")
+
+    view.toggle_sni_field
+    view.exit_sni_field
+    view.editing_sni?.should be_false
+  end
+
+  # COMPLEMENT: unset SNI must not change anything the pane did before — the card keeps its
+  # 3 rows, so the template pane does not lose a line to a field nobody asked for.
+  it "leaves the TARGET card at its old height until an SNI exists" do
+    plain = sni_view
+    backend = MemoryBackend.new(100, 24)
+    plain.render(Screen.new(backend), Rect.new(0, 0, 100, 24))
+    backend.contains?("SNI ›").should be_false
+
+    set = sni_view("vhost.test")
+    b2 = MemoryBackend.new(100, 24)
+    set.render(Screen.new(b2), Rect.new(0, 0, 100, 24))
+    b2.contains?("SNI ›").should be_true
+    b2.contains?("vhost.test").should be_true
+  end
+
+  # The Repeater's focus rule, mirrored: SNI editing is an explicit per-visit sub-mode, so
+  # navigating away and back must not route URL keystrokes into @sni.
+  it "drops back to the URL field on any focus change" do
+    view = sni_view
+    view.toggle_sni_field
+    view.editing_sni?.should be_true
+    view.pane_advance(1)
+    view.editing_sni?.should be_false
+
+    view.focus_pane(:target)
+    view.toggle_sni_field
+    view.focus_first
+    view.editing_sni?.should be_false
+  end
+
+  it "backspace, caret movement and Home/End act on the field being edited" do
+    view = sni_view
+    view.toggle_sni_field
+    type(view, "abc")
+    view.target_backspace
+    view.sni_override.should eq("ab")
+    view.target_home
+    view.target_insert('Z')
+    view.sni_override.should eq("Zab")
+    view.target_end
+    view.target_insert('!')
+    view.sni_override.should eq("Zab!")
+    view.target.should eq("https://1.2.3.4") # never touched
+  end
+
+  # Persistence: the value has to survive the session round-trip a restart makes, and the
+  # reconcile has to see the two as equal afterwards (otherwise a peer sync would clobber it).
+  it "round-trips through the stored session record" do
+    view = sni_view
+    view.toggle_sni_field
+    type(view, "vhost.test")
+    rec = Gori::Store::FuzzSessionRecord.new(
+      1_i64, view.target, view.template_text, view.http2?, view.sni_override,
+      view.config_json, nil, 0, view.name)
+
+    reopened = FuzzerView.new
+    reopened.restore(rec)
+    reopened.sni_override.should eq("vhost.test")
+    reopened.editing_sni?.should be_false # a reopened tab is not mid-edit
+    reopened.session_side_matches?(rec).should be_true
+  end
+
+  # A session seeded from HISTORY is the case the defect was about: it starts with no SNI and
+  # must be able to acquire one.
+  it "lets a History-seeded (evidence) session set an SNI" do
+    view = FuzzerView.new
+    row = Gori::Store::FlowRow.new(
+      id: 1_i64, created_at: 0_i64, scheme: "https", method: "GET", host: "vhost.test",
+      port: 443, target: "/x", status: 200, size: 0_i64, state: Gori::Store::FlowState::Complete)
+    detail = Gori::Store::FlowDetail.new(row, "HTTP/1.1",
+      "GET /x HTTP/1.1\r\nHost: vhost.test\r\n\r\n".to_slice, nil,
+      "HTTP/1.1 200 OK\r\n\r\n".to_slice, nil)
+    view.load(detail)
+    view.evidence?.should be_true
+    view.focus_pane(:target)
+    view.toggle_sni_field
+    type(view, "other.test")
+    view.sni_override.should eq("other.test")
+  end
+end
+
+describe "fuzz.toggle-sni verb" do
+  it "is registered on ^S in the Fuzzer TARGET section" do
+    v = Gori::Verbs.registry["fuzz.toggle-sni"]
+    v.scope.should eq(Gori::Verb::Scope::Fuzzer)
+    v.section.should eq(:target)
+    v.chords.map(&.label).should eq(["ctrl-s"])
+    v.mnemonic.should eq('i') # 's' is fuzz.stop in Fuzzer COMMON
+    # The chord/mnemonic pair must not collide with anything the space menu can show
+    # alongside it (COMMON ∪ :target) — `validate_menu_keys!` is the boot-time check.
+    Gori::Verbs.registry.validate_menu_keys!
+  end
+end

--- a/spec/tui/repeater_evidence_binding_report_spec.cr
+++ b/spec/tui/repeater_evidence_binding_report_spec.cr
@@ -1,0 +1,98 @@
+require "../spec_helper"
+
+# `Repeater::Sender#evidence?` suppresses `Env.expand_bindings` on a captured request on
+# purpose — a capture's `$filter` is a byte the origin saw, not a reference anybody wrote —
+# and its own comment accepts the cost as "the direction that can only be READ WRONG, never
+# SENT wrong". That holds for the SUBSTITUTION. It does not hold for the REPORT: the status
+# line said `✓ sent → 200` with no further word while `Authorization: Bearer $CTOK` went out
+# literally and the tab's own binding hint showed a value for `$CTOK`.
+#
+# So the expansion stays suppressed and the fact is stated. This pins the predicate that
+# decides whether it is stated.
+
+private def with_store(&)
+  path = File.tempname("gori-evbind", ".db")
+  store = Gori::Store.open(path)
+  begin
+    yield store
+  ensure
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+private def with_layer(bindings : Gori::Bindings?, &)
+  previous = Gori::Env.layer
+  Gori::Env.layer = bindings
+  begin
+    yield
+  ensure
+    Gori::Env.layer = previous
+  end
+end
+
+private def bound(store, name : String, value : String) : Gori::Bindings
+  b = Gori::Bindings.load(store)
+  b.add(name, "", Gori::ExtractKind::JsonPath, "$.t").should be_nil
+  head = "HTTP/1.1 200 OK\r\n\r\n"
+  b.observe(
+    Gori::Repeater::Result.new(head.to_slice, %({"t":"#{value}"}).to_slice,
+      Gori::Proxy::Codec::Http1.parse_response_head(head.to_slice), 1_i64, nil),
+    Gori::InterceptFilter::Subject.new(method: "POST", host: "acme.test", target: "/login",
+      scheme: "https", status: 200)).should eq([name])
+  b
+end
+
+describe "RepeaterController.literal_bindings" do
+  it "names a BOUND binding an evidence tab is about to send unresolved" do
+    with_store do |store|
+      with_layer(bound(store, "CTOK", "SECRETVALUE12")) do
+        req = "GET /a HTTP/1.1\r\nHost: h\r\nAuthorization: Bearer $CTOK\r\n\r\n"
+        Gori::Tui::RepeaterController.literal_bindings(true, req).should eq(["CTOK"])
+      end
+    end
+  end
+
+  # COMPLEMENT 1: a DRAFT tab resolves the name, so there is nothing to report — reporting
+  # it there would be gori warning about a substitution it made correctly.
+  it "says nothing for a draft tab" do
+    with_store do |store|
+      with_layer(bound(store, "CTOK", "SECRETVALUE12")) do
+        req = "GET /a HTTP/1.1\r\nHost: h\r\nAuthorization: Bearer $CTOK\r\n\r\n"
+        Gori::Tui::RepeaterController.literal_bindings(false, req).should be_empty
+      end
+    end
+  end
+
+  # COMPLEMENT 2: an evidence tab with no declared name in it is the ordinary case and must
+  # stay silent, or every replay grows a warning about nothing.
+  it "says nothing for an evidence tab carrying no declared name" do
+    with_store do |store|
+      with_layer(bound(store, "CTOK", "SECRETVALUE12")) do
+        req = "GET /a?$filter=x HTTP/1.1\r\nHost: h\r\n\r\n"
+        Gori::Tui::RepeaterController.literal_bindings(true, req).should be_empty
+      end
+    end
+  end
+
+  # COMPLEMENT 3: a DECLARED but UNBOUND name is not this report's business — nothing would
+  # have been substituted for it on any surface, so there is no divergence to name.
+  it "says nothing for a declared name that has no value yet" do
+    with_store do |store|
+      b = Gori::Bindings.load(store)
+      b.add("CTOK", "", Gori::ExtractKind::JsonPath, "$.t").should be_nil
+      with_layer(b) do
+        req = "GET /a HTTP/1.1\r\nHost: h\r\nAuthorization: Bearer $CTOK\r\n\r\n"
+        Gori::Tui::RepeaterController.literal_bindings(true, req).should be_empty
+      end
+    end
+  end
+
+  it "says nothing with no binding layer at all" do
+    with_layer(nil) do
+      Gori::Tui::RepeaterController.literal_bindings(true, "GET /$CTOK HTTP/1.1\r\n\r\n").should be_empty
+    end
+  end
+end

--- a/spec/verb/registry_spec.cr
+++ b/spec/verb/registry_spec.cr
@@ -344,6 +344,10 @@ private class FakeContext < ExecContext
     @calls << :fuzz_toggle_http2
   end
 
+  def fuzz_toggle_sni : Nil
+    @calls << :fuzz_toggle_sni
+  end
+
   def fuzz_clear_marks : Nil
     @calls << :fuzz_clear_marks
   end

--- a/spec/verbs/history_spec.cr
+++ b/spec/verbs/history_spec.cr
@@ -295,6 +295,7 @@ describe "Gori::Verbs.register_history" do
        "fuzz.list-paste"      => :fuzz_list_paste,
        "fuzz.pretty-template" => :fuzz_pretty_template,
        "fuzz.toggle-http2"    => :fuzz_toggle_http2,
+       "fuzz.toggle-sni"      => :fuzz_toggle_sni,
        "fuzz.clear-marks"     => :fuzz_clear_marks,
       }.each do |id, intent|
         r[id].available?(ctx).should be_true

--- a/src/gori/bindings.cr
+++ b/src/gori/bindings.cr
@@ -25,10 +25,14 @@ module Gori
   # and injecting it produces exactly the 401s this feature exists to remove; and
   # re-extracting costs one request, so there is nothing to save.
   #
-  # The guarantee is BOUNDED and stated as such: a binding value never appears in
+  # The guarantee is BOUNDED and stated as such: gori never WRITES a binding value into
   # `settings.json`, the project DB, the event feed, an issue, a note, or a log line. It
   # DOES appear in captured traffic, because that is where it came from — masking a
-  # capture would be a P7 violation, not a fix.
+  # capture would be a P7 violation, not a fix. The same exception covers an author's own
+  # bytes: a request draft in which the OPERATOR (TUI editor, `gori run repeater`) or an
+  # AGENT (MCP `create_repeater`/`update_repeater`) typed the value is stored as typed.
+  # Rewriting a draft to `$NAME` is that same P7 violation one surface earlier, and it split
+  # the surfaces apart — see `MCP::Tools#stored_request`.
   #
   # One instance is SHARED between the TUI (which edits rules and reads the table), the
   # Repeater send path (which writes it) and every send seam (which reads it), so a Mutex

--- a/src/gori/bindings.cr
+++ b/src/gori/bindings.cr
@@ -113,6 +113,31 @@ module Gori
       false
     end
 
+    # Which boundary-forging byte classes `value` carries, named the way an operator reads
+    # them ("CR", "LF", "NUL"), in that order. Empty exactly when `boundary_forging?` is false.
+    #
+    # A SECOND pass and not a widening of the predicate above: that one answers a yes/no per
+    # resolved key on the proxy request path and must not allocate, while this one runs only
+    # once a refusal has already fired and is going to write an `events` row. A refusal that
+    # does not name what it found is barely better than silence — #491's lesson — and "a stray
+    # CR" is the difference between an operator editing their extract rule and an operator
+    # concluding gori is broken.
+    def self.boundary_bytes(value : String) : Array(String)
+      cr = lf = nul = false
+      value.each_byte do |b|
+        case b
+        when 0x0d_u8 then cr = true
+        when 0x0a_u8 then lf = true
+        when 0x00_u8 then nul = true
+        end
+      end
+      found = [] of String
+      found << "CR" if cr
+      found << "LF" if lf
+      found << "NUL" if nul
+      found
+    end
+
     @rules : Array(Store::ExtractRule)
     @compiled : Array(Compiled)
     @values : Hash(String, Bound)
@@ -133,6 +158,9 @@ module Gori
       # Rule ids already reported as needing an entity that was not buffered, at that rule
       # revision — see `miss_no_entity`.
       @no_entity_reported = Set(Int64).new
+      # Rule ids already reported as having read a body that is not valid UTF-8, at that rule
+      # revision — see `report_scrubbed`.
+      @scrub_reported = Set(Int64).new
       # Rule ids that already reported a plain miss at binding revision `@miss_reported_rev`
       # — see `report_miss?`.
       @miss_reported = Set(Int64).new
@@ -197,7 +225,15 @@ module Gori
     # Every value held, enabled or not — the MASKING half of the split above. A token whose
     # rule the operator switched off stops resolving, but it was still observed from a real
     # response and is still in memory, so `Env.mask_secrets` must keep redacting it out of
-    # exports, notes and the detail view. See `Env.masking_vars`.
+    # everything the operator AUTHORS. See `Env.masking_vars`.
+    #
+    # Which is: an issue's title / host / notes (`mcp/tools/issues.cr`, `cli/run/issues.cr`), a
+    # Repeater tab's target / request / name / tags (`mcp/tools/repeater.cr`,
+    # `cli/run/repeater.cr`) and a WS message an operator composed (`store/repeater_sessions.cr`).
+    # NOT an export and NOT the flow detail view, and that is deliberate rather than a gap: both
+    # render CAPTURED bytes, which is the exception the class doc above states — masking a
+    # capture would be a P7 violation, not a fix. (This comment used to name exports and the
+    # detail view; it named two surfaces that must never call this, and no surface that does.)
     def held_values : Hash(String, String)
       @mutex.synchronize do
         h = {} of String => String
@@ -485,6 +521,9 @@ module Gori
       return [] of String if picked.empty?
       bound = [] of String
       now = Time.utc
+      # Decided at most ONCE per response and only if a `text_only?` descriptor actually binds
+      # off it — the check decodes the entity, so a project of cookie rules never pays for it.
+      lossy = nil.as(Bool?)
       picked.each do |c|
         # A body-scoped descriptor on a response gori never buffered cannot possibly match, and
         # saying "found nothing" would blame the selector for gori's own decision. Say which it
@@ -502,6 +541,17 @@ module Gori
         if reason = unusable(value)
           record_miss(c.rule, reason, flow_id, throttle)
           next
+        end
+        # A `regex` / `jsonpath` descriptor can only read the body as text, and Crystal's
+        # readers need a valid subject — so on a body that is not valid UTF-8 the descriptor
+        # ran over a repaired copy and the value bound is not the bytes the origin sent, while
+        # a `cookie`, `header` or `position` descriptor on the SAME response returns them
+        # exactly. Bind anyway: a page in a legacy encoding with a CSRF token in it is an
+        # ordinary target and refusing would break a case that works today. But say it, because
+        # this is the one place a binding's value can differ from its response.
+        if c.rule.kind.text_only?
+          lossy = Gori::TokenExtract.text_lossy?(raw) if lossy.nil?
+          report_scrubbed(c.rule, flow_id) if lossy
         end
         @mutex.synchronize { @values[c.rule.name] = Bound.new(value, c.rule.id, now) }
         bound << c.rule.name
@@ -554,6 +604,21 @@ module Gori
         "$#{rule.name}: #{rule.token_loc.label} found nothing (#{reason})", flow_id: flow_id)
     end
 
+    # A bind that HAPPENED but not over the origin's bytes. Once per rule per rule revision,
+    # the same key and the same reason as `miss_no_entity`: this is a structural fact about
+    # the target's body, so it is news when the operator edits the rule and noise on every
+    # subsequent response. Warn and not info — the operator's next request carries a value
+    # gori repaired, and that is the kind of thing a 401 is later blamed on.
+    private def report_scrubbed(rule : Store::ExtractRule, flow_id : Int64?) : Nil
+      return unless @mutex.synchronize { @scrub_reported.add?(rule.id) }
+      @store.insert_event("bindings", "extract_scrubbed", "warn",
+        "$#{rule.name}: #{rule.token_loc.label} read a response body that is not valid UTF-8 — a " \
+        "regex/jsonpath descriptor has no byte-level reading, so every invalid byte was replaced " \
+        "with U+FFFD before it ran and the bound value may not be the bytes the origin sent " \
+        "(a cookie, header or position descriptor reads the same response byte-exact)",
+        flow_id: flow_id)
+    end
+
     private def miss_no_entity(rule : Store::ExtractRule, flow_id : Int64?) : Nil
       return unless @mutex.synchronize { @no_entity_reported.add?(rule.id) }
       @store.insert_event("bindings", "extract_no_body", "warn",
@@ -598,6 +663,7 @@ module Gori
         @rev &+= 1
         # An edit is the operator looking at this rule, so let it say the no-body thing again.
         @no_entity_reported.clear
+        @scrub_reported.clear
       end
       @enabled_count.set(fresh.count(&.enabled?))
       @body_count.set(fresh.count { |r| r.enabled? && r.body_scoped? })

--- a/src/gori/cli/run/repeater.cr
+++ b/src/gori/cli/run/repeater.cr
@@ -305,9 +305,15 @@ module Gori
 
           pos = store.repeaters_meta.size
 
+          # The REQUEST is stored as authored, the target (a short operator-typed field with
+          # no wire semantics of its own) is masked as before. Same seam and same reason as
+          # `MCP::Tools#stored_request`: `mask_secrets` here rewrote an author's live value —
+          # or, on `--flow`, a CAPTURE's own bytes — to `$KEY` in the stored row, and the TUI
+          # then read that row through `RepeaterView#evidence?`, which does not expand
+          # `$NAME`. One row, `$KEY` on the wire from the TUI and the value from here.
           id = store.insert_repeater(
             target: Env.mask_secrets(tgt_str),
-            request: Env.mask_secrets(req_content).to_slice,
+            request: req_content.to_slice,
             http2: http2,
             auto_cl: auto_cl,
             flow_id: flow_id,

--- a/src/gori/decoder/converter.cr
+++ b/src/gori/decoder/converter.cr
@@ -44,8 +44,17 @@ module Gori
       getter direction : Direction
       getter description : String
       getter fn : Proc(Bytes, Bytes)
+      # WHY this converter cannot run, or nil when it can. Only a saved chain sets it: the
+      # library registers a recursive / over-MAX_TOKENS entry anyway, as a step that raises,
+      # so its NAME still resolves and the failure is visible instead of looking like a typo
+      # (see decoder/library.cr). `apply` raises this same sentence — but a caller that must
+      # decide BEFORE it sends anything cannot find out by calling it, and the one that
+      # guessed instead put un-transformed payloads on the wire and reported `0 errors`.
+      # Asking the registry is the same fact, one step earlier and with no side effect.
+      getter unusable : String?
 
-      def initialize(@name, @aliases, @category, @direction, @description, @fn)
+      def initialize(@name, @aliases, @category, @direction, @description, @fn,
+                     @unusable : String? = nil)
       end
 
       def apply(input : Bytes) : Bytes

--- a/src/gori/decoder/library.cr
+++ b/src/gori/decoder/library.cr
@@ -33,11 +33,30 @@ module Gori::Decoder
 
       flat = {} of String => Array(String)?
       why = {} of String => String
+      # TWO passes, and the split is the whole point. `flatten` asks `r[tok]?` to decide
+      # "built-in, leave it alone" from "saved name, splice it" — so flattening and registering
+      # in ONE loop mutated the registry it was probing: by the time entry i was flattened,
+      # entries 0..i-1 answered `r[tok]?` and every BACKWARD reference stayed a run-time nested
+      # `Decoder.run` instead of being spliced. Only forward references were spliced, so only
+      # forward references were counted against MAX_TOKENS — and the ordinary authoring order
+      # (save the helper, THEN save the chain that calls it) is entirely backward references,
+      # which left the guard dead on the path it exists for. Measured: a 25-deep library written
+      # helper-last is refused at MAX_TOKENS; the same library written helper-first ran 73
+      # seconds of CPU for one `run decoder`, and 2.8 s for three fuzz requests at depth 18.
+      # It also made one library mean two different things — the two orderings reported
+      # different failing tokens at different prefix depths for the same broken entry.
+      #
+      # With `r` held pristine (built-ins only) for the whole flatten phase, both orderings
+      # produce the same `flat`/`why`, so the library's meaning no longer depends on the order
+      # its entries happen to sit in settings.json.
+      order.each { |nk| flatten(nk, specs, r, flat, why, [] of String) }
       order.each do |nk|
         name, spec = specs[nk]
-        tokens = flatten(nk, specs, r, flat, why, [] of String)
         begin
-          r.register build(name, spec, tokens, why[nk]?, r)
+          # `flat` is total over `order` after the first pass: `flatten` writes `flat[nk]` on
+          # every path that reaches its tail, and the one path that returns WITHOUT memoizing
+          # (the `stack.includes?` cycle frame) cannot fire at depth 0, where the stack is empty.
+          r.register build(name, spec, flat[nk]?, why[nk]?, r)
         rescue
           # Registry#register raises on a duplicate key, and the two filters above already
           # exclude every way one can arise. This bounds the blast radius if that ever drifts:
@@ -54,6 +73,10 @@ module Gori::Decoder
     #
     # A token that is neither a built-in nor a saved name is left ALONE: `run` then reports it
     # as an unknown converter, which is the same answer typing it directly would give.
+    #
+    # `r` MUST be the pristine built-in registry here — see `register_all`'s two passes. If a
+    # saved entry has already been registered into it, `r[tok]?` answers true for that name and
+    # the reference below is left as a run-time call rather than spliced.
     private def self.flatten(nk : String, specs, r : Registry,
                              flat : Hash(String, Array(String)?), why : Hash(String, String),
                              stack : Array(String)) : Array(String)?
@@ -68,6 +91,9 @@ module Gori::Decoder
       failed = false
       Decoder.parse_spec(specs[nk][1]).each do |tok|
         tk = Registry.normalize(tok)
+        # A built-in wins (register_all never lets a saved name shadow one), and an unknown
+        # token stays as typed. Everything else is a saved name and gets spliced — in EITHER
+        # direction, because `r` holds no saved entry at this point.
         if r[tok]? || !specs.has_key?(tk)
           out << tok
         else
@@ -94,20 +120,25 @@ module Gori::Decoder
 
     private def self.build(name : String, spec : String, tokens : Array(String)?,
                            reason : String?, r : Registry) : Converter
+      msg = tokens.nil? ? "#{name}: #{reason || "unusable saved chain"}" : nil
       fn =
-        if tokens.nil?
-          msg = "#{name}: #{reason || "unusable saved chain"}"
+        if m = msg
           # The `: Bytes` return annotation is what lets an unconditionally-raising body sit in
           # a Proc(Bytes, Bytes) without a dead trailing expression to type it.
-          ->(_input : Bytes) : Bytes { raise DecoderError.new(msg) }
+          ->(_input : Bytes) : Bytes { raise DecoderError.new(m) }
         else
-          flat = tokens.join(" > ")
+          flat = tokens.not_nil!.join(" > ")
           ->(input : Bytes) { apply(name, r, flat, input) }
         end
       # `Array(String).new` and not `[] of String`: a positional `[] of T` followed by more
       # positional args makes the parser read the rest as a PROC TYPE ("expecting '->'").
+      #
+      # `unusable: msg` carries the SAME sentence the proc raises, askable without calling it —
+      # this entry is registered only so its name resolves and the reason is visible, and a
+      # caller that has to refuse a plan before the first dial has to be able to see that
+      # without running the converter over the operator's payload.
       Converter.new(name, Array(String).new, Category::Saved, Direction::Transform,
-        "saved chain: #{spec.strip.empty? ? "(empty)" : spec.strip}", fn)
+        "saved chain: #{spec.strip.empty? ? "(empty)" : spec.strip}", fn, unusable: msg)
     end
 
     # Run the flattened spec as this one step. A failure INSIDE the recipe is re-raised with

--- a/src/gori/fuzz/engine.cr
+++ b/src/gori/fuzz/engine.cr
@@ -510,7 +510,23 @@ module Gori::Fuzz
         break unless loc
         nxt = redirect_request(loc)
         break unless nxt
-        current = @backend.send(nxt)
+        # WHOLE-message verbatim, and not `nil` and not the job's spans. `Sender#send`'s
+        # 1-argument overload means "no exclusions", i.e. substitute every `$NAME` an extract
+        # rule has bound — and `nxt` is assembled below from a `Location` the ORIGIN chose. A
+        # target that reflects a query parameter into `Location` (an ordinary login/redirect
+        # endpoint, and precisely what an open-redirect probe aims at) therefore reproduced the
+        # operator's payload inside this hop, where the exclusion the first hop got no longer
+        # applied: `--payloads '$TOKEN'` put the live session credential in the target's query
+        # string and access log while every surface still showed `$TOKEN` and `0 errors`.
+        #
+        # The job's spans cannot be forwarded — they index the ORIGINAL request's offsets, and
+        # the origin may have re-encoded, moved or duplicated the payload on its way through
+        # `Location`, so locating them again is guesswork with a credential as the stake.
+        # Excluding the whole message needs no guess and gives up nothing: every byte of `nxt`
+        # is either a literal gori wrote (`GET`, `Host:`, `Connection: close`) or the origin's
+        # own `Location`. Neither is a place an operator could have written a `$NAME` for a
+        # binding to resolve, so there is nothing here to substitute in the first place.
+        current = @backend.send(nxt, [{0, nxt.size}])
         retried ||= current.retried?
         total_us += current.duration_us
         hops += 1
@@ -518,8 +534,13 @@ module Gori::Fuzz
       end
       # Report the whole chain's end-to-end time, not just the final hop's — otherwise a
       # slow original request that 3xx's to a fast resource masks a time-based signal.
+      # Named tail, for the reason `Repeater::Result#as_retried` states: `retried` used to sit
+      # in the eighth POSITIONAL slot, which `timed_out` had taken in the same round — so every
+      # keep-alive re-send in a redirect-following sweep lost its row marker and gained a false
+      # `timed_out`. The constructor's tail is keyword-only now, so this cannot recur silently.
       hops > 0 ? Repeater::Result.new(current.head, current.body, current.response, total_us,
-        current.error, current.incomplete?, current.delivered?, retried) : current
+        current.error, current.incomplete?,
+        delivered: current.delivered?, timed_out: current.timed_out?, retried: retried) : current
     end
 
     private def redirect_request(loc : String) : Bytes?

--- a/src/gori/fuzz/plan.cr
+++ b/src/gori/fuzz/plan.cr
@@ -43,6 +43,24 @@ module Gori::Fuzz
     end
   end
 
+  # A `§value¦chain§` marker names a converter this run cannot apply: an unknown token, or a
+  # saved chain gori ITSELF registered as unusable (recursive, or past `Library::MAX_TOKENS`).
+  # Either way the payload would go out un-transformed, which is the one outcome a marked
+  # position must never produce silently.
+  #
+  # Deliberately NOT a `PlanError`. That enum is the machine-readable FACT behind a sentence
+  # each surface writes in its own idiom, naming its own controls (`--mark TOKEN` vs `^A
+  # params · ^K word`) — and this refusal has no surface idiom to write. The chain lives in
+  # settings.json, all four surfaces resolve it through the same `Decoder.shared_registry`, and
+  # the remedy (`gori run decoder list`, or the Decoder tab) is word-for-word the same
+  # everywhere. So the builder writes the sentence once and every surface's EXISTING
+  # `Gori::Error` path carries it unchanged: `gori run fuzz` aborts with it (cli.cr:72), MCP
+  # codes it `INVALID_ARGUMENT` with the message intact (mcp/tools.cr:1644), the Fuzzer tab
+  # shows it in place of the run. That also keeps the change inside the fuzz boundary — a new
+  # `PlanError::Reason` member breaks the exhaustive `case … in` in six files outside it.
+  class ChainError < Gori::Error
+  end
+
   # A normalized, surface-independent description of ONE fuzz run.
   #
   # Each surface's remaining job is to parse ITS OWN input format into this — `OptionParser`
@@ -206,6 +224,10 @@ module Gori::Fuzz
       end
       template = Template.parse(text, options.http2?)
       raise PlanError.new(PlanError::Reason::NoPositions, "the template has no §…§ positions") if template.position_count == 0
+      # The twin of `refuse_unresolved`, one line down and for the same reason: a `¦chain` this
+      # run cannot apply leaves the position's payload UNTRANSFORMED on the wire. See
+      # `refuse_unusable_chains`.
+      refuse_unusable_chains(template, Decoder.shared_registry)
 
       # The string the Layer-1 scope check matches on, taken from the template's BASELINE
       # rendering (every position = its own default) rather than the raw text. The TUI's
@@ -279,6 +301,51 @@ module Gori::Fuzz
       detail = Env.token_list(names)
       raise PlanError.new(PlanError::Reason::UnresolvedEnv,
         "unresolved env #{detail}", detail)
+    end
+
+    # Refuse a run whose `§value¦chain§` markers name a converter the registry cannot apply.
+    #
+    # `Template#apply_chains` returns the payload VERBATIM when its chain does not run, with a
+    # comment arguing that a streaming fuzz run has nowhere to surface a per-position error.
+    # That was written when the only way to reach it was a typo. The saved-chain library added
+    # a class that is not a typo: a name the operator saved, that the `^Y` autocomplete offers
+    # and `gori run decoder list` prints as an ordinary converter, and that the library
+    # registered as an always-raising step precisely so the failure would be VISIBLE — and this
+    # path swallowed the raise. Five marked positions, three of them naming such a chain, put
+    # the raw payload in the query string under `1 sent · 0 errors`, `"error":null`,
+    # `"matched":true`. `gori run decoder` names the identical refusal off the identical
+    # registry one screen away.
+    #
+    # So it is refused HERE, beside `refuse_unresolved`, whose comment makes the same argument
+    # for `$KEY`: this builder is the surface-independent chokepoint every fuzz surface goes
+    # through, and a refusal before the first dial is the only report a sweep of ten thousand
+    # requests can act on.
+    #
+    # Two kinds, both answerable from the registry with no side effect:
+    #   * the token resolves to nothing         → unknown converter
+    #   * it resolves to an UNUSABLE saved chain → `Converter#unusable` carries the reason
+    # The second is why this is not a build-time dry run over each position's default: a dry
+    # run cannot tell "this chain is broken" from "this chain is fine and the DEFAULT value
+    # isn't valid input for it" (`base64-decode` over a `§admin§` default raises, and refusing
+    # that run would block a legitimate sweep). Asking whether the converter can run at all
+    # answers the first question and leaves the second — genuinely per-payload — alone.
+    private def self.refuse_unusable_chains(template : Template, registry : Decoder::Registry) : Nil
+      bad = [] of String
+      template.positions.each do |pos|
+        next if pos.chain.empty?
+        Decoder.parse_spec(pos.chain).each do |tok|
+          conv = registry[tok]?
+          if conv.nil?
+            bad << "#{tok}: unknown converter"
+          elsif reason = conv.unusable
+            bad << reason # already prefixed with the chain's own name
+          end
+        end
+      end
+      return if bad.empty?
+      raise ChainError.new("§…§ chain cannot run: #{bad.uniq.join("; ")}. " \
+                           "The payload would go out untransformed — fix or remove the chain " \
+                           "(list the converters with `gori run decoder list`)")
     end
 
     # Non-overlapping occurrences of a literal token (mirrors what `String#gsub` will

--- a/src/gori/fuzz/template.cr
+++ b/src/gori/fuzz/template.cr
@@ -224,10 +224,18 @@ module Gori::Fuzz
     end
 
     # Map each payload through its position's Decoder chain (empty chain = identity),
-    # returning a new payload array to feed `render`. A chain that fails — an unknown
-    # token, a step that raised, or output over MAX_OUT — leaves that value
+    # returning a new payload array to feed `render`. A chain that fails on THIS payload — a
+    # step that raised on these bytes, or output over MAX_OUT — leaves that value
     # UNTRANSFORMED: Decoder.run never raises, and a streaming fuzz run has nowhere to
-    # surface a per-position error (validate chains in the Decoder tab). Decoder works
+    # surface a per-position error (validate chains in the Decoder tab).
+    #
+    # What this must NOT be reached with any more is a chain that could never run at all —
+    # an unknown token, or a saved chain the library registered as unusable (recursive, past
+    # MAX_TOKENS). Those are a property of the TEMPLATE, not of a payload, so they are refused
+    # once at `Fuzz::Plan.build` (`refuse_unusable_chains`) before the first dial rather than
+    # silently swallowed here on every request of the sweep. What is left is genuinely
+    # per-payload — `base64-decode` over a payload that isn't base64 — where the next payload
+    # may well succeed and there is nothing to refuse up front. Decoder works
     # on Bytes but the template splices Strings, so the transformed bytes are rewrapped
     # with String.new — encoders (base64/url/hex/hash/escape) stay ASCII; a decoder that
     # produces raw bytes may lose fidelity, the same limit binary bodies already have.

--- a/src/gori/mcp/tools/repeater.cr
+++ b/src/gori/mcp/tools/repeater.cr
@@ -5,6 +5,59 @@ require "../../store"
 module Gori
   module MCP
     class Tools
+      # The request bytes to PERSIST: the author's own, verbatim.
+      #
+      # These used to be `Env.mask_secrets(request).to_slice`, and that is a draft-time
+      # transform applied to the operator's authored test case — the P7 line. `mask_secrets`
+      # resolves against `Env.masking_vars`, which folds in `Bindings#held_values`, so an
+      # agent that typed a LIVE token had gori rewrite it to `$CTOK` **in the stored row**.
+      # No other writer does this: the TUI persists what the operator typed
+      # (`RepeaterController#save_current_repeater`) and so does `gori run repeater`.
+      #
+      # It was not merely surprising, it SPLIT the surfaces. `flow_id` survives an
+      # `update_repeater` that replaces every byte, and the TUI turns `flow_id` into
+      # `RepeaterView#evidence?` — which by design does NOT expand `$NAME` (a capture's
+      # `$filter` is a byte the origin saw, not a reference anybody wrote). So one stored row
+      # put `Authorization: Bearer $CTOK` on the wire from the TUI and the real token from
+      # MCP and the CLI, under `✓ sent → 200` on all three.
+      #
+      # Redaction is kept where it belongs: on the way OUT. Every field this tool returns to
+      # the LLM (`summary`, `target`, `name`) is still derived from a masked copy, exactly as
+      # `send_request`'s reply already separates `wire` from its masked display. What changes
+      # is that a value the AUTHOR put in a request draft is stored the way they wrote it —
+      # the same standing as an operator typing it into the TUI editor, and the same standing
+      # `flows` already gives it for captured traffic. `bindings.cr`'s redaction guarantee
+      # names this exception alongside the capture one.
+      private def stored_request(request : String) : Bytes
+        request.to_slice
+      end
+
+      # Only when it FIRED. `summary` is the masked projection, so without this an author who
+      # sent a live value reads a summary spelling it `$CTOK` with no statement anywhere that
+      # the two are the same bytes — a silent substitution where a named report belonged.
+      private def emit_secrets_masked(j : JSON::Builder, raw : String, masked : String) : Nil
+        names = masked_names(raw, masked)
+        return if names.empty?
+        j.field("secrets_masked") { j.array { names.each { |n| j.string n } } }
+        j.field "secrets_masked_note",
+          "#{Env.token_list(names)} #{names.size == 1 ? "resolves" : "resolve"} to a value present in this " \
+          "request; the stored request keeps your bytes and only this result masks them"
+      end
+
+      # The names `mask_secrets` rewrote in these bytes, so the reply can name them. gori no
+      # longer edits the stored draft, but an author who handed over a live credential should
+      # be told gori recognised one rather than left to infer it from a `summary` that reads
+      # differently from what they sent. A name the author TYPED as `$NAME` is excluded — it
+      # was already `$NAME` before the pass and nothing was substituted for it.
+      private def masked_names(raw : String, masked : String) : Array(String)
+        return [] of String if raw == masked
+        prefix = Settings.env_prefix
+        return [] of String if prefix.empty?
+        Env.masking_vars.keys
+          .select { |n| masked.includes?("#{prefix}#{n}") && !raw.includes?("#{prefix}#{n}") }
+          .sort!
+      end
+
       private def create_repeater(h) : Result
         issue_id = int(h, "issue_id")
         return Result.new(id_error(h, "issue_id"), is_error: true) if issue_id.nil? && present?(h, "issue_id")
@@ -109,14 +162,16 @@ module Gori
           return Result.new("'position' out of range", is_error: true)
         end
 
-        # Apply Env.mask_secrets
+        # Masked for the REPLY only — see `stored_request`. `target`, `sni` and `name` are
+        # short author-typed fields with no wire semantics of their own and are re-expanded
+        # identically by every surface, so masking those on the way in is harmless and stays.
         masked_target = Env.mask_secrets(target)
         masked_request = Env.mask_secrets(request)
         masked_sni = sni.try { |s| Env.mask_secrets(s) }
         name = str(h, "name").try { |n| Env.mask_secrets(n) }
 
-        # WebSocket mode check
-        is_ws = Repeater::WsEngine.upgrade_request?(masked_request)
+        # WebSocket mode check — on the bytes that will be STORED and sent, not a projection.
+        is_ws = Repeater::WsEngine.upgrade_request?(request)
 
         # Parsed BEFORE the row is inserted: a refused frame must leave nothing behind. Doing
         # it after produced a half-created session — an error result and a persisted repeater
@@ -129,7 +184,7 @@ module Gori
 
         id = store.insert_repeater(
           target: masked_target,
-          request: masked_request.to_slice,
+          request: stored_request(request),
           http2: http2,
           auto_cl: auto_cl,
           flow_id: flow_id,
@@ -174,6 +229,7 @@ module Gori
             # session no longer carries the absolute-form line, so this is the only record
             # that it was ever there.
             j.field "request_line_rewritten", true if rewrote_request_line
+            emit_secrets_masked(j, request, masked_request)
             # How many frames were actually stored, so an agent authoring a multi-frame
             # sequence can assert on it rather than take the count on trust.
             j.field "ws_out_message_count", ws_count if ws_count
@@ -352,7 +408,7 @@ module Gori
         unless store.update_repeater(
                  id: id,
                  target: masked_target,
-                 request: masked_request.to_slice,
+                 request: stored_request(request),
                  http2: http2,
                  auto_cl: auto_cl,
                  sni: masked_sni,
@@ -392,6 +448,21 @@ module Gori
             j.field "summary", summary
             j.field "position", existing.position
             j.field "ws_out_message_count", ws_count if ws_count
+            emit_secrets_masked(j, request, masked_request)
+            # `flow_id` is unchanged by this write, and it is not a label: the TUI turns it
+            # into `RepeaterView#evidence?`, which suppresses `$NAME` expansion because a
+            # capture's `$filter` is a byte and not a reference. Once these bytes are no
+            # longer the flow's, that reading is wrong — so the row is reported as what it
+            # now IS rather than left advertising a provenance none of its bytes have.
+            # Clearing the column outright needs a store change (`update_repeater` does not
+            # write `flow_id` at all); until then the disagreement is stated, not hidden.
+            if (fid = existing.flow_id) && String.new(existing.request) != request
+              j.field "flow_id", fid
+              j.field "derived_from_flow_note",
+                "repeater #{id} is still linked to flow #{fid}, but its request no longer holds that " \
+                "flow's bytes — the TUI reads that link as \"these bytes are a capture\" and sends " \
+                "$NAME literally there"
+            end
           end
         })
       rescue ex : Gori::Error

--- a/src/gori/mcp/tools/send.cr
+++ b/src/gori/mcp/tools/send.cr
@@ -282,9 +282,11 @@ module Gori
       EXCHANGE_BUDGET_PHRASE = "budget for the whole exchange"
 
       # Coarse category for a send's network error, from the engine's error text
-      # (gori's own controlled strings). "connect" (the dialer collapses DNS /
-      # refused / connect-timeout / TLS-verify into one failure — finer split would
-      # need dialer changes), "timeout" (idle read/write), "protocol" (a deterministic
+      # (gori's own controlled strings). "connect" (the TCP layer: refused, unreachable,
+      # a connect timeout, or a name that did not resolve — the dialer now separates a
+      # certificate rejection, a refused handshake and an origin that accepts and then goes
+      # silent into their own sentences, which land on "other"/"timeout" as they should),
+      # "timeout" (idle read/write, and a TLS handshake that never got an answer), "protocol" (a deterministic
       # framing/protocol refusal — see PROTOCOL_ERROR_PHRASES), "no_response", else "other".
       #
       # A pure function of the engine's sentence, so it is `self.` and directly testable: the

--- a/src/gori/mcp/tools/send.cr
+++ b/src/gori/mcp/tools/send.cr
@@ -324,10 +324,23 @@ module Gori
       # REQUEST that is partial, and re-sending would put the whole body back on the wire.
       # Everything else keeps the transient NETWORK_ERROR contract callers already apply
       # policy against. `retryable` is the field to branch on; the code names the cause.
-      private def emit_send_error_code(j : JSON::Builder, kind : String?) : Nil
+      #
+      # `delivered` is the SECOND term, and it is the one the error CODE cannot carry. The
+      # code is a pure function of gori's own sentence, and two failures with the same
+      # sentence shape — "the origin said nothing" vs "the origin answered an interim 1xx
+      # and THEN said nothing" — differ in the only fact a retry policy needs. gori writes a
+      # request in full before it reads, so ANY response byte (even a 100/103) proves the
+      # origin has the whole request and has had its chance to act on it. Both engines
+      # compute exactly that (`H2Engine.exchange`'s `delivered: reply.status != 0`,
+      # `Engine.exchange`'s rescue `delivered: !head.nil?`) and it reached NO surface, so MCP
+      # answered `retryable: true` for the very failures round 4 documented as "the origin
+      # already has the whole request … re-sending would double a side effect". Emitted
+      # alongside `retryable` so an agent sees WHY it may not retry, not only that it may not.
+      private def emit_send_error_code(j : JSON::Builder, kind : String?, delivered : Bool) : Nil
         code = Tools.send_error_code(kind)
         j.field "error_code", code
-        j.field "retryable", code == "NETWORK_ERROR"
+        j.field "retryable", Tools.send_retryable?(code, delivered)
+        j.field "delivered", delivered
       end
 
       # Split out and `self.` for the same reason `network_error_kind` is: the retry policy an
@@ -339,6 +352,12 @@ module Gori
         when "truncated_request" then "REQUEST_TRUNCATED"
         else                          "NETWORK_ERROR"
         end
+      end
+
+      # `self.` and separate from `send_error_code` for the same reason: this is the field an
+      # agent branches on, so a spec pins the PAIR rather than the code mapping alone.
+      def self.send_retryable?(code : String, delivered : Bool) : Bool
+        code == "NETWORK_ERROR" && !delivered
       end
 
       private def persist_send_repeater(h, save : Bool, built : RequestBuilder::Built,
@@ -359,10 +378,15 @@ module Gori
         # surface — the CLI refused it with the pseudo-header message and MCP read its method
         # back as `":method:"`. See `replayable_field_head`.
         saved_bytes = replayable_field_head(h2_fields, built, built.bytes)
+        # Masked for the PROBE scan and the reply, NOT for the row. The saved session is a
+        # REPLAY SOURCE (the sentence just above), and storing the masked projection made it
+        # a replay of different bytes: `flow_id` is set here, the TUI reads that as evidence,
+        # and `RepeaterView#evidence?` sends `$NAME` literally — so this row went out one way
+        # from the TUI and another from MCP. Same seam as `Tools#stored_request`.
         masked_req = Env.mask_secrets(String.new(saved_bytes))
         repeater_id = store.insert_repeater(
           target: masked_target,
-          request: masked_req.to_slice,
+          request: saved_bytes,
           http2: http2,
           auto_cl: true,
           flow_id: flow_id,
@@ -531,7 +555,7 @@ module Gori
               # Structured-error contract inside the payload (the payload IS the
               # structuredContent) so a caller can apply policy without string-matching the
               # message — including "do not retry this, report it" (see emit_send_error_code).
-              emit_send_error_code(j, kind)
+              emit_send_error_code(j, kind, result.delivered?)
             end
             if response = result.response
               j.field "status", response.status
@@ -718,7 +742,11 @@ module Gori
               kind = network_error_kind(err)
               j.field "error", Env.mask_secrets(err)
               j.field "error_kind", kind
-              emit_send_error_code(j, kind)
+              # A completed upgrade IS delivery on this surface: the origin answered the
+              # handshake, so it has that request and every frame gori wrote after it. The
+              # WS engine carries no `delivered?` of its own and `upgraded?` is the same
+              # fact — any response byte at all.
+              emit_send_error_code(j, kind, result.upgraded?)
             end
             unless result.handshake_head.empty?
               response = begin

--- a/src/gori/proto.cr
+++ b/src/gori/proto.cr
@@ -12,19 +12,40 @@ module Gori
       Grpc
       Sse
 
-      # Short uppercase tag for the History PROTO column (WS/GRPC/SSE); the Http
-      # member has no tag of its own — the column falls back to the scheme
-      # (HTTP/HTTPS) so the plaintext-vs-TLS signal is preserved for normal flows.
-      def label : String
+      # Short uppercase tag for the History PROTO column, TRANSPORT INCLUDED.
+      #
+      # The column has always distinguished HTTP from HTTPS, and this used to return a bare
+      # WS/GRPC/SSE tag that REPLACED the scheme — so for exactly the three protocols where
+      # gori has something extra to say, it dropped the one fact the Http member's fallback
+      # existed to preserve. A `ws://` row and a `wss://` row were pixel-identical: same
+      # METHOD, same PROTO, same HOST (the column carries no port), and "the app opened a
+      # CLEARTEXT WebSocket and put a session token in the first frame" is a finding the
+      # triage list could not express, while the store had the answer and the QL already
+      # filtered on it.
+      #
+      # `S` means TLS here for the same reason it does in HTTPS. Every string this can
+      # return is a value the `proto:` filter accepts (`Proto.split_transport` + `parse?`),
+      # which is the module's own claim: the label you see and the value you filter on
+      # cannot drift.
+      def label(scheme : String) : String
+        secure = Proto.secure?(scheme)
         case self
-        in Http then "HTTP"
-        in Ws   then "WS"
-        in Grpc then "GRPC"
-        in Sse  then "SSE"
+        in Http then secure ? "HTTPS" : "HTTP"
+        in Ws   then secure ? "WSS" : "WS"
+        in Grpc then secure ? "GRPCS" : "GRPC"
+        in Sse  then secure ? "SSES" : "SSE"
         end
       end
 
-      # Parse a QL `proto:` value. `websocket` is accepted as an alias for `ws`.
+      # Parse a QL `proto:` value's APPLICATION-protocol half. `websocket` is accepted as an
+      # alias for `ws`.
+      #
+      # Deliberately NOT an alias table that folds `wss` in here. This is also what the
+      # intercept catch condition canonicalizes through (`InterceptFilter.fold`), which has
+      # one field per leaf and so cannot carry a transport term — folding `wss` to `ws` there
+      # would silently WIDEN an operator's condition to cleartext sockets. The transport is
+      # split off first, by `Proto.split_transport`, and re-applied by the caller that can
+      # express it.
       def self.parse?(value : String) : Kind?
         case value.downcase
         when "http"            then Http
@@ -33,6 +54,31 @@ module Gori
         when "sse"             then Sse
         else                        nil
         end
+      end
+    end
+
+    # Is a flow's stored scheme a TLS one? The store keeps the HTTP scheme (`http`/`https`)
+    # even for a WebSocket — a `wss://` URL is a 101 handshake inside a CONNECT tunnel — so
+    # the `wss` spelling is accepted alongside for any caller that has a URL rather than a
+    # flow row. One place decides it, for the PROTO column and the QL alike.
+    def self.secure?(scheme : String) : Bool
+      scheme == "https" || scheme == "wss"
+    end
+
+    # Split a `proto:` value into its application-protocol spelling and the transport the
+    # operator NAMED, if any. `{value, nil}` when they named none — "either transport".
+    #
+    # The PROTO column prints the TLS spellings (`HTTPS`/`WSS`/`GRPCS`/`SSES`), so they have
+    # to be typeable; and they have to MEAN the transport they name rather than widening to
+    # the base protocol, which is why this returns a pair instead of aliasing inside
+    # `Kind.parse?`. `QL.proto_cond` turns the `true` half into a `scheme` term.
+    def self.split_transport(value : String) : {String, Bool?}
+      case value.downcase
+      when "https" then {"http", true}
+      when "wss"   then {"ws", true}
+      when "grpcs" then {"grpc", true}
+      when "sses"  then {"sse", true}
+      else              {value, nil}
       end
     end
 

--- a/src/gori/proxy/conn/client_conn.cr
+++ b/src/gori/proxy/conn/client_conn.cr
@@ -1475,17 +1475,35 @@ module Gori::Proxy
     end
 
     # The error text for a failed upstream acquire/send. A nil `upstream` is a DIAL failure,
-    # split into unreachable (connect), a TLS/verify rejection — the #323 case, whose fix is
-    # --insecure-upstream, so the recorded flow points there instead of at reachability — and
-    # a refusal by the configured upstream proxy, where the origin was never contacted at all.
+    # split into unreachable (connect), a name that never resolved, a certificate rejection —
+    # the #323 case, whose fix is --insecure-upstream, so the recorded flow points there
+    # instead of at reachability — a handshake the origin refused for some other reason, an
+    # origin that accepted the connection and then went silent, and a refusal by the
+    # configured upstream proxy, where the origin was never contacted at all.
     # A non-nil `upstream` means the socket was live but the mid-request write failed.
+    #
+    # The branches key on `err.kind`, never on `@verify_upstream`: the dialer knows whether
+    # verification is what rejected the origin, and guessing it from the flag is what made a
+    # black hole and a plaintext port both read as an untrusted certificate.
     private def upstream_error_message(host : String, port : Int32, upstream : IO?) : String
       return "upstream write failed: #{host}:#{port}" unless upstream.nil?
       err = @last_dial_error
-      if err && err.tls?
-        return "upstream TLS verification failed: #{host}:#{port} — origin certificate not trusted; " \
-               "retry with --insecure-upstream or set SSL_CERT_FILE" if @verify_upstream
-        return "upstream TLS handshake failed: #{host}:#{port}"
+      if err
+        case err.kind
+        when .tls_verify?
+          return "upstream TLS verification failed: #{host}:#{port} — origin certificate not trusted; " \
+                 "retry with --insecure-upstream or set SSL_CERT_FILE#{err.because}"
+        when .tls?
+          return "upstream TLS handshake failed: #{host}:#{port} — the port may not be TLS, or the " \
+                 "origin refused the protocol/cipher#{err.because}"
+        when .timeout?
+          return "upstream TLS handshake timed out: #{host}:#{port} — the origin accepted the " \
+                 "connection and then sent nothing; no certificate was exchanged, so " \
+                 "--insecure-upstream and SSL_CERT_FILE cannot help#{err.because}"
+        when .dns?
+          return "upstream DNS lookup failed: #{host} — the name did not resolve, so nothing was " \
+                 "dialed#{err.because}"
+        end
       end
       # A detail REPLACES the host-shaped sentence rather than decorating it. Every detail the
       # dialer sets is about a proxy — either one that refused the tunnel or one gori could not

--- a/src/gori/proxy/h2/assembler.cr
+++ b/src/gori/proxy/h2/assembler.cr
@@ -421,6 +421,7 @@ module Gori::Proxy::H2
     private def emit_request(stream_id : UInt32, stream : Stream) : Nil
       return if stream.flow_id # already emitted
       headers = stream.req.headers.not_nil!
+      note_extended_connect(stream, headers)
       method = pseudo(headers, ":method") || "GET"
       path = pseudo(headers, ":path") || "/"
       scheme = pseudo(headers, ":scheme") || "https"
@@ -429,7 +430,8 @@ module Gori::Proxy::H2
       cap = stream.req.body
       body = cap.total == 0 ? nil : cap.to_slice
 
-      head = synth_request_head(headers, authority, stream.req.trailer_names, stream.pushed_by)
+      head = synth_request_head(headers, authority, stream.req.trailer_names, stream.pushed_by,
+        pseudo(headers, ":protocol"))
       captured = Store::CapturedRequest.new(
         created_at: @created_at, scheme: scheme, host: host, port: port,
         method: method, target: path, http_version: "HTTP/2", head: head, body: body,
@@ -493,9 +495,7 @@ module Gori::Proxy::H2
     end
 
     # RFC 8441 extended CONNECT — `:method CONNECT` plus a `:protocol` pseudo-header, which is
-    # how a WebSocket is opened over HTTP/2. Such a stream ends as an abort ("h2 connection
-    # closed", "stream reset"), and that reason describes the SYMPTOM: what the operator needs
-    # to know is that gori carried the stream but read nothing on it.
+    # how a WebSocket is opened over HTTP/2.
     #
     # Deliberately an advisory and NOT a refusal. gori relays the ORIGIN's SETTINGS frame
     # verbatim (`StreamGate#write` / `Relay#emit` on stream 0), so a client facing an origin
@@ -505,12 +505,48 @@ module Gori::Proxy::H2
     # would break a path that works end to end. What does NOT work is everything gori adds:
     # the WS message transcript, the message gate, intercept and Match&Replace all live on the
     # HTTP/1.1 Upgrade path, so those frames are opaque DATA here. Say that, on the flow.
+    #
+    # ## Written when the stream is RECOGNISED, not when it aborts
+    #
+    # This sentence used to reach the flow only through `extended_connect_note` below, which
+    # `finalize_stream` calls — so it existed only for a stream that ended as an ABORT. The
+    # normal teardown of a conforming client (a WebSocket Close handshake, then END_STREAM)
+    # completes through `emit_ready` → `emit_response` and never goes near `finalize_stream`,
+    # so it landed in History as an ordinary `CONNECT → 200 complete` with `error` NULL and
+    # `advisory` NULL. With `:protocol` also filtered out of the stored head by
+    # `HeadCodec.synth_request`, NOTHING on disk — not History, not the QL, not `run show`,
+    # not HAR, not MCP `get_flow` — could identify the flow as a WebSocket that ran with no
+    # transcript, no message intercept and no Match&Replace. The recognition happens the
+    # moment the request head is decoded, so that is where the advisory is recorded;
+    # `advisory_of` joins the accumulated set onto BOTH halves, so it reaches every one of
+    # those surfaces with no further change.
+    private def note_extended_connect(stream : Stream, headers : Array({String, String})) : Nil
+      protocol = extended_connect_protocol(headers)
+      return unless protocol
+      text = extended_connect_sentence(protocol)
+      stream.advisories << text unless stream.advisories.includes?(text)
+    end
+
+    # The same sentence as an ABORT reason's tail. An aborted 8441 stream's own reason
+    # ("h2 connection closed", "stream reset") describes the SYMPTOM, and `flows.error` is
+    # where an operator reads it — so it keeps carrying the explanation too, rather than
+    # sending them to a second column for it.
     private def extended_connect_note(stream : Stream, reason : String) : String
       headers = stream.req.headers
       return reason unless headers
+      protocol = extended_connect_protocol(headers)
+      return reason unless protocol
+      "#{reason} — #{extended_connect_sentence(protocol)}"
+    end
+
+    # The `:protocol` pseudo-header's value, or nil when this is not an extended CONNECT.
+    private def extended_connect_protocol(headers : Array({String, String})) : String?
       protocol = pseudo(headers, ":protocol")
-      return reason if protocol.nil? || protocol.empty?
-      "#{reason} — this is an RFC 8441 extended CONNECT stream (:protocol #{protocol.inspect}). " \
+      protocol.nil? || protocol.empty? ? nil : protocol
+    end
+
+    private def extended_connect_sentence(protocol : String) : String
+      "this is an RFC 8441 extended CONNECT stream (:protocol #{protocol.inspect}). " \
       "gori relayed it byte-for-byte but did not decode it: WebSocket messages are read on the " \
       "HTTP/1.1 Upgrade path only, so this socket has no message transcript, no message " \
       "intercept and no Match&Replace"
@@ -552,10 +588,16 @@ module Gori::Proxy::H2
     # `finish_header_block` exactly as a response one is, so after the merge `x-req-trailer`
     # read like a header the client sent in its head. `Side#trailer_names` was already being
     # recorded for both sides.
+    #
+    # `protocol` is the third such capture-only extra, and it is here for the reason
+    # `note_extended_connect` states: `regular(fields)` filters every pseudo-header, so an
+    # RFC 8441 extended CONNECT's `:protocol` reached no stored byte at all and the head read
+    # as an ordinary CONNECT tunnel.
     private def synth_request_head(headers : Array({String, String}), authority : String,
                                    trailers : Array(String)? = nil,
-                                   pushed_by : UInt32? = nil) : Bytes
-      HeadCodec.synth_request(headers, authority, trailers, pushed_by)
+                                   pushed_by : UInt32? = nil,
+                                   protocol : String? = nil) : Bytes
+      HeadCodec.synth_request(headers, authority, trailers, pushed_by, protocol)
     end
 
     # `trailers` is the CAPTURE projection's extra: only the stored head names which fields

--- a/src/gori/proxy/h2/head_codec.cr
+++ b/src/gori/proxy/h2/head_codec.cr
@@ -53,8 +53,16 @@ module Gori::Proxy::H2
     # PUSH_PROMISE is the origin inventing a request, and `Assembler#handle_push_promise`
     # projects it as an ordinary flow, so History / QL / the Sitemap handed an operator reading
     # for evidence a row the origin authored, with nothing saying so.
+    #
+    # `protocol` is the third, and the same discipline again: the loop below skips ALL
+    # pseudo-headers, so an RFC 8441 extended CONNECT's `:protocol` — the one field that says
+    # a WebSocket is running on this stream — reached no stored byte, and the head read as an
+    # ordinary CONNECT tunnel in `gori run show`, HAR and MCP alike. Passed ONLY by the
+    # capture projection; the rewrite path re-synthesizes from the live fields and passes
+    # nothing, so this line can never reach an h2 wire.
     def synth_request(fields : Array({String, String}), authority : String,
-                      trailers : Array(String)? = nil, pushed_by : UInt32? = nil) : Bytes
+                      trailers : Array(String)? = nil, pushed_by : UInt32? = nil,
+                      protocol : String? = nil) : Bytes
       method = pseudo(fields, ":method") || "GET"
       path = pseudo(fields, ":path") || "/"
       String.build do |io|
@@ -65,9 +73,17 @@ module Gori::Proxy::H2
           io << TRAILER_MARKER << ": " << line_safe(trailers.join(", ")) << "\r\n"
         end
         pushed_by.try { |sid| io << PUSHED_MARKER << ": server push promised on stream " << sid << "\r\n" }
+        protocol.try do |p|
+          io << PROTOCOL_MARKER << ": " << line_safe(p) << "\r\n" unless p.empty?
+        end
         io << "\r\n"
       end.to_slice
     end
+
+    # See `synth_request`'s `protocol`: the RFC 8441 `:protocol` pseudo-header, which the
+    # pseudo filter drops and the h1 text form has no other place for. Additive, on the
+    # stored projection only — same discipline as `TRAILER_MARKER` and `PUSHED_MARKER`.
+    PROTOCOL_MARKER = "X-Gori-Protocol"
 
     # See `synth_request`'s `pushed_by`. Same discipline as `TRAILER_MARKER`: additive, on the
     # stored projection only, so nothing that reads a field off the head changes behaviour and

--- a/src/gori/proxy/upstream.cr
+++ b/src/gori/proxy/upstream.cr
@@ -54,8 +54,7 @@ module Gori::Proxy
       # hostname override only changes where we dial (see connect_target).
       route = Settings.upstream_route(host)
       if route.direct?
-        sock = direct_dial(target, target_port, connect_timeout, io_timeout)
-        sock ? {sock, nil} : {nil, DialError::ORIGIN_UNREACHABLE}
+        direct_dial_result(target, target_port, connect_timeout, io_timeout)
       elsif route.socks5?
         dial_via_socks5(route, target, target_port, connect_timeout, io_timeout)
       else
@@ -227,9 +226,24 @@ module Gori::Proxy
       h.starts_with?('[') && h.ends_with?(']') ? h[1...-1] : h
     end
 
+    # The socket alone, for the callers that already have their own account of a failure
+    # (the upstream-proxy dials below: a proxy that does not resolve and a proxy that refuses
+    # the port are one problem — "the proxy is unreachable" — and they say so themselves).
     private def self.direct_dial(host : String, port : Int32,
                                  connect_timeout : Time::Span = Settings.connect_timeout,
                                  io_timeout : Time::Span = Settings.io_timeout) : TCPSocket?
+      direct_dial_result(host, port, connect_timeout, io_timeout)[0]
+    end
+
+    # Same dial, paired with WHY there is no socket. A name that does not resolve and a port
+    # that refuses are both "no socket", but not the same problem: the first is a name /
+    # resolver / scope mistake and nothing was dialed at all, the second is a service that is
+    # not there. `Socket::Addrinfo::Error` is raised before the connect is attempted, which is
+    # exactly that line, so it earns its own kind instead of being folded into a reachability
+    # sentence that lists three causes and commits to none.
+    private def self.direct_dial_result(host : String, port : Int32,
+                                        connect_timeout : Time::Span = Settings.connect_timeout,
+                                        io_timeout : Time::Span = Settings.io_timeout) : {TCPSocket?, DialError?}
       sock = TCPSocket.new(bare_host(host), port, connect_timeout: connect_timeout)
       begin
         sock.sync = true # flush writes immediately (P6)
@@ -243,11 +257,13 @@ module Gori::Proxy
         # A peer RST between connect and option-setup would otherwise leak the open fd
         # (the outer rescue returns nil without closing it) — close it first.
         sock.close rescue nil
-        return nil
+        return {nil, DialError::ORIGIN_UNREACHABLE}
       end
-      sock
+      {sock, nil}
+    rescue ex : Socket::Addrinfo::Error
+      {nil, DialError.new(DialErrorKind::Dns, cause: exception_cause(ex))}
     rescue
-      nil
+      {nil, DialError::ORIGIN_UNREACHABLE}
     end
 
     # Connect to the upstream HTTP proxy and CONNECT-tunnel to the origin. Used for
@@ -747,26 +763,40 @@ module Gori::Proxy
     end
 
     # Why an upstream dial failed. Every send path records this so a failed flow says WHAT
-    # broke instead of a blanket "connect failed": a Connect failure is a reachability problem,
-    # a Tls failure under verify-on is almost always an untrusted / self-signed / expired
-    # origin cert (the #323 shape) whose fix is --insecure-upstream (or SSL_CERT_FILE), and a
-    # Proxy failure is neither — the origin was never contacted at all, and the fix is a
-    # credential or a proxy ACL. A "connect failed" message actively hides all three.
+    # broke instead of a blanket "connect failed", and each member is a member because its FIX
+    # is different: Connect is a reachability problem, Dns is a name/resolver/scope one and
+    # nothing was dialed, TlsVerify is the #323 shape whose fix is --insecure-upstream (or
+    # SSL_CERT_FILE), Tls is "this port is not TLS" / a protocol-or-cipher refusal where a CA
+    # file is the WRONG advice, Timeout is a silent drop where neither TLS remedy can help, and
+    # Proxy is none of them — the origin was never contacted, and the fix is a credential or a
+    # proxy ACL. A "connect failed" message actively hides all six.
+    #
+    # A member is only ever reported when the dialer has EVIDENCE for it (see tls_dial_error):
+    # inferring one from the caller's verify flag is what made a black hole and a plaintext
+    # port both read as an untrusted certificate.
     enum DialErrorKind
-      Connect # TCP connect (to the origin, or to the upstream proxy itself) failed
-      Proxy   # the upstream proxy answered and REFUSED the tunnel (407/403/502, SOCKS5 REP≠0)
-      Tls     # origin reached, but the TLS handshake / certificate verification failed
+      Connect   # TCP connect (to the origin, or to the upstream proxy itself) failed
+      Proxy     # the upstream proxy answered and REFUSED the tunnel (407/403/502, SOCKS5 REP≠0)
+      Tls       # origin reached, the TLS handshake failed for a reason that is NOT verification
+      TlsVerify # origin reached, the handshake got to certificate verification and it rejected the chain
+      Timeout   # origin ACCEPTED the connection and then said nothing before the io timeout
+      Dns       # the name never resolved, so nothing was dialed at all
     end
 
     # The kind plus the sentence a surface should show. `detail` is nil only for the plain
     # Connect/Tls cases every caller already words for itself; when it is set it names the
     # thing that refused and what it said, which is the whole point of #F3 — a nil socket
     # cannot say "the proxy you configured wants credentials".
+    #
+    # `cause` is the opposite half: the underlying library's OWN words (OpenSSL's error
+    # string, the resolver's). Unlike `detail` it NEVER replaces the caller's sentence — it is
+    # appended as evidence, so "the port may not be TLS" can be checked instead of believed.
     struct DialError
       getter kind : DialErrorKind
       getter detail : String?
+      getter cause : String?
 
-      def initialize(@kind : DialErrorKind, @detail : String? = nil)
+      def initialize(@kind : DialErrorKind, @detail : String? = nil, @cause : String? = nil)
       end
 
       # A direct dial that did not connect. Deliberately carries NO detail: the caller already
@@ -775,8 +805,18 @@ module Gori::Proxy
       # the cases a caller CANNOT word for itself, which is every one involving a proxy.
       ORIGIN_UNREACHABLE = new(DialErrorKind::Connect)
 
+      # The TLS leg, whichever way it broke. Kept broad on purpose: a caller that only needs
+      # "was this the TLS handshake?" keeps working now that verification has its own kind.
       def tls? : Bool
-        @kind.tls?
+        @kind.tls? || @kind.tls_verify?
+      end
+
+      # `cause` parenthesised for interpolation at the end of a sentence that has already
+      # named the layer; empty when there is nothing to add, so a caller can splice it
+      # unconditionally.
+      def because : String
+        c = @cause
+        c && !c.empty? ? " (#{c})" : ""
       end
     end
 
@@ -816,7 +856,7 @@ module Gori::Proxy
         sync_close: true, hostname: sni || host)
       ssl.sync = true
       {ssl, nil}
-    rescue
+    rescue ex
       # A handshake failure inside Socket::Client.new (cert mismatch under verify,
       # expired/self-signed cert, plaintext-on-443, peer reset mid-handshake) does
       # NOT close the underlying socket — sync_close only transfers ownership once
@@ -824,7 +864,48 @@ module Gori::Proxy
       # per failed origin → fd exhaustion). `tcp` is non-nil here: `dial` never raises
       # (it returns nil), so the only raising step runs after the nil-guard above.
       tcp.try(&.close) rescue nil
-      {nil, DialError.new(DialErrorKind::Tls)}
+      {nil, tls_dial_error(ex, io_timeout)}
+    end
+
+    # What actually broke inside the TLS attempt. This used to be a bare `rescue` that threw
+    # the exception away and called every outcome `Tls`, which manufactured a verdict the code
+    # had not earned: a socket that accepts the TCP connection and then never speaks (a silent
+    # firewall drop, a wedged origin, an inline IPS) was reported as "origin certificate not
+    # trusted; retry with --insecure-upstream or set SSL_CERT_FILE" when no certificate had
+    # been exchanged at all — a wrong diagnosis with two useless remedies. OpenSSL already
+    # separates the cases; this only stops discarding the answer.
+    private def self.tls_dial_error(ex : Exception, io_timeout : Time::Span) : DialError
+      # A read timeout is not a TLS verdict — nothing came back to judge. Naming the layer
+      # TLS here is precisely what produced the certificate advice for a black hole, so it
+      # gets its own kind and carries how long gori actually waited (the stall was otherwise
+      # invisible: a failed dial records no duration).
+      if ex.is_a?(IO::TimeoutError)
+        return DialError.new(DialErrorKind::Timeout,
+          cause: "no TLS response within #{io_timeout.total_seconds.round(1)}s")
+      end
+      cause = exception_cause(ex)
+      # OpenSSL says "certificate verify failed" for an untrusted chain, an expired leaf AND a
+      # hostname mismatch — one kind, and the remedy (a CA file, or -k) is the same for all
+      # three. Everything else it raises is a protocol-level refusal, where offering a CA file
+      # is the wrong advice.
+      return DialError.new(DialErrorKind::TlsVerify, cause: cause) if cause.includes?("certificate verify failed")
+      DialError.new(DialErrorKind::Tls, cause: cause)
+    end
+
+    # Longest library verdict worth carrying into a stored flow error. OpenSSL's are ~60 bytes.
+    CAUSE_MAX = 200
+
+    # An exception's own words, never empty (a nil/blank message would render as a bare "()")
+    # and safe to store: Crystal decorates an IO failure with the object's inspect
+    # ("write (#<TCPSocket:0x104245c80>): Broken pipe"), which pins a heap address into a
+    # string the operator reads, the DB keeps and HAR/MCP export — and makes two identical
+    # failures compare unequal. Control bytes go the same way: a diagnostic is not traffic and
+    # must never carry a framing character into whatever renders it.
+    private def self.exception_cause(ex : Exception) : String
+      raw = ex.message.try(&.scrub) || ""
+      raw = raw.gsub(/\s*\(#<[^>]*>\)/, "").gsub(/[\x00-\x1f\x7f]+/, " ").strip
+      raw = raw[0, CAUSE_MAX] if raw.size > CAUSE_MAX
+      raw.empty? ? ex.class.name : raw
     end
 
     # A bare (unbracketed) IPv6 literal. The charset guard scrubs and rejects anything

--- a/src/gori/proxy/ws/message_gate.cr
+++ b/src/gori/proxy/ws/message_gate.cr
@@ -112,6 +112,9 @@ module Gori::Proxy::WS
       @dropped = 0
       @stranded = 0
       @lost = 0
+      # The peer on the far side of `@dst` already ended this direction with no CLOSE frame,
+      # so a write here can no longer be CLAIMED as a delivery. See `settle`.
+      @dst_dead = false
     end
 
     # Is anything still parked in this direction's queue? Asked by `Relay.run` at the
@@ -210,7 +213,26 @@ module Gori::Proxy::WS
     # released there is written to a dead socket. A held message therefore had until
     # `Relay::CLOSE_TIMEOUT` and then simply ceased to exist: no bytes on either socket, no
     # `ws_messages` row, and a teardown line calling it "released".
-    def settle(reason : String) : Nil
+    #
+    # ## `destination_dead` — the write still happens, the CLAIM does not
+    #
+    # `write_message` decides whether the peer saw the bytes by whether `@dst.write` RAISED,
+    # and that test is silently wrong on exactly this path: a local write to a socket whose
+    # peer has already sent FIN succeeds into the kernel buffer. So a message the operator
+    # was still holding when the peer vanished was written to a socket nobody was reading,
+    # and gori then recorded a `ws_messages` row identical to the one it writes for a message
+    # that really arrived — the transcript an operator writes a report from claiming the
+    # server received bytes it never received, with `@lost` (the counter that exists for
+    # precisely this) left at 0 so the teardown accounting had nothing to say either.
+    #
+    # `Relay.run` knows which destination is already past that point (`destination_dead?`),
+    # and it is the only thing that does. The bytes are STILL written — a genuine half-close
+    # (`shutdown(SHUT_WR)`) delivers them, and neither gori nor the operator can distinguish
+    # that from a full close — but the row is not written and `@lost` counts it, which is
+    # what `write_message`'s own doc-comment already intends: a `ws_messages` row is gori's
+    # claim that the peer saw these bytes.
+    def settle(reason : String, destination_dead : Bool = false) : Nil
+      @mutex.synchronize { @dst_dead = true } if destination_dead
       BYPASS_SETTLE_TURNS.times do
         drained = @mutex.synchronize { fail_open_locked(reason); @queue.empty? || @closed }
         break if drained
@@ -334,14 +356,22 @@ module Gori::Proxy::WS
       # socket is reported; inventing a failure for a keepalive frame here says nothing new.
     end
 
-    # True iff the bytes reached the socket. A failed write leaves NO capture row on purpose:
-    # a `ws_messages` row is gori's claim that the peer saw these bytes, and inventing one for
-    # a write that raised would be the same class of lie as the teardown line this replaced.
-    # The teardown log counts the loss instead.
+    # True iff the bytes can be CLAIMED to have reached the peer. A failed write leaves NO
+    # capture row on purpose: a `ws_messages` row is gori's claim that the peer saw these
+    # bytes, and inventing one for a write that raised would be the same class of lie as the
+    # teardown line this replaced. The teardown log counts the loss instead.
+    #
+    # A raise was the only failure this tested, and it is not the only one. Once the far end
+    # has ended this direction with no CLOSE frame (`@dst_dead`), the write below SUCCEEDS
+    # into a kernel buffer and says nothing at all about delivery — which is how a message an
+    # operator was still holding when the peer vanished came to be recorded byte-identically
+    # to one that really arrived. So the write is still attempted (a genuine half-close does
+    # deliver) and the claim is withheld. See `settle`.
     private def write_message(opcode : UInt8, payload : Bytes, raw : Bytes?,
                               shape : WS::Shape = WS::Shape::DEFAULT) : Bool
       @dst.write(raw || WS.encode(opcode, payload, mask: @mask, fin: true))
       @dst.flush
+      return false if @dst_dead
       # Record what gori WROTE, not what arrived — the same way step 1's rewrite path keeps
       # P7. The capture has to be the bytes the peer actually sees, framing included.
       @sink.on_ws_message(@flow_id, @direction, opcode.to_i, payload.dup, shape)
@@ -393,13 +423,47 @@ module Gori::Proxy::WS
 
     # --- warnings (once each, per gate) ---------------------------------------
 
+    # A statement about this gate, written where the operator will actually meet it.
+    #
+    # Both accountings below were `::Log.warn` / `::Log.info` only, and under `gori tui` a
+    # `Log` line reaches neither the notification centre nor stderr — so `Relay`'s own
+    # promise ("Nothing else tells the operator that their decision window closed — the queue
+    # row simply vanishes from the TUI") was unmet for every teardown that is not a CLOSE
+    # frame, and the `@dropped` case was equally silent. The row goes on the flow's own
+    # `ws_messages` stream, which is the seam `AssemblingPump#warn_teardown_loss` and the
+    # `Sec-WebSocket-Extensions` advisory already use: it sits exactly where the message the
+    # operator is looking for would have been, and travels to History's WS pane, `gori run
+    # show`, MCP `get_flow` and an export alike, instead of to a `gori.log` only an operator
+    # who knew to tail it ever reads.
+    #
+    # On `Relay::NOTICE_DIRECTION` and behind `NOTICE_PREFIX` for the reasons stated there —
+    # a diagnostic is not traffic, and a repeater seed must refuse to replay it. The row
+    # therefore cannot say which side it is about, so the SENTENCE does. Best-effort: a
+    # capture write that fails must never stop a socket from tearing down.
+    private def note(text : String) : Nil
+      ::Log.warn { "ws #{@direction}: #{text}" }
+      @sink.on_ws_message(@flow_id, Relay::NOTICE_DIRECTION, OP_TEXT.to_i,
+        "#{NOTICE_PREFIX}#{side}: #{text}".to_slice)
+    rescue
+      nil
+    end
+
+    # This direction in words — see `Relay::AssemblingPump#side`, same reason.
+    private def side : String
+      to_server? ? "client→server" : "server→client"
+    end
+
     private def warn_fail_open(reason : String) : Nil
       return if @warned_overflow
       @warned_overflow = true
-      ::Log.warn do
-        "ws #{@direction}: #{reason} — forwarding #{@queue.size} held message(s) unedited, " \
-        "in arrival order. WebSocket has no application-level flow control, so nothing " \
-        "throttles the sender while a hold is out"
+      if @dst_dead
+        note("#{reason}, and the peer had already ended this direction without a CLOSE " \
+             "frame — #{@queue.size} held message(s) are written out anyway, but gori " \
+             "cannot claim they arrived, so no ws_messages row is recorded for them")
+      else
+        note("#{reason} — forwarding #{@queue.size} held message(s) unedited, in arrival " \
+             "order. WebSocket has no application-level flow control, so nothing throttles " \
+             "the sender while a hold is out")
       end
     end
 
@@ -408,15 +472,14 @@ module Gori::Proxy::WS
     # something that was destroyed.
     private def warn_teardown : Nil
       return if @dropped == 0 && @stranded == 0 && @lost == 0
-      ::Log.info do
-        parts = [] of String
-        parts << "#{@dropped} dropped by the operator" if @dropped > 0
-        parts << "#{@lost} forwarded too late to reach the socket" if @lost > 0
-        parts << "#{@stranded} discarded still undecided" if @stranded > 0
-        "ws #{@direction}: held message(s) at teardown — #{parts.join(", ")}. None of these " \
-        "left a ws_messages row and neither endpoint can see the gap: a WebSocket message " \
-        "has no identity for a peer to miss"
-      end
+      parts = [] of String
+      parts << "#{@dropped} dropped by the operator" if @dropped > 0
+      parts << "#{@lost} written after the peer had already ended this direction, so gori " \
+               "cannot claim they arrived" if @lost > 0
+      parts << "#{@stranded} discarded still undecided" if @stranded > 0
+      note("held message(s) at teardown — #{parts.join(", ")}. None of these left a " \
+           "ws_messages row and neither endpoint can see the gap: a WebSocket message has " \
+           "no identity for a peer to miss")
     end
   end
 end

--- a/src/gori/proxy/ws/relay.cr
+++ b/src/gori/proxy/ws/relay.cr
@@ -45,6 +45,32 @@ module Gori::Proxy::WS
   # it applies to: when an intercept hold actually PARKS the message, where a control frame
   # cannot wait for a human (see `MessageGate`'s header).
   module Relay
+    # How one direction's pump stopped reading. `pump`/`AssemblingPump#run` used to answer
+    # this as a Bool ("did it relay a CLOSE frame?"), which collapsed the two ways a socket
+    # can end WITHOUT one — and gori knows which it was, because they arrive differently:
+    # a FIN is a clean end of stream (`read_fully?` → nil) and a reset RAISES on gori's own
+    # read. Neither reached the operator, so a `101 / complete / empty transcript` flow could
+    # not answer "did the peer hang up normally, or did something kill this socket" — which
+    # is the question that flow is opened to ask. It is also what `Relay.run` needs to know
+    # whether a gate's DESTINATION is still worth claiming a delivery to (see `MessageGate`).
+    enum Ending
+      # This direction relayed a CLOSE frame — the clean half of the RFC 6455 §7.1.1
+      # closing handshake. The peer is closing on purpose and is still reading.
+      Close
+      # End of stream with no CLOSE frame: the peer's FIN, or a frame truncated by it.
+      Eof
+      # The read raised: a transport reset, a broken pipe, an unreadable socket.
+      Reset
+    end
+
+    # One direction's outcome, tagged with WHICH direction it was — `run` needs the pairing
+    # to decide which gate's destination socket the ending is about.
+    record DirectionEnd, direction : String, ending : Ending do
+      def clean? : Bool
+        ending.close?
+      end
+    end
+
     # Cap on a reassembled (possibly fragmented) message we buffer for capture.
     # The raw forward is always byte-exact (P7); only the captured projection is
     # bounded, so a giant streamed message can't exhaust memory.
@@ -152,11 +178,11 @@ module Gori::Proxy::WS
       out_pump = assembling_pump(client, upstream, "out", flow_id, sink, out_rw, ctx, out_gate, mask: true)
       in_pump = assembling_pump(upstream, client, "in", flow_id, sink, in_rw, ctx, in_gate, mask: false)
 
-      done = Channel(Bool).new(2) # each pump's payload: did it end by relaying a CLOSE frame?
+      done = Channel(DirectionEnd).new(2) # each pump's payload: HOW that direction ended
       # client→server: RFC 6455 §5.3 requires every such frame to be masked, so a re-emitted
       # one carries a fresh key of gori's.
-      spawn { done.send(run_direction(client, upstream, "out", flow_id, sink, out_pump, out_gate)) }
-      spawn { done.send(run_direction(upstream, client, "in", flow_id, sink, in_pump, in_gate)) }
+      spawn { done.send(DirectionEnd.new("out", run_direction(client, upstream, "out", flow_id, sink, out_pump, out_gate))) }
+      spawn { done.send(DirectionEnd.new("in", run_direction(upstream, client, "in", flow_id, sink, in_pump, in_gate))) }
 
       # The first direction to end tells us how to tear down:
       #   - abnormal end (EOF / reset / truncated frame): the peer is gone — close both
@@ -169,12 +195,17 @@ module Gori::Proxy::WS
       #     used to drop it (the local "forward, then break" is near-instant; the peer's
       #     reply needs a real round trip). Give the other pump a bounded window
       #     (CLOSE_TIMEOUT) to relay that reply before tearing down.
-      first_clean = done.receive
+      first = done.receive
+      # Only the endings observed BEFORE the two `close` calls below are the PEERS'. The one
+      # reaped afterwards is gori's own teardown unblocking a parked read, and attributing
+      # that to a peer would be the diagnostic inventing traffic facts.
+      observed = [first]
       second_pending = true
-      if first_clean
+      if first.clean?
         select
-        when done.receive
+        when second = done.receive
           second_pending = false # other side finished within the window (reply relayed, or its own end)
+          observed << second
         when timeout(CLOSE_TIMEOUT)
           # peer never replied — give up waiting; the pump below is reaped after closing.
           warn_close_deadline(out_gate, in_gate)
@@ -184,14 +215,18 @@ module Gori::Proxy::WS
       # pump's `ensure`, which is only reached because the two lines below unblocked its
       # read — so a message released there is written to a socket that is already gone. This
       # is the one moment at which a held message can still reach its peer.
-      out_gate.try(&.settle("the socket is closing"))
-      in_gate.try(&.settle("the socket is closing"))
+      #
+      # ... and `destination_dead` is the moment at which it CANNOT, which is a different
+      # thing from failing to write. See the parameter's own doc on `MessageGate#settle`.
+      out_gate.try(&.settle("the socket is closing", destination_dead: destination_dead?(observed, "out")))
+      in_gate.try(&.settle("the socket is closing", destination_dead: destination_dead?(observed, "in")))
       # ... and the same moment, for the same reason, is the last one at which a HALF-assembled
       # message and the control frames parked between its fragments can still reach the peer.
       # The gates above resolve what a HUMAN still owns; this resolves what the pump itself is
       # withholding, and it goes second because those bytes arrived after everything queued.
       out_pump.try(&.flush_at_teardown)
       in_pump.try(&.flush_at_teardown)
+      record_teardown(sink, flow_id, observed)
       client.close rescue nil
       upstream.close rescue nil
       # Every path above consumes exactly one of the two `done` sends before this point
@@ -211,6 +246,58 @@ module Gori::Proxy::WS
       sink.on_ws_message(flow_id, NOTICE_DIRECTION, OP_TEXT.to_i, "#{NOTICE_PREFIX}#{n}".to_slice)
     rescue
       nil
+    end
+
+    # Is the socket a gate WRITES to already past the point where a delivery can be claimed?
+    #
+    # A gate's destination is the OTHER direction's source: `out`'s destination is the
+    # upstream leg, which the `in` pump reads, and `in`'s is the client, which `out` reads.
+    # So a direction's destination is known unreachable exactly when the OPPOSITE direction
+    # ended without a CLOSE frame — a peer that sent one is closing on purpose and is still
+    # reading, which is why the CLOSE path (`Relay::CLOSE_TIMEOUT`'s decision window) keeps
+    # forwarding and keeps writing its `ws_messages` row.
+    private def self.destination_dead?(observed : Array(DirectionEnd), direction : String) : Bool
+      other = direction == "out" ? "in" : "out"
+      observed.any? { |e| e.direction == other && !e.clean? }
+    end
+
+    # A peer that RESET the socket, said on the flow's own `ws_messages` stream — the seam
+    # `AssemblingPump#warn_teardown_loss` and the `Sec-WebSocket-Extensions` advisory already
+    # use, so it travels to History's WS pane, `gori run show`, MCP `get_flow` and an export
+    # rather than to a `gori.log` only an operator who knew to tail it ever reads.
+    #
+    # gori HAS the FIN-vs-RST bit and was throwing it away: a peer's reset RAISES on gori's
+    # own read while a FIN is a clean end of stream, and neither reached the flow. An operator
+    # looking at a `101 / complete / empty transcript` flow is asking exactly whether the peer
+    # hung up normally or something killed the socket, and nothing on disk could answer.
+    #
+    # Only the RESET earns a row, and the sentence says so, so its ABSENCE is readable rather
+    # than ambiguous. A WebSocket that ends on a FIN with no CLOSE frame is the ordinary way
+    # one dies in the field — a closed tab, a dropped network, a restarted origin — and
+    # annotating those would put a `[gori]` row on a large fraction of every capture to say
+    # "nothing unusual happened", which is exactly how the anomalous row stops being noticed.
+    # Only endings observed BEFORE `run` closes the sockets are considered, so gori's own
+    # teardown is never reported as a peer's. Best-effort, and on `NOTICE_DIRECTION` for the
+    # reason stated there.
+    private def self.record_teardown(sink : FlowSink, flow_id : Int64,
+                                     observed : Array(DirectionEnd)) : Nil
+      reset = observed.find(&.ending.reset?) || return
+      note = teardown_sentence(reset)
+      ::Log.info { "ws #{reset.direction}: #{note}" }
+      sink.on_ws_message(flow_id, NOTICE_DIRECTION, OP_TEXT.to_i,
+        "#{NOTICE_PREFIX}#{note}".to_slice)
+    rescue
+      nil
+    end
+
+    # The SENTENCE has to name the side, because the row is written on `NOTICE_DIRECTION`.
+    # `out` reads the client and `in` reads the server, so the peer named here is the one
+    # whose bytes stopped arriving.
+    private def self.teardown_sentence(e : DirectionEnd) : String
+      peer = e.direction == "out" ? "the client" : "the server"
+      "#{peer} ended this WebSocket with a transport-level RESET and no CLOSE frame — " \
+      "something killed the socket rather than closing it (RFC 6455 §7.1.1). A peer that " \
+      "closes normally, with or without the closing handshake, leaves no row here"
     end
 
     # CLOSE_TIMEOUT just expired with a message still held. Nothing else tells the operator
@@ -258,7 +345,7 @@ module Gori::Proxy::WS
     # One direction's loop, on whichever pump `assembling_pump` chose.
     private def self.run_direction(src : IO, dst : IO, direction : String, flow_id : Int64,
                                    sink : FlowSink, assembling : AssemblingPump?,
-                                   gate : MessageGate?) : Bool
+                                   gate : MessageGate?) : Ending
       return pump(src, dst, direction, flow_id, sink) unless assembling
       begin
         assembling.run
@@ -280,16 +367,16 @@ module Gori::Proxy::WS
     # through (byte-exact, P7) rather than aborting the whole tunnel; its payload is
     # too large to buffer, so capture records a marker for that frame instead.
     #
-    # Returns whether this direction ended by successfully relaying a CLOSE frame (the
-    # "clean" end of the RFC 6455 closing handshake) — as opposed to an abnormal end (EOF,
-    # reset, or a truncated frame, all `false`) — so `run` can tell the two cases apart and
-    # give the peer's replying CLOSE a bounded window instead of tearing the tunnel down
-    # the instant either direction stops.
-    private def self.pump(src : IO, dst : IO, direction : String, flow_id : Int64, sink : FlowSink) : Bool
+    # Returns HOW this direction ended (see `Ending`): a relayed CLOSE frame is the "clean"
+    # end of the RFC 6455 closing handshake, and `run` gives the peer's replying CLOSE a
+    # bounded window on it instead of tearing the tunnel down the instant either direction
+    # stops. The two abnormal ends are kept apart rather than collapsed, because gori reads
+    # them differently and the operator needs the difference.
+    private def self.pump(src : IO, dst : IO, direction : String, flow_id : Int64, sink : FlowSink) : Ending
       assembling = IO::Memory.new
       message_opcode = OP_TEXT
       scratch = Bytes.new(STREAM_CHUNK)
-      clean_close = false
+      ending = Ending::Eof
       shape = MessageShape.new
       controls = 0
       loop do
@@ -313,7 +400,7 @@ module Gori::Proxy::WS
           assembling = emit_pending(assembling, direction, flow_id, sink, message_opcode, shape) if h.data?
           break unless forward_oversized_frame(src, dst, h, direction, flow_id, sink, message_opcode, scratch)
           if h.close? # an oversized CLOSE still terminates the tunnel, like a normal one
-            clean_close = true
+            ending = Ending::Close
             break
           end
           next
@@ -326,13 +413,13 @@ module Gori::Proxy::WS
         shape.note(frame) if frame.data?
         assembling = capture_frame(frame, assembling, direction, flow_id, sink, message_opcode, shape)
         if frame.close?
-          clean_close = true
+          ending = Ending::Close
           break
         end
       end
-      clean_close
+      ending
     rescue
-      false # peer closed / reset: this direction ends
+      Ending::Reset # the read RAISED: a transport reset, not the peer's FIN
     ensure
       # An unterminated fragment when the direction ends. gori already put those bytes on the
       # wire frame by frame, so dropping them here made History disagree with what gori itself
@@ -457,15 +544,15 @@ module Gori::Proxy::WS
         @scratch = Bytes.new(STREAM_CHUNK)
       end
 
-      # Same contract as `Relay.pump`: true iff this direction ended by relaying a CLOSE.
-      def run : Bool
-        clean_close = false
+      # Same contract as `Relay.pump`: HOW this direction ended (see `Ending`).
+      def run : Ending
+        ending = Ending::Eof
         loop do
           h = WS.read_header(@src) || break
           unless h.data?
             break unless forward_control(h)
             if h.close?
-              clean_close = true
+              ending = Ending::Close
               break
             end
             next
@@ -478,9 +565,9 @@ module Gori::Proxy::WS
           frame = WS.read_body(@src, h) || break
           handle_data(frame)
         end
-        clean_close
+        ending
       rescue
-        false # peer closed / reset: this direction ends
+        Ending::Reset # the read RAISED: a transport reset, not the peer's FIN
       ensure
         # The abnormal exits (EOF, a truncated frame, a reset) are withholding the same bytes
         # a CLOSE would have been, and the byte-exact pump would already have forwarded them —

--- a/src/gori/ql.cr
+++ b/src/gori/ql.cr
@@ -273,19 +273,26 @@ module Gori
     # guard so `http` can negate them NULL-safely — a pending/typeless flow (NULL
     # content_type) counts as http, and `-proto:grpc` correctly keeps it. An
     # unknown value (proto:foo) drops the term, like a bad status: (never matches
-    # all). `websocket` is an alias for `ws`.
+    # all). `websocket` is an alias for `ws`, and `wss`/`grpcs`/`sses`/`https` add the
+    # transport the operator named — the spellings the PROTO column prints.
     GRPC_SQL = "(content_type IS NOT NULL AND lower(content_type) LIKE 'application/grpc%')"
     SSE_SQL  = "(content_type IS NOT NULL AND lower(content_type) LIKE 'text/event-stream%')"
 
     private def self.proto_cond(value : String) : {String, Array(DB::Any)}?
+      # The TLS spellings the History PROTO column prints (`WSS`/`GRPCS`/`SSES`/`HTTPS`) are
+      # accepted and mean what the column means: the application protocol AND the transport.
+      # Without the second half `proto:wss` would quietly return the cleartext rows too —
+      # the exact signal the column was changed to stop dropping.
+      base, secure = Proto.split_transport(value)
       no_args = [] of DB::Any
-      case Proto::Kind.parse?(value)
-      in Proto::Kind::Ws   then {"status = 101", no_args}
-      in Proto::Kind::Grpc then {GRPC_SQL, no_args}
-      in Proto::Kind::Sse  then {SSE_SQL, no_args}
-      in Proto::Kind::Http then {"(status IS NULL OR status <> 101) AND NOT #{GRPC_SQL} AND NOT #{SSE_SQL}", no_args}
-      in nil               then nil
-      end
+      sql = case Proto::Kind.parse?(base)
+            in Proto::Kind::Ws   then "status = 101"
+            in Proto::Kind::Grpc then GRPC_SQL
+            in Proto::Kind::Sse  then SSE_SQL
+            in Proto::Kind::Http then "(status IS NULL OR status <> 101) AND NOT #{GRPC_SQL} AND NOT #{SSE_SQL}"
+            in nil               then return nil
+            end
+      secure.nil? ? {sql, no_args} : {"(#{sql}) AND scheme = 'https'", no_args}
     end
 
     # size: → the TOTAL bytes (request + response), so it matches the displayed/JSON

--- a/src/gori/repeater/conn_pool.cr
+++ b/src/gori/repeater/conn_pool.cr
@@ -3,7 +3,7 @@ require "../proxy/codec/http1"
 require "./engine"
 
 # Non-blocking "is there residue in the read buffer?" — the piece Crystal's public IO has no
-# way to ask. `ConnPool#drained?` needs it because `read_head` reads byte-by-byte through the
+# way to ask. `ConnPool#checkout_state` needs it because `read_head` reads byte-by-byte through the
 # buffered layer, which pulls a large chunk off the socket into `@in_buffer_rem`; any bytes
 # the origin left past the framed body therefore sit in THAT buffer, not on the kernel socket,
 # where an fd-level `MSG_PEEK` cannot see them. `peek` would find them but calls `fill_buffer`
@@ -55,15 +55,22 @@ module Gori::Repeater
   # least likely to have hit the origin's idle timeout.
   class ConnPool
     # A parked socket the origin closed while it sat idle is normal (every server has a
-    # keep-alive idle timeout) and must not surface as a failed result: for an IDEMPOTENT
-    # request it is re-sent once on a fresh connection. Detected as a clean EOF before ANY
-    # response byte — a timeout, or a failure part-way through a response, is NOT retried,
-    # because the origin may well have processed the request.
+    # keep-alive idle timeout) and must not surface as a failed result. There are two moments
+    # it can be discovered, and they are NOT the same fact:
     #
-    # An origin that refuses reuse outright would otherwise pay that redial on every single
-    # send (two connections per request — worse than not pooling). After this many
-    # consecutive stale checkouts the pool gives up and runs in dial-per-send mode for the
-    # rest of the run.
+    #   * at CHECKOUT, before a byte of the next request is written (`Checkout::Closed`) —
+    #     the origin cannot have seen the request, so it goes out on a fresh connection as a
+    #     FIRST send, for any method, unmarked;
+    #   * DURING the exchange, because the FIN landed between the probe and the write
+    #     (`stale?`) — gori cannot tell whether the origin read it, so only an IDEMPOTENT
+    #     request is re-sent, and its Result is marked `retried`.
+    #
+    # Either way a timeout, or a failure part-way through a response, is NOT retried: the
+    # origin may well have processed the request.
+    #
+    # An origin that refuses reuse outright turns every park into a wasted probe and a redial.
+    # After this many consecutive stale checkouts — of EITHER kind — the pool gives up and
+    # runs in dial-per-send mode for the rest of the run.
     #
     # On `max_requests`: a stale re-send is not charged against the CAP (CappedBackend counts
     # calls into the Sender, and this retry happens below it), and STALE_GIVE_UP bounds the
@@ -106,12 +113,34 @@ module Gori::Repeater
       REPLAYABLE_METHODS.any? { |m| method.compare(m, case_insensitive: true) == 0 }
     end
 
+    # What the checkout probe found on a parked socket, right before this request would be
+    # written onto it. Three outcomes, not two, because the third one is the discriminator
+    # the class contract says it does not have (see `stale?`): a FIN that is ALREADY on the
+    # socket proves the origin never saw this request, since nothing has been written yet.
+    enum Checkout
+      # Nothing waiting. Write the request onto it.
+      Clean
+      # Unread bytes from the PREVIOUS exchange (a body past Content-Length, a HEAD-with-body).
+      # Retire: framing this request's response against them is the response-desync gori
+      # exists to DETECT, not to suffer.
+      Residue
+      # The peer's FIN arrived while the socket sat idle, before gori wrote a byte. Retire —
+      # and the re-dial that follows is a FIRST send, for ANY method.
+      Closed
+    end
+
     # Connections dialed (== handshakes paid) and requests served off a parked socket.
     # `dialed + reused == sends` for a run that never hit a stale retry.
     getter dialed : Int64 = 0_i64
     getter reused : Int64 = 0_i64
     # Re-sends caused by a parked socket the origin had already closed (see STALE_GIVE_UP).
     getter stale_retries : Int64 = 0_i64
+    # Parked sockets found ALREADY CLOSED at checkout, before a byte of this request went
+    # onto them. NOT re-sends: nothing had been sent, so the fresh connection carries the
+    # request's FIRST and only copy and no `retried` marker is warranted. Counted separately
+    # from `stale_retries` because the two answer different questions — this one is "how
+    # often did parking turn out to be pointless", which is what STALE_GIVE_UP acts on.
+    getter stale_checkouts : Int64 = 0_i64
     # Sends that hit a closed parked socket and were NOT replayed because the method is not
     # idempotent (see REPLAYABLE_METHODS). These came back as errors, exactly as they would
     # with keep-alive off — counted so a surface can say why a pooled run and an unpooled one
@@ -139,13 +168,34 @@ module Gori::Repeater
       # bytes were consumed — see reusable_response?.
       method = Repeater::Engine.request_method(bytes)
       if keepable && (io = @idle.pop?)
-        # Residue check AT CHECKOUT, not only when we parked it. The previous exchange's leftover
+        # Probe AT CHECKOUT, not only when we parked it. The previous exchange's leftover
         # bytes (a body past Content-Length, a HEAD-with-body) may not have arrived by the time
         # `recycle` ran — the origin can be a peer whose write races our park — so `recycle`'s
         # check is an early retire, and THIS one, right before we write onto the socket, is the
         # reliable one: by now any straggler residue is on the wire. Without it a poisoned socket
         # would frame this request's response against the previous response's leftovers.
-        unless drained?(io)
+        case checkout_state(io)
+        when Checkout::Closed
+          # The origin's FIN was on the socket BEFORE gori wrote a byte of this request. That
+          # proves what `stale?` (below) explicitly cannot: the ORIGIN NEVER SAW THIS REQUEST.
+          # So the re-dial is a FIRST send, not a replay — allowed for EVERY method, unmarked,
+          # and not charged as a stale re-send, because nothing was re-sent.
+          #
+          # Treating this as "drained" and writing the request onto the dead socket anyway
+          # cost half of every POST sweep: `send` wrote, the read failed with a reset, and
+          # the (correct) idempotency gate below then declined to replay a request whose
+          # delivery it could no longer disprove — one call too late. The two changes are
+          # individually right and jointly dropped the request. `stale?` and the method gate
+          # stay for the genuinely ambiguous case: a FIN that lands BETWEEN this probe and
+          # the write.
+          close(io)
+          @stale_checkouts += 1
+          # Still charged against STALE_GIVE_UP. An origin that closes every parked socket
+          # makes parking pointless, and that is the case the bound exists for whether the
+          # deadness is caught here or one exchange later.
+          note_stale
+          return dial_and_send(bytes, keepable, method)
+        when Checkout::Residue
           close(io)
           return dial_and_send(bytes, keepable, method)
         end
@@ -153,21 +203,25 @@ module Gori::Repeater
         result = Repeater::Engine.exchange(io, bytes, @host, @port, started)
         if stale?(result)
           close(io)
-          @consecutive_stale += 1
-          # Give up on pooling for the rest of the run rather than pay a wasted redial on
-          # every send. Already-parked sockets are dropped: they are the same vintage. Counted
-          # for BOTH outcomes below: an origin that always closes parked sockets is the case
-          # this bound exists for whether or not the method may be replayed.
-          if @consecutive_stale >= STALE_GIVE_UP
-            @pooling = false
-            drain
-          end
+          # Counted for BOTH outcomes below: an origin that always closes parked sockets is the
+          # case this bound exists for whether or not the method may be replayed.
+          note_stale
           # A non-idempotent request stops here with the result it actually got. Re-sending it
           # is what turned a dropped POST into a false 200 and charged the origin twice — see
           # REPLAYABLE_METHODS.
           unless ConnPool.replayable?(method)
             @unsafe_stale += 1
-            return result
+            # …and stop pooling AT ONCE, without waiting for STALE_GIVE_UP. That bound is sized
+            # for an idempotent sweep, where a stale checkout costs a wasted redial and the
+            # request still goes out. For a method the pool may not replay it costs a LOST
+            # PAYLOAD — a hole in the sweep, and one the operator cannot tell from a payload the
+            # origin genuinely refused — so the next two attempts before the bound trips would
+            # be two more holes. Measured against an origin that closes 50 ms after answering:
+            # three payloads lost with the shared bound, one with this. A handshake per send is
+            # a cheap price for the rest of the run agreeing with `--no-keep-alive`.
+            @pooling = false
+            drain
+            return unsafe_stale_result(result, method)
           end
           @stale_retries += 1
           return dial_and_send(bytes, keepable, method, retried: true)
@@ -184,6 +238,62 @@ module Gori::Repeater
     # not leave file descriptors open until GC.
     def close_all : Nil
       drain
+    end
+
+    # One more parked socket that turned out to be dead, from EITHER discovery point. Give up
+    # on pooling for the rest of the run rather than pay a wasted probe-and-redial on every
+    # send; already-parked sockets are dropped, because they are the same vintage.
+    private def note_stale : Nil
+      @consecutive_stale += 1
+      return if @consecutive_stale < STALE_GIVE_UP
+      @pooling = false
+      drain
+    end
+
+    # The row for a request that died on a parked socket and may NOT be replayed.
+    #
+    # `Engine.exchange` ends this path with the transport's own exception message, and that is
+    # not an operator-facing sentence. `read (#<TCPSocket:0x102e5cc80>): Connection reset by
+    # peer` on a fuzz row reads as "this payload provoked a reset" — a false positive in a
+    # security sweep — blames the ORIGIN for a socket gori wrote onto after the origin had
+    # closed it, and puts a heap pointer in the terminal, in `--format json` and in MCP
+    # `fuzz_results`. What gori actually knows is stated first; the transport's own words are
+    # kept as a trailing clause because they are the only evidence of HOW the socket died.
+    #
+    # The one thing this must NOT claim is that the request was not delivered. By here the
+    # FIN arrived after the probe said the socket was clean, so gori wrote the request and
+    # cannot know whether the origin read it — which is exactly why it is not replayed.
+    # `delivered?` stays false (gori heard nothing back) and the sentence says so in words.
+    private def unsafe_stale_result(result : Repeater::Result, method : String) : Repeater::Result
+      why = "the parked keep-alive connection to #{@host}:#{@port} was closed by the origin " \
+            "while this #{method} was being sent, and #{method} is not idempotent, so gori did " \
+            "NOT re-send it — this request may or may not have reached the origin"
+      detail = ConnPool.transport_detail(result.error)
+      # Named, not positional, for the three tail flags — same reason `as_retried` says so:
+      # they are the fields appended one per round, and a positional `true` in the wrong slot
+      # has silently set the wrong one twice now. This rebuilds a Result to change ONE field,
+      # so every other value is carried across verbatim.
+      Repeater::Result.new(result.head, result.body, result.response, result.duration_us,
+        detail ? "#{why} (#{detail})" : why, result.incomplete?,
+        delivered: result.delivered?, timed_out: result.timed_out?, retried: result.retried?)
+    end
+
+    # A Crystal `IO::Error` renders the socket's `inspect` into its message, so the transport's
+    # account of a failure arrives as `read (#<TCPSocket:0x102e5cc80>): Connection reset by
+    # peer`. The words after the colon are evidence worth keeping; the heap address is an
+    # implementation detail that means nothing to an operator, differs on every run (so two
+    # otherwise identical rows never compare equal), and has no business in a terminal, in
+    # `--format json` or in an MCP tool result. Pure and `self.` so a spec can pin the shape
+    # without a socket.
+    #
+    # `Upstream::DialError#cause` does the same scrub for the DIAL layer. This is deliberately
+    # separate rather than shared: the string here never passes through a `DialError` at all —
+    # it comes out of `Engine.exchange`, on a socket the pool had already CONNECTED and handed
+    # over, which is the one place a dial-layer scrubber can never see.
+    def self.transport_detail(message : String?) : String?
+      return nil unless message
+      cleaned = message.gsub(/\s*\(#<[^>]*>\)/, "").strip
+      cleaned.empty? ? nil : cleaned
     end
 
     # `retried` marks the Result as the SECOND copy of this request on the wire, so the row a
@@ -216,7 +326,7 @@ module Gori::Repeater
     # CHECKOUT (`send`), not here. Residue can arrive AFTER we would park — the origin's write
     # races our recycle — so checking here would miss a straggler and still hand a poisoned
     # socket to the next send. `reusable_response?` interrogates only the response HEAD and
-    # cannot see the leftover bytes; the checkout-time `drained?` is what catches them, once
+    # cannot see the leftover bytes; the checkout-time `checkout_state` is what catches them, once
     # they are reliably on the wire.
     private def recycle(io : IO, result : Repeater::Result, keepable : Bool, method : String) : Nil
       if @pooling && keepable && @idle.size < @max_idle && ConnPool.reusable_response?(result, method)
@@ -236,50 +346,56 @@ module Gori::Repeater
     # handshake, so a millisecond to prove it is safe is a good trade.
     DRAIN_PROBE = 1.millisecond
 
-    # Whether the socket has NO unread bytes waiting. A parked socket must be empty, or the
-    # next request reads the leftovers as its own response.
+    # What is waiting on a parked socket, asked once, right before this request is written.
+    # A parked socket must be empty, or the next request reads the leftovers as its own
+    # response — and it must be OPEN, or the next request is written into a closed pipe.
     #
     # For a plaintext `TCPSocket` this is an fd-level `MSG_PEEK` — Crystal's socket fd is
     # already non-blocking (evented IO), so `recv` returns immediately: `EAGAIN`/`EWOULDBLOCK`
-    # means nothing is waiting (drained), any byte or an EOF means retire. ~0.3µs, so it costs
-    # the keep-alive fast path nothing. A TLS socket hides its fd and the residue may sit in
-    # OpenSSL's decrypted buffer where a raw peek cannot see it, so it falls back to a short
-    # read probe, which naturally covers both `SSL_pending` and a kernel-buffered record.
-    private def drained?(io : IO) : Bool
+    # means nothing is waiting (Clean), a byte means Residue, and 0 means the peer sent FIN
+    # (Closed). ~0.3µs, so it costs the keep-alive fast path nothing. A TLS socket hides its
+    # fd and the residue may sit in OpenSSL's decrypted buffer where a raw peek cannot see it,
+    # so it falls back to a short read probe, which naturally covers both `SSL_pending` and a
+    # kernel-buffered record.
+    #
+    # EOF used to be folded into "drained", on the reasoning that a closed parked socket is the
+    # idle-timeout race the stale-retry path already handles. That stopped being true when the
+    # idempotency gate landed: for POST/PUT/PATCH/DELETE the stale path can no longer re-send,
+    # so handing back a socket proved dead DROPPED the request. It is now its own answer — and
+    # a better one for every method, because a FIN observed BEFORE the write means the origin
+    # never saw the request at all.
+    private def checkout_state(io : IO) : Checkout
       # 1. Residue already pulled into the buffered layer by `read_head`'s byte reads. This is
       #    where a body-past-Content-Length or a HEAD-with-body actually lands, and it is
       #    non-blocking, so it must be checked FIRST.
-      return false if io.is_a?(IO::Buffered) && io.gori_buffered_residue?
-      # 2. Residue still on the kernel socket. A plaintext `TCPSocket`'s fd is non-blocking
-      #    (evented IO), so `MSG_PEEK` returns at once: `EAGAIN`/`EWOULDBLOCK` = nothing waiting
-      #    (drained), any byte or EOF = retire. ~0.3µs, so the clean plaintext path pays
-      #    nothing. A TLS socket hides its fd and OpenSSL may hold a partial record, so it
-      #    falls back to a short read probe (only ever paid on a socket that turns out clean —
-      #    and a reused TLS socket has already saved a whole handshake).
-      # EOF here (the peer already sent FIN) is deliberately NOT treated as residue: a closed
-      # socket is the idle-timeout race the stale-retry path already handles by re-sending on a
-      # fresh connection, and papering over it here would bypass STALE_GIVE_UP's bookkeeping.
-      # Only actual WAITING BYTES cause misattribution, so only those retire the socket.
+      return Checkout::Residue if io.is_a?(IO::Buffered) && io.gori_buffered_residue?
+      # 2. Residue — or the peer's FIN — still on the kernel socket.
       if io.is_a?(TCPSocket)
         buf = uninitialized UInt8[1]
         n = LibC.recv(io.fd, buf.to_unsafe.as(Void*), LibC::SizeT.new(1), MSG_PEEK)
-        return true if n == 0 # EOF — let stale? handle it
-        n < 0 && {Errno::EAGAIN, Errno::EWOULDBLOCK}.includes?(Errno.value)
+        return Checkout::Closed if n == 0
+        return Checkout::Residue if n > 0
+        {Errno::EAGAIN, Errno::EWOULDBLOCK}.includes?(Errno.value) ? Checkout::Clean : Checkout::Residue
       elsif io.responds_to?(:read_timeout=) && io.responds_to?(:read_timeout)
         prev = io.read_timeout
         begin
           io.read_timeout = DRAIN_PROBE
-          io.read_byte.nil? # nil = EOF (drained, stale? handles it); a byte = residue (retire)
+          # nil = EOF (the peer closed); a byte = residue. The byte is consumed, which is why
+          # this branch only ever runs on a socket that is about to be retired either way.
+          io.read_byte.nil? ? Checkout::Closed : Checkout::Residue
         rescue IO::TimeoutError
-          true
+          Checkout::Clean
         ensure
           io.read_timeout = prev
         end
       else
-        true # an IO with no timeout knob is not a pooled socket; nothing to prove
+        Checkout::Clean # an IO with no timeout knob is not a pooled socket; nothing to prove
       end
     rescue
-      false # any probe error ⇒ do not risk parking a bad socket
+      # Any probe error ⇒ do not risk writing onto this socket. Reported as Residue rather
+      # than Closed: a failed probe proves nothing about whether the peer closed, and Closed
+      # is the answer that licenses re-sending a POST.
+      Checkout::Residue
     end
 
     # A REUSED socket that failed BEFORE any response byte arrived. Per the contract at the
@@ -305,6 +421,10 @@ module Gori::Repeater
     # What this does NOT establish, and used to be read as establishing, is that the ORIGIN
     # never saw the request. It only means gori heard nothing back. The method gate in `send`
     # is what covers the gap.
+    #
+    # `Checkout::Closed` DOES establish it, and is checked first — so by the time this runs the
+    # FIN arrived after the probe, i.e. genuinely while or after gori wrote. This is the narrow
+    # ambiguous window the method gate exists for, not the whole idle-close population.
     private def stale?(result : Repeater::Result) : Bool
       !result.error.nil? && result.response.nil? && !result.delivered?
     end

--- a/src/gori/repeater/engine.cr
+++ b/src/gori/repeater/engine.cr
@@ -45,7 +45,17 @@ module Gori
       # an agent reads this, and both showed a clean single send.
       getter? retried : Bool
 
-      def initialize(@head, @body, @response, @duration_us, @error = nil, @incomplete = false,
+      # The tail is KEYWORD-ONLY (`*`), and that is load-bearing rather than a style choice.
+      # `delivered`, `timed_out` and `retried` are three same-typed Bools that were appended one
+      # per round by three different fixers; twice, a call site written against the previous
+      # arity kept compiling and silently wrote its `true` into the field that had displaced
+      # the one it meant (`as_retried` in round 4, `Fuzz::Engine#follow_redirects` in round 5 —
+      # the latter still reporting `0 errors` while a row lost its re-send marker and gained a
+      # `timed_out` nothing had observed). A grep cannot catch that reliably: the second site
+      # was missed because the call spanned two lines and the sweep counted commas on the
+      # first. A keyword-only tail turns the whole class of mistake into a compile error, and
+      # leaves the sweep to the compiler.
+      def initialize(@head, @body, @response, @duration_us, @error = nil, @incomplete = false, *,
                      @delivered = false, @timed_out = false, @retried = false)
       end
 
@@ -60,9 +70,10 @@ module Gori
         # Named, not positional. Two fixers added a field to this constructor in the same round
         # and the merge reordered the tail — a positional `true` here silently set `timed_out`
         # instead, and the pool's re-send marker vanished with the suite still green but for the
-        # one spec that asserted it.
-        Result.new(@head, @body, @response, @duration_us, @error, @incomplete, @delivered,
-          timed_out: @timed_out, retried: true)
+        # one spec that asserted it. The constructor now REFUSES a positional tail (see there),
+        # so this shape is the only one that compiles.
+        Result.new(@head, @body, @response, @duration_us, @error, @incomplete,
+          delivered: @delivered, timed_out: @timed_out, retried: true)
       end
     end
 

--- a/src/gori/repeater/engine.cr
+++ b/src/gori/repeater/engine.cr
@@ -191,6 +191,9 @@ module Gori
         # would otherwise return the 100/103 as the repeater result. Read on until the final
         # (>=200) status. 101 Switching Protocols is terminal (a protocol upgrade), NOT skipped.
         interim_seen = 0
+        # The LAST interim status read, for the rescue below: a raise AFTER a 1xx is a
+        # different event from a raise before one, and only this loop knows which happened.
+        interim_status = nil.as(Int32?)
         while resp.status >= 100 && resp.status < 200 && resp.status != 101
           # RFC 9112 §6: a 1xx MUST NOT carry content. One that declares a body
           # (Content-Length / Transfer-Encoding) is malformed and a desync vector
@@ -201,6 +204,7 @@ module Gori
           # Cap the run so an origin streaming endless body-less 103s can't hang the
           # repeater/fuzz worker fiber indefinitely (there is no whole-request deadline).
           interim_seen += 1
+          interim_status = resp.status
           return error("too many interim 1xx responses from #{host}:#{port}", started, delivered: true) if interim_seen > MAX_INTERIM
           head = read_response_head(upstream)
           return error("upstream closed after interim 1xx from #{host}:#{port}", started, delivered: true) unless head
@@ -237,7 +241,29 @@ module Gori
         # on a parked socket) — the pre-delivery case the pool may re-send. A raise AFTER a head
         # was read (an interim-1xx read that then reset) means the origin already has the whole
         # request, so mark it delivered and do not re-send a non-idempotent one.
-        error(ex.message || "repeater error", started, delivered: !head.nil?)
+        error(exchange_error(ex, host, port, interim_status), started, delivered: !head.nil?)
+      end
+
+      # The sentence for a raise DURING the exchange.
+      #
+      # A bare `ex.message` — `"Read timed out"` — names neither the origin nor the one fact
+      # that decides what a caller may do next. An origin that answers `100 Continue` and then
+      # goes silent is the h1 twin of the case `H2Engine.no_response` writes a careful sentence
+      # for, and it read identically to a plain silent origin: same message, same `error_kind`,
+      # and (before `delivered?` reached a surface) the same `retryable: true`. The two are
+      # opposite instructions — the interim proves the origin has the whole request, because
+      # gori writes it up front.
+      #
+      # Only the INTERIM case is reworded. With no interim there is nothing gori knows that
+      # `ex.message` does not, and inventing a host-shaped sentence for every socket error
+      # would blur it into the dialer's own vocabulary.
+      private def self.exchange_error(ex : Exception, host : String, port : Int32,
+                                      interim : Int32?) : String
+        base = ex.message.presence || "repeater error"
+        return base unless interim
+        tail = ex.is_a?(IO::TimeoutError) ? "nothing more before the read timed out" : "the connection failed (#{base})"
+        "no response from #{host}:#{port} — the origin sent an interim #{interim} and then " \
+        "#{tail} (RFC 9110 §15.2: a 1xx precedes the final response, it is not one)"
       end
 
       # Read a response head with a TOTAL head-assembly deadline (parity with the proxy's

--- a/src/gori/repeater/engine.cr
+++ b/src/gori/repeater/engine.cr
@@ -270,35 +270,49 @@ module Gori
       #
       # With no detail the KIND still answers which layer broke, and that is the whole reason
       # `DialErrorKind` exists (`upstream.cr`: "a surface can say WHICH LAYER broke instead of
-      # a blanket 'connect failed'"). `dial_tls_result` returns `Tls` only after the TCP
+      # a blanket 'connect failed'"). `dial_tls_result` returns a TLS kind only after the TCP
       # connect SUCCEEDED and the handshake raised, and `Connect` whenever the socket itself
-      # never came up — so the three cases an operator has to tell apart (a firewall/DNS
-      # problem, an untrusted origin cert, and "this port is not TLS") are already separated
-      # by the time this runs. The proxy path has said all three since #323
+      # never came up — so the cases an operator has to tell apart (a firewall problem, a name
+      # that does not resolve, an untrusted origin cert, "this port is not TLS", and an origin
+      # that accepts the connection and then says nothing) are already separated by the time
+      # this runs. The proxy path has said so since #323
       # (`client_conn.cr#upstream_error_message`); every DIRECT sender — repeater, fuzz, mine,
       # sequence, discover, probe active, and `ConnPool` — collapsed them into one sentence
       # that named the first, which sent operators to debug DNS for a self-signed cert.
       #
-      # `scheme` is no longer consulted: only an https dial can produce a `Tls` kind, and a
-      # Connect kind means the TCP layer, whatever the scheme. It stays in the signature
-      # because every send path passes it positionally and it is what the sentence would be
-      # keyed on if a third transport ever appears.
+      # `verify` is no longer consulted either: the dialer reports `TlsVerify` only when
+      # certificate verification is what rejected the origin, so the remedy is offered to the
+      # people it can actually help. Guessing it from the flag is what made a black hole and a
+      # plaintext port both read as an untrusted certificate under verify-on. It stays in the
+      # signature because every send path passes it positionally.
+      #
+      # `scheme` is not consulted: only an https dial can produce a TLS kind, and a Connect
+      # kind means the TCP layer, whatever the scheme. Same reason for keeping it.
       def self.connect_error(scheme : String, host : String, port : Int32, verify : Bool,
                              err : Proxy::Upstream::DialError? = nil) : String
         if detail = err.try(&.detail)
           return "connect failed: #{detail}"
         end
-        if err.try(&.tls?)
-          if verify
+        if err
+          case err.kind
+          when .tls_verify?
             return "TLS verification failed: #{host}:#{port} — the origin's certificate is not " \
                    "trusted (self-signed/expired/wrong name); retry with -k/--insecure-upstream " \
-                   "or set SSL_CERT_FILE"
+                   "or set SSL_CERT_FILE#{err.because}"
+          when .tls?
+            return "TLS handshake failed: #{host}:#{port} — the port may not be TLS, or the origin " \
+                   "refused the protocol/cipher#{err.because}"
+          when .timeout?
+            return "TLS handshake timed out: #{host}:#{port} — the origin accepted the connection " \
+                   "and then sent nothing; no certificate was exchanged, so -k and SSL_CERT_FILE " \
+                   "cannot help#{err.because}"
+          when .dns?
+            return "connect failed: #{host} — the name did not resolve, so nothing was dialed#{err.because}"
           end
-          return "TLS handshake failed: #{host}:#{port} — the port may not be TLS, or the origin " \
-                 "refused the protocol/cipher"
         end
         # Reached only when the TCP layer is what failed, so the TLS clause that used to ride
-        # along here (and made this a catch-all) is gone.
+        # along here (and made this a catch-all) is gone. "DNS" stays in the list because a
+        # dial through an upstream proxy resolves at the PROXY, where gori cannot see it.
         "connect failed: #{host}:#{port} — host unreachable (DNS/refused/timeout)"
       end
 

--- a/src/gori/repeater/h2_engine.cr
+++ b/src/gori/repeater/h2_engine.cr
@@ -35,6 +35,15 @@ module Gori
       # are neither — a hostile origin can stream them forever without END_STREAM, and the
       # per-op io_timeout only fires on IDLE, so bytes-always-arriving pins the fiber. This
       # bounds the loop the way the h1 engine's MAX_INTERIM does (RFC-hostile-origin guard).
+      #
+      # And it is why there is deliberately NO h2 equivalent of `Repeater::Engine::MAX_INTERIM`,
+      # which round 5 asked about: on h1 that cap exists because "there is no whole-request
+      # deadline" (`engine.cr:202`), and on h2 there are two — this count and `flow.expires_at`,
+      # which does not restart on progress. Measured: 300 interim 103s then silence ends at the
+      # caller's `timeout` with `the origin sent an interim 103 and then nothing more before the
+      # read timed out`, which is what actually happened. A third bound would only replace that
+      # true sentence with a synthetic "too many interim responses" and add a phrase the MCP
+      # error-kind table would have to learn.
       MAX_FRAMES = 100_000
       # RFC 9113 §6.9.1: a flow-control window may never exceed 2^31-1, and a WINDOW_UPDATE
       # increment of 0 is a PROTOCOL_ERROR. Both are plausible real-world server bugs and
@@ -143,6 +152,10 @@ module Gori
       # then clears the fields it carried, so "the status is zero and there are no headers" —
       # the old test for "nothing arrived" — is false for an exchange that has no response at
       # all (RFC 9110 §15.2: a 1xx precedes the final response and is not one).
+      # `late_interim` is the status of an interim header block that arrived AFTER the final
+      # response — an RFC 9110 §15.2 violation the operator has to be told about, because it is
+      # what an h2 response-splitting / header-injection probe produces and what a buggy
+      # gateway emits. It rides alongside the final response rather than replacing it.
       private record Reply,
         status : Int32,
         headers : Array({String, String}),
@@ -152,7 +165,8 @@ module Gori
         rst : String?,
         trailers : Array(String)?,
         timed_out : Bool,
-        final_seen : Bool
+        final_seen : Bool,
+        late_interim : Int32? = nil
 
       def self.send(request : Bytes, *, scheme : String, host : String, port : Int32,
                     verify_upstream : Bool, sni : String? = nil,
@@ -160,8 +174,10 @@ module Gori
                     overrides : Gori::HostOverrides? = nil,
                     preserve_field_case : Bool = false) : Result
         started = Time.instant
-        upstream = open(scheme, host, port, verify_upstream, sni, timeout, overrides)
-        return failure(connect_error(scheme, host, port, verify_upstream), started) unless upstream
+        upstream, dial_failure = open(scheme, host, port, verify_upstream, sni, timeout, overrides)
+        unless upstream
+          return failure(connect_error(scheme, host, port, verify_upstream, dial_failure), started)
+        end
         begin
           headers, body = parse_request(request, scheme, host, port, preserve_field_case)
           exchange(upstream, headers, body, host, port, started, timeout)
@@ -192,8 +208,10 @@ module Gori
                            host : String, port : Int32, verify_upstream : Bool, sni : String? = nil,
                            timeout : Time::Span? = nil, overrides : Gori::HostOverrides? = nil) : Result
         started = Time.instant
-        upstream = open(scheme, host, port, verify_upstream, sni, timeout, overrides)
-        return failure(connect_error(scheme, host, port, verify_upstream), started) unless upstream
+        upstream, dial_failure = open(scheme, host, port, verify_upstream, sni, timeout, overrides)
+        unless upstream
+          return failure(connect_error(scheme, host, port, verify_upstream, dial_failure), started)
+        end
         begin
           exchange(upstream, fields, body, host, port, started, timeout)
         rescue ex
@@ -272,6 +290,16 @@ module Gori
         if violation = flow.violation
           parts << violation unless parts.empty?
         end
+        # Appended AFTER the violation gate on purpose: that gate deliberately reports a
+        # §6.9.1 violation only as a clause on something that already went wrong, and a late
+        # 1xx must not quietly promote it into a standalone failure. This one DOES stand
+        # alone — the response is intact and correct, and the violation is the finding.
+        if late = reply.late_interim
+          parts << "the origin sent an interim #{late} header block AFTER its final response " \
+                   "(RFC 9110 §15.2: a 1xx precedes the final response, it is not one). The " \
+                   "1xx and its fields were discarded; the status, headers and body reported " \
+                   "here are the final response's"
+        end
         parts.empty? ? nil : parts.join(" — ")
       end
 
@@ -343,23 +371,52 @@ module Gori
         (v = flow.violation) ? "#{base} — #{v}" : base
       end
 
+      # Why `open` produced no socket — the two facts the old bare `IO?` return could not
+      # carry, and whose absence made `connect_error` guess.
+      #
+      # `dial_error` is the dialer's own account, the same `DialError` the h1 engine hands
+      # `Repeater::Engine.connect_error`. `alpn` is set ONLY when the dial SUCCEEDED and the
+      # origin then selected something other than h2 — the one failure of the four that gori
+      # OBSERVED rather than inferred — and is the empty string when the origin offered no
+      # ALPN protocol at all. Exactly one of the two is ever set.
+      private record DialFailure,
+        dial_error : Proxy::Upstream::DialError? = nil,
+        alpn : String? = nil
+
+      # Open the connection an h2 send needs, or say why there isn't one.
+      #
+      # `dial_tls_result` / `dial_result` rather than the nil-returning `dial_tls` / `dial`:
+      # the nil variants discard `DialErrorKind` before any caller can ask, which is why four
+      # distinct failures — nothing listening, an untrusted certificate, a plaintext port
+      # addressed as https, and an origin whose ALPN offers only http/1.1 — arrived at the
+      # operator as one sentence while the same tab one `^V` away named three of them.
       private def self.open(scheme : String, host : String, port : Int32, verify : Bool,
                             sni : String? = nil, timeout : Time::Span? = nil,
-                            overrides : Gori::HostOverrides? = nil) : IO?
+                            overrides : Gori::HostOverrides? = nil) : {IO?, DialFailure?}
         ct = timeout || Settings.connect_timeout
         it = timeout || Settings.io_timeout
         if scheme == "https"
-          ssl = Proxy::Upstream.dial_tls(host, port, verify: verify, alpn: "h2", sni: sni, connect_timeout: ct, io_timeout: it, overrides: overrides)
-          return nil unless ssl
+          ssl, err = Proxy::Upstream.dial_tls_result(host, port, verify: verify, alpn: "h2",
+            sni: sni, connect_timeout: ct, io_timeout: it, overrides: overrides)
+          unless ssl
+            return {nil, DialFailure.new(dial_error: err || Proxy::Upstream::DialError::ORIGIN_UNREACHABLE)}
+          end
           # Origin completed the handshake but won't speak h2 — close the live
           # socket before bailing, else it leaks (it's never returned to `ensure`).
-          unless ssl.alpn_protocol == "h2"
+          negotiated = ssl.alpn_protocol
+          unless negotiated == "h2"
             ssl.close rescue nil
-            return nil
+            return {nil, DialFailure.new(alpn: negotiated || "")}
           end
-          ssl
+          {ssl, nil}
         else
-          Proxy::Upstream.dial(host, port, connect_timeout: ct, io_timeout: it, overrides: overrides) # h2c prior-knowledge
+          # h2c prior-knowledge. Nothing here can observe whether the origin speaks h2c — a
+          # plaintext port that does not will CONNECT fine and fail later, on the frames — so
+          # a nil socket is a TCP failure and nothing else, and the old "or the origin doesn't
+          # offer HTTP/2 (h2c) here" clause was a guess at a condition this call cannot see.
+          sock, err = Proxy::Upstream.dial_result(host, port, connect_timeout: ct, io_timeout: it,
+            overrides: overrides)
+          sock ? {sock.as(IO), nil} : {nil, DialFailure.new(dial_error: err || Proxy::Upstream::DialError::ORIGIN_UNREACHABLE)}
         end
       end
 
@@ -672,9 +729,10 @@ module Gori
         goaway = flow.goaway # the origin's stated reason for hanging up
         rst = flow.rst       # the origin's stated reason for killing the stream
         trailers = nil.as(Array(String)?)
-        final_seen = false         # the final (non-interim) response header block is absorbed
-        end_stream_pending = false # END_STREAM seen on a HEADERS frame whose block isn't closed yet
-        timed_out = false          # the read ended on an idle timeout, not on a closed socket
+        late_interim = nil.as(Int32?) # a 1xx block that arrived AFTER the final response
+        final_seen = false            # the final (non-interim) response header block is absorbed
+        end_stream_pending = false    # END_STREAM seen on a HEADERS frame whose block isn't closed yet
+        timed_out = false             # the read ended on an idle timeout, not on a closed socket
         pending = flow.pending
         at = 0
         progress = Time.instant # last time stream 1 actually moved
@@ -761,11 +819,10 @@ module Gori
             # status). Defer completion until END_HEADERS.
             end_stream_pending = frame.end_stream?
             if frame.end_headers?
-              status, names = absorb(header_buf, decoder, headers, status)
-              trailers = note_trailers(trailers, names, final_seen)
-              final_seen ||= !interim?(status)
+              status, final_seen, trailers, late_interim =
+                merge_block(header_buf, decoder, headers, status, final_seen, trailers,
+                  late_interim, end_stream_pending)
               done = clean_eos = true if end_stream_pending
-              headers.clear if !end_stream_pending && interim?(status)
             end
           when Frame::Type::Continuation
             next unless frame.stream_id == 1
@@ -773,11 +830,10 @@ module Gori
             break if header_buf.bytesize + frame.payload.size > MAX_HEADER_BLOCK # flood — abort
             header_buf.write(frame.payload)
             if frame.end_headers?
-              status, names = absorb(header_buf, decoder, headers, status)
-              trailers = note_trailers(trailers, names, final_seen)
-              final_seen ||= !interim?(status)
+              status, final_seen, trailers, late_interim =
+                merge_block(header_buf, decoder, headers, status, final_seen, trailers,
+                  late_interim, end_stream_pending)
               done = clean_eos = true if end_stream_pending
-              headers.clear if !end_stream_pending && interim?(status)
             end
           when Frame::Type::Data
             next unless frame.stream_id == 1
@@ -800,7 +856,58 @@ module Gori
         end
 
         Reply.new(status, headers, body.size == 0 ? nil : body.to_slice, clean_eos,
-          goaway, rst, trailers, timed_out, final_seen)
+          goaway, rst, trailers, timed_out, final_seen, late_interim)
+      end
+
+      # Fold one COMPLETED header block into the response being assembled, and decide what the
+      # block IS. Returns the updated `(status, final_seen, trailers, late_interim)`; `headers`
+      # is written through, as `absorb` already did.
+      #
+      # Four shapes reach here and only two of them used to be told apart:
+      #
+      #   1. the final response head            → keep everything
+      #   2. an interim 1xx BEFORE it           → drop its fields (§15.2: they precede the final
+      #                                           response and are not part of it) and keep
+      #                                           waiting; the status is overwritten by the
+      #                                           final block when it comes
+      #   3. a real trailers block after it     → keep the fields, record their NAMES as trailers
+      #   4. an interim 1xx AFTER it            → the origin violated §15.2; drop the block and
+      #                                           report it, do not let it become the response
+      #
+      # 4 was being handled as 2-and-3 at once: `absorb` overwrote the status with the 1xx's,
+      # `note_trailers` filed its field under trailers, and `headers.clear` — guarded on
+      # `interim?(status)` with no `!final_seen` term — then wiped everything the FINAL block
+      # had contributed. A `HEADERS(:status 200, content-type, content-length)` followed by
+      # `HEADERS(:status 103, link)` and the body was reported, and STORED, as a clean
+      # `status: 103` with no headers and the real 200 gone. That is precisely what an h2
+      # response-splitting probe produces, so gori was reporting a successful injection as a
+      # benign informational response.
+      private def self.merge_block(header_buf : IO::Memory, decoder : HPACK::Decoder,
+                                   headers : Array({String, String}), status : Int32,
+                                   final_seen : Bool, trailers : Array(String)?,
+                                   late_interim : Int32?,
+                                   end_stream_pending : Bool) : {Int32, Bool, Array(String)?, Int32?}
+        count_before = headers.size
+        status_before = status
+        status, names = absorb(header_buf, decoder, headers, status)
+        if final_seen
+          if interim?(status)
+            # Shape 4. Drop exactly what THIS block added — not the whole array — and give the
+            # final response its status back. The event itself is not swallowed: `exchange`
+            # turns `late_interim` into a named clause on the Result.
+            late_interim = status
+            headers.pop(headers.size - count_before)
+            status = status_before
+          else
+            trailers = note_trailers(trailers, names, true) # shape 3
+          end
+        else
+          final_seen = !interim?(status)
+          # Shape 2. Not when END_STREAM rode on the interim block itself: the stream is over,
+          # no final response is coming, and `no_response` reports that instead.
+          headers.clear if !end_stream_pending && !final_seen
+        end
+        {status, final_seen, trailers, late_interim}
       end
 
       # Names decoded from a header block that arrived AFTER the final response block are
@@ -1146,21 +1253,39 @@ module Gori
         Result.new(Bytes.new(0), nil, nil, elapsed(started), message)
       end
 
-      # A nil socket here means no usable HTTP/2 connection — could be unreachable,
-      # an origin that doesn't offer h2 over ALPN, or (for verified https) a cert that
-      # failed verification. Spell that out instead of a bare "connect failed".
+      # Why an h2 send has no connection.
       #
-      # The two conditions are SEPARATE. The guard used to be `scheme == "https" && verify`,
-      # so `-k` / MCP `insecure:true` / `gori mcp --insecure-upstream` routed an **https**
-      # target into the h2c `else` and reported a cleartext prior-knowledge diagnosis for a
-      # failed ALPN negotiation — sending the operator after a problem that does not exist,
-      # on the branch they hit most (`-k` is the normal mode against a lab origin). The
-      # transport decides the ALPN wording; verification only adds a clause.
-      private def self.connect_error(scheme : String, host : String, port : Int32, verify : Bool) : String
-        base = "h2 connect failed (no h2 negotiated): #{host}:#{port}"
-        return "#{base} — host unreachable or the origin doesn't offer HTTP/2 (h2c) here" unless scheme == "https"
-        cert = verify ? ", or its TLS certificate failed verification" : ""
-        "#{base} — host unreachable, the origin doesn't offer HTTP/2 via ALPN#{cert}"
+      # This used to build ONE sentence out of `scheme`/`verify` alone — "host unreachable, the
+      # origin doesn't offer HTTP/2 via ALPN, or its TLS certificate failed verification" — for
+      # four failures with four different fixes (firewall/DNS, add the private CA, "this port is
+      # not TLS", "this origin has no h2"), while the same operator one `^V` away got the h1
+      # engine's named refusals for three of them. `open` discarded the dialer's `DialError`
+      # before this could ask, so the collapse was structural, not a wording slip.
+      #
+      # The three transport failures are `Repeater::Engine.connect_error`'s to word, verbatim:
+      # they are not h2 problems at all — a refused TCP connect and an untrusted certificate
+      # fail identically whatever runs on top — and ONE function is what stops an h1 tab and an
+      # h2 tab ever again disagreeing about the same origin. It is also where the dialer's
+      # `detail` (an upstream proxy's own refusal) is already honoured, so that reaches h2 too.
+      #
+      # The fourth is h2's own, and it is the only one of the four gori can state without
+      # hedging: the handshake COMPLETED and the origin named the protocol it picked. It is
+      # also the case an operator hits constantly against a lab or legacy origin, and it was
+      # buried third in a list of three guesses.
+      private def self.connect_error(scheme : String, host : String, port : Int32, verify : Bool,
+                                     failure : DialFailure? = nil) : String
+        if alpn = failure.try(&.alpn)
+          # gori offers `h2` and nothing else, so an origin that speaks only HTTP/1.1 has no
+          # overlap to select and the negotiated protocol comes back EMPTY — that, not a
+          # counter-offer, is what the common case actually looks like on the wire. The
+          # non-empty branch is for an origin that selects a protocol gori never offered,
+          # which is itself worth naming rather than folding into "no h2".
+          picked = alpn.empty? ? "did not accept `h2` over ALPN (the only protocol gori offered)" : "selected ALPN `#{alpn}`, which gori did not offer"
+          return "h2 not negotiated: #{host}:#{port} — the origin completed the TLS handshake " \
+                 "but #{picked}, so it does not speak HTTP/2 here; send this request as " \
+                 "HTTP/1.1 instead, or use h2c (http://) if the origin takes prior-knowledge h2"
+        end
+        Engine.connect_error(scheme, host, port, verify, failure.try(&.dial_error))
       end
 
       private def self.elapsed(started : Time::Instant) : Int64

--- a/src/gori/repeater/ws_engine.cr
+++ b/src/gori/repeater/ws_engine.cr
@@ -123,8 +123,17 @@ module Gori
         # read that times out is the EXPECTED "server went quiet → stop" signal.
         ht = HANDSHAKE_TIMEOUT
         tls = scheme == "https" || scheme == "wss"
-        upstream = tls ? Proxy::Upstream.dial_tls(host, port, verify: verify_upstream, sni: sni, io_timeout: ht, overrides: overrides) : Proxy::Upstream.dial(host, port, io_timeout: ht, overrides: overrides)
-        return err("connect failed: #{host}:#{port}", started) unless upstream
+        # `*_result` rather than the socket-only dial: a WebSocket target fails to come up for
+        # exactly the reasons every other send path fails, and `Engine.connect_error` is where
+        # those sentences live. Dropping the `DialError` here left this one surface saying
+        # "connect failed: host:port" for an untrusted certificate, a plaintext port and an
+        # origin that accepts the connection and then goes silent.
+        upstream, dial_error = if tls
+                                 Proxy::Upstream.dial_tls_result(host, port, verify: verify_upstream, sni: sni, io_timeout: ht, overrides: overrides)
+                               else
+                                 Proxy::Upstream.dial_result(host, port, io_timeout: ht, overrides: overrides)
+                               end
+        return err(Engine.connect_error(scheme, host, port, verify_upstream, dial_error), started) unless upstream
 
         begin
           handshake, keys = build_handshake(upgrade_request, keep_key)

--- a/src/gori/rules.cr
+++ b/src/gori/rules.cr
@@ -15,6 +15,26 @@ module Gori
   # message) and the TUI (which edits the rule set). A Mutex guards the rule snapshot so
   # an edit can never tear a concurrent rewrite.
   class Rules < Proxy::HeadRewriter
+    # Why a `$NAME` in a replacement stopped its rule from applying, and which name did it.
+    #
+    # `substitute` has TWO refusals and they mean opposite things — "declared but no value
+    # yet" and "there IS a value and the head cannot carry it" — and they used to share one
+    # `nil`. `report_unbound` only ever understood the first: it computes
+    # `Env.unbound(rule.replacement)` and returns when that is empty, and a BOUND name is by
+    # definition not unbound. So the boundary refusal fired in total silence — no header on the
+    # wire, no event, no log line, no advisory, no status — and every head-scoped injection rule
+    # in the project simply ceased to exist the moment an origin minted a cookie with a stray
+    # CR in it. That is the origin disarming the operator's test setup invisibly, which is why
+    # the two now carry their reason and their key instead of a shared nil.
+    private enum Refusal
+      Unbound  # declared by an enabled extract rule, no value yet
+      Boundary # bound, and the value carries CR/LF/NUL — see `forges_boundary?`
+    end
+
+    # The key travels with the reason because the event has to name it: a replacement holding
+    # several `$NAME`s makes "the value carries CR" actionable only if it says whose.
+    private record Refused, reason : Refusal, key : String
+
     def initialize(@store : Store, @rules : Array(Store::MatchRule))
       @mutex = Mutex.new
       @stub_bodies = RuleStubBodyCache.new
@@ -449,8 +469,8 @@ module Gori
       # (env.cr) — puts eight meaningless characters on the wire in a credential's place.
       # The operator hears about it through the event feed rather than through a 401.
       repl = replacement_for(rule)
-      unless repl
-        report_unbound(rule) if report
+      if repl.is_a?(Refused)
+        report_refused(rule, repl) if report
         return text
       end
       case rule.op
@@ -480,7 +500,7 @@ module Gori
     # body injection (`Replace` with `part: Body`), static env vars in M&R rules — which
     # simply did not work before — and one syntax everywhere, with no schema change and no
     # new rule kind.
-    private def replacement_for(rule : Store::MatchRule) : String?
+    private def replacement_for(rule : Store::MatchRule) : String | Refused
       repl = rule.replacement
       prefix = Settings.env_prefix
       # The overwhelmingly common case, and the one that must cost nothing: no `$` in the
@@ -524,7 +544,7 @@ module Gori
     # Byte-level for the same reason `Env.expand` is: a BODY replacement can carry bytes
     # that are not valid UTF-8, and `String#chars` would turn each of them into U+FFFD.
     private def substitute(repl : String, prefix : String, vars : Hash(String, String),
-                           declared : Array(String), regex : Bool, head : Bool = false) : String?
+                           declared : Array(String), regex : Bool, head : Bool = false) : String | Refused
       bytes = repl.to_slice
       prefix_bytes = prefix.to_slice
       n = bytes.size
@@ -546,8 +566,8 @@ module Gori
         if parsed = Env.read_key_bytes?(bytes, i + plen, n)
           key, consumed = parsed
           # Declared by an extract rule but not bound yet → the rule must not apply.
-          return nil if !vars.has_key?(key) && declared.includes?(key)
-          return nil if head && forges_boundary?(vars, declared, key)
+          return Refused.new(Refusal::Unbound, key) if !vars.has_key?(key) && declared.includes?(key)
+          return Refused.new(Refusal::Boundary, key) if head && forges_boundary?(vars, declared, key)
           i += emit_key(buf, bytes, vars, key, consumed, prefix, plen, regex)
           next
         end
@@ -628,19 +648,45 @@ module Gori
 
     # One warn event per (rule, binding revision): a rule injecting an unbound `$SESSION`
     # into every proxied request would otherwise write one row per message. The value is
-    # never in the message — only the rule and the name, which is what #491 asked for.
-    private def report_unbound(rule : Store::MatchRule) : Nil
+    # never in the message — only the rule, the name and, for a boundary refusal, which byte
+    # class was found, which is what #491 asked for.
+    #
+    # Keyed on `Env.binding_rev` and not latched forever, so the report self-resets exactly
+    # when it becomes news again: that revision moves on every rebind, every clear and every
+    # extract-rule edit, which is the whole set of events that can change either answer.
+    private def report_refused(rule : Store::MatchRule, refused : Refused) : Nil
       brev = Env.binding_rev
       if brev != @unbound_reported_rev
         @unbound_reported_rev = brev
         @unbound_reported.clear
       end
       return unless @unbound_reported.add?(rule.id)
-      names = Env.unbound(rule.replacement)
-      return if names.empty?
       label = rule.name.presence || rule.pattern
-      @store.insert_event("bindings", "unbound", "warn",
-        "rewrite rule #{label.inspect} not applied: #{Env.token_list(names)} is not bound yet")
+      case refused.reason
+      in Refusal::Unbound
+        names = Env.unbound(rule.replacement)
+        return if names.empty?
+        @store.insert_event("bindings", "unbound", "warn",
+          "rewrite rule #{label.inspect} not applied: #{Env.token_list(names)} is not bound yet")
+      in Refusal::Boundary
+        vars, _ = subst_snapshot
+        classes = Bindings.boundary_bytes(vars[refused.key]? || "")
+        # Empty only if the value changed between the refusal and here, which is a rebind and
+        # therefore a new revision — say nothing rather than name a byte class that is no
+        # longer in the value.
+        return if classes.empty?
+        @store.insert_event("bindings", "boundary_refused", "warn",
+          "rewrite rule #{label.inspect} not applied: #{Env.token_list([refused.key])}'s value " \
+          "carries #{Rules.and_list(classes)} and would forge a message boundary in a header " \
+          "(the value is still bound — a body-scoped rule can carry it)")
+      end
+    end
+
+    # "CR" / "CR and LF" / "CR, LF and NUL". Small enough that reaching for a helper module
+    # would cost more than it saves, and the refusal above is its only caller.
+    def self.and_list(items : Array(String)) : String
+      return items.first? || "" if items.size <= 1
+      "#{items[0..-2].join(", ")} and #{items[-1]}"
     end
 
     # The line terminator a head uses — CRLF for real HTTP, LF as a fallback so a

--- a/src/gori/token_extract.cr
+++ b/src/gori/token_extract.cr
@@ -37,6 +37,16 @@ module Gori
       when "jsonpath", "json", "j" then JsonPath
       end
     end
+
+    # Kinds that can only read the body AS TEXT. Crystal's `Regex` raises `ArgumentError` on
+    # a subject that is not valid UTF-8 and `JSON.parse` wants one too, so both run over a
+    # `#scrub`bed copy of the body — see `TokenExtract.text_lossy?` for what that costs and
+    # `Bindings#run` for who has to say so. The other three read BYTES: `Cookie` and `Header`
+    # off the parsed head, and `Position` off the decoded entity, whose whole meaning is a
+    # byte range.
+    def text_only? : Bool
+      regex? || json_path?
+    end
   end
 
   # Where the token lives in a response. One `selector` string is reused per kind
@@ -126,12 +136,26 @@ module Gori
     end
 
     # A fixed half-open byte range of the decoded body, clamped to its bounds.
+    #
+    # Over the decoded BYTES, not over `decoded_text`. `Position` has no text reading at all —
+    # `body[100...140]` over a gzip stream is forty bytes of DEFLATE, and `bindings.cr` says so
+    # verbatim — so running the range over a `#scrub`bed String made every offset past an
+    # invalid byte slide by two, U+FFFD being three bytes where the invalid one was one. One
+    # origin response then gave a cookie descriptor the origin's `41 42 FF 43 44` and this one
+    # five DIFFERENT bytes for the same value, which is exactly the disagreement
+    # `bindings.cr` rules out: "the same `TokenLoc` on the same response has to mean one
+    # thing whether a Repeater send or the proxy saw it".
+    #
+    # The slice is handed to `String.new` unscrubbed. A `String` holding invalid UTF-8 survives
+    # every consumer of a bound value, and each of them says so where it is written:
+    # `Env.mask_secrets`, `Rules#substitute` and `Bindings.boundary_forging?` are all
+    # byte-level, and the store never sees a value at all.
     def self.position(raw : Repeater::Result, a : Int32, b : Int32) : String?
-      text = decoded_text(raw)
-      lo = a.clamp(0, text.bytesize)
-      hi = b.clamp(0, text.bytesize)
+      body = decoded_bytes(raw)
+      lo = a.clamp(0, body.size)
+      hi = b.clamp(0, body.size)
       return nil if hi <= lo
-      String.new(text.to_slice[lo...hi]).scrub
+      String.new(body[lo...hi])
     end
 
     # A leaf value at a dotted/bracketed path into a JSON body. Supports `$`, `.key`,
@@ -240,9 +264,30 @@ module Gori
       acc
     end
 
-    private def self.decoded_text(raw : Repeater::Result) : String
+    # The decoded entity, byte-exact (gzip/br/zstd handled through the same seam
+    # `Fuzz::Matcher` uses, so the two cannot disagree). What every BYTE-scoped reading gets.
+    private def self.decoded_bytes(raw : Repeater::Result) : Bytes
       decoded, _ = Proxy::Codec::ContentDecode.decode(raw.head, raw.body)
-      String.new(decoded || raw.body || Bytes.empty).scrub
+      decoded || raw.body || Bytes.empty
+    end
+
+    # The decoded entity read as TEXT, repaired so `Regex` and `JSON.parse` can run over it.
+    # Only `text_only?` kinds come through here; `text_lossy?` is how a caller learns that the
+    # repair happened and that the value it just got is not the origin's bytes.
+    private def self.decoded_text(raw : Repeater::Result) : String
+      String.new(decoded_bytes(raw)).scrub
+    end
+
+    # Whether reading this response's body as TEXT changes its bytes — i.e. the decoded entity
+    # is not valid UTF-8, so a `text_only?` descriptor necessarily ran over a `#scrub`bed copy
+    # in which every invalid byte became U+FFFD. The value such a descriptor returns is then
+    # NOT what the origin sent, and a caller that BINDS it has to say so rather than bind
+    # different bytes silently.
+    #
+    # `valid_encoding?` and not a scrub-and-compare: 9 µs against 130 µs on a valid 40 KB body,
+    # and this is asked once per response a rule has already claimed.
+    def self.text_lossy?(raw : Repeater::Result) : Bool
+      !String.new(decoded_bytes(raw)).valid_encoding?
     end
   end
 end

--- a/src/gori/tui/controllers/fuzzer_controller.cr
+++ b/src/gori/tui/controllers/fuzzer_controller.cr
@@ -120,12 +120,15 @@ module Gori::Tui
       stop = Hotkeys.binding_label(reg, "fuzz.stop", "^X")
       mark = Hotkeys.binding_label(reg, "fuzz.automark", "^A")
       read_common = "⇧arrows select · #{y} copy · space cmds"
+      sni = Hotkeys.binding_label(reg, "fuzz.toggle-sni", "^S")
       case v.focus
       when :target
-        if v.target_insert?
-          "type URL · ↵/↓ template · #{run} run · ↹ pane · esc read"
+        if v.editing_sni?
+          "type SNI · #{sni}/↵/esc URL · #{run} run"
+        elsif v.target_insert?
+          "type URL · #{sni} SNI · ↵/↓ template · #{run} run · ↹ pane · esc read"
         else
-          "i/↵ edit · #{read_common} · #{run} run · ↹ pane · esc tabs"
+          "i/↵ edit · #{read_common} · #{sni} SNI · #{run} run · ↹ pane · esc tabs"
         end
       when :template
         if v.template_insert?
@@ -222,6 +225,8 @@ module Gori::Tui
       return v.discard_chain_pane if v.chain_pane_active? # esc in the CHAIN pane → cancel + back (^Y again saves)
       if v.focus == :template && v.template_insert?
         v.exit_template_insert!
+      elsif v.focus == :target && v.editing_sni?
+        v.exit_sni_field # leave the SNI field, back to the URL (value kept)
       elsif v.focus == :target && v.target_insert?
         v.exit_target_insert!
       elsif v.focus == :detail
@@ -257,6 +262,19 @@ module Gori::Tui
         @host.status(err)
       else
         @host.status("pretty-printed template request body")
+      end
+    end
+
+    # ^S on the TARGET pane: edit the TLS SNI the whole sweep presents, leaving the dialed
+    # host alone. Same chord, same focus rule and same status wording as the Repeater's — a
+    # fuzz session seeded from History (⇧I) could otherwise never set one, so an https vhost
+    # sweep always presented the dialed IP.
+    def fuzz_toggle_sni : Nil
+      if (view = current_view) && view.focus == :target
+        view.toggle_sni_field
+        @host.status(view.editing_sni? ? "SNI override: type a domain · ^S/↵/esc back to URL" : "editing target URL")
+      else
+        @host.status("SNI override (^S) applies to the TARGET pane — ↹ to it")
       end
     end
 
@@ -315,6 +333,10 @@ module Gori::Tui
     end
 
     private def edit_target(ev : Termisu::Event::Key, v : FuzzerView) : Bool
+      if v.editing_sni?
+        edit_sni(ev, v)
+        return true
+      end
       return handle_target_read(ev, v) unless v.target_insert?
       key = ev.key
       case
@@ -323,6 +345,19 @@ module Gori::Tui
       else                            edit_target_common(ev, v)
       end
       true
+    end
+
+    # The SNI override sub-field: same single-line editing (the view's target mutators
+    # self-route to it while editing_sni?), but ↵/↑ return to the URL row rather than
+    # advancing panes, and ↓ still drops into the TEMPLATE pane below. Mirrors
+    # `RepeaterController#edit_repeater_sni`.
+    private def edit_sni(ev : Termisu::Event::Key, v : FuzzerView) : Nil
+      key = ev.key
+      case
+      when key.enter?, key.up? then v.exit_sni_field
+      when key.down?           then v.pane_advance(1)
+      else                          edit_target_common(ev, v)
+      end
     end
 
     private def handle_target_read(ev : Termisu::Event::Key, v : FuzzerView) : Bool

--- a/src/gori/tui/controllers/repeater_controller.cr
+++ b/src/gori/tui/controllers/repeater_controller.cr
@@ -827,7 +827,7 @@ module Gori::Tui
           @host.session.store.update_repeater_response(id, result.head, result.body, result.error, result.duration_us)
           probe_scan_repeater(id, result.head, result.body, result.duration_us, tab.flow_id, view)
         end
-        @host.status(result.ok? ? "sent → #{result.response.try(&.status)} in #{result.duration_us // 1000}ms#{result.incomplete? ? " (incomplete)" : ""}" : "repeater error: #{result.error}")
+        @host.status(result.ok? ? "sent → #{result.response.try(&.status)} in #{result.duration_us // 1000}ms#{result.incomplete? ? " (incomplete)" : ""}#{evidence_literal_note(view)}" : "repeater error: #{result.error}")
         applied = true
       end
       while pair = nonblocking_ws_result
@@ -1450,6 +1450,40 @@ module Gori::Tui
     private def current_repeater_tab : RepeaterTab?
       return nil if @current_repeater_idx < 0 || @current_repeater_idx >= @repeaters.size
       @repeaters[@current_repeater_idx]
+    end
+
+    # " · $CTOK sent literally (evidence tab — not substituted)" when an EVIDENCE tab just
+    # put a declared, BOUND session binding on the wire unresolved, or "" otherwise.
+    #
+    # `Sender#evidence?` suppresses `Env.expand_bindings` on a captured request on purpose —
+    # a capture's `$filter` is a byte the origin saw, not a reference — and its own comment
+    # accepts the cost as "the direction that can only be READ WRONG, never SENT wrong". That
+    # holds for the SUBSTITUTION. It does not hold for the REPORT: `✓ sent → 200` with no
+    # further word is gori claiming a clean send of bytes whose `$CTOK` the tab's OWN binding
+    # hint shows a value for. So the expansion stays suppressed and the fact is stated.
+    private def evidence_literal_note(view : RepeaterView) : String
+      names = RepeaterController.literal_bindings(view.evidence?, view.request_text)
+      return "" if names.empty?
+      " · #{Env.token_list(names)} sent literally (evidence tab — not substituted)"
+    end
+
+    # `self.` and pure so the rule is directly testable, the same reason
+    # `MCP::Tools.send_error_code` is: what an operator is told about their own send hangs
+    # off this predicate, and a Host double is not the thing worth building to pin it.
+    #
+    # Matched on the SPECIFIC declared name (`$CTOK`), not on the `$`+`[A-Za-z_]` shape,
+    # which is why the whole request rather than the head alone is safe to scan — the same
+    # argument `Env.expand_bindings` makes for scanning a body: a chance collision with a
+    # declared name in binary bytes is a 2^-56 event, not the ~3-per-4KB one the head/body
+    # split exists for. And these are exactly the bytes `expand_bindings` would have
+    # rewritten, so the two cannot disagree about what was withheld. An UNBOUND declared
+    # name is deliberately not reported: nothing would have been substituted for it on any
+    # surface, so there is no divergence to name (`Sender#refusal` owns that case).
+    def self.literal_bindings(evidence : Bool, text : String) : Array(String)
+      return [] of String unless evidence
+      prefix = Gori::Settings.env_prefix
+      return [] of String if prefix.empty?
+      Env.binding_values.keys.select { |n| text.includes?("#{prefix}#{n}") }.sort!
     end
 
     # The scope decision Repeater's direct sends (^R, send-group, WS, minimize) dial through.

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -75,6 +75,8 @@ module Gori::Tui
       @target = ""
       @tcx = 0
       @sni = ""
+      @scx = 0             # caret in the SNI row (@tcx is the URL row's)
+      @target_field = :url # which field the TARGET pane edits: :url | :sni
       @http2 = false
       @evidence = false
       @editor = TextArea.new
@@ -217,6 +219,7 @@ module Gori::Tui
       @http2 = built.http2
       @target = built.target
       @tcx = @target.size
+      @target_field = :url
       @editor.set_text(String.new(built.bytes).scrub)
       @evidence = true
       @focus = :template
@@ -229,6 +232,8 @@ module Gori::Tui
       @tcx = target.size
       @http2 = http2
       @sni = sni
+      @scx = @sni.size
+      @target_field = :url
       @editor.set_text(request_text)
       # A Repeater/reconstruction seed and ^N are DRAFTS: the operator authored (or gori
       # rebuilt) those bytes, so a `$KEY` in them is a variable reference they meant.
@@ -252,6 +257,8 @@ module Gori::Tui
       @tcx = rec.target.size
       @http2 = rec.http2?
       @sni = rec.sni || ""
+      @scx = @sni.size
+      @target_field = :url
       @editor.set_text(rec.template)
       # Provenance has to survive a restart, or a reopened capture silently becomes a
       # draft again. `flow_id` is what `insert_fuzz_session` already stored for the ⇧I
@@ -274,6 +281,8 @@ module Gori::Tui
       @tcx = @target.size
       @http2 = rec.http2?
       @sni = rec.sni || ""
+      @scx = @sni.size
+      @target_field = :url
       # set_text zeroes the caret/scroll and clears undo, so it must only run on a REAL text
       # change. The compare is EXACT (`wire_text` is set_text's byte-for-byte inverse), the
       # same test RepeaterView#apply_request_fields makes: the template is persisted in wire
@@ -372,37 +381,45 @@ module Gori::Tui
     end
 
     # --- focus ring ----------------------------------------------------------
+    # Every focus change exits the ^S SNI sub-field — the rule `RepeaterView#set_focus`
+    # states: SNI editing is an explicit per-visit sub-mode, so navigating away while in it
+    # and coming back must not silently route URL keystrokes into @sni.
     def focus_first : Nil
-      @focus = :target
+      set_focus(:target)
     end
 
     def focus_last : Nil
-      @focus = :results
+      set_focus(:results)
     end
 
     def focus_pane(pane : Symbol) : Nil
       return unless PANE_ORDER.includes?(pane)
       commit_chain_pane if @chain_focused
-      @focus = pane
+      set_focus(pane)
     end
 
     def focus_config : Nil
       commit_chain_pane if @chain_focused
-      @focus = :config
+      set_focus(:config)
       @cfg_row = 0 # land on the first payload set / the Add row
     end
 
     def pane_advance(dir : Int32) : Bool
       commit_chain_pane if @chain_focused
       if @focus == :detail
-        @focus = :results
+        set_focus(:results)
         return true
       end
       i = PANE_ORDER.index(@focus) || 0
       ni = i + dir
       return false if ni < 0 || ni >= PANE_ORDER.size
-      @focus = PANE_ORDER[ni]
+      set_focus(PANE_ORDER[ni])
       true
+    end
+
+    private def set_focus(pane : Symbol) : Nil
+      @focus = pane
+      @target_field = :url
     end
 
     def at_top? : Bool
@@ -1375,39 +1392,86 @@ module Gori::Tui
     end
 
     # --- target editing ------------------------------------------------------
+    # The TARGET card holds two single-line fields — the URL and the TLS SNI override —
+    # selected by @target_field (^S toggles), exactly as RepeaterView's does. The mutators
+    # below self-route, so the controller's key handling is the same for both rows.
+    #
+    # The knob was already whole here: `@sni` is persisted with the session, restored,
+    # compared by the reconcile, cloned by Duplicate and handed to `build_engine`. Only the
+    # AFFORDANCE was missing, so a fuzz session seeded from History (⇧I) could never present
+    # anything but the dialed IP — an https vhost sweep is exactly the run that needs one,
+    # and the sole working route was to open the request in the Repeater, set SNI there, and
+    # hand it back with `space ▸ Send to Fuzzer`.
+    def editing_sni? : Bool
+      @target_field == :sni
+    end
+
+    def toggle_sni_field : Nil
+      if @target_field == :sni
+        @target_field = :url
+      else
+        @target_field = :sni
+        @scx = @sni.size
+        @target_mode = InputMode::Insert
+      end
+    end
+
+    # Drop back to URL editing (↵/↑/esc in the SNI field) without changing the value.
+    def exit_sni_field : Nil
+      @target_field = :url
+    end
+
     def target_insert(ch : Char) : Nil
-      @target = "#{@target[0, @tcx]}#{ch}#{@target[@tcx..]}"
-      @tcx += 1
+      if @target_field == :sni
+        @sni = "#{@sni[0, @scx]}#{ch}#{@sni[@scx..]}"
+        @scx += 1
+      else
+        @target = "#{@target[0, @tcx]}#{ch}#{@target[@tcx..]}"
+        @tcx += 1
+      end
       @dirty = true
     end
 
     def target_backspace : Nil
-      return if @tcx == 0
-      @target = "#{@target[0, @tcx - 1]}#{@target[@tcx..]}"
-      @tcx -= 1
+      if @target_field == :sni
+        return if @scx == 0
+        @sni = "#{@sni[0, @scx - 1]}#{@sni[@scx..]}"
+        @scx -= 1
+      else
+        return if @tcx == 0
+        @target = "#{@target[0, @tcx - 1]}#{@target[@tcx..]}"
+        @tcx -= 1
+      end
       @dirty = true
     end
 
     def target_move(d : Int32) : Nil
-      @tcx = (@tcx + d).clamp(0, @target.size)
+      if @target_field == :sni
+        @scx = (@scx + d).clamp(0, @sni.size)
+      else
+        @tcx = (@tcx + d).clamp(0, @target.size)
+      end
     end
 
     def target_home : Nil
-      @tcx = 0
+      @target_field == :sni ? (@scx = 0) : (@tcx = 0)
     end
 
     def target_end : Nil
-      @tcx = @target.size
+      @target_field == :sni ? (@scx = @sni.size) : (@tcx = @target.size)
     end
 
     def target_read_move(dc : Int32, selecting : Bool = false) : Nil
       return if target_insert?
-      cx = @target_read.move_cx(@tcx, dc, @target.size, selecting: selecting)
-      @tcx = cx
+      if @target_field == :sni
+        @scx = @target_read.move_cx(@scx, dc, @sni.size, selecting: selecting)
+      else
+        @tcx = @target_read.move_cx(@tcx, dc, @target.size, selecting: selecting)
+      end
     end
 
     def target_copy_text : String
-      @target_read.copy_text(@target, @tcx)
+      @target_field == :sni ? @target_read.copy_text(@sni, @scx) : @target_read.copy_text(@target, @tcx)
     end
 
     # --- template editing ----------------------------------------------------
@@ -1644,7 +1708,7 @@ module Gori::Tui
         TrafficEmptyState.render(screen, rect, variant: :fuzzer, title: "no request loaded")
         return
       end
-      target_h = {rect.h, 3}.min
+      target_h = {rect.h, target_card_h}.min
       render_target(screen, Rect.new(rect.x, rect.y, rect.w, target_h), focused && @focus == :target)
       rest = Rect.new(rect.x, rect.y + target_h, rect.w, {rect.h - target_h, 0}.max)
       return if rest.h <= 0
@@ -1706,6 +1770,26 @@ module Gori::Tui
       insert ? Theme.accent : Theme.focus_gold
     end
 
+    # The TARGET card grows to a second content row (4 high vs 3) whenever an SNI override is
+    # set OR is being edited, so the override is always visible and the input row only
+    # appears once you reach for it (^S). Same rule and same numbers as RepeaterView.
+    private def sni_active? : Bool
+      !@sni.strip.empty? || (editing_sni? && @focus == :target)
+    end
+
+    private def target_card_h : Int32
+      sni_active? ? 4 : 3
+    end
+
+    # The TARGET card row prefixes (marker + the field value 1 col to its right). Constants
+    # so render_target and the click→caret mapping agree on the value base.
+    TARGET_PREFIX = "›"
+    SNI_PREFIX    = "SNI ›"
+
+    private def field_base(rect : Rect, prefix : String) : Int32
+      rect.x + 2 + prefix.size + 1
+    end
+
     private def render_target(screen : Screen, rect : Rect, focused : Bool) : Nil
       return if rect.h < 2
       ins = focused && target_insert?
@@ -1716,25 +1800,37 @@ module Gori::Tui
         bx = {rect.right - badge.size - 1, rect.x + 9}.max
         screen.text(bx, rect.y, badge, Theme.text_bright, Theme.accent_bg)
       end
-      base = rect.x + 4
-      screen.text(rect.x + 2, rect.y + 1, "›", focused ? Theme.accent : Theme.muted)
-      tw = {rect.right - base - 1, 1}.max
-      if focused && !ins
-        if span = @target_read.selection_span(@tcx)
-          paint_char_span_bg(screen, base, rect.y + 1, @target, span[0], span[1], Theme.accent_bg)
+      draw_target_row(screen, rect, rect.y + 1, TARGET_PREFIX, @target, @tcx,
+        focused && @target_field == :url, ins)
+      if sni_active? && rect.h >= 4
+        draw_target_row(screen, rect, rect.y + 2, SNI_PREFIX, @sni, @scx,
+          focused && @target_field == :sni, ins)
+      end
+    end
+
+    # One single-line field row of the TARGET card: a marker prefix, then the value, with the
+    # block caret + terminal cursor when this row is the active field. Mirrors
+    # RepeaterView#draw_target_row, including the `Screen.draw_width` caret measure that
+    # `target_click_to_cursor`'s `Screen.column_for` inverts and that `paint_char_span_bg`
+    # uses for the selection tint — the three-way agreement `display_width` broke on a value
+    # holding a zero-width char.
+    private def draw_target_row(screen : Screen, rect : Rect, row : Int32, prefix : String, value : String,
+                                cx : Int32, active : Bool, insert : Bool) : Nil
+      screen.text(rect.x + 2, row, prefix, active ? Theme.accent : Theme.muted)
+      base = field_base(rect, prefix)
+      w = {rect.right - base - 1, 1}.max
+      if active && !insert
+        if span = @target_read.selection_span(cx)
+          paint_char_span_bg(screen, base, row, value, span[0], span[1], Theme.accent_bg)
         end
       end
-      Highlight.draw(screen, base, rect.y + 1, Highlight.env_line(@target, Theme.text_bright), width: tw)
-      if focused
-        # column_width — same three-way agreement as RepeaterView#render_target: it matches
-        # paint_char_span_bg (the selection tint, just above) and inverts the
-        # Screen.column_for in target_click_to_cursor. display_width put the caret a column
-        # left of its glyph on a target holding a zero-width char.
-        cx = base + Screen.draw_width(@target[0, @tcx])
-        if cx < rect.right - 1
-          ch = @tcx < @target.size ? @target[@tcx] : ' '
-          screen.cell(cx, rect.y + 1, ch, Theme.bg, ins ? Theme.accent : Theme.accent_bg)
-          screen.cursor(cx, rect.y + 1)
+      Highlight.draw(screen, base, row, Highlight.env_line(value, Theme.text_bright), width: w)
+      if active
+        cursor_x = base + Screen.draw_width(value[0, cx])
+        if cursor_x < rect.right - 1
+          ch = cx < value.size ? value[cx] : ' '
+          screen.cell(cursor_x, row, ch, Theme.bg, insert ? Theme.accent : Theme.accent_bg)
+          screen.cursor(cursor_x, row)
         end
       end
     end
@@ -2499,8 +2595,16 @@ module Gori::Tui
     # base mirrors render_target (the "›" marker at rect.x+2, the value at rect.x+4).
     def target_click_to_cursor(rect : Rect, mx : Int32, my : Int32) : Nil
       return unless @loaded
-      base = rect.x + 4
-      @tcx = Screen.column_for(@target, mx - base)
+      # Row 2 is the SNI field when it is showing — a click there selects that field, the
+      # same mapping RepeaterView#target_click_to_cursor makes, so the caret cannot land on
+      # the row the click did not point at.
+      if sni_active? && my == rect.y + 2
+        @target_field = :sni
+        @scx = Screen.column_for(@sni, mx - field_base(rect, SNI_PREFIX))
+      else
+        @target_field = :url
+        @tcx = Screen.column_for(@target, mx - field_base(rect, TARGET_PREFIX))
+      end
     end
 
     # Mouse: place the TEMPLATE editor caret at a click. Re-derives the template
@@ -2508,7 +2612,7 @@ module Gori::Tui
     # left half → the card's 1-cell inset), so the caret lands where the click points.
     def template_click_to_cursor(rect : Rect, mx : Int32, my : Int32) : Nil
       return unless @loaded
-      target_h = {rect.h, 3}.min
+      target_h = {rect.h, target_card_h}.min
       rest = Rect.new(rect.x, rect.y + target_h, rect.w, {rect.h - target_h, 0}.max)
       return if rest.h <= 0
       top_h = {rest.h * 45 // 100, 5}.max
@@ -2537,7 +2641,7 @@ module Gori::Tui
     # sidebar). nil when the layout leaves no room. Backs results_row_at hit-testing.
     private def results_rect(rect : Rect) : Rect?
       return nil unless @loaded
-      target_h = {rect.h, 3}.min
+      target_h = {rect.h, target_card_h}.min
       rest = Rect.new(rect.x, rect.y + target_h, rect.w, {rect.h - target_h, 0}.max)
       return nil if rest.h <= 0
       top_h = {rest.h * 45 // 100, 5}.max
@@ -2567,7 +2671,7 @@ module Gori::Tui
     # render_template. Miss → nil (caller falls through to caret/focus).
     def template_chrome_hit(rect : Rect, mx : Int32, my : Int32) : Symbol?
       return nil unless @loaded
-      target_h = {rect.h, 3}.min
+      target_h = {rect.h, target_card_h}.min
       rest = Rect.new(rect.x, rect.y + target_h, rect.w, {rect.h - target_h, 0}.max)
       return nil if rest.h <= 0
       top_h = {rest.h * 45 // 100, 5}.max
@@ -2589,14 +2693,14 @@ module Gori::Tui
     # Hit-test the TARGET border NOR/INS chip. Geometry matches render_target.
     def target_chrome_hit(rect : Rect, mx : Int32, my : Int32) : Symbol?
       return nil unless @loaded
-      target_h = {rect.h, 3}.min
+      target_h = {rect.h, target_card_h}.min
       return nil if target_h < 2 || my != rect.y
       Frame.mode_badge_hit(mx, my, rect.y, rect.right - 1, rect.x + 8, target_insert?) ? :mode : nil
     end
 
     def pane_at(rect : Rect, mx : Int32, my : Int32) : Symbol?
       return nil unless @loaded && rect.contains?(mx, my)
-      target_h = {rect.h, 3}.min
+      target_h = {rect.h, target_card_h}.min
       return :target if my < rect.y + target_h
       rest = Rect.new(rect.x, rect.y + target_h, rect.w, {rect.h - target_h, 0}.max)
       return nil if rest.h <= 0

--- a/src/gori/tui/help_view.cr
+++ b/src/gori/tui/help_view.cr
@@ -97,6 +97,7 @@ module Gori::Tui
         Item.new("⇧arrows", "select text (line or char)"),
         Item.new("^A · ^K · ^T · ^U", "auto-mark params · mark word · mark point (manual §) · clear §"),
         Item.new("^V", "toggle transport HTTP/1.1 ↔ HTTP/2"),
+        Item.new("^S", "SNI override (on the target)", "fuzz.toggle-sni"),
         Item.new("^O", "focus the config pane (payload sets · Mode · Advanced · Run)"),
         Item.new("config", "↑/↓ rows · ↵ edit a set / Add / Advanced / Run · ←/→ Mode · Del remove a set"),
         Item.new("^L", "add a List payload set (one value per line, paste splits)"),

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -1525,9 +1525,10 @@ module Gori::Tui
         end
         screen.text(time_x, y, fmt_time(row.created_at), Theme.muted, bg)
         screen.text(method_x, y, row.method, Theme.method_color(row.method), bg)
-        # PROTO: surface WS/GRPC/SSE (accented so they pop out of the HTTP stream);
-        # plain HTTP flows keep showing the scheme (HTTP/HTTPS) — the plaintext-vs-TLS
-        # signal — since there is nothing else worth flagging on them.
+        # PROTO: surface WS/GRPC/SSE (accented so they pop out of the HTTP stream), each
+        # carrying the plaintext-vs-TLS signal the HTTP/HTTPS pair has always carried —
+        # `Proto::Kind#label` owns that spelling, because a bare WS tag REPLACED the scheme
+        # and made a `ws://` row and a `wss://` row byte-identical here.
         kind = Proto.classify(row.status, row.content_type)
         # A short-circuited flow says so IN the PROTO column, replacing HTTP/HTTPS (#511).
         # That column already answers "what kind of exchange was this", and for a stub the
@@ -1538,7 +1539,7 @@ module Gori::Tui
         # scheme is still on the row's URL and in the detail pane. Yellow, like #507's
         # `bypass:N` chip — "you are not seeing what you think", not a blocked/failed state.
         stub = row.short_circuited?
-        proto_label = stub ? "STUB" : (kind.http? ? row.scheme.upcase : kind.label)
+        proto_label = stub ? "STUB" : kind.label(row.scheme)
         proto_color = stub ? Theme.yellow : (kind.http? ? Theme.muted : Theme.accent)
         screen.text(proto_x, y, proto_label, proto_color, bg)
         screen.text(host_x, y, row.host, fg, bg, width: host_w) if host_w > 0

--- a/src/gori/tui/runner/fuzzer.cr
+++ b/src/gori/tui/runner/fuzzer.cr
@@ -63,6 +63,10 @@ class Gori::Tui::Runner < Gori::Verb::ExecContext
     fuzzer_controller.fuzz_toggle_http2
   end
 
+  def fuzz_toggle_sni : Nil
+    fuzzer_controller.fuzz_toggle_sni
+  end
+
   def fuzz_clear_marks : Nil
     fuzzer_controller.fuzz_clear_marks
   end

--- a/src/gori/verb/context/fuzzer.cr
+++ b/src/gori/verb/context/fuzzer.cr
@@ -3,6 +3,7 @@
 abstract class Gori::Verb::ExecContext
   abstract def fuzz_pretty_template : Nil
   abstract def fuzz_toggle_http2 : Nil # flip the fuzz transport h1↔h2 (override seed protocol)
+  abstract def fuzz_toggle_sni : Nil   # edit the TLS SNI the sweep presents (TARGET pane; dialed host unchanged)
 
   # fuzzer workbench (run/stop/marking handled inline; these power the palette + cross-tab)
   abstract def fuzz_selected : Nil            # send History's selection to the Fuzzer tab

--- a/src/gori/verbs/history.cr
+++ b/src/gori/verbs/history.cr
@@ -530,6 +530,16 @@ module Gori
       r.register Verb::Definition.new(
         "fuzz.clear-marks", "Clear markers", "Strip every §…§ marker (and its attached chain) from the template",
         Verb::Scope::Fuzzer, available: in_fuzzer, mnemonic: 'e', section: :template) { |ctx| ctx.fuzz_clear_marks; nil }
+      # Target-pane toggle (SNI override), the twin of repeater.toggle-sni: same ^S, same
+      # two-line editor, same focus rule. `FuzzerView` already carried @sni, persisted it
+      # with the session and handed it to build_engine — a session seeded from History had
+      # no way to REACH it, so an https vhost sweep always presented the dialed IP.
+      # 'i' (from SNI), not 's': 's' is fuzz.stop in Fuzzer COMMON, and COMMON renders
+      # alongside every section (see fuzz.find-subtab's 'f' for the same trade).
+      r.register Verb::Definition.new(
+        "fuzz.toggle-sni", "Toggle SNI override", "Override the TLS SNI the whole sweep presents (dialed host unchanged)",
+        Verb::Scope::Fuzzer, [Verb::Chord.new("s", ctrl: true)],
+        available: in_fuzzer, mnemonic: 'i', section: :target) { |ctx| ctx.fuzz_toggle_sni; nil }
       in_fuzzer_read = ->(ctx : Verb::ExecContext) { ctx.current_tab == :fuzzer && ctx.fuzzer_read_mode? }
       # The single smart Copy (see repeater.copy above) — copy-all is gone.
       r.register Verb::Definition.new(


### PR DESCRIPTION
Round 5. Four hunters, 15 defects, six parallel fixers. Three of the fifteen are regressions from round 4's own two PRs, and one is a defect in a round-4 *fix* that a grep missed.

## A live session credential went out on the redirect hop

Round 4 taught the fuzzer to exclude an operator's payload from session-binding substitution — so a payload that happens to read `$TOKEN` stays `$TOKEN` on the wire. `follow_redirects` then called the **one-argument** `Backend#send`, and the exclusion was lost at the hop. Against an origin that reflects a query parameter into `Location` — an ordinary login/redirect endpoint, and precisely what an open-redirect probe targets — gori put the live credential into the target's query string and access log, while every surface still showed `$TOKEN` and reported `0 errors`.

The fix passes a whole-message exclusion rather than recomputing spans: the origin may have re-encoded or moved the payload on its way through `Location`, so re-locating it is guesswork with a credential as the stake, and every byte of a redirect request is either gori's own or the origin's.

## The same positional-argument defect, at the site the last sweep missed

`Result` gained three same-typed `Bool`s, one per round, from three different fixers. Twice a call site written against the previous arity kept compiling and wrote its `true` into the field that had displaced the one it meant — `as_retried` in round 4, `follow_redirects` in round 5, the latter still reporting `0 errors` while a row lost its re-send marker and gained a `timed_out` nothing had observed. The round-4 grep missed the second site because the call spanned two lines and the sweep counted commas on the first.

The tail is now keyword-only. The compiler is the sweep.

## Half a POST sweep was never sent, and the rows blamed the origin

The pool's checkout probe sees the peer's FIN, deliberately treats it as "the stale-retry path will handle this", and hands the socket back. Round 4 then added the idempotency gate, which makes that reasoning false for POST/PUT/PATCH/DELETE: the request is written onto a socket gori has *proved* dead, and the gate correctly declines to replay a request whose delivery it can no longer disprove — one call too late. Measured 4 of 8 payloads delivered, at a steady 50% for the run, with rows reading `Connection reset by peer` (blaming the origin for a socket gori wrote onto after it closed) and a raw Crystal exception carrying a heap pointer into the terminal, `--format json` and MCP.

`MSG_PEEK` returning 0 at checkout establishes what the class doc says it cannot — nothing has been written yet — so retiring there is a *first* send, for any method. 8 of 8 now, and gori no longer duplicates idempotent requests either.

## Four records that did not match what happened

- **A held WebSocket message destroyed by the peer's disconnect was written to the capture as delivered.** A local write to a socket whose peer has already sent FIN succeeds into the kernel buffer, so the "did it reach the peer" test said yes for bytes that never left. The operator saw the queue row vanish with no notification anywhere.
- **A correctly-closed RFC 8441 WebSocket left no trace on disk** — no advisory, no `:protocol` in the stored head, no `proto:ws` match. The relay itself works end to end (round 3's finding is closed); only the record was silent, and only on the *clean* path.
- **A late 1xx deleted the final response.** An h2 `HEADERS` block carrying a 1xx after the final response overwrote the status, appended its fields as trailers, and wiped everything the final block contributed — reported and stored as a benign `103` with no headers. That is what an h2 response-splitting probe produces; gori was reporting the successful injection as innocuous.
- **The PROTO column dropped TLS-vs-cleartext for exactly the protocols where it matters.** A `ws://` row and a `wss://` row were pixel-identical. "The app opened a cleartext WebSocket and put a session token in the first frame" is a finding the triage list could not express.

## Diagnoses that pointed at the wrong fix

- **A black hole — a socket that accepts the connection and never speaks — was reported as an untrusted certificate**, with `--insecure-upstream` and `SSL_CERT_FILE` offered as remedies for an exchange in which no certificate existed. The dialer's bare `rescue` discarded OpenSSL's own words, which already distinguish `certificate verify failed` from `wrong version number` from a timeout. Five causes now give five sentences, on the proxy path and the direct senders alike, and the h2 engine — which had its own collapsing copy — delegates to the same function.
- **A bound value carrying CR/LF/NUL silently disarmed every head-scoped injection rule.** No header, no event, no log line. The value is the *origin's*, so an origin that mints a session cookie with a stray `\r` could invisibly disable the tester's setup while gori reported clean sends. The refusal is correct and is now named.
- **A body-scoped extract rule read a scrubbed copy of the body**, so an invalid UTF-8 byte became U+FFFD and every `position` offset after it slid by two. One response, five descriptors, three different answers about one value.
- **`retryable: true` for failures documented as "the origin already has the whole request".** Both engines compute `delivered?`; no renderer emitted it. An agent driving a POST would double the charge.
- **gori wrote a live token into storage as `$CTOK`**, then one surface sent it literally while the other two sent the token — one row, two wires. MCP masked on the way *in* rather than on the way out.

## The decoder chain library, first pass over new code

`Library.flatten` splices only *forward* references, so the `MAX_TOKENS` guard is never armed on the ordinary authoring order — save the helper, then save the chain that calls it. The same library refuses instantly written one way and burns 35 seconds of CPU written the other. And a chain gori itself registered as unusable sent the raw payload from a `¦chain` marker with `0 errors` and `matched: true`.

## Verification

Every fix reproduces the defect first, adds a spec, control-runs it against unfixed source, and re-runs the finding's own repro against a freshly built binary. Two fixers falsified the hunt's *cause* hypothesis before acting on it, and built a second origin to separate the two cases the original repro conflated.

```
crystal spec                 6323 examples, 0 failures
crystal build --no-codegen   exit 0
```

## Still open, with owners identified

`gori run mine --locations=json` writes a wordlist name as a raw JSON key, so the same credential leak exists there — query and form are safe only by accident, via `URI.encode_www_form`. The Repeater tab's own `¦chain` markers keep the shape fixed here for the Fuzzer. `update_repeater_ws_messages` masks WS payloads into the store the way MCP used to mask requests. And the Miner/Sequencer/Discover SNI affordance is not a one-liner per tab — the pattern is proven twice now, but each needs its own five pieces.