### PR TITLE
The credential leak round 5 didn't finish, plus three silent narrowings of operator material

### DIFF
--- a/spec/cli/run/cookie_spec.cr
+++ b/spec/cli/run/cookie_spec.cr
@@ -11,6 +11,12 @@ module Gori::CLI::Run
   def self.cookie_input_for_spec(positional : Array(String)) : String
     cookie_input(positional)
   end
+
+  # `--timestamp` parsing seam. The option callback wraps this and turns the raised
+  # ArgumentError into an `abort` (which exits, so it can't run in-process).
+  def self.parse_forge_timestamp_for_spec(v : String) : Int64
+    parse_forge_timestamp(v)
+  end
 end
 
 describe "gori run cookie" do
@@ -18,6 +24,36 @@ describe "gori run cookie" do
     # A cookie pasted from a terminal or piped through a shell routinely arrives with
     # surrounding whitespace/newline.
     Gori::CLI::Run.cookie_input_for_spec(["  #{RACK}\n"]).should eq(RACK)
+  end
+
+  describe "--forge --timestamp" do
+    it "parses a valid unix second" do
+      Gori::CLI::Run.parse_forge_timestamp_for_spec("1750000000").should eq(1750000000_i64)
+    end
+
+    it "accepts 0 as the epoch" do
+      Gori::CLI::Run.parse_forge_timestamp_for_spec("0").should eq(0_i64)
+    end
+
+    it "refuses an unparseable value by name (not silently 'now')" do
+      # Without the fix `to_i64?` returned nil and the `|| now` fallback stamped the
+      # current time, reporting a forged cookie as success.
+      expect_raises(ArgumentError, /invalid --timestamp "notanumber"/) do
+        Gori::CLI::Run.parse_forge_timestamp_for_spec("notanumber")
+      end
+    end
+
+    it "refuses an out-of-Int64-range value by name" do
+      expect_raises(ArgumentError, /invalid --timestamp/) do
+        Gori::CLI::Run.parse_forge_timestamp_for_spec("1180591620717411303424")
+      end
+    end
+
+    it "refuses a negative value by name" do
+      expect_raises(ArgumentError, /invalid --timestamp "-5" \(must not be negative\)/) do
+        Gori::CLI::Run.parse_forge_timestamp_for_spec("-5")
+      end
+    end
   end
 
   it "the CLI and MCP share the decode_json shape (no divergence)" do

--- a/spec/decoder_spec.cr
+++ b/spec/decoder_spec.cr
@@ -256,6 +256,33 @@ describe Gori::Decoder do
     it "punycode-decode rejects a malformed xn-- label instead of emitting garbage" do
       expect_raises(Gori::Decoder::DecoderError, /invalid punycode/) { conv("punycode-decode", "xn--a-!!") }
     end
+
+    # punycode-encode (alias idn-encode) is IDN encode, not raw bootstring: a label with an
+    # uppercase or otherwise un-mapped code point must be case-folded + NFC-normalised (RFC 3490
+    # ToASCII step 2) BEFORE the bootstring, so the output is the ACE label a resolver produces.
+    # Golden column is Python stdlib `s.encode('idna')`.
+    it "punycode-encode applies ToASCII case-folding so an upper/mixed-case IDN encodes to the resolver's label" do
+      conv("punycode-encode", "MÜNCHEN.de").should eq "xn--mnchen-3ya.de"
+      conv("punycode-encode", "München.de").should eq "xn--mnchen-3ya.de"
+      conv("punycode-encode", "BÜCHER.example").should eq "xn--bcher-kva.example"
+      # Cyrillic: not merely a case change in the OUTPUT — the bootstring DIGITS differ, because
+      # the lowercase Cyrillic code points are distinct characters (raw bootstring gave xn--c0adxhks).
+      conv("punycode-encode", "МОСКВА.РФ").should eq "xn--80adxhks.xn--p1ai"
+      # NFC normalisation: this label is DECOMPOSED ('u' + U+0308 combining diaeresis); the fix
+      # NFC-composes it before the bootstring so it folds to the same ACE as the precomposed form.
+      conv("punycode-encode", "münchen.de").should eq "xn--mnchen-3ya.de"
+      # Round-trips: the ACE our encoder now emits decodes back to the folded Unicode name.
+      conv("punycode-decode", conv("punycode-encode", "MÜNCHEN.de")).should eq "münchen.de"
+    end
+
+    # Complements of the branch the fix keys on: an already-lowercase IDN label is unchanged
+    # (no regression on the working path), and a pure-ASCII label passes through with its case
+    # intact (matching Python idna, which nameprep-maps only non-ASCII labels).
+    it "punycode-encode leaves an all-lowercase IDN and a pure-ASCII label exactly as before" do
+      conv("punycode-encode", "münchen.de").should eq "xn--mnchen-3ya.de" # all-lowercase: same as today
+      conv("punycode-encode", "PAYPAL.com").should eq "PAYPAL.com"         # pure ASCII: case preserved
+      conv("punycode-encode", "Example.COM").should eq "Example.COM"       # pure ASCII, mixed: untouched
+    end
   end
 
   describe "compression" do

--- a/spec/fuzz_presets_spec.cr
+++ b/spec/fuzz_presets_spec.cr
@@ -49,10 +49,11 @@ describe Gori::Fuzz::Presets do
   describe "user-file merge (extensibility)" do
     it "appends the user file built-in-first, order-preserving, de-duped" do
       builtin = F::Presets.load("sqli")
-      # One line that duplicates an existing built-in payload, one brand-new line,
-      # plus a comment and a blank that must be skipped.
+      # One line that duplicates an existing built-in payload, then one brand-new line.
+      # (The merge file is read verbatim — see the byte-exact `-w` spec below — so no
+      # comment/blank lines here; the dedup + order contract is what this covers.)
       path = File.tempname("gori-preset-merge")
-      File.write(path, "#{builtin.first}\n# a comment\n\nCUSTOM-PAYLOAD-#{Random::Secure.hex(3)}\n")
+      File.write(path, "#{builtin.first}\nCUSTOM-PAYLOAD-#{Random::Secure.hex(3)}\n")
       begin
         merged = F::Presets.load("sqli", path)
         # Built-in first, in the original order (the merge is a suffix).
@@ -61,6 +62,32 @@ describe Gori::Fuzz::Presets do
         merged.uniq.size.should eq(merged.size)
         merged.size.should eq(builtin.size + 1) # only the one genuinely-new line
         merged.last.should start_with("CUSTOM-PAYLOAD-")
+      ensure
+        File.delete(path) rescue nil
+      end
+    end
+
+    # H1 FINDING 1 (PROVENANCE): the user merge file is operator MATERIAL and must reach
+    # the wire byte-exact — exactly as the SAME file does through `-w` (WordlistFile,
+    # chomp only). The merge path must NOT strip leading/trailing whitespace, drop
+    # `#`-leading lines (SQL `#`, `#{7*7}` SSTI, a `#!/bin/sh` shebang are real payloads),
+    # or drop a blank line (an intentional empty payload; `-w` sends it too).
+    it "reads the merge file verbatim, byte-identical to `-w` (WordlistFile)" do
+      path = File.tempname("gori-preset-verbatim")
+      # A leading-space payload, a trailing-tab payload, two `#`-leading payloads, an
+      # intentional blank payload, and a normal one — none collide with a built-in.
+      File.write(path, "  SP-LEAD\nTRAIL-TAB\t\n#!/bin/sh\n#{"#"}{7*7}\n\nNORMAL-PAYLOAD\n")
+      begin
+        # The reference: exactly what `-w` puts on the wire for this file.
+        wordlist = [] of String
+        F::WordlistFile.new(path).each { |v| wordlist << v }
+        wordlist.should eq(["  SP-LEAD", "TRAIL-TAB\t", "#!/bin/sh", "#{"#"}{7*7}", "", "NORMAL-PAYLOAD"])
+
+        builtin = F::Presets.load("sqli")
+        merged = F::Presets.load("sqli", path)
+        # Merge is a built-in-first suffix; none of the user lines collide, so the tail
+        # must be byte-identical to the `-w` reference.
+        merged[builtin.size..].should eq(wordlist)
       ensure
         File.delete(path) rescue nil
       end

--- a/spec/fuzz_spec.cr
+++ b/spec/fuzz_spec.cr
@@ -157,6 +157,31 @@ describe F::Template do
     out.should eq("a=aGk=&b=keep&c=plain") # base64(hi)=aGk=; unknown chain passes through; no chain untouched
   end
 
+  # #567/H3 Finding 1: a chain that RESOLVES fine but RAISES on THIS payload's bytes left the
+  # payload untransformed with no way to report the reason — a wrong test on the wire under
+  # `0 errors`. apply_chains_reported carries the named reason alongside the (untransformed)
+  # value so the row can flag it.
+  it "apply_chains_reported names a per-payload chain failure and keeps the payload untransformed" do
+    reg = Gori::Decoder.default_registry
+    t = F::Template.parse("q=§x¦shell-escape§")
+    binary = String.new(Bytes[0xff_u8, 0xfe_u8]) # shell-escape needs valid UTF-8 → raises on this
+    value, err = t.apply_chains_reported([binary], reg).first
+    value.should eq(binary) # untransformed — the payload the operator most needed quoted
+    err.should_not be_nil
+    err.not_nil!.should contain("shell-escape") # names the converter that refused
+    err.not_nil!.should contain("chain")        # operator-facing, not a bare exception
+  end
+
+  # Complement of F1: a chain that SUCCEEDS carries no error; a position with NO chain carries
+  # no error. A false chain_error on a healthy row would be as bad as a swallowed failure.
+  it "apply_chains_reported reports no error when the chain runs or there is no chain" do
+    reg = Gori::Decoder.default_registry
+    t = F::Template.parse("a=§x¦shell-escape§&b=§y§")
+    out = t.apply_chains_reported(["a'b", "plain"], reg)
+    out[0].should eq({"'a'\\''b'", nil}) # shell-escape ran, no error
+    out[1].should eq({"plain", nil})     # no chain, verbatim, no error
+  end
+
   it "marked_spans still counts chained markers 1:1 with positions" do
     t = "a=§1¦base64-encode§&b=§2§"
     F::Template.marked_spans(t).size.should eq(F::Template.parse(t).position_count)
@@ -577,6 +602,40 @@ describe F::Engine do
     matched.first.status.should eq(500)
   end
 
+  # #567/H3 Finding 1, end-to-end: a wordlist carrying a payload its `¦chain` cannot run on
+  # used to go out UNTRANSFORMED under `0 errors` / `error:null`. The row must now carry
+  # chain_error, the send that succeeded but skipped its transform must count in the error
+  # tally, and the untransformed payload must be the one on the wire.
+  it "flags a per-payload chain failure on the row and in the error tally (sends untransformed)" do
+    reg = Gori::Decoder.default_registry
+    tmpl = F::Template.parse("GET /q=§x¦shell-escape§ HTTP/1.1\r\nHost: h\r\n\r\n")
+    binary = String.new(Bytes[0xff_u8, 0xfe_u8])
+    set = F::PayloadSet.new(F::InlineList.new(["a'b", binary, "c;d"]))
+    cfg = F::Config.new(mode: F::Mode::Sniper, concurrency: 1)
+    gen = F::Generator.new(tmpl, [set], cfg, reg)
+    wire = [] of String
+    backend = FakeBackend.new(F::Origin.new("http", "h", 80)) do |bytes|
+      wire << String.new(bytes).scrub
+      ok_result(200, "ok")
+    end
+    results, done = drain(F::Engine.new(gen, F::Matcher.new, backend, cfg))
+    results.size.should eq(3)
+
+    by_payload = results.index_by { |r| r.payloads.first }
+    by_payload["a'b"].chain_error.should be_nil  # shell-escape ran
+    by_payload["c;d"].chain_error.should be_nil  # shell-escape ran
+    failed = by_payload[binary]
+    failed.chain_error.should_not be_nil         # shell-escape refused this payload
+    failed.chain_error.not_nil!.should contain("shell-escape")
+
+    # The run's tally counts the swallowed chain — it is NOT hidden inside "0 errors".
+    done.as(F::DoneEvent).progress.errors.should eq(1_i64)
+
+    # And the untransformed payload is what actually reached the origin.
+    wire.any? { |w| w.includes?("/q=") && w.includes?(binary.scrub) }.should be_true
+    wire.any? { |w| w.includes?("/q='a'\\''b'") }.should be_true # the ones that ran WERE quoted
+  end
+
   it "retries on a network error up to the configured count" do
     attempts = 0
     set = F::PayloadSet.new(F::InlineList.new(["only"]))
@@ -700,6 +759,44 @@ describe Gori::CLI::Output do
     txt.should contain("#3")
     txt.should contain("admin")
     txt.should contain("403")
+  end
+
+  # #567/H3 Finding 2: a byte-faithful payload (a wordlist may hold invalid UTF-8, e.g. a
+  # raw \xff\xfe bad-strings entry) put raw bytes inside a JSON string, so one payload made
+  # the WHOLE document unparseable (poisoning every row). The MCP twin already scrubs; the CLI
+  # emitter was missed. Both --format json and --format jsonl must stay valid.
+  it "emits valid JSON for a non-UTF-8 payload (row and array)" do
+    binary = String.new(Bytes[0xff_u8, 0xfe_u8])
+    r = F::Result.new(1_i64, [binary], nil, 200, 3_i64, 1, 1, 10_i64, nil, true, false, nil)
+    row = Gori::CLI::Output.fuzz_row_json(r)         # jsonl path
+    arr = Gori::CLI::Output.fuzz_array_json([r])     # json path
+    # `valid_encoding?`, not `JSON.parse`: Crystal's parser tolerates its own invalid-UTF-8
+    # output, but jq / python's json / every other consumer rejects a document with a raw
+    # \xff in a string — which is exactly what the finding reproduced. The emitted bytes must
+    # be valid UTF-8.
+    row.valid_encoding?.should be_true
+    arr.valid_encoding?.should be_true
+    JSON.parse(arr)[0]["payloads"].as_a.size.should eq(1)
+  end
+
+  # Complement of F2: an all-ASCII payload is byte-identical to today (no format churn on the
+  # common path).
+  it "leaves an ASCII payload's JSON unchanged" do
+    r = F::Result.new(0_i64, ["admin"], 0, 200, 1_i64, 1, 1, 1_i64, nil, true, false, nil)
+    JSON.parse(Gori::CLI::Output.fuzz_row_json(r))["payloads"].should eq(["admin"])
+  end
+
+  # The chain_error reason reaches both the JSON row and the text row, and is absent (not a
+  # false null) on a clean row.
+  it "surfaces chain_error on the JSON and text rows, only when set" do
+    r = F::Result.new(2_i64, ["x"], 0, 200, 1_i64, 1, 1, 1_i64, nil, false, false, nil,
+      chain_error: "chain 'shell-escape' step 'shell-escape' failed: needs valid UTF-8 text")
+    j = JSON.parse(Gori::CLI::Output.fuzz_row_json(r))
+    j["chain_error"].as_s.should contain("shell-escape")
+    Gori::CLI::Output.fuzz_row_text(r).should contain("shell-escape")
+
+    clean = F::Result.new(3_i64, ["x"], 0, 200, 1_i64, 1, 1, 1_i64, nil, true, false, nil)
+    Gori::CLI::Output.fuzz_row_json(clean).should_not contain("chain_error")
   end
 end
 

--- a/spec/mcp_cookie_timestamp_spec.cr
+++ b/spec/mcp_cookie_timestamp_spec.cr
@@ -1,0 +1,95 @@
+require "./spec_helper"
+require "json"
+
+# `cookie_forge`'s `timestamp` arg must tell "absent" (→ now) from "present but unusable"
+# (→ named refusal). `int(h, "timestamp") || Time.utc.to_unix` collapsed the two: an
+# unparseable / fractional / out-of-range / negative value silently stamped the current
+# time and reported the forged cookie as success. See `Tools#cookie_forge_tool`.
+
+private def with_store(&)
+  path = File.tempname("gori-mcp-cookie-ts", ".db")
+  store = Gori::Store.open(path)
+  begin
+    yield store
+  ensure
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+private def cookie_tools(store) : Gori::MCP::Tools
+  Gori::MCP::Tools.new(store, allow_actions: true, verify_upstream: false)
+end
+
+private def forge(tools : Gori::MCP::Tools, ts : String)
+  args = %({"format":"flask","secret":"s3cr3t-key","payload":"{\\"user\\":\\"admin\\",\\"role\\":\\"root\\"}"#{ts}})
+  tools.call("cookie_forge", JSON.parse(args))
+end
+
+describe "MCP cookie_forge timestamp — refused by name, never silently 'now'" do
+  it "reproduces the golden Flask cookie for a valid timestamp" do
+    with_store do |store|
+      r = forge(cookie_tools(store), %(,"timestamp":1750000000))
+      r.is_error.should be_false
+      JSON.parse(r.text)["cookie"].as_s.should eq(
+        "eyJ1c2VyIjoiYWRtaW4iLCJyb2xlIjoicm9vdCJ9.aE7hgA.C-FfBh6RRZZCk2DOX6_rVia4_iQ")
+    end
+  end
+
+  it "accepts the same value sent as a string (lenient client encoding)" do
+    with_store do |store|
+      r = forge(cookie_tools(store), %(,"timestamp":"1750000000"))
+      r.is_error.should be_false
+      JSON.parse(r.text)["cookie"].as_s.should eq(
+        "eyJ1c2VyIjoiYWRtaW4iLCJyb2xlIjoicm9vdCJ9.aE7hgA.C-FfBh6RRZZCk2DOX6_rVia4_iQ")
+    end
+  end
+
+  it "defaults to now when timestamp is ABSENT (still succeeds)" do
+    with_store do |store|
+      r = forge(cookie_tools(store), "")
+      r.is_error.should be_false
+      JSON.parse(r.text)["cookie"].as_s.should_not be_empty
+    end
+  end
+
+  it "treats an explicit JSON null as absent (defaults to now)" do
+    with_store do |store|
+      r = forge(cookie_tools(store), %(,"timestamp":null))
+      r.is_error.should be_false
+    end
+  end
+
+  it "refuses an unparseable string by name (not silently 'now')" do
+    with_store do |store|
+      r = forge(cookie_tools(store), %(,"timestamp":"notanumber"))
+      r.is_error.should be_true
+      r.text.should contain("timestamp")
+    end
+  end
+
+  it "refuses a fractional number by name (no silent truncation)" do
+    with_store do |store|
+      r = forge(cookie_tools(store), %(,"timestamp":5.9))
+      r.is_error.should be_true
+      r.text.should contain("timestamp")
+    end
+  end
+
+  it "refuses a negative timestamp by name" do
+    with_store do |store|
+      r = forge(cookie_tools(store), %(,"timestamp":-5))
+      r.is_error.should be_true
+      r.text.should contain("must not be negative")
+    end
+  end
+
+  it "accepts 0 as the epoch" do
+    with_store do |store|
+      r = forge(cookie_tools(store), %(,"timestamp":0))
+      r.is_error.should be_false
+    end
+  end
+end

--- a/spec/miner/binding_provenance_spec.cr
+++ b/spec/miner/binding_provenance_spec.cr
@@ -1,0 +1,138 @@
+require "../spec_helper"
+
+private alias M = Gori::Miner
+private alias F = Gori::Fuzz
+
+# The PROVENANCE axis at the param-miner send seam (carried defect #1, round 6).
+#
+# The miner injects candidate names/values into the request and sends. Round 5 taught the
+# Fuzzer to exclude the operator's PAYLOAD bytes from session-binding expansion (`verbatim`
+# spans) so a `$TOKEN` under test is not replaced by the live session credential on the wire.
+# The miner reached the send seam through `Inject.apply` rather than the fuzz Generator, so it
+# never passed spans: an injected candidate name like `$SECRET` — which real param wordlists
+# carry — expanded to the bound value and left gori for the target, the run reporting 0 errors.
+#
+# These drive the real engine through a backend that mimics `Fuzz::Sender` exactly (the same
+# `Env.unbound` refusal + `Env.expand_bindings` pass), so the assertion is on the bytes that
+# would hit the socket.
+
+# A layer with `SECRET` DECLARED and BOUND to `livevalue` — the send-time binding half.
+private class StubLayer < Gori::Env::Layer
+  def initialize(@vals : Hash(String, String))
+  end
+
+  def declared : Array(String)
+    @vals.keys
+  end
+
+  def values : Hash(String, String)
+    @vals
+  end
+
+  def rev : UInt64
+    1_u64
+  end
+end
+
+# Records the WIRE bytes (after running the exact two-line pass `Fuzz::Sender` runs) and the
+# `verbatim` spans it was handed, so a test can assert both what left and what was protected.
+private class ExpandingBackend < F::Backend
+  getter origin : F::Origin
+  getter wire = [] of String
+  getter got_verbatim = [] of Array({Int32, Int32})?
+
+  def initialize(@origin : F::Origin)
+  end
+
+  def send(bytes : Bytes) : Gori::Repeater::Result
+    record(bytes, nil)
+  end
+
+  def send(bytes : Bytes, verbatim : Array({Int32, Int32})?) : Gori::Repeater::Result
+    record(bytes, verbatim)
+  end
+
+  private def record(bytes : Bytes, verbatim : Array({Int32, Int32})?) : Gori::Repeater::Result
+    @got_verbatim << verbatim
+    if (u = Gori::Env.unbound(bytes, verbatim)).present?
+      return Gori::Repeater::Result.new(Bytes.new(0), nil, nil, 0_i64, Gori::Env.unbound_error(u))
+    end
+    wire_bytes = Gori::Env.expand_bindings(bytes, verbatim)
+    @wire << String.new(wire_bytes)
+    ok
+  end
+
+  private def ok : Gori::Repeater::Result
+    body = "BASELINE BODY CONTENT"
+    head = "HTTP/1.1 200 OK\r\nContent-Length: #{body.bytesize}\r\n\r\n".to_slice
+    resp = Gori::Proxy::Codec::Http1.parse_response_head(head)
+    Gori::Repeater::Result.new(head, body.to_slice, resp, 1000_i64)
+  end
+end
+
+private def with_binding(name : String, value : String, &)
+  prev_layer = Gori::Env.layer
+  prev_prefix = Gori::Settings.env_prefix
+  Gori::Settings.env_prefix = "$"
+  Gori::Settings.env_vars = [] of {String, String}
+  Gori::Settings.project_env_vars = [] of {String, String}
+  Gori::Env.layer = StubLayer.new({name => value})
+  begin
+    yield
+  ensure
+    Gori::Env.layer = prev_layer
+    Gori::Settings.env_prefix = prev_prefix
+    Gori::Settings.env_vars = [] of {String, String}
+    Gori::Settings.project_env_vars = [] of {String, String}
+  end
+end
+
+private def mine_headers(backend : F::Backend, base : String, names : Array(String)) : Nil
+  c = M::Config.new
+  c.locations = [M::Location::Headers]
+  c.bucket_size = M::Config::DEFAULT_BUCKETS.dup
+  c.bucket_size[M::Location::Headers] = 4
+  c.concurrency = 1
+  c.stability_rounds = 2
+  c.confirm_rounds = 1
+  c.retries = 0
+  engine = M::Engine.new(base.to_slice, http2: false, names: names, backend: backend, config: c)
+  engine.run { }
+end
+
+describe "Gori::Miner::Engine session-binding provenance" do
+  it "does NOT expand a `$BINDING` in an injected candidate name (no credential leak)" do
+    with_binding("SECRET", "livevalue") do
+      backend = ExpandingBackend.new(F::Origin.new("http", "h", 80))
+      # `$SECRET` is a valid header-name token, and param wordlists really do carry templated
+      # names. The seed head carries its OWN `$SECRET` (the operator's captured session), which
+      # MUST still expand.
+      base = "GET /api HTTP/1.1\r\nHost: h\r\nAuthorization: $SECRET\r\n\r\n"
+      mine_headers(backend, base, ["alpha", "$SECRET", "beta"])
+
+      # The seed's own binding resolved on the wire (that is what bindings are for).
+      backend.wire.any?(&.includes?("Authorization: livevalue")).should be_true
+
+      # The INJECTED candidate name stayed literal — it was sent as a header called `$SECRET`,
+      # NOT expanded into a header called `livevalue` (which is the leak: the live credential
+      # as an injected header name, reported back as a clean run).
+      backend.wire.any?(&.includes?("$SECRET: ")).should be_true
+      backend.wire.none?(&.includes?("livevalue: ")).should be_true
+
+      # The spans that protect it actually reached the send seam.
+      backend.got_verbatim.any? { |v| v && !v.empty? }.should be_true
+    end
+  end
+
+  it "leaves a normal (no-`$`) candidate untouched — mining is not changed by the fix" do
+    with_binding("SECRET", "livevalue") do
+      backend = ExpandingBackend.new(F::Origin.new("http", "h", 80))
+      base = "GET /api HTTP/1.1\r\nHost: h\r\n\r\n"
+      mine_headers(backend, base, ["alpha", "beta", "gamma"])
+      # No `$` anywhere → expansion is a no-op, the canary values ride the wire intact, and the
+      # bound value never appears.
+      backend.wire.none?(&.includes?("livevalue")).should be_true
+      backend.wire.any? { |w| w.includes?("alpha: ") || w.includes?("beta: ") || w.includes?("gamma: ") }.should be_true
+    end
+  end
+end

--- a/spec/miner/inject_spec.cr
+++ b/spec/miner/inject_spec.cr
@@ -25,6 +25,13 @@ private def body_of(bytes : Bytes) : Bytes
   i ? bytes[i + 4, bytes.size - (i + 4)] : Bytes.empty
 end
 
+# The bytes the returned spans actually cover, concatenated — the exact text a send seam would
+# copy through verbatim (and NOT scan for a `$NAME`). Slices the FINAL bytes at each span, so a
+# wrong offset (e.g. an unshifted Content-Length trap) shows up as the wrong text here.
+private def covered(bytes : Bytes, spans : Array({Int32, Int32})) : String
+  String.build { |s| spans.each { |(a, b)| s.write(bytes[a, b - a]) } }
+end
+
 describe Gori::Miner::Inject do
   it "appends a query param when there is no query string" do
     res = M::Inject.apply(req("GET /a HTTP/1.1\r\nHost: h\r\n\r\n"), M::Location::Query, [{"p", "v"}])
@@ -216,6 +223,90 @@ describe Gori::Miner::Inject do
   it "strips CR/LF from injected header values (smuggling guard)" do
     res = M::Inject.apply(req("GET /a HTTP/1.1\r\nHost: h\r\n\r\n"), M::Location::Headers, [{"X-Test", "a\r\nEvil: 1"}])
     text(res).should eq("GET /a HTTP/1.1\r\nHost: h\r\nX-Test: aEvil: 1\r\n\r\n")
+  end
+
+  # `apply_with_spans` must return the byte ranges of the INJECTED name/value in the FINAL
+  # bytes so a send seam marks them verbatim (mirrors Fuzz::Job#payload_spans). If the spans
+  # were wrong the covered text would not equal the injected content, and a `$NAME` in a
+  # wordlist term would expand to a live session credential on the wire. Seed bytes must never
+  # be covered. The Content-Length-syncing locations (form/json/multipart) deliberately cross a
+  # digit boundary so the span-shift-across-sync path is exercised.
+  describe "#apply_with_spans span coverage" do
+    it "query: spans cover exactly the injected pair, seed excluded" do
+      bytes, spans = M::Inject.apply_with_spans(
+        req("GET /a?seedq=SEEDVAL HTTP/1.1\r\nHost: h\r\n\r\n"), M::Location::Query, [{"pMINE", "vCANARY"}])
+      spans.should_not be_empty
+      covered(bytes, spans).should eq("pMINE=vCANARY")
+    end
+
+    it "form: spans cover the injected pair after Content-Length resync (digit shift)" do
+      # body "x=1" (CL 3) → +"&pMINE=vCANARY" → CL "17": the 1→2 digit growth shifts every
+      # body offset by one, which the span must follow.
+      base = "POST /a HTTP/1.1\r\nHost: h\r\nContent-Type: application/x-www-form-urlencoded\r\nContent-Length: 3\r\n\r\nx=1"
+      bytes, spans = M::Inject.apply_with_spans(req(base), M::Location::Form, [{"pMINE", "vCANARY"}], add_cl_when_missing: false)
+      text(bytes).should contain("Content-Length: 17")
+      covered(bytes, spans).should eq("pMINE=vCANARY")
+    end
+
+    it "json: spans cover the injected key/value after reserialize + resync" do
+      base = "POST /a HTTP/1.1\r\nHost: h\r\nContent-Type: application/json\r\nContent-Length: 9\r\n\r\n{\"a\":\"1\"}"
+      bytes, spans = M::Inject.apply_with_spans(req(base), M::Location::Json, [{"pMINE", "vCANARY"}])
+      spans.should_not be_empty
+      covered(bytes, spans).should eq("\"pMINE\":\"vCANARY\"")
+      cov = covered(bytes, spans)
+      cov.should_not contain("\"a\"")
+    end
+
+    it "json: an injected key hitting every object node yields one span per node" do
+      base = "POST /a HTTP/1.1\r\nHost: h\r\nContent-Type: application/json\r\nContent-Length: 25\r\n\r\n{\"a\":{\"b\":1},\"c\":2}"
+      bytes, spans = M::Inject.apply_with_spans(req(base), M::Location::Json, [{"pMINE", "vCANARY"}])
+      spans.size.should eq(2) # root object + nested {"b":1}
+      spans.each { |(a, b)| String.new(bytes[a, b - a]).should eq("\"pMINE\":\"vCANARY\"") }
+    end
+
+    it "multipart: spans cover the injected part (name and value), seed part excluded" do
+      base = "POST /a HTTP/1.1\r\nHost: h\r\nContent-Type: multipart/form-data; boundary=BB\r\nContent-Length: 40\r\n\r\n--BB\r\nContent-Disposition: form-data; name=\"seedm\"\r\n\r\nSEEDVAL\r\n--BB--\r\n"
+      bytes, spans = M::Inject.apply_with_spans(req(base), M::Location::Multipart, [{"pMINE", "vCANARY"}])
+      spans.should_not be_empty
+      cov = covered(bytes, spans)
+      cov.should contain("name=\"pMINE\"")
+      cov.should contain("vCANARY")
+      cov.should_not contain("seedm")
+      cov.should_not contain("SEEDVAL")
+    end
+
+    it "headers: spans cover the injected header line, not the seed head" do
+      bytes, spans = M::Inject.apply_with_spans(
+        req("GET /a HTTP/1.1\r\nHost: h\r\n\r\n"), M::Location::Headers, [{"X-Mine", "vCANARY"}])
+      covered(bytes, spans).should eq("X-Mine: vCANARY")
+    end
+
+    it "headers: one span per injected header, filtered names produce none" do
+      bytes, spans = M::Inject.apply_with_spans(
+        req("GET /a HTTP/1.1\r\nHost: h\r\n\r\n"), M::Location::Headers,
+        [{"X-One", "1"}, {"Content-Length", "9"}, {"X-Two", "2"}]) # CL is a forbidden name → dropped
+      spans.size.should eq(2)
+      covered(bytes, spans).should eq("X-One: 1X-Two: 2")
+    end
+
+    it "cookies: spans cover the appended cookie on an existing Cookie header" do
+      bytes, spans = M::Inject.apply_with_spans(
+        req("GET /a HTTP/1.1\r\nHost: h\r\nCookie: s=1\r\n\r\n"), M::Location::Cookies, [{"pMINE", "vCANARY"}])
+      covered(bytes, spans).should eq("pMINE=vCANARY")
+      text(bytes).should contain("Cookie: s=1; pMINE=vCANARY") # byte-exact, unchanged from before
+    end
+
+    it "cookies: spans cover a freshly added Cookie header's value" do
+      bytes, spans = M::Inject.apply_with_spans(
+        req("GET /a HTTP/1.1\r\nHost: h\r\n\r\n"), M::Location::Cookies, [{"pMINE", "vCANARY"}])
+      covered(bytes, spans).should eq("pMINE=vCANARY")
+    end
+
+    it "returns no spans when nothing is injected" do
+      bytes, spans = M::Inject.apply_with_spans(
+        req("GET /a HTTP/1.1\r\nHost: h\r\n\r\n"), M::Location::Query, [] of {String, String})
+      spans.should be_empty
+    end
   end
 end
 

--- a/spec/store/store_spec.cr
+++ b/spec/store/store_spec.cr
@@ -13,6 +13,20 @@ private def with_store(events : Channel(Gori::Store::FlowEvent)? = nil, &)
   end
 end
 
+private def with_masking_env(*pairs : {String, String}, &)
+  saved_vars = Gori::Settings.env_vars
+  saved_project = Gori::Settings.project_env_vars
+  saved_prefix = Gori::Settings.env_prefix
+  Gori::Settings.env_vars = pairs.to_a
+  Gori::Settings.project_env_vars = [] of {String, String}
+  Gori::Settings.env_prefix = "$"
+  yield
+ensure
+  Gori::Settings.env_vars = saved_vars || [] of {String, String}
+  Gori::Settings.project_env_vars = saved_project || [] of {String, String}
+  Gori::Settings.env_prefix = saved_prefix || "$"
+end
+
 private def sample_request(method = "GET", host = "acme.test", target = "/")
   Gori::Store::CapturedRequest.new(
     created_at: 1_000_i64,
@@ -395,6 +409,42 @@ describe Gori::Store do
       store.flush
       store.ws_messages_for_repeater(rid).size.should eq(2)
       store.write_failures.should eq(0)
+    end
+  end
+
+  it "update_repeater_ws_messages persists the author's verbatim payload, not a $KEY mask (provenance)" do
+    # A store row is a claim that those EXACT bytes are the author's. A WS payload whose
+    # bytes happen to match a session binding's VALUE must be persisted verbatim — masking
+    # it to `$TOKEN` at the write seam would put `$TOKEN` on the wire from every later send
+    # (TUI evidence path, `gori run`, MCP), which is not what the author wrote. Binding
+    # expansion is a SEND-time transform, not a store-write one — same seam and same reason
+    # as `insert_repeater` (which stores the request bytes verbatim) and `insert_ws_one`
+    # (which stores a captured frame verbatim).
+    with_masking_env({"TOKEN", "SECRETVAL"}) do
+      with_store do |store|
+        rid = store.insert_repeater("wss://acme.test/ws", "GET /ws HTTP/1.1\r\n\r\n".to_slice, false, false, nil, 0)
+        store.update_repeater_ws_messages(rid, [Gori::Store::WsOutMessage.text("hello SECRETVAL")])
+        store.flush
+        stored = store.ws_messages_for_repeater(rid)
+        stored.size.should eq(1)
+        String.new(stored[0].payload).should eq("hello SECRETVAL") # NOT "hello $TOKEN"
+      end
+    end
+  end
+
+  it "update_repeater_ws_messages keeps a literal $KEY the author typed (no store-time expansion)" do
+    # The complement: a literal `$TOKEN` the author actually typed must survive verbatim in
+    # the store (it expands only at SEND time, or stays literal under --verbatim). This
+    # proves the write seam neither masks nor expands — it just records the author's bytes.
+    with_masking_env({"TOKEN", "SECRETVAL"}) do
+      with_store do |store|
+        rid = store.insert_repeater("wss://acme.test/ws", "GET /ws HTTP/1.1\r\n\r\n".to_slice, false, false, nil, 0)
+        store.update_repeater_ws_messages(rid, [Gori::Store::WsOutMessage.text("hello $TOKEN")])
+        store.flush
+        stored = store.ws_messages_for_repeater(rid)
+        stored.size.should eq(1)
+        String.new(stored[0].payload).should eq("hello $TOKEN") # stays literal; expands only at send
+      end
     end
   end
 

--- a/spec/tui/repeater_view_spec.cr
+++ b/spec/tui/repeater_view_spec.cr
@@ -588,6 +588,44 @@ describe Gori::Tui::RepeaterView do
     sent.includes?("Content-Length: 99").should be_false
   end
 
+  # A §…§ marker whose `¦chain` cannot run must REFUSE the send with a named ChainError
+  # (mirroring Fuzz::Plan#refuse_unusable_chains) — never drop the raw, untransformed value
+  # onto the wire. See RepeaterView#refuse_bad_chains.
+  it "refuses a §…§ send whose ¦chain names a MISSING converter (no bytes on the wire)" do
+    view = RepeaterView.new
+    view.restore("https://a.test",
+      "POST /x HTTP/1.1\nHost: a.test\n\ntok=§secret¦nosuchconv§", false, true)
+    ex = expect_raises(Gori::Fuzz::ChainError, /nosuchconv/) do
+      view.request_bytes
+    end
+    ex.message.not_nil!.should contain("unknown converter")
+    ex.message.not_nil!.should contain("would go out untransformed")
+  end
+
+  it "refuses a §…§ send whose ¦chain FAILS on its value (hex-decode over non-hex)" do
+    view = RepeaterView.new
+    # hex-decode over "secret" raises (non-hex chars) — the marked default is the one value
+    # going out, so unlike a Fuzz sweep there is no next payload; the raw value must not ship.
+    view.restore("https://a.test",
+      "POST /x HTTP/1.1\nHost: a.test\n\ntok=§secret¦hex-decode§", false, true)
+    expect_raises(Gori::Fuzz::ChainError, /hex-decode/) do
+      view.request_bytes
+    end
+  end
+
+  it "sends byte-exact when a §…§ ¦chain is VALID (the complement — must not over-refuse)" do
+    view = RepeaterView.new
+    view.restore("https://a.test",
+      "POST /x HTTP/1.1\nHost: a.test\n\ntok=§secret¦base64-encode§", false, true)
+    String.new(view.request_bytes).should contain("tok=c2VjcmV0") # runs, no refusal
+  end
+
+  it "leaves a request with NO §…§ marker unaffected by the chain refusal" do
+    view = RepeaterView.new
+    view.restore("https://a.test", "POST /x HTTP/1.1\nHost: a.test\n\nq=hi", false, false)
+    String.new(view.request_bytes).should eq("POST /x HTTP/1.1\r\nHost: a.test\r\n\r\nq=hi")
+  end
+
   it "CHAIN pane: focus a marker, type a chain, commit writes it back" do
     view = RepeaterView.new
     # marker at offset 0 → set_text zeroes the cursor, so it sits inside §v§

--- a/src/gori/cli/output.cr
+++ b/src/gori/cli/output.cr
@@ -166,7 +166,13 @@ module Gori
       def self.fuzz_row_fields(j : JSON::Builder, r : Fuzz::Result) : Nil
         j.object do
           j.field "index", r.index
-          j.field("payloads") { j.array { r.payloads.each { |p| j.string(p) } } }
+          # `.scrub`: a `Fuzz::Payload` is byte-faithful, so a wordlist entry may be invalid
+          # UTF-8 (a raw `\xff\xfe` bad-strings payload). `JSON::Builder#string` escapes JSON
+          # metacharacters but passes raw bytes straight through, so one such payload used to
+          # produce a document no JSON parser would accept — poisoning EVERY row, not just its
+          # own. Scrubbing to U+FFFD matches the MCP emitter (`Serialize.text`) and keeps the
+          # report parseable; the exact bytes that went out are recoverable from `request`.
+          j.field("payloads") { j.array { r.payloads.each { |p| j.string(p.scrub) } } }
           j.field "position", r.position
           j.field "status", r.status
           j.field "length", r.length
@@ -175,6 +181,14 @@ module Gori
           j.field "duration_us", r.duration_us
           j.field "matched", r.matched?
           j.field "error", r.error
+          # A declared `¦chain` that could not run on this payload — the payload went out
+          # UNTRANSFORMED. Emitted (and only when set) so a script never reads `"error":null`
+          # for a request that sent a different test than the operator asked for. `.scrub` for
+          # the same reason `payloads` is scrubbed: a codec's refusal can quote a byte from the
+          # payload, and one invalid byte would poison the whole document.
+          if ce = r.chain_error
+            j.field "chain_error", ce.scrub
+          end
           j.field "extracted", r.extracted
           # Only when true. This is an exception rather than a per-row property, and a `false`
           # on every row of every clean run would bury the one row that matters.
@@ -365,6 +379,8 @@ module Gori
           # request went out twice (see `Fuzz::Result#retried?`).
           io << "  re-sent" if r.retried?
           io << "  " << r.error if r.error
+          # The transform declared for this payload did not run; the payload went out raw.
+          io << "  ⚠ " << r.chain_error if r.chain_error
         end
       end
 

--- a/src/gori/cli/run/cookie.cr
+++ b/src/gori/cli/run/cookie.cr
@@ -38,7 +38,13 @@ module Gori
           p.on("--value=B64", "Base64 Marshal cookie value (Rack --forge, opaque)") { |v| value = v }
           p.on("--salt=SALT", "Flask/Django signing salt") { |v| salt = v }
           p.on("--algorithm=ALG", "Django HMAC algorithm: sha256 (default) | sha1") { |v| algorithm = v.downcase }
-          p.on("--timestamp=UNIX", "Unix second to stamp (--forge; default: now)") { |v| timestamp = v.to_i64? }
+          p.on("--timestamp=UNIX", "Unix second to stamp (--forge; default: now)") do |v|
+            begin
+              timestamp = parse_forge_timestamp(v)
+            rescue ex : ArgumentError
+              abort "gori run cookie: #{ex.message}"
+            end
+          end
           p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
           p.unknown_args { |rest, _| positional = rest }
@@ -61,6 +67,18 @@ module Gori
         rescue ex : Cookie::CookieError
           abort "gori run cookie: #{ex.message}"
         end
+      end
+
+      # Parse a `--forge --timestamp` value. A nil from `to_i64?` (unparseable or
+      # out-of-Int64-range) is NOT "absent" — the operator typed a value — so refuse it
+      # by name rather than let the `|| now` fallback at forge time silently stamp the
+      # current wall-clock time. Negatives can't be represented as an itsdangerous/Django
+      # signed timestamp, so refuse those too. "Absent → now" stays in emit_cookie_forge.
+      private def self.parse_forge_timestamp(v : String) : Int64
+        n = v.to_i64?
+        raise ArgumentError.new("invalid --timestamp #{v.inspect}") if n.nil?
+        raise ArgumentError.new("invalid --timestamp #{v.inspect} (must not be negative)") if n < 0
+        n
       end
 
       # The cookie subject: positional argument or STDIN (mirrors jwt_token_input).

--- a/src/gori/cli/run/fuzz.cr
+++ b/src/gori/cli/run/fuzz.cr
@@ -332,8 +332,10 @@ module Gori
       private def self.emit_fuzz_result(r : Fuzz::Result, format : Symbol, buffer : Array(Fuzz::Result)) : Bool
         # A re-sent row is shown even when it neither matched nor errored: it is the one row of
         # the run whose request reached the origin twice, and dropping it here would put the
-        # duplicate back where it was — invisible outside the connections summary.
-        return false unless r.matched? || r.error || r.retried?
+        # duplicate back where it was — invisible outside the connections summary. A row whose
+        # `¦chain` did not run is shown for the same reason: its payload went out untransformed,
+        # and hiding it would return it to `0 errors` invisibility.
+        return false unless r.matched? || r.error || r.retried? || r.chain_error
         case format
         when :jsonl then puts CLI::Output.fuzz_row_json(r)
         when :json  then buffer << r

--- a/src/gori/decoder/codecs.cr
+++ b/src/gori/decoder/codecs.cr
@@ -722,9 +722,21 @@ module Gori::Decoder
     # Domain-aware, because that is the only form an operator ever holds: each dot-separated
     # label carrying non-ASCII becomes "xn--" + its bootstring encoding, and a pure-ASCII
     # label passes through untouched (so a plain hostname is its own encoding).
+    #
+    # A non-ASCII label is first run through the RFC 3490 ToASCII step-2 map — case-fold +
+    # NFC — BEFORE the RFC 3492 bootstring, so the result is the ACE label a resolver actually
+    # produces (MÜNCHEN -> xn--mnchen-3ya, not the raw-bootstring xn--MNCHEN-psa; the Cyrillic
+    # МОСКВА even differs in the bootstring DIGITS, not just case, because its lowercase code
+    # points are distinct characters). Without this map the advertised homoglyph -> punycode
+    # homograph workflow would emit hostnames that resolve to nothing. A pure-ASCII label is
+    # already its own ACE form and passes through with its case intact, matching Python's idna
+    # ToASCII, which nameprep-maps only labels that carry non-ASCII.
     def punycode_encode(s : String) : String
       raise DecoderError.new("input too large for punycode (max #{PUNY_MAX_IN} chars)") if s.size > PUNY_MAX_IN
-      s.split('.').map { |label| label.ascii_only? ? label : "xn--" + puny_encode_label(label) }.join('.')
+      s.split('.').map do |label|
+        next label if label.ascii_only?
+        "xn--" + puny_encode_label(label.downcase.unicode_normalize(:nfc))
+      end.join('.')
     end
 
     def punycode_decode(s : String) : String

--- a/src/gori/fuzz/engine.cr
+++ b/src/gori/fuzz/engine.cr
@@ -454,7 +454,11 @@ module Gori::Fuzz
         result = run_one(job)
         @sent += 1
         @matched += 1 if result.matched?
-        @errors += 1 if result.error
+        # A swallowed `¦chain` (the transform did not run, the payload went out raw) is an
+        # error too — otherwise a sweep reports `0 errors` while sending the untransformed
+        # payload. `||` not `+2`: one request is one error even if it both failed on the wire
+        # AND carried a chain that could not run.
+        @errors += 1 if result.error || result.chain_error
         @events.send(ResultEvent.new(result)) # blocking — never drop a row
         emit_progress
       end

--- a/src/gori/fuzz/generator.cr
+++ b/src/gori/fuzz/generator.cr
@@ -169,14 +169,17 @@ module Gori::Fuzz
     # ── helpers ──────────────────────────────────────────────────────────────────
 
     private def emit(idx : Int64, payloads : Array(String), pos : Int32?) : Job
-      raw, spans = @template.render_spans(chained(payloads))
+      values, chain_error = chained_reported(payloads)
+      raw, spans = @template.render_spans(values)
       bytes = raw
       if @config.update_content_length?
         bytes, at, delta = ContentLength.sync_at(raw, @config.add_content_length_when_missing?)
         spans = shift_spans(spans, at, delta) unless delta == 0
       end
-      # keep the ORIGINAL payloads for reporting; only the wire bytes are transformed
-      Job.new(idx, payloads, pos, bytes, spans)
+      # keep the ORIGINAL payloads for reporting; only the wire bytes are transformed.
+      # `chain_error` names any position whose `¦chain` could not run on its payload, so a
+      # request that went out with the transform SKIPPED is not reported as a clean send.
+      Job.new(idx, payloads, pos, bytes, spans, chain_error)
     end
 
     # `spans` moved across the Content-Length rewrite, which is the one pass that runs
@@ -202,10 +205,25 @@ module Gori::Fuzz
 
     # Apply each position's inline Decoder chain to its payload (identity when no
     # registry was supplied). Kept separate so `render` stays a byte-verbatim splice.
+    # Values only — for the baseline/calibration paths, which never surface a per-row chain
+    # error (they seed the matcher, they are not reported requests).
     private def chained(payloads : Array(String)) : Array(String)
       # No registry, or no position has a chain ⇒ apply_chains is a per-element identity, so
       # return payloads verbatim (byte-for-byte the same wire request) and skip its allocation.
       (reg = @registry) && @has_chains ? @template.apply_chains(payloads, reg) : payloads
+    end
+
+    # Like `chained`, but for a REPORTED request: also returns the first position's chain
+    # failure reason (nil when every chain ran), so the emitted `Job` can carry it to the row.
+    # Fast path — no registry / no chains — returns the payloads verbatim with no error and no
+    # extra allocation, so the common `auto_mark` / bare `§v§` sweep is unchanged.
+    private def chained_reported(payloads : Array(String)) : {Array(String), String?}
+      return {payloads, nil} unless (reg = @registry) && @has_chains
+      transformed = @template.apply_chains_reported(payloads, reg)
+      # First failing position wins the row's reason; a request with several failing chains is
+      # still one wrong-on-the-wire request, and the first named cause is enough to act on.
+      err = transformed.each.compact_map(&.[1]).first?
+      {transformed.map(&.[0]), err}
     end
 
     private def set_for(p : Int32) : PayloadSet

--- a/src/gori/fuzz/matcher.cr
+++ b/src/gori/fuzz/matcher.cr
@@ -164,7 +164,8 @@ module Gori::Fuzz
         duration_us: raw.duration_us, error: raw.error, matched: matched,
         incomplete: raw.incomplete?, extracted: extracted,
         head: keep ? present(raw.head) : nil, body: keep ? raw.body : nil,
-        request: keep ? present(job.bytes) : nil, retried: raw.retried?)
+        request: keep ? present(job.bytes) : nil, retried: raw.retried?,
+        chain_error: job.chain_error)
     end
 
     private def decide(raw : Repeater::Result, status : Int32?, length : Int64,

--- a/src/gori/fuzz/presets.cr
+++ b/src/gori/fuzz/presets.cr
@@ -52,9 +52,15 @@ module Gori::Fuzz
           raise Gori::Error.new("preset merge file not found: #{path}") unless File.exists?(path)
           raise Gori::Error.new("preset merge file is a directory, not a file: #{path}") if File.directory?(path)
           raise Gori::Error.new("preset merge file not readable: #{path}") unless File::Info.readable?(path)
-          File.each_line(path) do |line|
-            stripped = line.strip
-            values << stripped unless stripped.empty? || stripped.starts_with?('#')
+          # The user merge file is operator MATERIAL, not a curated gori asset: read it
+          # with the SAME fidelity as `WordlistFile` (payload.cr, `gets(chomp: true)`) —
+          # chomp the line ending only, keeping leading/trailing whitespace, `#`-leading
+          # lines (a SQL `#` comment, `#{7*7}` SSTI, a `#!/bin/sh` shebang are all valid
+          # payloads) and blank lines (an intentional empty payload, sent by `-w` too).
+          # The strip + comment/blank skip below in `parse` is correct ONLY for the
+          # built-in `.txt` sets, whose headers document `#`/blank as comments.
+          File.each_line(path, chomp: true) do |line|
+            values << line
           end
         end
       end

--- a/src/gori/fuzz/template.cr
+++ b/src/gori/fuzz/template.cr
@@ -226,25 +226,57 @@ module Gori::Fuzz
     # Map each payload through its position's Decoder chain (empty chain = identity),
     # returning a new payload array to feed `render`. A chain that fails on THIS payload — a
     # step that raised on these bytes, or output over MAX_OUT — leaves that value
-    # UNTRANSFORMED: Decoder.run never raises, and a streaming fuzz run has nowhere to
-    # surface a per-position error (validate chains in the Decoder tab).
+    # UNTRANSFORMED (Decoder.run never raises). This is the VALUES-only view, for callers that
+    # do not report a per-row chain failure — the baseline/calibration seeds and the Repeater
+    # preview, which shows the same rendered bytes it sends. A REPORTED fuzz request uses
+    # `apply_chains_reported`, which also returns the named reason so the row can carry it
+    # rather than passing a wrong-on-the-wire request off as clean.
     #
-    # What this must NOT be reached with any more is a chain that could never run at all —
-    # an unknown token, or a saved chain the library registered as unusable (recursive, past
-    # MAX_TOKENS). Those are a property of the TEMPLATE, not of a payload, so they are refused
-    # once at `Fuzz::Plan.build` (`refuse_unusable_chains`) before the first dial rather than
-    # silently swallowed here on every request of the sweep. What is left is genuinely
-    # per-payload — `base64-decode` over a payload that isn't base64 — where the next payload
-    # may well succeed and there is nothing to refuse up front. Decoder works
-    # on Bytes but the template splices Strings, so the transformed bytes are rewrapped
-    # with String.new — encoders (base64/url/hex/hash/escape) stay ASCII; a decoder that
-    # produces raw bytes may lose fidelity, the same limit binary bodies already have.
+    # What this must NOT be reached with is a chain that could never run at all — an unknown
+    # token, or a saved chain the library registered as unusable (recursive, past MAX_TOKENS).
+    # Those are a property of the TEMPLATE, not of a payload, so they are refused once at
+    # `Fuzz::Plan.build` (`refuse_unusable_chains`) before the first dial. What is left is
+    # genuinely per-payload — `base64-decode` over a payload that isn't base64, `shell-escape`
+    # over a non-UTF-8 payload — where the next payload may well succeed and there is nothing
+    # to refuse up front. Decoder works on Bytes but the template splices Strings, so the
+    # transformed bytes are rewrapped with String.new — encoders (base64/url/hex/hash/escape)
+    # stay ASCII; a decoder that produces raw bytes may lose fidelity, the same limit binary
+    # bodies already have.
     def apply_chains(payloads : Array(String), registry : Decoder::Registry) : Array(String)
+      apply_chains_reported(payloads, registry).map(&.[0])
+    end
+
+    # Like `apply_chains`, but returns `{value, chain_error}` per payload: the transformed
+    # value AND — when the chain FAILED on THIS payload — the named reason it did not run
+    # (nil when it ran, or when there was no chain). The value in the failing case is the
+    # payload UNTRANSFORMED, a different request than the operator declared, so the reason
+    # rides out with it: a per-request `Fuzz::Result` already carries `error`/`retried`, so
+    # `chain_error` lands beside them and is counted in the run's error tally rather than
+    # swallowed under `0 errors` (#567/H3 Finding 1). Kept separate from `apply_chains` so the
+    # Repeater preview and baseline seeds — which have no per-row surface — need no change.
+    def apply_chains_reported(payloads : Array(String), registry : Decoder::Registry) : Array({String, String?})
       payloads.map_with_index do |p, k|
         spec = @positions[k]?.try(&.chain)
-        next p if spec.nil? || spec.empty?
+        next {p, nil} if spec.nil? || spec.empty?
         res = Decoder.run(registry, p.to_slice, spec)
-        (res.ok? && (o = res.output)) ? String.new(o) : p
+        if res.ok? && (o = res.output)
+          {String.new(o), nil}
+        else
+          {p, chain_failure_reason(spec, res)}
+        end
+      end
+    end
+
+    # A named, operator-facing reason a chain did not run on a payload, in the shape
+    # `gori run decoder` already prints one screen away — "chain '<spec>' step '<name>'
+    # failed: <message>" — so the row says WHY the payload went out raw, not merely that it
+    # did. Read-only over Decoder's public `ChainResult` (the codec package owns that struct).
+    private def chain_failure_reason(spec : String, res : Decoder::ChainResult) : String
+      if (i = res.failed_at) && (step = res.steps[i]?)
+        detail = step.error || (step.state.unknown? ? "unknown converter" : "failed")
+        "chain '#{spec}' step '#{step.name}' failed: #{detail}"
+      else
+        "chain '#{spec}' produced no output"
       end
     end
 

--- a/src/gori/fuzz/types.cr
+++ b/src/gori/fuzz/types.cr
@@ -53,12 +53,21 @@ module Gori
     # session bindings, so a payload of `$TOKEN` is sent as those six characters instead of
     # as the live session credential. Empty for a `Job` a spec or a non-generator caller
     # built by hand, which means "no exclusions" — the pre-existing behaviour.
+    #
+    # `chain_error` is set when a marked position's inline `¦chain` (a Decoder chain) could
+    # not run on THIS payload's bytes — e.g. `shell-escape` on a non-UTF-8 payload, or a
+    # `*-decode` on non-alphabet text. The chain resolved fine at template time (an
+    # un-resolvable chain is refused up front by `Plan.refuse_unusable_chains`), but raised
+    # on these specific bytes, so `Template#apply_chains` sent the payload UNTRANSFORMED. That
+    # is a different request than the operator declared; the reason rides to the row here so no
+    # surface reports it under `0 errors` / `"error":null`. nil = every chain ran (or none).
     record Job,
       index : Int64,
       payloads : Array(String),
       position : Int32?,
       bytes : Bytes,
-      payload_spans : Array({Int32, Int32}) = [] of {Int32, Int32}
+      payload_spans : Array({Int32, Int32}) = [] of {Int32, Int32},
+      chain_error : String? = nil
 
     # One emitted result row. `length`/`words`/`lines` are computed over the DECODED
     # response body (gzip/deflate/br/zstd inflated). `head`/`body`/`request` are
@@ -86,10 +95,18 @@ module Gori
       getter head : Bytes?
       getter body : Bytes?
       getter request : Bytes?
+      # The declared `¦chain` for one of this request's positions did NOT run on that payload
+      # (it raised on these bytes, or its output exceeded MAX_OUT), so the payload went out
+      # untransformed — a different test than the operator asked for. Carried per row and
+      # counted in the run's error tally so a swallowed chain is never hidden inside `0 errors`.
+      # Distinct from `error` (a network/send failure): a request can succeed on the wire yet
+      # still carry a chain_error. nil when every position's chain ran (or none was declared).
+      getter chain_error : String?
 
       def initialize(@index, @payloads, @position, @status, @length, @words, @lines,
                      @duration_us, @error, @matched, @incomplete, @extracted,
-                     @head = nil, @body = nil, @request = nil, @retried = false)
+                     @head = nil, @body = nil, @request = nil, @retried = false,
+                     @chain_error = nil)
       end
     end
 

--- a/src/gori/mcp/serialize.cr
+++ b/src/gori/mcp/serialize.cr
@@ -238,6 +238,10 @@ module Gori
           j.field "lines", r.lines
           j.field "duration_us", r.duration_us
           j.field "error", text(r.error)
+          # A declared `¦chain` that could not run on this payload — it went out UNTRANSFORMED.
+          # Emitted only when set, so an agent never reads a clean row for a request that sent a
+          # different test than asked. `error` stays the network/send failure; this is distinct.
+          j.field "chain_error", text(r.chain_error) if r.chain_error
           j.field "extracted", text(r.extracted)
           # This variation's request reached the origin TWICE: the keep-alive pool found its
           # parked socket closed and re-sent (see `Fuzz::Result#retried?`). Emitted only when

--- a/src/gori/mcp/tools/cookie.cr
+++ b/src/gori/mcp/tools/cookie.cr
@@ -63,7 +63,11 @@ module Gori
         return Result.new("missing required 'format' (flask/rack/django)", is_error: true) if format.nil? || format.empty?
         secret = str(h, "secret")
         return Result.new("missing required 'secret'", is_error: true) if secret.nil?
-        ts = int(h, "timestamp") || Time.utc.to_unix
+        # An explicitly-present but uncoercible 'timestamp' is a named refusal, not a
+        # silent "now" (optional_int_arg raises Gori::Error → INVALID_ARGUMENT). Absent
+        # still defaults to now. Negatives can't be a signed-cookie timestamp — refuse.
+        ts = optional_int_arg(h, "timestamp") || Time.utc.to_unix
+        raise Gori::Error.new("invalid 'timestamp' (must not be negative)") if ts < 0
         cookie = cookie_forge_build(format, secret, ts, h)
         Result.new(JSON.build { |j| j.object { j.field "cookie", cookie; j.field "format", format } })
       rescue ex : Cookie::CookieError # invalid JSON, missing payload/value, unknown format

--- a/src/gori/miner/engine.cr
+++ b/src/gori/miner/engine.cr
@@ -209,7 +209,12 @@ module Gori::Miner
       # One {name, canary} pair per candidate — the SAME array feeds the injector and the
       # detector (decide), so no per-bucket name→canary / canary→name hashes are built.
       pairs = task.names.map { |n| {n, Canary.fresh} }
-      raw = send_with_retries(Inject.apply(@base, task.location, pairs, @config.add_content_length_when_missing?))
+      # `apply_with_spans` (not `apply`): the spans mark the INJECTED candidate names/values
+      # so the send seam protects them from session-binding expansion. Without this a `$NAME`
+      # a param wordlist carries — or an injected byte colliding with a bound name — expands
+      # to the live credential and leaves gori for the target, the run reporting `0 errors`.
+      bytes, spans = Inject.apply_with_spans(@base, task.location, pairs, @config.add_content_length_when_missing?)
+      raw = send_with_retries(bytes, spans)
       if err = raw.error
         # A max-requests cap refusal isn't a network error — don't let it inflate @errors.
         unless err == Fuzz::CappedBackend::CAP_ERROR
@@ -269,7 +274,9 @@ module Gori::Miner
       last_canary = canary
       rounds.times do
         c = Canary.fresh
-        raw = send_with_retries(Inject.apply(@base, location, [{name, c}], @config.add_content_length_when_missing?))
+        # Same span-protection as the main loop — the confirm re-send injects the same name.
+        bytes, spans = Inject.apply_with_spans(@base, location, [{name, c}], @config.add_content_length_when_missing?)
+        raw = send_with_retries(bytes, spans)
         next if raw.error
         probe = Fingerprint.probe(raw)
         decision = Miner.decide(r, probe, [{name, c}], location)
@@ -422,10 +429,10 @@ module Gori::Miner
 
     # ── sending / pacing ────────────────────────────────────────────────────────────
 
-    private def send_with_retries(bytes : Bytes) : Repeater::Result
+    private def send_with_retries(bytes : Bytes, verbatim : Array({Int32, Int32})?) : Repeater::Result
       attempts = 0
       loop do
-        raw = @backend.send(bytes)
+        raw = @backend.send(bytes, verbatim)
         if raw.error.nil?
           @successful_sends += 1
           return raw

--- a/src/gori/miner/inject.cr
+++ b/src/gori/miner/inject.cr
@@ -30,15 +30,47 @@ module Gori::Miner
     def self.apply(request : Bytes, location : Location,
                    params : Array({String, String}),
                    add_cl_when_missing : Bool = false) : Bytes
-      return request if params.empty?
+      apply_with_spans(request, location, params, add_cl_when_missing)[0]
+    end
+
+    # `apply`, PLUS the byte spans in the RETURNED bytes that hold the injected candidate
+    # names and values (final, post Content-Length sync offsets). A send seam marks those
+    # `verbatim` so a `$NAME` an operator's wordlist carries — or any injected byte that
+    # collides with a live session binding — is NOT expanded to the real credential on the
+    # way to the target and reported back as a clean `0 errors` run. This is the same role
+    # `Fuzz::Job#payload_spans` plays for the Fuzzer (the round-5 fix); the miner reaches the
+    # send seam through here rather than through the fuzz Generator, so it needs its own spans.
+    #
+    # Only the INJECTED regions are protected: the seed's OWN `$BINDING` placeholders (the
+    # operator's captured request) lie outside every span and still resolve at send. The
+    # spans come out sorted and disjoint — what `Env.expand_bindings`' single-cursor walk
+    # requires — and a location that injects nothing returns an empty list.
+    def self.apply_with_spans(request : Bytes, location : Location,
+                              params : Array({String, String}),
+                              add_cl_when_missing : Bool = false) : {Bytes, Array({Int32, Int32})}
+      return {request, [] of {Int32, Int32}} if params.empty?
       case location
       in Location::Query     then inject_query(request, params)
-      in Location::Form      then Fuzz::ContentLength.sync(inject_form(request, params), add_cl_when_missing)
-      in Location::Multipart then Fuzz::ContentLength.sync(inject_multipart(request, params), add_cl_when_missing)
-      in Location::Json      then Fuzz::ContentLength.sync(inject_json(request, params), add_cl_when_missing)
+      in Location::Form      then sync_spans(inject_form(request, params), add_cl_when_missing)
+      in Location::Multipart then sync_spans(inject_multipart(request, params), add_cl_when_missing)
+      in Location::Json      then sync_spans(inject_json(request, params), add_cl_when_missing)
       in Location::Headers   then inject_headers(request, params)
       in Location::Cookies   then inject_cookies(request, params)
       end
+    end
+
+    # Content-Length sync over a freshly injected BODY, carrying the injected spans across
+    # the rewrite. The head's CL line can change length, moving every body offset by `delta`
+    # from `at` on — the exact shift `Fuzz::Generator#shift_spans` applies, for the exact
+    # reason: this rewrite happens between the splice and the socket, so a caller holding
+    # pre-sync offsets cannot re-derive them. A span at or past `at` moves; one before it
+    # (there is none here — every injected span lives in the body, well past the head) stays.
+    private def self.sync_spans(pair : {Bytes, Array({Int32, Int32})},
+                                add_when_missing : Bool) : {Bytes, Array({Int32, Int32})}
+      bytes, spans = pair
+      synced, at, delta = Fuzz::ContentLength.sync_at(bytes, add_when_missing)
+      spans = spans.map { |(a, b)| a >= at ? {a + delta, b + delta} : {a, b} } unless delta == 0
+      {synced, spans}
     end
 
     # ── head/body split (own copy of Fuzz::ContentLength's left-to-right scan) ────────
@@ -93,39 +125,40 @@ module Gori::Miner
       {nil, 0, "\r\n"}
     end
 
-    private def self.rebuild(head_lines : Array(String), eol : String, body : Bytes) : Bytes
-      io = IO::Memory.new
-      io << head_lines.join(eol) << eol << eol
-      io.write(body) unless body.empty?
-      io.to_slice
-    end
-
     # ── query ───────────────────────────────────────────────────────────────────────
 
-    private def self.inject_query(request : Bytes, params : Array({String, String})) : Bytes
+    private def self.inject_query(request : Bytes, params : Array({String, String})) : {Bytes, Array({Int32, Int32})}
       nl = request.index(0x0a_u8)
-      return request unless nl
+      return {request, [] of {Int32, Int32}} unless nl
       first = String.new(request[0, nl]).rstrip('\r')
       parts = first.split(' ')
-      return request unless parts.size == 3
+      return {request, [] of {Int32, Int32}} unless parts.size == 3
       extra = encode_pairs(params)
-      target = append_query(parts[1], extra)
-      new_first = "#{parts[0]} #{target} #{parts[2]}"
+      target = parts[1]
+      sep = query_separator(target)
       eol = (nl > 0 && request[nl - 1] == 0x0d_u8) ? "\r\n" : "\n"
       io = IO::Memory.new(request.size + extra.bytesize + 8)
-      io << new_first << eol
+      io << parts[0] << ' ' << target << sep
+      start = io.pos.to_i32
+      io << extra
+      span = {start, io.pos.to_i32}
+      io << ' ' << parts[2] << eol
       rest_at = nl + 1
       io.write(request[rest_at, request.size - rest_at])
-      io.to_slice
+      {io.to_slice, [span]}
     end
 
-    private def self.append_query(target : String, extra : String) : String
+    # The join byte that appends `extra` to the request target: `?` when there is no query
+    # yet, nothing when the target already ends in `?`/`&`, `&` otherwise. Split out from the
+    # old `append_query` so the injected span starts exactly AFTER this separator (the
+    # separator is framing gori wrote, not an injected candidate byte).
+    private def self.query_separator(target : String) : String
       if !target.includes?('?')
-        "#{target}?#{extra}"
+        "?"
       elsif target.ends_with?('?') || target.ends_with?('&')
-        "#{target}#{extra}"
+        ""
       else
-        "#{target}&#{extra}"
+        "&"
       end
     end
 
@@ -137,11 +170,11 @@ module Gori::Miner
     # body shape to preserve, so injecting here would fabricate a framing-broken request:
     # a body with no Content-Length and no Content-Type header at all. Bail out unmodified
     # instead, same as inject_multipart/inject_json do when their location doesn't apply.
-    private def self.inject_form(request : Bytes, params : Array({String, String})) : Bytes
+    private def self.inject_form(request : Bytes, params : Array({String, String})) : {Bytes, Array({Int32, Int32})}
       head, body, eol = split(request)
-      return request if body.empty?
+      return {request, [] of {Int32, Int32}} if body.empty?
       ct = (header_value(request, "content-type") || "").downcase
-      return request unless ct.includes?("x-www-form-urlencoded")
+      return {request, [] of {Int32, Int32}} unless ct.includes?("x-www-form-urlencoded")
       extra = encode_pairs(params)
       # The body is spliced through as bytes. It used to be copied into a String, then again by
       # the interpolation that joined it to `extra`, then a third time into the IO — and the
@@ -153,8 +186,9 @@ module Gori::Miner
         io.write(body)
         io << '&' unless body[body.size - 1] == 0x26_u8 # '&'
       end
+      start = io.pos.to_i32
       io << extra
-      io.to_slice
+      {io.to_slice, [{start, io.pos.to_i32}]}
     end
 
     # Encoded straight into one builder. The map/join form allocated two encoded Strings plus an
@@ -178,27 +212,34 @@ module Gori::Miner
     # `--boundary--` close delimiter (not MIME::Multipart::Builder, which would mint a fresh
     # boundary and force a Content-Type rewrite + re-serialization that mangles binary parts).
     # Multipart is ALWAYS CRLF internally (RFC 7578), regardless of the head's EOL.
-    private def self.inject_multipart(request : Bytes, params : Array({String, String})) : Bytes
+    private def self.inject_multipart(request : Bytes, params : Array({String, String})) : {Bytes, Array({Int32, Int32})}
       raw_ct = header_value(request, "content-type") # ORIGINAL case — the boundary is case-sensitive
-      return request unless raw_ct
+      return {request, [] of {Int32, Int32}} unless raw_ct
       boundary = MIME::Multipart.parse_boundary(raw_ct)
-      return request if boundary.nil? || boundary.empty?
+      return {request, [] of {Int32, Int32}} if boundary.nil? || boundary.empty?
 
       additions = build_multipart_parts(boundary, params)
-      return request if additions.empty?
+      return {request, [] of {Int32, Int32}} if additions.empty?
 
       head, body, eol = split(request)
       io = IO::Memory.new(head.size + body.size + additions.bytesize + eol.bytesize * 2 + 16)
       io.write(head)
       io << eol << eol
 
+      # The whole injected `additions` block is candidate content (Content-Disposition
+      # framing gori wrote plus the injected names/values) — mark it all verbatim: no injected
+      # byte is ever scanned for a `$NAME`, and the framing carries none.
+      start = 0
+      stop = 0
       close = "--#{boundary}--".to_slice
       if ci = last_index_of(body, close)
         io.write(body[0, ci])
         # A boundary delimiter must be preceded by CRLF; a well-formed body already ends the
         # prior part with it (so this no-ops), but a synthesised/edited body might not.
         io << "\r\n" unless ci >= 2 && body[ci - 2] == 0x0d_u8 && body[ci - 1] == 0x0a_u8
-        io << additions                    # each appended part already ends with CRLF
+        start = io.pos.to_i32
+        io << additions # each appended part already ends with CRLF
+        stop = io.pos.to_i32
         io.write(body[ci, body.size - ci]) # the close delimiter + any epilogue, verbatim
       else
         # Malformed (no close delimiter) or empty body: synthesise a well-formed tail so the
@@ -207,10 +248,12 @@ module Gori::Miner
           io.write(body)
           io << "\r\n" unless ends_with_crlf?(body)
         end
+        start = io.pos.to_i32
         io << additions
+        stop = io.pos.to_i32
         io << "--" << boundary << "--\r\n"
       end
-      io.to_slice
+      {io.to_slice, [{start, stop}]}
     end
 
     private def self.build_multipart_parts(boundary : String, params : Array({String, String})) : String
@@ -242,16 +285,72 @@ module Gori::Miner
       body.size >= 2 && body[body.size - 2] == 0x0d_u8 && body[body.size - 1] == 0x0a_u8
     end
 
+    # First occurrence of `needle` at or after `from`, byte-wise (String#index would corrupt a
+    # non-UTF-8 body). Used to locate an injected JSON fragment whose final offset only exists
+    # after `any.to_json` has reserialized the whole body.
+    private def self.forward_index_of(haystack : Bytes, needle : Bytes, from : Int32) : Int32?
+      return nil if needle.empty? || needle.size > haystack.size
+      i = from < 0 ? 0 : from
+      last = haystack.size - needle.size
+      while i <= last
+        return i if haystack[i, needle.size] == needle
+        i += 1
+      end
+      nil
+    end
+
+    # Sort spans by start and fold any that touch or overlap into one. `Env.expand_bindings`
+    # walks the verbatim list with a single forward cursor, so it requires sorted + disjoint
+    # ranges; only the JSON path can emit incidentally overlapping fragments, but every caller
+    # runs this so the invariant holds uniformly.
+    private def self.merge_spans(spans : Array({Int32, Int32})) : Array({Int32, Int32})
+      return spans if spans.size <= 1
+      sorted = spans.sort_by! { |(a, _)| a }
+      out = [] of {Int32, Int32}
+      cs, ce = sorted[0]
+      sorted.each_with_index do |(a, b), i|
+        next if i == 0
+        if a <= ce
+          ce = b if b > ce
+        else
+          out << {cs, ce}
+          cs, ce = a, b
+        end
+      end
+      out << {cs, ce}
+      out
+    end
+
     # ── json (object + nested objects + array roots) ─────────────────────────────────
 
-    private def self.inject_json(request : Bytes, params : Array({String, String})) : Bytes
+    private def self.inject_json(request : Bytes, params : Array({String, String})) : {Bytes, Array({Int32, Int32})}
       head, body, eol = split(request)
       new_body = inject_json_text(String.new(body).scrub, params)
-      return request unless new_body
+      return {request, [] of {Int32, Int32}} unless new_body
       io = IO::Memory.new(head.size + new_body.bytesize + eol.bytesize * 2)
       io.write(head)
       io << eol << eol << new_body
-      io.to_slice
+      out = io.to_slice
+
+      # A JSON candidate is reserialized (`any.to_json`) or textually spliced, so its final
+      # position is only known after the fact: locate every injected `"name":"value"` fragment
+      # in the new body (the SAME spelling both paths emit — `n.to_json`/`v.to_json`, no space,
+      # Crystal-compact). A name is injected into every object node, so a fragment can recur;
+      # each occurrence is a span. Values are canaries here (unique), so a fragment cannot
+      # collide with pre-existing body content, and merge_spans folds any incidental overlap so
+      # the list stays sorted+disjoint for `Env.expand_bindings`' cursor.
+      body_off = head.size + eol.bytesize * 2
+      nb = new_body.to_slice
+      spans = [] of {Int32, Int32}
+      params.each do |(n, v)|
+        frag = "#{n.to_json}:#{v.to_json}".to_slice
+        from = 0
+        while idx = forward_index_of(nb, frag, from)
+          spans << {body_off + idx, body_off + idx + frag.size}
+          from = idx + frag.size
+        end
+      end
+      {out, merge_spans(spans)}
     end
 
     # Inject candidate keys into EVERY object node of the JSON body — the root object, objects
@@ -309,32 +408,64 @@ module Gori::Miner
     # head bytes are copied through verbatim. The old path took String.new(head) (a full copy),
     # split it into a String per line, then rebuild joined them back into another full copy
     # before writing — three passes over the head to append to it.
-    private def self.inject_headers(request : Bytes, params : Array({String, String})) : Bytes
+    private def self.inject_headers(request : Bytes, params : Array({String, String})) : {Bytes, Array({Int32, Int32})}
       head, body, eol = split(request)
       io = IO::Memory.new(head.size + params.size * 48 + body.size + eol.bytesize * 2)
       io.write(head)
+      spans = [] of {Int32, Int32}
       params.each do |(n, v)|
-        io << eol << n << ": " << sanitize_value(v) if valid_header_name?(n)
+        next unless valid_header_name?(n)
+        io << eol
+        start = io.pos.to_i32
+        io << n << ": " << sanitize_value(v)
+        spans << {start, io.pos.to_i32}
       end
       io << eol << eol
       io.write(body) unless body.empty?
-      io.to_slice
+      {io.to_slice, spans}
     end
 
     # ── cookies ──────────────────────────────────────────────────────────────────────
 
-    private def self.inject_cookies(request : Bytes, params : Array({String, String})) : Bytes
+    private def self.inject_cookies(request : Bytes, params : Array({String, String})) : {Bytes, Array({Int32, Int32})}
       head, body, eol = split(request)
       lines = String.new(head).split(eol)
       additions = params.compact_map { |(n, v)| valid_cookie_name?(n) ? "#{n}=#{sanitize_value(v)}" : nil }
-      return request if additions.empty?
+      return {request, [] of {Int32, Int32}} if additions.empty?
+      joined = additions.join("; ")
       idx = lines.index { |l| (c = l.index(':')) && c > 0 && l[0...c].strip.downcase == "cookie" }
+
+      # Byte-identical to the old split/mutate/rebuild, but built through an IO so the injected
+      # `joined` span (the added `name=value; …`) is recorded in final offsets. Appended to an
+      # existing Cookie line, or added as a fresh one when there is none.
+      io = IO::Memory.new(head.size + joined.bytesize + body.size + eol.bytesize * 4 + 16)
+      start = 0
+      stop = 0
       if idx
-        lines[idx] = "#{lines[idx].rstrip}; #{additions.join("; ")}"
+        lines.each_with_index do |line, i|
+          io << eol if i > 0
+          if i == idx
+            io << line.rstrip << "; "
+            start = io.pos.to_i32
+            io << joined
+            stop = io.pos.to_i32
+          else
+            io << line
+          end
+        end
       else
-        lines << "Cookie: #{additions.join("; ")}"
+        lines.each_with_index do |line, i|
+          io << eol if i > 0
+          io << line
+        end
+        io << eol << "Cookie: "
+        start = io.pos.to_i32
+        io << joined
+        stop = io.pos.to_i32
       end
-      rebuild(lines, eol, body)
+      io << eol << eol
+      io.write(body) unless body.empty?
+      {io.to_slice, [{start, stop}]}
     end
 
     # ── name/value validity ──────────────────────────────────────────────────────────

--- a/src/gori/store/repeater_sessions.cr
+++ b/src/gori/store/repeater_sessions.cr
@@ -190,10 +190,16 @@ module Gori
 
     # Replace a repeater session's outbound WebSocket messages.
     #
-    # `Env.mask_secrets` is byte-level (it scans `to_slice`, never `String#chars`), so the
-    # String round-trip through it is lossless for a payload that is not valid UTF-8 — which
-    # is the whole reason this can take raw bytes at all. `String#scrub` was the lossy step,
-    # and it lived in the callers, not here.
+    # The author's payload is persisted VERBATIM — a store row is a claim that those exact
+    # bytes are the author's, so a value that happens to match a session binding must NOT be
+    # masked to `$KEY` here. `Env.mask_secrets` is a draft-/display-time transform; running
+    # it on this WRITE path rewrote a live value the author typed (or, when seeded from a
+    # `--flow`, a capture's own bytes) into `$CTOK`, which every later send (the TUI evidence
+    # path, `gori run`, MCP) then put on the wire instead of what the author wrote. Binding
+    # substitution belongs at the SEND seam (`Repeater::Sender#expand_messages` /
+    # `RepeaterView#ws_out_messages`), which expands `$KEY` unless the frame is evidence.
+    # This mirrors `insert_repeater` (request bytes stored verbatim) and `insert_ws_one`
+    # (a captured frame stored verbatim).
     #
     # The V7 shape columns ride along, through the same `bind_ws_shape` the capture writer
     # uses. A session is the only place a `declared_len` can live at all — a length header
@@ -206,7 +212,7 @@ module Gori
           ts = now_us
           # See insert_ws_one: an empty payload binds SQL NULL and violates the NOT NULL
           # column (an empty repeater message text hits this), so store X'' for it.
-          slice = Env.mask_secrets(String.new(msg.payload)).to_slice
+          slice = msg.payload
           empty = slice.empty?
           args = [0_i64, id, ts, "out", msg.opcode] of DB::Any
           args << slice unless empty

--- a/src/gori/tui/controllers/repeater_controller.cr
+++ b/src/gori/tui/controllers/repeater_controller.cr
@@ -677,7 +677,14 @@ module Gori::Tui
     end
 
     private def repeater_request_options(v : RepeaterView) : Array(CopyMenu::Option)
-      wire = String.new(v.request_bytes)
+      # Same §…§ `¦chain` refusal as the send path: copying an untransformable request would
+      # hand the operator a curl/raw command that sends the raw value — refuse it too.
+      wire = begin
+        String.new(v.request_bytes)
+      rescue ex : Fuzz::ChainError
+        @host.status("repeater: #{ex.message}")
+        return [] of CopyMenu::Option
+      end
       target = Env.expand(v.target)
       ws_messages = if v.ws_mode?
                       v.ws_out_messages.map { |message| String.new(message.payload).scrub }
@@ -1238,7 +1245,16 @@ module Gori::Tui
         return
       end
       results = @repeater_results
-      return unless plan = repeater_plan(view, [view.request_bytes], http2: view.http2?)
+      # A §…§ marker's `¦chain` that can't run refuses the send here rather than putting the
+      # raw, untransformed value on the wire (RepeaterView#refuse_bad_chains, mirroring
+      # Fuzz::Plan). Reported in the tab's own status line, like every other repeater refusal.
+      begin
+        wire = view.request_bytes
+      rescue ex : Fuzz::ChainError
+        @host.status("repeater: #{ex.message}")
+        return
+      end
+      return unless plan = repeater_plan(view, [wire], http2: view.http2?)
       save_current_repeater # persist the request we're about to send (before it goes inflight)
       if reason = plan.refusal
         results.send({view, Repeater::Result.new(Bytes.new(0), nil, nil, 0_i64, reason)})

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -2167,6 +2167,11 @@ module Gori::Tui
       # TUI used to drop it entirely, so a scope/sandbox refusal read as a bare "ERR".
       if err = r.error
         screen.text(x, y, err, Theme.red, bg, width: {inner.right - x, 1}.max)
+      elsif r.chain_error
+        # The send succeeded, but this row's `¦chain` did not run — its payload went out raw.
+        # Flag it in the list (the detail request pane names the reason) so a swallowed chain
+        # isn't invisible among clean rows. #567/H3 Finding 1.
+        screen.text(x, y, "⚠ ¦chain not applied", Theme.yellow, bg, width: {inner.right - x, 1}.max)
       else
         screen.text(x, y, "#{Fmt.size(r.length).ljust(8)} #{r.words.to_s.ljust(7)} #{Fmt.dur(r.duration_us)}", selected ? Theme.text : Theme.muted, bg, width: {inner.right - x, 1}.max)
       end
@@ -2495,6 +2500,8 @@ module Gori::Tui
         return ResultRequest.new(sent, false)
       end
       tmpl = @run_template || Fuzz::Template.parse(String.new(Env.expand_wire(@editor.wire_text)), @http2)
+      # Values only — the reason a chain didn't run is already carried on the row
+      # (r.chain_error), surfaced by detail_request_lines below.
       payloads = tmpl.apply_chains(r.payloads, Decoder.shared_registry)
       raw = tmpl.render(payloads)
       sync, add, _ = run_policy
@@ -2527,6 +2534,12 @@ module Gori::Tui
       req = result_request(r)
       lines = String.new(req.bytes).scrub.split('\n').map(&.rstrip('\r'))
       lines.unshift(FuzzerView.reconstruction_note(run_policy[2])) if req.reconstructed
+      # This pane already SHOWS the untransformed bytes for a row whose `¦chain` did not run
+      # (result_request re-applies the same chains the engine did). Say WHY, so the operator
+      # doesn't read the raw payload as the request they declared. #567/H3 Finding 1.
+      if ce = r.chain_error
+        lines.unshift("(¦chain not applied: #{ce})")
+      end
       lines
     end
 

--- a/src/gori/tui/repeater_view.cr
+++ b/src/gori/tui/repeater_view.cr
@@ -1571,9 +1571,13 @@ module Gori::Tui
     # position's default through its inline Decoder chain (Template#apply_chains), then
     # resync Content-Length as usual. Parsing the CRLF form (not @editor.text, which is LF)
     # keeps render's output in wire form so the existing CRLF-based sync_content_length works
-    # unchanged. A chain-less `§v§` renders `v`; a failing chain passes the value through.
+    # unchanged. A chain-less `§v§` renders `v`.
+    #
+    # `refuse: true` — this is the ONE path that puts these bytes on the wire, so a `¦chain`
+    # that cannot run is REFUSED here (see `refuse_bad_chains`) rather than let
+    # `Template#apply_chains` drop the raw, untransformed value onto the socket.
     private def marked_request_bytes : Bytes
-      finalize_wire(render_marked(expanded_editor_bytes))
+      finalize_wire(render_marked(expanded_editor_bytes, refuse: true))
     end
 
     # Render the §…§ template in `raw` (each marked default through its inline Decoder
@@ -1581,9 +1585,61 @@ module Gori::Tui
     # send AND the CL reflection so both derive Content-Length from the SAME rendered body —
     # otherwise the visible header showed a CL for the raw marked text while ^R sent one for
     # the rendered body.
-    private def render_marked(raw : Bytes) : Bytes
+    #
+    # `refuse` is OFF for the render/CL-reflection caller and ON only for the send: this runs
+    # on every frame while the operator types, so a broken chain must NOT raise here (it would
+    # crash the tab the operator is using to FIX the chain). The send path alone refuses.
+    private def render_marked(raw : Bytes, refuse : Bool = false) : Bytes
       tmpl = Fuzz::Template.parse(String.new(raw))
-      tmpl.render(tmpl.apply_chains(tmpl.default_payloads, Decoder.shared_registry))
+      registry = Decoder.shared_registry
+      refuse_bad_chains(tmpl, registry) if refuse
+      tmpl.render(tmpl.apply_chains(tmpl.default_payloads, registry))
+    end
+
+    # Refuse a send whose `§value¦chain§` markers name a converter that cannot run over the
+    # value about to go on the wire. The twin of `Fuzz::Plan#refuse_unusable_chains`, and it
+    # exists for the same reason: `Template#apply_chains` returns the value UNTRANSFORMED when
+    # its chain does not run (`Decoder.run` never raises), so a §…§ marker whose chain is
+    # unknown, names an unusable saved chain, or simply fails on its value would put the RAW
+    # value on the wire under a clean-looking send — a corrupted request, not a refusal.
+    #
+    # Where the Fuzzer runs many payloads per marked position and so refuses only the two
+    # TEMPLATE-level failures (unknown converter / unusable saved chain), leaving a genuinely
+    # per-payload failure to the next payload, the Repeater sends exactly ONE value — the
+    # marked default — so a chain that fails on THAT value IS the value that would go out
+    # untransformed. The unknown/unusable wording is byte-identical to `Fuzz::Plan` so the two
+    # engines report the same failure the same way (see `Fuzz::ChainError`); the per-value
+    # failure is the extra case a single-send surface must also name.
+    private def refuse_bad_chains(tmpl : Fuzz::Template, registry : Decoder::Registry) : Nil
+      bad = [] of String
+      tmpl.positions.each do |pos|
+        next if pos.chain.empty?
+        # The template-level failures, worded exactly as Fuzz::Plan#refuse_unusable_chains.
+        resolvable = true
+        Decoder.parse_spec(pos.chain).each do |tok|
+          conv = registry[tok]?
+          if conv.nil?
+            bad << "#{tok}: unknown converter"
+            resolvable = false
+          elsif reason = conv.unusable
+            bad << reason # already prefixed with the chain's own name
+            resolvable = false
+          end
+        end
+        # Then the per-value failure: base64-decode over a value that isn't base64, etc. A
+        # Fuzz sweep leaves this to the next payload; a repeater send has no next payload, so
+        # the marked default going out raw is the corruption to refuse.
+        next unless resolvable
+        res = Decoder.run(registry, pos.default.to_slice, pos.chain)
+        unless res.ok?
+          step = res.steps[res.failed_at || 0]
+          bad << "#{step.name}: #{step.error || "chain failed"}"
+        end
+      end
+      return if bad.empty?
+      raise Fuzz::ChainError.new("§…§ chain cannot run: #{bad.uniq.join("; ")}. " \
+                                 "The payload would go out untransformed — fix or remove the chain " \
+                                 "(list the converters with `gori run decoder list`)")
     end
 
     # A repeater round-trip is outstanding (set/cleared by the Runner around the


### PR DESCRIPTION
Round 6 hunted the three feature PRs that landed after round 5 (#567 decoder encodings, #568 fuzz payload presets, #569 cookie workbench) plus the four defects carried over from round 5. Four read-only hunters reproduced everything against a running binary; seven fixers worked in isolated worktrees. Every fix has a spec that was control-run RED at the base commit.

## The credential leak round 5 didn't finish

`gori run mine` put the operator's live session credential on the wire.

`Miner::Engine` sent injected requests through the one-argument `Backend#send`, so `Fuzz::Sender` ran `Env.expand_bindings` over the **whole** request — including the candidate names and values the miner had just injected. A wordlist term carrying `$NAME` (parameter wordlists do carry templated names) expanded to the live token and went to the target, and the run reported `0 errors`.

This is the exact class round 5 fixed for the Fuzzer. Round 5's sibling grep missed it because the miner injects through `Inject.apply`, not the fuzz `Generator` — different helper, same seam.

`Inject.apply_with_spans` now returns the injected byte spans in **final** offsets, which is most of the work: body locations shift under `ContentLength.sync_at`'s delta, and the JSON path reserialises the entire body through `any.to_json`, so the spans have to be located after reserialisation. `Miner::Engine` passes them as `verbatim`. The seed's own `$BINDING` still expands — that is what bindings are for — and only the injected regions stay literal.

```
BASE:  Authorization: livevalue    livevalue: gqcanary1   <- injected $SECRET became the credential
FIXED: Authorization: livevalue    $SECRET: gqcanary1     <- seed expands, injected stays literal
```

Flagged, not fixed: `probe/active.cr:112` sends one-argument through the same `Sender`. No leak reproduces today because current rule payloads avoid the `$NAME` shape, but the seam is structurally unprotected.

## Bytes the author never wrote

`update_repeater_ws_messages` ran the author's live WebSocket payload through `Env.mask_secrets` **before the INSERT**, so a payload byte-matching a binding's value was persisted as `$CTOK`. Every later send reads the stored bytes, so TUI, `gori run` and MCP all emitted something the author never typed. The store now persists verbatim, matching its two siblings (`insert_repeater`, `insert_ws_one`); substitution stays at the send seam.

A store row is a claim that those exact bytes are the author's.

## Two silent narrowings of operator material

**The preset merge file** ran through the same `strip` + `#`-comment-skip as the curated built-in sets. The same file sent byte-exact via `-w` lost three of six payloads via `--preset NAME:FILE`, and the count looked honest, so the loss was invisible. A `#!/bin/sh` shebang and `#{7*7}` are payloads, not comments. The merge file is now read chomp-only like `WordlistFile`; the built-in `.txt` sets keep their curated treatment.

```
44 sent (38 built-in + 6 user), all six verbatim:
  GET /q?x= OR 1=1        (leading space kept)
  GET /q?x=PAYLOADTAB\t   (trailing tab kept)
  GET /q?x=#!/bin/sh      GET /q?x=#{7*7}      GET /q?x=      GET /q?x=NORMAL
```

**A fuzz `¦chain` that failed on a specific payload** sent that payload untransformed and reported `error:null`. `Decoder.run` produced the named refusal; `template.cr:242` threw it away. PR #567 made this ordinary rather than exotic — seven of the nine new converters raise on inputs a normal wordlist contains. The payload that most needed shell-quoting went out unquoted, inside `0 errors`.

The reason now rides to the surface as `chain_error` on the row (CLI, MCP, TUI detail pane) and counts in the error tally. The payload still goes out untransformed rather than being rejected — it is operator material — but the run no longer claims it was fine.

## The rest

- **Repeater `¦chain` had no refusal** where Fuzz has `ChainError`, so an unresolvable chain sent a corrupted request. The refusal lives in `repeater_view.cr`, gated to the send path only — `render_marked` also runs every frame for Content-Length reflection, and raising there would crash the tab the operator is using to fix the chain.
- **`punycode-encode` skipped RFC 3490 ToASCII**, so any label with an uppercase character encoded to a hostname no resolver produces. `МОСКВА.РФ` differed in the bootstring *digits*, not just case. This broke the exact homograph workflow the converter was added for. Now matches Python `idna` on every vector.
- **`--format json` emitted invalid JSON** for a non-UTF-8 payload — one `\xff\xfe` poisoned the whole document. The MCP twin already scrubbed; only the CLI emitter was missed.
- **`--forge --timestamp <garbage>`** silently stamped "now" and exited 0. Present-but-invalid is now a named refusal on both CLI and MCP; absent still defaults to now.

## Verification

`crystal spec` **6429 examples, 0 failures** (baseline 6389 + 40 new). `crystal build --no-codegen` clean at every merge step. Each fix was reproduced first, control-run RED at `5609db39`, and re-verified against a freshly built binary.

Hunters also confirmed all four round-5 fixes survived #567/#568/#569, and that the cookie crypto is sound: gori's Flask and Rack forgeries are byte-identical to the real libraries' output and are accepted by Flask, Django and Rack themselves.

## Follow-ups filed, not fixed

`probe/active.cr` one-argument sends · SNI masked on write (SNI is on the wire) · Repeater `%%%` group-send doesn't render markers · `discover/wordlist.cr` and `miner/wordlist.cr` share the strip+skip shape (judgment call — a path or parameter name is less plausibly whitespace-bearing than a payload).
