### PR TITLE
A one-byte needle, a forgeable diagnostic, and a wordlist that shrank without saying so

### DIFF
--- a/spec/bindings_spec.cr
+++ b/spec/bindings_spec.cr
@@ -819,6 +819,17 @@ describe "Gori::Rules — replacement resolution (#501)" do
       Gori::Rules.escape_backrefs(plain).should be(plain)
     end
 
+    it "doubles a backslash byte-wise, leaving invalid UTF-8 around it untouched" do
+      # `String#gsub("\\", "\\\\")` delegates to the Char overload (1-byte needle) and walks
+      # the value with `each_char`, so an invalid byte on either side of the backslash used
+      # to come back as three-byte U+FFFD each. Raw fixture, searched byte-wise, matching the
+      # bytes a round-7 fixer actually measured on the wire: 0xFF 0xFE 0x5C 0x78.
+      bytes = Bytes[0xff_u8, 0xfe_u8, 0x5c_u8, 0x78_u8]
+      value = String.new(bytes)
+      escaped = Gori::Rules.escape_backrefs(value)
+      escaped.to_slice.should eq(Bytes[0xff_u8, 0xfe_u8, 0x5c_u8, 0x5c_u8, 0x78_u8])
+    end
+
     it "does not let a server-controlled \\1 in a token become a capture group" do
       with_store do |store|
         b = Gori::Bindings.load(store)
@@ -853,6 +864,36 @@ describe "Gori::Rules — replacement resolution (#501)" do
             Gori::Store::MatchKind::Regex)
           head = "GET / HTTP/1.1\r\nCookie: sid=x\r\n\r\n".to_slice
           String.new(rules.rewrite_request(head, "a")).should contain("Cookie: sid=\\k<oops>")
+        end
+      end
+    end
+
+    it "sends a Position-bound value with invalid UTF-8 through a regex rule byte-exact" do
+      # `TokenExtract.position` hands its slice to `String.new` unscrubbed by design (see the
+      # comment on it), so a Position binding can carry bytes no `String` literal in this file
+      # can spell. Build the fixture at the byte level and drive it through the real path:
+      # extract → bind → regex Match&Replace → wire.
+      body_bytes = Bytes[0x41_u8, 0xff_u8, 0xfe_u8, 0x5c_u8, 0x78_u8, 0x42_u8] # A <inval> <inval> \ x B
+      with_store do |store|
+        b = Gori::Bindings.load(store)
+        b.add("TOK", "", Gori::ExtractKind::Position, "", 1, 5)
+        b.observe(response_result("HTTP/1.1 200 OK\r\n\r\n", String.new(body_bytes)), subject)
+        b.values["TOK"].to_slice.should eq(body_bytes[1...5])
+        with_layer(b) do
+          rules = Gori::Rules.load(store)
+          rules.add(Gori::Store::RuleTarget::Request, Gori::Store::RulePart::Head,
+            "MARKER", "$TOK", Gori::Store::RuleOp::Replace, Gori::Store::MatchKind::Regex)
+          head = "GET /MARKER HTTP/1.1\r\nHost: a\r\n\r\n".to_slice
+          got = rules.rewrite_request(head, "a")
+          # Byte-exact round trip: `escape_backrefs` doubles the backslash so the SECOND
+          # `gsub` (the one splicing `$TOK`'s resolved text into the wire) reads the pair as
+          # its own "\\" escape and collapses it back to one — the net wire bytes must equal
+          # the ORIGINAL captured value, invalid bytes included, not `ef bf bd` triples.
+          exp_buf = IO::Memory.new
+          exp_buf.write("GET /".to_slice)
+          exp_buf.write(body_bytes[1...5])
+          exp_buf.write(" HTTP/1.1\r\nHost: a\r\n\r\n".to_slice)
+          got.should eq(exp_buf.to_slice)
         end
       end
     end

--- a/spec/cli/run/mine_spec.cr
+++ b/spec/cli/run/mine_spec.cr
@@ -1,0 +1,62 @@
+require "../../spec_helper"
+
+# Round 8 item 2: `gori run mine --locations json` against a request whose body EXISTS but is
+# not valid UTF-8 used to route through the generic
+#
+#   gori run mine: json: not applicable to this request (no matching existing body), skipping
+#
+# — the wrong reason for a body that plainly IS there. `Detect`/`Inject` correctly refuse to
+# OFFER Json for such a body (round 7, miner/inject.cr's `json_object_node_count` — it cannot
+# round-trip through `JSON::Any`), but "no matching existing body" tells the operator the wrong
+# thing. The CLI now gives that one case its own sentence.
+#
+# The CLI's wording lives behind `private def self.` (nothing outside `gori run` may phrase
+# it), so it is reached through a shim in the same module — the pattern
+# `env_unresolved_error_for_spec` (spec/cli/run/bind_from_disabled_rule_spec.cr) already uses.
+module Gori::CLI::Run
+  def self.mine_inapplicable_reason_for_spec(loc : Miner::Location, request : Bytes) : String
+    mine_inapplicable_reason(loc, request)
+  end
+end
+
+private alias M = Gori::Miner
+
+# Byte-exact fixture per the round-8 rule: build the non-UTF-8 body from a raw `Bytes`
+# literal, never a String literal (a Crystal String literal must itself be valid UTF-8).
+private def request_with_body(body : Bytes, content_type : String? = "application/json") : Bytes
+  head_lines = ["POST / HTTP/1.1", "Host: x"]
+  head_lines << "Content-Type: #{content_type}" if content_type
+  head_lines << "Content-Length: #{body.size}"
+  head = (head_lines.join("\r\n") + "\r\n\r\n").to_slice
+  io = IO::Memory.new(head.size + body.size)
+  io.write(head)
+  io.write(body)
+  io.to_slice
+end
+
+describe "Gori::CLI::Run — mine inapplicable-location wording" do
+  it "gives JSON its own accurate reason when the body exists but is not valid UTF-8" do
+    request = request_with_body(Bytes[0xFF, 0xFE, 0x01, 0x02])
+    reason = Gori::CLI::Run.mine_inapplicable_reason_for_spec(M::Location::Json, request)
+    reason.should contain("not valid UTF-8")
+    reason.should_not contain("no matching existing body")
+  end
+
+  it "keeps the generic reason for JSON when there is genuinely no body (complement)" do
+    request = "GET / HTTP/1.1\r\nHost: x\r\n\r\n".to_slice
+    reason = Gori::CLI::Run.mine_inapplicable_reason_for_spec(M::Location::Json, request)
+    reason.should eq("not applicable to this request (no matching existing body)")
+  end
+
+  it "keeps the generic reason for JSON when the body is present and valid UTF-8 (complement)" do
+    request = request_with_body(%({"a":1}).to_slice)
+    reason = Gori::CLI::Run.mine_inapplicable_reason_for_spec(M::Location::Json, request)
+    reason.should eq("not applicable to this request (no matching existing body)")
+  end
+
+  it "keeps the generic reason for a non-JSON location regardless of body encoding (complement)" do
+    request = request_with_body(Bytes[0xFF, 0xFE, 0x01, 0x02], content_type: nil)
+    reason = Gori::CLI::Run.mine_inapplicable_reason_for_spec(M::Location::Form, request)
+    reason.should eq("not applicable to this request (no matching existing body)")
+  end
+end

--- a/spec/discover/wordlist_spec.cr
+++ b/spec/discover/wordlist_spec.cr
@@ -1,0 +1,79 @@
+require "../spec_helper"
+
+# Round 8, item 1 (round 7 h1-seams.md FINDING 4): the user merge file for `--wordlist` is
+# operator MATERIAL. `Wordlist.load` used to `.strip` every line before appending it, which
+# not only destroyed a leading/trailing space or tab but then let the stripped copy DEDUPE
+# AWAY against its own trimmed twin — a path segment silently vanished from the run with no
+# warning. Fixed to `chomp: true` (line-ending only), classifying blank/`#`-comment lines on
+# a TRIMMED copy but yielding the UNSTRIPPED line, exactly the fidelity round 6 gave
+# `Fuzz::Presets`/`WordlistFile` for payloads.
+private alias D = Gori::Discover
+
+private def with_wordlist(raw : String, &)
+  path = File.tempname("gori-discover-wordlist", ".txt")
+  File.write(path, raw)
+  begin
+    yield path
+  ensure
+    File.delete?(path)
+  end
+end
+
+describe Gori::Discover::Wordlist do
+  it "loads the built-in list stripped and comment-free (unchanged, curated asset)" do
+    D::Wordlist.builtin.should_not be_empty
+    D::Wordlist.builtin.none?(&.empty?).should be_true
+    D::Wordlist.builtin.none? { |n| n.starts_with?('#') }.should be_true
+  end
+
+  describe "user merge file (operator material)" do
+    it "keeps a leading/trailing space or tab instead of stripping it away" do
+      with_wordlist("zzadmin \n zzadmin\nzzTRAILTAB\t\n") do |path|
+        merged = D::Wordlist.load(path)
+        merged.should contain("zzadmin ")
+        merged.should contain(" zzadmin")
+        merged.should contain("zzTRAILTAB\t")
+      end
+    end
+
+    it "does NOT collapse the trailing-space and leading-space variants into one entry" do
+      with_wordlist("zzadmin \n zzadmin\n") do |path|
+        merged = D::Wordlist.load(path)
+        # Both survive as DISTINCT entries — this is the exact dedupe-away this round fixes.
+        merged.count { |n| n == "zzadmin " || n == " zzadmin" }.should eq(2)
+      end
+    end
+
+    it "still skips a blank line and a #-comment line (kept as intentional conventions)" do
+      with_wordlist("zzone\n\n#zzcomment\nzztwo\n") do |path|
+        merged = D::Wordlist.load(path)
+        merged.should contain("zzone")
+        merged.should contain("zztwo")
+        merged.none?(&.starts_with?('#')).should be_true
+        merged.none?(&.empty?).should be_true
+      end
+    end
+
+    it "keeps an interior # (not comment-classified) and still de-dupes an exact duplicate" do
+      with_wordlist("zzhash#x\nzzhash#x\n") do |path|
+        merged = D::Wordlist.load(path)
+        merged.count("zzhash#x").should eq(1) # exact duplicate — legitimate dedupe
+      end
+    end
+
+    it "merges built-in first, order preserving, de-duped against a real collision" do
+      baseline = D::Wordlist.load # deduped baseline (raw .builtin may carry internal dupes)
+      with_wordlist("#{baseline.first}\nCUSTOM-#{Random::Secure.hex(3)}\n") do |path|
+        merged = D::Wordlist.load(path)
+        merged[0, baseline.size].should eq(baseline)
+        merged.uniq.size.should eq(merged.size)
+      end
+    end
+
+    it "raises for a missing merge path" do
+      expect_raises(File::NotFoundError) do
+        D::Wordlist.load("/no/such/gori-wordlist-#{Random::Secure.hex(4)}.txt")
+      end
+    end
+  end
+end

--- a/spec/mcp_mine_grpc_spec.cr
+++ b/spec/mcp_mine_grpc_spec.cr
@@ -1,0 +1,115 @@
+require "./spec_helper"
+require "socket"
+
+# Round 8 — the MCP half of the Miner gRPC-blindness wiring. `mine_results` had the same
+# `name/location/evidence/confidence/canary/status/delta` shape as the CLI row and the same
+# gap: `status` is the h2 `:status`, which is 200 for every gRPC response, so an agent mining
+# a gRPC service through MCP could not tell an isolated candidate the target GRANTED from one
+# it PERMISSION_DENIED — both read as a plain 200 finding.
+#
+# Real TCP origin (not a FakeBackend) so this exercises the actual MCP job pipeline: mine_start
+# → the live send → mine_results, the same path `spec/mcp_wiring_spec.cr` uses for its own
+# gaps. The origin denies (grpc-status 7) every query unless it carries `secret=`, which it
+# grants (grpc-status 0) AND grows the body — the metric signal Miner's bisection isolates.
+
+private def with_store(&)
+  path = File.tempname("gori-mcpmine-grpc", ".db")
+  store = Gori::Store.open(path)
+  begin
+    yield store
+  ensure
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+private def tools_for(store) : Gori::MCP::Tools
+  Gori::MCP::Tools.new(store, allow_actions: true, verify_upstream: false)
+end
+
+private def call_json(tools, name, args : String) : JSON::Any
+  r = tools.call(name, JSON.parse(args))
+  fail "tool #{name} errored: #{r.text}" if r.is_error
+  JSON.parse(r.text)
+end
+
+private def poll_until_done(tools, job_id : String, seconds = 20) : JSON::Any
+  deadline = Time.instant + seconds.seconds
+  loop do
+    st = call_json(tools, "mine_status", %({"job_id":#{job_id.to_json}}))
+    return st unless st["status"].as_s == "running"
+    fail "mine_status #{job_id} never left :running within #{seconds}s" if Time.instant > deadline
+    sleep 0.02.seconds
+  end
+end
+
+# Grants (grpc-status 0, grown body) only a query carrying `secret=`; denies (grpc-status 7)
+# everything else, deterministically — a stable baseline for calibration.
+private def grpc_mine_origin : Int32
+  server = TCPServer.new("127.0.0.1", 0)
+  port = server.local_address.port
+  spawn do
+    while conn = server.accept?
+      spawn do
+        begin
+          conn.read_timeout = 2.seconds
+          while head = Gori::Proxy::Codec::Http1.read_head(conn)
+            line = String.new(head).lines.first? || ""
+            target = line.split(' ')[1]? || ""
+            granted = target.includes?("secret=")
+            body = granted ? "OK" + "X" * 40 : "OK"
+            code = granted ? 0 : 7
+            msg = granted ? nil : "nope; you may not"
+            resp = String.build do |io|
+              io << "HTTP/1.1 200 OK\r\ncontent-type: application/grpc\r\n"
+              io << "Content-Length: #{body.bytesize}\r\ngrpc-status: #{code}\r\n"
+              io << "grpc-message: #{msg}\r\n" if msg
+              io << "\r\n" << body
+            end
+            conn << resp
+            conn.flush
+          end
+        rescue
+        end
+        conn.close rescue nil
+      end
+    end
+  end
+  port
+end
+
+private GRPC_MINE_ORIGIN_PORT = grpc_mine_origin
+
+describe "MCP mine_results over gRPC" do
+  it "carries grpc_status/grpc_status_name/grpc_message on the isolated Finding row" do
+    port = GRPC_MINE_ORIGIN_PORT
+    wl = File.tempname("gori-mine-grpc-wl", ".txt")
+    File.write(wl, "alpha\nbeta\ngamma\nsecret\ndelta\nepsilon\nzeta\neta\n")
+    begin
+      with_store do |store|
+        tools = tools_for(store)
+        start = call_json(tools, "mine_start",
+          {"template" => "GET /pkg.Svc/Method HTTP/1.1\r\nHost: 127.0.0.1:#{port}\r\n\r\n",
+           "url" => "http://127.0.0.1:#{port}", "locations" => "query",
+           "wordlist" => wl, "bucket" => 4, "concurrency" => 2,
+           "allow_unscoped" => true}.to_json)
+        poll_until_done(tools, start["job_id"].as_s)
+        res = call_json(tools, "mine_results", %({"job_id":#{start["job_id"].as_s.to_json}}))
+        findings = res["findings"].as_a
+        secret = findings.find { |f| f["name"].as_s == "secret" }
+        fail "expected a finding for 'secret' — got #{findings.map(&.["name"])}" unless secret
+        secret["status"].as_i.should eq(200) # h2 :status is 200 for the granted call too
+        secret["grpc_status"].as_i.should eq(0)
+        secret["grpc_status_name"].as_s.should eq("OK")
+        secret["grpc_message"]?.should be_nil
+
+        # Complement: a plain (non-gRPC) mine's rows carry no grpc_* fields at all.
+        findings.each { |f| f.as_h.has_key?("delta").should be_true }
+      end
+    ensure
+      File.delete?(wl)
+    end
+  end
+end

--- a/spec/mcp_mine_grpc_spec.cr
+++ b/spec/mcp_mine_grpc_spec.cr
@@ -90,12 +90,18 @@ describe "MCP mine_results over gRPC" do
     begin
       with_store do |store|
         tools = tools_for(store)
+        # `bucket` deliberately LARGE (not forced small): `wordlist` is MERGED with the
+        # built-in ~400-name list (the same merge `mine_status{skipped}` above pins), so a
+        # small bucket here would fan out into a couple hundred real TCP round trips through
+        # this Python origin — still correct, but needlessly slow/flaky under a busy test
+        # run. A big bucket keeps clean buckets at ONE request each; only the bucket holding
+        # `secret` bisects, which is all this spec needs to exercise.
         start = call_json(tools, "mine_start",
           {"template" => "GET /pkg.Svc/Method HTTP/1.1\r\nHost: 127.0.0.1:#{port}\r\n\r\n",
            "url" => "http://127.0.0.1:#{port}", "locations" => "query",
-           "wordlist" => wl, "bucket" => 4, "concurrency" => 2,
+           "wordlist" => wl, "bucket" => 128, "concurrency" => 2,
            "allow_unscoped" => true}.to_json)
-        poll_until_done(tools, start["job_id"].as_s)
+        poll_until_done(tools, start["job_id"].as_s, 40)
         res = call_json(tools, "mine_results", %({"job_id":#{start["job_id"].as_s.to_json}}))
         findings = res["findings"].as_a
         secret = findings.find { |f| f["name"].as_s == "secret" }

--- a/spec/mcp_mine_grpc_spec.cr
+++ b/spec/mcp_mine_grpc_spec.cr
@@ -93,15 +93,17 @@ describe "MCP mine_results over gRPC" do
         # `bucket` deliberately LARGE (not forced small): `wordlist` is MERGED with the
         # built-in ~400-name list (the same merge `mine_status{skipped}` above pins), so a
         # small bucket here would fan out into a couple hundred real TCP round trips through
-        # this Python origin — still correct, but needlessly slow/flaky under a busy test
-        # run. A big bucket keeps clean buckets at ONE request each; only the bucket holding
-        # `secret` bisects, which is all this spec needs to exercise.
+        # this origin — still correct, but needlessly slow under a busy full-suite run. A
+        # big bucket keeps clean buckets at ONE request each; only the bucket holding
+        # `secret` bisects, which is all this spec needs to exercise. `concurrency` 1: the
+        # single-threaded fiber scheduler serializes everything anyway, and a busy 6000+
+        # example run can starve a concurrent job's dispatcher fiber past a short deadline.
         start = call_json(tools, "mine_start",
           {"template" => "GET /pkg.Svc/Method HTTP/1.1\r\nHost: 127.0.0.1:#{port}\r\n\r\n",
            "url" => "http://127.0.0.1:#{port}", "locations" => "query",
-           "wordlist" => wl, "bucket" => 128, "concurrency" => 2,
+           "wordlist" => wl, "bucket" => 128, "concurrency" => 1,
            "allow_unscoped" => true}.to_json)
-        poll_until_done(tools, start["job_id"].as_s, 40)
+        poll_until_done(tools, start["job_id"].as_s, 90)
         res = call_json(tools, "mine_results", %({"job_id":#{start["job_id"].as_s.to_json}}))
         findings = res["findings"].as_a
         secret = findings.find { |f| f["name"].as_s == "secret" }

--- a/spec/miner/grpc_verdict_spec.cr
+++ b/spec/miner/grpc_verdict_spec.cr
@@ -1,0 +1,114 @@
+require "../spec_helper"
+
+private alias M = Gori::Miner
+private alias F = Gori::Fuzz
+
+# Round 8 — `grep -rni grpc src/gori/{miner,discover,sequencer,probe}/` returned only two
+# `tech_grpc` display labels in probe/issue.cr. Miner (like Fuzz before round 7) reads only
+# the h2 `:status`, which is 200 BY DEFINITION for every gRPC response — so a mine against a
+# target that PERMISSION_DENIED-ed every candidate but granted the hidden one looked exactly
+# like a mine against a target with no gRPC awareness at all: the isolated Finding carried a
+# `status` of 200 either way. The real per-candidate outcome lives in the `grpc-status` /
+# `grpc-message` trailers the confirming round's response head carries (`Fuzz::GrpcVerdict`,
+# the same projection round 7 wired into the Fuzzer).
+#
+# A backend simulating a gRPC service: every candidate except one magic name is denied
+# (grpc-status 7) with a short body; the magic name is granted (grpc-status 0) AND its body
+# grows, which is the metric signal `Miner.decide` isolates via bisection. So the Finding this
+# produces is exactly the shape a real "hidden parameter that bypasses an authz check on a
+# gRPC endpoint" investigation looks for — and the DEFECT was that its `grpc_status` was
+# unreachable no matter how the candidate was isolated.
+private class GrpcHiddenParamBackend < F::Backend
+  getter origin : F::Origin
+  getter sent : Int32 = 0
+
+  def initialize(@origin : F::Origin, @grant : String)
+  end
+
+  def send(bytes : Bytes) : Gori::Repeater::Result
+    @sent += 1
+    params = query_params(bytes)
+    granted = params.has_key?(@grant)
+    body = granted ? "OK" + "X" * 40 : "OK"
+    code = granted ? 0 : 7
+    msg = granted ? nil : "nope; you may not"
+    head = String.build do |io|
+      io << "HTTP/1.1 200 OK\r\ncontent-type: application/grpc\r\n"
+      io << "Content-Length: #{body.bytesize}\r\ngrpc-status: #{code}\r\n"
+      io << "grpc-message: #{msg}\r\n" if msg
+      io << "\r\n"
+    end.to_slice
+    resp = Gori::Proxy::Codec::Http1.parse_response_head(head)
+    Gori::Repeater::Result.new(head, body.to_slice, resp, 1000_i64)
+  end
+
+  private def query_params(bytes : Bytes) : Hash(String, String)
+    pairs = Hash(String, String).new
+    line = String.new(bytes).lines.first? || ""
+    target = line.split(' ')[1]? || ""
+    qi = target.index('?')
+    return pairs unless qi
+    target[(qi + 1)..].split('&').each do |pair|
+      k, _, v = pair.partition('=')
+      pairs[k] = v unless k.empty?
+    end
+    pairs
+  end
+end
+
+private def cfg : M::Config
+  c = M::Config.new
+  c.locations = [M::Location::Query]
+  c.bucket_size = M::Config::DEFAULT_BUCKETS.dup
+  c.bucket_size[M::Location::Query] = 4 # small → forces bisection
+  c.concurrency = 2
+  c.stability_rounds = 2
+  c.confirm_rounds = 1
+  c.retries = 0
+  c
+end
+
+private def mine(backend : F::Backend, names : Array(String), config : M::Config) : Array(M::Finding)
+  base = "GET /pkg.Svc/Method HTTP/1.1\r\nHost: h\r\n\r\n".to_slice
+  engine = M::Engine.new(base, http2: false, names: names, backend: backend, config: config)
+  findings = [] of M::Finding
+  engine.run do |ev|
+    findings << ev.finding if ev.is_a?(M::FindingEvent)
+  end
+  findings
+end
+
+describe "mine over gRPC" do
+  it "carries the confirming round's grpc-status/grpc-message onto the isolated Finding" do
+    backend = GrpcHiddenParamBackend.new(F::Origin.new("http", "h", 80), "secret")
+    names = ["alpha", "beta", "gamma", "secret", "delta", "epsilon", "zeta", "eta"]
+    findings = mine(backend, names, cfg)
+
+    secret = findings.find { |f| f.name == "secret" }
+    raise "expected a finding for 'secret'" unless secret
+    secret.status.should eq(200) # the h2 status is 200 for the granted call too — the whole point
+    secret.grpc_status.should eq(0)
+    secret.grpc_message.should be_nil # an empty grpc-message is absent, not ""
+
+    findings.map(&.name).should_not contain("alpha")
+  end
+
+  # F1, the reporting half: CLI JSON/text and MCP JSON only render the field when present,
+  # so a non-gRPC mine's rows are unchanged (the complement below).
+  it "emits grpc_status / grpc_status_name / grpc_message on the CLI and MCP rows, only when present" do
+    f = M::Finding.new("secret", M::Location::Query, M::Evidence::Length, M::Confidence::Confirmed,
+      nil, 200, 40_i64, grpc_status: 7, grpc_message: "nope; you may not")
+    j = JSON.parse(Gori::CLI::Output.mine_row_json(f))
+    j["grpc_status"].as_i.should eq(7)
+    j["grpc_status_name"].as_s.should eq("PERMISSION_DENIED")
+    j["grpc_message"].as_s.should eq("nope; you may not")
+    text = Gori::CLI::Output.mine_row_text(f)
+    text.should contain("grpc 7 PERMISSION_DENIED")
+    text.should contain("nope; you may not")
+
+    # Complement: an ordinary (non-gRPC) finding is byte-identical to what it was.
+    plain = M::Finding.new("secret", M::Location::Query, M::Evidence::Length, M::Confidence::Confirmed, nil, 200, 40_i64)
+    Gori::CLI::Output.mine_row_json(plain).should_not contain("grpc")
+    Gori::CLI::Output.mine_row_text(plain).should_not contain("grpc")
+  end
+end

--- a/spec/miner/wordlist_spec.cr
+++ b/spec/miner/wordlist_spec.cr
@@ -1,0 +1,78 @@
+require "../spec_helper"
+
+# Round 8, item 1 (round 7 h1-seams.md FINDING 4): the user merge file for `--wordlist` is
+# operator MATERIAL. `Wordlist.load` used to `.strip` every line before appending it, which
+# not only destroyed a leading/trailing space or tab but then let the stripped copy DEDUPE
+# AWAY against its own trimmed twin — a parameter NAME silently vanished from the run with
+# no warning. Fixed to `chomp: true` (line-ending only), classifying blank/`#`-comment lines
+# on a TRIMMED copy but yielding the UNSTRIPPED line, exactly the fidelity round 6 gave
+# `Fuzz::Presets`/`WordlistFile` for payloads.
+private alias M = Gori::Miner
+
+private def with_wordlist(raw : String, &)
+  path = File.tempname("gori-miner-wordlist", ".txt")
+  File.write(path, raw)
+  begin
+    yield path
+  ensure
+    File.delete?(path)
+  end
+end
+
+describe Gori::Miner::Wordlist do
+  it "loads the built-in list stripped and comment-free (unchanged, curated asset)" do
+    M::Wordlist.builtin.should_not be_empty
+    M::Wordlist.builtin.none?(&.empty?).should be_true
+    M::Wordlist.builtin.none? { |n| n.starts_with?('#') }.should be_true
+  end
+
+  describe "user merge file (operator material)" do
+    it "keeps a leading/trailing space or tab instead of stripping it away" do
+      with_wordlist("zzp \n zzp2\nzzTRAILTAB\t\n") do |path|
+        merged = M::Wordlist.load(path)
+        merged.should contain("zzp ")
+        merged.should contain(" zzp2")
+        merged.should contain("zzTRAILTAB\t")
+      end
+    end
+
+    it "does NOT collapse a trailing-space and a plain variant into one entry" do
+      with_wordlist("zzp\nzzp \n") do |path|
+        merged = M::Wordlist.load(path)
+        merged.count { |n| n == "zzp" || n == "zzp " }.should eq(2)
+      end
+    end
+
+    it "still skips a blank line and a #-comment line (kept as intentional conventions)" do
+      with_wordlist("zzone\n\n#zzcomment\nzztwo\n") do |path|
+        merged = M::Wordlist.load(path)
+        merged.should contain("zzone")
+        merged.should contain("zztwo")
+        merged.none?(&.starts_with?('#')).should be_true
+        merged.none?(&.empty?).should be_true
+      end
+    end
+
+    it "keeps an interior # (not comment-classified) and still de-dupes an exact duplicate" do
+      with_wordlist("zzhash#x\nzzhash#x\n") do |path|
+        merged = M::Wordlist.load(path)
+        merged.count("zzhash#x").should eq(1) # exact duplicate — legitimate dedupe
+      end
+    end
+
+    it "merges built-in first, order preserving, de-duped against a real collision" do
+      baseline = M::Wordlist.load # deduped baseline (raw .builtin may carry internal dupes)
+      with_wordlist("#{baseline.first}\nCUSTOM-#{Random::Secure.hex(3)}\n") do |path|
+        merged = M::Wordlist.load(path)
+        merged[0, baseline.size].should eq(baseline)
+        merged.uniq.size.should eq(merged.size)
+      end
+    end
+
+    it "raises for a missing merge path" do
+      expect_raises(File::NotFoundError) do
+        M::Wordlist.load("/no/such/gori-wordlist-#{Random::Secure.hex(4)}.txt")
+      end
+    end
+  end
+end

--- a/spec/probe_spec.cr
+++ b/spec/probe_spec.cr
@@ -297,6 +297,41 @@ describe Gori::Probe::Active do
     end
   end
 
+  # `canary_pairs`/`canary_json` rebuild the BODY THE PROBE SENDS, only ever generating a
+  # FRESH value for the param they canary — every other byte in the body (a bare flag with no
+  # `=`, another param's NAME, an untouched JSON field) is carried through from the captured
+  # request. A `.scrub` before that rebuild corrupted invalid UTF-8 anywhere in it, so a probe
+  # for an unrelated field sent the origin `U+FFFD` where the capture had a raw byte. Raw
+  # fixture, searched byte-wise.
+  it "sends a form-body probe with an untouched non-UTF-8 field byte-exact" do
+    with_store do |store|
+      buf = IO::Memory.new
+      buf.write(Bytes[0x66_u8, 0x6c_u8, 0xff_u8, 0x67_u8]) # "fl" 0xFF "g" — no '=', never touched
+      buf << "&a=1"
+      req_body = String.new(buf.to_slice)
+      detail = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/submit", method: "POST",
+        req_headers: "Content-Type: application/x-www-form-urlencoded\r\n", req_body: req_body,
+        content_type: nil)
+      plan = Gori::Probe::Active::ReflectedParam.new.plan(detail, Gori::Probe::Active::Options.new(allow_unsafe: true)).not_nil!
+      plan.request.hexstring.should contain(Bytes[0x66_u8, 0x6c_u8, 0xff_u8, 0x67_u8].hexstring)
+    end
+  end
+
+  it "sends a JSON-body probe with an untouched non-UTF-8 nested string byte-exact" do
+    with_store do |store|
+      buf = IO::Memory.new
+      buf << %({"a":"s","b":{"x":")
+      buf.write_byte(0xff_u8)
+      buf << %("}})
+      req_body = String.new(buf.to_slice)
+      detail = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/j", method: "POST",
+        req_headers: "Content-Type: application/json\r\n", req_body: req_body, content_type: nil)
+      plan = Gori::Probe::Active::ReflectedParam.new.plan(detail, Gori::Probe::Active::Options.new(allow_unsafe: true)).not_nil!
+      # `"x":"<0xFF>"` must survive as one raw byte, not the three-byte U+FFFD `efbfbd`.
+      plan.request.hexstring.should contain(Bytes[0x22_u8, 0xff_u8, 0x22_u8].hexstring)
+    end
+  end
+
   it "has no probe for a request without parameters" do
     with_store do |store|
       detail = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/static/app.js", content_type: nil)

--- a/spec/proxy/h2/head_codec_spec.cr
+++ b/spec/proxy/h2/head_codec_spec.cr
@@ -178,6 +178,55 @@ describe Gori::Proxy::H2::HeadCodec do
       marked.should end_with("X-Gori-Trailers: grpc-status\r\n\r\n")
     end
 
+    # Round 7 F3 / round 8 item 3 (axis 5: a diagnostic is not traffic — and the converse,
+    # traffic must not impersonate a diagnostic). gori does not enforce RFC 9113 §8.2.1
+    # lowercase field names on receive (an `X-Upper` field survives verbatim, right for a
+    # test tool), so a PEER can send a REAL field literally named `X-Gori-Trailers` with an
+    # ordinary response — no real trailer block required. Reproduced against
+    # `grpcorigin.py --scenario forgemarker` (round7/h2grpc): before this fix the peer's
+    # forged line and gori's own synthesized marker were byte-for-byte identical in the
+    # projected head, with the real trailers sandwiched in between.
+    it "renames an incoming field that collides with the trailer marker" do
+      fields = tuples([f(":status", "200"), f("X-Gori-Trailers", "grpc-status, grpc-message"),
+                        f("grpc-status", "0"), f("grpc-message", "all good")])
+      head = String.new(HeadCodec.synth_response(fields, ["grpc-status", "grpc-message"]))
+      # The peer's bytes are not thrown away (P7)…
+      head.should contain("X-Peer-X-Gori-Trailers: grpc-status, grpc-message")
+      # …but the UNPREFIXED marker name now names gori's diagnostic, and only that, exactly
+      # once — the forged line can no longer be read as gori's own.
+      head.should end_with("X-Gori-Trailers: grpc-status, grpc-message\r\n\r\n")
+      head.should_not contain("\nX-Gori-Trailers: grpc-status, grpc-message\r\nX-Gori-Trailers:")
+    end
+
+    # The wire's actual, RFC-compliant case (a real origin would send this, not the exact
+    # mixed-case marker) still collides on the marker STRING and must still be renamed.
+    it "renames the marker collision case-insensitively (the RFC-compliant lowercase form)" do
+      fields = tuples([f(":status", "200"), f("x-gori-trailers", "forged"), f("grpc-status", "0")])
+      head = String.new(HeadCodec.synth_response(fields, ["grpc-status"]))
+      head.should contain("X-Peer-x-gori-trailers: forged")
+      head.should_not contain("\nx-gori-trailers: forged")
+      head.should contain("X-Gori-Trailers: grpc-status") # gori's real marker, unambiguous
+    end
+
+    # Complement: an ordinary field name must never be touched.
+    it "does not rename a field with no marker collision" do
+      fields = tuples([f(":status", "200"), f("x-request-id", "abc")])
+      head = String.new(HeadCodec.synth_response(fields))
+      head.should contain("x-request-id: abc")
+      head.should_not contain("X-Peer-")
+    end
+
+    # Same guard on the request side, where a peer field could collide with the PUSH or
+    # protocol markers instead (`synth_request` shares `regular` with `synth_response`).
+    it "renames an incoming field colliding with the push/protocol markers (request side)" do
+      fields = req_fields + [f("X-Gori-Pushed", "forged"), f("X-Gori-Protocol", "forged")]
+      head = String.new(HeadCodec.synth_request(tuples(fields), "api.example.com", nil, 3_u32, "websocket"))
+      head.should contain("X-Peer-X-Gori-Pushed: forged")
+      head.should contain("X-Peer-X-Gori-Protocol: forged")
+      head.should contain("X-Gori-Pushed: server push promised on stream 3")
+      head.should contain("X-Gori-Protocol: websocket")
+    end
+
     # The marker is a CAPTURE-projection field. The rewrite path re-synthesizes from the LIVE
     # decoded fields and passes no trailer list, so this fabricated line can never be encoded
     # back onto an h2 wire — this pins that the round trip HeadRewrite drives stays clean.

--- a/spec/rules_spec.cr
+++ b/spec/rules_spec.cr
@@ -103,6 +103,21 @@ describe Gori::Rules do
     end
   end
 
+  it "leaves invalid UTF-8 elsewhere in the body untouched by a 1-byte literal pattern" do
+    # `String#gsub(String, String)` delegates to the `Char` overload for a 1-byte needle,
+    # which (for a multi-byte replacement) rewrites the WHOLE string with `each_char` —
+    # turning every invalid UTF-8 byte into U+FFFD, matched or not. A captured body is
+    # exactly the case: raw fixture, searched byte-wise, matching what a round-8 fixer
+    # measured for the sibling defect in `escape_backrefs`.
+    with_store do |store|
+      rules = Gori::Rules.load(store)
+      rules.add(Gori::Store::RuleTarget::Request, Gori::Store::RulePart::Body, "X", "YY")
+      body_bytes = Bytes[0x41_u8, 0xff_u8, 0x58_u8, 0x42_u8] # A <invalid> X B
+      got = rules.rewrite_request_body(String.new(body_bytes).to_slice, "")
+      got.should eq(Bytes[0x41_u8, 0xff_u8, 0x59_u8, 0x59_u8, 0x42_u8]) # A <invalid, untouched> Y Y B
+    end
+  end
+
   it "reports no body rewrite when only head rules exist" do
     with_store do |store|
       rules = Gori::Rules.load(store)

--- a/spec/sequencer/grpc_verdict_spec.cr
+++ b/spec/sequencer/grpc_verdict_spec.cr
@@ -1,0 +1,73 @@
+require "../spec_helper"
+
+private alias Q = Gori::Sequencer
+private alias F = Gori::Fuzz
+
+# Round 8 — `grep -rni grpc src/gori/{miner,discover,sequencer,probe}/` returned only two
+# `tech_grpc` display labels in probe/issue.cr. Sequencer's live-replay collection reads
+# `raw.response.try(&.status)` for `Sample#status`, and for gRPC the h2 `:status` is 200 BY
+# DEFINITION — so a token-randomness collection replaying against a target that is actually
+# denying every call (an expired/invalid session, say — the exact case an operator runs
+# Sequencer to characterize) reported every sample as a healthy 200, with the real per-call
+# outcome (`grpc-status`/`grpc-message` trailers) nowhere. `Fuzz::GrpcVerdict` is the same
+# projection round 7 wired into the Fuzzer over `raw.head`.
+private class GrpcCookieBackend < F::Backend
+  getter origin : F::Origin
+
+  def initialize(@origin : F::Origin, @code : Int32, @message : String?)
+  end
+
+  def send(bytes : Bytes) : Gori::Repeater::Result
+    head = String.build do |io|
+      io << "HTTP/1.1 200 OK\r\ncontent-type: application/grpc\r\n"
+      io << "Set-Cookie: SID=1000; Path=/\r\nContent-Length: 2\r\n"
+      io << "grpc-status: #{@code}\r\n"
+      io << "grpc-message: #{@message}\r\n" if @message
+      io << "\r\n"
+    end.to_slice
+    resp = Gori::Proxy::Codec::Http1.parse_response_head(head)
+    Gori::Repeater::Result.new(head, "ok".to_slice, resp, 500_i64)
+  end
+end
+
+private def drain(engine : Q::Engine) : Array(Q::Sample)
+  samples = [] of Q::Sample
+  engine.run { |ev| samples << ev.sample if ev.is_a?(Q::SampleEvent) }
+  samples
+end
+
+private def collect_one(backend : F::Backend) : Q::Sample
+  config = Q::Config.new(mode: Q::Mode::LiveReplay,
+    token_loc: Q::TokenLoc.cookie("SID"), goal: 1, concurrency: 1, retries: 0)
+  req = "GET /pkg.Svc/Method HTTP/1.1\r\nHost: h\r\n\r\n".to_slice
+  drain(Q::Engine.new(req, http2: false, backend: backend, config: config)).first
+end
+
+describe "sequence over gRPC" do
+  it "carries the grpc-status/grpc-message trailers on the collected Sample, distinguishing denied from granted" do
+    denied = collect_one(GrpcCookieBackend.new(F::Origin.new("http", "h", 80), 7, "nope; you may not"))
+    denied.status.should eq(200) # the h2 status is 200 for BOTH — that is the whole point
+    denied.grpc_status.should eq(7)
+    denied.grpc_message.should eq("nope; you may not")
+
+    granted = collect_one(GrpcCookieBackend.new(F::Origin.new("http", "h", 80), 0, nil))
+    granted.status.should eq(200)
+    granted.grpc_status.should eq(0)
+    granted.grpc_message.should be_nil # an empty grpc-message is absent, not ""
+
+    denied.grpc_status.should_not eq(granted.grpc_status)
+  end
+
+  # The reporting half: `--format jsonl` only renders the fields when present, so a
+  # non-gRPC sample's JSON line is unchanged (the complement).
+  it "emits grpc_status / grpc_status_name / grpc_message on the jsonl sample row, only when present" do
+    s = Q::Sample.new(0, "tok", 200, 3, 500_i64, nil, grpc_status: 7, grpc_message: "nope; you may not")
+    j = JSON.parse(Gori::CLI::Output.sequence_sample_json(s))
+    j["grpc_status"].as_i.should eq(7)
+    j["grpc_status_name"].as_s.should eq("PERMISSION_DENIED")
+    j["grpc_message"].as_s.should eq("nope; you may not")
+
+    plain = Q::Sample.new(1, "tok2", 200, 4, 500_i64, nil)
+    Gori::CLI::Output.sequence_sample_json(plain).should_not contain("grpc")
+  end
+end

--- a/spec/tui/fuzzer_view_spec.cr
+++ b/spec/tui/fuzzer_view_spec.cr
@@ -71,6 +71,48 @@ describe Gori::Tui::FuzzerView do
     end
   end
 
+  # Round 8 — the h2 `:status` in the row's leftmost column is 200 by definition for every
+  # gRPC response, so a fuzzer sweep against a target that PERMISSION_DENIED-ed every call
+  # rendered byte-identical rows to one that granted them all. `Fuzz::Result#grpc_status` /
+  # `#grpc_message` existed since round 7 (the Fuzzer ENGINE had the fields); this pins that
+  # the RESULTS list row — which round 7 never touched — actually renders them.
+  describe "gRPC verdict in the results row" do
+    it "renders grpc-status/grpc-message, distinguishing a denied call from a granted one" do
+      view = loaded_fuzzer
+      view.focus_pane(:results)
+      view.append_result(Gori::Fuzz::Result.new(0_i64, ["p0"], nil, 200, 12_i64, 2, 1, 1000_i64,
+        nil, false, false, nil, grpc_status: 7, grpc_message: "nope; you may not"))
+      # Wide enough that the results row is not ellipsis-truncated before the grpc suffix —
+      # this pins the RENDERED text, not just that it was drawn somewhere off-screen.
+      backend = MemoryBackend.new(220, 30)
+      view.render(Screen.new(backend), Rect.new(0, 0, 220, 30))
+      backend.contains?("grpc 7 PERMISSION_DENIED").should be_true
+      backend.contains?("nope; you may not").should be_true
+    end
+
+    it "renders a granted call distinctly from a denied one" do
+      view = loaded_fuzzer
+      view.focus_pane(:results)
+      view.append_result(Gori::Fuzz::Result.new(0_i64, ["p0"], nil, 200, 12_i64, 2, 1, 1000_i64,
+        nil, false, false, nil, grpc_status: 0, grpc_message: nil))
+      backend = MemoryBackend.new(220, 30)
+      view.render(Screen.new(backend), Rect.new(0, 0, 220, 30))
+      backend.contains?("grpc 0 OK").should be_true
+      backend.contains?("PERMISSION_DENIED").should be_false
+    end
+
+    # Complement: an ordinary (non-gRPC) row is byte-identical to what it was — no new
+    # field noise.
+    it "leaves a non-gRPC row unchanged" do
+      view = loaded_fuzzer
+      view.focus_pane(:results)
+      view.append_result(fuzz_result(0, 200, 1200))
+      backend = MemoryBackend.new(120, 30)
+      view.render(Screen.new(backend), Rect.new(0, 0, 120, 30))
+      backend.contains?("grpc").should be_false
+    end
+  end
+
   describe "#auto_mark" do
     # Fuzz::Template.auto_mark is a deliberate no-op once ANY § is present: it will not
     # double-mark, and it must not clear the operator's own markers to re-derive them.

--- a/spec/tui/repeater_view_spec.cr
+++ b/spec/tui/repeater_view_spec.cr
@@ -1452,6 +1452,35 @@ describe Gori::Tui::RepeaterView do
     end
   end
 
+  it "carries a binary out-frame's invalid UTF-8 byte-exact into a wscat -x command" do
+    # `RepeaterController#repeater_request_options` turns each `ws_out_messages` payload into
+    # the `String` `CopyMenu.request_options` feeds to `wscat_command`. That String used to go
+    # through `.scrub` first, so "Copy as wscat" of a binary out-frame handed the operator a
+    # command that did not reproduce what gori actually sent — the same defect a round-7 fixer
+    # closed for "Copy as cURL"'s `--data-raw` (see `CopyMenu.shell_quote`'s comment). Fixed by
+    # dropping the controller's `.scrub`, since `shell_quote` is byte-safe on its own. This
+    # reproduces the controller's exact composition — `RepeaterView` for the frame, the
+    # controller's own map expression, then the real (unmodified) `CopyMenu` — without needing
+    # a full `Host` (no spec anywhere constructs a TUI controller; see `tab_controller.cr`).
+    bin = Bytes[0xff_u8, 0xfe_u8, 0x01_u8, 0x02_u8]
+    repeater_tmp_store do |store|
+      id = store.insert_flow(Gori::Store::CapturedRequest.new(
+        created_at: 1_i64, scheme: "https", host: "ws.test", port: 443,
+        method: "GET", target: "/ws", http_version: "HTTP/1.1",
+        head: "GET /ws HTTP/1.1\r\nHost: ws.test\r\nUpgrade: websocket\r\n\r\n".to_slice, body: nil))
+      view = RepeaterView.new
+      view.load_ws(store.get_flow(id).not_nil!, [Gori::Store::WsOutMessage.new(2, bin)])
+
+      # The exact expression now in `repeater_controller.cr` (`String.new`, not `.scrub`).
+      ws_messages = view.ws_out_messages.map { |message| String.new(message.payload) }
+      opts = Gori::Tui::CopyMenu.request_options(
+        String.new(view.request_bytes), "https://ws.test", websocket_messages: ws_messages)
+      wscat = opts.find! { |o| o.key == 'w' }
+      wscat.text.to_slice.hexstring.should contain(bin.hexstring)
+      wscat.text.to_slice.hexstring.should_not contain("efbfbd")
+    end
+  end
+
   it "keeps an unsaved message edit when a peer's request-side change reconciles in" do
     # `apply_peer_request` runs on every cross-session request-side change and re-seeds the
     # message pane. Adopting the peer's messages under an unsaved local edit would send

--- a/src/gori/cli/output.cr
+++ b/src/gori/cli/output.cr
@@ -226,6 +226,17 @@ module Gori
           j.field "canary", f.canary
           j.field "status", f.status
           j.field "delta", f.delta
+          # The gRPC CALL's outcome. `status` above is 200 for every gRPC response, so without
+          # these a mine against a target denying every candidate was byte-identical to one
+          # allowing them all. Emitted only when the confirming round carried them, so a
+          # non-gRPC run's JSON is unchanged. `.scrub`: `grpc-message` is origin-chosen text.
+          if gs = f.grpc_status
+            j.field "grpc_status", gs
+            j.field "grpc_status_name", Proxy::H2::Grpc.status_name(gs)
+          end
+          if gm = f.grpc_message
+            j.field "grpc_message", gm.scrub
+          end
         end
       end
 
@@ -236,6 +247,10 @@ module Gori
           io << f.name.ljust(24)
           io << "  " << f.location.label.ljust(9)
           io << "· " << f.evidence.label
+          if gs = f.grpc_status
+            io << "  grpc " << gs << ' ' << Proxy::H2::Grpc.status_name(gs)
+            io << " · " << f.grpc_message if f.grpc_message
+          end
         end
       end
 

--- a/src/gori/cli/output.cr
+++ b/src/gori/cli/output.cr
@@ -278,6 +278,17 @@ module Gori
             j.field "token", s.token
             j.field "length", s.length
             j.field "error", s.error
+            # The gRPC CALL's outcome. `status` above is 200 for every gRPC response, so
+            # without these a collection against a target denying every call read as healthy.
+            # Emitted only when the response actually carried them, so a non-gRPC sample's
+            # JSON line is unchanged. `.scrub`: `grpc-message` is origin-chosen text.
+            if gs = s.grpc_status
+              j.field "grpc_status", gs
+              j.field "grpc_status_name", Proxy::H2::Grpc.status_name(gs)
+            end
+            if gm = s.grpc_message
+              j.field "grpc_message", gm.scrub
+            end
           end
         end
       end

--- a/src/gori/cli/run/mine.cr
+++ b/src/gori/cli/run/mine.cr
@@ -140,13 +140,30 @@ module Gori
         end
       end
 
-      # A location the operator named with --locations that this request cannot carry (no
-      # matching existing body). Kept in the run rather than dropped, so say so instead of
-      # letting the name count quietly come up short.
+      # A location the operator named with --locations that this request cannot carry. Kept
+      # in the run rather than dropped, so say so instead of letting the name count quietly
+      # come up short.
       private def self.warn_mine_locations(plan : Miner::Plan) : Nil
         plan.inapplicable.each do |loc|
-          STDERR.puts "gori run mine: #{loc.label}: not applicable to this request (no matching existing body), skipping"
+          STDERR.puts "gori run mine: #{loc.label}: #{mine_inapplicable_reason(loc, plan.request)}, skipping"
         end
+      end
+
+      # "No matching existing body" is the right sentence for query/form/multipart/json when
+      # there truly is no such body — but wrong for `json` on a body that EXISTS and simply
+      # is not valid UTF-8: `Detect`/`Inject` correctly refuse to OFFER Json there (round 7 —
+      # `Miner::Inject#json_object_node_count` reports 0 rather than mining a `.scrub`-corrupted
+      # copy, since a non-UTF-8 body cannot round-trip through `JSON::Any`), but naming that
+      # refusal "no matching existing body" tells the operator the wrong thing about a request
+      # that plainly has a body. Give that one case its own accurate sentence.
+      private def self.mine_inapplicable_reason(loc : Miner::Location, request : Bytes) : String
+        if loc.json?
+          _, body, _ = Miner::Inject.split(request)
+          if !body.empty? && !String.new(body).valid_encoding?
+            return "the body is not valid UTF-8 and cannot round-trip through JSON"
+          end
+        end
+        "not applicable to this request (no matching existing body)"
       end
 
       # {raw request text (byte-exact, BEFORE Env expansion — Miner::Plan owns that),

--- a/src/gori/discover/wordlist.cr
+++ b/src/gori/discover/wordlist.cr
@@ -20,13 +20,30 @@ module Gori::Discover
       names = builtin.dup
       if path = user_path.try(&.strip)
         unless path.empty?
-          File.each_line(path) do |line|
-            stripped = line.strip
-            names << stripped unless stripped.empty? || stripped.starts_with?('#')
-          end
+          merge_user_file(path) { |line| names << line }
         end
       end
       dedup(names)
+    end
+
+    # The user merge file is operator MATERIAL, not a curated gori asset: a leading or
+    # trailing space/tab in a path SEGMENT is a real test (the classic IIS/ASP.NET
+    # trailing-space / trailing-dot access-control bypass pair), and the rest of the
+    # pipeline already carries it to the wire byte-exact once it survives the loader —
+    # only the loader was destroying it. So this reads with `chomp: true` (line-ending
+    # only, same fidelity as `Fuzz::WordlistFile#next_value`, payload.cr) and keeps the
+    # BLANK-LINE and `#`-COMMENT conventions (both standard for a line-oriented wordlist
+    # file, and neither is expressible any other way in the format) — but classifies
+    # blank/comment on the TRIMMED copy, never on the entry it yields, so
+    # `"zzadmin "` / `" zzadmin"` / `"zzTRAILTAB\t"` each survive as distinct, unstripped
+    # entries instead of being silently trimmed and then DEDUPED away against the
+    # trimmed twin (round 7, h1-seams.md FINDING 4).
+    private def self.merge_user_file(path : String, & : String ->) : Nil
+      File.each_line(path, chomp: true) do |line|
+        trimmed = line.strip
+        next if trimmed.empty? || trimmed.starts_with?('#')
+        yield line
+      end
     end
 
     private def self.parse(raw : String) : Array(String)

--- a/src/gori/mcp/tools/mine.cr
+++ b/src/gori/mcp/tools/mine.cr
@@ -169,6 +169,14 @@ module Gori
           j.field "canary", Serialize.text(f.canary)
           j.field "status", f.status
           j.field "delta", f.delta
+          # The gRPC CALL's outcome, from the confirming round's `grpc-status`/`grpc-message`
+          # trailers — `status` above is 200 for every gRPC response. Emitted only when the
+          # response actually carried it, so a non-gRPC run's rows are unchanged.
+          if gs = f.grpc_status
+            j.field "grpc_status", gs
+            j.field "grpc_status_name", Proxy::H2::Grpc.status_name(gs)
+          end
+          j.field "grpc_message", Serialize.text(f.grpc_message) if f.grpc_message
         end
       end
 

--- a/src/gori/miner/engine.cr
+++ b/src/gori/miner/engine.cr
@@ -4,6 +4,7 @@ require "./inject"
 require "./fingerprint"
 require "./baseline"
 require "../fuzz/engine"
+require "../fuzz/matcher"
 
 module Gori::Miner
   # The hard-cap wrapper (baseline calibration + bucket probes + confirmation rounds all
@@ -272,6 +273,8 @@ module Gori::Miner
       last_status = nil.as(Int32?)
       last_delta = 0_i64
       last_canary = canary
+      last_grpc_status = nil.as(Int32?)
+      last_grpc_message = nil.as(String?)
       rounds.times do
         c = Canary.fresh
         # Same span-protection as the main loop — the confirm re-send injects the same name.
@@ -287,12 +290,17 @@ module Gori::Miner
           last_status = probe.metrics.status
           last_delta = probe.metrics.length - r.base_length
           last_canary = c if evidence.reflection?
+          # Same projection the Fuzzer uses (`Fuzz::GrpcVerdict.response`): the h2 `:status`
+          # above is 200 for every gRPC call, so for a gRPC target this — not `last_status` —
+          # is the isolated candidate's real outcome. nil/nil for a non-gRPC response, at the
+          # cost of one allocation-free byte scan.
+          last_grpc_status, last_grpc_message = Fuzz::GrpcVerdict.response(raw.head)
           break if hits >= majority
         end
       end
       return nil if hits == 0
       Finding.new(name, location, evidence, confidence_for(hits >= majority, location),
-        last_canary, last_status, last_delta)
+        last_canary, last_status, last_delta, last_grpc_status, last_grpc_message)
     end
 
     private def confidence_for(reproduced : Bool, location : Location) : Confidence

--- a/src/gori/miner/types.cr
+++ b/src/gori/miner/types.cr
@@ -124,7 +124,13 @@ module Gori
       confidence : Confidence,
       canary : String?, # the value that reflected (nil for metric-based)
       status : Int32?,  # observed response status when isolated
-      delta : Int64     # observed length delta vs baseline (0 for pure reflection)
+      delta : Int64,    # observed length delta vs baseline (0 for pure reflection)
+      # The gRPC CALL's outcome (`grpc-status`/`grpc-message` trailers) off the confirming
+      # round's response head — the h2 `:status` above is 200 for every gRPC response, so
+      # without this a mine against a target that denies every candidate looked identical to
+      # one that allowed them all. nil for any non-gRPC target (see `Fuzz::GrpcVerdict`).
+      grpc_status : Int32? = nil,
+      grpc_message : String? = nil
 
     # Live counters. `names_done/names_total` is the stable progress bar; `sent` is the
     # real request count (always larger — bucketing + bisection + confirmation).

--- a/src/gori/miner/wordlist.cr
+++ b/src/gori/miner/wordlist.cr
@@ -17,15 +17,33 @@ module Gori::Miner
     # preserved. A missing/unreadable user path raises File::Error → the frontend reports it.
     def self.load(user_path : String? = nil) : Array(String)
       names = builtin.dup
-      if path = user_path.try(&.strip)
+      if path = user_path.try(&.strip) # open the STRIPPED path (the emptiness check used it too)
         unless path.empty?
-          File.each_line(path) do |line| # open the STRIPPED path (the emptiness check used it too)
-            stripped = line.strip
-            names << stripped unless stripped.empty? || stripped.starts_with?('#')
-          end
+          merge_user_file(path) { |line| names << line }
         end
       end
       dedup(names)
+    end
+
+    # The user merge file is operator MATERIAL, not a curated gori asset: a leading or
+    # trailing space/tab in a parameter NAME is a real test (e.g. a literal `"id "` a
+    # backend framework trims before lookup while gori's own encoder does not), and the
+    # rest of the pipeline already carries it to the wire byte-exact once it survives
+    # the loader (`zzhash#x` -> `zzhash%23x`, interior tab -> `%09`) — only the loader
+    # was destroying it. So this reads with `chomp: true` (line-ending only, same
+    # fidelity as `Fuzz::WordlistFile#next_value`, payload.cr) and keeps the BLANK-LINE
+    # and `#`-COMMENT conventions (both standard for a line-oriented wordlist file, and
+    # neither is expressible any other way in the format) — but classifies blank/comment
+    # on the TRIMMED copy, never on the entry it yields, so `"zzp "` / `" zzp"` /
+    # `"zzTRAILTAB\t"` each survive as distinct, unstripped entries instead of being
+    # silently trimmed and then DEDUPED away against the trimmed twin (round 7,
+    # h1-seams.md FINDING 4).
+    private def self.merge_user_file(path : String, & : String ->) : Nil
+      File.each_line(path, chomp: true) do |line|
+        trimmed = line.strip
+        next if trimmed.empty? || trimmed.starts_with?('#')
+        yield line
+      end
     end
 
     private def self.parse(raw : String) : Array(String)

--- a/src/gori/probe/active/reflected_param.cr
+++ b/src/gori/probe/active/reflected_param.cr
@@ -74,7 +74,10 @@ module Gori
             req = Proxy::Codec::Http1.parse_request_head(detail.request_head)
             ct = (req.headers.get?("Content-Type") || "").downcase
             if ct.includes?("x-www-form-urlencoded")
-              each_param_name(String.new(body).scrub) { |raw| names << {decode_name(raw), "form"} }
+              # Not `.scrub`: the body is captured bytes and this key must stay
+              # byte-identical to `plan`'s (see `canary_pairs` below), which reads the
+              # same un-scrubbed text to build the request it actually SENDS.
+              each_param_name(String.new(body)) { |raw| names << {decode_name(raw), "form"} }
             elsif ct.includes?("json")
               each_json_string_key(body) { |k| names << {k, "json"} }
             end
@@ -103,7 +106,15 @@ module Gori
           if body && !body.empty?
             ct = (req.headers.get?("Content-Type") || "").downcase
             if ct.includes?("x-www-form-urlencoded")
-              nb, fp = canary_pairs(String.new(body).scrub, "form")
+              # Not `.scrub`: this rebuilds the BODY THE PROBE SENDS. `canary_pairs` only
+              # ever emits a fresh canary for a param's VALUE — never reads it back — but
+              # every param NAME and every pair the split/`=` scan skips (no `=`, empty
+              # name) is copied out of this text verbatim. Scrubbing first meant an
+              # untouched, unrelated field carrying a raw non-UTF-8 byte reached the origin
+              # as three `U+FFFD` bytes instead of the one the operator's capture had.
+              # `String#split(Char)`/`#index`/`#[]` only slice on byte offsets found by
+              # scanning, so the un-scrubbed text is safe to split.
+              nb, fp = canary_pairs(String.new(body), "form")
               params.concat(fp)
               new_body = nb.to_slice
             elsif ct.includes?("json")
@@ -147,9 +158,12 @@ module Gori
         end
 
         # The top-level JSON keys with a STRING value — the SAME fields canary_json canaries.
+        # Not `.scrub`: must read the same bytes `canary_json` does, or a key name carrying
+        # invalid UTF-8 would compute a different dedup key than `plan` does. `JSON.parse`
+        # does not require valid UTF-8 inside a string body to parse it.
         private def each_json_string_key(body : Bytes, & : String ->)
           h = begin
-            JSON.parse(String.new(body).scrub).as_h?
+            JSON.parse(String.new(body)).as_h?
           rescue JSON::ParseException
             nil
           end
@@ -294,10 +308,16 @@ module Gori
 
         # Replace top-level JSON string values with canaries; nil unless the root is an object
         # with at least one string field.
+        #
+        # Not `.scrub`: this rebuilds the BODY THE PROBE SENDS. Every string field NOT chosen
+        # for a canary is carried through as the `JSON::Any` this parse produced (`merged[k] =
+        # v`), so scrubbing first meant any non-canaried string field holding a raw non-UTF-8
+        # byte reached the origin as `U+FFFD`. `JSON.parse` does not require its input to be
+        # valid UTF-8 to parse a string value's bytes, and `to_json` round-trips them as-is.
         private def canary_json(body : Bytes) : {Bytes?, Array(Param)}
           params = [] of Param
           h = begin
-            JSON.parse(String.new(body).scrub).as_h?
+            JSON.parse(String.new(body)).as_h?
           rescue JSON::ParseException
             nil
           end

--- a/src/gori/proxy/h2/head_codec.cr
+++ b/src/gori/proxy/h2/head_codec.cr
@@ -496,8 +496,35 @@ module Gori::Proxy::H2
       fields.any? { |(n, _)| host_field?(n) }
     end
 
+    # Axis 5 (round 7 F3): a diagnostic is not traffic, and the converse — traffic must not
+    # be able to impersonate a diagnostic. `synth_request`/`synth_response` append
+    # `TRAILER_MARKER`/`PUSHED_MARKER`/`PROTOCOL_MARKER` into the SAME text namespace an
+    # incoming field occupies, and gori deliberately does not enforce RFC 9113 §8.2.1
+    # lowercase field names on receive (an `X-Upper` field survives verbatim — right for a
+    # test tool), so a hostile origin/CDN/WAF can send a REAL field literally named
+    # `X-Gori-Trailers` (gori's exact capitalisation) with an ordinary response — no real
+    # trailer block required. Reproduced: `grpcorigin.py --scenario forgemarker` puts
+    # `X-Gori-Trailers: grpc-status, grpc-message` in the INITIAL HEADERS, then sends real
+    # trailers; the projected head carried the peer's line and gori's own diagnostic back to
+    # back, byte-for-byte identical, with nothing distinguishing which is which.
+    #
+    # So an incoming field whose name collides with a marker (case-insensitively — the
+    # marker string comparison, not the wire's lowercase requirement) is renamed BEFORE it
+    # reaches the text, the same "stay injective, let the operator SEE the anomaly" discipline
+    # `line_safe` already applies to a CRLF in a value (#517): the peer's bytes are still
+    # shown, just under a name that cannot collide with gori's own.
+    private def peer_field_name(n : String) : String
+      reserved_marker?(n) ? "X-Peer-#{n}" : n
+    end
+
+    private def reserved_marker?(name : String) : Bool
+      name.compare(TRAILER_MARKER, case_insensitive: true) == 0 ||
+        name.compare(PUSHED_MARKER, case_insensitive: true) == 0 ||
+        name.compare(PROTOCOL_MARKER, case_insensitive: true) == 0
+    end
+
     private def regular(fields : Array({String, String}), &) : Nil
-      fields.each { |(n, v)| yield n, v unless pseudo?(n) }
+      fields.each { |(n, v)| yield peer_field_name(n), v unless pseudo?(n) }
     end
 
     # Regular fields in the rewritten head's order, LOWERCASED: an uppercase field name is

--- a/src/gori/rules.cr
+++ b/src/gori/rules.cr
@@ -482,7 +482,15 @@ module Gori
             text
           end
         else
-          text.gsub(rule.pattern, repl)
+          # `&block`, not `text.gsub(rule.pattern, repl)`: when `rule.pattern` is a single
+          # byte, `String#gsub(String, String)` delegates to the `Char` overload, which (for
+          # a multi-byte `repl`) walks ALL of `text` with `each_char` — corrupting every
+          # invalid UTF-8 byte anywhere in the message, matched or not, to U+FFFD. A body is
+          # captured bytes and a one-character literal pattern is an ordinary operator
+          # choice, so this reached the wire on any binary body a single-char rule happened
+          # to touch. The block form scans by byte index and copies with `unsafe_byte_slice`
+          # — byte-exact regardless of what `text` or `repl` contain.
+          text.gsub(rule.pattern) { repl }
         end
       in Store::RuleOp::AddHeader    then head_add_header(text, rule.pattern, repl)
       in Store::RuleOp::SetHeader    then head_set_header(text, rule.pattern, repl)
@@ -640,8 +648,22 @@ module Gori
     # Double every backslash so a substituted value cannot be read as a capture reference
     # by `String#gsub(Regex, String)`. `gsub(String, String)` interprets nothing, so this is
     # applied to the regex path alone.
+    #
+    # Byte-scanned, not `value.gsub("\\", "\\\\")`: a 1-byte `String` needle makes `gsub`
+    # delegate to the `Char` overload, which walks the value with `each_char` and rewrites
+    # any invalid UTF-8 byte to U+FFFD — three wire bytes for one. A `value` bound from
+    # `TokenExtract.position` is exactly the case this bites: it is `String.new`'d
+    # unscrubbed off a captured byte range (see the comment there), so it can carry
+    # arbitrary bytes on the way into a regex-rule replacement.
     def self.escape_backrefs(value : String) : String
-      value.includes?('\\') ? value.gsub("\\", "\\\\") : value
+      bytes = value.to_slice
+      return value unless bytes.includes?(0x5C_u8)
+      buf = IO::Memory.new(bytes.size + 8)
+      bytes.each do |b|
+        buf.write_byte(0x5C_u8) if b == 0x5C_u8
+        buf.write_byte(b)
+      end
+      String.new(buf.to_slice)
     end
 
     # Env vars + currently-bound bindings, plus the declared-name list, cached until either

--- a/src/gori/sequencer/engine.cr
+++ b/src/gori/sequencer/engine.cr
@@ -1,6 +1,7 @@
 require "./types"
 require "./extract"
 require "../fuzz/engine"
+require "../fuzz/matcher"
 
 module Gori::Sequencer
   # Collects tokens into an Event stream. LIVE REPLAY sends the ONE fixed @request
@@ -220,7 +221,13 @@ module Gori::Sequencer
         @first_error ||= e unless e == Fuzz::CappedBackend::CAP_ERROR
       end
       @collected += 1 if token
-      @events.send(SampleEvent.new(Sample.new(idx, token, status, len, raw.duration_us, err)))
+      # The gRPC CALL's real outcome — `status` above is 200 for every gRPC response, so
+      # without this a live-replay collection against a target rejecting every call (an
+      # expired session cookie, say) read as healthy on every sample. nil/nil (and free, past
+      # the allocation-free needle scan) for a non-gRPC response.
+      grpc_status, grpc_message = Fuzz::GrpcVerdict.response(raw.head)
+      @events.send(SampleEvent.new(Sample.new(idx, token, status, len, raw.duration_us, err,
+        grpc_status, grpc_message)))
       emit_progress
     end
 

--- a/src/gori/sequencer/types.cr
+++ b/src/gori/sequencer/types.cr
@@ -47,7 +47,14 @@ module Gori
       status : Int32?,
       length : Int32,
       duration_us : Int64,
-      error : String?
+      error : String?,
+      # The gRPC CALL's outcome (`grpc-status`/`grpc-message` trailers) — `status` above is
+      # 200 for every gRPC response, so a live-replay collection against a gRPC endpoint that
+      # is actually rejecting every call (an expired session token, say) looked identical to
+      # one collecting from a healthy target: every sample read "200". nil for a manual-mode
+      # sample (no network) and for any non-gRPC response (see `Fuzz::GrpcVerdict`).
+      grpc_status : Int32? = nil,
+      grpc_message : String? = nil
 
     # Live counters. `collected` counts successful extractions (the goal is met by
     # these); `sent` is the real request count (always ≥ collected — misses + retries).

--- a/src/gori/tui/controllers/repeater_controller.cr
+++ b/src/gori/tui/controllers/repeater_controller.cr
@@ -687,7 +687,12 @@ module Gori::Tui
       end
       target = Env.expand(v.target)
       ws_messages = if v.ws_mode?
-                      v.ws_out_messages.map { |message| String.new(message.payload).scrub }
+                      # Not `.scrub`: `CopyMenu.wscat_command` writes each message through
+                      # `shell_quote`, which is already byte-safe (see its comment) — scrubbing
+                      # here first corrupted a binary out-frame into a `wscat -x` command that
+                      # does not reproduce what gori actually sent, the same defect a round-7
+                      # fixer closed for "Copy as cURL"'s `--data-raw`.
+                      v.ws_out_messages.map { |message| String.new(message.payload) }
                     end
       CopyMenu.request_options(wire, target, websocket_messages: ws_messages)
     end

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -15,6 +15,7 @@ require "./chain_pane"
 require "./chain_overlay"
 require "../store"
 require "../fuzz"
+require "../proxy/h2/grpc"
 require "../decoder"
 require "./fuzz_set_overlay"
 require "./fuzz_advanced_overlay"
@@ -2196,7 +2197,17 @@ module Gori::Tui
         # isn't invisible among clean rows. #567/H3 Finding 1.
         screen.text(x, y, "⚠ ¦chain not applied", Theme.yellow, bg, width: {inner.right - x, 1}.max)
       else
-        screen.text(x, y, "#{Fmt.size(r.length).ljust(8)} #{r.words.to_s.ljust(7)} #{Fmt.dur(r.duration_us)}", selected ? Theme.text : Theme.muted, bg, width: {inner.right - x, 1}.max)
+        line = "#{Fmt.size(r.length).ljust(8)} #{r.words.to_s.ljust(7)} #{Fmt.dur(r.duration_us)}"
+        # For a gRPC target the h2 `:status` to the left is 200 by definition; THIS is the
+        # call's real outcome. Only rendered when the response carried it, so a non-gRPC row
+        # is unchanged — same fields `cli/output.cr:fuzz_row_text` already renders.
+        if gs = r.grpc_status
+          x2 = screen.text(x, y, line, selected ? Theme.text : Theme.muted, bg, width: {inner.right - x, 1}.max)
+          gline = " grpc #{gs} #{Proxy::H2::Grpc.status_name(gs)}#{r.grpc_message ? " · #{r.grpc_message}" : ""}"
+          screen.text(x2, y, gline, gs == 0 ? Theme.green : Theme.red, bg, width: {inner.right - x2, 1}.max)
+        else
+          screen.text(x, y, line, selected ? Theme.text : Theme.muted, bg, width: {inner.right - x, 1}.max)
+        end
       end
     end
 


### PR DESCRIPTION
Round 8 is a short round: no hunting, three fixers working the follow-ups round 7 had located and reproduced but not fixed. Every fix was reproduced first and control-run RED at `8172906b`.

## The last byte-provenance leaks on wire paths

Round 7 established the rule — **any String rebuild over captured bytes is a byte-provenance bug until proven otherwise** — and closed about eight instances. These were the ones the final sweep had found and left.

**A Match&Replace rule corrupted binary bodies wholesale.** `Rules.escape_backrefs` used `gsub("\\", "\\\\")`, a one-byte needle, which delegates to the `Char` overload and walks the value as characters: `ff fe 5c 78` came out `ef bf bd ef bf bd 5c 5c 78`. This is reachable in practice because a substitution value *can* be non-UTF-8 by design — `TokenExtract.position` hands its slice to `String.new` unscrubbed, and its comment asserts `Rules#substitute` is byte-level, which was true of substitute's own scan and false in the one regex branch that called `escape_backrefs`.

The fixer then found the larger sibling next door: `apply_rule`'s **literal** branch did `text.gsub(rule.pattern, repl)`, so a single-character literal rule corrupted every invalid byte anywhere in the head or body — not merely the matched region. Any binary body touched by such a rule was rewritten wholesale.

**Active probes sent corrupted requests.** `reflected_param.cr` read the request body through `.scrub` at four sites, and `plan()` rebuilds the actual probe request from that copy — so a raw `0xFF` in a field the canary never touched reached the origin as `ef bf bd`. The `dedup_key` fast path had to move with it, or it would compute a different key than `plan` and break the documented byte-identical invariant.

**Copy as wscat** scrubbed each WebSocket out-frame, handing the operator a command that does not reproduce what gori sent. `shell_quote` has been byte-safe since round 7, so the scrub was all that stood in the way.

## An origin could forge gori's own diagnostic

gori synthesises `X-Gori-Trailers` to show which trailers a response carried. An origin can send that header itself, byte-for-byte, and both lines appeared identically — so a hostile origin could fabricate a trailer set the operator reads as gori's own finding.

The cause is precise: gori deliberately does not enforce RFC 9113 §8.2.1 lowercase-on-receive, so a peer can match the marker's exact case. An incoming field colliding case-insensitively with a gori marker is now renamed `X-Peer-<name>` before synthesis — staying injective and letting the operator see the anomaly, the same discipline `line_safe` uses.

Axis 5 has a converse: a diagnostic is not traffic, **and traffic must not be able to impersonate a diagnostic**.

## The operator's wordlist shrank without saying so

`discover/wordlist.cr` and `miner/wordlist.cr` stripped every merge-file line, and a stripped entry then **deduped away against its own trimmed twin** — so `"zzadmin "` and `" zzadmin"` collapsed into one and the count still looked honest. Round 6 called this a judgment call on the grounds that a path or parameter name is less plausibly whitespace-bearing than a payload; round 7 reproduced it and overturned that.

Now read chomp-only, matching `Fuzz::WordlistFile`: `zzp ` / ` zzp` / `zzTRAILTAB\t` each reach the wire distinctly. The built-in curated lists keep their strip-and-comment treatment — they are gori's assets, exactly as `fuzz/presets.cr` already distinguishes.

## gRPC verdicts reach three more surfaces

For gRPC the HTTP/2 `:status` is 200 by definition; the outcome lives in the trailers. Round 7 made that visible on the Fuzzer. The Miner, the Sequencer and the TUI Fuzzer row still showed a bare `200`, so a denied call and a granted one were byte-identical.

`Miner::Finding` and `Sequencer::Sample` now carry `grpc_status`/`grpc_message`, captured through the same `Fuzz::GrpcVerdict` projection rather than a second implementation, and rendered on CLI, MCP and the TUI row only when present. Discover was checked and correctly skipped: its sender is GET-only by construction, so it cannot produce a gRPC call at all and a field there would be dead. MCP's Sequencer surface has no per-sample row to wire.

## Reported, not fixed

**`discover/extract.cr:83`** reaches the wire — an extracted href becomes a crawled URL — and a raw `0xE9` is extracted as `ef bf bd 63 61 66 65`. But unlike every other `.scrub` this round, `Regex#scan` genuinely *raises* on invalid UTF-8 here, so the scrub is load-bearing rather than incidental. A byte-exact fix needs a length-preserving sanitize plus a re-slice of the original bytes at the match's byte offsets — materially larger than this round's budget, and the consequence is crawl coverage rather than replay integrity. Left with the analysis written down.

Also noted: Discover still drops a **trailing** space from a path, one seam further down in `URI.parse` — a different file and a stdlib behaviour, so it was reported rather than folded into the wordlist fix.

## Verification

`crystal spec` **6654 examples, 0 failures** (baseline 6618 + 36). `crystal build --no-codegen` clean at every merge step. Two honest boundaries worth stating: the wscat fix's spec is a regression guard on the composed formula rather than a strict control-run, because nothing in this codebase instantiates a TUI controller; and one gRPC integration spec was hardened after a scheduler-contention timeout under full-suite load — it is green here across the full suite.
