### PR TITLE
A trusted root replaced without a word, a dead tunnel blamed on the target, and a WebSocket message that has no head

### DIFF
--- a/spec/cli/run/intercept_spec.cr
+++ b/spec/cli/run/intercept_spec.cr
@@ -65,6 +65,78 @@ describe "Gori::CLI::Run.intercept_edit_bytes" do
   end
 end
 
+# R9/F1 — a held WebSocket message has NO head/body split at all (no start line, no headers),
+# so `intercept_edit_bytes`'s HTTP-shaped CRLF rule has no boundary to bound itself by: with no
+# blank line found, `normalize_head_crlf` (called via `intercept_edit_bytes`) treated the WHOLE
+# message as "header" and promoted every bare LF to CRLF. `cmd_intercept_edit` now branches on
+# the held row's `kind` BEFORE picking a rule (`ws_edit_bytes` for `row.ws?`, the function above
+# for everything else) — this describes that new function directly, at the 838f55a3 control run
+# `Gori::CLI::Run.intercept_edit_bytes("line1\nline2\nline3", true)` would have produced
+# `"line1\r\nline2\r\nline3"` (19 bytes) for the identical input this spec pins at 17.
+describe "Gori::CLI::Run.ws_edit_bytes" do
+  it "takes a WS text edit LITERALLY — no CRLF promotion, no boundary search at all" do
+    content = "line1\nline2\nline3"
+    result = Gori::CLI::Run.ws_edit_bytes(content, 1_i64, false, used_raw_file: false)
+    result.should be_a(Bytes)
+    String.new(result.as(Bytes)).should eq(content) # bare LF preserved — NOT "\r\n"
+  end
+
+  it "is unchanged when there is no LF at all (the complement)" do
+    content = "no-newlines-here"
+    result = Gori::CLI::Run.ws_edit_bytes(content, 1_i64, false, used_raw_file: false)
+    String.new(result.as(Bytes)).should eq(content)
+  end
+
+  it "never resyncs a Content-Length header even when the payload LOOKS like an HTTP head" do
+    # A boundary DOES exist in this payload (a literal blank line) — proof the WS path never
+    # even runs the HTTP boundary search, rather than running it and happening to no-op.
+    content = "part1\n\npart2"
+    result = Gori::CLI::Run.ws_edit_bytes(content, 1_i64, false, used_raw_file: false)
+    String.new(result.as(Bytes)).should eq(content)
+  end
+
+  it "refuses a BINARY frame through --raw (used_raw_file: false) with an actionable message" do
+    result = Gori::CLI::Run.ws_edit_bytes("\xFF\xFE", 5_i64, true, used_raw_file: false)
+    result.should be_a(String)
+    result.as(String).should contain("item 5")
+    result.as(String).should contain("--raw-file")
+  end
+
+  it "allows a BINARY frame through --raw-file (used_raw_file: true) — the byte-exact channel" do
+    body = Bytes[0xFF, 0xFE, 0x01, 0x02]
+    content = String.new(body) # what File.read of the exact bytes hands back
+    result = Gori::CLI::Run.ws_edit_bytes(content, 5_i64, true, used_raw_file: true)
+    result.should be_a(Bytes)
+    result.as(Bytes).to_a.should eq(body.to_a)
+  end
+
+  it "never refuses a TEXT WS item regardless of which channel carried it" do
+    Gori::CLI::Run.ws_edit_bytes("hello", 1_i64, false, used_raw_file: false).should be_a(Bytes)
+    Gori::CLI::Run.ws_edit_bytes("hello", 1_i64, false, used_raw_file: true).should be_a(Bytes)
+  end
+end
+
+private def ws_held(kind : String = "wsout", binary : Bool = false) : Gori::Store::HeldRow
+  Gori::Store::HeldRow.new(
+    session_token: "t", item_id: 7_i64, kind: kind, method: "GET", host: "127.0.0.1",
+    port: 20602, scheme: "http", target: "http://127.0.0.1:20602/chat",
+    raw: "line1\nline2".to_slice, held_at_ms: 0_i64, binary: binary)
+end
+
+describe "Gori::Store::HeldRow#ws?/#binary?" do
+  it "is true for both WS directions, false for request/response" do
+    ws_held("wsout").ws?.should be_true
+    ws_held("wsin").ws?.should be_true
+    held("request", "/a").ws?.should be_false
+    held("response", "200 OK").ws?.should be_false
+  end
+
+  it "carries the binary flag across the bridge row" do
+    ws_held(binary: false).binary?.should be_false
+    ws_held(binary: true).binary?.should be_true
+  end
+end
+
 # `HeldRow#target` carries TWO different things depending on `kind`: a request's target, or a
 # RESPONSE's status reason. The row builder never branched on it, so a held response rendered
 # as `http://127.0.0.1200 OK` — a string that looks like a URL, is not one, drops the port,

--- a/spec/interceptor_spec.cr
+++ b/spec/interceptor_spec.cr
@@ -509,6 +509,41 @@ describe "Interceptor scope gates over an ABSOLUTE-FORM target" do
       end
     end
 
+    # R9/F1-b. `apply_intercept_command`'s "edited" ack used to pass `desc = item.label`
+    # (computed BEFORE the edit, off the item's ORIGINAL held bytes) unconditionally — so an
+    # edit that legitimately changes a WS message's length acked the WRONG size: the caller's
+    # only receipt for an irreversible forward named bytes that never went on the wire. `size:`
+    # lets the settle side report what it is ACTUALLY about to forward.
+    it "reports the size the caller PASSES, not the held item's original raw size (#123 ack fix)" do
+      with_store do |store|
+        ic = Gori::Interceptor.new(Gori::Scope.load(store))
+        ic.toggle
+        out = ic.enqueue_ws("line1\nline2\nline3".to_slice, to_server: true, method: "GET",
+          target: "/ws", host: "acme.test", port: 443, scheme: "https", flow_id: 9_i64,
+          binary: false).not_nil!
+        out.raw.size.should eq(17)
+        # An edit that grows the payload (e.g. appends text) must ack the NEW size.
+        out.label(size: 19).should eq("acme.test/ws client->server 19B")
+        # The default (no size: argument) still reflects the HELD bytes, for a plain
+        # forward/drop where nothing was rewritten.
+        out.label.should eq("acme.test/ws client->server 17B")
+      end
+    end
+
+    # `size:` is a no-op for request/response — neither branch of `Item#label`'s case renders a
+    # byte count — so passing it from the one shared call site in `apply_intercept_command`
+    # cannot regress an HTTP ack (the complement `size:` has to hold).
+    it "ignores size: for a request/response label — only the WS branches render a byte count" do
+      with_store do |store|
+        ic = Gori::Interceptor.new(Gori::Scope.load(store))
+        ic.toggle
+        req = ic.enqueue_request("x".to_slice, method: "GET", target: "/held",
+          host: "127.0.0.1", port: 19201, scheme: "http").not_nil!
+        req.label(size: 999).should eq(req.label)
+        req.label(size: 999).should eq("GET 127.0.0.1/held")
+      end
+    end
+
     # R4. The composition is ONE definition now: `InterceptView#row_label` and
     # `InterceptController#intercept_label` had their own per-kind branches and call this
     # instead, passing the EDITED method/target so a queue row and a forward toast name the

--- a/spec/mcp_spec.cr
+++ b/spec/mcp_spec.cr
@@ -3536,6 +3536,109 @@ describe "MCP intercept_forward_edit" do
   end
 end
 
+# Seeds a real intercept_held row (session_token "sess-1", matching `with_live_intercept`'s
+# bridge) so `intercept_forward_edit` can actually see the item's `kind`/`binary` BEFORE it
+# picks a normalization rule — the thing round 9's F1 found missing entirely.
+private def seed_held_ws(store, item_id : Int64 = 1_i64, *, raw : Bytes, binary : Bool = false,
+                         kind : String = "wsout") : Nil
+  store.publish_intercept_held("sess-1", [
+    Gori::Store::HeldRow.new("sess-1", item_id, kind, "GET", "127.0.0.1", 20602, "http",
+      "http://127.0.0.1:20602/chat", raw, 0_i64, binary: binary),
+  ])
+end
+
+# R9/F1 — `intercept_forward_edit`'s `raw` channel ran EVERY held item through
+# `RequestBuilder.normalize_raw`, a rule written for an HTTP head (find the first blank line,
+# CRLF-promote bare LF before it). A WebSocket message has no such boundary at all, so with none
+# found the WHOLE payload was treated as "header" and every bare LF promoted — an unedited
+# 17-byte round trip reached the origin as 19 bytes. Control run at 838f55a3 (before this fix):
+# `Gori::MCP::RequestBuilder.normalize_raw("line1\nline2\nline3")` produces
+# `"line1\r\nline2\r\nline3"` (19 bytes) for the exact input this spec pins byte-exact at 17.
+describe "MCP intercept_forward_edit — WebSocket byte provenance (R9/F1)" do
+  it "takes a WS text edit's 'raw' LITERALLY — no CRLF promotion, even with bare LF and no boundary" do
+    with_store do |store|
+      payload = "line1\nline2\nline3"
+      seed_held_ws(store, raw: payload.to_slice)
+      with_live_intercept(store) do
+        r = tools_for(store).call("intercept_forward_edit", JSON.parse({"item_id" => 1, "raw" => payload}.to_json))
+        r.is_error.should be_false
+      end
+      String.new(queued_intercept_bytes(store)).should eq(payload) # bare LF preserved, 17 bytes
+    end
+  end
+
+  it "is unchanged when the WS edit has no LF at all (the complement)" do
+    with_store do |store|
+      payload = "no-newlines-here"
+      seed_held_ws(store, raw: payload.to_slice)
+      with_live_intercept(store) do
+        tools_for(store).call("intercept_forward_edit",
+          JSON.parse({"item_id" => 1, "raw" => payload}.to_json)).is_error.should be_false
+      end
+      String.new(queued_intercept_bytes(store)).should eq(payload)
+    end
+  end
+
+  it "never resyncs Content-Length for a WS item, even when the payload contains a literal blank line" do
+    with_store do |store|
+      payload = "part1\n\npart2" # looks like it has an HTTP boundary — must not matter for WS
+      seed_held_ws(store, raw: payload.to_slice)
+      with_live_intercept(store) do
+        r = tools_for(store).call("intercept_forward_edit", JSON.parse({"item_id" => 1, "raw" => payload}.to_json))
+        r.is_error.should be_false
+        JSON.parse(r.text)["content_length_synced"].as_bool.should be_false
+      end
+      String.new(queued_intercept_bytes(store)).should eq(payload)
+    end
+  end
+
+  it "still CRLF-normalizes an ordinary HTTP head's raw edit — the WS branch must not leak" do
+    with_store do |store|
+      seed_held_ws(store, raw: "GET / HTTP/1.1\r\n\r\n".to_slice, kind: "request")
+      with_live_intercept(store) do
+        raw = "POST /a HTTP/1.1\nHost: acme.test\n\nline1\nline2"
+        tools_for(store).call("intercept_forward_edit",
+          JSON.parse({"item_id" => 1, "raw" => raw}.to_json)).is_error.should be_false
+      end
+      String.new(queued_intercept_bytes(store))
+        .should eq "POST /a HTTP/1.1\r\nHost: acme.test\r\nContent-Length: 11\r\n\r\nline1\nline2"
+    end
+  end
+
+  it "refuses 'raw' for a WS BINARY frame, pointing at raw_base64, and never touches the queue" do
+    with_store do |store|
+      seed_held_ws(store, raw: Bytes[0xFF, 0xFE, 0x01, 0x02], binary: true)
+      # The refusal is decided from the held row's `binary?` flag alone — it fires before `raw`
+      # is even inspected, so a plain ASCII edit is enough to prove the gate is there. Needs the
+      # bridge published so `held_row_for_edit` can find the row at all — without it, the item
+      # is invisible and this would fail for the WRONG reason (PROJECT_BUSY, no live capturing
+      # instance) rather than the refusal under test. No `with_live_intercept` here: nothing is
+      # ever enqueued on this path, so its auto-ack fiber would just poll past this block.
+      store.set_intercept_bridge({
+        "capturing" => true, "enabled" => true, "direction" => "both", "filter" => "",
+        "session_token" => "sess-1", "heartbeat_ms" => Time.utc.to_unix_ms,
+      }.to_json)
+      r = tools_for(store).call("intercept_forward_edit", JSON.parse({"item_id" => 1, "raw" => "anything"}.to_json))
+      r.error_code.should eq "INVALID_ARGUMENT"
+      r.text.should contain "raw_base64"
+      store.intercept_commands_after(0_i64, 10).should be_empty # never enqueued
+    end
+  end
+
+  it "still allows raw_base64 byte-exact on a WS BINARY frame" do
+    with_store do |store|
+      body = Bytes[0xFF, 0xFE, 0x01, 0x02]
+      seed_held_ws(store, raw: body, binary: true)
+      with_live_intercept(store) do
+        r = tools_for(store).call("intercept_forward_edit",
+          JSON.parse({"item_id" => 1, "raw_base64" => Base64.strict_encode(body)}.to_json))
+        r.is_error.should be_false
+      end
+      queued_intercept_bytes(store).should eq(body)
+    end
+  end
+end
+
 describe "MCP job project binding" do
   # A finished job outlives a switch_project (only a RUNNING one blocks the switch), and its
   # buffered results carry History flow ids that resolve to unrelated rows in the new DB.

--- a/spec/proxy/tls/cert_authority_spec.cr
+++ b/spec/proxy/tls/cert_authority_spec.cr
@@ -117,6 +117,71 @@ describe Gori::Proxy::Tls::CertAuthority do
     end
   end
 
+  # Regression: `File.exists?(cert) && File.exists?(key)` collapsed "neither exists" (fine,
+  # first run) and "exactly one exists" (a broken pair — partial restore, an accidental `rm`,
+  # a disk fault) into the SAME else-branch, which silently minted and installed a brand-new
+  # root over the survivor: a different keypair, a different serial, a different fingerprint,
+  # reported as full success. An operator (or their whole team) who already trusted the old
+  # root got a new one out from under them with no signal anything changed.
+  describe "a broken pair (exactly one of cert/key survives)" do
+    it "refuses (does not silently mint) when the cert survives but the key is gone" do
+      with_ca_dir do |dir|
+        ca = Gori::Proxy::Tls::CertAuthority.load_or_create(dir) # mint a real pair first
+        original_pem = ca.ca_cert_pem
+        File.delete(File.join(dir, "root.key.pem")) # simulate the lost/corrupted key
+
+        expect_raises(Gori::Error, /root\.crt\.pem.*root\.key\.pem.*missing/) do
+          Gori::Proxy::Tls::CertAuthority.load_or_create(dir)
+        end
+
+        # The survivor must be untouched — no silent regeneration happened.
+        File.read(File.join(dir, "root.crt.pem")).should eq(original_pem)
+        File.exists?(File.join(dir, "root.key.pem")).should be_false
+      end
+    end
+
+    it "refuses (does not silently mint) when the key survives but the cert is gone" do
+      with_ca_dir do |dir|
+        Gori::Proxy::Tls::CertAuthority.load_or_create(dir) # mint a real pair first
+        key_bytes = File.read(File.join(dir, "root.key.pem"))
+        File.delete(File.join(dir, "root.crt.pem")) # simulate the lost/corrupted cert
+
+        expect_raises(Gori::Error, /root\.key\.pem.*root\.crt\.pem.*missing/) do
+          Gori::Proxy::Tls::CertAuthority.load_or_create(dir)
+        end
+
+        # The survivor must be untouched — no silent regeneration happened.
+        File.read(File.join(dir, "root.key.pem")).should eq(key_bytes)
+        File.exists?(File.join(dir, "root.crt.pem")).should be_false
+      end
+    end
+
+    it "still succeeds silently on a genuine first run (neither file exists)" do
+      with_ca_dir do |dir|
+        Gori::Proxy::Tls::CertAuthority.load_or_create(dir) # must not raise
+        File.exists?(File.join(dir, "root.crt.pem")).should be_true
+        File.exists?(File.join(dir, "root.key.pem")).should be_true
+      end
+    end
+
+    it "still loads a healthy existing pair unchanged (complement of the broken-pair guard)" do
+      with_ca_dir do |dir|
+        pem1 = Gori::Proxy::Tls::CertAuthority.load_or_create(dir).ca_cert_pem
+        pem2 = Gori::Proxy::Tls::CertAuthority.load_or_create(dir).ca_cert_pem
+        pem2.should eq(pem1) # both files present → load, not raise, not regenerate
+      end
+    end
+
+    it "still lets `regenerate!` deliberately replace a healthy pair" do
+      with_ca_dir do |dir|
+        ca = Gori::Proxy::Tls::CertAuthority.load_or_create(dir)
+        before = ca.ca_cert_pem
+        ca.regenerate!
+        ca.ca_cert_pem.should_not eq(before) # deliberate swap still works
+      end
+    end
+  end
+
   it "exports the root CA as DER matching its PEM body" do
     with_ca_dir do |dir|
       ca = Gori::Proxy::Tls::CertAuthority.load_or_create(dir)

--- a/spec/proxy/upstream_spec.cr
+++ b/spec/proxy/upstream_spec.cr
@@ -85,6 +85,98 @@ describe Gori::Proxy::Upstream do
       end
     end
 
+    # Round 9 / r9-tls Finding 2. A proxy that answers `200 Connection Established` and then
+    # closes WITHOUT relaying anything (an overloaded proxy, an ACL that 200s before checking,
+    # a proxy whose own backend dial failed after it already committed) hands back a socket
+    # that, to the subsequent TLS handshake, looks EXACTLY like a direct connection to a broken
+    # origin — nothing on the bare socket remembers it came through a tunnel. Before this fix
+    # `tls_dial_error` reported plain `Tls` with no proxy context, so the operator was told the
+    # ORIGIN's port "may not be TLS" when the origin was never contacted at all.
+    it "tags the DialError with the proxy when it answers 200 and then closes with no data" do
+      proxy = TCPServer.new("127.0.0.1", 0)
+      pport = proxy.local_address.port
+      spawn do
+        conn = proxy.accept
+        while (h = conn.gets("\r\n", chomp: true)) && !h.empty?
+        end
+        conn << "HTTP/1.1 200 Connection Established\r\n\r\n"
+        conn.flush rescue nil
+        conn.close rescue nil # no relay at all — the tunnel produced nothing
+      end
+
+      Gori::Settings.upstream_proxy = "127.0.0.1:#{pport}"
+      begin
+        sock, err = Gori::Proxy::Upstream.dial_tls_result("example.test", 443, verify: false,
+          io_timeout: 3.seconds)
+        sock.should be_nil
+        # Same kind a direct black-hole/non-TLS port gets (Tls, via OpenSSL's own EOF verdict) —
+        # the NEW information is `via_proxy` / `proxy_note`, not a new DialErrorKind.
+        err.try(&.kind).should eq(Gori::Proxy::Upstream::DialErrorKind::Tls)
+        err.try(&.via_proxy).should eq("upstream HTTP proxy 127.0.0.1:#{pport}")
+        note = err.try(&.proxy_note).to_s
+        note.should contain("upstream HTTP proxy 127.0.0.1:#{pport}")
+        note.should contain("tunnel produced no data")
+        note.should contain("proxy may be at fault, not the target")
+      ensure
+        Gori::Settings.upstream_proxy = ""
+        proxy.close rescue nil
+      end
+    end
+
+    # Complement: an untrusted-cert rejection through the SAME proxy shape must NOT get the
+    # tunnel-blame clause — real handshake bytes crossed the tunnel and the ORIGIN's chain is
+    # what failed, so `proxy_note` must stay empty even though the dial went via a proxy.
+    it "does NOT tag a TlsVerify failure with the proxy note — real bytes crossed the tunnel" do
+      ca_cert, ca_key = Gori::Proxy::Tls::CertBuilder.build_root("gori-spec Untrusted CA (r9)")
+      leaf_cert, leaf_key = Gori::Proxy::Tls::CertBuilder.build_leaf("localhost", ca_cert, ca_key)
+      origin_ctx = Gori::Proxy::Tls::ContextFactory.server_context(leaf_cert, leaf_key, ca_cert: ca_cert)
+
+      origin = TCPServer.new("127.0.0.1", 0)
+      oport = origin.local_address.port
+      spawn do
+        next unless raw = origin.accept?
+        begin
+          ssl = OpenSSL::SSL::Socket::Server.new(raw, origin_ctx, sync_close: true)
+          ssl.close rescue nil
+        rescue
+          raw.close rescue nil
+        end
+      end
+
+      proxy = TCPServer.new("127.0.0.1", 0)
+      pport = proxy.local_address.port
+      spawn do
+        conn = proxy.accept
+        while (h = conn.gets("\r\n", chomp: true)) && !h.empty?
+        end
+        conn << "HTTP/1.1 200 Connection Established\r\n\r\n"
+        conn.flush rescue nil
+        # A real (bidirectional) tunnel this time — bytes DO cross it, unlike the
+        # accept-then-close example above.
+        upstream = TCPSocket.new("127.0.0.1", oport)
+        done = Channel(Nil).new(2)
+        spawn { IO.copy(conn, upstream) rescue nil; done.send(nil) }
+        spawn { IO.copy(upstream, conn) rescue nil; done.send(nil) }
+        2.times { done.receive }
+        conn.close rescue nil
+        upstream.close rescue nil
+      end
+
+      Gori::Settings.upstream_proxy = "127.0.0.1:#{pport}"
+      begin
+        sock, err = Gori::Proxy::Upstream.dial_tls_result("127.0.0.1", oport, verify: true,
+          sni: "localhost", io_timeout: 3.seconds)
+        sock.should be_nil
+        err.try(&.kind).should eq(Gori::Proxy::Upstream::DialErrorKind::TlsVerify)
+        err.try(&.via_proxy).should be_nil
+        err.try(&.proxy_note).should eq("")
+      ensure
+        Gori::Settings.upstream_proxy = ""
+        proxy.close rescue nil
+        origin.close rescue nil
+      end
+    end
+
     it "fails the dial (rather than buffering unboundedly) when the proxy floods the CONNECT reply headers" do
       proxy = TCPServer.new("127.0.0.1", 0)
       pport = proxy.local_address.port
@@ -561,6 +653,38 @@ describe Gori::Proxy::Upstream do
         .because.should eq("")
       Gori::Proxy::Upstream::DialError.new(Gori::Proxy::Upstream::DialErrorKind::Tls,
         cause: "wrong version number").because.should eq(" (wrong version number)")
+    end
+  end
+
+  # Round 9 / r9-tls Finding 2.
+  describe "DialError#proxy_note" do
+    it "is empty for a direct (non-proxied) DialError, whatever its kind" do
+      Gori::Proxy::Upstream::DialError::ORIGIN_UNREACHABLE.proxy_note.should eq("")
+      Gori::Proxy::Upstream::DialError.new(Gori::Proxy::Upstream::DialErrorKind::Tls,
+        cause: "wrong version number").proxy_note.should eq("")
+      Gori::Proxy::Upstream::DialError.new(Gori::Proxy::Upstream::DialErrorKind::Timeout,
+        cause: "no TLS response within 3.0s").proxy_note.should eq("")
+    end
+
+    it "names the proxy and blames the tunnel, not the target, when via_proxy is set" do
+      err = Gori::Proxy::Upstream::DialError.new(Gori::Proxy::Upstream::DialErrorKind::Tls,
+        cause: "SSL_connect: Unexpected EOF while reading",
+        via_proxy: "upstream HTTP proxy 127.0.0.1:8080")
+      err.proxy_note.should eq(
+        " (reached via upstream HTTP proxy 127.0.0.1:8080 — the tunnel produced no data; " \
+        "the proxy may be at fault, not the target)")
+    end
+  end
+
+  describe "Upstream.proxied_via" do
+    it "is nil for a direct route and the proxy label for a configured one" do
+      Gori::Proxy::Upstream.proxied_via("h.test").should be_nil
+      Gori::Settings.upstream_proxy = "10.0.0.1:3128"
+      begin
+        Gori::Proxy::Upstream.proxied_via("h.test").should eq("upstream HTTP proxy 10.0.0.1:3128")
+      ensure
+        Gori::Settings.upstream_proxy = ""
+      end
     end
   end
 end

--- a/spec/proxy/ws_hold_spec.cr
+++ b/spec/proxy/ws_hold_spec.cr
@@ -380,6 +380,13 @@ describe Gori::Proxy::WS::MessageGate do
   # actually holding may not sit on the peer's PONG — that is the liveness argument
   # `MessageGate`'s header is built on — so the control frame overtakes it, exactly once, and
   # the message's own frames follow on release with the control frame NOT duplicated.
+  #
+  # R9: this reordering is deliberate and the STORE stays honest (the PING's own capture row,
+  # written at arrival by `Relay.capture_control`, keeps the TRUE order — this test's `first`
+  # arrived before `ping` and `data_rows` below still shows the PING's row after nothing else
+  # changed there) — but the LIVE wire genuinely reorders it ahead of the data it interleaved,
+  # and that used to happen with no signal at all. `MessageGate#submit` now writes the same
+  # `[gori] …` notice every other routine edge case in this class gets.
   it "lets an interleaved PING overtake a message that is really held, and only then" do
     first = masked(WS::OP_TEXT, "hold".to_slice, fin: false)
     ping = masked(WS::OP_PING, "pi".to_slice)
@@ -404,7 +411,12 @@ describe Gori::Proxy::WS::MessageGate do
       released = Bytes.new(first.size + second.size)
       r.ts_r.read_fully(released)
       released.should eq(first + second) # the peer's own frames, and the PING not sent twice
-      sink.messages.should eq([{"out", 9, "pi"}, {"out", 1, "hold-me"}])
+      data_rows(sink).should eq([{"out", 9, "pi"}, {"out", 1, "hold-me"}])
+      notice_rows(sink).map(&.[](2)).should eq(
+        ["[gori] client→server: a control frame interleaved with this message was sent ahead " \
+         "of it, because the message itself has to wait (held, or queued behind an earlier " \
+         "hold) and a control frame cannot wait with it. The true arrival order is preserved " \
+         "in History; only the live wire is reordered"])
     end
     r.shutdown
   end

--- a/spec/repeater/connect_error_spec.cr
+++ b/spec/repeater/connect_error_spec.cr
@@ -120,4 +120,96 @@ describe "Gori::Repeater::Engine.connect_error" do
     ]
     all.uniq.size.should eq(5)
   end
+
+  # Round 9 / r9-tls Finding 2. A proxy that answers 200 to CONNECT and then closes without
+  # relaying anything hands the TLS handshake a socket that fails EXACTLY like a direct
+  # black-hole/non-TLS origin — before this fix, the operator was told the ORIGIN's port "may
+  # not be TLS" when the origin was never contacted. `via_proxy` on the DialError is the fix;
+  # these assert how `connect_error` renders it.
+  describe "the proxy-tunnel clause (round 9 / Finding 2)" do
+    it "appends the clause, AFTER the OpenSSL cause, for a proxied Tls failure" do
+      err = U::DialError.new(U::DialErrorKind::Tls,
+        cause: "SSL_connect: Unexpected EOF while reading",
+        via_proxy: "upstream HTTP proxy 127.0.0.1:8080")
+      msg = E.connect_error("https", "h.test", 443, false, err)
+      msg.should eq(
+        "TLS handshake failed: h.test:443 — the port may not be TLS, or the origin refused " \
+        "the protocol/cipher (SSL_connect: Unexpected EOF while reading) (reached via " \
+        "upstream HTTP proxy 127.0.0.1:8080 — the tunnel produced no data; the proxy may be " \
+        "at fault, not the target)")
+    end
+
+    it "appends the same clause for a proxied Timeout (the tunnel opened, then silence)" do
+      err = U::DialError.new(U::DialErrorKind::Timeout,
+        cause: "no TLS response within 3.0s", via_proxy: "upstream SOCKS5 proxy 127.0.0.1:1080")
+      msg = E.connect_error("https", "h.test", 443, true, err)
+      msg.should contain("TLS handshake timed out: h.test:443")
+      msg.should contain("no TLS response within 3.0s")
+      msg.should contain("reached via upstream SOCKS5 proxy 127.0.0.1:1080")
+      msg.should contain("tunnel produced no data")
+    end
+
+    # Complement of the two above: the UNPROXIED (direct) case must render BYTE-IDENTICAL to
+    # what it did before this fix (`handshake_error`/`blackhole_error` above never set
+    # `via_proxy`) — this is the regression risk the round explicitly flags.
+    it "adds nothing for a direct dial — today's wording is unchanged" do
+      E.connect_error("https", "h.test", 443, false, handshake_error)
+        .should eq("TLS handshake failed: h.test:443 — the port may not be TLS, or the origin " \
+                   "refused the protocol/cipher (SSL_connect: error:0A00010B:SSL routines::wrong version number)")
+      E.connect_error("https", "h.test", 443, true, blackhole_error)
+        .should eq("TLS handshake timed out: h.test:443 — the origin accepted the connection " \
+                   "and then sent nothing; no certificate was exchanged, so -k and " \
+                   "SSL_CERT_FILE cannot help (no TLS response within 3.0s)")
+    end
+
+    # Complement: a certificate REJECTION through a proxy must not get the tunnel-blame clause
+    # — real bytes crossed the tunnel, so the ORIGIN (not the proxy) earned the verdict. Even
+    # if `via_proxy` were (incorrectly) set on a TlsVerify error, `connect_error`'s OWN rendering
+    # must not surface it — this is defensive on the render side, independent of the fact that
+    # `tls_dial_error` never sets `via_proxy` for this kind.
+    it "never shows the clause for TlsVerify, even if via_proxy were set" do
+      err = U::DialError.new(U::DialErrorKind::TlsVerify,
+        cause: "certificate verify failed", via_proxy: "upstream HTTP proxy 127.0.0.1:8080")
+      E.connect_error("https", "h.test", 443, true, err).should_not contain("reached via upstream")
+    end
+
+    # Complement: the proxy's OWN refusal (407/403/502) already names itself precisely via
+    # `detail`, used verbatim — this must keep working unchanged (no double-tagging).
+    it "does not touch the existing verbatim wording for a proxy that refused the tunnel outright" do
+      err = U::DialError.new(U::DialErrorKind::Proxy, "upstream HTTP proxy proxy.test:8080 refused CONNECT h.test:443: HTTP/1.1 407 Proxy Authentication Required — the proxy requires authentication; set `username` + `password_env` on the matching upstream rule")
+      E.connect_error("https", "h.test", 443, true, err)
+        .should eq("connect failed: upstream HTTP proxy proxy.test:8080 refused CONNECT h.test:443: HTTP/1.1 407 Proxy Authentication Required — the proxy requires authentication; set `username` + `password_env` on the matching upstream rule")
+    end
+  end
+end
+
+# Round 9 / r9-tls Finding 2, the PLAIN-HTTP half. `Engine.exchange` gets no `DialError` at all
+# when the dial itself SUCCEEDED (a proxy answering 200 to CONNECT is a successful tunnel open,
+# by the CONNECT protocol's own rules) — the silence only shows up later, on the very first
+# read. So `no_response_error` has to ask `Settings.upstream_route` directly rather than reading
+# a `DialError` field; these specs exercise exactly that live global-state seam, save/restoring
+# it the same way `spec/settings_spec.cr` does around every other `Settings.upstream_proxy=` use.
+describe "Gori::Repeater::Engine.no_response_error" do
+  it "stays exactly today's wording for a direct (unproxied) host" do
+    Gori::Repeater::Engine.no_response_error("origin.test", 8080)
+      .should eq("no response from origin.test:8080")
+  end
+
+  it "appends the proxy-tunnel clause when the host currently routes through a configured proxy" do
+    Gori::Settings.upstream_proxy = "127.0.0.1:1"
+    begin
+      Gori::Repeater::Engine.no_response_error("origin.test", 8080).should eq(
+        "no response from origin.test:8080 (reached via upstream HTTP proxy 127.0.0.1:1 — " \
+        "the tunnel produced no data; the proxy may be at fault, not the target)")
+    ensure
+      Gori::Settings.upstream_proxy = ""
+    end
+  end
+
+  it "goes back to the plain sentence once the proxy is cleared" do
+    Gori::Settings.upstream_proxy = "127.0.0.1:1"
+    Gori::Settings.upstream_proxy = ""
+    Gori::Repeater::Engine.no_response_error("origin.test", 8080)
+      .should eq("no response from origin.test:8080")
+  end
 end

--- a/spec/repeater/ws_engine_spec.cr
+++ b/spec/repeater/ws_engine_spec.cr
@@ -142,6 +142,39 @@ describe Gori::Repeater::WsEngine do
     result.ok?.should be_false
   end
 
+  # Round 9 / r9-tls Finding 2, verified on the WS engine (the round's "verify at least one
+  # additional engine" requirement — the h1 repeater was the hunter's live repro). A `ws://`
+  # target behind a proxy that answers 200 to CONNECT and then closes without relaying is the
+  # same shape as a plain h1 clean-EOF: `read_head` returns nil on the very first read, and
+  # (before this fix) `WsEngine.send` built its OWN hardcoded "no response from …" string
+  # instead of reusing `Engine.no_response_error` — so it silently missed the proxy-tunnel
+  # clause the h1 builder now carries. This exercises that exact sibling gap.
+  it "names the proxy when a ws:// target's tunnel opens and then produces no data" do
+    proxy = TCPServer.new("127.0.0.1", 0)
+    pport = proxy.local_address.port
+    spawn do
+      conn = proxy.accept
+      while (h = conn.gets("\r\n", chomp: true)) && !h.empty?
+      end
+      conn << "HTTP/1.1 200 Connection Established\r\n\r\n"
+      conn.flush rescue nil
+      conn.close rescue nil # no relay — the tunnel produced nothing
+    end
+
+    Gori::Settings.upstream_proxy = "127.0.0.1:#{pport}"
+    begin
+      result = WsEngine.send(UPGRADE, [] of WsEngine::OutMsg,
+        scheme: "http", host: "127.0.0.1", port: 20999, verify_upstream: false)
+      result.ok?.should be_false
+      result.error.not_nil!.should eq(
+        "no response from 127.0.0.1:20999 (reached via upstream HTTP proxy 127.0.0.1:#{pport} " \
+        "— the tunnel produced no data; the proxy may be at fault, not the target)")
+    ensure
+      Gori::Settings.upstream_proxy = ""
+      proxy.close rescue nil
+    end
+  end
+
   it "preserves non-UTF-8 header value bytes verbatim in the replayed handshake" do
     got = Channel(Bytes).new(1)
     origin = TCPServer.new("127.0.0.1", 0)

--- a/src/gori/cli/run/intercept.cr
+++ b/src/gori/cli/run/intercept.cr
@@ -376,7 +376,11 @@ module Gori
                      "(whichever leg — request or response — is held). The BODY is forwarded\n" \
                      "VERBATIM (no $KEY expansion, no line-ending rewrite); header lines are\n" \
                      "CRLF-terminated and Content-Length is resynced to the new body unless\n" \
-                     "--no-update-content-length holds the value you declared."
+                     "--no-update-content-length holds the value you declared.\n\n" \
+                     "A held WebSocket message has no head at all, so it is taken literally —\n" \
+                     "no CRLF rewrite, no Content-Length resync. A BINARY WS frame additionally\n" \
+                     "requires --raw-file (the byte-exact channel): --raw is a shell argument\n" \
+                     "and cannot carry a byte over 0x7F unchanged."
           p.on("--project=NAME", "Project to update (default: most-recently-active)") { |v| project_name = v }
           p.on("--db=PATH", "Explicit SQLite db file to update") { |v| db_path = v }
           p.on("--raw=RAW", "Verbatim replacement wire message") { |v| raw = v }
@@ -403,17 +407,73 @@ module Gori
                   end
         abort "gori run intercept edit: replacement message must not be empty" if content.empty?
 
-        # CRLF-normalize the HEAD ALONE, bounded by `Env.head_body_boundary` — the split
-        # every other edit path on this branch already uses (`Env.expand_wire`, the TUI's
-        # `intercept_view`). Only HTTP header lines require CRLF termination; a raw 0x0A in
-        # the BODY is a byte (binary data, or a bare LF the operator deliberately wrote), and
-        # rewriting it contradicted this subcommand's own "forwarded VERBATIM" contract —
-        # `--raw-file` is its only byte-exact channel, and an `alpha\rbeta\ngamma` body came
-        # out a byte longer with the LF promoted. (That split, and the Content-Length choice
-        # beside it, live in `intercept_edit_bytes` so a spec can pin the exact bytes.)
-        bytes = intercept_edit_bytes(content, update_cl)
+        # A WebSocket message (held row's `kind` is wsout/wsin) is not an HTTP head+body — no
+        # start line, no headers, no head/body split — so the CRLF-normalize/Content-Length
+        # rewrite below (written for an HTTP head) must never touch it: with no blank line to
+        # bound a "header block", the whole payload was treated as one and every bare LF the
+        # operator typed got promoted to CRLF. `row` is nil (falls through to the HTTP-shaped
+        # path below, harmlessly — `enqueue_intercept` resolves `no_such_item` on its own) when
+        # there is no live bridge, no session token, or the item is no longer held.
+        row = held_row_for_edit(project_name, db_path, item_id)
+        bytes =
+          if row.try(&.ws?)
+            result = ws_edit_bytes(content, item_id, row.try(&.binary?) || false, used_raw_file: !raw_file.nil?)
+            abort "gori run intercept edit: #{result}" if result.is_a?(String)
+            result
+          else
+            # CRLF-normalize the HEAD ALONE, bounded by `Env.head_body_boundary` — the split
+            # every other edit path on this branch already uses (`Env.expand_wire`, the TUI's
+            # `intercept_view`). Only HTTP header lines require CRLF termination; a raw 0x0A in
+            # the BODY is a byte (binary data, or a bare LF the operator deliberately wrote),
+            # and rewriting it contradicted this subcommand's own "forwarded VERBATIM" contract
+            # — `--raw-file` is its byte-exact channel for an HTTP body, and an
+            # `alpha\rbeta\ngamma` body came out a byte longer with the LF promoted. (That
+            # split, and the Content-Length choice beside it, live in `intercept_edit_bytes` so
+            # a spec can pin the exact bytes.)
+            intercept_edit_bytes(content, update_cl)
+          end
         status, detail = enqueue_intercept(project_name, db_path, "forward_edit", item_id: item_id, bytes: bytes)
         emit_intercept_ack(status, detail, format)
+      end
+
+      # The held row for `item_id`, straight off the #123 bridge — nil when no live bridge, no
+      # session token, or the item is no longer held. Mirrors MCP's `held_row_for_edit`; needed
+      # here for the identical reason (`kind`/`binary?` before choosing a normalization rule).
+      private def self.held_row_for_edit(project_name : String?, db_path : String?, item_id : Int64) : Store::HeldRow?
+        project = resolve_read_project(project_name, db_path)
+        store = open_store(project)
+        begin
+          bridge = intercept_bridge_state(store)
+          return nil unless bridge
+          token = bridge["session_token"]?.try(&.as_s?) || ""
+          return nil if token.empty?
+          store.intercept_held(token).find { |r| r.item_id == item_id }
+        ensure
+          store.close
+        end
+      end
+
+      # The replacement bytes for a held WS item's `raw`/`raw-file` edit — taken LITERALLY, no
+      # CRLF-normalize, no Content-Length resync (a WS message has no head for either to apply
+      # to; see the matching comment on MCP's `Tools#intercept_edit_bytes`) — or the refusal
+      # message when the channel cannot carry it byte-exact.
+      #
+      # `--raw-file` reads the FILE's bytes directly (no shell/argv re-encoding), so it is
+      # byte-exact for a BINARY WS frame the same way MCP's `raw_base64` is; `--raw` is an argv
+      # STRING — already re-encoded as text before this process ever saw it, so a byte over
+      # 0x7F is unrecoverable here (the OS/shell owns that re-encoding, not gori). A binary WS
+      # item through `--raw` is refused by name rather than forwarding the wrong bytes,
+      # mirroring the TUI's read-only stance on a binary WS message (`read_only_selection?`).
+      #
+      # Public and pure (no store, no process exit) so a spec can pin the decision without a
+      # live capturing instance.
+      def self.ws_edit_bytes(content : String, item_id : Int64, binary : Bool, *, used_raw_file : Bool) : Bytes | String
+        if binary && !used_raw_file
+          return "held item #{item_id} is a WebSocket BINARY message — --raw is a shell argument and cannot " \
+                 "carry it byte-exact (a byte over 0x7F is already re-encoded before gori sees it); use " \
+                 "--raw-file with the exact bytes"
+        end
+        content.to_slice
       end
 
       # The exact bytes `edit` enqueues, from the replacement message and the CL choice.

--- a/src/gori/interceptor.cr
+++ b/src/gori/interceptor.cr
@@ -137,15 +137,22 @@ module Gori
       # forward toast name the message the operator is actually about to send — the one
       # reason a surface ever needs different values here.
       #
+      # `size` defaults to the HELD byte count, but a caller settling a `forward_edit` must
+      # pass the size of the bytes it is ACTUALLY about to put on the wire: an edit that
+      # legitimately changes a WS message's length (or used to, silently, before the CRLF
+      # normalization bug this size param was added alongside) made the ack lie about what it
+      # had just sent — "client->server 17B" for a message that left as 19 bytes. The ack is
+      # the caller's only receipt for an irreversible action, so it has to describe the ACT.
+      #
       # `Gori::Url.origin_path` is the shared spelling of the absolute-form rule; it used to
       # be copied into this file because `Interceptor` is core and the only other copy was
       # `Tui::Url`'s.
-      def label(m : String = method, t : String = target) : String
+      def label(m : String = method, t : String = target, size : Int32 = raw.size) : String
         case kind
         in .request?  then "#{m} #{host}#{Gori::Url.origin_path(t)}"
         in .response? then "#{m} #{host} -> #{t}"
-        in .ws_out?   then "#{host}#{Gori::Url.origin_path(t)} client->server #{raw.size}B"
-        in .ws_in?    then "#{host}#{Gori::Url.origin_path(t)} server->client #{raw.size}B"
+        in .ws_out?   then "#{host}#{Gori::Url.origin_path(t)} client->server #{size}B"
+        in .ws_in?    then "#{host}#{Gori::Url.origin_path(t)} server->client #{size}B"
         end
       end
     end

--- a/src/gori/mcp/serialize.cr
+++ b/src/gori/mcp/serialize.cr
@@ -187,6 +187,14 @@ module Gori
         j.field "head_only", true if row.head_only?
         row.head_only_note.try { |n| j.field "head_only_note", text(n) }
         row.edit_refusal.try { |r| j.field "edit_refusal", text(r) }
+        # A WebSocket BINARY frame (opcode 2): `raw` (a JSON string) cannot carry it byte-exact
+        # — any byte above 0x7F re-encodes to multiple UTF-8 bytes on the way back out — so
+        # `intercept_forward_edit` refuses `raw` for this item and `raw_base64` is the only
+        # edit channel. Said here, before the agent writes one, same reasoning as `head_only`.
+        if row.ws? && row.binary?
+          j.field "binary", true
+          j.field "binary_note", "this is a WebSocket BINARY message — 'raw' cannot edit it byte-exact (a JSON string re-encodes any byte over 0x7F); use 'raw_base64'"
+        end
       end
 
       # Detail projection: full redacted head + body size. The FULL raw message base64 (for

--- a/src/gori/mcp/tools/intercept.cr
+++ b/src/gori/mcp/tools/intercept.cr
@@ -69,6 +69,21 @@ module Gori
         Result.new(JSON.build { |j| Serialize.intercept_item_detail(j, row, include_sensitive, Time.utc.to_unix_ms) })
       end
 
+      # The held row for `item_id`, straight off the #123 bridge — nil when no live bridge, no
+      # session token, or the item is no longer held (already forwarded/dropped elsewhere).
+      # `intercept_forward_edit` needs this BEFORE it picks a normalization rule: a WS item has
+      # no HTTP head at all, so the rule that CRLF-promotes bare LF in a "header block" must
+      # never run on it (see `intercept_edit_bytes`). A nil here just falls back to the
+      # HTTP-shaped rule, which is harmless — the enqueue below will resolve `no_such_item` on
+      # its own if the row really is gone.
+      private def held_row_for_edit(item_id : Int64) : Store::HeldRow?
+        bridge = intercept_bridge_state
+        return nil unless bridge
+        token = bridge["session_token"]?.try(&.as_s?) || ""
+        return nil if token.empty?
+        store.intercept_held(token).find { |r| r.item_id == item_id }
+      end
+
       # --- #123 live intercept (write side; gated behind allow_actions) -------
 
       # A capturing instance is "live" only if its bridge says capturing AND the heartbeat is
@@ -99,7 +114,8 @@ module Gori
       private def intercept_forward_edit(h) : Result
         id = int(h, "item_id")
         return err(id_error(h, "item_id"), "INVALID_ARGUMENT", field: "item_id") unless id
-        edited = intercept_edit_bytes(h)
+        row = held_row_for_edit(id)
+        edited = intercept_edit_bytes(h, row)
         return edited if edited.is_a?(Result)
         # Bytes are LITERAL — no Env.expand_wire, so a remote agent's $SECRET references are
         # never expanded into forwarded traffic; and no smuggling guard, because byte-exact
@@ -113,20 +129,48 @@ module Gori
         # byte-exact. Default on keeps the ordinary edit ("I changed the body, frame it for
         # me") working; `update_content_length:false` is the desync switch, and the result
         # says which one ran so the caller never has to assume.
-        sync = bool_arg(h, "update_content_length", true)
+        #
+        # A WS item never gets this rewrite, full stop — not even when the caller asked for it.
+        # There is no head, so `ContentLength.sync` would have to invent a header LINE and
+        # splice it into the payload body (`add_when_missing` was written for a GET growing a
+        # body, not for turning a chat message into one), exactly the trap the TUI's own
+        # `pending_edit` comment calls out. Mirrors the TUI: WS is never offered the toggle.
+        ws = row.try(&.ws?) || false
+        sync = !ws && bool_arg(h, "update_content_length", true)
         bytes = sync ? Fuzz::ContentLength.sync(edited, add_when_missing: true) : edited
         enqueue_intercept("forward_edit", item_id: id, bytes: bytes,
           extra: {"content_length_synced" => JSON::Any.new(sync && bytes != edited)})
       end
 
-      # The replacement wire message. `raw_base64` is the byte-exact channel — a JSON string
-      # cannot carry arbitrary octets, so it is the ONLY way a binary body survives the round
-      # trip `intercept_get` starts when it hands back `raw_base64`. `raw` stays for the common
-      # text edit; there, lone LFs in the HEADER block become CRLF (a hand-typed message still
-      # frames) while the BODY is left untouched, via the same rule send_request's `raw` uses.
-      # Exactly one of the two, so a caller that sends both is told rather than silently having
-      # one ignored.
-      private def intercept_edit_bytes(h) : Bytes | Result
+      # The replacement wire message.
+      #
+      # `raw_base64` is the byte-exact channel for ANY held item — a JSON string cannot carry
+      # arbitrary octets, so it is the only way a binary body (or a binary WS frame) survives
+      # the round trip `intercept_get` starts when it hands back `raw_base64`.
+      #
+      # `raw` behaves differently depending on WHAT is held, because the two shapes are not the
+      # same message:
+      #   - An HTTP head+body: lone LFs in the HEADER block become CRLF (a hand-typed message
+      #     still frames) while the BODY is left untouched — `RequestBuilder.normalize_raw`,
+      #     the same rule `send_request`'s `raw` uses.
+      #   - A WebSocket message (`row.ws?`): there IS no header block — no start line, no
+      #     headers, no head/body split — so running the HTTP rule on it is not "safe
+      #     normalization", it is corruption: with no blank line to bound it, the WHOLE payload
+      #     is treated as "header" and every bare LF the operator typed is promoted to CRLF (a
+      #     17-byte unedited round trip came back 19 bytes on the wire). `raw` is taken
+      #     LITERALLY instead, mirroring the TUI's `@loaded_ws` branch in
+      #     `intercept_view#pending_edit` (`wire_bytes`, never `Env.expand_wire`/normalize).
+      #   - A WebSocket BINARY frame (`row.binary?`): even taken literally, a JSON string
+      #     cannot carry an arbitrary octet — a byte above 0x7F round-trips through JSON's
+      #     Unicode text encoding as MULTIPLE bytes, silently growing the payload (`0xFF` came
+      #     back `0xC3 0xBF`). The TUI refuses to even open its editor on a binary WS message
+      #     for the identical reason (`read_only_selection?`); `raw` refuses here by name
+      #     instead of forwarding the wrong bytes, and `raw_base64` is the byte-exact escape
+      #     hatch it already is for a binary HTTP body.
+      #
+      # Exactly one of `raw`/`raw_base64`, so a caller that sends both is told rather than
+      # silently having one ignored.
+      private def intercept_edit_bytes(h, row : Store::HeldRow?) : Bytes | Result
         b64 = str(h, "raw_base64").presence
         raw = str(h, "raw").presence
         if b64 && raw
@@ -144,6 +188,13 @@ module Gori
         unless raw
           return err("missing required 'raw' (the full edited wire message) — or 'raw_base64' for byte-exact bytes",
             "INVALID_ARGUMENT", field: "raw")
+        end
+        if row.try(&.ws?)
+          if row.try(&.binary?)
+            return err("held item #{row.not_nil!.item_id} is a WebSocket BINARY message — 'raw' is a JSON string and cannot carry it byte-exact (a byte over 0x7F re-encodes to multiple bytes); use 'raw_base64' instead",
+              "INVALID_ARGUMENT", field: "raw")
+          end
+          return raw.to_slice
         end
         RequestBuilder.normalize_raw(raw)
       end

--- a/src/gori/proxy/tls/cert_authority.cr
+++ b/src/gori/proxy/tls/cert_authority.cr
@@ -51,6 +51,23 @@ module Gori::Proxy::Tls
         # 0600 (a mounted share) must not make gori refuse to start.
         File.chmod(key_path, 0o600) rescue nil
         new(Cert.read_pem(cert_path), KeyPair.read_pem(key_path), cert_path)
+      elsif File.exists?(cert_path) || File.exists?(key_path)
+        # Exactly ONE of the pair survives — a partial restore, an accidental `rm
+        # root.key.pem`, a disk fault that clobbered one inode. This is NOT the first-run
+        # case (neither file exists, handled below) and must not be folded into it: a lone
+        # cert can't sign anything without its key, and a lone key has no certificate left
+        # to present as the root a client already trusts. Silently minting a fresh pair here
+        # would overwrite the survivor with a brand-new root — same identity swap as
+        # `regenerate!`, but done by ACCIDENT and reported as clean success. Refuse instead,
+        # naming exactly which file is missing, so the operator can restore it from backup
+        # or make the swap deliberately via `gori ca regenerate` (which also re-trusts
+        # clients as part of the workflow, not as a silent side effect).
+        present = File.exists?(cert_path) ? CA_CERT_FILE : CA_KEY_FILE
+        missing = File.exists?(cert_path) ? CA_KEY_FILE : CA_CERT_FILE
+        raise Gori::Error.new(
+          "CA pair broken in #{dir}: found #{present} but #{missing} is missing — restore " \
+          "#{missing} from backup, or run `gori ca regenerate` to mint a fresh CA (existing " \
+          "clients will need to re-trust it)")
       else
         cert, key = CertBuilder.build_root(common_name)
         cert.write_pem(cert_path)

--- a/src/gori/proxy/upstream.cr
+++ b/src/gori/proxy/upstream.cr
@@ -311,6 +311,32 @@ module Gori::Proxy
       "upstream #{route.socks5? ? "SOCKS5" : "HTTP"} proxy #{route.host}:#{route.port}"
     end
 
+    # `proxy_label`, but nil for a direct route — the question a FAILURE BUILDER asks once it
+    # already has a socket (or a clean EOF) and needs to know whether that socket came through
+    # a tunnel. `Settings.upstream_route` is the SAME single decision point `dial_result` reads
+    # (see its own comment: "ONE decision point for how do we reach this host"), so re-asking it
+    # here — rather than threading a value through every dial's return tuple — reaches every
+    # caller (repeater h1/h2/WS engines, ConnPool, the live MITM `ClientConn`) without changing
+    # any of their signatures. Public: `Repeater::Engine#no_response_error` has no `DialError` to
+    # read (a proxy that opens the tunnel and then goes silent is not a dial FAILURE — the dial
+    # succeeded; the silence shows up later, on the first read) and needs to ask this question
+    # directly.
+    def self.proxied_via(host : String) : String?
+      route = Settings.upstream_route(host)
+      route.direct? ? nil : proxy_label(route)
+    end
+
+    # The clause to append when a failure happened on a socket that reached this far via an
+    # upstream proxy tunnel and produced no origin bytes at all: a proxy that answers `200
+    # Connection Established` and then closes is, on the bare socket, indistinguishable from the
+    # ORIGIN itself refusing or hanging — nothing on that socket remembers it came through a
+    # tunnel. Left unqualified (`label` rather than re-deriving it) so `DialError#proxy_note` and
+    # `proxied_via`'s callers share exactly one wording.
+    def self.proxy_tunnel_note(label : String?) : String
+      return "" unless label
+      " (reached via #{label} — the tunnel produced no data; the proxy may be at fault, not the target)"
+    end
+
     # Whether this route has credentials to present. A username alone is legitimate (some
     # proxies key on it), so either half being present counts.
     private def self.authenticating?(route : Settings::UpstreamRoute) : Bool
@@ -795,8 +821,16 @@ module Gori::Proxy
       getter kind : DialErrorKind
       getter detail : String?
       getter cause : String?
+      # The upstream proxy this dial's socket came through (see `Upstream.proxied_via`), set
+      # ONLY for the kinds where the failure happened after a proxy tunnel opened but before any
+      # origin byte arrived (`Tls`, `Timeout`) — never `TlsVerify` (a certificate WAS exchanged
+      # and judged, so the origin, not the tunnel, is what failed) and never `Connect`/`Proxy`
+      # (those already name the proxy precisely via `detail`, e.g. "…refused CONNECT…"). nil for
+      # a direct dial, or for any kind where a proxy tag would be redundant or wrong.
+      getter via_proxy : String?
 
-      def initialize(@kind : DialErrorKind, @detail : String? = nil, @cause : String? = nil)
+      def initialize(@kind : DialErrorKind, @detail : String? = nil, @cause : String? = nil,
+                     @via_proxy : String? = nil)
       end
 
       # A direct dial that did not connect. Deliberately carries NO detail: the caller already
@@ -817,6 +851,14 @@ module Gori::Proxy
       def because : String
         c = @cause
         c && !c.empty? ? " (#{c})" : ""
+      end
+
+      # The proxy-tunnel clause (see `via_proxy` above), appended AFTER `because` — the OpenSSL
+      # cause ("Unexpected EOF while reading") and the proxy attribution are two separate facts,
+      # not alternatives: the first says WHAT happened, the second says WHERE the fault most
+      # likely sits. Empty when this dial was not proxied (or the kind doesn't carry the tag).
+      def proxy_note : String
+        Upstream.proxy_tunnel_note(@via_proxy)
       end
     end
 
@@ -864,7 +906,7 @@ module Gori::Proxy
       # per failed origin → fd exhaustion). `tcp` is non-nil here: `dial` never raises
       # (it returns nil), so the only raising step runs after the nil-guard above.
       tcp.try(&.close) rescue nil
-      {nil, tls_dial_error(ex, io_timeout)}
+      {nil, tls_dial_error(ex, io_timeout, host)}
     end
 
     # What actually broke inside the TLS attempt. This used to be a bare `rescue` that threw
@@ -874,14 +916,24 @@ module Gori::Proxy
     # trusted; retry with --insecure-upstream or set SSL_CERT_FILE" when no certificate had
     # been exchanged at all — a wrong diagnosis with two useless remedies. OpenSSL already
     # separates the cases; this only stops discarding the answer.
-    private def self.tls_dial_error(ex : Exception, io_timeout : Time::Span) : DialError
+    #
+    # `host` is the name being dialed — used ONLY to ask `proxied_via` whether this socket came
+    # through an upstream proxy tunnel, for the two kinds below where that fact would otherwise
+    # be lost: a proxy that answers `200 Connection Established` and then closes leaves a socket
+    # that looks, to OpenSSL, exactly like a direct connection to a broken/non-TLS origin — the
+    # `Tls`/`Timeout` cases are precisely "origin reached (the tunnel opened) and then nothing
+    # came back", which is also exactly what an accept-then-close proxy produces. `TlsVerify` is
+    # deliberately excluded: a certificate WAS exchanged and rejected, so real bytes crossed the
+    # tunnel and the origin — not the proxy — earned that verdict.
+    private def self.tls_dial_error(ex : Exception, io_timeout : Time::Span, host : String) : DialError
       # A read timeout is not a TLS verdict — nothing came back to judge. Naming the layer
       # TLS here is precisely what produced the certificate advice for a black hole, so it
       # gets its own kind and carries how long gori actually waited (the stall was otherwise
       # invisible: a failed dial records no duration).
       if ex.is_a?(IO::TimeoutError)
         return DialError.new(DialErrorKind::Timeout,
-          cause: "no TLS response within #{io_timeout.total_seconds.round(1)}s")
+          cause: "no TLS response within #{io_timeout.total_seconds.round(1)}s",
+          via_proxy: proxied_via(host))
       end
       cause = exception_cause(ex)
       # OpenSSL says "certificate verify failed" for an untrusted chain, an expired leaf AND a
@@ -889,7 +941,7 @@ module Gori::Proxy
       # three. Everything else it raises is a protocol-level refusal, where offering a CA file
       # is the wrong advice.
       return DialError.new(DialErrorKind::TlsVerify, cause: cause) if cause.includes?("certificate verify failed")
-      DialError.new(DialErrorKind::Tls, cause: cause)
+      DialError.new(DialErrorKind::Tls, cause: cause, via_proxy: proxied_via(host))
     end
 
     # Longest library verdict worth carrying into a stored flow error. OpenSSL's are ~60 bytes.

--- a/src/gori/proxy/ws/message_gate.cr
+++ b/src/gori/proxy/ws/message_gate.cr
@@ -149,8 +149,19 @@ module Gori::Proxy::WS
         # A control frame that arrived between its fragments cannot wait with it: a PONG
         # parked behind a hold is how the peer's ping timer closes the socket (this class's
         # header). So THIS is where the interleave is given up, and the only place — the
-        # controls go out now, the message's own frames follow on release.
-        raw.try(&.controls).try { |c| write_raw(c) }
+        # controls go out now, the message's own frames follow on release. Deliberate, and
+        # the STORE stays honest (`capture_control` records the TRUE arrival order, so History
+        # shows it correctly) — only the LIVE wire reorders. Every other routine edge case in
+        # this class gets a `note()`; this one didn't, so an operator watching live traffic saw
+        # a PING ahead of the data it was actually interleaved with and no signal that gori
+        # did that on purpose.
+        raw.try(&.controls).try do |c|
+          write_raw(c)
+          note("a control frame interleaved with this message was sent ahead of it, because " \
+               "the message itself has to wait (held, or queued behind an earlier hold) and a " \
+               "control frame cannot wait with it. The true arrival order is preserved in " \
+               "History; only the live wire is reordered")
+        end
         kept = payload.dup
         slot = Slot.new(opcode, kept, raw, shape)
         item = held ? start_hold(opcode, kept) : nil

--- a/src/gori/repeater/engine.cr
+++ b/src/gori/repeater/engine.cr
@@ -177,8 +177,17 @@ module Gori
       # pool matches on it to tell "the origin had already closed this parked socket" (retry
       # once on a fresh connection) apart from a timeout or a mid-response failure (never
       # retried — the origin may well have processed the request).
+      #
+      # There is no `DialError` to read here — the DIAL succeeded (a proxy that answers `200
+      # Connection Established` and then closes is a successful tunnel open, by the CONNECT
+      # protocol's own rules); the silence only shows up later, on this first read. So this
+      # asks `Settings.upstream_route` directly, the same single decision point `dial_result`
+      # itself consults — the only way to reach the fact from here without threading a new
+      # value through every dial's return tuple (which would touch `ClientConn`'s live-MITM
+      # path and every other engine's signature for a clause only THIS message needs). A plain,
+      # unproxied miss keeps today's exact wording: `proxied_via` is nil for a direct route.
       def self.no_response_error(host : String, port : Int32) : String
-        "no response from #{host}:#{port}"
+        "no response from #{host}:#{port}#{Proxy::Upstream.proxy_tunnel_note(Proxy::Upstream.proxied_via(host))}"
       end
 
       # Writes one request on an already-open connection and reads its single response
@@ -338,11 +347,11 @@ module Gori
                    "or set SSL_CERT_FILE#{err.because}"
           when .tls?
             return "TLS handshake failed: #{host}:#{port} — the port may not be TLS, or the origin " \
-                   "refused the protocol/cipher#{err.because}"
+                   "refused the protocol/cipher#{err.because}#{err.proxy_note}"
           when .timeout?
             return "TLS handshake timed out: #{host}:#{port} — the origin accepted the connection " \
                    "and then sent nothing; no certificate was exchanged, so -k and SSL_CERT_FILE " \
-                   "cannot help#{err.because}"
+                   "cannot help#{err.because}#{err.proxy_note}"
           when .dns?
             return "connect failed: #{host} — the name did not resolve, so nothing was dialed#{err.because}"
           end

--- a/src/gori/repeater/ws_engine.cr
+++ b/src/gori/repeater/ws_engine.cr
@@ -140,7 +140,11 @@ module Gori
           upstream.write(handshake)
           upstream.flush
           head = Proxy::Codec::Http1.read_head(upstream)
-          return err("no response from #{host}:#{port}", started) unless head
+          # `Engine.no_response_error`, not a local copy of the sentence: a plain `ws://` target
+          # behind a proxy that answers the CONNECT and then closes without relaying anything is
+          # the same shape as the h1 repeater's clean-EOF case, and a hand-duplicated string here
+          # would silently miss the proxy-tunnel clause that builder now carries.
+          return err(Engine.no_response_error(host, port), started) unless head
 
           resp = Proxy::Codec::Http1.parse_response_head(head)
           unless resp.status == 101

--- a/src/gori/store/intercept_bridge.cr
+++ b/src/gori/store/intercept_bridge.cr
@@ -22,9 +22,9 @@ module Gori
           placeholders = Array.new(rows.size, "?").join(",")
           c.exec("DELETE FROM intercept_held WHERE session_token = ? AND item_id NOT IN (#{placeholders})", args: keep)
           rows.each do |r|
-            c.exec("INSERT OR IGNORE INTO intercept_held (session_token, item_id, kind, method, host, port, scheme, target, flow_id, raw, held_at_ms, edited, edit_refusal, head_only) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+            c.exec("INSERT OR IGNORE INTO intercept_held (session_token, item_id, kind, method, host, port, scheme, target, flow_id, raw, held_at_ms, edited, edit_refusal, head_only, binary) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
               token, r.item_id, r.kind, r.method, r.host, r.port, r.scheme, r.target, r.flow_id, r.raw, r.held_at_ms, r.edited ? 1 : 0,
-              r.edit_refusal, r.head_only? ? 1 : 0)
+              r.edit_refusal, r.head_only? ? 1 : 0, r.binary? ? 1 : 0)
           end
         end
         nil
@@ -33,7 +33,7 @@ module Gori
 
     def intercept_held(token : String) : Array(HeldRow)
       rows = [] of HeldRow
-      @db.query("SELECT session_token, item_id, kind, method, host, port, scheme, target, flow_id, raw, held_at_ms, edited, viewed_ms, edit_refusal, head_only FROM intercept_held WHERE session_token = ? ORDER BY item_id", token) do |rs|
+      @db.query("SELECT session_token, item_id, kind, method, host, port, scheme, target, flow_id, raw, held_at_ms, edited, viewed_ms, edit_refusal, head_only, binary FROM intercept_held WHERE session_token = ? ORDER BY item_id", token) do |rs|
         rs.each { rows << read_held(rs) }
       end
       rows
@@ -59,8 +59,9 @@ module Gori
       raw = rs.read(Bytes); held_at_ms = rs.read(Int64); edited = rs.read(Int32) != 0
       viewed_ms = rs.read(Int64)
       edit_refusal = rs.read(String?); head_only = rs.read(Int32) != 0
+      binary = rs.read(Int32) != 0
       HeldRow.new(token, item_id, kind, method, host, port, scheme, target, raw, held_at_ms, flow_id, edited, viewed_ms,
-        edit_refusal, head_only)
+        edit_refusal, head_only, binary)
     end
 
     # Append one MCP->TUI intercept command. Returns last_insert_rowid (0 on a dropped write —

--- a/src/gori/store/models.cr
+++ b/src/gori/store/models.cr
@@ -959,10 +959,23 @@ module Gori
       # every later message on that stream is in it.
       getter edit_refusal : String?
       getter? head_only : Bool
+      # Mirrors `Interceptor::Item#binary?` (opcode == OP_BIN) across the bridge — the same
+      # fact the TUI's editor already gates `read_only_selection?` on. Without it here, MCP
+      # `intercept_forward_edit`/CLI `intercept edit` had no way to tell a text WS message from
+      # a binary one before choosing whether the `raw` (JSON-string / argv-string) channel can
+      # carry it byte-exact at all.
+      getter? binary : Bool
 
       def initialize(@session_token, @item_id, @kind, @method, @host, @port, @scheme,
                      @target, @raw, @held_at_ms, @flow_id = nil, @edited = false, @viewed_ms = 0_i64,
-                     @edit_refusal = nil, @head_only = false)
+                     @edit_refusal = nil, @head_only = false, @binary = false)
+      end
+
+      # This row is a WebSocket message (either direction) — no start line, no headers, no
+      # head/body split. The kind-check `intercept_forward_edit`/`cmd_intercept_edit` need
+      # before deciding whether an HTTP-head-shaped CRLF-normalize even applies.
+      def ws? : Bool
+        kind == "wsout" || kind == "wsin"
       end
 
       # The head-only CAVEAT, and deliberately NOT folded into `edit_refusal`.

--- a/src/gori/store/schema.cr
+++ b/src/gori/store/schema.cr
@@ -713,7 +713,20 @@ module Gori
         "ALTER TABLE intercept_held ADD COLUMN head_only INTEGER NOT NULL DEFAULT 0",
       ]
 
-      MIGRATIONS = [V1, V2, V3, V4, V5, V6, V7, V8]
+      # `intercept_held.binary` mirrors `Interceptor::Item#binary?` (opcode == OP_BIN) across
+      # the #123 bridge — a fact known at hold time that neither `intercept_edit_bytes` (MCP)
+      # nor `cmd_intercept_edit` (CLI) could see before this column existed, so a WebSocket
+      # BINARY frame edited through the TEXT `raw` channel (a JSON string / an argv string,
+      # both of which force-reencode any byte above 0x7F) was silently rewritten rather than
+      # refused the way the TUI's editor already refuses it (read-only there, `binary?`
+      # gating `read_only_selection?`). Same 0-default rationale as `head_only`: a per-session
+      # snapshot mirror that `clear_intercept_state!` wipes at the next capture start, so no
+      # existing row needs a real answer back-filled.
+      V9 = [
+        "ALTER TABLE intercept_held ADD COLUMN binary INTEGER NOT NULL DEFAULT 0",
+      ]
+
+      MIGRATIONS = [V1, V2, V3, V4, V5, V6, V7, V8, V9]
 
       def self.migrate!(db : DB::Database) : Nil
         db.using_connection do |conn|

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -586,7 +586,7 @@ module Gori::Tui
         # surface described a CRLF-carrying h2 message as ordinarily editable.
         Store::HeldRow.new(token, it.id, it.kind.to_s.downcase, it.method, it.host, it.port,
           it.scheme, it.target, it.raw, it.held_at_ms, it.flow_id, false, 0_i64,
-          it.edit_refusal, it.head_only?)
+          it.edit_refusal, it.head_only?, it.binary?)
       end
       @session.store.publish_intercept_held(token, rows)
     end
@@ -675,8 +675,13 @@ module Gori::Tui
             store.ack_intercept_command(cmd.id, "error", "already decided by another surface: #{desc}")
             return false
           end
-          store.ack_intercept_command(cmd.id, "edited", desc)
-          push_agent_note(:success, "forwarded (edited) #{desc}", item)
+          # `size: bytes.size`, NOT `desc`'s default (the item's ORIGINAL held size): an edit
+          # that changes a WS message's length must say so in its own ack, the caller's only
+          # record of what actually went out. Has no effect on a request/response label (that
+          # branch of `Item#label` doesn't render a byte count), so this is safe for every kind.
+          edited_desc = item.label(size: bytes.size)
+          store.ack_intercept_command(cmd.id, "edited", edited_desc)
+          push_agent_note(:success, "forwarded (edited) #{edited_desc}", item)
         end
         true
       when "toggle"


### PR DESCRIPTION
Round 9 left the send paths — eight rounds have swept those — and audited three areas that had never had a dedicated pass: the store and every import road, the intercept lifecycle, and TLS/CA/dial. Three findings, all reproduced first and control-run RED at `838f55a3`.

The three share a shape. In each case **gori already does the right thing one branch away**, and the failing path simply never reached the machinery:

| defect | the correct path sitting next to it |
|---|---|
| a half-missing CA pair silently mints a new root | a *fully* corrupt pair is refused loudly with a named error and exit 1 |
| a proxy tunnel that dies after CONNECT is blamed on the origin | a proxy that *refuses* CONNECT is named precisely, down to the 407 |
| a WS edit is CRLF-corrupted on MCP and CLI | the TUI has had an explicit `@loaded_ws` guard all along |

## A trusted root, replaced without a word

`CertAuthority.load_or_create` branched only on "both files present" versus "not both". It could not tell a first run (neither exists) from a broken pair — a partial restore, an accidental `rm root.key.pem`, a disk fault that took one inode. Both landed in the same `else`, which **overwrote the surviving `root.crt.pem`** with a brand-new self-signed root:

```
before  serial=7FC49D3086E95847  SHA1=C6:2D:24:…
after   serial=…                 SHA1=…            exit 0, no warning, clean banner
```

The operator — or their whole team, in a shared setup — has already installed and trusted that root in a browser, a keychain, a device profile. After the swap every MITM presents a leaf chained to a root nobody trusts, and the tester attributes the TLS failures to the target. This is the one artifact whose entire value is that it does not change.

Now a broken pair is refused by name, in either direction, saying which file survived and which is missing, and offering the two real options: restore from backup, or `gori ca regenerate` — which has always been the deliberate, confirmed way to do exactly this swap. First run still mints silently, and a healthy pair still loads untouched.

## A dead proxy tunnel, blamed on the target

A proxy that answers `200 Connection Established` and then goes silent — an overloaded proxy, an ACL that 200s before checking, the proxy's own backend dial failing after it committed — produced this:

```
TLS handshake failed: <origin>:<port> — the port may not be TLS, or the origin
refused the protocol/cipher (SSL_connect: Unexpected EOF while reading)
```

That asserts something false about an origin that was never reached. It is round 5's "black hole read as an untrusted certificate" one layer further out, and it costs a tester real time: they go audit their target's TLS configuration when the fault is in their own proxy.

Fixed at the dial seam rather than at the message. `Upstream.proxied_via(host)` re-asks `Settings.upstream_route(host)` — the same decision point the dial itself consults — so h1, h2, WebSocket, the connection pool and SOCKS5 all get the corrected verdict without a single signature change. The clause attaches only to `Tls` and `Timeout`, never to `TlsVerify` (a real certificate crossed and was judged) or to `Connect`/`Proxy` (already precisely worded), and direct-dial wording is byte-identical to before.

The sibling grep earned its keep: `ws_engine.cr` had hand-copied the old `"no response from …"` string instead of calling the shared builder, so it would have kept the defect after a message-level fix. SOCKS5 was an open question in the report and turned out covered for free, because the lookup is route-based rather than code-path-based — verified live against a purpose-built SOCKS5 proxy.

## A WebSocket message has no head

`intercept_forward_edit` (MCP) and `cmd_intercept_edit` (CLI) ran every `raw` edit through a normalize rule written for HTTP heads: *find the first blank line, promote bare LF to CRLF before it*. A WS payload has no head/body boundary at all, so with no blank line the whole message counted as header and every LF was promoted. An **unedited** round trip of `"line1\nline2\nline3"` left as 19 bytes instead of 17, on both surfaces. The control isolates it exactly — the same edit through `raw_base64` was always byte-exact.

Both surfaces now read the held item's kind before choosing a rule, which required threading `binary` across the cross-process bridge (schema `V9`, defaulting 0 for the same reason `head_only` does: it is a per-session mirror that the next capture start wipes). Content-Length sync is forced off for WS regardless of the flag, so a payload containing a blank line cannot get a bogus `Content-Length:` spliced into it.

Two more from the same investigation. The ack reported the **original** held size — "17B" while 19 bytes went out — and now reports what was actually forwarded. And a binary WS frame edited through any *text* channel was silently mis-encoded (`0xFF` becomes `0xC3 0xBF` through JSON or argv, 4 bytes becoming 6): that is not a bug to repair but a channel that structurally cannot carry arbitrary octets, so both surfaces now refuse by name and point at the byte-exact one — `raw_base64` for MCP, `--raw-file` for CLI. The item stays held, and the same edit through the named channel succeeds.

Also: a control frame that overtakes a held message now emits the `[gori]` notice every other routine edge case in `WS::MessageGate` already emitted. The reordering itself is correct and deliberate — liveness over ordering, and History keeps the true sequence — but the live view gave the operator no signal.

## What was attacked and held

Three quarters of this round is negative results, and they are the reason the next one can skip this ground.

**The store and every import road: no defect.** Capture round-trip against invalid UTF-8, NUL bodies, 5 MiB truncation, chunked, gzip, Content-Length mismatches and conflicts, duplicate headers, colon-less headers, 8 KB headers; HAR export→reimport; Burp entity round-trip. All five importers funnel through one `Builder.pending_request` chokepoint, so the CR/LF/NUL boundary guard fires for HAR, OpenAPI, URL lists, Postman and Insomnia alike — and Burp bypasses it *by design*, because it carries the operator's own wire bytes and, as the source says, routing it through the builder "would destroy the hand-forged requests that are the whole reason to import from Burp". A Postman or Insomnia collection naming `/etc/passwd` as a file body lands with a zero-length body and never touches disk.

**The intercept lifecycle: solid.** Holding a request-direction h2 stream does stall a later stream, but that is RFC 9113 §5.1.1 forcing gori's hand, and holding a *response* costs a concurrent stream nothing. Pseudo-header order is rebuilt from the original fields, so a client's exact order survives an edit box that cannot express order. A deliberately malformed §8.3 order forwards byte-for-byte when untouched and is **refused by name** when edited, rather than silently re-sorted. Drop gives an h1 client a labelled 502, an h2 client `RST_STREAM(CANCEL)` with the HEADERS never reaching the origin, and a WS client nothing at all — each stored as `aborted`. Fragmented messages are held, reassembled for display, and reproduced frame-for-frame with FIN bits intact. Nothing hangs a client: toggling intercept off released three held requests in 0.65 s.

**TLS verdicts: correct across six origin shapes** — self-signed, expired, wrong-CN, incomplete chain, TLS 1.0-only, and plain HTTP on an https port. Every failure named the real cause, and `-k` was offered only for the four that are genuinely verification failures. Verification, SNI and `http://` tunnelling all survive an upstream proxy hop unchanged.

## Verification

`crystal spec` **6689 examples, 0 failures** (baseline 6654 + 35). `crystal build --no-codegen` clean at every merge step.

Two boundaries stated plainly. The WS fixer wiped its own uncommitted work with a `git checkout HEAD --` while HEAD was still base, caught it before reporting, reconstructed from its edit history and re-verified end to end — flagged rather than glossed, and the merged tree was independently re-run here (full suite plus the four directly-affected specs, 351 examples). And `client_conn.cr`, the live MITM path, already carries the new `via_proxy` field unread; picking up the proxy clause there is a one-line-per-branch follow-up left out of scope.
