### PR TITLE
A stranded link made safe instead of deleted, and the last delete that could still strand one

### DIFF
--- a/spec/store/link_ref_id_reuse_migration_spec.cr
+++ b/spec/store/link_ref_id_reuse_migration_spec.cr
@@ -1,0 +1,148 @@
+require "../spec_helper"
+
+# Builds a database at the PRE-V10 shape by running V1..V9 exactly as a released gori would
+# have, plants what an operator's existing project already contains, and returns the path so
+# `Store.open` can drive the real V9 -> V10 upgrade over it.
+private def build_pre_v10(kind : String, sessions : Array(Int64), orphan_ref : Int64?) : String
+  path = File.tempname("gori-v10", ".db")
+  DB.open("sqlite3:#{path}") do |db|
+    db.using_connection do |c|
+      Gori::Store::Schema::MIGRATIONS[0...9].each { |statements| statements.each { |sql| c.exec(sql) } }
+      c.exec("PRAGMA user_version = 9")
+      sessions.each do |id|
+        if kind == "fuzz"
+          c.exec("INSERT INTO fuzz_sessions (id, created_at, updated_at, target, template, config, position) " \
+                 "VALUES (?,0,0,'https://kept.test','GET / HTTP/1.1\r\n\r\n','',0)", id)
+        else
+          c.exec("INSERT INTO miner_sessions (id, created_at, updated_at, target, request, config, position) " \
+                 "VALUES (?,0,0,'https://kept.test',?,'',0)", id, "GET / HTTP/1.1\r\n\r\n".to_slice)
+        end
+      end
+      if ref = orphan_ref
+        # An issue the operator linked to a session they later closed — exactly the link row
+        # the pre-#574 delete path left behind.
+        c.exec("INSERT INTO issues (title, severity, host, created_at, updated_at, status) " \
+               "VALUES ('finding', 3, 'kept.test', 0, 0, 0)")
+        c.exec("INSERT INTO entity_links (owner_kind, owner_id, ref_kind, ref_id, created_at) " \
+               "VALUES ('issue', 1, ?, ?, 0)", kind, ref)
+      end
+    end
+  end
+  path
+end
+
+private def migrate_and_open(path : String, &)
+  store = Gori::Store.open(path)
+  begin
+    yield store
+  ensure
+    store.close
+  end
+end
+
+private def cleanup(path : String)
+  File.delete?(path)
+  File.delete?("#{path}-wal")
+  File.delete?("#{path}-shm")
+end
+
+# V10 makes rowid reuse impossible on the two tables an `entity_links` row can name.
+#
+# Before it, closing the highest-id sub-tab freed that id, the next ^N was handed it back, and
+# a link the pre-#574 delete path had stranded silently re-bound — `stale: false` — to a
+# session against a DIFFERENT target, so an issue's evidence named traffic nobody attached.
+# #574 stopped NEW strays being created; this is the half that reaches databases already
+# carrying them, and it does so WITHOUT deleting the operator's link: seeding `sqlite_sequence`
+# past every referenced id leaves the stray resolving to nothing, which `Links` already renders
+# as `(gone)` with `stale: true`.
+describe "Store::Schema V10" do
+  it "upgrades a V9 database and stops a reused fuzz id from re-pointing an issue's evidence" do
+    # Sessions 1 and 2 live; 3 was closed and its link survived. max(id) is 2, so pre-V10 the
+    # next insert was handed exactly 3.
+    path = build_pre_v10("fuzz", [1_i64, 2_i64], 3_i64)
+    begin
+      migrate_and_open(path) do |store|
+        store.@db.scalar("PRAGMA user_version").as(Int64).should eq(Gori::Store::Schema::VERSION.to_i64)
+
+        # PRESERVED, not swept: deleting it would discard a fact the operator put there.
+        links = store.list_links(Gori::Store::LinkOwnerKind::Issue, 1_i64)
+        links.size.should eq(1)
+        links.first.ref_id.should eq(3_i64)
+
+        fresh = store.insert_fuzz_session("https://unrelated.test", "GET /x HTTP/1.1\r\n\r\n",
+          false, nil, "{}", nil, 0, "unrelated")
+        fresh.should_not eq(3_i64)
+        store.get_fuzz_session(3_i64).should be_nil # the stray still resolves to nothing
+      end
+    ensure
+      cleanup(path)
+    end
+  end
+
+  it "covers the empty-table case that defeats AUTOINCREMENT on its own" do
+    # No rows to copy, so the rebuild creates no sqlite_sequence row and ids would restart at
+    # 1 — straight onto the stray. The explicit seed is the only thing that closes this.
+    path = build_pre_v10("fuzz", [] of Int64, 1_i64)
+    begin
+      migrate_and_open(path) do |store|
+        fresh = store.insert_fuzz_session("https://unrelated.test", "GET /x HTTP/1.1\r\n\r\n",
+          false, nil, "{}", nil, 0, "unrelated")
+        fresh.should_not eq(1_i64)
+        store.list_links(Gori::Store::LinkOwnerKind::Issue, 1_i64).size.should eq(1)
+      end
+    ensure
+      cleanup(path)
+    end
+  end
+
+  it "does the same for miner sessions" do
+    path = build_pre_v10("miner", [1_i64, 2_i64], 3_i64)
+    begin
+      migrate_and_open(path) do |store|
+        fresh = store.insert_miner_session("https://unrelated.test", "GET /x HTTP/1.1\r\n\r\n".to_slice,
+          false, nil, "{}", nil, 0, "unrelated")
+        fresh.should_not eq(3_i64)
+        store.get_miner_session(3_i64).should be_nil
+      end
+    ensure
+      cleanup(path)
+    end
+  end
+
+  it "preserves existing rows, their ids and their data through the rebuild" do
+    path = build_pre_v10("fuzz", [1_i64, 2_i64], nil)
+    begin
+      migrate_and_open(path) do |store|
+        kept = store.get_fuzz_session(2_i64)
+        kept.should_not be_nil
+        kept.not_nil!.target.should eq("https://kept.test")
+        # Ids are dense and unchanged, so the sequence simply continues.
+        store.insert_fuzz_session("https://next.test", "GET / HTTP/1.1\r\n\r\n",
+          false, nil, "{}", nil, 0, "next").should eq(3_i64)
+      end
+    ensure
+      cleanup(path)
+    end
+  end
+
+  it "leaves a fresh database consistent and at the current version" do
+    path = File.tempname("gori-v10-fresh", ".db")
+    begin
+      migrate_and_open(path) do |store|
+        store.@db.scalar("PRAGMA user_version").as(Int64).should eq(Gori::Store::Schema::VERSION.to_i64)
+        store.@db.scalar("PRAGMA integrity_check").as(String).should eq("ok")
+        # V1 creates these with a plain PK and V10 rebuilds them in the same transaction, so
+        # even a brand-new database lands on the AUTOINCREMENT definition.
+        %w[fuzz_sessions miner_sessions].each do |t|
+          store.@db.scalar("SELECT sql FROM sqlite_master WHERE name = ?", t).as(String)
+            .should contain("AUTOINCREMENT")
+        end
+        # The position index survived the rebuild.
+        store.@db.scalar("SELECT COUNT(*) FROM sqlite_master WHERE type='index' " \
+                         "AND name='idx_fuzz_sessions_position'").as(Int64).should eq(1_i64)
+      end
+    ensure
+      cleanup(path)
+    end
+  end
+end

--- a/spec/store/session_link_cascade_spec.cr
+++ b/spec/store/session_link_cascade_spec.cr
@@ -15,11 +15,20 @@ private def with_store(&)
 end
 
 # Closing a Fuzzer/Miner sub-tab must take that session's `entity_links` rows with it, for the
-# reason `delete_repeater` states: `fuzz_sessions.id` / `miner_sessions.id` are plain
-# `INTEGER PRIMARY KEY` (no AUTOINCREMENT), and a tab close deletes at the TOP of the id space,
-# so the next `^N` is handed the id that just went. A surviving link then resolves — `stale:
-# false`, no `(gone)` — to an UNRELATED session, and an issue's evidence names a target the
-# operator never linked.
+# reason `delete_repeater` states: a link that outlives its session is a pointer with nothing
+# to check it.
+#
+# Historically that was acute — `fuzz_sessions.id` / `miner_sessions.id` were plain
+# `INTEGER PRIMARY KEY`, a tab close deletes at the TOP of the id space, so the next `^N` was
+# handed the id that just went and a surviving link re-bound (`stale: false`, no `(gone)`) to
+# an UNRELATED session, naming a target the operator never linked. Schema V10 gave both tables
+# AUTOINCREMENT and seeded `sqlite_sequence` past every referenced id, so that reuse can no
+# longer happen and a stray is now merely dead.
+#
+# The cascade is still the primary guarantee and is what these examples pin: V10 is the
+# backstop for a stray created some way this cascade does not cover (an out-of-band delete, a
+# future delete path written without it), not a replacement for it. See
+# spec/store/link_ref_id_reuse_migration_spec.cr for the backstop's own coverage.
 describe "workbench session deletes cascade entity_links" do
   it "drops a fuzz session's links so a reused rowid cannot re-point an issue's evidence" do
     with_store do |store|
@@ -33,10 +42,17 @@ describe "workbench session deletes cascade entity_links" do
       store.get_fuzz_session(sid).should be_nil
       store.list_links(Gori::Store::LinkOwnerKind::Issue, issue_id).should be_empty
 
-      # The emptied table hands the same rowid to the next session, against a different target.
+      # The next session against a different target. Before V10 the emptied table handed it
+      # back the SAME rowid, and this example asserted that — the reuse was the whole reason
+      # the cascade above mattered. V10 (AUTOINCREMENT + a seeded sqlite_sequence) removed that
+      # premise, so the assertion is now its inverse. Both layers are kept and tested
+      # separately on purpose: the cascade means no stray link survives a tab close, and V10
+      # means a stray that survives some OTHER way — an out-of-band sqlite3 delete, a future
+      # delete path written without the cascade — is merely dead rather than dangerous.
+      # spec/store/link_ref_id_reuse_migration_spec.cr pins that second layer.
       reused = store.insert_fuzz_session("https://unrelated.test", "GET /b HTTP/1.1\r\nHost: unrelated.test\r\n\r\n",
         false, nil, "{}", nil, 0, "other target")
-      reused.should eq(sid) # the reuse this spec exists for — not an incidental id
+      reused.should_not eq(sid)
 
       resolved = Gori::Links.resolve_all(store,
         store.list_links(Gori::Store::LinkOwnerKind::Issue, issue_id))
@@ -58,9 +74,11 @@ describe "workbench session deletes cascade entity_links" do
       store.get_miner_session(sid).should be_nil
       store.list_links(Gori::Store::LinkOwnerKind::Issue, issue_id).should be_empty
 
+      # Was `eq(sid)` until V10 stopped rowid reuse — see the fuzz example above for why the
+      # assertion inverted and why both layers are still worth keeping.
       reused = store.insert_miner_session("https://unrelated.test",
         "GET /b HTTP/1.1\r\nHost: unrelated.test\r\n\r\n".to_slice, false, nil, "{}", nil, 0, "other target")
-      reused.should eq(sid)
+      reused.should_not eq(sid)
 
       resolved = Gori::Links.resolve_all(store,
         store.list_links(Gori::Store::LinkOwnerKind::Issue, issue_id))
@@ -109,6 +127,33 @@ describe "workbench session deletes cascade entity_links" do
       store.delete_fuzz_session(sid)
       store.list_links(Gori::Store::LinkOwnerKind::Issue, issue_id).should be_empty
       store.list_links(Gori::Store::LinkOwnerKind::Note, note_id).should be_empty
+    end
+  end
+end
+
+# The sequencer delete takes the same cascade PRE-EMPTIVELY. Nothing can exercise it today —
+# `LinkRefKind` has no `Sequencer` variant, so no link can name a sequencer session and the
+# DELETE matches zero rows. What this example actually pins is that the delete still works and
+# is harmless with the extra statement in it, so the line does not rot before the day it
+# matters. If a `Sequencer` variant is ever added, replace this with the real fuzz/miner shape
+# above — and give sequencer_sessions the V10 AUTOINCREMENT rebuild it was left out of.
+describe "delete_sequencer_session" do
+  it "deletes the session and is a no-op on entity_links, which cannot reference it" do
+    with_store do |store|
+      issue_id = store.insert_issue("tokens", Gori::Store::Severity::Low, "victim.test", nil)
+      sid = store.insert_sequencer_session("https://victim.test",
+        "GET /a HTTP/1.1\r\nHost: victim.test\r\n\r\n".to_slice, false, nil, "{}", nil, 0, "token run")
+      # A link on the SAME numeric id but a kind that does exist — the cascade must not take
+      # it, which is what makes the ref_kind predicate load-bearing rather than decorative.
+      fuzz_sid = store.insert_fuzz_session("https://victim.test", "GET /a HTTP/1.1\r\n\r\n",
+        false, nil, "{}", nil, 0, "sweep")
+      fuzz_sid.should eq(sid) # both tables start at 1, so the ids collide by construction
+      store.add_link(Gori::Store::LinkOwnerKind::Issue, issue_id,
+        Gori::Store::LinkRefKind::Fuzz, fuzz_sid).should_not be_nil
+
+      store.delete_sequencer_session(sid)
+      store.get_sequencer_session(sid).should be_nil
+      store.list_links(Gori::Store::LinkOwnerKind::Issue, issue_id).size.should eq(1)
     end
   end
 end

--- a/src/gori/store/schema.cr
+++ b/src/gori/store/schema.cr
@@ -726,7 +726,119 @@ module Gori
         "ALTER TABLE intercept_held ADD COLUMN binary INTEGER NOT NULL DEFAULT 0",
       ]
 
-      MIGRATIONS = [V1, V2, V3, V4, V5, V6, V7, V8, V9]
+      # Make rowid reuse impossible on the two tables an `entity_links` row can point at, so
+      # a stranded link can never re-point at material nobody attached.
+      #
+      # `entity_links.ref_id` is a plain integer selected by `ref_kind` — the ref is
+      # polymorphic, so no foreign key can express it and no `ON DELETE CASCADE` is available.
+      # Until #574 neither `delete_fuzz_session` nor `delete_miner_session` deleted the link
+      # rows, and both tables are `INTEGER PRIMARY KEY` WITHOUT AUTOINCREMENT — so SQLite
+      # reassigns `max(rowid)+1`, while closing a sub-tab (^W) deletes at the TOP of the id
+      # space. The next `^N` was handed the id that had just gone, and a surviving link
+      # silently re-bound (`stale: false`) to a session against a DIFFERENT target: an issue's
+      # evidence confidently naming traffic the operator never linked. #574 closed the delete
+      # path; this closes the property that made a stranded link DANGEROUS rather than merely
+      # dead, and it is the half that reaches databases already carrying strays.
+      #
+      # Deliberately NOT a sweep of those strays. Deleting them is irreversible and discards a
+      # fact the operator put there, and it is unnecessary: `Links.resolve_fuzz` already
+      # renders an absent row as `fuzz #N (gone)` with `stale: true` (pinned by
+      # spec/links_spec.cr), which is strictly more informative than no row at all. Seeding
+      # `sqlite_sequence` past the highest id ANY surviving link references makes every stray
+      # permanently safe instead of permanently deleted — including the case that defeats
+      # AUTOINCREMENT on its own, where the table is EMPTY at migration time so the copy
+      # creates no `sqlite_sequence` row and ids would otherwise restart at 1 under a stray
+      # pointing at 1.
+      #
+      # Two ordering facts this depends on, both verified rather than assumed: the seed reads
+      # the live table by its FINAL name, so it must run AFTER the rename; and a
+      # `sqlite_sequence` row FOLLOWS `ALTER TABLE … RENAME TO`, so the DELETE below targets
+      # the row the copy just created and cannot leave a stale duplicate under the old name.
+      #
+      # Columns are enumerated rather than `SELECT *` — leaning on column order is how a
+      # rebuild migration silently corrupts data. The shapes are V1's, still current (no
+      # V2..V9 statement touches these tables). A fresh database runs V1's plain-PK CREATE and
+      # then rebuilds it here in the same transaction: microseconds on an empty table, and it
+      # keeps every database, new or migrated, on exactly one definition.
+      #
+      # `sequencer_sessions` is NOT rebuilt. `LinkRefKind.parse` accepts only
+      # flow|repeater|fuzz|miner, so nothing can reference a sequencer session and there is no
+      # id to protect today — `delete_sequencer_session` takes the cascade pre-emptively, and
+      # its comment says that whoever adds a `Sequencer` variant needs this rebuild too.
+      # `flows` is not swept either, and must not be: the prune paths delete from the BOTTOM
+      # (`id <= cutoff`), so `MAX(id)` survives and a pruned flow's id never returns — its
+      # links are already safely `(gone)`.
+      V10 = [
+        <<-SQL,
+        CREATE TABLE fuzz_sessions_v10 (
+          id         INTEGER PRIMARY KEY AUTOINCREMENT,
+          created_at INTEGER NOT NULL,
+          updated_at INTEGER NOT NULL,
+          target     TEXT    NOT NULL,
+          template   TEXT    NOT NULL,
+          http2      INTEGER NOT NULL DEFAULT 0,
+          sni        TEXT,
+          config     TEXT    NOT NULL DEFAULT '',
+          flow_id    INTEGER,
+          position   INTEGER NOT NULL DEFAULT 0,
+          name       TEXT
+        )
+        SQL
+        <<-SQL,
+        INSERT INTO fuzz_sessions_v10
+          (id, created_at, updated_at, target, template, http2, sni, config, flow_id, position, name)
+          SELECT id, created_at, updated_at, target, template, http2, sni, config, flow_id, position, name
+          FROM fuzz_sessions
+        SQL
+        "DROP TABLE fuzz_sessions",
+        "ALTER TABLE fuzz_sessions_v10 RENAME TO fuzz_sessions",
+        "CREATE INDEX idx_fuzz_sessions_position ON fuzz_sessions (position, id)",
+        "DELETE FROM sqlite_sequence WHERE name = 'fuzz_sessions'",
+        <<-SQL,
+        INSERT INTO sqlite_sequence (name, seq)
+          SELECT 'fuzz_sessions', COALESCE(MAX(v), 0) FROM (
+            SELECT MAX(id) AS v FROM fuzz_sessions
+            UNION ALL
+            SELECT MAX(ref_id) FROM entity_links WHERE ref_kind = 'fuzz'
+          )
+        SQL
+
+        <<-SQL,
+        CREATE TABLE miner_sessions_v10 (
+          id         INTEGER PRIMARY KEY AUTOINCREMENT,
+          created_at INTEGER NOT NULL,
+          updated_at INTEGER NOT NULL,
+          target     TEXT    NOT NULL,
+          request    BLOB    NOT NULL,
+          http2      INTEGER NOT NULL DEFAULT 0,
+          sni        TEXT,
+          config     TEXT    NOT NULL DEFAULT '',
+          flow_id    INTEGER,
+          position   INTEGER NOT NULL DEFAULT 0,
+          name       TEXT
+        )
+        SQL
+        <<-SQL,
+        INSERT INTO miner_sessions_v10
+          (id, created_at, updated_at, target, request, http2, sni, config, flow_id, position, name)
+          SELECT id, created_at, updated_at, target, request, http2, sni, config, flow_id, position, name
+          FROM miner_sessions
+        SQL
+        "DROP TABLE miner_sessions",
+        "ALTER TABLE miner_sessions_v10 RENAME TO miner_sessions",
+        "CREATE INDEX idx_miner_sessions_position ON miner_sessions (position, id)",
+        "DELETE FROM sqlite_sequence WHERE name = 'miner_sessions'",
+        <<-SQL,
+        INSERT INTO sqlite_sequence (name, seq)
+          SELECT 'miner_sessions', COALESCE(MAX(v), 0) FROM (
+            SELECT MAX(id) AS v FROM miner_sessions
+            UNION ALL
+            SELECT MAX(ref_id) FROM entity_links WHERE ref_kind = 'miner'
+          )
+        SQL
+      ]
+
+      MIGRATIONS = [V1, V2, V3, V4, V5, V6, V7, V8, V9, V10]
 
       def self.migrate!(db : DB::Database) : Nil
         db.using_connection do |conn|

--- a/src/gori/store/sequencer_sessions.cr
+++ b/src/gori/store/sequencer_sessions.cr
@@ -55,8 +55,26 @@ module Gori
       }
     end
 
+    # Cascades `entity_links` PRE-EMPTIVELY. Unlike the fuzz/miner siblings this fixes nothing
+    # today: `LinkRefKind` has no `Sequencer` variant, so `parse` accepts only
+    # flow|repeater|fuzz|miner and no link can name a sequencer session — the DELETE below
+    # matches zero rows by construction. It is here because this delete was the last one in the
+    # family written the way fuzz's and miner's were, and those two shipped a real bug (#574):
+    # an uncascaded link outlives its session, and because `id` is `INTEGER PRIMARY KEY`
+    # without AUTOINCREMENT the next insert reuses the id and the stray link silently re-binds
+    # to a different target.
+    #
+    # So, for whoever adds a `Sequencer` variant to `LinkRefKind`: this line already covers the
+    # delete path, but the OTHER half is missing. `sequencer_sessions` was deliberately left
+    # out of the V10 rebuild that gave fuzz/miner `AUTOINCREMENT` (there was no id to protect),
+    # and it needs its own migration on that day — otherwise reuse makes a stray dangerous
+    # rather than merely dead. See the V10 comment in schema.cr for the shape.
     def delete_sequencer_session(id : Int64) : Nil
-      exec_task ->(c : DB::Connection) { c.exec("DELETE FROM sequencer_sessions WHERE id = ?", id); nil }
+      exec_task ->(c : DB::Connection) {
+        c.exec("DELETE FROM entity_links WHERE ref_kind = 'sequencer' AND ref_id = ?", id)
+        c.exec("DELETE FROM sequencer_sessions WHERE id = ?", id)
+        nil
+      }
     end
   end
 end


### PR DESCRIPTION
Follow-up to #574, taking the two items that PR explicitly left open: the half
that reaches databases already carrying stranded links, and the one delete in the
family still written the old way.

## Schema V10 — rowid reuse

`entity_links.ref_id` is a plain integer selected by `ref_kind`. The ref is
polymorphic, so no foreign key can express it and `ON DELETE CASCADE` is not
available. `fuzz_sessions` / `miner_sessions` were `INTEGER PRIMARY KEY` WITHOUT
AUTOINCREMENT, so SQLite reassigns `max(rowid)+1` — and a sub-tab close deletes at
the TOP of the id space, so the next `^N` was handed the id that just went and a
stranded link re-bound (`stale: false`) to a session against a different target.
#574 stopped new strays being created; it did nothing for the ones already on
disk.

**This is not the sweep I proposed in #574.** Deleting those rows is irreversible
and discards a fact the operator put there — and it turns out to be unnecessary.
`Links.resolve_fuzz` already renders an absent row as `fuzz #N (gone)` with
`stale: true` (pinned by `spec/links_spec.cr`), which is strictly more
informative than no row at all. Seeding `sqlite_sequence` from
`max(table max, max referenced ref_id)` gives the same guarantee while keeping
the link. It also covers the case that defeats `AUTOINCREMENT` on its own: an
empty table at migration time creates no `sqlite_sequence` row, so ids would
restart at 1 straight onto a stray pointing at 1.

Care taken in the rebuild, since this is a released schema:

- Columns enumerated, never `SELECT *` — column-order coupling is how these
  migrations silently corrupt data.
- Shapes are V1's, still current; no V2..V9 statement touches these tables.
- All three insert paths omit `id` (checked), so `AUTOINCREMENT` governs every
  row the app writes.
- The seed reads the live table by its final name, so it must run **after** the
  rename; a `sqlite_sequence` row follows `ALTER TABLE … RENAME TO`, so the
  `DELETE` targets the row the copy created and leaves no duplicate. Both
  verified against real SQLite rather than assumed.
- `flows` is deliberately not swept: its prune paths delete from the *bottom*
  (`id <= cutoff`), so `MAX(id)` survives, a pruned flow's id never returns, and
  its links are already safely `(gone)`.

## sequencer_sessions

`delete_sequencer_session` was the last delete in the family written without the
cascade. It fixes nothing today — `LinkRefKind.parse` accepts only
`flow|repeater|fuzz|miner`, so the `DELETE` matches zero rows by construction —
but it is the shape that shipped a real bug twice, so it takes the cascade
pre-emptively. It is deliberately left **out** of the V10 rebuild (no id to
protect yet); both its comment and V10's say that whoever adds a `Sequencer`
variant needs that rebuild too.

## Verification

Fail-before confirmed by unregistering V10 from `MIGRATIONS`: 4 of 5 new examples
fail; the 5th (rows/ids/data preserved through the rebuild) is green both ways by
design.

Two assertions in #574's cascade spec **inverted** — they asserted the reuse
*happens*, which was the whole reason the cascade mattered. V10 removes that
premise. The spec now records why both layers are still kept: the cascade means
no stray survives a tab close, V10 means a stray created some other way (an
out-of-band `sqlite3` delete, a future delete path written without the cascade)
is merely dead rather than dangerous.

Exercised against a real v0.2.0 project database at `user_version` 9 with a stray
planted:

```
before: user_version=9   autoinc=0
after:  user_version=10  autoinc=1  seq=9   (max of table max 4, stray ref 9)
        stray link preserved (ref_id=9), rows and ids intact, integrity_check ok
        next inserted session -> id 10, and the stray resolves to nothing
```

`crystal spec`: **6766 examples, 0 failures, 0 errors**. Build and
`crystal tool format --check` clean.
