### PR TITLE
Wrapped lines with one number each, a paste that stops doubling, and an insert mode that scrolls and selects

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -14,5 +14,5 @@ shards:
 
   termisu:
     git: https://github.com/hahwul/termisu.git
-    version: 0.6.0+git.commit.965cbbb11084ce9be5999c4e9a20520b9fd6354e
+    version: 0.6.0+git.commit.bb83fd6f261838f03ecff1c27832e25aec5d0668
 

--- a/spec/tui/paste_newline_spec.cr
+++ b/spec/tui/paste_newline_spec.cr
@@ -69,3 +69,53 @@ describe Gori::Tui::PasteNewline do
     filter.swallow?(ctrl_enter).should be_false
   end
 end
+
+# Bracketed paste (termisu#3, gori enables DEC 2004 in app.cr). The markers are not
+# keystrokes and must never reach a view; between them `pasting?` is true.
+#
+# This is the half that fixes the reported bug. The pair rule below could never collapse
+# CR CR — that is byte-for-byte two deliberate Enters — so on a terminal that maps the LF of
+# a pasted CRLF to a second CR, a Burp-copied request gained a blank line per line. Mode 2004
+# stops the translation at the source; there is nothing left here to be clever about.
+private def pkey(k : Termisu::Input::Key, char : Char? = nil)
+  Termisu::Event::Key.new(k, Termisu::Input::Modifier::None, char)
+end
+
+describe "PasteNewline bracketed paste" do
+  it "swallows both markers and reports pasting? in between" do
+    pn = Gori::Tui::PasteNewline.new
+    pn.pasting?.should be_false
+    pn.swallow?(pkey(Termisu::Input::Key::PasteStart)).should be_true
+    pn.pasting?.should be_true
+    pn.swallow?(pkey(Termisu::Input::Key::PasteEnd)).should be_true
+    pn.pasting?.should be_false
+  end
+
+  it "still collapses a CRLF delivered inside a paste" do
+    pn = Gori::Tui::PasteNewline.new
+    pn.swallow?(pkey(Termisu::Input::Key::PasteStart))
+    pn.swallow?(pkey(Termisu::Input::Key::Enter, '\r')).should be_false # the newline
+    pn.swallow?(pkey(Termisu::Input::Key::Enter, '\n')).should be_true  # its LF half, dropped
+    pn.swallow?(pkey(Termisu::Input::Key::PasteEnd))
+  end
+
+  # A blank line inside the pasted body is CR LF CR LF: one Enter survives per pair, so the
+  # blank line is preserved rather than eaten.
+  it "keeps a blank line that was really in the clipboard" do
+    pn = Gori::Tui::PasteNewline.new
+    pn.swallow?(pkey(Termisu::Input::Key::PasteStart))
+    kept = [{'\r', false}, {'\n', true}, {'\r', false}, {'\n', true}].count do |(c, _)|
+      !pn.swallow?(pkey(Termisu::Input::Key::Enter, c))
+    end
+    kept.should eq(2) # two newlines => one blank line
+  end
+
+  # The marker resets the pair state: a CR typed immediately before a paste must not pair
+  # with the paste's first LF and swallow a real line break.
+  it "does not let a keystroke before the paste pair with the paste's first byte" do
+    pn = Gori::Tui::PasteNewline.new
+    pn.swallow?(pkey(Termisu::Input::Key::Enter, '\r')).should be_false
+    pn.swallow?(pkey(Termisu::Input::Key::PasteStart))
+    pn.swallow?(pkey(Termisu::Input::Key::Enter, '\n')).should be_false
+  end
+end

--- a/spec/tui/repeater_view_spec.cr
+++ b/spec/tui/repeater_view_spec.cr
@@ -193,11 +193,19 @@ describe Gori::Tui::RepeaterView do
   end
 
   # The memo reuses the SAME styled Line object across frames — safe only because every
-  # downstream consumer (Highlight.draw / slice_left / line_width_upto) is read-only. Guard
-  # that: style a wide line (frame 1), scroll it sideways so slice_left runs on the cached
-  # Line (frame 2), then scroll back — the head must be intact (a slice_left that mutated
-  # its input in place would have corrupted the cached Line).
-  it "styled-line memo survives a horizontal-scroll round-trip without corrupting the cached line" do
+  # downstream consumer (Highlight.draw / slice_chars / line_width_upto) is read-only.
+  #
+  # ASSERTION INVERTED BY SOFT WRAP. This used to prove the guard by scrolling the pane
+  # sideways so `slice_left` ran on the cached Line and checking the head disappeared. The
+  # response pane no longer scrolls sideways — a long body line WRAPS — so "head off the
+  # left edge" is not a state the pane can reach, and `view.hscroll` is now a no-op stub.
+  # What still needs guarding is the same thing: the per-row slicer (`Highlight.slice_chars`
+  # now, driving the continuation rows) must not mutate the memoized Line. So the exercise
+  # is the SLICE rather than the scroll — render a body wide enough to wrap (so every row
+  # after the first is a slice of the cached Line), scroll DOWN through it and back, and
+  # require the first row to be intact. A slicer that mutated in place would have eaten the
+  # head exactly as before.
+  it "styled-line memo survives a wrap-slice round-trip without corrupting the cached line" do
     view = RepeaterView.new
     view.load_blank
     view.focus_pane(:response)
@@ -207,48 +215,53 @@ describe Gori::Tui::RepeaterView do
 
     at0 = MemoryBackend.new(50, 12)
     view.render(Screen.new(at0), Rect.new(0, 0, 50, 12))
-    at0.contains?("ALPHATOKEN").should be_true # left edge visible, memo populated
+    at0.contains?("ALPHATOKEN").should be_true  # first row of the body, memo populated
+    at0.contains?("OMEGATOKEN").should be_false # its tail is further down, on a later row
 
-    view.hscroll(10) # slide the pane right → slice_left runs on the cached Line
+    view.scroll(6) # drop the head off the TOP → the visible rows are all slices of the memo
     scrolled = MemoryBackend.new(50, 12)
     view.render(Screen.new(scrolled), Rect.new(0, 0, 50, 12))
-    scrolled.contains?("ALPHATOKEN").should be_false # scrolled past the head (proves the slice took effect)
+    scrolled.contains?("ALPHATOKEN").should be_false
+    scrolled.contains?("OMEGATOKEN").should be_true # the tail IS reachable — by wrapping, not by panning
 
-    view.hscroll(-10) # back to the left edge
+    view.scroll(-6) # back to the top
     back = MemoryBackend.new(50, 12)
     view.render(Screen.new(back), Rect.new(0, 0, 50, 12))
-    back.contains?("ALPHATOKEN").should be_true # cached Line uncorrupted by the intervening slice
+    back.contains?("ALPHATOKEN").should be_true # cached Line uncorrupted by the intervening slices
   end
 
   # Reveal mode is the surface built to inspect whitespace, and it was the one surface a
   # tabbed line could not be scrolled across. Reveal.styled gives every control char a
   # 1-column marker (tab → '→'), so the row DRAWS one cell per tab, but the h-scroll clamp
   # measured the raw string with display_width, where a tab is 0 columns. On a tab-heavy
-  # line the clamp's ceiling collapsed to 0 and @xscroll was pinned there every frame, so
+  # line the clamp's ceiling collapsed to 0 and the offset was pinned there every frame, so
   # the tail of the line was permanently unreachable no matter how far right you scrolled.
-  it "scrolls a tab-filled line all the way to its end in reveal mode" do
+  #
+  # ASSERTION INVERTED BY SOFT WRAP. The bug's root cause — a width measure that scores a
+  # tab 0 while the draw gives it a cell — is unchanged and still the thing under test, but
+  # it now shows up in the WRAP rather than in a scroll ceiling: `Wrap` must break this line
+  # on `grapheme_cols` (tab = 1), so the 74 drawn columns land on two rows and the tail is
+  # visible WITHOUT scrolling at all. Measured under display_width the line is 14 columns,
+  # would not wrap, and ENDTOK would be off the right edge again — so the assertion flips
+  # from "invisible until scrolled" to "visible on the continuation row", and the old
+  # failure mode is still caught.
+  it "wraps a tab-filled line by its DRAWN width in reveal mode, tail and all" do
     view = RepeaterView.new
     view.load_blank
     view.focus_pane(:response)
     hdr = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\n"
     line = "STARTTOK#{"\t" * 60}ENDTOK"
-    # The two measures disagree by the tab count — that gap IS the unreachable tail.
+    # The two measures disagree by the tab count — that gap IS the tail that used to vanish.
     Screen.display_width(line).should eq(14)
     Screen.draw_width(line).should eq(74)
     view.apply(Gori::Repeater::Result.new(hdr.to_slice, line.to_slice, nil, 1000_i64))
     view.reveal = true
 
-    at0 = MemoryBackend.new(120, 20)
-    view.render(Screen.new(at0), Rect.new(0, 0, 120, 20))
-    at0.contains?("STARTTOK").should be_true # left edge
-    at0.contains?("ENDTOK").should be_false  # tail is off to the right
+    at0 = MemoryBackend.new(60, 20)
+    view.render(Screen.new(at0), Rect.new(0, 0, 60, 20))
+    at0.contains?("STARTTOK").should be_true # first row of the line
+    at0.contains?("ENDTOK").should be_true   # …and its tail, on a continuation row
     at0.contains?("→").should be_true        # reveal really is drawing tab markers
-
-    30.times { view.hscroll(4) } # slide right, well past the line's drawn width
-    scrolled = MemoryBackend.new(120, 20)
-    view.render(Screen.new(scrolled), Rect.new(0, 0, 120, 20))
-    scrolled.contains?("ENDTOK").should be_true    # the tail is reachable
-    scrolled.contains?("STARTTOK").should be_false # …and the head has genuinely scrolled off
   end
 
   it "duplicate_from copies request content, flags, and last response (no source flow)" do
@@ -1762,24 +1775,33 @@ describe Gori::Tui::RepeaterView do
     end
   end
 
-  it "hscroll scrolls a long response body line sideways into view (shift+←/→)" do
+  # ASSERTION INVERTED BY SOFT WRAP. This pinned the old behaviour exactly: a body line
+  # wider than the pane was CLIPPED ("TAIL" absent) until ⇧→ scrolled it in, at which point
+  # the head disappeared. Both halves of that are now wrong on purpose — the response pane
+  # wraps, so the head and the tail of one logical line are on screen together and there is
+  # no state in which either is unreachable. `hscroll` survives only as a no-op stub for the
+  # still-registered chord, so calling it must change nothing.
+  it "wraps a long response body line instead of clipping it (no horizontal scroll)" do
     view = RepeaterView.new
     view.load_blank
     long_line = "HEAD" + ("." * 60) + "TAIL"
     ok = Gori::Repeater::Result.new("HTTP/1.1 200 OK\r\n\r\n".to_slice, long_line.to_slice, nil, 1000_i64)
     view.apply(ok)
 
-    rect = Rect.new(0, 0, 100, 20)
-    backend = MemoryBackend.new(100, 20)
+    rect = Rect.new(0, 0, 40, 20)
+    backend = MemoryBackend.new(40, 20)
     view.render(Screen.new(backend), rect)
     backend.contains?("HEAD").should be_true
-    backend.contains?("TAIL").should be_false # off the right edge, clipped
+    backend.contains?("TAIL").should be_true # on a continuation row, not off the right edge
 
-    20.times { view.hscroll(1) } # scroll well past the line's width
-    backend2 = MemoryBackend.new(100, 20)
-    view.render(Screen.new(backend2), rect)
-    backend2.contains?("TAIL").should be_true
-    backend2.contains?("HEAD").should be_false # scrolled off the left edge
+    # `hscroll` and its ⇧←/→ binding are GONE, not stubbed. Leaving the no-op in place was
+    # worse than dead code: `handle_repeater_response_hscroll` ran BEFORE the response pane's
+    # key ladder and returned true for ⇧←/→, so it swallowed the chord that the ladder maps to
+    # `resp_nav_step(..., selecting: true)`. Horizontal selection in the response pane was
+    # silently inert for as long as the stub existed. Removing both restores it; the wrap
+    # assertion above no longer needs a scroll call to be meaningful, because there is no
+    # state in which the tail is off-screen.
+    view.responds_to?(:hscroll).should be_false
   end
 
   it "defaults request and target to READ mode" do

--- a/spec/tui/repeater_wrap_spec.cr
+++ b/spec/tui/repeater_wrap_spec.cr
@@ -1,0 +1,169 @@
+require "../spec_helper"
+require "../support/memory_backend"
+
+include Gori::Tui
+
+# The response body rect the view derives internally, re-derived here so a click spec can
+# aim at a real cell. Mirrors `resp_click_to_cursor` / `render`: the TARGET card band, then
+# the right half of what is left, then the card's 1-cell inset.
+private def resp_body_rect(rect : Gori::Tui::Rect) : Gori::Tui::Rect
+  target_h = {rect.h, 3}.min # target_card_h with no SNI override
+  content = Gori::Tui::Rect.new(rect.x, rect.y + target_h, rect.w, {rect.h - target_h, 0}.max)
+  half = {(content.w - 1) // 2, 1}.max
+  Gori::Tui::Rect.new(content.x + half + 1, content.y, {content.w - half - 1, 1}.max, content.h).inset(1, 1)
+end
+
+private def loaded_view(body : String, ct : String = "text/plain") : Gori::Tui::RepeaterView
+  view = Gori::Tui::RepeaterView.new
+  view.load_blank
+  view.focus_pane(:response)
+  hdr = "HTTP/1.1 200 OK\r\nContent-Type: #{ct}\r\n\r\n"
+  view.apply(Gori::Repeater::Result.new(hdr.to_slice, body.to_slice, nil, 1000_i64))
+  view
+end
+
+describe "Gori::Tui::RepeaterView soft wrap" do
+  # The Burp-style contract, on the RESPONSE side: a body line too wide for the pane spills
+  # onto continuation rows, and the row number is printed once, on the first of them.
+  it "wraps a long response line and numbers only its first visual row" do
+    Gori::Settings.show_gutter = true
+    view = loaded_view("HEAD#{"." * 80}TAIL")
+    rect = Rect.new(0, 0, 80, 20)
+    b = MemoryBackend.new(80, 20)
+    view.render(Screen.new(b), rect)
+    body = resp_body_rect(rect)
+    # Find the row holding HEAD; the row under it is a continuation with a blank gutter.
+    head_row = (0...20).find { |y| b.row(y).includes?("HEAD") }.not_nil!
+    gw = Gutter.width(4)                                # status line + header + blank + body
+    b.row(head_row)[body.x, gw].should_not eq(" " * gw) # numbered
+    b.row(head_row + 1)[body.x, gw].should eq(" " * gw) # continuation: no number
+    b.contains?("TAIL").should be_true                  # the tail is on screen, not clipped away
+  ensure
+    Gori::Settings.show_gutter = true
+  end
+
+  # The inverse of that render. Before wrap, screen row N of the response WAS logical line
+  # scroll+N, so a click on a continuation row selected a line that isn't even drawn there.
+  it "round-trips a click on a continuation row of the response body" do
+    view = loaded_view("0123456789" * 12) # 120 chars, one body line
+    rect = Rect.new(0, 0, 80, 20)
+    b = MemoryBackend.new(80, 20)
+    view.render(Screen.new(b), rect)
+    body = resp_body_rect(rect)
+    gw = Gori::Settings.show_gutter ? Gutter.width(4) : 0
+    cw = body.w - gw
+    # The body line is the 4th row of the message (status, header, blank, body), so its
+    # first visual row is at body.y + 3; the one under it is its continuation.
+    view.resp_click_to_cursor(rect, body.x + gw + 2, body.y + 4)
+    view.resp_cursor.cy.should eq(3)      # still the BODY line …
+    view.resp_cursor.cx.should eq(cw + 2) # … one wrapped row in, plus two columns
+  end
+
+  it "moves the response caret down without the pane losing it (visual ensure_visible)" do
+    view = loaded_view("#{"z" * 400}\nSENTINEL")
+    rect = Rect.new(0, 0, 80, 14)
+    b = MemoryBackend.new(80, 14)
+    view.render(Screen.new(b), rect)
+    view.resp_move(1, 0) # header
+    view.resp_move(1, 0) # blank
+    view.resp_move(1, 0) # the 400-char body line
+    view.resp_move(1, 0) # SENTINEL, many wrapped rows below the fold
+    b2 = MemoryBackend.new(80, 14)
+    view.render(Screen.new(b2), rect)
+    b2.contains?("SENTINEL").should be_true
+  end
+
+  # The wheel steps DRAWN rows. With a line-indexed offset one notch jumped the whole
+  # wrapped line, so most of the response was unreachable by scrolling.
+  it "scrolls the response by one visual row per notch" do
+    view = loaded_view("#{"a" * 300}\n#{"b" * 300}")
+    rect = Rect.new(0, 0, 80, 14)
+    b = MemoryBackend.new(80, 14)
+    view.render(Screen.new(b), rect)
+    body = resp_body_rect(rect)
+    resp = ->(back : MemoryBackend, y : Int32) { back.row(y)[body.x, body.w] }
+    top = resp.call(b, body.y)
+    view.resp_scroll_view(1)
+    b2 = MemoryBackend.new(80, 14)
+    view.render(Screen.new(b2), rect)
+    # One notch advanced by exactly one drawn row: what was the SECOND row is now the first.
+    resp.call(b2, body.y).should eq(resp.call(b, body.y + 1))
+    resp.call(b2, body.y).should_not eq(top)
+  end
+
+  # The diff pane prefixes every row with a 2-column "+ "/"- " decoration, so its wrap runs
+  # on a line two columns wider than the one the caret and search address. Getting that
+  # conversion wrong puts render and hit-testing on two different grids — which only shows
+  # up once a line is wide enough to wrap.
+  it "wraps the diff pane on the DECORATED line and still hit-tests the bare text" do
+    view = Gori::Tui::RepeaterView.new
+    view.load_blank
+    view.focus_pane(:response)
+    hdr = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\n"
+    view.apply(Gori::Repeater::Result.new(hdr.to_slice, "first".to_slice, nil, 1000_i64))
+    view.apply(Gori::Repeater::Result.new(hdr.to_slice, ("Q" * 150).to_slice, nil, 1000_i64))
+    view.toggle_resp_mode # → diff
+    rect = Rect.new(0, 0, 80, 20)
+    b = MemoryBackend.new(80, 20)
+    view.render(Screen.new(b), rect)
+    body = resp_body_rect(rect)
+    gw = Gori::Settings.show_gutter ? Gutter.width(view.resp_plain_lines.size) : 0
+    row = (0...20).find { |y| b.row(y).includes?("+ QQ") }.not_nil!
+    # A click 4 columns into the row BELOW the "+ " one: that row carries no decoration, so
+    # its first char is at (row 0's content width - 2) into the bare text.
+    view.resp_click_to_cursor(rect, body.x + gw + 4, row + 1)
+    cw = body.w - gw
+    view.resp_cursor.cx.should eq(cw - 2 + 4)
+  end
+  # Requirement: a selection that covers a wrap boundary highlights to the END of the
+  # visual row, then continues on the next one. Clipping the span per row is the whole of
+  # it, and it is exactly the arithmetic that looks right until you count cells.
+  it "tints a selection across a wrap break to the end of the row and onto the next" do
+    view = loaded_view("0123456789" * 12)
+    rect = Rect.new(0, 0, 80, 20)
+    b = MemoryBackend.new(80, 20)
+    view.render(Screen.new(b), rect)
+    body = resp_body_rect(rect)
+    gw = Gori::Settings.show_gutter ? Gutter.width(4) : 0
+    cw = body.w - gw
+    3.times { view.resp_move(1, 0) } # status, header, blank → the body line
+    view.resp_cursor.cy.should eq(3)
+    view.resp_move(0, cw + 5, selecting: true) # anchor at col 0, caret 5 columns past the break
+    b2 = MemoryBackend.new(80, 20)
+    view.render(Screen.new(b2), rect)
+    r0 = body.y + 3 # the body line's first visual row
+    b2.bg_grid[r0][body.x + gw].should eq(Theme.accent_bg)
+    b2.bg_grid[r0][body.x + gw + cw - 1].should eq(Theme.accent_bg) # …tinted to the row's end
+    b2.bg_grid[r0 + 1][body.x + gw].should eq(Theme.accent_bg)      # …and resumed below
+    b2.bg_grid[r0 + 1][body.x + gw + 4].should eq(Theme.accent_bg)
+    # gw+5 is the caret cell itself (also accent_bg); the tint must stop right after it.
+    b2.bg_grid[r0 + 1][body.x + gw + 6].should_not eq(Theme.accent_bg)
+  end
+
+  # The gutter is sized from a per-mode line count, and those counts are NOT all the same:
+  # `resp_line_count` (what the old click path measured with) has no group-transcript
+  # branch and falls through to the plain response view's total. A click that re-derived
+  # its own content width from that would key the wrap memo at a width the rows were never
+  # laid out at — flushing and rebuilding it every click, against a stale anchor. Hit
+  # testing reads back the geometry render published instead; this pins that in the one
+  # mode where the two counts genuinely disagree.
+  it "hit-tests a group transcript at the width RENDER used, not a re-derived one" do
+    view = Gori::Tui::RepeaterView.new
+    view.load_blank
+    view.focus_pane(:response)
+    hdr = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\n"
+    res = Gori::Repeater::Result.new(hdr.to_slice, ("W" * 200).to_slice, nil, 1000_i64)
+    view.apply_group([{"req 1", res}])
+    rect = Rect.new(0, 0, 80, 20)
+    b = MemoryBackend.new(80, 20)
+    view.render(Screen.new(b), rect)
+    body = resp_body_rect(rect)
+    row = (0...20).find { |y| b.row(y).includes?("WWWW") }.not_nil!
+    before = view.resp_plain_lines.size
+    view.resp_click_to_cursor(rect, body.x + 6, row + 1) # a continuation row of the W line
+    view.resp_plain_lines.size.should eq(before)         # sanity: same transcript
+    # The caret must be on the W row, one wrapped row in — not on some other transcript row.
+    view.resp_plain_lines[view.resp_cursor.cy].should start_with("WWWW")
+    view.resp_cursor.cx.should be > 0
+  end
+end

--- a/spec/tui/text_area_ins_select_spec.cr
+++ b/spec/tui/text_area_ins_select_spec.cr
@@ -1,0 +1,251 @@
+require "../spec_helper"
+require "../support/memory_backend"
+
+include Gori::Tui
+
+# INSERT-mode selection in the shared `TextArea` — the model behind the Repeater request
+# pane's "⇧arrows select, Del removes it" once the view forwards the shift (see
+# `RepeaterController#edit_repeater_request`, which names the one missing seam).
+#
+# READ mode has had a selection since ReadCursor; INS had none, so ⇧→ moved the caret like a
+# bare → and ⌫ always took exactly one character. Everything here is about the INS half:
+# where the anchor lives, what collapses it, what a delete does with it, and — the part the
+# soft-wrap layer makes non-obvious — which CELLS the band covers when the selected run
+# crosses a wrap break.
+
+# An editor rendered into a `w` × `h` pane with the block caret on (i.e. INSERT), so a spec
+# can assert the painted cells and the model in the same frame. Mirrors `text_area_wrap_spec`.
+private def ins_render(ed : Gori::Tui::TextArea, w : Int32, h : Int32,
+                       gutter : Bool = false, cursor : Bool = true) : MemoryBackend
+  ed.gutter = gutter
+  b = MemoryBackend.new(w, h)
+  ed.render(Gori::Tui::Screen.new(b), Gori::Tui::Rect.new(0, 0, w, h), cursor: cursor)
+  b
+end
+
+describe "Gori::Tui::TextArea INSERT-mode selection" do
+  describe "extending and collapsing" do
+    it "⇧→ selects from the caret and a plain → collapses it" do
+      ed = TextArea.new("hello")
+      ed.selection?.should be_false
+      ed.move(0, 1, selecting: true)
+      ed.selection?.should be_true
+      ed.selection_text.should eq("h")
+      ed.move(0, 1, selecting: true)
+      ed.selection_text.should eq("he")
+      ed.move(0, 1) # unmodified arrow
+      ed.selection?.should be_false
+      ed.selection_text.should be_nil
+    end
+
+    # ⇧→ then ⇧← puts the caret back ON the anchor. If that still counted as a selection the
+    # next ⌫ would delete the empty run and stop there — a key that visibly does nothing.
+    it "reports no selection once the caret returns to the anchor" do
+      ed = TextArea.new("hello")
+      ed.move(0, 1, selecting: true)
+      ed.move(0, -1, selecting: true)
+      ed.selection?.should be_false
+      ed.backspace # falls through to the ordinary one-character delete
+      ed.text.should eq("hello")
+      ed.move(0, 1)
+      ed.backspace
+      ed.text.should eq("ello")
+    end
+
+    # The anchor is shared with the read model's shape; the MOTION is this editor's own. A
+    # ⇧↓ on a wrapped line steps ONE VISUAL ROW and keeps the display column — it does not
+    # take the whole logical line the way `ReadCursor#move` does for a read-only pane, which
+    # here would select 20 characters the caret never crossed.
+    it "⇧↓ extends by one visual row on a wrapped line, not to end-of-line" do
+      ed = TextArea.new("0123456789ABCDEFGHIJ")
+      ed.wrap = true
+      ins_render(ed, 12, 4)
+      ed.move(1, 0, selecting: true)
+      ed.selection_text.should eq("0123456789AB") # exactly the first visual row
+    end
+
+    it "extends across a line break" do
+      ed = TextArea.new("hello\nworld")
+      ed.place_cursor(0, 3)
+      ed.move(1, 0, selecting: true)
+      ed.selection_text.should eq("lo\nwor")
+    end
+
+    # Upward selections are where a hand-rolled copy goes wrong: the CARET column belongs to
+    # the top line and the ANCHOR column to the bottom one, the reverse of a downward drag.
+    # `selection_text` defers to ReadCursor precisely so that fix is not re-derived here.
+    it "copies an upward selection in document order" do
+      ed = TextArea.new("hello\nworld")
+      ed.place_cursor(1, 1)
+      ed.move(-1, 0, selecting: true)
+      ed.selection_text.should eq("ello\nw")
+    end
+  end
+
+  describe "deleting a selection" do
+    it "⌫ removes the whole selection instead of one character" do
+      ed = TextArea.new("hello world")
+      ed.place_cursor(0, 1)
+      4.times { ed.move(0, 1, selecting: true) }
+      before = ed.edits
+      ed.backspace
+      ed.text.should eq("h world")
+      ed.cx.should eq(1)
+      ed.selection?.should be_false
+      # The owner gates `mark_req_edit` on @edits changing — a cut that did not bump it
+      # would delete the text and leave the tab clean, so the edit is never persisted.
+      ed.edits.should_not eq(before)
+    end
+
+    it "Del removes the whole selection instead of the character under the caret" do
+      ed = TextArea.new("hello world")
+      ed.place_cursor(0, 1)
+      4.times { ed.move(0, 1, selecting: true) }
+      ed.delete
+      ed.text.should eq("h world")
+    end
+
+    it "undoes the cut as one step" do
+      ed = TextArea.new("hello world")
+      ed.place_cursor(0, 1)
+      4.times { ed.move(0, 1, selecting: true) }
+      ed.backspace
+      ed.text.should eq("h world")
+      ed.undo
+      ed.text.should eq("hello world")
+    end
+
+    # ⌫ at the very start of the buffer returns early ("no character before the caret"), and
+    # that early return must not swallow a selection that begins there.
+    it "removes a selection anchored at the buffer start" do
+      ed = TextArea.new("hello")
+      3.times { ed.move(0, 1, selecting: true) }
+      ed.backspace
+      ed.text.should eq("lo")
+    end
+
+    # The merged line keeps the LAST consumed line's terminator, exactly as a backspace-join
+    # does. Keeping the first line's instead would put an LF where the capture had CRLF (or
+    # the reverse) on a line the operator never touched — bytes on the wire, not a rendering
+    # detail.
+    it "keeps the trailing line's ending when the cut joins lines" do
+      ed = TextArea.new("a\nbb\r\nccc")
+      ed.place_cursor(0, 1)
+      ed.move(1, 0, selecting: true) # caret to (1, 1)
+      ed.selection_text.should eq("\nb")
+      ed.backspace
+      ed.text.should eq("ab\nccc")
+      ed.wire_text.should eq("ab\r\nccc")
+    end
+  end
+
+  describe "replace on type" do
+    it "a printable typed over a selection replaces it, undoable as one step" do
+      ed = TextArea.new("hello world")
+      ed.place_cursor(0, 1)
+      4.times { ed.move(0, 1, selecting: true) }
+      ed.insert('X')
+      ed.text.should eq("hX world")
+      ed.selection?.should be_false
+      ed.undo
+      ed.text.should eq("hello world")
+    end
+
+    it "↵ over a selection replaces it with the break" do
+      ed = TextArea.new("hello world")
+      ed.place_cursor(0, 5)
+      6.times { ed.move(0, 1, selecting: true) }
+      ed.insert_newline
+      ed.text.should eq("hello\n")
+    end
+  end
+
+  describe "what collapses the selection" do
+    # The wheel DRAGS the caret when the viewport would leave it behind. That drag is not a
+    # selecting move: left alone it would stretch the selection to wherever the operator
+    # scrolled, and the next keystroke would replace all of it.
+    it "drops the selection when the wheel drags the caret, keeps it when it does not" do
+      ed = TextArea.new((0...10).map { |i| "line#{i}" }.join("\n"))
+      ins_render(ed, 20, 3)
+      ed.place_cursor(2, 0)
+      ed.move(0, 1, selecting: true)
+      ed.scroll_view(1) # rows 1..3 — the caret on line 2 is still inside
+      ed.selection?.should be_true
+      ed.scroll_view(5) # the caret cannot stay on line 2
+      ed.selection?.should be_false
+    end
+
+    it "drops the selection on a click, a goto and a read-mode caret write" do
+      {->(e : TextArea) { e.click_to_cursor(Rect.new(0, 0, 20, 3), 2, 0) },
+       ->(e : TextArea) { e.goto_line(2) },
+       ->(e : TextArea) { e.place_cursor(1, 1) },
+       ->(e : TextArea) { e.home },
+       ->(e : TextArea) { e.end_of_line }}.each do |act|
+        ed = TextArea.new("hello\nworld")
+        ins_render(ed, 20, 3)
+        ed.move(0, 1, selecting: true)
+        ed.selection?.should be_true
+        act.call(ed)
+        ed.selection?.should be_false
+      end
+    end
+  end
+
+  describe "painting the band" do
+    # THE wrap contract for an over-painter: a selection running past the right edge must
+    # tint its row TO THE END and carry on at column 0 of the continuation row. Clipping to
+    # the logical line instead paints one band at the first row's columns and leaves the
+    # rest of the selected text looking unselected.
+    it "tints to the end of a visual row and continues on the next" do
+      ed = TextArea.new("0123456789ABCDEFGHIJ")
+      ed.wrap = true
+      ed.place_cursor(0, 8)
+      8.times { ed.move(0, 1, selecting: true) } # chars 8…15, across the break at 12
+      b = ins_render(ed, 12, 4)
+      b.row(0).should eq("0123456789AB")
+      b.row(1)[0, 8].should eq("CDEFGHIJ")
+      (0...8).each { |x| b.bg_at(x, 0).should_not eq(Theme.accent_bg) } # before the anchor
+      (8...12).each { |x| b.bg_at(x, 0).should eq(Theme.accent_bg) }    # to the row's end
+      (0...4).each { |x| b.bg_at(x, 1).should eq(Theme.accent_bg) }     # and on into row 1
+      b.bg_at(4, 1).should_not eq(Theme.accent_bg)                      # the caret cell, not the band
+    end
+
+    it "tints whole intermediate lines of a multi-line selection" do
+      ed = TextArea.new("aaa\nbbb\nccc")
+      ed.place_cursor(0, 2)
+      ed.move(1, 0, selecting: true)
+      ed.move(1, 0, selecting: true) # caret at (2, 2)
+      b = ins_render(ed, 8, 3)
+      b.bg_at(1, 0).should_not eq(Theme.accent_bg)
+      b.bg_at(2, 0).should eq(Theme.accent_bg)
+      (0...3).each { |x| b.bg_at(x, 1).should eq(Theme.accent_bg) } # the whole middle line
+      (0...2).each { |x| b.bg_at(x, 2).should eq(Theme.accent_bg) }
+      b.bg_at(2, 2).should_not eq(Theme.accent_bg)
+    end
+
+    # READ mode paints its OWN selection over this editor (`paint_request_read_chrome`), and
+    # it is called with `focused && !insert`. Drawing this band there too would double-tint
+    # in one mode and show a stale INS band in the other, so the block caret — on only in
+    # INSERT — is the gate.
+    it "does not paint the band while the block caret is off (READ mode)" do
+      ed = TextArea.new("hello")
+      3.times { ed.move(0, 1, selecting: true) }
+      b = ins_render(ed, 8, 2, cursor: false)
+      (0...8).each { |x| b.bg_at(x, 0).should_not eq(Theme.accent_bg) }
+    end
+
+    # A concealed `¦chain` occupies no cells, so the band has to be laid down as the VISIBLE
+    # runs between the hidden ones. Painting straight through would tint the cells the
+    # chain's neighbours stand in and shift the rest of the row right by its length.
+    it "skips concealed characters instead of tinting through them" do
+      ed = TextArea.new("abcdef")
+      ed.conceal_spans = [{2, 4}] # "cd" is in the buffer but off the screen
+      4.times { ed.move(0, 1, selecting: true) }
+      ed.cx.should eq(6) # the caret hops the whole hidden run in one press
+      b = ins_render(ed, 8, 2)
+      b.row(0)[0, 4].should eq("abef")
+      (0...4).each { |x| b.bg_at(x, 0).should eq(Theme.accent_bg) }
+      b.bg_at(4, 0).should_not eq(Theme.accent_bg) # nothing was drawn past the last glyph
+    end
+  end
+end

--- a/spec/tui/text_area_wrap_spec.cr
+++ b/spec/tui/text_area_wrap_spec.cr
@@ -1,0 +1,225 @@
+require "../spec_helper"
+require "../support/memory_backend"
+
+include Gori::Tui
+
+# A wrapping editor rendered into a `w` × `h` pane, with the gutter on (the Repeater
+# request shape). Returns the editor and the painted screen so a spec can assert both the
+# cells and the caret state the same frame produced.
+private def wrap_render(text : String, w : Int32, h : Int32, gutter : Bool = true,
+                        highlight : Symbol? = nil, cursor : Bool = false,
+                        ta : Gori::Tui::TextArea? = nil) : {Gori::Tui::TextArea, MemoryBackend}
+  ed = ta || Gori::Tui::TextArea.new(text)
+  ed.gutter = gutter
+  ed.wrap = true
+  b = MemoryBackend.new(w, h)
+  ed.render(Gori::Tui::Screen.new(b), Gori::Tui::Rect.new(0, 0, w, h), cursor: cursor, highlight: highlight)
+  {ed, b}
+end
+
+describe "Gori::Tui::TextArea soft wrap" do
+  # THE Burp-style contract the feature is named for: a logical line spills onto as many
+  # rows as it needs, and the line NUMBER appears exactly once — on the first of them. A
+  # continuation row is blank in the gutter and its text starts in the same column as the
+  # first row's, so the reader can still see at a glance where line 2 begins and ends.
+  #
+  # Before soft wrap this assertion could not even be posed: line 2's tail was clipped at
+  # the pane edge (or reachable only by ⇧→), and screen row 2 held line 3.
+  describe "gutter numbering" do
+    it "numbers the first visual row of a logical line and leaves continuations blank" do
+      _, b = wrap_render("short\n#{"x" * 30}\nlast", 20, 6)
+      gw = Gutter.width(3) # 3 lines → 2 number columns + 1 gap
+      b.row(0)[0, gw].should eq(" 1 ")
+      b.row(0)[gw..].rstrip.should eq("short")
+      b.row(1)[0, gw].should eq(" 2 ")
+      b.row(1)[gw..].should eq("x" * (20 - gw)) # first row of line 2, filled to the edge
+      b.row(2)[0, gw].should eq("   ")          # continuation: NO number
+      b.row(2)[gw..].rstrip.should eq("x" * (30 - (20 - gw)))
+      b.row(3)[0, gw].should eq(" 3 ") # line 3 got pushed down by the wrap
+      b.row(3)[gw..].rstrip.should eq("last")
+    end
+
+    # The gutter is sized from the LOGICAL line count. Wrapping multiplies the drawn rows,
+    # and if the width tracked those instead, the text column would shift sideways every
+    # time a line happened to spill — the numbers name logical lines, and there are still
+    # exactly as many of those as before.
+    it "does not widen the gutter because wrapping produced more rows" do
+      _, b = wrap_render("#{"y" * 200}\nz", 20, 12)
+      gw = Gutter.width(2)
+      gw.should eq(3)
+      # 200 chars over 17 content columns = 12 rows; the second line is off the bottom, so
+      # the gutter must still be sized for "2", not for the dozen rows on screen.
+      (0...12).each { |r| b.row(r)[0, gw].should eq(r == 0 ? " 1 " : "   ") }
+    end
+  end
+
+  describe "breaking on display columns" do
+    # Width correctness is the whole risk in this layer. A CJK glyph is TWO cells, so a
+    # break computed on String#size puts half a glyph past the right edge — the terminal
+    # then either drops it or smears it over the pane border.
+    it "never splits a wide CJK glyph across the break" do
+      # 5 content columns; "한글날" is 6, so the third syllable must move down whole.
+      ed, b = wrap_render("한글날개", 8, 4, gutter: true)
+      # gutter is 3 wide for a 1-line buffer, leaving 5 content columns for 2 glyphs.
+      ed.last_rows.map { |r| "한글날개"[r.a...r.b] }.should eq(["한글", "날개"])
+      b.grid[0][3].should eq('한')
+      b.grid[0][5].should eq('글')
+      b.grid[0][7].should eq(' ') # the odd column stays empty rather than half a glyph
+      b.grid[1][3].should eq('날')
+    end
+
+    it "never splits a combining sequence or a ZWJ family" do
+      family = "\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}\u{200D}\u{1F466}"
+      ed, _ = wrap_render("ab#{family}cd", 10, 4, gutter: false)
+      # Every row must reconstruct the source exactly — a split cluster would lose or
+      # duplicate codepoints here.
+      ed.last_rows.map { |r| ed.lines_snapshot[r.li][r.a...r.b] }.join.should eq("ab#{family}cd")
+    end
+  end
+
+  # The inverse of render. A click on a continuation row must resolve to the logical
+  # column that is actually drawn there — before wrap, screen row 1 WAS logical line 1, so
+  # this click landed on the wrong line entirely.
+  describe "click hit-testing" do
+    it "round-trips a click on a continuation row to the right logical column" do
+      line = "0123456789" * 4 # 40 chars, one logical line
+      ed, _ = wrap_render(line, 20, 6, gutter: false)
+      # 20 content columns ⇒ rows are [0,20), [20,40).
+      ed.click_to_cursor(Rect.new(0, 0, 20, 6), 3, 1) # row 1, column 3
+      ed.cy.should eq(0)
+      ed.cx.should eq(23)
+      ed.click_to_cursor(Rect.new(0, 0, 20, 6), 0, 1)
+      ed.cx.should eq(20) # column 0 of the continuation row is the break itself
+      ed.click_to_cursor(Rect.new(0, 0, 20, 6), 7, 0)
+      ed.cx.should eq(7) # …and the first row is unchanged
+    end
+
+    it "agrees with where the caret paints, on a continuation row" do
+      line = "0123456789" * 4
+      ed, _ = wrap_render(line, 20, 6, gutter: false)
+      ed.click_to_cursor(Rect.new(0, 0, 20, 6), 5, 1)
+      b = MemoryBackend.new(20, 6)
+      ed.render(Screen.new(b), Rect.new(0, 0, 20, 6), cursor: true)
+      # The caret cell is the one the click named: row 1, column 5, holding '5'.
+      b.grid[1][5].should eq('5')
+      b.bg_grid[1][5].should eq(Theme.accent)
+    end
+
+    it "clamps a click past the end of a wrapped row to the break, not the next row's text" do
+      ed, _ = wrap_render("0123456789" * 4, 20, 6, gutter: false)
+      ed.click_to_cursor(Rect.new(0, 0, 20, 6), 19, 0)
+      ed.cx.should eq(19) # last cell of row 0 …
+      ed.click_to_cursor(Rect.new(0, 0, 20, 6), 25, 0)
+      ed.cx.should eq(20) # … and past it stops at the break
+    end
+  end
+
+  describe "caret movement across a wrap boundary" do
+    it "steps ↓ onto the continuation row of the SAME logical line" do
+      ed, _ = wrap_render("#{"0123456789" * 4}\nnext", 20, 6, gutter: false)
+      ed.place_cursor(0, 5)
+      ed.move(1, 0)
+      ed.cy.should eq(0)  # still logical line 1 …
+      ed.cx.should eq(25) # … one visual row down, same display column
+      ed.move(1, 0)
+      ed.cy.should eq(1) # now onto the next logical line
+      ed.cx.should eq(4) # clamped to its length ("next" is 4 wide)
+    end
+
+    it "steps ↑ back over the boundary to the column it came from" do
+      ed, _ = wrap_render("0123456789" * 4, 20, 6, gutter: false)
+      ed.place_cursor(0, 27)
+      ed.move(-1, 0)
+      ed.cx.should eq(7)
+      ed.move(-1, 0)
+      ed.cx.should eq(7) # already on the first row — nowhere further up
+    end
+
+    # ↑ on a continuation row must NOT pop focus out of the pane: there are still rows
+    # above the caret inside it.
+    it "reports at_top?/at_bottom? per VISUAL row, not per logical line" do
+      ed, _ = wrap_render("0123456789" * 6, 20, 6, gutter: false) # 60 chars ⇒ 3 rows
+      ed.place_cursor(0, 25)
+      ed.at_top?.should be_false
+      ed.at_bottom?.should be_false
+      ed.place_cursor(0, 3)
+      ed.at_top?.should be_true
+      ed.place_cursor(0, 59)
+      ed.at_bottom?.should be_true
+    end
+
+    it "keeps the caret on a cluster boundary when it crosses onto a CJK row" do
+      ed, _ = wrap_render("abcde한글날abc", 11, 4, gutter: false)
+      ed.place_cursor(0, 1)
+      ed.move(1, 0)
+      # Whatever row it lands on, the index must start a cluster — never between the two
+      # halves of a wide glyph.
+      line = ed.lines_snapshot[0]
+      Screen.cluster_start(line, ed.cx).should eq(ed.cx)
+    end
+  end
+
+  describe "vertical scrolling in visual rows" do
+    # @scroll indexes LOGICAL lines and would drift the moment anything wrapped; the anchor
+    # is (line, sub-row) and the wheel moves it one DRAWN row at a time.
+    it "scrolls by one visual row, not one logical line" do
+      ed, _ = wrap_render("#{"a" * 60}\n#{"b" * 60}", 20, 4, gutter: false)
+      ed.scroll_view(1)
+      b = MemoryBackend.new(20, 4)
+      ed.render(Screen.new(b), Rect.new(0, 0, 20, 4), cursor: false)
+      b.row(0).should eq("a" * 20) # the SECOND row of line 1, not line 2
+      ed.last_rows[0].a.should eq(20)
+      ed.last_rows[0].li.should eq(0)
+    end
+
+    it "scrolls the caret's row into view when it is below the pane" do
+      ed, _ = wrap_render("#{"a" * 200}\ntail", 20, 4, gutter: false)
+      ed.place_cursor(1, 0)
+      b = MemoryBackend.new(20, 4)
+      ed.render(Screen.new(b), Rect.new(0, 0, 20, 4), cursor: true)
+      b.row(3).rstrip.should eq("tail") # caret's row is the last visible one
+      ed.last_rows.last.li.should eq(1)
+    end
+  end
+
+  describe "search highlight" do
+    # A match straddling the break is highlighted on BOTH rows. Per-row scanning would
+    # find it on neither, which is strictly worse than the horizontal scrolling this
+    # replaced (that at least showed the match once you scrolled to it).
+    it "marks both halves of a match that crosses a wrap break" do
+      ed, b = wrap_render("aaaaaaaaNEEDLEaaaa", 12, 4, gutter: false)
+      ed.search_hl = "needle"
+      b = MemoryBackend.new(12, 4)
+      ed.render(Screen.new(b), Rect.new(0, 0, 12, 4), cursor: false)
+      (8..11).each { |x| b.bg_grid[0][x].should eq(Theme.yellow) } # "NEED"
+      (0..1).each { |x| b.bg_grid[1][x].should eq(Theme.yellow) }  # "LE"
+      b.bg_grid[0][7].should_not eq(Theme.yellow)
+      b.bg_grid[1][2].should_not eq(Theme.yellow)
+    end
+  end
+
+  describe "coexistence with the request editor's other overlays" do
+    it "keeps syntax colours across the break" do
+      ed, b = wrap_render("GET /aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa HTTP/1.1", 20, 6,
+        gutter: false, highlight: :request)
+      # Whole line reconstructed from the drawn rows, so nothing was dropped at the seam.
+      ed.last_rows.map { |r| ed.lines_snapshot[r.li][r.a...r.b] }.join
+        .should eq("GET /aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa HTTP/1.1")
+      b.row(0).should eq("GET /aaaaaaaaaaaaaaa")
+      b.row(1).should eq("aaaaaaaaaaaaaaa HTTP")
+      b.row(2).rstrip.should eq("/1.1")
+    end
+
+    # The hidden `¦chain` of a §…§ marker occupies no cells, so it must buy no width in the
+    # wrap either — counting it shortens every row on the marked line.
+    it "wraps a concealed marker line by what is actually drawn" do
+      text = "GET /?a=§v¦b64§ HTTP/1.1"
+      ed = Gori::Tui::TextArea.new(text)
+      ed.conceal_spans = [{10, 14}] # the "¦b64" run
+      ed, b = wrap_render(text, 20, 6, gutter: false, ta: ed)
+      # 24 raw chars, 20 drawn (4 concealed) — exactly one row.
+      ed.last_rows.size.should eq(1)
+      b.row(0).should eq("GET /?a=§v§ HTTP/1.1")
+    end
+  end
+end

--- a/spec/tui/wrap_spec.cr
+++ b/spec/tui/wrap_spec.cr
@@ -1,0 +1,176 @@
+require "../spec_helper"
+require "../support/memory_backend"
+
+include Gori::Tui
+
+# Every row of `line` under `width`, as text — the projection the render loop draws.
+private def rows_of(line : String, width : Int32, conceal = nil) : Array(String)
+  lay = Wrap.layout(line, width, conceal)
+  (0...lay.rows).map { |r| line[lay.start_of(r)...lay.end_of(r)] }
+end
+
+describe Gori::Tui::Wrap do
+  describe "layout" do
+    it "keeps a line that fits on a single row" do
+      lay = Wrap.layout("GET /x HTTP/1.1", 40)
+      lay.rows.should eq(1)
+      lay.start_of(0).should eq(0)
+      lay.end_of(0).should eq(15)
+    end
+
+    # An empty line still occupies one row: it is where the caret goes, and every mapping
+    # below (row_of, start_of) assumes row 0 exists.
+    it "gives an empty line one row" do
+      lay = Wrap.layout("", 40)
+      lay.rows.should eq(1)
+      lay.start_of(0).should eq(0)
+      lay.end_of(0).should eq(0)
+    end
+
+    it "breaks an ASCII line every `width` columns and loses nothing" do
+      line = ("abcdefghij" * 5) # 50 chars
+      rows_of(line, 12).should eq(["abcdefghijab", "cdefghijabcd", "efghijabcdef", "ghijabcdefgh", "ij"])
+      rows_of(line, 12).join.should eq(line)
+    end
+
+    # The rows must always concatenate back to the source, at every width — a wrap that
+    # drops or duplicates a character corrupts every offset downstream of it (caret,
+    # click, selection, search).
+    it "is a lossless partition at every width" do
+      line = "a\t한글x#{"\u{1F44D}\u{1F3FD}"}e\u{0301},{\"k\":\"v\"}"
+      (1..24).each do |w|
+        rows_of(line, w).join.should eq(line) # (width #{w})
+      end
+    end
+
+    it "never returns a start inside a grapheme cluster" do
+      family = "\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}\u{200D}\u{1F466}"
+      line = "ab#{family}cd#{family}ef"
+      starts = [] of Int32
+      i = 0
+      line.each_grapheme { |g| starts << i; i += g.size }
+      starts << line.size
+      (1..20).each do |w|
+        lay = Wrap.layout(line, w)
+        (0...lay.rows).each { |r| starts.should contain(lay.start_of(r)) } # (width #{w})
+      end
+    end
+
+    # The requirement that motivates measuring in DISPLAY COLUMNS rather than String#size:
+    # a wide CJK glyph is two cells, so an odd width must push it whole to the next row
+    # rather than leave half of it hanging over the edge.
+    it "never lets a wide CJK glyph straddle the break" do
+      line = "한글날abc"
+      # width 5 fits 두 glyphs (4 cols); the third would need cols 5-6.
+      rows_of(line, 5).should eq(["한글", "날abc"])
+      (2..10).each do |w|
+        lay = Wrap.layout(line, w)
+        (0...lay.rows).each do |r|
+          seg = line[lay.start_of(r)...lay.end_of(r)]
+          # Either the row fits, or it holds exactly one cluster too wide for any row.
+          (Screen.draw_width(seg) <= w || seg.each_grapheme.size == 1).should be_true # (w #{w} row #{r})
+        end
+      end
+    end
+
+    it "gives a cluster wider than the whole row a row of its own rather than splitting it" do
+      rows_of("한글", 1).should eq(["한", "글"])
+    end
+
+    it "maps a char index back to the row that starts it" do
+      lay = Wrap.layout("0123456789", 4)
+      lay.rows.should eq(3)
+      lay.row_of(0).should eq(0)
+      lay.row_of(3).should eq(0)
+      lay.row_of(4).should eq(1) # a break offset belongs to the row it STARTS
+      lay.row_of(7).should eq(1)
+      lay.row_of(8).should eq(2)
+      lay.row_of(10).should eq(2) # end-of-line terminates the last row
+    end
+
+    it "round-trips row_of against start_of/end_of at every index, ASCII and not" do
+      ["0123456789abcdefghij", "한글날abc한글날abc", "a\tb\u{0301}c한d"].each do |line|
+        (1..9).each do |w|
+          lay = Wrap.layout(line, w)
+          (0..line.size).each do |cx|
+            r = lay.row_of(cx)
+            (lay.start_of(r) <= cx).should be_true                   # (#{line.inspect} w#{w} cx#{cx})
+            (cx <= lay.end_of(r)).should be_true                     # (#{line.inspect} w#{w} cx#{cx})
+            (r == lay.rows - 1 || cx < lay.end_of(r)).should be_true # (#{line.inspect} w#{w} cx#{cx})
+          end
+        end
+      end
+    end
+
+    # Concealed chars (the hidden `¦chain` of a §…§ marker) draw no cells, so they must
+    # buy no width: counting them shortens every row on the marked line by the chain's
+    # length and the break lands left of the pane edge.
+    it "gives concealed chars no width" do
+      line = "§v¦chain§tail"
+      conceal = [{3, 8}] # the "chain" run
+      rows_of(line, 20, conceal).size.should eq(1)
+      Wrap.layout(line, 20, conceal).rows.should eq(1)
+      # Without the conceal the same line is 13 drawn columns and needs two rows at 8.
+      Wrap.layout(line, 8).rows.should eq(2)
+      Wrap.layout(line, 8, conceal).rows.should eq(1) # 8 visible columns exactly
+    end
+  end
+
+  describe "row_col / row_index" do
+    it "are exact inverses at every cluster boundary within a row" do
+      line = "a\t한#{"\u{1F44D}\u{1F3FD}"}e\u{0301}z글"
+      lay = Wrap.layout(line, 6)
+      (0...lay.rows).each do |r|
+        a = lay.start_of(r)
+        b = lay.end_of(r)
+        i = a
+        while i <= b
+          col = Wrap.row_col(line, nil, a, i)
+          Wrap.row_index(line, nil, a, b, col).should eq(i) # (row #{r} idx #{i})
+          i = i >= b ? b + 1 : Screen.cluster_end(line, i + 1)
+        end
+      end
+    end
+
+    it "clamps a click past the end of a wrapped row to the break, not into the next row" do
+      line = "0123456789"
+      lay = Wrap.layout(line, 4)
+      a, b = lay.start_of(1), lay.end_of(1)
+      Wrap.row_index(line, nil, a, b, 99).should eq(b)
+      Wrap.row_index(line, nil, a, b, 0).should eq(a)
+      Wrap.row_index(line, nil, a, b, 2).should eq(a + 2)
+    end
+  end
+
+  describe "mark_search" do
+    # A match straddling a wrap break used to be highlighted on NEITHER row when each row
+    # was scanned in isolation (its head is an incomplete match, so is its tail). Both
+    # halves must light up.
+    it "highlights both halves of a match that crosses the break" do
+      line = "aaaaNEEDLEaaaa"
+      lay = Wrap.layout(line, 7) # break falls inside "NEEDLE" (cols 0-6 = "aaaaNEE")
+      b = MemoryBackend.new(20, 2)
+      s = Screen.new(b)
+      (0...lay.rows).each do |r|
+        a0, b0 = lay.start_of(r), lay.end_of(r)
+        s.text(0, r, line[a0...b0], Theme.text)
+        Wrap.mark_search(s, 0, r, line, a0, b0, "needle", 20)
+      end
+      # "NEE" on row 0 (cols 4-6), "DLE" on row 1 (cols 0-2), all yellow.
+      (4..6).each { |x| b.bg_grid[0][x].should eq(Theme.yellow) }
+      (0..2).each { |x| b.bg_grid[1][x].should eq(Theme.yellow) }
+      b.bg_grid[0][3].should_not eq(Theme.yellow)
+      b.bg_grid[1][3].should_not eq(Theme.yellow)
+    end
+
+    it "places a within-row match at the drawn column, not the char index" do
+      line = "한글NEEDLE"
+      b = MemoryBackend.new(20, 1)
+      s = Screen.new(b)
+      s.text(0, 0, line, Theme.text)
+      Wrap.mark_search(s, 0, 0, line, 0, line.size, "needle", 20)
+      b.bg_grid[0][3].should_not eq(Theme.yellow) # still the second CJK glyph's cells
+      (4..9).each { |x| b.bg_grid[0][x].should eq(Theme.yellow) }
+    end
+  end
+end

--- a/src/gori/app.cr
+++ b/src/gori/app.cr
@@ -172,6 +172,15 @@ module Gori
         # is left in raw/no-echo).
         term.enable_enhanced_keyboard       # Kitty 17u (disambig + report_text) for better IME/Unicode; avoids report_all_keys(31u) which can split Hangul jamo. Committed text via raw UTF-8 bytes (IME composed syllables) + CSI for specials; Preedit via 0-code CSI if terminal provides.
         term.enable_mouse if Settings.mouse # SGR-1006 click + scroll-wheel nav; one enable covers both the picker and the runner (same term). Runner reconciles live on settings save; term.close disables on exit.
+        # DEC 2004. Unconditional and not a setting: without it a paste is indistinguishable
+        # from typing, and on a terminal that maps the LF of a pasted CRLF to a second CR one
+        # pasted line break arrives as CR CR — two Enters, a blank line after every pasted
+        # line, and in the Repeater editor a head that ends right after the request line (no
+        # Host → the origin answers 400). With it the terminal sends the clipboard bytes
+        # verbatim between \e[200~ and \e[201~, which `Tui::PasteNewline` swallows. Terminals
+        # that don't implement 2004 ignore the sequence and fall back to PasteNewline's pair
+        # rule, so enabling it can only help. term.close disables it on exit.
+        term.enable_bracketed_paste
         # First-run onboarding: no settings.json yet → walk the user through bind /
         # theme setup once. Inside `begin` so the `ensure term.close` restores
         # the terminal if it raises. The wizard persists settings.json (even on skip),

--- a/src/gori/tui/controllers/repeater_controller.cr
+++ b/src/gori/tui/controllers/repeater_controller.cr
@@ -621,7 +621,14 @@ module Gori::Tui
       when :response
         v.resp_navigable? ? v.resp_scroll_view(step) : v.scroll(step)
       when :request
-        v.request_scroll_view(step) unless v.request_insert?
+        # INS scrolls like NOR. It is the same pane showing the same text and the wheel is
+        # not an editing gesture — the operator who presses `i` has not asked to give up
+        # scrolling, and every other TextArea-backed pane in the tree (Notes, the Decoder
+        # input) already wheels while in insert mode. The `unless v.request_insert?` that
+        # stood here was one of TWO guards on this path; the other is inside
+        # `RepeaterView#request_scroll_view`, so neither is sufficient on its own and
+        # dropping this one is half the fix (see the report / that method).
+        v.request_scroll_view(step)
       end
       true
     end
@@ -1745,17 +1752,25 @@ module Gori::Tui
       return handle_repeater_request_read(ev, view) unless view.request_insert?
       key = ev.key
       c = ev.char || key.to_char
+      # ⇧arrow extends the INS selection, a plain arrow collapses it — `TextArea#move`
+      # implements both, along with the ⌫/Del that removes the selection, replace-on-type,
+      # and the wrap-aware band that paints it.
+      #
+      # ⇧↑ is deliberately NOT routed through the `at_top?` pop: at the top of the buffer a
+      # plain ↑ leaves the editor for the target field above, and doing that mid-extend would
+      # abandon a selection the operator is still building. Extending stays inside the editor,
+      # where `move` clamps at line 0.
       case
       when ev.ctrl_z?     then view.edit_undo
       when key.enter?     then view.edit_newline
-      when key.backspace? then view.edit_backspace unless guard_marker_delete(view, view.marker_break_on_backspace)
-      when key.up?        then view.at_top? ? view.focus_first : view.edit_move(-1, 0) # ↑-at-top → target field above
-      when key.down?      then view.edit_move(1, 0)
-      when key.left?      then view.edit_move(0, -1)
-      when key.right?     then view.edit_move(0, 1)
+      when key.backspace? then edit_repeater_delete(view, backward: true)
+      when key.up?        then (view.at_top? && !ev.shift?) ? view.focus_first : view.edit_move(-1, 0, selecting: ev.shift?)
+      when key.down?      then view.edit_move(1, 0, selecting: ev.shift?)
+      when key.left?      then view.edit_move(0, -1, selecting: ev.shift?)
+      when key.right?     then view.edit_move(0, 1, selecting: ev.shift?)
       when key.home?      then view.edit_home
       when key.end?       then view.edit_end
-      when key.delete?    then view.edit_delete unless guard_marker_delete(view, view.marker_break_on_delete)
+      when key.delete?    then edit_repeater_delete(view, backward: false)
       else
         if c && !ev.ctrl? && !ev.alt?
           view.edit_insert(c)
@@ -1763,6 +1778,24 @@ module Gori::Tui
         end
       end
       true
+    end
+
+    # ⌫ / Del in INS. A SELECTION outranks the marker-delimiter confirm, and the order is
+    # not cosmetic: `marker_break_on_backspace` inspects the ONE character beside the caret,
+    # so a caret parked just past a closing `§` raises "remove marker §N" for a marker the
+    # selection need not even touch — and the confirm SKIPS the delete, so the selected text
+    # survives while an unrelated marker is stripped on accept. Ask about the selection
+    # first; the confirm still owns the no-selection case, which is the one it was written
+    # for. (`pane_selection?` reports false while the request pane is in INS today, so this
+    # is behaviour-identical until that view-side gate learns about the editor's own
+    # selection — see the report; it is written this way so the order is already right when
+    # it does.)
+    private def edit_repeater_delete(view : RepeaterView, backward : Bool) : Nil
+      unless view.pane_selection?
+        span = backward ? view.marker_break_on_backspace : view.marker_break_on_delete
+        return if guard_marker_delete(view, span)
+      end
+      backward ? view.edit_backspace : view.edit_delete
     end
 
     # A backspace/forward-delete of a marker delimiter (§/¦) would unbalance the marker
@@ -1896,7 +1929,6 @@ module Gori::Tui
     # bare letters defer to the keymap (rebindable verbs + Global breath).
     private def handle_repeater_response(ev : Termisu::Event::Key, view : RepeaterView) : Bool
       return true.tap { @host.open_space_menu } if ev.key.space? && !ev.ctrl? && !ev.alt?
-      return true if handle_repeater_response_hscroll(ev, view)
       key = ev.key
       selecting = ev.shift?
       transcript = view.ws_mode? || view.grpc_mode? || view.group_mode?
@@ -1923,23 +1955,6 @@ module Gori::Tui
 
     private def resp_nav_step(view : RepeaterView, dr : Int32, dc : Int32, selecting : Bool, nav : Bool) : Nil
       nav ? view.resp_move(dr, dc, selecting: selecting) : view.scroll(dr)
-    end
-
-    # Shift+←/→ horizontal scroll, split out of handle_repeater_response to keep its
-    # cyclomatic complexity under ameba's threshold (this repo's dispatch-methods
-    # habitually tip over the limit one branch at a time). Works even in WS/gRPC
-    # transcript mode, so it's checked before that gate.
-    private def handle_repeater_response_hscroll(ev : Termisu::Event::Key, view : RepeaterView) : Bool
-      key = ev.key
-      if key.left? && ev.shift?
-        view.hscroll(-1)
-        true
-      elsif key.right? && ev.shift?
-        view.hscroll(1)
-        true
-      else
-        false
-      end
     end
   end
 end

--- a/src/gori/tui/highlight.cr
+++ b/src/gori/tui/highlight.cr
@@ -610,6 +610,43 @@ module Gori::Tui
       out
     end
 
+    # The styled `[a, b)` CHARACTER slice of a line, keeping every surviving character's
+    # exact styling — the soft-wrap counterpart of `conceal`, and the same 1:1 invariant:
+    # the result's span texts concatenate to `line`'s text over that range, no more and no
+    # less. One visual row of a wrapped logical line is exactly this slice.
+    #
+    # Char offsets, not display columns, and that is deliberate: `Wrap::Layout` decides
+    # where the break falls by walking CLUSTERS and hands back char indices, so slicing by
+    # column here would re-derive the break with a second measure — the drift this codebase
+    # keeps paying for. Because the break is always a cluster boundary, no span can be cut
+    # mid-cluster and no straddling-glyph padding is needed (unlike `slice_left`, which cuts
+    # at an arbitrary caller-supplied column).
+    def self.slice_chars(line : Line, a : Int32, b : Int32) : Line
+      # Identity when the slice covers the whole line — the common case for every
+      # unwrapped line, and it must not allocate a copy per row per frame. O(spans), and
+      # deliberately NOT "materialise the plain text and compare lengths": that would
+      # rebuild a multi-MB body line on the hot render path.
+      total = line.sum { |span| span.text.size }
+      return line if a <= 0 && b >= total
+      sliced = Line.new
+      return sliced if a >= b
+      off = 0 # char offset of the current span's first char within the whole line
+      line.each do |span|
+        t = span.text
+        len = t.size
+        if off + len <= a # span entirely before the slice
+          off += len
+          next
+        end
+        break if off >= b # span entirely after it — spans are ordered, so we're done
+        la = {a - off, 0}.max
+        lb = {b - off, len}.min
+        sliced << Span.new(la == 0 && lb == len ? t : t[la...lb], span.fg, span.attr) if la < lb
+        off += len
+      end
+      sliced
+    end
+
     # Total drawn column span of a styled line (sum of its spans) — used to clamp a
     # horizontal scroll offset against the widest currently-visible row. Uses draw_width,
     # which is what `draw` below actually advances by: ≥1 per cluster so an embedded tab

--- a/src/gori/tui/paste_newline.cr
+++ b/src/gori/tui/paste_newline.cr
@@ -2,32 +2,73 @@ require "termisu"
 
 module Gori
   module Tui
-    # Collapses a pasted CRLF into ONE newline.
+    # Makes one pasted line break insert one newline.
     #
-    # Both 0x0D and 0x0A arrive as `Key::Enter`, and gori enables no bracketed-paste mode,
-    # so pasting CRLF text — what every other HTTP tool puts on the clipboard — inserted a
-    # blank line after EVERY line. In the Repeater editor that ends the head right after the
-    # request line: the request goes out with no Host header, and the origin answers 400
-    # (RFC 9112 §3.2 — an HTTP/1.1 request without Host is malformed).
+    # Two mechanisms, because terminals differ in whether the first is available.
     #
-    # Only the LF of a CR-then-LF pair is dropped. A keyboard Enter is a lone CR and Ctrl+J
-    # a lone LF (both still one Enter), and a genuine blank line inside a pasted body is
-    # CR LF CR LF — one Enter per pair, so the blank line survives.
+    # BRACKETED PASTE (the reliable one). `Terminal#enable_bracketed_paste` puts the terminal
+    # in DEC mode 2004, after which it wraps a paste in `\e[200~` … `\e[201~` and hands the
+    # clipboard bytes over VERBATIM — no CR/LF translation of any kind. The markers arrive as
+    # `Key::PasteStart` / `Key::PasteEnd`; both are swallowed here so no view ever sees them,
+    # and `pasting?` is true in between. Verbatim delivery is the whole point: a clipboard
+    # CRLF really is CR LF, so the pair rule below becomes exact rather than a guess.
     #
-    # Lives apart from `Runner` (which needs a tty and so can't be driven from a spec) so
-    # the state machine is testable on its own; Runner keeps one and filters every event
-    # through it at the single `handle` funnel.
+    # THE CR-CR PROBLEM this exists for. Without bracketed paste a terminal is free to
+    # translate. The reported failure — pasting a request copied from Burp Suite left a blank
+    # line after every line — is a terminal that maps the LF of each pasted CRLF to a SECOND
+    # CR, so one line break arrives as CR CR: two `Key::Enter`s the pair rule cannot collapse,
+    # because CR CR is byte-for-byte what pressing Enter twice looks like. Nothing in the
+    # event stream separates those two, which is why the fix had to be the mode rather than a
+    # smarter heuristic here (termisu#3).
+    #
+    # THE PAIR RULE (the fallback, unchanged). Both 0x0D and 0x0A arrive as `Key::Enter`, so
+    # on a terminal WITHOUT bracketed paste a pasted CRLF still inserts two newlines. Only the
+    # LF of a CR-then-LF pair is dropped: a keyboard Enter is a lone CR and Ctrl+J a lone LF
+    # (both still one Enter), and a genuine blank line inside a pasted body is CR LF CR LF —
+    # one Enter per pair, so the blank line survives. It stays live even when bracketing is
+    # on: it costs nothing there (a bracketed CRLF is the same pair) and it is the only thing
+    # standing on a terminal that ignores mode 2004.
+    #
+    # Lives apart from `Runner` (which needs a tty and so can't be driven from a spec) so the
+    # state machine is testable on its own; Runner keeps one and filters every event through
+    # it at the single `handle` funnel.
     class PasteNewline
       def initialize
         @after_cr = false
+        @in_paste = false
       end
 
-      # True when `ev` is the LF half of a pasted CRLF and the caller must drop it.
+      # True while the events being delivered came from a bracketed paste rather than the
+      # keyboard. Nothing reads it yet; it is the seam for a caller that needs to treat pasted
+      # input differently (a bulk insert without per-character work, say), and it is what
+      # makes the swallowed markers observable to a spec.
+      def pasting? : Bool
+        @in_paste
+      end
+
+      # True when the caller must drop `ev` — either a paste boundary marker, or the LF half
+      # of a pasted CRLF.
       #
-      # Depends on termisu reporting WHICH byte produced the Enter (`Event::Key#char`, set
-      # in input/parser.cr). On a build that doesn't, both halves report '\n' — the pair
-      # never matches and this is inert rather than wrong.
+      # Depends on termisu reporting WHICH byte produced the Enter (`Event::Key#char`, set in
+      # input/parser.cr). On a build that doesn't, both halves report '\n' — the pair never
+      # matches and the rule is inert rather than wrong.
       def swallow?(ev : Termisu::Event::Any) : Bool
+        if ev.is_a?(Termisu::Event::Key)
+          key = ev.key
+          # A marker is not a keystroke, so it never reaches a view. The pair state is reset
+          # with it: whatever byte preceded the paste has nothing to do with the paste's first
+          # line break, and whatever ended the paste has nothing to do with the next keypress.
+          if key.paste_start?
+            @in_paste = true
+            @after_cr = false
+            return true
+          elsif key.paste_end?
+            @in_paste = false
+            @after_cr = false
+            return true
+          end
+        end
+
         if ev.is_a?(Termisu::Event::Key) && ev.key.enter? && !ev.ctrl? && !ev.alt?
           char = ev.char
           swallow = @after_cr && char == '\n'

--- a/src/gori/tui/repeater_view.cr
+++ b/src/gori/tui/repeater_view.cr
@@ -8,6 +8,7 @@ require "../env"
 require "./hex_view"
 require "./hex_edit"
 require "./text_area"
+require "./wrap"
 require "./gutter"
 require "./search_hi"
 require "./reveal"
@@ -85,8 +86,12 @@ module Gori::Tui
       @scx = 0             # SNI cursor
       @target_field = :url # which field the TARGET pane edits: :url | :sni
       @editor = TextArea.new
-      @editor.gutter = true       # line numbers in the request body (pairs with ^G)
-      @editor.follow_x = true     # long lines (headers, URLs, base64 params) scroll horizontally to keep the cursor visible
+      @editor.gutter = true # line numbers in the request body (pairs with ^G)
+      # Soft wrap, Burp-style: a long header / URL / minified body spills onto continuation
+      # rows instead of running off the right edge, and the line number stays on the first
+      # of them. Replaces the old ⇧←/→ horizontal scroll outright — a request pane you have
+      # to pan sideways to read is a request pane you misread.
+      @editor.wrap = true
       @editor.env_complete = true # `$KEY` autocomplete against the registered env vars (expanded on send)
       @editor.chain_peek = true   # tooltip revealing the concealed ¦chain of the §…§ marker under the caret
       @search_hl = ""             # active ^F query → highlight in the response pane (request is via @editor)
@@ -120,7 +125,24 @@ module Gori::Tui
       @focus = :request
       @resp_mode = :response # :response | :diff
       @scroll = 0
-      @xscroll = 0 # horizontal scroll offset shared by response/diff/reveal/transcript
+      # THE response-pane scroll anchor: the top drawn row is visual row @scroll_sub of
+      # logical row @scroll. Replaces the horizontal offset this pane used to carry —
+      # response, diff, reveal and transcript all soft-wrap now, so there is nothing off to
+      # the side to scroll to. A (row, sub-row) pair rather than a flat visual index for the
+      # reason spelled out in Wrap: a flat index can only be produced by wrapping the whole
+      # response, and a response is routinely multiple MB.
+      @scroll_sub = 0
+      @resp_wrap = {} of Int32 => Wrap::Layout # per-row wrap memo, keyed by the width below
+      @resp_wrap_w = -1
+      # Gutter + content width from the LAST render of whichever response pane is active.
+      # Hit-testing and the scroll walkers read these rather than re-deriving them, because
+      # the per-mode line counts the gutter is sized from are not all the same
+      # (`resp_line_count` has no group-transcript branch, for one) and the wrap memo is
+      # KEYED on the content width — a click that recomputed a different width would not
+      # merely land a column off, it would flush and rebuild the memo at a width the anchor
+      # was never laid out against.
+      @resp_last_gw = 0
+      @resp_last_cw = 0
       @loaded = false
       @http2 = false
       # WebSocket repeater mode (a 101 flow): the request editor holds the editable
@@ -163,7 +185,7 @@ module Gori::Tui
       @decode_kind = nil.as(Symbol?) # nil | :saml | :graphql
       @decoded = TextArea.new        # the payload editor (lower split)
       @decoded.gutter = true
-      @decoded.follow_x = true     # long decoded payload lines (SAML XML, GraphQL query) scroll horizontally
+      @decoded.wrap = true         # long decoded payload lines (SAML XML, GraphQL query) wrap, like the envelope
       @decoded.env_complete = true # env tokens re-encode into the request on send here too (WS messages, decoded payload)
       @req_pane = :envelope        # :envelope | :decoded — which split sub-pane is active
       @decoded_dirty = false       # the decoded payload was edited → re-encode on send
@@ -344,6 +366,11 @@ module Gori::Tui
     def exit_request_insert! : Nil
       @request_mode = InputMode::Read
       req_editor.env_complete_close # no dangling $ENV dropdown once we leave insert mode
+      # Drop the INS selection with the mode that owns it. Its band is only painted while
+      # `cursor` is on (INS), so leaving the anchor set hides it without clearing it — and
+      # `esc` then `i` brought a band back that the operator had visually dismissed, over a
+      # caret they had since moved.
+      req_editor.clear_selection
     end
 
     # --- $ENV autocomplete in the request editor (delegates to the active req editor) ---
@@ -534,7 +561,7 @@ module Gori::Tui
       @focus = :request
       @resp_mode = :response
       @scroll = 0
-      @xscroll = 0
+      resp_wrap_reset
       @diffable = true
       @loaded = true
       @dirty = false
@@ -575,7 +602,7 @@ module Gori::Tui
       @focus = :request
       @resp_mode = :response
       @scroll = 0
-      @xscroll = 0
+      resp_wrap_reset
       @diffable = false
       @loaded = true
       @dirty = false
@@ -814,7 +841,7 @@ module Gori::Tui
       @ws_result = result
       @ws_lines_cache = nil
       @scroll = 0
-      @xscroll = 0
+      resp_wrap_reset
       # Seed @result so the HTTP response tab can render the handshake response
       @result = Repeater::Result.new(result.handshake_head, Bytes.empty, nil, result.duration_us, result.error)
       reset_result_caches
@@ -872,7 +899,7 @@ module Gori::Tui
       @focus = :request
       @resp_mode = :response
       @scroll = 0
-      @xscroll = 0
+      resp_wrap_reset
       @diffable = false
       @loaded = true
       @dirty = false
@@ -936,7 +963,7 @@ module Gori::Tui
       @focus = :request
       @resp_mode = :response
       @scroll = 0
-      @xscroll = 0
+      resp_wrap_reset
       @diffable = false
       @loaded = true
       @dirty = false
@@ -1409,7 +1436,7 @@ module Gori::Tui
       @resp_hex = false
       @reveal = false
       @scroll = 0
-      @xscroll = 0
+      resp_wrap_reset
       @resp_cursor.reset
       @inflight = false
       @loaded = true
@@ -1459,7 +1486,7 @@ module Gori::Tui
       @focus = :target
       @resp_mode = :response
       @scroll = 0
-      @xscroll = 0
+      resp_wrap_reset
       @diffable = false
       @req_hex_edit = nil # a fresh load/restore replaces the request → drop any hex buffer
       @scroll_req = 0
@@ -1579,7 +1606,7 @@ module Gori::Tui
       @focus = :target
       @resp_mode = :response
       @scroll = 0
-      @xscroll = 0
+      resp_wrap_reset
       @diffable = false
       @loaded = true
       @dirty = false
@@ -1650,7 +1677,7 @@ module Gori::Tui
       @focus = :request
       @resp_mode = :response
       @scroll = 0
-      @xscroll = 0
+      resp_wrap_reset
       @loaded = true
       @dirty = true
       @inflight = false
@@ -2522,7 +2549,7 @@ module Gori::Tui
       # left untouched, keeping the user where they were.
       @resp_mode = :response unless @resp_mode == :diff && result.ok? && diff_baseline_lines
       @scroll = 0
-      @xscroll = 0
+      resp_wrap_reset
     end
 
     # --- request editor (focus == :request) ---
@@ -2582,7 +2609,12 @@ module Gori::Tui
       mark_req_edit if ed.edits != before # no-op at buffer start — see edit_undo
     end
 
-    def edit_move(dr : Int32, dc : Int32) : Nil
+    # `selecting` is the Shift half of ⇧←/→/↑/↓: it extends the INS-mode selection from its
+    # anchor instead of collapsing it. Defaulted false so every existing caller is a plain
+    # move. The pane-crossing branch below deliberately does NOT forward it — a selection
+    # that jumped from the ENVELOPE into the DECODED sub-pane would span two buffers, and
+    # neither `cut_selection` nor the band painter can express that.
+    def edit_move(dr : Int32, dc : Int32, selecting : Bool = false) : Nil
       return unless @focus == :request
       # In a split-decode tab, a vertical step off the end of one sub-pane crosses into
       # the other (↓ off the ENVELOPE bottom → DECODED top; ↑ off the DECODED top →
@@ -2600,7 +2632,7 @@ module Gori::Tui
           return
         end
       end
-      req_editor.move(dr, dc)
+      req_editor.move(dr, dc, selecting)
       # Cursor navigation is NOT a content edit: leave @dirty alone. Marking it here made
       # pure arrow-key movement persist the tab (V11) and, worse, latch sync-clobber
       # protection so a live cross-session update could no longer refresh the tab.
@@ -2688,7 +2720,7 @@ module Gori::Tui
       @editor.reveal = on
       @decoded.reveal = on # the decode split's payload editor honours reveal too
       @scroll = 0          # reveal renders the response from RAW bytes → a different line count; reset like pretty=/x/d
-      @xscroll = 0
+      resp_wrap_reset
     end
 
     # Pretty toggle feeds `resp_view`, so a change drops only the response-view cache
@@ -2699,7 +2731,7 @@ module Gori::Tui
       @pretty = on
       drop_resp_view_cache
       @scroll = 0 # reflow changes the line count → a stale offset could blank the pane (like x/d toggles)
-      @xscroll = 0
+      resp_wrap_reset
     end
 
     # ^F highlight, scoped to the searched pane (the Runner picks which).
@@ -2805,14 +2837,14 @@ module Gori::Tui
     def toggle_resp_mode : Nil
       @resp_mode = @resp_mode == :response ? :diff : :response
       @scroll = 0
-      @xscroll = 0
+      resp_wrap_reset
     end
 
     # 'x' toggles a raw hex dump of the response bytes (overrides response/diff).
     def toggle_resp_hex : Nil
       @resp_hex = !@resp_hex
       @scroll = 0 # row-based offset differs from the line-based one
-      @xscroll = 0
+      resp_wrap_reset
     end
 
     getter? resp_hex : Bool
@@ -2833,8 +2865,23 @@ module Gori::Tui
       @resp_hex_bytes = combine(result.head, result.body)
     end
 
+    # Scroll the response pane by `delta` DRAWN rows. In hex the pane draws its own fixed
+    # rows and there is nothing to wrap, so that mode keeps the plain row offset.
     def scroll(delta : Int32) : Nil
-      @scroll = (@scroll + delta).clamp(0, {resp_line_count - 1, 0}.max)
+      if @resp_hex || @resp_last_cw <= 0
+        @scroll = (@scroll + delta).clamp(0, {resp_line_count - 1, 0}.max)
+        @scroll_sub = 0 # the anchor line moved by whole lines; a carried sub-row would
+        return          # be read against a line that was never laid out at that row
+      end
+      size, line_at, _ = resp_drawn_source
+      return if size <= 0
+      fn = resp_layout_fn(@resp_last_cw, line_at)
+      @scroll = @scroll.clamp(0, size - 1)
+      @scroll, @scroll_sub = if delta < 0
+                               Wrap.step_back(@scroll, @scroll_sub, -delta, fn)
+                             else
+                               Wrap.step_forward(@scroll, @scroll_sub, delta, size, fn)
+                             end
     end
 
     # Response READ: move caret (and optional selection). Scroll follows the caret.
@@ -2847,22 +2894,66 @@ module Gori::Tui
       ensure_resp_visible(@resp_last_h) if @resp_last_h > 0
     end
 
+    # The INS half of the guard is gone: the wheel scrolls the request editor in insert
+    # mode exactly as it does in normal mode. There were TWO guards for this, one here and
+    # one in the controller's handle_wheel, so removing either alone changed nothing — they
+    # landed together in the replay→repeater migration rather than as a decision, and the
+    # neighbours disagree with them (Notes and the Decoder input scroll in insert mode with
+    # no mode guard at all).
+    #
+    # `scroll_view` moves the viewport and drags the caret only when the window would
+    # otherwise leave it behind — that is what NOR already uses, and mode consistency is the
+    # point. A pure detached viewport is not available here: `render` calls `ensure_visible`
+    # on EVERY frame, so a detached scroll would snap back on the next one.
+    #
+    # The hex half stays. `@req_hex_edit` is a different widget and the TextArea behind it
+    # holds stale bytes, so scrolling it would move a buffer the operator is not looking at.
     def request_scroll_view(step : Int32) : Nil
-      return if request_insert? || request_hex?
+      return if request_hex?
       req_editor.scroll_view(step)
     end
 
-    # Wheel: O(1) total from BodyLines offsets; materialise only the caret line for cx clamp.
+    # Wheel: `step` is DRAWN rows. Still O(viewport) — the anchor walk never counts the
+    # response's total rows (see @scroll_sub) and only the caret line is materialised.
     def resp_scroll_view(step : Int32) : Nil
       return unless resp_navigable?
-      size, line_at = resp_line_source
-      return if @resp_last_h <= 0 || size <= @resp_last_h
-      max = size - @resp_last_h
-      @scroll = (@scroll + step).clamp(0, max)
-      lo = @scroll
-      hi = {@scroll + @resp_last_h - 1, size - 1}.min
-      cy = @resp_cursor.cy.clamp(lo, hi)
-      @resp_cursor.sync(cy, @resp_cursor.cx.clamp(0, line_at.call(cy).size))
+      size, drawn_at, off = resp_drawn_source
+      _, line_at = resp_line_source
+      return if @resp_last_h <= 0 || size <= 0
+      cw = @resp_last_cw
+      if cw <= 0
+        return if size <= @resp_last_h
+        @scroll = (@scroll + step).clamp(0, size - @resp_last_h)
+        @scroll_sub = 0 # see `scroll`: no layout exists yet to carry a sub-row against
+      else
+        fn = resp_layout_fn(cw, drawn_at)
+        @scroll = @scroll.clamp(0, size - 1)
+        @scroll, @scroll_sub = if step < 0
+                                 Wrap.step_back(@scroll, @scroll_sub, -step, fn)
+                               else
+                                 Wrap.step_forward(@scroll, @scroll_sub, step, size, fn)
+                               end
+        mli, msub = Wrap.max_anchor(size, @resp_last_h, fn)
+        if @scroll > mli || (@scroll == mli && @scroll_sub > msub)
+          @scroll = mli
+          @scroll_sub = msub
+        end
+      end
+      # Pull the caret into the window, compared in VISUAL rows: a caret on the anchor LINE
+      # can still be several wrapped rows above the anchor ROW, and the line-only clamp let
+      # it sit there and drag the view straight back on the next ensure_resp_visible.
+      rows = resp_rows(cw, @resp_last_h, size, drawn_at)
+      return if rows.empty?
+      first = rows[0]
+      last = rows[rows.size - 1]
+      cy = @resp_cursor.cy
+      cx = @resp_cursor.cx + off # compare in the DRAWN line's coordinates (diff decoration)
+      if cy < first.li || (cy == first.li && cx < first.a)
+        cy, cx = first.li, first.a
+      elsif cy > last.li || (cy == last.li && cx > last.b)
+        cy, cx = last.li, last.a
+      end
+      @resp_cursor.sync(cy, {cx - off, 0}.max.clamp(0, line_at.call(cy).size))
     end
 
     def resp_click_to_cursor(rect : Rect, mx : Int32, my : Int32) : Nil
@@ -2874,9 +2965,26 @@ module Gori::Tui
       col = Rect.new(content.x + half + 1, content.y, {content.w - half - 1, 1}.max, content.h)
       return unless col.contains?(mx, my)
       body = response_body_rect(col)
-      gw = resp_gutter_w(body)
-      size, line_at = resp_line_source
-      @resp_cursor.click_to_cursor(body, mx, my, @scroll, size, line_at, gw, @xscroll)
+      # Render's own numbers, not a re-derivation — see @resp_last_gw. Falls back to the
+      # gutter estimate only before the first frame, when nothing has been laid out yet.
+      gw = @resp_last_cw > 0 ? @resp_last_gw : resp_gutter_w(body)
+      cw = @resp_last_cw > 0 ? @resp_last_cw : {body.w - gw, 0}.max
+      size, drawn_at, off = resp_drawn_source
+      _, line_at = resp_line_source
+      return if size <= 0
+      row = my - body.y
+      return if row < 0
+      rows = resp_rows(cw, body.h, size, drawn_at)
+      return if rows.empty?
+      # The wrap inverse, not `@scroll + row`: a screen row is a VISUAL row now, and the
+      # continuation rows between it and the anchor are exactly what the old arithmetic
+      # skipped. `Wrap.row_index` clamps to the row it was given, so a click past the end of
+      # a wrapped row stops at the break rather than selecting the next row's first char.
+      vr = rows[row]? || rows[rows.size - 1]
+      drawn = drawn_at.call(vr.li)
+      hit = Wrap.row_index(drawn, nil, vr.a, vr.b, mx - (body.x + gw))
+      @resp_cursor.clear_selection
+      @resp_cursor.sync(vr.li, {hit - off, 0}.max.clamp(0, line_at.call(vr.li).size))
       ensure_resp_visible(body.h)
     end
 
@@ -2906,8 +3014,16 @@ module Gori::Tui
       req_editor.lines_snapshot
     end
 
+    # The INS branch is the other half of `pane_selection?` — see the comment there for why
+    # the two must move together. `selection_text` is `String?` (nil when nothing is
+    # selected); the `||` keeps the NOR path's caret-line fallback rather than letting insert
+    # mode be the one place where a copy with no selection yields nothing.
     def request_copy_text : String
-      @req_read.copy_text(req_editor)
+      if pane_insert?(:request)
+        req_editor.selection_text || @req_read.copy_text(req_editor)
+      else
+        @req_read.copy_text(req_editor)
+      end
     end
 
     def request_copy_all_text : String
@@ -2989,7 +3105,14 @@ module Gori::Tui
 
     def pane_selection? : Bool
       case @focus
-      when :request  then !pane_insert?(:request) && @req_read.selection?
+      # Two selection models, one per mode, and they can never both be live: `@req_read` is
+      # the NOR band (its painter is called with `focused && !ins`), `req_editor` holds the
+      # INS one. Reporting only the NOR side made "Copy selection" absent in INS even with a
+      # visible ⇧-arrow band. Changed together with `request_copy_text` below — this predicate
+      # drives `Runner#read_selection_active?`, which gates BOTH the space-menu entry's title
+      # and `read_copy`, so claiming a selection here while copy still read `@req_read` would
+      # offer "Copy selection" and then copy the caret line.
+      when :request  then pane_insert?(:request) ? req_editor.selection? : @req_read.selection?
       when :response then @resp_cursor.selection?
       when :target   then !pane_insert?(:target) && @target_read.selection?
       else                false
@@ -3036,22 +3159,104 @@ module Gori::Tui
       end
     end
 
+    # Keep the caret's VISUAL row inside the pane. Line-indexed scrolling drifts the moment
+    # anything wraps — the caret can be on the anchor line and still be a dozen drawn rows
+    # off-screen — so the comparison and the re-anchor both happen in rows (Wrap).
+    # Falls back to the line-based arithmetic before the first render, when no width is
+    # known yet and nothing has been laid out to disagree with.
     private def ensure_resp_visible(view_h : Int32) : Nil
       return if view_h <= 0
       cy = @resp_cursor.cy
-      if cy < @scroll
-        @scroll = cy
-      elsif cy >= @scroll + view_h
-        @scroll = cy - view_h + 1
+      cw = @resp_last_cw
+      size, line_at, off = resp_drawn_source
+      if cw <= 0 || size <= 0
+        if cy < @scroll
+          @scroll = cy
+        elsif cy >= @scroll + view_h
+          @scroll = cy - view_h + 1
+        end
+        @scroll = 0 if @scroll < 0
+        return
       end
+      @scroll = @scroll.clamp(0, size - 1)
+      fn = resp_layout_fn(cw, line_at)
+      csub = fn.call(cy).row_of(@resp_cursor.cx + off)
+      @scroll, @scroll_sub = Wrap.ensure_visible(@scroll, @scroll_sub, cy, csub, view_h, fn)
     end
 
-    # Horizontal companion to `scroll` (shift+←/→): nudges the response/diff/reveal/
-    # transcript pane sideways. Floored at 0 here; the render loop clamps the upper
-    # bound to the widest row actually on screen, so it can't scroll past content.
-    def hscroll(delta : Int32) : Nil
-      @xscroll = {@xscroll + delta * 4, 0}.max
+    # --- response soft wrap ----------------------------------------------------
+
+    # Ceiling on the response wrap memo — see TextArea::WRAP_CACHE_CAP, same reasoning.
+    RESP_WRAP_CACHE_CAP = 512
+
+    # Drop the wrap memo and put the anchor back on a first row. Called from every site that
+    # swaps what the pane is showing (a new result, a mode toggle, reveal/pretty, a fresh
+    # load) — the same sites that used to zero the horizontal offset, which is not a
+    # coincidence: those are exactly the moments the old layout stops describing the pane.
+    private def resp_wrap_reset : Nil
+      @scroll_sub = 0
+      @resp_wrap.clear
     end
+
+    # Publish the geometry the active response pane just drew with, so hit-testing and the
+    # scroll walkers key the wrap memo on exactly the width the rows were laid out at.
+    private def resp_record_metrics(gw : Int32, cw : Int32) : Nil
+      @resp_last_gw = gw
+      @resp_last_cw = cw
+    end
+
+    private def resp_layout(li : Int32, cw : Int32, line_at : Int32 -> String) : Wrap::Layout
+      if @resp_wrap_w != cw
+        @resp_wrap.clear
+        @resp_wrap_w = cw
+      end
+      if hit = @resp_wrap[li]?
+        return hit
+      end
+      @resp_wrap.clear if @resp_wrap.size >= RESP_WRAP_CACHE_CAP
+      @resp_wrap[li] = Wrap.layout(line_at.call(li), cw)
+    end
+
+    private def resp_layout_fn(cw : Int32, line_at : Int32 -> String) : Int32 -> Wrap::Layout
+      ->(i : Int32) { resp_layout(i, cw, line_at) }
+    end
+
+    # The response pane's drawn rows for an `h`-row viewport at content width `cw`.
+    private def resp_rows(cw : Int32, h : Int32, size : Int32, line_at : Int32 -> String) : Array(Wrap::Row)
+      return [] of Wrap::Row if size <= 0 || h <= 0 || cw <= 0
+      @scroll = @scroll.clamp(0, size - 1)
+      Wrap.rows(@scroll, @scroll_sub, h, size, resp_layout_fn(cw, line_at))
+    end
+
+    # What the pane actually DRAWS per row, which is what the wrap has to be computed on.
+    # Identical to `resp_line_source` in every mode but DIFF, where each row is prefixed
+    # with a 2-column "+ "/"- " decoration: those columns shift every break, so wrapping the
+    # bare text there would put the anchor, the click inverse and the draw on three
+    # different grids. The third element is that decoration's width, the single constant
+    # that converts between the two coordinate systems (see `render_diff`).
+    private def resp_drawn_source : {Int32, Proc(Int32, String), Int32}
+      if transcript_rows?.nil? && !@reveal && @resp_mode == :diff
+        data = diff_lines
+        return {data.size, ->(i : Int32) do
+          d = data[i]
+          prefix = case d.kind
+                   when .add? then '+'
+                   when .del? then '-'
+                   else            ' '
+                   end
+          "#{prefix} #{d.text}"
+        end, DIFF_PREFIX_COLS}
+      end
+      size, line_at = resp_line_source
+      {size, line_at, 0}
+    end
+
+    # ⇧←/→ used to nudge the response/diff/reveal/transcript pane sideways. There is no
+    # sideways any more: every one of those panes soft-wraps, so the content the operator
+    # was panning to is already on the next row. Kept as an explicit no-op ONLY because the
+    # chord is still bound in `controllers/repeater_controller.cr` — deleting the method
+    # breaks that build, and that file is not in this change's scope. The binding and this
+    # stub should go together.
 
     # ^G go-to-line in the response pane: scroll so 1-based line `n` is at the top
     # (interpreted in the currently-shown mode — response/diff/hex row). Hex mode has
@@ -3065,6 +3270,7 @@ module Gori::Tui
         cy = (n - 1).clamp(0, size - 1)
         @resp_cursor.sync(cy, 0)
         @scroll = cy
+        @scroll_sub = 0 # ^G names a LOGICAL line, so land on its first visual row
       else
         @scroll = (n - 1).clamp(0, {resp_line_count - 1, 0}.max)
       end
@@ -3342,6 +3548,12 @@ module Gori::Tui
       paint_request_read_chrome(screen, inner, focused && !ins)
     end
 
+    # READ-mode over-paint (selection tint + block caret) on top of the frame the editor
+    # just drew. It inverts `TextArea#last_rows` — the rows that were ACTUALLY laid down —
+    # rather than re-deriving `line - scroll`: under soft wrap a screen row is no longer a
+    # logical line, and the two derivations drifting apart is precisely how a selection ends
+    # up tinting the wrong text. Every span is clipped to its row, so a selection crossing a
+    # wrap break is painted on each row it covers.
     private def paint_request_read_chrome(screen : Screen, rect : Rect, active : Bool) : Nil
       return unless active
       ed = req_editor
@@ -3349,37 +3561,48 @@ module Gori::Tui
       return if lines.empty?
       @req_read.sync_from(ed)
       sel_bg = Theme.accent_bg
-      scr = ed.scroll
-      @req_read.cursor.highlight_spans(lines).each do |(li, x0, x1)|
-        next unless li >= scr && li < scr + rect.h
-        row = li - scr
-        gw = ed.gutter? ? Gutter.width(lines.size) : 0
-        paint_char_span_bg(screen, rect.x + gw, rect.y + row, lines[li], x0, x1, sel_bg)
-      end
-      cy, cx = ed.cy, ed.cx
-      return unless cy >= scr && cy < scr + rect.h
-      row = cy - scr
+      rows = ed.last_rows
+      return if rows.empty?
       gw = ed.gutter? ? Gutter.width(lines.size) : 0
-      line = lines[cy]
-      px = rect.x + gw + Screen.draw_width(line[0, cx])
-      if px < rect.x + rect.w
+      spans = @req_read.cursor.highlight_spans(lines)
+      cy, cx = ed.cy, ed.cx
+      rows.each_with_index do |vr, row|
+        y = rect.y + row
+        line = lines[vr.li]? || ""
+        spans.each do |(li, x0, x1)|
+          next unless li == vr.li
+          a = {x0, vr.a}.max
+          b = {x1, vr.b}.min
+          next if a >= b
+          paint_char_span_bg(screen, rect.x + gw, y, line, a, b, sel_bg, vr.a)
+        end
+        # The caret belongs to exactly one row: the one whose slice contains it, with the
+        # end of a wrapped row losing to the row it starts (Wrap::Layout#row_of's rule,
+        # spelled out here because ReadCursor holds no layout of its own).
+        next unless vr.li == cy && cx >= vr.a && (cx < vr.b || vr.b >= line.size)
+        px = rect.x + gw + Wrap.row_col(line, nil, vr.a, cx)
+        next unless px < rect.x + rect.w
         ch = cx < line.size ? line[cx] : ' '
-        screen.cell(px, rect.y + row, ch, Theme.bg, Theme.accent_bg)
-        screen.cursor(px, rect.y + row)
+        screen.cell(px, y, ch, Theme.bg, Theme.accent_bg)
+        screen.cursor(px, y)
       end
     end
 
+    # `row_start` is the char index the drawn row begins at — 0 for an unwrapped line, the
+    # wrap break for a continuation row. Columns are measured from THERE, so a tint on a
+    # continuation row starts at the pane's left edge like the text it covers.
     private def paint_char_span_bg(screen : Screen, x : Int32, y : Int32, line : String,
-                                   x0 : Int32, x1 : Int32, bg : Color) : Nil
+                                   x0 : Int32, x1 : Int32, bg : Color, row_start : Int32 = 0) : Nil
       return if x0 >= x1
       # Cluster-wise, matching the base draw and the caret. Summing draw_width over single
       # CHARS is exactly the retired per-codepoint measure: it drifts right by each
       # cluster's inflation (1 column for a skin tone, 9 for a ZWJ family), and drawing
       # char-by-char also SHREDS a cluster across cells, stranding a bare combining mark in
       # one of its own. Span edges snap outward so the tint covers whole glyphs.
-      a = Screen.cluster_start(line, {x0, line.size}.min)
+      a = {Screen.cluster_start(line, {x0, line.size}.min), row_start}.max
       b = Screen.cluster_end(line, {x1, line.size}.min)
-      px = x + Screen.draw_width(line[0, a])
+      return if a >= b
+      px = x + Wrap.row_col(line, nil, row_start, a)
       i = a
       while i < b
         e = Screen.cluster_end(line, i + 1)
@@ -3441,10 +3664,22 @@ module Gori::Tui
       total = rv.total
       gw = Settings.show_gutter ? {Gutter.width(total), body.w}.min : 0
       cw = {body.w - gw, 0}.max
-      rows = (0...body.h).compact_map { |i| i < total ? styled_resp_line(rv, i) : nil }
-      rows.each_with_index do |styled, i|
-        Gutter.draw(screen, body.x, body.y + i, i, gw) if gw > 0
-        shown = @xscroll > 0 ? Highlight.slice_left(styled, @xscroll) : styled
+      return if cw <= 0
+      # This card is always pinned to the top of the handshake response and has its own
+      # tiny window, so it wraps from row 0 with a local layout rather than sharing the
+      # transcript's anchor + memo (different line source, ≤7 rows to lay out).
+      rows = Wrap.rows(0, 0, body.h, total, ->(i : Int32) { Wrap.layout(rv.line_text(i), cw) })
+      rows.each_with_index do |vr, i|
+        if gw > 0
+          if vr.sub == 0
+            Gutter.draw(screen, body.x, body.y + i, vr.li, gw)
+          else
+            screen.text(body.x, body.y + i, " " * {gw - 1, 0}.max, Theme.muted, width: gw)
+          end
+        end
+        # slice_chars is the identity for a row that IS the whole line, so an unwrapped
+        # handshake header costs nothing extra.
+        shown = Highlight.slice_chars(styled_resp_line(rv, vr.li), vr.a, vr.b)
         Highlight.draw(screen, body.x + gw, body.y + i, shown, width: cw)
       end
     end
@@ -3500,24 +3735,17 @@ module Gori::Tui
       end
       gw = Settings.show_gutter ? {Gutter.width(lines.size), body.w}.min : 0
       cw = {body.w - gw, 0}.max
-      # draw_width, not display_width: the rows are drawn with `screen.text` (below), which
-      # advances ≥1 per grapheme, so a control byte inside a WS text frame owns a cell the
-      # raw measure scores 0 — the clamp then stopped short of the real content. Switching
-      # to the _upto variant also gives this site the early exit its siblings have: it runs
-      # every frame, and one WS frame can carry a multi-MB single-line payload.
-      widest = (0...body.h).compact_map { |i| lines[@scroll + i]? }.max_of? { |(t, _)| Screen.draw_width_upto(t, @xscroll + cw + 1) } || 0
-      @xscroll = @xscroll.clamp(0, {widest - cw, 0}.max)
       @resp_last_h = body.h
+      resp_record_metrics(gw, cw)
+      return if cw <= 0
       sel_spans = resp_sel_spans_if(focused)
-      (0...body.h).each do |i|
-        li = @scroll + i
-        break if li >= lines.size
-        text, color = lines[li]
-        Gutter.draw(screen, body.x, body.y + i, li, gw, current: focused && li == @resp_cursor.cy) if gw > 0
-        shown = @xscroll > 0 ? Highlight.slice_left_text(text, @xscroll) : text
-        screen.text(body.x + gw, body.y + i, shown, color, width: cw)
-        paint_resp_line_chrome(screen, body.x + gw, body.y + i, li, text, focused, sel_spans)
-        SearchHi.mark(screen, body.x + gw, body.y + i, shown, @search_hl, body.x + gw + cw) unless @search_hl.empty?
+      resp_rows(cw, body.h, lines.size, ->(i : Int32) { lines[i][0] }).each_with_index do |vr, i|
+        text, color = lines[vr.li]
+        y = body.y + i
+        draw_resp_gutter(screen, body.x, y, gw, vr, focused)
+        screen.text(body.x + gw, y, text[vr.a...vr.b], color, width: cw)
+        paint_resp_line_chrome(screen, body.x + gw, y, vr.li, text, focused, sel_spans, vr.a, vr.b)
+        Wrap.mark_search(screen, body.x + gw, y, text, vr.a, vr.b, @search_hl, body.x + gw + cw) unless @search_hl.empty?
       end
       Frame.scroll_gauge(screen, body, lines.size, @scroll, focused)
     end
@@ -3699,25 +3927,22 @@ module Gori::Tui
       @resp_last_h = rect.h
       gw = Settings.show_gutter ? {Gutter.width(total), rect.w}.min : 0
       cw = {rect.w - gw, 0}.max
-      # draw_width, not display_width: the rows below are drawn through Reveal.styled, which
-      # maps EVERY control char to a 1-column marker (tab → '→', CR → '␍'). display_width
-      # calls a tab 0 columns, so the clamp under-counted by one per tab and pinned @xscroll
-      # short of the content — on a tab-indented body it pinned it at 0 outright, leaving the
-      # tail of the line permanently unreachable on the very surface built to inspect tabs.
-      # _upto keeps the early exit: this runs every frame and a minified line can be MBs.
-      widest = (0...rect.h).compact_map { |i| lines[@scroll + i]? }.max_of? { |l| Screen.draw_width_upto(l, @xscroll + cw + 1) } || 0
-      @xscroll = @xscroll.clamp(0, {widest - cw, 0}.max)
+      resp_record_metrics(gw, cw)
+      return if cw <= 0
       sel_spans = resp_sel_spans_if(focused)
-      (0...rect.h).each do |i|
-        li = @scroll + i
-        break if li >= total
-        Gutter.draw(screen, rect.x, rect.y + i, li, gw, current: focused && li == @resp_cursor.cy) if gw > 0
-        styled = Reveal.styled(lines[li], li < total - 1, cw + @xscroll)
-        styled = Highlight.slice_left(styled, @xscroll) if @xscroll > 0
-        Highlight.draw(screen, rect.x + gw, rect.y + i, styled, width: cw)
-        paint_resp_line_chrome(screen, rect.x + gw, rect.y + i, li, lines[li], focused, sel_spans)
-        st = @xscroll > 0 ? Highlight.slice_left_text(lines[li], @xscroll) : lines[li]
-        SearchHi.mark(screen, rect.x + gw, rect.y + i, st, @search_hl, rect.x + gw + cw) unless @search_hl.empty?
+      # Reveal substitutes a 1-column marker for every control char (tab → '→', CR → '␍'),
+      # which is exactly what `Screen.grapheme_cols` already scores them, so the wrap of the
+      # RAW line and the wrap of the revealed line are the same break — no second layout.
+      resp_rows(cw, rect.h, total, ->(i : Int32) { lines[i] }).each_with_index do |vr, i|
+        y = rect.y + i
+        line = lines[vr.li]
+        draw_resp_gutter(screen, rect.x, y, gw, vr, focused)
+        # `last` only on the row that actually ends the line — the ␊ marker belongs at the
+        # true end of the line, not at every wrap break inside it.
+        eol = vr.b >= line.size && vr.li < total - 1
+        Highlight.draw(screen, rect.x + gw, y, Reveal.styled(line[vr.a...vr.b], eol, cw), width: cw)
+        paint_resp_line_chrome(screen, rect.x + gw, y, vr.li, line, focused, sel_spans, vr.a, vr.b)
+        Wrap.mark_search(screen, rect.x + gw, y, line, vr.a, vr.b, @search_hl, rect.x + gw + cw) unless @search_hl.empty?
       end
     end
 
@@ -3755,35 +3980,61 @@ module Gori::Tui
       @resp_last_h = rect.h
       gw = Settings.show_gutter ? {Gutter.width(total), rect.w}.min : 0
       cw = {rect.w - gw, 0}.max
-      rows = (0...rect.h).compact_map { |i| (li = @scroll + i) < total ? styled_resp_line(rv, li) : nil }
-      @xscroll = @xscroll.clamp(0, {(rows.max_of? { |l| Highlight.line_width_upto(l, @xscroll + cw + 1) } || 0) - cw, 0}.max)
+      resp_record_metrics(gw, cw)
+      return if cw <= 0
       sel_spans = resp_sel_spans_if(focused)
-      rows.each_with_index do |styled, i|
-        li = @scroll + i
+      # The wrap is computed on the PLAIN text (`line_text`) and the styled overlay is then
+      # sliced to the same char range — Highlight is a 1:1 colour overlay, so one layout
+      # describes both and the colours cannot land a column off the glyphs.
+      resp_rows(cw, rect.h, total, ->(i : Int32) { rv.line_text(i) }).each_with_index do |vr, i|
+        li = vr.li
+        y = rect.y + i
         need_plain = (focused && resp_navigable? && (li == @resp_cursor.cy || sel_spans)) || !@search_hl.empty?
         text = need_plain ? rv.line_text(li) : nil
-        Gutter.draw(screen, rect.x, rect.y + i, li, gw, current: focused && li == @resp_cursor.cy) if gw > 0
-        shown = @xscroll > 0 ? Highlight.slice_left(styled, @xscroll) : styled
-        Highlight.draw(screen, rect.x + gw, rect.y + i, shown, width: cw)
-        paint_resp_line_chrome(screen, rect.x + gw, rect.y + i, li, text, focused, sel_spans) if text
+        draw_resp_gutter(screen, rect.x, y, gw, vr, focused)
+        shown = Highlight.slice_chars(styled_resp_line(rv, li), vr.a, vr.b)
+        Highlight.draw(screen, rect.x + gw, y, shown, width: cw)
+        paint_resp_line_chrome(screen, rect.x + gw, y, li, text, focused, sel_spans, vr.a, vr.b) if text
         if (t = text) && !@search_hl.empty?
-          st = @xscroll > 0 ? Highlight.slice_left_text(t, @xscroll) : t
-          SearchHi.mark(screen, rect.x + gw, rect.y + i, st, @search_hl, rect.x + gw + cw)
+          Wrap.mark_search(screen, rect.x + gw, y, t, vr.a, vr.b, @search_hl, rect.x + gw + cw)
         end
       end
     end
 
+    # Response-pane gutter: the row number rides the FIRST visual row of a logical row only
+    # (Burp style); a continuation gets a blank of the same width so the text column stays
+    # put and no stale digits survive there.
+    private def draw_resp_gutter(screen : Screen, x : Int32, y : Int32, gw : Int32,
+                                 vr : Wrap::Row, focused : Bool) : Nil
+      return if gw <= 0
+      if vr.sub == 0
+        Gutter.draw(screen, x, y, vr.li, gw, current: focused && vr.li == @resp_cursor.cy)
+      else
+        screen.text(x, y, " " * {gw - 1, 0}.max, Theme.muted, width: gw)
+      end
+    end
+
+    # Selection tint + block caret for ONE drawn row. `rs`/`re` bound the row's slice of the
+    # line (the whole line when nothing wrapped), so a selection spanning a wrap break is
+    # painted on each row it covers and the caret paints on exactly one of them — the row
+    # that STARTS at its column, matching Wrap::Layout#row_of.
     private def paint_resp_line_chrome(screen : Screen, x : Int32, y : Int32, li : Int32, line : String,
-                                       focused : Bool, sel_spans : Array({Int32, Int32, Int32})? = nil) : Nil
+                                       focused : Bool, sel_spans : Array({Int32, Int32, Int32})? = nil,
+                                       rs : Int32 = 0, re : Int32 = -1) : Nil
       return unless focused && resp_navigable?
+      re = line.size if re < 0
       if spans = sel_spans
         spans.each do |(l, x0, x1)|
-          paint_char_span_bg(screen, x, y, line, x0, x1, Theme.accent_bg) if l == li
+          next unless l == li
+          a = {x0, rs}.max
+          b = {x1, re}.min
+          paint_char_span_bg(screen, x, y, line, a, b, Theme.accent_bg, rs) if a < b
         end
       end
       return unless li == @resp_cursor.cy
       cx = @resp_cursor.cx.clamp(0, line.size)
-      px = x + Screen.draw_width(line[0, cx])
+      return unless cx >= rs && (cx < re || re >= line.size)
+      px = x + Wrap.row_col(line, nil, rs, cx)
       ch = cx < line.size ? line[cx] : ' '
       screen.cell(px, y, ch, Theme.bg, Theme.accent_bg)
       screen.cursor(px, y)
@@ -3796,39 +4047,45 @@ module Gori::Tui
       @resp_cursor.highlight_spans(size, line_at)
     end
 
+    # The diff pane draws a 2-column "+ "/"- " decoration in front of each line, so the
+    # wrapped row is a slice of `full` (decoration + text) while the caret, selection and
+    # search all address `text`. The two coordinate systems differ by exactly 2 characters
+    # of width 1 each — that constant is the ONLY place they are reconciled, here.
+    DIFF_PREFIX_COLS = 2
+
     private def render_diff(screen : Screen, rect : Rect, focused : Bool) : Nil
       data = diff_lines
       gw = Settings.show_gutter ? {Gutter.width(data.size), rect.w}.min : 0
       cw = {rect.w - gw, 0}.max
-      rows = (0...rect.h).compact_map do |i|
-        di = @scroll + i
-        next nil if di >= data.size
-        d = data[di]
-        prefix, color = case d.kind
-                        when .add? then {'+', Theme.green}
-                        when .del? then {'-', Theme.red}
-                        else            {' ', Theme.muted}
-                        end
-        {di, "#{prefix} #{d.text}", color, d.text}
-      end
-      # draw_width, not display_width — `full` (the "+ "/"- " prefix plus the diff line) is
-      # drawn by `screen.text` below, so a control char in either side of the diff holds a
-      # cell the raw measure scores 0 and the clamp cut the line short. _upto for the early
-      # exit, as everywhere else this clamp shape appears: it runs every frame.
-      @xscroll = @xscroll.clamp(0, {(rows.max_of? { |(_, full, _, _)| Screen.draw_width_upto(full, @xscroll + cw + 1) } || 0) - cw, 0}.max)
       @resp_last_h = rect.h
+      resp_record_metrics(gw, cw)
+      return if cw <= 0
       sel_spans = resp_sel_spans_if(focused)
-      rows.each_with_index do |(di, full, color, text), i|
-        Gutter.draw(screen, rect.x, rect.y + i, di, gw, current: focused && di == @resp_cursor.cy) if gw > 0
-        shown = @xscroll > 0 ? Highlight.slice_left_text(full, @xscroll) : full
-        screen.text(rect.x + gw, rect.y + i, shown, color, width: cw)
-        paint_resp_line_chrome(screen, rect.x + gw + 2, rect.y + i, di, text, focused, sel_spans)
-        # Highlight only the line text (past the 2-col "+ "/"- " prefix, shifted left by
-        # any horizontal scroll), so the marks match what response_search_lines counts
-        # (d.text), not the diff decoration.
-        mark_x = rect.x + gw + {2 - @xscroll, 0}.max
-        st = @xscroll > 2 ? Highlight.slice_left_text(text, @xscroll - 2) : text
-        SearchHi.mark(screen, mark_x, rect.y + i, st, @search_hl, rect.x + gw + cw) unless @search_hl.empty?
+      # The pane scrolls in rows of the DECORATED line, so that is what the anchor, the wrap
+      # memo and the click inverse all index — `resp_line_source` hands out the bare text,
+      # which is 2 columns narrower and would wrap at different offsets. `resp_drawn_source`
+      # is the single definition of that; using it here keeps render and hit-testing on one
+      # grid instead of two that agree until a line is exactly pane-wide.
+      _, decorated, _ = resp_drawn_source
+      resp_rows(cw, rect.h, data.size, decorated).each_with_index do |vr, i|
+        d = data[vr.li]
+        y = rect.y + i
+        color = case d.kind
+                when .add? then Theme.green
+                when .del? then Theme.red
+                else            Theme.muted
+                end
+        draw_resp_gutter(screen, rect.x, y, gw, vr, focused)
+        screen.text(rect.x + gw, y, decorated.call(vr.li)[vr.a...vr.b], color, width: cw)
+        # Re-base the row onto `text`: on the first row the text starts DIFF_PREFIX_COLS in,
+        # on a continuation it starts at the pane edge.
+        tx = rect.x + gw + {DIFF_PREFIX_COLS - vr.a, 0}.max
+        ts = {vr.a - DIFF_PREFIX_COLS, 0}.max
+        te = {vr.b - DIFF_PREFIX_COLS, 0}.max
+        paint_resp_line_chrome(screen, tx, y, vr.li, d.text, focused, sel_spans, ts, te)
+        # Mark only the line text, so the highlights match what response_search_lines
+        # counts (d.text) rather than the diff decoration.
+        Wrap.mark_search(screen, tx, y, d.text, ts, te, @search_hl, rect.x + gw + cw) unless @search_hl.empty?
       end
     end
 
@@ -3878,6 +4135,7 @@ module Gori::Tui
     # Memoized + dropped only when a new result is applied (reset_result_caches), so
     # a held Repeater tab isn't re-parsed / re-highlighted / re-diffed 20×/sec.
     private def reset_result_caches : Nil
+      resp_wrap_reset # the wrap memo describes the OLD rows; a new result replaces them
       drop_resp_view_cache
       @diff_lines_cache = nil
       @resp_hex_bytes = nil

--- a/src/gori/tui/text_area.cr
+++ b/src/gori/tui/text_area.cr
@@ -2,9 +2,11 @@ require "./screen"
 require "./theme"
 require "./frame"
 require "./highlight"
+require "./wrap"
 require "../env"
 require "../settings"
 require "./gutter"
+require "./read_cursor"
 require "./search_hi"
 require "./reveal"
 require "./env_complete"
@@ -29,6 +31,15 @@ module Gori::Tui
     # knows where the head ends — a break typed into a BODY is a body byte and must stay one.
     DEFAULT_EOL = "\n"
 
+    # One DRAWN row — see `Wrap::Row`. Aliased rather than redeclared so this editor and
+    # the Repeater's response pane cannot grow two slightly different ideas of a row.
+    alias VRow = Wrap::Row
+
+    # Ceiling on the per-line wrap memo. A visible window is tens of rows, so this covers
+    # many screens of local scroll while capping memory; on overflow the whole memo is
+    # dropped and the next frame re-wraps just the visible window (cheap — see `layout_of`).
+    WRAP_CACHE_CAP = 512
+
     def initialize(text : String = "")
       @lines = [""]
       @eols = [""]
@@ -37,7 +48,29 @@ module Gori::Tui
       @scroll = 0
       @xscroll = 0      # leftmost visible display COLUMN (horizontal scroll); only moves when @follow_x is on
       @last_h = 0       # viewport height from the last render — lets scroll_view (wheel) clamp
+      @last_cw = 0      # content width from the last render — the wrap mappings outside render need it
       @follow_x = false # follow the cursor horizontally (long lines scroll into view); off ⇒ legacy right-clip
+      # --- soft wrap (opt-in; see `wrap=`) -------------------------------------
+      # Off by default, so every editor that does NOT ask for it keeps @xscroll/@follow_x
+      # and renders byte-for-byte as before. On, a logical line spills onto as many visual
+      # rows as it needs and @xscroll is pinned at 0 — the two are mutually exclusive by
+      # construction, not by convention.
+      @wrap = false
+      # THE scroll anchor when wrapping: the top visible row is row @scroll_sub of logical
+      # line @scroll. A (line, sub-row) pair IS a visual-row coordinate — it is Vim's
+      # topline+skipcol and VS Code's line-map — and it is deliberately not a FLAT visual
+      # row index, because a flat index can only be produced by wrapping every line from the
+      # top of the buffer. That is an O(whole document) pass on every width change and every
+      # edit, over bodies that reach multiple MB; with the anchor, scrolling, ensure_visible
+      # and hit-testing are all O(viewport height). Always 0 when @wrap is off, so @scroll
+      # keeps its old meaning for the seven owners that read it.
+      @scroll_sub = 0
+      @wrap_cache = {} of Int32 => Wrap::Layout
+      @wrap_rev = -1 # @edits the memo was built for
+      @wrap_w = -1   # content width the memo was built for
+      @line_offs = [] of Int32
+      @line_off_rev = -1
+      @last_rows = [] of VRow
       @preedit = ""
       # Cached syntax-highlight overlay (1:1 with @lines), rebuilt only when the
       # buffer content changes — not on every render frame. @styled_kind tracks
@@ -64,6 +97,21 @@ module Gori::Tui
       # the ^Y overlay). All column math (caret, click, h-scroll, marker band) is remapped
       # to the concealed line; when empty the widget is byte-for-byte unchanged.
       @conceal_spans = [] of {Int32, Int32}
+      # The FIXED end of an INSERT-mode selection ({cy, cx}), or nil when nothing is
+      # selected; the moving end is the caret itself, so there is exactly one copy of each
+      # coordinate. nil for every editor that never calls `move(..., selecting: true)`, and
+      # every path this adds is one nil check behind that — an editor without a selection
+      # renders and edits byte-for-byte as before.
+      #
+      # This layer, not the owner's `ReadCursor`, is where an INS selection belongs, for
+      # three reasons that all point the same way: deleting or replacing one is a BUFFER
+      # mutation and undo/@edits/@styled/@conceal live here; painting one needs the wrap
+      # layout (`layout_of`, `Wrap.row_col`), which only this file has; and the READ-mode
+      # over-painter that draws the NOR selection is called with `focused && !insert`, so in
+      # INS nothing outside this editor paints at all. The read-mode model stays exactly
+      # where it is — the two never coexist (see `render`, which draws this one only when
+      # the block caret is on, i.e. only in INS).
+      @sel_anchor = nil.as({Int32, Int32}?)
       @undo_stack = [] of UndoState
       # Opt-in `$ENV` autocomplete popup (nil = disabled). Enabled only on the outbound
       # request editors (Repeater request, Fuzzer template) where env tokens are expanded on
@@ -85,15 +133,47 @@ module Gori::Tui
     setter search_hl : String
     setter reveal : Bool
     setter bg_regions : Array({Int32, Int32, Color})
-    setter conceal_spans : Array({Int32, Int32})
     # Enable horizontal cursor-following (the Project description); off everywhere
     # else, so those editors keep @xscroll == 0 and their hot render path unchanged.
+    # Ignored while @wrap is on — a wrapped line has nothing off to the side.
     setter follow_x : Bool
     getter edits : Int32
     getter cy : Int32
     getter cx : Int32
     getter scroll : Int32
     getter? gutter : Bool
+    getter? wrap : Bool
+    # The rows this editor drew on its LAST frame, in screen order (index == row offset
+    # from `rect.y`). Published so an owner that over-paints on top of the editor — the
+    # Repeater's READ-mode selection tint and caret — inverts exactly the layout that was
+    # drawn instead of re-deriving it and drifting. Empty before the first render.
+    getter last_rows : Array(VRow)
+
+    # Turn soft wrap on for THIS editor. Long lines spill onto continuation rows instead of
+    # being clipped (or side-scrolled) at the right edge; the line number stays on the first
+    # visual row only. Enabled for the Repeater request/decoded editors, where the whole
+    # point of the pane is that a long header or a minified body is readable at a glance;
+    # every other editor leaves it off and is unaffected.
+    #
+    # Turning it on pins @xscroll at 0 for good: with wrap there is nothing to the side of
+    # the viewport, and leaving a stale offset behind would shift every row left by it.
+    def wrap=(on : Bool) : Nil
+      return if @wrap == on
+      @wrap = on
+      @xscroll = 0
+      @scroll_sub = 0
+      @wrap_cache.clear
+    end
+
+    # Conceal ranges arrive fresh from the owner every frame and are derived from the
+    # buffer, but NOT always via an edit: toggling ^K (markers live ⇄ inert) swaps them
+    # wholesale without touching @edits. The wrap memo is keyed on @edits, so it has to be
+    # dropped here too — a stale layout would keep reserving cells for a chain that is no
+    # longer hidden (or hiding one that is).
+    def conceal_spans=(spans : Array({Int32, Int32})) : Nil
+      @wrap_cache.clear if @wrap && spans != @conceal_spans
+      @conceal_spans = spans
+    end
 
     # The exact LF form `set_text` would store for `text` — the single source of truth for
     # "does this incoming string already match what the buffer holds?" **as a document**.
@@ -144,10 +224,12 @@ module Gori::Tui
       @cy = 0
       @cx = 0
       @scroll = 0
+      @scroll_sub = 0
       @xscroll = 0
       @preedit = ""
       @styled = nil
       @edits += 1
+      @sel_anchor = nil # the anchor indexes the OLD buffer — it names nothing in this one
       @undo_stack.clear
       # Drop stale conceal offsets — they index the OLD buffer; the owner re-feeds fresh
       # ones next render. Guards any move/place between now and that render.
@@ -254,6 +336,17 @@ module Gori::Tui
 
     def insert(ch : Char) : Nil
       push_undo
+      # Replace-on-type: a printable typed over a selection REPLACES it. The cut runs after
+      # push_undo and before the splice, so the pair is ONE undo step — ⌃Z brings back both
+      # the deleted run and the character that displaced it, which is what "replace" means.
+      #
+      # One caveat, and it is the owner's to close, not this file's: `RepeaterView#edit_insert`
+      # asks `Fuzz::Template.insert_breaks_marker?` about the caret BEFORE calling here, so
+      # for a selection the answer describes the pre-cut buffer. It only bites when the typed
+      # char is `§` or `¦` — the predicate returns false for everything else — so an ordinary
+      # keystroke over a selection is exact and only a literal marker delimiter typed over a
+      # selection can be escaped on a stale offset.
+      cut_selection
       line = @lines[@cy]
       cx = @cx.clamp(0, line.size)
       @lines[@cy] = "#{line[0, cx]}#{ch}#{line[cx..]}"
@@ -272,6 +365,7 @@ module Gori::Tui
     def insert_string(str : String) : Nil
       return if str.empty?
       push_undo
+      cut_selection # replace-on-paste, one undo step — see `insert`
       line = @lines[@cy]
       cx = @cx.clamp(0, line.size)
       @lines[@cy] = "#{line[0, cx]}#{str}#{line[cx..]}"
@@ -287,6 +381,7 @@ module Gori::Tui
     # Caret ends past both, so the literal sits behind it like a normal keystroke.
     def insert_pair(ch : Char) : Nil
       push_undo
+      cut_selection # replace-on-type, one undo step — see `insert`
       line = @lines[@cy]
       cx = @cx.clamp(0, line.size)
       @lines[@cy] = "#{line[0, cx]}#{ch}#{ch}#{line[cx..]}"
@@ -312,6 +407,7 @@ module Gori::Tui
 
     def insert_newline : Nil
       push_undo
+      cut_selection # ↵ over a selection replaces it with the break — see `insert`
       line = @lines[@cy]
       cx = @cx.clamp(0, line.size)
       @lines[@cy] = line[0, cx]
@@ -330,6 +426,10 @@ module Gori::Tui
     end
 
     def backspace : Nil
+      # A selection outranks the character: ⌫ with text selected removes the SELECTION, at
+      # the buffer start as much as anywhere else — so the early return below (which exists
+      # for "there is no character before the caret") must not fire first.
+      return if delete_selection
       return if @cx == 0 && @cy == 0 # buffer start — nothing to delete, don't dirty (mirrors delete)
       if @cx > 0
         push_undo
@@ -373,17 +473,20 @@ module Gori::Tui
     # (no buffer change), so @styled/@edits are untouched — mirrors `move`.
     def home : Nil
       @cx = 0
+      @sel_anchor = nil # an unmodified jump collapses the selection, like a plain arrow
       env_complete_close
     end
 
     def end_of_line : Nil
       @cx = @lines[@cy].size
+      @sel_anchor = nil
       env_complete_close
     end
 
     # Forward delete: remove the char under the cursor, or join the next line when at EOL.
     # A buffer mutation, so it invalidates the highlight cache and bumps @edits (like backspace).
     def delete : Nil
+      return if delete_selection # a selection outranks the char under the caret — see `backspace`
       line = @lines[@cy]
       cx = @cx.clamp(0, line.size)
       if cx < line.size
@@ -410,11 +513,35 @@ module Gori::Tui
       refresh_env_complete
     end
 
-    def move(dr : Int32, dc : Int32) : Nil
+    # `selecting` (shift held) pins the far end of a selection at wherever the caret is
+    # standing and then moves the caret; without it the arrow COLLAPSES any selection, which
+    # is what every editor does and what makes ⇧→→ a reliable way to lose a selection.
+    #
+    # The motion itself is this method's own, deliberately NOT `ReadCursor#move`: that one
+    # steps LOGICAL lines and snaps ⇧↑/⇧↓ to end-of-line (whole-line selection, right for a
+    # read-only pane), while an INS caret steps one VISUAL row under soft wrap and keeps its
+    # display column. Selecting has to move the caret exactly where an unmodified arrow would
+    # — over wrapped rows, grapheme clusters and concealed `¦chain` runs alike — or the
+    # selection covers text the user never crossed. So the ANCHOR is shared with the read
+    # model's shape and the MOTION is not.
+    def move(dr : Int32, dc : Int32, selecting : Bool = false) : Nil
+      if selecting
+        @sel_anchor ||= {@cy, @cx}
+      else
+        @sel_anchor = nil
+      end
       if dr != 0
-        @cy = (@cy + dr).clamp(0, @lines.size - 1)
-        @cx = @cx.clamp(0, @lines[@cy].size)
-        snap_cx_to_cluster(0) # the column carried across rows can land mid-cluster
+        if wrapping?
+          # ↑/↓ step one VISUAL row, not one logical line. On an unwrapped line the two are
+          # the same thing; on a wrapped one, stepping by logical line would jump the caret
+          # over everything the pane is showing between here and the next line number,
+          # which is exactly the confusion soft wrap exists to remove.
+          move_visual(dr)
+        else
+          @cy = (@cy + dr).clamp(0, @lines.size - 1)
+          @cx = @cx.clamp(0, @lines[@cy].size)
+          snap_cx_to_cluster(0) # the column carried across rows can land mid-cluster
+        end
       end
       if dc != 0
         @cx += dc
@@ -443,17 +570,119 @@ module Gori::Tui
       refresh_env_complete
     end
 
+    # --- INSERT-mode selection (opt-in: nothing here fires until `move(…, selecting: true)`) ---
+
+    # Whether a NON-EMPTY selection is held. Emptiness matters and is not pedantry: ⇧→ then
+    # ⇧← puts the caret back on the anchor, and if that still counted as a selection the next
+    # ⌫ would delete zero characters instead of one — a dead key the operator cannot explain.
+    def selection? : Bool
+      !selection_range.nil?
+    end
+
+    def clear_selection : Nil
+      @sel_anchor = nil
+    end
+
+    # The selected text, or nil when nothing is selected.
+    #
+    # The multi-line slice is `ReadCursor`'s rather than a second copy of it: that method
+    # already assigns the boundary columns to the lines they belong to in DOCUMENT order and
+    # clamps each to its own line's length — the fix for an upward selection copying the
+    # wrong text and raising `IndexError` on a short top line. Duplicating it here is exactly
+    # how that bug would come back on the INS side only.
+    #
+    # The anchor is planted through `move(0, 0, selecting: true)`, whose `@anchor ||= {cy, cx}`
+    # runs while both motion branches are guarded off by the zero deltas, and the caret is
+    # then placed with `sync`, which documents itself as moving the caret WITHOUT disturbing
+    # the selection. That dance exists because `ReadCursor` exposes no anchor setter and
+    # read_cursor.cr is owned elsewhere this round; an `anchor=` there would replace it.
+    def selection_text : String?
+      r = selection_range
+      return nil unless r
+      y0, x0, y1, x1 = r
+      rc = ReadCursor.new
+      rc.sync(y0, x0)
+      rc.move(0, 0, @lines, selecting: true)
+      rc.sync(y1, x1)
+      rc.selection_text(@lines)
+    end
+
+    # Remove the selection as one undoable edit, leaving the caret where it started.
+    # Returns false (and touches nothing, not even @edits) when there is no selection, so a
+    # caller can use it as the first line of ⌫/Del without a second predicate call.
+    def delete_selection : Bool
+      return false unless selection_range
+      push_undo
+      cut_selection
+      refresh_env_complete
+      true
+    end
+
+    # The selection as a DOCUMENT-ORDERED {y0, x0, y1, x1}, or nil when there is none (or it
+    # is empty). Both ends are clamped to the buffer as it stands now: the anchor was planted
+    # against an earlier revision and an external `replace_line` / `resync Content-Length`
+    # can have shortened its line since.
+    private def selection_range : {Int32, Int32, Int32, Int32}?
+      anc = @sel_anchor
+      return nil unless anc
+      ay = anc[0].clamp(0, @lines.size - 1)
+      ax = anc[1].clamp(0, @lines[ay].size)
+      cy = @cy.clamp(0, @lines.size - 1)
+      cx = @cx.clamp(0, @lines[cy].size)
+      return nil if ay == cy && ax == cx # collapsed — see `selection?`
+      (ay < cy || (ay == cy && ax < cx)) ? {ay, ax, cy, cx} : {cy, cx, ay, ax}
+    end
+
+    # Splice the selection out of the buffer WITHOUT pushing undo — the caller owns the undo
+    # unit, which is what lets replace-on-type be one ⌃Z instead of two. No-op (false) when
+    # nothing is selected, so every insert path can call it unconditionally.
+    #
+    # The line ENDINGS follow `backspace`'s join rule exactly: joining lines y0…y1 into one
+    # drops the terminators that separated them and keeps `@eols[y1]`, the ending of the last
+    # line consumed. A cut that kept `@eols[y0]` instead would put the FIRST line's CRLF on a
+    # body line that was LF-terminated (or the reverse), changing bytes on the wire that the
+    # operator never touched.
+    private def cut_selection : Bool
+      r = selection_range
+      @sel_anchor = nil
+      return false unless r
+      y0, x0, y1, x1 = r
+      @lines[y0] = "#{@lines[y0][0, x0]}#{@lines[y1][x1..]}"
+      (y1 - y0).times do
+        @lines.delete_at(y0 + 1)
+        @eols.delete_at(y0)
+      end
+      @cy = y0
+      @cx = x0
+      # The splice re-clusters across the seam the same way a backspace-join does: if the
+      # kept tail opens with a combining mark it has just fused onto the head's last glyph,
+      # so the seam is now cluster interior. Snap forward, past the fused glyph — see the
+      # long note in `backspace`.
+      snap_cx_to_cluster(1)
+      @styled = nil
+      @edits += 1
+      true
+    end
+
     # Cursor is on the first line — the Runner pops focus to the tab bar when ↑
     # is pressed here (natural upward flow, matching the body lists).
+    #
+    # Under wrap it is the first VISUAL row that pops focus, not the first logical line:
+    # the caret on row 3 of a wrapped line 1 still has three rows above it inside this
+    # pane, and stealing that ↑ would make those rows unreachable from the keyboard.
     def at_top? : Bool
-      @cy == 0
+      return @cy == 0 unless wrapping?
+      @cy == 0 && layout_of(0, @last_cw).row_of(@cx) == 0
     end
 
     # Cursor is on the last line — used to cross out of the editor on ↓ (e.g. the
     # Decoder INPUT editor descends to the CHAIN field) without swallowing normal
-    # downward cursor movement.
+    # downward cursor movement. Last VISUAL row under wrap — see `at_top?`.
     def at_bottom? : Bool
-      @cy == @lines.size - 1
+      last = @lines.size - 1
+      return @cy == last unless wrapping?
+      lay = layout_of(last, @last_cw)
+      @cy == last && lay.row_of(@cx) == lay.rows - 1
     end
 
     # Cursor at the very start (first line, first column) — used to pop focus out of
@@ -472,20 +701,31 @@ module Gori::Tui
       return if rect.empty? || @lines.empty?
       row = my - rect.y
       return if row < 0
-      @cy = {@scroll + row, @lines.size - 1}.min
       gw = @gutter ? {Gutter.width(@lines.size), rect.w}.min : 0
+      cw = {rect.w - gw, 0}.max
+      # Rebuild the SAME row list render lays down (same rect, same anchor, same wrap
+      # function) rather than reading @last_rows: the mapping then holds for a click that
+      # arrives before the first frame, and there is exactly one definition of where a row
+      # begins. Without wrap this is one row per line and `@scroll + row` falls straight out.
+      rows = visible_rows(cw, rect.h)
+      return if rows.empty?
+      vr = rows[row]? || rows[rows.size - 1]
+      @cy = vr.li
       # + @xscroll: the click lands at display column (mx - content_x) WITHIN the
-      # visible window, which is @xscroll columns into the full line.
+      # visible window, which is @xscroll columns into the full line (always 0 under wrap).
       target = mx - (rect.x + gw) + @xscroll
       line = @lines[@cy]
       cr = @conceal_spans.empty? ? nil : line_conceal(line_start_offset(@cy), line.size)
-      # On a concealed line the click column is in concealed space; map it back through
-      # the hidden runs so a click never lands the caret on an unseen ¦chain char.
-      # No cluster snap needed: BOTH inverses already return a cluster start by construction
-      # (Screen.column_for walks clusters; concealed_col_to_raw does too, and its conceal
-      # edges `¦`/`§` always begin a cluster — see snap_cx_out_of_conceal).
-      @cx = (cr && !cr.empty?) ? concealed_col_to_raw(line, cr, target) : Screen.column_for(line, target)
+      # `Wrap.row_index` is the exact inverse of `Wrap.row_col`, which is what the caret,
+      # the selection tint and the search overdraw all measure with — so a click lands on
+      # the cell the caret would paint, on a continuation row as much as on a first row. It
+      # steps by CLUSTER and hops whole concealed runs, so the result is always a cluster
+      # start and never an unseen `¦chain` char; it clamps to the row's own end, so a click
+      # past the text of a wrapped row stops at the break instead of running into the next
+      # row's characters.
+      @cx = Wrap.row_index(line, cr, vr.a, vr.b, target)
       snap_cx_out_of_conceal(0) # a click on the closing-§ column resolves to it; nudge to a legal rest
+      @sel_anchor = nil         # a plain click collapses the selection (no shift-click here yet)
       env_complete_close
     end
 
@@ -495,19 +735,58 @@ module Gori::Tui
     # immediately (no "wheel until the cursor reaches the edge" lag). No-op before the
     # first render (height unknown) or when the buffer already fits.
     def scroll_view(step : Int32) : Nil
-      return if @last_h <= 0 || @lines.size <= @last_h
-      max = @lines.size - @last_h
-      @scroll = (@scroll + step).clamp(0, max)
-      @cy = @cy.clamp(@scroll, {@scroll + @last_h - 1, @lines.size - 1}.min)
+      return if @last_h <= 0
+      before = {@cy, @cx}
+      if wrapping?
+        scroll_view_wrapped(step)
+      elsif @lines.size > @last_h
+        max = @lines.size - @last_h
+        @scroll = (@scroll + step).clamp(0, max)
+        @cy = @cy.clamp(@scroll, {@scroll + @last_h - 1, @lines.size - 1}.min)
+        @cx = @cx.clamp(0, @lines[@cy].size)
+        snap_cx_to_cluster(0) # the row changed under the caret; its column may re-cluster
+        env_complete_close
+      end
+      # The caret is DRAGGED (not steered) when the window would otherwise leave it behind.
+      # A drag is not a selecting move, so it must not silently grow a selection: the wheel
+      # would then extend it to wherever the operator scrolled, and the next keystroke — a
+      # replace-on-type — would eat everything in between. Dropped only when the drag really
+      # happened; scrolling with the caret still on screen leaves the selection alone.
+      @sel_anchor = nil if @sel_anchor && {@cy, @cx} != before
+    end
+
+    # Wheel under soft wrap: `step` is VISUAL rows, so one notch moves one drawn row even
+    # when that row is the middle of a wrapped line. The anchor walks; nothing counts the
+    # buffer's total rows (see @scroll_sub), and the bottom stop is found by walking BACK
+    # one viewport from the last row — O(viewport), not O(document).
+    private def scroll_view_wrapped(step : Int32) : Nil
+      cw = @last_cw
+      return if cw <= 0
+      advance_anchor(step, cw)
+      mli, msub = Wrap.max_anchor(@lines.size, @last_h, layout_fn(cw))
+      if @scroll > mli || (@scroll == mli && @scroll_sub > msub)
+        @scroll = mli
+        @scroll_sub = msub
+      end
+      # Pull the caret into the window so render's ensure_visible doesn't snap the view
+      # straight back to where it was (mirrors the unwrapped branch). The comparison has to
+      # be in VISUAL rows: a caret on line 0 is "inside" a window that starts at row 3 of
+      # line 0 only by logical-line arithmetic, and that arithmetic is exactly what made
+      # the wheel fight ensure_visible to a standstill.
+      rows = visible_rows(cw, @last_h)
+      return if rows.empty?
+      first = rows[0]
+      last = rows[rows.size - 1]
+      if @cy < first.li || (@cy == first.li && @cx < first.a)
+        @cy = first.li
+        @cx = first.a
+      elsif @cy > last.li || (@cy == last.li && layout_of(last.li, cw).row_of(@cx) > last.sub)
+        @cy = last.li
+        @cx = last.a
+      end
       @cx = @cx.clamp(0, @lines[@cy].size)
       snap_cx_to_cluster(0) # the row changed under the caret; its column may re-cluster
       env_complete_close
-    end
-
-    # Horizontal viewport nudge (shift+←/→ in READ panes). No-op unless @follow_x.
-    def hscroll_view(step : Int32) : Nil
-      return unless @follow_x
-      @xscroll = {@xscroll + step * 4, 0}.max
     end
 
     # Jump the cursor to 1-based line `n`, column 0 (out-of-range clamps to the
@@ -515,6 +794,7 @@ module Gori::Tui
     def goto_line(n : Int32) : Nil
       @cy = (n - 1).clamp(0, @lines.size - 1)
       @cx = 0
+      @sel_anchor = nil
       env_complete_close
     end
 
@@ -523,6 +803,10 @@ module Gori::Tui
       @cy = cy.clamp(0, @lines.size - 1)
       @cx = cx.clamp(0, @lines[@cy].size)
       snap_cx_to_cluster(0) # caller-supplied index — unconstrained, may land mid-cluster
+      # This is how the READ-mode cursor writes itself back (TextReadState#apply), so it is
+      # also where an INS selection left behind by `esc` is retired: navigating in NOR must
+      # not leave a stale INS selection waiting to reappear the next time `i` is pressed.
+      @sel_anchor = nil
       env_complete_close
     end
 
@@ -566,6 +850,7 @@ module Gori::Tui
       @cy = cy
       @cx = off.clamp(0, @lines[cy].size)
       snap_cx_to_cluster(0) # a flat buffer offset carries no cluster guarantee
+      @sel_anchor = nil
       env_complete_close
     end
 
@@ -653,39 +938,83 @@ module Gori::Tui
     def render(screen : Screen, rect : Rect, cursor : Bool, highlight : Symbol? = nil, peek : Bool = false,
                gauge : Bool = false, gauge_focused : Bool = false) : Nil
       return if rect.empty?
-      @last_h = rect.h # remembered for scroll_view (wheel) clamping
-      ensure_visible(rect.h)
+      @last_h = rect.h                                           # remembered for scroll_view (wheel) clamping
       gw = @gutter ? {Gutter.width(@lines.size), rect.w}.min : 0 # never exceed the pane
       cx0 = rect.x + gw                                          # content start x (after the optional gutter)
       cw = {rect.w - gw, 0}.max                                  # content width
-      ensure_visible_x(cw)                                       # slide @xscroll so the caret stays on screen (no-op unless @follow_x)
+      # The gutter is sized from the LOGICAL line count and must stay that way: wrapping
+      # multiplies the drawn rows, and letting the numbers widen to match would shift the
+      # text column every time a line spilled — the gutter names logical lines, and there
+      # are exactly as many of those as there ever were.
+      @last_cw = cw # the wrap mappings that run outside render (move / click / at_top?) need it
+      if wrapping?
+        ensure_visible_wrapped(cw, rect.h)
+      else
+        ensure_visible(rect.h)
+        ensure_visible_x(cw) # slide @xscroll so the caret stays on screen (no-op unless @follow_x)
+      end
       styled = highlight ? highlighted(highlight) : nil
+      rows = visible_rows(cw, rect.h)
+      @last_rows = rows
+      # The visual row the caret lives on, decided ONCE by Wrap::Layout#row_of — the same
+      # function the click inverse and the goal-column move consult, so the three cannot
+      # disagree about which row owns a caret sitting exactly on a wrap break.
+      caret_sub = wrapping? ? layout_of(@cy, cw).row_of(caret_index(@cy)) : 0
       # Buffer char-offset of the first visible line — advanced per row so each line
       # knows its start for the bg-region overlay without an O(n²) rescan. Only the
       # opt-in bg_regions consumer (the Fuzzer template) pays the O(@scroll) prefix sum;
       # Repeater/Notes (no regions) skip it so their hot path is unchanged.
       line_off = 0
       (0...@scroll).each { |k| line_off += @lines[k].size + 1 } unless @bg_regions.empty? && @conceal_spans.empty? # +1 for '\n'
-      caret_cell = nil.as({Int32, Int32}?)                                                                         # the drawn caret's screen cell — anchors the env-complete popup
-      (0...rect.h).each do |i|
-        li = @scroll + i
-        break if li >= @lines.size
-        Gutter.draw(screen, rect.x, rect.y + i, li, gw, current: li == @cy) if @gutter
-        line = @lines[li]
+      cur_li = @scroll
+      caret_cell = nil.as({Int32, Int32}?) # the drawn caret's screen cell — anchors the env-complete popup
+      rows.each_with_index do |vr, i|
+        li = vr.li
+        # Walk `line_off` up to this row's logical line. Rows arrive in document order, so
+        # the whole loop is still one pass over the visible lines (continuation rows of the
+        # same line don't advance it — they share their line's start offset).
+        while cur_li < li
+          line_off += @lines[cur_li].size + 1
+          cur_li += 1
+        end
+        # The line number rides the FIRST visual row of a logical line and nothing else
+        # (Burp style). A continuation row gets a blank of the same width rather than no
+        # write at all, so the text column stays put and no stale digits survive there.
+        if @gutter
+          if vr.sub == 0
+            Gutter.draw(screen, rect.x, rect.y + i, li, gw, current: li == @cy)
+          else
+            screen.text(rect.x, rect.y + i, " " * {gw - 1, 0}.max, Theme.muted, width: gw)
+          end
+        end
+        composing = li == @cy && !@preedit.empty?
+        # `drawn_line` folds the IME preedit into the caret line: under wrap the composing
+        # text is what shifts the break, so layout, draw, caret and click must all measure
+        # the SAME string or the row the caret sits on isn't the row it was laid out on.
+        line = drawn_line(li)
+        a, b = vr.a, vr.b
+        whole = a == 0 && b == line.size
+        seg = whole ? line : line[a...b]
         # Concealed lines (a §…§ marker with a hidden ¦chain) go through a dedicated draw:
-        # delete the concealed chars from the styled line, then h-scroll-slice + draw. The
+        # delete the concealed chars from the styled line, then slice + draw. The
         # IME-preedit caret line is left raw (its columns shift with the composing text).
-        cr = (@conceal_spans.empty? || (li == @cy && !@preedit.empty?)) ? nil : line_conceal(line_off, line.size)
+        cr = (@conceal_spans.empty? || composing) ? nil : line_conceal(line_off, line.size)
         if cr && !cr.empty? && !@reveal
-          draw_concealed_line(screen, cx0, rect.y + i, li, line, styled, cr, cw)
-        elsif @xscroll > 0
+          draw_concealed_line(screen, cx0, rect.y + i, li, line, styled, cr, cw, a, b)
+        elsif @xscroll > 0 # unwrapped editors only — `wrap=` pins @xscroll at 0
           draw_scrolled(screen, cx0, rect.y + i, li, line, styled, cw)
         elsif @reveal
-          Highlight.draw(screen, cx0, rect.y + i, Reveal.styled(line, false, cw), width: cw)
+          Highlight.draw(screen, cx0, rect.y + i, Reveal.styled(seg, false, cw), width: cw)
+        elsif composing && wrapping?
+          # The styled overlay is built from the BUFFER and so cannot describe the
+          # composing text; under wrap it is part of the laid-out line, so it is drawn
+          # from spans instead. (Unwrapped editors keep the legacy order below, where a
+          # highlighted line wins and the preedit shows only through the caret glyph.)
+          Highlight.draw(screen, cx0, rect.y + i, preedit_spans(line, a, b), width: cw)
         elsif styled && (sl = styled[li]?)
-          Highlight.draw(screen, cx0, rect.y + i, sl, width: cw)
+          Highlight.draw(screen, cx0, rect.y + i, Highlight.slice_chars(sl, a, b), width: cw)
         else
-          if li == @cy && !@preedit.empty?
+          if composing
             prefix = line[0, @cx]
             suffix = line[@cx..]
             px = cx0
@@ -706,31 +1035,47 @@ module Gori::Tui
               screen.text(px, rect.y + i, suffix, Theme.text, width: cw - (px - cx0))
             end
           else
-            screen.text(cx0, rect.y + i, line, Theme.text, width: cw)
+            screen.text(cx0, rect.y + i, seg, Theme.text, width: cw)
           end
         end
         # Marker tint UNDER search/cursor — skip the IME-preedit line (its columns are
-        # shifted by the composing text, which isn't in `line`). paint_bg_regions itself
-        # no-ops when there are no regions or in reveal mode.
-        paint_bg_regions(screen, cx0, rect.y + i, line_off, line, cw, cr) unless li == @cy && !@preedit.empty?
-        line_off += line.size + 1 # advance BEFORE the cursor `next` so it can't desync
+        # shifted by the composing text, which isn't in the buffer line). paint_bg_regions
+        # itself no-ops when there are no regions or in reveal mode.
+        paint_bg_regions(screen, cx0, rect.y + i, line_off, @lines[li], cw, cr, a, b) unless composing
         unless @search_hl.empty?
-          # Mark on the visible (left-sliced) text so the highlight columns line up
-          # with the cells we actually drew once horizontally scrolled.
-          st = @xscroll > 0 ? slice_left(line, @xscroll) : line
-          SearchHi.mark(screen, cx0, rect.y + i, st, @search_hl, cx0 + cw)
+          if wrapping?
+            # Scan the WHOLE logical line and clip each hit to this row, so a match that
+            # straddles a wrap break lights up on both rows instead of on neither — see
+            # Wrap.mark_search.
+            Wrap.mark_search(screen, cx0, rect.y + i, line, a, b, @search_hl, cx0 + cw, cr)
+          else
+            # Mark on the visible (left-sliced) text so the highlight columns line up
+            # with the cells we actually drew once horizontally scrolled.
+            st = @xscroll > 0 ? Highlight.slice_left_text(line, @xscroll) : line
+            SearchHi.mark(screen, cx0, rect.y + i, st, @search_hl, cx0 + cw)
+          end
         end
+        # The INS selection tint, over the text and the search marks, under the caret —
+        # the same stacking (and the same `Theme.accent_bg`) the READ-mode over-painter
+        # uses, so the band does not change appearance when `i` is pressed. `cursor` is the
+        # gate: it is on only in INSERT, which is exactly when the owner's read-mode painter
+        # stands down, so the two selections can never be drawn at once.
+        paint_selection(screen, cx0, rect.y + i, li, line, cr, a, b, cw) if cursor
         # The caret cell is captured for the caret line whether or not the block cursor
         # is drawn (cursor=false in NORMAL) — the value peek anchors to it in read mode too.
         # The block-cursor GLYPH itself still paints only when `cursor` (insert mode).
-        next unless li == @cy
+        next unless li == @cy && vr.sub == caret_sub
+        ci = caret_index(li)
         # draw_width (not display_width): a raw control char in the prefix occupies a cell
         # and click-to-cursor counts it, so the caret must too — else it sits one column
         # left of the real position and paints over a glyph. Per CLUSTER, matching the draw
         # exactly: `@cx` rests only on cluster boundaries (snap_cx_to_cluster), so this is
-        # single-valued and Screen.column_for inverts it.
-        prefix_w = (cr && !cr.empty?) ? concealed_col(line, cr, @cx) : Screen.draw_width(line[0, @cx])
-        preedit_w = Screen.draw_width(@preedit)
+        # single-valued and Wrap.row_index inverts it. Measured from the ROW's first char,
+        # which is char 0 of the line whenever nothing wrapped.
+        prefix_w = Wrap.row_col(line, cr, a, ci)
+        # Unwrapped editors draw the preedit AFTER the buffer text without it being part of
+        # `line`, so its width is added here; under wrap `drawn_line` already spliced it in.
+        preedit_w = wrapping? ? 0 : Screen.draw_width(@preedit)
         cxs = cx0 + prefix_w + preedit_w - @xscroll
         if cxs >= cx0 && cxs < cx0 + cw
           caret_cell = {cxs, rect.y + i}
@@ -740,7 +1085,7 @@ module Gori::Tui
             # concealed line the raw char there may be a hidden `¦chain` byte, so skip past
             # any concealed run to the glyph the user actually sees (the closing §).
             r = @cx
-            cr.each { |(a, b)| r = b if r >= a && r < b } if cr && !cr.empty?
+            cr.each { |(ra, rb)| r = rb if r >= ra && r < rb } if cr && !cr.empty?
             # The whole CLUSTER at `r`, not `line[r]`: parking on `é` (e + U+0301) or a ZWJ
             # family has to invert the glyph the user sees, not its leading codepoint.
             ch = @preedit.empty? ? Screen.caret_glyph(line, r) : Screen.caret_glyph(@preedit, 0)
@@ -767,10 +1112,174 @@ module Gori::Tui
           end
         end
       end
+      # The gauge stays in LOGICAL lines under wrap — a deliberate approximation, not an
+      # oversight. Sizing it in visual rows means knowing how many the whole buffer has,
+      # which is the one O(document) question this design exists to never ask (see
+      # @scroll_sub). The thumb therefore tracks the anchor LINE and can step unevenly on a
+      # heavily wrapped buffer; it is a proportion indicator, not a coordinate.
       Frame.scroll_gauge(screen, rect, @lines.size, @scroll, gauge_focused) if gauge
       # The env-complete dropdown + value peek paint LAST (over the text, anchored at the
       # caret) so they never render when the caret is off-screen.
       render_env_popups(screen, caret_cell, rect, cursor, peek)
+    end
+
+    # --- soft-wrap layout ------------------------------------------------------
+    # Everything below is inert (or trivially one-row-per-line) while @wrap is off.
+
+    # Wrap is only meaningful once a render has told us how wide the content column is —
+    # every mapping outside render (move / click / at_top? / wheel) needs that width, and
+    # guessing one would put the caret on a different row than the draw did.
+    private def wrapping? : Bool
+      @wrap && @last_cw > 0
+    end
+
+    # Logical line `li` AS DRAWN: the buffer line, with any IME preedit spliced in at the
+    # caret. One string for layout, draw, caret and click, so the composing text cannot
+    # move the wrap break out from under the caret that produced it.
+    private def drawn_line(li : Int32) : String
+      line = @lines[li]
+      return line unless wrapping? && li == @cy && !@preedit.empty?
+      cx = @cx.clamp(0, line.size)
+      "#{line[0, cx]}#{@preedit}#{line[cx..]}"
+    end
+
+    # The caret's index into `drawn_line(li)` — past the composing text, which is where an
+    # insertion point belongs.
+    private def caret_index(li : Int32) : Int32
+      return @cx unless wrapping? && li == @cy && !@preedit.empty?
+      @cx.clamp(0, @lines[li].size) + @preedit.size
+    end
+
+    # The wrap of line `li` at content width `cw`, memoized on (@edits, cw).
+    #
+    # The memo is what keeps a keystroke cheap: without it every frame re-wraps every
+    # visible line, and with a multi-MB minified body that is a grapheme walk over
+    # megabytes per frame. The memo alone would not be enough either — which is why
+    # `Wrap::Layout` stores no per-row table for an ASCII line — but together they make the
+    # common case (a big ASCII body, scrolled) O(1) per row with no allocation at all.
+    private def layout_of(li : Int32, cw : Int32) : Wrap::Layout
+      cr = @conceal_spans.empty? ? nil : line_conceal(line_start_offset(li), @lines[li].size)
+      # The caret line while an IME is composing changes with every jamo WITHOUT bumping
+      # @edits, so it must never enter the memo — a stale layout there desyncs the caret
+      # from the row it is drawn on.
+      return Wrap.layout(drawn_line(li), cw, cr) if li == @cy && !@preedit.empty?
+      if @wrap_rev != @edits || @wrap_w != cw
+        @wrap_cache.clear
+        @wrap_rev = @edits
+        @wrap_w = cw
+      end
+      if hit = @wrap_cache[li]?
+        return hit
+      end
+      @wrap_cache.clear if @wrap_cache.size >= WRAP_CACHE_CAP
+      @wrap_cache[li] = Wrap.layout(@lines[li], cw, cr)
+    end
+
+    # A `Wrap` layout provider bound to this buffer at content width `cw`.
+    private def layout_fn(cw : Int32) : Int32 -> Wrap::Layout
+      ->(i : Int32) { layout_of(i, cw) }
+    end
+
+    # The rows the pane shows, top to bottom, starting at the (line, sub-row) anchor.
+    # Without wrap this is the identity it always was: one row per logical line from
+    # @scroll, `sub` 0, the whole line.
+    private def visible_rows(cw : Int32, h : Int32) : Array(VRow)
+      unless wrapping?
+        rows = Array(VRow).new({h, 0}.max)
+        return rows if h <= 0
+        (0...h).each do |i|
+          li = @scroll + i
+          break if li >= @lines.size
+          rows << VRow.new(li, 0, 0, @lines[li].size)
+        end
+        return rows
+      end
+      @scroll = @scroll.clamp(0, @lines.size - 1)
+      Wrap.rows(@scroll, @scroll_sub, h, @lines.size, layout_fn(cw))
+    end
+
+    # Wrapped companion to `ensure_visible`: keep the caret's VISUAL row inside the pane.
+    # The walk itself is `Wrap.ensure_visible` (shared with the Repeater response pane).
+    private def ensure_visible_wrapped(cw : Int32, h : Int32) : Nil
+      return if h <= 0 || cw <= 0
+      @scroll = @scroll.clamp(0, @lines.size - 1)
+      csub = layout_of(@cy, cw).row_of(caret_index(@cy))
+      @scroll, @scroll_sub = Wrap.ensure_visible(@scroll, @scroll_sub, @cy, csub, h, layout_fn(cw))
+    end
+
+    # Place the anchor `back` visual rows above (li, sub).
+    private def anchor_back_from(li : Int32, sub : Int32, back : Int32, cw : Int32) : Nil
+      @scroll, @scroll_sub = Wrap.step_back(li, sub, back, layout_fn(cw))
+    end
+
+    # Move the anchor `step` visual rows (negative = up), stopping at the buffer's ends.
+    private def advance_anchor(step : Int32, cw : Int32) : Nil
+      @scroll, @scroll_sub = if step < 0
+                               Wrap.step_back(@scroll, @scroll_sub, -step, layout_fn(cw))
+                             else
+                               Wrap.step_forward(@scroll, @scroll_sub, step, @lines.size, layout_fn(cw))
+                             end
+    end
+
+    # ↑/↓ across wrapped rows: step `dr` VISUAL rows, keeping the caret's display column.
+    # The column is measured from the row's first char and mapped back through
+    # `Wrap.row_index`, the same inverse pair the caret and the click use — so a run of ↓
+    # then ↑ lands back where it started at every cluster boundary.
+    private def move_visual(dr : Int32) : Nil
+      cw = @last_cw
+      line = @lines[@cy]
+      cr = @conceal_spans.empty? ? nil : line_conceal(line_start_offset(@cy), line.size)
+      lay = layout_of(@cy, cw)
+      sub = lay.row_of(@cx)
+      goal = Wrap.row_col(line, cr, lay.start_of(sub), @cx)
+      li = @cy
+      n = dr.abs
+      while n > 0
+        if dr > 0
+          if sub + 1 < lay.rows
+            sub += 1
+          elsif li < @lines.size - 1
+            li += 1
+            lay = layout_of(li, cw)
+            sub = 0
+          else
+            break
+          end
+        else
+          if sub > 0
+            sub -= 1
+          elsif li > 0
+            li -= 1
+            lay = layout_of(li, cw)
+            sub = lay.rows - 1
+          else
+            break
+          end
+        end
+        n -= 1
+      end
+      @cy = li
+      tline = @lines[li]
+      tcr = @conceal_spans.empty? ? nil : line_conceal(line_start_offset(li), tline.size)
+      @cx = Wrap.row_index(tline, tcr, lay.start_of(sub), lay.end_of(sub), goal)
+      snap_cx_to_cluster(0) # row_index already lands on a boundary; cheap guard for the empty-row case
+    end
+
+    # The composing caret line as spans: buffer text, the preedit underlined, buffer text —
+    # sliced to the visual row `[a, b)`. Only reached under wrap (see the draw dispatch).
+    private def preedit_spans(line : String, a : Int32, b : Int32) : Highlight::Line
+      cx = @cx.clamp(0, @lines[@cy].size)
+      pe = cx + @preedit.size
+      spans = Highlight::Line.new
+      add = ->(lo : Int32, hi : Int32, attr : Attribute) do
+        s = {lo, a}.max
+        e = {hi, b}.min
+        spans << Highlight::Span.new(line[s...e], Theme.text, attr) if s < e
+      end
+      add.call(0, cx, Attribute::None)
+      add.call(cx, pe, Attribute::Underline)
+      add.call(pe, line.size, Attribute::None)
+      spans
     end
 
     # The caret-anchored `$ENV` overlays, drawn after the text. The autocomplete dropdown
@@ -819,6 +1328,70 @@ module Gori::Tui
       false
     end
 
+    # Band the INS selection over ONE visual row `[a, b)` of logical line `li`.
+    #
+    # The span is clipped to the row rather than to the line, which is the whole reason this
+    # is per-row: a selection running off the right edge of a wrapped row must tint that row
+    # to its end AND continue on the next one. Clipping to the line instead paints the band
+    # once, at the columns of the first row, and leaves the rest of the selection looking
+    # unselected — the exact failure the wrap layer introduced for every over-painter.
+    #
+    # Derived from `selection_range` in O(1) per row instead of asking `ReadCursor` for the
+    # whole span list: that walk is O(the selection), and a selection here can cover a
+    # multi-MB response body pasted into the request. It mirrors ReadCursor#highlight_spans'
+    # rule exactly — first line from its column to EOL, last line to its column, everything
+    # between whole — with the columns already put in document order by `selection_range`.
+    private def paint_selection(screen : Screen, cx0 : Int32, y : Int32, li : Int32, line : String,
+                                cr : Array({Int32, Int32})?, a : Int32, b : Int32, cw : Int32) : Nil
+      return if @sel_anchor.nil?
+      return if @reveal                       # reveal rewrites the glyphs — see paint_bg_regions
+      return if li == @cy && !@preedit.empty? # composing: `line` holds text the buffer offsets don't index
+      return unless r = selection_range
+      y0, x0, y1, x1 = r
+      return if li < y0 || li > y1
+      lo = {li == y0 ? x0 : 0, a}.max
+      hi = {li == y1 ? x1 : line.size, b}.min
+      return if lo >= hi
+      if cr.nil? || cr.empty?
+        paint_sel_chunk(screen, cx0, y, line, cr, a, lo, hi, cw)
+        return
+      end
+      # A concealed `¦chain` occupies no cells, so the band is laid down as the VISIBLE runs
+      # between the hidden ones; painting straight through would tint cells the chain's
+      # neighbours are standing in and shift the rest of the row's tint right by its length.
+      chunk = lo
+      i = lo
+      while i < hi
+        if run = cr.find { |(ra, rb)| i >= ra && i < rb }
+          paint_sel_chunk(screen, cx0, y, line, cr, a, chunk, i, cw)
+          i = {run[1], hi}.min
+          chunk = i
+        else
+          i += 1
+        end
+      end
+      paint_sel_chunk(screen, cx0, y, line, cr, a, chunk, hi, cw)
+    end
+
+    # One contiguous, fully-visible `[s, e)` of the row that starts at `row_start`, re-drawn
+    # on the selection background. Columns come from `Wrap.row_col` — the measure the base
+    # draw, the caret and the click all use — so the band covers exactly the cells the text
+    # was put in, wide glyphs and tabs included.
+    private def paint_sel_chunk(screen : Screen, cx0 : Int32, y : Int32, line : String,
+                                cr : Array({Int32, Int32})?, row_start : Int32,
+                                s : Int32, e : Int32, cw : Int32) : Nil
+      return if s >= e
+      from = Wrap.row_col(line, cr, row_start, s) - @xscroll
+      to = {Wrap.row_col(line, cr, row_start, e) - @xscroll, cw}.min
+      seg = line[s...e]
+      if from < 0 # h-scrolled off the left edge (unwrapped follow_x editors only)
+        seg = Highlight.slice_left_text(seg, -from)
+        from = 0
+      end
+      return if from >= to || seg.empty?
+      screen.text(cx0 + from, y, seg, Theme.text, Theme.accent_bg, width: to - from)
+    end
+
     # Overlay the bg_regions intersecting THIS line. `off0` is the line's start offset
     # in the full LF-joined buffer. Column math mirrors the base draw + caret
     # (Screen.draw_width / grapheme_cols ≥1 per cluster, so a tab in a marker band can't
@@ -828,22 +1401,28 @@ module Gori::Tui
     # shifted left by @xscroll and clipped to the visible window — a no-op when
     # @xscroll == 0 (the common case, since only the Fuzzer template sets bg_regions and
     # it doesn't enable follow_x).
+    #
+    # `rs`/`re` bound the VISUAL ROW being painted: the whole line without wrap, one wrapped
+    # slice of it with. A region is clipped to the row, so a marker that spans a wrap break
+    # is banded on every row it covers rather than once, in the wrong cells.
     private def paint_bg_regions(screen : Screen, cx0 : Int32, y : Int32, off0 : Int32,
-                                 line : String, cw : Int32, cr : Array({Int32, Int32})? = nil) : Nil
+                                 line : String, cw : Int32, cr : Array({Int32, Int32})? = nil,
+                                 rs : Int32 = 0, re : Int32 = -1) : Nil
       return if @bg_regions.empty? || @reveal # opt-in; reveal rewrites the glyphs
-      return paint_bg_regions_concealed(screen, cx0, y, off0, line, cw, cr) if cr && !cr.empty?
+      re = line.size if re < 0
+      return paint_bg_regions_concealed(screen, cx0, y, off0, line, cw, cr, rs, re) if cr && !cr.empty?
       line_end = off0 + line.size
       @bg_regions.each do |(a, b, color)|
         next if b <= off0 || a >= line_end # region doesn't touch this line
-        la = (a - off0).clamp(0, line.size)
-        lb = (b - off0).clamp(0, line.size)
+        la = (a - off0).clamp(rs, re)
+        lb = (b - off0).clamp(rs, re)
         next if la >= lb
-        start_col = Screen.draw_width(line[0, la]) - @xscroll
-        end_col = Screen.draw_width(line[0, lb]) - @xscroll
+        start_col = Wrap.row_col(line, nil, rs, la) - @xscroll
+        end_col = Wrap.row_col(line, nil, rs, lb) - @xscroll
         draw_from = {start_col, 0}.max
         draw_to = {end_col, cw}.min
         next if draw_from >= draw_to
-        seg = slice_left(line[la, lb - la], draw_from - start_col)
+        seg = Highlight.slice_left_text(line[la, lb - la], draw_from - start_col)
         screen.text(cx0 + draw_from, y, seg, Theme.marker_fg, color, width: draw_to - draw_from)
       end
     end
@@ -854,14 +1433,16 @@ module Gori::Tui
     # each concealed run — the closing § — is accented so a chained marker reads distinctly
     # from a plain one; the rest keep Theme.marker_fg.
     private def paint_bg_regions_concealed(screen : Screen, cx0 : Int32, y : Int32, off0 : Int32,
-                                           line : String, cw : Int32, cr : Array({Int32, Int32})) : Nil
+                                           line : String, cw : Int32, cr : Array({Int32, Int32}),
+                                           rs : Int32 = 0, re : Int32 = -1) : Nil
+      re = line.size if re < 0
       line_end = off0 + line.size
       @bg_regions.each do |(a, b, color)|
         next if b <= off0 || a >= line_end
-        la = (a - off0).clamp(0, line.size)
-        lb = (b - off0).clamp(0, line.size)
+        la = (a - off0).clamp(rs, re)
+        lb = (b - off0).clamp(rs, re)
         next if la >= lb
-        col = concealed_display_prefix(line, cr, la) # display columns before the first drawn char
+        col = Wrap.row_col(line, cr, rs, la) # display columns before the first drawn char, within this row
         i = la
         while i < lb
           hit = cr.find { |(ra, rb)| i >= ra && i < rb }
@@ -900,70 +1481,34 @@ module Gori::Tui
       out
     end
 
-    # Full-buffer char offset of line `cy`'s first char (only walked when concealing).
+    # Full-buffer char offset of line `cy`'s first char (only reached when concealing),
+    # memoized on @edits.
+    #
+    # It used to walk the buffer per call, which was tolerable when `snap_cx_out_of_conceal`
+    # was the only caller — once per caret move. Soft wrap needs the conceal ranges of every
+    # VISIBLE line to lay it out, so a linear walk per line turns one frame into
+    # O(lines × rows). The table is built once per edit and read h times instead.
     private def line_start_offset(cy : Int32) : Int32
-      off = 0
-      (0...cy).each { |i| off += @lines[i].size + 1 } # +1 for the joining '\n'
-      off
-    end
-
-    # Display column (draw_width semantics, matching the caret) of raw caret index `cx`
-    # on a concealed line: the width of the surviving chars in [0, cx). A cx inside a
-    # concealed run collapses to that run's start column (both edges share the cell).
-    private def concealed_col(line : String, ranges : Array({Int32, Int32}), cx : Int32) : Int32
-      cx = cx.clamp(0, line.size)
-      w = 0
-      pos = 0
-      ranges.each do |(a, b)|
-        break if a >= cx
-        w += Screen.draw_width(line[pos...a]) if a > pos
-        return w if b >= cx # cx lands inside/at this run → column at the run's start
-        pos = b
-      end
-      w + Screen.draw_width(line[pos...cx])
-    end
-
-    # As `concealed_col` — draw_width / grapheme_cols semantics matching Highlight.draw's
-    # ≥1 floor, used by the band over-paint so tint columns line up with drawn cells.
-    private def concealed_display_prefix(line : String, ranges : Array({Int32, Int32}), cx : Int32) : Int32
-      w = 0
-      pos = 0
-      ranges.each do |(a, b)|
-        break if a >= cx
-        w += Screen.draw_width(line[pos...a]) if a > pos
-        return w if b >= cx
-        pos = b
-      end
-      w + Screen.draw_width(line[pos...cx])
-    end
-
-    # Inverse of `concealed_col` for click-to-cursor: the raw char index whose concealed
-    # display cell holds column `target`. Never returns an index inside a concealed run
-    # (those cells aren't drawn), so a click can't land the caret on a hidden char.
-    private def concealed_col_to_raw(line : String, ranges : Array({Int32, Int32}), target : Int32) : Int32
-      return 0 if target <= 0
-      col = 0
-      i = 0
-      n = line.size
-      while i < n
-        hit = ranges.find { |(a, b)| i >= a && i < b }
-        if hit
-          i = hit[1]
-          next
+      if @line_off_rev != @edits
+        @line_off_rev = @edits
+        offs = Array(Int32).new(@lines.size + 1)
+        acc = 0
+        @lines.each do |l|
+          offs << acc
+          acc += l.size + 1 # +1 for the joining '\n'
         end
-        # Step by CLUSTER, matching `concealed_col`'s draw_width and the cells actually
-        # drawn, so this stays that function's exact inverse and a click lands where the
-        # caret paints. A conceal run opens on a `¦` and closes before a `§`: neither is
-        # ASCII, but both are Grapheme_Cluster_Break=Other and so always BEGIN a cluster,
-        # which is what guarantees no cluster straddles a run boundary.
-        e = Screen.cluster_end(line, i + 1)
-        w = Screen.draw_width(line[i...e])
-        return i if target < col + w
-        col += w
-        i = e
+        offs << acc
+        @line_offs = offs
       end
-      n
+      @line_offs[cy.clamp(0, @lines.size)]
     end
+
+    # NOTE: the three concealed-column helpers that used to live here — `concealed_col`,
+    # `concealed_display_prefix` (a verbatim duplicate of it) and `concealed_col_to_raw` —
+    # are gone. `Wrap.row_col` / `Wrap.row_index` are the same measure and the same inverse,
+    # generalised over a row's starting offset (which is 0 for an unwrapped line, so the
+    # behaviour is identical), and folding them together is the point: this file's standing
+    # hazard is a second nearly-identical width measure drifting from the one the draw uses.
 
     # Pull @cx onto a grapheme-CLUSTER boundary. `@cx` stays a CHARACTER index — conceal
     # ranges, bg_regions, marker spans and the search / find-replace offsets are all char-
@@ -1074,27 +1619,38 @@ module Gori::Tui
       # (snap_cx_to_cluster) and every measure here, in `cxs`/`prefix_w`, and in
       # Highlight.slice_left is draw_width, so the window, the slice and the caret finally
       # agree — that reconciliation was the caret-model change this comment used to defer.
-      full = concealed ? concealed_col(line, cr.not_nil!, line.size) : Screen.draw_width(line)
+      full = concealed ? Wrap.row_col(line, cr, 0, line.size) : Screen.draw_width(line)
       if full + pw <= cw
         @xscroll = 0
         return
       end
       cx = @cx.clamp(0, line.size)
-      curx = (concealed ? concealed_col(line, cr.not_nil!, cx) : Screen.draw_width(line[0, cx])) + pw
+      curx = (concealed ? Wrap.row_col(line, cr, 0, cx) : Screen.draw_width(line[0, cx])) + pw
       @xscroll = curx if curx < @xscroll                # caret left of the window → snap left
       @xscroll = curx - cw + 1 if curx >= @xscroll + cw # caret past the right edge → snap right
       @xscroll = 0 if @xscroll < 0
     end
 
-    # Draw a line whose §…§ markers hide a ¦chain: delete the concealed chars from the
-    # styled line (a single plain span when highlighting is off), then h-scroll-slice and
-    # draw. The marker band + accented closing § are over-painted afterwards by
-    # paint_bg_regions (concealment-aware). Only reached when the line has conceal ranges.
+    # Draw one visual row `[a, b)` of a line whose §…§ markers hide a ¦chain: cut the row
+    # out of the styled line, delete the concealed chars from it (a single plain span when
+    # highlighting is off), then h-scroll-slice and draw. The marker band + accented closing
+    # § are over-painted afterwards by paint_bg_regions (concealment-aware). Only reached
+    # when the line has conceal ranges; `[0, line.size)` — the whole line — without wrap.
+    #
+    # The conceal ranges are re-based onto the row before `Highlight.conceal` sees them:
+    # that function indexes the LINE it is given, and the line it is given here is the row.
     private def draw_concealed_line(screen : Screen, cx0 : Int32, y : Int32, li : Int32,
                                     line : String, styled : Array(Highlight::Line)?,
-                                    cr : Array({Int32, Int32}), cw : Int32) : Nil
-      base = (styled && styled[li]?) || [Highlight::Span.new(line, Theme.text)]
-      cl = Highlight.conceal(base, cr)
+                                    cr : Array({Int32, Int32}), cw : Int32,
+                                    a : Int32 = 0, b : Int32 = -1) : Nil
+      b = line.size if b < 0
+      base = Highlight.slice_chars((styled && styled[li]?) || [Highlight::Span.new(line, Theme.text)], a, b)
+      local = a == 0 ? cr : cr.compact_map do |(ra, rb)|
+        lo = {ra, a}.max - a
+        hi = {rb, b}.min - a
+        lo < hi ? {lo, hi} : nil
+      end
+      cl = Highlight.conceal(base, local)
       cl = Highlight.slice_left(cl, @xscroll) if @xscroll > 0
       Highlight.draw(screen, cx0, y, cl, width: cw)
     end
@@ -1117,15 +1673,8 @@ module Gori::Tui
         spans << Highlight::Span.new(suffix, Theme.text) unless suffix.empty?
         Highlight.draw(screen, cx0, y, Highlight.slice_left(spans, @xscroll), width: cw)
       else
-        screen.text(cx0, y, slice_left(line, @xscroll), Theme.text, width: cw)
+        screen.text(cx0, y, Highlight.slice_left_text(line, @xscroll), Theme.text, width: cw)
       end
-    end
-
-    # Drop the first `start_col` display columns of `s`. A wide glyph straddling the
-    # cut becomes leading spaces for its still-visible cells, so the remaining glyphs
-    # keep their columns. Identity when start_col <= 0.
-    private def slice_left(s : String, start_col : Int32) : String
-      Highlight.slice_left_text(s, start_col)
     end
 
     private def push_undo : Nil
@@ -1145,6 +1694,7 @@ module Gori::Tui
       @cy = state.cy.clamp(0, @lines.size - 1)
       @cx = state.cx.clamp(0, @lines[@cy].size)
       snap_cx_to_cluster(0) # the snapshot's line may differ from the one we clamp against
+      @sel_anchor = nil     # the anchor names offsets in the buffer the undo just replaced
       @styled = nil
       @edits += 1
       refresh_env_complete

--- a/src/gori/tui/wrap.cr
+++ b/src/gori/tui/wrap.cr
@@ -1,0 +1,324 @@
+require "./screen"
+require "./theme"
+
+module Gori::Tui
+  # Soft wrap: one LOGICAL line → N VISUAL rows, Burp-style (the line number is printed
+  # once, on the first row; continuation rows keep a blank gutter and align under the text).
+  #
+  # The break is greedy and measured in DISPLAY COLUMNS via `Screen.grapheme_cols`, never
+  # `String#size`. That is the whole contract of this module and the reason it exists as one:
+  # the repo has repeatedly grown a second, subtly-different width measure next to the one
+  # the draw uses, and every time the two drift the pane paints in the wrong cells (#278
+  # tabs, #285 emoji). A cluster is the atom — it is placed whole on a row or moved whole to
+  # the next — so a wide CJK glyph can never be split across the break, and neither can a
+  # combining sequence, a ZWJ family or a keycap. A single cluster WIDER than the wrap width
+  # still gets a row of its own rather than being cut in half.
+  #
+  # Positions are raw CHARACTER indices into the source line, matching `TextArea#cx` and
+  # every other column index in this codebase, so `Screen.draw_width` / `Screen.column_for`
+  # keep inverting each other at the row boundaries.
+  module Wrap
+    # One DRAWN row of a pane: the logical line it belongs to, its index WITHIN that line
+    # (`sub`), and the `[a, b)` character slice of the line it shows.
+    #
+    # Without wrap there is exactly one row per logical line (`sub == 0`, `a == 0`,
+    # `b == line.size`). With it, `sub` is the ONLY thing a gutter consults — number on row
+    # 0, blank after — so the Burp-style "one line number per logical line" rule has a
+    # single home instead of being re-derived by each painter.
+    record Row, li : Int32, sub : Int32, a : Int32, b : Int32
+
+    # The wrap of ONE line at ONE width. Immutable, cheap to keep, and — for the case that
+    # actually matters for performance, a multi-MB minified ASCII body line — it holds no
+    # per-row array at all: ASCII is exactly one column per character (see
+    # `Screen.draw_width`'s fast path, which is exact rather than an approximation), so the
+    # rows are a uniform grid and every query is arithmetic. A 5 MB line costs O(1) memory
+    # and O(1) per row instead of a 65k-entry offset table.
+    struct Layout
+      # Number of visual rows. Always ≥ 1: an empty line still occupies one row (it is
+      # where the caret goes), and every mapping below assumes row 0 exists.
+      getter rows : Int32
+
+      # `starts` nil ⇒ the uniform ASCII grid; otherwise the char index each row begins at,
+      # ascending, `starts[0] == 0`.
+      def initialize(@len : Int32, @width : Int32, @starts : Array(Int32)?)
+        s = @starts
+        @rows = s ? s.size : (@len <= 0 ? 1 : (@len + @width - 1) // @width)
+      end
+
+      # Char index where visual row `r` begins (clamped into [0, len]).
+      def start_of(r : Int32) : Int32
+        return 0 if r <= 0
+        return @len if r >= @rows
+        if s = @starts
+          s[r]
+        else
+          {r * @width, @len}.min
+        end
+      end
+
+      # Char index one past the last char of visual row `r`. The last row always ends at
+      # the end of the line, so `end_of(rows - 1) == len` no matter how the grid divides.
+      def end_of(r : Int32) : Int32
+        r + 1 >= @rows ? @len : start_of(r + 1)
+      end
+
+      # The visual row holding char index `cx`.
+      #
+      # A cx sitting exactly ON a break belongs to the row it STARTS, not the one it ends —
+      # that is where the caret is drawn and where a click at column 0 of the continuation
+      # row resolves to, so the two agree. The end of the buffer line is the exception: it
+      # terminates the last row (there is no further row to start).
+      def row_of(cx : Int32) : Int32
+        return 0 if cx <= 0
+        return @rows - 1 if cx >= @len
+        if s = @starts
+          # Binary search for the last start ≤ cx.
+          lo = 0
+          hi = s.size - 1
+          while lo < hi
+            mid = (lo + hi + 1) // 2
+            s[mid] <= cx ? (lo = mid) : (hi = mid - 1)
+          end
+          lo
+        else
+          {cx // @width, @rows - 1}.min
+        end
+      end
+    end
+
+    # Wrap `line` to `width` display columns.
+    #
+    # `conceal` are line-local `[a, b)` char ranges that are HIDDEN from the draw (the
+    # `¦chain` segment of a §…§ marker). They occupy no cells, so they must contribute no
+    # width here either — otherwise the break lands short of the right edge by however many
+    # bytes the chain holds, and the marker's own row is the one that mis-paints. Concealed
+    # chars stay inside whichever row their neighbours land on: a run's edges are `¦`/`§`,
+    # both Grapheme_Cluster_Break=Other, so a run never straddles a cluster and a break can
+    # never fall inside one.
+    def self.layout(line : String, width : Int32, conceal : Array({Int32, Int32})? = nil) : Layout
+      len = line.size
+      # A degenerate width can't be divided into; one row, clipped by the drawer as before.
+      return Layout.new(len, 1, [0]) if width <= 0
+      if (conceal.nil? || conceal.empty?) && line.ascii_only?
+        return Layout.new(len, width, nil) # uniform grid — see Layout
+      end
+      starts = [0]
+      col = 0
+      i = 0
+      line.each_grapheme do |g|
+        n = g.size
+        w = hidden?(conceal, i) ? 0 : Screen.grapheme_cols(g.to_s)
+        # `col > 0`: a cluster too wide for the whole row keeps its own row rather than
+        # being split — the one case where a row overflows `width` on purpose.
+        if col > 0 && col + w > width
+          starts << i
+          col = 0
+        end
+        col += w
+        i += n
+      end
+      Layout.new(len, width, starts)
+    end
+
+    # --- the (line, sub-row) scroll anchor -----------------------------------
+    # A pane scrolled by wrapped rows does NOT hold a flat visual-row index: producing one
+    # means wrapping every line from the top of the document, which is an O(whole buffer)
+    # pass on every width change and every edit, over bodies that reach multiple MB. It
+    # holds a (logical line, sub-row) pair instead — Vim's topline+skipcol, VS Code's
+    # line-map — and the three walkers below are all the arithmetic that needs. Each is
+    # O(the number of rows it is asked to move), never O(document).
+    #
+    # `layout_at` hands back the Layout for a line; the caller memoizes it (see the wrap
+    # caches in TextArea and RepeaterView) so a walk over a viewport is a handful of hash
+    # hits rather than a re-wrap.
+
+    # `h` rows starting at (li, sub), stopping at the end of the source.
+    def self.rows(li : Int32, sub : Int32, h : Int32, size : Int32,
+                  layout_at : Int32 -> Layout) : Array(Row)
+      built = Array(Row).new({h, 0}.max)
+      return built if h <= 0 || size <= 0
+      li = li.clamp(0, size - 1)
+      sub = {sub, 0}.max
+      while li < size && built.size < h
+        lay = layout_at.call(li)
+        sub = 0 if sub >= lay.rows # an edit shrank the anchor line under us
+        while sub < lay.rows && built.size < h
+          built << Row.new(li, sub, lay.start_of(sub), lay.end_of(sub))
+          sub += 1
+        end
+        li += 1
+        sub = 0
+      end
+      built
+    end
+
+    # The position `back` visual rows ABOVE (li, sub), stopping at the top of the buffer.
+    def self.step_back(li : Int32, sub : Int32, back : Int32,
+                       layout_at : Int32 -> Layout) : {Int32, Int32}
+      while back > 0
+        if sub > 0
+          step = {back, sub}.min
+          sub -= step
+          back -= step
+        elsif li > 0
+          li -= 1
+          sub = layout_at.call(li).rows - 1
+          back -= 1
+        else
+          break
+        end
+      end
+      {li, sub}
+    end
+
+    # The position `fwd` visual rows BELOW (li, sub), stopping at the end of the buffer.
+    def self.step_forward(li : Int32, sub : Int32, fwd : Int32, size : Int32,
+                          layout_at : Int32 -> Layout) : {Int32, Int32}
+      fwd.times do
+        lay = layout_at.call(li)
+        if sub + 1 < lay.rows
+          sub += 1
+        elsif li < size - 1
+          li += 1
+          sub = 0
+        else
+          break
+        end
+      end
+      {li, sub}
+    end
+
+    # The anchor that puts the buffer's LAST visual row on the bottom line of an `h`-row
+    # pane — the wrapped equivalent of clamping a scroll offset to `size - h`. Walks back
+    # one viewport from that last row, so it costs O(h) and never counts the document.
+    def self.max_anchor(size : Int32, h : Int32, layout_at : Int32 -> Layout) : {Int32, Int32}
+      return {0, 0} if size <= 0
+      last = size - 1
+      step_back(last, layout_at.call(last).rows - 1, {h - 1, 0}.max, layout_at)
+    end
+
+    # The anchor that keeps the caret's visual row (cy, csub) inside an `h`-row viewport,
+    # given the current anchor. Above the window the anchor simply becomes the caret's own
+    # row. Below it, the forward walk counts rows and bails the moment it has seen a
+    # viewport's worth — every logical line contributes at least one row, so that bound is
+    # hit after at most `h` lines — and the anchor is then one viewport back from the caret.
+    # O(h) whatever the document's size.
+    def self.ensure_visible(li : Int32, sub : Int32, cy : Int32, csub : Int32, h : Int32,
+                            layout_at : Int32 -> Layout) : {Int32, Int32}
+      return {li, sub} if h <= 0
+      return {cy, csub} if cy < li || (cy == li && csub < sub)
+      n = 0
+      at = li
+      while at <= cy
+        lay = layout_at.call(at)
+        from = at == li ? sub : 0
+        to = at == cy ? csub : lay.rows - 1
+        n += to - from + 1
+        break if n > h
+        return {li, sub} if at == cy # the caret's row is inside the window
+        at += 1
+      end
+      step_back(cy, csub, h - 1, layout_at)
+    end
+
+    # Whether char index `i` falls inside a concealed run. Linear in the run count, which is
+    # the marker count on one line — single digits in every real request.
+    private def self.hidden?(conceal : Array({Int32, Int32})?, i : Int32) : Bool
+      return false unless conceal
+      conceal.any? { |(a, b)| i >= a && i < b }
+    end
+
+    # Overdraw ^F search matches on ONE visual row `[a, b)` of `line`, which was drawn
+    # starting at content-x `x`; clipped to `max_x` (exclusive).
+    #
+    # Separate from `SearchHi.mark` — and NOT a call to it with the row's text — because
+    # `SearchHi.mark` is given only the string it should scan and therefore cannot know that
+    # something preceded it on the same logical line. Handed one wrapped row at a time it
+    # highlights a match straddling the break on NEITHER row: the head is an incomplete
+    # match at the end of one row, the tail an incomplete match at the start of the next.
+    # Highlighted-nowhere is worse than the horizontal scrolling this replaces, which at
+    # least showed the match once you scrolled to it. So the scan runs over the WHOLE
+    # logical line and each match is clipped to the row — a straddling match is highlighted
+    # on BOTH rows it occupies, which is also what the reader expects to see.
+    def self.mark_search(screen : Screen, x : Int32, y : Int32, line : String,
+                         a : Int32, b : Int32, query : String, max_x : Int32,
+                         conceal : Array({Int32, Int32})? = nil) : Nil
+      return if query.empty? || line.empty? || a >= b
+      q = query.downcase
+      dl = line.downcase
+      # Match in the downcased copy, then slice the ORIGINAL to preserve case — valid only
+      # while downcase is 1:1 (mirrors SearchHi.mark, including its fallback).
+      src = dl.size == line.size ? line : dl
+      pos = 0
+      while (i = dl.index(q, pos))
+        pos = i + q.size
+        ma = {i, a}.max
+        mb = {pos, b}.min
+        next if ma >= mb # this match doesn't touch the row
+        col = x + row_col(line, conceal, a, ma)
+        seg = src[ma...mb]
+        # Concealed chars inside the match aren't on screen; drop them so the overdraw
+        # reproduces exactly the cells the base draw painted.
+        seg = strip_hidden(seg, conceal, ma) if conceal && !conceal.empty?
+        screen.text(col, y, seg, Theme.bg, Theme.yellow, width: {max_x - col, 0}.max) if col < max_x && !seg.empty?
+      end
+    end
+
+    # Display column of raw char index `cx` measured from the start of the visual row that
+    # begins at `a`, with concealed chars contributing no cells. `draw_width` semantics
+    # (≥1 per cluster), matching what `Highlight.draw` / `Screen#text` actually advance —
+    # so caret, selection tint, search overdraw and click all land on the same cells.
+    def self.row_col(line : String, conceal : Array({Int32, Int32})?, a : Int32, cx : Int32) : Int32
+      lo = a.clamp(0, line.size)
+      hi = cx.clamp(lo, line.size)
+      return 0 if lo >= hi
+      return Screen.draw_width(line[lo...hi]) if conceal.nil? || conceal.empty?
+      w = 0
+      pos = lo
+      conceal.each do |(ra, rb)|
+        next if rb <= lo
+        break if ra >= hi
+        s = {ra, lo}.max
+        w += Screen.draw_width(line[pos...s]) if s > pos
+        return w if rb >= hi # cx lands inside the run → the run's own start column
+        pos = {rb, pos}.max
+      end
+      w + Screen.draw_width(line[pos...hi])
+    end
+
+    # Inverse of `row_col` for click hit-testing: the raw char index whose drawn cell holds
+    # display column `target` within the visual row `[a, b)`. Clamped to the row, so a click
+    # past the end of a wrapped row lands on the break rather than running into the next
+    # row's text, and never returns an index inside a concealed run (those cells aren't
+    # drawn) nor inside a cluster (it steps by cluster, like the draw).
+    def self.row_index(line : String, conceal : Array({Int32, Int32})?, a : Int32, b : Int32,
+                       target : Int32) : Int32
+      lo = a.clamp(0, line.size)
+      hi = b.clamp(lo, line.size)
+      return lo if target <= 0
+      col = 0
+      i = lo
+      while i < hi
+        if conceal && (run = conceal.find { |(ra, rb)| i >= ra && i < rb })
+          i = {run[1], hi}.min
+          next
+        end
+        e = {Screen.cluster_end(line, i + 1), hi}.min
+        w = Screen.draw_width(line[i...e])
+        return i if target < col + w
+        col += w
+        i = e
+      end
+      hi
+    end
+
+    # `seg`, whose first char is at line index `off`, with the concealed chars removed.
+    private def self.strip_hidden(seg : String, conceal : Array({Int32, Int32}), off : Int32) : String
+      String.build do |io|
+        seg.each_char_with_index do |c, k|
+          io << c unless hidden?(conceal, off + k)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Four editor/UX items. Every one was reproduced against a running binary before it
was fixed, and re-verified against the built binary after.

Depends on **hahwul/termisu#3** (merged, `bb83fd6`); `shard.lock` is bumped in the
last commit.

## 1. A pasted line break inserted two newlines

Pasting a request copied from Burp Suite left a blank line after every line — which
in the Repeater editor ends the head right after the request line, so the request
goes out with no `Host` and the origin answers 400.

Injecting bytes into the running TUI isolated it:

| injected | result |
|---|---|
| `CR LF` | correct |
| `CR` alone | correct |
| **`CR CR`** | **blank line after every line** |

The terminal maps the LF of each pasted CRLF to a second CR. `PasteNewline` only
collapsed CR-then-LF, so it never fired. **No content rule can close this** — `CR CR`
is byte-for-byte what pressing Enter twice looks like — so the fix is DEC mode 2004
upstream: it brackets the paste *and* makes the terminal deliver clipboard bytes
verbatim. The CR-then-LF pair rule stays as the fallback for terminals that ignore
2004.

Verified on the wire: `\e[?2004h` at startup, `\e[?2004l` on exit, markers swallowed
(no `[200~` leaking into the buffer), one newline per pasted line.

*Honest limit:* tmux's `paste-buffer` replaces LF with CR even when `-p` asks for
brackets, so that specific command still doubles. A normal paste into a tmux pane is
unaffected.

## 2. Long lines wrap instead of scrolling sideways (Burp-style)

One logical line → N visual rows; the gutter numbers the **first row only**,
continuations align under the text column.

```
 3 User-Agent: goriX-Long: AAAABBBBCCCCDDDDE
   EEEFFFFGGGGHHHHIIIIJJJJKKKKLLLLMMMMNNNNOO
   OOPPPP
 4 Accept: */*
```

`src/gori/tui/wrap.cr` is the whole layout primitive — one module, so a second width
measure can't grow beside the one the draw uses. Breaks are on **display columns**
and cluster-atomic (a CJK glyph, combining sequence or ZWJ family is never split).

The scroll anchor is `(logical line, visual row within it)`, **not** a flat visual
index: a flat index can only be built by wrapping the whole document on every width
change and every edit. Render, `ensure_visible`, wheel, click and ↑/↓ are all
O(viewport). Layout is memoized per line keyed on `(revision, width)`; an ASCII line
stores no per-row table at all, so a multi-MB minified line costs O(1).

Search highlighting scans the whole logical line and clips per row, so a match
straddling a break lights on **both** rows — marking per-row would light it on
neither.

**Found while implementing:** the diff pane prefixes rows with a 2-column `"+ "`, so
its wrap must run on the *decorated* line while caret/click/search address the bare
text. Those were two grids that agreed until a line was exactly pane-wide.

## 3. Wheel was dead in INS mode

Two guards, one in `handle_wheel` and one in `RepeaterView#request_scroll_view`, so
removing either alone changed nothing. They landed together in the replay→repeater
migration rather than as a decision — and the same widget wheels fine in insert mode
in Notes and the Decoder input. Both gone; the hex guard stays (different widget,
stale buffer behind it).

## 4. Shift-selection and delete in INS mode

⇧arrows extend, plain arrows collapse, ⌫/Del remove, typing replaces (one undo unit).
Lives in `TextArea`: deleting a selection is a buffer mutation, painting it across
wrapped rows needs the new wrap layer, and in INS the NOR painter isn't called at
all — so the two selections can never both be on screen.

⇧↑ deliberately does not take the `at_top?` escape to the target field: leaving the
editor mid-extend would abandon a selection still being built.

**Bonus fix.** Removing the now-dead `hscroll` stub restored something wrap had
silently broken: `handle_repeater_response_hscroll` ran *before* the response pane's
key ladder and returned true for ⇧←/→, swallowing the chord the ladder maps to
`resp_nav_step(selecting: true)`. Horizontal selection in the response pane was inert
for as long as that stub existed.

## Verification

`crystal spec spec/tui` → **1967 examples, 0 failures**. Build and format clean on
every file touched.

Live on the built binary: wheel scrolls 21→6→15 in INS; ⇧→×8 selects `DELETEME` and
Delete removes exactly it; a long line wraps with the number on the first row only.

Three existing h-scroll specs **flipped rather than being deleted**, each with a
comment saying why and what is still under test.

⚠️ `spec/project_registry_spec.cr` (5) and `spec/capture_status_spec.cr` (3) fail on
my machine — another gori instance holds port 8070. They fail identically on a
stashed clean tree, so they are environmental, not from this branch. CI should be
green.
