### PR TITLE
A space menu that outgrew its corner: 19 entries centered into semantic columns, and an arrow key that used to dismiss it

### DIFF
--- a/spec/tui/space_menu_spec.cr
+++ b/spec/tui/space_menu_spec.cr
@@ -282,10 +282,11 @@ describe Gori::Tui::SpaceMenu do
     backend2.contains?("SPACE · COMMON").should be_false # flat render — no section suffix
   end
 
-  # #442 — History's Body menu is the SINGLE-GROUP case (no context section), where the card
-  # title is normally bare "SPACE". A banner has to reach that branch too, or a batch action
-  # over 3 marked flows would look identical to a single-flow one.
-  it "puts a state banner in the card title, including on a flat single-group render" do
+  # #442 — History's Body menu has no context SECTION, so the card title is normally a
+  # bare "SPACE". A banner has to reach that branch too, or a batch action over 3 marked
+  # flows would look identical to a single-flow one. It is also the branch that carries
+  # SEMANTIC groups, which must not leak a focus-area label into the title.
+  it "puts a state banner in the card title, and never a focus-area label on a semantically-grouped menu" do
     ctx = FakeExecContext.new
     ctx.selected = 5_i64
     menu = SpaceMenu.new(Gori::Verbs.registry)
@@ -294,7 +295,10 @@ describe Gori::Tui::SpaceMenu do
     backend = MemoryBackend.new(100, 30)
     menu.render(Screen.new(backend), Rect.new(0, 0, 100, 28))
     backend.contains?("SPACE · 3 MARKED").should be_true
-    backend.contains?("COMMON").should be_false # still flat: no group headers
+    # Semantic bands render (VIEW/SEND/…), but the focus-area label never does: there is
+    # no focused sub-area here, so "COMMON" would be naming something that isn't shown.
+    backend.contains?("─ VIEW ─").should be_true
+    backend.contains?("COMMON").should be_false
 
     # No banner ⇒ byte-identical to before (a bare "SPACE" card).
     menu.open(Gori::Verb::Scope::Body, :common, ctx)
@@ -497,16 +501,191 @@ describe Gori::Tui::SpaceMenu do
     menu.entries.empty?.should be_true
   end
 
-  it "renders a bottom-right SPACE popup with the mnemonic key + title" do
+  it "renders a centered SPACE popup with the mnemonic key + title" do
     ctx = FakeExecContext.new
     ctx.selected = 5_i64
     menu = SpaceMenu.new(Gori::Verbs.registry)
     menu.open(Gori::Verb::Scope::Body, :common, ctx)
 
     backend = MemoryBackend.new(80, 24)
-    menu.render(Screen.new(backend), Rect.new(0, 3, 80, 20))
+    body = Rect.new(0, 3, 80, 20)
+    menu.render(Screen.new(backend), body)
     backend.contains?("SPACE").should be_true     # the card title
     backend.contains?("Copy flow").should be_true # an entry title
+
+    # Centered, not corner-anchored: the card had outgrown a corner, and bottom-right it
+    # covered the very columns the operator decides from (PATH / STATUS / SIZE / DUR).
+    # Gutters match within the 1 cell an odd leftover cannot split.
+    b = menu.box(body)
+    ((b.x - body.x) - (body.right - b.right)).abs.should be <= 1
+    ((b.y - body.y) - (body.bottom - b.bottom)).abs.should be <= 1
+  end
+
+  it "splits into reading-order columns when one column will not fit, and never strands a header" do
+    ctx = FakeExecContext.new
+    ctx.selected = 5_i64
+    menu = SpaceMenu.new(Gori::Verbs.registry)
+    menu.open(Gori::Verb::Scope::Body, :common, ctx)
+    menu.entries.size.should be > SpaceMenu::MAX_ROWS # more entries than one column holds
+
+    body = Rect.new(0, 0, 100, 26)
+    b = menu.box(body)
+    b.h.should be <= body.h
+    backend = MemoryBackend.new(100, 26)
+    menu.render(Screen.new(backend), body)
+
+    # Nothing clipped: the first and last entries of the LAST band are both on screen,
+    # which is only possible once a second column exists.
+    backend.contains?("Open flow detail").should be_true # first band (VIEW)
+    backend.contains?("Clear history").should be_true    # last band (DANGER)
+    backend.contains?("▼").should be_false               # …and no scrolling was needed
+
+    # Every band header that renders has at least one of its entries on the SAME row or
+    # below it in the same column — i.e. no header alone at a column's last row.
+    interior = (1...(b.h - 1)).map { |i| backend.row(b.y + i) }
+    last_row = interior.last
+    Gori::Tui::SpaceMenu::GROUP_LABELS.each_value do |label|
+      last_row.includes?("─ #{label} ─").should be_false
+    end
+  end
+
+  # The semantic axis must be purely additive: it subdivides what `section` already
+  # selected and NEVER gates what is reachable. A half-tagged scope is the risky case —
+  # an untagged verb must keep a home rather than vanish between the bands.
+  it "subdivides a bucket into semantic bands, keeping untagged verbs under the bucket label" do
+    reg = Gori::Verb::Registry.new
+    [{'a', :view}, {'b', :view}, {'c', :send}, {'d', :danger}].each_with_index do |(key, group), i|
+      reg.register(Gori::Verb::Definition.new(
+        "demo.tagged.#{i}", "Tagged #{key}", "x", Gori::Verb::Scope::Body,
+        mnemonic: key, group: group) { |_| nil })
+    end
+    # Deliberately left :none — the half-tagged case.
+    reg.register(Gori::Verb::Definition.new(
+      "demo.untagged", "Untagged one", "x", Gori::Verb::Scope::Body,
+      mnemonic: 'z') { |_| nil })
+
+    menu = SpaceMenu.new(reg)
+    menu.open(Gori::Verb::Scope::Body, :common, FakeExecContext.new)
+
+    # Nothing dropped, and the bands are in GROUP_ORDER with the leftovers last.
+    menu.entries.size.should eq(5)
+    menu.entries.map(&.id).should contain("demo.untagged")
+    menu.verb_for('z').try(&.id).should eq("demo.untagged")
+
+    backend = MemoryBackend.new(60, 30)
+    menu.render(Screen.new(backend), Rect.new(0, 0, 60, 28))
+    backend.contains?("─ VIEW ─").should be_true
+    backend.contains?("─ SEND ─").should be_true
+    backend.contains?("─ DANGER ─").should be_true
+    backend.contains?("─ COMMON ─").should be_true # the untagged leftover's home
+    backend.contains?("Untagged one").should be_true
+  end
+
+  it "leaves a fully untagged scope byte-identical to the pre-grouping flat list" do
+    reg = Gori::Verb::Registry.new
+    4.times do |i|
+      reg.register(Gori::Verb::Definition.new(
+        "demo.#{i}", "Item #{i}", "x", Gori::Verb::Scope::Body,
+        mnemonic: ('a'.ord + i).unsafe_chr) { |_| nil })
+    end
+    menu = SpaceMenu.new(reg)
+    menu.open(Gori::Verb::Scope::Body, :common, FakeExecContext.new)
+
+    backend = MemoryBackend.new(60, 30)
+    menu.render(Screen.new(backend), Rect.new(0, 0, 60, 28))
+    backend.contains?("Item 0").should be_true
+    backend.contains?("─").should be_true           # the card border, yes
+    backend.contains?("─ COMMON ─").should be_false # but no header row at all
+    Gori::Tui::SpaceMenu::GROUP_LABELS.each_value do |label|
+      backend.contains?("─ #{label} ─").should be_false
+    end
+  end
+
+  it "keeps the single scrolling column on a terminal too short to split" do
+    ctx = FakeExecContext.new
+    ctx.selected = 5_i64
+    menu = SpaceMenu.new(Gori::Verbs.registry)
+    menu.open(Gori::Verb::Scope::Body, :common, ctx)
+
+    backend = MemoryBackend.new(40, 8)
+    menu.render(Screen.new(backend), Rect.new(0, 0, 40, 6))
+    backend.contains?("▼").should be_true # still the pre-column vertical-scroll path
+  end
+
+  # ↑/↓ walk the whole list in reading order; ←/→ is the across axis the column layout
+  # implies. Before this, an arrow key that wasn't up/down fell through to the "unmapped
+  # leader key" branch and DISMISSED the menu.
+  it "moves the selection across columns with move_column, landing only on real entries" do
+    ctx = FakeExecContext.new
+    ctx.selected = 5_i64
+    menu = SpaceMenu.new(Gori::Verbs.registry)
+    menu.open(Gori::Verb::Scope::Body, :common, ctx)
+
+    body = Rect.new(0, 0, 100, 26) # wide + tall enough to split into columns
+    first = menu.selected_verb.try(&.id)
+
+    menu.move_column(1, body)
+    right = menu.selected_verb.try(&.id)
+    right.should_not eq(first) # actually moved
+    right.should_not be_nil    # …onto a real entry, not a header or a filler
+
+    menu.move_column(-1, body)
+    menu.selected_verb.try(&.id).should eq(first) # and back
+
+    # Clamped at the outer columns rather than wrapping or going out of range.
+    menu.move_column(-1, body)
+    menu.selected_verb.try(&.id).should eq(first)
+    8.times { menu.move_column(1, body) }
+    menu.selected_verb.should_not be_nil
+  end
+
+  it "leaves move_column inert when the popup is a single column" do
+    ctx = FakeExecContext.new
+    ctx.selected = 5_i64
+    menu = SpaceMenu.new(Gori::Verbs.registry)
+    menu.open(Gori::Verb::Scope::Body, :common, ctx)
+
+    narrow = Rect.new(0, 0, 40, 6) # the short/narrow single-column scroll path
+    before = menu.selected_verb.try(&.id)
+    menu.move_column(1, narrow)
+    menu.selected_verb.try(&.id).should eq(before)
+    menu.move_column(-1, narrow)
+    menu.selected_verb.try(&.id).should eq(before)
+  end
+
+  # Runner#click_space_menu keys off BOTH of these: row_at nil + inside the box ⇒ inert,
+  # row_at nil + outside ⇒ dismiss. Centering made this load-bearing (the card now sits
+  # over the list and carries header rows the operator can plausibly click), so pin the
+  # two predicates the Runner relies on.
+  it "reports its box so a click inside it can be told from a click outside" do
+    ctx = FakeExecContext.new
+    ctx.selected = 5_i64
+    menu = SpaceMenu.new(Gori::Verbs.registry)
+    menu.open(Gori::Verb::Scope::Body, :common, ctx)
+
+    body = Rect.new(0, 0, 100, 26)
+    b = menu.box(body)
+    b.contains?(b.x + 2, b.y + 1).should be_true # a header row: inside, but row_at is nil
+    menu.row_at(body, b.x + 2, b.y + 1).should be_nil
+    b.contains?(body.x, body.y).should be_false # the body's corner is outside the card
+  end
+
+  it "does not make a header row or a column-break filler clickable" do
+    ctx = FakeExecContext.new
+    ctx.selected = 5_i64
+    menu = SpaceMenu.new(Gori::Verbs.registry)
+    menu.open(Gori::Verb::Scope::Body, :common, ctx)
+
+    body = Rect.new(0, 0, 100, 26)
+    b = menu.box(body)
+    # The first interior row of column 1 is the VIEW header (see the grouped render).
+    menu.row_at(body, b.x + 2, b.y + 1).should be_nil
+    # …and every cell that DOES resolve maps to a real entry index.
+    (1...(b.h - 1)).each do |i|
+      if idx = menu.row_at(body, b.x + 2, b.y + i)
+        idx.should be < menu.entries.size
+      end
+    end
   end
 
   it "scrolls to keep the selection on-screen when the popup is shorter than the list" do

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -1402,12 +1402,17 @@ module Gori::Tui
     # (click_project moved to ProjectController#handle_click)
 
     # The space menu floats over everything: a click on an entry runs it, a click
-    # elsewhere dismisses it. Always consumes the click (returns true).
+    # OUTSIDE the card dismisses it, and a click inside that isn't an entry (a group
+    # header, a column-break filler, the gap between columns, the border) is inert —
+    # matching every other centered modal. That last case matters now the card is
+    # centered and multi-column: it carries real header rows the operator can plausibly
+    # click, and dismissing on those would throw away the menu mid-decision.
+    # Always consumes the click (returns true).
     private def click_space_menu(layout : Layout, mx : Int32, my : Int32) : Bool
       if idx = @space_menu.row_at(layout.body, mx, my)
         @space_menu.set_selected(idx)
         run_space_verb(@space_menu.selected_verb)
-      else
+      elsif !@space_menu.box(layout.body).contains?(mx, my)
         close_space_menu
       end
       true
@@ -2504,25 +2509,43 @@ module Gori::Tui
         @space_menu.move(-1)
       elsif key.down? || key.tab?
         @space_menu.move(1)
+      elsif key.left?
+        space_menu_move_column(-1)
+      elsif key.right?
+        space_menu_move_column(1)
       elsif key.enter?
         run_space_verb(@space_menu.selected_verb)
       elsif (c = ev.char) && !ev.ctrl? && !ev.alt?
-        # A bound mnemonic always wins (helix leader). Only when j/k are NOT a live
+        # A bound mnemonic always wins (helix leader). Only when j/k/h/l are NOT a live
         # mnemonic in this menu do they fall back to vim-style nav — so the reflex
         # keystroke moves the selection instead of dismissing the menu, while scopes
-        # that bind 'k' (e.g. link-to-issue) keep their mnemonic.
+        # that bind 'k' (link-to-issue) or 'h' (add-host, dismiss-host) keep theirs.
         if verb = @space_menu.verb_for(c)
           run_space_verb(verb)
         elsif c == 'j'
           @space_menu.move(1)
         elsif c == 'k'
           @space_menu.move(-1)
+        elsif c == 'h'
+          space_menu_move_column(-1)
+        elsif c == 'l'
+          space_menu_move_column(1)
         else
           close_space_menu # an unmapped leader key dismisses (helix feel)
         end
       else
         close_space_menu
       end
+    end
+
+    # ←/→ (and h/l) in the space menu: how many columns the popup has is a function of
+    # the body it is drawn into, so recompute the same geometry render uses. Silently
+    # inert when the menu is a single column or already at the outer one — an arrow key
+    # must never dismiss the menu the way an unmapped leader key does.
+    private def space_menu_move_column(delta : Int32) : Nil
+      w, h = @backend.size
+      return unless Layout.usable?(w, h)
+      @space_menu.move_column(delta, Layout.compute(w, h, statusline_active?).body)
     end
 
     # Close the menu, then run the verb (if any) and surface its status toast.
@@ -3032,7 +3055,7 @@ module Gori::Tui
     # the active tab, and any open overlay (so the user always sees what the keys
     # under their fingers do right now).
     private def key_hints : String
-      return "press a key · ↑/↓ select · ↵ run · esc close" if @space_menu_open
+      return "press a key · ↑/↓ select · ←/→ column · ↵ run · esc close" if @space_menu_open
       if pt = prompt_picker # prompt-tier Overlays carry their own hint too
         return pt.hint
       end

--- a/src/gori/tui/space_menu.cr
+++ b/src/gori/tui/space_menu.cr
@@ -5,46 +5,81 @@ require "../verb"
 require "../hotkeys"
 
 module Gori::Tui
-  # The "space" action menu — a helix-style leader popup anchored at the
-  # BOTTOM-RIGHT of the body. Pressing space in a navigable area opens it; it
-  # lists that area's own verbs (the Verb::Scope + Verb::Section captured at
-  # open), each fronted by a single mnemonic key. Pressing the key runs the verb
-  # through the SAME Verb::Definition#call path as a keybinding and the palette
-  # (P1 — no separate execution path).
+  # The "space" action menu — a leader popup CENTERED in the body. Pressing space in
+  # a navigable area opens it; it lists that area's own verbs (the Verb::Scope +
+  # Verb::Section captured at open), each fronted by a single mnemonic key. Pressing
+  # the key runs the verb through the SAME Verb::Definition#call path as a keybinding
+  # and the palette (P1 — no separate execution path).
   #
-  # Where Ctrl-P's PaletteState is a centered fuzzy-typed modal of every Global
-  # verb, the space menu is mnemonic-only (no text input, no fuzzy filter): the
-  # shown set is exactly `for_scope` narrowed to verbs that have a `menu_key`,
-  # then split into a COMMON group (tab-wide) and a CONTEXT group (the focused
-  # section — a body pane, the tab bar, or the sub-tab strip). Render is ALWAYS a
-  # narrow single-column list — one entry per row, growing tall rather than wide
-  # — with a dim section-header row between groups. When there's only ONE group
-  # to show (section == :common, or nothing tags the focused section yet, i.e.
-  # single-region tabs like History/Sitemap/Notes/…), the header is OMITTED
-  # entirely: a flat list, pixel-identical to the pre-grouping menu. Pure
-  # input/state + rendering; the Runner owns opening/closing, capturing the
+  # Where Ctrl-P's PaletteState is a centered fuzzy-typed modal of every Global verb,
+  # the space menu is mnemonic-only (no text input, no fuzzy filter): the shown set is
+  # exactly `for_scope` narrowed to verbs that have a `menu_key`. THAT — the
+  # interaction, not the position — is what keeps the two surfaces from collapsing
+  # into each other. Both are centered cards; one is typed, one is one-keypress. Adding
+  # a query line here would make it a second palette wherever it was drawn.
+  #
+  # Grouping runs on two orthogonal axes:
+  #   * `Verb::Definition#section` — FOCUS AREA. Splits into a COMMON band (tab-wide)
+  #     and a CONTEXT band (the focused pane / tab bar / sub-tab strip). A section's
+  #     verbs appear ONLY while that area is focused.
+  #   * `Verb::Definition#group` — SEMANTIC BAND (VIEW / SEND / TRIAGE / COPY / SCOPE /
+  #     DANGER). Never gates visibility; it subdivides whatever bands `section`
+  #     produced. This is what makes the single-region scopes scannable — History's
+  #     Body is 19 entries with no focus sub-areas at all, so `section` alone can
+  #     never break it up.
+  # A bucket whose verbs are all `:none` keeps its own label and renders exactly as it
+  # did before, so an untagged scope is untouched.
+  #
+  # Layout is a single narrow column until that column would not fit, then COLUMN-MAJOR
+  # multi-column (see #layout) — read down, then across. Group headers never strand at
+  # a column's last row (#pad_rows); a group larger than the space left in a column
+  # does continue into the next one, which reads correctly in down-then-across order.
+  # Pure input/state + rendering; the Runner owns opening/closing, capturing the
   # scope+section, and executing the selection.
   class SpaceMenu
-    # Tallest popup before it scrolls. Sized to clear the busiest scope (History's
-    # Body has 13 menu entries) with headroom, so the common case never scrolls; when
-    # it does (a short terminal, or a future scope with more verbs) render() draws
-    # ▲/▼ markers. box() still clamps the height to the body, so this is only the
-    # "don't grow past this even on a tall terminal" ceiling.
+    # Tallest ONE COLUMN may grow before the layout either adds a column or (when it
+    # can't) scrolls. box() still clamps to the body, so this is only the "don't grow
+    # past this even on a tall terminal" ceiling. History's Body — the busiest scope at
+    # 19 entries, 25 rows with its semantic headers — exceeds this on purpose: it is
+    # what a second column is for.
     MAX_ROWS = 16
 
-    # Fixed per-row chrome around the title in the narrow single-column layout:
-    # left border(1) + selection indicator(1) + mnemonic key(1) + gap(1) + scroll-
-    # marker column(1) + right border(1) = 6, plus room for an optional dim
-    # direct-chord label (e.g. `^R`) when the verb has a rebindable binding that
-    # differs from the space mnemonic.
-    CHROME    = 6
-    CHORD_COL = 5 # reserved right gutter for e.g. `^R` / `⇧I`
+    # Fixed per-row chrome around the title: left border(1) + selection indicator(1) +
+    # mnemonic key(1) + gap(1) + scroll-marker column(1) + right border(1) = 6, plus
+    # room for an optional dim direct-chord label (e.g. `^R`) when the verb has a
+    # rebindable binding that differs from the space mnemonic. At ncols == 1 this is
+    # exactly the box width over the title; see #cell_w for the multi-column split.
+    CHROME = 6
 
     SECTION_LABELS = {
       :common => "COMMON", :request => "REQUEST", :response => "RESPONSE", :target => "TARGET",
       :template => "TEMPLATE", :config => "CONFIG", :results => "RESULTS", :detail => "DETAIL",
       :input => "INPUT", :chain => "CHAIN", :output => "OUTPUT", :tab => "TAB", :subtab => "SUBTAB",
     } of Symbol => String
+
+    # The semantic bands a bucket is subdivided into, in RENDER ORDER — read top-to-
+    # bottom / left-to-right, so the order is the reading order and :danger lands last
+    # (a destructive key is never the neighbour of the key above it by accident).
+    # A verb's Verb::Definition#group picks its band; :none-tagged verbs are not
+    # subdivided at all (see #split_semantic).
+    GROUP_ORDER = [:view, :send, :triage, :copy, :scope, :danger]
+
+    GROUP_LABELS = {
+      :view   => "VIEW",   # inspect / filter / display toggles — changes what you SEE
+      :send   => "SEND",   # hand the selection to another tool (Repeater, Fuzzer, …)
+      :triage => "TRIAGE", # mark, tag, file, link, promote — engagement bookkeeping
+      :copy   => "COPY",   # copy out (clipboard / copy-as)
+      :scope  => "SCOPE",  # scope lens + scope membership
+      :danger => "DANGER", # deletes and clears
+    } of Symbol => String
+
+    # Below this many interior rows a column is too stubby to be worth splitting into,
+    # so a very short terminal keeps the single-column vertical scroll (▲/▼) instead of
+    # sprouting 3-row columns. Only consulted when the list does not already fit.
+    MIN_COL_ROWS = 8
+
+    # Gap between adjacent columns in the multi-column layout.
+    COL_GAP = 2
 
     getter selected : Int32
 
@@ -92,20 +127,26 @@ module Gori::Tui
       common = all.select { |v| v.section == :common }
       context = section == :common ? [] of Verb::Definition : all.select { |v| v.section == section }
 
-      # Only NON-EMPTY sections become a group — an empty COMMON (never happens in
+      # Only NON-EMPTY sections become a bucket — an empty COMMON (never happens in
       # practice, but defensive) or an empty CONTEXT (the common case for
       # single-region tabs, or a section nothing is tagged for yet) simply drops out
       # rather than rendering a header with nothing under it.
+      ctx_label = SECTION_LABELS[section]? || section.to_s.upcase
+      buckets = [] of {String, Array(Verb::Definition)}
+      buckets << {SECTION_LABELS[:common], common} unless common.empty?
+      buckets << {ctx_label, context} unless context.empty?
+
+      # Each focus-area bucket is then subdivided by the SEMANTIC axis when its verbs
+      # carry one — that is what breaks the single-region scopes (History's 19-entry
+      # Body) into scannable bands. An untagged bucket keeps its own label and renders
+      # exactly as it did before.
       groups = [] of {String, Array(Verb::Definition)}
-      groups << {SECTION_LABELS[:common], common} unless common.empty?
-      label = SECTION_LABELS[section]? || section.to_s.upcase
-      groups << {label, context} unless context.empty?
+      buckets.each { |(label, verbs)| groups.concat(split_semantic(label, verbs)) }
 
       if groups.size <= 1
         # Nothing to distinguish — one flat column, no headers.
         @entries = groups.empty? ? ([] of Verb::Definition) : groups[0][1]
         @groups = [] of Group
-        @section_label = banner || ""
       else
         @entries = groups.flat_map(&.[1])
         idx = 0
@@ -114,14 +155,34 @@ module Gori::Tui
           idx += verbs.size
           g
         end
-        @section_label = banner || label
       end
+      # The card-title suffix tracks the FOCUS AREA only, never the semantic bands: a
+      # semantically-grouped single-region menu (History Body) still reads a bare
+      # "SPACE", because there is no focused sub-area to name. A banner always wins.
+      @section_label = banner || (context.empty? ? "" : ctx_label)
       # Widest of the entry titles AND the group headers ("─ LABEL ─", 4 chars of
       # chrome around the label) — a grouped view with a long section label (e.g.
       # SECTION_LABELS additions) must still fit inside the box the entries sized.
       entry_w = @entries.empty? ? 0 : @entries.max_of { |v| menu_title(v, ctx).size + chord_hint_w(v) }
       header_w = @groups.empty? ? 0 : @groups.max_of { |g| g.label.size + 4 }
       @title_w = {entry_w, header_w}.max
+    end
+
+    # One bucket's rows: its semantic bands (GROUP_ORDER, non-empty only) when ANY verb
+    # in it carries a `group`, else the bucket itself under its own focus-area label.
+    # Verbs left `:none` inside an otherwise-tagged bucket keep that bucket's label as a
+    # trailing band, so a half-tagged scope can never silently drop a verb — the worst
+    # case is one extra header, never a missing action.
+    private def split_semantic(label : String, verbs : Array(Verb::Definition)) : Array({String, Array(Verb::Definition)})
+      return [{label, verbs}] if verbs.all? { |v| v.group == :none }
+      bands = [] of {String, Array(Verb::Definition)}
+      GROUP_ORDER.each do |g|
+        band = verbs.select { |v| v.group == g }
+        bands << {GROUP_LABELS[g], band} unless band.empty?
+      end
+      rest = verbs.select { |v| v.group == :none }
+      bands << {label, rest} unless rest.empty?
+      bands
     end
 
     # Extra width when we paint a dim direct-chord label next to the title.
@@ -147,6 +208,37 @@ module Gori::Tui
     def move(delta : Int32) : Nil
       return if @entries.empty?
       @selected = (@selected + delta).clamp(0, @entries.size - 1)
+    end
+
+    # Move the selection one COLUMN left/right, keeping its row offset within the column.
+    # ↑/↓ already walk the whole list in reading order (down a column, then on to the top
+    # of the next), so ←/→ is the across axis that layout implies. A no-op in the
+    # single-column layout — there is nowhere to go — and at the outer columns.
+    #
+    # It never lands on a header or a column-break filler: it takes the nearest ENTRY row
+    # in the target column, searching down from the same offset then up. Needs `body`
+    # because how many columns exist is a function of the space available (see #grid).
+    def move_column(delta : Int32, body : Rect) : Nil
+      return if @entries.empty? || delta == 0
+      g = grid(body)
+      return if g.ncols <= 1 || g.col_rows <= 0
+      rows = g.rows
+      sel_row = rows.index { |r| r.entry == @selected } || 0
+      col = sel_row // g.col_rows
+      off = sel_row % g.col_rows
+      target = (col + delta).clamp(0, g.ncols - 1)
+      return if target == col
+      base = target * g.col_rows
+      (0...g.col_rows).each do |d|
+        {off + d, off - d}.each do |o|
+          next if o < 0 || o >= g.col_rows
+          next unless row = rows[base + o]?
+          if idx = row.entry
+            @selected = idx
+            return
+          end
+        end
+      end
     end
 
     def selected_verb : Verb::Definition?
@@ -177,18 +269,91 @@ module Gori::Tui
       rows
     end
 
-    # The popup box: narrow, bottom-right of `body`, exactly as wide as the widest
-    # title needs (+ CHROME) and as tall as the row list needs (+ frame, capped at
-    # MAX_ROWS). Empty Rect when there's nothing to show or it can't fit.
+    # The resolved column grid for a given body, AND the exact row list to
+    # draw (padded, see #pad_rows). `ncols` == 1 is the pre-column layout in every
+    # respect (including vertical scroll and an unpadded row list), so a narrow or short
+    # terminal behaves exactly as it did. Columns are filled COLUMN-MAJOR: column c holds
+    # rows [c*col_rows, (c+1)*col_rows), so reading order is down-then-across and a
+    # group's rows stay contiguous.
+    private record Grid, ncols : Int32, col_rows : Int32, viewport : Int32, rows : Array(DisplayRow)
+
+    # Push a group header off the LAST row of a column: a header there is stranded, with
+    # every one of its entries in the next column (the bug the first column build had —
+    # History's `─ TRIAGE ─` sat alone at the bottom of column 1 while t/T/a started
+    # column 2). A filler row takes that slot instead and the header moves over with its
+    # items. Fillers are inert everywhere: not drawn, not selectable, not clickable.
+    private def pad_rows(rows : Array(DisplayRow), col_rows : Int32) : Array(DisplayRow)
+      return rows if col_rows <= 1
+      out = [] of DisplayRow
+      rows.each do |r|
+        out << DisplayRow.new(nil, nil) if r.label && (out.size % col_rows) == col_rows - 1
+        out << r
+      end
+      out
+    end
+
+    # How many columns to use, how the rows divide between them, and the padded rows.
+    # Multi-column only kicks in when the list does NOT already fit AND a column would be
+    # tall enough to be worth having (MIN_COL_ROWS) AND at least two columns fit the
+    # width — otherwise a single scrolling column, exactly as before.
+    private def grid(body : Rect) : Grid
+      base = display_rows
+      avail = { {body.h - 2, MAX_ROWS}.min, 1 }.max # interior rows one column may use
+      cell = @title_w + 3                           # indicator + key + gap + title
+      fit = {(body.w - 3 + COL_GAP) // (cell + COL_GAP), 1}.max
+      if base.size <= avail || avail < MIN_COL_ROWS || fit < 2
+        return Grid.new(1, base.size, {base.size, avail}.min, base)
+      end
+      ncols = {(base.size + avail - 1) // avail, fit}.min
+      col_rows = (base.size + ncols - 1) // ncols
+      # Padding adds rows, which can push the balanced height back up — settle it by
+      # growing the column (up to avail), then by adding a column. Bounded: each pass
+      # strictly grows col_rows or ncols, both of which are capped.
+      4.times do
+        need = (pad_rows(base, col_rows).size + ncols - 1) // ncols
+        break if need <= col_rows
+        if need <= avail
+          col_rows = need
+        elsif ncols < fit
+          ncols += 1
+          col_rows = (base.size + ncols - 1) // ncols
+        else
+          col_rows = avail
+          break
+        end
+      end
+      Grid.new(ncols, col_rows, {col_rows, avail}.min, pad_rows(base, col_rows))
+    end
+
+    # The interior width of ONE column inside a drawn box (indicator + key + gap +
+    # title). The single source both render and row_at derive their x math from, so the
+    # two can never disagree. At ncols == 1 this is `b.w - 3`, i.e. exactly the width the
+    # pre-column layout used (CHROME = the 3 here + scroll gutter + 2 borders).
+    private def cell_w(b : Rect, ncols : Int32) : Int32
+      {(b.w - 3 - (ncols - 1) * COL_GAP) // ncols, 1}.max
+    end
+
+    # The popup box: CENTERED in `body` (like the palette's card), as wide as its
+    # column(s) need and as tall as one column's rows need (+ frame). Empty Rect when
+    # there's nothing to show or it can't fit.
+    #
+    # Centered rather than bottom-right (the original helix-leader placement): the card
+    # had grown past what a corner can hold — History's Body alone is 19 entries — and
+    # anchored at the bottom-right it covered exactly the columns the operator decides
+    # from (PATH / STATUS / SIZE / DUR). Centering is also gori's own idiom for a modal
+    # card; the corner popup was the outlier. What keeps this from collapsing into a
+    # second Ctrl-P is the INTERACTION, not the position: no query line, no fuzzy
+    # filter — one mnemonic keypress per action (see the class comment).
     def box(body : Rect) : Rect
       return Rect.new(0, 0, 0, 0) if @entries.empty?
-      total_rows = display_rows.size
-      rows = {total_rows, MAX_ROWS}.min
-      w = {@title_w + CHROME, body.w - 2}.min
-      h = {rows + 2, body.h}.min
+      g = grid(body)
+      cell = @title_w + 3
+      # left border + columns (+ gaps) + scroll gutter + right border
+      w = {3 + g.ncols * cell + (g.ncols - 1) * COL_GAP, body.w - 2}.min
+      h = {g.viewport + 2, body.h}.min
       return Rect.new(0, 0, 0, 0) if w < 10 || h < 3
-      x = body.right - w - 1 # one-col gutter inside the body's right edge
-      y = body.bottom - h    # bottom edge flush with the body bottom (above status)
+      x = body.x + (body.w - w) // 2
+      y = body.y + (body.h - h) // 2
       Rect.new(x, y, w, h)
     end
 
@@ -202,47 +367,59 @@ module Gori::Tui
       title = @section_label.empty? ? "SPACE" : "SPACE · #{@section_label}"
       Frame.card(screen, b, title, border: Theme.border_focus)
 
-      rows = display_rows
+      g = grid(body)
+      rows = g.rows
       viewport = b.h - 2
-      ensure_visible(rows, viewport)
-      visible = {viewport, rows.size - @scroll}.min
+      cw = cell_w(b, g.ncols)
+      ensure_visible(rows, viewport, g)
+      # The scroll affordance is per-COLUMN-height now: with ncols == 1 that is the whole
+      # list (identical to before), and with columns it is how far one column reaches.
+      visible = {viewport, g.col_rows - @scroll}.min
       (0...viewport).each do |i|
-        ridx = @scroll + i
-        break if ridx >= rows.size
-        row = rows[ridx]
         ry = b.y + 1 + i
-        # A header row is never "active" (row.entry is nil, never equal to @selected),
-        # so this covers both rows uniformly.
-        active = row.entry == @selected
-        bg = active ? Theme.accent_bg : Theme.panel
-        screen.fill(Rect.new(b.x + 1, ry, b.w - 2, 1), bg)
-        # Draw the scroll affordance BEFORE the header early-return: the boundary
-        # viewport row can land on a header, and the ▲/▼/↕ marker must still show
-        # (it was previously swallowed whenever that happened).
-        if mark = scroll_marker(i, visible, viewport, rows.size)
-          screen.cell(b.right - 2, ry, mark, Theme.muted, bg)
+        # One background sweep per screen row, then each column paints into its own cell.
+        # A row that is short in one column (the last column is partly empty when the
+        # rows do not divide evenly) simply leaves that cell blank.
+        screen.fill(Rect.new(b.x + 1, ry, b.w - 2, 1), Theme.panel)
+        if mark = scroll_marker(i, visible, viewport, g.col_rows)
+          screen.cell(b.right - 2, ry, mark, Theme.muted, Theme.panel)
         end
-        if label = row.label
-          # Clamp to the box interior (mirrors the entry row's width: below) so a long
-          # header can never paint past the right border / scroll-marker column.
-          screen.text(b.x + 2, ry, "─ #{label} ─", Theme.muted, bg, width: {b.w - 4, 0}.max)
-          next
-        end
-        idx = row.entry.not_nil!
-        v = @entries[idx]
-        screen.cell(b.x + 1, ry, active ? '▎' : ' ', Theme.accent, bg)
-        screen.text(b.x + 2, ry, v.menu_key.to_s, Theme.accent, bg, Attribute::Bold)
-        title_fg = active ? Theme.text_bright : Theme.text
-        # Reserve the rightmost interior col for the scroll marker, and (when set)
-        # a dim direct-chord label so rebinds stay visible without changing mnemonics.
-        hint = chord_hint(v)
-        hint_w = hint ? hint.size + 1 : 0
-        title_text = @ctx.try { |c| menu_title(v, c) } || v.title
-        screen.text(b.x + 4, ry, title_text, title_fg, bg, width: {b.w - 6 - hint_w, 0}.max)
-        if hint
-          screen.text(b.right - 2 - hint.size, ry, hint, Theme.muted, bg)
+        (0...g.ncols).each do |c|
+          ridx = c * g.col_rows + @scroll + i
+          next if ridx >= rows.size || @scroll + i >= g.col_rows
+          draw_cell(screen, rows[ridx], b.x + 1 + c * (cw + COL_GAP), ry, cw)
         end
       end
+    end
+
+    # One cell of the grid: a dim "─ LABEL ─" header, an entry row, or nothing at all
+    # for a pad_rows filler. `cx`/`cw` are the cell's own left edge and width, so this is
+    # identical whether it is the only column or one of several.
+    private def draw_cell(screen : Screen, row : DisplayRow, cx : Int32, ry : Int32, cw : Int32) : Nil
+      return if row.label.nil? && row.entry.nil? # a pad_rows filler — draws as blank
+                # A header row is never "active" (row.entry is nil, never equal to @selected), so
+                # this covers both rows uniformly.
+      active = row.entry == @selected
+      bg = active ? Theme.accent_bg : Theme.panel
+      screen.fill(Rect.new(cx, ry, cw, 1), bg) if active
+      if label = row.label
+        # Clamp to the cell (mirrors the entry row's width below) so a long header can
+        # never paint past its column / the scroll-marker gutter.
+        screen.text(cx + 1, ry, "─ #{label} ─", Theme.muted, bg, width: {cw - 1, 0}.max)
+        return
+      end
+      return unless idx = row.entry
+      v = @entries[idx]
+      screen.cell(cx, ry, active ? '▎' : ' ', Theme.accent, bg)
+      screen.text(cx + 1, ry, v.menu_key.to_s, Theme.accent, bg, Attribute::Bold)
+      # Reserve room inside the cell for (when set) a dim direct-chord label, so rebinds
+      # stay visible without changing mnemonics.
+      hint = chord_hint(v)
+      hint_w = hint ? hint.size + 1 : 0
+      title_text = @ctx.try { |c| menu_title(v, c) } || v.title
+      screen.text(cx + 3, ry, title_text, active ? Theme.text_bright : Theme.text, bg,
+        width: {cw - 3 - hint_w, 0}.max)
+      screen.text(cx + cw - hint.size, ry, hint, Theme.muted, bg) if hint
     end
 
     # The scroll affordance for row `i`: ▲ on the top row when entries are hidden
@@ -260,20 +437,22 @@ module Gori::Tui
       nil
     end
 
-    # Scroll so the selection stays visible when the popup is shorter than the row
-    # list (short terminals) — mirrors the palette/command-line behaviour. Works in
+    # Scroll so the selection stays visible when a COLUMN is shorter than the rows it
+    # holds (short terminals) — mirrors the palette/command-line behaviour. Works in
     # DISPLAY-ROW space (headers count as rows) so it's correct whether or not this
-    # frame has a header at all.
-    private def ensure_visible(rows : Array(DisplayRow), viewport : Int32) : Nil
+    # frame has a header at all, and in column space so the offset is the selection's
+    # position WITHIN its own column (identical to the flat case at ncols == 1).
+    private def ensure_visible(rows : Array(DisplayRow), viewport : Int32, g : Grid) : Nil
       return if viewport <= 0 || rows.empty?
       sel_row = rows.index { |r| r.entry == @selected } || 0
-      @scroll = sel_row if sel_row < @scroll
-      @scroll = sel_row - viewport + 1 if sel_row >= @scroll + viewport
+      off = g.col_rows > 0 ? sel_row % g.col_rows : sel_row
+      @scroll = off if off < @scroll
+      @scroll = off - viewport + 1 if off >= @scroll + viewport
       @scroll = 0 if @scroll < 0
     end
 
-    # Maps a click in `body` to an entry index (or nil) — inverts box()'s rows.
-    # Header rows aren't clickable.
+    # Maps a click in `body` to an entry index (or nil) — inverts box()/render()'s grid.
+    # Header rows and the inter-column gap aren't clickable.
     def row_at(body : Rect, mx : Int32, my : Int32) : Int32?
       b = box(body)
       return nil if b.empty?
@@ -281,10 +460,17 @@ module Gori::Tui
       i = my - (b.y + 1)
       return nil if i < 0 || i >= viewport
       return nil if mx <= b.x || mx >= b.right - 1
-      rows = display_rows
-      ridx = @scroll + i
+      g = grid(body)
+      cw = cell_w(b, g.ncols)
+      rel = mx - (b.x + 1)
+      c = rel // (cw + COL_GAP)
+      return nil if c >= g.ncols                   # the scroll gutter, not a column
+      return nil if rel - c * (cw + COL_GAP) >= cw # landed in the gap between columns
+      return nil if @scroll + i >= g.col_rows
+      rows = g.rows
+      ridx = c * g.col_rows + @scroll + i
       return nil if ridx >= rows.size
-      rows[ridx].entry
+      rows[ridx].entry # nil for a header or a pad_rows filler — neither is clickable
     end
   end
 end

--- a/src/gori/verb.cr
+++ b/src/gori/verb.cr
@@ -134,12 +134,24 @@ module Gori
       # that scope's menu. Defaults to :common so untouched registrations render
       # exactly as they do today (one flat group).
       getter section : Symbol
+      # The SEMANTIC band this verb sits in within whatever section shows it —
+      # :view / :send / :triage / :copy / :scope / :danger (see
+      # Tui::SpaceMenu::GROUP_LABELS). Orthogonal to `section`, which is a FOCUS-AREA
+      # axis: `section` answers "which pane is focused" (and a section's verbs only
+      # appear when that pane IS focused), while `group` answers "what kind of action
+      # is this" and never gates visibility. The single-region scopes — History's Body
+      # (19 entries), HistoryDetail (16), Probe (14), Sitemap (10) — have no focus
+      # sub-areas at all, so `section` can never break their one flat list up; `group`
+      # is what makes them scannable. Defaults to :none, which renders exactly as
+      # before (no header, no subdivision), so an untagged scope is unchanged.
+      getter group : Symbol
 
       def initialize(@id : String, @title : String, @description : String, @scope : Scope,
                      @chords : Array(Chord) = [] of Chord, @hidden : Bool = false,
                      @available : ExecContext -> Bool = ->(_ctx : ExecContext) { true },
                      @coming_soon : Bool = false, @category : Category = Category::Action,
                      @mnemonic : Char? = nil, @section : Symbol = :common,
+                     @group : Symbol = :none,
                      &@handler : ExecContext -> String?)
       end
 

--- a/src/gori/verbs/core.cr
+++ b/src/gori/verbs/core.cr
@@ -123,12 +123,12 @@ module Gori
         # Batch-capable (#442): gates on the effective target set (marks if any, else the
         # cursor row) — which also aligns the gate with what the handler already acted on
         # (history_target_flow_id, i.e. the OPEN DETAIL's flow when one is up).
-        Verb::Scope::Body, available: ->(ctx : Verb::ExecContext) { ctx.current_tab == :history && !ctx.selected_flow_ids.empty? }, mnemonic: 'h') { |ctx| ctx.scope_add_host; nil }
+        Verb::Scope::Body, available: ->(ctx : Verb::ExecContext) { ctx.current_tab == :history && !ctx.selected_flow_ids.empty? }, mnemonic: 'h', group: :scope) { |ctx| ctx.scope_add_host; nil }
 
       r.register Verb::Definition.new(
         "scope.toggle", "Toggle scope lens", "Filter History/Sitemap to in-scope flows on/off",
         Verb::Scope::Body, [Verb::Chord.new("s", shift: true)],
-        available: ->(ctx : Verb::ExecContext) { ctx.current_tab == :history }, mnemonic: 's') { |ctx| ctx.scope_toggle_lens; nil }
+        available: ->(ctx : Verb::ExecContext) { ctx.current_tab == :history }, mnemonic: 's', group: :scope) { |ctx| ctx.scope_toggle_lens; nil }
 
       # --- Project tab SCOPE pane: the rule-list action menu (space) + its a/e/d keys.
       # Project scope is unique to that pane, so no current_tab gate is needed. The lens

--- a/src/gori/verbs/history.cr
+++ b/src/gori/verbs/history.cr
@@ -29,15 +29,15 @@ module Gori
       r.register Verb::Definition.new(
         "body.open", "Open flow detail", "View the selected request/response", Verb::Scope::Body,
         [Verb::Chord.new("enter"), Verb::Chord.new("right"), Verb::Chord.new("l")],
-        available: history_selected, mnemonic: 'o') { |ctx| ctx.open_detail; nil }
+        available: history_selected, mnemonic: 'o', group: :view) { |ctx| ctx.open_detail; nil }
 
       r.register Verb::Definition.new(
         "history.query", "Filter (QL)", "Filter the list with a query (host: status:>=500 size:>10000 body~regex …)",
-        Verb::Scope::Body, [Verb::Chord.new("/")], available: in_history) { |ctx| ctx.history_query; nil }
+        Verb::Scope::Body, [Verb::Chord.new("/")], available: in_history, group: :view) { |ctx| ctx.history_query; nil }
 
       r.register Verb::Definition.new(
         "history.toggle-follow", "Toggle follow", "Follow newest flows (tail) on/off",
-        Verb::Scope::Body, [Verb::Chord.new("f")], available: in_history) { |ctx| ctx.toggle_follow; nil }
+        Verb::Scope::Body, [Verb::Chord.new("f")], available: in_history, group: :view) { |ctx| ctx.toggle_follow; nil }
 
       # --- multi-select marks (#442) ---
       # Marks make the EXISTING space menu act on N flows — every batch verb below reads
@@ -54,7 +54,7 @@ module Gori
       r.register Verb::Definition.new(
         "history.mark-toggle", "Mark flow", "Mark/unmark this flow and step to the next older one — the space menu then acts on every marked flow",
         Verb::Scope::Body, [Verb::Chord.new("t")],
-        available: history_selected, mnemonic: 't') { |ctx| ctx.history_mark_toggle; nil }
+        available: history_selected, mnemonic: 't', group: :triage) { |ctx| ctx.history_mark_toggle; nil }
 
       # ⇧T, the list's Ctrl+A: mark everything the CURRENT filter shows, so `/ status:>=500`
       # then ⇧T marks exactly the errors. The chord is Chord.new("t", shift: true), NOT
@@ -63,7 +63,7 @@ module Gori
       r.register Verb::Definition.new(
         "history.mark-all", "Mark all (filtered)", "Mark every flow the current filter shows",
         Verb::Scope::Body, [Verb::Chord.new("t", shift: true)],
-        available: in_history, mnemonic: 'T') { |ctx| ctx.history_mark_all; nil }
+        available: in_history, mnemonic: 'T', group: :triage) { |ctx| ctx.history_mark_all; nil }
 
       # esc clears too (HistoryController#handle_body_key shadows body.to-menu only while
       # marks are set) — that's the reflex; this is the discoverable form. Menu-only: 'N' is
@@ -96,7 +96,7 @@ module Gori
       r.register Verb::Definition.new(
         "history.copy", "Copy flow", "Copy the selected flow — or every marked flow's URL — to the clipboard",
         Verb::Scope::Body, [Verb::Chord.new("y")],
-        available: history_targets) { |ctx| ctx.copy_selection; nil }
+        available: history_targets, group: :copy) { |ctx| ctx.copy_selection; nil }
 
       # "Copy as X" for the list, mirroring repeater.copy-as / detail.copy-as: a picker over
       # urls / host list / curl / raw requests / raw responses / req+res pairs, spanning the
@@ -105,44 +105,44 @@ module Gori
       # from the Project tab — that verb now lives in Verb::Scope::ProjectDesc.)
       r.register Verb::Definition.new(
         "history.copy-as", "Copy as…", "Pick a copy format for the selected/marked flows (urls/hosts/curl/raw)",
-        Verb::Scope::Body, available: history_targets, mnemonic: 'Y') { |ctx| ctx.copy_as_open; nil }
+        Verb::Scope::Body, available: history_targets, mnemonic: 'Y', group: :copy) { |ctx| ctx.copy_as_open; nil }
 
       r.register Verb::Definition.new(
         "history.repeater", "Repeater flow", "Open the selected flow in the Repeater tab",
         Verb::Scope::Body, [Verb::Chord.new("r", ctrl: true)],
-        available: history_targets, mnemonic: 'r') { |ctx| ctx.repeater_selected; nil }
+        available: history_targets, mnemonic: 'r', group: :send) { |ctx| ctx.repeater_selected; nil }
 
       # Spider + brute-force the selected flow's host (opens the Discover config popup; the
       # run streams into the Target → Discover sub-tab). Menu-only (no chord).
       r.register Verb::Definition.new(
         "history.discover", "Discover from flow", "Spider + brute-force the selected flow's host",
         Verb::Scope::Body, [] of Verb::Chord,
-        available: history_targets, mnemonic: 'd') { |ctx| ctx.history_discover; nil }
+        available: history_targets, mnemonic: 'd', group: :send) { |ctx| ctx.history_discover; nil }
 
       # Send the selected flow to the Comparer's next slot (A → B → A), then open the
       # Comparer tab to view the diff.
       r.register Verb::Definition.new(
         "history.compare", "Send to Comparer", "Send the selected flow to the Comparer (next slot A/B)",
-        Verb::Scope::Body, available: history_targets, mnemonic: 'c') { |ctx| ctx.comparer_add_selected; nil }
+        Verb::Scope::Body, available: history_targets, mnemonic: 'c', group: :send) { |ctx| ctx.comparer_add_selected; nil }
 
       # Manually run the Probe ACTIVE checks (reflected params, CORS) against the selected flow,
       # regardless of the Probe mode — opens a confirm dialog with the expected request count.
       # Menu-only ('A'); mirrors detail.probe-active in the drill-in.
       r.register Verb::Definition.new(
         "history.probe-active", "Run active scan", "Run the Probe active checks against the selected flow (shows the request count first)",
-        Verb::Scope::Body, available: history_targets, mnemonic: 'A') { |ctx| ctx.probe_active_selected; nil }
+        Verb::Scope::Body, available: history_targets, mnemonic: 'A', group: :send) { |ctx| ctx.probe_active_selected; nil }
 
       # Delete the selected flow (confirm-gated). Menu-only — L3 destructive; 'X' is free
       # across Body COMMON (lowercase 'x' is select-line). Mirrors probe.delete-selected.
       r.register Verb::Definition.new(
         "history.delete", "Delete flow", "Delete the selected flow from History (asks first)",
-        Verb::Scope::Body, available: history_targets, mnemonic: 'X') { |ctx| ctx.history_delete; nil }
+        Verb::Scope::Body, available: history_targets, mnemonic: 'X', group: :danger) { |ctx| ctx.history_delete; nil }
 
       # Wipe the project's entire History (confirm-gated). Menu-only; 'C' is free across
       # Body COMMON (lowercase 'c' is compare). Available whenever History has any rows.
       r.register Verb::Definition.new(
         "history.clear", "Clear history", "Delete ALL History flows for this project (asks first)",
-        Verb::Scope::Body, available: in_history, mnemonic: 'C') { |ctx| ctx.history_clear; nil }
+        Verb::Scope::Body, available: in_history, mnemonic: 'C', group: :danger) { |ctx| ctx.history_clear; nil }
 
       # --- repeater workbench (request editing is inline; these power the palette
       # and show their key hints — actual keys are handled directly by the TUI) ---
@@ -354,15 +354,15 @@ module Gori
       # ^X (plain `x` = select-line), so it carries an explicit 'e' mnemonic for the menu.
       r.register Verb::Definition.new(
         "detail.toggle-hex", "Hex view", "Toggle a raw hex dump of the request/response bytes",
-        Verb::Scope::HistoryDetail, [Verb::Chord.new("x", ctrl: true)], mnemonic: 'e') { |ctx| ctx.toggle_detail_hex; nil }
+        Verb::Scope::HistoryDetail, [Verb::Chord.new("x", ctrl: true)], mnemonic: 'e', group: :view) { |ctx| ctx.toggle_detail_hex; nil }
 
       r.register Verb::Definition.new(
         "detail.toggle-ws", "Reveal whitespace", "Show whitespace/CR/LF as glyphs (·→␍␊)",
-        Verb::Scope::HistoryDetail, [Verb::Chord.new("b")]) { |ctx| ctx.toggle_reveal; nil }
+        Verb::Scope::HistoryDetail, [Verb::Chord.new("b")], group: :view) { |ctx| ctx.toggle_reveal; nil }
 
       r.register Verb::Definition.new(
         "detail.toggle-pretty", "Pretty bodies", "Pretty-print JSON/XML/form/… bodies (display only)",
-        Verb::Scope::HistoryDetail, [Verb::Chord.new("p")]) { |ctx| ctx.toggle_pretty; nil }
+        Verb::Scope::HistoryDetail, [Verb::Chord.new("p")], group: :view) { |ctx| ctx.toggle_pretty; nil }
 
       # The flow actions mirror the History list's "space" menu so the muscle memory
       # carries into the drill-in (the user's goal). Each keeps the list's exact chord
@@ -371,63 +371,63 @@ module Gori
       r.register Verb::Definition.new(
         "detail.repeater", "Repeater flow", "Open this flow in the Repeater tab",
         Verb::Scope::HistoryDetail, [Verb::Chord.new("r", ctrl: true)],
-        mnemonic: 'r') { |ctx| ctx.close_detail; ctx.repeater_selected; nil }
+        mnemonic: 'r', group: :send) { |ctx| ctx.close_detail; ctx.repeater_selected; nil }
 
       # Create an issue while reading the flow — the natural moment to file one.
       # Without this, ⇧F silently dead-ends in the detail (it's a Body-scope verb).
       r.register Verb::Definition.new(
         "detail.issue", "Add issue", "Create an issue from this flow",
         Verb::Scope::HistoryDetail, [Verb::Chord.new("f", shift: true)],
-        mnemonic: 'a') { |ctx| ctx.close_detail; ctx.issue_create; nil }
+        mnemonic: 'a', group: :triage) { |ctx| ctx.close_detail; ctx.issue_create; nil }
 
       # Send the open flow to the Comparer (mirrors history.compare from the list).
       r.register Verb::Definition.new(
         "detail.compare", "Send to Comparer", "Send this flow to the Comparer (next slot A/B)",
-        Verb::Scope::HistoryDetail, mnemonic: 'c') { |ctx| ctx.comparer_add_selected; nil }
+        Verb::Scope::HistoryDetail, mnemonic: 'c', group: :send) { |ctx| ctx.comparer_add_selected; nil }
 
       # Copy the selection (or current line) from the navigable detail text — flow copy
       # lives in the space menu only (history.copy / detail.copy-flow).
       r.register Verb::Definition.new(
         "detail.copy", "Copy selection", "Copy the selected text (or current line) to the clipboard",
         Verb::Scope::HistoryDetail, [Verb::Chord.new("y")],
-        mnemonic: 'y') { |ctx| ctx.detail_copy_selection; nil }
+        mnemonic: 'y', group: :copy) { |ctx| ctx.detail_copy_selection; nil }
 
       # "Copy as X" for the drill-in: same focus-aware format picker as Repeater, over the
       # REQUEST/RESPONSE pane bytes. Menu key 'Y' pairs with copy's 'y' (free in the
       # HistoryDetail menu, whose keys are y/O/r/a/c/z/h/x/b/p).
       r.register Verb::Definition.new(
         "detail.copy-as", "Copy as…", "Pick a copy format for this pane (url/headers/body/cookies/curl/raw)",
-        Verb::Scope::HistoryDetail, mnemonic: 'Y') { |ctx| ctx.copy_as_open; nil }
+        Verb::Scope::HistoryDetail, mnemonic: 'Y', group: :copy) { |ctx| ctx.copy_as_open; nil }
 
       r.register Verb::Definition.new(
         "detail.copy-flow", "Copy flow", "Copy this flow's raw request to the clipboard",
-        Verb::Scope::HistoryDetail, mnemonic: 'O') { |ctx| ctx.copy_selection; nil }
+        Verb::Scope::HistoryDetail, mnemonic: 'O', group: :copy) { |ctx| ctx.copy_selection; nil }
 
       # Send the open flow to the Fuzzer (mirrors history.fuzz ⇧I/'z' from the list) —
       # close the detail first so it doesn't float over the Fuzzer tab.
       r.register Verb::Definition.new(
         "detail.fuzz", "Send to Fuzzer", "Open this flow in the Fuzzer tab",
         Verb::Scope::HistoryDetail, [Verb::Chord.new("i", shift: true)],
-        mnemonic: 'z') { |ctx| ctx.close_detail; ctx.fuzz_selected; nil }
+        mnemonic: 'z', group: :send) { |ctx| ctx.close_detail; ctx.fuzz_selected; nil }
 
       # Add the open flow's host to the scope lens (mirrors scope.add-host 'h' from the
       # list — also menu-only there; 'h' is the ← pane-nav chord in the detail).
       r.register Verb::Definition.new(
         "detail.add-host", "Add host to scope", "Add this flow's host to the scope lens",
-        Verb::Scope::HistoryDetail, mnemonic: 'h') { |ctx| ctx.scope_add_host; nil }
+        Verb::Scope::HistoryDetail, mnemonic: 'h', group: :scope) { |ctx| ctx.scope_add_host; nil }
 
       # Run the Probe active checks against the open flow (mirrors history.probe-active 'A' from
       # the list) — close the detail first so the confirm dialog isn't buried under it.
       r.register Verb::Definition.new(
         "detail.probe-active", "Run active scan", "Run the Probe active checks against this flow (shows the request count first)",
-        Verb::Scope::HistoryDetail, mnemonic: 'A') { |ctx| ctx.close_detail; ctx.probe_active_selected; nil }
+        Verb::Scope::HistoryDetail, mnemonic: 'A', group: :send) { |ctx| ctx.close_detail; ctx.probe_active_selected; nil }
 
       # Delete the open flow (mirrors history.delete). Menu-only 'X' — free in HistoryDetail
       # (lowercase 'x' is select-line). Confirm runs after the menu closes; the controller
       # captures the id so a live reload can't retarget the delete.
       r.register Verb::Definition.new(
         "detail.delete", "Delete flow", "Delete this flow from History (asks first)",
-        Verb::Scope::HistoryDetail, mnemonic: 'X') { |ctx| ctx.history_delete; nil }
+        Verb::Scope::HistoryDetail, mnemonic: 'X', group: :danger) { |ctx| ctx.history_delete; nil }
     end
 
     # Fuzzer/Intruder verbs: the cross-tab "send to Fuzzer" (⇧I from History, palette
@@ -443,7 +443,7 @@ module Gori
       r.register Verb::Definition.new(
         "history.fuzz", "Send to Fuzzer", "Open the selected flow in the Fuzzer tab",
         Verb::Scope::Body, [Verb::Chord.new("i", shift: true)],
-        available: history_targets, mnemonic: 'z') { |ctx| ctx.fuzz_selected; nil }
+        available: history_targets, mnemonic: 'z', group: :send) { |ctx| ctx.fuzz_selected; nil }
       r.register Verb::Definition.new(
         "repeater.fuzz", "Send to Fuzzer", "Turn this repeater request into a fuzz template",
         Verb::Scope::Repeater, available: in_repeater, mnemonic: 'f') { |ctx| ctx.fuzz_from_repeater; nil }
@@ -559,10 +559,10 @@ module Gori
 
       r.register Verb::Definition.new(
         "history.mine", "Mine parameters", "Discover hidden parameters for the selected flow",
-        Verb::Scope::Body, available: history_targets, mnemonic: 'm') { |ctx| ctx.mine_selected; nil }
+        Verb::Scope::Body, available: history_targets, mnemonic: 'm', group: :send) { |ctx| ctx.mine_selected; nil }
       r.register Verb::Definition.new(
         "detail.mine", "Mine parameters", "Discover hidden parameters for this flow",
-        Verb::Scope::HistoryDetail, mnemonic: 'm') { |ctx| ctx.close_detail; ctx.mine_selected; nil }
+        Verb::Scope::HistoryDetail, mnemonic: 'm', group: :send) { |ctx| ctx.close_detail; ctx.mine_selected; nil }
       r.register Verb::Definition.new(
         "repeater.mine", "Mine parameters", "Discover hidden parameters for this repeater request",
         Verb::Scope::Repeater, available: in_repeater, mnemonic: 'm') { |ctx| ctx.mine_from_repeater; nil }

--- a/src/gori/verbs/issues.cr
+++ b/src/gori/verbs/issues.cr
@@ -9,7 +9,7 @@ module Gori
       r.register Verb::Definition.new(
         "issue.create", "Add issue", "Create an issue from the selected flow (every marked flow is attached as evidence)", Verb::Scope::Body,
         [Verb::Chord.new("f", shift: true)],
-        available: ->(ctx : Verb::ExecContext) { ctx.current_tab == :history && !ctx.selected_flow_ids.empty? }, mnemonic: 'a') { |ctx| ctx.issue_create; nil }
+        available: ->(ctx : Verb::ExecContext) { ctx.current_tab == :history && !ctx.selected_flow_ids.empty? }, mnemonic: 'a', group: :triage) { |ctx| ctx.issue_create; nil }
 
       # issues list
       r.register Verb::Definition.new(

--- a/src/gori/verbs/probe.cr
+++ b/src/gori/verbs/probe.cr
@@ -21,72 +21,72 @@ module Gori
       # open-evidence (parity with the detail scope).
       r.register Verb::Definition.new(
         "probe.open", "Open issue", "View the selected issue's detail", Verb::Scope::Probe,
-        [Verb::Chord.new("enter"), Verb::Chord.new("l"), Verb::Chord.new("right")], mnemonic: 'v') { |ctx| ctx.probe_open; nil }
+        [Verb::Chord.new("enter"), Verb::Chord.new("l"), Verb::Chord.new("right")], mnemonic: 'v', group: :view) { |ctx| ctx.probe_open; nil }
 
       r.register Verb::Definition.new(
         "probe.filter", "Filter issues", "Filter the list (severity:/status:/category:/host:/code:/free text)",
-        Verb::Scope::Probe, [Verb::Chord.new("/")]) { |ctx| ctx.probe_query; nil }
+        Verb::Scope::Probe, [Verb::Chord.new("/")], group: :view) { |ctx| ctx.probe_query; nil }
 
       # Probe-local `m` (mode cycle). Global Match & Replace is palette-only by default,
       # so this no longer needs to shadow a Global bare letter.
       r.register Verb::Definition.new(
         "probe.mode", "Set mode", "Choose the scan mode (off / passive / passive+active)",
-        Verb::Scope::Probe, [Verb::Chord.new("m")]) { |ctx| ctx.probe_set_mode; nil }
+        Verb::Scope::Probe, [Verb::Chord.new("m")], group: :view) { |ctx| ctx.probe_set_mode; nil }
 
       # `c`: one-key dismiss for the selected row (open ⇄ false-positive). The high-value
       # triage action; mutes recurring noise so it drops out of the default open-only lens.
       r.register Verb::Definition.new(
         "probe.dismiss-selected", "Dismiss issue", "Toggle dismiss (false-positive ⇄ open) on the selected issue",
-        Verb::Scope::Probe, [Verb::Chord.new("c")]) { |ctx| ctx.probe_dismiss; nil }
+        Verb::Scope::Probe, [Verb::Chord.new("c")], group: :triage) { |ctx| ctx.probe_dismiss; nil }
 
       r.register Verb::Definition.new(
         "probe.toggle-closed", "Show closed", "Toggle between open-only and all issues (incl. dismissed)",
-        Verb::Scope::Probe, [Verb::Chord.new("a")]) { |ctx| ctx.probe_toggle_closed; nil }
+        Verb::Scope::Probe, [Verb::Chord.new("a")], group: :view) { |ctx| ctx.probe_toggle_closed; nil }
 
       # Toggle the scope lens from Probe too (History has its own ⇧S binding; Sitemap
       # mirrors it). scope_toggle_lens reloads the active Probe list, and the bar shows
       # the ⇧S chip — so the toggle is reachable where its effect is visible.
       r.register Verb::Definition.new(
         "probe.scope-toggle", "Toggle scope lens", "Filter issues to in-scope hosts on/off",
-        Verb::Scope::Probe, [Verb::Chord.new("s", shift: true)], mnemonic: 's') { |ctx| ctx.scope_toggle_lens; nil }
+        Verb::Scope::Probe, [Verb::Chord.new("s", shift: true)], mnemonic: 's', group: :scope) { |ctx| ctx.scope_toggle_lens; nil }
 
       # Bulk dismiss — space-menu only (mnemonic, no stray hotkey): mute a whole check
       # code, or a whole host, in one confirmed action. 'r' is reserved for repeater-evidence
       # (parity with the detail scope).
       r.register Verb::Definition.new(
         "probe.dismiss-code", "Dismiss all with this code", "Mute every open issue sharing the selected issue's check code",
-        Verb::Scope::Probe, mnemonic: 'g') { |ctx| ctx.probe_dismiss_code; nil }
+        Verb::Scope::Probe, mnemonic: 'g', group: :triage) { |ctx| ctx.probe_dismiss_code; nil }
 
       r.register Verb::Definition.new(
         "probe.dismiss-host", "Dismiss all on this host", "Mute every open issue on the selected issue's host",
-        Verb::Scope::Probe, mnemonic: 'h') { |ctx| ctx.probe_dismiss_host; nil }
+        Verb::Scope::Probe, mnemonic: 'h', group: :triage) { |ctx| ctx.probe_dismiss_host; nil }
 
       # Detail-parity actions on the selected row (no need to drill in first).
       r.register Verb::Definition.new(
         "probe.open-evidence", "Open evidence", "Open the selected issue's sample flow in History",
-        Verb::Scope::Probe, [Verb::Chord.new("o")]) { |ctx| ctx.probe_open_flow; nil }
+        Verb::Scope::Probe, [Verb::Chord.new("o")], group: :view) { |ctx| ctx.probe_open_flow; nil }
 
       r.register Verb::Definition.new(
         "probe.repeater-evidence", "Repeater evidence", "Send the selected issue's sample flow to Repeater",
-        Verb::Scope::Probe, [Verb::Chord.new("r")]) { |ctx| ctx.probe_repeater_flow; nil }
+        Verb::Scope::Probe, [Verb::Chord.new("r")], group: :send) { |ctx| ctx.probe_repeater_flow; nil }
 
       # Re-run the ACTIVE checks against the selected issue's sample flow (menu-only 'A') — opens
       # a confirm with the expected request count. 'a' is toggle-closed; capital 'A' is free.
       r.register Verb::Definition.new(
         "probe.active-rescan", "Run active scan", "Re-run the Probe active checks against the selected issue's sample flow",
-        Verb::Scope::Probe, mnemonic: 'A') { |ctx| ctx.probe_active_rescan; nil }
+        Verb::Scope::Probe, mnemonic: 'A', group: :send) { |ctx| ctx.probe_active_rescan; nil }
 
       r.register Verb::Definition.new(
         "probe.promote-selected", "Promote to issue", "Create a Issue from the selected issue",
-        Verb::Scope::Probe, [Verb::Chord.new("p")]) { |ctx| ctx.probe_promote; nil }
+        Verb::Scope::Probe, [Verb::Chord.new("p")], group: :triage) { |ctx| ctx.probe_promote; nil }
 
       r.register Verb::Definition.new(
         "probe.delete-selected", "Delete issue", "Delete the selected issue",
-        Verb::Scope::Probe, [Verb::Chord.new("d")]) { |ctx| ctx.probe_delete; nil }
+        Verb::Scope::Probe, [Verb::Chord.new("d")], group: :danger) { |ctx| ctx.probe_delete; nil }
 
       r.register Verb::Definition.new(
         "probe.clear", "Clear issues", "Delete all Probe issues for this project", Verb::Scope::Probe,
-        [Verb::Chord.new("x")]) { |ctx| ctx.probe_clear; nil }
+        [Verb::Chord.new("x")], group: :danger) { |ctx| ctx.probe_clear; nil }
 
       r.register Verb::Definition.new(
         "probe.leave", "Back to menu", "Return focus to the tab menu", Verb::Scope::Probe,

--- a/src/gori/verbs/read_edit.cr
+++ b/src/gori/verbs/read_edit.cr
@@ -136,7 +136,7 @@ module Gori
       r.register Verb::Definition.new(
         "detail.select-line", "Select line", "Select the entire current line",
         Verb::Scope::HistoryDetail, [Verb::Chord.new("x")],
-        available: in_detail_nav, mnemonic: 'x') { |ctx| ctx.read_select_line; nil }
+        available: in_detail_nav, mnemonic: 'x', group: :view) { |ctx| ctx.read_select_line; nil }
       r.register Verb::Definition.new(
         "detail.clear-selection", "Clear selection", "Clear the text selection",
         Verb::Scope::HistoryDetail, available: in_sel, mnemonic: 'v') { |ctx| ctx.read_clear_selection; nil }

--- a/src/gori/verbs/sequencer.cr
+++ b/src/gori/verbs/sequencer.cr
@@ -15,10 +15,10 @@ module Gori
 
       r.register Verb::Definition.new(
         "history.sequence", "Send to Sequencer", "Collect this flow's token and analyze its randomness",
-        Verb::Scope::Body, available: history_selected, mnemonic: 'q') { |ctx| ctx.sequence_selected; nil }
+        Verb::Scope::Body, available: history_selected, mnemonic: 'q', group: :send) { |ctx| ctx.sequence_selected; nil }
       r.register Verb::Definition.new(
         "detail.sequence", "Send to Sequencer", "Collect this flow's token and analyze its randomness",
-        Verb::Scope::HistoryDetail, mnemonic: 'q') { |ctx| ctx.close_detail; ctx.sequence_selected; nil }
+        Verb::Scope::HistoryDetail, mnemonic: 'q', group: :send) { |ctx| ctx.close_detail; ctx.sequence_selected; nil }
       r.register Verb::Definition.new(
         "repeater.sequence", "Send to Sequencer", "Collect this request's token repeatedly and analyze randomness",
         Verb::Scope::Repeater, available: in_repeater, mnemonic: 'q') { |ctx| ctx.sequence_from_repeater; nil }
@@ -27,7 +27,7 @@ module Gori
       # retired :sitemap top-level symbol and never fire (Sitemap is now a Target sub-tab).
       r.register Verb::Definition.new(
         "sitemap.sequence", "Send to Sequencer", "Collect the selected endpoint's token and analyze randomness",
-        Verb::Scope::Sitemap, mnemonic: 'q') { |ctx| ctx.sequence_from_sitemap; nil }
+        Verb::Scope::Sitemap, mnemonic: 'q', group: :send) { |ctx| ctx.sequence_from_sitemap; nil }
 
       r.register Verb::Definition.new(
         "sequence.run", "Run collection", "Re-run token collection for this session", Verb::Scope::Sequencer,

--- a/src/gori/verbs/sitemap.cr
+++ b/src/gori/verbs/sitemap.cr
@@ -27,7 +27,7 @@ module Gori
 
       r.register Verb::Definition.new(
         "sitemap.query", "Filter (QL)", "Filter the tree with a query (host: path: method: status: tag: …)",
-        Verb::Scope::Sitemap, [Verb::Chord.new("/")]) { |ctx| ctx.sitemap_query; nil }
+        Verb::Scope::Sitemap, [Verb::Chord.new("/")], group: :view) { |ctx| ctx.sitemap_query; nil }
 
       # --- multi-select marks (mirrors History #442) ---
       # Marks make the EXISTING action menu act on N paths — the batch verbs below read the
@@ -41,7 +41,7 @@ module Gori
       # into the same batch as the endpoints under them.
       r.register Verb::Definition.new(
         "sitemap.mark-toggle", "Mark path", "Mark/unmark this path and step down — the action menu then acts on every marked path",
-        Verb::Scope::Sitemap, [Verb::Chord.new("t")]) { |ctx| ctx.sitemap_mark_toggle; nil }
+        Verb::Scope::Sitemap, [Verb::Chord.new("t")], group: :triage) { |ctx| ctx.sitemap_mark_toggle; nil }
 
       # ⇧↑/⇧↓ extend a contiguous range from the anchor — the keyboard form of a GUI
       # shift+click. Free in this scope: Keymap#lookup matches a Chord record EXACTLY, so
@@ -73,12 +73,12 @@ module Gori
       r.register Verb::Definition.new(
         "sitemap.tag", "Tag path", "Pin a free-text memo to the selected — or every marked — path (filter with tag:)",
         Verb::Scope::Sitemap, [Verb::Chord.new("t", shift: true)],
-        mnemonic: 'T') { |ctx| ctx.sitemap_tag; nil }
+        mnemonic: 'T', group: :triage) { |ctx| ctx.sitemap_tag; nil }
 
       # `g` — fold/unfold path-param ids (/users/<uuid> → {uuid}, /users/1,2,3… → [1, 2, 3 … +N]).
       r.register Verb::Definition.new(
         "sitemap.toggle-grouping", "Fold ids", "Fold path-param ids into {uuid}/{hex}/{date} and [1, 2, 3 …] groups",
-        Verb::Scope::Sitemap, [Verb::Chord.new("g")]) { |ctx| ctx.sitemap_toggle_grouping; nil }
+        Verb::Scope::Sitemap, [Verb::Chord.new("g")], group: :view) { |ctx| ctx.sitemap_toggle_grouping; nil }
 
       # Toggle the scope lens from the Sitemap too (History has its own ⇧S binding).
       # scope_toggle_lens reloads the active sitemap, and the bar shows the ⇧S chip —
@@ -86,7 +86,7 @@ module Gori
       # action menu (its only chord is ⇧S, which yields no menu key).
       r.register Verb::Definition.new(
         "sitemap.scope-toggle", "Toggle scope lens", "Filter the tree to in-scope endpoints on/off",
-        Verb::Scope::Sitemap, [Verb::Chord.new("s", shift: true)], mnemonic: 's') { |ctx| ctx.scope_toggle_lens; nil }
+        Verb::Scope::Sitemap, [Verb::Chord.new("s", shift: true)], mnemonic: 's', group: :scope) { |ctx| ctx.scope_toggle_lens; nil }
 
       # `a` — add the cursor row to the project scope, pre-filling the SAME popup the Project
       # tab's `a` opens (hence the same chord): a host row seeds a `host` rule, a path row a
@@ -94,12 +94,12 @@ module Gori
       # rule is authored there instead of retyping the host in the Project tab.
       r.register Verb::Definition.new(
         "sitemap.scope-add", "Add to scope", "Add the selected host — or host + path — to the scope rules",
-        Verb::Scope::Sitemap, [Verb::Chord.new("a")], mnemonic: 'a') { |ctx| ctx.sitemap_scope_add; nil }
+        Verb::Scope::Sitemap, [Verb::Chord.new("a")], mnemonic: 'a', group: :scope) { |ctx| ctx.sitemap_scope_add; nil }
 
       # `d` — spider + brute-force the selected host/path (opens the Discover config popup).
       r.register Verb::Definition.new(
         "sitemap.discover", "Discover here", "Spider + brute-force the selected host or path subtree",
-        Verb::Scope::Sitemap, [Verb::Chord.new("d")], mnemonic: 'd') { |ctx| ctx.sitemap_discover; nil }
+        Verb::Scope::Sitemap, [Verb::Chord.new("d")], mnemonic: 'd', group: :send) { |ctx| ctx.sitemap_discover; nil }
 
       # `o` — read the bytes behind the selected endpoint: resolve its representative captured
       # flow and open History's detail on it. Same chord and same shape as the Issues tab's
@@ -110,13 +110,13 @@ module Gori
       # shows one flow, so there is nothing for a batch to mean here.
       r.register Verb::Definition.new(
         "sitemap.open-flow", "Open flow", "Open the selected endpoint's captured request/response in History",
-        Verb::Scope::Sitemap, [Verb::Chord.new("o")], mnemonic: 'o') { |ctx| ctx.sitemap_open_flow; nil }
+        Verb::Scope::Sitemap, [Verb::Chord.new("o")], mnemonic: 'o', group: :view) { |ctx| ctx.sitemap_open_flow; nil }
 
       # `r` — send the selected endpoint (or every marked one) to Repeater, resolving a
       # representative captured flow per path.
       r.register Verb::Definition.new(
         "sitemap.repeater", "Send to Repeater", "Open the selected — or every marked — endpoint's captured request in Repeater",
-        Verb::Scope::Sitemap, [Verb::Chord.new("r")], mnemonic: 'r') { |ctx| ctx.sitemap_repeater; nil }
+        Verb::Scope::Sitemap, [Verb::Chord.new("r")], mnemonic: 'r', group: :send) { |ctx| ctx.sitemap_repeater; nil }
 
       r.register Verb::Definition.new(
         "sitemap.to-menu", "Back to sub-tabs", "Move focus up to the Sitemap/Discover strip", Verb::Scope::Sitemap,


### PR DESCRIPTION
## Why

History's Body space menu is **19 entries** — past `MAX_ROWS = 16`, so it was already scrolling — and anchored bottom-right it covered exactly the columns the operator decides from (PATH / STATUS / TYPE / SIZE / DUR). The stale count in the `MAX_ROWS` comment ("History's Body has 13 menu entries") is what made it look fine.

## What

**Centered.** `box()` centers the card — gori's own idiom for a modal; the corner popup was the outlier. What keeps this from collapsing into a second `Ctrl-P` is the **interaction**, not the position: still no query line, still one mnemonic keypress per action. Centering alone would not have paid off, since the 16-row cap means 19 entries plus headers do not fit one column either way.

**A semantic axis.** `Verb::Definition#group` — VIEW / SEND / TRIAGE / COPY / SCOPE / DANGER — orthogonal to `section`. `section` is a *focus-area* axis and a section's verbs only appear while that pane is focused, so it can never subdivide the single-region scopes; tagging History's Body verbs with it would have made them **vanish**. Defaults to `:none`, rendering exactly as before, so untagged scopes are untouched.

Tagged: Body (19), HistoryDetail (16), Probe (14), Sitemap (10). Leaving Probe flat at 14 while History grouped would have been incoherent.

**Columns.** COLUMN-MAJOR when one column will not fit, read down-then-across. A short or narrow terminal keeps the single scrolling column and its ▲/▼ markers unchanged. `pad_rows` keeps a group header off a column's last row, where it would strand with every one of its entries in the next column.

```
╭─ SPACE ─────────────────────────────────────────────╮
│ ─ VIEW ─                   ─ TRIAGE ─               │
│▎o Open flow detail     ↵   t Mark flow              │
│ / Filter (QL)              T Mark all (filtered) ⇧T │
│ f Toggle follow            a Add issue           ⇧F │
│ ─ SEND ─                   ─ COPY ─                 │
│ r Repeater flow       ^R   y Copy flow              │
│ d Discover from flow       Y Copy as…               │
│ c Send to Comparer         ─ SCOPE ─                │
│ A Run active scan          h Add host to scope      │
│ z Send to Fuzzer      ⇧I   s Toggle scope lens   ⇧S │
│ m Mine parameters          ─ DANGER ─               │
│ q Send to Sequencer        X Delete flow            │
│                            C Clear history          │
╰─────────────────────────────────────────────────────╯
```

## Two things the bigger card exposed

- **`←`/`→` used to dismiss the menu.** They fell through to the "unmapped leader key" branch — not merely unsupported. They (and `h`/`l`) now move by column, following the existing mnemonic-wins rule so History's `h` (add host) and Probe's `h` (dismiss host) keep theirs. Inert, never dismissing, at the outer columns and in the single-column layout.
- **A click on a header row dismissed the menu.** `click_space_menu` now treats a click inside the card that isn't an entry (header, column-break filler, gap, border) as inert. The card sits over the list now and carries header rows a user can plausibly click.

## Judgment calls worth a second opinion

The taxonomy and per-verb assignments are judgment, not derived from anything in the tree. Two are arguable:

- `probe.mode` as `:view` — it is really a config toggle
- `probe.dismiss-*` as `:triage` vs `:danger` — dismissal is semi-destructive

## Also

Drop `CHORD_COL` (unreferenced before this change); rename the new private `SpaceMenu::Layout` record to `Grid` so it does not shadow `Tui::Layout`; extract `draw_cell`, which also retires a pre-existing `not_nil!`.

## Verification

| | |
|---|---|
| `spec/tui/space_menu_spec.cr` | 48 examples, 0 failures (8 new) |
| Full suite | 6833 examples, 8 failures |
| Build / `crystal tool format` | pass |
| ameba | 25 → 24 |

The 8 failures are `capture_status_spec` + `project_registry_spec` proxy port-binding, reproduced identically on a `git stash -u` clean tree — this sandbox cannot bind ports.