### PR TITLE
Twelve smaller findings, and a ^C that erased your notifications because the quit-arm learned to yield

### DIFF
--- a/spec/tui/column_overflow_spec.cr
+++ b/spec/tui/column_overflow_spec.cr
@@ -1,0 +1,143 @@
+require "../spec_helper"
+require "../support/memory_backend"
+
+include Gori::Tui
+
+# Width must be measured in DISPLAY COLUMNS, never `String#size`. A Hangul/CJK syllable is
+# one character and TWO columns, so a char-count budget ("fits in 22") lets a cell paint
+# double its allowance — through the neighbouring column, through the card's right border,
+# and (Fuzzer) across the gap into the DIST sidebar. `Screen.draw_width` is the column
+# measure `Screen#text` actually advances by, and `Screen.column_for` is its exact inverse
+# at cluster boundaries (`foundation_spec.cr`), so truncating with the pair can never split
+# a wide glyph.
+
+private def tmp_sitemap_store(&)
+  path = File.tempname("gori-colspill", ".db")
+  store = Gori::Store.open(path)
+  begin
+    yield store
+  ensure
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+private def capture_flow(store, host, method, target)
+  store.insert_flow(Gori::Store::CapturedRequest.new(
+    created_at: 1_i64, scheme: "http", host: host, port: 80,
+    method: method, target: target, http_version: "HTTP/1.1",
+    head: "#{method} #{target} HTTP/1.1\r\nHost: #{host}\r\n\r\n".to_slice, body: nil))
+end
+
+# The screen row the tagged leaf landed on: the only row carrying both the memo marker and
+# the method chip.
+private def tagged_row(b : MemoryBackend, h : Int32) : Int32
+  (0...h).each { |y| return y if b.row(y).includes?("#") && b.row(y).includes?("GET") }
+  -1
+end
+
+describe "SitemapView tag column" do
+  # At 70 cols the tag column is [45, 60] and the GET chip sits at [66, 68]. A 9-syllable
+  # memo is 12 chars but 21 COLUMNS, so `text.size > avail` (12 > 16) was false, nothing
+  # truncated, and the right-aligned origin `tag_right - text.size + 1` started the run 5
+  # columns too far right — straight through the gap and over the METHODS chip.
+  it "never paints a CJK memo past the tag column's right edge" do
+    tmp_sitemap_store do |store|
+      capture_flow(store, "acme.test", "GET", "/api/users")
+      store.set_sitemap_tag("acme.test", "/api/users", "결제플로우확인요망")
+
+      view = SitemapView.new
+      view.reload(store)
+      b = MemoryBackend.new(70, 20)
+      view.render(Screen.new(b), Rect.new(0, 0, 70, 20))
+
+      y = tagged_row(b, 20)
+      y.should_not eq(-1)
+      row = b.row(y) # one char per CELL, so an index here is a column
+      # tag_right is column 60; 61..65 is the mandated gap before the METHODS column.
+      (61..65).each { |x| row[x].should eq(' ') } # (col #{x})
+      row[66, 3].should eq("GET")
+      # The memo is still SHOWN — clipped with an ellipsis, not dropped.
+      b.row(y).should contain("…")
+    end
+  end
+
+  # The truncation branch was worse than the branch that never fired: `text[0, avail - 1]`
+  # cut by CHARACTERS, so 15 chars of Hangul is 27 columns drawn from a char-derived origin
+  # 9 columns left of where it belongs — over the whole METHODS column AND the right border.
+  it "keeps a long CJK memo inside the tag column when it truncates" do
+    tmp_sitemap_store do |store|
+      capture_flow(store, "acme.test", "GET", "/api/users")
+      store.set_sitemap_tag("acme.test", "/api/users", "결제플로우확인요망결제플로우확인요")
+
+      view = SitemapView.new
+      view.reload(store)
+      b = MemoryBackend.new(70, 20)
+      view.render(Screen.new(b), Rect.new(0, 0, 70, 20))
+
+      y = tagged_row(b, 20)
+      y.should_not eq(-1)
+      row = b.row(y)
+      (61..65).each { |x| row[x].should eq(' ') } # (col #{x})
+      row[66, 3].should eq("GET")
+      row[69].should eq(' ') # the row's last column stays clear of the memo
+    end
+  end
+end
+
+describe "FuzzerView results payload cell" do
+  # 80 cols with the DIST sidebar on (`v`) gives RESULTS `inner.w = 53` — its right border
+  # is column 54 and the DIST card starts at 56. A 22-character Hangul payload is 44
+  # COLUMNS, so `payload.size > 22` was false, `ljust(22)` added nothing, and the row ran 22
+  # columns long; neither `screen.text` passed `width:`, so the status cell alone was drawn
+  # from column 53 straight over the border and into the gap.
+  it "does not paint a CJK payload past the RESULTS card border" do
+    hangul = "가나다라마바사아자차카타파하거너더러머버서어" # 22 syllables = 44 columns
+    hangul.size.should eq(22)
+    Screen.draw_width(hangul).should eq(44)
+
+    rendered = ["p" * 22, hangul].map do |payload|
+      view = FuzzerView.new
+      view.load_request("https://h", "GET /?x=1 HTTP/1.1\r\nHost: h\r\n\r\n", false, "")
+      view.focus_pane(:results) # the DIST sidebar is on by default (`v` toggles it)
+      view.append_result(Gori::Fuzz::Result.new(
+        0_i64, [payload], nil, 200, 1200_i64, 40, 5, 1000_i64, nil, false, false, nil))
+      b = MemoryBackend.new(80, 24)
+      view.render(Screen.new(b), Rect.new(0, 0, 80, 24), true)
+      b
+    end
+    ascii_b, cjk_b = rendered
+
+    hdr = (0...24).find { |y| ascii_b.row(y).includes?("  #   payload") }.not_nil!
+    row_y = hdr + 1
+    cjk_b.row(row_y).should contain("200") # the row really rendered
+
+    # Column 54 is the RESULTS card's right border and 55 the gap before DIST. Nothing the
+    # payload cell does may reach either — and everything from the border rightwards must be
+    # byte-identical to the ASCII control, whose cells all land well inside.
+    cjk_b.row(row_y)[54].should eq(Frame::V)
+    cjk_b.row(row_y)[54..].should eq(ascii_b.row(row_y)[54..])
+  end
+
+  # The other half of the same defect, reachable with a plain ASCII payload: a body under
+  # DIST_MIN_TOTAL (a 40-column terminal ⇒ body.w 36) gets no sidebar, RESULTS takes the
+  # full width, and the status cell then ends EXACTLY at `inner.right`. Every remaining cell
+  # was clamped with `{inner.right - x, 1}.max` — floored at ONE, not zero — so the
+  # len/words/time cell still painted a column at `inner.right`, which is the column
+  # `Frame.card` drew this card's own right border on.
+  it "spends no column at all once the row reaches the card's right edge" do
+    view = FuzzerView.new
+    view.load_request("https://h", "GET /?x=1 HTTP/1.1\r\nHost: h\r\n\r\n", false, "")
+    view.focus_pane(:results)
+    view.append_result(Gori::Fuzz::Result.new(
+      0_i64, ["ab"], nil, 200, 1200_i64, 40, 5, 1000_i64, nil, false, false, nil))
+    b = MemoryBackend.new(36, 24)
+    view.render(Screen.new(b), Rect.new(0, 0, 36, 24), true)
+
+    row_y = (0...24).find { |y| b.row(y).includes?("  #   payload") }.not_nil! + 1
+    b.row(row_y).should contain("200") # the row really rendered
+    b.row(row_y)[35].should eq(Frame::V)
+  end
+end

--- a/spec/tui/discover_headers_overlay_spec.cr
+++ b/spec/tui/discover_headers_overlay_spec.cr
@@ -109,6 +109,64 @@ describe Gori::Tui::DiscoverHeadersOverlay do
     h.rendered?("headers editor").should be_true
   end
 
+  it "does not hold the operator behind a refusal the card has no room to draw" do
+    # THE TRAP. `try_commit` is this sub-editor's ONLY exit, and it refuses while any line
+    # is unusable — but the refusal is drawn on the render branch that needs a card, and
+    # `overlay_box` bails below w 34 / h 8. `Layout.usable?` admits 40x8, so the whole
+    # 8–17-row band is live-but-unrenderable: esc → :stay, click-away → :stay, and the one
+    # line that DOES draw advertises "esc to close", a key that never fires. Only ^C/^D
+    # (quitting gori outright) or a resize got out. A refusal nobody can read is a lock,
+    # not a guard, so it may only hold while the card that explains it is on screen.
+    band = Gori::Tui::Rect.new(0, 0, 40, 10)
+    ov = DiscoverHeadersOverlay.new([] of {String, String})
+    ov.overlay_box(band).should be_nil
+    h = OverlayHarness.new(ov, area: band)
+    h.type("Authorization Bearer abc") # no colon → parse_lines refuses the line (sep.empty?)
+    ov.rejected_lines.size.should eq(1)
+    # The shell draws a frame before it reads a key, and THAT frame is what tells the
+    # overlay the card did not fit — `handle_key` never sees `area`. Asserted rather than
+    # commented, so the render below cannot be mistaken for spec noise and deleted: before
+    # a frame has said otherwise the guard still holds, which is the safe default.
+    ov.handle_key(Termisu::Event::Key.new(Termisu::Input::Key::Escape)).should eq(:stay)
+    h.render
+    h.press(Termisu::Input::Key::Escape).should eq(:closed)
+    h.commits.should eq(1)
+
+    # Click-away is handed `area` directly, so it needs no remembered frame at all.
+    clicked = DiscoverHeadersOverlay.new([] of {String, String})
+    ch = OverlayHarness.new(clicked, area: band)
+    ch.type("Authorization Bearer abc")
+    clicked.handle_click(band, 5, 3).should eq(:commit) # the raw vocabulary, not :stay
+    ch.click(5, 3).should eq(:closed)
+    ch.commits.should eq(1)
+
+    # …and the line that replaces the card names a key that actually fires, plus the count
+    # of lines the save will drop — the whole overlay exists so that drop is never silent.
+    # Both facts LEAD the sentence: 40 columns clip it right after "widen the wi…".
+    msg = OverlayHarness.new(DiscoverHeadersOverlay.new([] of {String, String}), area: band)
+    msg.type("Authorization Bearer abc")
+    msg.rendered?("esc saves & closes · 1 line dropped").should be_true
+  end
+
+  it "still refuses an exit while the card IS on screen to explain it" do
+    # The other half of the same invariant: where the refusal renders, it keeps its teeth.
+    # An authenticated sweep that runs unauthenticated and reports "found nothing" is the
+    # worst way this can fail, so a visible refusal must still block the save.
+    ov = DiscoverHeadersOverlay.new([] of {String, String})
+    h = OverlayHarness.new(ov)
+    h.type("Authorization Bearer abc")
+    h.render
+    h.press(Termisu::Input::Key::Escape).should eq(:open)
+    h.commits.should eq(0)
+    h.rendered?("will not be sent").should be_true
+
+    # …and fixing the line resolves it, which is the claim the file's header comment makes.
+    24.times { h.press(Termisu::Input::Key::Backspace) } # "Authorization Bearer abc".size
+    h.type("Authorization: Bearer abc")
+    h.press(Termisu::Input::Key::Escape).should eq(:closed)
+    ov.headers.should eq([{"Authorization", "Bearer abc"}])
+  end
+
   it "hit-tests against the rect the shell passes, not the whole screen" do
     # Production hands `layout.body` — 6 rows shorter and offset — so the card is 14 rows
     # here against 16 under OverlayHarness::DEFAULT_AREA, and its top edge sits lower. A

--- a/spec/tui/exit_jobs_spec.cr
+++ b/spec/tui/exit_jobs_spec.cr
@@ -109,9 +109,36 @@ describe "Runner exit prompts" do
     end
   end
 
-  it "keeps both quit prompts byte-identical when nothing is running" do
+  # The confirm is still byte-identical to what shipped. THE ARM HINT'S ASSERTION CHANGED,
+  # deliberately: it used to end "· q: back to projects" unconditionally, but `app.back-key`
+  # is registered in Verb::Scope::Sidebar ONLY (verbs/core.cr — as a Global chord it dumped
+  # you to the picker from mid-browse), while the arm is raised by `handle_key`, which is
+  # focus-blind. So the toast advertised a key that is dead in a list body, types a literal
+  # `q` in an editor, and CLOSES THE DETAIL in the History drill-in (detail.close binds q
+  # too). The clause now has to be asked for — see the scope example below.
+  it "keeps the quit confirm byte-identical when nothing is running, and offers q only on request" do
     Runner.quit_confirm_message(nil, 0).should eq("Quit gori? (pending edits are committed first)")
-    Runner.quit_arm_hint(nil, 0).should eq("press ^D (or ^C) again to quit · q: back to projects")
+    Runner.quit_arm_hint(nil, 0).should eq("press ^D (or ^C) again to quit")
+    Runner.quit_arm_hint(nil, 0, back_key: true)
+      .should eq("press ^D (or ^C) again to quit · q: back to projects")
+  end
+
+  # What `back_key` has to be told, resolved through the real registry + keymap — the same
+  # lookup `Runner#back_key_live?` performs. If `q` ever becomes Global (or a scope gains its
+  # own binding) this example is what says whether the hint may name it.
+  it "offers q exactly where app.back-key resolves, and nowhere else" do
+    keymap = Gori::Verb::Keymap.build(Gori::Verbs.registry)
+    q = Gori::Verb::Chord.new("q")
+    {
+      Gori::Verb::Scope::Sidebar       => "app.back-key", # the tab bar — where "q projects" is hinted
+      Gori::Verb::Scope::HistoryDetail => "detail.close", # q is BOUND here, to something else
+      Gori::Verb::Scope::Body          => nil,            # a list body: q does nothing at all
+      Gori::Verb::Scope::Repeater      => nil,            # an editor: q is a literal char
+    }.each do |scope, id|
+      keymap.lookup(q, scope).should eq(id)
+      live = id == "app.back-key"
+      Runner.quit_arm_hint(nil, 0, back_key: live).includes?("q: back to projects").should eq(live)
+    end
   end
 
   it "names the live jobs in both quit prompts" do
@@ -123,6 +150,41 @@ describe "Runner exit prompts" do
       "mining 1")
     Runner.quit_arm_hint(jobs.active_summary, jobs.active.size).should eq(
       "1 job running (mining 1) — press ^D (or ^C) again to quit and stop it")
+  end
+end
+
+# The quit POLICY both entry points consume — `handle_key`'s ^C/^D (chord: true) and
+# `Runner#quit!` (chord: false), which is the intent the palette's "Quit gori" verb
+# dispatches. They used to answer this question in two places and disagree: the chord
+# honoured settings:general "Confirm before quit" and the palette went straight to the
+# teardown — stop_all_jobs / commit_pending_edits / outcome — with no modal, on the ONLY
+# discoverable quit in the app (Hotkeys::FIXED_IDS keeps the chord off the rebind list
+# because "single-key quit is a footgun"). A live Discover crawl or Fuzz run died unnamed
+# and unasked, while `leave_project` — one row above it in the same palette, and less
+# destructive — always confirms and names the jobs.
+describe "Runner.quit_decision" do
+  it "confirms a palette quit when 'Confirm before quit' is on — the bug this pins" do
+    Runner.quit_decision(true, chord: false, armed: false).should eq(Runner::QuitAction::Confirm)
+  end
+
+  # The setting's text is unconditional ("require a confirm modal to quit") and
+  # quit_confirm_message(nil, 0) is written for the idle case: a guarantee that only holds
+  # while a job happens to be running is not one, and quitting idle still commits pending
+  # edits and drops the session.
+  it "confirms with the setting on from either path, armed or not, jobs or not" do
+    [true, false].each do |armed|
+      Runner.quit_decision(true, chord: true, armed: armed).should eq(Runner::QuitAction::Confirm)
+      Runner.quit_decision(true, chord: false, armed: armed).should eq(Runner::QuitAction::Confirm)
+    end
+  end
+
+  # Only a keystroke can arm. The arm is a typo guard for a chord under the fingers, and its
+  # toast reads "press ^D (or ^C) again" — a chord the palette operator never pressed; ^P,
+  # a filter and ↵ on a row that reads "Quit gori" is already that second deliberate act.
+  it "keeps the chord's double press when the setting is off, and does not arm the palette" do
+    Runner.quit_decision(false, chord: true, armed: false).should eq(Runner::QuitAction::Arm)
+    Runner.quit_decision(false, chord: true, armed: true).should eq(Runner::QuitAction::Quit)
+    Runner.quit_decision(false, chord: false, armed: false).should eq(Runner::QuitAction::Quit)
   end
 end
 
@@ -162,8 +224,22 @@ private class ExitShell
     end
   end
 
-  # Mirror of Runner#quit! (no confirm on the default double-press path).
+  # Mirror of Runner#quit! — the GUARDED entry, which is the whole point of it: the palette's
+  # "Quit gori" verb dispatches this same intent (verbs/core.cr → ctx.quit!), so whatever
+  # guard lives here is the guard the only discoverable quit gets. The teardown is
+  # `finish_quit`, and the confirm's accept block calls THAT — routing it back through `quit!`
+  # would re-raise the confirm forever. The policy call is the real `Runner.quit_decision`,
+  # not a re-decision, so this double cannot drift from the shell on the question that matters.
   def quit! : Nil
+    if Runner.quit_decision(Gori::Settings.confirm_quit?, chord: false, armed: false).confirm?
+      @message = Runner.quit_confirm_message(@jobs.active_summary, @jobs.active.size)
+      confirm(@message, danger: true, title: "QUIT GORI", label: "quit") { finish_quit }
+    else
+      finish_quit
+    end
+  end
+
+  private def finish_quit : Nil
     stop_all_jobs
     commit_pending_edits
     @outcome = :quit
@@ -171,9 +247,10 @@ private class ExitShell
 
   getter? danger = false
 
-  private def confirm(message : String, *, danger : Bool, &action : -> Nil) : Nil
+  private def confirm(message : String, *, danger : Bool, title : String = "LEAVE PROJECT",
+                      label : String = "leave", &action : -> Nil) : Nil
     @danger = danger
-    ov = ConfirmDialog.new("LEAVE PROJECT", message, confirm_label: "leave",
+    ov = ConfirmDialog.new(title, message, confirm_label: label,
       danger: danger)
     accepted = false
     ov.on_commit = -> { accepted = true; true }
@@ -244,17 +321,102 @@ describe "leave project with live jobs" do
   end
 end
 
+# `Settings.confirm_quit` is a process-global class_property?: flipping it without putting
+# it back leaks into every later example in the same `crystal spec` run. Same capture/restore
+# idiom as settings_view_spec.cr:465.
+private def with_confirm_quit(on : Bool, &)
+  prev = Gori::Settings.confirm_quit?
+  Gori::Settings.confirm_quit = on
+  begin
+    yield
+  ensure
+    Gori::Settings.confirm_quit = prev
+  end
+end
+
 describe "quit with live jobs" do
   # ^D ^D kills the process, so the engine fibers die with it — but the Jobs registry and
   # every engine's own `request_stop` are what make that an orderly stop rather than a
   # truncation, and `quit!` shares the leave path's helper so the two exits cannot drift.
+  # Pinned to the DEFAULT setting (confirm_quit off) now that `quit!` is confirm-gated:
+  # this example is about the teardown, and the gate has its own block below.
   it "stops every job-owning controller" do
-    shell = ExitShell.new
-    shell.jobs.start(:miner, "GET /api")
-    shell.quit!
-    shell.outcome.should eq(:quit)
-    shell.stopped.should eq([:discover, :fuzzer, :miner, :sequencer, :repeater, :oast])
-    shell.jobs.any_active?.should be_false
-    shell.committed?.should be_true
+    with_confirm_quit(false) do
+      shell = ExitShell.new
+      shell.jobs.start(:miner, "GET /api")
+      shell.quit!
+      shell.outcome.should eq(:quit)
+      shell.stopped.should eq([:discover, :fuzzer, :miner, :sequencer, :repeater, :oast])
+      shell.jobs.any_active?.should be_false
+      shell.committed?.should be_true
+    end
+  end
+end
+
+# The palette's "Quit gori" reaches the shell as ctx.quit! (spec/verbs/core_spec.cr pins that
+# dispatch), so THIS is that path: with "Confirm before quit" on it must raise the same modal
+# the ^C/^D chord raises, name the same jobs, and — like leave_project — change nothing until
+# the operator accepts. It used to tear down on the spot.
+describe "quit through the guarded entry (the palette's Quit gori)" do
+  it "raises the QUIT GORI confirm with the setting on, and names the live jobs" do
+    with_confirm_quit(true) do
+      shell = ExitShell.new
+      shell.jobs.start(:discover, "http://127.0.0.1:19703/")
+      shell.quit!
+
+      shell.outcome.should eq(:running) # nothing torn down yet — the modal is up
+      shell.stopped.should be_empty
+      shell.committed?.should be_false
+      shell.danger?.should be_true
+      shell.message.should eq(
+        "Quit gori? (pending edits are committed first)\n" \
+        "1 job still running — quitting stops it.\n" \
+        "discovering 1")
+
+      shell.press(Termisu::Input::Key::LowerY)
+      shell.outcome.should eq(:quit)
+      shell.stopped.should eq([:discover, :fuzzer, :miner, :sequencer, :repeater, :oast])
+      shell.jobs.any_active?.should be_false
+      shell.committed?.should be_true
+    end
+  end
+
+  it "leaves the jobs running when the confirm is cancelled" do
+    with_confirm_quit(true) do
+      shell = ExitShell.new
+      shell.jobs.start(:fuzz, "GET /a")
+      shell.quit!
+
+      shell.press(Termisu::Input::Key::Escape)
+      shell.outcome.should eq(:running) # still in gori
+      shell.stopped.should be_empty     # NOTHING was stopped
+      shell.jobs.any_active?.should be_true
+      shell.committed?.should be_false
+    end
+  end
+
+  # Nothing running is still a quit worth confirming (it commits pending edits and drops the
+  # session), and the modal keeps the original one-line wording.
+  it "still confirms with the setting on when nothing is running" do
+    with_confirm_quit(true) do
+      shell = ExitShell.new
+      shell.quit!
+      shell.outcome.should eq(:running)
+      shell.message.should eq("Quit gori? (pending edits are committed first)")
+      shell.press(Termisu::Input::Key::LowerY)
+      shell.outcome.should eq(:quit)
+    end
+  end
+
+  # With the setting OFF the palette quits immediately — today's behaviour, kept on purpose:
+  # arming here would toast "press ^D (or ^C) again", a chord this operator never pressed.
+  it "quits outright with the setting off (the default)" do
+    with_confirm_quit(false) do
+      shell = ExitShell.new
+      shell.jobs.start(:miner, "GET /api")
+      shell.quit!
+      shell.outcome.should eq(:quit)
+      shell.committed?.should be_true
+    end
   end
 end

--- a/spec/tui/fuzz_advanced_overlay_spec.cr
+++ b/spec/tui/fuzz_advanced_overlay_spec.cr
@@ -141,6 +141,39 @@ describe Gori::Tui::FuzzAdvancedOverlay do
     ov.snapshot.update_cl.should be_true
   end
 
+  it "never focuses a row it did not draw — the hint row and the bottom border are not rows" do
+    # `render` reserves the last two interior lines (the hint on box.bottom-2, the border on
+    # box.bottom-1), but handle_click computed `i = my - (box.y + 1)` with no upper bound
+    # beyond `ri < ROWS.size`, so a click on either selected @scroll + visible (+1) — an
+    # index that was never under the cursor — and the next render scrolled to follow it.
+    # Focus-only (no commit-on-row-click here), so nothing fired; still the wrong row.
+    #
+    # Production hands `layout.body`, which is what makes this reachable: the card clips to
+    # 14 rows there, so only 11 of the 17 ROWS are drawn. Under the harness's 80x24 default
+    # every row fits and `visible == ROWS.size` hides the whole bug.
+    body = Gori::Tui::Rect.new(2, 4, 76, 18)
+    ov = FuzzAdvancedOverlay.new(blank_snapshot)
+    h = OverlayHarness.new(ov, area: body)
+    box = h.box.not_nil!
+    box.y.should eq(6) # rows run box.y+1 (7) .. 17; hint on 18, border on 19
+
+    h.click_in_box(2, 12).should eq(:open) # the hint row
+    h.click_in_box(2, 13).should eq(:open) # the bottom border
+    h.type("9")
+    ov.snapshot.conc.should eq("209")  # focus never left row 0…
+    ov.snapshot.m_words.should eq("")  # …and did not land on an undrawn row (hint → +11)
+    ov.snapshot.m_regex.should eq("")  # …nor on the one past it (border → +12)
+    ov.snapshot.m_status.should eq("") # …nor anywhere else in the match block
+
+    # Positive control: the LAST drawn row is still a live click target.
+    edge = FuzzAdvancedOverlay.new(blank_snapshot)
+    eh = OverlayHarness.new(edge, area: body)
+    eh.click_in_box(2, 11).should eq(:open)
+    eh.type("7")
+    edge.snapshot.m_size.should eq("7")
+    edge.snapshot.conc.should eq("20")
+  end
+
   it "offsets a click by the scroll position once the list has scrolled" do
     # Production hands an overlay `layout.body` — 6 rows shorter and offset from the screen —
     # so this 18-row card renders clipped to 14 and the row list must scroll to reach the

--- a/spec/tui/hotkeys_overlay_spec.cr
+++ b/spec/tui/hotkeys_overlay_spec.cr
@@ -1,4 +1,6 @@
 require "../spec_helper"
+require "../support/memory_backend"
+require "../support/overlay_harness"
 
 include Gori::Tui
 
@@ -63,6 +65,67 @@ describe HotkeysOverlay do
     working.values.first.should be_nil # explicit unbind
     o.reset_selected
     o.to_working[0].should be_empty # back to default
+  ensure
+    reset_settings
+  end
+
+  it "does not read a Ctrl chord as the bare letter in browse mode" do
+    # `elsif c = ev.char` had no modifier guard, and Event::Key#char falls back to
+    # `key.to_char` — so every Ctrl+letter arrived here as the bare letter. ^X (stop/hex in
+    # six scopes, high-traffic muscle memory) ran unbind_selected, setting the highlighted
+    # verb to an explicit unbind that ↵ then persisted. ^R reset it, ^E armed capture, ^J/^K
+    # moved. Every sibling dispatcher already guards this (Runner#handle_palette_key,
+    # #handle_space_menu_key, TabController#handle_subtab_filter_key).
+    o = fresh_overlay
+    h = OverlayHarness.new(o)
+
+    # char nil → the key.to_char fallback, which is the shape the Ctrl+letter parser emits.
+    h.press(Termisu::Input::Key::LowerX, ctrl: true).should eq(:open)
+    o.to_working[0].should be_empty
+    # …and the Kitty shape, which attaches the char explicitly.
+    h.press(Termisu::Input::Key::LowerX, 'x', ctrl: true).should eq(:open)
+    o.to_working[0].should be_empty
+
+    h.press(Termisu::Input::Key::LowerR, ctrl: true).should eq(:open)
+    o.to_working[0].should be_empty # ^R is not reset_selected
+    h.press(Termisu::Input::Key::UpperR, 'R', ctrl: true).should eq(:open)
+    o.to_working[0].should be_empty
+    h.press(Termisu::Input::Key::LowerE, ctrl: true).should eq(:open)
+    o.capturing?.should be_false # ^E does not arm capture
+
+    # Positive control: the bare letters still do their job, so the guard cannot pass by
+    # breaking the feature it protects.
+    h.press(Termisu::Input::Key::LowerX, 'x').should eq(:open)
+    working, _ = o.to_working
+    working.size.should eq(1)
+    working.values.first.should be_nil # explicit unbind
+  ensure
+    reset_settings
+  end
+
+  it "still records a modified chord in CAPTURE mode, where it is legitimate input" do
+    # HotkeysOverlay is the one overlay whose raw_key_capture? is true, and only while
+    # capturing — the browse-mode guard must not reach that path or the rebinder could no
+    # longer bind any Ctrl/Alt chord at all.
+    o = fresh_overlay
+    o.begin_capture
+    o.capturing?.should be_true
+    o.handle_key(Termisu::Event::Key.new(Termisu::Input::Key::LowerY,
+      Termisu::Input::Modifier::Alt, nil)).should eq(:stay)
+    o.capturing?.should be_false
+    o.to_working[0].values.first.should eq(Gori::Verb::Chord.new("y", alt: true))
+  ensure
+    reset_settings
+  end
+
+  it "treats ^X in capture as a binding attempt, never as the browse unbind" do
+    o = fresh_overlay
+    o.begin_capture
+    o.handle_key(Termisu::Event::Key.new(Termisu::Input::Key::LowerX,
+      Termisu::Input::Modifier::Ctrl, nil)).should eq(:stay)
+    # Whether the validator accepts ^X or rejects it inline is its business; what must never
+    # happen is the browse-mode unbind writing a nil into the working copy.
+    o.to_working[0].each_value { |v| v.should_not be_nil }
   ensure
     reset_settings
   end

--- a/spec/tui/links_overlay_spec.cr
+++ b/spec/tui/links_overlay_spec.cr
@@ -177,6 +177,54 @@ describe Gori::Tui::LinksOverlay do
     end
   end
 
+  it "a row click while ADDING must not open that row — the armed add is the target" do
+    # `handle_key` dispatches to handle_add_key while adding; `handle_click` was left to
+    # PickerOverlay, which knows nothing about the mode. So from Issues → space → l → a,
+    # with the card reading "add: f flow · r repeater · z fuzz · m miner", clicking any row
+    # returned :commit: the shell recorded it as `opening`, on_close found pending_add nil
+    # and ran navigate_link_ref, teleporting the operator into an unrelated flow while the
+    # armed add was silently dropped. `row_at` already subtracts the adding footer row, so
+    # the geometry was mode-aware while the outcome was not.
+    with_store do |store|
+      id = store.insert_issue("t", Gori::Store::Severity::High, "app.test", nil)
+      3.times { |i| store.add_link(Gori::Store::LinkOwnerKind::Issue, id, Gori::Store::LinkRefKind::Repeater, (i + 1).to_i64) }
+      lo = links_for(store, id)
+      h = OverlayHarness.new(lo)
+      opened = [] of Int64
+      h.on_commit do
+        opened << lo.selected_link.not_nil!.link.ref_id
+        true
+      end
+
+      h.press(Termisu::Input::Key::LowerA, 'a')
+      lo.adding?.should be_true
+      h.click_in_box(3, 4).should eq(:open) # list starts at box.y + 3; this is the 2nd row
+      opened.should be_empty                # NOT a navigation
+      h.commits.should eq(0)
+      lo.adding?.should be_true # …and the arm survives the stray click
+      lo.pending_add.should be_nil
+
+      # The source key still lands exactly where it always did.
+      h.press(Termisu::Input::Key::LowerR, 'r').should eq(:closed)
+      lo.pending_add.should eq('r')
+    end
+  end
+
+  it "a click OUTSIDE while adding still drops the whole card, unlike esc" do
+    # DELIBERATE ASYMMETRY, pinned so it reads as a decision rather than an oversight: esc
+    # pops one level (back to browse) and a click-away drops the card. That is the house
+    # idiom for a modal with a sub-mode — HotkeysOverlay#handle_click cancels outright while
+    # capturing, where handle_capture_key's esc only leaves capture. Making LinksOverlay the
+    # one modal whose outside click does not dismiss would cost more consistency than the
+    # two depths do, and nothing is lost: pending_add stays nil, so on_close runs inert.
+    lo = LinksOverlay.new(Gori::Store::LinkOwnerKind::Issue, 1_i64)
+    h = OverlayHarness.new(lo)
+    h.press(Termisu::Input::Key::LowerA, 'a')
+    h.click(0, 0).should eq(:closed)
+    h.commits.should eq(0)
+    lo.pending_add.should be_nil
+  end
+
   it "can be rebuilt on a chosen row, for the add path that never left the list" do
     # Runner#open_link_add_picker uses this when a source has nothing to link ("no fuzz
     # sessions to link"): the user never left the card, so it is rebuilt on the row they

--- a/spec/tui/notifications_overlay_spec.cr
+++ b/spec/tui/notifications_overlay_spec.cr
@@ -159,10 +159,95 @@ describe Gori::Tui::NotificationsOverlay do
     picked.should eq(["a"]) # newest-first (c, b, a), so row 2 is the oldest note
   end
 
+  it "keeps the cursor on the note being read when a drain pushes a new one" do
+    # THE LOST UPDATE. This overlay holds no snapshot — `notes` re-derives `@store.all`
+    # (newest-first) on every call — while the cursor was a bare Int32. Any background
+    # completion that reaches a controller drain (a Probe issue, an OAST callback, a
+    # fuzz/miner/discover Done) becomes index 0 and shifts everything by +1, so the ↵ the
+    # operator presses against the frame they were reading jumps to the NEIGHBOUR.
+    # OastController#drain_events guards the identical shape by capturing {session_id, uid}
+    # and re-anchoring @cb_sel; a Note's `id` is that stable key here (never recycled —
+    # `clear` does not reset @next_id).
+    s = store("a", "b", "c") # newest-first: c, b, a
+    ov = NotificationsOverlay.new(s)
+    h = OverlayHarness.new(ov)
+    h.press(Termisu::Input::Key::Down).should eq(:open)
+    ov.selected_note.not_nil!.message.should eq("b")
+
+    s.push(:success, "Probe: issue on GET /x") # a drain lands mid-read
+    ov.selected_note.not_nil!.message.should eq("b")
+
+    # The highlight has to move with it, or the frame disagrees with what ↵ will do.
+    box = h.box.not_nil!
+    h.render.row(box.y + 2 + 2).should contain("▎") # list is now [Probe…, c, b, a]
+    h.render.row(box.y + 2 + 2).should contain("b")
+
+    jumped = [] of String
+    h.on_commit do
+      jumped << ov.selected_note.not_nil!.message
+      true
+    end
+    h.press(Termisu::Input::Key::Enter).should eq(:closed)
+    jumped.should eq(["b"])
+  end
+
+  it "anchors from the moment it opens, before the operator has moved at all" do
+    # The unmoved-cursor case is the same bug: the center opens on the newest note, a drain
+    # prepends, and ↵ opens something the operator never saw. The Runner builds a fresh
+    # overlay per open (Runner#open_notifications), so `initialize` IS the open.
+    s = store("a")
+    ov = NotificationsOverlay.new(s)
+    s.push(:warn, "OAST: callback for s1")
+    ov.selected_note.not_nil!.message.should eq("a")
+  end
+
+  it "falls back to the clamped index when the anchored note is gone" do
+    # `clear` and the retention trim can retire the anchor. OastController's re-anchor is a
+    # no-op when the key no longer resolves; the same choice here keeps the cursor roughly
+    # where it was rather than snapping to the top of a list the operator did not touch.
+    s = store("a", "b", "c")
+    ov = NotificationsOverlay.new(s)
+    ov.move(2) # → "a", the oldest
+    ov.selected_note.not_nil!.message.should eq("a")
+    s.clear
+    s.push(:info, "fresh")
+    ov.selected_note.not_nil!.message.should eq("fresh") # clamped, never an index error
+  end
+
   it "clamps the selection on an empty store instead of raising" do
     h = OverlayHarness.new(NotificationsOverlay.new(Notifications.new))
     h.press(Termisu::Input::Key::Down).should eq(:open)
     h.overlay.as(NotificationsOverlay).selected_note.should be_nil
     h.rendered?("(no notifications yet)").should be_true
+  end
+end
+
+# `c` clears the whole store, so it must not fire on a modified chord. This is not
+# hypothetical tidiness: `Event::Key#char` is `@char || key.to_char`, so ^C reports 'c', and
+# the branch was reachable-by-accident-only — the shell used to claim ^C for the quit-arm
+# before any overlay saw a key. Once the quit-arm learned to yield while a modal is up (so ^D
+# could reach the Fuzzer payload-set editor), ^C started reaching this overlay, where it
+# erased every notification instead of arming quit. Pinned so the guard cannot be dropped as
+# redundant on the strength of a Runner invariant that already changed once.
+describe "NotificationsOverlay clear guard" do
+  it "clears on a bare c but never on ^C or ⌥C" do
+    store = Gori::Tui::Notifications.new
+    store.push(:info, "first")
+    store.push(:info, "second")
+
+    ov = Gori::Tui::NotificationsOverlay.new(store)
+    ctrl_c = Termisu::Event::Key.new(Termisu::Input::Key::LowerC, Termisu::Input::Modifier::Ctrl)
+    alt_c = Termisu::Event::Key.new(Termisu::Input::Key::LowerC, Termisu::Input::Modifier::Alt)
+
+    # The chord an operator presses to leave must not destroy their evidence.
+    ov.handle_key(ctrl_c).should eq(:stay)
+    store.all.size.should eq(2)
+    ov.handle_key(alt_c).should eq(:stay)
+    store.all.size.should eq(2)
+
+    # The advertised mnemonic still works — the hint says "c clear".
+    ov.hint.should contain("c clear")
+    ov.handle_key(Termisu::Event::Key.new(Termisu::Input::Key::LowerC)).should eq(:stay)
+    store.all.size.should eq(0)
   end
 end

--- a/spec/tui/oast_callback_cap_spec.cr
+++ b/spec/tui/oast_callback_cap_spec.cr
@@ -1,0 +1,313 @@
+require "../spec_helper"
+require "../support/memory_backend"
+require "file_utils"
+
+include Gori::Tui
+
+# The OAST callbacks buffer is the ONE result list in the TUI whose growth is paced by a
+# NETWORK PEER rather than by the operator.
+#
+# `OastController#apply_callback` appended one `CbRow` per interaction — each holding the full
+# `raw_request` AND `raw_response` strings — with no cap and no eviction anywhere in the file,
+# and `@seen` interned one uid per row in lockstep. Nothing trimmed either; the only thing that
+# ever cleared them was a full `reload`, which then re-materialised the WHOLE table
+# (`oast_callbacks_since(0)` has no LIMIT) and handed it straight back.
+#
+# The operator does not fill this one. interact.sh-class domains attract unsolicited
+# third-party scanner traffic, and the poller ingests at `POLL_INTERVAL = 5.seconds` for as
+# long as the listener lives — so retained bytes were a function of how long the listener was
+# left up and how popular the provider's domain is, neither of which the operator controls.
+# Every sibling buffer in this layer is bounded (`Notifications::CAP` 100, `Jobs::CAP` 50,
+# `FuzzerView::RESULT_CAP` 5000); this one was the outlier.
+#
+# The fix is a WINDOW, not a destructive trim: the newest `CALLBACK_CAP` rows are held in
+# memory, every evicted row is still in `oast_callbacks`, and the pane SAYS SO — a silent cap
+# in the one tab whose whole job is evidence is its own defect. These examples pin all three
+# halves: the buffer stops growing, `@seen` stops growing with it, and the operator can see it.
+
+# The narrow shell facade a controller is given. Everything here is inert except `session`,
+# `jobs` and `notifications` — the only members the callback drain touches — because a
+# controller reaches the shell ONLY through this module, so stubbing it is stubbing the shell.
+# File-local rather than shared with repeater_refusal_inline_spec's identical double: `Host` is
+# ~30 abstract methods and a shared support double would be a fourth file to keep in sync with
+# the module every time it grows.
+private class FakeHost
+  include Gori::Tui::Host
+
+  getter statuses = [] of String
+
+  def initialize(@session : Gori::Session)
+    @jobs = Gori::Tui::Jobs.new
+    @notifications = Gori::Tui::Notifications.new
+  end
+
+  def session : Gori::Session
+    @session
+  end
+
+  def jobs : Gori::Tui::Jobs
+    @jobs
+  end
+
+  def notifications : Gori::Tui::Notifications
+    @notifications
+  end
+
+  def status(message : String) : Nil
+    @statuses << message
+  end
+
+  def request_overlay(kind : Symbol) : Nil
+  end
+
+  def request_focus(pane : Symbol) : Nil
+  end
+
+  def focus_body : Nil
+  end
+
+  def switch_tab(tab : Symbol) : Nil
+  end
+
+  def goto_tab(tab : Symbol) : Nil
+  end
+
+  def open_palette : Nil
+  end
+
+  def open_space_menu : Nil
+  end
+
+  def open_fuzz_set_editor(edit_index : Int32?) : Nil
+  end
+
+  def open_fuzz_advanced_editor : Nil
+  end
+
+  def reconfigure_sequence : Nil
+  end
+
+  def open_scope_rule_editor(edit_id : Int64?, kind : String, match_type : String, pattern : String) : Nil
+  end
+
+  def open_custom_rule_editor(rule : Gori::Probe::CustomRule?) : Nil
+  end
+
+  def open_rewriter_rule_editor(rule : Gori::Store::MatchRule?) : Nil
+  end
+
+  def open_extract_rule_editor(rule : Gori::Store::ExtractRule?) : Nil
+  end
+
+  def open_chain_save : Nil
+  end
+
+  def open_chain_load : Nil
+  end
+
+  def open_oast_provider_editor(provider : Gori::Oast::ProviderConfig?) : Nil
+  end
+
+  def confirm(title : String, message : String, *, confirm_label : String, danger : Bool,
+              return_to : Symbol = :none, &action : -> Nil) : Nil
+    action.call # no modal in a spec: a confirmed action runs straight through
+  end
+
+  def overlay : Symbol
+    :none
+  end
+
+  def active_tab : Symbol
+    :oast
+  end
+
+  def focus : Symbol
+    :body
+  end
+
+  def reveal? : Bool
+    false
+  end
+
+  def toggle_reveal : Nil
+  end
+
+  def pretty? : Bool
+    false
+  end
+
+  def toggle_pretty : Nil
+  end
+
+  def toggle_scope_lens : Nil
+  end
+
+  def toggle_sandbox : Nil
+  end
+
+  def apply_project_network(bind_host : String, bind_port : Int32, upstream : String,
+                            connect_secs : Int32, io_secs : Int32, capture_mib : Int32) : String
+    ""
+  end
+end
+
+# The CA is the one slow part of standing a Session up (a root keypair), and it is pure
+# infrastructure here — no example asserts anything about it — so it is built once.
+private CAP_CA_ROOT = File.tempname("gori-oast-cap-ca")
+Spec.after_suite { FileUtils.rm_rf(CAP_CA_ROOT) }
+
+# A real Session (the controller reads `session.store` on construction and on every fold) with
+# ONE persisted OAST session row, so the folded rows get a real session_id and a real label —
+# the same path a reopened project takes, no test-only seam.
+private def with_oast_controller(&)
+  root = File.tempname("gori-oast-cap")
+  Dir.mkdir_p(root)
+  project = Gori::ProjectRegistry.new(root).temp("oastcap")
+  session = Gori::Session.open(Gori::Config.new(listen: "127.0.0.1", port: 0),
+    Gori::Proxy::Tls::CertAuthority.load_or_create(CAP_CA_ROOT), Gori::Verbs.registry, project)
+  begin
+    sid = session.store.insert_oast_session(nil, "interactsh", "https://oast.test",
+      "c0rr3lat10n", "s3cret", nil, nil)
+    host = FakeHost.new(session)
+    yield OastController.new(host), host, session, sid
+  ensure
+    session.close
+    FileUtils.rm_rf(root) if Dir.exists?(root)
+  end
+end
+
+# One interaction as the poller would deliver it. The raw sides are deliberately non-trivial —
+# they are the bytes the unbounded buffer was retaining, and the reason a row is not free.
+private def interaction(n : Int32) : Gori::Oast::Interaction
+  Gori::Oast::Interaction.new(
+    unique_id: "uid-#{n.to_s.rjust(6, '0')}",
+    protocol: "dns",
+    method: nil,
+    source_ip: "203.0.113.#{n % 256}",
+    full_id: "#{n.to_s.rjust(6, '0')}.oast.test",
+    raw_request: ";; QUESTION SECTION:\n;#{n.to_s.rjust(6, '0')}.oast.test. IN A\n" + ("x" * 256),
+    raw_response: ";; ANSWER SECTION:\n#{n.to_s.rjust(6, '0')}.oast.test. 60 IN A 203.0.113.1",
+    at: Time.unix(1_700_000_000_i64 + n))
+end
+
+# Push `count` interactions through the SAME path the poll fiber uses: the events channel plus
+# `drain_events` on the main fiber. The channel holds 256 and one drain handles DRAIN_CAP (512),
+# so this interleaves rather than filling the channel — exactly what a real flood does across
+# consecutive run-loop ticks.
+private def flood(controller : OastController, sid : Int64, count : Int32, from : Int32 = 0) : Nil
+  (from...(from + count)).each do |n|
+    controller.@oast_events.send(Gori::Oast::CallbackEvent.new(sid, interaction(n)))
+    controller.drain_events if (n - from + 1) % 200 == 0
+  end
+  controller.drain_events
+end
+
+# What the operator actually sees in the CALLBACKS card, which is the whole point of capping
+# visibly rather than silently.
+private def callbacks_pane(controller : OastController) : String
+  backend = MemoryBackend.new(120, 40)
+  controller.render_body(Screen.new(backend), Rect.new(0, 0, 120, 40), :body)
+  (0...40).map { |y| backend.row(y) }.join("\n")
+end
+
+describe "Gori::Tui::OastController — the callback buffer is a bounded window" do
+  it "stops growing past CALLBACK_CAP, and stops @seen growing with it" do
+    over = 50
+    total = OastController::CALLBACK_CAP + over
+    with_oast_controller do |controller, _host, session, sid|
+      flood(controller, sid, total)
+
+      # The defect: this was `total`, and one CbRow carries the full raw request AND response.
+      controller.@callbacks.size.should eq(OastController::CALLBACK_CAP)
+      # @seen interned one uid per row in lockstep — capping the rows alone would have left
+      # the same unbounded growth behind, just with a smaller constant.
+      controller.@seen.values.sum(&.size).should eq(OastController::CALLBACK_CAP)
+      controller.@evicted.should eq(over)
+
+      # A WINDOW, not a destructive trim: not one interaction left the project DB.
+      session.store.oast_callbacks_since(0_i64).size.should eq(total)
+      # …and the window is over the NEWEST rows, which is what makes eviction survivable:
+      # a callback that arrives late can be the one that proves the vuln.
+      uids = controller.@callbacks.map(&.uid)
+      uids.last.should eq("uid-#{(total - 1).to_s.rjust(6, '0')}")
+      uids.includes?("uid-000000").should be_false
+    end
+  end
+
+  it "tells the operator the pane is a window — a silent cap in an evidence tool is its own defect" do
+    with_oast_controller do |controller, host, _session, sid|
+      flood(controller, sid, OastController::CALLBACK_CAP + 50)
+
+      # Standing marker in the card title: the count must not read as "this is all there is".
+      pane = callbacks_pane(controller)
+      pane.should contain("CALLBACKS (#{OastController::CALLBACK_CAP} of #{OastController::CALLBACK_CAP + 50})")
+      pane.should contain("50 older kept in the project DB")
+
+      # And a one-time note, because the callbacks that get evicted are the ones that arrived
+      # while the operator was on another tab.
+      capped = host.notifications.all.select(&.message.includes?("newest #{OastController::CALLBACK_CAP}"))
+      capped.size.should eq(1)
+      capped.first.level.should eq(:warn)
+    end
+  end
+
+  it "says so in the no-match empty state too, so a filter miss is not read as evidence of absence" do
+    with_oast_controller do |controller, _host, _session, sid|
+      flood(controller, sid, OastController::CALLBACK_CAP + 50)
+      controller.start_cb_filter
+      "203.0.113.999".each_char do |ch| # a source IP no interaction in this flood carries
+        controller.handle_cb_filter_key(Termisu::Event::Key.new(Termisu::Input::Key::LowerA, char: ch))
+      end
+
+      pane = callbacks_pane(controller)
+      pane.should contain("no callbacks match")
+      # Without this the operator filters for the source IP they care about, reads "no match",
+      # and concludes it never hit — when the row is in the table the filter never saw.
+      pane.should contain("filter covers the newest #{OastController::CALLBACK_CAP} only")
+      pane.should contain("50 older are in the project DB")
+    end
+  end
+
+  it "keeps the window (and the marker) across a tab revisit, which re-reads the whole table" do
+    over = 50
+    total = OastController::CALLBACK_CAP + over
+    with_oast_controller do |controller, _host, _session, sid|
+      flood(controller, sid, total)
+      controller.on_enter # full reload: clears everything and re-folds the WHOLE table
+
+      controller.@callbacks.size.should eq(OastController::CALLBACK_CAP)
+      controller.@seen.values.sum(&.size).should eq(OastController::CALLBACK_CAP)
+      # Recomputed from the table, not carried across — a revisit must not inflate the count.
+      controller.@evicted.should eq(over)
+      callbacks_pane(controller).should contain("#{over} older kept in the project DB")
+    end
+  end
+
+  it "keeps dedup sound: a uid still inside the window never appends a second row" do
+    with_oast_controller do |controller, _host, _session, sid|
+      flood(controller, sid, OastController::CALLBACK_CAP + 50)
+      before = controller.@callbacks.size
+
+      # The newest interaction, re-announced by the provider on the next poll. Its uid is
+      # inside the window, so @seen still holds it — trimming the OLD end is what preserves
+      # that, since reconcile only ever re-reads rows NEWER than the watermark.
+      controller.@oast_events.send(
+        Gori::Oast::CallbackEvent.new(sid, interaction(OastController::CALLBACK_CAP + 49)))
+      controller.drain_events
+
+      controller.@callbacks.size.should eq(before)
+      controller.@evicted.should eq(50)
+    end
+  end
+
+  it "reports the session's TOTAL hits, not the window's — a counter that walks backwards is worse than none" do
+    total = OastController::CALLBACK_CAP + 50
+    with_oast_controller do |controller, _host, _session, sid|
+      flood(controller, sid, total)
+      # @seen used to BE the hit count (its size is the job note's "N hits"); now that it is
+      # windowed, the count is carried separately or the listener's progress would shrink as
+      # it kept receiving.
+      controller.@hits[sid].should eq(total)
+    end
+  end
+end

--- a/spec/tui/pane_overspill_spec.cr
+++ b/spec/tui/pane_overspill_spec.cr
@@ -1,0 +1,132 @@
+require "../spec_helper"
+require "../support/memory_backend"
+
+include Gori::Tui
+
+# THE invariant: the rects a view splits its container into must sum to no more than the
+# container it was handed. Sequencer/Miner/Discover each FLOORED a pane height for
+# legibility (`{h, 3}.max`, `{h, 1}.max`) with no matching ceiling at `rect.h`, so on a
+# short body they placed the lower pane past `rect.bottom` and painted rows nobody owns —
+# the status bar's row and the bottom margin, which no later pass repaints. `Layout.usable?`
+# gates render and click at 40x8, so the reachable degenerate band is `body.h ∈ {1, 2}`;
+# every example here renders into a backend TALLER than the rect so the overspill has
+# somewhere to land and can be asserted as blank.
+
+# Renders into a backend `pad` rows taller than `rect` and returns it, so the rows below
+# the container are observable rather than clipped away by Screen's bounds check.
+private def blank_row?(b : MemoryBackend, y : Int32) : Bool
+  b.cluster_row(y).chars.all?(&.whitespace?)
+end
+
+private def first_row_index(b : MemoryBackend, h : Int32, text : String) : Int32
+  (0...h).each { |y| return y if b.row(y).includes?(text) }
+  -1
+end
+
+describe "short-body pane overspill" do
+  # 60x12 with the sub-tab strip shown gives Sequencer a content rect of Rect(3, 7, 54, 2).
+  # `cfg_h` floored at 3 and the lower pane at 2 painted rows 7..11 — row 10 is the status
+  # row (repainted after) and ROW 11 is the bottom margin, outside the layout entirely.
+  it "SequencerView keeps every drawn cell inside the rect it was handed" do
+    {1, 2}.each do |body_h|
+      view = SequencerView.new
+      view.load("http://h.test", "GET /a HTTP/1.1\r\nHost: h.test\r\n\r\n".to_slice, false, nil,
+        Gori::Sequencer::Config.new)
+      b = MemoryBackend.new(60, 12)
+      rect = Rect.new(3, 12 - 2 - body_h, 54, body_h) # two spare rows below, as the real layout has
+      view.render(Screen.new(b), rect, true)
+
+      (rect.bottom...12).each do |y|
+        blank_row?(b, y).should be_true # (h=#{body_h}) row #{y} is outside the container
+      end
+      # …and the hit-test must agree with the geometry, not with the inflated one: a click
+      # on a row the renderer never owned belongs to no pane.
+      view.pane_at(rect, rect.x + 2, rect.bottom).should be_nil # (h=#{body_h})
+    end
+  end
+
+  it "MinerView keeps every drawn cell inside the rect it was handed" do
+    {1, 2}.each do |body_h|
+      view = MinerView.new
+      view.load("http://h.test", "GET /a HTTP/1.1\r\nHost: h.test\r\n\r\n".to_slice, false, nil,
+        Gori::Miner::Config.new)
+      b = MemoryBackend.new(60, 12)
+      rect = Rect.new(3, 12 - 2 - body_h, 54, body_h)
+      view.render(Screen.new(b), rect, true)
+
+      (rect.bottom...12).each do |y|
+        blank_row?(b, y).should be_true # (h=#{body_h}) row #{y} is outside the container
+      end
+      view.pane_at(rect, rect.x + 2, rect.bottom).should be_nil # (h=#{body_h})
+    end
+  end
+
+  it "DiscoverView keeps every drawn cell inside the rect it was handed" do
+    {1, 2}.each do |body_h|
+      view = DiscoverView.new
+      view.add(DiscoverRun.new("http://a.test/", Gori::Discover::Config.new))
+      b = MemoryBackend.new(60, 12)
+      rect = Rect.new(3, 12 - 2 - body_h, 54, body_h)
+      view.render(Screen.new(b), rect, true)
+
+      (rect.bottom...12).each do |y|
+        blank_row?(b, y).should be_true # (h=#{body_h}) row #{y} is outside the container
+      end
+      view.pane_at(rect, rect.x + 2, rect.bottom).should be_nil # (h=#{body_h})
+    end
+  end
+
+  # The other half of the fix: render and the hit-test must derive from ONE source. These
+  # pin the agreement at a HEALTHY size, where the clamp is a no-op — so the shared
+  # derivation is what is under test, not the degenerate band.
+  it "SequencerView#pane_at answers with the pane the renderer actually drew" do
+    view = SequencerView.new
+    view.load("http://h.test", "GET /a HTTP/1.1\r\nHost: h.test\r\n\r\n".to_slice, false, nil,
+      Gori::Sequencer::Config.new)
+    rect = Rect.new(0, 0, 70, 30) # < 84 wide ⇒ Samples stacked above Analysis
+    b = MemoryBackend.new(70, 30)
+    view.render(Screen.new(b), rect, true)
+
+    samples_y = first_row_index(b, 30, "SAMPLES")
+    analysis_y = first_row_index(b, 30, "ANALYSIS")
+    samples_y.should be > 0
+    analysis_y.should be > samples_y
+    view.pane_at(rect, 5, 0).should eq(:config)
+    view.pane_at(rect, 5, samples_y).should eq(:samples)
+    view.pane_at(rect, 5, analysis_y).should eq(:analysis)
+  end
+
+  it "MinerView#pane_at answers with the pane the renderer actually drew" do
+    view = MinerView.new
+    view.load("http://h.test", "GET /a HTTP/1.1\r\nHost: h.test\r\n\r\n".to_slice, false, nil,
+      Gori::Miner::Config.new)
+    rect = Rect.new(0, 0, 70, 30)
+    b = MemoryBackend.new(70, 30)
+    view.render(Screen.new(b), rect, true)
+
+    findings_y = first_row_index(b, 30, "FINDINGS")
+    findings_y.should be > 0
+    view.pane_at(rect, 5, 0).should eq(:summary)
+    view.pane_at(rect, 5, findings_y).should eq(:results)
+    view.pane_at(rect, 5, findings_y - 1).should eq(:summary)
+  end
+
+  # The divergence a SHARED derivation removes and two hand-matched clamps would not:
+  # `render` floored `sum_h` at 1, `pane_at` re-derived it and did NOT, so at `rect.h == 3`
+  # (where the `rect.h - 3` step drives `sum_h` to 0) the row `render` gave to SUMMARY
+  # hit-tested to :results. Nothing caught it — the two copies were only ever compared by
+  # eye. `pane_rects` makes the disagreement unrepresentable.
+  it "MinerView#pane_at does not disagree with render on the row SUMMARY owns" do
+    view = MinerView.new
+    view.load("http://h.test", "GET /a HTTP/1.1\r\nHost: h.test\r\n\r\n".to_slice, false, nil,
+      Gori::Miner::Config.new)
+    rect = Rect.new(0, 0, 70, 3)
+    b = MemoryBackend.new(70, 3)
+    view.render(Screen.new(b), rect, true)
+
+    view.pane_at(rect, 5, rect.y).should eq(:summary) # SUMMARY's row, not FINDINGS'
+    findings_y = first_row_index(b, 3, "FINDINGS")
+    findings_y.should eq(1) # the card render actually framed starts below it
+    view.pane_at(rect, 5, findings_y).should eq(:results)
+  end
+end

--- a/spec/tui/tui_audit_remainder_spec.cr
+++ b/spec/tui/tui_audit_remainder_spec.cr
@@ -1,0 +1,223 @@
+require "../spec_helper"
+require "../support/memory_backend"
+
+include Gori::Tui
+
+# Regressions for the four TUI-audit defects that survived the first fix round:
+# the Issues scroll clamp, the History cursor drift on an emptied list, the
+# preview-focus soft-lock after a resize collapses the pane, and the two missing
+# width clamps. Each `it` here failed before its fix and passes after.
+
+private def tmp_store(&)
+  path = File.tempname("gori-audit", ".db")
+  store = Gori::Store.open(path)
+  begin
+    yield store
+  ensure
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+private def add_flow(store, method, target, host = "h.test")
+  id = store.insert_flow(Gori::Store::CapturedRequest.new(
+    created_at: 1_i64, scheme: "http", host: host, port: 80,
+    method: method, target: target, http_version: "HTTP/1.1",
+    head: "#{method} #{target} HTTP/1.1\r\nHost: #{host}\r\n\r\n".to_slice, body: nil))
+  store.update_response(Gori::Store::CapturedResponse.new(
+    flow_id: id, status: 200, head: "HTTP/1.1 200 OK\r\n\r\nbody".to_slice,
+    body: "body".to_slice, content_type: "text/plain"))
+  id
+end
+
+describe "TUI audit remainder — IssuesView scroll clamp" do
+  # The list can shrink UNDER a scrolled viewport (a batch delete that takes the cursor row,
+  # a `/` query that excludes it): apply_filter re-clamps @selected but never @scroll, and
+  # ensure_visible only had the two "bring the cursor into view" rules — neither fires when
+  # the cursor is already inside the stale window. IssuesView draws no scroll gauge, so the
+  # symptom is silent: a 44-issue result paints 3 rows with 7 rows of dead space below it.
+  it "clamps @scroll to the shrunken list so the pane refills instead of showing dead space" do
+    prev = Gori::Settings.issues_preview
+    begin
+      Gori::Settings.issues_preview = false # keep list_split whole: this asserts on list_h
+      tmp_store do |store|
+        60.times { |i| store.insert_issue("issue #{i}", Gori::Store::Severity::Medium, "h.test", nil) }
+        view = IssuesView.new
+        view.reload(store)
+
+        rect = Rect.new(0, 0, 100, 13) # rows start at rect.y + 3 ⇒ list_h = 10
+        view.move(50)
+        view.render(Screen.new(MemoryBackend.new(100, 13)), rect)
+        view.@scroll.should eq(41) # ensure_visible pulled the window down to the cursor
+
+        ids = view.@issues.map(&.id)
+        view.delete_ids(store, ids[44..]).should be_true # 16 gone, INCLUDING the cursor row
+        view.selected_index.should eq(43)                # id anchor lost ⇒ clamped to the new end
+
+        backend = MemoryBackend.new(100, 13)
+        view.render(Screen.new(backend), rect)
+        view.@scroll.should eq(34) # 44 issues − 10 visible rows
+        (3...13).count { |y| backend.row(y).blank? }.should eq(0)
+      end
+    ensure
+      Gori::Settings.issues_preview = prev
+    end
+  end
+end
+
+describe "TUI audit remainder — HistoryView cursor on an emptied list" do
+  # `Clear history` leaves @selected at the 0 PLACEHOLDER with @follow already off. The
+  # incremental insert path then treated that 0 as a real anchor and shifted it on every
+  # prepend, putting the cursor one past the end — selected_id nil, every id-keyed verb a
+  # silent no-op, and (off-tab, where nothing re-clamps) a reload that re-targets the
+  # cursor onto a row the operator never chose.
+  it "does not walk the cursor past the end when inserts land on a cleared (empty) list" do
+    tmp_store do |store|
+      add_flow(store, "GET", "/a")
+      add_flow(store, "GET", "/b")
+      view = HistoryView.new
+      view.reload(store)
+      view.move(1) # off the live tail ⇒ follow off
+      view.follow?.should be_false
+
+      view.clear(store).should be_true
+      view.rows.size.should eq(0)
+      view.follow?.should be_false # clear does not re-arm follow — the drift precondition
+
+      3.times { |i| view.on_event(Gori::Store::FlowEvent.new(add_flow(store, "GET", "/new#{i}"), :inserted), store) }
+
+      view.rows.size.should eq(3)
+      view.selected.should be < view.rows.size # 0 <= @selected < @rows.size
+      held = view.selected_id
+      held.should_not be_nil # a cursor with no row makes ↵/r/t/d/copy silent no-ops
+
+      view.reload(store)               # what on_enter does when the tab comes back
+      view.selected_id.should eq(held) # ...and it must not silently re-target the cursor
+    end
+  end
+end
+
+describe "TUI audit remainder — preview focus after a collapsing resize" do
+  # list_split hands back no preview below rect.h 12 (an 80x19 terminal), but @preview_focus
+  # kept naming the pane that is no longer drawn. preview_scroll_focused? has no geometry
+  # check, so ↑/↓, PgUp/PgDn and the wheel all fed an invisible pane's scroll offset and the
+  # list stopped moving — a soft-lock only Tab or a row click could clear.
+  it "snaps HistoryView preview focus back to the list when the pane collapses" do
+    prev = Gori::Settings.history_preview
+    begin
+      Gori::Settings.history_preview = true
+      tmp_store do |store|
+        add_flow(store, "GET", "/a")
+        add_flow(store, "GET", "/b")
+        add_flow(store, "GET", "/c")
+        view = HistoryView.new
+        view.reload(store)
+        view.set_preview_focus(:req)
+        view.preview_focus.should eq(:req)
+
+        rect = Rect.new(0, 0, 80, 11) # 80x19 terminal ⇒ body.inset(1,1).h == 11
+        view.list_split(rect)[1].should be_nil
+        view.render_list(Screen.new(MemoryBackend.new(80, 11)), rect)
+
+        view.preview_focus.should eq(:list)
+        before = view.selected
+        view.move(1)
+        view.selected.should_not eq(before) # arrows drive the list, not an invisible pane
+      end
+    ensure
+      Gori::Settings.history_preview = prev
+    end
+  end
+
+  it "snaps IssuesView preview focus back to the list when the pane collapses" do
+    prev = Gori::Settings.issues_preview
+    begin
+      Gori::Settings.issues_preview = true
+      tmp_store do |store|
+        3.times { |i| store.insert_issue("issue #{i}", Gori::Store::Severity::Medium, "h.test", nil) }
+        view = IssuesView.new
+        view.reload(store)
+        view.set_preview_focus(:preview)
+        view.preview_focus.should eq(:preview)
+
+        rect = Rect.new(0, 0, 80, 11)
+        view.list_split(rect)[1].should be_nil
+        view.render(Screen.new(MemoryBackend.new(80, 11)), rect)
+
+        view.preview_focus.should eq(:list)
+        before = view.selected_index
+        view.move(1)
+        view.selected_index.should_not eq(before)
+      end
+    ensure
+      Gori::Settings.issues_preview = prev
+    end
+  end
+end
+
+describe "TUI audit remainder — missing width clamps" do
+  # METHOD sits in a fixed 8-column cell (method_x = rect.x + 16, proto_x = rect.x + 24) but
+  # was drawn with no `width:` at all, so its limit was the whole screen. RFC 9110 permits
+  # any token and the parser caps nothing, so a long method ran through PROTO/HOST/PATH.
+  it "clamps an over-long METHOD token to its 8-column cell" do
+    tmp_store do |store|
+      add_flow(store, "X-CUSTOM-METHOD", "/vc")
+      view = HistoryView.new
+      view.reload(store)
+
+      backend = MemoryBackend.new(100, 12)
+      view.render_list(Screen.new(backend), Rect.new(0, 0, 100, 12))
+      line = backend.row(3) # list_top = rect.y + 3 (QL bar, header, divider)
+
+      # Budget is the FULL 8, not 7-in-8 like the neighbouring cells. PROTO draws at its own
+      # absolute `proto_x`, so a full 8 columns cannot bleed into it — 7 would only buy a
+      # blank gap, and it costs `PROPFIND` and `CHECKOUT` (both exactly 8, both methods this
+      # tool is pointed at), which the unclamped code rendered correctly. A clamp that
+      # truncates a real method is a regression the clamp introduced; a tight column is not.
+      line[16, 8].should eq("X-CUSTO…") # ellipsized inside the cell, not clipped silently
+      line[24, 4].should eq("HTTP")     # PROTO starts at its own x, untouched
+      line[28, 3].should eq("   ")      # nothing bleeds out of METHOD toward HOST
+      line.should contain("h.test")
+    end
+  end
+
+  # The other half of choosing 8 over 7: the widest REAL methods must survive the clamp. If
+  # someone re-tightens this cell to 7 for the sake of a gap column, this fails and says why.
+  it "renders an exactly-8-character method in full, without eating PROTO" do
+    tmp_store do |store|
+      add_flow(store, "PROPFIND", "/dav")
+      view = HistoryView.new
+      view.reload(store)
+
+      backend = MemoryBackend.new(100, 12)
+      view.render_list(Screen.new(backend), Rect.new(0, 0, 100, 12))
+      line = backend.row(3)
+
+      line[16, 8].should eq("PROPFIND") # no ellipsis — it fits the cell exactly
+      line[24, 4].should eq("HTTP")     # and PROTO is still where it belongs
+    end
+  end
+
+  # The Issues row right-aligns the host from rect.right, and the leftover feeds the title
+  # budget. Both used host.size — CHARACTERS — while the host is the flow's raw wire `Host`
+  # with no punycode/IDNA anywhere on the path, so a wide-glyph host started too far right,
+  # painted past the card's border, and over-budgeted the title underneath itself.
+  it "right-aligns an IDN host by display columns, not characters" do
+    tmp_store do |store|
+      store.insert_issue("cross-site scripting in the search parameter",
+        Gori::Store::Severity::High, "日本語.test", nil)
+      view = IssuesView.new
+      view.reload(store)
+
+      Screen.display_width("日本語.test").should eq(11) # 8 characters, 11 columns
+      backend = MemoryBackend.new(80, 10)            # backend wider than the pane, so an overrun shows
+      view.render(Screen.new(backend), Rect.new(0, 0, 40, 10))
+
+      backend.cluster_grid[3][28].should eq("日") # rect.right − 11 − 1
+      backend.row(3)[27].should eq(' ')          # title budget stops short of the host
+      backend.row(3)[39, 4].should eq("    ")    # nothing at or past the pane's edge
+    end
+  end
+end

--- a/src/gori/tui/controllers/oast_controller.cr
+++ b/src/gori/tui/controllers/oast_controller.cr
@@ -24,6 +24,23 @@ module Gori::Tui
     DRAIN_CAP     = 512
     POLL_INTERVAL = 5.seconds
 
+    # Ring cap on the in-memory callback window. A per-project result buffer fed by a NETWORK
+    # PEER must have a cap or an eviction policy: unlike every other result list in this layer,
+    # growth here is paced by the PROVIDER, not the operator. An interact.sh-class domain
+    # attracts unsolicited third-party scanner traffic, the poller ingests it every
+    # POLL_INTERVAL for as long as the listener lives, and each interaction costs one CbRow
+    # holding the FULL raw_request and raw_response. Unbounded, that is the only buffer in the
+    # TUI a third party can grow (Notifications::CAP 100, Jobs::CAP 50, FuzzerView::RESULT_CAP
+    # 5000 are all bounded).
+    #
+    # This is a VIEW WINDOW, not a destructive trim: every evicted row is still in the
+    # `oast_callbacks` table, and `reload` re-forms the window over the newest CALLBACK_CAP of
+    # them. Lower than FuzzerView's 5000 because a fuzz row keeps bodies only for matches while
+    # every OAST row carries both raw sides in full — 2000 is ~2-4 MiB of live interactions and
+    # is two orders of magnitude past the few dozen callbacks a real assessment produces, so
+    # the operator's own evidence never reaches it; only a flood does.
+    CALLBACK_CAP = 2000
+
     # A live listening session: the engine Session + its provider + poll fiber.
     # `provider_key` is the scope-qualified Oast::ProviderConfig#key (stable across both
     # scopes; a global provider has no project-DB row id to key off).
@@ -63,7 +80,10 @@ module Gori::Tui
       @providers = [] of Oast::ProviderConfig
       @listeners = [] of Listener
       @callbacks = [] of CbRow
-      @seen = Hash(Int64, Set(String)).new     # session_id → seen provider_uids (dedup)
+      @seen = Hash(Int64, Set(String)).new     # session_id → seen provider_uids, WINDOWED (dedup)
+      @hits = Hash(Int64, Int32).new           # session_id → TOTAL callbacks folded (survives eviction)
+      @evicted = 0                             # rows dropped off the old end of the window (still in the DB)
+      @evict_announced = false                 # the one-time "the pane is a window now" note has fired
       @session_label = Hash(Int64, String).new # session_id → provider label for the table
       @active_sub = 0
       @cb_sel = 0
@@ -158,11 +178,16 @@ module Gori::Tui
     # Authoritative full rebuild (init + on_enter): re-read providers/sessions, then fold the
     # whole callback table in one rowid-ordered query (id order == chronological, so no sort).
     # Also reflects any peer-process deletions. Live/soft-sync updates go through reconcile.
+    # The fold is windowed by trim_callbacks, so the REBUILT state is the newest CALLBACK_CAP
+    # rows and the eviction counter is recomputed from scratch rather than carried across —
+    # the window is a function of the table, so a revisit must not inflate it.
     def reload : Nil
       store = @host.session.store
       @providers = Oast.provider_configs(store)
       @callbacks.clear
       @seen.clear
+      @hits.clear
+      @evicted = 0
       @session_label.clear
       @max_cb_id = 0_i64
       store.oast_sessions.each do |s|
@@ -195,13 +220,43 @@ module Gori::Tui
     # if it was new (not a dedup hit). Rows arrive id-ascending, so the watermark only grows;
     # a callback the live drain already appended is read once here, skipped, and its id clears
     # the watermark so it is never re-read again (bounds reconcile to new-since-last rows).
+    # That same id-ascending order is what makes the windowing below keep the NEWEST rows.
     private def fold_callback(cb : Store::OastCallbackRecord) : Bool
       @max_cb_id = cb.id if cb.id > @max_cb_id
       seen = (@seen[cb.session_id] ||= Set(String).new)
       return false if seen.includes?(cb.provider_uid)
       seen << cb.provider_uid
+      @hits[cb.session_id] = (@hits[cb.session_id]? || 0) + 1
       @callbacks << cb_row(cb, @session_label[cb.session_id]? || "oast")
+      trim_callbacks
       true
+    end
+
+    # Hold @callbacks to CALLBACK_CAP by dropping its OLDEST rows, and drop their uids from
+    # @seen with them — @seen grew one interned uid per row in lockstep, so capping the rows
+    # alone would only slow the same unbounded growth down.
+    #
+    # Evicting the OLD end is what keeps dedup sound. The one re-announcement that must never
+    # double-append is `reconcile` re-reading a row the live drain already appended, and those
+    # rows are always NEWER than @max_cb_id — never the ones dropped here. Both callers fold
+    # id-ascending (`oast_callbacks_since` is ORDER BY id; the live drain is chronological), so
+    # the surviving window is the newest CALLBACK_CAP rows, not an arbitrary slice. The residual
+    # trade is a provider re-announcing an interaction OLDER than the window: the table stays
+    # single-copy (UNIQUE(session_id, provider_uid) + INSERT OR IGNORE) but the pane would show
+    # that row a second time, and @hits would over-count it until the next reload.
+    #
+    # @cb_sel indexes the REVERSED (newest-first) display, so dropping the old end leaves every
+    # newer row's index untouched — the least disruptive end to evict. The one case it moves
+    # under is a selection parked at the very bottom of a FULL window during a flood:
+    # reanchor_callback_selection cannot find the evicted row and the render clamp lands @cb_sel
+    # on its neighbour. Accepted rather than given machinery — that row is leaving either way.
+    private def trim_callbacks : Nil
+      return if @callbacks.size <= CALLBACK_CAP
+      while @callbacks.size > CALLBACK_CAP
+        old = @callbacks.shift
+        @seen[old.session_id]?.try(&.delete(old.uid))
+        @evicted += 1
+      end
     end
 
     def on_enter : Nil
@@ -525,12 +580,28 @@ module Gori::Tui
     private def render_callback_table(screen : Screen, rect : Rect, focused : Bool) : Nil
       ordered = ordered_callbacks
       filtering = !@filter.value.strip.empty?
-      title = filtering ? "CALLBACKS (#{ordered.size}/#{@callbacks.size})" : "CALLBACKS (#{@callbacks.size})"
+      # A capped pane must SAY it is capped. Once the window has evicted, a bare count is the
+      # worst of both: `2000` stands still while callbacks keep arriving, reading as "nothing
+      # new" in the one tab whose whole job is evidence. Name the window, the total behind it,
+      # and where the rest went.
+      held = @evicted > 0 ? "#{@callbacks.size} of #{@callbacks.size + @evicted}" : @callbacks.size.to_s
+      title = filtering ? "CALLBACKS (#{ordered.size}/#{held})" : "CALLBACKS (#{held})"
+      title += " · #{@evicted} older kept in the project DB" if @evicted > 0
       Frame.card(screen, rect, title, border: focused ? Theme.focus_gold : Theme.border, bg: Theme.bg)
       inner = rect.inset(1, 1)
       if ordered.empty?
         msg = filtering ? "no callbacks match “#{@filter.value.strip}” — esc to clear" : "no callbacks yet — get a payload (g), use it in a target, watch here"
         screen.text(inner.x + 1, inner.y, msg, Theme.muted, Theme.bg, width: inner.w - 2)
+        # A no-match over a WINDOW is not a no-match over the evidence. Unqualified, the
+        # operator filters for the source IP they care about, reads "no match", and concludes
+        # it never hit — when the row is sitting in the table the filter never saw. Its OWN row
+        # (not appended to the message) so it survives the width clamp on an 80-column terminal,
+        # where a tacked-on clause is exactly the part that gets cut.
+        if filtering && @evicted > 0 && inner.h > 1
+          screen.text(inner.x + 1, inner.y + 1,
+            "filter covers the newest #{@callbacks.size} only — #{@evicted} older are in the project DB",
+            Theme.yellow, Theme.bg, width: inner.w - 2)
+        end
         return
       end
       header_y = inner.y
@@ -1029,6 +1100,7 @@ module Gori::Tui
         i = ev.interaction
         return if seen.includes?(i.unique_id)
         seen << i.unique_id
+        @hits[sid] = (@hits[sid]? || 0) + 1
         label = @session_label[sid]? || "oast"
         store = @host.session.store
         # Persist the interaction's OWN time (not now) so a callback shows the same timestamp
@@ -1037,6 +1109,8 @@ module Gori::Tui
           i.full_id, i.raw_request.to_slice, i.raw_response.try(&.to_slice), i.at.to_unix_ms * 1000)
         @callbacks << CbRow.new(sid, i.unique_id, i.protocol, i.method, i.source_ip, i.full_id,
           label, i.at, i.raw_request, i.raw_response)
+        trim_callbacks
+        announce_window_cap
         @cb_version += 1
         n = @listeners.find { |l| l.session.id == sid }
         @host.jobs.progress(n.job_id, nil, nil, "#{callbacks_for(sid)} hits") if n
@@ -1045,10 +1119,29 @@ module Gori::Tui
       end
     end
 
-    # @seen[sid] holds exactly the distinct provider_uids folded in for that session (one per
-    # CbRow), so its size is the hit count — O(1), vs. an O(n) scan of the whole list per hit.
+    # Say it ONCE, the first time a LIVE callback pushes a row off the window. The standing
+    # marker in the CALLBACKS title only reaches an operator who is looking at the tab, and
+    # the callbacks that get evicted are precisely the ones that arrived while they were
+    # somewhere else — a cap the operator can only discover by noticing an absence is a silent
+    # cap. Live path only, and not because reload's trim is less real — a cold open of a
+    # project whose table already holds more than CALLBACK_CAP evicts too — but because that
+    # operator is LOOKING at the pane and its title already carries the marker, while pushing a
+    # note from `reload` would mean touching @host.notifications during construction. The flag
+    # is sticky across reloads so a tab revisit cannot re-fire it.
+    private def announce_window_cap : Nil
+      return if @evict_announced || @evicted == 0
+      @evict_announced = true
+      @host.notifications.push(:warn,
+        "OAST callbacks pane now shows the newest #{CALLBACK_CAP} — older ones stay in the project DB",
+        Jobs::Goto.new(:oast), source: "oast")
+    end
+
+    # The hit count in the job note is the session's TOTAL, so it is counted separately rather
+    # than read off @seen#size: @seen is now windowed (trim_callbacks drops evicted uids), and
+    # a listener whose counter walked BACKWARDS as it kept receiving would be worse than no
+    # counter. One Int32 per session, so it costs nothing the labels don't already cost.
     private def callbacks_for(sid : Int64) : Int32
-      @seen[sid]?.try(&.size) || 0
+      @hits[sid]? || 0
     end
 
     private def poll_http : Oast::Http

--- a/src/gori/tui/discover_headers_overlay.cr
+++ b/src/gori/tui/discover_headers_overlay.cr
@@ -22,14 +22,28 @@ module Gori::Tui
   # said `custom headers: 1 set`, 284 probes went out with ZERO carrying `Authorization`,
   # and the run reported `1 endpoint`. An authenticated sweep that runs unauthenticated
   # and reports "found nothing" over the whole authenticated surface is the worst way this
-  # can fail, so esc now REFUSES to close while a line is unusable and names it. There is
-  # no trap: deleting or fixing the line always resolves it, and a blank line is not a
-  # header anyone asked for (parse_lines skips those without reporting them).
+  # can fail, so esc now REFUSES to close while a line is unusable and names it. Deleting
+  # or fixing the line always resolves it, and a blank line is not a header anyone asked
+  # for (parse_lines skips those without reporting them).
+  #
+  # The refusal holds ONLY while the card that explains it is on screen. It used to hold
+  # unconditionally, and that was a trap with no keyboard exit: `overlay_box` bails below
+  # w 34 / h 8 while `Layout.usable?` admits 40x8, so the whole 8–17-row band is
+  # live-but-unrenderable — the refusal was drawn on a branch that never ran, esc and
+  # click-away both answered :stay, and the one line that DID draw advertised a dead key.
+  # Only ^C/^D (quitting gori) or a resize got out. A refusal nobody can read is a lock,
+  # not a guard: where the editor cannot show the line, esc saves and the degraded line
+  # says how many lines that drops, so the save is still never silent.
   class DiscoverHeadersOverlay < Overlay
     def initialize(headers : Array({String, String}))
       text = headers.map { |name, value| "#{name}: #{value}" }.join("\n")
       @editor = TextArea.new(text)
       @refused = nil.as(String?)
+      # Did the LAST frame have room for the card? `handle_key` gets no `area`, so this is
+      # the only channel by which the key path can know whether a refusal is readable.
+      # Defaults true so the guard keeps its teeth before the first frame — the shell draws
+      # before it reads a key, so production always answers from a real frame.
+      @card_drawn = true
     end
 
     # Current headers parsed from the editor buffer.
@@ -73,9 +87,18 @@ module Gori::Tui
 
     # There is nothing to cancel INTO — the user is still inside the Discover popup — so a
     # click outside the card saves exactly like esc, which is what the shell did before.
+    #
+    # This path is handed `area`, so it settles the "is the card on screen" question from
+    # live geometry and tells the key path too — then defers to the one policy in
+    # try_commit rather than restating it. No card means no refusal to read, so the click
+    # saves; `on_commit` here re-opens the Discover popup and reports false
+    # (Runner#open_discover_headers), and going through try_commit is what keeps @refused
+    # consistent with the geometry on the off chance the card survives that.
     def handle_click(area : Rect, mx : Int32, my : Int32) : Symbol
       box = overlay_box(area)
-      (box.nil? || !box.contains?(mx, my)) ? try_commit : :stay
+      @card_drawn = !box.nil?
+      return try_commit unless box
+      box.contains?(mx, my) ? :stay : try_commit
     end
 
     # esc = save & close (:commit); every other key edits the buffer (:stay).
@@ -92,9 +115,14 @@ module Gori::Tui
 
     # Close only when every non-blank line is a header gori will actually put on the wire;
     # otherwise stay open with the refusal on the hint row.
+    #
+    # …unless the last frame had no room for the card. The refusal lives on the hint row of
+    # a card that was never drawn, and the editor the user would fix the line in is not on
+    # screen either, so holding here is an inescapable modal rather than a correction the
+    # operator can act on. Save instead; the degraded render line names the dropped lines.
     private def try_commit : Symbol
       @refused = refusal
-      @refused ? :stay : :commit
+      (@refused && @card_drawn) ? :stay : :commit
     end
 
     # ⏎ inserts a new header line; the rest are the usual TextArea editing/caret keys.
@@ -130,8 +158,9 @@ module Gori::Tui
 
     def render(screen : Screen, area : Rect) : Nil
       box = overlay_box(area)
+      @card_drawn = !box.nil? # what try_commit reads on the next key (see there)
       unless box
-        screen.text(area.x + 1, area.y, "headers editor needs a larger window · esc to close", Theme.muted, Theme.bg) unless area.empty?
+        render_degraded(screen, area) unless area.empty?
         return
       end
       # bg: Theme.bg (not the card default panel) so the embedded editor, which paints
@@ -150,6 +179,23 @@ module Gori::Tui
         screen.text(box.x + 2, hintline, refused, Theme.red, Theme.bg, width: box.w - 4)
       else
         screen.text(box.x + 2, hintline, "one per line · Host/Connection ignored · esc saves & closes", Theme.muted, Theme.bg, width: box.w - 4)
+      end
+    end
+
+    # The one line the card collapses to when there is no room for it. esc LEADS the
+    # sentence on purpose: at 40 columns this clips, and the fact the operator needs is
+    # which key gets them out. When lines will be dropped it says how many, so the save is
+    # reported even here — a silent drop of an Authorization header is the failure this
+    # whole overlay exists to prevent.
+    private def render_degraded(screen : Screen, area : Rect) : Nil
+      n = rejected_lines.size
+      if n.zero?
+        screen.text(area.x + 1, area.y, "headers editor needs a larger window · esc saves & closes", Theme.muted, Theme.bg)
+      else
+        plural = n == 1 ? "" : "s"
+        screen.text(area.x + 1, area.y,
+          "esc saves & closes · #{n} line#{plural} dropped · widen the window to fix",
+          Theme.red, Theme.bg)
       end
     end
   end

--- a/src/gori/tui/discover_view.cr
+++ b/src/gori/tui/discover_view.cr
@@ -236,10 +236,22 @@ module Gori::Tui
 
     # --- rendering ---
     def render(screen : Screen, rect : Rect, focused : Bool) : Nil
-      runs_rect = Rect.new(rect.x, rect.y, rect.w, runs_pane_height(rect))
-      res_rect = Rect.new(rect.x, rect.y + runs_rect.h, rect.w, {rect.h - runs_rect.h, 1}.max)
+      return if rect.empty?
+      runs_rect, res_rect = pane_rects(rect)
       render_runs(screen, runs_rect, focused && @focus == :runs)
-      render_findings(screen, res_rect, focused && @focus == :findings)
+      render_findings(screen, res_rect, focused && @focus == :findings) unless res_rect.empty?
+    end
+
+    # The {runs, findings} rects for `rect`, TILING it exactly: the two cover `rect` and
+    # nothing outside it. Shared with `pane_at`/`click` via `runs_pane_height`.
+    #
+    # The findings height was floored at 1 with no ceiling, so on a 1-row body the card was
+    # placed at `rect.y + 1` — a whole row outside the rect this view was handed, which
+    # nothing repaints. A pane the container cannot pay for is now declined outright.
+    private def pane_rects(rect : Rect) : {Rect, Rect}
+      runs_h = runs_pane_height(rect)
+      {Rect.new(rect.x, rect.y, rect.w, runs_h),
+       Rect.new(rect.x, rect.y + runs_h, rect.w, {rect.h - runs_h, 0}.max)}
     end
 
     # The RUNS card grows a row per run so a second and third crawl are VISIBLE rather than
@@ -250,7 +262,9 @@ module Gori::Tui
       # borders(2) + column header(1) + one row per run + divider(1) + detail(2)
       h = {@runs.size + 6, {rect.h - 6, 7}.max}.min
       h = rect.h - 3 if h > rect.h - 3
-      {h, 1}.max
+      # Floored at 1 so the card never vanishes, then capped at what the container actually
+      # granted — a floor with no ceiling is what puts a pane outside its own rect.
+      { {h, 1}.max, rect.h }.min
     end
 
     # {rows_y, rows_cap, detail_y} for the RUNS card's interior — the row band and the
@@ -402,6 +416,10 @@ module Gori::Tui
       n = r ? r.findings.size : 0
       Frame.card(screen, rect, "FINDINGS (#{n})", border: focused ? Theme.focus_gold : Theme.border, bg: Theme.bg)
       inner = rect.inset(1, 1)
+      # A card under 3 rows has no interior — `inset` floors the height at 0 but keeps
+      # `inner.y` one row down, so an unguarded placeholder lands OUTSIDE the pane.
+      # (`render_runs` has carried this guard all along; this pane did not.)
+      return if inner.h <= 0 || inner.w <= 0
       return unless r
       if r.findings.empty?
         # "no endpoints found" over a crawl that stopped on its budget is the claim this
@@ -468,7 +486,9 @@ module Gori::Tui
     # --- click hit-test ---
     def pane_at(rect : Rect, mx : Int32, my : Int32) : Symbol?
       return nil unless rect.contains?(mx, my)
-      my < rect.y + runs_pane_height(rect) ? :runs : :findings
+      runs_rect, res_rect = pane_rects(rect) # the tiling render draws into, not a re-derivation
+      return :runs if runs_rect.contains?(mx, my)
+      res_rect.contains?(mx, my) ? :findings : nil
     end
 
     # Focus the clicked pane, and on a RUNS row select that run — clicking a row is the
@@ -477,7 +497,7 @@ module Gori::Tui
       return unless pane = pane_at(rect, mx, my)
       focus_pane(pane)
       return unless pane == :runs
-      card = Rect.new(rect.x, rect.y, rect.w, runs_pane_height(rect))
+      card, _ = pane_rects(rect) # the same rect render framed, so a row click can't miss it
       rows_y, rows_cap, _ = run_bands(card)
       row = my - rows_y
       return unless 0 <= row < rows_cap

--- a/src/gori/tui/fuzz_advanced_overlay.cr
+++ b/src/gori/tui/fuzz_advanced_overlay.cr
@@ -174,6 +174,15 @@ module Gori::Tui
       Rect.new(area.x + (area.w - w) // 2, area.y + (area.h - h) // 2, w, h)
     end
 
+    # Rows the card can actually draw. The last two interior lines are spoken for — the hint
+    # on box.bottom-2, the border on box.bottom-1 — so the list ends at box.bottom-3. ONE
+    # definition, read by both render and handle_click, which is the shape every sibling
+    # form uses (NotificationsOverlay, HotkeysOverlay, TabsOverlay …): a hit-test that does
+    # not invert its own render selects rows the cursor was never over.
+    private def list_capacity(box : Rect) : Int32
+      {(box.bottom - 2) - (box.y + 1), 1}.max
+    end
+
     def render(screen : Screen, area : Rect) : Nil
       box = overlay_box(area)
       unless box
@@ -182,7 +191,7 @@ module Gori::Tui
       end
       Frame.card(screen, box, "ADVANCED", bg: Theme.bg, border: Theme.border_focus)
       top = box.y + 1
-      visible = {(box.bottom - 2) - top, 1}.max # last interior row reserved for the hint
+      visible = list_capacity(box)
       @scroll = @sel if @sel < @scroll
       @scroll = @sel - visible + 1 if @sel >= @scroll + visible
       @scroll = @scroll.clamp(0, {ROWS.size - visible, 0}.max)
@@ -217,12 +226,19 @@ module Gori::Tui
 
     # Focus the row under a click; a click outside the card APPLIES (esc semantics), the
     # same dismissal the shell used to run through apply_close_fuzz_advanced.
+    #
+    # The `i < list_capacity` bound is the half that was missing: without it a click on the
+    # hint row or the bottom border — both INSIDE the box, neither a drawn row — resolved to
+    # @scroll + visible (+1) and focused a field the cursor was nowhere near, after which
+    # render scrolled the list to follow. Reachable only when the card clips (production's
+    # `layout.body` draws 11 of the 17 rows), which is why the 80x24 specs never saw it.
     def handle_click(area : Rect, mx : Int32, my : Int32) : Symbol
       box = overlay_box(area)
       return :commit if box.nil? || !box.contains?(mx, my)
       i = my - (box.y + 1)
+      return :stay if i < 0 || i >= list_capacity(box)
       ri = @scroll + i
-      @sel = ri if 0 <= i && 0 <= ri < ROWS.size
+      @sel = ri if ri < ROWS.size
       :stay
     end
   end

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -52,6 +52,9 @@ module Gori::Tui
     DIST_MIN_TOTAL  = 60 # narrowest bottom width that still earns a sidebar
     DIST_MIN_VW     = 22 # min / max sidebar width
     DIST_MAX_VW     = 34
+    # Results-table payload column, in display COLUMNS (see `payload_cell`). The header
+    # string in `render_results` reserves exactly this much between `#` and `status`.
+    PAYLOAD_COL_W = 22
 
     getter focus : Symbol # :target | :template | :config | :results | :detail
     getter target : String
@@ -2182,33 +2185,58 @@ module Gori::Tui
       screen.fill(Rect.new(inner.x, y, inner.w, 1), bg) if selected
       screen.cell(inner.x, y, selected ? '▎' : (r.matched? ? '✓' : ' '), r.matched? ? Theme.accent : Theme.muted, bg)
       payload = r.payloads.join(", ")
-      line = "#{r.index.to_s.ljust(4)} #{payload.size > 22 ? "#{payload[0, 21]}…" : payload.ljust(22)}"
-      x = screen.text(inner.x + 2, y, line, selected ? Theme.text_bright : Theme.text, bg)
+      line = "#{r.index.to_s.ljust(4)} #{payload_cell(payload)}"
+      # `width:` on BOTH of these: they used to draw unclamped, so a payload cell that
+      # measured short (see payload_cell) pushed the status cell past `inner.right`, over
+      # the card's right border and across the gap into the DIST sidebar.
+      x = screen.text(inner.x + 2, y, line, selected ? Theme.text_bright : Theme.text, bg,
+        width: {inner.right - (inner.x + 2), 0}.max)
       sc = r.status.try(&.to_s) || (r.error ? "ERR" : "—")
-      x = screen.text(x + 1, y, sc.ljust(7), status_color(r), bg)
+      x = screen.text(x + 1, y, sc.ljust(7), status_color(r), bg, width: {inner.right - (x + 1), 0}.max)
       # A send that never got a response has no length/words/duration worth showing — the
       # reason does. `cli/output.cr:fuzz_row_text` already appends `r.error` per row; the
       # TUI used to drop it entirely, so a scope/sandbox refusal read as a bare "ERR".
+      #
+      # Every remaining-width clamp below is floored at 0, NOT 1: once `x` reaches
+      # `inner.right` there are no columns left to spend, and a floor of 1 kept painting one
+      # cell per call PAST the card's border — which is how an over-wide payload leaked into
+      # the DIST sidebar. `Screen#text` returns immediately on a width of 0, so 0 is a clean
+      # no-draw and the gRPC `x2` chain no-ops instead of cascading.
       if err = r.error
-        screen.text(x, y, err, Theme.red, bg, width: {inner.right - x, 1}.max)
+        screen.text(x, y, err, Theme.red, bg, width: {inner.right - x, 0}.max)
       elsif r.chain_error
         # The send succeeded, but this row's `¦chain` did not run — its payload went out raw.
         # Flag it in the list (the detail request pane names the reason) so a swallowed chain
         # isn't invisible among clean rows. #567/H3 Finding 1.
-        screen.text(x, y, "⚠ ¦chain not applied", Theme.yellow, bg, width: {inner.right - x, 1}.max)
+        screen.text(x, y, "⚠ ¦chain not applied", Theme.yellow, bg, width: {inner.right - x, 0}.max)
       else
         line = "#{Fmt.size(r.length).ljust(8)} #{r.words.to_s.ljust(7)} #{Fmt.dur(r.duration_us)}"
         # For a gRPC target the h2 `:status` to the left is 200 by definition; THIS is the
         # call's real outcome. Only rendered when the response carried it, so a non-gRPC row
         # is unchanged — same fields `cli/output.cr:fuzz_row_text` already renders.
         if gs = r.grpc_status
-          x2 = screen.text(x, y, line, selected ? Theme.text : Theme.muted, bg, width: {inner.right - x, 1}.max)
+          x2 = screen.text(x, y, line, selected ? Theme.text : Theme.muted, bg, width: {inner.right - x, 0}.max)
           gline = " grpc #{gs} #{Proxy::H2::Grpc.status_name(gs)}#{r.grpc_message ? " · #{r.grpc_message}" : ""}"
-          screen.text(x2, y, gline, gs == 0 ? Theme.green : Theme.red, bg, width: {inner.right - x2, 1}.max)
+          screen.text(x2, y, gline, gs == 0 ? Theme.green : Theme.red, bg, width: {inner.right - x2, 0}.max)
         else
-          screen.text(x, y, line, selected ? Theme.text : Theme.muted, bg, width: {inner.right - x, 1}.max)
+          screen.text(x, y, line, selected ? Theme.text : Theme.muted, bg, width: {inner.right - x, 0}.max)
         end
       end
+    end
+
+    # The payload cell, exactly PAYLOAD_COL_W display COLUMNS wide — never `String#size`.
+    # A Hangul payload is one char but TWO columns per char, so `payload.size > 22` read
+    # false at 44 columns and `ljust(22)` then padded a cell already at double its budget:
+    # the row ran 22 columns long, pushing every cell to its right over the RESULTS border
+    # and into the DIST sidebar. `column_for` is the exact inverse of `draw_width` at
+    # cluster boundaries, so the cut lands on a boundary and no wide glyph is split; the
+    # pad is the COLUMN shortfall, which is why the ellipsis branch pads too (a cut that
+    # stops short of a wide glyph leaves one column to make up).
+    private def payload_cell(payload : String) : String
+      w = Screen.draw_width(payload)
+      return "#{payload}#{" " * (PAYLOAD_COL_W - w)}" if w <= PAYLOAD_COL_W
+      cut = payload[0, Screen.column_for(payload, PAYLOAD_COL_W - 1)]
+      "#{cut}…#{" " * (PAYLOAD_COL_W - 1 - Screen.draw_width(cut))}"
     end
 
     private def status_color(r : Fuzz::Result) : Color

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -381,10 +381,18 @@ module Gori::Tui
           # Inserts arrive increasing-id (FIFO). Prepend for newest-first (id DESC),
           # append for oldest-first (id ASC) so binary search stays valid.
           if newest_first?
+            # An EMPTY list has no row under the cursor: @selected/@scroll are the 0
+            # placeholder, not an anchor on anything. Shifting them for the prepend below
+            # would put the cursor one past the end on every insert (selected_id nil ⇒
+            # ↵/r/t/d/copy all silent no-ops) — and off-tab nothing re-clamps it, so the
+            # reload on_enter runs loses the id anchor too and parks the cursor on the
+            # OLDEST flow of a newest-first list. Reachable after `Clear history` (or `f`
+            # on an already-empty list), which leaves @follow off with @selected at 0.
+            anchored = !@rows.empty?
             @rows.unshift(row)
             if @follow
               @selected = 0
-            else
+            elsif anchored
               # Keep the highlight + viewport on the same flows the user is looking at.
               @selected += 1
               @scroll += 1
@@ -1415,6 +1423,12 @@ module Gori::Tui
                     listen : {String, Int32}? = nil, capturing : Bool = true) : Nil
       return if rect.empty?
       list_rect, preview_rect = list_split(rect)
+      # No preview pane at this size (or after a resize down — list_split collapses it below
+      # rect.h 12, i.e. any terminal under 20 rows) ⇒ snap focus back to the list, or
+      # move()/scroll would route arrows to an invisible pane and freeze list navigation.
+      # HistoryController#refresh_preview re-homes focus when the preview PREF goes off; the
+      # SIZE removing the pane has no other place to be heard (mirrors ProbeView#render).
+      @preview_focus = :list if preview_rect.nil?
       render_list_body(screen, list_rect, focused, listen: listen, capturing: capturing)
       render_preview_pane(screen, preview_rect, focused) if preview_rect
     end
@@ -1524,7 +1538,17 @@ module Gori::Tui
           screen.cell(rect.x, y, marked ? '▌' : '▎', Theme.accent, bg)
         end
         screen.text(time_x, y, fmt_time(row.created_at), Theme.muted, bg)
-        screen.text(method_x, y, row.method, Theme.method_color(row.method), bg)
+        # METHOD is a FIXED 8-column cell (method_x .. proto_x), so it needs its own clamp —
+        # without a `width:` the limit is the whole SCREEN. RFC 9110 permits any token here and
+        # the parser caps nothing, so a long method (`VERSION-CONTROL`, a smuggled
+        # `X-CUSTOM-METHOD`) ran straight through PROTO/HOST/PATH.
+        #
+        # 8, not the 7-in-8 the neighbouring cells use. PROTO is drawn at its own absolute
+        # `proto_x`, so a full 8 cannot bleed into it — the only thing 7 buys is a blank gap,
+        # and it costs `PROPFIND` and `CHECKOUT`, both exactly 8 and both methods this tool is
+        # pointed at (WebDAV, DeltaV). Truncating a real method the unclamped code rendered
+        # correctly would be a regression introduced by the clamp; a tight column is not.
+        screen.text(method_x, y, row.method, Theme.method_color(row.method), bg, width: 8)
         # PROTO: surface WS/GRPC/SSE (accented so they pop out of the HTTP stream), each
         # carrying the plaintext-vs-TLS signal the HTTP/HTTPS pair has always carried —
         # `Proto::Kind#label` owns that spelling, because a bare WS tag REPLACED the scheme

--- a/src/gori/tui/hotkeys_overlay.cr
+++ b/src/gori/tui/hotkeys_overlay.cr
@@ -149,10 +149,28 @@ module Gori::Tui
         cycle_profile(1)
       elsif key.backspace?
         unbind_selected
-      elsif c = ev.char
+      elsif c = bare_char(ev)
         handle_char(c)
       end
       :stay
+    end
+
+    # The printable char of an UNMODIFIED key — nil for a Ctrl/Alt chord. Load-bearing, not
+    # defensive noise: `Event::Key#char` falls back to `key.to_char`, so the plain
+    # `c = ev.char` this replaces read every Ctrl+letter as the bare letter. ^X ran
+    # unbind_selected, setting the highlighted verb to an explicit unbind that ↵ then
+    # persisted — and ^X is stop/hex in six scopes, pure muscle memory. Same leak on ^R
+    # (reset), ^E (arm capture) and ^J/^K (move). Every sibling dispatcher already guards
+    # this — Runner#handle_palette_key, #handle_space_menu_key,
+    # TabController#handle_subtab_filter_key — with the inline `&& !ev.ctrl? && !ev.alt?`;
+    # it is a method here only to keep handle_browse_key under the complexity bar.
+    #
+    # It cannot reach CAPTURE mode, where a Ctrl chord is legitimate input being recorded:
+    # handle_key forks on capturing? first, so this runs only in :browse. ^P is claimed by
+    # an earlier branch, and Shift is untouched, so ⇧R (reset all) still lands.
+    private def bare_char(ev : Termisu::Event::Key) : Char?
+      return nil if ev.ctrl? || ev.alt?
+      ev.char
     end
 
     private def handle_char(c : Char) : Nil

--- a/src/gori/tui/issues_view.cr
+++ b/src/gori/tui/issues_view.cr
@@ -655,6 +655,11 @@ module Gori::Tui
         render_detail(screen, rect, focused)
       else
         list_rect, preview_rect = list_split(rect)
+        # No preview pane at this size (or after a resize down) ⇒ snap focus back to the list,
+        # or move()/scroll would route arrows to an invisible pane and freeze list navigation.
+        # IssuesController#preview_scroll_focused? gates on the PREF alone, so the geometry has
+        # no other place to be heard (mirrors ProbeView#render).
+        @preview_focus = :list if preview_rect.nil?
         render_list(screen, list_rect, focused && @preview_focus == :list)
         render_preview_pane(screen, preview_rect, focused) if preview_rect
       end
@@ -695,10 +700,16 @@ module Gori::Tui
         screen.text(rect.x + 1, y, severity_badge(f.severity), severity_color(f.severity), bg, Attribute::Bold)
         screen.text(rect.x + 6, y, status_tag(f.status), status_color(f.status), bg)
         # Right-aligned host; the title fills the gap up to it (ellipsized).
+        # Both the alignment origin AND the title budget must be measured in COLUMNS, not
+        # characters: this is the flow's raw wire `Host` and nothing on the path applies
+        # punycode/IDNA, so `日本語.test` (8 chars / 11 columns) would start 3 columns too far
+        # right — over the card's border — and hand the title 3 columns it doesn't have,
+        # sliding it underneath the host so the two garble each other.
         right = rect.right - 1
         if (host = f.host) && !host.empty?
-          screen.text(rect.right - host.size - 1, y, host, Theme.muted, bg)
-          right = rect.right - host.size - 2
+          hw = Screen.display_width(host)
+          screen.text(rect.right - hw - 1, y, host, Theme.muted, bg, width: hw)
+          right = rect.right - hw - 2
         end
         title_fg = selected || marked ? Theme.text_bright : Theme.text
         tw = {right - title_x, 0}.max
@@ -1045,7 +1056,13 @@ module Gori::Tui
       return if h <= 0
       @scroll = @selected if @selected < @scroll
       @scroll = @selected - h + 1 if @selected >= @scroll + h
-      @scroll = 0 if @scroll < 0
+      # Never scroll past what fits: apply_filter re-clamps @selected when the list SHRINKS
+      # (a batch delete, a `/` query) but never touches @scroll, and neither rule above fires
+      # while the clamped cursor is still inside the stale window. The draw loop then breaks
+      # at the (now shorter) end and leaves dead space below — and IssuesView paints no scroll
+      # gauge, so 44 results silently read as the 3 that happen to be under the old window.
+      # Pull the window back to the last full page (mirrors HistoryView#ensure_visible).
+      @scroll = @scroll.clamp(0, {@issues.size - h, 0}.max)
     end
   end
 end

--- a/src/gori/tui/links_overlay.cr
+++ b/src/gori/tui/links_overlay.cr
@@ -121,6 +121,27 @@ module Gori::Tui
       :stay
     end
 
+    # Adding is a MODE, and the mouse has to respect it. `handle_key` forks to
+    # handle_add_key while armed, but the click path was left to PickerOverlay, which knows
+    # nothing about the mode: a row click answered :commit, the shell recorded that row as
+    # `opening`, and on_close — pending_add still nil — ran navigate_link_ref, teleporting
+    # the operator into an unrelated flow/repeater/fuzz while the armed add was silently
+    # abandoned. While adding, the only meaningful input is f/r/z/m, so a click inside the
+    # card is swallowed exactly as handle_add_key swallows a stray key.
+    #
+    # A click OUTSIDE still drops the whole card, deliberately NOT the one-level pop esc
+    # does here. Click-away is the shell-wide dismiss gesture (Overlay#handle_click), and
+    # HotkeysOverlay — the other modal with a sub-mode — makes the same split: its click
+    # handler cancels outright while capturing, where handle_capture_key's esc only leaves
+    # capture. Making this the one modal whose outside click does not dismiss would cost
+    # more consistency than the two depths do, and nothing leaks: pending_add stays nil, so
+    # on_close runs inert.
+    def handle_click(area : Rect, mx : Int32, my : Int32) : Symbol
+      return super unless adding?
+      box = overlay_box(area)
+      (box.nil? || !box.contains?(mx, my)) ? :cancel : :stay
+    end
+
     def overlay_box(area : Rect) : Rect?
       w = {area.w - 4, 88}.min
       h = area.h - 2
@@ -130,6 +151,10 @@ module Gori::Tui
       Rect.new(x, y, w, h)
     end
 
+    # Still mode-aware even though `handle_click` no longer reaches it while adding: this is
+    # the geometry statement (render reserves the same footer row), and the mode gate above
+    # is a policy that could move. Dropping the subtraction would silently mis-map the last
+    # row the moment either one changes.
     def row_at(box : Rect, mx : Int32, my : Int32) : Int32?
       list_top = box.y + 3
       list_h = box.bottom - 1 - list_top - (@adding ? 1 : 0)

--- a/src/gori/tui/miner_view.cr
+++ b/src/gori/tui/miner_view.cr
@@ -408,14 +408,27 @@ module Gori::Tui
     end
 
     # --- rendering ---
-    def render(screen : Screen, rect : Rect, focused : Bool) : Nil
-      return render_detail(screen, rect, focused) if @focus == :detail
+    # The {summary, results} rects for `rect`, TILING it exactly. ONE derivation, shared by
+    # `render` and `pane_at`, so the hit-test cannot drift from the drawn geometry.
+    #
+    # Both heights were floored at 1 with no ceiling at the container, so on a 1-row body
+    # the results card was placed at `rect.y + 1` — a whole row outside the rect this view
+    # was handed, which nothing repaints. The floor is now capped at what the container
+    # granted and a zero-row pane is declined instead of being given a row it doesn't have.
+    private def pane_rects(rect : Rect) : {Rect, Rect}
       sum_h = {rect.h // 3, 8}.min
       sum_h = rect.h - 3 if sum_h > rect.h - 3
-      sum_rect = Rect.new(rect.x, rect.y, rect.w, {sum_h, 1}.max)
-      res_rect = Rect.new(rect.x, rect.y + sum_rect.h, rect.w, {rect.h - sum_rect.h, 1}.max)
+      sum_h = { {sum_h, 1}.max, rect.h }.min
+      {Rect.new(rect.x, rect.y, rect.w, sum_h),
+       Rect.new(rect.x, rect.y + sum_h, rect.w, {rect.h - sum_h, 0}.max)}
+    end
+
+    def render(screen : Screen, rect : Rect, focused : Bool) : Nil
+      return if rect.empty?
+      return render_detail(screen, rect, focused) if @focus == :detail
+      sum_rect, res_rect = pane_rects(rect)
       render_summary(screen, sum_rect, focused && @focus == :summary)
-      render_results(screen, res_rect, focused && @focus == :results)
+      render_results(screen, res_rect, focused && @focus == :results) unless res_rect.empty?
     end
 
     private def render_summary(screen : Screen, rect : Rect, focused : Bool) : Nil
@@ -427,7 +440,9 @@ module Gori::Tui
       Frame.toggle_badge(screen, rect.right - 1, rect.y, rect.x + "MINER".size + 4, chord, name, @running)
       x = rect.x + 2
       y = rect.y + 1
-      screen.text(x, y, summary(rect.w - 4), Theme.text_bright, Theme.bg, Attribute::Bold)
+      # Guarded like every line below it: on a 1-2 row card `rect.y + 1` is the bottom
+      # border row or past the card entirely, and this line alone was unconditional.
+      screen.text(x, y, summary(rect.w - 4), Theme.text_bright, Theme.bg, Attribute::Bold) if y < rect.bottom - 1
       y += 1
       screen.text(x, y, target_origin, Theme.muted, Theme.bg, width: rect.w - 4) if y < rect.bottom - 1
       y += 1
@@ -463,6 +478,9 @@ module Gori::Tui
     private def render_results(screen : Screen, rect : Rect, focused : Bool) : Nil
       Frame.card(screen, rect, "FINDINGS (#{@results.size})", border: focused ? Theme.focus_gold : Theme.border, bg: Theme.bg)
       inner = rect.inset(1, 1)
+      # A card under 3 rows has no interior — `inset` floors the height at 0 but keeps
+      # `inner.y` one row down, so an unguarded placeholder lands OUTSIDE the pane.
+      return if inner.h <= 0 || inner.w <= 0
       if @results.empty?
         # Distinguish never-run from a completed run that found nothing, using the
         # same signal the status line does (names_total > 0 ⇒ a run happened).
@@ -527,6 +545,7 @@ module Gori::Tui
     private def render_detail(screen : Screen, rect : Rect, focused : Bool) : Nil
       Frame.card(screen, rect, "FINDING", border: focused ? Theme.focus_gold : Theme.border, bg: Theme.bg)
       inner = rect.inset(2, 1)
+      return if inner.h <= 0 || inner.w <= 0 # see render_results: no interior to draw into
       f = selected_finding
       unless f
         screen.text(inner.x, inner.y, "no finding selected", Theme.muted, Theme.bg)
@@ -555,12 +574,15 @@ module Gori::Tui
     end
 
     # --- click hit-test ---
+    # Derived from `pane_rects`, the same tiling `render` draws into, so the two cannot
+    # drift; it also used to skip the ceiling `render` skipped, agreeing with a results
+    # card placed outside the container.
     def pane_at(rect : Rect, mx : Int32, my : Int32) : Symbol?
-      return :detail if @focus == :detail && rect.contains?(mx, my)
-      sum_h = {rect.h // 3, 8}.min
-      sum_h = rect.h - 3 if sum_h > rect.h - 3
-      return :summary if my < rect.y + sum_h
-      rect.contains?(mx, my) ? :results : nil
+      return nil unless rect.contains?(mx, my)
+      return :detail if @focus == :detail
+      sum_rect, res_rect = pane_rects(rect)
+      return :results if res_rect.contains?(mx, my)
+      sum_rect.contains?(mx, my) ? :summary : nil
     end
   end
 end

--- a/src/gori/tui/notifications_overlay.cr
+++ b/src/gori/tui/notifications_overlay.cr
@@ -6,8 +6,8 @@ require "./notifications"
 
 module Gori::Tui
   # The notification center: a centered overlay listing recent notifications (newest
-  # first). Pure state (@selected) + render; the injected closures run a note's `goto`
-  # and the palette hop. Reads the live store, so a note pushed by a drain while the
+  # first). Pure state (the anchored cursor) + render; the injected closures run a note's
+  # `goto` and the palette hop. Reads the live store, so a note pushed by a drain while the
   # center is open appears at once. Chosen over a persistent "Activity" tab — lighter,
   # and it reuses the existing modal-overlay machinery.
   #
@@ -23,16 +23,52 @@ module Gori::Tui
     # close would land on top of the palette. See Runner#open_notifications.
     property on_palette : Proc(Nil)?
 
+    # The id of the note the cursor is anchored to (see index_in). nil when the store is
+    # empty, or when the cursor has never landed on a note.
+    @anchor : Int32?
+
     def initialize(@store : Notifications)
       @selected = 0
+      # Seeded at open — the Runner builds a fresh overlay per open_notifications, so this
+      # IS the open — which covers the cursor the operator never moved. `latest` is the
+      # newest note, i.e. row 0 of the newest-first list, and is O(1) where `all` reverses
+      # the whole ring.
+      @anchor = @store.latest.try(&.id)
     end
 
     def reset : Nil
       @selected = 0
+      @anchor = @store.latest.try(&.id)
     end
 
     def notes : Array(Notifications::Note)
       @store.all
+    end
+
+    # Where the cursor sits in `list`. The overlay holds no snapshot on purpose — `notes`
+    # re-derives the live store on every call, so a drain's note appears at once — and
+    # pushes PREPEND (Notifications#all is `@notes.reverse`). A bare Int32 cursor therefore
+    # slides onto the neighbour the moment any background completion lands: a Probe issue,
+    # an OAST callback, a fuzz/miner/discover Done. The operator arrows to a note, reads the
+    # frame, presses ↵ — and run_goto jumps somewhere they never selected.
+    #
+    # OastController#drain_events guards the identical shape by capturing {session_id, uid}
+    # before its inserts and re-anchoring @cb_sel after ("a bare `@cb_sel` would silently
+    # slide onto a neighbor"). A Note's `id` is that stable key here: monotonic, and `clear`
+    # does not reset the counter, so an id is never recycled onto a different note.
+    #
+    # @selected is the FALLBACK, consulted only when the anchor no longer resolves — the
+    # note aged out of the ring, or the store was cleared under us. OAST's re-anchor is a
+    # no-op in exactly that case and for the same reason: leaving the cursor near where it
+    # was beats snapping to the top of a list the operator never touched.
+    private def index_in(list : Array(Notifications::Note)) : Int32
+      return 0 if list.empty?
+      if a = @anchor
+        if i = list.index { |n| n.id == a }
+          return i
+        end
+      end
+      @selected.clamp(0, list.size - 1)
     end
 
     # --- Overlay contract (see overlay.cr) ---
@@ -63,7 +99,15 @@ module Gori::Tui
         move(1)
       elsif k.enter?
         return :commit
-      elsif c == 'c'
+      elsif c == 'c' && !ev.ctrl? && !ev.alt?
+        # Guarded, and not merely for tidiness. `Event::Key#char` is `@char || key.to_char`,
+        # so `^C` reports 'c' — and this branch WIPES the whole store. It used to be
+        # unreachable by accident: the shell claimed ^C for the quit-arm before any overlay
+        # saw a key. That stopped being true when the quit-arm learned to yield while a modal
+        # is up (so ^D could reach the Fuzzer payload editor), which quietly handed this
+        # branch the one chord an operator presses to LEAVE. Pressing it here erased every
+        # notification instead. A destructive mnemonic must own its guard rather than borrow
+        # one from a Runner invariant that can change out from under it.
         @store.clear
         reset
       end
@@ -82,16 +126,23 @@ module Gori::Tui
       :stay
     end
 
+    # Both movers re-anchor: the cursor lands on a note, and it is that note the overlay
+    # holds onto until the operator moves again.
     def move(d : Int32) : Nil
-      @selected = (@selected + d).clamp(0, {notes.size - 1, 0}.max)
+      list = notes
+      @selected = (index_in(list) + d).clamp(0, {list.size - 1, 0}.max)
+      @anchor = list[@selected]?.try(&.id)
     end
 
     def set_selected(idx : Int32) : Nil
-      @selected = idx.clamp(0, {notes.size - 1, 0}.max)
+      list = notes
+      @selected = idx.clamp(0, {list.size - 1, 0}.max)
+      @anchor = list[@selected]?.try(&.id)
     end
 
     def selected_note : Notifications::Note?
-      notes[@selected]?
+      list = notes
+      list[index_in(list)]?
     end
 
     # Centered box for `area`, sized to the content (min 6 rows), or nil when it can't
@@ -110,26 +161,29 @@ module Gori::Tui
         screen.text(area.x + 1, area.y, "notifications need a larger window · esc to close", Theme.muted, Theme.bg) unless area.empty?
         return
       end
+      # ONE reversed copy per frame, and one resolved cursor: `notes` allocates, draw_row
+      # used to call it per row, and the window must be computed against the SAME index the
+      # highlight uses or the two disagree the first time a drain prepends.
+      list = notes
       Frame.card(screen, box, "NOTIFICATIONS", border: Theme.border_focus)
-      meta = "#{notes.size} item#{notes.size == 1 ? "" : "s"}"
+      meta = "#{list.size} item#{list.size == 1 ? "" : "s"}"
       screen.text({box.right - meta.size - 2, box.x + 16}.max, box.y, meta, Theme.muted, Theme.panel)
 
       cap = list_capacity(box)
-      if notes.empty?
+      if list.empty?
         screen.text(box.x + 3, box.y + 2, "(no notifications yet)", Theme.muted, Theme.panel) if cap > 0
         return
       end
-      start = list_window(cap)
+      sel = index_in(list)
+      start = list_window(cap, list, sel)
       cap.times do |row|
         i = start + row
-        break if i >= notes.size
-        draw_row(screen, box, i, box.y + 2 + row)
+        break if i >= list.size
+        draw_row(screen, box, list[i], i == sel, box.y + 2 + row)
       end
     end
 
-    private def draw_row(screen : Screen, box : Rect, i : Int32, py : Int32) : Nil
-      note = notes[i]
-      sel = i == @selected
+    private def draw_row(screen : Screen, box : Rect, note : Notifications::Note, sel : Bool, py : Int32) : Nil
       bg = sel ? Theme.accent_bg : Theme.panel
       screen.fill(Rect.new(box.x + 1, py, box.w - 2, 1), bg)
       screen.cell(box.x + 1, py, sel ? '▎' : ' ', Theme.accent, bg)
@@ -159,17 +213,21 @@ module Gori::Tui
       cap = list_capacity(box)
       row = my - (box.y + 2)
       return nil if row < 0 || row >= cap
-      i = list_window(cap) + row
-      i < notes.size ? i : nil
+      list = notes
+      i = list_window(cap, list, index_in(list)) + row
+      i < list.size ? i : nil
     end
 
     private def list_capacity(box : Rect) : Int32
       {box.bottom - 1 - (box.y + 2), 0}.max
     end
 
-    private def list_window(cap : Int32) : Int32
-      return 0 if cap <= 0 || notes.size <= cap
-      { {@selected - cap + 1, 0}.max, notes.size - cap }.min
+    # Takes the list and the RESOLVED cursor rather than reading @selected: after a drain
+    # prepends, @selected is the stale row number and scrolling by it would put the window
+    # somewhere the highlight is not.
+    private def list_window(cap : Int32, list : Array(Notifications::Note), sel : Int32) : Int32
+      return 0 if cap <= 0 || list.size <= cap
+      { {sel - cap + 1, 0}.max, list.size - cap }.min
     end
 
     private def glyph(level : Symbol) : {Char, Color}

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -1009,14 +1009,16 @@ module Gori::Tui
       ov = active_overlay
       raw_capture = ov.try(&.raw_key_capture?) || false
       if Runner.quit_chord_claimed?(ev, modal: !ov.nil?)
-        if Settings.confirm_quit?
+        # The policy is `Runner.quit_decision`, shared with `quit!` (the palette's Quit) so
+        # the two entry points cannot answer "does this need a confirm?" differently again.
+        case Runner.quit_decision(Settings.confirm_quit?, chord: true, armed: @quit_armed)
+        in .confirm?
           # Opt-in (settings:general): a confirm modal replaces the double-press arm. Skip
           # re-opening if the quit confirm is already up (^D then just waits for y/n/esc).
-          confirm("QUIT GORI", quit_message,
-            confirm_label: "quit", danger: true) { quit! } unless @overlay.confirm?
-        elsif @quit_armed
-          quit!
-        else
+          raise_quit_confirm unless @overlay.confirm?
+        in .quit?
+          finish_quit # the second press IS the confirmation
+        in .arm?
           @quit_armed = true
           @toast = quit_arm_hint
         end
@@ -3074,8 +3076,21 @@ module Gori::Tui
 
     # Body hints come from the active tab's controller (it knows its focused pane);
     # falls back to the bare ring reminder if no controller is registered.
+    #
+    # The `q projects` clause is conditional for the same reason `quit_arm_hint`'s is:
+    # `app.back-key` lives in Verb::Scope::Sidebar ONLY (deliberately — see verbs/core.cr,
+    # where a Global `q` used to dump you to the picker mid-browse), so advertising it from a
+    # focus-agnostic emitter names a key that does nothing in a list and types a literal `q`
+    # in an editor. This is the fallback path — reached only when the active tab has no
+    # registered controller — but a hint that lies is worse in the place the operator has
+    # least to go on.
     private def body_hints : String
-      @tabs[@active_tab]?.try(&.body_hint(@focus)) || "↹/esc tabs · ^P cmds · q projects · ^D quit"
+      fallback = String.build do |s|
+        s << "↹/esc tabs · ^P cmds · "
+        s << "q projects · " if back_key_live?
+        s << "^D quit"
+      end
+      @tabs[@active_tab]?.try(&.body_hint(@focus)) || fallback
     end
 
     private def render_body(screen : Screen, rect : Rect) : Nil
@@ -3176,10 +3191,48 @@ module Gori::Tui
 
     # --- ExecContext (verbs drive the UI through these) ----------------------
 
+    # The operator ASKED to quit — the ExecContext intent the palette's "Quit gori" verb
+    # dispatches (verbs/core.cr), and the same decision the ^C/^D chord makes in handle_key.
+    #
+    # It is the GUARDED entry, not the teardown, and that is the whole point: `Settings.
+    # confirm_quit?` ("Confirm before quit — require a confirm modal to quit") is an opt-in
+    # promise about EVERY quit, and the palette entry is the only discoverable one
+    # (`Hotkeys::FIXED_IDS` keeps the chord off the rebind list because "single-key quit is a
+    # footgun"). This method used to be the teardown itself, so the one exposed entry point was
+    # the one that skipped the setting: ^P → "Quit gori" → ↵ killed a live Discover crawl with
+    # no modal and without naming a single running job, while `leave_project` — the LESS
+    # destructive sibling one row above it in the same palette — always confirms.
+    #
+    # The teardown is `finish_quit`; the confirm's accept block calls THAT, or accepting would
+    # re-enter here and raise a second confirm forever.
+    #
+    # With the setting OFF this still quits immediately rather than arming. The arm exists
+    # because ^C/^D is one mistyped keystroke, and its toast says "press ^D (or ^C) again" — a
+    # chord the palette operator never pressed; ^P, typing a filter, and ↵ on a row that reads
+    # "Quit gori" is already the deliberate act the arm asks for.
     def quit! : Nil
+      # chord: false — a palette dispatch can never arm, so this is Confirm or Quit.
+      if Runner.quit_decision(Settings.confirm_quit?, chord: false, armed: false).confirm?
+        raise_quit_confirm
+      else
+        finish_quit
+      end
+    end
+
+    # The teardown, past every guard. Private so a new caller has to come through `quit!` (and
+    # therefore through the confirm) to reach it; the only direct callers are the second ^C/^D
+    # press — where the first press already served as the confirmation — and the accept block
+    # of the QUIT GORI modal.
+    private def finish_quit : Nil
       stop_all_jobs
       commit_pending_edits
       @outcome = :quit
+    end
+
+    # The one QUIT GORI modal, raised from both quit paths so the chord and the palette cannot
+    # show different prompts — the same anti-drift reason the message helpers below are shared.
+    private def raise_quit_confirm : Nil
+      confirm("QUIT GORI", quit_message, confirm_label: "quit", danger: true) { finish_quit }
     end
 
     # `q` from the TABS row. When jobs are live the confirm NAMES them and says what
@@ -3224,7 +3277,22 @@ module Gori::Tui
     end
 
     private def quit_arm_hint : String
-      Runner.quit_arm_hint(@jobs.active_summary, @jobs.active.size)
+      Runner.quit_arm_hint(@jobs.active_summary, @jobs.active.size, back_key: back_key_live?)
+    end
+
+    # Does `q` actually go back to the project picker from where the operator is standing?
+    # `app.back-key` is registered in `Verb::Scope::Sidebar` ONLY (verbs/core.cr: as a Global
+    # chord it also dumped you to the picker from the verb-driven Sitemap/Issues bodies), but
+    # the quit arm fires from `handle_key`, which is focus-blind — so the hint used to advertise
+    # `q` from a History list (dead), the History detail (`detail.close` binds q — it closes the
+    # detail, it does not leave the project) or the Notes editor (types a literal q).
+    #
+    # Resolved through the SAME lookup the dispatcher uses (`resolve_verb_id`/`current_scope`)
+    # rather than a hardcoded `@focus == :menu`, and compared against the verb ID rather than
+    # merely "is q bound?", so neither a settings:hotkeys rebind nor a scope with its own `q`
+    # can leave the hint pointing at a key that does something else.
+    private def back_key_live? : Bool
+      resolve_verb_id(Verb::Chord.new("q"), current_scope) == "app.back-key"
     end
 
     # The three EXIT prompts, as pure functions of `Jobs#active_summary` + the active
@@ -3254,14 +3322,53 @@ module Gori::Tui
     end
 
     # A status toast, not a card, so this one stays on a single line.
-    def self.quit_arm_hint(active : String?, count : Int32) : String
-      base = "press ^D (or ^C) again to quit · q: back to projects"
-      return base unless active
-      "#{job_count(count)} running (#{active}) — press ^D (or ^C) again to quit and stop #{count == 1 ? "it" : "them"}"
+    #
+    # `back_key` is the caller's answer to "is `q` → back to projects live where this hint will
+    # be read?" (see `Runner#back_key_live?`). It defaults to NOT advertising, because the
+    # failure this argument exists to prevent is a hint naming a key that is dead in the focus
+    # it is shown from — and a hint that says less is recoverable, one that lies is not.
+    # The running-jobs sentence never offered `q` and is byte-identical to what shipped.
+    def self.quit_arm_hint(active : String?, count : Int32, *, back_key : Bool = false) : String
+      base = "press ^D (or ^C) again to quit"
+      return "#{job_count(count)} running (#{active}) — #{base} and stop #{count == 1 ? "it" : "them"}" if active
+      back_key ? "#{base} · q: back to projects" : base
     end
 
     private def self.job_count(count : Int32) : String
       "#{count} job#{count == 1 ? "" : "s"}"
+    end
+
+    # What an operator-initiated quit request does right now.
+    enum QuitAction
+      Confirm # raise the QUIT GORI modal (settings:general "Confirm before quit")
+      Arm     # first ^C/^D: hint in the status bar and wait for the second press
+      Quit    # tear down now (finish_quit)
+    end
+
+    # The quit POLICY — ONE function, consumed by BOTH entry points (`handle_key`'s ^C/^D and
+    # `quit!`, which the palette's "Quit gori" verb dispatches). They diverged once, and that
+    # was the bug: the chord honoured `Settings.confirm_quit?` while the palette — the only
+    # discoverable Quit in the app — went straight to the teardown, so the opt-in "require a
+    # confirm modal to quit" was silently ignored on the one path an operator can find.
+    #
+    # `chord` is "this request was a single keystroke". Only a keystroke can Arm: the arm is a
+    # typo guard for a chord that sits under the fingers, and its toast names ^D/^C — which a
+    # palette operator never pressed. ^P → filter → ↵ on a row reading "Quit gori" is already
+    # the deliberate second act the arm is asking for, so a non-chord request quits outright.
+    #
+    # With the setting ON the answer is Confirm regardless of `armed` and regardless of whether
+    # any job is live: the setting's own text is unconditional, `quit_confirm_message(nil, 0)`
+    # is written for the idle case, and a guarantee that only holds while a job happens to be
+    # running is not a guarantee. (Quitting idle still commits pending edits and drops the
+    # session, so there is something to be asked about.)
+    #
+    # Pure + class-level for the same reason the exit prompts above are: the Runner needs a
+    # live tty. `@overlay.confirm?` deliberately stays at the chord's call site — "don't stack a
+    # second modal on the one already asking this question" is dispatch, not policy.
+    def self.quit_decision(confirm_setting : Bool, *, chord : Bool, armed : Bool) : QuitAction
+      return QuitAction::Confirm if confirm_setting
+      return QuitAction::Quit if !chord || armed
+      QuitAction::Arm
     end
 
     # Does the shell's pre-filter claim ^C/^D for the global quit arm, or does it YIELD them

--- a/src/gori/tui/sequencer_view.cr
+++ b/src/gori/tui/sequencer_view.cr
@@ -440,29 +440,48 @@ module Gori::Tui
     end
 
     # --- rendering ---
-    def render(screen : Screen, rect : Rect, focused : Bool) : Nil
-      return render_detail(screen, rect, focused) if @focus == :detail
+    # The {config, samples, analysis} rects for `rect`, TILING it exactly: the three cover
+    # `rect` and nothing outside it. ONE derivation, shared by `render` and `pane_at`, so a
+    # click can never be resolved against a geometry the renderer did not use.
+    #
+    # Each height is FLOORED for legibility (a config card under 3 rows says nothing worth
+    # framing), and a floor with no matching CEILING is exactly what let this view paint
+    # outside its container: on a 2-row body `cfg_h` floored back up to 3 and the lower pane
+    # to 2, so five rows were drawn into two — over the status row and into the bottom
+    # margin, which no later pass repaints. Every floor is therefore capped at what the
+    # container actually granted, and a pane that comes out zero rows tall is declined by
+    # `render` rather than handed a minimum the container cannot pay for.
+    #
+    # `sw` needs no cap: it is gated behind `lower.w >= 84`, far above its floor of 30.
+    private def pane_rects(rect : Rect) : {Rect, Rect, Rect}
       cfg_h = {rect.h // 3, 7}.min
       cfg_h = rect.h - 4 if cfg_h > rect.h - 4
-      cfg_h = {cfg_h, 3}.max
+      cfg_h = { {cfg_h, 3}.max, rect.h }.min
       cfg_rect = Rect.new(rect.x, rect.y, rect.w, cfg_h)
-      lower = Rect.new(rect.x, rect.y + cfg_h, rect.w, {rect.h - cfg_h, 2}.max)
-      render_config(screen, cfg_rect, focused && @focus == :config)
-
-      @side_by_side = lower.w >= 84
-      if @side_by_side
+      lower = Rect.new(rect.x, rect.y + cfg_h, rect.w, {rect.h - cfg_h, 0}.max)
+      if lower.w >= 84
         sw = {lower.w * 42 // 100, 30}.max
-        s_rect = Rect.new(lower.x, lower.y, sw, lower.h)
-        a_rect = Rect.new(lower.x + sw, lower.y, lower.w - sw, lower.h)
-        render_samples(screen, s_rect, focused && @focus == :samples)
-        render_analysis(screen, a_rect, focused && @focus == :analysis)
+        {cfg_rect,
+         Rect.new(lower.x, lower.y, sw, lower.h),
+         Rect.new(lower.x + sw, lower.y, lower.w - sw, lower.h)}
       else
-        sh = {lower.h * 45 // 100, 4}.max
-        s_rect = Rect.new(lower.x, lower.y, lower.w, sh)
-        a_rect = Rect.new(lower.x, lower.y + sh, lower.w, {lower.h - sh, 3}.max)
-        render_samples(screen, s_rect, focused && @focus == :samples)
-        render_analysis(screen, a_rect, focused && @focus == :analysis)
+        sh = { {lower.h * 45 // 100, 4}.max, lower.h }.min
+        {cfg_rect,
+         Rect.new(lower.x, lower.y, lower.w, sh),
+         Rect.new(lower.x, lower.y + sh, lower.w, lower.h - sh)}
       end
+    end
+
+    def render(screen : Screen, rect : Rect, focused : Bool) : Nil
+      return if rect.empty?
+      return render_detail(screen, rect, focused) if @focus == :detail
+      cfg_rect, s_rect, a_rect = pane_rects(rect)
+      # The layout flag the CONTROLLER reads for ↑/↓ pane traversal, so it is written here
+      # and never by `pane_at` — a hit-test must not move focus state as a side effect.
+      @side_by_side = rect.w >= 84
+      render_config(screen, cfg_rect, focused && @focus == :config)
+      render_samples(screen, s_rect, focused && @focus == :samples) unless s_rect.empty?
+      render_analysis(screen, a_rect, focused && @focus == :analysis) unless a_rect.empty?
     end
 
     private def render_config(screen : Screen, rect : Rect, focused : Bool) : Nil
@@ -471,7 +490,9 @@ module Gori::Tui
       Frame.toggle_badge(screen, rect.right - 1, rect.y, rect.x + "SEQUENCER".size + 4, chord, name, @running)
       x = rect.x + 2
       y = rect.y + 1
-      screen.text(x, y, summary(rect.w - 4), Theme.text_bright, Theme.bg, Attribute::Bold)
+      # Guarded like every line below it: on a 1-2 row card `rect.y + 1` is the bottom
+      # border row or past the card entirely, and this line alone was unconditional.
+      screen.text(x, y, summary(rect.w - 4), Theme.text_bright, Theme.bg, Attribute::Bold) if y < rect.bottom - 1
       y += 1
       if y < rect.bottom - 1
         mode = @config.mode.live_replay? ? "live replay · #{target_origin}" : "manual paste"
@@ -508,6 +529,9 @@ module Gori::Tui
     private def render_samples(screen : Screen, rect : Rect, focused : Bool) : Nil
       Frame.card(screen, rect, "SAMPLES (#{@samples.size})", border: focused ? Theme.focus_gold : Theme.border, bg: Theme.bg)
       inner = rect.inset(1, 1)
+      # A card under 3 rows has no interior — `inset` floors the height at 0 but keeps
+      # `inner.y` one row down, so an unguarded placeholder lands OUTSIDE the pane.
+      return if inner.h <= 0 || inner.w <= 0
       if @samples.empty?
         msg = if @running
                 "collecting…"
@@ -671,6 +695,7 @@ module Gori::Tui
     private def render_detail(screen : Screen, rect : Rect, focused : Bool) : Nil
       Frame.card(screen, rect, "TOKEN", border: focused ? Theme.focus_gold : Theme.border, bg: Theme.bg)
       inner = rect.inset(2, 1)
+      return if inner.h <= 0 || inner.w <= 0 # see render_samples: no interior to draw into
       s = selected_sample
       unless s
         screen.text(inner.x, inner.y, "no sample selected", Theme.muted, Theme.bg)
@@ -697,21 +722,16 @@ module Gori::Tui
     end
 
     # --- click hit-test ---
+    # Derived from `pane_rects`, the same tiling `render` draws into — the two used to
+    # re-compute the geometry independently, so the hit-test faithfully agreed with the
+    # INFLATED rects rather than with the pane the operator could see.
     def pane_at(rect : Rect, mx : Int32, my : Int32) : Symbol?
-      return :detail if @focus == :detail && rect.contains?(mx, my)
-      cfg_h = {rect.h // 3, 7}.min
-      cfg_h = rect.h - 4 if cfg_h > rect.h - 4
-      cfg_h = {cfg_h, 3}.max
-      return :config if my < rect.y + cfg_h
       return nil unless rect.contains?(mx, my)
-      lower = Rect.new(rect.x, rect.y + cfg_h, rect.w, rect.h - cfg_h)
-      if lower.w >= 84
-        sw = {lower.w * 42 // 100, 30}.max
-        mx < lower.x + sw ? :samples : :analysis
-      else
-        sh = {lower.h * 45 // 100, 4}.max
-        my < lower.y + sh ? :samples : :analysis
-      end
+      return :detail if @focus == :detail
+      cfg_rect, s_rect, a_rect = pane_rects(rect)
+      return :samples if s_rect.contains?(mx, my)
+      return :analysis if a_rect.contains?(mx, my)
+      cfg_rect.contains?(mx, my) ? :config : nil
     end
   end
 end

--- a/src/gori/tui/sitemap_view.cr
+++ b/src/gori/tui/sitemap_view.cr
@@ -893,9 +893,23 @@ module Gori::Tui
       avail = tag_right - tag_col_left(rect) + 1
       return if avail < 5 # not worth a stub
       text = " # #{tag}"
-      text = "#{text[0, avail - 1]}…" if text.size > avail
-      x = tag_right - text.size + 1
-      screen.text(x, y, text, Theme.accent, bg) if x >= label_end + 1
+      # Budget, right-alignment origin AND clip all in display COLUMNS. A memo of Hangul
+      # syllables is one char but TWO columns each, so `text.size > avail` read false at
+      # twice the budget (nothing truncated) and `tag_right - text.size + 1` started the run
+      # columns too far right — through the mandated gap, over the METHODS chips and the
+      # card's right border. `column_for` is the exact inverse of `draw_width` at cluster
+      # boundaries, so the cut can never split a wide glyph. `comparer_view.cr#slot_short`
+      # solves the same problem the same way.
+      w = Screen.draw_width(text)
+      if w > avail
+        text = "#{text[0, Screen.column_for(text, avail - 1)]}…"
+        w = Screen.draw_width(text)
+      end
+      x = tag_right - w + 1
+      # `width:` as well as a column-derived origin: a hard ceiling at `tag_right`, so any
+      # future drift between the measure and the draw clips instead of overwriting the
+      # column to its right.
+      screen.text(x, y, text, Theme.accent, bg, width: {tag_right - x + 1, 0}.max) if x >= label_end + 1
     end
 
     # Screen-x where the right cluster (methods/aside) begins; nil when the row has none.

--- a/src/gori/verbs/core.cr
+++ b/src/gori/verbs/core.cr
@@ -21,6 +21,13 @@ module Gori
 
       # Quit is palette-only here; the keyboard path is a deliberate double ^D/^C
       # handled in the Runner (single Q quitting was too easy to hit by accident).
+      #
+      # `quit!` is the Runner's GUARDED entry, not its teardown: it goes through
+      # Runner.quit_decision, the same policy the chord uses, so this entry honours
+      # settings:general "Confirm before quit". That matters here specifically —
+      # Hotkeys::FIXED_IDS makes this palette row the ONLY discoverable way to quit, and
+      # it used to reach the teardown directly, killing a live Discover/Fuzz run with no
+      # modal and no naming of the jobs while `app.back` above it always confirms.
       r.register Verb::Definition.new(
         "app.quit", "Quit gori", "Exit gori entirely", Verb::Scope::Global,
         [] of Verb::Chord, category: Verb::Category::System) { |ctx| ctx.quit!; nil }


### PR DESCRIPTION
The remaining 12 findings from the TUI stability audit — everything #574 and #576
left as medium/low. Six commits, one per theme, each independently reviewable.

## The one worth reading first: a regression from #577

An audit agent flagged, as an aside outside its assignment, that
`NotificationsOverlay`'s `c` clear branch had no ctrl guard — *"harmless today only
because the shell's pre-filter claims ^C as the quit-arm before any overlay sees
it."*

**That premise stopped being true in #577.** Teaching the quit-arm to yield while a
modal is up — so `^D` could reach the Fuzzer payload-set editor whose `^D favorite`
it was shadowing — handed this branch the one chord an operator presses to leave.
`Event::Key#char` is `@char || key.to_char`, so `^C` reports `'c'`, and the branch
calls `@store.clear`. Pressing `^C` in the Notifications overlay erased the whole
notification history instead of arming quit.

It surfaced only because the agent wrote down *why* something was safe rather than
that it was. A destructive mnemonic owns its own guard now, and the spec pins it so
it can't be dropped as redundant on the strength of an invariant that already
changed once.

## The rest

**Overlays.** `DiscoverHeadersOverlay` could not be closed at all below 44×18 — its
only exit refuses while a header line lacks a colon, and the refusal text is drawn
only on the branch that isn't taken, so the card advertised "esc to close" while esc
returned `:stay`. `LinksOverlay` committed the clicked row while in add mode,
teleporting the operator to an unrelated flow and dropping the armed add.
`FuzzAdvancedOverlay`'s hit-test didn't invert its render. `HotkeysOverlay` read
`^X` as bare `x` and unbound the highlighted binding.

**Lists.** Issues never clamped `@scroll` after a shrink, so 44 results could read
as ten with no gauge to say otherwise. History drove the cursor past the end of an
emptied list and parked it on the *oldest* flow of a newest-first list. Both kept
preview focus after a resize removed the preview, freezing list navigation.

**Geometry.** Sequencer, Miner and Discover floored pane heights with no ceiling at
what the container granted — Sequencer painted a line of body text *below the status
bar* at 60×12. Fixed by tiling to exactly the container from one `pane_rects`, shared
by render and hit-test, rather than two clamps that agree today.

**Width.** Sitemap's tag column and Fuzzer's payload cell measured in characters, so
CJK content overran into neighbouring columns and the card border. History's METHOD
cell had no clamp at all.

**Quit.** The palette's "Quit gori" ignored `confirm_quit?` entirely — and
`Hotkeys::FIXED_IDS` makes the palette the only discoverable quit, so the one exposed
entry point skipped every guard. Both paths now route through one pure
`Runner.quit_decision`.

**OAST.** The callback buffer was unbounded and paced by the *provider*, not the
operator. Capped as a **view window over the durable table**, not a trim: after a
2050-callback flood the store still holds 2050. Truncation is announced three ways —
including the filtered no-match message, because otherwise an operator filters for a
source IP, reads "no match", and concludes it never hit.

## Judgement calls, called out rather than buried

- **METHOD budgeted at the full 8**, not the 7-in-8 its neighbours use. PROTO draws
  at its own absolute x so 8 can't bleed into it; 7 would truncate `PROPFIND` and
  `CHECKOUT`, which the *unclamped* code rendered correctly. A clamp that breaks a
  real method is a regression the clamp introduced. Pinned by a spec.
- **`confirm_quit?` ON with nothing running still confirms** — the setting's text is
  unconditional, and a guarantee that only holds while a job happens to be live isn't
  one.
- **The `q` hint is now focus-aware rather than the binding widened** — the Sidebar
  narrowing is a documented decision (a Global `q` used to dump you to the picker
  mid-browse), so the binding was right and the emitter was wrong.
- **LinksOverlay's outside-click still cancels the whole card** while esc pops one
  level. Click-away is the shell-wide dismiss gesture and `HotkeysOverlay` already
  makes this split; pinned as a decision rather than left ambiguous.

## Known gaps, stated

Evicted OAST callbacks are durable but **not reachable from the pane** — no paging
UI. That needs `oast_callbacks_page(limit, before_id)` in `store/oast_sessions.cr`,
which would also make `reload` O(CAP) instead of O(table).

## Verification

`crystal spec` → **6868 examples, 8 failures**; `crystal spec spec/tui` → **2010
examples, 0 failures**. Build and per-file format clean.

Every fix has a regression spec verified to fail before it — mostly by reverting the
exact pre-change file rather than a hand-rolled probe, so there's no probe to get
wrong. Where the fail-before could only be a compile error (a newly extracted pure
helper), a mutation test was used instead: reintroducing the original bug fails 5
examples.

Live on the built binary: no content below the status bar at 60×12, 58×11, 56×10 or
54×9, and a resize sweep to 40×8 across the affected tabs with no crash.

⚠️ The 8 full-suite failures are `project_registry_spec` (5) and `capture_status_spec`
(3) — another gori instance holds port 8070 on my machine. They fail identically on a
stashed clean tree. CI should be green.
