### PR TITLE
Transport reliability: bare-LF byte-fidelity + fuzz/WS truthful-reporting, and a request-smuggling/desync detector

### DIFF
--- a/spec/cli_run_spec.cr
+++ b/spec/cli_run_spec.cr
@@ -359,6 +359,23 @@ describe "gori run fuzz — errored result visibility (#410)" do
     buf.size.should eq(2) # the errored row + the match; the bare no-match was not buffered
     buf.any? { |r| r.error == "connect failed" }.should be_true
   end
+
+  # B1/B2: the retention gate must also keep a row whose only distinction is that its response
+  # was TRUNCATED (incomplete) or that `--retries` RE-SENT it — each a fact the run observed
+  # that a matched-only gate would drop, leaving the surface reading a clean short body / a
+  # single clean send. Both were added to the `emit_fuzz_result` predicate alongside `retried?`.
+  it "keeps an unmatched row that was re-sent by --retries, or whose response was incomplete" do
+    buf = [] of Gori::Fuzz::Result
+    resent = Gori::Fuzz::Result.new(index: 0_i64, payloads: ["p"], position: 0, status: 200,
+      length: 0_i64, words: 0, lines: 0, duration_us: 1_i64, error: nil, matched: false,
+      incomplete: false, extracted: nil, resent_count: 2)
+    incomplete = Gori::Fuzz::Result.new(index: 1_i64, payloads: ["p"], position: 0, status: 200,
+      length: 2_i64, words: 0, lines: 0, duration_us: 1_i64, error: nil, matched: false,
+      incomplete: true, extracted: nil)
+    Gori::CLI::Run.emit_fuzz_result_for_spec(resent, buf).should be_true
+    Gori::CLI::Run.emit_fuzz_result_for_spec(incomplete, buf).should be_true
+    buf.size.should eq(2)
+  end
 end
 
 # `gori run repeater send`'s session-replay resolution used to live in a private CLI helper

--- a/spec/fuzz/content_length_spec.cr
+++ b/spec/fuzz/content_length_spec.cr
@@ -1,0 +1,108 @@
+require "../spec_helper"
+
+private alias F = Gori::Fuzz
+
+# Byte-fidelity regressions for the bare-LF / mixed-EOL blind spots in `Fuzz::ContentLength`.
+# The module's contract is byte-level and zero-allocation (content_length.cr:11-16); these
+# specs pin the exact wire bytes, because the whole point of a smuggling/desync primitive is
+# that ONE hidden byte changes how a downstream parser frames the message.
+describe F::ContentLength do
+  describe "duplicate Content-Length (a desync primitive must survive the resync)" do
+    it "leaves a bare-LF-hidden second Content-Length byte-intact (only the first is rewritten)" do
+      # The second `Content-Length: 100` is terminated by a BARE LF, so a CRLF-only line split
+      # would merge it into the first line and DELETE it on rewrite — silently disarming the
+      # exact desync vector the fuzzer crafted. Tokenizing on LF (like an LF-lenient backend,
+      # and like the file's own `chunked?`) keeps it a distinct line: the first CL is resynced
+      # to the real body length (3), the hidden CL is preserved verbatim.
+      req = "POST / HTTP/1.1\r\nContent-Length: 6\nContent-Length: 100\r\n\r\nabc".to_slice
+      out = String.new(F::ContentLength.sync(req))
+      out.should eq("POST / HTTP/1.1\r\nContent-Length: 3\nContent-Length: 100\r\n\r\nabc")
+      out.should contain("Content-Length: 100") # the hidden header is NOT dropped
+    end
+
+    it "leaves a CRLF-visible second Content-Length intact too (parity = proof the bug was a bug)" do
+      # The CRLF-visible duplicate was ALREADY handled correctly (the `\r\n` after the first CL
+      # is a line boundary under either split). Asserting the same outcome as the bare-LF case
+      # is what makes the bare-LF deletion a bug rather than a policy — the two must agree.
+      req = "POST / HTTP/1.1\r\nContent-Length: 6\r\nContent-Length: 100\r\n\r\nabc".to_slice
+      out = String.new(F::ContentLength.sync(req))
+      out.should eq("POST / HTTP/1.1\r\nContent-Length: 3\r\nContent-Length: 100\r\n\r\nabc")
+      out.should contain("Content-Length: 100")
+    end
+  end
+
+  describe "mixed `\\n\\r\\n` head/body separator" do
+    it "recomputes the CL and splices the mixed separator back verbatim" do
+      # Last header line ended in a bare LF, the blank line itself was CRLF: the separator is
+      # `\n\r\n`, NOT a repeated `eol`. `boundary` must recognize the 3-byte spelling (else no
+      # boundary is found and the stale CL 5 is never resynced), and the rewrite must splice
+      # `\n\r\n` back byte-for-byte rather than rebuild it as `\n\n` / `\r\n\r\n`.
+      req = "POST / HTTP/1.1\r\nContent-Length: 5\n\r\nabc".to_slice
+      out = String.new(F::ContentLength.sync(req))
+      out.should eq("POST / HTTP/1.1\r\nContent-Length: 3\n\r\nabc")
+    end
+
+    it "picks the earliest blank line when the BODY also holds a CRLFCRLF" do
+      # The body contains its own `\r\n\r\n`; the head's earlier mixed `\n\r\n` must win so the
+      # CL counts the whole body, and the body is spliced back byte-exact.
+      req = "POST / HTTP/1.1\r\nContent-Length: 0\n\r\nX\r\n\r\nY".to_slice
+      out = String.new(F::ContentLength.sync(req))
+      out.should eq("POST / HTTP/1.1\r\nContent-Length: 6\n\r\nX\r\n\r\nY") # body "X\r\n\r\nY" = 6 bytes
+    end
+
+    it "preserves a mixed-separator body byte-exact on the no-op (already-canonical) path" do
+      # CL already equals the body length: sync is a no-op, but only if `boundary` found the
+      # `\n\r\n` at all. Returns the input unchanged.
+      req = "POST / HTTP/1.1\r\nContent-Length: 3\n\r\nabc".to_slice
+      F::ContentLength.sync(req).should eq(req)
+    end
+
+    it "appends a fresh CL keeping the mixed separator's bare-LF spelling" do
+      # add_when_missing on a `\n\r\n` head: the inserted CL line is terminated by the bare LF
+      # that the separator leads with, so the operator's blank-line spelling survives the insert.
+      req = "POST / HTTP/1.1\n\r\nabc".to_slice
+      out = String.new(F::ContentLength.sync(req, add_when_missing: true))
+      out.should eq("POST / HTTP/1.1\nContent-Length: 3\n\r\nabc")
+    end
+  end
+
+  describe "sync_at {at, delta} — the contract Generator#shift_spans remaps §-spans by" do
+    it "reports at/delta so a §-span AFTER the CL line remaps onto the same output bytes" do
+      # The authored CL grows 1 → 12 (one extra digit), so every byte from the CL line's
+      # terminator on shifts by +1. A payload span living in the body (offset >= at) must be
+      # relocated by exactly delta — that is the whole `shift_spans(a >= at ? a+delta : a)` rule.
+      head = "POST / HTTP/1.1\r\nContent-Length: 1\r\n\r\n"
+      body = "0123456789ab" # 12 bytes → CL becomes "12", delta = +1
+      req = (head + body).to_slice
+      body_at = head.bytesize
+
+      synced, at, delta = F::ContentLength.sync_at(req)
+      delta.should eq(1)
+      at.should be < body_at # the edit is up in the head, before any body span
+
+      # Emulate Generator#shift_spans for a body span and prove it lands on the exact body bytes.
+      new_body_at = body_at >= at ? body_at + delta : body_at
+      new_body_at.should eq(body_at + delta)
+      String.new(synced[new_body_at, body.bytesize]).should eq(body)
+    end
+
+    it "bounds the CORRECT (bare-LF-terminated) line, so at/delta track the real edited span" do
+      # With a bare-LF-hidden duplicate, `at` must be the bare-LF position that ends the FIRST
+      # CL line — not the far-away CRLF after the hidden second CL. Here the first CL grows
+      # 6 → 12 (delta +1); the hidden `Content-Length: 100` is preserved and a body span still
+      # remaps by the true head growth.
+      head = "POST / HTTP/1.1\r\nContent-Length: 6\nContent-Length: 100\r\n\r\n"
+      body = "0123456789ab" # 12 bytes
+      req = (head + body).to_slice
+      body_at = head.bytesize
+
+      synced, at, delta = F::ContentLength.sync_at(req)
+      delta.should eq(1)
+      at.should be < body_at
+      String.new(synced).should contain("Content-Length: 100") # hidden CL survived the rewrite
+
+      new_body_at = body_at >= at ? body_at + delta : body_at
+      String.new(synced[new_body_at, body.bytesize]).should eq(body)
+    end
+  end
+end

--- a/spec/fuzz/redirect_hop_spec.cr
+++ b/spec/fuzz/redirect_hop_spec.cr
@@ -360,12 +360,34 @@ describe "Fuzz::Engine#follow_redirects — the collapsed Result's fields" do
   end
 
   it "does not invent a timed_out from a retried send" do
-    # `Fuzz::Result` has no `timed_out` field to leak it to a surface today, so this asserts
-    # on the Repeater::Result the follower builds, through the field that DOES reach a row.
-    r = Gori::Repeater::Result.new(Bytes.empty, nil, nil, 1_i64, nil, false, retried: true)
-    r.retried?.should be_true
-    r.timed_out?.should be_false
-    r.delivered?.should be_false
+    # `Fuzz::Result` now HAS a `timed_out` field (B1), so assert on the ROW a surface reads, not
+    # only on the Repeater::Result underneath: a keep-alive re-send must reach the row as
+    # `retried?` and must NOT show up there as `timed_out?`. (The defect was that `retried` once
+    # sat in the constructor slot `timed_out` had taken, so a re-send silently set `timed_out`.)
+    res, _ = follow([reply(302, "/next", retried: true), reply(200)])
+    res.retried?.should be_true
+    res.timed_out?.should be_false
+  end
+
+  # B3: a hop the gate refuses must NOT destroy the payload's real answer — the 302 an
+  # open-redirect probe is hunting. The row keeps status 302; the hop failure rides as a NOTE.
+  it "keeps the payload's 302 when the redirect hop is scope-refused, and notes the refusal" do
+    refused = Gori::Repeater::Result.new(Bytes.new(0), nil, nil, 0_i64,
+      Gori::Outbound::EXCLUDE_SWEEP_ERROR)
+    res, backend = follow([reply(302, "/offsite"), refused])
+    backend.sent.size.should eq(2)          # the hop WAS attempted
+    res.status.should eq(302)               # …but the 302 survives the collapse
+    res.error.should_not be_nil
+    res.error.not_nil!.should contain("redirect hop refused")
+  end
+
+  # The complement: a hop that FAILS on the wire is treated the same — keep the 3xx, note it.
+  it "keeps the 302 when a redirect hop errors on the wire" do
+    dead = Gori::Repeater::Result.new(Bytes.new(0), nil, nil, 0_i64, "connection refused")
+    res, _ = follow([reply(302, "/next"), dead])
+    res.status.should eq(302)
+    res.error.not_nil!.should contain("redirect hop refused")
+    res.error.not_nil!.should contain("connection refused")
   end
 
   it "preserves a genuine timed_out on the last hop" do

--- a/spec/fuzz/truthful_reporting_spec.cr
+++ b/spec/fuzz/truthful_reporting_spec.cr
@@ -1,0 +1,215 @@
+require "../spec_helper"
+require "socket"
+
+private alias F = Gori::Fuzz
+
+# Workstream B (#10 truthful-reporting): three coupled fixes on the Fuzzer result path.
+#   B1 — `incomplete`/`timed_out` are now READ (a truncated body was reported as the whole one).
+#   B2 — a `--retries` config re-send is MARKED on the row and every failed attempt counts.
+#   B3 — `blocked` is a PAYLOAD-unit count (retries/hops no longer inflate it and poison
+#        `all_blocked`), and a scope-refused redirect hop no longer overwrites the payload's 302.
+
+# A Backend whose canned reply is decided per call by a block — the block closes over a counter,
+# so a spec can make the same payload fail twice and then succeed, or refuse a payload by name.
+private class ScriptBackend < F::Backend
+  getter origin : F::Origin
+  getter calls = 0
+
+  def initialize(@origin : F::Origin, &@fn : Bytes, Int32 -> Gori::Repeater::Result)
+  end
+
+  def send(bytes : Bytes) : Gori::Repeater::Result
+    @calls += 1
+    @fn.call(bytes, @calls)
+  end
+end
+
+private def ok_reply(status : Int32, body : String) : Gori::Repeater::Result
+  head = "HTTP/1.1 #{status} OK\r\nContent-Length: #{body.bytesize}\r\n\r\n".to_slice
+  Gori::Repeater::Result.new(head, body.to_slice, Gori::Proxy::Codec::Http1.parse_response_head(head), 1_i64)
+end
+
+private def drain(engine : F::Engine) : {Array(F::Result), F::DoneEvent?}
+  results = [] of F::Result
+  done = nil.as(F::DoneEvent?)
+  engine.run do |ev|
+    case ev
+    when F::ResultEvent then results << ev.result
+    when F::DoneEvent   then done = ev
+    end
+  end
+  {results, done}
+end
+
+private def one_position_gen(payloads : Array(String), cfg : F::Config) : F::Generator
+  tpl = F::Template.parse("GET /x?p=§a§ HTTP/1.1\r\nHost: h\r\n\r\n")
+  F::Generator.new(tpl, [F::PayloadSet.new(F::InlineList.new(payloads))], cfg)
+end
+
+# An origin that declares Content-Length: 100 but writes 2 bytes and hangs up — the classic
+# "origin closed before the framed body finished" truncation the capture must not report whole.
+private class ShortBodyOrigin
+  getter port : Int32
+
+  def initialize
+    @server = TCPServer.new("127.0.0.1", 0)
+    @port = @server.local_address.port
+    spawn do
+      while conn = @server.accept?
+        spawn do
+          if Gori::Proxy::Codec::Http1.read_head(conn)
+            conn << "HTTP/1.1 200 OK\r\nContent-Length: 100\r\n\r\nab"
+            conn.flush
+          end
+          conn.close rescue nil
+        end
+      end
+    rescue
+      # server closed
+    end
+  end
+
+  def close : Nil
+    @server.close
+  end
+end
+
+# ─────────────────────────── B1 — incomplete / timed_out ───────────────────────────
+
+describe "Fuzz result — B1 incomplete/timed_out are read, not dropped" do
+  it "propagates incomplete AND timed_out from the Repeater result onto the row" do
+    head = "HTTP/1.1 200 OK\r\nContent-Length: 100\r\n\r\n".to_slice
+    raw = Gori::Repeater::Result.new(head, "ab".to_slice,
+      Gori::Proxy::Codec::Http1.parse_response_head(head), 5_i64, nil, true, timed_out: true)
+    job = F::Job.new(0_i64, ["x"], 0, "GET / HTTP/1.1\r\nHost: h\r\n\r\n".to_slice)
+    res = F::Matcher.new.build(job, raw)
+    res.incomplete?.should be_true
+    res.timed_out?.should be_true
+  end
+
+  it "surfaces incomplete + the read-deadline reason on JSON, text and MCP, only when set" do
+    head = "HTTP/1.1 200 OK\r\nContent-Length: 100\r\n\r\n".to_slice
+    raw = Gori::Repeater::Result.new(head, "ab".to_slice,
+      Gori::Proxy::Codec::Http1.parse_response_head(head), 5_i64, nil, true, timed_out: true)
+    job = F::Job.new(0_i64, ["x"], 0, "GET / HTTP/1.1\r\nHost: h\r\n\r\n".to_slice)
+    res = F::Matcher.new.build(job, raw)
+
+    j = JSON.parse(Gori::CLI::Output.fuzz_row_json(res))
+    j["incomplete"].as_bool.should be_true
+    j["incomplete_reason"].as_s.should contain("read deadline") # timed_out → the deadline sentence
+
+    Gori::CLI::Output.fuzz_row_text(res).should contain("read deadline")
+
+    mcp = JSON.parse(JSON.build { |b| Gori::MCP::Serialize.fuzz_result(b, res) })
+    mcp["incomplete"].as_bool.should be_true
+    mcp["incomplete_reason"].as_s.should contain("read deadline")
+
+    # A clean, complete row carries none of it (no false `incomplete` on every row).
+    clean = F::Matcher.new.build(job, ok_reply(200, "abcdef"))
+    Gori::CLI::Output.fuzz_row_json(clean).should_not contain("incomplete")
+    Gori::CLI::Output.fuzz_row_text(clean).should_not contain("incomplete")
+  end
+
+  it "reports a real early-close origin (CL > bytes) as incomplete, not as the whole response" do
+    origin = ShortBodyOrigin.new
+    begin
+      cfg = F::Config.new(mode: F::Mode::Sniper, concurrency: 1, timeout: 2.seconds)
+      gen = one_position_gen(["x"], cfg)
+      backend = F::Sender.new(F::Origin.new("http", "127.0.0.1", origin.port),
+        ungated_outbound, false, false)
+      results, _ = drain(F::Engine.new(gen, F::Matcher.new, backend, cfg))
+      results.size.should eq(1)
+      results[0].incomplete?.should be_true
+      results[0].timed_out?.should be_false # the origin CLOSED; it did not stall on a deadline
+      j = JSON.parse(Gori::CLI::Output.fuzz_row_json(results[0]))
+      j["incomplete"].as_bool.should be_true
+      j["incomplete_reason"].as_s.should contain("origin closed")
+    ensure
+      origin.close
+    end
+  end
+end
+
+# ─────────────────────────── B2 — config-retry marked, errors counted ───────────────────────────
+
+describe "Fuzz engine — B2 a --retries re-send is marked and every failed attempt counts" do
+  it "marks resent + counts every superseded attempt when the POST succeeds on try 3" do
+    cfg = F::Config.new(mode: F::Mode::Sniper, concurrency: 1, retries: 2, retry_pause: 0.seconds)
+    gen = one_position_gen(["x"], cfg)
+    backend = ScriptBackend.new(F::Origin.new("http", "h", 80)) do |_bytes, n|
+      n < 3 ? Gori::Repeater::Result.new(Bytes.new(0), nil, nil, 0_i64, "connection reset") : ok_reply(200, "ok")
+    end
+    results, done = drain(F::Engine.new(gen, F::Matcher.new, backend, cfg))
+
+    results.size.should eq(1)
+    results[0].resent?.should be_true
+    results[0].resent_count.should eq(2) # attempts 1 and 2 were superseded
+    results[0].error.should be_nil       # …and the final attempt (3) succeeded
+    backend.calls.should eq(3)
+    # `errors` counts EVERY failed attempt (2), not only the final result (0 here).
+    done.not_nil!.progress.errors.should eq(2)
+  end
+
+  it "counts the final failure too when all retries are exhausted" do
+    cfg = F::Config.new(mode: F::Mode::Sniper, concurrency: 1, retries: 2, retry_pause: 0.seconds)
+    gen = one_position_gen(["x"], cfg)
+    backend = ScriptBackend.new(F::Origin.new("http", "h", 80)) do |_bytes, _n|
+      Gori::Repeater::Result.new(Bytes.new(0), nil, nil, 0_i64, "connection reset")
+    end
+    results, done = drain(F::Engine.new(gen, F::Matcher.new, backend, cfg))
+
+    results[0].resent_count.should eq(2)
+    results[0].error.should_not be_nil
+    backend.calls.should eq(3)                 # 1 original + 2 retries
+    done.not_nil!.progress.errors.should eq(3) # 2 superseded + the final one
+  end
+end
+
+# ─────────────────────────── B3 — blocked is payload-unit ───────────────────────────
+
+describe "Fuzz engine — B3 blocked counts payloads, not attempts/hops" do
+  it "counts a refused payload once (not once per retry) and never retries it" do
+    cfg = F::Config.new(mode: F::Mode::Sniper, concurrency: 1, retries: 2, retry_pause: 0.seconds)
+    gen = one_position_gen(["ok", "b1", "b2"], cfg)
+    backend = ScriptBackend.new(F::Origin.new("http", "h", 80)) do |bytes, _n|
+      s = String.new(bytes)
+      if s.includes?("p=b1") || s.includes?("p=b2")
+        Gori::Repeater::Result.new(Bytes.new(0), nil, nil, 0_i64, Gori::Outbound::EXCLUDE_SWEEP_ERROR)
+      else
+        ok_reply(200, "ok")
+      end
+    end
+    _, done = drain(F::Engine.new(gen, F::Matcher.new, backend, cfg))
+    p = done.not_nil!.progress
+
+    p.blocked.should eq(2)   # payload-unit — NOT 6 (2 refused × 3 attempts under the old bug)
+    p.sent.should eq(3)
+    backend.calls.should eq(3) # each refused payload sent ONCE; no wasted retries of a stable gate
+    # A refused payload is still one error (the refusal produces an errored Result); NOT three.
+    # Under the old retry-a-gate bug this read 6 — pin the corrected, once-per-payload contract.
+    p.errors.should eq(2)
+    # `all_blocked` (mcp/tools/fuzz.cr) is `sent>0 && blocked>=sent` — false because a payload 200'd.
+    (p.sent > 0 && p.blocked >= p.sent).should be_false
+    p.blocked_reason.should eq(Gori::Outbound::EXCLUDE_SWEEP_ERROR)
+  end
+
+  # The inverse of the poisoning: a fully-refused run must still read `all_blocked == true`.
+  # `@blocked` is bumped only in `run_one`'s payload path, so auto-calibration sends (which go
+  # straight to `@backend`, outside `run_one`) correctly do NOT count — but they must also not
+  # derail the sweep, or a run where nothing left the machine would read `blocked < sent`.
+  it "keeps blocked == sent on a fully-refused run even with auto-calibration on" do
+    cfg = F::Config.new(mode: F::Mode::Sniper, concurrency: 1, auto_calibrate: true)
+    gen = one_position_gen(["a", "b"], cfg)
+    backend = ScriptBackend.new(F::Origin.new("http", "h", 80)) do |_bytes, _n|
+      Gori::Repeater::Result.new(Bytes.new(0), nil, nil, 0_i64, Gori::Outbound::SANDBOX_SWEEP_ERROR)
+    end
+    engine = F::Engine.new(gen, F::Matcher.new(auto_calibrate: true), backend, cfg)
+    engine.calibrate_baseline # 6 refused calibration sends — must not inflate @blocked nor stop the sweep
+    _, done = drain(engine)
+    p = done.not_nil!.progress
+
+    p.sent.should eq(2)
+    p.blocked.should eq(2)
+    (p.sent > 0 && p.blocked >= p.sent).should be_true # fully blocked, and it SAYS so
+  end
+end

--- a/spec/mcp_probe_spec.cr
+++ b/spec/mcp_probe_spec.cr
@@ -247,7 +247,9 @@ describe "MCP probe rules + mode tools" do
       tools = Gori::MCP::Tools.new(store, allow_actions: true, verify_upstream: false)
       res = call_json(tools, "list_probe_rules", "{}")
       res["mode"].as_s.should eq("passive") # the fresh-project default
-      res["disabled_count"].as_i.should eq(0)
+      # One built-in ships OFF by default (the opt-in request-smuggling detector), so a fresh
+      # project already reports it disabled — see Probe::DEFAULT_DISABLED_RULES.
+      res["disabled_count"].as_i.should eq(1)
       rules = res["rules"].as_a
       rules.size.should be > 0
       kinds = rules.map { |r| r["kind"].as_s }.uniq
@@ -278,7 +280,8 @@ describe "MCP probe rules + mode tools" do
       before.should contain("secret_in_url")
 
       call_json(tools, "set_probe_rule_enabled", %({"id":"secret_in_url","enabled":false}))["enabled"].as_bool.should be_false
-      call_json(tools, "list_probe_rules", "{}")["disabled_count"].as_i.should eq(1)
+      # 2 = secret_in_url (just disabled) + request_smuggling (off by default).
+      call_json(tools, "list_probe_rules", "{}")["disabled_count"].as_i.should eq(2)
 
       after = call_json(tools, "probe_scan", "{}")["issues"].as_a.map { |g| g["code"].as_s }
       after.should_not contain("secret_in_url")

--- a/spec/outbound_spec.cr
+++ b/spec/outbound_spec.cr
@@ -390,6 +390,16 @@ describe Gori::Outbound do
       Gori::Outbound.request_target("POST\t/a/b\tHTTP/1.1\r\n").should eq("/a/b")
     end
 
+    # A LEADING BLANK LINE before the request-line must not blind the gate: reading the empty
+    # first line and `split[1]?`-ing it to nil would gate "/" while the REAL target (a later
+    # line) goes on the wire — a Sandbox bypass. Scan to the first non-blank line instead.
+    it "recovers the target past leading blank line(s) before the request line" do
+      Gori::Outbound.request_target("\r\nGET /admin/x HTTP/1.1\r\nHost: h\r\n\r\n").should eq("/admin/x")
+      Gori::Outbound.request_target("\nGET /admin/x HTTP/1.1\r\n".to_slice).should eq("/admin/x")
+      Gori::Outbound.request_target("\r\n\r\nGET /admin/x HTTP/1.1\r\n").should eq("/admin/x") # doubled leading blank
+      Gori::Outbound.request_target("\r\nPOST  /a/b\tHTTP/1.1\r\n").should eq("/a/b")           # blank line + irregular ws
+    end
+
     it "keeps the scope gate honest against a doubled-space request line" do
       with_scope do |scope, _store|
         scope.add("include", "host", "acme.test")
@@ -402,6 +412,9 @@ describe Gori::Outbound do
         # …and a doubled space must NOT slip past it.
         ob.send_block("https", "acme.test", Gori::Outbound.request_target(
           "GET  /admin/x HTTP/1.1\r\nHost: acme.test\r\n\r\n")).should eq(Gori::Outbound::SANDBOX_ERROR)
+        # …nor a leading blank line before the request-line (the same target-read bypass).
+        ob.send_block("https", "acme.test", Gori::Outbound.request_target(
+          "\r\nGET /admin/x HTTP/1.1\r\nHost: acme.test\r\n\r\n")).should eq(Gori::Outbound::SANDBOX_ERROR)
       end
     end
   end

--- a/spec/probe/request_smuggling_spec.cr
+++ b/spec/probe/request_smuggling_spec.cr
@@ -1,0 +1,477 @@
+require "../spec_helper"
+require "socket"
+
+private alias P = Gori::Probe
+private alias F = Gori::Fuzz
+private alias S = Gori::Store
+private alias Codec = Gori::Proxy::Codec
+
+private UNSAFE     = P::Active::Options.new(allow_unsafe: true)
+private AGGRESSIVE = P::Active::Options.new(allow_unsafe: true, aggressive: true)
+
+# A captured HTTP/1.1 POST flow whose RESPONSE head carries a front-end fingerprint (so the
+# rule's front-end pre-filter passes). Built directly (no store) so the tests assert on the
+# rule alone. `resp_head` lets a test drop the front-end hint to exercise the pre-filter.
+private def frontended_detail(host : String = "acme.test", port : Int32 = 443, scheme : String = "https",
+                              http_version : String = "HTTP/1.1",
+                              resp_head : String = "HTTP/1.1 200 OK\r\nVia: 1.1 varnish\r\nContent-Type: text/html\r\n\r\n") : S::FlowDetail
+  target = "/app"
+  head = "POST #{target} HTTP/1.1\r\nHost: #{host}\r\nContent-Type: application/json\r\nContent-Length: 2\r\n\r\n"
+  row = S::FlowRow.new(
+    1_i64, 1_i64, scheme, "POST", host, port, target,
+    200, 100_i64, S::FlowState::Complete, 11_i64, 1_i64, "text/html")
+  S::FlowDetail.new(row, http_version, head.to_slice, "{}".to_slice,
+    resp_head.to_slice, "<html></html>".to_slice)
+end
+
+# request_framing over the HEAD of a crafted request (mirrors the rule's own off-wire guard).
+private def framing_raises?(req : Bytes) : Bool
+  s = String.new(req)
+  i = s.index("\r\n\r\n")
+  head = i ? req[0, i + 4] : req
+  Codec::Body.request_framing(Codec::Http1.parse_request_head(head))
+  false
+rescue Gori::Error
+  true
+rescue
+  false
+end
+
+private def obfuscated?(req : Bytes) : Bool
+  s = String.new(req)
+  i = s.index("\r\n\r\n")
+  head = i ? req[0, i + 4] : req
+  Codec::Http1.obfuscated_header?(head)
+end
+
+# ── synthetic Repeater::Result builders for the pure verdict layer ──────────────────────
+private def r_fast(us : Int64 = 50_000_i64) : Gori::Repeater::Result
+  Gori::Repeater::Result.new("HTTP/1.1 200 OK\r\n\r\n".to_slice, Bytes.empty, nil, us)
+end
+
+private def r_hung(us : Int64 = 8_000_000_i64) : Gori::Repeater::Result
+  # A read that timed out on a blocked tier: errored, and far slower than the baseline.
+  Gori::Repeater::Result.new(Bytes.new(0), nil, nil, us, "read timed out")
+end
+
+private def r_timed_out(us : Int64 = 8_000_000_i64) : Gori::Repeater::Result
+  Gori::Repeater::Result.new(Bytes.new(0), nil, nil, us, nil, false, timed_out: true)
+end
+
+private def r_ok_complete(body : String = "ok") : Gori::Repeater::Result
+  head = "HTTP/1.1 200 OK\r\nContent-Length: #{body.bytesize}\r\n\r\n"
+  Gori::Repeater::Result.new(head.to_slice, body.to_slice, nil, 100_000_i64)
+end
+
+private def r_incomplete : Gori::Repeater::Result
+  Gori::Repeater::Result.new("HTTP/1.1 200 OK\r\n".to_slice, nil, nil, 100_000_i64, nil, true)
+end
+
+private def r_error(msg : String = "boom") : Gori::Repeater::Result
+  Gori::Repeater::Result.new(Bytes.new(0), nil, nil, 100_000_i64, msg)
+end
+
+private def r_reflects_canary : Gori::Repeater::Result
+  body = "you asked for gori-smuggle-deadbeef"
+  head = "HTTP/1.1 200 OK\r\nContent-Length: #{body.bytesize}\r\n\r\n"
+  Gori::Repeater::Result.new(head.to_slice, body.to_slice, nil, 100_000_i64)
+end
+
+# A full timing-layer result list: two fast baselines followed by the three variants' probe
+# pairs (each `pair` is a {a, b} tuple), then an optional differential {smuggle, benign}.
+private def results_for(clte : {Gori::Repeater::Result, Gori::Repeater::Result},
+                        tecl : {Gori::Repeater::Result, Gori::Repeater::Result},
+                        tete : {Gori::Repeater::Result, Gori::Repeater::Result},
+                        baseline : Gori::Repeater::Result = r_fast,
+                        baseline2 : Gori::Repeater::Result = r_fast,
+                        diff : {Gori::Repeater::Result, Gori::Repeater::Result}? = nil) : Array(Gori::Repeater::Result)
+  out = [baseline, baseline2, clte[0], clte[1], tecl[0], tecl[1], tete[0], tete[1]]
+  if d = diff
+    out << d[0] << d[1]
+  end
+  out
+end
+
+# A recording backend: captures the wire bytes of every `send` (the injected-backend path in
+# Active.analyze routes pipeline members through the DEFAULT send_pipeline → per-member `send`).
+private class RecordingBackend < F::Backend
+  getter origin : F::Origin
+  getter wire = [] of String
+
+  def initialize(@origin : F::Origin)
+  end
+
+  def send(bytes : Bytes) : Gori::Repeater::Result
+    send(bytes, nil)
+  end
+
+  def send(bytes : Bytes, verbatim : Array({Int32, Int32})?) : Gori::Repeater::Result
+    @wire << String.new(bytes)
+    body = "{}"
+    head = "HTTP/1.1 200 OK\r\nContent-Length: #{body.bytesize}\r\n\r\n"
+    Gori::Repeater::Result.new(head.to_slice, body.to_slice, nil, 40_000_i64)
+  end
+end
+
+private def with_store(&)
+  path = File.tempname("gori-smuggle", ".db")
+  store = Gori::Store.open(path)
+  begin
+    yield store
+  ensure
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+describe Gori::Probe::Active::RequestSmuggling do
+  rule = P::Active::RequestSmuggling.new
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # LAYER 1 — Craft (pure): the crafted bytes trip gori's own codec exactly as the
+  # technique requires, with the exact chunk shapes the timing signal depends on.
+  # ─────────────────────────────────────────────────────────────────────────────
+  describe "craft" do
+    it "builds a benign, cleanly-framed baseline and 3×2 timing probes" do
+      plan = rule.plan(frontended_detail, UNSAFE).not_nil!
+      # baseline (plan.request) is a benign CL:0 POST — framing is NOT ambiguous.
+      framing_raises?(plan.request).should be_false
+      String.new(plan.request).should contain("Content-Length: 0")
+      # followups = [baseline2, clte, clte, tecl, tecl, tete, tete]
+      plan.followups.size.should eq(7)
+    end
+
+    it "makes the CL.TE probe raise the CL+TE rejection with a lone incomplete chunk" do
+      plan = rule.plan(frontended_detail, UNSAFE).not_nil!
+      clte = plan.followups[1]
+      s = String.new(clte)
+      s.should contain("Content-Length: 6")
+      s.should contain("Transfer-Encoding: chunked")
+      s.should contain("1\r\nZ\r\n") # one 1-byte chunk, NO terminating 0-chunk
+      framing_raises?(clte).should be_true
+    end
+
+    it "makes the TE.CL probe raise the CL+TE rejection with a short CL and a bare terminator" do
+      plan = rule.plan(frontended_detail, UNSAFE).not_nil!
+      tecl = plan.followups[3]
+      s = String.new(tecl)
+      s.should contain("Content-Length: 6") # one greater than the 5 body bytes sent
+      s.should contain("0\r\n\r\n")          # terminating chunk only
+      framing_raises?(tecl).should be_true
+    end
+
+    it "makes the TE.TE probe obfuscated AND framing-rejected (space before the colon)" do
+      plan = rule.plan(frontended_detail, UNSAFE).not_nil!
+      tete = plan.followups[5]
+      String.new(tete).should contain("Transfer-Encoding : chunked")
+      obfuscated?(tete).should be_true
+      framing_raises?(tete).should be_true
+    end
+
+    it "arms the differential pipeline (self-attributed canary) ONLY under aggressive+unsafe" do
+      # Plain unsafe: timing only, no pipeline, no probe_timeout.
+      plan = rule.plan(frontended_detail, UNSAFE).not_nil!
+      plan.pipeline.should be_empty
+      plan.probe_timeout.should be_nil
+
+      # Aggressive+unsafe: a [complete-smuggle+canary, benign GET /] pipeline group.
+      aplan = rule.plan(frontended_detail, AGGRESSIVE).not_nil!
+      aplan.pipeline.size.should eq(2)
+      String.new(aplan.pipeline[0]).should contain("gori-smuggle-") # self-attributed canary path
+      String.new(aplan.pipeline[0]).should contain("Transfer-Encoding: chunked")
+      String.new(aplan.pipeline[1]).should start_with("GET / HTTP/1.1")
+      aplan.probe_timeout.should_not be_nil
+    end
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Pre-filter + dedup equivalence
+  # ─────────────────────────────────────────────────────────────────────────────
+  describe "pre-filter" do
+    it "declines without allow_unsafe (synthetic POST bodies)" do
+      rule.plan(frontended_detail, P::Active::Options::DEFAULT).should be_nil
+      rule.dedup_key(frontended_detail, P::Active::Options::DEFAULT).should be_nil
+    end
+
+    it "declines on HTTP/2 (no CL/TE ambiguity there)" do
+      rule.plan(frontended_detail(http_version: "HTTP/2"), UNSAFE).should be_nil
+    end
+
+    it "declines when no front-end fingerprint is present in the response head" do
+      plain = frontended_detail(resp_head: "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n")
+      rule.plan(plain, UNSAFE).should be_nil
+    end
+
+    it "fires the pre-filter on a Server: cloudflare hint too" do
+      cf = frontended_detail(resp_head: "HTTP/1.1 200 OK\r\nServer: cloudflare\r\n\r\n")
+      rule.plan(cf, UNSAFE).should_not be_nil
+    end
+
+    it "keeps dedup_key byte-identical to plan's, and tags |aggr when the differential is armed" do
+      rule.dedup_key(frontended_detail, UNSAFE).should eq(rule.plan(frontended_detail, UNSAFE).not_nil!.dedup_key)
+      rule.dedup_key(frontended_detail, AGGRESSIVE).should eq(rule.plan(frontended_detail, AGGRESSIVE).not_nil!.dedup_key)
+      rule.dedup_key(frontended_detail, UNSAFE).not_nil!.should_not contain("aggr")
+      rule.dedup_key(frontended_detail, AGGRESSIVE).not_nil!.should contain("aggr")
+    end
+
+    it "dedup_key is nil in EXACTLY the cases plan is (equivalence invariant, incl. gated-out)" do
+      cases = [
+        {frontended_detail, UNSAFE},                                                # eligible
+        {frontended_detail, AGGRESSIVE},                                            # eligible + armed
+        {frontended_detail, P::Active::Options::DEFAULT},                           # no allow_unsafe
+        {frontended_detail(http_version: "HTTP/2"), UNSAFE},                        # h2
+        {frontended_detail(resp_head: "HTTP/1.1 200 OK\r\n\r\n"), UNSAFE},          # no front-end hint
+      ]
+      cases.each do |(d, o)|
+        rule.dedup_key(d, o).should eq(rule.plan(d, o).try(&.dedup_key))
+      end
+    end
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # LAYER 3 — Verdict (pure, synthetic Results).
+  # ─────────────────────────────────────────────────────────────────────────────
+  describe "verdict" do
+    detail = frontended_detail
+    plan = rule.plan(detail, AGGRESSIVE).not_nil!
+
+    it "fires High for a variant whose BOTH timing probes hung against a fast baseline" do
+      res = results_for(clte: {r_hung, r_hung}, tecl: {r_fast, r_fast}, tete: {r_fast, r_fast})
+      dets = rule.detections_all(plan, res, detail)
+      dets.size.should eq(1)
+      dets[0].code.should eq("request_smuggling_clte")
+      dets[0].severity.should eq(S::Severity::High)
+      dets[0].evidence.not_nil!.should contain("2/2")
+    end
+
+    it "also fires on a timed_out (not just errored) probe pair" do
+      res = results_for(clte: {r_fast, r_fast}, tecl: {r_timed_out, r_timed_out}, tete: {r_fast, r_fast})
+      dets = rule.detections_all(plan, res, detail)
+      dets.map(&.code).should eq(["request_smuggling_tecl"])
+    end
+
+    it "fires nothing when no probe hung (fast+fast everywhere)" do
+      res = results_for(clte: {r_fast, r_fast}, tecl: {r_fast, r_fast}, tete: {r_fast, r_fast})
+      rule.detections_all(plan, res, detail).should be_empty
+    end
+
+    it "DECLINES a variant on jitter (only one of its two probes hung)" do
+      res = results_for(clte: {r_hung, r_fast}, tecl: {r_fast, r_fast}, tete: {r_fast, r_fast})
+      rule.detections_all(plan, res, detail).should be_empty
+    end
+
+    it "DECLINES the whole flow on a slow/unstable baseline (a hang is not attributable)" do
+      slow = r_fast(2_000_000_i64) # 2s > BASE_FAST
+      res = results_for(clte: {r_hung, r_hung}, tecl: {r_hung, r_hung}, tete: {r_hung, r_hung},
+        baseline: slow, baseline2: slow)
+      rule.detections_all(plan, res, detail).should be_empty
+    end
+
+    it "DECLINES when a baseline failed to send (no anchor for the timing test)" do
+      res = results_for(clte: {r_hung, r_hung}, tecl: {r_fast, r_fast}, tete: {r_fast, r_fast},
+        baseline2: r_error)
+      rule.detections_all(plan, res, detail).should be_empty
+    end
+
+    it "escalates to Critical when the differential confirm fires (benign follow-up incomplete)" do
+      res = results_for(clte: {r_hung, r_hung}, tecl: {r_fast, r_fast}, tete: {r_fast, r_fast},
+        diff: {r_ok_complete, r_incomplete})
+      dets = rule.detections_all(plan, res, detail)
+      dets.size.should eq(1)
+      dets[0].severity.should eq(S::Severity::Critical)
+      dets[0].evidence.not_nil!.should contain("differential confirmed")
+    end
+
+    it "confirms via a benign follow-up that REFLECTS the smuggled canary" do
+      res = results_for(clte: {r_hung, r_hung}, tecl: {r_fast, r_fast}, tete: {r_fast, r_fast},
+        diff: {r_ok_complete, r_reflects_canary})
+      dets = rule.detections_all(plan, res, detail)
+      dets[0].severity.should eq(S::Severity::Critical)
+    end
+
+    it "does NOT count a differential confirm when the smuggle itself errored (follow-up was skipped)" do
+      # smuggle errored ⇒ send_pipeline retired the socket ⇒ benign is a 'skipped' Result whose
+      # error says nothing about a poison. Timing still fires (High), but never escalates.
+      res = results_for(clte: {r_hung, r_hung}, tecl: {r_fast, r_fast}, tete: {r_fast, r_fast},
+        diff: {r_error, r_error("skipped — the connection closed earlier in the group")})
+      dets = rule.detections_all(plan, res, detail)
+      dets.size.should eq(1)
+      dets[0].severity.should eq(S::Severity::High)
+    end
+
+    it "emits a clte finding when the differential confirms but no timing variant pinned" do
+      res = results_for(clte: {r_fast, r_fast}, tecl: {r_fast, r_fast}, tete: {r_fast, r_fast},
+        diff: {r_ok_complete, r_reflects_canary})
+      dets = rule.detections_all(plan, res, detail)
+      dets.size.should eq(1)
+      dets[0].code.should eq("request_smuggling_clte")
+      dets[0].severity.should eq(S::Severity::Critical)
+    end
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # LAYER 2 — Seam: the pipeline lands on ONE socket in order; group refusal;
+  # both send loops route the pipeline.
+  # ─────────────────────────────────────────────────────────────────────────────
+  describe "seam" do
+    it "Sender#send_pipeline sends the whole group on ONE socket, in order" do
+      # A keep-alive origin tagging every response with its connection id; identical ids prove
+      # one shared socket (mirrors spec/repeater_spec.cr's send_pipeline harness).
+      origin = TCPServer.new("127.0.0.1", 0)
+      port = origin.local_address.port
+      spawn do
+        cid = 0
+        while conn = origin.accept?
+          cid += 1
+          id = cid
+          begin
+            while head = Codec::Http1.read_head(conn)
+              path = String.new(head).split(' ')[1]? || "?"
+              body = "c#{id}#{path}"
+              conn << "HTTP/1.1 200 OK\r\nContent-Length: #{body.bytesize}\r\n\r\n" << body
+              conn.flush
+            end
+          rescue
+          ensure
+            conn.close rescue nil
+          end
+        end
+      end
+
+      sender = F::Sender.new(F::Origin.new("http", "127.0.0.1", port), ungated_outbound, false, false)
+      reqs = ["GET /a HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n".to_slice,
+              "GET /b HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n".to_slice]
+      results = sender.send_pipeline(reqs)
+      results.size.should eq(2)
+      results.all?(&.ok?).should be_true
+      String.new(results[0].body.not_nil!).should eq("c1/a")
+      String.new(results[1].body.not_nil!).should eq("c1/b") # SAME c1 → one connection, in order
+    ensure
+      origin.try &.close
+    end
+
+    it "Sender#send_pipeline refuses the WHOLE group when any member is out of scope" do
+      with_store do |store|
+        scope = Gori::Scope.load(store)
+        scope.add("exclude", "host", "blocked.test")
+        sender = F::Sender.new(F::Origin.new("https", "blocked.test", 443),
+          Gori::Outbound.interactive(scope), false, false)
+        reqs = ["GET /a HTTP/1.1\r\nHost: blocked.test\r\n\r\n".to_slice,
+                "GET /b HTTP/1.1\r\nHost: blocked.test\r\n\r\n".to_slice]
+        results = sender.send_pipeline(reqs)
+        results.size.should eq(2)
+        results.all? { |r| !r.ok? }.should be_true # every member refused (group refusal)
+        sender.blocked.should be > 0_i64
+      end
+    end
+
+    it "the Backend DEFAULT send_pipeline delegates to per-member send" do
+      backend = RecordingBackend.new(F::Origin.new("http", "127.0.0.1", 80))
+      reqs = ["GET /x HTTP/1.1\r\n\r\n".to_slice, "GET /y HTTP/1.1\r\n\r\n".to_slice]
+      backend.send_pipeline(reqs).size.should eq(2)
+      backend.wire.size.should eq(2) # one `send` per member
+    end
+
+    it "Active.analyze routes the pipeline to the wire when the rule is ENABLED (default-off flip)" do
+      backend = RecordingBackend.new(F::Origin.new("https", "acme.test", 443))
+      # request_smuggling is default-OFF, so its id PRESENT in the disabled set means ENABLED.
+      P::Active.analyze(frontended_detail, outbound: ungated_outbound, backend: backend,
+        opts: AGGRESSIVE, disabled: Set{"request_smuggling"})
+      # The differential smuggle (canary) and a CL.TE timing probe both reached the wire.
+      backend.wire.any?(&.includes?("gori-smuggle-")).should be_true
+      backend.wire.any?(&.includes?("Transfer-Encoding: chunked")).should be_true
+    end
+
+    it "Active.analyze sends NO smuggling probe when the rule is default-off (empty disabled set)" do
+      backend = RecordingBackend.new(F::Origin.new("https", "acme.test", 443))
+      P::Active.analyze(frontended_detail, outbound: ungated_outbound, backend: backend,
+        opts: AGGRESSIVE) # disabled defaults to empty ⇒ default-off rule stays off
+      backend.wire.none?(&.includes?("gori-smuggle-")).should be_true
+    end
+
+    it "the Analyzer loop (the TUI twin) runs the rule and its timing probes reach a real socket" do
+      server = TCPServer.new("127.0.0.1", 0)
+      port = server.local_address.port
+      seen = [] of String
+      spawn do
+        while sock = server.accept?
+          begin
+            head = Codec::Http1.read_head(sock)
+            seen << (head ? String.new(head) : "")
+            sock << "HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+            sock.flush
+          rescue
+          ensure
+            sock.close rescue nil
+          end
+        end
+      end
+
+      begin
+        with_store do |store|
+          scope = Gori::Scope.load(store)
+          scope.add("include", "host", "127.0.0.1")
+          # Enable the default-off rule for this project (presence ⇒ enabled).
+          store.set_probe_disabled_rules(Set{"request_smuggling"})
+          detail = frontended_detail(host: "127.0.0.1", port: port, scheme: "http")
+          a = P::Analyzer.new(store, scope, Channel(S::FlowEvent).new(1), P::Mode::Active, false)
+          a.start
+          a.run_active_now(detail, allow_unsafe: true)
+          # request_smuggling runs LAST in the RULES list, so wait for its marker specifically
+          # (not a bare count) — poll to a deadline without a bare receive (PR #555 idiom).
+          deadline = Time.instant + 12.seconds
+          until seen.any?(&.includes?("Transfer-Encoding: chunked")) || Time.instant > deadline
+            sleep 20.milliseconds
+          end
+          a.stop
+        end
+        seen.should_not be_empty
+        # A CL.TE / TE.CL timing probe (Transfer-Encoding: chunked) reached the socket through
+        # the analyzer's own send loop — proving execute_active runs request_smuggling end-to-end.
+        seen.any?(&.includes?("Transfer-Encoding: chunked")).should be_true
+      ensure
+        server.close
+      end
+    end
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # C3 — default-off wiring (the flip lives in Probe.rule_disabled?/set_rule_enabled).
+  # ─────────────────────────────────────────────────────────────────────────────
+  describe "default-off wiring" do
+    it "treats request_smuggling as DISABLED on a fresh project (empty set)" do
+      empty = Set(String).new
+      P.rule_disabled?("request_smuggling", empty).should be_true
+      P.rule_enabled?("request_smuggling", empty).should be_false
+      # An ordinary rule is unaffected — enabled on a fresh project.
+      P.rule_enabled?("reflected_param", empty).should be_true
+    end
+
+    it "enabling a default-off rule stores its id PRESENT; disabling removes it" do
+      s = Set(String).new
+      P.set_rule_enabled(s, "request_smuggling", true)
+      s.includes?("request_smuggling").should be_true
+      P.rule_enabled?("request_smuggling", s).should be_true
+      P.set_rule_enabled(s, "request_smuggling", false)
+      s.includes?("request_smuggling").should be_false
+      P.rule_enabled?("request_smuggling", s).should be_false
+    end
+
+    it "an ordinary rule keeps the historic sense (present ⇒ disabled)" do
+      s = Set(String).new
+      P.set_rule_enabled(s, "reflected_param", false)
+      s.includes?("reflected_param").should be_true
+      P.rule_enabled?("reflected_param", s).should be_false
+    end
+
+    it "the Rules catalog shows request_smuggling disabled by default" do
+      with_store do |store|
+        entry = P::RuleCatalog.load(store).find { |e| e.id == "request_smuggling" }.not_nil!
+        entry.enabled.should be_false
+        entry.kind.should eq("active")
+      end
+    end
+  end
+end

--- a/spec/probe_spec.cr
+++ b/spec/probe_spec.cr
@@ -2930,7 +2930,11 @@ describe "Gori::Probe::Active (manual run estimate)" do
       r = rule.requests_per_flow
       r.begin.should be >= 1
       r.end.should be >= r.begin
-      r.end.should be <= 8 # nothing floods a single flow with probes
+      # Nothing floods a single flow with probes. The ONE exception is the OFF-BY-DEFAULT,
+      # opt-in request-smuggling detector: it legitimately spends more (2 baselines + 3 variants
+      # × 2 timing probes + a 2-member differential group) because it runs only when the operator
+      # explicitly enables it AND opts into unsafe/aggressive — see Probe::DEFAULT_DISABLED_RULES.
+      r.end.should be <= (rule.info.id == "request_smuggling" ? 10 : 8)
     end
     by_id = Gori::Probe::Active::RULES.to_h { |rule| {rule.info.id, rule.requests_per_flow} }
     # BackslashPowered: TWO baselines (the second proves the endpoint is stable enough to diff
@@ -2942,6 +2946,9 @@ describe "Gori::Probe::Active (manual run estimate)" do
     by_id["forbidden_bypass"].should eq(2..2)
     by_id["url_rewrite_bypass"].should eq(3..3)
     by_id["path_normalization_bypass"].should eq(6..7)
+    # The off-by-default request-smuggling detector: 2 baselines + 3 variants × 2 timing probes
+    # (8), plus the 2-member differential group under aggressive+unsafe (10).
+    by_id["request_smuggling"].should eq(8..10)
     ["reflected_param", "cors_reflection"].each { |id| by_id[id].should eq(1..1) }
   end
 

--- a/spec/proxy/codec/body_spec.cr
+++ b/spec/proxy/codec/body_spec.cr
@@ -92,6 +92,16 @@ describe "Gori::Proxy::Codec::Body.read_complete" do
     complete.should be_false
   end
 
+  it "reports COMPLETE for a chunked body with a bare-LF chunk-data terminator" do
+    # The capture path (Repeater/Fuzz/Miner) dispatches through copy_chunked too, so the
+    # bare-LF terminator fix reaches it: a lone-LF terminator must not truncate the capture
+    # or read as "upstream closed". The captured bytes are the wire form, framing included.
+    src = IO::Memory.new("5\r\nhello\n0\r\n\r\n")
+    bytes, complete = Body.read_complete(src, BodyFraming::Chunked, 0_i64)
+    complete.should be_true
+    String.new(bytes.not_nil!).should eq("5\r\nhello\n0\r\n\r\n")
+  end
+
   it "reports complete for a close-delimited body (EOF is the framing)" do
     src = IO::Memory.new("whatever")
     _, complete = Body.read_complete(src, BodyFraming::CloseDelimited, 0_i64)
@@ -396,6 +406,36 @@ describe Gori::Proxy::Codec::Body do
       Body.stream(src, dst, BodyFraming::Chunked, 0_i64, IO::Memory.new).should be_true
       dst.to_s.should eq("0\r\nA\n\r\n") # forwarded through the genuine blank line
       src.gets_to_end.should eq("NEXT")  # next message starts clean — no orphaned CRLF
+    end
+
+    it "reads a bare-LF chunk-data terminator without eating the next size line (no desync)" do
+      # Non-conformant lone-LF terminators after the chunk DATA. The old blind read_exact(src, 2)
+      # assumed a 2-byte CRLF, so on a bare LF it swallowed the LF PLUS the first byte of the
+      # NEXT chunk-size line ("\n6" here) → the next read parsed "\n" as a size line, failed, and
+      # returned false: a truncated forward + a false "upstream closed". CRLF size lines isolate
+      # the fix to the data terminator (:441). The body must forward byte-exact and complete.
+      wire = "5\r\nHELLO\n6\r\n WORLD\n0\r\n\r\nNEXT"
+      src = IO::Memory.new(wire)
+      dst = IO::Memory.new
+      tee = IO::Memory.new
+      Body.stream(src, dst, BodyFraming::Chunked, 0_i64, tee).should be_true
+      expected = "5\r\nHELLO\n6\r\n WORLD\n0\r\n\r\n"
+      dst.to_s.should eq(expected) # forwarded byte-exact through the bare-LF terminators
+      tee.to_s.should eq(expected)
+      src.gets_to_end.should eq("NEXT") # next keep-alive message left intact — the desync proof
+    end
+
+    it "forwards a fully bare-LF chunked body byte-exact and complete" do
+      # Every delimiter is a lone LF (both size lines and data terminators). parse_chunk_size
+      # strips the size line's LF and read_crlf_line reads each 1-byte data terminator, so the
+      # whole body streams through unchanged and completes — matching the random-access
+      # de-chunker's bare-LF case (content_decode.cr scan_chunks).
+      wire = "5\nHELLO\n6\n WORLD\n0\n\nNEXT"
+      src = IO::Memory.new(wire)
+      dst = IO::Memory.new
+      Body.stream(src, dst, BodyFraming::Chunked, 0_i64, IO::Memory.new).should be_true
+      dst.to_s.should eq("5\nHELLO\n6\n WORLD\n0\n\n")
+      src.gets_to_end.should eq("NEXT")
     end
 
     it "aborts a chunked body whose trailer section overruns the cap (memory/CPU DoS guard)" do

--- a/spec/repeater/flow_cl_policy_spec.cr
+++ b/spec/repeater/flow_cl_policy_spec.cr
@@ -57,6 +57,13 @@ describe "Gori::Env.head_body_boundary" do
     Gori::Env.head_body_boundary("GET / HTTP/1.1\r\nHost: h\r\n\r\nbody".to_slice).should eq(27)
   end
 
+  it "accepts a `\\n\\r\\n` terminator (bare-LF header end + CRLF blank line)" do
+    # The 4th spelling: a header line ended by a lone LF, then a CRLF blank line. Missed by
+    # both neighbors (LFLF needs a second LF; CRLFCRLF starts on CR), so the whole message
+    # used to read as head and the body's bare LFs were promoted to CRLF. Body starts at 25.
+    Gori::Env.head_body_boundary("GET / HTTP/1.1\nHost: h\n\r\nbody".to_slice).should eq(25)
+  end
+
   it "takes whichever spelling comes FIRST, not a fixed preference" do
     # A body that itself contains a CRLFCRLF must not move the boundary past the real one.
     bytes = "GET / HTTP/1.1\nHost: h\n\nA\r\n\r\nB".to_slice
@@ -66,6 +73,26 @@ describe "Gori::Env.head_body_boundary" do
   it "returns the full size when there is no terminator at all" do
     bytes = "GET /no-terminator HTTP/1.1".to_slice
     Gori::Env.head_body_boundary(bytes).should eq(bytes.size)
+  end
+end
+
+# End-to-end proof that the `\n\r\n` boundary fix reaches the wire through the shared
+# plan builder. A draft whose Content-Length line is bare-LF-terminated and whose blank
+# line is CRLF used to read as all-head: `expand_wire` then promoted the BODY's bare LF to
+# CRLF (`a\nb` → `a\r\nb`) and the auto-CL resync re-framed it to `Content-Length: 4` — a
+# silently corrupted request. With the boundary recognized, the head is normalized and the
+# 3-byte body `a\nb` is spliced through verbatim.
+describe "Gori::Repeater::Plan.build with a `\\n\\r\\n` head boundary" do
+  it "sends the body `a\\nb` (3 bytes) unchanged, not reframed to `a\\r\\nb`/CL:4" do
+    wire = "POST /p HTTP/1.1\r\nHost: h\r\nContent-Length: 3\n\r\na\nb"
+    options = Gori::Repeater::PlanOptions.new([wire.to_slice], target: "http://h")
+    ungated = Gori::Outbound.waived(nil, Gori::Outbound::Reason::NoProject)
+    out = String.new(Gori::Repeater::Plan.build(options, ungated).bytes)
+
+    out.should end_with("\r\n\r\na\nb")     # body verbatim, head terminated with a real blank line
+    out.should_not contain("a\r\nb")        # the body's bare LF was NOT promoted to CRLF
+    out.should contain("Content-Length: 3") # framed over the real 3-byte body
+    out.should_not contain("Content-Length: 4")
   end
 end
 

--- a/spec/repeater/minimize_spec.cr
+++ b/spec/repeater/minimize_spec.cr
@@ -78,6 +78,26 @@ private class JsonOrigin < F::Backend
   end
 end
 
+# A JSON API where every authored key EXCEPT `drop` is load-bearing — its response shrinks
+# unless the body still carries `keep`, BOTH `dup` occurrences, the `\/`-escaped `path`, and
+# the `1.50` number. So the minimizer keeps them and we can assert they survived byte-for-byte,
+# while `drop` (which the response ignores) is removed. If the candidate splice re-encoded the
+# JSON, the probe body would read `a/b`/`1.5`/one `dup` and `drop` would look load-bearing.
+private class JsonByteOrigin < F::Backend
+  getter origin : F::Origin = F::Origin.new("http", "h", 80)
+
+  def send(bytes : Bytes) : Gori::Repeater::Result
+    req = String.new(bytes)
+    body = req.includes?("\r\n\r\n") ? req.split("\r\n\r\n", 2)[1] : ""
+    full = body.includes?(%("keep")) && body.includes?(%("dup")) &&
+           body.includes?("a\\/b") && body.includes?("1.50")
+    payload = full ? "the full record body goes here" : "short"
+    head = "HTTP/1.1 200 OK\r\nContent-Length: #{payload.bytesize}\r\n\r\n".to_slice
+    r = Gori::Proxy::Codec::Http1.parse_response_head(head)
+    Gori::Repeater::Result.new(head, payload.to_slice, r, 1000_i64)
+  end
+end
+
 # Every send errors (unreachable origin).
 private class DeadOrigin < F::Backend
   getter origin : F::Origin = F::Origin.new("http", "h", 80)
@@ -198,6 +218,37 @@ describe Gori::Repeater::Minimize do
     report.minimized_text.should contain(%("keep":1))
     report.minimized_text.should_not contain("drop")
     report.removed.map(&.label).should contain("drop")
+  end
+
+  it "byte-splices a JSON key without re-encoding: dup keys, `\\/`, and `1.50` survive verbatim" do
+    # The old `JSON.parse(body).to_json` candidate canonicalized the operator's authored bytes
+    # (collapsed the duplicate `dup`, unescaped `\/`→`/`, reformatted `1.50`→`1.5`) in BOTH the
+    # probe requests and `--apply`'s stored `minimized_text` — corrupting the very framing/
+    # encoding a smuggling or WAF-bypass probe tests. The splice must preserve every OTHER byte.
+    body = %({"keep":1,"drop":2,"dup":3,"dup":4,"path":"a\\/b","num":1.50})
+    text = [
+      "POST /j HTTP/1.1",
+      "Host: h",
+      "Content-Type: application/json",
+      "Content-Length: #{body.bytesize}",
+      "",
+      body,
+    ].join("\n")
+
+    report = minimize(JsonByteOrigin.new, text, auto_cl: true)
+    report.aborted.should be_false
+    # `drop` is removed — which, since the origin only reports "full" when the probe body still
+    # reads `a\/b`/`1.50`/both `dup`s, also proves the PROBE candidate kept those bytes verbatim.
+    report.removed.map(&.label).should contain("drop")
+    report.minimized_text.should_not contain("drop")
+    # Everything load-bearing survived, byte-for-byte, in the STORED text.
+    report.minimized_text.should contain(%("keep":1))
+    report.minimized_text.should contain(%("dup":3))   # the duplicate key is NOT collapsed…
+    report.minimized_text.should contain(%("dup":4))   # …both occurrences remain
+    report.minimized_text.should contain("a\\/b")       # `\/` is NOT unescaped to `/`
+    report.minimized_text.should contain("1.50")        # `1.50` is NOT reformatted to `1.5`
+    # And the drop splice took its trailing comma with it, leaving valid JSON.
+    report.minimized_text.should contain(%({"keep":1,"dup":3))
   end
 
   it "leaves body params alone when Auto-Content-Length is off (can't safely re-length)" do

--- a/spec/repeater/ws_engine_spec.cr
+++ b/spec/repeater/ws_engine_spec.cr
@@ -285,6 +285,12 @@ describe Gori::Repeater::WsEngine do
     String.new(inbound[0].payload).should eq("UNTERMINATED")
     inbound[0].shape.fin.should be_false
     result.close_code.should eq(1000)
+    # This `fin: false` row is the ORIGIN's §5.4 violation, not gori truncating at a cap: no
+    # cap fired (12 bytes, well under every limit), so it must carry NO gori marker and leave
+    # `truncated` unset. Marking it would put a fresh misreport where B4 removed one — the very
+    # thing the cap gate exists to keep separate.
+    result.truncated.should be_nil
+    result.messages.none? { |m| WS.notice?(m.payload) }.should be_true
   end
 
   # Same buffer, no CLOSE: the origin just goes away mid-message. Every exit from the drain
@@ -318,6 +324,63 @@ describe Gori::Repeater::WsEngine do
     inbound[0].shape.fin.should be_true
     inbound[0].shape.rsv.should eq(4) # §5.2 puts an extension's flags on the FIRST frame
     inbound[0].shape.frames.should eq(3)
+  end
+
+  # --- B4 (#10 L8-F1): a drain that hits a cap must SAY so, not report a clean transcript ---
+  #
+  # Before this, every cap was a bare `break` returning only the close code, so a truncated
+  # drain was byte-identical to a complete one. Each test drives a real cap over a scripted
+  # origin and asserts BOTH signals the fix adds: a `NOTICE_PREFIX` marker row in `messages`
+  # (which `WS.notice?` recognises and a repeater seed refuses to replay) and the Result-level
+  # `truncated` sentence naming the cap.
+
+  it "marks the transcript truncated past the control-frame cap" do
+    # 65 PINGs = one past MAX_CONTROL_MESSAGES (64), then a CLOSE. The CLOSE is what makes this
+    # deterministic: it proves the engine consumed the WHOLE script, so the 65th ping really
+    # was seen and dropped rather than the socket being torn down early.
+    script = IO::Memory.new
+    (WsEngine::MAX_CONTROL_MESSAGES + 1).times { script.write(WS.encode(WS::OP_PING, "p".to_slice, mask: false)) }
+    script.write(WS.encode(WS::OP_CLOSE, Bytes[0x03, 0xE8], mask: false))
+    port = start_scripted_ws_origin(script.to_slice)
+    result = WsEngine.send(UPGRADE, [] of WsEngine::OutMsg,
+      scheme: "http", host: "127.0.0.1", port: port, verify_upstream: false, idle: 500.milliseconds)
+
+    result.close_code.should eq(1000)                                     # whole script consumed
+    result.truncated.not_nil!.should contain("control-frame cap")
+    result.messages.any? { |m| WS.notice?(m.payload) }.should be_true     # the marker row
+    # Only the cap's worth of ping rows survive (plus the CLOSE and the one marker), never all 65.
+    result.messages.count { |m| m.opcode == WS::OP_PING.to_i }.should eq(WsEngine::MAX_CONTROL_MESSAGES)
+  end
+
+  it "marks the transcript truncated past the message cap" do
+    # One completed TEXT message past MAX_RECV_MESSAGES (1000); the drain breaks at the cap.
+    script = IO::Memory.new
+    (WsEngine::MAX_RECV_MESSAGES + 1).times { script.write(WS.encode(WS::OP_TEXT, "x".to_slice, mask: false)) }
+    port = start_scripted_ws_origin(script.to_slice)
+    result = WsEngine.send(UPGRADE, [] of WsEngine::OutMsg,
+      scheme: "http", host: "127.0.0.1", port: port, verify_upstream: false, idle: 500.milliseconds)
+
+    result.truncated.not_nil!.should contain("message capture cap")
+    result.messages.any? { |m| WS.notice?(m.payload) }.should be_true
+    # The cap fired at exactly MAX_RECV_MESSAGES data rows — never the full 1001.
+    result.messages.count { |m| m.direction == "in" && m.opcode == 1 && !WS.notice?(m.payload) }
+      .should eq(WsEngine::MAX_RECV_MESSAGES)
+  end
+
+  it "marks an oversized fragment's fin:false row as gori-truncated, not a §5.4 violation" do
+    # A single unterminated fragment one byte past MAX_RECV_BYTES (and under the 16 MiB read
+    # cap, so `read_frame` still buffers it). gori — not the origin — stops accumulating, so the
+    # flushed `fin: false` row is OUR truncation; the adjacent marker + `truncated` say which.
+    big = Bytes.new((WsEngine::MAX_RECV_BYTES + 1).to_i, 0x41_u8)
+    port = start_scripted_ws_origin(WS.encode(WS::OP_TEXT, big, mask: false, fin: false))
+    result = WsEngine.send(UPGRADE, [] of WsEngine::OutMsg,
+      scheme: "http", host: "127.0.0.1", port: port, verify_upstream: false, idle: 500.milliseconds)
+
+    inbound = result.messages.select { |m| m.direction == "in" }
+    inbound[0].shape.fin.should be_false                                  # the truncated fragment
+    inbound[0].payload.size.should eq(big.size)
+    result.truncated.not_nil!.should contain("server-payload cap")
+    inbound.any? { |m| WS.notice?(m.payload) }.should be_true             # the marker sits adjacent
   end
 end
 

--- a/src/gori/cli/output.cr
+++ b/src/gori/cli/output.cr
@@ -204,6 +204,23 @@ module Gori
           # Only when true. This is an exception rather than a per-row property, and a `false`
           # on every row of every clean run would bury the one row that matters.
           j.field "retried", true if r.retried?
+          # `--retries` re-sent this variation after a network error — DISTINCT from `retried`
+          # (a keep-alive pool re-send). Only when it happened, with the count.
+          if r.resent?
+            j.field "resent", true
+            j.field "resent_count", r.resent_count
+          end
+          # The captured response is SHORT (origin closed early / read deadline / capture
+          # ceiling), so `length`/`words`/`lines` describe a fragment. Only when it happened, with
+          # the SAME three-way sentence `CLI::Run.incomplete_reason` gives the Repeater and MCP so
+          # a truncation is never worded two ways. The classifier keys off the raw body, kept only
+          # under keep_bodies — an unmatched body-dropped row still names closed/timeout, just not
+          # the ceiling cause. A synthetic Repeater::Result forwards the body + timing.
+          if r.incomplete?
+            j.field "incomplete", true
+            j.field "incomplete_reason",
+              CLI::Run.incomplete_reason(Repeater::Result.new(Bytes.new(0), r.body, nil, r.duration_us), r.timed_out?)
+          end
         end
       end
 
@@ -421,9 +438,19 @@ module Gori
           # Before the error text, because it qualifies the SEND rather than the response: this
           # request went out twice (see `Fuzz::Result#retried?`).
           io << "  re-sent" if r.retried?
+          # A CONFIG-retry re-send (`--retries`), with its count — DISTINCT from the keep-alive
+          # `re-sent` above. Beside it because both qualify the SEND, not the response.
+          io << "  re-sent (" << r.resent_count << "×)" if r.resent?
           io << "  " << r.error if r.error
           # The transform declared for this payload did not run; the payload went out raw.
           io << "  ⚠ " << r.chain_error if r.chain_error
+          # A trailing clause when the captured response was cut short, with the SAME three-way
+          # sentence the Repeater appends (`Run.incomplete_reason`) so `length`/`words` above are
+          # not read as the whole response. Body-keyed ceiling detection is exact only when the
+          # body was kept (keep_bodies); a body-dropped row still names closed vs. timeout.
+          if r.incomplete?
+            io << "  " << Run.incomplete_reason(Repeater::Result.new(Bytes.new(0), r.body, nil, r.duration_us), r.timed_out?)
+          end
         end
       end
 

--- a/src/gori/cli/run/fuzz.cr
+++ b/src/gori/cli/run/fuzz.cr
@@ -384,8 +384,11 @@ module Gori
         # the run whose request reached the origin twice, and dropping it here would put the
         # duplicate back where it was — invisible outside the connections summary. A row whose
         # `¦chain` did not run is shown for the same reason: its payload went out untransformed,
-        # and hiding it would return it to `0 errors` invisibility.
-        return false unless r.matched? || r.error || r.retried? || r.chain_error
+        # and hiding it would return it to `0 errors` invisibility. `incomplete?` (the captured
+        # response was truncated — a real finding that must not read as a clean short body) and
+        # `resent?` (a `--retries` config re-send) join for the same argument: each is a fact the
+        # run OBSERVED that vanishes if a matched-only gate drops the unmatched row carrying it.
+        return false unless r.matched? || r.error || r.retried? || r.resent? || r.incomplete? || r.chain_error
         case format
         when :jsonl then puts CLI::Output.fuzz_row_json(r)
         when :json  then buffer << r

--- a/src/gori/cli/run/probe.cr
+++ b/src/gori/cli/run/probe.cr
@@ -435,7 +435,9 @@ module Gori
             store.set_probe_custom_rule_enabled(row_id, enabled)
           else
             disabled = store.probe_disabled_rules
-            enabled ? disabled.delete(id) : disabled.add(id)
+            # `set_rule_enabled` (not a bare delete/add) so a DEFAULT-OFF rule toggles correctly:
+            # for those ids the stored-set membership is INVERTED — see Probe::DEFAULT_DISABLED_RULES.
+            Probe.set_rule_enabled(disabled, id, enabled)
             store.set_probe_disabled_rules(disabled)
           end
           puts "Rule '#{id}' is now #{enabled ? "enabled" : "disabled"}."

--- a/src/gori/cli/run/repeater.cr
+++ b/src/gori/cli/run/repeater.cr
@@ -737,6 +737,10 @@ module Gori
               j.field "close_code", result.close_code
               j.field "error", result.error
               j.field "note", result.note
+              # The inbound transcript stopped SHORT of the server at a cap. A synthetic row
+              # already sits in `messages` below; this is the summary half so a script reading
+              # the envelope (not walking the array) still sees the transcript is incomplete.
+              j.field "truncated", result.truncated
               j.field "messages" do
                 j.array do
                   result.messages.each do |m|
@@ -765,6 +769,7 @@ module Gori
         elsif result.ok?
           STDERR.puts "→ WebSocket upgraded=#{result.upgraded?} in #{CLI::Output.human_us(result.duration_us)}#{result.close_code ? " (close #{result.close_code})" : ""}"
           STDERR.puts "note: #{result.note}" if result.note
+          STDERR.puts "truncated: #{result.truncated}" if result.truncated
           result.messages.each { |m| puts ws_transcript_line(m) }
         else
           STDERR.puts "repeater failed: #{result.error}"

--- a/src/gori/env.cr
+++ b/src/gori/env.cr
@@ -716,8 +716,8 @@ module Gori
     # buffer (no body), which `expand_wire` then normalizes in full, matching the
     # pre-existing behavior for header-only text.
     # The end of the head (index of the first byte of the body) in wire-form bytes:
-    # the FIRST of `\n\n` or `\r\n\r\n`, whichever occurs earlier — never a fixed
-    # preference for one spelling, which is how a body containing a CRLFCRLF has
+    # the FIRST of `\n\n`, `\n\r\n`, or `\r\n\r\n`, whichever occurs earlier — never a
+    # fixed preference for one spelling, which is how a body containing a CRLFCRLF has
     # repeatedly moved this boundary in this codebase. Returns `bytes.size` when the
     # message has no terminator at all (a hand-authored head is still a head).
     #
@@ -731,6 +731,14 @@ module Gori
       while i < n
         if bytes[i] == 0x0A_u8 && i + 1 < n && bytes[i + 1] == 0x0A_u8
           return i + 2
+        end
+        # `\n\r\n` (0x0A 0x0D 0x0A): a bare-LF header terminator followed by a CRLF blank
+        # line. The two neighboring checks both miss it — LFLF needs `bytes[i+1]==0x0A`
+        # and CRLFCRLF starts on `0x0D` — so without this branch the message reads as
+        # all-head and the body's bare LFs get promoted to CRLF. Body starts at i+3.
+        if bytes[i] == 0x0A_u8 && i + 2 < n &&
+           bytes[i + 1] == 0x0D_u8 && bytes[i + 2] == 0x0A_u8
+          return i + 3
         end
         if bytes[i] == 0x0D_u8 && i + 3 < n &&
            bytes[i + 1] == 0x0A_u8 && bytes[i + 2] == 0x0D_u8 && bytes[i + 3] == 0x0A_u8

--- a/src/gori/fuzz/content_length.cr
+++ b/src/gori/fuzz/content_length.cr
@@ -39,7 +39,7 @@ module Gori::Fuzz
 
       body_start = sep + sep_w
       body_len = bytes.size - body_start
-      cl = find_cl_line(bytes, sep, eol) # {line_start, line_end} of the CL header, or nil
+      cl = find_cl_line(bytes, sep) # {line_start, content_end} of the CL header, or nil
 
       if cl.nil?
         # No Content-Length header. Both the "leave GETs clean" default and a chunked
@@ -49,7 +49,7 @@ module Gori::Fuzz
         return {bytes, 0, 0} if chunked?(bytes, sep, eol)
         # The insertion goes in at `sep`, so everything from the head/body separator on has
         # moved by the line it added (its own eol + name + digits).
-        return {append_cl(bytes, sep, body_start, body_len, eol), sep,
+        return {append_cl(bytes, sep, sep_w, body_start, body_len, eol), sep,
                 eol.bytesize + CL_CANON.bytesize + body_len.to_s.bytesize}
       end
 
@@ -63,46 +63,43 @@ module Gori::Fuzz
       # `[ls, le)` is replaced by `canon`, so `le` onwards moves. Offsets INSIDE the old line
       # have no image in the output at all — a payload spliced into the Content-Length VALUE
       # is what this pass overwrites, and the caller is told the region ends at `le`.
-      {replace_cl(bytes, ls, le, sep, body_start, body_len, eol, canon), le,
+      {replace_cl(bytes, ls, le, sep, sep_w, body_start, body_len, canon), le,
        canon.bytesize - (le - ls)}
     end
 
     # ── head scanning (byte level, no String/Array allocation) ────────────────────
 
-    # Byte range `{line_start, line_end}` of the Content-Length header line within the
-    # head `[0, sep)`, or nil when absent. `line_end` is the index of the terminating
-    # `eol` (or `sep` for the last header line). Header lines split on `eol`; the name is
-    # matched case-insensitively with leading/trailing ASCII whitespace stripped and a
+    # Byte range `{line_start, content_end}` of the Content-Length header line within the
+    # head `[0, sep)`, or nil when absent. `content_end` is the START of the line's terminator
+    # (or `sep` for the last header line, whose terminator is the blank-line separator). The
+    # name is matched case-insensitively with leading/trailing ASCII whitespace stripped and a
     # colon required past the line start — 1:1 with the old `header_name?`.
-    private def self.find_cl_line(bytes : Bytes, sep : Int32, eol : String) : {Int32, Int32}?
+    #
+    # Head lines are tokenized on LF (0x0A) then a trailing CR is chomped — the SAME rule as
+    # `chunked?` below, NOT a split on the boundary `eol`. A CRLF head can still carry a
+    # bare-LF-terminated header (a smuggling/desync vector the fuzzer deliberately crafts), and
+    # an LF-lenient backend reads that as its own line — so a bare-LF-hidden SECOND
+    # `Content-Length` must become its own line here too. That is the whole point: only the
+    # FIRST `Content-Length` is bounded (and rewritten), and the hidden one is left byte-intact,
+    # matching the already-correct CRLF-visible-duplicate case. Splitting on `eol` (CRLF-only)
+    # would instead swallow the bare LF, merge the two headers into one "line", and silently
+    # delete the hidden one on rewrite — corrupting the very primitive under test.
+    private def self.find_cl_line(bytes : Bytes, sep : Int32) : {Int32, Int32}?
       a = 0
       while a < sep
-        le = line_end(bytes, a, sep, eol)
-        return {a, le} if cl_line?(bytes, a, le)
-        a = le >= sep ? sep : le + eol.bytesize
+        nl = a
+        while nl < sep && bytes[nl] != 0x0a_u8
+          nl += 1
+        end
+        # `[a, e)` is the line content with any trailing CR chomped; `e` also marks the START of
+        # the terminator (CR+LF, a bare LF, or the head boundary when no LF is found), so
+        # `replace_cl` can splice `[e, …)` — the terminator plus every following byte — verbatim.
+        e = nl
+        e -= 1 if e > a && bytes[e - 1] == 0x0d_u8
+        return {a, e} if cl_line?(bytes, a, e)
+        a = nl + 1 # resume just past the LF (or past `sep`, ending the loop, when none was found)
       end
       nil
-    end
-
-    # Index of the `eol` sequence starting at or after `a` (bounded by `sep`), or `sep`
-    # when the line runs to the head boundary. Splits on the SAME `eol` the boundary
-    # picked, so a bare LF inside a CRLF head stays part of one line (as split(eol) did).
-    private def self.line_end(bytes : Bytes, a : Int32, sep : Int32, eol : String) : Int32
-      if eol.bytesize == 2 # "\r\n"
-        i = a
-        while i + 1 < sep
-          return i if bytes[i] == 0x0d_u8 && bytes[i + 1] == 0x0a_u8
-          i += 1
-        end
-        sep
-      else # "\n"
-        i = a
-        while i < sep
-          return i if bytes[i] == 0x0a_u8
-          i += 1
-        end
-        sep
-      end
     end
 
     # True when the line `[a, le)` is the `content-length` header (case-insensitive,
@@ -167,42 +164,62 @@ module Gori::Fuzz
 
     # ── rebuild (only when the value actually changes) ────────────────────────────
 
-    # Replace the CL header line in place with the canonical form, keeping every other
-    # head byte and the body slice exact. Equivalent to the old split/replace/rejoin.
-    private def self.replace_cl(bytes : Bytes, ls : Int32, le : Int32, sep : Int32,
-                                body_start : Int32, body_len : Int32, eol : String, canon : String) : Bytes
+    # Replace the CL header line in place with the canonical form, keeping every other head
+    # byte and the body slice exact. The blank-line separator is spliced back VERBATIM
+    # (`bytes[sep, sep_w]`) rather than rebuilt from a doubled `eol`: a mixed `\n\r\n` separator
+    # (last header line ended in a bare LF, blank line was CRLF) is not a repeated `eol`, so
+    # doubling `eol` would silently rewrite the operator's separator bytes.
+    private def self.replace_cl(bytes : Bytes, ls : Int32, le : Int32, sep : Int32, sep_w : Int32,
+                                body_start : Int32, body_len : Int32, canon : String) : Bytes
       io = IO::Memory.new(bytes.size + 16)
       io.write(bytes[0, ls])        # head up to the CL line
       io << canon                   # canonical "Content-Length: N"
-      io.write(bytes[le, sep - le]) # the CL line's eol through the rest of the head
-      io << eol << eol
+      io.write(bytes[le, sep - le]) # the CL line's terminator through the rest of the head
+      io.write(bytes[sep, sep_w])   # the blank-line separator, verbatim (may be mixed `\n\r\n`)
       io.write(bytes[body_start, body_len]) if body_len > 0
       io.to_slice
     end
 
-    # Append a fresh CL header line to a head that lacks one.
-    private def self.append_cl(bytes : Bytes, sep : Int32, body_start : Int32,
+    # Append a fresh CL header line to a head that lacks one. `eol` terminates the prior last
+    # header line; the separator is then spliced VERBATIM (`bytes[sep, sep_w]`) — for a mixed
+    # `\n\r\n` separator its leading byte is the new CL line's own (bare-LF) terminator, so the
+    # operator's blank-line spelling survives the insert. `sync_at`'s append `delta`
+    # (`eol.bytesize + CL_CANON + digits`) still holds: only that prefix is inserted at `sep`.
+    private def self.append_cl(bytes : Bytes, sep : Int32, sep_w : Int32, body_start : Int32,
                                body_len : Int32, eol : String) : Bytes
       io = IO::Memory.new(bytes.size + 32)
-      io.write(bytes[0, sep])
-      io << eol << CL_CANON << body_len
-      io << eol << eol
+      io.write(bytes[0, sep])           # head, up to the blank-line separator
+      io << eol << CL_CANON << body_len # terminate the prior header line, then the new CL line
+      io.write(bytes[sep, sep_w])       # blank-line separator, verbatim (its lead byte(s) terminate the new line)
       io.write(bytes[body_start, body_len]) if body_len > 0
       io.to_slice
     end
 
     # ── boundary + chunked ────────────────────────────────────────────────────────
 
-    # Locate the head/body separator = the FIRST blank line, whether CRLFCRLF or
-    # LFLF. Returns its start index (nil if none), width, and line ending. A single
-    # left-to-right scan (not "all CRLFCRLF, then all LFLF") matters when the head is
-    # LF-terminated but the BODY contains a CRLFCRLF: scanning all CRLFCRLF first would
-    # find the body's and split at the wrong place. A well-formed CRLF head has no
-    # LFLF inside it, so this is unchanged for normal CRLF messages.
+    # Locate the head/body separator = the FIRST blank line. Returns its start index
+    # (nil if none), its full byte WIDTH, and the terminator of the header line that
+    # PRECEDES the blank line. Three spellings are recognized:
+    #   LFLF `\n\n` (width 2, prior eol `\n`), CRLFCRLF `\r\n\r\n` (width 4, prior eol `\r\n`),
+    #   and the mixed `\n\r\n` (width 3, prior eol `\n`) — the last header line ended in a bare
+    #   LF and the blank line itself was CRLF. `\r\n\n` needs no branch: it is already caught as
+    #   LFLF one byte in (the leading CR stays in the head, matching the old behavior).
+    # For the mixed spelling the separator is NOT a repeated `eol`, so callers splice
+    # `bytes[start, width]` VERBATIM instead of doubling `eol` (see replace_cl / append_cl);
+    # `eol` is retained only as the prior line's terminator (all `append_cl` needs).
+    # A single left-to-right scan (not "all CRLFCRLF, then all LFLF") matters when the head is
+    # LF-terminated but the BODY contains a CRLFCRLF: scanning all CRLFCRLF first would find the
+    # body's and split at the wrong place. A well-formed CRLF head has no LFLF/`\n\r\n` inside
+    # it, so this is unchanged for normal CRLF messages; the earliest match wins because every
+    # spelling is tested at the same `i` and the leftmost hit is returned first.
     private def self.boundary(bytes : Bytes) : {Int32?, Int32, String}
       i = 0
       while i + 1 < bytes.size
         return {i, 2, "\n"} if bytes[i] == 0x0a_u8 && bytes[i + 1] == 0x0a_u8 # LFLF
+        if i + 2 < bytes.size && bytes[i] == 0x0a_u8 &&
+           bytes[i + 1] == 0x0d_u8 && bytes[i + 2] == 0x0a_u8 # mixed `\n\r\n` (bare-LF header + CRLF blank)
+          return {i, 3, "\n"}
+        end
         if i + 3 < bytes.size && bytes[i] == 0x0d_u8 && bytes[i + 1] == 0x0a_u8 &&
            bytes[i + 2] == 0x0d_u8 && bytes[i + 3] == 0x0a_u8 # CRLFCRLF
           return {i, 4, "\r\n"}

--- a/src/gori/fuzz/engine.cr
+++ b/src/gori/fuzz/engine.cr
@@ -113,6 +113,25 @@ module Gori::Fuzz
     def extra_requests : Int64
       0_i64
     end
+
+    # Send a GROUP of requests as ONE same-connection sequence, capturing each response in
+    # order — the primitive the active request-smuggling / desync rule needs (see
+    # `Repeater::Engine.send_pipeline`): a desync induced by member N surfaces only in the
+    # response to member N+1 on the SAME socket, which fresh-connection-per-send `send` can
+    # never reveal. `timeout` bounds the group's per-operation reads (nil = the backend's own).
+    #
+    # A CONCRETE DEFAULT, not a second abstract, and it deliberately delegates to per-member
+    # `send`: every wrapper backend (`GatedBackend`/`CappedBackend`) then inherits its gating /
+    # capping through the `send` overrides it already has, and every spec double stays a
+    # three-line class with no group logic to write. Only `Sender` — the production transport —
+    # overrides this to reach a REAL dedicated socket (the default's per-member sends are each a
+    # fresh connection, so it does not prove a same-socket desync; a caller that needs the true
+    # single socket is on `Sender`, and a spec that only asserts routing/gating does not need it).
+    # Whole-buffer `verbatim` per member, matching how the probe path marks every send: a crafted
+    # smuggling probe carries no operator `$NAME` to expand.
+    def send_pipeline(requests : Array(Bytes), timeout : Time::Span? = nil) : Array(Repeater::Result)
+      requests.map { |b| send(b, Backend.all_verbatim(b)) }
+    end
   end
 
   # Production backend over the Repeater engines (fresh connection per send — there is
@@ -250,6 +269,40 @@ module Gori::Fuzz
 
     def extra_requests : Int64
       @pool.try(&.stale_retries) || 0_i64
+    end
+
+    # Same-connection group send for the active smuggling/desync probe. Unlike `send`, the whole
+    # group MUST ride ONE dedicated socket (a desync induced by member N shows up only in member
+    # N+1's response), so this routes to `Repeater::Engine.send_pipeline`, which dials one socket
+    # and retires it on the first error/incomplete exchange. That deliberately BYPASSES the
+    # keep-alive `ConnPool` (`reusable_request?` refuses CL+TE / obfuscated payloads by design —
+    # exactly the bytes this carries) and never touches `Fuzz::ContentLength.sync`: the caller owns
+    # the framing (a deliberately wrong Content-Length is the whole point), so nothing rewrites it.
+    def send_pipeline(requests : Array(Bytes), timeout : Time::Span? = nil) : Array(Repeater::Result)
+      return [] of Repeater::Result if requests.empty?
+      # send_pipeline frames HTTP/1.1 only (`Repeater::Engine.send_pipeline` is h1). h2 multiplexes
+      # its own connection per send with separate stream-state rules, so a "same socket" group is
+      # meaningless there — DEGRADE to the per-member default (each on its own h2 connection via
+      # `send`, still gated, still one Result per request in order). The rule pre-filters to
+      # HTTP/1.1 anyway, so this is a belt-and-braces guard, not a hot path.
+      return super if @http2
+      # GROUP-GATE up front, sweep-side, mirroring `Repeater::Sender#group_refusal`: one blocked
+      # member refuses the WHOLE batch and returns all-error Results — a group is one connection
+      # carrying a deliberate sequence, so a partial send would be a misleading half-probe. The
+      # target is read off each member AFTER the same binding expansion `send` applies, so the
+      # scope decision is identical to the lone-send path (BEFORE the socket, per `ClientConn`).
+      requests.each do |req|
+        target = Gori::Outbound.request_target(@evidence ? req : Gori::Env.expand_bindings(req))
+        if err = @outbound.sweep_block(@origin.scheme, @origin.host, target)
+          @blocked += requests.size
+          @blocked_reason ||= err
+          return requests.map { Repeater::Result.new(Bytes.new(0), nil, nil, 0_i64, err) }
+        end
+      end
+      reqs = @evidence ? requests : requests.map { |b| Gori::Env.expand_bindings(b) }
+      Repeater::Engine.send_pipeline(reqs, scheme: @origin.scheme, host: @origin.host,
+        port: @origin.port, verify_upstream: @verify, sni: @sni,
+        timeout: timeout || @timeout, overrides: @overrides)
     end
   end
 

--- a/src/gori/fuzz/engine.cr
+++ b/src/gori/fuzz/engine.cr
@@ -401,6 +401,16 @@ module Gori::Fuzz
     @sent : Int64
     @matched : Int64
     @errors : Int64
+    # PAYLOAD-unit refusals, counted on the ENGINE rather than read off `@backend.blocked`. The
+    # backend increments on EVERY refused `send` call, so a gate-refused payload that `--retries`
+    # re-sent — and a redirect hop the gate refused — each bumped it, and `all_blocked`
+    # (`sent>0 && blocked>=sent`, mcp/tools/fuzz.cr) then read true on a run where a payload came
+    # back 200. Here it is exactly one increment per refused PAYLOAD (see `run_one`), the unit
+    # that compares to `@sent`. The backend keeps its own per-call counter — the Miner
+    # (miner/engine.cr) and the injected-backend Probe path read it and are out of this scope —
+    # but the fuzz `snapshot` now publishes THIS one.
+    @blocked : Int64
+    @blocked_reason : String?
     @dispatched : Int64
     @last_dispatch : Time::Instant
     @total : Int64?
@@ -422,6 +432,8 @@ module Gori::Fuzz
       @sent = 0_i64
       @matched = 0_i64
       @errors = 0_i64
+      @blocked = 0_i64
+      @blocked_reason = nil.as(String?)
       @dispatched = 0_i64
       @last_dispatch = Time.instant
       @total = nil.as(Int64?)
@@ -542,6 +554,13 @@ module Gori::Fuzz
         # payload. `||` not `+2`: one request is one error even if it both failed on the wire
         # AND carried a chain that could not run.
         @errors += 1 if result.error || result.chain_error
+        # Every SUPERSEDED attempt was a failed send too: `run_one` only re-sends after a
+        # network error, so `resent_count` is exactly the count of earlier attempts that failed
+        # and were replaced. The line above counts the FINAL result; without this one a POST
+        # that failed twice and then succeeded on try 3 reported `0 errors` for two real network
+        # failures. `resent_count` is 0 on the common path, so a clean run is byte-unchanged; and
+        # it never double-counts the final attempt, which is the one the `||` above already saw.
+        @errors += result.resent_count
         @events.send(ResultEvent.new(result)) # blocking — never drop a row
         emit_progress
       end
@@ -563,20 +582,48 @@ module Gori::Fuzz
 
     private def run_one(job : Job) : Result
       attempts = 0
+      resent_count = 0
       loop do
         # The payload spans ride with the bytes: `Sender` needs them to tell the operator's
         # test case from the template it was spliced into (see `Backend#send`).
         raw = @backend.send(job.bytes, job.payload_spans)
+        # A scope-gate refusal (Sandbox / an explicit exclude rule) is a PAYLOAD-unit block:
+        # count it once HERE and return, never retry it. Two things depended on this together:
+        #   * the OLD loop DID retry it — a gate error is not `CAP_ERROR` — so with `--retries N`
+        #     the same refused payload re-ran N times, and each re-run bumped `@backend.blocked`
+        #     again; `blocked` then climbed past `sent` and `all_blocked` read true on a run that
+        #     never was fully blocked. Retrying is also pointless: the decision is stable within
+        #     `Outbound::RELOAD_INTERVAL`, so a re-send only burns `retry_pause` and one request.
+        #   * counting on the engine (not the backend) is what keeps a refused redirect HOP —
+        #     which still bumps `@backend.blocked` — out of this tally, since only the PRIMARY
+        #     send reaches this line. See the `@blocked` field comment.
+        # Detected by the two exact strings `Outbound#sweep_block` returns and nothing else does,
+        # so it is precise and race-free across worker fibers (no shared-counter delta to read).
+        if gate_refused?(raw.error)
+          @blocked += 1
+          @blocked_reason ||= raw.error
+          return @matcher.build(job, raw, resent_count: resent_count)
+        end
         # Don't burn retries/sleep on a permanent max-requests stop — further send()s
-        # are also refused. Real network errors still retry as configured.
+        # are also refused. Real network errors still retry as configured; each retry means the
+        # previous attempt was a failed send, tallied via `resent_count` (see `worker_loop`).
         if raw.error && raw.error != CappedBackend::CAP_ERROR && attempts < @config.retries
           attempts += 1
+          resent_count += 1
           sleep @config.retry_pause
           next
         end
         raw = follow_redirects(raw) if @config.follow_redirects? && raw.error.nil?
-        return @matcher.build(job, raw)
+        return @matcher.build(job, raw, resent_count: resent_count)
       end
+    end
+
+    # A send the SCOPE GATE refused before the socket, told apart from a network error by the
+    # two exact strings `Outbound#sweep_block` returns (via `Sender#send`/`GatedBackend#send`).
+    # Kept a string compare rather than a new `Repeater::Result` flag: that struct is shared with
+    # every other engine and must not grow a fuzz-only field — the constants ARE the contract.
+    private def gate_refused?(err : String?) : Bool
+      err == Gori::Outbound::SANDBOX_SWEEP_ERROR || err == Gori::Outbound::EXCLUDE_SWEEP_ERROR
     end
 
     # Follow up to max_redirects SAME-ORIGIN redirects (relative, or absolute to the
@@ -589,6 +636,15 @@ module Gori::Fuzz
       # below keeps the last hop's fields, so without this an original request that was
       # re-sent and then redirected would report as a single clean send.
       retried = raw.retried?
+      # A hop that FAILED — the gate refused its off-scope `Location`, or the target was dead —
+      # must NOT overwrite the payload's real answer. The payload's answer is the 3xx we already
+      # hold in `current`, and that 302 is exactly what an open-redirect probe is hunting; the
+      # old collapse replaced it with the hop's "never dialed" error and destroyed the finding.
+      # When a hop errors we keep the last good response and carry the hop's failure as a NOTE on
+      # the collapsed error — status and body stay the payload's, since an error and a response
+      # are not exclusive (see `cli/run/repeater.cr`). A refused hop is also NOT a payload-block,
+      # so it never touches `@blocked`; only `run_one`'s PRIMARY refusal does.
+      hop_error : String? = nil
       hops = 0
       while hops < @config.max_redirects
         resp = current.response
@@ -613,11 +669,18 @@ module Gori::Fuzz
         # is either a literal gori wrote (`GET`, `Host:`, `Connection: close`) or the origin's
         # own `Location`. Neither is a place an operator could have written a `$NAME` for a
         # binding to resolve, so there is nothing here to substitute in the first place.
-        current = @backend.send(nxt, Backend.all_verbatim(nxt))
-        retried ||= current.retried?
-        total_us += current.duration_us
+        hop = @backend.send(nxt, Backend.all_verbatim(nxt))
+        retried ||= hop.retried?
+        total_us += hop.duration_us
         hops += 1
-        break unless current.error.nil?
+        # Keep `current` (the last good response, e.g. the 302) when the hop failed; attach the
+        # reason rather than replacing the response with it. Prefixed so no surface reads it as
+        # the PAYLOAD's own failure — it is a note about a hop gori chose to follow.
+        if err = hop.error
+          hop_error = "redirect hop refused: #{err}"
+          break
+        end
+        current = hop
       end
       # Report the whole chain's end-to-end time, not just the final hop's — otherwise a
       # slow original request that 3xx's to a fast resource masks a time-based signal.
@@ -626,7 +689,7 @@ module Gori::Fuzz
       # keep-alive re-send in a redirect-following sweep lost its row marker and gained a false
       # `timed_out`. The constructor's tail is keyword-only now, so this cannot recur silently.
       hops > 0 ? Repeater::Result.new(current.head, current.body, current.response, total_us,
-        current.error, current.incomplete?,
+        hop_error || current.error, current.incomplete?,
         delivered: current.delivered?, timed_out: current.timed_out?, retried: retried) : current
     end
 
@@ -720,7 +783,10 @@ module Gori::Fuzz
       # The gRPC framing tally rides along from the Matcher, which is the one object that
       # sees every RENDERED request (see `Matcher#grpc_template?`). All zeroes / nil unless
       # the template was a cleanly-framed gRPC request, so no surface changes for anything else.
-      Progress.new(@sent, total, @matched, @errors, @backend.blocked, @backend.blocked_reason,
+      # `@blocked`/`@blocked_reason` are the ENGINE's payload-unit tally (see the field comment),
+      # NOT `@backend.blocked` — the backend counts every refused call, which double-counts a
+      # gate-refused payload's retries and its redirect hops and poisons `all_blocked`.
+      Progress.new(@sent, total, @matched, @errors, @blocked, @blocked_reason,
         @backend.sent + @backend.extra_requests,
         @matcher.grpc_stale, @matcher.grpc_requests, @matcher.grpc_stale_reason)
     end

--- a/src/gori/fuzz/matcher.cr
+++ b/src/gori/fuzz/matcher.cr
@@ -276,7 +276,12 @@ module Gori::Fuzz
       Metrics.new(raw.response.try(&.status), body.size.to_i64, words, lines, raw.duration_us)
     end
 
-    def build(job : Job, raw : Repeater::Result) : Result
+    # `resent_count` is the number of CONFIG-retry re-sends `Engine#run_one` made after a
+    # network error (0 unless `--retries` fired); it is passed in because the retry loop lives
+    # in the engine, not here — this is the one build site for every Fuzz::Result, so the count
+    # has to arrive as an argument. `timed_out` rides straight off the Repeater result, the twin
+    # of the already-carried `incomplete?`: the engine observed both and, until now, dropped one.
+    def build(job : Job, raw : Repeater::Result, resent_count : Int32 = 0) : Result
       # The OUTGOING request, before anything is said about the response: a payload that
       # changed the gRPC message length leaves the 5-byte prefix declaring the old one.
       note_grpc_framing(job.bytes) if @grpc_template
@@ -302,7 +307,8 @@ module Gori::Fuzz
         head: keep ? present(raw.head) : nil, body: keep ? raw.body : nil,
         request: keep ? present(job.bytes) : nil, retried: raw.retried?,
         chain_error: job.chain_error,
-        grpc_status: grpc_status, grpc_message: grpc_message)
+        grpc_status: grpc_status, grpc_message: grpc_message,
+        timed_out: raw.timed_out?, resent_count: resent_count)
     end
 
     # Count a rendered request whose gRPC framing a payload broke. Only reached while

--- a/src/gori/fuzz/types.cr
+++ b/src/gori/fuzz/types.cr
@@ -116,11 +116,40 @@ module Gori
       # non-gRPC run's output is unchanged.
       getter grpc_status : Int32?
       getter grpc_message : String?
+      # The read that captured this response ended on an IDLE TIMEOUT — the origin held the
+      # socket open and simply stopped sending — rather than on a close or a completed body.
+      # `incomplete?` already says the captured body is SHORT; this says WHICH of the two events
+      # cut it, the twin of `Repeater::Result#timed_out?` (engine.cr:37). Until now `Fuzz::Result`
+      # had no such field at all: the engine observed both `incomplete?` and `timed_out?` and
+      # forwarded only the first, so `incomplete?` reached no consumer and a truncated body was
+      # reported as the whole response on every fuzz surface. Paired with `incomplete?` in the
+      # three-way `CLI::Run.incomplete_reason` classifier the Repeater already uses, so the two
+      # surfaces cannot come to word one flow's truncation differently. false for a completed
+      # send and for any failure that was not a read-deadline stall.
+      getter? timed_out : Bool
+      # How many times this variation was RE-SENT after a network error because `--retries` is on
+      # (a CONFIG retry). DISTINCT from `retried?` above, which is a keep-alive pool re-send on a
+      # parked socket the pool found closed — a caller must be able to tell "the pool redialed a
+      # dead socket" from "the request errored and `--retries` sent it again". `run_one` keeps
+      # re-sending every method on `--retries` by policy; the bug was never the re-send, it was
+      # that the row said nothing about it, so a POST that went out three times before it stuck
+      # read as a single clean send. It is also the count the run's `errors` adds per row: every
+      # superseded attempt is a failed send, and counting only the last one hid the rest inside
+      # `0 errors`. 0 = sent once, no config retry fired (the common path).
+      getter resent_count : Int32
+
+      # A CONFIG retry fired for this variation (see `resent_count`). Derived, not a second
+      # stored field: `resent_count > 0` IS "was it re-sent", and one field carries both the
+      # marker and the count. Deliberately separate from `retried?` (the keep-alive re-send).
+      def resent? : Bool
+        @resent_count > 0
+      end
 
       def initialize(@index, @payloads, @position, @status, @length, @words, @lines,
                      @duration_us, @error, @matched, @incomplete, @extracted,
                      @head = nil, @body = nil, @request = nil, @retried = false,
-                     @chain_error = nil, @grpc_status = nil, @grpc_message = nil)
+                     @chain_error = nil, @grpc_status = nil, @grpc_message = nil,
+                     @timed_out = false, @resent_count = 0)
       end
     end
 

--- a/src/gori/mcp/serialize.cr
+++ b/src/gori/mcp/serialize.cr
@@ -268,6 +268,27 @@ module Gori
           # not. This is where an agent reads it; before, a re-send appeared nowhere but the
           # CLI's own connections summary.
           j.field "retried", true if r.retried?
+          # The `--retries` config re-sent this variation after a network error — DISTINCT from
+          # `retried` above (a keep-alive pool re-send). Emitted only when it happened, with the
+          # count, so an agent can tell a POST that finally stuck on try 3 from a clean single send.
+          if r.resent?
+            j.field "resent", true
+            j.field "resent_count", r.resent_count
+          end
+          # The captured response is SHORT — the origin closed early, the read deadline fired, or
+          # gori hit its capture ceiling — so `length`/`words`/`lines` above describe a fragment,
+          # not the whole response. Emitted only when it happened (like `chain_error`), with the
+          # SAME three-way sentence `CLI::Run.incomplete_reason` gives the Repeater, so an agent
+          # never reads one flow's truncation worded two different ways. That classifier keys off
+          # the raw captured body, which a metrics-only fuzz row keeps only under keep_bodies: an
+          # unmatched, body-dropped row still names the closed/timeout cause correctly, just not
+          # the ceiling one — the body itself is the only evidence for the ceiling, per the
+          # classifier's own doc. A synthetic Repeater::Result carries the body + timing across.
+          if r.incomplete?
+            j.field "incomplete", true
+            j.field "incomplete_reason",
+              CLI::Run.incomplete_reason(Repeater::Result.new(Bytes.new(0), r.body, nil, r.duration_us), r.timed_out?)
+          end
           # Present when record_history recorded this result as a History flow —
           # fetch its full request/response with get_flow (headers redacted).
           j.field "flow_id", flow_id if flow_id

--- a/src/gori/mcp/tools/fuzz.cr
+++ b/src/gori/mcp/tools/fuzz.cr
@@ -147,8 +147,11 @@ module Gori
       private def store_fuzz_result(fjob : FuzzJob, r : Fuzz::Result, flow_id : Int64?) : Nil
         # A RE-SENT row is stored even when it did not match: its request reached the origin
         # twice, and "stored results are matched-only" would put the duplicate back out of an
-        # agent's reach entirely (the CLI at least printed a connections summary).
-        return unless r.matched? || r.retried?
+        # agent's reach entirely (the CLI at least printed a connections summary). `resent?` (a
+        # `--retries` config re-send) and `incomplete?` (the captured response was truncated) join
+        # for the same reason — each is a fact the run OBSERVED, and a matched-only gate would
+        # drop the unmatched row that carries it, so an agent reads `stored_results` as clean.
+        return unless r.matched? || r.retried? || r.resent? || r.incomplete?
         if fjob.results.size < FUZZ_MAX_STORED
           fjob.results << r
           fjob.result_flow_ids << flow_id

--- a/src/gori/mcp/tools/probe.cr
+++ b/src/gori/mcp/tools/probe.cr
@@ -229,7 +229,9 @@ module Gori
           store.set_probe_custom_rule_enabled(row_id, enabled)
         else
           disabled = store.probe_disabled_rules
-          enabled ? disabled.delete(id) : disabled.add(id)
+          # `set_rule_enabled` (not a bare delete/add) so a DEFAULT-OFF rule toggles correctly:
+          # for those ids the stored-set membership is INVERTED — see `Probe::DEFAULT_DISABLED_RULES`.
+          Probe.set_rule_enabled(disabled, id, enabled)
           store.set_probe_disabled_rules(disabled)
         end
         Result.new({"id" => id, "enabled" => enabled, "kind" => entry.kind}.to_json)

--- a/src/gori/mcp/tools/send.cr
+++ b/src/gori/mcp/tools/send.cr
@@ -753,6 +753,11 @@ module Gori
             j.field "duration_us", result.duration_us
             j.field "close_code", result.close_code if result.close_code
             j.field "note", Env.mask_secrets(result.note.not_nil!) if result.note
+            # A cap truncated the inbound transcript: the `messages` array below also carries a
+            # synthetic NOTICE_PREFIX row, but an agent reading only the envelope needs the fact
+            # too. The sentence is gori-authored (no operator bytes), but mask it anyway for the
+            # same one-rule reason the payloads are masked — this surface never emits raw.
+            j.field "truncated", Env.mask_secrets(result.truncated.not_nil!) if result.truncated
             # Only when it FIRED: the session's stored list held gori's own advisory rows and
             # this send is one frame per row short of the capture. See `CLI::Run.ws_seed_rows`.
             if notice_dropped > 0

--- a/src/gori/outbound.cr
+++ b/src/gori/outbound.cr
@@ -291,15 +291,31 @@ module Gori
     # with a URL-keyed include it inverts and fails closed. Do not read this comment as
     # covering the proxy gate.
     def self.request_target(bytes : Bytes) : String
-      request_target_line(String.new(bytes).each_line.first? || "")
+      request_target_line(String.new(bytes))
     end
 
     def self.request_target(text : String) : String
-      request_target_line(text.each_line.first? || "")
+      request_target_line(text)
     end
 
-    private def self.request_target_line(line : String) : String
-      line.split[1]? || "/"
+    # Read the request-TARGET off the request line — but from the first NON-BLANK line,
+    # not blindly the first line. A raw request may arrive with LEADING BLANK LINE(S)
+    # (an operator's authored bytes, or a peer that emits an empty line before the
+    # request-line); `each_line.first?` would then read an empty ("" / bare "\r") first
+    # line, `split[1]?` it to nil, and gate the innocuous "/" while the REAL target sits
+    # on a later line and goes on the wire — a scope/Sandbox bypass, the same failure mode
+    # as the doubled-space case below. So skip leading blank / whitespace-only lines, then
+    # split. The no-arg `split` still collapses whitespace runs (doubled space / tab) and
+    # drops empty parts, and tolerates a stray trailing "\r", so the malformed-first-line
+    # recovery is unchanged; a line with no target (or an all-blank input) still degrades
+    # to "/". The bytes themselves reach the wire byte-exact (P7) — only what the gate
+    # READS changes. (Still `Outbound`-only; see the proxy-gate caveat above.)
+    private def self.request_target_line(text : String) : String
+      text.each_line do |line|
+        next if line.strip.empty? # skip a leading blank / whitespace-only line (incl. a bare "\r")
+        return line.split[1]? || "/"
+      end
+      "/"
     end
 
     # The URL the gate evaluates, ALWAYS anchored on the DIAL target (the scheme/host the

--- a/src/gori/probe/active.cr
+++ b/src/gori/probe/active.cr
@@ -13,6 +13,7 @@ require "./active/path_normalization_bypass"
 require "./active/url_rewrite_bypass"
 require "./active/ssti"
 require "./active/nextjs_action_no_auth"
+require "./active/request_smuggling"
 require "../outbound"
 require "../scope"
 require "../fuzz/engine"
@@ -37,7 +38,7 @@ module Gori
                OpenRedirect.new, HostHeaderInjection.new,
                CrlfInjection.new, PathNormalizationBypass.new,
                UrlRewriteBypass.new, Ssti.new,
-               NextjsActionNoAuth.new] of Rule
+               NextjsActionNoAuth.new, RequestSmuggling.new] of Rule
 
       # Convenience facade over the primary (reflected-param) rule. The analyzer drives the
       # whole RULES list; these keep a stable single-rule entry point for callers/tests.
@@ -149,7 +150,9 @@ module Gori
         # Send-refusal reasons already reported for THIS flow (see the `result.ok?` branch).
         refusals = Set(String).new
         RULES.each do |rule|
-          next if disabled.includes?(rule.info.id)
+          # `rule_disabled?` (not a bare `disabled.includes?`) so a DEFAULT-OFF rule is skipped
+          # on a fresh project even though its id is absent from the set — see DEFAULT_DISABLED_RULES.
+          next if Probe.rule_disabled?(rule.info.id, disabled)
           # ISOLATE each rule. Without this, one rule raising in plan/detections_all took down
           # the whole scan — every rule after it AND (via Scan.scan_flows) every remaining flow,
           # discarding findings already collected. The TUI path has always had this: the analyzer
@@ -184,6 +187,13 @@ module Gori
             # rule from the same captured request, so a differential whose baseline resolved
             # `$id` and whose followup did not would be measuring the substitution.
             plan.followups.each { |req| results << sender.send(req, Fuzz::Backend.all_verbatim(req)) }
+            # THEN the pipeline group (if any): a same-connection sequence sent on ONE dedicated
+            # socket via `send_pipeline`, results appended in order so `detections_all` sees
+            # `[primary, followups…, pipeline…]`. Only the request-smuggling / desync rule ships
+            # one; empty for every other rule = a strict no-op. Kept BYTE-IDENTICAL to the
+            # analyzer's twin loop (`execute_active`) — `active_binding_provenance_spec` exists so
+            # the two cannot drift, the reason the followup marking sits on both.
+            results.concat(sender.send_pipeline(plan.pipeline, plan.probe_timeout)) unless plan.pipeline.empty?
             dets = rule.detections_all(plan, results, detail)
             out.concat(dets)
           rescue ex

--- a/src/gori/probe/active/request_smuggling.cr
+++ b/src/gori/probe/active/request_smuggling.cr
@@ -1,0 +1,392 @@
+require "./types"
+require "../../proxy/codec/http1"
+require "../../proxy/codec/body"
+
+module Gori
+  module Probe
+    module Active
+      # Active HTTP request-smuggling / desync detector (CL.TE / TE.CL / TE.TE).
+      #
+      # A smuggling vulnerability exists when a front-end and a back-end DISAGREE on where one
+      # request's body ends — because they read the Content-Length / Transfer-Encoding framing
+      # differently. gori can already *send* deliberate CL/TE conflicts (Repeater "send group",
+      # the codec's own rejection paths); this rule is the AUTOMATED detector that was the ironic
+      # gap for a framing-centric tool. It is a pure `Active::Rule`: it crafts its OWN synthetic
+      # `POST /` bytes (the captured method/body are irrelevant — only host/port/scheme and the
+      # framing environment matter) and the analyzer owns the send.
+      #
+      # SAFETY POSTURE (user-decided, baked in exactly here):
+      #   * TIMING is the DEFAULT signal. Each timing probe is an INCOMPLETE request that makes one
+      #     framing tier block waiting for bytes that never arrive. It is SELF-DAMAGING: the origin
+      #     abandons it on its own idle timeout and the blast radius is our OWN dedicated socket —
+      #     nothing is smuggled into anyone else's request. Timing probes ride `followups` (a FRESH
+      #     connection each), so the two repeats of a variant confirm INDEPENDENTLY (a shared socket
+      #     could not — the first hang would retire it and the second would read as "skipped").
+      #   * The DIFFERENTIAL confirm leg sends a COMPLETE smuggled prefix and reads the poisoned
+      #     follow-up on the SAME socket (a `pipeline` group). A complete prefix could, in a shared
+      #     back-end pool, affect ANOTHER user, so it runs ONLY under `opts.aggressive &&
+      #     opts.allow_unsafe` — never in the default automatic scan.
+      #   * DISABLED-BY-DEFAULT in the Rules sub-tab (it sends POST bodies): the rule's id is in
+      #     `Probe::DEFAULT_DISABLED_RULES`, so the operator must opt in before it ever runs — which
+      #     is what keeps the intrusive differential from auto-firing even in AGGRESSIVE mode.
+      #   * `opts.allow_unsafe` is required to build a plan at all (synthetic POST bodies), so an
+      #     automatic SAFE-method sweep is a strict no-op regardless of the toggle.
+      #
+      # VERDICT: High for a timing-only lead (a confirmed desync PRIMITIVE — one tier blocks on an
+      # incomplete body the other considered complete — but exploitation is unproven); Critical when
+      # the differential confirm fires (a smuggled canary demonstrably poisoned a neighbouring
+      # request). Two independent repeats per variant plus a fast, reproducible baseline turn
+      # endpoint jitter into a DECLINE rather than a finding (the backslash_powered discipline).
+      class RequestSmuggling < Rule
+        # µs thresholds for the timing verdict. A probe is "hung" when it runs at least
+        # DELAY_THRESHOLD longer than the baseline (a real desync makes a tier wait for its whole
+        # idle timeout — seconds — not the milliseconds a live endpoint answers in). BASE_FAST
+        # gates the whole verdict on a reproducibly FAST baseline: a slow/loaded endpoint cannot
+        # support a timing test, so it declines instead of firing on every variant.
+        DELAY_THRESHOLD =  4_000_000_i64 # 4s slower than baseline ⇒ a tier blocked
+        BASE_FAST       =  1_000_000_i64 # baseline must answer under 1s or we decline
+        # Per-probe read bound for the DIFFERENTIAL pipeline (well under the analyzer's
+        # ACTIVE_TIMEOUT of 10s): a poisoned follow-up either answers or misframes quickly, and we
+        # never want a hung pipeline member to eat the whole per-probe budget. Timing probes ride
+        # `followups`, which use the analyzer's Sender timeout — a hang there returns a clean
+        # timeout error (the signal) at that bound.
+        PROBE_TIMEOUT = 6.seconds
+
+        # Response-head tokens that betray a front-end/back-end split (a CDN, a reverse proxy, a
+        # load balancer). A desync can only exist when SOMETHING sits in front re-framing requests,
+        # so this is a PRE-FILTER that keeps the intrusive probe off plainly-single-origin targets.
+        # It is NEVER a verdict input — the timing/differential evidence is — only a gate on whether
+        # to spend the probes at all. Lower-cased compare against the raw response head.
+        FRONTEND_HEADER_HINTS = ["via:", "x-cache:", "x-served-by:", "x-varnish:", "cf-ray:",
+                                 "x-amz-cf-id:", "x-fastly", "fastly-", "x-envoy"]
+        FRONTEND_SERVER_HINTS = ["cloudflare", "cloudfront", "nginx", "awselb", "varnish",
+                                 "envoy", "haproxy", "akamai", "fastly"]
+
+        # The three desync classes, each a {code, short label, header-combo tag}. `detections_all`
+        # reads each variant's two timing probes back at a fixed offset (see PROBE_LAYOUT).
+        VARIANTS = [
+          {"request_smuggling_clte", "CL.TE", "CL + TE:chunked"},
+          {"request_smuggling_tecl", "TE.CL", "TE:chunked + CL"},
+          {"request_smuggling_tete", "TE.TE", "TE:chunked + obfuscated TE"},
+        ]
+
+        # Result layout the analyzer produces for this rule's plan:
+        #   [0] baseline #1 (plan.request)   [1] baseline #2 (stability twin)
+        #   [2],[3] CL.TE probes             [4],[5] TE.CL probes    [6],[7] TE.TE probes
+        #   [8] differential smuggle  [9] differential benign follow-up   (aggressive only)
+        BASELINE_COUNT   = 2
+        DIFF_SMUGGLE_IDX = BASELINE_COUNT + VARIANTS.size * 2       # 8
+        DIFF_BENIGN_IDX  = DIFF_SMUGGLE_IDX + 1                     # 9
+
+        def info : RuleInfo
+          RuleInfo.new("request_smuggling", "HTTP request smuggling / desync (CL.TE/TE.CL/TE.TE)",
+            "Sends incomplete CL.TE/TE.CL/TE.TE framing probes and flags a front-end/back-end desync " \
+            "by a timing hang (differential confirm under aggressive+unsafe). Off by default; sends POST bodies.",
+            Category::ACTIVE)
+        end
+
+        # 2 baselines + 2 probes per variant = 8 timing sends; +2 for the differential pipeline
+        # (aggressive+unsafe only). Static annotation for the Rules sub-tab + manual-run estimate.
+        def requests_per_flow : Range(Int32, Int32)
+          BASELINE_COUNT + VARIANTS.size * 2..DIFF_BENIGN_IDX + 1
+        end
+
+        def dedup_key(detail : Store::FlowDetail, opts : Options = Options::DEFAULT) : String?
+          g = gate(detail, opts) || return nil
+          key_string(g[0], g[1], opts)
+        end
+
+        def plan(detail : Store::FlowDetail, opts : Options = Options::DEFAULT) : Plan?
+          host, port = gate(detail, opts) || return nil
+          hdr = host_header(host, port, detail.row.scheme)
+          baseline = benign_post(hdr)
+          followups = [benign_post(hdr)] # baseline #2 — the stability twin (measure-against-itself)
+          # Two INDEPENDENT repeats of each variant's timing probe (fresh connection each). Order
+          # matches PROBE_LAYOUT so detections_all can read them back positionally.
+          followups << clte_probe(hdr) << clte_probe(hdr)
+          followups << tecl_probe(hdr) << tecl_probe(hdr)
+          followups << tete_probe(hdr) << tete_probe(hdr)
+
+          pipeline = [] of Bytes
+          timeout = nil.as(Time::Span?)
+          if differential_armed?(opts)
+            # The COMPLETE smuggled prefix carries a self-attributed random canary path; the benign
+            # GET rides the SAME socket right behind it. The smuggle's OWN response must come back
+            # complete (so `send_pipeline` does not retire the socket before the benign follow-up) —
+            # `detections_all` only counts a confirm when it did.
+            canary = "/gori-smuggle-#{Random::Secure.hex(6)}"
+            pipeline = [diff_smuggle(hdr, canary), diff_benign(hdr)]
+            timeout = PROBE_TIMEOUT
+          end
+          Plan.new(baseline, canary_params(opts), key_string(host, port, opts), followups,
+            pipeline: pipeline, probe_timeout: timeout)
+        end
+
+        # results = [baseline1, baseline2, clte×2, tecl×2, tete×2, (smuggle, benign)?]. Fire a
+        # variant when BOTH its probes hung against a fast, reproducible baseline; escalate to
+        # Critical when the differential leg confirms a real poison. One Detection per fired variant.
+        def detections_all(plan : Plan, results : Array(Repeater::Result), detail : Store::FlowDetail) : Array(Detection)
+          t_base = stable_baseline(results) || return [] of Detection
+          confirmed = differential_confirmed?(results)
+          out = [] of Detection
+          VARIANTS.each_with_index do |(code, label, combo), i|
+            a = results[BASELINE_COUNT + i * 2]?
+            b = results[BASELINE_COUNT + i * 2 + 1]?
+            next unless a && b
+            next unless hung?(a, t_base) && hung?(b, t_base) # BOTH repeats — one alone is jitter
+            out << detection(detail, code, label, combo, t_base, confirmed)
+          end
+          # A differential that fired but pinned NO timing variant is still a confirmed poison —
+          # the smuggle prefix is CL.TE-shaped, so attribute it there rather than silently drop it.
+          if confirmed && out.empty?
+            c, l, combo = VARIANTS[0]
+            out << detection(detail, c, l, combo, t_base, true)
+          end
+          out
+        rescue
+          [] of Detection
+        end
+
+        # Single-response fallback (module facade / one-shot caller): the timing test needs the
+        # whole probe set, so one response alone yields nothing. The analyzer always calls
+        # detections_all with the full result list.
+        def detections(plan : Plan, result : Repeater::Result, detail : Store::FlowDetail) : Array(Detection)
+          detections_all(plan, [result], detail)
+        end
+
+        # ── gate ─────────────────────────────────────────────────────────────────────
+
+        # Shared gate for plan + dedup_key (so they cannot drift — the equivalence invariant: nil
+        # from exactly the same inputs): {host, port} for an HTTP/1.1 flow, under allow_unsafe, that
+        # a front-end appears to sit in front of; nil otherwise. Every branch is a PRE-FILTER, never
+        # a verdict input.
+        private def gate(detail : Store::FlowDetail, opts : Options) : {String, Int32}?
+          # OFF-WIRE self-validation — HERE (in the SHARED gate), not in `plan`, precisely so
+          # `dedup_key` returns nil in the same cases: prove the crafts still trip gori's OWN codec
+          # exactly as the technique requires (CL.TE/TE.CL raise the CL+TE rejection; TE.TE trips
+          # obfuscated_header? AND raises the obfuscation error). A future codec change that stops
+          # reading these as ambiguous turns the rule into a NO-OP instead of shipping a probe whose
+          # evidence would no longer be true. Host-independent + memoized, so it costs nothing per call.
+          return nil unless crafts_ok?
+          # HTTP/2 has one unambiguous framing (length-prefixed frames) — the h1 CL/TE ambiguity
+          # this rule exercises does not exist there, and `send_pipeline` is h1-only anyway.
+          return nil if detail.http_version.starts_with?("HTTP/2")
+          # Synthetic POST bodies — never sent under a safe-method automatic sweep.
+          return nil unless opts.allow_unsafe
+          return nil unless frontend_present?(detail.response_head)
+          host = detail.row.host
+          return nil if host.empty?
+          {host, detail.row.port}
+        end
+
+        # A LIGHT heuristic that something re-frames requests in front of the origin (a desync needs
+        # a front-end/back-end disagreement to exist). Pre-filter ONLY — a miss just skips the probe.
+        private def frontend_present?(response_head : Bytes?) : Bool
+          head = response_head
+          return false unless head && !head.empty?
+          hay = String.new(head).downcase
+          return true if FRONTEND_HEADER_HINTS.any? { |h| hay.includes?(h) }
+          # `Server:` naming a known edge/proxy product.
+          hay.each_line do |line|
+            next unless line.starts_with?("server:")
+            return FRONTEND_SERVER_HINTS.any? { |s| line.includes?(s) }
+          end
+          false
+        rescue
+          false
+        end
+
+        # host:PORT surface key (+`|aggr` when the differential leg is armed — an aggressive scan
+        # sends a WIDER probe set than a plain unsafe one, so its key must differ or the
+        # ACTIVE↔AGGRESSIVE backfill would skip an already-seen surface and never send the extra
+        # leg). Byte-identical between plan and dedup_key for the same opts.
+        private def key_string(host : String, port : Int32, opts : Options) : String
+          "request_smuggling|#{host}:#{port}#{differential_armed?(opts) ? "|aggr" : ""}"
+        end
+
+        private def differential_armed?(opts : Options) : Bool
+          opts.aggressive && opts.allow_unsafe
+        end
+
+        # No canary↔param mapping (this rule tests transport framing, not a parameter); the Param
+        # list only carries an `|aggr`-visible marker so the Rules estimate/tooling has a stable row.
+        private def canary_params(opts : Options) : Array(Param)
+          [] of Param
+        end
+
+        # ── verdict helpers ────────────────────────────────────────────────────────────
+
+        # The baseline µs to compare probes against, or nil to DECLINE the whole flow. Both benign
+        # baselines must have SENT cleanly, come back COMPLETE, and answer under BASE_FAST — a
+        # failed, incomplete, or slow baseline cannot anchor a timing test, so every variant would
+        # be a coin flip. Uses the SLOWER of the two, so a single fast fluke can't lower the bar.
+        private def stable_baseline(results : Array(Repeater::Result)) : Int64?
+          b1 = results[0]?
+          b2 = results[1]?
+          return nil unless b1 && b2
+          return nil unless b1.ok? && b2.ok?
+          return nil if b1.incomplete? || b2.incomplete?
+          t = Math.max(b1.duration_us, b2.duration_us)
+          t < BASE_FAST ? t : nil
+        end
+
+        # A probe "hung" iff it ran at least DELAY_THRESHOLD longer than the baseline (an idle
+        # read timing out on a tier that blocked for bytes that never arrived) or the transport
+        # reported an idle timeout. A FAST error (a strict 4xx reject, a connection refused, a
+        # prompt RST) is deliberately NOT counted — it is not a timing signal, so this can't
+        # false-fire on a server that simply rejects the ambiguous framing quickly.
+        private def hung?(p : Repeater::Result, t_base : Int64) : Bool
+          return true if p.timed_out?
+          p.duration_us - t_base > DELAY_THRESHOLD
+        end
+
+        # The differential leg confirmed a poison: the COMPLETE smuggle got its own complete
+        # response (so the socket was NOT retired and the benign follow-up really rode behind it),
+        # AND that benign follow-up came back ANOMALOUS — errored/incomplete after a live smuggle,
+        # a malformed/ambiguous head a lenient recipient would reframe, or a body reflecting our
+        # own smuggled canary path. Absent/empty pipeline (timing-only) ⇒ false.
+        private def differential_confirmed?(results : Array(Repeater::Result)) : Bool
+          smuggle = results[DIFF_SMUGGLE_IDX]?
+          benign = results[DIFF_BENIGN_IDX]?
+          return false unless smuggle && benign
+          # Socket must have survived the smuggle — otherwise `benign` is a "skipped" Result and its
+          # error says nothing about a poison.
+          return false unless smuggle.ok? && !smuggle.incomplete?
+          return true if benign.error || benign.incomplete?
+          head = benign.head
+          return false if head.empty?
+          resp = Proxy::Codec::Http1.parse_response_head(head)
+          return true if resp.malformed?
+          return true if Proxy::Codec::Http1.framing_ambiguous?(head, resp.headers)
+          # The benign GET was for `/`; our smuggled canary path surfacing in ITS response means the
+          # back-end served the smuggled request instead — the clearest possible confirmation.
+          if body = benign.body
+            return String.new(body).includes?("gori-smuggle-")
+          end
+          false
+        rescue
+          false
+        end
+
+        private def detection(detail : Store::FlowDetail, code : String, label : String, combo : String,
+                              t_base : Int64, confirmed : Bool) : Detection
+          base_ms = (t_base / 1000).to_i
+          ev = "#{label}: #{combo}; baseline #{base_ms}ms → probe hung >#{DELAY_THRESHOLD // 1_000_000}s, 2/2"
+          ev += "; differential confirmed" if confirmed
+          Detection.new(code, Category::ACTIVE, detail.row.host, detail.row.url,
+            "Possible HTTP request smuggling / desync (#{label})",
+            confirmed ? Store::Severity::Critical : Store::Severity::High,
+            ev[0, 120], detail.row.id)
+        end
+
+        # ── craft ────────────────────────────────────────────────────────────────────
+
+        # "host[:port]" for the Host header — the port is elided only for the scheme's default.
+        private def host_header(host : String, port : Int32, scheme : String) : String
+          default = scheme == "https" ? 443 : 80
+          port == default ? host : "#{host}:#{port}"
+        end
+
+        # A benign, COMPLETE, body-less POST — the timing baseline. CL:0 is unambiguous framing, so
+        # every conformant tier answers it fast and identically.
+        private def benign_post(hdr : String) : Bytes
+          "POST / HTTP/1.1\r\nHost: #{hdr}\r\nContent-Length: 0\r\n\r\n".to_slice
+        end
+
+        # CL.TE timing probe: front-end honours Content-Length (reads the whole 6-byte body and
+        # forwards it), back-end honours Transfer-Encoding (reads chunk `1`=`Z`, then BLOCKS waiting
+        # for the terminating `0`-chunk that never comes). CL == the exact body length, so a
+        # CL-only server answers fast; only a TE-reading tier hangs.
+        private def clte_probe(hdr : String) : Bytes
+          body = "1\r\nZ\r\n" # 6 bytes: one 1-byte chunk, no 0-terminator
+          "POST / HTTP/1.1\r\nHost: #{hdr}\r\nContent-Length: #{body.bytesize}\r\nTransfer-Encoding: chunked\r\n\r\n#{body}".to_slice
+        end
+
+        # TE.CL timing probe: front-end honours Transfer-Encoding (the `0`-chunk ends the request),
+        # back-end honours Content-Length (waits for 6 body bytes but only 5 — `0\r\n\r\n` — arrive,
+        # so it BLOCKS for the missing byte). A TE-only server answers fast; only a CL-reading tier
+        # hangs. CL is deliberately one greater than the bytes sent.
+        private def tecl_probe(hdr : String) : Bytes
+          body = "0\r\n\r\n" # 5 bytes: the terminating chunk only
+          "POST / HTTP/1.1\r\nHost: #{hdr}\r\nContent-Length: #{body.bytesize + 1}\r\nTransfer-Encoding: chunked\r\n\r\n#{body}".to_slice
+        end
+
+        # TE.TE timing probe: an OBFUSCATED Transfer-Encoding (whitespace before the colon) that a
+        # lenient tier strips and honours (reads chunked → blocks on the incomplete chunk) while a
+        # strict tier cannot match the field name and falls back to Content-Length (reads 6 bytes →
+        # complete). `Http1.obfuscated_header?` sees the space-before-colon (self-validated).
+        private def tete_probe(hdr : String) : Bytes
+          body = "1\r\nZ\r\n"
+          "POST / HTTP/1.1\r\nHost: #{hdr}\r\nTransfer-Encoding : chunked\r\nContent-Length: #{body.bytesize}\r\n\r\n#{body}".to_slice
+        end
+
+        # The COMPLETE differential smuggle (aggressive+unsafe only): a CL.TE prefix whose
+        # Content-Length spans the ENTIRE buffer (so a CL front-end forwards all of it and the outer
+        # request gets a normal, complete response), while a TE back-end ends the outer request at
+        # the `0`-chunk and leaves the trailing `GET /<canary>` buffered as the START of the next
+        # request — poisoning whatever rides the socket next (our benign GET).
+        private def diff_smuggle(hdr : String, canary : String) : Bytes
+          smuggled = "0\r\n\r\nGET #{canary} HTTP/1.1\r\nX-Gori-Smuggle: 1\r\n"
+          "POST / HTTP/1.1\r\nHost: #{hdr}\r\nContent-Length: #{smuggled.bytesize}\r\nTransfer-Encoding: chunked\r\n\r\n#{smuggled}".to_slice
+        end
+
+        # The benign follow-up that rides the socket right behind the smuggle. On a desyncing
+        # back-end it is prefixed by the buffered `GET /<canary>` and answers anomalously.
+        private def diff_benign(hdr : String) : Bytes
+          "GET / HTTP/1.1\r\nHost: #{hdr}\r\n\r\n".to_slice
+        end
+
+        # ── off-wire self-validation ───────────────────────────────────────────────────
+
+        # Memoized craft validity (see `gate`). Host-independent — the framing STRUCTURE the codec
+        # judges is identical for every host — so it is computed once against a representative host
+        # and cached. `@@` (not a const) because it calls instance craft helpers; a class variable
+        # keeps it a single evaluation shared across the registry's one rule instance.
+        @@crafts_ok : Bool? = nil
+
+        private def crafts_ok? : Bool
+          v = @@crafts_ok
+          return v unless v.nil?
+          @@crafts_ok = crafts_valid?("selfcheck.invalid")
+        end
+
+        # Prove the crafts still mean what their evidence claims, against gori's OWN codec. Any drift
+        # ⇒ the rule declines (via `gate`) rather than sending a probe whose framing the current
+        # codec no longer reads as ambiguous.
+        private def crafts_valid?(hdr : String) : Bool
+          framing_rejected?(clte_probe(hdr)) &&
+            framing_rejected?(tecl_probe(hdr)) &&
+            framing_rejected?(diff_smuggle(hdr, "/gori-smuggle-selfcheck")) &&
+            obfuscation_rejected?(tete_probe(hdr))
+        end
+
+        # `Body.request_framing` RAISES on this craft (the CL+TE / obfuscation rejection). We pass
+        # the HEAD only — the boundary the codec parses — mirroring how the proxy holds `raw_head`.
+        private def framing_rejected?(req : Bytes) : Bool
+          head = head_of(req)
+          Proxy::Codec::Body.request_framing(Proxy::Codec::Http1.parse_request_head(head))
+          false
+        rescue Gori::Error
+          true
+        rescue
+          false
+        end
+
+        # The TE.TE craft trips `obfuscated_header?` AND makes `request_framing` raise the
+        # obfuscation error — both, so a codec that learned to tolerate one still turns this off.
+        private def obfuscation_rejected?(req : Bytes) : Bool
+          head = head_of(req)
+          Proxy::Codec::Http1.obfuscated_header?(head) && framing_rejected?(req)
+        end
+
+        # The request head up to and including the terminating CRLFCRLF (or the whole buffer if it
+        # somehow lacks one), so the codec parses the same boundary the proxy would capture.
+        private def head_of(req : Bytes) : Bytes
+          s = String.new(req)
+          i = s.index("\r\n\r\n")
+          i ? req[0, i + 4] : req
+        end
+      end
+    end
+  end
+end

--- a/src/gori/probe/active/types.cr
+++ b/src/gori/probe/active/types.cr
@@ -46,8 +46,22 @@ module Gori
       # rule — any FOLLOW-UP requests. The analyzer sends `request` first, then each entry of
       # `followups` in order, and hands every response to `detections_all` (primary first). Single-
       # probe rules leave `followups` empty, so exactly one request is sent (the historic behaviour).
+      #
+      # `pipeline` is a SAME-CONNECTION request GROUP: the analyzer sends it AFTER `request` +
+      # `followups` on ONE dedicated socket, back-to-back and in order, via `Fuzz::Backend#send_pipeline`
+      # (`Repeater::Engine.send_pipeline` underneath), and appends its results in order — so
+      # `detections_all` sees `[primary, followups…, pipeline…]`. This is the ONE thing a fresh
+      # connection per send can never reveal: a desync induced by pipeline member N surfaces only as a
+      # corrupted/misaligned response to member N+1 on the same socket. The active request-smuggling /
+      # desync rule is the only one that uses it (a CL.TE/TE.CL/TE.TE probe sequence); `probe_timeout`
+      # bounds those sends tighter than the analyzer's ACTIVE_TIMEOUT so an INCOMPLETE timing probe
+      # returns (via a read timeout) well inside the per-probe budget. An EMPTY `pipeline` (every other
+      # rule) is a strict no-op — the branch is skipped and behaviour is byte-for-byte unchanged. Both
+      # tail-default so all existing `Plan.new` sites (≤4 positional args) keep compiling untouched.
       record Plan, request : Bytes, params : Array(Param), dedup_key : String,
-        followups : Array(Bytes) = [] of Bytes
+        followups : Array(Bytes) = [] of Bytes,
+        pipeline : Array(Bytes) = [] of Bytes,
+        probe_timeout : Time::Span? = nil
 
       # Strip a scheme://authority prefix so an absolute-form (forward-proxy) target becomes
       # origin-form; an already-origin-form target passes through unchanged. The authority

--- a/src/gori/probe/analyzer.cr
+++ b/src/gori/probe/analyzer.cr
@@ -198,7 +198,7 @@ module Gori
                           opts : Active::Options = Active::Options::DEFAULT) : Array(ActiveEstimate)
         return [] of ActiveEstimate if active_degraded?
         Active::RULES.compact_map do |rule|
-          next if @disabled.includes?(rule.info.id)
+          next if Probe.rule_disabled?(rule.info.id, @disabled)
           next unless rule.dedup_key(detail, opts)
           ActiveEstimate.new(rule.info, rule.requests_per_flow)
         end
@@ -226,7 +226,7 @@ module Gori
           errored = false
           Active::RULES.each do |rule|
             break if @stopped
-            next if @disabled.includes?(rule.info.id)
+            next if Probe.rule_disabled?(rule.info.id, @disabled)
             plan = rule.plan(detail, opts)
             next unless plan
             if wrote = execute_active(rule, plan, detail, repeater_id: repeater_id, notify: notify)
@@ -394,7 +394,7 @@ module Gori
         # permissive when the ⇧S display lens is off. AGGRESSIVE never widens this.
         return unless @outbound.allows?(url, row.host)
         opts = active_opts
-        Active::RULES.each { |rule| enqueue_probe(rule, detail, opts) unless @disabled.includes?(rule.info.id) }
+        Active::RULES.each { |rule| enqueue_probe(rule, detail, opts) unless Probe.rule_disabled?(rule.info.id, @disabled) }
       rescue Channel::ClosedError
       end
 
@@ -509,6 +509,12 @@ module Gori
         # Verbatim here too — a differential whose baseline resolved `$id` and whose followup
         # did not would be measuring the substitution rather than the target.
         plan.followups.each { |req| results << sender.send(req, Fuzz::Backend.all_verbatim(req)) }
+        # THEN the pipeline group (if any): the request-smuggling / desync rule's same-connection
+        # probe sequence, sent on ONE dedicated socket via `send_pipeline`, results appended in
+        # order → `detections_all` sees `[primary, followups…, pipeline…]`. Empty for every other
+        # rule = a strict no-op. Kept BYTE-IDENTICAL to the twin loop in `Active.analyze` — the
+        # two look interchangeable, so they share one spelling and cannot drift again.
+        results.concat(sender.send_pipeline(plan.pipeline, plan.probe_timeout)) unless plan.pipeline.empty?
         detections = rule.detections_all(plan, results, detail)
         return 0 if detections.empty?
         wrote = 0

--- a/src/gori/probe/issue.cr
+++ b/src/gori/probe/issue.cr
@@ -24,6 +24,40 @@ module Gori
     # value would leave those findings unfilterable.
     FILTER_CATEGORIES = SCAN_CATEGORIES + [Category::CUSTOM]
 
+    # Built-in rules that ship DISABLED and must be explicitly enabled in the Rules sub-tab
+    # before they run. Today only the active request-smuggling / desync detector: it sends
+    # synthetic POST bodies, and under AGGRESSIVE mode its differential-confirm leg puts a
+    # COMPLETE smuggled prefix on the wire (which, against a shared back-end pool, could affect
+    # another user) — so the user-decided posture is off-by-default, opt-in only.
+    #
+    # The per-project `probe_disabled_rules` store records the operator's DEVIATION FROM DEFAULT,
+    # so membership FLIPS meaning for these ids: for an ordinary (default-ON) rule, being in the
+    # set means "turned off"; for a default-OFF rule, being in the set means "turned on". One
+    # stored set still captures the whole config, and a fresh project (empty set) has every
+    # ordinary rule on and every default-off rule off. Read AND write BOTH go through the three
+    # helpers below, so the flip lives in exactly ONE place and no surface (catalog, analyzer,
+    # headless scan, the toggle commands) can drift on what "disabled" means.
+    DEFAULT_DISABLED_RULES = Set{"request_smuggling"}
+
+    # Whether the analyzer/scan must SKIP rule `id`, given the project's stored disabled-id set.
+    def self.rule_disabled?(id : String, stored : Set(String)) : Bool
+      DEFAULT_DISABLED_RULES.includes?(id) ? !stored.includes?(id) : stored.includes?(id)
+    end
+
+    # The Rules-sub-tab "enabled" flag — the strict inverse, spelled once so the two agree.
+    def self.rule_enabled?(id : String, stored : Set(String)) : Bool
+      !rule_disabled?(id, stored)
+    end
+
+    # Apply a Rules sub-tab toggle to `stored` (mutated in place); callers then persist it via
+    # `Store#set_probe_disabled_rules`. Honours the flip: for a default-OFF rule, enabling means
+    # PRESENT and disabling means ABSENT — the mirror of an ordinary rule, so the historic
+    # `enabled ? delete : add` shorthand cannot be used directly on these ids.
+    def self.set_rule_enabled(stored : Set(String), id : String, enabled : Bool) : Nil
+      want_present = DEFAULT_DISABLED_RULES.includes?(id) ? enabled : !enabled
+      want_present ? stored.add(id) : stored.delete(id)
+    end
+
     # Static, display-only metadata for one built-in check — the identity the Rules
     # sub-tab lists and toggles by. `id` is a stable slug (one per Rule class, even when
     # the class emits several codes, e.g. Cookies → cookie_*); disabling a rule keys off it.
@@ -104,6 +138,9 @@ module Gori
       "url_rewrite_bypass"             => "A probe reached a denied resource by requesting / with an X-Original-URL / X-Rewrite-URL header naming the gated path, and got different (served) content than the plain root. Don't let application URL-rewrite headers override the routed path for authorization; strip X-Original-URL / X-Rewrite-URL at the edge and enforce access control on the actual request path. Single-shot; confirm manually.",
       "ssti"                           => "A probe injected template expressions in this parameter and the server returned their evaluated results (7*7→49 and 7*8→56), indicating server-side template injection — frequently a path to remote code execution. Never build templates from user input; pass user data as template variables/context, use a sandboxed or logic-less engine, and validate input. Confirm the engine and impact manually.",
       "nextjs_action_no_auth"          => "A probe re-sent this Next.js server action (Next-Action) with the session Cookie / Authorization removed and still received a comparable 2xx response. Next.js does not authenticate or authorize server actions for you — enforce authentication and per-user authorization INSIDE every 'use server' function (and treat each action as a public, unauthenticated endpoint until it does). Single-shot; confirm the unauthenticated response actually contains privileged data.",
+      "request_smuggling_clte"         => "A timing probe hung on a CL.TE framing conflict: the front-end framed this request by Content-Length while the back-end honoured Transfer-Encoding, so one tier blocked on a body the other had already ended — a request-smuggling / desync primitive. The front-end and back-end MUST agree on framing: reject any request carrying BOTH Content-Length and Transfer-Encoding (RFC 7230 §3.3.3), normalize/strip conflicting framing at the edge, and prefer HTTP/2 end-to-end (its length-prefixed framing removes the ambiguity). Confirm manually with the Repeater 'send group' (a complete smuggled prefix + a benign follow-up on one connection).",
+      "request_smuggling_tecl"         => "A timing probe hung on a TE.CL framing conflict: the front-end honoured Transfer-Encoding (the request ended at the terminating chunk) while the back-end waited for Content-Length bytes that never arrived — a request-smuggling / desync primitive. The front-end and back-end MUST agree on framing: reject requests carrying BOTH Content-Length and Transfer-Encoding, have the edge re-chunk or strip conflicting framing, and prefer HTTP/2 end-to-end. Confirm manually with the Repeater 'send group'.",
+      "request_smuggling_tete"         => "A timing probe hung on a TE.TE framing conflict: an OBFUSCATED Transfer-Encoding header (whitespace before the colon / duplicated TE) was honoured by one tier and ignored by the other, desyncing where the body ends — a request-smuggling primitive. Normalize or REJECT obfuscated Transfer-Encoding at the edge (whitespace-before-colon, obs-fold, duplicated/hidden TE), reject Content-Length + Transfer-Encoding together, and prefer HTTP/2 end-to-end. Confirm manually with the Repeater 'send group'.",
       "jwt_alg_none"                   => "A token in use declares alg:none, i.e. it carries no signature. Pin the accepted algorithm server-side (never trust the token's own header), reject 'none' outright, and verify every token before reading its claims. Confirm whether the server actually accepts it with the JWT workbench / `gori run jwt --attacks`.",
       "jwt_weak_alg"                   => "The token's alg is outside the standard JWS set, so how the verifier handles it is unpredictable. Use a registered algorithm (EdDSA / ES256 / RS256, or HS256 with a high-entropy secret) and validate it against a server-side allowlist.",
       "jwt_no_expiry"                  => "The token carries no exp claim, so it stays valid until the signing key changes. Issue short-lived access tokens with exp (and refresh tokens for longevity), and reject tokens without one.",

--- a/src/gori/probe/rule_catalog.cr
+++ b/src/gori/probe/rule_catalog.cr
@@ -52,8 +52,10 @@ module Gori
       # one the enable/disable surfaces take.
       private def builtin(info : RuleInfo, kind : String, disabled : Set(String),
                           estimate : String? = nil) : Entry
+        # `rule_enabled?` (not a bare `!disabled.includes?`) so a DEFAULT-OFF rule shows off on a
+        # fresh project even though its id is absent from the set — see `DEFAULT_DISABLED_RULES`.
         Entry.new(id: info.id, name: info.name, description: info.description,
-          category: info.category, kind: kind, enabled: !disabled.includes?(info.id),
+          category: info.category, kind: kind, enabled: Probe.rule_enabled?(info.id, disabled),
           estimate: estimate)
       end
 

--- a/src/gori/proxy/codec/body.cr
+++ b/src/gori/proxy/codec/body.cr
@@ -437,16 +437,35 @@ module Gori::Proxy::Codec
           end
           return true # terminating chunk reached
         end
-        return false unless copy_n(src, dst, tee, size, cbuf) # truncated mid-chunk
-        if crlf = read_exact(src, 2)                          # the CRLF terminating the chunk data
-          emit(dst, tee, crlf)
-        end
+        return false unless copy_n(src, dst, tee, size, cbuf)             # truncated mid-chunk
+        return false unless copy_chunk_terminator(src, dst, tee, line_buf) # bad/absent chunk-data terminator → desync
       end
     end
 
     private def self.emit(dst : IO, tee : IO, bytes : Bytes) : Nil
       dst.write(bytes)
       tee.write(bytes)
+    end
+
+    # Consume + forward the terminator after a chunk's DATA: an OPTIONAL CR then the
+    # REQUIRED LF. The old blind read_exact(src, 2) assumed a 2-byte CRLF, so on a bare-LF
+    # terminator (1 byte — non-conformant but seen on the wire) it swallowed the LF PLUS the
+    # first byte of the NEXT chunk-size line: every later chunk misframes, the forward
+    # truncates, and read_complete reports a false "upstream closed". read_crlf_line reads
+    # up-to-and-including the LF, so it takes exactly "\r\n" (conformant — byte-identical to
+    # the old read) or "\n" (bare-LF), mirroring scan_chunks' "optional CR then LF"
+    # (content_decode.cr:218-224) in streaming form. But read_crlf_line reads to the NEXT LF,
+    # so reject anything that is not JUST the terminator (>2 bytes, LF-less, or a 2-byte form
+    # that is not CR+LF): an EOF/cap-truncated read or junk before the LF is a framing error
+    # → false (abort/close), exactly like a bad size line (:412) or an unterminated trailer
+    # (:432). Emit only after the check, so a truncated terminator never reaches the wire.
+    private def self.copy_chunk_terminator(src : IO, dst : IO, tee : IO, line_buf : IO::Memory) : Bool
+      term = read_crlf_line(src, line_buf)
+      return false if term.nil?
+      return false unless term.size <= 2 && term[term.size - 1] == 0x0a_u8 &&
+                          (term.size == 1 || term[0] == 0x0d_u8)
+      emit(dst, tee, term)
+      true
     end
 
     # Reads up to and including the next LF. Returns nil on EOF before any byte.
@@ -469,12 +488,6 @@ module Gori::Proxy::Codec
       end
       return nil if buf.bytesize == 0
       scratch ? buf.to_slice : buf.to_slice.dup
-    end
-
-    private def self.read_exact(io : IO, n : Int32) : Bytes?
-      buf = Bytes.new(n)
-      read = io.read_fully?(buf)
-      read ? buf : nil
     end
 
     # Parse a chunk-size line: hex digits before any ';' chunk-extension. Returns

--- a/src/gori/repeater/minimize.cr
+++ b/src/gori/repeater/minimize.cr
@@ -375,16 +375,148 @@ module Gori::Repeater
     end
 
     private def self.json_candidate(key : String) : Candidate
+      # BYTE-SPLICE the target key out of the AUTHORED body, never `JSON.parse(body).to_json`:
+      # re-encoding canonicalizes the operator's bytes — it drops duplicate keys, unescapes
+      # `\/` and `\uXXXX`, reformats `1.50`→`1.5`, and strips interior whitespace — which would
+      # rewrite BOTH the probe requests AND `--apply`'s stored `minimized_text`, corrupting the
+      # very framing/encoding a smuggling or WAF-bypass probe is testing. Mirrors form_candidate
+      # / query_candidate, which splice the original substrings rather than re-serialize. Removes
+      # EVERY top-level occurrence so a duplicated target key is fully gone (matching the old
+      # parse→delete→reserialize semantics), while every OTHER byte survives verbatim.
       Candidate.new(Kind::Param, key, ->(text : String) {
         hl, body, sep = split_text(text)
         return nil unless sep
-        parsed = (JSON.parse(body) rescue nil)
-        return nil unless parsed
-        obj = parsed.as_h?
-        return nil unless obj && obj.has_key?(key)
-        obj.delete(key)
-        join_text(hl, parsed.to_json, sep)
+        new_body = body
+        removed = false
+        loop do
+          spliced, hit = json_splice_key(new_body, key)
+          break unless hit
+          new_body = spliced
+          removed = true
+        end
+        return nil unless removed
+        join_text(hl, new_body, sep)
       })
+    end
+
+    # Removes the FIRST top-level member whose (decoded) key equals `key` from a JSON object
+    # `body`, splicing the ORIGINAL bytes so everything kept — duplicate keys, `\/`, `\uXXXX`,
+    # `1.50`, interior whitespace — is preserved byte-for-byte. Returns {new_body, true} on a
+    # removal, {body, false} when the object is malformed or the key is absent (caller then
+    # keeps the candidate, the safe direction). Parses ONLY to find the member's byte range.
+    private def self.json_splice_key(body : String, key : String) : {String, Bool}
+      bytes = body.to_slice
+      n = bytes.size
+      i = json_skip_ws(bytes, 0, n)
+      return {body, false} unless i < n && bytes[i] == 0x7B_u8 # not a `{` object
+      i += 1
+      prev_comma = -1 # byte index of the comma before the current member, if any
+      first = true
+      while i < n
+        i = json_skip_ws(bytes, i, n)
+        break if i < n && bytes[i] == 0x7D_u8 # end of object, key not found
+        return {body, false} unless i < n
+        unless first
+          return {body, false} unless bytes[i] == 0x2C_u8 # members are comma-separated
+          prev_comma = i
+          i = json_skip_ws(bytes, i + 1, n)
+        end
+        first = false
+        return {body, false} unless i < n && bytes[i] == 0x22_u8 # a key is a `"`-string
+        key_start = i
+        key_end = json_string_end(bytes, i, n)
+        return {body, false} unless key_end
+        this_key = (String.from_json(body.byte_slice(key_start, key_end - key_start)) rescue nil)
+        i = json_skip_ws(bytes, key_end, n)
+        return {body, false} unless i < n && bytes[i] == 0x3A_u8 # `:` between key and value
+        i = json_skip_ws(bytes, i + 1, n)
+        value_end = json_value_end(bytes, i, n)
+        return {body, false} unless value_end
+        if this_key == key
+          # Cut the member plus exactly ONE adjacent comma so the survivors stay valid JSON
+          # and untouched. A trailing comma (there's a next member) is preferred; else the
+          # leading comma (this is the last member); else it was the sole member.
+          k = json_skip_ws(bytes, value_end, n)
+          if k < n && bytes[k] == 0x2C_u8
+            return {body.byte_slice(0, key_start) + body.byte_slice(k + 1, n - (k + 1)), true}
+          elsif prev_comma >= 0
+            return {body.byte_slice(0, prev_comma) + body.byte_slice(value_end, n - value_end), true}
+          else
+            return {body.byte_slice(0, key_start) + body.byte_slice(value_end, n - value_end), true}
+          end
+        end
+        i = value_end
+      end
+      {body, false}
+    end
+
+    # JSON insignificant whitespace (RFC 8259 §2): space, tab, LF, CR.
+    private def self.json_ws?(b : UInt8) : Bool
+      b == 0x20_u8 || b == 0x09_u8 || b == 0x0A_u8 || b == 0x0D_u8
+    end
+
+    # First byte offset at or after `i` that is not JSON whitespace (or `n` if none).
+    private def self.json_skip_ws(bytes : Bytes, i : Int32, n : Int32) : Int32
+      while i < n && json_ws?(bytes[i])
+        i += 1
+      end
+      i
+    end
+
+    # Byte offset just PAST the JSON string that starts at `bytes[i] == '"'`, honoring `\"`
+    # (and every other `\`-escape by skipping the escaped byte). nil if it is unterminated.
+    private def self.json_string_end(bytes : Bytes, i : Int32, n : Int32) : Int32?
+      j = i + 1
+      while j < n
+        c = bytes[j]
+        if c == 0x5C_u8 # backslash: the next byte is escaped, skip both
+          j += 2
+          next
+        end
+        return j + 1 if c == 0x22_u8 # closing quote
+        j += 1
+      end
+      nil
+    end
+
+    # Byte offset just PAST the JSON value beginning at the first non-ws byte `bytes[i]`. Skips
+    # a string (escape-aware), balances an object/array while honoring nested strings, or reads
+    # a literal (number/true/false/null) up to the next structural byte or whitespace. nil when
+    # the value is malformed/unterminated. Only structural ASCII bytes are inspected, so
+    # multi-byte UTF-8 inside a string passes through opaquely.
+    private def self.json_value_end(bytes : Bytes, i : Int32, n : Int32) : Int32?
+      return nil unless i < n
+      case bytes[i]
+      when 0x22_u8 # string
+        json_string_end(bytes, i, n)
+      when 0x7B_u8, 0x5B_u8 # object `{` or array `[`
+        depth = 0
+        j = i
+        while j < n
+          c = bytes[j]
+          if c == 0x22_u8
+            e = json_string_end(bytes, j, n)
+            return nil unless e
+            j = e
+            next
+          elsif c == 0x7B_u8 || c == 0x5B_u8
+            depth += 1
+          elsif c == 0x7D_u8 || c == 0x5D_u8
+            depth -= 1
+            return j + 1 if depth == 0
+          end
+          j += 1
+        end
+        nil
+      else # number / true / false / null — up to a structural byte or whitespace
+        j = i
+        while j < n
+          c = bytes[j]
+          break if c == 0x2C_u8 || c == 0x7D_u8 || c == 0x5D_u8 || json_ws?(c)
+          j += 1
+        end
+        j == i ? nil : j
+      end
     end
 
     # ── comparison ─────────────────────────────────────────────────────────────────────

--- a/src/gori/repeater/ws_engine.cr
+++ b/src/gori/repeater/ws_engine.cr
@@ -100,9 +100,17 @@ module Gori
         getter note : String?  # a non-fatal advisory (e.g. handshake accept mismatch)
         getter close_code : Int32?
         getter? upgraded : Bool
+        # A cap-driven truncation of the inbound transcript, as the operator-facing sentence
+        # (nil when the drain ran to a clean CLOSE/EOF/idle). DISTINCT from `note`: `note` is a
+        # delivery/handshake advisory about a run that is otherwise complete, whereas this says
+        # the captured `messages` are SHORT of what the server sent — messages/bytes/frames/
+        # deadline/control cap. `drain` also appends ONE synthetic NOTICE_PREFIX `Message` row
+        # carrying the same sentence, so the truncation is visible in the transcript on every
+        # surface without each serializer having to special-case it; this field is the summary.
+        getter truncated : String?
 
         def initialize(@handshake_head, @messages, @duration_us, @error = nil,
-                       @note = nil, @close_code = nil, @upgraded = false)
+                       @note = nil, @close_code = nil, @upgraded = false, @truncated = nil)
         end
 
         def ok? : Bool
@@ -171,7 +179,10 @@ module Gori
           # The FIRST inbound read keeps the generous handshake bound (a slow first
           # reply isn't a dead server); drain narrows to `idle` once frames flow.
           sent_count = messages.size
-          close_code = drain(upstream, messages, idle)
+          # `drain` now reports its OWN truncation: a bare `break` at a cap was indistinguishable
+          # from a clean end, so it returns the cap sentence (nil when it ran to CLOSE/EOF/idle)
+          # alongside the close code — and has already pushed the matching NOTICE_PREFIX marker row.
+          close_code, truncated = drain(upstream, messages, idle)
           # Only when the operator did not send one themselves. §5.5.1 allows exactly one
           # CLOSE per direction, so appending gori's after theirs would put a second one on
           # the wire that they did not ask for — and the second frame, not the first, is what
@@ -187,7 +198,7 @@ module Gori
           # delivery is unconfirmed.
           note = with_delivery_note(note, sent_count, messages.size, close_code)
           Result.new(head, messages, elapsed(started), note: note,
-            close_code: close_code, upgraded: true)
+            close_code: close_code, upgraded: true, truncated: truncated)
         rescue ex
           # A failure BEFORE/at the upgrade is a real error; once upgraded, drain swallows
           # mid-exchange IO errors itself, so reaching here means the handshake failed.
@@ -208,7 +219,18 @@ module Gori
 
       # Read inbound frames until the server sends Close, goes idle (read timeout),
       # or a cap trips. Reassembles fragmented data messages; answers Ping with a
-      # Pong. Returns the close status code if the server framed one.
+      # Pong. Returns `{close status code, truncation sentence}` — the second is nil on a
+      # clean end and the reason when ANY cap fired (messages/bytes/frames/deadline/control).
+      #
+      # Truncating at a cap and reporting a CLEAN result is the bug this pair returns fix
+      # (#10 L8-F1): a bare `break` returned only the close code, so a drain that stopped
+      # short of the server's frames was indistinguishable from one that ran to the end. The
+      # sibling `Relay.capture_control` (proxy/ws/relay.cr:465) already does the honest thing —
+      # ONE synthetic NOTICE_PREFIX row so the truncation shows in the transcript and can never
+      # be replayed (`Store::WsMessage#notice?` refuses it). `drain` does the same at EVERY cap
+      # and surfaces the reason to the summary as well. The break-site caps set the reason
+      # UNCONDITIONALLY (the cap that ended the loop is the salient one); the control cap, which
+      # does not break, only fills it in if nothing else has (`||=`).
       #
       # Reassembly has THREE moments, not one, and this method used to have only the last:
       #
@@ -224,7 +246,7 @@ module Gori
       # correctly, so the two surfaces disagreed about the same protocol. `emit_pending` is
       # 1 and 3, `Proxy::WS::MessageShape` is the accumulator both now share, and the flushed
       # fragment carries `fin: false` — gori reports the violation rather than repairing it.
-      private def self.drain(io : IO, messages : Array(Message), idle : Time::Span) : Int32?
+      private def self.drain(io : IO, messages : Array(Message), idle : Time::Span) : {Int32?, String?}
         assembling = IO::Memory.new
         msg_opcode = Proxy::WS::OP_TEXT
         shape = Proxy::WS::MessageShape.new
@@ -233,6 +255,7 @@ module Gori
         recv_count = 0
         frames = 0
         close_code = nil.as(Int32?)
+        truncated = nil.as(String?) # the cap sentence, once any cap has fired
         started = Time.instant
         loop do
           # Count EVERY frame, not just completed messages: an origin flooding pings or
@@ -240,7 +263,10 @@ module Gori
           # the read timeout, so this frame ceiling is what guarantees termination.
           # A wall-clock deadline also caps total drain time: a steady sub-idle ping cadence
           # stays under MAX_DRAIN_FRAMES yet could otherwise pin the tab "inflight" for hours.
-          break if Time.instant - started > DRAIN_DEADLINE
+          if Time.instant - started > DRAIN_DEADLINE
+            truncated = "the #{DRAIN_DEADLINE.total_seconds.to_i}s drain deadline was reached; later server frames were not captured"
+            break
+          end
           frame = begin
             Proxy::WS.read_frame(io)
           rescue IO::Error
@@ -248,7 +274,10 @@ module Gori
           end
           break if frame.nil? # EOF / truncated
           frames += 1
-          break if frames > MAX_DRAIN_FRAMES
+          if frames > MAX_DRAIN_FRAMES
+            truncated = "the #{MAX_DRAIN_FRAMES}-frame drain ceiling was reached; later server frames were not captured"
+            break
+          end
           # After the first frame, narrow the per-read bound to `idle` so a silent gap
           # ends the drain promptly (the first read kept the generous handshake bound).
           narrow_read_timeout(io, idle) if frames == 1
@@ -264,13 +293,23 @@ module Gori
                 recv_count += 1
                 recv_bytes += assembling.bytesize
                 assembling = emit_pending(messages, assembling, msg_opcode, shape)
-                break if recv_caps_hit?(recv_count, recv_bytes)
+                if reason = recv_caps_reason(recv_count, recv_bytes)
+                  truncated = reason
+                  break
+                end
               end
               msg_opcode = frame.opcode
             end
             shape.note(frame)
             assembling.write(frame.payload)
-            break if assembling.bytesize > MAX_RECV_BYTES # runaway fragmented message
+            if assembling.bytesize > MAX_RECV_BYTES # runaway fragmented message
+              # gori — not the origin — stops accumulating here, so the fragment the post-loop
+              # `emit_pending` flushes with `fin: false` is OUR truncation, not the origin's
+              # §5.4 violation. Marking it (the adjacent marker row + this sentence) is what
+              # keeps that row from being MISread as a server that never sent a FIN.
+              truncated = bytes_cap_sentence
+              break
+            end
             if frame.fin?
               payload = assembling.to_slice.dup
               recv_bytes += payload.size
@@ -280,7 +319,10 @@ module Gori
               # so the two agree about identical bytes.
               messages << Message.new("in", msg_opcode.to_i, payload, shape.take)
               assembling = IO::Memory.new
-              break if recv_caps_hit?(recv_count, recv_bytes)
+              if reason = recv_caps_reason(recv_count, recv_bytes)
+                truncated = reason
+                break
+              end
             end
           elsif frame.close?
             # The CLOSE frame itself joins the transcript, not just its status code. The code
@@ -305,6 +347,12 @@ module Gori
             if ctl_count < MAX_CONTROL_MESSAGES
               ctl_count += 1
               messages << Message.new("in", frame.opcode.to_i, frame.payload.dup, frame.shape)
+            else
+              # Past the cap the ping/pong is still ANSWERED (see send_pong below) but no longer
+              # recorded — a drop that otherwise looks exactly like an origin that stopped
+              # pinging. `||=`, not `=`: this does not end the drain, so a hard cap that DOES end
+              # it later should own the summary; control only fills in when nothing else fired.
+              truncated ||= "the #{MAX_CONTROL_MESSAGES}-control-frame cap was reached; later ping/pong frames were not recorded"
             end
             send_pong(io, frame.payload) if frame.opcode == Proxy::WS::OP_PING
           end
@@ -313,7 +361,21 @@ module Gori
         # EOF, on a truncated frame, on a cap and on the CLOSE path alike — the same reason
         # `Relay.pump` puts its own flush in an `ensure` rather than at the tail.
         emit_pending(messages, assembling, msg_opcode, shape)
-        close_code
+        # The one truncation marker, AFTER the flush so it sits adjacent to (just after) any
+        # `fin: false` fragment the runaway-byte cap left behind — the row that says WHY that
+        # fragment ends unterminated. NOTICE_PREFIX + an "in" TEXT frame mirrors the relay
+        # sibling exactly: it renders in the inbound transcript like the rows it caps, yet a
+        # WS repeater seed can never put gori's own sentence back on the wire.
+        messages << truncation_marker(truncated) if truncated
+        {close_code, truncated}
+      end
+
+      # The synthetic row a capped drain leaves behind. Built from `NOTICE_PREFIX` (what
+      # `Store::WsMessage#notice?` reads to refuse a replay) so it is a diagnostic and not
+      # traffic, and carrying the SAME sentence the Result's `truncated` field does so the row
+      # and the summary can never disagree. Direction "in"/OP_TEXT matches `Relay`'s notices.
+      private def self.truncation_marker(reason : String) : Message
+        Message.new("in", Proxy::WS::OP_TEXT.to_i, "#{Proxy::WS::NOTICE_PREFIX}#{reason}".to_slice)
       end
 
       # Whatever fragments are buffered, as ONE message, and a fresh buffer. A no-op when
@@ -328,8 +390,23 @@ module Gori
         IO::Memory.new
       end
 
-      private def self.recv_caps_hit?(count : Int32, bytes : Int64) : Bool
-        count >= MAX_RECV_MESSAGES || bytes >= MAX_RECV_BYTES
+      # The recv-cap sentence when a DATA cap has tripped, else nil — so the caller both learns
+      # it must stop AND which cap to name, in one check. Message count is tested first because
+      # a flood of tiny messages and one giant payload are different findings.
+      private def self.recv_caps_reason(count : Int32, bytes : Int64) : String?
+        if count >= MAX_RECV_MESSAGES
+          "the #{MAX_RECV_MESSAGES}-message capture cap was reached; later server messages were not captured"
+        elsif bytes >= MAX_RECV_BYTES
+          bytes_cap_sentence
+        end
+      end
+
+      # The byte-cap sentence, in ONE place: the accumulated-recv path (`recv_caps_reason`) and
+      # the single-fragment runaway path both hit the same 8 MiB limit and must word it
+      # identically. A byte-identical literal in two spots is precisely the "two copies and one
+      # omission" the sibling relay's header warns produced its merged-row/dropped-bytes bugs.
+      private def self.bytes_cap_sentence : String
+        "the #{MAX_RECV_BYTES // (1024 * 1024)} MiB server-payload cap was reached; the transcript is truncated"
       end
 
       # Both socket types respond; responds_to? keeps the union's IO type happy.

--- a/src/gori/tui/controllers/probe_controller.cr
+++ b/src/gori/tui/controllers/probe_controller.cr
@@ -427,7 +427,10 @@ module Gori::Tui
       case row.kind
       when :builtin
         dis = store.probe_disabled_rules
-        row.enabled? ? dis.add(row.rule_id) : dis.delete(row.rule_id)
+        # Toggle to the OPPOSITE of the displayed state via `set_rule_enabled` (not a bare
+        # add/delete): a DEFAULT-OFF rule inverts the stored-set membership — see
+        # Gori::Probe::DEFAULT_DISABLED_RULES.
+        Gori::Probe.set_rule_enabled(dis, row.rule_id, !row.enabled?)
         store.set_probe_disabled_rules(dis)
         @host.status(row.enabled? ? "disabled rule \"#{row.title}\"" : "enabled rule \"#{row.title}\"")
       when :custom

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -2211,6 +2211,12 @@ module Gori::Tui
         screen.text(x, y, "⚠ ¦chain not applied", Theme.yellow, bg, width: {inner.right - x, 0}.max)
       else
         line = "#{Fmt.size(r.length).ljust(8)} #{r.words.to_s.ljust(7)} #{Fmt.dur(r.duration_us)}"
+        # Compact per-row markers — the detail panes carry the full story; here they flag a SHORT
+        # capture (so the size/words to the left aren't read as the whole response) and a
+        # `--retries` re-send, so a scan of the list catches both. Built from the row's own flags,
+        # not the CLI classifier: the TUI has no CLI dependency.
+        line += "  ⚠ incomplete" if r.incomplete?
+        line += "  ⟳ ×#{r.resent_count}" if r.resent?
         # For a gRPC target the h2 `:status` to the left is 200 by definition; THIS is the
         # call's real outcome. Only rendered when the response carried it, so a non-gRPC row
         # is unchanged — same fields `cli/output.cr:fuzz_row_text` already renders.
@@ -2602,6 +2608,12 @@ module Gori::Tui
       if ce = r.chain_error
         lines.unshift("(¦chain not applied: #{ce})")
       end
+      # The `--retries` config re-sent this request after a network error (DISTINCT from a
+      # keep-alive re-send) — a note here because it qualifies the REQUEST that went out, and
+      # the raw bytes above give no hint that they were sent more than once.
+      if r.resent?
+        lines.unshift("(re-sent #{r.resent_count}× after a network error — --retries)")
+      end
       lines
     end
 
@@ -2620,6 +2632,13 @@ module Gori::Tui
       if body && !body.empty?
         lines << ""
         lines.concat(String.new(body).scrub.split('\n').map(&.rstrip('\r')))
+      end
+      # The captured response was cut short (origin closed early, a read deadline fired, or the
+      # capture ceiling stopped the read), so what is shown above is a FRAGMENT. Flagged from the
+      # row's own flags, not the CLI classifier — the TUI has no CLI dependency — keeping the
+      # timeout distinction the operator needs to tell "raise the deadline" from "origin closed".
+      if r.incomplete?
+        lines.unshift(r.timed_out? ? "(incomplete — the read deadline expired; the response is truncated)" : "(incomplete — the response is truncated)")
       end
       lines
     end

--- a/src/gori/tui/repeater_view.cr
+++ b/src/gori/tui/repeater_view.cr
@@ -810,10 +810,13 @@ module Gori::Tui
               j.field "upgraded", wr.upgraded?
               j.field "error", wr.error
               j.field "note", wr.note
+              j.field "truncated", wr.truncated # a cap cut the inbound transcript short
               j.field "close_code", wr.close_code
               j.field "duration_us", wr.duration_us
               j.field "messages_sent", wr.messages.count(&.direction.==("out"))
-              j.field "messages_received", wr.messages.count(&.direction.==("in"))
+              # Exclude the synthetic truncation marker: it is an inbound-direction diagnostic,
+              # not a frame the peer sent (see `ws_transcript_lines`).
+              j.field "messages_received", wr.messages.count { |m| m.direction == "in" && !Proxy::WS.notice?(m.payload) }
             end
           end
         end
@@ -3767,7 +3770,9 @@ module Gori::Tui
             rows << {"✗ #{err}", Theme.red}
           else
             sent = r.messages.count(&.direction.==("out"))
-            recv = r.messages.count(&.direction.==("in"))
+            # A synthetic truncation marker is an inbound-direction row but NOT a frame the peer
+            # sent, so it must not inflate "N received" — a diagnostic is not traffic (frame.cr).
+            recv = r.messages.count { |m| m.direction == "in" && !Proxy::WS.notice?(m.payload) }
             foot = String.build do |io|
               io << "✓ upgraded"
               io << " · closed #{r.close_code}" if r.close_code
@@ -3776,6 +3781,12 @@ module Gori::Tui
             rows << {foot, Theme.muted}
             if note = r.note
               rows << {"⚠ #{note}", Theme.yellow}
+            end
+            # The cap-truncation summary. A `← [gori] …` marker row already sits above in the
+            # transcript; this footer line is the same fact where the operator reads the run's
+            # outcome, next to the note it is deliberately kept separate from.
+            if trunc = r.truncated
+              rows << {"⚠ #{trunc}", Theme.yellow}
             end
           end
         end


### PR DESCRIPTION
## Summary

Transport-layer stability work in two tracks, from a round-7 audit of the send path (Repeater / Fuzzer / proxy / WebSocket):

- **Reliability fixes** — byte-fidelity + truthful-reporting defects that caused *silent false negatives* and evidence corruption (the trust contract a scanner/fuzzer lives on).
- **New capability** — an automated HTTP request-smuggling / desync detector (CL.TE / TE.CL / TE.TE).

The two are coupled: the audit's dominant theme is that gori hardened *some* of its hand-rolled bare-LF / mixed-EOL line scanners (`scan_chunks`, `chunked?`, the doubled-space `request_target` fix) but left *sibling* scanners in the same files unhardened — and those gaps both corrupt the operator's authored bytes and would corrupt the very desync primitives the new detector must send intact. So the byte-fidelity fixes are a prerequisite for a trustworthy detector.

## Reliability fixes

| Area | Change |
|---|---|
| `env.head_body_boundary` | Recognize the `\n\r\n` head/body boundary spelling (bare-LF header terminator + CRLF blank line). Previously the whole request read as head, so body bare-LFs were promoted to CRLF and Content-Length re-framed. One shared primitive → fixes every consumer (repeater send, `intercept edit --raw-file`, MCP `send_request{repeater_id}`, TUI, fuzz/mine/sequence templates). |
| `Fuzz::ContentLength` | See a bare-LF-hidden second `Content-Length` as its own line (LF-tokenize + CR-chomp, mirroring the file's own `chunked?`) so it is left intact instead of silently deleted; splice a mixed `\n\r\n` separator verbatim instead of rebuilding it from a doubled `eol`. Stops laundering a request-smuggling primitive under the default auto-CL. |
| `Proxy::Codec::Body#copy_chunked` | Read a bare-LF chunk-data terminator (optional CR then LF) instead of a blind 2-byte CRLF read. Stops the proxy truncating a non-conformant chunked body mid-stream and blaming the origin ("upstream closed"); one fix covers the forward and capture paths. |
| `Outbound.request_target` | Skip leading blank line(s) before reading the request-target for the scope/Sandbox gate. A leading blank line made the gate evaluate `/` while the real target went on the wire — a containment-gate bypass on every active-send surface. |
| `Repeater::Minimize` (JSON) | Byte-splice the target key out of the authored JSON body instead of `JSON.parse(...).to_json` (which canonicalized: dropped duplicate keys, unescaped `\/`/`\uXXXX`, reformatted numbers, stripped whitespace) — matching the sibling form/query candidates. Preserves the exact parser-discrepancy/WAF-bypass bytes being minimized, in both the probes and `--apply`. |
| `Fuzz::Result` reporting | Surface `incomplete`/`timed_out` on every fuzz surface (they were written but read by no one → a truncated body reported as whole = a silent false negative); mark a config-`--retries` re-send (`resent`) and count every failed attempt in `errors`; count `blocked` per payload rather than per attempt so MCP `all_blocked` compares like units; keep a redirect-refused hop from overwriting the payload's real 302. |
| WebSocket `drain` | Mark a transcript truncated at its caps (messages / bytes / frames / deadline / control) with a `NOTICE_PREFIX` marker row + a `truncated` summary field, mirroring the proxy relay sibling — instead of reporting a clean transcript, and instead of a runaway-fragment `fin:false` row reading as an origin §5.4 violation. |

## New: request-smuggling / desync detector

A new active probe `RequestSmuggling` (`request_smuggling_clte` / `_tecl` / `_tete`) plus a minimal transport seam:

- **Seam**: `Fuzz::Backend#send_pipeline` — a same-connection request group over one dedicated socket (via the existing `Repeater::Engine.send_pipeline`), scope-gated like a group send, bypassing the keep-alive pool (which refuses these payloads by design), never re-framing the crafted bytes. Declared on `Active::Plan` (`pipeline` + `probe_timeout`, both tail-default → a strict no-op for every existing rule) and driven identically by both send loops.
- **Methodology**: timing-based (self-damaging incomplete probes, N=2 independent confirmation, decline on jitter or a globally-slow endpoint) with an optional differential/socket-poison confirm.
- **Safety posture**: timing-only by default; the intrusive differential leg (which sends a complete smuggled prefix) runs **only** under `aggressive` + `allow_unsafe`; the rule is **disabled-by-default** in the Rules sub-tab. Severity High for a timing lead, Critical when the differential confirms.

## Testing

- Full suite green: the only failures are pre-existing `Gori::Session` proxy-bind assertions (`project_registry_spec` / `capture_status_spec`) that fail only when a live `gori` process holds the port — present on an unmodified checkout, not from this change.
- Each fix ships with its spec; specs that pinned the old (wrong) behavior were updated deliberately. New: `spec/fuzz/content_length_spec.cr`, `spec/fuzz/truthful_reporting_spec.cr`, `spec/probe/request_smuggling_spec.cr` (craft / seam / verdict layers), plus additions to `flow_cl_policy`, `minimize`, `body`, `outbound`, `ws_engine`, `redirect_hop` specs.

## Out of scope (follow-ups)

Documented but intentionally not in this PR: the proxy-side siblings of the bare-LF gate/chunked fixes (fenced by desync-detection specs), h2 GOAWAY `last_stream_id` handling, the proxy connection-reuse residue / slowloris / gateway-error findings, the fuzz `--rate` per-payload pacing, the discover rescue fiber leak, and Probe Active's `FlowRow#url` scope anchor.
