### PR TITLE
An arrow key that skipped every wrapped row it was drawing: ↓/↑ now step visual rows in NORMAL and in the response pane

### DIFF
--- a/spec/tui/repeater_wrap_spec.cr
+++ b/spec/tui/repeater_wrap_spec.cr
@@ -59,18 +59,114 @@ describe "Gori::Tui::RepeaterView soft wrap" do
     view.resp_cursor.cx.should eq(cw + 2) # … one wrapped row in, plus two columns
   end
 
-  it "moves the response caret down without the pane losing it (visual ensure_visible)" do
+  # ↓ steps one VISUAL row. It used to step a logical LINE, which on a wrapped line jumped
+  # the caret over every continuation row the pane was showing — from the first row of a
+  # 400-char body line straight to SENTINEL, skipping the eleven rows in between. Those rows
+  # are drawn; nothing but this arrow could reach them.
+  it "moves the response caret down one visual row at a time, then onto the next line" do
     view = loaded_view("#{"z" * 400}\nSENTINEL")
     rect = Rect.new(0, 0, 80, 14)
     b = MemoryBackend.new(80, 14)
     view.render(Screen.new(b), rect)
+    body = resp_body_rect(rect)
+    gw = Gori::Settings.show_gutter ? Gutter.width(5) : 0 # status, header, blank, body ×2
+    cw = body.w - gw
     view.resp_move(1, 0) # header
     view.resp_move(1, 0) # blank
-    view.resp_move(1, 0) # the 400-char body line
-    view.resp_move(1, 0) # SENTINEL, many wrapped rows below the fold
+    view.resp_move(1, 0) # the 400-char body line, first visual row
+    view.resp_cursor.cy.should eq(3)
+    view.resp_cursor.cx.should eq(0)
+    view.resp_move(1, 0)
+    view.resp_cursor.cy.should eq(3)  # still the same LINE …
+    view.resp_cursor.cx.should eq(cw) # … one wrapped row into it, at the same column
+    # Every remaining continuation row is its own press; only the last one leaves the line.
+    rows = (400 + cw - 1) // cw
+    (rows - 2).times { view.resp_move(1, 0) }
+    view.resp_cursor.cy.should eq(3)
+    view.resp_cursor.cx.should eq((rows - 1) * cw)
+    view.resp_move(1, 0)
+    view.resp_cursor.cy.should eq(4) # SENTINEL, many wrapped rows below the fold
+    # …and the pane scrolled along with it (ensure_visible counts visual rows too).
     b2 = MemoryBackend.new(80, 14)
     view.render(Screen.new(b2), rect)
     b2.contains?("SENTINEL").should be_true
+  end
+
+  # Diff mode prefixes every row with a 2-column "+ "/"- ", so the DECORATED line is two
+  # columns longer than the text and can need one more row than the bare text would. The
+  # caret must be walked in those decorated coordinates — the grid the pane was laid out and
+  # drawn on — and handed back in the bare ones the cursor holds.
+  #
+  # A body of exactly 2×cw is the case that tells the two apart: bare it is 2 rows, decorated
+  # it is 3, and that third row IS drawn. Wrapping the bare text would leave the line one
+  # press early and make the row unreachable — the same class of bug as skipping wrapped rows
+  # entirely, just one row wide.
+  it "steps the response caret by visual rows in diff mode, across the +/- decoration" do
+    rect = Rect.new(0, 0, 80, 14)
+    body = resp_body_rect(rect)
+    gw = Gori::Settings.show_gutter ? Gutter.width(7) : 0
+    cw = body.w - gw
+    payload = "#{"z" * (cw * 2)}\nTAIL"
+    view = loaded_view(payload)
+    hdr = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\n"
+    # A second send gives diff a baseline (the first response) to compare against.
+    view.apply(Gori::Repeater::Result.new(hdr.to_slice, payload.to_slice, nil, 1000_i64))
+    view.toggle_resp_mode # response → diff
+    view.render(Screen.new(MemoryBackend.new(80, 14)), rect)
+    # The diff's own line list: status, header, its blank separators, then the two body lines.
+    body_li = 5
+    body_li.times { view.resp_move(1, 0) }
+    view.resp_cursor.cy.should eq(body_li)
+    view.resp_cursor.cx.should eq(0)
+    view.resp_move(1, 0)
+    view.resp_cursor.cy.should eq(body_li) # the SAME diff line, one row down …
+    view.resp_cursor.cx.should eq(cw)      # … directly under the column it held
+    view.resp_move(1, 0)
+    # The third row: the two chars the decoration pushed past the second break. Bare-text
+    # wrapping has no such row and would already have moved on to TAIL.
+    view.resp_cursor.cy.should eq(body_li)
+    view.resp_cursor.cx.should eq(cw * 2)
+    view.resp_move(1, 0)
+    view.resp_cursor.cy.should eq(body_li + 1) # only now onto TAIL
+  end
+
+  # The two grids disagree about the last DIFF_PREFIX_COLS columns of a diff row: text index
+  # cw-2 is the start of the decorated line's second row, but would still be on the first row
+  # of a bare-text wrap. A click resolves it the decorated way (that is the row it was drawn
+  # on), so an arrow that measured the bare text would think the caret was one row higher
+  # than it is — and ↑ from there leaves the line entirely instead of moving within it.
+  it "agrees with the click about which diff row the caret is on" do
+    rect = Rect.new(0, 0, 80, 14)
+    body = resp_body_rect(rect)
+    gw = Gori::Settings.show_gutter ? Gutter.width(7) : 0
+    cw = body.w - gw
+    payload = "#{"z" * (cw * 2)}\nTAIL"
+    view = loaded_view(payload)
+    hdr = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\n"
+    view.apply(Gori::Repeater::Result.new(hdr.to_slice, payload.to_slice, nil, 1000_i64))
+    view.toggle_resp_mode
+    view.render(Screen.new(MemoryBackend.new(80, 14)), rect)
+    body_li = 5
+    # Column 0 of that line's SECOND drawn row — the five short lines above it take one row
+    # each, so it is the sixth row of the pane.
+    view.resp_click_to_cursor(rect, body.x + gw, body.y + body_li + 1)
+    view.resp_cursor.cy.should eq(body_li)
+    view.resp_cursor.cx.should eq(cw - 2) # the decoration ate two columns of this row
+    view.resp_move(-1, 0)
+    view.resp_cursor.cy.should eq(body_li) # back to the line's FIRST row, still the same line
+    view.resp_cursor.cx.should eq(0)
+  end
+
+  # ↑ is the exact inverse: a run of ↓ then the same number of ↑ lands back where it began.
+  it "moves the response caret back up through the wrapped rows it came down" do
+    view = loaded_view("#{"z" * 400}\nSENTINEL")
+    rect = Rect.new(0, 0, 80, 14)
+    view.render(Screen.new(MemoryBackend.new(80, 14)), rect)
+    6.times { view.resp_move(1, 0) }
+    view.resp_cursor.cy.should eq(3) # inside the wrapped line, not past it
+    6.times { view.resp_move(-1, 0) }
+    view.resp_cursor.cy.should eq(0)
+    view.resp_cursor.cx.should eq(0)
   end
 
   # The wheel steps DRAWN rows. With a line-indexed offset one notch jumped the whole

--- a/spec/tui/text_area_wrap_spec.cr
+++ b/spec/tui/text_area_wrap_spec.cr
@@ -159,6 +159,82 @@ describe "Gori::Tui::TextArea soft wrap" do
     end
   end
 
+  # NORMAL mode drives the caret through `TextReadState`, not `TextArea#move` — and NORMAL is
+  # the mode the request pane opens in, so it is the ↓ the operator actually presses. It
+  # stepped logical LINES while INSERT stepped visual rows: on a long header or a minified
+  # body that jumped the caret over every continuation row the pane was drawing, and the two
+  # modes disagreed about what "down" meant in the one pane that wraps.
+  describe "READ-mode caret movement (NORMAL)" do
+    it "steps ↓ onto the continuation row of the SAME logical line" do
+      ed, _ = wrap_render("#{"0123456789" * 4}\nnext", 20, 6, gutter: false)
+      read = TextReadState.new
+      ed.place_cursor(0, 5)
+      read.move(ed, 1, 0)
+      ed.cy.should eq(0)  # still logical line 1 …
+      ed.cx.should eq(25) # … one visual row down at the same column, exactly as INSERT does
+      read.move(ed, 1, 0)
+      ed.cy.should eq(1) # only now onto the next logical line
+      ed.cx.should eq(4) # clamped to its length
+    end
+
+    it "steps ↑ back over the boundary to the column it came from" do
+      ed, _ = wrap_render("0123456789" * 4, 20, 6, gutter: false)
+      read = TextReadState.new
+      ed.place_cursor(0, 27)
+      read.move(ed, -1, 0)
+      ed.cx.should eq(7)
+      read.move(ed, -1, 0)
+      ed.cx.should eq(7) # first row already — nowhere further up
+    end
+
+    # ⇧↓ has to end where a plain ↓ would or the selection covers rows the operator never
+    # crossed. Under wrap that lands mid-line, which the char rectangle already models — the
+    # end-of-line snap was only ever what stepping whole lines happened to produce.
+    it "extends a selection by one visual row, not to the end of the logical line" do
+      line = "0123456789" * 4
+      ed, _ = wrap_render(line, 20, 6, gutter: false)
+      read = TextReadState.new
+      ed.place_cursor(0, 5)
+      read.move(ed, 1, 0, selecting: true)
+      ed.cx.should eq(25)
+      read.copy_text(ed).should eq(line[5...25])
+    end
+
+    # A `§value¦chain§` marker's chain segment is concealed: it occupies no cells, so a ↓ that
+    # measured the raw text would park the caret on a character that is not on screen — where
+    # the operator sees the caret in one place and the next keystroke acts somewhere else.
+    # `Wrap.row_index` steps over a run rather than into it; this is the read path proving it.
+    it "lands outside a concealed run when it steps onto the row holding one" do
+      # Row 0 is the 20 x's; row 1 draws "§v§yyyy", the "¦b64" between them being hidden.
+      text = "#{"x" * 20}§v¦b64§yyyy"
+      run = {22, 26} # the "¦b64" chars
+      ed = TextArea.new(text)
+      ed.conceal_spans = [run]
+      ed, _ = wrap_render(text, 20, 6, gutter: false, ta: ed)
+      read = TextReadState.new
+      ed.place_cursor(0, 2)
+      read.move(ed, 1, 0)
+      ed.cy.should eq(0)
+      # Display column 2 of row 1 is the CLOSING §: the hidden run drew nothing, so the two
+      # columns before it are "§v". Measuring the raw text instead would stop on the "¦".
+      ed.cx.should eq(26)
+      (run[0]...run[1]).should_not contain(ed.cx)
+    end
+
+    # Every non-wrapping owner — Notes, the project description, the Fuzzer template — keeps
+    # the logical step it always had; there are no continuation rows for it to visit.
+    it "still steps logical lines when the editor does not wrap" do
+      ed = TextArea.new("#{"0123456789" * 4}\nnext")
+      ed.gutter = false
+      ed.render(Screen.new(MemoryBackend.new(20, 6)), Rect.new(0, 0, 20, 6), cursor: false)
+      read = TextReadState.new
+      ed.place_cursor(0, 5)
+      read.move(ed, 1, 0)
+      ed.cy.should eq(1)
+      ed.cx.should eq(4)
+    end
+  end
+
   describe "vertical scrolling in visual rows" do
     # @scroll indexes LOGICAL lines and would drift the moment anything wrapped; the anchor
     # is (line, sub-row) and the wheel moves it one DRAWN row at a time.

--- a/src/gori/tui/read_cursor.cr
+++ b/src/gori/tui/read_cursor.cr
@@ -103,6 +103,28 @@ module Gori::Tui
       end
     end
 
+    # Put the caret on an ALREADY-RESOLVED position, applying `move`'s anchor rules: shift
+    # pins the far end where the caret stands now, an unmodified move collapses the
+    # selection. For a destination only the owner can compute — the visual row a soft-wrapped
+    # ↑/↓ lands on, which needs a layout this class deliberately does not have (see
+    # `Wrap.step_caret`, and `RepeaterView#paint_request_read_chrome` on why it has none).
+    #
+    # Vertical steps through `move` snap to end-of-line; this does NOT, and that difference
+    # is the point rather than an oversight. Under wrap the caret stops mid-line at the
+    # display column it kept, and ⇧↓ has to end exactly where a plain ↓ would or the
+    # selection covers rows the operator never crossed. Both the span painter and
+    # `selection_text` handle a mid-line boundary already — the char rectangle is the model,
+    # the EOL snap was only ever what stepping whole lines happened to produce.
+    def move_to(cy : Int32, cx : Int32, selecting : Bool = false) : Nil
+      if selecting
+        @anchor ||= {@cy, @cx}
+      else
+        @anchor = nil
+      end
+      @cy = cy
+      @cx = cx
+    end
+
     def click_to_cursor(rect : Rect, mx : Int32, my : Int32, scroll : Int32,
                         lines : Array(String), gutter_w : Int32 = 0, xscroll : Int32 = 0) : Nil
       click_to_cursor(rect, mx, my, scroll, lines.size, ->(i : Int32) { lines[i] }, gutter_w, xscroll)

--- a/src/gori/tui/repeater_view.cr
+++ b/src/gori/tui/repeater_view.cr
@@ -2889,12 +2889,38 @@ module Gori::Tui
 
     # Response READ: move caret (and optional selection). Scroll follows the caret.
     # Lazy line source — vertical steps only materialise the destination line.
+    #
+    # ↑/↓ step one VISUAL row (see `resp_visual_target`), like the request editor's.
     def resp_move(dr : Int32, dc : Int32, selecting : Bool = false) : Nil
       return unless resp_navigable?
       size, line_at = resp_line_source
       return if size <= 0
-      @resp_cursor.move(dr, dc, size, line_at, selecting)
+      if target = resp_visual_target(dr)
+        @resp_cursor.move_to(target[0], target[1], selecting: selecting)
+      else
+        @resp_cursor.move(dr, dc, size, line_at, selecting)
+      end
       ensure_resp_visible(@resp_last_h) if @resp_last_h > 0
+    end
+
+    # The caret `dr` visual rows away, in the BARE line coordinates `@resp_cursor` holds, or
+    # nil when this pane has no wrap to walk — hex draws its own fixed rows, and before the
+    # first frame there is no content width to have laid anything out at (`scroll` guards on
+    # the same pair). The caller then steps logical lines, which is what a row is there.
+    #
+    # The walk runs on the DRAWN line, because that is what the wrap was computed on: in
+    # diff mode every row carries a `"+ "`/`"- "` decoration whose columns shift each break.
+    # So the column goes in as `cx + off` and the result comes back out through the same
+    # `{cx - off, 0}.max.clamp(…)` the click and the wheel already use — a caret that lands
+    # on the decoration belongs at column 0 of the text, the only place it can be drawn.
+    private def resp_visual_target(dr : Int32) : {Int32, Int32}?
+      return nil if dr == 0 || @resp_hex || @resp_last_cw <= 0
+      size, drawn_at, off = resp_drawn_source
+      return nil if size <= 0
+      _, line_at = resp_line_source
+      li, dcx = Wrap.step_caret(@resp_cursor.cy, @resp_cursor.cx + off, dr, size,
+        drawn_at, resp_layout_fn(@resp_last_cw, drawn_at))
+      {li, {dcx - off, 0}.max.clamp(0, line_at.call(li).size)}
     end
 
     # The INS half of the guard is gone: the wheel scrolls the request editor in insert

--- a/src/gori/tui/text_area.cr
+++ b/src/gori/tui/text_area.cr
@@ -1222,47 +1222,33 @@ module Gori::Tui
     end
 
     # ↑/↓ across wrapped rows: step `dr` VISUAL rows, keeping the caret's display column.
-    # The column is measured from the row's first char and mapped back through
-    # `Wrap.row_index`, the same inverse pair the caret and the click use — so a run of ↓
-    # then ↑ lands back where it started at every cluster boundary.
     private def move_visual(dr : Int32) : Nil
-      cw = @last_cw
-      line = @lines[@cy]
-      cr = @conceal_spans.empty? ? nil : line_conceal(line_start_offset(@cy), line.size)
-      lay = layout_of(@cy, cw)
-      sub = lay.row_of(@cx)
-      goal = Wrap.row_col(line, cr, lay.start_of(sub), @cx)
-      li = @cy
-      n = dr.abs
-      while n > 0
-        if dr > 0
-          if sub + 1 < lay.rows
-            sub += 1
-          elsif li < @lines.size - 1
-            li += 1
-            lay = layout_of(li, cw)
-            sub = 0
-          else
-            break
-          end
-        else
-          if sub > 0
-            sub -= 1
-          elsif li > 0
-            li -= 1
-            lay = layout_of(li, cw)
-            sub = lay.rows - 1
-          else
-            break
-          end
-        end
-        n -= 1
-      end
-      @cy = li
-      tline = @lines[li]
-      tcr = @conceal_spans.empty? ? nil : line_conceal(line_start_offset(li), tline.size)
-      @cx = Wrap.row_index(tline, tcr, lay.start_of(sub), lay.end_of(sub), goal)
+      @cy, @cx = visual_row_target(dr) || return
       snap_cx_to_cluster(0) # row_index already lands on a boundary; cheap guard for the empty-row case
+    end
+
+    # Where the caret would land `dr` VISUAL rows away, or nil when this editor has nothing
+    # to wrap (soft wrap off, or no render has measured the content width yet) — in which
+    # case a visual row IS a logical line and the caller's plain step is already right.
+    #
+    # Public because NORMAL mode's caret is driven from outside, by `TextReadState`, and it
+    # has to move exactly where an INSERT-mode arrow would: this editor owns the wrap memo
+    # and the conceal spans, so the alternative is a second layout somewhere that cannot
+    # see either. Reports only the destination and touches no state — the read model plants
+    # its own anchor and writes back through `place_cursor`.
+    def visual_row_target(dr : Int32) : {Int32, Int32}?
+      return nil unless wrapping?
+      return nil if dr == 0
+      cw = @last_cw
+      conceal_at = if @conceal_spans.empty?
+                     nil
+                   else
+                     ->(i : Int32) : Array({Int32, Int32})? { line_conceal(line_start_offset(i), @lines[i].size) }
+                   end
+      Wrap.step_caret(@cy, @cx, dr, @lines.size,
+        ->(i : Int32) { @lines[i] },
+        ->(i : Int32) { layout_of(i, cw) },
+        conceal_at)
     end
 
     # The composing caret line as spans: buffer text, the preedit underlined, buffer text —

--- a/src/gori/tui/text_read_state.cr
+++ b/src/gori/tui/text_read_state.cr
@@ -26,11 +26,25 @@ module Gori::Tui
       apply(editor, lines)
     end
 
+    # ↑/↓ step one VISUAL row whenever the editor soft-wraps, matching what the same arrow
+    # does in INSERT mode. Stepping logical lines here jumped the caret over every
+    # continuation row of a long header or a minified body — past everything the pane was
+    # showing between one line number and the next — so the two modes disagreed about what
+    # "down" means in the one pane that wraps.
+    #
+    # The destination comes from the editor because the editor owns the wrap layout;
+    # `visual_row_target` is nil for every non-wrapping owner (Notes, the project
+    # description, the Fuzzer template), which then keeps the plain logical step it always
+    # had. Horizontal moves are unaffected: a wrapped row has no sideways.
     def move(editor : TextArea, dr : Int32, dc : Int32, selecting : Bool = false) : Nil
       lines = editor.lines_snapshot
       return if lines.empty?
       @cursor.sync(editor.cy, editor.cx)
-      @cursor.move(dr, dc, lines, selecting: selecting)
+      if dr != 0 && (target = editor.visual_row_target(dr))
+        @cursor.move_to(target[0], target[1], selecting: selecting)
+      else
+        @cursor.move(dr, dc, lines, selecting: selecting)
+      end
       apply(editor, lines)
     end
 

--- a/src/gori/tui/wrap.cr
+++ b/src/gori/tui/wrap.cr
@@ -221,6 +221,64 @@ module Gori::Tui
       step_back(cy, csub, h - 1, layout_at)
     end
 
+    # --- the caret's own vertical step ---------------------------------------
+    # ↑/↓ move the caret one VISUAL row, keeping its display column — the motion every
+    # editor performs and the one soft wrap makes non-trivial, because a logical step
+    # would jump the caret over every continuation row the pane is showing between here
+    # and the next line number. Which is exactly the confusion soft wrap exists to remove.
+    #
+    # It lives HERE, next to `row_col` and `row_index`, rather than in each pane, because
+    # it is those two composed: measure the column within the row the caret is on, walk
+    # rows, then invert the measure on the row it landed on. A pane that re-derived the
+    # walk would also re-derive the measure, which is this module's standing hazard (see
+    # the header). One implementation serves the request editor (INSERT via
+    # `TextArea#move_visual`, NORMAL via `TextReadState`) and the response pane alike.
+    #
+    # `line_at`/`layout_at` must describe the SAME text the pane draws — for the response
+    # in diff mode that is the `"+ "`-prefixed line, so the caller converts its column
+    # into those coordinates and back out again (see `RepeaterView#resp_visual_target`).
+    #
+    # Returns the destination `{line, char index}`, stopping at either end of the buffer.
+    # The column is a display column, so a step onto a shorter row lands at that row's end
+    # — and, `row_index` being cluster-wise, never inside a glyph or a concealed run.
+    def self.step_caret(li : Int32, cx : Int32, dr : Int32, size : Int32,
+                        line_at : Int32 -> String,
+                        layout_at : Int32 -> Layout,
+                        conceal_at : (Int32 -> Array({Int32, Int32})?)? = nil) : {Int32, Int32}
+      return {li, cx} if dr == 0 || size <= 0
+      li = li.clamp(0, size - 1)
+      lay = layout_at.call(li)
+      sub = lay.row_of(cx)
+      goal = row_col(line_at.call(li), conceal_at.try &.call(li), lay.start_of(sub), cx)
+      n = dr.abs
+      while n > 0
+        if dr > 0
+          if sub + 1 < lay.rows
+            sub += 1
+          elsif li < size - 1
+            li += 1
+            lay = layout_at.call(li)
+            sub = 0
+          else
+            break
+          end
+        else
+          if sub > 0
+            sub -= 1
+          elsif li > 0
+            li -= 1
+            lay = layout_at.call(li)
+            sub = lay.rows - 1
+          else
+            break
+          end
+        end
+        n -= 1
+      end
+      target = line_at.call(li)
+      {li, row_index(target, conceal_at.try &.call(li), lay.start_of(sub), lay.end_of(sub), goal)}
+    end
+
     # Whether char index `i` falls inside a concealed run. Linear in the run count, which is
     # the marker count on one line — single digits in every real request.
     private def self.hidden?(conceal : Array({Int32, Int32})?, i : Int32) : Bool


### PR DESCRIPTION
Soft wrap lives in three Repeater panes — the request editor, the decoded payload editor, and the response — but only **one** of the three vertical-caret paths knew about it:

| path | pane / mode | before |
|---|---|---|
| `TextArea#move` | request, **INSERT** | visual rows ✅ |
| `TextReadState#move` → `ReadCursor#move` | request, **NORMAL** | logical lines ❌ |
| `RepeaterView#resp_move` | **response** | logical lines ❌ |

NORMAL is the mode the pane opens in, so the arrow the operator actually presses was a broken one: on a long header or a minified body, ↓ jumped from the line's first row straight past every continuation row the pane was drawing, to the next line number. Those rows are on screen and nothing else could reach them — which is exactly the confusion soft wrap exists to remove.

## The fix

`Wrap.step_caret` is now the one implementation, and it lives next to `row_col` / `row_index` because it is those two composed: measure the display column within the row the caret is on, walk rows, invert the measure on the row it landed on. A pane that re-derived the walk would also re-derive the measure, which is that module's standing hazard. All three paths share it:

- **`TextArea#visual_row_target`** reports the destination and touches no state, so the read model can plant its own anchor; `move_visual` is three lines over it.
- **`ReadCursor#move_to`** applies `move`'s anchor rules to a caller-resolved position — `ReadCursor` still holds no layout of its own, as its callers document.
- **`RepeaterView#resp_visual_target`** walks the **drawn** line, because that is what the wrap was computed on: in diff mode the `"+ "` / `"- "` decoration shifts every break, so the column goes in as `cx + off` and comes back out through the same `{cx - off, 0}.max.clamp(…)` the click and the wheel already use.

Non-wrapping owners — Notes, the project description, the Fuzzer template, the History / Fuzzer / Decoder detail panes — get `nil` from `visual_row_target` and keep the logical step they always had. There are no continuation rows there to visit.

## Intentional behavior changes

Both are confined to the panes that soft-wrap.

- **⇧↓ / ⇧↑ in NORMAL extend by visual row** instead of snapping to end-of-line. `text_area.cr` states the invariant — selecting must move the caret exactly where an unmodified arrow would, or the selection covers text the user never crossed — and both `highlight_spans` and `selection_text` were already char rectangles, so the EOL snap was only ever what stepping whole lines happened to produce.
- **No sticky desired-column.** ↓ through a short row still forgets the original column, which is what INSERT mode already does; making NORMAL match INSERT is the fix here. A remembered column is new state with its own invalidation on edit, click and horizontal move, and would change every pane — left as follow-up.

## Verification

- `just test` green: **6943 examples, 0 failures**.
- **Six new specs**: NORMAL ↓ / ↑, ⇧↓ extent, a non-wrapping owner, a concealed `¦chain` run the caret must step *over* rather than *into*, diff-mode rows, and the click/arrow agreement that pins the decoration offset. Each was confirmed to **fail** when its own code path is sabotaged — the diff-offset and conceal cases failed with precisely the predicted wrong values (`cy` 5→4, `cx` 26→22). An earlier diff assertion passed under sabotage and was replaced: the response wrap memo is keyed on `(li, cw)` alone, which made the mutation a no-op.
- One existing response spec asserted logical stepping incidentally while testing `ensure_visible`; rewritten to the new contract, keeping its original point.
- Lint parity against baseline (22 = 22 on these files, none in new code); changed files pass `crystal tool format --check`.
- Driven in the real TUI too: ↓ walks screen rows 17→18→19→20 (the wrapped rows) then 21 (the next line), holding its column, and ↑ retraces them exactly.