### PR TITLE
A WebSocket handshake whose keyboard worked and never said so, a MESSAGES pane no drag could touch, and a handshake response you could read but not copy

### DIFF
--- a/spec/tui/read_chrome_badge_parity_spec.cr
+++ b/spec/tui/read_chrome_badge_parity_spec.cr
@@ -1,0 +1,259 @@
+require "../spec_helper"
+require "../support/memory_backend"
+
+include Gori::Tui
+
+# Four defects found by sweeping the tree for the shapes the Repeater's WebSocket panes had:
+# a second derivation of something the widget already knows, and a draw that disagrees with the
+# hit-test it is drawn for. Every one of them is a place where the screen and the clipboard, or
+# the screen and the click, told the operator different things.
+#
+#   A. FuzzerView drew the `§N` marker-count badge 4 cells INSIDE the 7-cell NOR/INS chip, so the
+#      TEMPLATE border read "↵: §2" — the mode chip destroyed and the count ambiguous.
+#   B. FuzzerView#template_home/end and JwtSession's Home/End moved the EDITOR caret without
+#      adopting it into the READ cursor. Symptoms differ because the painters differ: the Fuzzer
+#      (which `sync_from`s every frame) kept a phantom band whose ends had crossed, so `y` copied
+#      ""; JWT (which paints purely from its read cursor) moved a caret nobody could see.
+#   C. Every NOR/INS chip was drawn from `focused && insert?` while its hit-test and its click
+#      handler read `insert?` alone. A pane that retained INS while focus moved away drew the
+#      7-cell " ↵:NOR " over a 5-cell " INS " hit rect — two dead cells — and clicking a chip
+#      that said "↵:NOR" turned insert OFF.
+#   D. The READ band and block caret measured the RAW line in the two panes that CONCEAL text
+#      (`§value¦chain§`), so both landed N columns right of what they addressed, and the band —
+#      which re-draws its own text — put the hidden `¦chain` back on screen. Copy was correct
+#      throughout, so the band highlighted different bytes than `y` put on the clipboard.
+describe "READ-mode chrome + border badge parity" do
+  # The rows a 120×N render puts things on: the TARGET band is 3 rows, so the request/template
+  # card's top border is row 3 and its first content row is row 4.
+  border_y = 3
+  content_y = 4
+
+  describe "A · fuzzer §N badge" do
+    it "chains the marker count clear of the NOR/INS chip" do
+      view = FuzzerView.new
+      view.load_request("https://h", "GET /?x=§1§&y=§2§ HTTP/1.1\r\nHost: h\r\n\r\n", false, "")
+      view.focus_pane(:template)
+      b = MemoryBackend.new(120, 30)
+      view.render(Screen.new(b), Rect.new(0, 0, 120, 30))
+      row = b.row(border_y)
+
+      # Both are legible and neither is inside the other.
+      row.should contain("↵:NOR")
+      row.should contain("§2")
+      row.index("§2").not_nil!.should be < row.index("↵:NOR").not_nil! # count chains LEFT
+      row.should_not contain("↵: §")                                   # the overlap's signature
+    end
+
+    it "keeps the mode chip clickable with the count beside it" do
+      view = FuzzerView.new
+      view.load_request("https://h", "GET /?x=§1§ HTTP/1.1\r\nHost: h\r\n\r\n", false, "")
+      view.focus_pane(:template)
+      rect = Rect.new(0, 0, 120, 30)
+      b = MemoryBackend.new(120, 30)
+      view.render(Screen.new(b), rect)
+      col = b.row(border_y).index("↵:NOR").not_nil!
+      view.template_chrome_hit(rect, col + 1, border_y).should eq(:mode)
+    end
+  end
+
+  describe "B · READ-mode Home/End adopt the read cursor" do
+    it "extends on ⇧End and collapses on a plain Home (fuzzer template)" do
+      view = FuzzerView.new
+      view.load_request("https://h", "GET /abc HTTP/1.1\r\nHost: h\r\n\r\n", false, "")
+      view.focus_pane(:template)
+      view.render(Screen.new(MemoryBackend.new(120, 30)), Rect.new(0, 0, 120, 30))
+      view.template_insert?.should be_false
+
+      view.template_end(true)
+      view.pane_selection?.should be_true
+      view.pane_copy_text.should eq("GET /abc HTTP/1.1")
+
+      # A plain Home must COLLAPSE. Left un-adopted, the anchor stayed put while the caret went
+      # to column 0 — the band's two ends crossed and `y` copied nothing at all.
+      view.pane_select_line
+      view.template_home(false)
+      view.pane_selection?.should be_false
+      view.pane_copy_text.should eq("GET /abc HTTP/1.1") # the caret line, not ""
+    end
+
+    it "moves the READ caret, not just the editor's (jwt input)" do
+      s = JwtSession.new("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhIn0.sig", nil)
+      s.input_mode.should eq(InputMode::Read)
+      s.input_read.cursor.cx.should eq(0)
+
+      s.input_end
+      # JwtView#paint_read_chrome draws from `input_read` alone, so this is the number that
+      # decides where the block caret lands.
+      s.input_read.cursor.cx.should eq(s.input.lines_snapshot[0].size)
+      s.input_read.selection?.should be_false
+
+      s.input_home(true) # ⇧Home extends back to column 0
+      s.input_read.selection?.should be_true
+      s.input_read.cursor.cx.should eq(0)
+
+      s.input_home(false) # …and a plain Home collapses it
+      s.input_read.selection?.should be_false
+    end
+
+    it "leaves INSERT mode's own anchor alone (jwt input)" do
+      s = JwtSession.new("abcdef", nil)
+      s.input_mode = InputMode::Insert
+      s.input_end(true)
+      s.input.selection?.should be_true       # the editor owns it in INS …
+      s.input_read.selection?.should be_false # … and the read cursor stays out of it
+    end
+  end
+
+  describe "C · the NOR/INS chip states the pane's real mode" do
+    # `Frame.mode_badge`'s two labels are different widths, and `chrome_hit` is called from a
+    # click handler with no idea which pane had focus when the frame was drawn.
+    it "draws INS on an unfocused Repeater pane that retained it, and hit-tests the same cells" do
+      view = RepeaterView.new
+      view.restore("https://h.test", "GET / HTTP/1.1\r\nHost: h.test\r\n\r\n", false, true)
+      view.focus_pane(:request)
+      view.enter_request_insert!
+      view.focus_pane(:response) # focus leaves; nothing exits insert on a focus change
+      view.request_insert?.should be_true
+
+      rect = Rect.new(0, 0, 120, 24)
+      b = MemoryBackend.new(120, 24)
+      view.render(Screen.new(b), rect)
+      row = b.row(border_y)
+      row.should contain("INS")
+      row.should_not contain("↵:NOR") # the label no longer lies about the mode
+
+      # Every cell of the drawn chip hit-tests as :mode, and the run is exactly " INS " wide.
+      hits = (0...120).select { |x| view.chrome_hit(rect, x, border_y) == :mode }
+      hits.should_not be_empty
+      (hits.last - hits.first + 1).should eq(Frame.mode_badge_label(true).size)
+      ins_at = row.index("INS").not_nil!
+      hits.should contain(ins_at)
+      hits.should contain(ins_at + 2)
+    end
+
+    it "does the same on the Repeater TARGET card" do
+      view = RepeaterView.new
+      view.restore("https://h.test", "GET / HTTP/1.1\r\nHost: h.test\r\n\r\n", false, true)
+      view.focus_pane(:target)
+      view.enter_target_insert!
+      view.focus_pane(:request)
+      rect = Rect.new(0, 0, 120, 24)
+      b = MemoryBackend.new(120, 24)
+      view.render(Screen.new(b), rect)
+      b.row(0).should contain("INS")
+      col = b.row(0).index("INS").not_nil!
+      view.chrome_hit(rect, col, 0).should eq(:target_mode)
+    end
+
+    it "does the same on the Fuzzer TARGET card" do
+      view = FuzzerView.new
+      view.load_request("https://h", "GET / HTTP/1.1\r\nHost: h\r\n\r\n", false, "")
+      view.focus_pane(:target)
+      view.enter_target_insert!
+      view.focus_pane(:template)
+      rect = Rect.new(0, 0, 120, 30)
+      b = MemoryBackend.new(120, 30)
+      view.render(Screen.new(b), rect)
+      b.row(0).should contain("INS")
+      col = b.row(0).index("INS").not_nil!
+      view.target_chrome_hit(rect, col, 0).should eq(:mode)
+    end
+
+    # Focus is still on screen — it moved to the border, where it always was.
+    it "still dims the border of the unfocused pane" do
+      view = RepeaterView.new
+      view.restore("https://h.test", "GET / HTTP/1.1\r\nHost: h.test\r\n\r\n", false, true)
+      view.focus_pane(:request)
+      view.enter_request_insert!
+      focused = MemoryBackend.new(120, 24)
+      view.render(Screen.new(focused), Rect.new(0, 0, 120, 24))
+      lit = focused.fg_grid[border_y][1]
+
+      view.focus_pane(:response)
+      dim = MemoryBackend.new(120, 24)
+      view.render(Screen.new(dim), Rect.new(0, 0, 120, 24))
+      dim.fg_grid[border_y][1].should_not eq(lit)
+    end
+  end
+
+  describe "D · READ chrome over a concealed ¦chain" do
+    # `§v¦b64§` renders as `§v§` — the chain is concealed in the buffer, occupying no cells. A
+    # caret addressing a byte to its RIGHT therefore belongs at the DRAWN column, not the raw one.
+    marked = "GET /?a=§v¦b64§&z=TAIL HTTP/1.1\r\nHost: h\r\n\r\n"
+
+    it "puts the Repeater's READ caret on the glyph it addresses" do
+      view = RepeaterView.new
+      view.restore("https://h.test", marked, false, true)
+      view.focus_pane(:request)
+      rect = Rect.new(0, 0, 120, 24)
+      view.render(Screen.new(MemoryBackend.new(120, 24)), rect)
+
+      view.request_text.lines.first.index("TAIL").not_nil!.times { view.request_read_move(0, 1) }
+      b = MemoryBackend.new(120, 24)
+      view.render(Screen.new(b), rect)
+
+      caret = (0...120).find { |x| b.bg_grid[content_y][x] == Theme.accent_bg }
+      caret.should eq(b.row(content_y).index("TAIL")) # not 4 columns right of it
+    end
+
+    it "keeps the Repeater's READ band from unconcealing the chain" do
+      view = RepeaterView.new
+      view.restore("https://h.test", marked, false, true)
+      view.focus_pane(:request)
+      rect = Rect.new(0, 0, 120, 24)
+      view.render(Screen.new(MemoryBackend.new(120, 24)), rect)
+      view.pane_select_line
+
+      b = MemoryBackend.new(120, 24)
+      view.render(Screen.new(b), rect)
+      b.row(content_y).should contain("§v§")      # still concealed under the band …
+      b.row(content_y).should_not contain("¦b64") # … the band does not put it back
+      view.pane_copy_text.should contain("¦b64")  # while the COPY keeps the real bytes
+    end
+
+    it "puts the Fuzzer's READ caret on the glyph it addresses" do
+      view = FuzzerView.new
+      view.load_request("https://h", marked, false, "")
+      view.focus_pane(:template)
+      rect = Rect.new(0, 0, 120, 30)
+      view.render(Screen.new(MemoryBackend.new(120, 30)), rect)
+
+      view.template_text.lines.first.index("TAIL").not_nil!.times { view.template_read_move(0, 1) }
+      b = MemoryBackend.new(120, 30)
+      view.render(Screen.new(b), rect)
+
+      caret = (0...120).find { |x| b.bg_grid[content_y][x] == Theme.accent_bg }
+      caret.should eq(b.row(content_y).index("TAIL"))
+    end
+
+    it "keeps the Fuzzer's READ band from unconcealing the chain" do
+      view = FuzzerView.new
+      view.load_request("https://h", marked, false, "")
+      view.focus_pane(:template)
+      rect = Rect.new(0, 0, 120, 30)
+      view.render(Screen.new(MemoryBackend.new(120, 30)), rect)
+      view.pane_select_line
+
+      b = MemoryBackend.new(120, 30)
+      view.render(Screen.new(b), rect)
+      b.row(content_y).should contain("§v§")
+      b.row(content_y).should_not contain("¦b64")
+      view.pane_copy_text.should contain("¦b64")
+    end
+
+    # A marker-free buffer must be byte-for-byte what it always drew: `conceal_of` returns nil
+    # there, so the band and caret take the same path they took before this change.
+    it "is unchanged on a buffer with nothing concealed" do
+      view = RepeaterView.new
+      view.restore("https://h.test", "GET /?a=v&z=TAIL HTTP/1.1\r\nHost: h\r\n\r\n", false, true)
+      view.focus_pane(:request)
+      rect = Rect.new(0, 0, 120, 24)
+      view.render(Screen.new(MemoryBackend.new(120, 24)), rect)
+      view.request_text.lines.first.index("TAIL").not_nil!.times { view.request_read_move(0, 1) }
+      b = MemoryBackend.new(120, 24)
+      view.render(Screen.new(b), rect)
+      caret = (0...120).find { |x| b.bg_grid[content_y][x] == Theme.accent_bg }
+      caret.should eq(b.row(content_y).index("TAIL"))
+    end
+  end
+end

--- a/spec/tui/repeater_decode_spec.cr
+++ b/spec/tui/repeater_decode_spec.cr
@@ -1,4 +1,5 @@
 require "../spec_helper"
+require "../support/memory_backend"
 require "base64"
 require "uri"
 require "json"
@@ -144,6 +145,100 @@ describe "RepeaterView split-decode (SAML/GraphQL)" do
       view.req_pane.should eq(:decoded)
       view.edit_move(-1, 0) # ↑ off the DECODED top → ENVELOPE
       view.req_pane.should eq(:envelope)
+    end
+
+    # The same crossing in READ mode, which is where it did not exist: the step lived inline
+    # in `edit_move` (INS only), so `request_read_move` clamped at each sub-pane's edge and
+    # `^T` was the only way across. Both modes call `try_cross_req_pane` now.
+    it "crosses in READ mode too, and drops the read selection when it does" do
+      detail = detail_of("/graphql", gql_head, gql_body)
+      op = Gori::Graphql.from_flow("/graphql", gql_head.to_slice, gql_body.to_slice).not_nil!
+      view = RepeaterView.new
+      view.load_graphql(detail, op)
+      view.request_insert?.should be_false # a decode tab opens in READ, like every other tab
+
+      view.pane_select_line
+      view.pane_selection?.should be_true
+
+      10.times { view.request_read_move(1, 0) } # past the ENVELOPE's last line
+      view.req_pane.should eq(:decoded)
+      view.pane_selection?.should be_false # an anchor cannot follow the caret into another buffer
+
+      view.request_read_move(-1, 0)
+      view.req_pane.should eq(:envelope)
+    end
+  end
+
+  # Mouse gestures in the split column, which used to return early on `@decode_kind`: a drag
+  # selected nothing and a double-click took no word, in either sub-pane. They go through the
+  # same `request_hit` / `request_sub_rect` / `place_request_caret` seam as plain HTTP and WS.
+  describe "mouse drag + double-click in the split sub-panes" do
+    gql_body = %({"query":"query FindUser { name }"})
+    gql_head = "POST /graphql HTTP/1.1\r\nHost: api.test\r\nContent-Type: application/json\r\nContent-Length: #{gql_body.bytesize}\r\n\r\n"
+
+    # The DECODED card's content rect, re-derived as `render` does (target band → left half →
+    # `decode_split` with the ACTIVE pane enlarged → the card's 1-cell inset).
+    decoded_rect = ->(view : RepeaterView, rect : Rect) {
+      target_h = {rect.h, 3}.min
+      content = Rect.new(rect.x, rect.y + target_h, rect.w, {rect.h - target_h, 0}.max)
+      half = {(content.w - 1) // 2, 1}.max
+      col = Rect.new(content.x, content.y, half, content.h)
+      inactive = {col.h // 3, 1}.max
+      env_h = view.req_pane == :envelope ? {col.h - inactive, 1}.max : inactive
+      Rect.new(col.x, col.y + env_h, col.w, {col.h - env_h, 0}.max).inset(1, 1)
+    }
+
+    rendered = -> {
+      detail = detail_of("/graphql", gql_head, gql_body)
+      op = Gori::Graphql.from_flow("/graphql", gql_head.to_slice, gql_body.to_slice).not_nil!
+      view = RepeaterView.new
+      view.load_graphql(detail, op)
+      rect = Rect.new(0, 0, 100, 24)
+      b = MemoryBackend.new(100, 24)
+      view.render(Screen.new(b), rect) # geometry: @last_cw / last_rows are set here
+      {view, b, rect}
+    }
+
+    it "adopts the DECODED sub-pane a press landed in and places its caret" do
+      view, b, rect = rendered.call
+      view.req_pane.should eq(:envelope)
+      dec = decoded_rect.call(view, rect)
+      x = b.row(dec.y).index("query").not_nil!
+
+      view.request_click_to_cursor(rect, x, dec.y)
+      view.req_pane.should eq(:decoded)
+      view.pane_copy_text.should contain("FindUser") # the caret line is the GraphQL query
+    end
+
+    # ^T into DECODED first, so the card is already at its active (enlarged) size and one
+    # render describes the layout both the press and the drag are inverted against.
+    it "extends a READ-mode selection inside the DECODED sub-pane" do
+      view, _, rect = rendered.call
+      view.toggle_req_pane
+      view.req_pane.should eq(:decoded)
+      b = MemoryBackend.new(100, 24)
+      view.render(Screen.new(b), rect)
+
+      dec = decoded_rect.call(view, rect)
+      x = b.row(dec.y).index("query").not_nil!
+      view.request_click_to_cursor(rect, x, dec.y)
+      view.request_drag_to_cursor(rect, x + 5, dec.y)
+
+      view.pane_selection?.should be_true
+      view.pane_copy_text.should eq("query")
+    end
+
+    it "takes the word under a double-click in the DECODED sub-pane" do
+      view, _, rect = rendered.call
+      view.toggle_req_pane
+      b = MemoryBackend.new(100, 24)
+      view.render(Screen.new(b), rect)
+
+      dec = decoded_rect.call(view, rect)
+      x = b.row(dec.y).index("FindUser").not_nil! + 2
+      view.request_click_to_cursor(rect, x, dec.y)
+      view.request_select_word.should be_true
+      view.pane_copy_text.should eq("FindUser")
     end
   end
 end

--- a/spec/tui/repeater_grpc_framing_spec.cr
+++ b/spec/tui/repeater_grpc_framing_spec.cr
@@ -102,4 +102,49 @@ describe "RepeaterView gRPC framing failure" do
       backend.contains?("(no complete gRPC messages)").should be_true
     end
   end
+
+  # The GRPC REQUEST head is a mode-switched text editor (`i`/esc, READ selection, and — since
+  # the READ over-paint reached this branch — a visible NORMAL block caret), so it carries the
+  # NOR/INS chip like every other non-hex request card. Draw and hit-test share
+  # `Frame.right_badge_edge` over one badge list; this pins them together, because a chip that
+  # is drawn but not hit-testable (or the reverse) is the exact defect `␣K:KEY` had.
+  it "draws a clickable NOR/INS mode chip on the request head" do
+    grpc_tmp_store do |store|
+      view = def_view.call(store)
+      view.focus_pane(:request)
+      rect = Rect.new(0, 0, 160, 24)
+      b = MemoryBackend.new(160, 24)
+      view.render(Screen.new(b), rect)
+
+      # The request card's top border: below the 3-row TARGET band.
+      border_y = rect.y + 3
+      row = b.row(border_y)
+      row.should contain("↵:NOR")
+      col = row.index("↵:NOR").not_nil!
+      view.chrome_hit(rect, col + 1, border_y).should eq(:mode)
+
+      # And it reports the mode it is in, rather than a fixed label.
+      view.enter_request_insert!
+      b2 = MemoryBackend.new(160, 24)
+      view.render(Screen.new(b2), rect)
+      b2.row(border_y).should contain("INS")
+    end
+  end
+
+  # Hex draws no chip (a nibble cursor has no READ/INS), so none may be hit-testable there.
+  it "reports no mode chip while the payload is hex-edited" do
+    grpc_tmp_store do |store|
+      view = def_view.call(store)
+      view.focus_pane(:request)
+      rect = Rect.new(0, 0, 160, 24)
+      view.render(Screen.new(MemoryBackend.new(160, 24)), rect)
+      border_y = rect.y + 3
+
+      view.toggle_request_hex.should be_true
+      b = MemoryBackend.new(160, 24)
+      view.render(Screen.new(b), rect)
+      b.row(border_y).should_not contain("↵:NOR")
+      (0...160).each { |x| view.chrome_hit(rect, x, border_y).should_not eq(:mode) }
+    end
+  end
 end

--- a/spec/tui/repeater_view_spec.cr
+++ b/spec/tui/repeater_view_spec.cr
@@ -2217,6 +2217,65 @@ describe Gori::Tui::RepeaterView do
       view.request_text.should_not contain("Content-Length: 30")
     end
   end
+
+  # The single-pane REQUEST column, through the shared hit-test seam
+  # (`request_hit`/`request_sub_rect`/`place_request_caret`) the split panes now share. There
+  # was no drag or double-click coverage anywhere in the suite before, so the seam's
+  # rewrite had nothing pinning the case it was factored out of.
+  describe "mouse drag + double-click (plain HTTP request pane)" do
+    head = "GET /alpha/beta HTTP/1.1\nHost: h.test\nUser-Agent: gori\n\n"
+
+    rendered = -> {
+      view = RepeaterView.new
+      view.restore("https://h.test", head, false, true)
+      view.focus_pane(:request)
+      rect = Rect.new(0, 0, 100, 24)
+      b = MemoryBackend.new(100, 24)
+      view.render(Screen.new(b), rect) # geometry: @last_cw / last_rows are set here
+      {view, b, rect}
+    }
+
+    # The request card sits under the 3-row TARGET band, in the left half, inset by its border.
+    body_y = 4
+
+    it "extends a READ-mode selection along the request line" do
+      view, b, rect = rendered.call
+      x0 = b.row(body_y).index("GET").not_nil!
+      view.request_click_to_cursor(rect, x0, body_y)
+      view.request_drag_to_cursor(rect, x0 + 3, body_y)
+      view.pane_selection?.should be_true
+      view.pane_copy_text.should eq("GET")
+    end
+
+    it "extends an INSERT-mode selection through the editor's own anchor" do
+      view, b, rect = rendered.call
+      x0 = b.row(body_y).index("GET").not_nil!
+      view.enter_request_insert!
+      view.request_click_to_cursor(rect, x0, body_y)
+      view.request_drag_to_cursor(rect, x0 + 3, body_y)
+      view.pane_selection?.should be_true
+      view.pane_copy_text.should eq("GET")
+    end
+
+    # `word_char?` breaks a path at every `/`, so double-clicking inside "beta" takes the
+    # segment and not the whole target.
+    it "takes the word under a double-click" do
+      view, b, rect = rendered.call
+      x = b.row(body_y).index("beta").not_nil! + 1
+      view.request_click_to_cursor(rect, x, body_y)
+      view.request_select_word.should be_true
+      view.pane_copy_text.should eq("beta")
+    end
+
+    # Hex has a nibble cursor, which has no selection to extend — the one request shape still
+    # excluded from the drag.
+    it "leaves the hex nibble cursor alone on a drag" do
+      view, b, rect = rendered.call
+      view.toggle_request_hex.should be_true
+      view.request_drag_to_cursor(rect, b.row(body_y).size - 1, body_y) # must not raise
+      view.pane_selection?.should be_false
+    end
+  end
 end
 
 describe "RepeaterView WebSocket frame shapes (V7)" do

--- a/spec/tui/repeater_ws_editor_parity_spec.cr
+++ b/spec/tui/repeater_ws_editor_parity_spec.cr
@@ -1,0 +1,737 @@
+require "../spec_helper"
+require "../support/memory_backend"
+
+include Gori::Tui
+
+# The Repeater's REQUEST column is one pane for plain HTTP and TWO for a WebSocket flow
+# (HANDSHAKE REQUEST over MESSAGES) or a decode tab (ENVELOPE over DECODED). Every editor
+# gesture the single-pane case had was gated off, painted for the wrong mode, or simply
+# missing in the split one:
+#
+#   * `request_drag_to_cursor` / `request_select_word` returned early on `@ws_mode ||
+#     @decode_kind`, so a drag selected nothing and a double-click took no word;
+#   * the WS/gRPC render branches returned before `paint_request_read_chrome`, so READ mode
+#     drew no caret and no selection band — an operator pressing ↓ or ⇧→ saw the screen not
+#     change and read that as "the keyboard does nothing here";
+#   * `render_decoded` passed `cursor: focused` unconditionally, so MESSAGES drew an INSERT
+#     caret in both modes and its READ selection — the one `y` copies — was invisible;
+#   * the cross-pane arrow step lived inline in `edit_move` (INS only), so a WebSocket tab —
+#     which `restore` leaves in READ mode — could not reach HANDSHAKE from MESSAGES with the
+#     arrows at all; and
+#   * `␣K:KEY` was drawn by `render_request` but absent from `chrome_hit`'s badge list, so
+#     the badge was a dead cell.
+#
+# The shared seam is `request_sub_rect` / `request_hit` / `place_request_caret` /
+# `try_cross_req_pane`: the split and the single pane walk the same code now, so a fix on one
+# cannot land on only one of them.
+describe "RepeaterView WebSocket editor parity" do
+  ws_head = "GET /ws HTTP/1.1\r\nHost: ws.test\r\nUpgrade: websocket\r\n" \
+            "Connection: Upgrade\r\nSec-WebSocket-Key: abc\r\nSec-WebSocket-Version: 13\r\n\r\n"
+
+  msgs = -> {
+    [
+      Gori::Store::WsOutMessage.text("hello world"),
+      Gori::Store::WsOutMessage.text("second frame"),
+      Gori::Store::WsOutMessage.text("third frame"),
+    ]
+  }
+
+  # The two request sub-pane CONTENT rects, re-derived exactly as `render` does (target band →
+  # left half → `decode_split`, the ACTIVE pane enlarged to ~2/3 → the card's 1-cell inset).
+  # Reads `view.req_pane` rather than taking it as an argument: a WS tab opens on MESSAGES
+  # (`apply_request_fields` / `load_ws` both set `@req_pane = :decoded`), and hard-coding the
+  # other one aims every click a few rows off.
+  sub_rects = ->(view : RepeaterView, rect : Rect) {
+    target_h = {rect.h, 3}.min # target_card_h with no SNI override
+    content = Rect.new(rect.x, rect.y + target_h, rect.w, {rect.h - target_h, 0}.max)
+    half = {(content.w - 1) // 2, 1}.max
+    col = Rect.new(content.x, content.y, half, content.h)
+    inactive = {col.h // 3, 1}.max
+    env_h = view.req_pane == :envelope ? {col.h - inactive, 1}.max : inactive
+    env = Rect.new(col.x, col.y, col.w, env_h)
+    dec = Rect.new(col.x, col.y + env_h, col.w, {col.h - env_h, 0}.max)
+    {env.inset(1, 1), dec.inset(1, 1)}
+  }
+
+  # A rendered WS repeater, optionally switched to the HANDSHAKE pane first. The render pass is
+  # load-bearing, not decoration: `@last_cw`, `last_rows` and the wrap memo are all set there,
+  # and every geometry inverse below (and `paint_request_read_chrome` itself) is inert until
+  # one has run.
+  render_ws = ->(rect : Rect, on_handshake : Bool) {
+    view = RepeaterView.new
+    view.restore("https://ws.test", ws_head, false, true, ws_messages: msgs.call)
+    view.focus_pane(:request)
+    view.toggle_req_pane if on_handshake # ^T — the tab opens on MESSAGES
+    b = MemoryBackend.new(rect.w, rect.h)
+    view.render(Screen.new(b), rect)
+    {view, b}
+  }
+
+  # The screen column a known token was drawn at, so a click aims at a real cell instead of at
+  # a re-derived gutter width (which depends on the buffer's line count and the gutter setting).
+  col_of = ->(b : MemoryBackend, y : Int32, token : String) {
+    b.row(y).index(token).not_nil!
+  }
+
+  describe "mouse drag" do
+    it "extends a READ-mode selection inside the MESSAGES pane" do
+      rect = Rect.new(0, 0, 100, 30)
+      view, b = render_ws.call(rect, false)
+      _, dec = sub_rects.call(view, rect)
+      x0 = col_of.call(b, dec.y, "hello")
+
+      view.request_click_to_cursor(rect, x0, dec.y)
+      view.request_drag_to_cursor(rect, x0 + 5, dec.y)
+
+      view.pane_selection?.should be_true
+      view.pane_copy_text.should eq("hello")
+    end
+
+    it "extends a READ-mode selection inside the HANDSHAKE REQUEST pane" do
+      rect = Rect.new(0, 0, 100, 30)
+      view, b = render_ws.call(rect, true)
+      env, _ = sub_rects.call(view, rect)
+      x0 = col_of.call(b, env.y, "GET")
+
+      view.request_click_to_cursor(rect, x0, env.y)
+      view.request_drag_to_cursor(rect, x0 + 3, env.y)
+
+      view.pane_selection?.should be_true
+      view.pane_copy_text.should eq("GET")
+    end
+
+    it "extends an INSERT-mode selection in the MESSAGES pane through the editor's own anchor" do
+      rect = Rect.new(0, 0, 100, 30)
+      view, b = render_ws.call(rect, false)
+      _, dec = sub_rects.call(view, rect)
+      x0 = col_of.call(b, dec.y, "hello")
+
+      view.enter_request_insert!
+      view.request_click_to_cursor(rect, x0, dec.y)
+      view.request_drag_to_cursor(rect, x0 + 5, dec.y)
+
+      view.pane_selection?.should be_true
+      view.pane_copy_text.should eq("hello")
+    end
+
+    # A drag that wanders out of a 1/3-height sub-pane must keep extending the selection it
+    # started rather than jumping buffers — a selection spanning two documents is not something
+    # either the band painter or a copy can express.
+    it "keeps a drag out of the MESSAGES pane on the MESSAGES buffer" do
+      rect = Rect.new(0, 0, 100, 30)
+      view, b = render_ws.call(rect, false)
+      _, dec = sub_rects.call(view, rect)
+      x0 = col_of.call(b, dec.y, "hello")
+
+      view.request_click_to_cursor(rect, x0, dec.y)
+      view.req_pane.should eq(:decoded)
+      view.request_drag_to_cursor(rect, x0 + 4, rect.y) # far ABOVE the card
+
+      view.req_pane.should eq(:decoded) # still the pane the press claimed
+      view.pane_copy_text.should_not contain("HTTP/1.1")
+    end
+
+    # The click is the one gesture that DOES switch panes — and it must invert the layout that
+    # was drawn, so the rect comes out before `switch_req_pane` resizes the two cards.
+    it "adopts the sub-pane the press landed in" do
+      rect = Rect.new(0, 0, 100, 30)
+      view, b = render_ws.call(rect, false) # MESSAGES active
+      env, _ = sub_rects.call(view, rect)
+      x0 = col_of.call(b, env.y, "GET")
+
+      view.request_click_to_cursor(rect, x0 + 1, env.y)
+      view.req_pane.should eq(:envelope)
+      view.pane_copy_text.should eq("GET /ws HTTP/1.1") # caret line, no selection
+    end
+  end
+
+  describe "double-click" do
+    it "selects the word under the pointer in the MESSAGES pane" do
+      rect = Rect.new(0, 0, 100, 30)
+      view, b = render_ws.call(rect, false)
+      _, dec = sub_rects.call(view, rect)
+      x = col_of.call(b, dec.y, "world") + 2 # inside the token
+
+      view.request_click_to_cursor(rect, x, dec.y)
+      view.request_select_word.should be_true
+      view.pane_copy_text.should eq("world")
+    end
+
+    it "selects the word under the pointer in the HANDSHAKE REQUEST pane" do
+      rect = Rect.new(0, 0, 100, 30)
+      view, b = render_ws.call(rect, true)
+      env, _ = sub_rects.call(view, rect)
+      x = col_of.call(b, env.y, "GET") + 1
+
+      view.request_click_to_cursor(rect, x, env.y)
+      view.request_select_word.should be_true
+      view.pane_copy_text.should eq("GET")
+    end
+
+    # The real two-press sequence ACROSS a pane switch, at ONE physical (mx, my) — the case a
+    # spec that re-derives the rect between the presses cannot see. Press 1 adopts the lower
+    # card and the split resizes under it: the active pane grows to ~2/3, so the LOWER card's
+    # top edge moves UP by ~1/3 of the column (`env.y` is always `col.y`, which is why the
+    # upper card is immune and only this direction was ever wrong). A second hit-test would
+    # therefore invert the same screen row against a rect that has since moved and spread a
+    # word ~10 rows below the pointer. The double-click spreads from the caret press 1 placed
+    # instead, so no second inverse exists to disagree.
+    it "takes the word actually under the pointer when the press crossed into MESSAGES" do
+      rect = Rect.new(0, 0, 100, 30)
+      view, b = render_ws.call(rect, true) # HANDSHAKE active → MESSAGES is the small lower card
+      view.req_pane.should eq(:envelope)
+      _, dec = sub_rects.call(view, rect)
+      y = dec.y + 1 # "second frame", the 2nd message line
+      x = col_of.call(b, y, "second") + 2
+
+      view.request_click_to_cursor(rect, x, y) # press 1: adopts MESSAGES, split resizes
+      view.req_pane.should eq(:decoded)
+      view.request_select_word.should be_true # press 2: SAME cell, no re-derive
+      view.pane_copy_text.should eq("second")
+    end
+  end
+
+  describe "READ-mode chrome" do
+    # The functional heart of "the keyboard does nothing": both panes paint a block caret in
+    # NORMAL now, so a caret move is visible. `Theme.accent_bg` is the caret/selection tint the
+    # plain REQUEST pane has always used.
+    it "paints a NORMAL-mode block caret in the MESSAGES pane" do
+      rect = Rect.new(0, 0, 100, 30)
+      view, b = render_ws.call(rect, false)
+      view.request_insert?.should be_false
+      _, dec = sub_rects.call(view, rect)
+      b.bg_grid[dec.y][col_of.call(b, dec.y, "hello")].should eq(Theme.accent_bg)
+    end
+
+    it "paints a NORMAL-mode block caret in the HANDSHAKE REQUEST pane" do
+      rect = Rect.new(0, 0, 100, 30)
+      view, b = render_ws.call(rect, true)
+      env, _ = sub_rects.call(view, rect)
+      b.bg_grid[env.y][col_of.call(b, env.y, "GET")].should eq(Theme.accent_bg)
+    end
+
+    it "paints the READ selection band across the MESSAGES pane" do
+      rect = Rect.new(0, 0, 100, 30)
+      view, b = render_ws.call(rect, false)
+      view.pane_select_line # `x` — the whole caret line
+      b2 = MemoryBackend.new(rect.w, rect.h)
+      view.render(Screen.new(b2), rect)
+
+      _, dec = sub_rects.call(view, rect)
+      x0 = col_of.call(b, dec.y, "hello")
+      # "hello world" is 11 chars — the band covers them, tinted like the plain pane's.
+      (0...11).each do |i|
+        b2.bg_grid[dec.y][x0 + i].should eq(Theme.accent_bg)
+      end
+      view.pane_copy_text.should eq("hello world")
+    end
+
+    # INSERT keeps the editor's own caret + band. The two painters are mutually exclusive by
+    # construction (`cursor` is the gate on one, `!ins` on the other), so a mode switch must
+    # not leave two carets on screen.
+    it "does not paint the READ band while the MESSAGES pane is in INSERT" do
+      rect = Rect.new(0, 0, 100, 30)
+      view, b = render_ws.call(rect, false)
+      view.pane_select_line
+      view.enter_request_insert!
+      b2 = MemoryBackend.new(rect.w, rect.h)
+      view.render(Screen.new(b2), rect)
+
+      _, dec = sub_rects.call(view, rect)
+      x0 = col_of.call(b, dec.y, "hello")
+      b2.bg_grid[dec.y][x0 + 6].should_not eq(Theme.accent_bg) # mid-"world": the READ band is gone
+    end
+  end
+
+  describe "cross-pane arrows" do
+    # `restore` leaves the tab in READ mode, which is exactly the state in which the arrows
+    # used to clamp: ↓ stopped at the bottom of HANDSHAKE and ↑ at the top of MESSAGES, so
+    # `^T` was the only way between the two panes.
+    it "steps ↓ off the HANDSHAKE bottom into MESSAGES in READ mode" do
+      rect = Rect.new(0, 0, 100, 30)
+      view, _ = render_ws.call(rect, true)
+      view.request_insert?.should be_false
+      view.req_pane.should eq(:envelope)
+
+      12.times { view.request_read_move(1, 0) } # past the handshake's last line
+      view.req_pane.should eq(:decoded)
+    end
+
+    it "steps ↑ off the MESSAGES top back into HANDSHAKE in READ mode" do
+      rect = Rect.new(0, 0, 100, 30)
+      view, _ = render_ws.call(rect, false)
+      view.req_pane.should eq(:decoded)
+
+      view.request_read_move(-1, 0)
+      view.req_pane.should eq(:envelope)
+    end
+
+    # A page is a viewport gesture: it clamps inside its own sub-pane, matching `edit_page` in
+    # INSERT (which never went through `edit_move`'s cross-pane branch either).
+    it "does not cross panes on PageDown" do
+      rect = Rect.new(0, 0, 100, 30)
+      view, _ = render_ws.call(rect, true)
+      5.times { view.request_read_page(1) }
+      view.req_pane.should eq(:envelope)
+    end
+
+    # Crossing ends the selection: one `@req_read` serves both buffers, so an anchor carried
+    # across would paint a band using one document's coordinates over another's text.
+    it "drops the read selection when the arrows cross panes" do
+      rect = Rect.new(0, 0, 100, 30)
+      view, _ = render_ws.call(rect, false)
+      view.pane_select_line
+      view.pane_selection?.should be_true
+
+      view.request_read_move(-1, 0)
+      view.req_pane.should eq(:envelope)
+      view.pane_selection?.should be_false
+    end
+  end
+
+  describe "READ-mode Home/End" do
+    # These move the EDITOR caret directly, so READ has to adopt the result. Without
+    # `sync_to`, a plain Home left the anchor where it was and painted a band the operator had
+    # just collapsed, while ⇧Home planted no anchor and extended nothing.
+    it "extends the read selection on ⇧End and collapses it on a plain Home" do
+      rect = Rect.new(0, 0, 100, 30)
+      view, _ = render_ws.call(rect, false)
+
+      view.edit_end(selecting: true)
+      view.pane_selection?.should be_true
+      view.pane_copy_text.should eq("hello world")
+
+      view.edit_home
+      view.pane_selection?.should be_false
+    end
+  end
+
+  describe "border chrome" do
+    it "hit-tests the ␣K:KEY badge that render_request draws" do
+      rect = Rect.new(0, 0, 100, 30)
+      view, b = render_ws.call(rect, true)
+      env, _ = sub_rects.call(view, rect)
+      border_y = env.y - 1 # the card's top border, one row above its content
+      col = col_of.call(b, border_y, "␣K:KEY")
+      view.chrome_hit(rect, col + 2, border_y).should eq(:ws_key)
+    end
+
+    it "hit-tests the NOR/INS mode badge on the HANDSHAKE card" do
+      rect = Rect.new(0, 0, 100, 30)
+      view, b = render_ws.call(rect, true)
+      env, _ = sub_rects.call(view, rect)
+      border_y = env.y - 1
+      col = col_of.call(b, border_y, "↵:NOR")
+      view.chrome_hit(rect, col + 1, border_y).should eq(:mode)
+    end
+
+    it "still reports ^R:SEND" do
+      rect = Rect.new(0, 0, 100, 30)
+      view, b = render_ws.call(rect, true)
+      env, _ = sub_rects.call(view, rect)
+      border_y = env.y - 1
+      col = col_of.call(b, border_y, "^R:SEND")
+      view.chrome_hit(rect, col + 2, border_y).should eq(:send)
+    end
+  end
+
+  describe "pointer-aware wheel" do
+    # The wheel used to scroll whichever sub-pane held the caret, so a notch over HANDSHAKE
+    # moved MESSAGES. `request_hit` answers the same question the click asks.
+    it "scrolls the sub-pane under the pointer, not the active one" do
+      rect = Rect.new(0, 0, 100, 20)
+      long_head = String.build do |io|
+        io << "GET /ws HTTP/1.1\r\n"
+        (1..20).each { |i| io << "X-Pad-#{i}: v\r\n" }
+        io << "\r\n"
+      end
+      view = RepeaterView.new
+      view.restore("https://ws.test", long_head, false, true, ws_messages: msgs.call)
+      view.focus_pane(:request)
+      view.req_pane.should eq(:decoded) # MESSAGES is active
+      b = MemoryBackend.new(rect.w, rect.h)
+      view.render(Screen.new(b), rect)
+      b.contains?("GET /ws").should be_true
+
+      env, _ = sub_rects.call(view, rect)
+      view.request_scroll_view_at(3, rect, env.x + 1, env.y) # wheel over HANDSHAKE
+      b2 = MemoryBackend.new(rect.w, rect.h)
+      view.render(Screen.new(b2), rect)
+
+      view.req_pane.should eq(:decoded)          # the wheel is not a focus change
+      b2.contains?("GET /ws").should be_false    # HANDSHAKE scrolled off its first line
+      b2.contains?("hello world").should be_true # MESSAGES did not move
+    end
+  end
+
+  describe "response transcript" do
+    # ←/→ were gated off for WS / gRPC / group transcripts, leaving vertical motion only —
+    # while a mouse drag over the same rows selected by character and `resp_copy_text` copied
+    # exactly that span. `resp_drawn_source` reports a 0-column decoration offset for a
+    # transcript (only DIFF has one), so the caret columns are the row's own.
+    it "moves the read caret horizontally with ←/→ and extends with ⇧→" do
+      view = RepeaterView.new
+      view.restore("https://ws.test", ws_head, false, true, ws_messages: msgs.call)
+      view.apply_ws(Gori::Repeater::WsEngine::Result.new(
+        "HTTP/1.1 101 Switching Protocols\r\n\r\n".to_slice,
+        [Gori::Repeater::WsEngine::Message.new("out", 1, "ping-payload".to_slice)],
+        100_i64, upgraded: true))
+      view.focus_pane(:response)
+      rect = Rect.new(0, 0, 100, 30)
+      view.render(Screen.new(MemoryBackend.new(rect.w, rect.h)), rect)
+
+      view.resp_move(0, 1)
+      view.resp_move(0, 1)
+      view.resp_cursor.cx.should eq(2)
+
+      view.resp_move(0, 1, selecting: true)
+      view.pane_selection?.should be_true
+      view.resp_copy_text.should_not be_empty
+    end
+  end
+
+  # The RESPONSE column is split too — HANDSHAKE RESPONSE over TRANSCRIPT — and the handshake
+  # card was on screen and completely unreachable: `response_body_rect` hard-coded the transcript
+  # rect, so a click there produced a negative row and was dropped, and `resp_line_source`
+  # answered with transcript rows whatever the pointer was over. No caret, no selection, no copy.
+  #
+  # It now works the same way the request column does: `@resp_pane` picks the line source, the
+  # press adopts the card it landed in, and `switch_resp_pane` parks the outgoing pane's
+  # {scroll, cursor} while dropping the line-indexed wrap memo that describes the other document.
+  describe "response column split" do
+    handshake = "HTTP/1.1 101 Switching Protocols\r\n" \
+                "Upgrade: websocket\r\nConnection: Upgrade\r\n" \
+                "Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=\r\n\r\n"
+
+    sent = -> {
+      view = RepeaterView.new
+      view.restore("https://ws.test", ws_head, false, true, ws_messages: msgs.call)
+      view.apply_ws(Gori::Repeater::WsEngine::Result.new(
+        handshake.to_slice,
+        [
+          Gori::Repeater::WsEngine::Message.new("out", 1, "ping-payload".to_slice),
+          Gori::Repeater::WsEngine::Message.new("in", 1, "pong-payload".to_slice),
+        ],
+        100_i64, upgraded: true))
+      view.focus_pane(:response)
+      view
+    }
+
+    # Same derivation as `ws_resp_split`: the handshake keeps a fixed 7 rows while the transcript
+    # is active, and grows to ~2/3 when it becomes active.
+    resp_rects = ->(view : RepeaterView, rect : Rect) {
+      target_h = {rect.h, 3}.min
+      content = Rect.new(rect.x, rect.y + target_h, rect.w, {rect.h - target_h, 0}.max)
+      half = {(content.w - 1) // 2, 1}.max
+      col = Rect.new(content.x + half + 1, content.y, {content.w - half - 1, 1}.max, content.h)
+      hs_h = view.resp_pane == :handshake ? {col.h - {col.h // 3, 1}.max, 1}.max : 7
+      hs_h = hs_h.clamp(1, {col.h - 2, 1}.max)
+      hs = Rect.new(col.x, col.y, col.w, hs_h)
+      tr = Rect.new(col.x, col.y + hs_h, col.w, {col.h - hs_h, 0}.max)
+      {hs.inset(1, 1), tr.inset(1, 1)}
+    }
+
+    render = ->(view : RepeaterView, rect : Rect) {
+      b = MemoryBackend.new(rect.w, rect.h)
+      view.render(Screen.new(b), rect)
+      b
+    }
+
+    # A token's column WITHIN the response card — the search starts at the card's left edge.
+    # A bare `row.index(token)` finds the REQUEST column's copy on the same screen row: row 4
+    # holds `GET /ws HTTP/1.1` on the left and `HTTP/1.1 101 …` on the right, and the first
+    # match is the one in the pane this spec is not clicking.
+    col_in = ->(b : MemoryBackend, card : Rect, y : Int32, token : String) {
+      b.row(y).index(token, card.x).not_nil!
+    }
+
+    it "opens on the transcript, leaving a non-split column's behaviour untouched" do
+      view = sent.call
+      view.resp_pane.should eq(:transcript)
+      plain = RepeaterView.new
+      plain.restore("https://h.test", "GET / HTTP/1.1\r\nHost: h.test\r\n\r\n", false, true)
+      plain.resp_pane.should eq(:transcript)
+    end
+
+    it "adopts the HANDSHAKE card on a click and places its caret there" do
+      view = sent.call
+      rect = Rect.new(0, 0, 100, 30)
+      b = render.call(view, rect)
+      hs, _ = resp_rects.call(view, rect)
+      x = col_in.call(b, hs, hs.y, "HTTP/1.1")
+
+      view.resp_click_to_cursor(rect, x, hs.y)
+      view.resp_pane.should eq(:handshake)
+      view.resp_cursor.cy.should eq(0)
+      view.resp_copy_text.should eq("HTTP/1.1 101 Switching Protocols")
+    end
+
+    it "drag-selects inside the HANDSHAKE card" do
+      view = sent.call
+      rect = Rect.new(0, 0, 100, 30)
+      b = render.call(view, rect)
+      hs, _ = resp_rects.call(view, rect)
+      x = col_in.call(b, hs, hs.y, "HTTP/1.1")
+
+      view.resp_click_to_cursor(rect, x, hs.y) # adopts + places
+      view.resp_drag_to_cursor(rect, x + 8, hs.y)
+
+      view.pane_selection?.should be_true
+      view.resp_copy_text.should eq("HTTP/1.1")
+    end
+
+    it "double-clicks a word in the HANDSHAKE card" do
+      view = sent.call
+      rect = Rect.new(0, 0, 100, 30)
+      b = render.call(view, rect)
+      hs, _ = resp_rects.call(view, rect)
+      y = hs.y + 3 # the Sec-WebSocket-Accept line
+      b.row(y).should contain("Sec-WebSocket-Accept")
+      x = col_in.call(b, hs, y, "Accept") + 2
+
+      view.resp_click_to_cursor(rect, x, y)
+      view.resp_select_word.should be_true
+      view.resp_copy_text.should eq("Sec-WebSocket-Accept")
+    end
+
+    it "selects a whole handshake line with x and copies it" do
+      view = sent.call
+      rect = Rect.new(0, 0, 100, 30)
+      b = render.call(view, rect)
+      hs, _ = resp_rects.call(view, rect)
+      view.resp_click_to_cursor(rect, col_in.call(b, hs, hs.y + 1, "Upgrade"), hs.y + 1)
+      view.resp_pane.should eq(:handshake)
+
+      view.pane_select_line
+      view.pane_selection?.should be_true
+      view.pane_copy_text.should eq("Upgrade: websocket")
+    end
+
+    it "copies the whole handshake head, not the transcript, while that card is active" do
+      view = sent.call
+      rect = Rect.new(0, 0, 100, 30)
+      b = render.call(view, rect)
+      hs, _ = resp_rects.call(view, rect)
+      view.resp_click_to_cursor(rect, col_in.call(b, hs, hs.y, "HTTP"), hs.y)
+
+      all = view.pane_copy_all_text
+      all.should contain("Sec-WebSocket-Accept")
+      all.should_not contain("ping-payload") # that is the transcript's
+
+      # And "copy as" offers the head/body split, because this card really is an HTTP head.
+      view.response_parts.should_not be_nil
+      view.response_parts.not_nil![0].should contain("101 Switching Protocols")
+    end
+
+    it "paints the caret + selection band on the ACTIVE card only" do
+      view = sent.call
+      rect = Rect.new(0, 0, 100, 30)
+      b = render.call(view, rect)
+      hs, tr = resp_rects.call(view, rect)
+      # Transcript active: its first row carries the block caret, the handshake's does not.
+      b.bg_grid[tr.y][col_in.call(b, tr, tr.y, "→")].should eq(Theme.accent_bg)
+      b.bg_grid[hs.y][col_in.call(b, hs, hs.y, "HTTP")].should_not eq(Theme.accent_bg)
+
+      view.toggle_resp_pane.should eq(:handshake)
+      b2 = render.call(view, rect)
+      hs2, tr2 = resp_rects.call(view, rect)
+      b2.bg_grid[hs2.y][col_in.call(b2, hs2, hs2.y, "HTTP")].should eq(Theme.accent_bg)
+      b2.bg_grid[tr2.y][col_in.call(b2, tr2, tr2.y, "→")].should_not eq(Theme.accent_bg)
+    end
+
+    it "grows the handshake card when it becomes active and shrinks it back" do
+      view = sent.call
+      rect = Rect.new(0, 0, 100, 30)
+      render.call(view, rect)
+      hs_before, _ = resp_rects.call(view, rect)
+      view.toggle_resp_pane
+      render.call(view, rect)
+      hs_after, _ = resp_rects.call(view, rect)
+      hs_after.h.should be > hs_before.h
+      view.toggle_resp_pane
+      render.call(view, rect)
+      resp_rects.call(view, rect)[0].h.should eq(hs_before.h)
+    end
+
+    describe "cross-card arrows" do
+      it "steps ↓ off the handshake bottom into the transcript" do
+        view = sent.call
+        rect = Rect.new(0, 0, 100, 30)
+        render.call(view, rect)
+        view.toggle_resp_pane.should eq(:handshake)
+
+        # Step until it crosses, then stop — further ↓ presses would keep walking DOWN the
+        # transcript and the landing line is what this pins.
+        20.times { break if view.resp_pane == :transcript; view.resp_move(1, 0) }
+        view.resp_pane.should eq(:transcript)
+        view.resp_cursor.cy.should eq(0) # landed on the transcript's first line
+      end
+
+      it "steps ↑ off the transcript top back into the handshake, at its last line" do
+        view = sent.call
+        rect = Rect.new(0, 0, 100, 30)
+        render.call(view, rect)
+        view.resp_pane.should eq(:transcript)
+
+        view.resp_move(-1, 0)
+        view.resp_pane.should eq(:handshake)
+        view.resp_copy_text.should_not contain("ping-payload")
+      end
+
+      # ↑ at the very top of the UPPER card still ejects to the tab bar — that is the only
+      # remaining upward exit, and `at_top?` is what the Runner reads for it.
+      it "reports at_top? only on the handshake's first line" do
+        view = sent.call
+        rect = Rect.new(0, 0, 100, 30)
+        render.call(view, rect)
+        view.at_top?.should be_false # on the transcript: ↑ crosses instead of ejecting
+        view.toggle_resp_pane
+        20.times { view.resp_move(-1, 0) }
+        view.resp_pane.should eq(:handshake)
+        view.at_top?.should be_true
+      end
+
+      it "drops the selection when the arrows cross cards" do
+        view = sent.call
+        rect = Rect.new(0, 0, 100, 30)
+        render.call(view, rect)
+        view.pane_select_line
+        view.pane_selection?.should be_true
+        view.resp_move(-1, 0)
+        view.resp_pane.should eq(:handshake)
+        view.pane_selection?.should be_false
+      end
+    end
+
+    # Each card keeps its own place, like the two TextAreas of the request column do.
+    it "parks and restores each card's scroll + caret across a switch" do
+      view = sent.call
+      rect = Rect.new(0, 0, 100, 30)
+      render.call(view, rect)
+      view.resp_move(1, 0) # transcript, line 1
+      view.resp_cursor.cy.should eq(1)
+
+      view.toggle_resp_pane
+      render.call(view, rect)
+      view.resp_move(1, 0)
+      view.resp_move(1, 0) # handshake, line 2
+      view.resp_cursor.cy.should eq(2)
+
+      view.toggle_resp_pane # back to the transcript
+      view.resp_cursor.cy.should eq(1)
+      view.toggle_resp_pane # and back to the handshake
+      view.resp_cursor.cy.should eq(2)
+    end
+
+    # A parked caret can outlive the document it was parked in: a resend rebuilds the transcript.
+    it "clamps a parked caret that no longer exists in its document" do
+      view = sent.call
+      rect = Rect.new(0, 0, 100, 30)
+      render.call(view, rect)
+      2.times { view.resp_move(1, 0) } # transcript, line 2
+      view.toggle_resp_pane            # park it
+
+      # A resend with a single-row transcript (error only) shrinks it under the parked line.
+      view.apply_ws(Gori::Repeater::WsEngine::Result.new(
+        Bytes.empty, [] of Gori::Repeater::WsEngine::Message, 5_i64, "connect failed"))
+      render.call(view, rect)
+      view.toggle_resp_pane.should eq(:transcript)
+      size, _ = view.resp_line_source
+      view.resp_cursor.cy.should be < size # inside the new document, not past its end
+    end
+
+    # `bg_grid` proves the CHROME half of the `active` gate. This proves the METRICS half, which
+    # is the more dangerous one: both cards render every frame, so whichever wrote
+    # `@resp_last_gw`/`@resp_last_cw`/`@resp_last_h` last would win regardless of which card the
+    # cursor is on — and every click and wheel notch would then invert against the wrong geometry
+    # while the caret still looked correct. A click that lands on the row it aimed at, in the
+    # ENLARGED handshake card, can only work if that card published its own numbers.
+    it "publishes the active card's own geometry, so a click lands on the row it aimed at" do
+      view = sent.call
+      rect = Rect.new(0, 0, 100, 30)
+      render.call(view, rect)
+      view.toggle_resp_pane.should eq(:handshake)
+      b = render.call(view, rect) # the card is now ~2/3 of the column, with its own gutter width
+      hs, _ = resp_rects.call(view, rect)
+
+      # Aim at each of the four head lines in turn; each must resolve to its own index.
+      ["HTTP/1.1", "Upgrade:", "Connection:", "Sec-WebSocket-Accept"].each_with_index do |token, li|
+        y = hs.y + li
+        view.resp_click_to_cursor(rect, col_in.call(b, hs, y, token), y)
+        view.resp_cursor.cy.should eq(li)
+      end
+      view.resp_copy_text.should contain("Sec-WebSocket-Accept")
+    end
+
+    # A parked anchor is an index into a document that a resend replaces. `@scroll_sub` is the
+    # sharp edge: it indexes INTO a specific line's wrap layout, so restoring one across a park is
+    # only meaningful if that line still wraps identically — which nothing can prove. It is zeroed
+    # rather than restored, and `apply_ws` clears the whole parked anchor because a send replaces
+    # both documents at once.
+    it "does not carry a parked sub-row anchor into a rebuilt document" do
+      view = sent.call
+      rect = Rect.new(0, 0, 60, 30) # narrow, so a transcript row wraps and a sub-row exists
+      render.call(view, rect)
+      2.times { view.scroll(1) } # walk the anchor into a CONTINUATION row of a wrapped line
+      view.toggle_resp_pane.should eq(:handshake)
+
+      view.apply_ws(Gori::Repeater::WsEngine::Result.new(
+        handshake.to_slice,
+        [Gori::Repeater::WsEngine::Message.new("out", 1, "x".to_slice)],
+        7_i64, upgraded: true))
+      render.call(view, rect)
+      view.toggle_resp_pane.should eq(:transcript)
+
+      # `apply_ws` cleared the parked anchor, so the rebuilt transcript comes back at its top —
+      # first logical line, FIRST visual row. A carried sub-row would open the pane part-way into
+      # a line that the new document never laid out at that row.
+      size, _ = view.resp_line_source
+      view.resp_cursor.cy.should be < size
+      b = render.call(view, rect)
+      _, tr = resp_rects.call(view, rect)
+      b.row(tr.y).should contain("→ x") # line 1 from its start, not mid-wrap
+      view.resp_cursor.cy.should eq(0)
+    end
+
+    # `@resp_hex` can be set on a plain HTTP response and then survive the SAME view becoming a
+    # WebSocket tab (edit the request into an upgrade handshake — `apply_request_fields` flips
+    # `@ws_mode` and nothing clears the flag). The hex dump is never what a transcript draws, so
+    # letting the flag speak for navigability killed the caret, the selection and every arrow key
+    # with no visual change — and, with `at_top?` now crossing cards, left a column with no way out.
+    it "stays navigable when a stale response-hex flag survives into WebSocket mode" do
+      view = RepeaterView.new
+      view.restore("https://h.test", "GET / HTTP/1.1\r\nHost: h.test\r\n\r\n", false, true)
+      view.focus_pane(:response)
+      view.toggle_resp_hex
+      view.resp_hex?.should be_true
+      view.resp_navigable?.should be_false # a real HTTP response: the dump IS what is drawn
+
+      # The same view becomes a WebSocket tab, flag and all.
+      view.restore("https://ws.test", ws_head, false, true, ws_messages: msgs.call)
+      view.focus_pane(:response)
+      view.ws_mode?.should be_true
+      view.resp_hex?.should be_true       # the flag survived, as it always did …
+      view.resp_navigable?.should be_true # … but it no longer speaks for a pane it cannot draw
+
+      rect = Rect.new(0, 0, 100, 30)
+      b = render.call(view, rect)
+      hs, _ = resp_rects.call(view, rect)
+      view.resp_click_to_cursor(rect, col_in.call(b, hs, hs.y, "not sent"), hs.y)
+      view.resp_pane.should eq(:handshake)
+      view.at_top?.should be_true # and it can still be left upward
+    end
+
+    # ^F over the handshake card searches the handshake, not the transcript.
+    it "searches the active card" do
+      view = sent.call
+      rect = Rect.new(0, 0, 100, 30)
+      render.call(view, rect)
+      view.response_search_lines("payload").should_not be_empty # transcript
+      view.response_search_lines("Sec-WebSocket-Accept").should be_empty
+
+      view.toggle_resp_pane
+      view.response_search_lines("Sec-WebSocket-Accept").should_not be_empty
+      view.response_search_lines("payload").should be_empty
+    end
+  end
+end

--- a/src/gori/tui/controllers/jwt_controller.cr
+++ b/src/gori/tui/controllers/jwt_controller.cr
@@ -40,6 +40,30 @@ module Gori::Tui
       @header = TextArea.new("")
       @payload = TextArea.new("")
     end
+
+    # Home/End on the INPUT pane. They move the EDITOR's caret, so READ mode has to adopt the
+    # result: `JwtView#paint_read_chrome` paints purely from `input_read`, which nothing here was
+    # updating — so both keys moved a caret nobody could see and left the painted block caret
+    # parked where it stood. `selecting` was not threaded either, so ⇧Home/⇧End behaved as plain
+    # Home/End and could not start a selection.
+    #
+    # The pair lives on the session rather than in the controller's `case` because both halves —
+    # the editor move and the read-cursor adoption — have to travel together; four sibling views
+    # (Notes, Issues, Project, the Decoder input) pair them at their own seam for the same reason.
+    def input_home(selecting : Bool = false) : Nil
+      @input.home(selecting)
+      adopt_input_caret(selecting)
+    end
+
+    def input_end(selecting : Bool = false) : Nil
+      @input.end_of_line(selecting)
+      adopt_input_caret(selecting)
+    end
+
+    private def adopt_input_caret(selecting : Bool) : Nil
+      return if @input_mode == InputMode::Insert # INS owns its own anchor, inside the TextArea
+      @input_read.sync_to(@input, selecting: selecting)
+    end
   end
 
   # The JWT tab: a hidden workbench for decoding, editing/re-signing, and generating
@@ -322,8 +346,8 @@ module Gori::Tui
         s.input.at_bottom? ? cross_pane(s, 1) : s.input_read.move(s.input, 1, 0, selecting: selecting)
       when key.left?  then s.input_read.move(s.input, 0, -1, selecting: selecting)
       when key.right? then s.input_read.move(s.input, 0, 1, selecting: selecting)
-      when key.home?  then s.input.home
-      when key.end?   then s.input.end_of_line
+      when key.home?  then s.input_home(selecting) # editor move + read-cursor adopt — see JwtSession
+      when key.end?   then s.input_end(selecting)
       when c && !ev.ctrl? && !ev.alt? && !c.control?
         return false # x/y + Global breath → keymap
       end

--- a/src/gori/tui/controllers/repeater_controller.cr
+++ b/src/gori/tui/controllers/repeater_controller.cr
@@ -237,10 +237,13 @@ module Gori::Tui
       return "HEX: 0-9a-f overtype · Ins/Del/⌫ bytes · ←/→/↑/↓ move · #{hex}/esc exit" if v.request_hex?
       read_common = "⇧arrows select · #{y} copy · space cmds"
       if v.ws_mode?
-        return v.focus == :response ? "↑/↓ move · #{read_common} · ⇧←/→ h-scroll · ^F find · #{send} send · ↹ pane · esc tabs" : ws_hint(v)
+        # The response column has two cards on a WS tab, so name the card being read and the
+        # key that swaps them — the same shape `ws_hint` uses for the request column's two.
+        return ws_resp_hint(v, read_common, send) if v.focus == :response
+        return ws_hint(v)
       end
       if v.grpc_mode?
-        return v.focus == :response ? "↑/↓ move · #{read_common} · ⇧←/→ h-scroll · ^F find · #{send} send · ↹ pane · esc tabs" : grpc_hint(v)
+        return v.focus == :response ? "↑/↓ move · #{read_common} · ←/→ char · ^F find · #{send} send · ↹ pane · esc tabs" : grpc_hint(v)
       end
       return decode_hint(v) if v.decode_mode? && v.focus == :request
       case v.focus
@@ -252,7 +255,7 @@ module Gori::Tui
         end
       when :response
         nav = v.resp_navigable? ? "↑/↓ move" : "↑/↓ scroll"
-        "#{nav} · #{read_common} · #{diff} diff · ⇧←/→ h-scroll · #{hex} hex · #{pretty} pretty · ^F find · ↵/#{send} send · ↹ pane · esc tabs"
+        "#{nav} · #{read_common} · #{diff} diff · ←/→ char · #{hex} hex · #{pretty} pretty · ^F find · ↵/#{send} send · ↹ pane · esc tabs"
       when :request
         if v.request_insert?
           # `↹ text`, not `↹ pane`: in INSERT, Tab inserts a TAB CHARACTER (handle_editor_tab
@@ -386,6 +389,14 @@ module Gori::Tui
       "#{mode} #{sub} · ^T switch · ^G goto · ^F find · esc read · ↹ pane"
     end
 
+    # The RESPONSE column's footer on a WS tab — the twin of `ws_hint`, naming the card being
+    # read and `^T` as the way to the other one. Without it the handshake response card was
+    # reachable and nothing said so.
+    private def ws_resp_hint(v : RepeaterView, read_common : String, send : String) : String
+      card = v.resp_pane == :handshake ? "handshake response" : "transcript"
+      "↑/↓ move #{card} · #{read_common} · ←/→ char · ^T switch · ^F find · #{send} send · ↹ pane · esc tabs"
+    end
+
     # --- request-pane toggles (keymap-driven verbs; carry the pane-gating + status) ---
     # A gRPC request flow: an HTTP/2 call whose request content-type is application/grpc.
     private def grpc_flow?(detail : Store::FlowDetail) : Bool
@@ -422,6 +433,15 @@ module Gori::Tui
     def repeater_toggle_decoded : Nil
       view = current_view
       return @host.status("no repeater open") unless view
+      # With the RESPONSE pane focused on a WebSocket tab, ^T toggles THAT column's two cards
+      # (handshake response ⇄ transcript) instead of the request's. Same key, same gesture —
+      # "switch the card I am reading" — on whichever column has focus; this method has been
+      # context-sensitive since it was written, and the response column is the third context.
+      if view.ws_mode? && view.focus == :response
+        pane = view.toggle_resp_pane
+        @host.status(pane == :handshake ? "reading the handshake response (101 head)" : "reading the message transcript")
+        return
+      end
       if view.decode_mode? || view.ws_mode?
         @host.request_focus(:body)
         view.focus_pane(:request)
@@ -469,8 +489,17 @@ module Gori::Tui
         on = view.toggle_request_hex
         @host.status(on ? "hex edit: on — sends exact bytes (^X/esc exit; not text-safe)" : "hex edit: off")
       elsif view.focus == :response
-        view.toggle_resp_hex
-        @host.status(view.resp_hex? ? "response hex dump: on — raw bytes (^X exit)" : "response hex dump: off")
+        # A transcript pane never renders the hex dump — `render_response` returns at its own
+        # branch long before the `@resp_hex` one — but `resp_navigable?` reads the same flag, so
+        # setting it here silently killed the caret, the selection and every arrow key while the
+        # pane looked completely unchanged. (Reachable only on a pipelined GROUP send: WS and
+        # gRPC are refused above.) Refuse it where it cannot be honoured.
+        if view.group_mode?
+          @host.status("no hex dump for a group transcript — it is N responses, not one byte stream")
+        else
+          view.toggle_resp_hex
+          @host.status(view.resp_hex? ? "response hex dump: on — raw bytes (^X exit)" : "response hex dump: off")
+        end
       else
         @host.status("hex edit (^X) applies to the REQUEST or RESPONSE pane — ↹ to one")
       end
@@ -604,6 +633,9 @@ module Gori::Tui
       when :req_hex
         view.focus_pane(:request)
         repeater_toggle_hex
+      when :ws_key
+        view.focus_pane(:request)
+        repeater_toggle_ws_key
       when :send
         view.focus_pane(:request)
         repeater_send
@@ -622,6 +654,21 @@ module Gori::Tui
           view.enter_target_insert!
         end
       end
+    end
+
+    # The wheel with the pointer position: a split request column (WS handshake + messages, a
+    # decode tab's envelope + payload) scrolls the sub-pane UNDER the cursor rather than the
+    # one holding the caret. Everything else — including the whole response column — keeps the
+    # coordinate-free behaviour, so this is the split's fix and nothing else's change.
+    def handle_wheel_at(step : Int32, mx : Int32, my : Int32, rect : Rect) : Bool
+      v = current_view
+      return true unless v
+      body = body_rect_below_filter(rect)
+      if v.focus == :request && v.pane_at(body, mx, my) == :request
+        v.request_scroll_view_at(step, body, mx, my)
+        return true
+      end
+      handle_wheel(step)
     end
 
     def handle_wheel(step : Int32) : Bool
@@ -772,8 +819,9 @@ module Gori::Tui
       body = body_rect_below_filter(rect)
       return false if v.chrome_hit(body, mx, my) # a border badge is a button, not text
       case v.focus
-      when :request  then v.request_select_word(body, mx, my)
-      when :response then v.resp_select_word(body, mx, my)
+      # Both spread from the caret the press placed rather than hit-testing again — see the view.
+      when :request  then v.request_select_word
+      when :response then v.resp_select_word
       else                false
       end
     end
@@ -2051,14 +2099,18 @@ module Gori::Tui
       transcript = view.ws_mode? || view.grpc_mode? || view.group_mode?
       nav = view.resp_navigable?
       c = ev.char || key.to_char
+      # ←/→ (and ⇧←/⇧→) move the read caret by a character in EVERY navigable response shape,
+      # transcripts included. They used to be gated off for WS / gRPC / group, which left the
+      # transcript with vertical motion only — while a mouse drag across the same rows selected
+      # by character and `resp_copy_text` copied exactly that char span. Nothing in the model
+      # was transcript-specific: `resp_drawn_source` reports a decoration offset of 0 for a
+      # transcript (only DIFF has one), so the caret columns are the row's own columns.
       case
-      when key.enter?               then repeater_send
-      when key.up?, key.lower_k?    then view.at_top? ? view.focus_first : resp_nav_step(view, -1, 0, selecting, nav)
-      when key.down?, key.lower_j?  then resp_nav_step(view, 1, 0, selecting, nav)
-      when key.left? && !selecting  then resp_nav_step(view, 0, -1, false, nav) unless transcript
-      when key.right? && !selecting then resp_nav_step(view, 0, 1, false, nav) unless transcript
-      when key.left? && selecting   then resp_nav_step(view, 0, -1, true, nav) unless transcript
-      when key.right? && selecting  then resp_nav_step(view, 0, 1, true, nav) unless transcript
+      when key.enter?              then repeater_send
+      when key.up?, key.lower_k?   then view.at_top? ? view.focus_first : resp_nav_step(view, -1, 0, selecting, nav)
+      when key.down?, key.lower_j? then resp_nav_step(view, 1, 0, selecting, nav)
+      when key.left?               then resp_nav_step(view, 0, -1, selecting, nav)
+      when key.right?              then resp_nav_step(view, 0, 1, selecting, nav)
       when transcript
         # Transcript: no d/x/p tools; still let Global breath / copy through.
         return false if c && !ev.ctrl? && !ev.alt? && !c.control?

--- a/src/gori/tui/frame.cr
+++ b/src/gori/tui/frame.cr
@@ -144,6 +144,15 @@ module Gori::Tui
     # Notes, …). NOR advertises ↵ (and i) as the way into insert; INS is a plain lit label
     # (esc exits — already in the status strip). Clickable via `mode_badge_hit`. Returns
     # the badge's left x for chaining, or `right_edge` when it doesn't fit.
+    #
+    # `insert` must be the pane's REAL mode — never `focused && insert?`. The two labels are
+    # different WIDTHS (" ↵:NOR " is 7 cells, " INS " is 5), and `mode_badge_hit` is called from a
+    # click handler that has no idea which pane had focus when the frame was drawn; every caller's
+    # hit-test therefore passes the bare mode. Gating the label on focus desynchronised the two:
+    # a pane that retained INS while focus moved away (no view exits insert on a focus change)
+    # drew the 7-cell NOR chip over a 5-cell hit rect — two dead cells on its left — and a click
+    # on a chip reading "↵:NOR" ran the INS branch and turned insert OFF. Focus belongs in the
+    # BORDER (`Frame.pane_border(focused, insert:)`), not in this label.
     def self.mode_badge(screen : Screen, right_edge : Int32, y : Int32, min_x : Int32,
                         insert : Bool) : Int32
       text = mode_badge_label(insert)

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -1623,12 +1623,22 @@ module Gori::Tui
 
     # Home/End: caret to line start/end — pure navigation, no dirty. `selecting` is the Shift
     # half (extends instead of collapsing), like the arrows.
+    #
+    # These move the EDITOR's caret directly, so READ mode has to adopt the result — the anchor
+    # rules live in `@template_read`, and `paint_template_read_chrome`'s per-frame `sync_from`
+    # copies cy/cx while leaving the anchor alone. Without `sync_to`: a plain Home left the anchor
+    # where it was and painted a band from there to column 0, over a selection the operator had
+    # just collapsed — and `y` then copied "" because the band's two ends had crossed. ⇧Home/⇧End
+    # planted no anchor at all and extended nothing. `sync_to` is the helper written for exactly
+    # this pair; Notes, Issues, Project and the Decoder input all already call it.
     def template_home(selecting : Bool = false) : Nil
       @editor.home(selecting)
+      @template_read.sync_to(@editor, selecting: selecting) unless template_insert?
     end
 
     def template_end(selecting : Bool = false) : Nil
       @editor.end_of_line(selecting)
+      @template_read.sync_to(@editor, selecting: selecting) unless template_insert?
     end
 
     # ⌃/⌥ + Home/End — the buffer's start/end rather than the line's.
@@ -1938,7 +1948,9 @@ module Gori::Tui
       return if rect.h < 2
       ins = focused && target_insert?
       Frame.card(screen, rect, "TARGET", bg: Theme.bg, border: pane_border(focused, insert: ins))
-      Frame.mode_badge(screen, rect.right - 1, rect.y, rect.x + 8, ins)
+      # The REAL mode, not `ins` — `target_chrome_hit` measures the bare `target_insert?`, and the
+      # two labels are different widths. See `Frame.mode_badge`.
+      Frame.mode_badge(screen, rect.right - 1, rect.y, rect.x + 8, target_insert?)
       unless @sni.strip.empty?
         badge = " SNI "
         bx = {rect.right - badge.size - 1, rect.x + 9}.max
@@ -1994,9 +2006,19 @@ module Gori::Tui
       # estimate stays there as a passive summary (render_run_summary).
       run_x = Frame.action_badge(screen, rect.right - 1, rect.y, min_x, "^R", "RUN", !running?)
       pretty_x = Frame.toggle_badge(screen, run_x, rect.y, min_x, "^U", "PRETTY", false)
-      Frame.mode_badge(screen, pretty_x, rect.y, min_x, ins)
-      screen.text({pretty_x - badge.size, min_x}.max, rect.y, badge,
-        pc > 0 ? Theme.text_bright : Theme.muted, pc > 0 ? Theme.accent_bg : Theme.bg)
+      # The mode chip states the pane's REAL mode, not `focused && …`: `template_chrome_hit` and
+      # `apply_chrome_click` both read `template_insert?` alone, so gating the LABEL on focus made
+      # an unfocused pane that had retained INS draw " ↵:NOR " (7 cols) over a 5-col " INS " hit
+      # rect — two dead cells on the left of the chip — and a click on a chip reading "↵:NOR" then
+      # EXITED insert mode. Focus is still carried, by the border colour below.
+      mode_x = Frame.mode_badge(screen, pretty_x, rect.y, min_x, template_insert? || @chain_focused)
+      # …and `§N` chains off the mode chip's left edge. It used to be drawn at `pretty_x - 4`,
+      # which is INSIDE the 7-cell mode badge — so it overwrote "NOR " and the border read
+      # "↵: §2", destroying the mode chip and leaving the marker count ambiguous. Every other
+      # badge on every other pane chains off its neighbour's returned left x; this one did not.
+      badge_x = mode_x - badge.size
+      screen.text(badge_x, rect.y, badge,
+        pc > 0 ? Theme.text_bright : Theme.muted, pc > 0 ? Theme.accent_bg : Theme.bg) if badge_x >= min_x
       # Marker i ↔ position i ↔ generator.set_for(i). The value gets the position hue; a
       # trailing ¦chain (Decoder transform-on-send) is over-painted with a neutral band so
       # it reads as metadata, not payload. Colours resolved fresh each frame (offsets are
@@ -2018,29 +2040,37 @@ module Gori::Tui
       paint_template_read_chrome(screen, inner, read_active)
     end
 
+    # READ-mode over-paint (selection band + block caret) on top of the frame the editor drew.
+    #
+    # Band and caret both go through the EDITOR, which owns the concealed-run map. This pane is
+    # THE place operators write `§value¦chain§`, and the `¦chain` is concealed here — so measuring
+    # a span on the raw line put the tint and the caret N columns right of the text they addressed
+    # (N = the hidden width to their left), and re-drawing the raw segment for the band put the
+    # hidden chain back on screen: selecting a line UNCONCEALED it and shifted the rest of the row.
+    # The copy was right all along (it reads buffer coordinates), so the band highlighted different
+    # bytes than `y` copied. See the READ-mode over-paint seam in `text_area.cr`.
+    #
+    # `scroll`-relative rows are correct here where they would not be in the Repeater: this editor
+    # does not soft-wrap (no `wrap = true`), so one logical line is one drawn row.
     private def paint_template_read_chrome(screen : Screen, rect : Rect, active : Bool) : Nil
       return unless active
       lines = @editor.lines_snapshot
       return if lines.empty?
       @template_read.sync_from(@editor)
-      sel_bg = Theme.accent_bg
       scr = @editor.scroll
+      gw = @editor.gutter? ? Gutter.width(lines.size) : 0
+      cw = {rect.w - gw, 0}.max
       @template_read.cursor.highlight_spans(lines).each do |(li, x0, x1)|
         next unless li >= scr && li < scr + rect.h
-        row = li - scr
-        gw = @editor.gutter? ? Gutter.width(lines.size) : 0
-        paint_char_span_bg(screen, rect.x + gw, rect.y + row, lines[li], x0, x1, sel_bg)
+        @editor.paint_read_band(screen, rect.x + gw, rect.y + (li - scr), li, x0, x1, 0, -1, cw)
       end
       cy, cx = @editor.cy, @editor.cx
       return unless cy >= scr && cy < scr + rect.h
-      row = cy - scr
-      gw = @editor.gutter? ? Gutter.width(lines.size) : 0
-      line = lines[cy]
-      px = rect.x + gw + Screen.draw_width(line[0, cx])
+      col, ch = @editor.read_caret_cell(cy, cx)
+      px = rect.x + gw + col
       if px < rect.x + rect.w
-        ch = cx < line.size ? line[cx] : ' '
-        screen.cell(px, rect.y + row, ch, Theme.bg, Theme.accent_bg)
-        screen.cursor(px, rect.y + row)
+        screen.cell(px, rect.y + (cy - scr), ch, Theme.bg, Theme.accent_bg)
+        screen.cursor(px, rect.y + (cy - scr))
       end
     end
 

--- a/src/gori/tui/repeater_view.cr
+++ b/src/gori/tui/repeater_view.cr
@@ -143,6 +143,16 @@ module Gori::Tui
       # was never laid out against.
       @resp_last_gw = 0
       @resp_last_cw = 0
+      # Which card of a split RESPONSE column is being read (WebSocket only — see resp_split?).
+      # Starts on the transcript: that is what an operator opens a WS tab to read, and it keeps
+      # a non-WS tab's behaviour literally unchanged.
+      @resp_pane = :transcript
+      # The INACTIVE response sub-pane's parked {scroll, scroll_sub, cy, cx}. The active pane's
+      # copy lives in the live fields, so every existing consumer of `@scroll` / `@resp_cursor`
+      # keeps reading them with no idea a second pane exists; `switch_resp_pane` swaps the two.
+      # Parked rather than reset, mirroring the request column — each TextArea there keeps its
+      # own caret and scroll, so crossing back lands where you left.
+      @resp_alt = {0, 0, 0, 0}
       @loaded = false
       @http2 = false
       # WebSocket repeater mode (a 101 flow): the request editor holds the editable
@@ -420,7 +430,7 @@ module Gori::Tui
     end
 
     def resp_navigable? : Bool
-      @focus == :response && !@resp_hex
+      @focus == :response && !resp_hex_active?
     end
 
     # --- persistence accessors (the Runner saves these + reconciles by them) ---
@@ -851,6 +861,11 @@ module Gori::Tui
       @ws_result = result
       @ws_lines_cache = nil
       @scroll = 0
+      # A send replaces BOTH response documents — the transcript here, and the handshake head via
+      # the `@result` seed below (which `reset_result_caches` re-derives `resp_view` from). So the
+      # parked sub-pane's anchor describes a document that no longer exists; zero it with the live
+      # one rather than leaving `clamp_resp_cursor` to salvage a position from the last run.
+      @resp_alt = {0, 0, 0, 0}
       resp_wrap_reset
       # Seed @result so the HTTP response tab can render the handshake response
       @result = Repeater::Result.new(result.handshake_head, Bytes.empty, nil, result.duration_us, result.error)
@@ -984,7 +999,7 @@ module Gori::Tui
     # The editor the request column's input/cursor targets: the decoded payload when its
     # split sub-pane is active, else the envelope (the only editor in a non-decode tab).
     private def req_editor : TextArea
-      ((@decode_kind || @ws_mode) && @req_pane == :decoded) ? @decoded : @editor
+      (req_split? && @req_pane == :decoded) ? @decoded : @editor
     end
 
     # ^T: toggle the active request sub-pane (envelope ⇄ decoded). No-op outside a
@@ -1006,12 +1021,75 @@ module Gori::Tui
     # it); entering DECODED RE-DECODES the envelope's current param (so it reflects any
     # envelope edits). No-op outside a decode tab / when the pane is unchanged.
     private def switch_req_pane(to : Symbol) : Nil
-      return unless @decode_kind || @ws_mode
+      return unless req_split?
       return if to == @req_pane
       if @decode_kind
         to == :envelope ? commit_decoded : refresh_decoded
       end
       @req_pane = to
+      # ONE `@req_read` serves both sub-panes (it is a cursor over whatever `req_editor`
+      # returns), so an anchor left over from the pane being left would paint a band across
+      # the arriving buffer's text — coordinates from one document applied to another. A
+      # single-buffer tab never had this to answer for; a split one does, and the answer is
+      # that crossing panes ends the selection, exactly as it would in INS (`edit_move`'s
+      # cross-pane branch deliberately does not forward `selecting`).
+      @req_read.clear_selection
+      req_editor.clear_selection
+    end
+
+    # ^T on the RESPONSE column: toggle the active card (handshake ⇄ transcript). No-op outside
+    # a WebSocket tab. Returns the new active pane so the controller can name it in a toast.
+    def toggle_resp_pane : Symbol
+      switch_resp_pane(@resp_pane == :transcript ? :handshake : :transcript)
+      @resp_pane
+    end
+
+    # Change the active RESPONSE card. The two panes are different DOCUMENTS behind one cursor
+    # and one scroll anchor, so the swap has three parts and all three are load-bearing:
+    #
+    #   * the outgoing pane's {scroll, scroll_sub, cy, cx} is parked and the incoming pane's is
+    #     restored, so crossing back lands where you left (what the request column gets for
+    #     free from each TextArea holding its own);
+    #   * the wrap memo is dropped. It is keyed by LINE INDEX (guarded only on width), so line 3
+    #     of the transcript would otherwise hand back a layout computed for line 3 of the
+    #     handshake head — the anchor, the click inverse and the draw all reading one memo built
+    #     from the wrong text; and
+    #   * the selection is cleared. An anchor cannot span two documents, exactly as on the
+    #     request side.
+    private def switch_resp_pane(to : Symbol) : Nil
+      return unless resp_split?
+      return if to == @resp_pane
+      parked = @resp_alt
+      @resp_alt = {@scroll, @scroll_sub, @resp_cursor.cy, @resp_cursor.cx}
+      @resp_pane = to
+      @resp_cursor.clear_selection
+      resp_wrap_reset # drops the memo AND zeroes @scroll_sub — restore after, not before
+      @scroll = parked[0]
+      @resp_cursor.sync(parked[2], parked[3])
+      clamp_resp_cursor
+    end
+
+    # Pull the parked anchor + caret back inside the pane being restored into. Both documents
+    # change out from under a parked position — a resend rebuilds the transcript AND re-seeds the
+    # handshake head — so a caret parked at line 40 can come back to a 3-line document.
+    #
+    # `@scroll_sub` is deliberately NOT restored, only zeroed (by `resp_wrap_reset` above): a
+    # sub-row is an index INTO a specific line's wrap layout, so the only way to carry one across
+    # a park is to prove the line still wraps the same way, and nothing here can. Reading a stale
+    # one is exactly what `scroll`'s own comment refuses to do ("a carried sub-row would be read
+    # against a line that was never laid out at that row"). The cost is at most one wrapped row of
+    # remembered scroll position; the alternative is tracking invalidation across every site that
+    # replaces either document.
+    private def clamp_resp_cursor : Nil
+      size, line_at = resp_line_source
+      if size <= 0
+        @resp_cursor.sync(0, 0)
+        @scroll = 0
+        return
+      end
+      cy = @resp_cursor.cy.clamp(0, size - 1)
+      @resp_cursor.sync(cy, @resp_cursor.cx.clamp(0, line_at.call(cy).size))
+      @scroll = @scroll.clamp(0, size - 1)
     end
 
     # Re-encode the (edited) decoded payload back into the envelope — SAML param via
@@ -1706,11 +1784,17 @@ module Gori::Tui
       @target_mode = InputMode::Read
     end
 
-    # {head, body} strings of the last HTTP response (nil until a send lands, or in
-    # WS/gRPC mode where the "response" is a transcript, not raw head+body bytes).
-    # Feeds the RESPONSE pane's "copy as X" options (status+headers / body / raw).
+    # {head, body} strings of the last HTTP response (nil until a send lands, or where the
+    # "response" is a transcript rather than raw head+body bytes). Feeds the RESPONSE pane's
+    # "copy as X" options (status+headers / body / raw).
+    #
+    # A WebSocket tab reading its HANDSHAKE RESPONSE card is NOT one of those cases: that card
+    # shows a real HTTP 101 head (`apply_ws` seeds `@result` with it), so it gets the same
+    # head/body/raw options every other response head gets. It is only the TRANSCRIPT that has
+    # no head+body to split, and that is what `@resp_pane` distinguishes.
     def response_parts : {String, String}?
-      return nil if @ws_mode || @grpc_mode
+      return nil if @grpc_mode
+      return nil if @ws_mode && !resp_handshake_active?
       res = @result
       return nil unless res
       {String.new(res.head), (b = res.body) ? String.new(b) : ""}
@@ -2457,6 +2541,13 @@ module Gori::Tui
       mx >= content.x + half + 1 ? :response : nil
     end
 
+    # The HANDSHAKE REQUEST card's right-chained badges, right-to-left — ONE list, read by the
+    # draw (`render_request`, for both the badges and where the mode chip chains to) and by the
+    # hit-test below. `␣K:KEY` was drawn from one place and hit-tested from another, and the
+    # second one did not list it: the badge was a dead cell, while HTTP's `^L:CL`/`^U:PRETTY`
+    # next to it have always been clickable.
+    WS_BADGES = [{:send, "^R", "SEND"}, {:ws_key, "␣K", "KEY"}] of {Symbol, String, String}
+
     # Border-chrome hit-test for REQUEST/RESPONSE toggle chips. Shares geometry with
     # render_request / render_response_chrome (label strings + start_x / right chain).
     # Returns a chip id, or nil so the caller can fall through to caret placement.
@@ -2488,34 +2579,37 @@ module Gori::Tui
         end
       end
 
-      # REQUEST badges: ^R:SEND is always rightmost (primary action). Then CL/PRETTY (or
-      # HEX) when drawn; NOR/INS mode chip chains left of those. Decode / CHAIN splits
-      # keep chrome on the top card. WS/gRPC skip the mode chip (no render_mode_badge).
-      req_card = (@decode_kind || @ws_mode) ? decode_split(left)[0] : left
+      # REQUEST badges: ^R:SEND is always rightmost (primary action). Then CL/PRETTY (or HEX,
+      # or gRPC's ^X:MSG, or WS's ␣K:KEY) when drawn; the NOR/INS mode chip chains left of
+      # those. Decode / CHAIN splits keep chrome on the top card.
+      req_card = req_split? ? decode_split(left)[0] : left
       if req_card.w >= 2 && my == req_card.y
         label = render_request_label
         min_x = req_card.x + label.size + 4
         right_edge = req_card.right - 1
-        badges = [{:send, "^R", "SEND"}] of {Symbol, String, String}
-        if @grpc_mode
-          if @req_hex_edit
-            badges << {:req_hex, "^X", "HEX"} # editing the payload
-          elsif @grpc_reframable
-            badges << {:req_hex, "^X", "MSG"} # click to hex-edit the unary payload
-          end
-        elsif !@ws_mode
-          if @req_hex_edit
-            badges << {:req_hex, "^X", "HEX"}
-          else
-            badges << {:cl, "^L", "CL"}
-            badges << {:pretty_req, "^U", "PRETTY"}
-          end
-        end
+        badges = if @grpc_mode
+                   b = [{:send, "^R", "SEND"}] of {Symbol, String, String}
+                   if @req_hex_edit
+                     b << {:req_hex, "^X", "HEX"} # editing the payload
+                   elsif @grpc_reframable
+                     b << {:req_hex, "^X", "MSG"} # click to hex-edit the unary payload
+                   end
+                   b
+                 elsif @ws_mode
+                   WS_BADGES # ^R:SEND + ␣K:KEY — the list render_request draws from
+                 elsif @req_hex_edit
+                   [{:send, "^R", "SEND"}, {:req_hex, "^X", "HEX"}] of {Symbol, String, String}
+                 else
+                   [{:send, "^R", "SEND"}, {:cl, "^L", "CL"}, {:pretty_req, "^U", "PRETTY"}] of {Symbol, String, String}
+                 end
         if hit = Frame.right_badge_hit(mx, my, req_card.y, right_edge, min_x, badges)
           return hit
         end
-        # Mode chip only drawn for plain HTTP request (not WS / gRPC / hex-edit).
-        unless @ws_mode || @grpc_mode || @req_hex_edit
+        # Mode chip: drawn on every non-hex request card — plain HTTP, the WS handshake and the
+        # gRPC head are all mode-switched text editors. Hex is the exception and draws none (a
+        # nibble cursor has no READ/INS), so hit-testing one there would invent a live cell over
+        # a badge that was never painted — the inverse of the dead `␣K:KEY` this pass fixed.
+        unless @req_hex_edit
           mode_edge = Frame.right_badge_edge(right_edge, min_x, badges)
           if Frame.mode_badge_hit(mx, my, req_card.y, mode_edge, min_x, request_insert?)
             return :mode
@@ -2525,70 +2619,115 @@ module Gori::Tui
       nil
     end
 
-    # Mouse: place the request-editor caret (text) or nibble cursor (hex) at a click.
-    # `rect` is the full body rect render() receives; re-derive the request half-pane
-    # (target band + split, then the card's 1-cell inset) exactly as render_request does.
+    # Mouse: place the request-editor caret (text) or nibble cursor (hex) at a click. A split
+    # tab (WS HANDSHAKE/MESSAGES, SAML/GraphQL ENVELOPE/DECODED) first adopts the sub-pane the
+    # pointer is in, then places the caret in it — through the SAME mode branch a single-pane
+    # tab uses, which is the whole point of the seam below.
+    #
+    # The split used to call `TextArea#click_to_cursor` directly, bypassing `@req_read`. That
+    # left READ mode's cursor model untouched by a click, so its anchor kept whatever an
+    # earlier selection had planted — invisible only because nothing painted the read band in
+    # those panes. Both halves are fixed together.
     def request_click_to_cursor(rect : Rect, mx : Int32, my : Int32) : Nil
       return unless @loaded
-      target_h = {rect.h, target_card_h}.min
-      content = Rect.new(rect.x, rect.y + target_h, rect.w, {rect.h - target_h, 0}.max)
-      return if content.h <= 0
-      half = {(content.w - 1) // 2, 1}.max
-      col = Rect.new(content.x, content.y, half, content.h)
-      if @decode_kind || @ws_mode # split: click selects the envelope/handshake or decoded/messages sub-pane + places its caret
-        env, dec = decode_split(col)
-        if my >= dec.y
-          switch_req_pane(:decoded)
-          @decoded.click_to_cursor(dec.inset(1, 1), mx, my)
-        else
-          switch_req_pane(:envelope)
-          @editor.click_to_cursor(env.inset(1, 1), mx, my)
-        end
-        return
-      end
+      pane = request_hit(rect, mx, my) || return
+      # The rect comes out BEFORE the switch: `decode_split` sizes the two cards from
+      # `@req_pane` (the active one is enlarged), so switching first would invert the click
+      # against a layout that has not been drawn yet. The caret goes in AFTER, because
+      # `switch_req_pane` can `set_text` an editor (commit/re-decode) and reset its caret.
+      inner = request_sub_rect(rect, pane) || return
+      switch_req_pane(pane)
       commit_chain_pane if @chain_focused # a click outside the ^Y modal commits + dismisses it, then places the caret
-      inner = col.inset(1, 1)
-      if h = @req_hex_edit
-        h.click_to_nibble(inner, mx, my, @scroll_req) # hex mode: place the nibble cursor
-      elsif request_insert?
-        @editor.click_to_cursor(inner, mx, my)
-      else
-        @req_read.click(@editor, inner, mx, my) # READ mode paints the read cursor's selection
-      end
+      place_request_caret(inner, mx, my)
     end
 
     # Mouse DRAG in the request pane — extend the selection to the pointer. The two modes keep
     # their own selection models (INS: the editor's own anchor, painted by `TextArea#render`;
     # READ: `@req_read`, painted by the owner), and each is extended through the model that
-    # owns it. Hex and the split-decode panes are excluded: a nibble cursor has no selection
-    # and a drag across two buffers has no meaning.
+    # owns it.
+    #
+    # Always the ACTIVE sub-pane's rect, never the one under the pointer: a drag that wanders
+    # into the other half of a split column must keep extending the selection it started, not
+    # jump buffers mid-gesture (neither `cut_selection` nor the band painter can express a
+    # selection spanning two buffers). `TextArea#click_to_cursor` clamps a row past the pane's
+    # bottom to its last visible row and pins one above the top when `selecting`, so leaving
+    # the sub-pane vertically extends to its edge — which is what a drag off a 1/3-height
+    # sub-pane means.
+    #
+    # Hex stays excluded: a nibble cursor has no selection to extend.
     def request_drag_to_cursor(rect : Rect, mx : Int32, my : Int32) : Nil
-      return unless @loaded && !@req_hex_edit && @decode_kind.nil? && !@ws_mode
-      inner = request_editor_rect(rect) || return
+      return unless @loaded && !@req_hex_edit
+      inner = request_sub_rect(rect, @req_pane) || return
+      place_request_caret(inner, mx, my, selecting: true)
+    end
+
+    # Mouse DOUBLE-CLICK in the request pane — spread to the word under the CARET, which the
+    # press of the pair has already placed at the pointer (`handle_click` runs first, always).
+    # No geometry, and that is the point: a second hit-test would have to invert the same screen
+    # row again, and in a split column the layout MOVED in between — press 1 adopts the lower
+    # sub-pane, which grows the active card to ~2/3 and lifts the lower card's top edge by ~1/3
+    # of the column. (The upper card's `y` is `col.y` whatever its height, so only this
+    # direction was ever wrong.) Inverting against the new rect selected a token about a third of
+    # a column below the pointer; spreading from the caret inherits press 1's correct inverse.
+    def request_select_word : Bool
+      return false unless @loaded && !@req_hex_edit
+      ed = req_editor
+      request_insert? ? ed.select_word_at_cursor : @req_read.select_word_at_cursor(ed)
+    end
+
+    # The one place a pointer position becomes a caret in the request column. INS drives the
+    # editor's own anchor; READ drives `@req_read` (whose `click` runs the editor's hit test
+    # and then owns the selection). Hex has neither, so it places its nibble cursor instead.
+    private def place_request_caret(inner : Rect, mx : Int32, my : Int32, selecting : Bool = false) : Nil
+      if h = @req_hex_edit
+        return if selecting # a nibble cursor has no selection to drag
+        h.click_to_nibble(inner, mx, my, @scroll_req)
+        return
+      end
+      ed = req_editor
       if request_insert?
-        @editor.click_to_cursor(inner, mx, my, selecting: true)
+        ed.click_to_cursor(inner, mx, my, selecting: selecting)
       else
-        @req_read.click(@editor, inner, mx, my, selecting: true)
+        @req_read.click(ed, inner, mx, my, selecting: selecting)
       end
     end
 
-    # Mouse DOUBLE-CLICK in the request pane — select the word under the pointer.
-    def request_select_word(rect : Rect, mx : Int32, my : Int32) : Bool
-      return false unless @loaded && !@req_hex_edit && @decode_kind.nil? && !@ws_mode
-      inner = request_editor_rect(rect) || return false
-      request_insert? ? @editor.select_word_at(inner, mx, my) : @req_read.select_word(@editor, inner, mx, my)
+    # Whether the request column is split into two editor cards (WS handshake + messages, or
+    # a decode tab's envelope + payload). The predicate `req_editor`, `mark_req_edit`,
+    # `render` and the hit-tests all branch on — spelled once so they cannot drift.
+    private def req_split? : Bool
+      !@decode_kind.nil? || @ws_mode
     end
 
-    # The plain-text request editor's content rect inside `rect` (the body render() gets), or
-    # nil when the pane is too small to hold one. The same derivation
-    # `request_click_to_cursor` walks, factored out so the click, the drag and the
-    # double-click cannot land on three slightly different rects.
-    private def request_editor_rect(rect : Rect) : Rect?
+    # Which request sub-pane the point (mx, my) falls in — `:decoded` for the lower card of a
+    # split column, `:envelope` otherwise (and always, for a single-pane tab). nil when the
+    # column has no room to draw. Geometry only; the caller decides what to do with it.
+    private def request_hit(rect : Rect, mx : Int32, my : Int32) : Symbol?
+      col = request_col_rect(rect) || return nil
+      return :envelope unless req_split?
+      _, dec = decode_split(col)
+      my >= dec.y ? :decoded : :envelope
+    end
+
+    # The CONTENT rect (after the card's 1-cell inset) of request sub-pane `pane` inside
+    # `rect` — the body rect render() receives. nil when the column is too small to hold one.
+    # The click, the drag, the double-click and the wheel all measure with this, so none of
+    # them can land on a slightly different rect than the render did.
+    private def request_sub_rect(rect : Rect, pane : Symbol) : Rect?
+      col = request_col_rect(rect) || return nil
+      return col.inset(1, 1) unless req_split?
+      env, dec = decode_split(col)
+      (pane == :decoded ? dec : env).inset(1, 1)
+    end
+
+    # The request half-pane (the whole left column, borders included) — render's own
+    # derivation: the target band on top, then a half-width request|response split.
+    private def request_col_rect(rect : Rect) : Rect?
       target_h = {rect.h, target_card_h}.min
       content = Rect.new(rect.x, rect.y + target_h, rect.w, {rect.h - target_h, 0}.max)
       return nil if content.h <= 0
       half = {(content.w - 1) // 2, 1}.max
-      Rect.new(content.x, content.y, half, content.h).inset(1, 1)
+      Rect.new(content.x, content.y, half, content.h)
     end
 
     # Vertical split of the request column into {envelope, decoded} rects for a decode
@@ -2602,13 +2741,67 @@ module Gori::Tui
       {env, dec}
     end
 
+    # Vertical split of the RESPONSE column into {handshake, transcript} rects for a WebSocket
+    # tab — the request column's `decode_split` on the other side of the divider.
+    #
+    # The default sizing is deliberately NOT symmetric with `decode_split`: a 101 handshake
+    # response is 4-5 header lines, so while the TRANSCRIPT is the active card the handshake
+    # keeps the fixed 7 rows it has always had, and the transcript keeps everything else. Only
+    # when the handshake becomes the active card does it grow to ~2/3 — which is what makes a
+    # long handshake response (a proxy that answers with a full HTML error page, say) readable
+    # and selectable instead of a 5-line porthole.
     private def ws_resp_split(col : Rect) : {Rect, Rect}
-      # The handshake response header is short (typically 4-5 lines of HTTP headers).
-      # We allocate a fixed height (7 rows) for the handshake card, and the rest for transcript.
-      handshake_h = 7.clamp(1, {col.h - 2, 1}.max)
+      handshake_h = if @resp_pane == :handshake
+                      {col.h - {col.h // 3, 1}.max, 1}.max
+                    else
+                      WS_HANDSHAKE_ROWS
+                    end
+      handshake_h = handshake_h.clamp(1, {col.h - 2, 1}.max)
       handshake = Rect.new(col.x, col.y, col.w, handshake_h)
       transcript = Rect.new(col.x, col.y + handshake_h, col.w, {col.h - handshake_h, 0}.max)
       {handshake, transcript}
+    end
+
+    WS_HANDSHAKE_ROWS = 7 # the handshake card's height while the TRANSCRIPT owns the column
+
+    # Whether the RESPONSE column is split into two cards. WebSocket is the only mode that
+    # splits it: gRPC and a pipelined group render one transcript over the whole column.
+    # `req_split?`'s counterpart, and read by the same shape of hit-test / render code.
+    private def resp_split? : Bool
+      @ws_mode
+    end
+
+    # Which response sub-pane owns the read cursor: `:handshake` | `:transcript`. Always
+    # `:transcript` when the column is not split, so a non-WS tab answers exactly as before.
+    getter resp_pane : Symbol
+
+    # Whether the response column is a TRANSCRIPT rather than one HTTP response. A flag check —
+    # deliberately not `transcript_rows?`, which builds (and caches, and theme-checks) the rows:
+    # this is read per drawn row through `resp_navigable?`.
+    private def resp_transcript? : Bool
+      @ws_mode || @grpc_mode || group_mode?
+    end
+
+    # Whether the hex dump is what the response pane is ACTUALLY drawing. `@resp_hex` alone is
+    # not that question: `render_response` returns at its WS / gRPC / group branch long before the
+    # hex one, so on a transcript the flag describes a pane nobody can see — while
+    # `resp_navigable?` still read it and silently killed the caret, the selection and every arrow
+    # key with no visual change at all.
+    #
+    # The flag survives (flip back to a single HTTP response and the dump is still on); only its
+    # authority over the transcript is withdrawn. Reachable without any hex chip being clickable
+    # on a WS tab: `^X` a plain HTTP response, then edit the request into an upgrade handshake —
+    # `apply_request_fields` flips the SAME view into ws_mode and nothing clears `@resp_hex`
+    # (`apply_group` is the only place that ever did). With `at_top?` now crossing cards rather
+    # than ejecting, that left a response column you could neither navigate nor leave upward.
+    private def resp_hex_active? : Bool
+      @resp_hex && !resp_transcript?
+    end
+
+    # The HANDSHAKE RESPONSE card is the one being read/selected right now. The single
+    # predicate `resp_line_source`, `resp_line_count` and the two renderers branch on.
+    private def resp_handshake_active? : Bool
+      resp_split? && @resp_pane == :handshake
     end
 
     # Mouse: focus the URL or SNI field of the TARGET band by which row was clicked,
@@ -2637,7 +2830,7 @@ module Gori::Tui
       when :request
         if h = @req_hex_edit
           h.at_top?
-        elsif (@decode_kind || @ws_mode) && @req_pane == :decoded
+        elsif req_split? && @req_pane == :decoded
           false
         else
           @editor.at_top?
@@ -2646,8 +2839,19 @@ module Gori::Tui
         # ↑/⇧↑ move/extend the read cursor upward until it reaches line 0 with scroll at top,
         # instead of ejecting the pane whenever the response fits on screen (@scroll stays 0).
         # The non-navigable hex dump has no caret, so keep scroll-based ejection there.
-      when :response then resp_navigable? ? (@resp_cursor.cy == 0 && @scroll == 0) : @scroll == 0
-      else                false
+      when :response
+        # On a split column's LOWER card, ↑ at the top crosses UP to the HANDSHAKE RESPONSE
+        # (handled in resp_move) rather than ejecting to the tab bar — the response-side twin of
+        # the `:decoded` branch above, and the reason the handshake card is reachable by keyboard
+        # at all.
+        if resp_split? && @resp_pane == :transcript
+          false
+        elsif resp_navigable?
+          @resp_cursor.cy == 0 && @scroll == 0
+        else
+          @scroll == 0
+        end
+      else false
       end
     end
 
@@ -2681,7 +2885,7 @@ module Gori::Tui
     # by skipping it — an undo snapshot is a state the buffer really held, Content-Length line
     # included, so what comes back is already self-consistent.
     private def mark_req_edit(reflect : Bool = true) : Nil
-      if (@decode_kind || @ws_mode) && @req_pane == :decoded
+      if req_split? && @req_pane == :decoded
         @decoded_dirty = true
         @ws_out_edited = true
       else
@@ -2761,35 +2965,61 @@ module Gori::Tui
     # neither `cut_selection` nor the band painter can express that.
     def edit_move(dr : Int32, dc : Int32, selecting : Bool = false) : Nil
       return unless @focus == :request
-      # In a split-decode tab, a vertical step off the end of one sub-pane crosses into
-      # the other (↓ off the ENVELOPE bottom → DECODED top; ↑ off the DECODED top →
-      # ENVELOPE bottom), syncing the two at the boundary — so the split feels like one
-      # continuous column. (↑ off the ENVELOPE top pops to the tab bar via at_top?.)
-      if (@decode_kind || @ws_mode) && dc == 0
-        if dr > 0 && @req_pane == :envelope && @editor.at_bottom?
-          switch_req_pane(:decoded)
-          @decoded.goto_line(1)
-          return
-        end
-        if dr < 0 && @req_pane == :decoded && @decoded.at_top?
-          switch_req_pane(:envelope)
-          @editor.goto_line(Int32::MAX) # clamps to the last line
-          return
-        end
-      end
+      return if dc == 0 && try_cross_req_pane(dr)
       req_editor.move(dr, dc, selecting)
       # Cursor navigation is NOT a content edit: leave @dirty alone. Marking it here made
       # pure arrow-key movement persist the tab (V11) and, worse, latch sync-clobber
       # protection so a live cross-session update could no longer refresh the tab.
     end
 
+    # In a split column, a vertical step off the end of one sub-pane crosses into the other
+    # (↓ off the ENVELOPE/HANDSHAKE bottom → DECODED/MESSAGES top; ↑ off the lower pane's top
+    # → the upper pane's last line), so the split feels like one continuous column. (↑ off the
+    # upper pane's top pops to the tab bar via `at_top?`.) Returns true when it crossed and
+    # the caller must not also step inside a buffer.
+    #
+    # Shared by INS (`edit_move`) and READ (`request_read_move`) on purpose. It lived inline
+    # in `edit_move` only, so a WebSocket tab — which `restore` leaves in READ mode — could
+    # not get from HANDSHAKE to MESSAGES with the arrow keys at all: ↓ clamped at the bottom
+    # of one buffer and ↑ clamped at the top of the other, leaving `^T` as the only way
+    # across. That is the same "the keyboard does nothing here" the invisible READ caret
+    # produced, from a different direction.
+    private def try_cross_req_pane(dr : Int32) : Bool
+      return false unless req_split?
+      if dr > 0 && @req_pane == :envelope && @editor.at_bottom?
+        switch_req_pane(:decoded)
+        @decoded.goto_line(1)
+        @req_read.sync_from(@decoded) # READ paints from @req_read; leave it on the arriving caret
+        return true
+      end
+      if dr < 0 && @req_pane == :decoded && @decoded.at_top?
+        switch_req_pane(:envelope)
+        @editor.goto_line(Int32::MAX) # clamps to the last line
+        @req_read.sync_from(@editor)
+        return true
+      end
+      false
+    end
+
     # Home/End: pure navigation (caret to line start/end) → does NOT dirty, like edit_move.
+    #
+    # These move the EDITOR's caret directly, so READ mode has to adopt the result: without
+    # `sync_to`, a plain Home left `@req_read`'s anchor where it was and the band was painted
+    # from there to column 0 — a selection the operator had just collapsed — while ⇧Home
+    # planted no anchor at all and extended nothing. `sync_to` is the helper written for
+    # exactly this pair; Notes, Issues, Project and the Decoder input all already call it.
     def edit_home(selecting : Bool = false) : Nil
-      req_editor.home(selecting) if @focus == :request
+      return unless @focus == :request
+      ed = req_editor
+      ed.home(selecting)
+      @req_read.sync_to(ed, selecting: selecting) unless request_insert?
     end
 
     def edit_end(selecting : Bool = false) : Nil
-      req_editor.end_of_line(selecting) if @focus == :request
+      return unless @focus == :request
+      ed = req_editor
+      ed.end_of_line(selecting)
+      @req_read.sync_to(ed, selecting: selecting) unless request_insert?
     end
 
     # PageUp / PageDown in the request editor: `dir` is -1/+1, sized from the editor's OWN
@@ -2809,7 +3039,7 @@ module Gori::Tui
     # routed through `edit_move` there and everything else still comes here.
     def edit_motion_key(ev : Termisu::Event::Key) : Bool
       return false unless @focus == :request
-      if (@decode_kind || @ws_mode) && (ev.key.up? || ev.key.down?)
+      if req_split? && (ev.key.up? || ev.key.down?)
         edit_move(ev.key.up? ? -1 : 1, 0, selecting: ev.shift?)
         return true
       end
@@ -3067,7 +3297,7 @@ module Gori::Tui
     # Scroll the response pane by `delta` DRAWN rows. In hex the pane draws its own fixed
     # rows and there is nothing to wrap, so that mode keeps the plain row offset.
     def scroll(delta : Int32) : Nil
-      if @resp_hex || @resp_last_cw <= 0
+      if resp_hex_active? || @resp_last_cw <= 0
         @scroll = (@scroll + delta).clamp(0, {resp_line_count - 1, 0}.max)
         @scroll_sub = 0 # the anchor line moved by whole lines; a carried sub-row would
         return          # be read against a line that was never laid out at that row
@@ -3089,6 +3319,7 @@ module Gori::Tui
     # ↑/↓ step one VISUAL row (see `resp_visual_target`), like the request editor's.
     def resp_move(dr : Int32, dc : Int32, selecting : Bool = false) : Nil
       return unless resp_navigable?
+      return if dc == 0 && try_cross_resp_pane(dr)
       size, line_at = resp_line_source
       return if size <= 0
       if target = resp_visual_target(dr)
@@ -3096,6 +3327,43 @@ module Gori::Tui
       else
         @resp_cursor.move(dr, dc, size, line_at, selecting)
       end
+      ensure_resp_visible(@resp_last_h) if @resp_last_h > 0
+    end
+
+    # A vertical step off the end of one response card crosses into the other — ↓ off the
+    # HANDSHAKE RESPONSE bottom lands on the TRANSCRIPT's first line, ↑ off the TRANSCRIPT top
+    # lands on the handshake's last — so the column reads as one document, exactly as
+    # `try_cross_req_pane` makes the request column read as one. Returns true when it crossed.
+    #
+    # (↑ off the HANDSHAKE top still pops to the tab bar, via `at_top?`.)
+    private def try_cross_resp_pane(dr : Int32) : Bool
+      return false unless resp_split?
+      size, _ = resp_line_source
+      return false if size <= 0
+      if dr > 0 && @resp_pane == :handshake && @resp_cursor.cy >= size - 1
+        switch_resp_pane(:transcript)
+        resp_goto_edge(:first)
+        return true
+      end
+      if dr < 0 && @resp_pane == :transcript && @resp_cursor.cy == 0
+        switch_resp_pane(:handshake)
+        resp_goto_edge(:last)
+        return true
+      end
+      false
+    end
+
+    # Park the read cursor on the arriving pane's first or last line, column 0, with the view
+    # following. `switch_resp_pane` restores a PARKED caret; this overrides it for the crossing
+    # case, where the caret has to land at the boundary the step arrived through.
+    private def resp_goto_edge(edge : Symbol) : Nil
+      size, _ = resp_line_source
+      return if size <= 0
+      cy = edge == :first ? 0 : size - 1
+      @resp_cursor.clear_selection
+      @resp_cursor.sync(cy, 0)
+      @scroll = cy
+      @scroll_sub = 0
       ensure_resp_visible(@resp_last_h) if @resp_last_h > 0
     end
 
@@ -3110,7 +3378,7 @@ module Gori::Tui
     # `{cx - off, 0}.max.clamp(…)` the click and the wheel already use — a caret that lands
     # on the decoration belongs at column 0 of the text, the only place it can be drawn.
     private def resp_visual_target(dr : Int32) : {Int32, Int32}?
-      return nil if dr == 0 || @resp_hex || @resp_last_cw <= 0
+      return nil if dr == 0 || resp_hex_active? || @resp_last_cw <= 0
       size, drawn_at, off = resp_drawn_source
       return nil if size <= 0
       _, line_at = resp_line_source
@@ -3136,6 +3404,19 @@ module Gori::Tui
     def request_scroll_view(step : Int32) : Nil
       return if request_hex?
       req_editor.scroll_view(step)
+    end
+
+    # The same wheel notch, aimed at the sub-pane the POINTER is over rather than the active
+    # one. A single-pane column answers identically (the hit is always `:envelope`), so this
+    # only changes a split column — where wheeling over MESSAGES used to scroll HANDSHAKE
+    # because that was the sub-pane holding the caret. `scroll_view` drags the caret into the
+    # window it moved, exactly as it does for the focused pane, so the inactive pane keeps a
+    # caret consistent with what it is showing.
+    def request_scroll_view_at(step : Int32, rect : Rect, mx : Int32, my : Int32) : Nil
+      return if request_hex?
+      pane = request_hit(rect, mx, my)
+      return request_scroll_view(step) unless pane
+      (pane == :decoded ? @decoded : @editor).scroll_view(step)
     end
 
     # Wheel: `step` is DRAWN rows. Still O(viewport) — the anchor walk never counts the
@@ -3181,38 +3462,64 @@ module Gori::Tui
       @resp_cursor.sync(cy, {cx - off, 0}.max.clamp(0, line_at.call(cy).size))
     end
 
-    # Mouse DRAG in the response pane — extend the read selection to the pointer.
-    def resp_drag_to_cursor(rect : Rect, mx : Int32, my : Int32) : Nil
-      resp_click_to_cursor(rect, mx, my, selecting: true)
+    # Mouse PRESS in the response column. On a split (WebSocket) column the press first adopts
+    # the card it landed in — the response half of what `request_click_to_cursor` does — and the
+    # body rect is taken BEFORE the switch, because `ws_resp_split` sizes the two cards from
+    # `@resp_pane` and switching first would invert the click against a layout not yet drawn.
+    def resp_click_to_cursor(rect : Rect, mx : Int32, my : Int32) : Nil
+      return unless resp_navigable? && @loaded
+      col = response_col_rect(rect) || return
+      return unless col.contains?(mx, my)
+      pane = resp_hit(col, my)
+      body = resp_body_rect_for(col, pane)
+      switch_resp_pane(pane)
+      resp_place_caret(body, mx, my, selecting: false)
     end
 
-    # Mouse DOUBLE-CLICK in the response pane — select the word under the pointer. The hit
-    # test is `resp_click_to_cursor`'s (the response's own wrap + BodyLines source), so this
-    # only has to supply the word spread.
-    def resp_select_word(rect : Rect, mx : Int32, my : Int32) : Bool
+    # Mouse DRAG in the response pane — extend the read selection to the pointer. Always the
+    # ACTIVE card, never the one under the pointer: a drag that wanders across the divider keeps
+    # extending the selection it started, because an anchor cannot span two documents.
+    def resp_drag_to_cursor(rect : Rect, mx : Int32, my : Int32) : Nil
+      return unless resp_navigable? && @loaded
+      col = response_col_rect(rect) || return
+      resp_place_caret(response_body_rect(col), mx, my, selecting: true)
+    end
+
+    # Mouse DOUBLE-CLICK in the response pane — spread to the word under the CARET, which the
+    # press of the pair already placed (`handle_click` always runs first). No second hit test,
+    # for the reason `request_select_word` spells out: adopting a card resizes the column, so
+    # re-inverting the same screen row would address a rect that has since moved.
+    def resp_select_word : Bool
       return false unless resp_navigable? && @loaded
-      before = {@resp_cursor.cy, @resp_cursor.cx}
-      resp_click_to_cursor(rect, mx, my)
-      return false if {@resp_cursor.cy, @resp_cursor.cx} == before && !@resp_click_hit
       size, line_at = resp_line_source
+      return false if size <= 0
       @resp_cursor.select_word_at_cursor(size, line_at)
     end
 
-    # Whether the last `resp_click_to_cursor` actually landed on the pane (as opposed to
-    # returning early on a click outside it) — the double-click needs to tell "the caret did
-    # not move because the pointer was already there" from "the click missed entirely".
-    @resp_click_hit = false
-
-    def resp_click_to_cursor(rect : Rect, mx : Int32, my : Int32, selecting : Bool = false) : Nil
-      @resp_click_hit = false
-      return unless resp_navigable? && @loaded
+    # The response half-pane (the whole right column, borders included) — render's own
+    # derivation, factored out so the click, the drag and the wheel share it.
+    private def response_col_rect(rect : Rect) : Rect?
       target_h = {rect.h, target_card_h}.min
       content = Rect.new(rect.x, rect.y + target_h, rect.w, {rect.h - target_h, 0}.max)
-      return if content.h <= 0
+      return nil if content.h <= 0
       half = {(content.w - 1) // 2, 1}.max
-      col = Rect.new(content.x + half + 1, content.y, {content.w - half - 1, 1}.max, content.h)
-      return unless col.contains?(mx, my)
-      body = response_body_rect(col)
+      Rect.new(content.x + half + 1, content.y, {content.w - half - 1, 1}.max, content.h)
+    end
+
+    # Which response card the row `my` falls in. `:transcript` for an unsplit column, always.
+    private def resp_hit(col : Rect, my : Int32) : Symbol
+      return :transcript unless resp_split?
+      handshake, _ = ws_resp_split(col)
+      my < handshake.bottom ? :handshake : :transcript
+    end
+
+    private def resp_body_rect_for(col : Rect, pane : Symbol) : Rect
+      return col.inset(1, 1) unless resp_split?
+      handshake, transcript = ws_resp_split(col)
+      (pane == :handshake ? handshake : transcript).inset(1, 1)
+    end
+
+    private def resp_place_caret(body : Rect, mx : Int32, my : Int32, selecting : Bool) : Nil
       # Render's own numbers, not a re-derivation — see @resp_last_gw. Falls back to the
       # gutter estimate only before the first frame, when nothing has been laid out yet.
       gw = @resp_last_cw > 0 ? @resp_last_gw : resp_gutter_w(body)
@@ -3229,7 +3536,6 @@ module Gori::Tui
       end
       rows = resp_rows(cw, body.h, size, drawn_at)
       return if rows.empty?
-      @resp_click_hit = true
       # The wrap inverse, not `@scroll + row`: a screen row is a VISUAL row now, and the
       # continuation rows between it and the anchor are exactly what the old arithmetic
       # skipped. `Wrap.row_index` clamps to the row it was given, so a click past the end of
@@ -3247,19 +3553,31 @@ module Gori::Tui
       ensure_resp_visible(body.h)
     end
 
+    # READ-mode caret move in the request column. A single-row `dc == 0` step first asks
+    # whether it leaves the sub-pane entirely — the same question INS asks in `edit_move`,
+    # through the same helper — so the split column is one continuous document in both modes.
     def request_read_move(dr : Int32, dc : Int32, selecting : Bool = false) : Nil
       return if request_insert? || request_hex?
-      lines = request_read_lines
-      return if lines.empty?
-      @req_read.move(req_editor, dr, dc, selecting: selecting)
+      return if dc == 0 && try_cross_req_pane(dr)
+      request_read_step(dr, dc, selecting)
     end
 
     # PageUp / PageDown with the request pane in READ mode: the read cursor steps a screenful,
     # sized from the editor that draws the same pane. `ReadCursor#move` clamps the row itself,
     # so a page past the last line lands on it rather than doing nothing.
+    #
+    # Deliberately NOT through `request_read_move`: a page clamps inside its own sub-pane
+    # rather than crossing into the next one, which is what `edit_page` does in INS (it never
+    # went through `edit_move` either). A screenful is a viewport gesture; crossing panes on it
+    # would skip past everything between the caret and the boundary.
     def request_read_page(dir : Int32, selecting : Bool = false) : Nil
       return if request_insert? || request_hex?
-      request_read_move(dir * req_editor.page_rows, 0, selecting: selecting)
+      request_read_step(dir * req_editor.page_rows, 0, selecting)
+    end
+
+    private def request_read_step(dr : Int32, dc : Int32, selecting : Bool) : Nil
+      return if request_read_lines.empty?
+      @req_read.move(req_editor, dr, dc, selecting: selecting)
     end
 
     def target_read_move(dc : Int32, selecting : Bool = false) : Nil
@@ -3308,21 +3626,23 @@ module Gori::Tui
     end
 
     def resp_plain_lines : Array(String)
-      if t = transcript_rows?
-        t.map(&.[0])
-      elsif @resp_mode == :diff
-        diff_lines.map(&.text)
-      elsif @reveal && (rl = reveal_lines)
-        rl
-      else
-        rv = resp_view
-        (0...rv.total).map { |i| rv.line_text(i) }
-      end
+      size, line_at = resp_line_source
+      (0...size).map { |i| line_at.call(i) }
     end
 
-    # O(1) count + lazy line fetch for BodyLines-backed response panes.
+    # O(1) count + lazy line fetch for the response pane the read cursor is on. THE one
+    # definition of "what lines is this pane showing" — the caret, the selection, the copy, the
+    # search, the wheel and the click inverse all read it, so a new pane wires into every one of
+    # them by appearing here and nowhere else.
+    #
+    # The handshake branch comes FIRST because `transcript_rows?` answers for the whole of WS
+    # mode: on a WebSocket tab both cards exist, and which one this returns is exactly what
+    # `@resp_pane` decides.
     def resp_line_source
-      if t = transcript_rows?
+      if resp_handshake_active?
+        rv = resp_view # the 101 head, the same source render_ws_handshake draws
+        {rv.total, ->(i : Int32) { rv.line_text(i) }}
+      elsif t = transcript_rows?
         {t.size, ->(i : Int32) { t[i][0] }}
       elsif @resp_mode == :diff
         data = diff_lines
@@ -3417,13 +3737,11 @@ module Gori::Tui
       {Gutter.width(resp_line_count), body.w}.min
     end
 
+    # The content rect of the response card the read cursor is on. It used to hard-code the
+    # transcript for WS mode, which is why a click on the HANDSHAKE RESPONSE card produced a
+    # negative row and was dropped — the card was on screen and unreachable.
     private def response_body_rect(col : Rect) : Rect
-      if @ws_mode
-        _, transcript = ws_resp_split(col)
-        transcript.inset(1, 1)
-      else
-        col.inset(1, 1)
-      end
+      resp_body_rect_for(col, @resp_pane)
     end
 
     # Keep the caret's VISUAL row inside the pane. Line-indexed scrolling drifts the moment
@@ -3519,11 +3837,11 @@ module Gori::Tui
     end
 
     # ⇧←/→ used to nudge the response/diff/reveal/transcript pane sideways. There is no
-    # sideways any more: every one of those panes soft-wraps, so the content the operator
-    # was panning to is already on the next row. Kept as an explicit no-op ONLY because the
-    # chord is still bound in `controllers/repeater_controller.cr` — deleting the method
-    # breaks that build, and that file is not in this change's scope. The binding and this
-    # stub should go together.
+    # sideways any more: every one of those panes soft-wraps, so the content the operator was
+    # panning to is already on the next row. The method, its binding and — as of the transcript
+    # ←/→ fix — the footer hint that still advertised "⇧←/→ h-scroll" are all gone; ⇧←/→ now
+    # extends the read selection by a character, in the transcript as much as in a plain
+    # response (see `handle_repeater_response`). Nothing is left to delete.
 
     # ^G go-to-line in the response pane: scroll so 1-based line `n` is at the top
     # (interpreted in the currently-shown mode — response/diff/hex row). Hex mode has
@@ -3545,20 +3863,16 @@ module Gori::Tui
 
     # ^F search in the response pane: 0-based line indices containing `query` in the
     # CURRENTLY-shown mode (response text or diff). Empty in hex mode.
+    # Through `resp_line_source`, not a fourth per-mode ladder of its own. That re-derivation
+    # had already drifted twice over: it had no REVEAL branch, so searching a whitespace-revealed
+    # response scanned the plain lines and returned indices into a document the pane was not
+    # showing — and it would have needed a fifth branch for the WS handshake card. One source.
     def response_search_lines(query : String) : Array(Int32)
       hits = [] of Int32
-      return hits if query.empty? || @resp_hex
+      return hits if query.empty? || resp_hex_active?
       q = query.downcase
-      if t = transcript_rows? # the transcript is the active "response" pane (WS / gRPC / group)
-        t.each_with_index { |row, i| hits << i if row[0].downcase.includes?(q) }
-        return hits
-      end
-      if @resp_mode == :diff
-        diff_lines.each_with_index { |d, i| hits << i if d.text.downcase.includes?(q) }
-      else
-        rv = resp_view
-        (0...rv.total).each { |i| hits << i if rv.line_text(i).downcase.includes?(q) }
-      end
+      size, line_at = resp_line_source
+      (0...size).each { |i| hits << i if line_at.call(i).downcase.includes?(q) }
       hits
     end
 
@@ -3582,7 +3896,7 @@ module Gori::Tui
       left = Rect.new(content.x, content.y, half, content.h)
       right = Rect.new(content.x + half + 1, content.y, {content.w - half - 1, 0}.max, content.h)
       req_focused = focused && @focus == :request
-      if @decode_kind || @ws_mode # split the request column into ENVELOPE/HANDSHAKE (top) + DECODED/MESSAGES (bottom)
+      if req_split? # split the request column into ENVELOPE/HANDSHAKE (top) + DECODED/MESSAGES (bottom)
         env, dec = decode_split(left)
         render_request(screen, env, req_focused && @req_pane == :envelope)
         render_decoded(screen, dec, req_focused && @req_pane == :decoded)
@@ -3673,7 +3987,16 @@ module Gori::Tui
         screen.text(bx, rect.y, badge, Theme.text_bright, Theme.accent_bg) if bx > rect.x + label.size + 4
       end
       # XML/JSON-ish payload / WS messages → plain editing (no HTTP request/header colouring).
-      @decoded.render(screen, rect.inset(1, 1), cursor: focused, highlight: nil, peek: focused, gauge: true, gauge_focused: focused)
+      #
+      # `cursor` is gated on INSERT, exactly as the plain REQUEST pane gates it, and READ gets
+      # the over-painted band + block caret instead. It used to be a bare `focused`: the pane
+      # drew an insert caret in both modes, so the operator could not tell which one they were
+      # in, and a READ-mode selection — the one `y`/space▸copy actually copies — was invisible
+      # while `x`, ⇧arrows and a drag were all quietly building it.
+      inner = rect.inset(1, 1)
+      ins = focused && request_insert?
+      @decoded.render(screen, inner, cursor: ins, highlight: nil, peek: focused, gauge: true, gauge_focused: focused)
+      paint_request_read_chrome(screen, inner, @decoded, focused && !ins)
     end
 
     private def pane_border(focused : Bool, insert : Bool = false) : Color
@@ -3685,7 +4008,7 @@ module Gori::Tui
       return if rect.h < 2
       ins = focused && target_insert?
       Frame.card(screen, rect, "TARGET", bg: Theme.bg, border: pane_border(focused, insert: ins))
-      Frame.mode_badge(screen, rect.right - 1, rect.y, rect.x + 8, ins)
+      Frame.mode_badge(screen, rect.right - 1, rect.y, rect.x + 8, target_insert?) # the REAL mode, not focused&&mode — see Frame.mode_badge
       # An at-a-glance SNI marker on the top border (right of the title) whenever an
       # override is set, so a custom SNI is visible even before the row is reached.
       unless @sni.strip.empty?
@@ -3777,10 +4100,16 @@ module Gori::Tui
           Frame.toggle_badge(screen, send_edge, rect.y, min_x, "^X", "HEX", true)
           @scroll_req = h.render(screen, rect.inset(1, 1), focused, @scroll_req)
         else
-          Frame.toggle_badge(screen, send_edge, rect.y, min_x, "^X", "MSG", false) if @grpc_reframable
-          @editor.conceal_spans = [] of {Int32, Int32} # gRPC frames aren't §-marker HTTP text — no stale concealment
+          msg_edge = Frame.toggle_badge(screen, send_edge, rect.y, min_x, "^X", "MSG", false) if @grpc_reframable
+          # The gRPC head is a mode-switched text editor like every other non-hex request card
+          # (`i`/esc, READ selection, and — since the read chrome landed here — a visible NORMAL
+          # caret), so it carries the chip too. It was skipped while its READ caret was invisible;
+          # leaving it off now would make this the one pane showing a block caret with nothing on
+          # screen naming the mode it belongs to.
+          Frame.mode_badge(screen, msg_edge || send_edge, rect.y, min_x, request_insert?) # the REAL mode — see Frame.mode_badge
+          @editor.conceal_spans = [] of {Int32, Int32}                                    # gRPC frames aren't §-marker HTTP text — no stale concealment
           @editor.chain_peek_text = nil
-          @editor.render(screen, rect.inset(1, 1), cursor: focused && request_insert?, highlight: :request, peek: focused, gauge: true, gauge_focused: focused)
+          render_plain_request_editor(screen, rect.inset(1, 1), focused, ins)
         end
         return
       end
@@ -3789,10 +4118,16 @@ module Gori::Tui
         # OFF (the default) means gori drops it and appends a fresh one, so the key in this
         # editor is NOT the key on the wire — which is worth a badge on its own, because the
         # pane otherwise reads as byte-exact. ON sends the block as written.
+        #
+        # The NOR/INS chip chains left of it, over the SAME badge list `chrome_hit` measures
+        # (`WS_BADGES`), so the click and the draw agree about where each one sits. Without it
+        # the WS handshake was the one editor pane in the tree whose input mode was not on
+        # screen anywhere — and the pane it belongs to is a `restore`-lands-in-READ tab.
+        Frame.mode_badge(screen, Frame.right_badge_edge(right_edge, min_x, WS_BADGES), rect.y, min_x, request_insert?)
         Frame.toggle_badge(screen, send_edge, rect.y, min_x, "␣K", "KEY", @ws_keep_key)
         @editor.conceal_spans = [] of {Int32, Int32} # WS messages aren't §-marker HTTP text — no stale concealment
         @editor.chain_peek_text = nil
-        @editor.render(screen, rect.inset(1, 1), cursor: focused && request_insert?, highlight: :request, peek: focused, gauge: true, gauge_focused: focused)
+        render_plain_request_editor(screen, rect.inset(1, 1), focused, ins)
         return
       end
       if h = @req_hex_edit
@@ -3802,7 +4137,7 @@ module Gori::Tui
       end
       cl_x = Frame.toggle_badge(screen, send_edge, rect.y, min_x, "^L", "CL", @auto_content_length)
       mode_x = Frame.toggle_badge(screen, cl_x, rect.y, min_x, "^U", "PRETTY", false)
-      mark_x = Frame.mode_badge(screen, mode_x, rect.y, min_x, ins)
+      mark_x = Frame.mode_badge(screen, mode_x, rect.y, min_x, request_insert?) # the REAL mode — see Frame.mode_badge
       # Only when a `§` is actually in the buffer, so a request without one draws exactly the
       # border it drew before. Unlit = the capture's § are literal bytes (^K declares them);
       # lit = this buffer is a template and ^R renders them. See `markers_live?`.
@@ -3810,9 +4145,20 @@ module Gori::Tui
         Frame.toggle_badge(screen, mark_x, rect.y, min_x, "^K", "MARK", markers_live?)
       end
       update_request_marker_tint
-      inner = rect.inset(1, 1)
+      render_plain_request_editor(screen, rect.inset(1, 1), focused, ins)
+    end
+
+    # The envelope editor + its READ-mode over-paint, for every non-hex shape of the top
+    # request card (plain HTTP, the WS handshake, a gRPC head, a decode tab's ENVELOPE).
+    #
+    # The two calls belong together and were only paired on the plain-HTTP path: the WS and
+    # gRPC branches returned before the over-paint, so in READ mode those panes drew NO caret
+    # at all (`cursor` is off outside INS) and no selection band. An operator pressing ↓ or
+    # ⇧→ in a WebSocket handshake saw the screen not change — the keyboard was working and
+    # only its evidence was missing.
+    private def render_plain_request_editor(screen : Screen, inner : Rect, focused : Bool, ins : Bool) : Nil
       @editor.render(screen, inner, cursor: ins, highlight: :request, peek: focused, gauge: true, gauge_focused: focused)
-      paint_request_read_chrome(screen, inner, focused && !ins)
+      paint_request_read_chrome(screen, inner, @editor, focused && !ins)
     end
 
     # READ-mode over-paint (selection tint + block caret) on top of the frame the editor
@@ -3821,35 +4167,41 @@ module Gori::Tui
     # logical line, and the two derivations drifting apart is precisely how a selection ends
     # up tinting the wrong text. Every span is clipped to its row, so a selection crossing a
     # wrap break is painted on each row it covers.
-    private def paint_request_read_chrome(screen : Screen, rect : Rect, active : Bool) : Nil
+    # `ed` is passed in rather than read from `req_editor`: the caller knows which card it is
+    # drawing, and a split column has two. Deriving it here meant that painting the DECODED
+    # card while the ENVELOPE was the active sub-pane would invert the ENVELOPE's `last_rows`
+    # into the DECODED rect — the exact "two derivations drifting apart" this method's own
+    # comment warns about, one level up. The `active` gate happens to make that unreachable
+    # today; the parameter makes it unrepresentable.
+    private def paint_request_read_chrome(screen : Screen, rect : Rect, ed : TextArea, active : Bool) : Nil
       return unless active
-      ed = req_editor
       lines = ed.lines_snapshot
       return if lines.empty?
       @req_read.sync_from(ed)
-      sel_bg = Theme.accent_bg
       rows = ed.last_rows
       return if rows.empty?
       gw = ed.gutter? ? Gutter.width(lines.size) : 0
+      cw = {rect.w - gw, 0}.max
       spans = @req_read.cursor.highlight_spans(lines)
       cy, cx = ed.cy, ed.cx
       rows.each_with_index do |vr, row|
         y = rect.y + row
         line = lines[vr.li]? || ""
+        # The band and the caret both go through the EDITOR, which owns the concealed-run map:
+        # `§value¦chain§` hides the `¦chain` in this very pane, and measuring the span here on the
+        # raw line put the tint N columns right of its text while re-drawing the raw segment
+        # unconcealed the chain (see the READ-mode over-paint seam in `text_area.cr`).
         spans.each do |(li, x0, x1)|
           next unless li == vr.li
-          a = {x0, vr.a}.max
-          b = {x1, vr.b}.min
-          next if a >= b
-          paint_char_span_bg(screen, rect.x + gw, y, line, a, b, sel_bg, vr.a)
+          ed.paint_read_band(screen, rect.x + gw, y, li, x0, x1, vr.a, vr.b, cw)
         end
         # The caret belongs to exactly one row: the one whose slice contains it, with the
         # end of a wrapped row losing to the row it starts (Wrap::Layout#row_of's rule,
         # spelled out here because ReadCursor holds no layout of its own).
         next unless vr.li == cy && cx >= vr.a && (cx < vr.b || vr.b >= line.size)
-        px = rect.x + gw + Wrap.row_col(line, nil, vr.a, cx)
+        col, ch = ed.read_caret_cell(vr.li, cx, vr.a)
+        px = rect.x + gw + col
         next unless px < rect.x + rect.w
-        ch = cx < line.size ? line[cx] : ' '
         screen.cell(px, y, ch, Theme.bg, Theme.accent_bg)
         screen.cursor(px, y)
       end
@@ -3918,9 +4270,19 @@ module Gori::Tui
     NO_REGIONS = [] of {Int32, Int32, Int32}
     NO_SPANS   = [] of {Int32, Int32}
 
-    private def render_ws_handshake(screen : Screen, rect : Rect, focused : Bool) : Nil
+    # The HANDSHAKE RESPONSE card (the 101 head). `active` says this card owns the response read
+    # cursor, and it decides two things:
+    #
+    #   * the ANCHOR. Active, the card scrolls on the shared `@scroll`/`@scroll_sub` and publishes
+    #     the metrics the hit-tests and scroll walkers read, so it is navigable like any other
+    #     response pane. Inactive, it stays pinned to row 0 with a local layout and publishes
+    #     nothing — the transcript owns the cursor then, and clobbering the metrics with this
+    #     card's would send every click and wheel notch to the wrong geometry.
+    #   * the CHROME. Only the active card paints the caret + selection band; the other one's
+    #     cursor coordinates address a different document.
+    private def render_ws_handshake(screen : Screen, rect : Rect, focused : Bool, active : Bool) : Nil
       return if rect.w < 2 || rect.h < 2
-      Frame.card(screen, rect, "HANDSHAKE RESPONSE", bg: Theme.bg, border: pane_border(focused))
+      Frame.card(screen, rect, "HANDSHAKE RESPONSE", bg: Theme.bg, border: pane_border(focused && active))
       if result = @result
         meta = result.ok? ? "#{Fmt.dur(result.duration_us)} · #{Fmt.size((result.head.size + (result.body.try(&.size) || 0)).to_i64)}" : Fmt.dur(result.duration_us)
         meta_x = rect.right - meta.size - 1
@@ -3931,32 +4293,45 @@ module Gori::Tui
       total = rv.total
       gw = Settings.show_gutter ? {Gutter.width(total), body.w}.min : 0
       cw = {body.w - gw, 0}.max
+      lit = focused && active
+      if active
+        @resp_last_h = body.h
+        resp_record_metrics(gw, cw)
+      end
       return if cw <= 0
-      # This card is always pinned to the top of the handshake response and has its own
-      # tiny window, so it wraps from row 0 with a local layout rather than sharing the
-      # transcript's anchor + memo (different line source, ≤7 rows to lay out).
-      rows = Wrap.rows(0, 0, body.h, total, ->(i : Int32) { Wrap.layout(rv.line_text(i), cw) })
+      line_text = ->(i : Int32) { rv.line_text(i) }
+      sel_spans = active ? resp_sel_spans_if(lit) : nil
+      # Active: the shared anchor + wrap memo, so this card can be scrolled and the caret walked
+      # through it. Inactive: pinned to row 0 with a local layout, which is what it always did
+      # (it is 7 rows showing a 4-5 line head — there is nothing to scroll to).
+      rows = if active
+               resp_rows(cw, body.h, total, line_text)
+             else
+               Wrap.rows(0, 0, body.h, total, ->(i : Int32) { Wrap.layout(line_text.call(i), cw) })
+             end
       rows.each_with_index do |vr, i|
-        if gw > 0
-          if vr.sub == 0
-            Gutter.draw(screen, body.x, body.y + i, vr.li, gw)
-          else
-            screen.text(body.x, body.y + i, " " * {gw - 1, 0}.max, Theme.muted, width: gw)
-          end
-        end
+        y = body.y + i
+        draw_resp_gutter(screen, body.x, y, gw, vr, lit)
         # slice_chars is the identity for a row that IS the whole line, so an unwrapped
         # handshake header costs nothing extra.
         shown = Highlight.slice_chars(styled_resp_line(rv, vr.li), vr.a, vr.b)
-        Highlight.draw(screen, body.x + gw, body.y + i, shown, width: cw)
+        Highlight.draw(screen, body.x + gw, y, shown, width: cw)
+        next unless active
+        text = line_text.call(vr.li)
+        paint_resp_line_chrome(screen, body.x + gw, y, vr.li, text, lit, sel_spans, vr.a, vr.b)
+        Wrap.mark_search(screen, body.x + gw, y, text, vr.a, vr.b, @search_hl, body.x + gw + cw) unless @search_hl.empty?
       end
+      Frame.scroll_gauge(screen, body, total, @scroll, lit) if active
     end
 
     private def render_response(screen : Screen, rect : Rect, focused : Bool) : Nil
       return if rect.w < 2 || rect.h < 2
       if @ws_mode
         handshake_rect, transcript_rect = ws_resp_split(rect)
-        render_ws_handshake(screen, handshake_rect, focused)
-        render_transcript(screen, transcript_rect, focused, "TRANSCRIPT", ws_transcript_lines, @ws_result.try(&.duration_us))
+        on_handshake = @resp_pane == :handshake
+        render_ws_handshake(screen, handshake_rect, focused, active: on_handshake)
+        render_transcript(screen, transcript_rect, focused, "TRANSCRIPT", ws_transcript_lines,
+          @ws_result.try(&.duration_us), active: !on_handshake)
         return
       end
       if @grpc_mode
@@ -3984,11 +4359,20 @@ module Gori::Tui
       Frame.scroll_gauge(screen, body, resp_line_count, @scroll, focused)
     end
 
-    # Shared windowed renderer for the WS / gRPC transcript panes (a list of
+    # Shared windowed renderer for the WS / gRPC / group transcript panes (a list of
     # {text, colour} rows, scrolled by @scroll). `dur_us` rides the top border.
+    #
+    # `active` is only ever false for the WS transcript while the HANDSHAKE RESPONSE card above
+    # it owns the cursor — gRPC and a pipelined group fill the whole column and are always
+    # active. It gates the same two things it gates on the handshake card: the shared anchor +
+    # published metrics, and the caret/selection chrome. Both cards render every frame, so
+    # whichever one wrote the metrics LAST would otherwise win regardless of which one the
+    # cursor is actually on.
     private def render_transcript(screen : Screen, rect : Rect, focused : Bool,
-                                  title : String, lines : Array({String, Color}), dur_us : Int64?) : Nil
-      Frame.card(screen, rect, title, bg: Theme.bg, border: pane_border(focused))
+                                  title : String, lines : Array({String, Color}), dur_us : Int64?,
+                                  active : Bool = true) : Nil
+      lit = focused && active
+      Frame.card(screen, rect, title, bg: Theme.bg, border: pane_border(lit))
       if d = dur_us
         meta = Fmt.dur(d)
         mx = rect.right - meta.size - 1
@@ -4002,19 +4386,27 @@ module Gori::Tui
       end
       gw = Settings.show_gutter ? {Gutter.width(lines.size), body.w}.min : 0
       cw = {body.w - gw, 0}.max
-      @resp_last_h = body.h
-      resp_record_metrics(gw, cw)
+      if active
+        @resp_last_h = body.h
+        resp_record_metrics(gw, cw)
+      end
       return if cw <= 0
-      sel_spans = resp_sel_spans_if(focused)
-      resp_rows(cw, body.h, lines.size, ->(i : Int32) { lines[i][0] }).each_with_index do |vr, i|
+      sel_spans = active ? resp_sel_spans_if(lit) : nil
+      rows = if active
+               resp_rows(cw, body.h, lines.size, ->(i : Int32) { lines[i][0] })
+             else
+               Wrap.rows(0, 0, body.h, lines.size, ->(i : Int32) { Wrap.layout(lines[i][0], cw) })
+             end
+      rows.each_with_index do |vr, i|
         text, color = lines[vr.li]
         y = body.y + i
-        draw_resp_gutter(screen, body.x, y, gw, vr, focused)
+        draw_resp_gutter(screen, body.x, y, gw, vr, lit)
         screen.text(body.x + gw, y, text[vr.a...vr.b], color, width: cw)
-        paint_resp_line_chrome(screen, body.x + gw, y, vr.li, text, focused, sel_spans, vr.a, vr.b)
+        next unless active
+        paint_resp_line_chrome(screen, body.x + gw, y, vr.li, text, lit, sel_spans, vr.a, vr.b)
         Wrap.mark_search(screen, body.x + gw, y, text, vr.a, vr.b, @search_hl, body.x + gw + cw) unless @search_hl.empty?
       end
-      Frame.scroll_gauge(screen, body, lines.size, @scroll, focused)
+      Frame.scroll_gauge(screen, body, lines.size, @scroll, lit) if active
     end
 
     # The transcript as {text, colour} rows (cached; rebuilt only when a new result
@@ -4366,13 +4758,15 @@ module Gori::Tui
 
     # --- content ------------------------------------------------------------
 
-    # The visible line count of the active response view (drives the scroll bound).
+    # The visible line count of the active response view (drives the scroll bound + the gauge).
     private def resp_line_count : Int32
-      if @ws_mode
+      if resp_handshake_active?
+        {resp_view.total, 1}.max
+      elsif @ws_mode
         {ws_transcript_lines.size, 1}.max
       elsif @grpc_mode
         {grpc_transcript_lines.size, 1}.max
-      elsif @resp_hex
+      elsif resp_hex_active?
         (bytes = resp_hex_bytes) ? HexView.rows(bytes.size) : 1
       elsif @resp_mode == :diff
         diff_lines.size

--- a/src/gori/tui/text_area.cr
+++ b/src/gori/tui/text_area.cr
@@ -938,6 +938,18 @@ module Gori::Tui
     # grabbing the run of spaces: the gesture means "give me this token", and there is none.
     def select_word_at(rect : Rect, mx : Int32, my : Int32) : Bool
       click_to_cursor(rect, mx, my)
+      select_word_at_cursor
+    end
+
+    # The word-spread half of `select_word_at`, WITHOUT the hit test — for a caller whose caret
+    # is already where the pointer put it. `ReadCursor` carries this same pair for the same
+    # reason (see its comment): a second inverse can disagree with the first when the layout
+    # moved between the two presses of a double-click, which is exactly what a Repeater split
+    # column does — adopting the lower sub-pane on press 1 resizes both cards, so press 2's
+    # rect is no longer the one press 1 was inverted against.
+    def select_word_at_cursor : Bool
+      return false if @lines.empty?
+      @cy = @cy.clamp(0, @lines.size - 1)
       line = @lines[@cy]
       cx = @cx.clamp(0, line.size)
       return false if cx >= line.size || line[cx].whitespace?
@@ -1627,26 +1639,88 @@ module Gori::Tui
       return if li < y0 || li > y1
       lo = {li == y0 ? x0 : 0, a}.max
       hi = {li == y1 ? x1 : line.size, b}.min
+      paint_band(screen, cx0, y, line, cr, a, lo, hi, cw)
+    end
+
+    # --- READ-mode over-paint seam --------------------------------------------------------
+    # The NORMAL-mode selection band and block caret are drawn by the OWNER (the Repeater's
+    # request pane, the Fuzzer template, Notes, …): that selection lives in a `ReadCursor` this
+    # widget deliberately does not model. The COLUMN MATH, though, is this widget's — and both
+    # owners of a CONCEALING editor had re-derived it without the concealed runs, which is two
+    # separate wrongs at once:
+    #
+    #   * measured on the raw line, the caret and the band land N columns right of the text they
+    #     address, N being the width of the `¦chain` runs hidden to their left; and
+    #   * each band chunk RE-DRAWS its own text, so painting from the raw line put the hidden
+    #     chain back on screen — selecting a line UNCONCEALED it and shifted the rest of the row.
+    #
+    # Both were live in the Repeater's request pane and the Fuzzer template, the two places an
+    # operator actually writes `§value¦chain§`. The copy was correct throughout (it reads buffer
+    # coordinates), so the band highlighted different bytes than `y` put on the clipboard.
+    #
+    # These two methods are the same measure and the same conceal walk `render` uses for the
+    # INSERT band, exposed so an owner cannot derive a second, conceal-blind one.
+
+    # This line's concealed runs in LINE-local char coords, or nil when nothing is hidden there
+    # (which is every editor that never sets `conceal_spans`, and every line of one that does).
+    def conceal_of(li : Int32) : Array({Int32, Int32})?
+      return nil if @conceal_spans.empty? || @reveal
+      line = @lines[li]? || return nil
+      cr = line_conceal(line_start_offset(li), line.size)
+      cr.empty? ? nil : cr
+    end
+
+    # Where a READ block caret for buffer index `cx` on line `li` belongs: its drawn column
+    # (measured from `row_start`, which is the wrap break for a continuation row) and the first
+    # VISIBLE glyph at or after it — a caret parked on a hidden `¦chain` byte has to invert the
+    # glyph the operator can actually see, which is the closing `§`. `render` computes exactly
+    # this pair for the INSERT caret.
+    def read_caret_cell(li : Int32, cx : Int32, row_start : Int32 = 0) : {Int32, Char | String}
+      line = @lines[li]? || ""
+      cr = conceal_of(li)
+      col = Wrap.row_col(line, cr, row_start, cx)
+      r = cx
+      cr.each { |(ra, rb)| r = rb if r >= ra && r < rb } if cr
+      {col, Screen.caret_glyph(line, r)}
+    end
+
+    # Paint `[x0, x1)` of line `li` on the selection background, clipped to the drawn row
+    # `[row_start, row_end)` and split around this editor's concealed runs. `cx0` is the row's
+    # first content cell (past the gutter); `cw` its width.
+    def paint_read_band(screen : Screen, cx0 : Int32, y : Int32, li : Int32,
+                        x0 : Int32, x1 : Int32, row_start : Int32, row_end : Int32, cw : Int32) : Nil
+      line = @lines[li]? || return
+      lo = {x0, row_start}.max
+      hi = {x1, row_end < 0 ? line.size : row_end}.min
+      paint_band(screen, cx0, y, line, conceal_of(li), row_start, lo, hi, cw)
+    end
+
+    # `[lo, hi)` of `line` on the selection background, split around the concealed runs in `cr`.
+    #
+    # A concealed `¦chain` occupies no cells, so the band is laid down as the VISIBLE runs between
+    # the hidden ones; painting straight through would tint cells the chain's neighbours are
+    # standing in, shift the rest of the row's tint right by its length, and — because each chunk
+    # RE-DRAWS its own text — put the hidden chain back on screen.
+    private def paint_band(screen : Screen, cx0 : Int32, y : Int32, line : String,
+                           cr : Array({Int32, Int32})?, row_start : Int32,
+                           lo : Int32, hi : Int32, cw : Int32) : Nil
       return if lo >= hi
       if cr.nil? || cr.empty?
-        paint_sel_chunk(screen, cx0, y, line, cr, a, lo, hi, cw)
+        paint_sel_chunk(screen, cx0, y, line, cr, row_start, lo, hi, cw)
         return
       end
-      # A concealed `¦chain` occupies no cells, so the band is laid down as the VISIBLE runs
-      # between the hidden ones; painting straight through would tint cells the chain's
-      # neighbours are standing in and shift the rest of the row's tint right by its length.
       chunk = lo
       i = lo
       while i < hi
         if run = cr.find { |(ra, rb)| i >= ra && i < rb }
-          paint_sel_chunk(screen, cx0, y, line, cr, a, chunk, i, cw)
+          paint_sel_chunk(screen, cx0, y, line, cr, row_start, chunk, i, cw)
           i = {run[1], hi}.min
           chunk = i
         else
           i += 1
         end
       end
-      paint_sel_chunk(screen, cx0, y, line, cr, a, chunk, hi, cw)
+      paint_sel_chunk(screen, cx0, y, line, cr, row_start, chunk, hi, cw)
     end
 
     # One contiguous, fully-visible `[s, e)` of the row that starts at `row_start`, re-drawn

--- a/src/gori/tui/text_read_state.cr
+++ b/src/gori/tui/text_read_state.cr
@@ -79,6 +79,17 @@ module Gori::Tui
       lines = editor.lines_snapshot
       return false if lines.empty?
       editor.click_to_cursor(rect, mx, my)
+      select_word_at_cursor(editor, lines)
+    end
+
+    # The word spread WITHOUT the hit test, for a caller whose caret is already at the pointer
+    # (the press of a double-click placed it). `ReadCursor` and `TextArea` both carry this pair;
+    # the reason is a layout that can move BETWEEN the two presses — a Repeater split column
+    # resizes both of its cards when press 1 adopts the lower one, so a second hit-test would
+    # invert the same screen row against a rect that has since shifted.
+    def select_word_at_cursor(editor : TextArea, lines : Array(String)? = nil) : Bool
+      lines ||= editor.lines_snapshot
+      return false if lines.empty?
       @cursor.sync(editor.cy, editor.cx)
       return false unless @cursor.select_word_at_cursor(lines)
       apply(editor, lines)


### PR DESCRIPTION
The Repeater's request column is **one** pane for plain HTTP and **two** for a WebSocket flow (HANDSHAKE REQUEST over MESSAGES) or a decode tab (ENVELOPE over DECODED). Every editor gesture the single-pane case had was gated off, painted for the wrong mode, or simply missing in the split one — and the response column's second card was on screen and unreachable. Then a sweep for the same shapes across the tree turned up four more.

## The split request column

- **Invisible keyboard.** The WS and gRPC render branches returned before `paint_request_read_chrome`, so NORMAL mode drew no caret and no selection band: ↓ or ⇧→ in a handshake changed nothing on screen. `render_decoded` passed `cursor: focused` unconditionally, so MESSAGES drew an INSERT caret in both modes and its READ selection — the one `y` copies — was invisible while `x`, ⇧arrows and a drag were all building it.
- **Cross-pane arrows.** The step that leaves one sub-pane lived inline in `edit_move`, INSERT only. `restore` leaves a tab in READ, so a reopened WebSocket tab could not reach MESSAGES from HANDSHAKE with the arrows at all — `^T` was the only way across.
- **Mouse.** `request_drag_to_cursor` / `request_select_word` returned early on `@ws_mode || @decode_kind`. The split's click also bypassed `@req_read`, so READ's cursor kept whatever anchor an earlier selection had left.
- **Double-click across a pane switch.** Adopting the lower card on press 1 resizes both (the active one grows to ~2/3, lifting the lower card's top edge), so a second hit-test addressed a rect that had moved and spread a word a third of a column below the pointer. It spreads from the caret press 1 placed now.

One seam — `request_col_rect` / `request_hit` / `request_sub_rect` / `place_request_caret` / `try_cross_req_pane` — so the split and the single pane walk the same code.

## The response column

`response_body_rect` hard-coded the transcript in WS mode, so a click on **HANDSHAKE RESPONSE** produced a negative row and was dropped, and `resp_line_source` answered with transcript rows whatever the pointer was over. No caret, no selection, no copy — on a card showing a real HTTP 101 head.

It is a sub-pane now (`@resp_pane`): the click adopts the card it landed in, `^T` switches, ↑/↓ cross, `^F`/`^G` follow, "copy as" offers head/body/raw, and the card grows to ~2/3 when active (a fixed 7 rows had been hiding the tail of every handshake response longer than five lines). `switch_resp_pane` parks the outgoing card's `{scroll, cursor}` and drops the line-indexed wrap memo that describes the other document.

Transcript ←/→ were gated off for WS/gRPC/group, leaving vertical motion only — while a mouse drag over the same rows selected by character and `resp_copy_text` copied exactly that span.

## Chrome

`␣K:KEY` was drawn but absent from `chrome_hit`'s badge list — a dead cell, while HTTP's `^L:CL`/`^U:PRETTY` beside it have always been clickable. Both read one `WS_BADGES` list now. The handshake and the gRPC head get the NOR/INS chip they were missing.

## Two silent-state bugs, found reviewing the above

- A parked `@scroll_sub` indexes **into** a line's wrap layout, so restoring one across a park is only meaningful if that line still wraps identically. Zeroed; `apply_ws` clears the whole parked anchor because a send replaces both documents.
- `@resp_hex` survives the same view becoming a WebSocket tab (`apply_group` was the only place that cleared it), while a transcript never draws the hex dump — so the flag silently killed the caret, the selection and every arrow key with no visual change, and with `at_top?` now crossing cards it left a column with no way out.

## Four more, from the sweep

| | |
|---|---|
| `§N` badge | Drawn 4 cells **inside** the 7-cell NOR/INS chip, so the Fuzzer TEMPLATE border read `↵: §2` — mode chip destroyed, count ambiguous. |
| READ Home/End | Fuzzer + JWT moved the editor caret without adopting it into the READ cursor. Fuzzer kept a phantom band whose ends had crossed, so **`y` copied `""`**; JWT paints from its read cursor, so Home/End moved a caret nobody could see. Four sibling views already call `sync_to`. |
| Mode chip | Drawn from `focused && insert?` while the hit-test and the click handler read `insert?` alone. The labels are different **widths**, so an unfocused pane that retained INS drew 7-cell `↵:NOR` over a 5-cell `INS` hit rect, and clicking a chip that said `↵:NOR` turned insert **off**. |
| READ chrome over a concealed `¦chain` | Both painters measured the raw line, so caret and band landed N columns right of what they addressed, and the band — which re-draws its own text — **unconcealed the hidden chain**. Copy was correct throughout, so the band highlighted different bytes than `y` put on the clipboard. |

`TextArea` now exposes the measure and the conceal-splitting walk it already used for the INSERT band (`conceal_of` / `read_caret_cell` / `paint_read_band`), so an owner cannot derive a second, conceal-blind one.

## Deliberately not done

- The **response wheel stays coordinate-free**. The inactive handshake card renders pinned to row 0 and has no scroll state to move, so there is nothing to aim at until `^T` or a click grows it. This is an asymmetry with the request column, which did become pointer-aware.
- READ mode still has no `⌃Home`/`⌃End` buffer jump, in the Repeater or the Fuzzer.

## Also fixed while here

`response_search_lines` re-derived a per-mode ladder beside `resp_line_source` and had drifted — no REVEAL branch, so searching a whitespace-revealed response returned indices into a document the pane was not showing. And three Repeater response footers advertised `⇧←/→ h-scroll` beside `⇧arrows select`, for an h-scroll that has been a no-op stub since the panes learned to wrap.

## Verification

- **7044 examples, 8 failures** — the 8 are the known environmental `Gori::Session` port-bind failures in `project_registry_spec` / `capture_status_spec` (a live gori process holds the port); they fail identically on `main`.
- Two new spec files (996 lines) plus additions to four existing ones. **Every fix was verified by reverting it and watching the spec fail**, so these land as regressions rather than assertions.
- The WebSocket work was also driven end-to-end in a real terminal against a live WS origin: injected SGR press/motion/release drags in both request sub-panes and in the handshake response card, double-click word select across a pane switch (row 35 → 25 as the split resized, still the right token), the `␣K:KEY` and mode chips clicked at their drawn columns, cross-card arrows both ways, and a pointer-aware wheel moving one card while the other stayed put.
- `crystal tool format --check` clean on every touched file. Ameba over the 7 touched sources: 62 → 63 findings, the one delta a `Metrics/CyclomaticComplexity` advisory, while the largest offenders in those files shrank (`chrome_hit` 34→24, `render_request` 27→24).
