### PR TITLE
An arrow key that skipped every wrapped row, a click that landed on a line it wasn't drawn on: the History detail now wraps like the Repeater

### DIFF
--- a/spec/support/fake_context.cr
+++ b/spec/support/fake_context.cr
@@ -186,10 +186,6 @@ class FakeExecContext < Gori::Verb::ExecContext
     rec(:detail_copy_selection)
   end
 
-  def hscroll_detail(delta : Int32) : Nil
-    rec(:hscroll_detail, delta)
-  end
-
   def toggle_detail_pane : Nil
     rec(:toggle_detail_pane)
   end

--- a/spec/tui/history_view_spec.cr
+++ b/spec/tui/history_view_spec.cr
@@ -373,7 +373,12 @@ describe Gori::Tui::HistoryView do
     end
   end
 
-  it "hscroll_detail scrolls a long response body line sideways into view (shift+←/→)" do
+  # Was: "hscroll_detail scrolls a long response body line sideways into view (shift+←/→)".
+  # There is no sideways any more — the detail's req/res panes soft-wrap, so the tail of a
+  # long line is on the next row with nothing to chase it with. What is still under test is
+  # the same requirement the h-scroll spec encoded: BOTH ends of an over-wide line must be
+  # reachable, and now they are visible at once.
+  it "wraps a long response body line so both ends are on screen without scrolling" do
     tmp_store do |store|
       id = store.insert_flow(Gori::Store::CapturedRequest.new(
         created_at: 1_i64, scheme: "https", host: "h.test", port: 443,
@@ -393,13 +398,11 @@ describe Gori::Tui::HistoryView do
       backend = MemoryBackend.new(80, 16)
       view.render_detail(Screen.new(backend), rect)
       backend.contains?("HEAD").should be_true
-      backend.contains?("TAIL").should be_false # off the right edge, clipped
-
-      20.times { view.hscroll_detail(1) } # scroll well past the line's width
-      backend2 = MemoryBackend.new(80, 16)
-      view.render_detail(Screen.new(backend2), rect)
-      backend2.contains?("TAIL").should be_true
-      backend2.contains?("HEAD").should be_false # scrolled off the left edge
+      backend.contains?("TAIL").should be_true # on a continuation row, not clipped away
+      # …and on DIFFERENT rows: the tail wrapped rather than being squeezed onto one line.
+      head_y = (0...16).find { |y| backend.row(y).includes?("HEAD") }.not_nil!
+      tail_y = (0...16).find { |y| backend.row(y).includes?("TAIL") }.not_nil!
+      tail_y.should be > head_y
     end
   end
 
@@ -442,7 +445,11 @@ describe Gori::Tui::HistoryView do
     end
   end
 
-  it "follows the caret horizontally as ←/→ walk a long line (no explicit h-scroll)" do
+  # Was: "follows the caret horizontally as ←/→ walk a long line (no explicit h-scroll)".
+  # The caret no longer drags a horizontal offset — the line is wrapped, so walking ←/→ to
+  # its end lands the caret on a continuation row that is already drawn. What is still under
+  # test is that the walk REACHES the end of the line and the pane keeps showing it.
+  it "walks the caret to the end of a wrapped line without scrolling the pane sideways" do
     tmp_store do |store|
       id = store.insert_flow(Gori::Store::CapturedRequest.new(
         created_at: 1_i64, scheme: "https", host: "h.test", port: 443,
@@ -459,22 +466,24 @@ describe Gori::Tui::HistoryView do
       view.toggle_pane # request -> response
 
       rect = Rect.new(0, 0, 80, 16)
-      # The first render records the body's content width so caret moves can follow-x.
+      # The first render publishes the body's content width, which the wrap is keyed on.
       b0 = MemoryBackend.new(80, 16)
       view.render_detail(Screen.new(b0), rect)
       b0.contains?("HEAD").should be_true
-      b0.contains?("TAIL").should be_false # off the right edge at xscroll 0
+      b0.contains?("TAIL").should be_true # already on a continuation row
 
       # Park the caret at the start of the long body line, then walk it to end-of-line
       # (the body has no trailing newline, so moving past EOL clamps — it never wraps).
       row = view.detail_search_lines("HEAD").first
       view.goto_detail_line(row + 1)
-      130.times { view.detail_move(0, 1) } # plain ←/→ horizontal caret; ensure_detail_visible_x tracks it
+      130.times { view.detail_move(0, 1) } # plain ←/→ horizontal caret
+      view.detail_read.cy.should eq(row)
+      view.detail_read.cx.should eq(108) # HEAD + 100 dots + TAIL
 
       b1 = MemoryBackend.new(80, 16)
       view.render_detail(Screen.new(b1), rect)
-      b1.contains?("TAIL").should be_true  # caret-follow scrolled the tail into view
-      b1.contains?("HEAD").should be_false # the start slid off the left edge
+      b1.contains?("TAIL").should be_true # the caret's row is still on screen …
+      b1.contains?("HEAD").should be_true # … and so is the line's start
     end
   end
 
@@ -551,12 +560,13 @@ describe Gori::Tui::HistoryView do
     end
   end
 
-  # Same clamp bug as RepeaterView#render_reveal, but here it also FOUGHT the caret:
-  # ensure_detail_visible_x slides @detail_xscroll using column_width (a tab counts 1),
-  # then this clamp immediately clawed it back with display_width (a tab counts 0). The
-  # caret-follow and the clamp were pulling in opposite directions every frame, so on a
-  # tab-indented body the caret could never scroll into view at the end of a line.
-  it "scrolls a tab-filled response line to its end in reveal mode" do
+  # Was: "scrolls a tab-filled response line to its end in reveal mode" — a regression test
+  # for two measures disagreeing about a tab's width (display_width says 0, draw_width says
+  # 1) while one drove the h-scroll clamp and the other the caret-follow. There is no
+  # h-scroll left to clamp, but the SAME disagreement would now break the wrap: `Wrap` breaks
+  # on `Screen.grapheme_cols`, so a 100-tab line has to occupy several drawn rows rather than
+  # the single 14-column one the raw measure would predict.
+  it "wraps a tab-filled response line onto continuation rows in reveal mode" do
     tmp_store do |store|
       line = "STARTTOK#{"\t" * 100}ENDTOK"
       Screen.display_width(line).should eq(14) # the raw measure the clamp used to trust
@@ -580,14 +590,13 @@ describe Gori::Tui::HistoryView do
       at0 = MemoryBackend.new(80, 16)
       view.render_detail(Screen.new(at0), rect)
       at0.contains?("STARTTOK").should be_true
-      at0.contains?("ENDTOK").should be_false # tail off to the right
-      at0.contains?("→").should be_true       # reveal is drawing tab markers
+      at0.contains?("→").should be_true      # reveal is drawing tab markers
+      at0.contains?("ENDTOK").should be_true # …and the tail wrapped into view
 
-      20.times { view.hscroll_detail(4) }
-      scrolled = MemoryBackend.new(80, 16)
-      view.render_detail(Screen.new(scrolled), rect)
-      scrolled.contains?("ENDTOK").should be_true    # reachable now
-      scrolled.contains?("STARTTOK").should be_false # head genuinely scrolled off
+      # The two must be on different rows: 114 drawn columns cannot fit one ~76-column row.
+      start_y = (0...16).find { |y| at0.row(y).includes?("STARTTOK") }.not_nil!
+      end_y = (0...16).find { |y| at0.row(y).includes?("ENDTOK") }.not_nil!
+      end_y.should be > start_y
     end
   end
 

--- a/spec/tui/history_wrap_spec.cr
+++ b/spec/tui/history_wrap_spec.cr
@@ -1,0 +1,281 @@
+require "../spec_helper"
+require "../support/memory_backend"
+
+include Gori::Tui
+
+# The detail body rect the view derives internally, re-derived here so a click spec can aim
+# at a real cell. Mirrors `render_detail` and `HistoryController#detail_text_rect`: the pane
+# chip strip and the mode row, then a 1-column inset each side. `render_detail` is handed the
+# framed card's INNER rect by the controller, so the specs pass their rect straight through.
+private def detail_body_rect(rect : Gori::Tui::Rect) : Gori::Tui::Rect
+  Gori::Tui::Rect.new(rect.x + 1, rect.y + 2, {rect.w - 2, 0}.max,
+    {rect.bottom - (rect.y + 2), 0}.max)
+end
+
+private def tmp_store(&)
+  path = File.tempname("gori-hw", ".db")
+  store = Gori::Store.open(path)
+  begin
+    yield store
+  ensure
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+# A flow whose RESPONSE carries `body`, opened on the response pane with the body level
+# focused. The response's line space is: status line, Content-Type, blank, then the body.
+private def response_view(store, body : String, ct : String = "text/plain") : Gori::Tui::HistoryView
+  id = store.insert_flow(Gori::Store::CapturedRequest.new(
+    created_at: 1_i64, scheme: "https", host: "h.test", port: 443,
+    method: "GET", target: "/api", http_version: "HTTP/1.1",
+    head: "GET /api HTTP/1.1\r\nHost: h.test\r\n\r\n".to_slice, body: nil))
+  store.update_response(Gori::Store::CapturedResponse.new(
+    flow_id: id, status: 200,
+    head: "HTTP/1.1 200 OK\r\nContent-Type: #{ct}\r\n\r\n".to_slice,
+    body: body.to_slice, content_type: ct))
+  view = Gori::Tui::HistoryView.new
+  view.reload(store)
+  view.open_detail(store)
+  view.toggle_pane # request → response
+  view.set_detail_focus(:body)
+  view
+end
+
+# The index of the first BODY line in the response pane's line space (status, header, blank).
+private BODY_LI = 3
+
+describe "Gori::Tui::HistoryView detail soft wrap" do
+  # The Burp-style contract on the History detail: a body line too wide for the pane spills
+  # onto continuation rows, and the line number is printed once, on the first of them.
+  it "wraps a long response line and numbers only its first visual row" do
+    Gori::Settings.show_gutter = true
+    tmp_store do |store|
+      view = response_view(store, "HEAD#{"." * 100}TAIL")
+      rect = Rect.new(0, 0, 80, 20)
+      b = MemoryBackend.new(80, 20)
+      view.render_detail(Screen.new(b), rect)
+      body = detail_body_rect(rect)
+      gw = Gutter.width(4) # status, header, blank, body
+      head_row = (0...20).find { |y| b.row(y).includes?("HEAD") }.not_nil!
+      b.row(head_row)[body.x, gw].should_not eq(" " * gw) # numbered
+      b.row(head_row + 1)[body.x, gw].should eq(" " * gw) # continuation: no number
+      b.contains?("TAIL").should be_true                  # on screen, not clipped away
+    end
+  ensure
+    Gori::Settings.show_gutter = true
+  end
+
+  # The inverse of that render. Before wrap, screen row N of the detail WAS logical line
+  # @detail_scroll + N, so a click on a continuation row selected a line that isn't even
+  # drawn there — and the old path went through ReadCursor, which does exactly that sum.
+  it "round-trips a click on a continuation row of the detail body" do
+    tmp_store do |store|
+      view = response_view(store, "0123456789" * 15) # 150 chars, one body line
+      rect = Rect.new(0, 0, 80, 20)
+      b = MemoryBackend.new(80, 20)
+      view.render_detail(Screen.new(b), rect)
+      body = detail_body_rect(rect)
+      gw = Gori::Settings.show_gutter ? Gutter.width(4) : 0
+      cw = body.w - gw
+      view.detail_click_to_cursor(body, body.x + gw + 2, body.y + BODY_LI + 1, focused: true)
+      view.detail_read.cy.should eq(BODY_LI) # still the BODY line …
+      view.detail_read.cx.should eq(cw + 2)  # … one wrapped row in, plus two columns
+    end
+  end
+
+  # ↓ steps one VISUAL row. It used to step a logical LINE, which on a wrapped line jumped
+  # the caret over every continuation row the pane was showing — from the first row of a
+  # 400-char body line straight to SENTINEL, skipping the rows in between. Those rows are
+  # drawn; nothing but this arrow could reach them.
+  it "moves the detail caret down one visual row at a time, then onto the next line" do
+    tmp_store do |store|
+      view = response_view(store, "#{"z" * 400}\nSENTINEL")
+      rect = Rect.new(0, 0, 80, 14)
+      view.render_detail(Screen.new(MemoryBackend.new(80, 14)), rect)
+      body = detail_body_rect(rect)
+      gw = Gori::Settings.show_gutter ? Gutter.width(5) : 0 # status, header, blank, body ×2
+      cw = body.w - gw
+      BODY_LI.times { view.detail_move(1, 0) } # status → header → blank → the 400-char line
+      view.detail_read.cy.should eq(BODY_LI)
+      view.detail_read.cx.should eq(0)
+      view.detail_move(1, 0)
+      view.detail_read.cy.should eq(BODY_LI) # still the same LINE …
+      view.detail_read.cx.should eq(cw)      # … one wrapped row into it, at the same column
+      rows = (400 + cw - 1) // cw
+      (rows - 2).times { view.detail_move(1, 0) }
+      view.detail_read.cy.should eq(BODY_LI)
+      view.detail_read.cx.should eq((rows - 1) * cw)
+      view.detail_move(1, 0)
+      view.detail_read.cy.should eq(BODY_LI + 1) # SENTINEL, many wrapped rows below the fold
+      # …and the pane scrolled along with it (ensure_detail_visible counts visual rows too).
+      b2 = MemoryBackend.new(80, 14)
+      view.render_detail(Screen.new(b2), rect)
+      b2.contains?("SENTINEL").should be_true
+    end
+  end
+
+  # ↑ is the exact inverse: a run of ↓ then the same number of ↑ lands back where it began.
+  it "moves the detail caret back up through the wrapped rows it came down" do
+    tmp_store do |store|
+      view = response_view(store, "#{"z" * 400}\nSENTINEL")
+      rect = Rect.new(0, 0, 80, 14)
+      view.render_detail(Screen.new(MemoryBackend.new(80, 14)), rect)
+      6.times { view.detail_move(1, 0) }
+      view.detail_read.cy.should eq(BODY_LI) # inside the wrapped line, not past it
+      6.times { view.detail_move(-1, 0) }
+      view.detail_read.cy.should eq(0)
+      view.detail_read.cx.should eq(0)
+    end
+  end
+
+  # ↑-at-the-very-top pops focus out to the chip strip (HistoryController#detail_body_up).
+  # Gated on the logical line alone, a caret parked three rows into a wrapped line 0 would
+  # pop instead of stepping up — skipping the very rows the arrow was asked to walk.
+  it "is not 'at top' while the caret sits on a continuation row of line 0" do
+    tmp_store do |store|
+      # A single over-wide status line, so line 0 itself wraps.
+      id = store.insert_flow(Gori::Store::CapturedRequest.new(
+        created_at: 1_i64, scheme: "https", host: "h.test", port: 443,
+        method: "GET", target: "/#{"q" * 200}", http_version: "HTTP/1.1",
+        head: "GET /#{"q" * 200} HTTP/1.1\r\nHost: h.test\r\n\r\n".to_slice, body: nil))
+      store.update_response(Gori::Store::CapturedResponse.new(
+        flow_id: id, status: 200, head: "HTTP/1.1 200 OK\r\n\r\n".to_slice,
+        body: nil, content_type: nil))
+      view = Gori::Tui::HistoryView.new
+      view.reload(store)
+      view.open_detail(store).should be_true # REQUEST pane: line 0 is the long request line
+      view.set_detail_focus(:body)
+      rect = Rect.new(0, 0, 80, 14)
+      view.render_detail(Screen.new(MemoryBackend.new(80, 14)), rect)
+
+      view.detail_at_top?.should be_true
+      view.detail_move(1, 0) # one VISUAL row down — still on line 0
+      view.detail_read.cy.should eq(0)
+      view.detail_read.cx.should be > 0
+      view.detail_at_top?.should be_false # …so ↑ must step back, not pop to the strip
+      view.detail_move(-1, 0)
+      view.detail_at_top?.should be_true
+    end
+  end
+
+  # The wheel steps DRAWN rows. With a line-indexed offset one notch jumped the whole
+  # wrapped line, so most of a minified body was unreachable by scrolling.
+  it "scrolls the detail by one visual row per notch" do
+    tmp_store do |store|
+      # Four wrapped body lines: more drawn rows than the pane has, or the anchor clamp
+      # (max_anchor) correctly refuses to scroll content that already fits.
+      view = response_view(store, (1..4).map { |i| "#{('a' + i - 1)}" * 300 }.join('\n'))
+      rect = Rect.new(0, 0, 80, 14)
+      b = MemoryBackend.new(80, 14)
+      view.render_detail(Screen.new(b), rect)
+      body = detail_body_rect(rect)
+      row = ->(back : MemoryBackend, y : Int32) { back.row(y)[body.x, body.w] }
+      top = row.call(b, body.y)
+      view.detail_scroll_view(1)
+      b2 = MemoryBackend.new(80, 14)
+      view.render_detail(Screen.new(b2), rect)
+      # One notch advanced by exactly one drawn row: what was the SECOND row is now the first.
+      row.call(b2, body.y).should eq(row.call(b, body.y + 1))
+      row.call(b2, body.y).should_not eq(top)
+    end
+  end
+
+  # A selection that covers a wrap boundary must highlight to the END of the visual row, then
+  # continue on the next one. Clipping the span per row is the whole of it, and it is exactly
+  # the arithmetic that looks right until you count cells.
+  it "tints a selection across a wrap break to the end of the row and onto the next" do
+    tmp_store do |store|
+      view = response_view(store, "0123456789" * 15)
+      rect = Rect.new(0, 0, 80, 20)
+      b = MemoryBackend.new(80, 20)
+      view.render_detail(Screen.new(b), rect)
+      body = detail_body_rect(rect)
+      gw = Gori::Settings.show_gutter ? Gutter.width(4) : 0
+      cw = body.w - gw
+      BODY_LI.times { view.detail_move(1, 0) }
+      view.detail_read.cy.should eq(BODY_LI)
+      (cw + 5).times { view.detail_move(0, 1, selecting: true) }
+      b2 = MemoryBackend.new(80, 20)
+      view.render_detail(Screen.new(b2), rect)
+      r0 = body.y + BODY_LI # the body line's first visual row
+      b2.bg_grid[r0][body.x + gw].should eq(Theme.accent_bg)
+      b2.bg_grid[r0][body.x + gw + cw - 1].should eq(Theme.accent_bg) # …tinted to the row's end
+      b2.bg_grid[r0 + 1][body.x + gw].should eq(Theme.accent_bg)      # …and resumed below
+      b2.bg_grid[r0 + 1][body.x + gw + 4].should eq(Theme.accent_bg)
+      # gw+5 is the caret cell itself (also accent_bg); the tint must stop right after it.
+      b2.bg_grid[r0 + 1][body.x + gw + 6].should_not eq(Theme.accent_bg)
+    end
+  end
+
+  # A double-click on a continuation row must take the word UNDER the pointer. It went
+  # through `ReadCursor#select_word_at`, whose own hit test resolves `scroll + row` — so on
+  # any wrapped pane it grabbed a word from a line that wasn't even drawn there.
+  it "double-click selects the word under a continuation row of the detail body" do
+    tmp_store do |store|
+      view = response_view(store, "#{"x" * 120}NEEDLE#{"y" * 20}")
+      rect = Rect.new(0, 0, 80, 20)
+      b = MemoryBackend.new(80, 20)
+      view.render_detail(Screen.new(b), rect)
+      body = detail_body_rect(rect)
+      # NEEDLE lands on the SECOND visual row of the body line; aim at its first cell there.
+      ny = (0...20).find { |y| b.row(y).includes?("NEEDLE") }.not_nil!
+      nx = b.row(ny).index("NEEDLE").not_nil!
+      view.detail_select_word(body, nx, ny).should be_true
+      # The run is x…xNEEDLEy…y — one unbroken word-char token, so the whole line is the word.
+      view.detail_copy_text.should eq("#{"x" * 120}NEEDLE#{"y" * 20}")
+      view.detail_read.cy.should eq(BODY_LI)
+    end
+  end
+
+  # Every detail pane is navigable, so FRAMES / EVENTS / MESSAGES / SAML / JWT / GRAPHQL /
+  # PARAMS all draw through the same wrapped path as req/res — but they are built as
+  # PRE-STYLED head arrays (`log_head` + `wrap`), not as the windowed raw body. The wrap is
+  # measured on `DetailView#line_text` while the draw slices `#line_at`, so the two have to
+  # agree char-for-char on those lines or the colours land a column off the glyphs and every
+  # click on the pane resolves to the wrong column. EVENTS stands in for the family.
+  it "wraps a pre-styled decoded pane (EVENTS) on the same grid it draws" do
+    tmp_store do |store|
+      long = "z" * 300
+      view = response_view(store, "data: #{long}\n\n", "text/event-stream")
+      view.set_detail_pane_public(:events)
+      rect = Rect.new(0, 0, 80, 20)
+      b = MemoryBackend.new(80, 20)
+      view.render_detail(Screen.new(b), rect)
+      body = detail_body_rect(rect)
+      gw = Gori::Settings.show_gutter ? Gutter.width(2) : 0 # "▸ event #1" + its data line
+      # The data line wrapped: its number rides the first row, the rest are blank-guttered.
+      zrow = (0...20).find { |y| b.row(y).includes?("zzz") }.not_nil!
+      b.row(zrow)[body.x, gw].should_not eq(" " * gw)
+      b.row(zrow + 1)[body.x, gw].should eq(" " * gw)
+      # …and a click on the continuation row resolves onto that same logical line, at the
+      # column the row's own text starts from — proving line_text and line_at share a grid.
+      view.detail_click_to_cursor(body, body.x + gw, zrow + 1, focused: true)
+      view.detail_read.cy.should eq(1) # the data line, not the "▸ event #1" header
+      view.detail_read.cx.should eq(body.w - gw)
+    end
+  end
+
+  # Search highlighting scans the WHOLE logical line and clips each hit to the row, so a match
+  # straddling a break lights up on BOTH rows. Marking per-row would light it on NEITHER: the
+  # head and the tail are each an incomplete match.
+  it "highlights a search match that straddles a wrap break on both rows" do
+    tmp_store do |store|
+      rect = Rect.new(0, 0, 80, 20)
+      body = detail_body_rect(rect)
+      gw = Gori::Settings.show_gutter ? Gutter.width(4) : 0
+      cw = body.w - gw
+      # Place "SPLITME" so the break falls in its middle.
+      pad = cw - 3
+      view = response_view(store, "#{"." * pad}SPLITME#{"." * 20}")
+      view.search_hl = "SPLITME"
+      b = MemoryBackend.new(80, 20)
+      view.render_detail(Screen.new(b), rect)
+      r0 = body.y + BODY_LI
+      b.bg_at(body.x + gw + pad, r0).should eq(Theme.yellow) # "SPL" on the first row …
+      b.bg_at(body.x + gw, r0 + 1).should eq(Theme.yellow)   # … "ITME" on the next
+    end
+  end
+end

--- a/spec/verb/registry_spec.cr
+++ b/spec/verb/registry_spec.cr
@@ -152,10 +152,6 @@ private class FakeContext < ExecContext
     @calls << :detail_copy_selection
   end
 
-  def hscroll_detail(delta : Int32) : Nil
-    @calls << :hscroll_detail
-  end
-
   def toggle_detail_pane : Nil
     @calls << :toggle_detail_pane
   end

--- a/src/gori/tui/controllers/history_controller.cr
+++ b/src/gori/tui/controllers/history_controller.cr
@@ -587,10 +587,6 @@ module Gori::Tui
       @history.list_copy_as_menu(@host.session.store, ids)
     end
 
-    def hscroll_detail(delta : Int32) : Nil
-      @history.hscroll_detail(delta)
-    end
-
     def toggle_detail_pane : Nil
       @history.toggle_pane
     end

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -12,6 +12,7 @@ require "./url"
 require "./fmt"
 require "./flow_status"
 require "./read_cursor"
+require "./wrap"
 require "./copy_menu"
 require "../store"
 require "../repeater/flow_request"
@@ -60,6 +61,9 @@ module Gori::Tui
     getter? follow : Bool
     getter? querying : Bool
     getter query : String
+    # The detail body's read caret (mirrors RepeaterView#resp_cursor) — the pane's own
+    # position, which the wrap walkers move in visual rows.
+    getter detail_read : ReadCursor
 
     def initialize(@max_rows : Int32 = MAX_ROWS, @trim_slack : Int32 = TRIM_SLACK)
       # Display order follows Settings.history_list_order: newest-first (id DESC) or
@@ -107,8 +111,14 @@ module Gori::Tui
       @detail_graphql = nil.as(Graphql::Op?)         # GraphQL operation → GRAPHQL pane
       @detail_form = nil.as(Array(FormData::Field)?) # form/multipart params → PARAMS pane
       @decoded_id = nil.as(Int64?)                   # flow the decoded panes above were parsed from (skip re-decode)
+      # Scroll anchor: a (logical line, visual sub-row) pair rather than a flat visual-row
+      # index — see the header of `Wrap`. @detail_scroll_sub is 0 in hex (which draws its own
+      # fixed rows) and before the first frame has published a content width.
       @detail_scroll = 0
-      @detail_xscroll = 0 # horizontal scroll offset for the detail body (caret-follow)
+      @detail_scroll_sub = 0
+      # Per-line wrap memo for the detail body, keyed by the content width below.
+      @detail_wrap = {} of Int32 => Wrap::Layout
+      @detail_wrap_w = -1
       @detail_pane = initial_detail_pane
       @detail_focus = :strip                 # :strip (chip row) | :body (caret/text) — two-level detail focus
       @search_hl = ""                        # active ^F query → highlight in the detail body
@@ -130,8 +140,13 @@ module Gori::Tui
       @detail_styled_cache = {} of Int32 => Highlight::Line
       @detail_cache_rev = Theme.revision # the theme the cached (colour-baked) head/notes were built under
       @detail_read = ReadCursor.new
+      # The geometry the last text render actually drew with. Hit-testing reads these back
+      # rather than re-deriving them: `detail_gutter_w` is fed a different total by each
+      # render path (dv.total vs reveal_lines.size), so a re-derivation could key the wrap
+      # memo at a width the rows were never laid out at — flushing it on every click.
       @detail_last_h = 0
-      @detail_last_cw = 0 # last body content width — drives horizontal caret-follow (ensure_detail_visible_x)
+      @detail_last_gw = 0
+      @detail_last_cw = 0
       # settings:layout History Req/Res preview (list page bottom pane) — separate from full detail.
       @preview_detail = nil.as(Store::FlowDetail?)
       @preview_id = nil.as(Int64?)
@@ -794,7 +809,7 @@ module Gori::Tui
       # (DETAIL_LOG_CAP) with the full count kept for the "older not loaded" note.
       load_detail_logs(store)
       @detail_scroll = 0
-      @detail_xscroll = 0
+      detail_wrap_reset
       @detail_pane = initial_detail_pane
       @detail_focus = :strip # open lands on the strip (sub-tabs/chips); down-arrow enters the body
       drop_detail_cache
@@ -901,7 +916,7 @@ module Gori::Tui
       return if log_pane? # frames/events have no raw-bytes hex; don't strand a hidden flag
       @detail_hex = !@detail_hex
       @detail_scroll = 0 # row-based offset differs from the line-based one
-      @detail_xscroll = 0
+      detail_wrap_reset
       @detail_read.reset
     end
 
@@ -935,72 +950,159 @@ module Gori::Tui
       end
     end
 
-    # True when the detail is at its very top: caret on row 0 (navigable text) or the
-    # scroll offset pinned to 0 (hex dump). Mirrors the list's at_top? so a ↑ here pops
-    # focus to the tab bar exactly as it does from the list's first row.
+    # True when the detail is at its very top: caret on the FIRST VISUAL ROW of line 0
+    # (navigable text) or the scroll offset pinned to 0 (hex dump). Mirrors the list's
+    # at_top? so a ↑ here pops focus to the tab bar exactly as it does from the list's
+    # first row. The sub-row half matters under wrap: a caret parked three rows into a
+    # wrapped line 0 is not at the top, and popping focus from there would skip the very
+    # rows the ↑ was asked to walk.
     def detail_at_top? : Bool
-      detail_navigable? ? @detail_read.cy == 0 : @detail_scroll == 0
+      return @detail_scroll == 0 unless detail_navigable?
+      @detail_read.cy == 0 && detail_caret_sub == 0
+    end
+
+    # The caret's visual row WITHIN its logical line, or 0 when nothing has been laid out
+    # yet (hex, or before the first frame published a content width).
+    private def detail_caret_sub : Int32
+      cw = @detail_last_cw
+      return 0 if @detail_hex || cw <= 0
+      size, line_at = detail_line_source
+      return 0 if size <= 0 || @detail_read.cy >= size
+      detail_layout(@detail_read.cy, cw, line_at).row_of(@detail_read.cx)
     end
 
     # READ-mode caret move (+ optional shift selection). Arrow keys / detail.up/down
     # route here when the pane is navigable text (not a raw hex dump).
     # Lazy (size + line_at): a vertical step only materialises the destination line —
     # never every BodyLines entry on a multi-MiB body.
+    #
+    # ↑/↓ step one VISUAL row (see `detail_visual_target`), so they walk the continuation
+    # rows the pane is drawing instead of jumping over them to the next line number.
     def detail_move(dr : Int32, dc : Int32, selecting : Bool = false) : Nil
       return unless detail_navigable?
       size, line_at = detail_line_source
       return if size <= 0
-      @detail_read.move(dr, dc, size, line_at, selecting)
+      if target = detail_visual_target(dr, size, line_at)
+        @detail_read.move_to(target[0], target[1], selecting: selecting)
+      else
+        @detail_read.move(dr, dc, size, line_at, selecting)
+      end
       ensure_detail_visible(@detail_last_h) if @detail_last_h > 0
-      ensure_detail_visible_x(@detail_last_cw) if @detail_last_cw > 0
     end
 
-    # Wheel: scroll the viewport without moving the caret (READ panes).
-    # Uses detail_view.total (O(1) line count from BodyLines offsets) rather than
-    # materialising every plain line just to know the scroll range.
+    # The caret `dr` visual rows away, or nil when this pane has no wrap to walk — hex draws
+    # its own fixed rows, and before the first frame there is no content width to have laid
+    # anything out at. The caller then steps logical lines, which is what a row is there.
+    private def detail_visual_target(dr : Int32, size : Int32,
+                                     line_at : Int32 -> String) : {Int32, Int32}?
+      return nil if dr == 0 || @detail_hex || @detail_last_cw <= 0
+      Wrap.step_caret(@detail_read.cy, @detail_read.cx, dr, size, line_at,
+        detail_layout_fn(@detail_last_cw, line_at))
+    end
+
+    # Wheel: scroll the viewport by DRAWN rows without moving the caret (READ panes).
+    # Still O(viewport) — the anchor walk never counts the pane's total rows (see
+    # @detail_scroll_sub) and only the caret's line is materialised.
     def detail_scroll_view(step : Int32) : Nil
       return unless detail_navigable?
-      total = if @reveal && (rl = reveal_lines)
-                rl.size
-              else
-                detail_view.total
-              end
-      return if @detail_last_h <= 0 || total <= @detail_last_h
-      max = total - @detail_last_h
-      @detail_scroll = (@detail_scroll + step).clamp(0, max)
-      lo = @detail_scroll
-      hi = {@detail_scroll + @detail_last_h - 1, total - 1}.min
-      cy = @detail_read.cy.clamp(lo, hi)
-      line_len = if @reveal && (rl = reveal_lines)
-                   rl[cy]?.try(&.size) || 0
-                 else
-                   detail_view.line_text(cy).size
-                 end
-      @detail_read.sync(cy, @detail_read.cx.clamp(0, line_len))
+      size, line_at = detail_line_source
+      return if @detail_last_h <= 0 || size <= 0
+      cw = @detail_last_cw
+      if cw <= 0
+        return if size <= @detail_last_h
+        @detail_scroll = (@detail_scroll + step).clamp(0, size - @detail_last_h)
+        @detail_scroll_sub = 0 # no layout exists yet to carry a sub-row against
+      else
+        fn = detail_layout_fn(cw, line_at)
+        @detail_scroll = @detail_scroll.clamp(0, size - 1)
+        @detail_scroll, @detail_scroll_sub = if step < 0
+                                               Wrap.step_back(@detail_scroll, @detail_scroll_sub, -step, fn)
+                                             else
+                                               Wrap.step_forward(@detail_scroll, @detail_scroll_sub, step, size, fn)
+                                             end
+        mli, msub = Wrap.max_anchor(size, @detail_last_h, fn)
+        if @detail_scroll > mli || (@detail_scroll == mli && @detail_scroll_sub > msub)
+          @detail_scroll = mli
+          @detail_scroll_sub = msub
+        end
+      end
+      # Pull the caret into the window, compared in VISUAL rows: a caret on the anchor LINE
+      # can still be several wrapped rows above the anchor ROW, and a line-only clamp would
+      # leave it there to drag the view straight back on the next ensure_detail_visible.
+      rows = detail_rows(cw, @detail_last_h, size, line_at)
+      if rows.empty?
+        cy = @detail_read.cy.clamp(0, size - 1)
+        @detail_read.sync(cy, @detail_read.cx.clamp(0, line_at.call(cy).size))
+        return
+      end
+      first = rows[0]
+      last = rows[rows.size - 1]
+      cy = @detail_read.cy
+      cx = @detail_read.cx
+      if cy < first.li || (cy == first.li && cx < first.a)
+        cy, cx = first.li, first.a
+      elsif cy > last.li || (cy == last.li && cx > last.b)
+        cy, cx = last.li, last.a
+      end
+      @detail_read.sync(cy, cx.clamp(0, line_at.call(cy).size))
     end
 
     # `selecting` is the DRAG half: the anchor stays where the press left it and the caret
     # follows the pointer, so a drag over the request/response text selects it — the mouse
     # spelling of the ⇧arrows this pane already had.
+    #
+    # The hit test is the wrap's inverse, not `@detail_scroll + row`: a screen row is a
+    # VISUAL row now, and the continuation rows between it and the anchor are exactly what
+    # the old arithmetic skipped.
     def detail_click_to_cursor(rect : Rect, mx : Int32, my : Int32, focused : Bool,
                                selecting : Bool = false) : Nil
+      @detail_click_hit = false
       return unless focused && detail_navigable?
       size, line_at = detail_line_source
       return if rect.empty? || size <= 0
-      gw = detail_gutter_w(rect, size)
-      @detail_read.click_to_cursor(rect, mx, my, @detail_scroll, size, line_at, gw, @detail_xscroll, selecting)
+      # Render's own numbers, not a re-derivation — see @detail_last_gw. Falls back to the
+      # gutter estimate only before the first frame, when nothing has been laid out yet.
+      gw = @detail_last_cw > 0 ? @detail_last_gw : detail_gutter_w(rect, size)
+      cw = @detail_last_cw > 0 ? @detail_last_cw : {rect.w - gw, 0}.max
+      row = my - rect.y
+      # A drag above the pane pins to its first visible row — the pointer left the top edge
+      # with the button held, which is an upward selection, not a miss.
+      if row < 0
+        return unless selecting
+        row = 0
+      end
+      rows = detail_rows(cw, rect.h, size, line_at)
+      return if rows.empty?
+      @detail_click_hit = true
+      # `Wrap.row_index` clamps to the row it was given, so a click past the end of a wrapped
+      # row stops at the break rather than selecting the next row's first char.
+      vr = rows[row]? || rows[rows.size - 1]
+      cx = Wrap.row_index(line_at.call(vr.li), nil, vr.a, vr.b, mx - (rect.x + gw))
+      if selecting
+        @detail_read.move_to(vr.li, cx, selecting: true) # keeps (or plants) the anchor
+      else
+        @detail_read.clear_selection
+        @detail_read.sync(vr.li, cx)
+      end
       ensure_detail_visible(rect.h)
     end
 
-    # Double-click: select the word under the pointer. False when the pane is not navigable
-    # (the hex dump) or the pointer is on whitespace — the caller then leaves the plain
-    # click's caret placement standing.
+    # Whether the last `detail_click_to_cursor` actually landed on the pane (as opposed to
+    # returning early on a click outside it) — the double-click needs to tell "the caret did
+    # not move because the pointer was already there" from "the click missed entirely".
+    @detail_click_hit = false
+
+    # Double-click: select the word under the pointer. The hit test is
+    # `detail_click_to_cursor`'s (the pane's own wrap + windowed line source), so this only
+    # has to supply the word spread. False when the pane is not navigable (the hex dump) or
+    # the pointer is on whitespace — the caller then leaves the plain click's caret standing.
     def detail_select_word(rect : Rect, mx : Int32, my : Int32) : Bool
       return false unless detail_navigable?
       size, line_at = detail_line_source
       return false if rect.empty? || size <= 0
-      gw = detail_gutter_w(rect, size)
-      hit = @detail_read.select_word_at(rect, mx, my, @detail_scroll, size, line_at, gw, @detail_xscroll)
+      detail_click_to_cursor(rect, mx, my, focused: true)
+      return false unless @detail_click_hit
+      hit = @detail_read.select_word_at_cursor(size, line_at)
       ensure_detail_visible(rect.h)
       hit
     end
@@ -1209,40 +1311,75 @@ module Gori::Tui
       {Gutter.width(total), body.w}.min
     end
 
+    # Keep the caret's VISUAL row inside the pane. Line-indexed scrolling drifts the moment
+    # anything wraps — the caret can be on the anchor line and still be a dozen drawn rows
+    # off-screen — so the comparison and the re-anchor both happen in rows (Wrap). Falls back
+    # to the line-based arithmetic before the first render, when no width is known yet and
+    # nothing has been laid out to disagree with.
     private def ensure_detail_visible(view_h : Int32) : Nil
       return if view_h <= 0
       cy = @detail_read.cy
-      if cy < @detail_scroll
-        @detail_scroll = cy
-      elsif cy >= @detail_scroll + view_h
-        @detail_scroll = cy - view_h + 1
-      end
-    end
-
-    # Horizontal companion to ensure_detail_visible: slide @detail_xscroll so the caret
-    # column stays inside the visible content width [xscroll, xscroll + cw). Mirrors
-    # TextArea#ensure_visible_x; uses Screen.draw_width (the caret painter's measure, and
-    # the one Highlight.slice_left consumes @detail_xscroll in — they used to disagree).
-    private def ensure_detail_visible_x(cw : Int32) : Nil
-      return if cw <= 0
+      cw = @detail_last_cw
       size, line_at = detail_line_source
-      return if size <= 0 || @detail_read.cy >= size
-      line = line_at.call(@detail_read.cy)
-      if Screen.draw_width(line) <= cw
-        @detail_xscroll = 0
+      if @detail_hex || cw <= 0 || size <= 0
+        if cy < @detail_scroll
+          @detail_scroll = cy
+        elsif cy >= @detail_scroll + view_h
+          @detail_scroll = cy - view_h + 1
+        end
+        @detail_scroll = 0 if @detail_scroll < 0
         return
       end
-      cx = @detail_read.cx.clamp(0, line.size)
-      curx = Screen.draw_width(line[0, cx])
-      @detail_xscroll = curx if curx < @detail_xscroll
-      @detail_xscroll = curx - cw + 1 if curx >= @detail_xscroll + cw
-      @detail_xscroll = 0 if @detail_xscroll < 0
+      @detail_scroll = @detail_scroll.clamp(0, size - 1)
+      fn = detail_layout_fn(cw, line_at)
+      csub = fn.call(cy.clamp(0, size - 1)).row_of(@detail_read.cx)
+      @detail_scroll, @detail_scroll_sub =
+        Wrap.ensure_visible(@detail_scroll, @detail_scroll_sub, cy.clamp(0, size - 1), csub, view_h, fn)
     end
 
-    # Horizontal companion to `scroll_detail` (shift+←/→). Floored at 0 here; the
-    # render loop clamps the upper bound to the widest row actually on screen.
-    def hscroll_detail(delta : Int32) : Nil
-      @detail_xscroll = {@detail_xscroll + delta * 4, 0}.max
+    # --- detail soft wrap ------------------------------------------------------
+
+    # Ceiling on the detail wrap memo — see RepeaterView::RESP_WRAP_CACHE_CAP, same reasoning.
+    DETAIL_WRAP_CACHE_CAP = 512
+
+    # Drop the wrap memo and put the anchor back on a first row. Called from every site that
+    # swaps what the pane is showing (a fresh open, a pane/hex/reveal/pretty toggle) — the
+    # same sites that used to zero the horizontal offset, which is not a coincidence: those
+    # are exactly the moments the old layout stops describing the pane.
+    private def detail_wrap_reset : Nil
+      @detail_scroll_sub = 0
+      @detail_wrap.clear
+    end
+
+    # Publish the geometry the active detail pane just drew with, so hit-testing and the
+    # scroll walkers key the wrap memo on exactly the width the rows were laid out at.
+    private def detail_record_metrics(gw : Int32, cw : Int32) : Nil
+      @detail_last_gw = gw
+      @detail_last_cw = cw
+    end
+
+    private def detail_layout(li : Int32, cw : Int32, line_at : Int32 -> String) : Wrap::Layout
+      if @detail_wrap_w != cw
+        @detail_wrap.clear
+        @detail_wrap_w = cw
+      end
+      if hit = @detail_wrap[li]?
+        return hit
+      end
+      @detail_wrap.clear if @detail_wrap.size >= DETAIL_WRAP_CACHE_CAP
+      @detail_wrap[li] = Wrap.layout(line_at.call(li), cw)
+    end
+
+    private def detail_layout_fn(cw : Int32, line_at : Int32 -> String) : Int32 -> Wrap::Layout
+      ->(i : Int32) { detail_layout(i, cw, line_at) }
+    end
+
+    # The detail pane's drawn rows for an `h`-row viewport at content width `cw`.
+    private def detail_rows(cw : Int32, h : Int32, size : Int32,
+                            line_at : Int32 -> String) : Array(Wrap::Row)
+      return [] of Wrap::Row if size <= 0 || h <= 0 || cw <= 0
+      @detail_scroll = @detail_scroll.clamp(0, size - 1)
+      Wrap.rows(@detail_scroll, @detail_scroll_sub, h, size, detail_layout_fn(cw, line_at))
     end
 
     # ^G go-to-line in the detail view: scroll so 1-based line `n` is at the top
@@ -1257,6 +1394,7 @@ module Gori::Tui
         cy = (n - 1).clamp(0, size - 1)
         @detail_read.sync(cy, 0)
         @detail_scroll = cy
+        @detail_scroll_sub = 0 # ^G names a LOGICAL line, so land on its first visual row
       else
         @detail_scroll = (n - 1).clamp(0, detail_scroll_max)
       end
@@ -1275,7 +1413,10 @@ module Gori::Tui
       return if @reveal == on
       @reveal = on
       @detail_scroll = 0
-      @detail_xscroll = 0
+      # Reveal renders on its own line space, so the memo (keyed only by line index and
+      # width) would hand the new path the OLD lines' layouts. drop_detail_cache is not on
+      # this path — it clears the windowed view, which reveal doesn't use — so reset here.
+      detail_wrap_reset
       @detail_read.reset
     end
 
@@ -1287,7 +1428,7 @@ module Gori::Tui
       @pretty = on
       drop_detail_cache
       @detail_scroll = 0 # reflow changes the line count → a stale offset could blank the pane (like hex/pane toggles)
-      @detail_xscroll = 0
+      detail_wrap_reset
       @detail_read.reset
     end
 
@@ -1393,7 +1534,7 @@ module Gori::Tui
     private def set_detail_pane(pane : Symbol) : Nil
       @detail_pane = pane
       @detail_scroll = 0
-      @detail_xscroll = 0
+      detail_wrap_reset
       drop_detail_cache       # pane switch changes the content
       @detail_hex_bytes = nil # …and the hex source bytes
       @detail_read.reset
@@ -1840,8 +1981,8 @@ module Gori::Tui
     end
 
     # The normal (non-hex, non-reveal) detail body: request/response/decoded-pane text,
-    # windowed + horizontally scrollable. Split out of render_detail to keep that
-    # dispatch's cyclomatic complexity under ameba's threshold.
+    # windowed + soft-wrapped. Split out of render_detail to keep that dispatch's
+    # cyclomatic complexity under ameba's threshold.
     # Steady-scroll hot path: only materialises/styles VISIBLE lines — never the full
     # multi-MiB body. Full plain-line materialisation is reserved for selection spans
     # (rare) and caret/search helpers outside the every-frame loop.
@@ -1851,11 +1992,8 @@ module Gori::Tui
       @detail_last_h = body.h
       gw = Settings.show_gutter ? {Gutter.width(total), body.w}.min : 0
       cw = {body.w - gw, 0}.max
-      @detail_last_cw = cw # remember for horizontal caret-follow (ensure_detail_visible_x)
-      # Styles each visible line ONCE (into `rows`), then clamps/slices from that —
-      # never re-styles just to measure width (mirrors RepeaterView#render_response_body).
-      rows = (0...body.h).compact_map { |i| (li = @detail_scroll + i) < total ? styled_detail_line(dv, li) : nil }
-      @detail_xscroll = @detail_xscroll.clamp(0, {(rows.max_of? { |l| Highlight.line_width_upto(l, @detail_xscroll + cw + 1) } || 0) - cw, 0}.max)
+      detail_record_metrics(gw, cw)
+      return if cw <= 0
       ensure_detail_visible(body.h) if detail_navigable? && focused
       # Selection spans only fetch lines in the selected range (lazy line_at).
       sel_spans = if focused && detail_navigable? && @detail_read.selection?
@@ -1864,19 +2002,21 @@ module Gori::Tui
                   else
                     nil
                   end
-      rows.each_with_index do |styled, i|
-        li = @detail_scroll + i
-        Gutter.draw(screen, body.x, body.y + i, li, gw, current: focused && li == @detail_read.cy) if gw > 0
-        shown = @detail_xscroll > 0 ? Highlight.slice_left(styled, @detail_xscroll) : styled
-        Highlight.draw(screen, body.x + gw, body.y + i, shown, width: cw)
+      # The wrap is computed on the PLAIN text (`line_text`) and the styled overlay is then
+      # sliced to the same char range — Highlight is a 1:1 colour overlay, so one layout
+      # describes both and the colours cannot land a column off the glyphs.
+      detail_rows(cw, body.h, total, ->(i : Int32) { dv.line_text(i) }).each_with_index do |vr, i|
+        li = vr.li
+        y = body.y + i
+        draw_detail_gutter(screen, body.x, y, gw, vr, focused)
+        Highlight.draw(screen, body.x + gw, y, Highlight.slice_chars(styled_detail_line(dv, li), vr.a, vr.b), width: cw)
         need_plain = (focused && detail_navigable? && (li == @detail_read.cy || sel_spans)) || !@search_hl.empty?
         plain = need_plain ? dv.line_text(li) : nil
-        paint_detail_line_chrome(screen, body.x + gw, body.y + i, li, plain, focused, cw, sel_spans)
-        # The plain-text line + its left-slice feed ONLY the search overlay, so skip both
-        # when no query is active (else every frame builds/scans discarded strings per row).
+        paint_detail_line_chrome(screen, body.x + gw, y, li, plain, focused, sel_spans, vr.a, vr.b) if plain
+        # The plain-text line feeds ONLY the search overlay, so skip it when no query is
+        # active (else every frame builds/scans discarded strings per row).
         if (text = plain) && !@search_hl.empty?
-          st = @detail_xscroll > 0 ? Highlight.slice_left_text(text, @detail_xscroll) : text
-          SearchHi.mark(screen, body.x + gw, body.y + i, st, @search_hl, body.x + gw + cw)
+          Wrap.mark_search(screen, body.x + gw, y, text, vr.a, vr.b, @search_hl, body.x + gw + cw)
         end
       end
     end
@@ -1888,67 +2028,86 @@ module Gori::Tui
       @detail_last_h = body.h
       gw = Settings.show_gutter ? {Gutter.width(total), body.w}.min : 0
       cw = {body.w - gw, 0}.max
-      @detail_last_cw = cw # remember for horizontal caret-follow (ensure_detail_visible_x)
-      # draw_width, not display_width — as RepeaterView#render_reveal. Reveal.styled gives
-      # every control char a 1-column marker, so a tab is a drawn cell the raw measure calls
-      # 0. Here it also FOUGHT the caret: ensure_detail_visible_x sets @detail_xscroll with
-      # column_width (tab ≥1), then this clamp immediately clawed it back with the smaller
-      # raw measure, so on a tabbed line the caret could never scroll into view at all.
-      widest = (0...body.h).compact_map { |i| lines[@detail_scroll + i]? }.max_of? { |l| Screen.draw_width_upto(l, @detail_xscroll + cw + 1) } || 0
-      @detail_xscroll = @detail_xscroll.clamp(0, {widest - cw, 0}.max)
+      detail_record_metrics(gw, cw)
+      return if cw <= 0
       ensure_detail_visible(body.h) if detail_navigable? && focused
-      (0...body.h).each do |i|
-        li = @detail_scroll + i
-        break if li >= total
-        Gutter.draw(screen, body.x, body.y + i, li, gw, current: focused && li == @detail_read.cy) if gw > 0
-        styled = Reveal.styled(lines[li], li < total - 1, cw + @detail_xscroll)
-        styled = Highlight.slice_left(styled, @detail_xscroll) if @detail_xscroll > 0
-        Highlight.draw(screen, body.x + gw, body.y + i, styled, width: cw)
-        paint_detail_line_chrome(screen, body.x + gw, body.y + i, li, lines[li], focused, cw)
-        st = @detail_xscroll > 0 ? Highlight.slice_left_text(lines[li], @detail_xscroll) : lines[li]
-        SearchHi.mark(screen, body.x + gw, body.y + i, st, @search_hl, body.x + gw + cw) unless @search_hl.empty?
+      # Reveal substitutes a 1-column marker for every control char (tab → '→', CR → '␍'),
+      # which is exactly what `Screen.grapheme_cols` already scores them, so the wrap of the
+      # RAW line and the wrap of the revealed line are the same break — no second layout.
+      detail_rows(cw, body.h, total, ->(i : Int32) { lines[i] }).each_with_index do |vr, i|
+        y = body.y + i
+        line = lines[vr.li]
+        draw_detail_gutter(screen, body.x, y, gw, vr, focused)
+        # `last` only on the row that actually ends the line — the ␊ marker belongs at the
+        # true end of the line, not at every wrap break inside it.
+        eol = vr.b >= line.size && vr.li < total - 1
+        Highlight.draw(screen, body.x + gw, y, Reveal.styled(line[vr.a...vr.b], eol, cw), width: cw)
+        paint_detail_line_chrome(screen, body.x + gw, y, vr.li, line, focused, nil, vr.a, vr.b)
+        Wrap.mark_search(screen, body.x + gw, y, line, vr.a, vr.b, @search_hl, body.x + gw + cw) unless @search_hl.empty?
       end
     end
 
-    # cw = visible content width; caret + selection are shifted by @detail_xscroll and
-    # clipped to [x, x + cw) so they stay aligned with the horizontally-scrolled body.
+    # Detail-pane gutter: the line number rides the FIRST visual row of a logical line only
+    # (Burp style); a continuation gets a blank of the same width so the text column stays
+    # put and no stale digits survive there.
+    private def draw_detail_gutter(screen : Screen, x : Int32, y : Int32, gw : Int32,
+                                   vr : Wrap::Row, focused : Bool) : Nil
+      return if gw <= 0
+      if vr.sub == 0
+        Gutter.draw(screen, x, y, vr.li, gw, current: focused && vr.li == @detail_read.cy)
+      else
+        screen.text(x, y, " " * {gw - 1, 0}.max, Theme.muted, width: gw)
+      end
+    end
+
+    # Selection tint + block caret for ONE drawn row. `rs`/`re` bound the row's slice of the
+    # line (the whole line when nothing wrapped), so a selection spanning a wrap break is
+    # painted on each row it covers and the caret paints on exactly one of them — the row
+    # that STARTS at its column, matching Wrap::Layout#row_of.
     private def paint_detail_line_chrome(screen : Screen, x : Int32, y : Int32, li : Int32,
-                                         line : String?, focused : Bool, cw : Int32,
-                                         sel_spans : Array({Int32, Int32, Int32})? = nil) : Nil
-      return unless focused && detail_navigable? && line
+                                         line : String, focused : Bool,
+                                         sel_spans : Array({Int32, Int32, Int32})? = nil,
+                                         rs : Int32 = 0, re : Int32 = -1) : Nil
+      return unless focused && detail_navigable?
+      re = line.size if re < 0
       if spans = sel_spans
         spans.each do |(l, x0, x1)|
-          paint_char_span_bg(screen, x, y, line, x0, x1, cw, Theme.accent_bg) if l == li
+          next unless l == li
+          a = {x0, rs}.max
+          b = {x1, re}.min
+          paint_char_span_bg(screen, x, y, line, a, b, Theme.accent_bg, rs) if a < b
         end
       end
       return unless li == @detail_read.cy
       cx = @detail_read.cx.clamp(0, line.size)
-      px = x + Screen.draw_width(line[0, cx]) - @detail_xscroll
-      return if px < x || px >= x + cw # caret scrolled outside the visible content
+      return unless cx >= rs && (cx < re || re >= line.size)
+      px = x + Wrap.row_col(line, nil, rs, cx)
       ch = cx < line.size ? line[cx] : ' '
       screen.cell(px, y, ch, Theme.bg, Theme.accent_bg)
       screen.cursor(px, y)
     end
 
+    # `row_start` is the char index the drawn row begins at — 0 for an unwrapped line, the
+    # wrap break for a continuation row. Columns are measured from THERE, so a tint on a
+    # continuation row starts at the pane's left edge like the text it covers.
     private def paint_char_span_bg(screen : Screen, x : Int32, y : Int32, line : String,
-                                   x0 : Int32, x1 : Int32, cw : Int32, bg : Color) : Nil
-      return if x0 >= x1 || cw <= 0
-      # Start at the span's on-screen column: drawn width up to x0, shifted by xscroll.
+                                   x0 : Int32, x1 : Int32, bg : Color, row_start : Int32 = 0) : Nil
+      return if x0 >= x1
       # Cluster-wise, matching the base draw and the caret. Summing draw_width over single
       # CHARS is exactly the retired per-codepoint measure: it drifts right by each
       # cluster's inflation (1 column for a skin tone, 9 for a ZWJ family), and drawing
       # char-by-char also SHREDS a cluster across cells, stranding a bare combining mark in
       # one of its own. Span edges snap outward so the tint covers whole glyphs.
-      a = Screen.cluster_start(line, {x0, line.size}.min)
+      a = {Screen.cluster_start(line, {x0, line.size}.min), row_start}.max
       b = Screen.cluster_end(line, {x1, line.size}.min)
-      px = x + Screen.draw_width(line[0, a]) - @detail_xscroll
+      return if a >= b
+      px = x + Wrap.row_col(line, nil, row_start, a)
       i = a
       while i < b
         e = Screen.cluster_end(line, i + 1)
         seg = line[i...e]
-        w = Screen.draw_width(seg)
-        screen.text(px, y, seg, Theme.text, bg) if px >= x && px + w <= x + cw
-        px += w
+        screen.text(px, y, seg, Theme.text, bg)
+        px += Screen.draw_width(seg)
         i = e
       end
     end
@@ -2141,6 +2300,12 @@ module Gori::Tui
     private def drop_detail_cache : Nil
       @detail_cache = nil
       @detail_styled_cache.clear
+      # …and the wrap memo, which is keyed by (line index, width) only: new content at the
+      # same index would be laid out against the OLD line's breaks. `refresh_detail` reaches
+      # here without touching the anchor (by design — it must not scroll a live-updating
+      # flow), so the anchor is deliberately left alone; `Wrap.rows` re-clamps a sub-row that
+      # the new content made too large.
+      @detail_wrap.clear
     end
 
     # Ceiling on the styled-body memo (a visible window is ~tens of lines, so this covers many

--- a/src/gori/tui/runner/history.cr
+++ b/src/gori/tui/runner/history.cr
@@ -93,10 +93,6 @@ class Gori::Tui::Runner < Gori::Verb::ExecContext
     history_controller.detail_copy_selection
   end
 
-  def hscroll_detail(delta : Int32) : Nil
-    history_controller.hscroll_detail(delta)
-  end
-
   def toggle_detail_pane : Nil
     history_controller.toggle_detail_pane
   end

--- a/src/gori/verb/context/history.cr
+++ b/src/gori/verb/context/history.cr
@@ -36,9 +36,8 @@ abstract class Gori::Verb::ExecContext
   abstract def scroll_detail(delta : Int32) : Nil
   # Copy the selection (or current line) from the navigable detail text pane.
   abstract def detail_copy_selection : Nil
-  # Horizontal companion to scroll_detail (shift+←/→) — scrolls a long
-  # request/response/decoded line sideways instead of right-clipping it.
-  abstract def hscroll_detail(delta : Int32) : Nil
+  # (There is no horizontal companion to scroll_detail: the detail's req/res panes
+  # soft-wrap, so a long line is already on the next row rather than off the edge.)
   abstract def toggle_detail_pane : Nil
   # Walk the detail panes (REQ→RES→FRAMES) by `dir` (+1 right, −1 left); left
   # past REQUEST returns to the History list.

--- a/src/gori/verbs/history.cr
+++ b/src/gori/verbs/history.cr
@@ -340,9 +340,10 @@ module Gori
         "detail.up", "Move detail up", "Move the detail caret up (scroll in hex mode)", Verb::Scope::HistoryDetail,
         [Verb::Chord.new("k"), Verb::Chord.new("up")], hidden: true) { |ctx| ctx.scroll_detail(-1); nil }
 
-      # Shift+←/→ now extends a horizontal selection (handled inline in
-      # HistoryController#handle_detail_body_key), so there is no dedicated h-scroll
-      # binding — the caret follows the viewport instead (ensure_detail_visible_x).
+      # Shift+←/→ extends a horizontal selection (handled inline in
+      # HistoryController#handle_detail_body_key), and there is no h-scroll to bind
+      # anywhere: the detail's req/res panes soft-wrap, so a long line is already on the
+      # next drawn row rather than off the right edge.
 
       r.register Verb::Definition.new(
         "detail.toggle-pane", "Switch pane (cycle)", "Cycle REQ → RES → FRAMES",


### PR DESCRIPTION
The Repeater's response pane stopped scrolling sideways in cd2503b1 — a long header or a
minified body line wraps, one logical line becomes N visual rows, and the gutter numbers the
FIRST row only. The History drill-in's REQUEST / RESPONSE panes were left on the old model:
`@detail_xscroll`, a right-clipped line, and a tail you chased with a chord that no keymap
actually bound (`verbs/history.cr` said so in a comment). Two panes showing the same captured
bytes, disagreeing about what a row is.

They are one model now. `Wrap` was already the single layout primitive; this is the second
consumer of it, ported method-for-method off `RepeaterView` rather than re-derived — the
header of `wrap.cr` exists because a second width measure growing beside the one the draw
uses is this repo's standing hazard, and a second *anchor* walk beside it would be the same
mistake one level up.

ANCHOR. `@detail_scroll` was a logical line index; it is `(@detail_scroll,
@detail_scroll_sub)` — Vim's topline+skipcol. A flat visual-row index can only be produced by
wrapping every line from the top of the document, an O(document) pass on every width change
over bodies that reach multiple MB. Render, `ensure_detail_visible`, the wheel, the click and
↑/↓ are all O(viewport).

ARROWS. ↑/↓ stepped a logical LINE, which on a wrapped line jumped the caret over every
continuation row the pane was drawing between one line number and the next. Those rows are on
screen; nothing but this arrow could reach them. `detail_visual_target` walks
`Wrap.step_caret`, and falls back to the logical step exactly where there is no layout to
walk — hex, and the frames before the first render publishes a content width.

CLICK AND DOUBLE-CLICK went through `ReadCursor#click_to_cursor` / `#select_word_at`, whose
hit test resolves `@cy = scroll + row`. That is correct for one row per line and wrong for
every continuation row: the caret landed on a line that isn't drawn where the pointer is, and
a double-click took a word out of it. Both now invert the wrap (`Wrap.row_index`, clamped to
the row so a click past a break stops there instead of selecting the next row's first char)
and `select_word_at_cursor` supplies the word half from the caret the hit test placed.

GEOMETRY IS READ BACK, NOT RE-DERIVED. The click path called `detail_gutter_w(rect, size)`,
and `size` is a different number in each render path — `dv.total` in `render_detail_body`,
`lines.size` in `render_reveal`, a third in `detail_scroll_max`. A re-derived content width
keys the wrap memo at a width the rows were never laid out at, so it would flush and rebuild
on every click, against a stale anchor. `@detail_last_gw`/`@detail_last_cw` are what render
drew with; the estimate survives only as the pre-first-frame fallback. (The Repeater carries a
spec for exactly this hazard, `repeater_wrap_spec.cr:246`.)

`detail_at_top?` NEEDED THE SUB-ROW. `HistoryController#detail_body_up` pops focus to the chip
strip when the detail is at its top, and "top" was `@detail_read.cy == 0`. A caret three rows
into a wrapped line 0 answered true, so ↑ left the pane instead of walking the rows it was
asked to walk — the same bug class 506df413 fixed for the arrows themselves.

`ensure_detail_visible_x` IS GONE, not kept as a no-op. It slid a horizontal offset the
renderer no longer reads, and leaving it would recreate the fight the retired reveal clamp had
with it: two measures moving the same field in opposite directions every frame. Same for the
`hscroll_detail` chain — view, controller, `runner/history.cr`, the abstract def in
`verb/context/history.cr`, and the two spec doubles. Unlike the Repeater's stub there was no
binding to keep it alive for.

The wrap memo is dropped in `drop_detail_cache`, which is where `refresh_detail` already goes.
That matters: a Pending flow's content changes under a held anchor, and the memo is keyed by
(line index, width) only — new content at the same index would be handed the old line's
breaks. The anchor itself is deliberately left alone there (a live-updating flow must not
scroll), and `Wrap.rows` re-clamps a sub-row the new content made too large. `reveal=` resets
explicitly because it renders on its own line space without touching that cache.

BEHAVIOUR CHANGE, deliberate: ⇧↑/⇧↓ no longer snap to end-of-line. Vertical selecting moves go
through `ReadCursor#move_to`, which does not snap by design (see its comment) — under wrap the
caret stops mid-line at the display column it kept, and ⇧↓ has to end where a plain ↓ would or
the selection covers rows the operator never crossed. History's old `move` snapped, so ⇧↓ there
was effectively a whole-line select. This is the Repeater's behaviour, which is the
convergence; it is not an oversight.

SCOPE. The list page's bottom Req|Res *preview* is untouched — it clips with
`screen.text(width:)` and has no h-scroll, no gutter and no caret, so there is nothing to
converge. FuzzerView and InterceptView still carry their own `hscroll_detail`; those are
different panes and not in this change.

Three h-scroll specs flipped rather than deleted, each carrying a comment on what is still
under test (cd2503b1's own precedent). The reveal one is worth naming: it pinned a tab
measured as 0 columns by `display_width` and 1 by `draw_width`. There is no clamp left for
that to break, but the SAME disagreement would now break the wrap, so it asserts the 114-drawn-
column line occupies several rows instead. `spec/tui/history_wrap_spec.cr` mirrors
`repeater_wrap_spec.cr`, and includes the EVENTS pane: every detail pane is navigable, so the
decoded/log panes draw through this path too, and they are built as pre-styled head arrays
where the wrap is measured on `line_text` while the draw slices `line_at` — those two have to
agree char-for-char or the colours land off the glyphs.

Verified in a live TUI (tmux, isolated GORI_HOME, a 311-char response body): three visual rows
under one gutter number, three ↓ presses to cross the line, a click on the third row landing on
that line, and a ⇧↓ tint running to the row's end and resuming below.
