### PR TITLE
A wheel that died the moment you typed, a diff no byte could leave, and nine copies of one read pane

### DIFF
--- a/spec/support/fake_context.cr
+++ b/spec/support/fake_context.cr
@@ -1080,6 +1080,13 @@ class FakeExecContext < Gori::Verb::ExecContext
 
   property rewriter_rule_selected : Bool = false # settable so the has-rule gate can be exercised
   property rewriter_rules_sub : Bool = true      # settable so the RULES-sub-tab gate (load-preset) can be exercised
+  property rewriter_preview_out : Bool = false   # settable so the PREVIEW OUTPUT read-pane gate can be exercised
+  property comparer_diff : Bool = false          # settable so the Comparer row-cursor gate can be exercised
+  property intercept_preview : Bool = false      # settable so the Intercept preview read-pane gate can be exercised
+  property miner_detail_read : Bool = false      # settable so the Miner FINDING read-pane gate can be exercised
+  property sequencer_analysis : Bool = false     # settable so the Sequencer ANALYSIS read-pane gate can be exercised
+  property probe_detail_read : Bool = false      # settable so the Probe AFFECTED-URLS read-pane gate can be exercised
+  property oast_detail : Bool = false            # settable so the OAST callback-detail read-pane gate can be exercised
 
   def rewriter_add : Nil
     rec(:rewriter_add)
@@ -1115,6 +1122,34 @@ class FakeExecContext < Gori::Verb::ExecContext
 
   def rewriter_rules_sub? : Bool
     @rewriter_rules_sub
+  end
+
+  def rewriter_preview_out? : Bool
+    @rewriter_preview_out
+  end
+
+  def comparer_diff_shown? : Bool
+    @comparer_diff
+  end
+
+  def intercept_preview_readable? : Bool
+    @intercept_preview
+  end
+
+  def oast_detail_readable? : Bool
+    @oast_detail
+  end
+
+  def probe_detail_readable? : Bool
+    @probe_detail_read
+  end
+
+  def sequencer_analysis_readable? : Bool
+    @sequencer_analysis
+  end
+
+  def miner_detail_readable? : Bool
+    @miner_detail_read
   end
 
   def rewriter_save_preset : Nil

--- a/spec/tui/comparer_view_spec.cr
+++ b/spec/tui/comparer_view_spec.cr
@@ -13,6 +13,14 @@ private def flow(method, target, host = "h.test", body = "body")
   Gori::Store::FlowDetail.new(row, "HTTP/1.1", head, nil, resp, body.to_slice)
 end
 
+# A pair whose bodies differ on exactly one line, so the diff has a same / changed / same shape.
+private def diff_view : ComparerView
+  v = ComparerView.new
+  v.set_pair(flow("GET", "/a", body: "keep\nDROPPED\ntail"),
+    flow("GET", "/a", body: "keep\nADDED\ntail"))
+  v
+end
+
 describe ComparerView do
   it "builds auto labels from slots and prefers a custom name" do
     v = ComparerView.new
@@ -194,5 +202,86 @@ describe ComparerView do
       v.set_pane(:response)
       v.xscroll.should eq(0)
     end
+  end
+end
+
+# The Comparer was the one tab you could read and not get a byte out of: no caret, no selection,
+# no `y` — no copy verb in `Verb::Scope::Comparer` at all. It has a ROW cursor now
+# (`ReadPane(line_select_only: true)`): a screen row is two columns of the same diff, so a char
+# rectangle would address cells that are not adjacent, and the copy payload is the row projected
+# to unified-diff text (`  same` / `- left` / `+ right` / `~ left → right`).
+describe "ComparerView row cursor" do
+  it "copies the cursor's row as unified text, and the whole diff with nothing selected" do
+    v = diff_view
+    v.render(Screen.new(MemoryBackend.new(100, 20)), Rect.new(0, 0, 100, 20), true)
+    v.selection?.should be_false
+    first = v.copy_text
+    first.should_not be_empty
+    first[0].should eq(' ') # an unchanged row carries the two-space unified prefix
+
+    all = v.copy_all
+    all.lines.size.should be > 1
+    all.should contain("DROPPED")
+    all.should contain("ADDED")
+  end
+
+  it "grows a WHOLE-ROW selection on ⇧↓ and never a partial column span" do
+    v = diff_view
+    v.render(Screen.new(MemoryBackend.new(100, 20)), Rect.new(0, 0, 100, 20), true)
+    v.move_rows(1, true)
+    v.selection?.should be_true
+    text = v.copy_text
+    text.lines.size.should eq(2)
+    text.lines.each { |l| l.size.should be > 1 } # each is a full projected row, not a fragment
+    v.clear_selection
+    v.selection?.should be_false
+  end
+
+  it "places the row cursor at a click inside the diff body" do
+    v = diff_view
+    rect = Rect.new(0, 0, 100, 20)
+    v.render(Screen.new(MemoryBackend.new(100, 20)), rect, true)
+    body = v.body_rect(rect)
+    v.click_row(body, body.x + 3, body.y + 2)
+    v.rowsel.cursor.cy.should eq(2)
+    v.copy_text.should eq(v.rowsel.line(2))
+  end
+
+  # A wheel notch is a reading gesture: it must move the viewport and leave the cursor put,
+  # which is the split every other read pane in the tree makes.
+  it "scrolls on the wheel without moving the row cursor" do
+    v = ComparerView.new
+    long_a = (1..60).map { |i| "line#{i}" }.join("\n")
+    long_b = (1..60).map { |i| i == 30 ? "CHANGED" : "line#{i}" }.join("\n")
+    v.set_pair(flow("GET", "/a", body: long_a), flow("GET", "/a", body: long_b))
+    rect = Rect.new(0, 0, 100, 12)
+    v.render(Screen.new(MemoryBackend.new(100, 12)), rect, true)
+    v.rowsel.cursor.cy.should eq(0)
+
+    5.times { v.wheel(1) }
+    v.rowsel.scroll.should be > 0
+    v.rowsel.cursor.cy.should be >= v.rowsel.scroll # pulled into the window, not dragged along
+  end
+
+  it "drops the row cursor when the pair or the diffed half changes" do
+    v = diff_view
+    v.render(Screen.new(MemoryBackend.new(100, 20)), Rect.new(0, 0, 100, 20), true)
+    v.move_rows(2, true)
+    v.selection?.should be_true
+    v.toggle_pane # request ⇄ response renumbers every row
+    v.selection?.should be_false
+    v.rowsel.cursor.cy.should eq(0)
+  end
+
+  it "tints the whole cursor row, both columns and the marker band" do
+    v = diff_view
+    rect = Rect.new(0, 0, 100, 20)
+    b = MemoryBackend.new(100, 20)
+    v.render(Screen.new(b), rect, true)
+    body = v.body_rect(rect)
+    # The cursor is on row 0 of the body; the band must reach the right-hand column too.
+    b.bg_grid[body.y][2].should eq(Theme.accent_bg)
+    b.bg_grid[body.y][body.right - 3].should eq(Theme.accent_bg)
+    b.bg_grid[body.y + 1][2].should_not eq(Theme.accent_bg) # and only that row
   end
 end

--- a/spec/tui/extract_rule_overlay_spec.cr
+++ b/spec/tui/extract_rule_overlay_spec.cr
@@ -163,4 +163,27 @@ describe Gori::Tui::RewriterView do
     list.y.should eq(1)
     (pin.y > list.y).should be_true
   end
+
+  # PREVIEW OUTPUT is a `ReadPane` now, not a windowed draw over a bare String: it is the one
+  # place the post-rewrite bytes exist, and it had no caret, no selection and no `y`. The view
+  # half is what a spec can reach (the controller needs a Host) — that the pane it is handed is
+  # the pane it draws, into the rect `preview_output_body` hit-tests.
+  it "draws the PREVIEW OUTPUT through the read pane it is handed" do
+    v = RewriterView.new
+    rect = Rect.new(0, 0, 100, 30)
+    pane = ReadPane.new
+    pane.source(["OUTMARK one", "OUTMARK two"])
+    b = MemoryBackend.new(100, 30)
+    v.render(Screen.new(b), rect, [] of Gori::Store::MatchRule, 0, 0, 0,
+      :preview_out, true, false, TextArea.new("GET / HTTP/1.1\r\nHost: h\r\n\r\n"), pane)
+    b.contains?("PREVIEW OUTPUT").should be_true
+    b.contains?("OUTMARK one").should be_true
+
+    # The caret the pane painted sits inside the rect the click hit-test inverts against.
+    body = v.preview_output_body(rect)
+    body.empty?.should be_false
+    pane.click(body, body.x + 4, body.y + 1)
+    pane.cursor.cy.should eq(1)
+    pane.copy_text.should eq("OUTMARK two")
+  end
 end

--- a/spec/tui/fuzzer_view_spec.cr
+++ b/spec/tui/fuzzer_view_spec.cr
@@ -16,6 +16,27 @@ private def loaded_fuzzer : FuzzerView
   view
 end
 
+# A view with its RESULT detail open on a three-line response body — two marker words on
+# separate lines, so a hit-test that lands a row off is visible in what gets copied.
+private def detail_open_fuzzer : FuzzerView
+  view = loaded_fuzzer
+  body = "alpha ONEWORD tail\nbeta TWOWORD tail\ngamma THREEWORD tail"
+  r = Gori::Fuzz::Result.new(0_i64, ["p0"], nil, 200, 60_i64, 9, 5, 1000_i64, nil, false, false, nil,
+    "HTTP/1.1 200 OK\r\n\r\n".to_slice, body.to_slice)
+  view.append_result(r)
+  view.open_detail
+  view
+end
+
+# Screen cell of `word` after one render, so every mouse example inverts against what was
+# actually drawn rather than against the layout arithmetic.
+private def drawn_cell(view : FuzzerView, rect : Rect, word : String) : {Int32, Int32}
+  b = MemoryBackend.new(rect.w, rect.h)
+  view.render(Screen.new(b), rect)
+  y = (0...rect.h).find { |r| b.row(r).includes?(word) }.not_nil!
+  {b.row(y).index(word).not_nil!, y}
+end
+
 # A row the run's keep_bodies dropped: no head, no body, no request — the TUI default
 # (:matched) leaves EVERY non-matching row in this shape.
 private def unretained_result(idx : Int32, payloads : Array(String)) : Gori::Fuzz::Result
@@ -163,6 +184,47 @@ describe Gori::Tui::FuzzerView do
     grid2 = (0...30).map { |y| b2.row(y) }.join("\n")
     grid2.should contain("§x§")
     grid2.should_not contain("§x¦rot13§")
+  end
+
+  # `template_scroll_view` used to bail on `template_insert?`, so the wheel died the moment `i`
+  # was pressed — the same `unless insert?` the Repeater request pane shed, in the one other
+  # pane that had it. `chain_pane_active?` still bails: the ^Y sub-pane owns the wheel then.
+  describe "#template_scroll_view" do
+    seed = "GET /?x=1 HTTP/1.1\r\nHost: h\r\n" +
+           (1..30).map { |i| "X-#{i}: TAG#{i}" }.join("\r\n") + "\r\n\r\n"
+
+    it "scrolls the template in INS as it does in NOR" do
+      [true, false].each do |insert|
+        view = FuzzerView.new
+        view.load_request("https://h", seed, false, "")
+        view.focus_pane(:template)
+        view.enter_template_insert! if insert
+        rect = Rect.new(0, 0, 100, 22)
+        view.render(Screen.new(MemoryBackend.new(100, 22)), rect) # the editor learns its height
+
+        40.times { view.template_scroll_view(1) }
+        b = MemoryBackend.new(100, 22)
+        view.render(Screen.new(b), rect)
+        grid = (0...22).map { |y| b.row(y) }.join("\n")
+        grid.should contain("TAG30")     # scrolled to the tail…
+        grid.should_not contain("TAG1:") # …and off the head
+        view.template_insert?.should eq(insert)
+      end
+    end
+
+    it "leaves the template alone while the ^Y CHAIN sub-pane owns the wheel" do
+      view = FuzzerView.new
+      view.load_request("https://h", "§x§ HTTP/1.1\r\nHost: h\r\n" + seed, false, "")
+      view.focus_pane(:template)
+      view.focus_chain_pane.should be_nil
+      rect = Rect.new(0, 0, 100, 22)
+      view.render(Screen.new(MemoryBackend.new(100, 22)), rect)
+
+      40.times { view.template_scroll_view(1) }
+      b = MemoryBackend.new(100, 22)
+      view.render(Screen.new(b), rect)
+      (0...22).map { |y| b.row(y) }.join("\n").should contain("§x§") # still on the first row
+    end
   end
 
   it "CHAIN pane: esc discards the edit instead of committing it" do
@@ -1095,6 +1157,100 @@ describe "FuzzerView#template_click_to_cursor / #target_click_to_cursor" do
     # The per-codepoint measure over-counted by one for every combining mark.
     Screen.draw_width(target).should eq(15)
     target.each_char.sum { |c| Screen.draw_width(c.to_s) }.should eq(16)
+  end
+end
+
+# The RESULT detail paints a selection band, grows it on ⇧arrows and copies it with `y` — and
+# the pointer used to do nothing there at all: the controller's drag/double-click arms bailed
+# unless the TEMPLATE was focused and its click arm had no `:detail` branch. These pin the view
+# half (the controller has no unit harness — it needs a Host).
+describe "FuzzerView result-detail mouse" do
+  it "places the detail caret at a click and copies the line it landed on" do
+    view = detail_open_fuzzer
+    rect = Rect.new(0, 0, 110, 30)
+    x, y = drawn_cell(view, rect, "TWOWORD")
+    view.detail_click_to_cursor(rect, x, y)
+    view.detail_copy_text.should contain("TWOWORD") # no selection → the caret's whole line
+    view.detail_copy_text.should_not contain("ONEWORD")
+  end
+
+  it "takes the word under the pointer on a double-click" do
+    view = detail_open_fuzzer
+    rect = Rect.new(0, 0, 110, 30)
+    x, y = drawn_cell(view, rect, "TWOWORD")
+    view.detail_select_word(rect, x + 2, y).should be_true
+    view.detail_copy_text.should eq("TWOWORD")
+  end
+
+  it "extends the selection to the pointer on a drag" do
+    view = detail_open_fuzzer
+    rect = Rect.new(0, 0, 110, 30)
+    x1, y1 = drawn_cell(view, rect, "ONEWORD")
+    view.detail_click_to_cursor(rect, x1, y1) # the press
+    x2, y2 = drawn_cell(view, rect, "TWOWORD")
+    view.detail_click_to_cursor(rect, x2 + "TWOWORD".size, y2, selecting: true)
+    text = view.detail_copy_text
+    text.should contain("ONEWORD")
+    text.should contain("TWOWORD")
+    text.should_not contain("THREEWORD") # the drag stopped on line 2
+  end
+
+  it "reports no word on a double-click over whitespace past the line's end" do
+    view = detail_open_fuzzer
+    rect = Rect.new(0, 0, 110, 30)
+    _, y = drawn_cell(view, rect, "TWOWORD")
+    view.detail_select_word(rect, 100, y).should be_false
+  end
+
+  # The chip strip rides the card's TOP BORDER, drawn by render_detail_chips. It was drawn and
+  # dead; the History drill-in's equivalent strip has always been clickable.
+  it "switches the detail section from a chip click on the card border" do
+    view = detail_open_fuzzer
+    rect = Rect.new(0, 0, 110, 30)
+    b = MemoryBackend.new(110, 30)
+    view.render(Screen.new(b), rect)
+    y = (0...30).find { |r| b.row(r).includes?("request") && b.row(r).includes?("response") }.not_nil!
+    x = b.row(y).index("response").not_nil!
+
+    view.detail_chip_at(rect, x, y).should eq(:response)
+    view.detail_chip_at(rect, b.row(y).index("request").not_nil!, y).should eq(:request)
+    view.detail_chip_at(rect, x, y + 1).should be_nil # one row into the text is not the strip
+
+    # open_detail lands on :response, so drive a real transition both ways.
+    view.show_detail_pane(:request)
+    b2 = MemoryBackend.new(110, 30)
+    view.render(Screen.new(b2), rect)
+    b2.contains?("ONEWORD").should be_false # the request has no response body in it
+    b2.contains?("GET /?x=1").should be_true
+
+    view.show_detail_pane(:response)
+    b3 = MemoryBackend.new(110, 30)
+    view.render(Screen.new(b3), rect)
+    b3.contains?("ONEWORD").should be_true
+  end
+
+  # Re-clicking the chip you are already on must keep the pane's state. `detail_step_pane`'s
+  # range guard passes for a zero delta, so it re-assigns the same pane and runs its full reset
+  # — scroll, h-scroll, caret and both line caches — which would silently throw away the
+  # selection the operator had just made.
+  it "keeps the caret and the selection when the ACTIVE chip is clicked again" do
+    view = detail_open_fuzzer
+    rect = Rect.new(0, 0, 110, 30)
+    x, y = drawn_cell(view, rect, "TWOWORD")
+    view.detail_select_word(rect, x + 2, y).should be_true
+    view.detail_copy_text.should eq("TWOWORD")
+
+    view.show_detail_pane(:response) # already showing :response — a re-click
+    view.detail_copy_text.should eq("TWOWORD")
+  end
+
+  it "answers no chip and no caret move when the detail is not the pane on screen" do
+    view = detail_open_fuzzer
+    view.focus_pane(:template)
+    rect = Rect.new(0, 0, 110, 30)
+    view.detail_chip_at(rect, 20, 12).should be_nil
+    view.detail_click_to_cursor(rect, 20, 12) # inert rather than hit-testing a card that isn't drawn
+    view.detail_select_word(rect, 20, 12).should be_false
   end
 end
 

--- a/spec/tui/intercept_view_spec.cr
+++ b/spec/tui/intercept_view_spec.cr
@@ -123,6 +123,182 @@ describe Gori::Tui::InterceptView do
     end
   end
 
+  # The editor's four pointer entries (press, drag, double-click, wheel) must all invert against
+  # the rect `render` was handed. `InterceptController` passed the RAW body rect for drag and
+  # double-click while the press insetted it, so the two disagreed by a row and a column and a
+  # double-click never found a word to take. Pinned here at the view layer, where the rect is
+  # explicit: hit-test with exactly the rect the render used, and the word under the pointer is
+  # the word the gesture takes.
+  it "editor_select_word takes the word drawn under the pointer" do
+    tmp_interceptor do |ic|
+      raw = "GET /dt HTTP/1.1\r\nHost: acme.test\r\nX-Alpha: WORDONE\r\nX-Gamma: WORDTHREE\r\n\r\n"
+      hold_req(ic, "acme.test", "/dt", raw)
+      view = InterceptView.new
+      view.reload(ic)
+      view.toggle_edit
+      rect = Rect.new(0, 0, 110, 16)
+      b = MemoryBackend.new(110, 16)
+      view.render(Screen.new(b), rect)
+
+      y = (0...16).find { |r| b.row(r).includes?("WORDTHREE") }.not_nil!
+      x = b.row(y).index("WORDTHREE").not_nil! + 4 # mid-word
+
+      view.editor_select_word(rect, x, y).should be_true
+      view.edit_backspace # a selection outranks the char under the caret — see TextArea#backspace
+      view.editor_text.should contain("X-Gamma: ")
+      view.editor_text.should_not contain("WORDTHREE")
+      view.editor_text.should contain("WORDONE") # the neighbouring row is untouched
+    end
+  end
+
+  # `pane_at` is the hit-test the wheel now routes on as well as the click, so pin it against
+  # the columns the RENDER actually put each pane's text in rather than against `split_panes`'
+  # arithmetic — the two drifting apart is what would send a notch to the wrong pane.
+  it "pane_at answers with the pane the renderer drew at that column" do
+    tmp_interceptor do |ic|
+      hold_req(ic, "acme.test", "/login", "GET /login HTTP/1.1\r\nHost: acme.test\r\nX-Mark: DETAILONLY\r\n\r\n")
+      view = InterceptView.new
+      view.reload(ic)
+      rect = Rect.new(0, 0, 100, 16)
+      b = MemoryBackend.new(100, 16)
+      view.render(Screen.new(b), rect)
+
+      # Find a row+column the queue text occupies, and one the held bytes occupy.
+      list_y = (0...16).find { |y| b.row(y).includes?("/login") }.not_nil!
+      detail_y = (0...16).find { |y| b.row(y).includes?("DETAILONLY") }.not_nil!
+      list_x = b.row(list_y).index("/login").not_nil!
+      detail_x = b.row(detail_y).index("DETAILONLY").not_nil!
+
+      view.pane_at(rect, list_x, list_y).should eq(:list)
+      view.pane_at(rect, detail_x, detail_y).should eq(:detail)
+      view.pane_at(rect, list_x, rect.y).should be_nil # the filter-bar row owns its own zones
+    end
+  end
+
+  # The wheel used to reach nothing but `move` from anywhere in this tab, so over the DETAIL
+  # pane it walked the QUEUE — the pane drawing a scroll gauge was the one pane a notch could
+  # not move — and inside the editor it did nothing at all, because `move` bails while
+  # `@editing`. `scroll_detail_pane` is the one entry point for both faces of that pane.
+  describe "#scroll_detail_pane" do
+    it "scrolls the read-only preview while previewing" do
+      tmp_interceptor do |ic|
+        filler = (1..20).map { |i| "X-#{i}: v#{i}" }.join("\r\n")
+        raw = "GET /login HTTP/1.1\r\nHost: acme.test\r\nX-Top: TOPMARK\r\n#{filler}\r\nX-Bot: BOTMARK\r\n\r\n"
+        hold_req(ic, "acme.test", "/login", raw)
+        view = InterceptView.new
+        view.reload(ic)
+        rect = Rect.new(0, 0, 100, 8)
+        view.render(Screen.new(MemoryBackend.new(100, 8)), rect)
+
+        30.times { view.scroll_detail_pane(1) }
+        b = MemoryBackend.new(100, 8)
+        view.render(Screen.new(b), rect)
+        b.contains?("BOTMARK").should be_true
+        b.contains?("TOPMARK").should be_false
+      end
+    end
+
+    # INS scrolls like READ: `e` opens the editor, it does not withdraw the right to read the
+    # buffer. Mirrors the Repeater request pane, whose identical `unless insert?` guard went.
+    it "scrolls the held-message EDITOR while editing" do
+      tmp_interceptor do |ic|
+        filler = (1..20).map { |i| "X-#{i}: v#{i}" }.join("\r\n")
+        raw = "GET /login HTTP/1.1\r\nHost: acme.test\r\nX-Top: TOPMARK\r\n#{filler}\r\nX-Bot: BOTMARK\r\n\r\n"
+        hold_req(ic, "acme.test", "/login", raw)
+        view = InterceptView.new
+        view.reload(ic)
+        view.toggle_edit
+        view.editing?.should be_true
+        rect = Rect.new(0, 0, 100, 8)
+        view.render(Screen.new(MemoryBackend.new(100, 8)), rect) # the editor learns its height here
+
+        30.times { view.scroll_detail_pane(1) }
+        b = MemoryBackend.new(100, 8)
+        view.render(Screen.new(b), rect)
+        b.contains?("BOTMARK").should be_true
+        b.contains?("TOPMARK").should be_false
+        # The queue selection is untouched — the notch scrolled a pane, it did not load
+        # another held message.
+        view.selected_index.should eq(0)
+      end
+    end
+  end
+
+  # The read-only preview had a scroll gauge and no caret: readable, and not selectable or
+  # copyable by any route. It is a `ReadPane` sourced LAZILY from the item's `Highlight::Windowed`
+  # (a held body runs to megabytes), with `Highlight.plain` bridging the styled window to the text
+  # the caret and a copy address. Its caret comes from the POINTER — the tab has no focus tier for
+  # this pane, so a click places a read caret instead of opening the editor.
+  describe "read-only preview selection" do
+    it "places a caret at a click, takes a word, and copies it" do
+      tmp_interceptor do |ic|
+        raw = "GET /login HTTP/1.1\r\nHost: acme.test\r\nX-Mark: PREVIEWWORD\r\n\r\n"
+        hold_req(ic, "acme.test", "/login", raw)
+        view = InterceptView.new
+        view.reload(ic)
+        view.editing?.should be_false
+        rect = Rect.new(0, 0, 110, 16)
+        b = MemoryBackend.new(110, 16)
+        view.render(Screen.new(b), rect)
+
+        y = (0...16).find { |r| b.row(r).includes?("PREVIEWWORD") }.not_nil!
+        x = b.row(y).index("PREVIEWWORD").not_nil!
+        view.preview_click(rect, x + 2, y)
+        view.preview_copy_text.should contain("PREVIEWWORD") # the caret's whole line
+
+        view.preview_select_word(rect, x + 2, y).should be_true
+        view.preview_selection?.should be_true
+        view.preview_copy_text.should eq("PREVIEWWORD")
+      end
+    end
+
+    it "grows the selection on a drag and copies the whole message with nothing selected" do
+      tmp_interceptor do |ic|
+        raw = "GET /d HTTP/1.1\r\nHost: acme.test\r\nX-One: AAA\r\nX-Two: BBB\r\n\r\n"
+        hold_req(ic, "acme.test", "/d", raw)
+        view = InterceptView.new
+        view.reload(ic)
+        rect = Rect.new(0, 0, 110, 16)
+        b = MemoryBackend.new(110, 16)
+        view.render(Screen.new(b), rect)
+
+        y1 = (0...16).find { |r| b.row(r).includes?("X-One") }.not_nil!
+        x1 = b.row(y1).index("X-One").not_nil!
+        view.preview_click(rect, x1, y1)
+        view.preview_click(rect, x1 + 10, y1 + 1, selecting: true)
+        text = view.preview_copy_text
+        text.should contain("AAA")
+        text.should contain("X-Two")
+
+        view.preview_clear_selection
+        view.preview_selection?.should be_false
+        all = view.preview_copy_all
+        all.should contain("GET /d HTTP/1.1")
+        all.should contain("BBB")
+      end
+    end
+
+    # The read caret and the editor's are different carets over the same bytes: while the editor
+    # is open the preview is not drawn, so its gestures must stand down rather than address a
+    # pane nobody is looking at.
+    it "stands down entirely while the editor is open" do
+      tmp_interceptor do |ic|
+        hold_req(ic, "acme.test", "/e", "GET /e HTTP/1.1\r\nHost: acme.test\r\n\r\n")
+        view = InterceptView.new
+        view.reload(ic)
+        rect = Rect.new(0, 0, 110, 16)
+        view.render(Screen.new(MemoryBackend.new(110, 16)), rect)
+        view.toggle_edit
+        view.editing?.should be_true
+
+        view.preview_select_word(rect, 60, 8).should be_false
+        view.preview_selection?.should be_false
+        view.preview_copy_text.should eq("")
+        view.preview_copy_all.should eq("")
+      end
+    end
+  end
+
   it "edits a held request and forwards the edited bytes" do
     tmp_interceptor do |ic|
       hold_req(ic, "acme.test", "/", "GET / HTTP/1.1\r\nHost: acme.test\r\n\r\n")

--- a/spec/tui/issue_form_spec.cr
+++ b/spec/tui/issue_form_spec.cr
@@ -104,14 +104,84 @@ describe Gori::Tui::IssueForm do
     h.render.contains?("ㅎ").should be_false
   end
 
-  # Pre-seam the shell had NO click arm for this modal, so neither a click-away nor a click
-  # on the card did anything. The Overlay base default dismisses on click-away, so this
-  # asserts the RAW vocabulary: `:stay`, not merely "the harness still reports open".
-  it "ignores clicks entirely, inside the card and outside it" do
+  # This modal used to answer `:stay` to EVERY click, inside the card and out — the one
+  # overlay in the tree a click-away could not dismiss, while the `Overlay` base default and
+  # `PickerOverlay` give that to all thirty-odd others. Assert the RAW vocabulary, not merely
+  # "the harness reports closed", so the outcome is pinned as a dismiss and not a commit.
+  it "dismisses on a click outside the card, like every other modal" do
     h = OverlayHarness.new(IssueForm.new)
-    h.overlay.handle_click(h.area, 40, 12).should eq(:stay) # dead centre, on the card
-    h.overlay.handle_click(h.area, 0, 0).should eq(:stay)   # far corner, click-away
-    h.click(0, 0).should eq(:open)
+    h.overlay.handle_click(h.area, 0, 0).should eq(:cancel)
+    h.click(0, 0).should eq(:closed)
+    h.commits.should eq(0) # a click-away is a cancel, never a create
+  end
+
+  it "swallows a click on the card's inert rows rather than leaking it underneath" do
+    h = OverlayHarness.new(IssueForm.new)
+    box = h.box.not_nil!
+    h.overlay.handle_click(h.area, box.x + 2, box.y + 2).should eq(:stay) # blank row under the title
+    h.click_in_box(2, 2).should eq(:open)
+  end
+
+  # The card draws `title › <text>` on its second row and nothing inverted that column, so
+  # the caret could only be moved with ←/→ from wherever it happened to sit.
+  it "places the title caret at a click on the title row" do
+    h = OverlayHarness.new(IssueForm.new("abcdef"))
+    form = h.overlay.as(IssueForm)
+    # `title › ` is 8 columns past the card's 2-column inset, so +10 is the first title cell;
+    # +13 lands on 'd' — the click must put the caret BEFORE it, not at the end of the string.
+    h.click_in_box(13, IssueForm::TITLE_ROW).should eq(:open)
+    h.type("X")
+    form.issue_title.should eq("abcXdef")
+  end
+
+  it "clamps a click past the end of the title to the end of the text" do
+    h = OverlayHarness.new(IssueForm.new("ab"))
+    h.click_in_box(40, IssueForm::TITLE_ROW)
+    h.type("!")
+    h.overlay.as(IssueForm).issue_title.should eq("ab!")
+  end
+
+  # The severity row draws `severity ‹ MEDIUM ›  (tab to change)`. The chevrons and the hint
+  # both promise a step; before this the row was drawn and dead.
+  it "steps severity from the row's own chevrons" do
+    h = OverlayHarness.new(IssueForm.new)
+    form = h.overlay.as(IssueForm)
+    h.click_in_box(2 + IssueForm::SEV_PREFIX.index('‹').not_nil!, IssueForm::SEV_ROW) # the ‹ cell
+    form.severity.should eq(Gori::Store::Severity::Low)
+    h.click_in_box(2 + IssueForm::SEV_PREFIX.size + form.severity.label.size + 1, IssueForm::SEV_ROW) # the › cell
+    form.severity.should eq(Gori::Store::Severity::Medium)
+  end
+
+  it "treats a click on the severity label as the forward step its hint advertises" do
+    h = OverlayHarness.new(IssueForm.new)
+    h.click_in_box(2 + IssueForm::SEV_PREFIX.size + 1, IssueForm::SEV_ROW)
+    h.overlay.as(IssueForm).severity.should eq(Gori::Store::Severity::High)
+  end
+
+  # The interactive span ends at the closing `›`. Past it the row holds a hint and then blank
+  # cells; a dead cell that silently changes the severity of the issue about to be filed is the
+  # same divergence as an affordance that does nothing, pointed the other way.
+  it "leaves severity alone for a click past the row's drawn span" do
+    h = OverlayHarness.new(IssueForm.new)
+    box = h.box.not_nil!
+    h.click(box.right - 2, box.y + IssueForm::SEV_ROW).should eq(:open)
+    h.overlay.as(IssueForm).severity.should eq(Gori::Store::Severity::Medium) # untouched
+  end
+
+  # …and the cells LEFT of the `‹`, which draw the word "severity".
+  it "leaves severity alone for a click on the row's label text" do
+    h = OverlayHarness.new(IssueForm.new)
+    h.click_in_box(2, IssueForm::SEV_ROW)
+    h.overlay.as(IssueForm).severity.should eq(Gori::Store::Severity::Medium)
+  end
+
+  # `overlay_box` is now the geometry `render` itself draws from, so a card with no room to
+  # draw and the base "any click dismisses" path agree.
+  it "reports no box — and dismisses any click — when the area cannot hold the card" do
+    tiny = OverlayHarness.new(IssueForm.new, area: Gori::Tui::Rect.new(0, 0, 80, 4))
+    tiny.box.should be_nil
+    tiny.rendered?("NEW ISSUE").should be_false
+    tiny.overlay.handle_click(tiny.area, 1, 1).should eq(:cancel)
   end
 
   # The base default routes a wheel notch to `move`, which HERE walks the title caret —

--- a/spec/tui/read_cursor_spec.cr
+++ b/spec/tui/read_cursor_spec.cr
@@ -1,4 +1,5 @@
 require "../spec_helper"
+require "../support/memory_backend"
 
 include Gori::Tui
 
@@ -58,5 +59,45 @@ describe Gori::Tui::ReadCursor do
         x0.should be < x1
       end
     end
+  end
+end
+
+# `sync_from` and `click` differ in ONE way that decides what a mouse press means, and two
+# controllers picked the wrong one: `ReadCursor#sync` moves the caret and deliberately leaves
+# the anchor alone ("without disturbing selection", per its own doc), so a Decoder/JWT INPUT
+# press in READ mode used to re-shape a ⇧arrow selection instead of dropping it. Every other
+# read pane clicks through `TextReadState#click`, which collapses. The drag added in the same
+# change depends on this: `sync_to(selecting: true)` plants its anchor with `||=`, so without a
+# collapsing press it would extend from wherever an older selection had been left.
+describe Gori::Tui::TextReadState do
+  it "keeps the selection on sync_from and collapses it on a click" do
+    ed = TextArea.new("alpha bravo\ncharlie delta\necho foxtrot")
+    rect = Rect.new(0, 0, 40, 5)
+    ed.render(Screen.new(MemoryBackend.new(40, 5)), rect, true) # the editor learns its geometry
+
+    read = TextReadState.new
+    read.select_line(ed)
+    read.selection?.should be_true
+
+    read.sync_from(ed)
+    read.selection?.should be_true # a caret adopt is not a selection gesture
+
+    read.click(ed, rect, 3, 1) # a plain press on line 1
+    read.selection?.should be_false
+    read.cursor.cy.should eq(1)
+  end
+
+  it "grows the selection from the press position on a drag" do
+    ed = TextArea.new("alpha bravo\ncharlie delta\necho foxtrot")
+    rect = Rect.new(0, 0, 40, 5)
+    ed.render(Screen.new(MemoryBackend.new(40, 5)), rect, true)
+
+    read = TextReadState.new
+    read.click(ed, rect, 0, 0)                  # press at line 0 col 0
+    read.click(ed, rect, 7, 1, selecting: true) # drag into line 1
+    read.selection?.should be_true
+    text = read.copy_text(ed)
+    text.should start_with("alpha bravo")
+    text.should_not contain("foxtrot") # the drag stopped on line 1
   end
 end

--- a/spec/tui/read_pane_spec.cr
+++ b/spec/tui/read_pane_spec.cr
@@ -1,0 +1,275 @@
+require "../spec_helper"
+require "../support/memory_backend"
+
+include Gori::Tui
+
+# `ReadPane` is the one home for a scrollable read-only text pane: the ReadCursor, both scroll
+# axes, the last drawn height, the draw (gutter / h-slice / selection band / block caret / scroll
+# gauge) and every gesture. It was extracted from three hand-rolled copies (Decoder OUTPUT,
+# Fuzzer RESULT detail, History detail) whose drift was already a bug — see the class comment —
+# and it is what six read-only-but-unselectable panes are being built on.
+private def pane_source(n : Int32) : Array(String)
+  (0...n).map { |i| i == 3 ? "LONG#{"." * 60}TAIL" : "line#{i} word#{i}" }
+end
+
+# The backend is one column WIDER than the rect: `Frame.scroll_gauge` rides the border column
+# immediately right of the content (real callers pass `card.inset(1, 1)`), so a rect flush to the
+# backend's edge would push the gauge off-grid and silently drop it from every assertion.
+private def render_pane(pane : ReadPane, w = 40, h = 6, focused = true,
+                        styled_at : (Int32 -> Highlight::Line)? = nil) : MemoryBackend
+  b = MemoryBackend.new(w + 1, h)
+  pane.render(Screen.new(b), Rect.new(0, 0, w, h), focused, styled_at)
+  b
+end
+
+describe Gori::Tui::ReadPane do
+  describe "source" do
+    # The whole reason the API is `(size, line_at)` and not `Array(String)`: the Intercept
+    # preview reads through a `Highlight::Windowed` over a multi-MiB body, and a render that
+    # touched every line would stall the UI fiber. Pin that a frame is viewport-bounded.
+    it "only asks for the lines it draws" do
+      asked = [] of Int32
+      pane = ReadPane.new
+      pane.source(5_000, ->(i : Int32) { asked << i; "line#{i}" })
+      render_pane(pane, h: 6)
+      asked.uniq.size.should be <= 12 # 6 drawn rows, each read for the draw + the width clamp
+      asked.max.should be < 20        # never walks past the window
+    end
+
+    it "reports its size and answers out-of-range lines as empty" do
+      pane = ReadPane.new
+      pane.source(pane_source(4))
+      pane.size.should eq(4)
+      pane.empty?.should be_false
+      pane.line(-1).should eq("")
+      pane.line(9).should eq("")
+      ReadPane.new.empty?.should be_true
+    end
+  end
+
+  describe "render" do
+    it "draws the window from the scroll offset, with numbers when the gutter is on" do
+      pane = ReadPane.new(gutter: true)
+      pane.source(pane_source(20))
+      b = render_pane(pane, h: 4)
+      b.row(0).should contain("1") # 1-based gutter for line index 0
+      b.contains?("line0").should be_true
+      b.contains?("line3").should be_false # below the 4-row fold (line 3 is the long one)
+
+      12.times { pane.scroll_view(1) }
+      pane.scroll.should eq(12)
+      b2 = render_pane(pane, h: 4)
+      b2.contains?("line0").should be_false
+      b2.contains?("line15").should be_true # window 12..15, clamped at size - h = 16
+    end
+
+    # `styled_at` is colour ONLY: `Highlight`'s cardinal rule is that a styled line's span texts
+    # concatenate back to the plain line, and the component leans on that — the block caret paints
+    # `plain[cx]`, which is the glyph on screen precisely because the two agree.
+    it "colours the row from styled_at while the caret and the copy read the plain line" do
+      pane = ReadPane.new
+      pane.source(["plain text here"])
+      styled = ->(_i : Int32) {
+        [Highlight::Span.new("plain ", Theme.red), Highlight::Span.new("text here", Theme.green)] of Highlight::Span
+      }
+      b = render_pane(pane, styled_at: styled)
+      b.contains?("plain text here").should be_true
+      b.fg_grid[0][8].should eq(Theme.green) # inside the second span
+      b.fg_grid[0][2].should eq(Theme.red)   # inside the first, minus the caret cell at 0
+      pane.copy_text.should eq("plain text here")
+    end
+
+    it "leaves the gauge off a pane that fits and on one that overflows" do
+      short = ReadPane.new
+      short.source(pane_source(3))
+      render_pane(short, h: 8).contains?("┃").should be_false
+
+      tall = ReadPane.new
+      tall.source(pane_source(80))
+      render_pane(tall, h: 8).contains?("┃").should be_true
+    end
+  end
+
+  describe "keyboard" do
+    it "moves the caret and grows a selection on ⇧ vertical steps" do
+      pane = ReadPane.new
+      pane.source(pane_source(10))
+      pane.move(1, 0)
+      pane.copy_text.should eq("line1 word1") # no selection → the caret's line
+      pane.move(1, 0, selecting: true)
+      pane.selection?.should be_true
+      pane.copy_text.should contain("line1")
+      pane.copy_text.should contain("line2")
+    end
+
+    it "selects the current line and clears it" do
+      pane = ReadPane.new
+      pane.source(pane_source(5))
+      pane.move(2, 0)
+      pane.select_line
+      pane.selection?.should be_true
+      pane.copy_text.should eq("line2 word2")
+      pane.clear_selection
+      pane.selection?.should be_false
+    end
+
+    it "handles Home / End / PageUp / PageDown, with ⇧ extending" do
+      pane = ReadPane.new
+      pane.source(pane_source(40))
+      render_pane(pane, h: 6) # the pane learns its height, so a page is a real screenful
+
+      pane.motion_key(key(Termisu::Input::Key::PageDown)).should be_true
+      pane.cursor.cy.should be > 0
+      pane.motion_key(key(Termisu::Input::Key::PageUp)).should be_true
+      pane.cursor.cy.should eq(0)
+
+      pane.motion_key(key(Termisu::Input::Key::End)).should be_true
+      pane.cursor.cx.should eq("line0 word0".size)
+      pane.motion_key(key(Termisu::Input::Key::Home, shift: true)).should be_true
+      pane.selection?.should be_true # ⇧Home from EOL selects the line's text
+      pane.copy_text.should eq("line0 word0")
+
+      pane.motion_key(key(Termisu::Input::Key::LowerA)).should be_false # not a motion key
+    end
+
+    it "copies every line for the whole-pane fallback" do
+      pane = ReadPane.new
+      pane.source(["a", "b", "c"])
+      pane.copy_all.should eq("a\nb\nc")
+      ReadPane.new.copy_all.should eq("")
+    end
+  end
+
+  describe "#scroll_view" do
+    # The drift the extraction closed: the two hand-rolled copies disagreed about WHICH line the
+    # column is clamped against, and the one that read the line the caret was leaving indexed a
+    # position its own `cy` clamp had just ruled out of range.
+    it "clamps the caret into the new window and measures the column against the line it lands on" do
+      pane = ReadPane.new
+      pane.source(pane_source(40))
+      render_pane(pane, h: 6)
+      pane.motion_key(key(Termisu::Input::Key::End)) # caret at EOL of a long-ish line
+      long_cx = pane.cursor.cx
+
+      pane.scroll_view(20)
+      pane.cursor.cy.should be >= pane.scroll
+      pane.cursor.cy.should be < pane.scroll + 6
+      pane.cursor.cx.should be <= pane.line(pane.cursor.cy).size
+      pane.cursor.cx.should be <= long_cx
+    end
+
+    it "is inert before the first frame and on a pane that fits" do
+      pane = ReadPane.new
+      pane.source(pane_source(40))
+      pane.scroll_view(5) # no height yet
+      pane.scroll.should eq(0)
+
+      fits = ReadPane.new
+      fits.source(pane_source(3))
+      render_pane(fits, h: 8)
+      fits.scroll_view(5)
+      fits.scroll.should eq(0)
+    end
+  end
+
+  describe "mouse" do
+    it "places the caret at a click and takes the word on a double-click" do
+      pane = ReadPane.new(gutter: true)
+      pane.source(pane_source(6))
+      b = render_pane(pane)
+      y = (0...6).find { |r| b.row(r).includes?("word2") }.not_nil!
+      x = b.row(y).index("word2").not_nil!
+
+      pane.click(Rect.new(0, 0, 40, 6), x + 1, y)
+      pane.cursor.cy.should eq(2)
+      pane.select_word(Rect.new(0, 0, 40, 6), x + 1, y).should be_true
+      pane.copy_text.should eq("word2")
+    end
+
+    it "extends the selection to the pointer on a drag" do
+      pane = ReadPane.new
+      pane.source(pane_source(6))
+      rect = Rect.new(0, 0, 40, 6)
+      render_pane(pane)
+      pane.click(rect, 0, 0)                  # press on line 0 col 0
+      pane.click(rect, 5, 1, selecting: true) # drag into line 1
+      pane.selection?.should be_true
+      pane.copy_text.should start_with("line0 word0")
+      pane.copy_text.should_not contain("line2")
+    end
+
+    it "takes nothing on a double-click over whitespace past the line" do
+      pane = ReadPane.new
+      pane.source(pane_source(6))
+      render_pane(pane)
+      pane.select_word(Rect.new(0, 0, 40, 6), 38, 0).should be_false
+    end
+  end
+
+  # The hand-rolled copies painted the caret and the band at `x + draw_width(line[0, cx])` with
+  # no `- xscroll` term, so with the pane scrolled sideways both landed that many cells right of
+  # the glyph they addressed — or off the pane entirely, drawing over a neighbour. The component
+  # subtracts the offset and clips to the content width.
+  describe "horizontal scroll" do
+    it "keeps the caret inside the pane when the content is scrolled sideways" do
+      pane = ReadPane.new
+      pane.source(pane_source(6))
+      rect = Rect.new(0, 0, 40, 6)
+      pane.move(3, 0) # the long line
+      pane.motion_key(key(Termisu::Input::Key::End))
+      render_pane(pane)
+
+      b = MemoryBackend.new(40, 6)
+      pane.render(Screen.new(b), rect, true)
+      b.contains?("LONG").should be_true
+
+      15.times { pane.hscroll(1) }
+      b2 = MemoryBackend.new(40, 6)
+      pane.render(Screen.new(b2), rect, true)
+      b2.contains?("TAIL").should be_true
+      b2.contains?("LONG").should be_false # scrolled off the left
+      pane.xscroll.should be > 0
+    end
+  end
+
+  describe "line_select_only" do
+    # For the Comparer: a screen row is TWO columns of a diff, so a char rectangle would address
+    # cells that are not adjacent on screen. Selection is whole lines, and there is no word.
+    it "selects whole lines and never a word" do
+      pane = ReadPane.new(line_select_only: true)
+      pane.source(pane_source(6))
+      rect = Rect.new(0, 0, 40, 6)
+      render_pane(pane)
+
+      pane.select_word(rect, 3, 1).should be_false
+      pane.move(1, 0, selecting: true)
+      pane.selection?.should be_true
+      # Whole first line, then the whole second — not a partial column span.
+      pane.copy_text.should eq("line0 word0\nline1 word1")
+    end
+  end
+
+  describe "#reset" do
+    it "drops the caret, the selection and both scroll offsets" do
+      pane = ReadPane.new
+      pane.source(pane_source(40))
+      render_pane(pane)
+      pane.move(5, 0)
+      pane.select_line
+      10.times { pane.hscroll(1) }
+      pane.scroll_view(10)
+
+      pane.reset
+      pane.cursor.cy.should eq(0)
+      pane.cursor.cx.should eq(0)
+      pane.selection?.should be_false
+      pane.scroll.should eq(0)
+      pane.xscroll.should eq(0)
+    end
+  end
+end
+
+private def key(k : Termisu::Input::Key, shift : Bool = false) : Termisu::Event::Key
+  mods = shift ? Termisu::Input::Modifier::Shift : Termisu::Input::Modifier::None
+  Termisu::Event::Key.new(k, mods, nil)
+end

--- a/spec/verb/registry_spec.cr
+++ b/spec/verb/registry_spec.cr
@@ -1101,6 +1101,34 @@ private class FakeContext < ExecContext
     true
   end
 
+  def rewriter_preview_out? : Bool
+    false
+  end
+
+  def comparer_diff_shown? : Bool
+    false
+  end
+
+  def intercept_preview_readable? : Bool
+    false
+  end
+
+  def oast_detail_readable? : Bool
+    false
+  end
+
+  def probe_detail_readable? : Bool
+    false
+  end
+
+  def sequencer_analysis_readable? : Bool
+    false
+  end
+
+  def miner_detail_readable? : Bool
+    false
+  end
+
   def rewriter_save_preset : Nil
   end
 

--- a/src/gori/tui/comparer_view.cr
+++ b/src/gori/tui/comparer_view.cr
@@ -1,6 +1,7 @@
 require "./screen"
 require "./theme"
 require "./frame"
+require "./read_pane"
 require "./highlight"
 require "./url"
 require "./flow_status"
@@ -30,7 +31,13 @@ module Gori::Tui
       @slot_a = nil.as(Store::FlowDetail?)
       @slot_b = nil.as(Store::FlowDetail?)
       @pane = :response
-      @scroll = 0
+      # Row cursor + selection + vertical scroll for the diff. `line_select_only`: a screen row
+      # here is TWO columns of the same diff, so a char rectangle would address cells that are
+      # not next to each other — selection is whole rows, and there is no word to double-click.
+      # The pane draws NOTHING (this view paints two columns per row itself); it is called for
+      # `viewport_top`, `row_marked?` and the gestures. Before it, the Comparer was the one tab
+      # you could read a diff in and not get a single byte out of: no caret, no selection, no `y`.
+      @rowsel = ReadPane.new(line_select_only: true)
       # Leftmost visible display COLUMN, shared by BOTH columns (⇧←/→). One offset, not
       # two: the rows are LCS-aligned, so moving A and B together is what keeps a long
       # line comparable — an independent per-column offset would break that alignment.
@@ -91,9 +98,8 @@ module Gori::Tui
       @slot_b = other.@slot_b
       @pane = other.@pane
       @fill_next = other.@fill_next
-      @scroll = 0
       @xscroll = 0
-      invalidate
+      invalidate # resets the row cursor too
     end
 
     # Reset to a blank pair (used when closing the last sub-tab).
@@ -102,7 +108,7 @@ module Gori::Tui
       @slot_a = nil
       @slot_b = nil
       @pane = :response
-      @scroll = 0
+      @rowsel = ReadPane.new(line_select_only: true) # see initialize
       @xscroll = 0
       @fill_next = :a
       invalidate
@@ -166,9 +172,8 @@ module Gori::Tui
 
     def toggle_pane : Nil
       @pane = @pane == :response ? :request : :response
-      @scroll = 0  # request/response differ in length — start from the top
-      @xscroll = 0 # …and in width, so start from the left edge too
-      invalidate
+      @xscroll = 0 # request/response differ in width, so start from the left edge too
+      invalidate   # …and in length, so the row cursor starts from the top
     end
 
     # Jump straight to a half (mouse chip); no-op when already there.
@@ -176,9 +181,16 @@ module Gori::Tui
       return unless pane == :request || pane == :response
       return if @pane == pane
       @pane = pane
-      @scroll = 0
       @xscroll = 0
       invalidate
+    end
+
+    # The diff BODY: below the A/B header and the REQ⇄RES divider, above the footer. One
+    # derivation, so `render`, the row-cursor click and the drag all address the same rows.
+    def body_rect(rect : Rect) : Rect
+      top = rect.y + 2
+      h = {(rect.bottom - 1) - top, 0}.max
+      Rect.new(rect.x, top, rect.w, h)
     end
 
     # Hit-test the REQ / RES chips on the divider row (render_pane_selector geometry).
@@ -199,8 +211,64 @@ module Gori::Tui
 
     # --- scrolling ---------------------------------------------------------
 
+    # The row cursor, for the controller + the verbs.
+    def rowsel : ReadPane
+      @rowsel
+    end
+
+    # ↑/↓ (and the wheel, and ⇧ for a selection) move the CURSOR, which drags the viewport with
+    # it — selection-follow, like every list in the tree. The pane used to scroll a viewport with
+    # no cursor in it at all.
     def scroll(delta : Int32) : Nil
-      @scroll = {@scroll + delta, 0}.max # render clamps the ceiling against the body height
+      sync_rowsel
+      @rowsel.move(delta, 0)
+    end
+
+    def move_rows(delta : Int32, selecting : Bool) : Nil
+      sync_rowsel
+      @rowsel.move(delta, 0, selecting: selecting)
+    end
+
+    # A wheel notch scrolls the viewport without moving the cursor — the same split every other
+    # read pane makes between a reading gesture and a cursor gesture.
+    def wheel(delta : Int32) : Nil
+      sync_rowsel
+      @rowsel.scroll_view(delta)
+    end
+
+    def motion_key(ev : Termisu::Event::Key) : Bool
+      sync_rowsel
+      @rowsel.motion_key(ev)
+    end
+
+    def select_row_line : Nil
+      sync_rowsel
+      @rowsel.select_line
+    end
+
+    def clear_selection : Nil
+      @rowsel.clear_selection
+    end
+
+    def selection? : Bool
+      @rowsel.selection?
+    end
+
+    # The selected rows (or the cursor's row) as unified-diff text — see `unified_lines`.
+    def copy_text : String
+      sync_rowsel
+      @rowsel.copy_text
+    end
+
+    def copy_all : String
+      sync_rowsel
+      @rowsel.copy_all
+    end
+
+    # Place the row cursor at a click inside the diff BODY (`body_rect`), `selecting` for a drag.
+    def click_row(body : Rect, mx : Int32, my : Int32, selecting : Bool = false) : Nil
+      sync_rowsel
+      @rowsel.click(body, mx, my, selecting)
     end
 
     # ⇧←/→: shift BOTH columns by the same amount, 4 columns per step (Repeater/History/
@@ -211,7 +279,7 @@ module Gori::Tui
     end
 
     def at_top? : Bool
-      @scroll == 0
+      @rowsel.at_top?
     end
 
     # Current h-offset — for the footer readout and specs.
@@ -228,6 +296,30 @@ module Gori::Tui
       @styled_same = nil
       @lines_a = nil
       @lines_b = nil
+      @rowsel.reset # a new pair (or the other half of it) renumbers every row
+    end
+
+    # Point the row cursor at the current diff. Cheap and idempotent — `rows` is memoized, and
+    # this only re-hands the same two values — so every gesture and every verb can call it and
+    # none of them can act on a stale row count.
+    private def sync_rowsel : Nil
+      rs = rows
+      @rowsel.source(rs.size, ->(i : Int32) { unified_line(rs[i]) })
+    end
+
+    # ONE row projected to ONE line of unified-diff text — what a copy produces, and the reason
+    # the row cursor can address a two-column draw at all: the projection is 1:1 with the screen
+    # rows, so row N of the copy is row N of the diff.
+    #
+    # `~` (changed) carries BOTH sides, because that is the row's information; a `- `/`+ ` pair
+    # would double the line count and break that 1:1.
+    private def unified_line(r : Repeater::SideBySide::Row) : String
+      case r.kind
+      when .same?     then "  #{r.left}"
+      when .del_only? then "- #{r.left}"
+      when .add_only? then "+ #{r.right}"
+      else                 "~ #{r.left}  →  #{r.right}" # changed
+      end
     end
 
     private def rows : Array(Repeater::SideBySide::Row)
@@ -307,9 +399,10 @@ module Gori::Tui
         render_pane_selector(screen, rect)
       end
 
-      body_top = rect.y + 2
+      body = body_rect(rect)
+      body_top = body.y
+      body_h = body.h
       footer_y = rect.bottom - 1
-      body_h = {footer_y - body_top, 0}.max
 
       unless both_set?
         if body_h > 0
@@ -322,16 +415,19 @@ module Gori::Tui
 
       data = rows
       sr = styled_same
-      clamp_scroll(body_h, data.size)
+      sync_rowsel
+      top = @rowsel.viewport_top(body_h) # the state half of ReadPane#render — this view draws its own rows
       # Clamp against the NARROWER column: the two differ by at most one cell (odd frame
       # width), and pinning to the wider one would leave the narrow column's last cell of
       # the widest line permanently unreachable.
       clamp_hscroll(data, body_h, {left_w, right_w}.min)
       (0...body_h).each do |i|
-        di = @scroll + i
+        di = top + i
         break if di >= data.size
-        draw_diff_row(screen, rect.x, body_top + i, left_w, sep_x, right_x, right_w, data[di], sr[di]?)
+        marked = focused && @rowsel.row_marked?(di)
+        draw_diff_row(screen, rect.x, body_top + i, left_w, sep_x, right_x, right_w, data[di], sr[di]?, marked)
       end
+      Frame.scroll_gauge(screen, Rect.new(rect.x, body_top, rect.w, body_h), data.size, top, focused)
       draw_footer(screen, rect, footer_y)
     end
 
@@ -375,9 +471,19 @@ module Gori::Tui
       "#{row.method} #{row.host}#{Url.origin_path(row.target)} · #{FlowStatus.cell(row)[0]}"
     end
 
+    # `marked` = this row is under the row cursor, or inside a selection. It tints the WHOLE row
+    # (both columns and the marker band) rather than a character span, because that is the only
+    # honest highlight for a two-column diff — see the `line_select_only` note on `@rowsel`.
     private def draw_diff_row(screen : Screen, x : Int32, y : Int32, left_w : Int32,
                               sep_x : Int32, right_x : Int32, right_w : Int32,
-                              r : Repeater::SideBySide::Row, styled : Highlight::Line?) : Nil
+                              r : Repeater::SideBySide::Row, styled : Highlight::Line?,
+                              marked : Bool = false) : Nil
+      bg = marked ? Theme.accent_bg : Theme.bg
+      if marked
+        # Fill first, so a shorter line's tail carries the band too and the row reads as one
+        # selected unit instead of a ragged highlight the width of its text.
+        screen.text(x, y, " " * {left_w + SEP_W + right_w, 0}.max, Theme.text, bg)
+      end
       lcolor, rcolor, glyph, gcolor = case r.kind
                                       when .same?     then {Theme.text, Theme.text, '│', Theme.border}
                                       when .changed?  then {Theme.red, Theme.green, '~', Theme.yellow}
@@ -390,13 +496,13 @@ module Gori::Tui
       # columns scroll under it, so the ~/-/+ signal survives any h-offset.
       if styled && r.kind.same?
         shown = @xscroll > 0 ? Highlight.slice_left(styled, @xscroll) : styled
-        Highlight.draw(screen, x, y, shown, bg: Theme.bg, width: left_w) if left_w > 0
-        screen.cell(sep_x + 1, y, glyph, gcolor)
-        Highlight.draw(screen, right_x, y, shown, bg: Theme.bg, width: right_w) if right_w > 0
+        Highlight.draw(screen, x, y, shown, bg: bg, width: left_w) if left_w > 0
+        screen.cell(sep_x + 1, y, glyph, gcolor, bg)
+        Highlight.draw(screen, right_x, y, shown, bg: bg, width: right_w) if right_w > 0
       else
-        screen.text(x, y, sliced(r.left), lcolor, width: left_w) if left_w > 0
-        screen.cell(sep_x + 1, y, glyph, gcolor)
-        screen.text(right_x, y, sliced(r.right), rcolor, width: right_w) if right_w > 0
+        screen.text(x, y, sliced(r.left), lcolor, bg, width: left_w) if left_w > 0
+        screen.cell(sep_x + 1, y, glyph, gcolor, bg)
+        screen.text(right_x, y, sliced(r.right), rcolor, bg, width: right_w) if right_w > 0
       end
     end
 
@@ -414,10 +520,6 @@ module Gori::Tui
       screen.text(rect.x + 1, y, note, Theme.muted, width: {rect.w - 2, 1}.max) # pane + ←/→ moved to the divider selector
     end
 
-    private def clamp_scroll(body_h : Int32, total : Int32) : Nil
-      @scroll = @scroll.clamp(0, {total - body_h, 0}.max)
-    end
-
     # Pin the h-offset to the widest row CURRENTLY ON SCREEN, across both columns — the
     # same rule the Repeater response uses. Measured with draw_width_upto so a minified
     # multi-MB body line is never fully walked once per frame.
@@ -429,7 +531,7 @@ module Gori::Tui
       limit = @xscroll + cw + 1
       widest = 0
       (0...body_h).each do |i|
-        r = data[@scroll + i]?
+        r = data[@rowsel.scroll + i]?
         break unless r
         {r.left, r.right}.each do |t|
           next unless t

--- a/src/gori/tui/controllers/comparer_controller.cr
+++ b/src/gori/tui/controllers/comparer_controller.cr
@@ -125,14 +125,12 @@ module Gori::Tui
       return true if handle_body_hscroll(ev)
       case
       when key.up?, key.lower_k?
-        if view.at_top?
-          @host.request_focus(:subtabs)
-        else
-          view.scroll(-1)
-        end
+        # The cursor moves and drags the viewport with it; ⇧ grows a row selection. At the top
+        # the ↑ still leaves for the sub-tab strip, as it always did.
+        view.at_top? ? @host.request_focus(:subtabs) : view.move_rows(-1, ev.shift?)
         true
       when key.down?, key.lower_j?
-        view.scroll(1)
+        view.move_rows(1, ev.shift?)
         true
       when key.left?, key.right?, key.lower_h?, key.lower_l?
         view.toggle_pane
@@ -141,7 +139,7 @@ module Gori::Tui
         @host.request_focus(:subtabs)
         true
       else
-        false
+        view.motion_key(ev) # Home / End / PgUp / PgDn, ⇧ extending
       end
     end
 
@@ -161,8 +159,10 @@ module Gori::Tui
       end
     end
 
+    # A wheel notch scrolls the viewport and leaves the row cursor where it is — a reading
+    # gesture, not a cursor one. ↑/↓ are the cursor.
     def handle_wheel(step : Int32) : Bool
-      view.scroll(step)
+      view.wheel(step)
       true
     end
 
@@ -174,8 +174,56 @@ module Gori::Tui
       inner = body_rect_below_filter(rect)
       if pane = view.pane_chip_at(inner, mx, my)
         view.set_pane(pane)
+        return true
       end
+      body = view.body_rect(inner)
+      view.click_row(body, mx, my) unless body.empty?
       true
+    end
+
+    # --- mouse drag + double-click (see TabController#supports_drag?) ---
+    # A drag grows the ROW selection; there is no word to double-click (two columns, see
+    # `ComparerView`'s row-cursor note), so the double-click declines and the plain click stands.
+    def supports_drag? : Bool
+      view.both_set?
+    end
+
+    def handle_drag(rect : Rect, mx : Int32, my : Int32) : Nil
+      body = view.body_rect(body_rect_below_filter(rect))
+      view.click_row(body, mx, my, selecting: true) unless body.empty?
+    end
+
+    # --- READ-pane delegators (the Comparer read verbs + the Runner's read_* ladders) ---
+    def comparer_diff_shown? : Bool
+      view.both_set?
+    end
+
+    def comparer_selection_active? : Bool
+      view.selection?
+    end
+
+    def comparer_selection_text : String
+      view.copy_text
+    end
+
+    def comparer_select_line : Nil
+      view.select_row_line
+    end
+
+    def comparer_clear_selection : Nil
+      view.clear_selection
+    end
+
+    # `y`: the selected rows, or the whole diff when nothing is selected — as unified text, which
+    # is the only form a two-column diff has that pastes anywhere useful.
+    def comparer_copy : Nil
+      return unless view.both_set?
+      sel = view.selection?
+      text = sel ? view.copy_text : view.copy_all
+      return if text.empty?
+      written = Clipboard.copy(text)
+      note = Clipboard.note(written, text.bytesize)
+      @host.status(sel ? "copied #{written}b to clipboard#{note}" : "copied all (#{written}b)#{note}")
     end
 
     def body_hint(focus : Symbol) : String
@@ -183,7 +231,7 @@ module Gori::Tui
       a = Hotkeys.binding_label(reg, "comparer.pick-a", "a")
       b = Hotkeys.binding_label(reg, "comparer.pick-b", "b")
       s = Hotkeys.binding_label(reg, "comparer.swap", "s")
-      "←/→ req|res · ↑/↓ scroll · ⇧←/→ h-scroll · #{a}/#{b} pick · #{s} swap · ^N new · ^W close · space cmds · ↹/esc tabs"
+      "←/→ req|res · ↑/↓ row · ⇧↑/↓ select · y copy · ⇧←/→ h-scroll · #{a}/#{b} pick · #{s} swap · space cmds · esc tabs"
     end
   end
 end

--- a/src/gori/tui/controllers/decoder_controller.cr
+++ b/src/gori/tui/controllers/decoder_controller.cr
@@ -329,9 +329,16 @@ module Gori::Tui
              regions.input.x + 6, s.input_mode == InputMode::Insert)
           s.input_mode = s.input_mode == InputMode::Insert ? InputMode::Read : InputMode::Insert
           s.input_read.sync_from(s.input) if s.input_mode == InputMode::Read
-        else
+        elsif s.input_mode == InputMode::Insert
           s.input.click_to_cursor(regions.input.inset(1, 1), mx, my)
-          s.input_read.sync_from(s.input) unless s.input_mode == InputMode::Insert
+        else
+          # READ's selection lives in `input_read`, and `TextReadState#click` is the path that
+          # COLLAPSES it — `sync_from` deliberately does not touch the anchor (see
+          # `ReadCursor#sync`), so a plain click on top of a ⇧arrow selection used to re-shape
+          # it instead of dropping it, which is not what a click means anywhere else. The
+          # Repeater and Fuzzer template panes already click through their read state for
+          # exactly this reason; this is that call.
+          s.input_read.click(s.input, regions.input.inset(1, 1), mx, my)
         end
       elsif regions.chain.contains?(mx, my)
         s.pane = :chain
@@ -351,11 +358,17 @@ module Gori::Tui
       true
     end
 
+    # INS scrolls like READ. The `&& s.input_mode == InputMode::Read` that stood on the INPUT
+    # arm is the same guard `RepeaterView#request_scroll_view` shed: a wheel notch is not an
+    # editing gesture, and the operator who pressed `i` did not ask to give up reading the
+    # buffer they are typing into. `TextArea#scroll_view` pulls the caret into the new window
+    # itself, so the next inserted char lands where the pane is now looking rather than
+    # snapping the view back — which is what made this feel unsafe to allow.
     def handle_wheel(step : Int32) : Bool
       s = cur
       if s.pane == :output
         s.view.output_scroll_view(step, s.result)
-      elsif s.pane == :input && s.input_mode == InputMode::Read
+      elsif s.pane == :input
         s.input.scroll_view(step)
       end
       true

--- a/src/gori/tui/controllers/fuzzer_controller.cr
+++ b/src/gori/tui/controllers/fuzzer_controller.cr
@@ -204,21 +204,34 @@ module Gori::Tui
       !current_view.nil?
     end
 
-    # Motion with the button held — TEMPLATE only (the RESULTS list selects rows, and a drag
-    # across rows would just be a fast repeated select). No save/focus side effects: the
+    # Motion with the button held — the two TEXT panes only. The RESULTS list selects rows, and
+    # a drag across rows would just be a fast repeated select. No save/focus side effects: the
     # press that began the drag already did those.
+    #
+    # The RESULT detail is that second text pane: it has a caret, a painted selection band, a
+    # ⇧arrow grow and a `y`, and both arms here used to bail unless the TEMPLATE was focused —
+    # so the pointer was the one route into it that did nothing.
     def handle_drag(rect : Rect, mx : Int32, my : Int32) : Nil
       return unless v = current_view
-      return unless v.focus == :template
-      v.template_drag_to_cursor(body_rect_below_filter(rect), mx, my)
+      body = body_rect_below_filter(rect)
+      case v.focus
+      when :template then v.template_drag_to_cursor(body, mx, my)
+      when :detail   then v.detail_click_to_cursor(body, mx, my, selecting: true)
+      end
     end
 
     def handle_double_click(rect : Rect, mx : Int32, my : Int32) : Bool
       return false unless v = current_view
-      return false unless v.focus == :template
       body = body_rect_below_filter(rect)
-      return false if v.template_chrome_hit(body, mx, my) # a border badge is a button, not text
-      v.template_select_word(body, mx, my)
+      case v.focus
+      when :template
+        return false if v.template_chrome_hit(body, mx, my) # a border badge is a button, not text
+        v.template_select_word(body, mx, my)
+      when :detail
+        return false if v.detail_chip_at(body, mx, my) # a pane chip is a button, not text
+        v.detail_select_word(body, mx, my)
+      else false
+      end
     end
 
     # --- bracketed paste, in bulk (see TabController#accepts_bulk_paste?) ---
@@ -706,6 +719,14 @@ module Gori::Tui
           v.template_click_to_cursor(body, mx, my)
         when :target
           v.target_click_to_cursor(body, mx, my)
+        when :detail
+          # The chip strip on the card's top border first (it selects a section, it does not
+          # place a caret) — then the text, which had no click arm here at all.
+          if chip = v.detail_chip_at(body, mx, my)
+            v.show_detail_pane(chip)
+          else
+            v.detail_click_to_cursor(body, mx, my)
+          end
         end
       end
       true

--- a/src/gori/tui/controllers/history_controller.cr
+++ b/src/gori/tui/controllers/history_controller.cr
@@ -105,26 +105,44 @@ module Gori::Tui
       Rect.new(inner.x + 1, top, {inner.w - 2, 0}.max, h)
     end
 
+    # A click inside the detail drill-in: the pane chips, then the mode chips (both on the
+    # strip rows), then the text. Lifted out of `handle_click`, which carries the LIST arm as
+    # well and was over ameba's complexity ceiling with a third condition on this ladder.
+    private def click_detail(rect : Rect, inner : Rect, mx : Int32, my : Int32) : Nil
+      if pane = @history.detail_pane_at(inner, mx, my)
+        @history.set_detail_pane_public(pane)
+        @history.set_detail_focus(:strip) # a chip click parks focus on the strip
+        return
+      end
+      if mode = @history.detail_mode_at(inner, mx, my)
+        @host.focus_body
+        @history.set_detail_focus(:strip) # the mode chips live on the strip row too
+        case mode
+        when :hex    then @history.toggle_detail_hex
+        when :ws     then @host.toggle_reveal
+        when :pretty then @host.toggle_pretty
+        end
+        return
+      end
+      # `detail_text_rect`, not a second Rect built here: that helper's own comment says it
+      # exists so click, drag and double-click cannot land on three slightly different rects —
+      # and this arm was the third copy. Same rect, same rows: the helper answers nil exactly
+      # where the inline version clamped the height to 0, and a 0-height rect was already a
+      # no-op (`ReadCursor#click_to_cursor` returns on `rect.empty?`). The `my >= inner.y + 2`
+      # guard stays: without it a click on the strip row that missed every chip would newly
+      # pull focus down to the text level.
+      return unless my >= inner.y + 2
+      body = detail_text_rect(rect)
+      return unless body
+      @host.focus_body
+      @history.set_detail_focus(:body) # a body click enters the caret/text level
+      @history.detail_click_to_cursor(body, mx, my, focused: true)
+    end
+
     def handle_click(rect : Rect, mx : Int32, my : Int32) : Bool
       inner = rect.inset(1, 1) # framed insets 1,1
       if @host.overlay == :detail
-        if pane = @history.detail_pane_at(inner, mx, my)
-          @history.set_detail_pane_public(pane)
-          @history.set_detail_focus(:strip) # a chip click parks focus on the strip
-        elsif mode = @history.detail_mode_at(inner, mx, my)
-          @host.focus_body
-          @history.set_detail_focus(:strip) # the mode chips live on the strip row too
-          case mode
-          when :hex    then @history.toggle_detail_hex
-          when :ws     then @host.toggle_reveal
-          when :pretty then @host.toggle_pretty
-          end
-        elsif my >= inner.y + 2
-          body = Rect.new(inner.x + 1, inner.y + 2, {inner.w - 2, 0}.max, {inner.bottom - (inner.y + 2), 0}.max)
-          @host.focus_body
-          @history.set_detail_focus(:body) # a body click enters the caret/text level
-          @history.detail_click_to_cursor(body, mx, my, focused: true)
-        end
+        click_detail(rect, inner, mx, my)
         return true
       end
       @host.focus_body

--- a/src/gori/tui/controllers/intercept_controller.cr
+++ b/src/gori/tui/controllers/intercept_controller.cr
@@ -258,20 +258,74 @@ module Gori::Tui
     end
 
     # --- mouse drag + double-click (see TabController#supports_drag?) ---
+    # Both faces of the held-message pane drag: the editor's own caret while editing, the
+    # read-only preview's while previewing.
     def supports_drag? : Bool
-      @intercept.editing?
+      !@intercept.empty?
+    end
+
+    # All four pointer entries invert against `BodyChrome.frame_inner(rect)` — the SAME rect
+    # `render_body` hands the view through `BodyChrome.framed`. Drag and double-click used to
+    # pass the RAW body rect while the press insetted, so the press placed the caret through
+    # one mapping and the gesture that continued it used another: one row down, and one or two
+    # columns across, because `split_panes` divides a `w` that is 2 cells too wide. A press on
+    # line N whose drag extends from line N+1 is #587's shape ("a click that landed on a line it
+    # wasn't drawn on") — here inside the one pane where a selection is the point. The helper
+    # exists for exactly this ("shared by render and click hit-tests"); use it, not a fourth
+    # hand-written `inset(1, 1)`.
+    private def hit_rect(rect : Rect) : Rect
+      BodyChrome.frame_inner(rect)
     end
 
     def handle_drag(rect : Rect, mx : Int32, my : Int32) : Nil
-      @intercept.editor_drag_to_cursor(rect, mx, my)
+      inner = hit_rect(rect)
+      if @intercept.editing?
+        @intercept.editor_drag_to_cursor(inner, mx, my)
+      else
+        @intercept.preview_click(inner, mx, my, selecting: true)
+      end
     end
 
     def handle_double_click(rect : Rect, mx : Int32, my : Int32) : Bool
-      @intercept.editor_select_word(rect, mx, my)
+      inner = hit_rect(rect)
+      @intercept.editing? ? @intercept.editor_select_word(inner, mx, my) : @intercept.preview_select_word(inner, mx, my)
+    end
+
+    # --- READ-pane delegators (the preview's read verbs + the Runner's read_* ladders) ---
+    def intercept_preview_readable? : Bool
+      !@intercept.empty? && !@intercept.editing?
+    end
+
+    def intercept_preview_selection_active? : Bool
+      @intercept.preview_selection?
+    end
+
+    def intercept_preview_selection_text : String
+      @intercept.preview_copy_text
+    end
+
+    def intercept_preview_select_line : Nil
+      @intercept.preview_select_line
+    end
+
+    def intercept_preview_clear_selection : Nil
+      @intercept.preview_clear_selection
+    end
+
+    # `y`: the selection, or the whole held message when nothing is selected. The bytes here are
+    # the item's own — byte-exact, which is the point of holding it.
+    def intercept_preview_copy : Nil
+      return unless intercept_preview_readable?
+      sel = @intercept.preview_selection?
+      text = sel ? @intercept.preview_copy_text : @intercept.preview_copy_all
+      return if text.empty?
+      written = Clipboard.copy(text)
+      note = Clipboard.note(written, text.bytesize)
+      @host.status(sel ? "copied #{written}b to clipboard#{note}" : "copied all (#{written}b)#{note}")
     end
 
     def handle_click(rect : Rect, mx : Int32, my : Int32) : Bool
-      inner = rect.inset(1, 1)                        # framed insets 1,1
+      inner = hit_rect(rect)
       if zone = @intercept.bar_zone_at(inner, mx, my) # click the top filter bar
         @host.focus_body
         case zone
@@ -291,13 +345,43 @@ module Gori::Tui
           end_range_gesture unless idx == @intercept.selected_index
           @intercept.select_index(idx)
         end
-      else
-        @intercept.focus_detail
+      elsif @intercept.editing?
         @intercept.editor_click_to_cursor(inner, mx, my)
+      else
+        # A click on the read-only preview places a READ caret; it no longer starts editing.
+        # That is what makes the pane selectable at all — and the edit affordance was never the
+        # text, it is the `e`:EDIT badge on the card's own border (plus ↵ / `e`), which the
+        # bar-zone arm above already claims. The Intercept has no focus tier for this pane (Tab
+        # opens the editor, ⇧arrows are the queue's mark-range gesture), so the pointer is the
+        # only place a caret can come from here — hence mouse selection + `x`/`y`, and no
+        # keyboard caret.
+        @intercept.preview_click(inner, mx, my)
       end
       true
     end
 
+    # The wheel with the pointer position. This tab draws two panes side by side and only the
+    # LEFT one's wheel arm moves a selection, so a coordinate-free notch was wrong in both
+    # directions: over the held-message pane it walked the queue (reloading a different message
+    # under a preview that draws its own scroll gauge, and never scrolling that preview — whose
+    # only other path is PgUp/PgDn), and inside the editor it did nothing at all, because
+    # `move` bails while `@editing`. That bail stays: moving the selection with the editing flag
+    # up would leave the flag on with the editor no longer rendered. The fix is to send the
+    # notch to the pane under the pointer instead. Same move the Repeater's split request
+    # column made — see `RepeaterController#handle_wheel_at`.
+    #
+    # `hit_rect` for the same reason the press uses it: the view's hit-tests all invert against
+    # the framed interior `render_body` drew into.
+    def handle_wheel_at(step : Int32, mx : Int32, my : Int32, rect : Rect) : Bool
+      case @intercept.pane_at(hit_rect(rect), mx, my)
+      when :detail then @intercept.scroll_detail_pane(step)
+      when :list   then handle_wheel(step)
+      end # nil → the filter-bar row, the 1-cell gap column, or an empty queue: nothing to scroll
+      true
+    end
+
+    # The queue's own arm, kept separate so `:list` and any coordinate-free caller cannot
+    # drift. Self-guards on `@editing` (see `InterceptView#move`).
     def handle_wheel(step : Int32) : Bool
       @intercept.move(step)
       true

--- a/src/gori/tui/controllers/jwt_controller.cr
+++ b/src/gori/tui/controllers/jwt_controller.cr
@@ -504,30 +504,43 @@ module Gori::Tui
     end
 
     def handle_drag(rect : Rect, mx : Int32, my : Int32) : Nil
-      each_editor_at(rect, mx, my) { |ed, area| ed.click_to_cursor(area, mx, my, selecting: true) }
+      ed, area, read = editor_at(rect, mx, my) || return
+      ed.click_to_cursor(area, mx, my, selecting: true)
+      # In READ mode the band on screen is the read cursor's, not the editor's, so the drag has
+      # to grow THAT one. `sync_to(selecting: true)` plants the anchor with `||=`, which is only
+      # safe because the press collapsed the old selection (see `handle_click`) — without that
+      # collapse a drag would extend from an anchor the operator never pressed on.
+      read.try &.sync_to(ed, selecting: true)
     end
 
     def handle_double_click(rect : Rect, mx : Int32, my : Int32) : Bool
-      each_editor_at(rect, mx, my) { |ed, area| ed.select_word_at(area, mx, my) } || false
+      ed, area, read = editor_at(rect, mx, my) || return false
+      return read.select_word(ed, area, mx, my) if read
+      ed.select_word_at(area, mx, my)
     end
 
-    # Yield the editor under (mx, my) with its content rect, or nil when the pointer is not
-    # over one. One derivation for both gestures, matching `handle_click`'s layout call.
-    private def each_editor_at(rect : Rect, mx : Int32, my : Int32, & : TextArea, Rect -> _)
+    # The editor under (mx, my), its content rect, and the `TextReadState` that owns the
+    # SELECTION there — nil for a plain always-editing pane (HEADER / PAYLOAD, and INPUT while
+    # in INS, where the TextArea carries its own anchor). One derivation for both gestures,
+    # matching `handle_click`'s layout call.
+    #
+    # The INPUT arm used to bail unless the pane was in INS, which left READ mode — the mode
+    # whose whole purpose is select-and-copy, and which advertises "⇧arrows select · y copy" —
+    # with no drag and no double-click at all, while the identical Decoder pane has both. The
+    # press placed a caret there the whole time; only the two gestures that continue it were
+    # missing.
+    private def editor_at(rect : Rect, mx : Int32, my : Int32) : {TextArea, Rect, TextReadState?}?
       body = body_rect_below_filter(rect)
       s = cur
       if s.mode == :decode
         input_c, _, _ = s.view.decode_layout(body)
         return nil unless input_c.contains?(mx, my)
-        return nil unless s.input_mode == InputMode::Insert
-        yield s.input, input_c.inset(1, 1)
+        {s.input, input_c.inset(1, 1), s.input_mode == InputMode::Insert ? nil : s.input_read}
       else
         hdr_c, pay_c, _, _ = s.view.encode_layout(body)
-        if hdr_c.contains?(mx, my)
-          yield s.header, hdr_c.inset(1, 1)
-        elsif pay_c.contains?(mx, my)
-          yield s.payload, pay_c.inset(1, 1)
-        end
+        return {s.header, hdr_c.inset(1, 1), nil} if hdr_c.contains?(mx, my)
+        return {s.payload, pay_c.inset(1, 1), nil} if pay_c.contains?(mx, my)
+        nil
       end
     end
 
@@ -544,9 +557,12 @@ module Gori::Tui
                s.input_mode == InputMode::Insert)
             s.input_mode = s.input_mode == InputMode::Insert ? InputMode::Read : InputMode::Insert
             s.input_read.sync_from(s.input) if s.input_mode == InputMode::Read
-          else
+          elsif s.input_mode == InputMode::Insert
             s.input.click_to_cursor(input_c.inset(1, 1), mx, my)
-            s.input_read.sync_from(s.input) unless s.input_mode == InputMode::Insert
+          else
+            # Through the read state so the click COLLAPSES a ⇧arrow selection — see the same
+            # call in `DecoderController#handle_click` for why `sync_from` could not.
+            s.input_read.click(s.input, input_c.inset(1, 1), mx, my)
           end
         elsif dec_c.contains?(mx, my)
           enter_pane(s, :decoded)
@@ -570,13 +586,16 @@ module Gori::Tui
       true
     end
 
+    # The INPUT arm carries no `input_mode == Read` guard, for the reason spelled out on
+    # `DecoderController#handle_wheel`: a token pasted into this pane is long enough to need
+    # scrolling in both modes, and the wheel is a reading gesture in either.
     def handle_wheel(step : Int32) : Bool
       s = cur
       case s.pane
       when :decoded then s.view.scroll_decoded(step)
       when :output  then s.view.scroll_output(step)
       when :attacks then s.view.attacks_move(step)
-      when :input   then s.input.scroll_view(step) if s.input_mode == InputMode::Read
+      when :input   then s.input.scroll_view(step)
       end
       true
     end

--- a/src/gori/tui/controllers/miner_controller.cr
+++ b/src/gori/tui/controllers/miner_controller.cr
@@ -204,9 +204,11 @@ module Gori::Tui
     private def handle_detail(ev : Termisu::Event::Key, v : MinerView) : Nil
       key = ev.key
       if key.up? || key.lower_k?
-        v.detail_scroll(-1)
+        v.detail_move(-1, ev.shift?)
       elsif key.down? || key.lower_j?
-        v.detail_scroll(1)
+        v.detail_move(1, ev.shift?)
+      else
+        v.detail_motion_key(ev) # Home / End / PgUp / PgDn, ⇧ extending
       end
     end
 
@@ -216,15 +218,64 @@ module Gori::Tui
       if pane = v.pane_at(body, mx, my)
         v.focus_pane(pane) unless pane == :detail
         @host.focus_body
+        # The FINDING pane takes a row cursor from the pointer; the other two are lists the click
+        # already selected in.
+        v.detail_click(body, mx, my) if pane == :detail
       end
       true
+    end
+
+    # --- mouse drag + double-click (see TabController#supports_drag?) ---
+    # The FINDING pane only. Its rows are two columns, so there is no word to double-click.
+    def supports_drag? : Bool
+      current_view.try(&.focus) == :detail
+    end
+
+    def handle_drag(rect : Rect, mx : Int32, my : Int32) : Nil
+      return unless v = current_view
+      return unless v.focus == :detail
+      v.detail_click(body_rect_below_filter(rect), mx, my, selecting: true)
+    end
+
+    # --- READ-pane delegators (the FINDING read verbs + the Runner's read_* ladders) ---
+    def miner_detail_readable? : Bool
+      current_view.try { |v| v.focus == :detail } || false
+    end
+
+    def miner_selection_active? : Bool
+      current_view.try(&.detail_selection?) || false
+    end
+
+    def miner_selection_text : String
+      current_view.try(&.detail_copy_text) || ""
+    end
+
+    def miner_select_line : Nil
+      current_view.try(&.detail_select_line)
+    end
+
+    def miner_clear_selection : Nil
+      current_view.try(&.detail_clear_selection)
+    end
+
+    # `y`: the selected field rows, or the whole finding when nothing is selected. A mined
+    # parameter's evidence is what goes into a report, and it had no copy at all.
+    def miner_copy : Nil
+      v = current_view
+      return unless v && v.focus == :detail
+      sel = v.detail_selection?
+      text = sel ? v.detail_copy_text : v.detail_copy_all
+      return if text.empty?
+      written = Clipboard.copy(text)
+      note = Clipboard.note(written, text.bytesize)
+      @host.status(sel ? "copied #{written}b to clipboard#{note}" : "copied all (#{written}b)#{note}")
     end
 
     def handle_wheel(step : Int32) : Bool
       if v = current_view
         case v.focus
         when :results then v.results_move(step)
-        when :detail  then v.detail_scroll(step)
+        when :detail  then v.detail_wheel(step) # viewport only — ↑/↓ are the cursor
         end
       end
       true

--- a/src/gori/tui/controllers/oast_controller.cr
+++ b/src/gori/tui/controllers/oast_controller.cr
@@ -4,6 +4,7 @@ require "../theme"
 require "../frame"
 require "../highlight"
 require "../clipboard"
+require "../read_pane"
 require "../text_field"
 require "../../store"
 require "../../settings"
@@ -89,7 +90,10 @@ module Gori::Tui
       @cb_sel = 0
       @cb_scroll = 0
       @cb_detail = false
-      @cb_detail_scroll = 0
+      # The callback detail's caret, selection, scroll and draw. This pane holds the raw callback
+      # — the evidence an OAST finding rests on — and had no caret and no copy of its own: the
+      # tab's `y` copies the PAYLOAD, not what came back.
+      @cb_pane = ReadPane.new
       @filter = TextField.new # Callbacks free-text filter (`/`)
       @filter_editing = false
       @prov_sel = 0
@@ -111,6 +115,15 @@ module Gori::Tui
     # --- identity ---
     def tab : Symbol
       :oast
+    end
+
+    # The focus area the space menu shows alongside COMMON: `:detail` with a callback open,
+    # `:list` on the callbacks list, `:common` on Providers. The split exists because the two
+    # views spend `y` differently — the list copies the payload gori generated, the detail copies
+    # what came back — and two sections never render together.
+    def command_section : Symbol
+      return :common unless callbacks_sub?
+      @cb_detail ? :detail : :list
     end
 
     def command_scope : Verb::Scope
@@ -166,7 +179,7 @@ module Gori::Tui
 
     def body_hint(focus : Symbol) : String
       if callbacks_sub?
-        return "←/esc back · ↑/↓ scroll" if @cb_detail
+        return "↑/↓ move · ⇧arrows select · y copy · x line · space cmds · ←/esc back" if @cb_detail
         return "type to filter · ↵ keep · esc clear" if @filter_editing
         "↑/↓ select · ‹/› provider · g payload · y copy · / filter · ^R listen · ^X stop · ↵ detail · space cmds"
       else
@@ -653,12 +666,28 @@ module Gori::Tui
       screen.text(inner.x + 1, inner.y, meta, Theme.muted, Theme.bg, width: inner.w - 2)
       body = Rect.new(inner.x, inner.y + 2, inner.w, inner.h - 2)
       return if body.h <= 0 # collapsed pane (tiny terminal): a negative slice count would raise
-      text = row.raw_response ? "#{row.raw_request}\n\n--- response ---\n#{row.raw_response}" : row.raw_request
-      lines = text.split('\n')
-      @cb_detail_scroll = @cb_detail_scroll.clamp(0, {lines.size - body.h, 0}.max)
-      lines[@cb_detail_scroll, body.h]?.try &.each_with_index do |line, i|
-        screen.text(body.x + 1, body.y + i, line, Theme.text, Theme.bg, width: body.w - 2)
-      end
+      sync_cb_pane(row)
+      @cb_pane.render(screen, Rect.new(body.x + 1, body.y, {body.w - 2, 0}.max, body.h), focused)
+    end
+
+    # The raw callback as text: request, then the response when the provider captured one. The
+    # copy payload and the caret's coordinate system, in one place so the draw and a `y` cannot
+    # disagree about what "this callback" is.
+    private def cb_detail_text(row : CbRow) : String
+      row.raw_response ? "#{row.raw_request}\n\n--- response ---\n#{row.raw_response}" : row.raw_request
+    end
+
+    private def sync_cb_pane(row : CbRow) : Nil
+      @cb_pane.source(cb_detail_text(row).split('\n'))
+    end
+
+    # Run `blk` with the detail pane pointed at the open callback. Every gesture and every verb
+    # goes through it, so none can act on a pane sourced from a different row.
+    private def with_cb_pane(&) : Nil
+      return unless @cb_detail
+      row = selected_callback || return
+      sync_cb_pane(row)
+      yield
     end
 
     private def render_providers(screen : Screen, rect : Rect, focused : Bool) : Nil
@@ -805,15 +834,17 @@ module Gori::Tui
         when key.escape?, key.left?, key.lower_h?
           @cb_detail = false
         when key.up?, key.lower_k?
-          if @cb_detail_scroll <= 0
+          # At the top the ↑ still closes the detail and leaves; below it the caret steps, so
+          # ⇧↑ can grow a selection the way it does in every other read pane.
+          if @cb_pane.at_top?
             @cb_detail = false
             @host.request_focus(:subtabs)
           else
-            @cb_detail_scroll -= 1
+            with_cb_pane { @cb_pane.move(-1, 0, selecting: ev.shift?) }
           end
-        when key.down?, key.lower_j?
-          @cb_detail_scroll += 1
+        when key.down?, key.lower_j? then with_cb_pane { @cb_pane.move(1, 0, selecting: ev.shift?) }
         else
+          with_cb_pane { @cb_pane.motion_key(ev) } # Home / End / PgUp / PgDn, ⇧ extending
           return true
         end
         return true
@@ -827,7 +858,7 @@ module Gori::Tui
       when key.enter?
         if selected_callback
           @cb_detail = true
-          @cb_detail_scroll = 0
+          @cb_pane.reset # a different callback renumbers every line
         end
       when c == 'g' then generate_payload
       when c == 'y' then copy_payload
@@ -927,7 +958,7 @@ module Gori::Tui
       @filter_editing = false # a row click commits the filter, like History's list click
       if idx == @cb_sel
         @cb_detail = true
-        @cb_detail_scroll = 0
+        @cb_pane.reset
       else
         @cb_sel = idx
         sync_scroll
@@ -984,7 +1015,7 @@ module Gori::Tui
     def handle_wheel(step : Int32) : Bool
       if callbacks_sub?
         if @cb_detail
-          @cb_detail_scroll += step
+          with_cb_pane { @cb_pane.scroll_view(step) }
         else
           @cb_sel = (@cb_sel + step).clamp(0, {filtered_callbacks.size - 1, 0}.max)
           sync_scroll
@@ -1152,6 +1183,45 @@ module Gori::Tui
     def reveal_session(id : Int64) : Nil
       @active_sub = 0
       @host.focus_body
+    end
+
+    # --- READ-pane delegators (the callback detail's read verbs + the Runner's read_* ladders) ---
+    def oast_detail_readable? : Bool
+      callbacks_sub? && @cb_detail && !selected_callback.nil?
+    end
+
+    def oast_detail_selection_active? : Bool
+      @cb_detail && @cb_pane.selection?
+    end
+
+    def oast_detail_selection_text : String
+      row = selected_callback
+      return "" unless row && callbacks_sub? && @cb_detail
+      sync_cb_pane(row)
+      @cb_pane.copy_text
+    end
+
+    def oast_detail_select_line : Nil
+      with_cb_pane { @cb_pane.select_line }
+    end
+
+    def oast_detail_clear_selection : Nil
+      @cb_pane.clear_selection
+    end
+
+    # `y` inside the detail: the selection, or the whole callback. Distinct from the list's `y`,
+    # which copies the PAYLOAD gori generated — the two are the opposite directions of the same
+    # interaction, and an evidence tool must let you take what came BACK.
+    def oast_detail_copy : Nil
+      row = selected_callback
+      return unless row && callbacks_sub? && @cb_detail
+      sync_cb_pane(row)
+      sel = @cb_pane.selection?
+      text = sel ? @cb_pane.copy_text : @cb_pane.copy_all
+      return if text.empty?
+      written = Clipboard.copy(text)
+      note = Clipboard.note(written, text.bytesize)
+      @host.status(sel ? "copied #{written}b to clipboard#{note}" : "copied all (#{written}b)#{note}")
     end
   end
 end

--- a/src/gori/tui/controllers/probe_controller.cr
+++ b/src/gori/tui/controllers/probe_controller.cr
@@ -93,7 +93,7 @@ module Gori::Tui
       if rules_tab?
         return "↑/↓ move · ↵/x toggle · a add · e edit · d delete · space cmds · ↑ sub-tabs · esc tabs"
       elsif @probe.detail_open?
-        "o flow · r repeater · p promote · c dismiss · d delete · space cmds · ←/esc back"
+        "↑/↓ URL · ⇧arrows select · y copy · o flow · r repeater · p promote · space cmds · ←/esc back"
       elsif @probe.querying?
         "type to filter · ↹ complete · ↵ apply · esc clear"
       elsif @probe.mode.off?
@@ -131,7 +131,12 @@ module Gori::Tui
         end
         return true
       end
-      return true if @probe.detail_open? # detail pane: clicks are inert (use keys)
+      if @probe.detail_open?
+        # The AFFECTED URLS list takes a caret from the pointer; the rest of the card is chrome.
+        @host.focus_body
+        @probe.detail_click(content, mx, my)
+        return true
+      end
       @host.focus_body
       if @probe.preview_enabled? && @probe.preview_at?(content, mx, my)
         @probe.set_preview_focus(:preview)
@@ -152,7 +157,7 @@ module Gori::Tui
       if rules_tab?
         @rules.move(step)
       elsif @probe.detail_open?
-        @probe.scroll_detail(step)
+        @probe.detail_wheel(step) # viewport only — ↑/↓ are the caret
       else
         @probe.move(step)
       end
@@ -179,9 +184,9 @@ module Gori::Tui
       return false if ev.ctrl? || ev.alt?
       if @probe.detail_open?
         case
-        when key.up?, key.lower_k?   then @probe.scroll_detail(-1)
-        when key.down?, key.lower_j? then @probe.scroll_detail(1)
-        else                              return false
+        when key.up?, key.lower_k?   then @probe.detail_move(-1, ev.shift?)
+        when key.down?, key.lower_j? then @probe.detail_move(1, ev.shift?)
+        else                              return @probe.detail_motion_key(ev) # Home/End/PgUp/PgDn, ⇧ extending
         end
         return true
       end
@@ -500,6 +505,56 @@ module Gori::Tui
     private def reload_rules : Nil
       @rules.reload(@host.session.store)
       @host.session.probe.reload_rule_config
+    end
+
+    # --- mouse drag + double-click (see TabController#supports_drag?) ---
+    # The detail's AFFECTED URLS only: the issue list selects rows, where a drag is a fast
+    # repeated select and a double-click is two opens.
+    def supports_drag? : Bool
+      !rules_tab? && @probe.detail_open?
+    end
+
+    def handle_drag(rect : Rect, mx : Int32, my : Int32) : Nil
+      return unless supports_drag?
+      @probe.detail_click(BodyChrome.content_rect(rect, strip: true), mx, my, selecting: true)
+    end
+
+    def handle_double_click(rect : Rect, mx : Int32, my : Int32) : Bool
+      return false unless supports_drag?
+      @probe.detail_select_word(BodyChrome.content_rect(rect, strip: true), mx, my)
+    end
+
+    # --- READ-pane delegators (the detail's read verbs + the Runner's read_* ladders) ---
+    def probe_detail_readable? : Bool
+      !rules_tab? && @probe.detail_open?
+    end
+
+    def probe_detail_selection_active? : Bool
+      @probe.detail_selection?
+    end
+
+    def probe_detail_selection_text : String
+      @probe.detail_copy_text
+    end
+
+    def probe_detail_select_line : Nil
+      @probe.detail_select_line
+    end
+
+    def probe_detail_clear_selection : Nil
+      @probe.detail_clear_selection
+    end
+
+    # `y`: the selected URLs, or every affected URL when nothing is selected. This list IS the
+    # finding's evidence, and it had no copy at all.
+    def probe_detail_copy : Nil
+      return unless probe_detail_readable?
+      sel = @probe.detail_selection?
+      text = sel ? @probe.detail_copy_text : @probe.detail_copy_all
+      return if text.empty?
+      written = Clipboard.copy(text)
+      note = Clipboard.note(written, text.bytesize)
+      @host.status(sel ? "copied #{written}b to clipboard#{note}" : "copied all (#{written}b)#{note}")
     end
   end
 end

--- a/src/gori/tui/controllers/repeater_controller.cr
+++ b/src/gori/tui/controllers/repeater_controller.cr
@@ -680,11 +680,16 @@ module Gori::Tui
       when :request
         # INS scrolls like NOR. It is the same pane showing the same text and the wheel is
         # not an editing gesture — the operator who presses `i` has not asked to give up
-        # scrolling, and every other TextArea-backed pane in the tree (Notes, the Decoder
-        # input) already wheels while in insert mode. The `unless v.request_insert?` that
-        # stood here was one of TWO guards on this path; the other is inside
-        # `RepeaterView#request_scroll_view`, so neither is sufficient on its own and
-        # dropping this one is half the fix (see the report / that method).
+        # scrolling. That is now the rule for EVERY TextArea-backed pane in the tree, not
+        # just the ones that happened to have it: this claim named "Notes, the Decoder input"
+        # as already correct, and the Decoder input was in fact gated on
+        # `InputMode::Read` — as were the JWT input, the Fuzzer template
+        # (`FuzzerView#template_scroll_view`) and the Intercept held-message editor
+        # (`InterceptView#scroll_detail_pane`). All four dropped the mode test; a new pane
+        # that reads the MODE to decide whether the wheel works is re-introducing this bug.
+        # The `unless v.request_insert?` that stood here was one of TWO guards on this path;
+        # the other is inside `RepeaterView#request_scroll_view`, so neither is sufficient on
+        # its own and dropping this one is half the fix (see the report / that method).
         v.request_scroll_view(step)
       end
       true

--- a/src/gori/tui/controllers/rewriter_controller.cr
+++ b/src/gori/tui/controllers/rewriter_controller.cr
@@ -1,6 +1,7 @@
 require "../tab_controller"
 require "../rewriter_view"
 require "../text_area"
+require "../read_pane"
 require "../../store"
 require "../../rules"
 
@@ -30,7 +31,10 @@ module Gori::Tui
       sample = @host.session.store.setting(Store::REWRITER_SAMPLE_KEY) || DEFAULT_SAMPLE
       @preview_input = TextArea.new(sample)
       @saved_sample = @preview_input.text # what the store holds, in the form `commit` compares
-      @out_scroll = 0
+      # The transformed sample: caret, selection, both scroll axes and its whole draw. No gutter
+      # — these rows are a rewritten MESSAGE, and the sample's own line numbers would only
+      # invite the reader to map them onto the input pane, which a head/body rewrite can shift.
+      @out = ReadPane.new
       @last_body = Rect.new(0, 0, 0, 0) # last content rect — click/wheel geometry
     end
 
@@ -40,6 +44,13 @@ module Gori::Tui
 
     def command_scope : Verb::Scope
       Verb::Scope::Rewriter
+    end
+
+    # The focus area the space menu shows alongside COMMON. `:preview` while either preview pane
+    # holds focus, `:rules` otherwise — so the rule actions are offered where a rule is selected
+    # and the read actions where there is text to select, and neither view repeats a letter.
+    def command_section : Symbol
+      @sub == :rules && (@focus == :preview_in || @focus == :preview_out) ? :preview : :rules
     end
 
     def body_badge : Symbol
@@ -122,8 +133,9 @@ module Gori::Tui
       list = rule_list
       @sel = @sel.clamp(0, {list.size - 1, 0}.max)
       ensure_visible(inner, list.size)
+      sync_preview_out
       @view.render(screen, inner, list, @sel, @scroll, rules_engine.enabled_count,
-        @focus, body_focused, rules_engine.active?, @preview_input, preview_output, @out_scroll)
+        @focus, body_focused, rules_engine.active?, @preview_input, @out)
     end
 
     private def render_extract(screen : Screen, inner : Rect, body_focused : Bool) : Nil
@@ -173,6 +185,16 @@ module Gori::Tui
         @scroll = @sel - lh + 1
       end
       @scroll = @scroll.clamp(0, {count - lh, 0}.max)
+    end
+
+    # Point the OUTPUT pane at the current transform. Recomputed rather than cached, exactly as
+    # the old per-frame `preview_output` call was — `transform_message` over one sample is cheap
+    # next to a frame, and any cache key would have to track the sample AND every enabled rule.
+    # Called from `render_rules` and from each selection/copy delegator, so a verb never reads a
+    # pane pointed at a stale transform.
+    private def sync_preview_out : Nil
+      text = preview_output
+      @out.source(text.empty? ? ["(empty)"] : text.split('\n'))
     end
 
     # Enabled rules applied to the sample (request side; host from Host: header).
@@ -337,20 +359,26 @@ module Gori::Tui
 
     private def handle_preview_out_key(ev : Termisu::Event::Key) : Bool
       key = ev.key
+      # ⇧←/→ grow the selection sideways, and they are checked BEFORE the bare ← that leaves for
+      # the INPUT pane — inside the `case` below that arm claims EVERY left press, shifted or not,
+      # so ⇧← left the pane instead of selecting. (ameba's Lint/DuplicateWhenCondition is what
+      # named it: the later `when key.left?` was unreachable.) Same ordering the Comparer's
+      # `handle_body_hscroll` and the Repeater use, for the same reason.
+      if ev.shift? && (key.left? || key.right?)
+        @out.move(0, key.left? ? -1 : 1, selecting: true)
+        return true
+      end
       case
       when key.escape?, key.left? then @focus = :preview_in
       when key.up?, key.lower_k?
-        if @out_scroll <= 0
-          @focus = :preview_in
-        else
-          @out_scroll = {@out_scroll - 1, 0}.max
-        end
-      when key.down?, key.lower_j?
-        @out_scroll += 1
+        # At the top the ↑ crosses back to the INPUT editor, as it always did; below it the
+        # caret steps, so ⇧↑ can grow a selection the way it does in every other read pane.
+        @out.at_top? ? (@focus = :preview_in) : @out.move(-1, 0, selecting: ev.shift?)
+      when key.down?, key.lower_j? then @out.move(1, 0, selecting: ev.shift?)
       when key.space? && !ev.ctrl? && !ev.alt?
         @host.open_space_menu
       else
-        return false
+        return @out.motion_key(ev) # Home / End / PgUp / PgDn, ⇧ extending
       end
       true
     end
@@ -402,8 +430,88 @@ module Gori::Tui
         @preview_input.click_to_cursor(body, mx, my) unless body.empty?
       when :preview_out
         @focus = :preview_out
+        body = @view.preview_output_body(inner)
+        sync_preview_out
+        @out.click(body, mx, my) unless body.empty?
       end
       true
+    end
+
+    # --- mouse drag + double-click (see TabController#supports_drag?) ---
+    # The OUTPUT pane only: the rule list selects rows and the INPUT editor is a TextArea the
+    # shell already drags through its own arm below.
+    def supports_drag? : Bool
+      @sub == :rules && (@focus == :preview_in || @focus == :preview_out)
+    end
+
+    def handle_drag(rect : Rect, mx : Int32, my : Int32) : Nil
+      inner = BodyChrome.frame_inner(rect)
+      case @focus
+      when :preview_in
+        body = @view.preview_input_body(inner)
+        @preview_input.click_to_cursor(body, mx, my, selecting: true) unless body.empty?
+      when :preview_out
+        body = @view.preview_output_body(inner)
+        return if body.empty?
+        sync_preview_out
+        @out.click(body, mx, my, selecting: true)
+      end
+    end
+
+    def handle_double_click(rect : Rect, mx : Int32, my : Int32) : Bool
+      inner = BodyChrome.frame_inner(rect)
+      case @focus
+      when :preview_in
+        body = @view.preview_input_body(inner)
+        body.empty? ? false : @preview_input.select_word_at(body, mx, my)
+      when :preview_out
+        body = @view.preview_output_body(inner)
+        return false if body.empty?
+        sync_preview_out
+        @out.select_word(body, mx, my)
+      else false
+      end
+    end
+
+    # --- READ-pane delegators (the Rewriter verbs + the Runner's read_* ladders) ---
+    def rewriter_selection_active? : Bool
+      @sub == :rules && @focus == :preview_out && @out.selection?
+    end
+
+    def rewriter_selection_text : String
+      return "" unless @sub == :rules && @focus == :preview_out
+      sync_preview_out
+      @out.copy_text
+    end
+
+    def rewriter_select_line : Nil
+      return unless @sub == :rules && @focus == :preview_out
+      sync_preview_out
+      @out.select_line
+    end
+
+    def rewriter_clear_selection : Nil
+      @out.clear_selection
+    end
+
+    # `y`: the selection, or the whole transformed sample when nothing is selected. The pane is
+    # the only place the post-rewrite bytes exist — the sample in the store is the INPUT.
+    # Same `Clipboard.copy` + status shape every other tab's copy verb uses, so the toast reads
+    # the same and the OSC-52 truncation note is not re-derived here.
+    def rewriter_copy : Nil
+      return unless @sub == :rules && @focus == :preview_out
+      sync_preview_out
+      sel = @out.selection?
+      text = sel ? @out.copy_text : @out.copy_all
+      return if text.empty?
+      written = Clipboard.copy(text)
+      note = Clipboard.note(written, text.bytesize)
+      @host.status(sel ? "copied #{written}b to clipboard#{note}" : "copied all (#{written}b)#{note}")
+    end
+
+    # True while the OUTPUT pane is the focused one — the `available:` gate for its read verbs.
+    def rewriter_preview_out_focused? : Bool
+      @sub == :rules && @focus == :preview_out
     end
 
     def handle_wheel(step : Int32) : Bool
@@ -413,7 +521,7 @@ module Gori::Tui
       end
       case @focus
       when :preview_in  then @preview_input.scroll_view(step)
-      when :preview_out then @out_scroll = {@out_scroll + step, 0}.max
+      when :preview_out then sync_preview_out; @out.scroll_view(step)
       else                   move_sel(step)
       end
       true
@@ -618,7 +726,7 @@ module Gori::Tui
       when :preview_in
         "type sample HTTP · ↑ list · ↓/→ output · esc list"
       when :preview_out
-        "↑/↓ scroll · ← input · esc input"
+        "↑/↓ move · ⇧arrows select · y copy · x line · space cmds · ← input · esc input"
       else
         "[/] sub-tab · ↑/↓ select · ↓ preview · a add · ↵/e edit · x on/off · d delete · ⇧J/⇧K reorder · esc tabs"
       end

--- a/src/gori/tui/controllers/sequencer_controller.cr
+++ b/src/gori/tui/controllers/sequencer_controller.cr
@@ -215,19 +215,23 @@ module Gori::Tui
           # Side-by-side: up leaves to Config; stacked: Analysis sits under Samples.
           v.focus_pane(v.side_by_side? ? :config : :samples)
         else
-          v.analysis_scroll(-1)
+          v.analysis_move(-1, ev.shift?)
         end
       when key.down?, key.lower_j?
-        v.analysis_scroll(1)
+        v.analysis_move(1, ev.shift?)
+      else
+        v.analysis_motion_key(ev) # Home / End / PgUp / PgDn, ⇧ extending
       end
     end
 
     private def handle_detail(ev : Termisu::Event::Key, v : SequencerView) : Nil
       key = ev.key
       if key.up? || key.lower_k?
-        v.detail_scroll(-1)
+        v.detail_move(-1, ev.shift?)
       elsif key.down? || key.lower_j?
-        v.detail_scroll(1)
+        v.detail_move(1, ev.shift?)
+      else
+        v.detail_motion_key(ev) # Home / End / PgUp / PgDn, ⇧ extending
       end
     end
 
@@ -237,16 +241,84 @@ module Gori::Tui
       if pane = v.pane_at(body, mx, my)
         v.focus_pane(pane) unless pane == :detail
         @host.focus_body
+        # The ANALYSIS report takes a row cursor from the pointer; the other panes are lists and
+        # fields the click already selected.
+        v.analysis_click(v.analysis_body(body), mx, my) if pane == :analysis
+        v.detail_click(body, mx, my) if pane == :detail
       end
       true
+    end
+
+    # --- mouse drag + double-click (see TabController#supports_drag?) ---
+    # The ANALYSIS report only: a drag grows the row selection. No word to double-click — its rows
+    # are two columns, so the double-click declines and the plain click stands.
+    def supports_drag? : Bool
+      current_view.try { |v| v.focus == :analysis || v.focus == :detail } || false
+    end
+
+    def handle_drag(rect : Rect, mx : Int32, my : Int32) : Nil
+      return unless v = current_view
+      body = body_rect_below_filter(rect)
+      case v.focus
+      when :analysis then v.analysis_click(v.analysis_body(body), mx, my, selecting: true)
+      when :detail   then v.detail_click(body, mx, my, selecting: true)
+      end
+    end
+
+    # --- READ-pane delegators (the ANALYSIS read verbs + the Runner's read_* ladders) ---
+    # Two read panes, one set of delegators, chosen by focus: the ANALYSIS report and the TOKEN
+    # field list. Both are `line_select_only` row cursors over `"label  value"` projections, so a
+    # verb needs to know only which pane the operator is in.
+    def sequencer_analysis_readable? : Bool
+      current_view.try { |v| v.focus == :analysis || v.focus == :detail } || false
+    end
+
+    def sequencer_selection_active? : Bool
+      v = current_view
+      return false unless v
+      v.focus == :detail ? v.detail_selection? : v.analysis_selection?
+    end
+
+    def sequencer_selection_text : String
+      v = current_view
+      return "" unless v
+      v.focus == :detail ? v.detail_copy_text : v.analysis_copy_text
+    end
+
+    def sequencer_select_line : Nil
+      v = current_view || return
+      v.focus == :detail ? v.detail_select_line : v.analysis_select_line
+    end
+
+    def sequencer_clear_selection : Nil
+      v = current_view || return
+      v.focus == :detail ? v.detail_clear_selection : v.analysis_clear_selection
+    end
+
+    # `y`: the selected report rows, or the whole entropy report when nothing is selected. The
+    # report is the finding — a randomness verdict you cannot paste into an issue is half a tool.
+    def sequencer_copy : Nil
+      v = current_view
+      return unless v && (v.focus == :analysis || v.focus == :detail)
+      detail = v.focus == :detail
+      sel = detail ? v.detail_selection? : v.analysis_selection?
+      text = if sel
+               detail ? v.detail_copy_text : v.analysis_copy_text
+             else
+               detail ? v.detail_copy_all : v.analysis_copy_all
+             end
+      return if text.empty?
+      written = Clipboard.copy(text)
+      note = Clipboard.note(written, text.bytesize)
+      @host.status(sel ? "copied #{written}b to clipboard#{note}" : "copied all (#{written}b)#{note}")
     end
 
     def handle_wheel(step : Int32) : Bool
       if v = current_view
         case v.focus
         when :samples  then v.samples_move(step)
-        when :analysis then v.analysis_scroll(step)
-        when :detail   then v.detail_scroll(step)
+        when :analysis then v.analysis_wheel(step) # viewport only — ↑/↓ are the cursor
+        when :detail   then v.detail_wheel(step)   # viewport only — ↑/↓ are the cursor
         end
       end
       true

--- a/src/gori/tui/decoder_view.cr
+++ b/src/gori/tui/decoder_view.cr
@@ -4,6 +4,7 @@ require "./frame"
 require "./text_area"
 require "./input_mode"
 require "./read_cursor"
+require "./read_pane"
 require "./text_read_state"
 require "./gutter"
 require "../decoder"
@@ -26,8 +27,6 @@ module Gori::Tui
 
     @prefer : Decoder::RenderAs? = nil # nil = auto
     @prefer_idx : Int32 = 0
-    @out_scroll : Int32 = 0
-    @out_xscroll : Int32 = 0 # horizontal scroll offset for the OUTPUT card (shift+←/→)
     @last_step_count : Int32 = 0
     # Cached OUTPUT lines, rebuilt only when the chain recomputes or the display mode
     # changes (NOT every frame) — encoding/splitting a near-MAX_OUT (32 MiB) output on
@@ -35,8 +34,10 @@ module Gori::Tui
     # controller on every recompute) + cycle_out_mode set the dirty flag.
     @out_lines : Array(String) = [] of String
     @out_dirty : Bool = true
-    @out_read = ReadCursor.new
-    @out_last_h : Int32 = 0
+    # The OUTPUT pane's caret, selection, both scroll axes and its whole draw. Gutter on: these
+    # rows ARE source lines of the decoded text, and ^G-style line references only mean
+    # something with numbers beside them.
+    @out = ReadPane.new(gutter: true)
 
     # Card rects for the four sections, stacked top-to-bottom. Each is a full
     # `Frame.card` (border + interior), NOT a divided slice of one outer frame —
@@ -200,133 +201,68 @@ module Gori::Tui
       end
     end
 
+    # The OUTPUT card's interior. Everything below `output_lines` — the scroll clamps, the
+    # gutter, the h-slice, the selection band, the block caret, the gauge — is `ReadPane`'s;
+    # this pane was one of the three hand-rolled copies that component was extracted from, and
+    # migrating it is what proves the component's API rather than merely fitting new callers.
+    # Red text is the only thing left that is the Decoder's own: a failed chain prints its
+    # error here instead of bytes.
     private def render_output(screen : Screen, rect : Rect, result : Decoder::ChainResult, focused : Bool = false) : Nil
       return if rect.h <= 0
-      lines = output_lines(result)
-      @out_last_h = rect.h
-      @out_scroll = @out_scroll.clamp(0, {lines.size - rect.h, 0}.max)
-      fg = result.output.nil? ? Theme.red : Theme.text
-      gw = {Gutter.width(lines.size), rect.w}.min
-      cw = {rect.w - gw, 0}.max
-      rows = (0...rect.h).compact_map { |i| lines[@out_scroll + i]? }
-      # draw_width, not display_width: the rows go out through `screen.text` below, which
-      # advances ≥1 per grapheme. Decoder output is exactly where raw control bytes surface
-      # (a base64/hex decode of binary), and the raw measure scores every one of them 0 —
-      # so the clamp pinned @out_xscroll short and the tail of a decoded line was
-      # unreachable. _upto preserves the per-frame early exit on a huge single-line decode.
-      @out_xscroll = @out_xscroll.clamp(0, {(rows.max_of? { |l| Screen.draw_width_upto(l, @out_xscroll + cw + 1) } || 0) - cw, 0}.max)
-      ensure_out_visible(rect.h) if focused
-      rows.each_with_index do |line, i|
-        li = @out_scroll + i
-        Gutter.draw(screen, rect.x, rect.y + i, li, gw, current: focused && li == @out_read.cy)
-        shown = @out_xscroll > 0 ? Highlight.slice_left_text(line, @out_xscroll) : line
-        screen.text(rect.x + gw, rect.y + i, shown, fg, Theme.bg, width: cw)
-        paint_out_line_chrome(screen, rect.x + gw, rect.y + i, li, line, lines, focused)
-      end
-      Frame.scroll_gauge(screen, rect, lines.size, @out_scroll, focused)
+      output_lines(result) # keeps @out's source in step with the cache
+      @out.render(screen, rect, focused, fg: result.output.nil? ? Theme.red : Theme.text)
     end
 
+    # Every gesture below is `ReadPane`'s; the `result` argument stays because the OUTPUT text
+    # is derived from it and `output_lines` is what keeps the pane's source in step with the
+    # cache (a recompute or a ^X mode flip re-splits, everything else is a hash-free read).
+
     def output_move(dr : Int32, dc : Int32, result : Decoder::ChainResult, selecting : Bool = false) : Nil
-      lines = output_lines(result)
-      return if lines.empty?
-      @out_read.move(dr, dc, lines, selecting: selecting)
-      ensure_out_visible(@out_last_h) if @out_last_h > 0
+      output_lines(result)
+      @out.move(dr, dc, selecting)
     end
 
     def output_scroll_view(step : Int32, result : Decoder::ChainResult) : Nil
-      lines = output_lines(result)
-      return if @out_last_h <= 0 || lines.size <= @out_last_h
-      max = lines.size - @out_last_h
-      @out_scroll = (@out_scroll + step).clamp(0, max)
-      lo = @out_scroll
-      hi = {@out_scroll + @out_last_h - 1, lines.size - 1}.min
-      @out_read.sync(
-        @out_read.cy.clamp(lo, hi),
-        @out_read.cx.clamp(0, lines[@out_read.cy].size))
+      output_lines(result)
+      @out.scroll_view(step)
     end
 
     # `selecting` is the DRAG half — the anchor stays where the press landed.
     def output_click_to_cursor(rect : Rect, mx : Int32, my : Int32, result : Decoder::ChainResult,
                                selecting : Bool = false) : Nil
-      lines = output_lines(result)
-      return if rect.empty? || lines.empty?
-      gw = {Gutter.width(lines.size), rect.w}.min
-      @out_read.click_to_cursor(rect, mx, my, @out_scroll, lines, gw, @out_xscroll, selecting)
-      ensure_out_visible(rect.h)
+      output_lines(result)
+      @out.click(rect, mx, my, selecting)
     end
 
     # Double-click: select the word under the pointer.
     def output_select_word(rect : Rect, mx : Int32, my : Int32, result : Decoder::ChainResult) : Bool
-      lines = output_lines(result)
-      return false if rect.empty? || lines.empty?
-      gw = {Gutter.width(lines.size), rect.w}.min
-      hit = @out_read.select_word_at(rect, mx, my, @out_scroll, lines, gw, @out_xscroll)
-      ensure_out_visible(rect.h)
-      hit
+      output_lines(result)
+      @out.select_word(rect, mx, my)
     end
 
     # READ-mode Home/End/Page over the OUTPUT pane, with ⇧ extending the selection. The page
     # step comes from the pane's LAST RENDERED height, so it matches what is on screen.
     def output_motion_key(ev : Termisu::Event::Key, result : Decoder::ChainResult) : Bool
-      lines = output_lines(result)
-      return false if lines.empty?
-      key = ev.key
-      shift = ev.shift?
-      page = {@out_last_h - 2, 1}.max
-      case
-      when key.home?      then @out_read.move_to(@out_read.cy, 0, selecting: shift)
-      when key.end?       then @out_read.move_to(@out_read.cy, lines[@out_read.cy.clamp(0, lines.size - 1)].size, selecting: shift)
-      when key.page_up?   then @out_read.move(-page, 0, lines, selecting: shift)
-      when key.page_down? then @out_read.move(page, 0, lines, selecting: shift)
-      else                     return false
-      end
-      ensure_out_visible(@out_last_h) if @out_last_h > 0
-      true
+      output_lines(result)
+      @out.motion_key(ev)
     end
 
     def output_copy_text(result : Decoder::ChainResult) : String
-      lines = output_lines(result)
-      return "" if lines.empty?
-      @out_read.selection_text(lines) || @out_read.current_line(lines)
+      output_lines(result)
+      @out.copy_text
     end
 
     def output_selection? : Bool
-      @out_read.selection?
+      @out.selection?
     end
 
     def output_select_line(result : Decoder::ChainResult) : Nil
-      lines = output_lines(result)
-      return if lines.empty?
-      @out_read.select_line(lines)
-      ensure_out_visible(@out_last_h) if @out_last_h > 0
+      output_lines(result)
+      @out.select_line
     end
 
     def output_clear_selection : Nil
-      @out_read.clear_selection
-    end
-
-    private def ensure_out_visible(view_h : Int32) : Nil
-      return if view_h <= 0
-      cy = @out_read.cy
-      if cy < @out_scroll
-        @out_scroll = cy
-      elsif cy >= @out_scroll + view_h
-        @out_scroll = cy - view_h + 1
-      end
-    end
-
-    private def paint_out_line_chrome(screen : Screen, x : Int32, y : Int32, li : Int32, line : String,
-                                      lines : Array(String), focused : Bool) : Nil
-      return unless focused
-      @out_read.highlight_spans(lines).each do |(l, x0, x1)|
-        paint_char_span_bg(screen, x, y, line, x0, x1, Theme.accent_bg) if l == li
-      end
-      return unless li == @out_read.cy
-      cx = @out_read.cx.clamp(0, line.size)
-      px = x + Screen.draw_width(line[0, cx])
-      ch = cx < line.size ? line[cx] : ' '
-      screen.cell(px, y, ch, Theme.bg, Theme.accent_bg)
-      screen.cursor(px, y)
+      @out.clear_selection
     end
 
     private def paint_char_span_bg(screen : Screen, x : Int32, y : Int32, line : String,
@@ -356,6 +292,7 @@ module Gori::Tui
       if @out_dirty
         @out_lines = output_text(result).split('\n')
         @out_dirty = false
+        @out.source(@out_lines) # the pane addresses exactly the text it is about to draw
       end
       @out_lines
     end
@@ -429,29 +366,22 @@ module Gori::Tui
       ] of {Symbol, String, String}).nil?
     end
 
-    def scroll_output(step : Int32) : Nil
-      @out_scroll += step
-    end
-
-    # Horizontal companion to `scroll_output` (shift+←/→). Floored at 0 here; render
-    # clamps the upper bound to the widest row actually on screen.
+    # Shift+←/→ over the OUTPUT card.
     def hscroll_output(step : Int32) : Nil
-      @out_xscroll = {@out_xscroll + step * 4, 0}.max
+      @out.hscroll(step)
     end
 
     # Whether the OUTPUT is scrolled to the top — ↑ here pops focus up to CHAIN
-    # (render clamps @out_scroll on every frame, so this reads the true top).
+    # (render clamps the scroll on every frame, so this reads the true top).
     def output_at_top? : Bool
-      @out_scroll <= 0 && @out_read.cy <= 0
+      @out.at_top?
     end
 
     # Invoked by the controller after every recompute: reset scroll AND invalidate
     # the cached output lines (the content changed).
     def reset_output_scroll : Nil
-      @out_scroll = 0
-      @out_xscroll = 0
       @out_dirty = true
-      @out_read.reset
+      @out.reset
     end
   end
 

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -1347,6 +1347,84 @@ module Gori::Tui
       detail_plain_lines.join("\n")
     end
 
+    # --- mouse over the RESULT detail ---------------------------------------
+    # This pane paints a selection band, grows it on ⇧arrows and copies it with `y`, and the
+    # POINTER was the one way in that did nothing at all: the controller's drag and
+    # double-click arms both bailed unless the focused pane was the template, and its click arm
+    # had no `:detail` branch, so a click focused the card and left the caret where it was.
+    # Compare the History drill-in, which has had all four (chips, caret, drag, word) since it
+    # grew a read cursor. The inverse is `DecoderView#output_click_to_cursor`'s: `ReadCursor`
+    # owns the mapping, the pane supplies the scroll anchor, the gutter and the h-scroll.
+
+    # The card `render_bottom` hands `render_detail`, so every gesture inverts against exactly
+    # the rect that was drawn. nil unless the detail is what is actually on screen there.
+    private def detail_card_rect(rect : Rect) : Rect?
+      return nil unless @focus == :detail
+      _, _, bottom = stack_rects(rect)
+      bottom.h > 0 ? bottom : nil
+    end
+
+    # The detail card's interior + its gutter width, or nil when there is nothing to hit-test.
+    private def detail_hit_geometry(rect : Rect) : {Rect, Array(String), Int32}?
+      return nil unless detail_navigable?
+      card = detail_card_rect(rect)
+      return nil unless card
+      lines = detail_plain_lines
+      return nil if lines.empty?
+      inner = card.inset(1, 1)
+      return nil if inner.empty?
+      {inner, lines, {Gutter.width(lines.size), inner.w}.min}
+    end
+
+    def detail_click_to_cursor(rect : Rect, mx : Int32, my : Int32, selecting : Bool = false) : Nil
+      inner, lines, gw = detail_hit_geometry(rect) || return
+      @detail_cursor.click_to_cursor(inner, mx, my, @detail_scroll, lines, gw, @detail_xscroll, selecting)
+      ensure_detail_visible(inner.h)
+    end
+
+    def detail_select_word(rect : Rect, mx : Int32, my : Int32) : Bool
+      hit = detail_hit_geometry(rect)
+      return false unless hit
+      inner, lines, gw = hit
+      took = @detail_cursor.select_word_at(inner, mx, my, @detail_scroll, lines, gw, @detail_xscroll)
+      ensure_detail_visible(inner.h)
+      took
+    end
+
+    # The pane chip under (mx, my) on the detail card's TOP BORDER, or nil. Inverts
+    # `render_detail_chips` — same start column, same `" label "` padding, same +1 gap, same
+    # right-edge break — so the strip the card draws is the strip a click can reach. The
+    # History detail's chips have been clickable via `detail_pane_at`; these were drawn only.
+    def detail_chip_at(rect : Rect, mx : Int32, my : Int32) : Symbol?
+      card = detail_card_rect(rect)
+      return nil unless card && my == card.y
+      x = card.x + 14
+      detail_panes.each do |pane|
+        label = " #{detail_pane_label(pane)} "
+        break if x + label.size >= card.right - 1
+        return pane if mx >= x && mx < x + label.size
+        x += label.size + 1
+      end
+      nil
+    end
+
+    # Show `pane` in the detail card (a chip click), no-op for a pane this result has no
+    # section for. Routes through `detail_step_pane`'s reset so the scroll, the h-scroll, the
+    # caret and both line caches are dropped together, exactly as ←/→ does. Named `show_` not
+    # `set_`: it is a navigation action with side effects, not a writer for `@detail_pane`.
+    #
+    # The already-showing case has to bail BEFORE that, because a zero delta is not a no-op in
+    # `detail_step_pane` — its range guard passes, it re-assigns the same pane and runs the whole
+    # reset. Clicking the chip you are already on would then silently throw away your scroll
+    # position and your selection, which is the opposite of what re-clicking a tab means.
+    def show_detail_pane(pane : Symbol) : Nil
+      return if pane == @detail_pane
+      panes = detail_panes
+      i = panes.index(pane)
+      return unless i
+      detail_step_pane(i - (panes.index(@detail_pane) || 0))
+    end
+
     # Horizontal companion to `detail_scroll` (shift+←/→). Floored at 0 here; the
     # render loop clamps the upper bound to the widest row actually on screen.
     def hscroll_detail(delta : Int32) : Nil
@@ -1701,8 +1779,15 @@ module Gori::Tui
       template_read_move(dir * @editor.page_rows, 0, selecting: selecting)
     end
 
+    # `chain_pane_active?` still bails — the ^Y chain sub-pane owns the wheel while it is up,
+    # so scrolling the template underneath it would move a pane the operator is not in.
+    # `template_insert?` does NOT, and that was the defect: the guard read the MODE, not the
+    # pane, so the wheel died the moment `i` was pressed. Same reasoning as
+    # `RepeaterController#handle_wheel`'s dropped `unless v.request_insert?` — INS is the same
+    # pane showing the same bytes, and `scroll_view` pulls the caret into the new window so the
+    # next keystroke lands where the operator is looking.
     def template_scroll_view(step : Int32) : Nil
-      return if template_insert? || chain_pane_active?
+      return if chain_pane_active?
       @editor.scroll_view(step)
     end
 
@@ -1862,17 +1947,31 @@ module Gori::Tui
         TrafficEmptyState.render(screen, rect, variant: :fuzzer, title: "no request loaded")
         return
       end
-      target_h = {rect.h, target_card_h}.min
-      render_target(screen, Rect.new(rect.x, rect.y, rect.w, target_h), focused && @focus == :target)
-      rest = Rect.new(rect.x, rect.y + target_h, rect.w, {rect.h - target_h, 0}.max)
-      return if rest.h <= 0
-      top_h = {rest.h * 45 // 100, 5}.max
-      top_h = rest.h if rest.h < 6
-      top = Rect.new(rest.x, rest.y, rest.w, top_h)
-      bottom = Rect.new(rest.x, rest.y + top_h, rest.w, {rest.h - top_h, 0}.max)
+      target, top, bottom = stack_rects(rect)
+      render_target(screen, target, focused && @focus == :target)
+      return if top.h <= 0
       render_top(screen, top, focused)
       render_bottom(screen, bottom, focused) if bottom.h > 0
       render_chain_overlay(screen, rect) if @chain_focused # centered ^Y modal ON TOP (replaces the old split)
+    end
+
+    # The body's three horizontal bands — TARGET, the template/config row, and the
+    # results-or-detail row — in one place because `render`, `pane_at` and the detail
+    # hit-tests all need them and each used to re-derive `target_h` / `top_h` by hand. A
+    # `top.h` of 0 means the body is too short for anything under TARGET (render bails, the
+    # hit-tests answer nil), which is the `rest.h <= 0` guard those copies carried.
+    private def stack_rects(rect : Rect) : {Rect, Rect, Rect}
+      target_h = {rect.h, target_card_h}.min
+      target = Rect.new(rect.x, rect.y, rect.w, target_h)
+      rest_h = {rect.h - target_h, 0}.max
+      empty = Rect.new(rect.x, rect.y + target_h, rect.w, 0)
+      return {target, empty, empty} if rest_h <= 0
+      rest_y = rect.y + target_h
+      top_h = {rest_h * 45 // 100, 5}.max
+      top_h = rest_h if rest_h < 6
+      {target,
+       Rect.new(rect.x, rest_y, rect.w, top_h),
+       Rect.new(rect.x, rest_y + top_h, rect.w, {rest_h - top_h, 0}.max)}
     end
 
     private def render_top(screen : Screen, rect : Rect, focused : Bool) : Nil
@@ -2974,20 +3073,17 @@ module Gori::Tui
 
     def pane_at(rect : Rect, mx : Int32, my : Int32) : Symbol?
       return nil unless @loaded && rect.contains?(mx, my)
-      target_h = {rect.h, target_card_h}.min
-      return :target if my < rect.y + target_h
-      rest = Rect.new(rect.x, rect.y + target_h, rect.w, {rect.h - target_h, 0}.max)
-      return nil if rest.h <= 0
-      top_h = {rest.h * 45 // 100, 5}.max
-      top_h = rest.h if rest.h < 6
-      if my < rest.y + top_h
-        half = {(rest.w - 1) // 2, 1}.max
-        mx < rest.x + half ? :template : :config
+      target, top, bottom = stack_rects(rect)
+      return :target if target.contains?(mx, my)
+      return nil if top.h <= 0
+      if my < top.bottom
+        half = {(top.w - 1) // 2, 1}.max
+        mx < top.x + half ? :template : :config
       elsif @focus == :detail
         :detail
       else
-        vw = @show_dist ? dist_width(rest.w) : 0
-        vw > 0 && mx >= rest.x + rest.w - vw ? nil : :results # read-only DIST sidebar → no-op
+        vw = @show_dist ? dist_width(bottom.w) : 0
+        vw > 0 && mx >= bottom.x + bottom.w - vw ? nil : :results # read-only DIST sidebar → no-op
       end
     end
   end

--- a/src/gori/tui/highlight.cr
+++ b/src/gori/tui/highlight.cr
@@ -663,6 +663,16 @@ module Gori::Tui
       line.sum { |span| Screen.draw_width(span.text) }
     end
 
+    # The styled line's own characters, colour dropped. The bridge for a pane whose ONLY source
+    # is styled — the windowed message views (`Windowed#line_at` returns a `Line`) — into
+    # anything that addresses text: `ReadPane`'s caret and selection, a copy, a search. Spans
+    # partition the line in order and carry no inserted padding, so this is the exact string the
+    # draw put on screen.
+    def self.plain(line : Line) : String
+      return line[0].text if line.size == 1
+      String.build { |io| line.each { |span| io << span.text } }
+    end
+
     # As `line_width`, but stops summing once the running width reaches `limit` — and
     # caps WITHIN a span too (a huge minified body is one plain span > MAX_HL_LINE), so
     # the per-frame h-scroll clamp never fully measures a multi-MB line. See

--- a/src/gori/tui/intercept_view.cr
+++ b/src/gori/tui/intercept_view.cr
@@ -5,6 +5,7 @@ require "./traffic_empty_state"
 require "../settings"
 require "./highlight"
 require "./text_area"
+require "./read_pane"
 require "./url"
 require "../interceptor"
 require "../store"
@@ -83,9 +84,12 @@ module Gori::Tui
       @detail_win_id = nil.as(Int64?)
       @detail_win_rev = Theme.revision # the theme the cached (colour-baked) head was built under
       @detail_win_edit_rev = -1        # @editor.edits the preview was built at (-1 = built from the pristine held bytes)
-      @detail_xscroll = 0              # horizontal scroll offset for the read-only held-item preview
-      @detail_scroll = 0               # vertical scroll offset (lines) for the read-only preview
-      @reload_rev = -1                 # Interceptor#revision the queue snapshot was last taken at (-1 ⇒ never)
+      # The read-only held-item preview: caret, selection, both scroll axes and its draw. Sourced
+      # from the item's `Highlight::Windowed` LAZILY — a held body runs to megabytes and this is
+      # the pane that must not materialise it. `Highlight.plain` is the bridge from the styled
+      # window to the text the caret and a copy address; the window itself paints.
+      @preview = ReadPane.new
+      @reload_rev = -1 # Interceptor#revision the queue snapshot was last taken at (-1 ⇒ never)
       # Multi-select marks (#442's model, ported to the hold queue), keyed by ITEM ID rather
       # than row index: a forward/drop of an earlier entry shifts every index below it, so an
       # index-keyed set would silently retarget on the next revision tick. Unlike History there
@@ -784,12 +788,6 @@ module Gori::Tui
       @editing = false
     end
 
-    # Click the detail pane → focus the editor, but only when an item is loaded
-    # (mirrors toggle_edit's guard; loads the selected item's bytes if needed).
-    def focus_detail : Nil
-      toggle_edit unless @editing || selected_item.nil?
-    end
-
     # Mouse: place the held-message editor cursor at a click. `rect` is the body rect
     # render() receives; re-derive the right (detail) pane + its 1-cell inset exactly
     # as render_detail does. Only meaningful while editing (the editor is shown then).
@@ -1029,22 +1027,8 @@ module Gori::Tui
       if @editing && @loaded_id == it.id
         @editor.render(screen, inner, cursor: focused, highlight: mode, gauge: true, gauge_focused: focused)
       else
-        win = detail_window_for(it)
-        total = win.total
-        # Clamp the vertical offset so a body longer than the pane is scrollable but can
-        # never blank it (content may be shorter than a stale offset). Cap at total-inner.h
-        # so the LAST screenful stays visible at max scroll (not just one trailing line).
-        # Upper-bound clamp lives here (mirrors @detail_xscroll below).
-        @detail_scroll = @detail_scroll.clamp(0, {total - inner.h, 0}.max)
-        # Styles each visible line ONCE (into `rows`), then clamps/slices from that —
-        # mirrors RepeaterView#render_response_body / HistoryView#render_detail.
-        rows = (0...inner.h).compact_map { |i| (li = @detail_scroll + i) < total ? win.line_at(li) : nil }
-        @detail_xscroll = @detail_xscroll.clamp(0, {(rows.max_of? { |l| Highlight.line_width_upto(l, @detail_xscroll + inner.w + 1) } || 0) - inner.w, 0}.max)
-        rows.each_with_index do |styled, i|
-          shown = @detail_xscroll > 0 ? Highlight.slice_left(styled, @detail_xscroll) : styled
-          Highlight.draw(screen, inner.x, inner.y + i, shown, width: inner.w)
-        end
-        Frame.scroll_gauge(screen, inner, total, @detail_scroll, focused)
+        sync_preview(it)
+        @preview.render(screen, inner, focused, styled_at: preview_styled_at(it))
       end
     end
 
@@ -1074,11 +1058,24 @@ module Gori::Tui
       screen.text(x, rect.y, label, Theme.muted)
     end
 
+    # The item's styled window, and the plain projection of it the caret/selection/copy use.
+    # Both lazy: `line_at` is only ever called for a row that is drawn, or for the one row a
+    # caret sits on.
+    private def preview_styled_at(it : Interceptor::Item) : Int32 -> Highlight::Line
+      win = detail_window_for(it)
+      ->(i : Int32) { win.line_at(i) }
+    end
+
+    private def sync_preview(it : Interceptor::Item) : Nil
+      win = detail_window_for(it)
+      @preview.source(win.total, ->(i : Int32) { Highlight.plain(win.line_at(i)) })
+    end
+
     # Nudge the read-only held-item preview sideways (shift+←/→). No-op while
     # editing — the TextArea editor's own follow_x already handles that case.
     def hscroll_detail(delta : Int32) : Nil
       return if @editing
-      @detail_xscroll = {@detail_xscroll + delta * 4, 0}.max
+      @preview.hscroll(delta)
     end
 
     # Vertical companion to hscroll_detail (shift+↑/↓): scroll the read-only preview so a
@@ -1086,7 +1083,94 @@ module Gori::Tui
     # risks mutating byte-exact held bytes). Floored at 0 here; render clamps the upper bound.
     def vscroll_detail(delta : Int32) : Nil
       return if @editing
-      @detail_scroll = {@detail_scroll + delta, 0}.max
+      with_preview { @preview.scroll_view(delta) }
+    end
+
+    # Run `blk` with the preview pointed at the selected item — every gesture and every verb
+    # goes through it, so none of them can act on a pane sourced from a different held message.
+    private def with_preview(&) : Nil
+      return if @editing
+      it = selected_item || return
+      sync_preview(it)
+      yield
+    end
+
+    # ↑/↓ and ⇧↑/↓ over the preview: the caret moves, ⇧ grows the selection. The pane had a
+    # scroll gauge and no caret at all — readable, and not selectable or copyable by any route.
+    def preview_move(dr : Int32, dc : Int32, selecting : Bool = false) : Nil
+      with_preview { @preview.move(dr, dc, selecting: selecting) }
+    end
+
+    def preview_motion_key(ev : Termisu::Event::Key) : Bool
+      return false if @editing
+      it = selected_item || return false
+      sync_preview(it)
+      @preview.motion_key(ev)
+    end
+
+    def preview_select_line : Nil
+      with_preview { @preview.select_line }
+    end
+
+    def preview_clear_selection : Nil
+      @preview.clear_selection
+    end
+
+    def preview_selection? : Bool
+      !@editing && @preview.selection?
+    end
+
+    def preview_copy_text : String
+      return "" if @editing
+      it = selected_item || return ""
+      sync_preview(it)
+      @preview.copy_text
+    end
+
+    def preview_copy_all : String
+      return "" if @editing
+      it = selected_item || return ""
+      sync_preview(it)
+      @preview.copy_all
+    end
+
+    # Mouse into the read-only preview. `rect` is the body rect render() receives; re-derive the
+    # right pane's interior exactly as render_detail does.
+    def preview_click(rect : Rect, mx : Int32, my : Int32, selecting : Bool = false) : Nil
+      return if @editing
+      _, right = split_panes(body_rect(rect))
+      inner = right.inset(1, 1)
+      return if inner.empty?
+      with_preview { @preview.click(inner, mx, my, selecting) }
+    end
+
+    def preview_select_word(rect : Rect, mx : Int32, my : Int32) : Bool
+      return false if @editing
+      _, right = split_panes(body_rect(rect))
+      inner = right.inset(1, 1)
+      return false if inner.empty?
+      it = selected_item || return false
+      sync_preview(it)
+      @preview.select_word(inner, mx, my)
+    end
+
+    # A wheel notch over the DETAIL pane, whichever of its two faces is up: the TextArea while
+    # editing, the read-only window while previewing. One entry point because the pointer does
+    # not know which is drawn there, and because `move` — what the wheel used to reach from
+    # anywhere in this tab — must NOT run for this pane: it walks the queue, which reloads a
+    # different held message under a preview that draws its own scroll gauge.
+    #
+    # Editing scrolls like previewing (`TextArea#scroll_view` pulls the caret into the new
+    # window), for the reason `DecoderController#handle_wheel` spells out: the wheel is a
+    # reading gesture, and `e` is not a request to stop reading. `vscroll_detail` keeps its own
+    # `@editing` bail, so the two faces cannot both move on one notch.
+    def scroll_detail_pane(delta : Int32) : Nil
+      @editing ? @editor.scroll_view(delta) : vscroll_detail(delta)
+    end
+
+    # At the top of the read-only preview — ↑ there pops focus back to the queue.
+    def preview_at_top? : Bool
+      @preview.at_top?
     end
 
     # Windowed view of the held item's raw bytes, cached by item id (held bytes
@@ -1102,10 +1186,7 @@ module Gori::Tui
       edit_rev = edited ? @editor.edits : -1
       cached = @detail_win
       return cached if cached && @detail_win_id == it.id && @detail_win_rev == Theme.revision && @detail_win_edit_rev == edit_rev
-      if @detail_win_id != it.id # a newly-previewed item resets both scroll axes
-        @detail_xscroll = 0
-        @detail_scroll = 0
-      end
+      @preview.reset if @detail_win_id != it.id # a newly-previewed item renumbers every row
       @detail_win_id = it.id
       @detail_win_rev = Theme.revision
       @detail_win_edit_rev = edit_rev

--- a/src/gori/tui/issue_form.cr
+++ b/src/gori/tui/issue_form.cr
@@ -16,6 +16,17 @@ module Gori::Tui
   # pending link with it: a cancelled create-and-link can no longer leave a stale ref
   # behind for a later standalone create to silently attach.
   class IssueForm < Overlay
+    # Card geometry + the two labels the draw lays down, in one place because `render` and the
+    # click hit-tests below both measure off them. A second copy of `"severity ‹ "` next to the
+    # inverse is this repo's standing hazard: the moment the two drift, the click lands on a
+    # cell the card never drew there.
+    TITLE_PREFIX = "title › "
+    SEV_PREFIX   = "severity ‹ "
+    SEV_SUFFIX   = " ›  (tab to change)"
+    TITLE_ROW    = 1
+    SEV_ROW      = 3
+    CARD_H       = 6
+
     getter issue_title : String
     getter host : String?
     getter flow_id : Int64?
@@ -76,10 +87,28 @@ module Gori::Tui
       :stay
     end
 
-    # Inert on purpose: the pre-seam shell had no click arm for this modal, so neither a
-    # click-away nor a click on the card did anything. Caret placement by click is the
-    # follow-up that will give this a real body.
+    # This was inert on purpose, carrying the pre-seam shell's lack of a click arm forward and
+    # naming caret placement as the follow-up. It is the follow-up. Inert made this the ONE
+    # modal in the tree a click-away could not dismiss — the base `Overlay#handle_click` gives
+    # every other one that, and `PickerOverlay` repeats it for the seven pickers — so an
+    # operator who opened NEW ISSUE by mistake had to find esc, with no visible hint that a
+    # click outside would not do.
+    #
+    # Inside the card, the two rows the draw makes look interactive now are:
+    #   · the title row → place the caret at the pointer (the same inverse `TextField` uses)
+    #   · the DRAWN span of the severity row → step the cycler, `‹` back and the rest forward,
+    #     which is what the chevrons and the row's own "(tab to change)" already promise
+    # Anything else inside — including the empty tail of the severity row past its label — is
+    # swallowed, so it neither leaks to the pane underneath nor makes dead cells do something.
     def handle_click(area : Rect, mx : Int32, my : Int32) : Symbol
+      box = overlay_box(area)
+      return :cancel if box.nil? || !box.contains?(mx, my)
+      if my == box.y + TITLE_ROW
+        @cx = Screen.column_for(@issue_title, mx - title_base(box)) # already clamped to the string
+        @preedit = ""                                               # a caret move ends any in-progress composition, as `insert` does
+      elsif my == box.y + SEV_ROW && (lo = sev_back_x(box)) && mx >= lo && mx <= sev_forward_end(box)
+        severity_cycle(mx == lo ? -1 : 1)
+      end
       :stay
     end
 
@@ -116,21 +145,47 @@ module Gori::Tui
       @preedit = text
     end
 
-    def render(screen : Screen, area : Rect) : Nil
+    # The card `render` draws — extracted from it so the click-away hit test and the draw are
+    # one geometry. `nil` = no room, which is also the `Overlay#overlay_box` contract for
+    # "treat any click as a dismiss".
+    def overlay_box(area : Rect) : Rect?
       w = {area.w - 4, 56}.min
-      h = 6
-      return if w < 12 || area.h < h
-      x = area.x + (area.w - w) // 2
-      y = area.y + (area.h - h) // 2
-      box = Rect.new(x, y, w, h)
+      return nil if w < 12 || area.h < CARD_H
+      Rect.new(area.x + (area.w - w) // 2, area.y + (area.h - CARD_H) // 2, w, CARD_H)
+    end
+
+    def render(screen : Screen, area : Rect) : Nil
+      box = overlay_box(area)
+      return unless box
+      w = box.w
       Frame.card(screen, box, @heading, border: Theme.border_focus)
-      prefix = "title › "
-      screen.text(box.x + 2, box.y + 1, prefix, Theme.accent, Theme.panel)
-      base = box.x + 2 + prefix.size
-      screen.input_line(base, box.y + 1, @issue_title, @cx, @preedit, Theme.text_bright, Theme.panel, width: w - prefix.size - 4)
-      sx = screen.text(box.x + 2, box.y + 3, "severity ‹ ", Theme.accent, Theme.panel)
-      sx = screen.text(sx, box.y + 3, @severity.label.upcase, sev_color(@severity), Theme.panel, Attribute::Bold)
-      screen.text(sx, box.y + 3, " ›  (tab to change)", Theme.muted, Theme.panel)
+      screen.text(box.x + 2, box.y + TITLE_ROW, TITLE_PREFIX, Theme.accent, Theme.panel)
+      screen.input_line(title_base(box), box.y + TITLE_ROW, @issue_title, @cx, @preedit,
+        Theme.text_bright, Theme.panel, width: w - TITLE_PREFIX.size - 4)
+      sx = screen.text(box.x + 2, box.y + SEV_ROW, SEV_PREFIX, Theme.accent, Theme.panel)
+      sx = screen.text(sx, box.y + SEV_ROW, @severity.label.upcase, sev_color(@severity), Theme.panel, Attribute::Bold)
+      screen.text(sx, box.y + SEV_ROW, SEV_SUFFIX, Theme.muted, Theme.panel)
+    end
+
+    # Content column the title text starts at — `screen.text`'s own advance over the prefix,
+    # so the caret inverse uses the same measure the draw did.
+    private def title_base(box : Rect) : Int32
+      box.x + 2 + Screen.draw_width(TITLE_PREFIX)
+    end
+
+    # The `‹` cell on the severity row, measured off SEV_PREFIX itself rather than re-typed —
+    # the only cell that steps BACKWARD, everything from there to `sev_forward_end` reads as the
+    # forward step the label's own "(tab to change)" names.
+    private def sev_back_x(box : Rect) : Int32
+      i = SEV_PREFIX.index('‹') || 0
+      box.x + 2 + Screen.draw_width(SEV_PREFIX[0, i])
+    end
+
+    # Last cell of the interactive span: the closing `›`, one column past the label, which is
+    # where `render`'s third `screen.text` puts it (SEV_SUFFIX opens with a space). The cells
+    # after it hold the "(tab to change)" hint and then nothing — a click there must be inert.
+    private def sev_forward_end(box : Rect) : Int32
+      box.x + 2 + Screen.draw_width(SEV_PREFIX) + Screen.draw_width(@severity.label.upcase) + 1
     end
 
     private def sev_color(s : Store::Severity) : Color

--- a/src/gori/tui/miner_view.cr
+++ b/src/gori/tui/miner_view.cr
@@ -2,6 +2,7 @@ require "json"
 require "./screen"
 require "./theme"
 require "./frame"
+require "./read_pane"
 require "../host_overrides"
 require "../store"
 require "../miner"
@@ -50,7 +51,11 @@ module Gori::Tui
       @focus = :summary
       @sel = 0
       @scroll = 0
-      @detail_scroll = 0
+      # The FINDING pane's row cursor, selection, scroll and draw-state. `line_select_only`: a row
+      # is a label and a value in two columns, so selection is whole rows and the copy payload is
+      # `"label  value"` (see `detail_plain`). The pane paints its own two columns, so
+      # `ReadPane#render` is never called — `viewport_top` and `row_marked?` are.
+      @finding = ReadPane.new(line_select_only: true)
       @job_id = 0
     end
 
@@ -237,12 +242,62 @@ module Gori::Tui
 
     def open_detail : Nil
       return if @results.empty?
-      @detail_scroll = 0
+      @finding.reset
       @focus = :detail
     end
 
+    # ↑/↓ (⇧ to select) walk the FINDING's fields; the wheel scrolls the viewport.
     def detail_scroll(d : Int32) : Nil
-      @detail_scroll = {@detail_scroll + d, 0}.max
+      with_finding { @finding.move(d, 0) }
+    end
+
+    def detail_move(d : Int32, selecting : Bool) : Nil
+      with_finding { @finding.move(d, 0, selecting: selecting) }
+    end
+
+    def detail_wheel(d : Int32) : Nil
+      with_finding { @finding.scroll_view(d) }
+    end
+
+    def detail_motion_key(ev : Termisu::Event::Key) : Bool
+      return false if selected_finding.nil?
+      sync_finding
+      @finding.motion_key(ev)
+    end
+
+    def detail_select_line : Nil
+      with_finding { @finding.select_line }
+    end
+
+    def detail_clear_selection : Nil
+      @finding.clear_selection
+    end
+
+    def detail_selection? : Bool
+      @finding.selection?
+    end
+
+    def detail_copy_text : String
+      return "" if selected_finding.nil?
+      sync_finding
+      @finding.copy_text
+    end
+
+    def detail_copy_all : String
+      return "" if selected_finding.nil?
+      sync_finding
+      @finding.copy_all
+    end
+
+    # The FINDING card's interior — the rect `render_detail` draws into.
+    def detail_body(rect : Rect) : Rect
+      rect.inset(2, 1)
+    end
+
+    def detail_click(rect : Rect, mx : Int32, my : Int32, selecting : Bool = false) : Nil
+      body = detail_body(rect)
+      return if body.empty?
+      with_finding { @finding.click(body, mx, my, selecting) }
     end
 
     def close_detail : Nil
@@ -552,12 +607,42 @@ module Gori::Tui
         return
       end
       lines = detail_lines(f)
-      lines.each_with_index do |(lbl, val, color), i|
-        y = inner.y + i - @detail_scroll
-        next unless inner.y <= y < inner.bottom
-        screen.text(inner.x, y, lbl, Theme.muted, Theme.bg)
-        screen.text(inner.x + 12, y, val, color, Theme.bg, width: inner.w - 12)
+      sync_finding
+      top = @finding.viewport_top(inner.h)
+      inner.h.times do |i|
+        li = top + i
+        break if li >= lines.size
+        lbl, val, color = lines[li]
+        y = inner.y + i
+        bg = focused && @finding.row_marked?(li) ? Theme.accent_bg : Theme.bg
+        screen.fill(Rect.new(inner.x, y, inner.w, 1), bg) if bg != Theme.bg
+        screen.text(inner.x, y, lbl, Theme.muted, bg)
+        screen.text(inner.x + 12, y, val, color, bg, width: inner.w - 12)
       end
+      Frame.scroll_gauge(screen, inner, lines.size, top, focused)
+    end
+
+    # ONE field row projected to ONE line of text — the copy payload, 1:1 with the screen rows.
+    private def detail_plain(row : {String, String, Color}) : String
+      "#{row[0]}  #{row[1]}"
+    end
+
+    # Point the row cursor at the selected finding's fields. Idempotent, so every gesture and
+    # every verb can call it and none can act on a pane sourced from another finding.
+    private def sync_finding : Nil
+      f = selected_finding
+      unless f
+        @finding.source(0, ->(_i : Int32) { "" })
+        return
+      end
+      ls = detail_lines(f)
+      @finding.source(ls.size, ->(i : Int32) { detail_plain(ls[i]) })
+    end
+
+    private def with_finding(&) : Nil
+      return if selected_finding.nil?
+      sync_finding
+      yield
     end
 
     private def detail_lines(f : Miner::Finding) : Array({String, String, Color})

--- a/src/gori/tui/probe_view.cr
+++ b/src/gori/tui/probe_view.cr
@@ -1,6 +1,7 @@
 require "./screen"
 require "./theme"
 require "./frame"
+require "./read_pane"
 require "./traffic_empty_state"
 require "../settings"
 require "../store"
@@ -30,7 +31,10 @@ module Gori::Tui
       @scroll = 0
       @detail = nil.as(Store::ProbeIssue?)
       @detail_flow = nil.as(Store::FlowRow?)
-      @detail_scroll = 0
+      # The AFFECTED URLS list in the detail: caret, selection, scroll and draw. The list is the
+      # finding's evidence and had no caret and no copy — the one thing an operator wants out of a
+      # scan issue is the URLs it fired on.
+      @affected = ReadPane.new
       @query = ""
       @qcx = 0
       @preedit_q = ""
@@ -289,17 +293,82 @@ module Gori::Tui
       return false unless issue
       @detail = issue
       @detail_flow = issue.sample_flow_id.try { |fid| store.flow_row(fid) }
-      @detail_scroll = 0
+      @affected.reset
       true
     end
 
     def close_detail : Nil
       @detail = nil
-      @detail_scroll = 0
+      @affected.reset
     end
 
+    # ↑/↓ (⇧ to select) walk the AFFECTED URLS; the wheel scrolls the viewport and leaves the
+    # caret put, the split every read pane in the tree makes.
     def scroll_detail(delta : Int32) : Nil
-      @detail_scroll = {@detail_scroll + delta, 0}.max
+      with_affected { @affected.move(delta, 0) }
+    end
+
+    def detail_move(delta : Int32, selecting : Bool) : Nil
+      with_affected { @affected.move(delta, 0, selecting: selecting) }
+    end
+
+    def detail_wheel(delta : Int32) : Nil
+      with_affected { @affected.scroll_view(delta) }
+    end
+
+    def detail_motion_key(ev : Termisu::Event::Key) : Bool
+      issue = @detail || return false
+      sync_affected(issue)
+      @affected.motion_key(ev)
+    end
+
+    def detail_at_top? : Bool
+      @affected.at_top?
+    end
+
+    def detail_select_line : Nil
+      with_affected { @affected.select_line }
+    end
+
+    def detail_clear_selection : Nil
+      @affected.clear_selection
+    end
+
+    def detail_selection? : Bool
+      !@detail.nil? && @affected.selection?
+    end
+
+    def detail_copy_text : String
+      issue = @detail || return ""
+      sync_affected(issue)
+      @affected.copy_text
+    end
+
+    def detail_copy_all : String
+      issue = @detail || return ""
+      sync_affected(issue)
+      @affected.copy_all
+    end
+
+    # The AFFECTED list's rect inside the detail card — the derivation `render_detail` walks, so
+    # the click and the draw address the same rows. nil when the card is too short for any.
+    def affected_rect(rect : Rect) : Rect?
+      list_y = rect.y + 7 # header row + 3 meta rows + divider + section head (see render_detail)
+      h = {rect.bottom - list_y, 0}.max
+      h > 0 ? Rect.new(rect.x + 1, list_y, {rect.w - 2, 0}.max, h) : nil
+    end
+
+    def detail_click(rect : Rect, mx : Int32, my : Int32, selecting : Bool = false) : Nil
+      box = affected_rect(rect) || return
+      with_affected { @affected.click(box, mx, my, selecting) }
+    end
+
+    def detail_select_word(rect : Rect, mx : Int32, my : Int32) : Bool
+      box = affected_rect(rect)
+      return false unless box
+      issue = @detail || return false
+      sync_affected(issue)
+      @affected.select_word(box, mx, my)
     end
 
     # `c`: one-key dismiss for the targeted issue. open → false-positive (mute), anything
@@ -606,12 +675,21 @@ module Gori::Tui
       screen.text(rect.x + 1, y + 1, head, Theme.accent, attr: Attribute::Bold)
       list_y = y + 2
       avail = {rect.bottom - list_y, 0}.max
-      @detail_scroll = @detail_scroll.clamp(0, {issue.affected.size - avail, 0}.max)
-      (0...avail).each do |i|
-        idx = @detail_scroll + i
-        break if idx >= issue.affected.size
-        screen.text(rect.x + 1, list_y + i, issue.affected[idx], Theme.text, width: w)
-      end
+      return if avail <= 0
+      sync_affected(issue)
+      @affected.render(screen, Rect.new(rect.x + 1, list_y, w, avail), focused)
+    end
+
+    # Point the AFFECTED pane at the open issue's URL list. Cheap and idempotent, so every
+    # gesture and every verb can call it and none can act on a pane sourced from another issue.
+    private def sync_affected(issue : Store::ProbeIssue) : Nil
+      @affected.source(issue.affected)
+    end
+
+    private def with_affected(&) : Nil
+      issue = @detail || return
+      sync_affected(issue)
+      yield
     end
 
     private def chip(screen : Screen, x : Int32, y : Int32, label : String, color : Color) : Int32

--- a/src/gori/tui/read_pane.cr
+++ b/src/gori/tui/read_pane.cr
@@ -1,0 +1,332 @@
+require "./screen"
+require "./theme"
+require "./frame"
+require "./gutter"
+require "./highlight"
+require "./read_cursor"
+require "./geometry"
+
+module Gori::Tui
+  # A scrollable READ-ONLY text pane: the state (`ReadCursor` + vertical scroll + horizontal
+  # scroll + last drawn height), the draw (gutter, h-slice, selection band, block caret, scroll
+  # gauge) and every gesture (arrows, ⇧arrows, Home/End/PgUp/PgDn, wheel, click, drag,
+  # double-click, select-line, copy) in one place.
+  #
+  # WHY THIS EXISTS. Three panes had already grown their own copy of exactly this — the Decoder
+  # OUTPUT, the Fuzzer RESULT detail and the History detail — each ~90 lines of the same
+  # arithmetic, and the drift between them was a real bug: `DecoderView#output_scroll_view`
+  # clamped `cx` against the line the caret was LEAVING while `FuzzerView#detail_scroll_view`,
+  # the same method over the same widget, clamped it against the line it lands on (and carried a
+  # comment about the `IndexError` that costs). Six MORE panes are scrollable and readable today
+  # with nothing selectable — Comparer, Miner detail, Sequencer analysis/detail, Probe detail,
+  # OAST callback detail, the Intercept read-only preview, Rewriter preview-out — so the choice
+  # was one home or nine.
+  #
+  # THE SOURCE IS `(size, line_at)`, NEVER AN ARRAY. `ReadCursor` carries both shapes and says
+  # why: the lazy provider is what keeps caret moves, wheel notches and selection painting from
+  # materialising every off-screen line of a multi-MiB body. The Intercept preview reads through
+  # a `Highlight::Windowed`; a pane holding `Array(String)` would have to build one.
+  #
+  # The PLAIN text is what the caret addresses, the selection spans and a copy produces.
+  # `styled_at` is an OPTIONAL second provider for the draw only — the Fuzzer detail's coloured
+  # overlay, the Intercept preview's syntax highlighting — because the two must be allowed to
+  # disagree about colour while agreeing exactly about columns. Where a pane has only styled
+  # lines (the windowed message views), `Highlight.plain` is the bridge.
+  #
+  # `styled_at` must be COLOUR ONLY: its span texts have to concatenate back to the same line
+  # `line_at` returns, which is `Highlight`'s own cardinal rule (see its header). The component
+  # leans on it — the block caret paints `plain[cx]`, and that is the glyph the reader sees
+  # precisely because the two agree. A provider that changed the characters would put a different
+  # letter in the caret cell than in the row around it.
+  class ReadPane
+    getter cursor : ReadCursor
+    # First visible line, clamped by `render` against the height it actually drew.
+    getter scroll : Int32 = 0
+    # Horizontal offset in display columns (⇧←/→). Clamped by `render` to the widest row on
+    # screen, so a pane whose long line scrolls off can always be scrolled back.
+    getter xscroll : Int32 = 0
+    # Interior height of the last `render`. `0` before the first frame — every gesture that
+    # needs a viewport (page, wheel) is inert until then, which is what the panes did already.
+    getter last_h : Int32 = 0
+
+    @size = 0
+    @line_at : (Int32 -> String) = ->(_i : Int32) { "" }
+
+    # `gutter` draws 1-based line numbers (`Gutter`), like the Decoder OUTPUT and the Repeater
+    # panes; a pane whose rows are not source lines (the Comparer's diff rows, a field list)
+    # leaves it off.
+    #
+    # `line_select_only` drops the horizontal half of the selection: ←/→ still move the caret,
+    # but a selection is always whole lines and a double-click takes nothing. For a pane whose
+    # screen row is not one run of text — the Comparer draws TWO columns per row — a char
+    # rectangle would address cells that are not next to each other on screen.
+    def initialize(*, @gutter : Bool = false, @line_select_only : Bool = false)
+      @cursor = ReadCursor.new
+    end
+
+    # Point the pane at its text. Call this when the CONTENT changes (a recompute, a new
+    # selection in the list above, a mode flip), not every frame: it is the one place the
+    # caret's bounds come from, and `reset_cursor` is how a pane says "this is different text".
+    def source(size : Int32, line_at : Int32 -> String) : Nil
+      @size = {size, 0}.max
+      @line_at = line_at
+    end
+
+    def source(lines : Array(String)) : Nil
+      source(lines.size, ->(i : Int32) { lines[i]? || "" })
+    end
+
+    def size : Int32
+      @size
+    end
+
+    def empty? : Bool
+      @size <= 0
+    end
+
+    def line(i : Int32) : String
+      i >= 0 && i < @size ? @line_at.call(i) : ""
+    end
+
+    # Drop the caret, the selection and both scroll offsets — the pane is showing different
+    # text now, so a line index from the old text means nothing in the new one.
+    def reset : Nil
+      @cursor.reset
+      @scroll = 0
+      @xscroll = 0
+    end
+
+    # --- keyboard -------------------------------------------------------------
+
+    def move(dr : Int32, dc : Int32, selecting : Bool = false) : Nil
+      return if empty?
+      if @line_select_only && dr != 0 && selecting
+        # Whole-line growth: `ReadCursor#move`'s selecting branch already parks the caret at
+        # EOL on a vertical step, which IS the line selection this mode wants.
+        @cursor.move(dr, 0, @size, @line_at, selecting: true)
+      else
+        @cursor.move(dr, dc, @size, @line_at, selecting: selecting && !@line_select_only)
+      end
+      ensure_visible
+    end
+
+    # Home / End / PageUp / PageDown, with ⇧ extending. Returns false when `ev` is none of
+    # them, so a caller can fall through to its own keymap.
+    def motion_key(ev : Termisu::Event::Key) : Bool
+      return false if empty?
+      key = ev.key
+      shift = ev.shift?
+      page = {@last_h - 2, 1}.max
+      case
+      when key.home?      then @cursor.move_to(@cursor.cy, 0, selecting: shift)
+      when key.end?       then @cursor.move_to(@cursor.cy, line(@cursor.cy.clamp(0, @size - 1)).size, selecting: shift)
+      when key.page_up?   then @cursor.move(-page, 0, @size, @line_at, selecting: shift)
+      when key.page_down? then @cursor.move(page, 0, @size, @line_at, selecting: shift)
+      else                     return false
+      end
+      ensure_visible
+      true
+    end
+
+    def select_line : Nil
+      return if empty?
+      @cursor.select_line(@size, @line_at)
+      ensure_visible
+    end
+
+    def clear_selection : Nil
+      @cursor.clear_selection
+    end
+
+    def selection? : Bool
+      @cursor.selection?
+    end
+
+    # The selection, or — with nothing selected — the caret's own line. The `y` payload every
+    # read pane in the tree offers.
+    def copy_text : String
+      return "" if empty?
+      @cursor.selection_text(@size, @line_at) || @cursor.current_line(@size, @line_at)
+    end
+
+    # Every line, for the "copy the whole pane" fallback. Materialises the text on purpose —
+    # it is going to the clipboard, which is one string either way.
+    def copy_all : String
+      return "" if empty?
+      String.build do |io|
+        (0...@size).each do |i|
+          io << '\n' if i > 0
+          io << @line_at.call(i)
+        end
+      end
+    end
+
+    # Viewport scroll (the wheel), independent of the caret: shift the window, then pull the
+    # caret into it so `render`'s `ensure_visible` cannot snap the view back. `cy` is clamped
+    # into the window BEFORE `cx` is measured, so the column is measured against the line the
+    # caret lands on — the `IndexError` `FuzzerView#detail_scroll_view` documents.
+    def scroll_view(step : Int32) : Nil
+      return if @last_h <= 0 || @size <= @last_h
+      @scroll = (@scroll + step).clamp(0, @size - @last_h)
+      lo = @scroll
+      hi = {@scroll + @last_h - 1, @size - 1}.min
+      cy = @cursor.cy.clamp(lo, hi)
+      @cursor.sync(cy, @cursor.cx.clamp(0, line(cy).size))
+    end
+
+    # ⇧←/→. Floored at 0 here; `render` clamps the upper bound to the widest row on screen.
+    def hscroll(step : Int32) : Nil
+      @xscroll = {@xscroll + step * 4, 0}.max
+    end
+
+    # At the top of the pane — the test a controller uses to decide whether ↑ should leave for
+    # the pane above rather than move the caret.
+    def at_top? : Bool
+      @scroll <= 0 && @cursor.cy <= 0
+    end
+
+    # --- mouse ----------------------------------------------------------------
+
+    # Place the caret at (mx, my) inside `rect` — the SAME rect `render` was given.
+    # `selecting` is the drag half: the anchor stays where the press left it.
+    def click(rect : Rect, mx : Int32, my : Int32, selecting : Bool = false) : Nil
+      return if empty? || rect.empty?
+      @cursor.click_to_cursor(rect, mx, my, @scroll, @size, @line_at, gutter_w(rect), @xscroll, selecting)
+      # A line-select pane has no meaningful column, so a drag there grows whole lines.
+      @cursor.select_line(@size, @line_at) if @line_select_only && selecting && @cursor.selection?
+      ensure_visible
+    end
+
+    # Double-click: take the word under the pointer. Always false in `line_select_only` mode —
+    # there is no single run of text under the pointer to take.
+    def select_word(rect : Rect, mx : Int32, my : Int32) : Bool
+      return false if empty? || rect.empty? || @line_select_only
+      took = @cursor.select_word_at(rect, mx, my, @scroll, @size, @line_at, gutter_w(rect), @xscroll)
+      ensure_visible
+      took
+    end
+
+    # --- render ---------------------------------------------------------------
+
+    # The state half of `render`, for a pane that draws its OWN rows and so never calls it: the
+    # Comparer paints two diff columns per row, and the Miner / Probe / Sequencer details paint
+    # label-and-value fields. They still need a viewport height (pages, the wheel and the
+    # selection-follow scroll are all measured in it) and they still need `scroll` clamped to the
+    # text — so they call this where `render` would have gone, then read `scroll` and `cursor` to
+    # place their own rows and their own band.
+    #
+    # Returns the first visible line, which is what such a painter loops from.
+    def viewport_top(h : Int32) : Int32
+      @last_h = h
+      @scroll = @scroll.clamp(0, {@size - h, 0}.max)
+      @scroll
+    end
+
+    # Whether `li` is inside the selection (or, with nothing selected, is the caret's row) — the
+    # row-band test for a self-drawing pane. Char columns are deliberately not exposed here: a
+    # pane that draws its own rows is one whose screen row is not a single run of the text.
+    def row_marked?(li : Int32) : Bool
+      if r = @cursor.selected_line_range
+        li >= r[0] && li <= r[1]
+      else
+        li == @cursor.cy
+      end
+    end
+
+    # Draw the pane into `rect` (the framed INTERIOR — pass what a `Frame.card` left inside).
+    # `styled_at` supplies a coloured overlay per line; without it the plain line is drawn in
+    # `fg`. The caret and the band are painted from the PLAIN line either way, so they land on
+    # the cells the draw advanced over.
+    def render(screen : Screen, rect : Rect, focused : Bool,
+               styled_at : (Int32 -> Highlight::Line)? = nil,
+               fg : Color = Theme.text, bg : Color = Theme.bg) : Nil
+      return if rect.empty?
+      viewport_top(rect.h)
+      gw = gutter_w(rect)
+      cw = {rect.w - gw, 0}.max
+      ensure_visible if focused
+
+      shown = (0...rect.h).compact_map { |i| (li = @scroll + i) < @size ? li : nil }
+      # draw_width_upto, not display_width: these rows go out through `screen.text` /
+      # `Highlight.draw`, which advance ≥1 cell per grapheme. A control byte scores 0 on the raw
+      # measure, which used to pin the clamp short and leave the tail of such a line
+      # unreachable. `_upto` keeps the per-frame early exit on a huge single line.
+      widest = shown.max_of? { |li| Screen.draw_width_upto(@line_at.call(li), @xscroll + cw + 1) } || 0
+      @xscroll = @xscroll.clamp(0, {widest - cw, 0}.max)
+
+      # Built ONCE per frame rather than per row: this used to sit inside the per-row chrome
+      # painter in two of the panes, i.e. rebuilt and thrown away `rect.h` times.
+      spans = focused && @cursor.selection? ? @cursor.highlight_spans(@size, @line_at) : nil
+      shown.each_with_index do |li, i|
+        y = rect.y + i
+        plain = @line_at.call(li)
+        Gutter.draw(screen, rect.x, y, li, gw, current: focused && li == @cursor.cy) if gw > 0
+        if styled_at
+          sl = styled_at.call(li)
+          sl = Highlight.slice_left(sl, @xscroll) if @xscroll > 0
+          Highlight.draw(screen, rect.x + gw, y, sl, bg: bg, width: cw)
+        else
+          text = @xscroll > 0 ? Highlight.slice_left_text(plain, @xscroll) : plain
+          screen.text(rect.x + gw, y, text, fg, bg, width: cw)
+        end
+        paint_chrome(screen, rect.x + gw, y, li, plain, spans, focused, cw)
+      end
+      Frame.scroll_gauge(screen, rect, @size, @scroll, focused, bg: bg)
+    end
+
+    # The selection band + the block caret for one drawn row, over whatever the base draw put
+    # there. Both measure the PLAIN line with `Screen.draw_width`, which is what `screen.text`
+    # and `Highlight.draw` advance by — so the tint covers the glyphs it addresses.
+    private def paint_chrome(screen : Screen, x : Int32, y : Int32, li : Int32, plain : String,
+                             spans : Array({Int32, Int32, Int32})?, focused : Bool, cw : Int32) : Nil
+      return unless focused
+      spans.try &.each do |(l, x0, x1)|
+        paint_span_bg(screen, x, y, plain, x0, x1, cw) if l == li
+      end
+      return unless li == @cursor.cy
+      cx = @cursor.cx.clamp(0, plain.size)
+      px = x + Screen.draw_width(plain[0, cx]) - @xscroll
+      return if px < x || px >= x + cw
+      ch = cx < plain.size ? plain[cx] : ' '
+      screen.cell(px, y, ch, Theme.bg, Theme.accent_bg)
+      screen.cursor(px, y)
+    end
+
+    # Cluster-wise, matching the base draw and the caret. Summing `draw_width` over single
+    # CHARS is the retired per-codepoint measure: it drifts right by each cluster's inflation
+    # (1 column for a skin tone, 9 for a ZWJ family) and drawing char-by-char also shreds a
+    # cluster across cells. Span edges snap outward so the tint covers whole glyphs.
+    private def paint_span_bg(screen : Screen, x : Int32, y : Int32, plain : String,
+                              x0 : Int32, x1 : Int32, cw : Int32) : Nil
+      return if x0 >= x1
+      a = Screen.cluster_start(plain, {x0, plain.size}.min)
+      b = Screen.cluster_end(plain, {x1, plain.size}.min)
+      px = x + Screen.draw_width(plain[0, a]) - @xscroll
+      i = a
+      while i < b
+        e = Screen.cluster_end(plain, i + 1)
+        seg = plain[i...e]
+        w = Screen.draw_width(seg)
+        screen.text(px, y, seg, Theme.text, Theme.accent_bg) if px >= x && px + w <= x + cw
+        px += w
+        i = e
+      end
+    end
+
+    private def gutter_w(rect : Rect) : Int32
+      @gutter ? {Gutter.width(@size), rect.w}.min : 0
+    end
+
+    # Keep the caret's line inside the window. Selection-follow, like every list in the tree.
+    private def ensure_visible : Nil
+      return if @last_h <= 0
+      cy = @cursor.cy
+      if cy < @scroll
+        @scroll = cy
+      elsif cy >= @scroll + @last_h
+        @scroll = cy - @last_h + 1
+      end
+      @scroll = @scroll.clamp(0, {@size - @last_h, 0}.max)
+    end
+  end
+end

--- a/src/gori/tui/rewriter_view.cr
+++ b/src/gori/tui/rewriter_view.cr
@@ -2,6 +2,7 @@ require "./screen"
 require "./theme"
 require "./frame"
 require "./text_area"
+require "./read_pane"
 require "../rules/stub"
 require "../store"
 require "../bindings"
@@ -66,8 +67,7 @@ module Gori::Tui
 
     def render(screen : Screen, rect : Rect, rules : Array(Store::MatchRule), sel : Int32,
                scroll : Int32, enabled_count : Int32, focus : Symbol, body_focused : Bool,
-               live : Bool, preview_input : TextArea, preview_output : String,
-               out_scroll : Int32) : Nil
+               live : Bool, preview_input : TextArea, preview_out : ReadPane) : Nil
       return if rect.w < 6 || rect.h < 2
       render_sub_strip(screen, rect, :rules, body_focused)
       list_r, pin_r, pout_r = layout(rect)
@@ -75,8 +75,7 @@ module Gori::Tui
         body_focused && focus == :list, live)
       unless pin_r.empty?
         render_preview_input(screen, pin_r, preview_input, body_focused && focus == :preview_in)
-        render_preview_output(screen, pout_r, preview_output, out_scroll,
-          body_focused && focus == :preview_out)
+        render_preview_output(screen, pout_r, preview_out, body_focused && focus == :preview_out)
       end
     end
 
@@ -307,20 +306,15 @@ module Gori::Tui
       ed.render(screen, body, cursor: focused, highlight: :request, gauge: true, gauge_focused: focused)
     end
 
-    private def render_preview_output(screen : Screen, rect : Rect, text : String,
-                                      scroll : Int32, focused : Bool) : Nil
+    # The transformed sample. The pane owns its scroll, caret, selection and gauge — this used
+    # to be a plain windowed draw over a `String` with no caret at all, so the one pane that
+    # shows what a rule DID to a message was the one you could not copy a line out of.
+    private def render_preview_output(screen : Screen, rect : Rect, pane : ReadPane, focused : Bool) : Nil
       return if rect.w < 4 || rect.h < 2
       Frame.card(screen, rect, "PREVIEW OUTPUT", bg: Theme.bg, border: Frame.pane_border(focused))
       body = rect.inset(1, 1)
       return if body.empty?
-      lines = text.empty? ? ["(empty)"] : text.split('\n')
-      top = scroll.clamp(0, {lines.size - body.h, 0}.max)
-      (0...body.h).each do |i|
-        line = lines[top + i]?
-        break unless line
-        screen.text(body.x, body.y + i, line, Theme.text, Theme.bg, width: body.w)
-      end
-      Frame.scroll_gauge(screen, body, lines.size, top, focused)
+      pane.render(screen, body, focused)
     end
 
     # Both moved onto `Rules` (rules.cr) when the global rule-preset library started

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -5152,13 +5152,20 @@ module Gori::Tui
 
     def read_selection_active? : Bool
       case @active_tab
-      when :notes    then notes_controller.view.selection?
-      when :repeater then repeater_controller.repeater_selection_active?
-      when :fuzzer   then fuzzer_controller.fuzzer_selection_active?
-      when :decoder  then decoder_controller.decoder_selection_active?
-      when :jwt      then jwt_controller.jwt_selection_active?
-      when :issues   then issues_controller.issues_notes_selection_active?
-      when :project  then project_controller.project_desc_selection_active?
+      when :notes     then notes_controller.view.selection?
+      when :repeater  then repeater_controller.repeater_selection_active?
+      when :fuzzer    then fuzzer_controller.fuzzer_selection_active?
+      when :decoder   then decoder_controller.decoder_selection_active?
+      when :jwt       then jwt_controller.jwt_selection_active?
+      when :issues    then issues_controller.issues_notes_selection_active?
+      when :project   then project_controller.project_desc_selection_active?
+      when :rewriter  then rewriter_controller.rewriter_selection_active?
+      when :comparer  then comparer_controller.comparer_selection_active?
+      when :intercept then intercept_controller.intercept_preview_selection_active?
+      when :oast      then oast_controller.oast_detail_selection_active?
+      when :probe     then probe_controller.probe_detail_selection_active?
+      when :sequencer then sequencer_controller.sequencer_selection_active?
+      when :miner     then miner_controller.miner_selection_active?
       when :history
         @overlay.detail? && history_controller.detail_selection_active?
       else
@@ -5172,13 +5179,20 @@ module Gori::Tui
     # *_selection_text getter. "" when the active tab has no selection surface.
     def read_selection_text : String
       case @active_tab
-      when :notes    then notes_controller.notes_selection_text
-      when :repeater then repeater_controller.repeater_selection_text
-      when :fuzzer   then fuzzer_controller.fuzzer_selection_text
-      when :decoder  then decoder_controller.decoder_selection_text
-      when :jwt      then jwt_controller.jwt_selection_text
-      when :issues   then issues_controller.issues_notes_selection_text
-      when :project  then project_controller.project_desc_selection_text
+      when :notes     then notes_controller.notes_selection_text
+      when :repeater  then repeater_controller.repeater_selection_text
+      when :fuzzer    then fuzzer_controller.fuzzer_selection_text
+      when :decoder   then decoder_controller.decoder_selection_text
+      when :jwt       then jwt_controller.jwt_selection_text
+      when :issues    then issues_controller.issues_notes_selection_text
+      when :project   then project_controller.project_desc_selection_text
+      when :rewriter  then rewriter_controller.rewriter_selection_text
+      when :comparer  then comparer_controller.comparer_selection_text
+      when :intercept then intercept_controller.intercept_preview_selection_text
+      when :oast      then oast_controller.oast_detail_selection_text
+      when :probe     then probe_controller.probe_detail_selection_text
+      when :sequencer then sequencer_controller.sequencer_selection_text
+      when :miner     then miner_controller.miner_selection_text
       when :history
         @overlay.detail? ? history_controller.detail_selection_text : ""
       else
@@ -5188,13 +5202,20 @@ module Gori::Tui
 
     def read_select_line : Nil
       case @active_tab
-      when :notes    then notes_controller.view.select_line
-      when :repeater then repeater_controller.repeater_select_line
-      when :fuzzer   then fuzzer_controller.fuzzer_select_line
-      when :decoder  then decoder_controller.decoder_select_line
-      when :jwt      then jwt_controller.jwt_select_line
-      when :issues   then issues_controller.issues_notes_select_line
-      when :project  then project_controller.project_desc_select_line
+      when :notes     then notes_controller.view.select_line
+      when :repeater  then repeater_controller.repeater_select_line
+      when :fuzzer    then fuzzer_controller.fuzzer_select_line
+      when :decoder   then decoder_controller.decoder_select_line
+      when :jwt       then jwt_controller.jwt_select_line
+      when :issues    then issues_controller.issues_notes_select_line
+      when :project   then project_controller.project_desc_select_line
+      when :rewriter  then rewriter_controller.rewriter_select_line
+      when :comparer  then comparer_controller.comparer_select_line
+      when :intercept then intercept_controller.intercept_preview_select_line
+      when :oast      then oast_controller.oast_detail_select_line
+      when :probe     then probe_controller.probe_detail_select_line
+      when :sequencer then sequencer_controller.sequencer_select_line
+      when :miner     then miner_controller.miner_select_line
       when :history
         history_controller.detail_select_line if @overlay.detail?
       end
@@ -5202,13 +5223,20 @@ module Gori::Tui
 
     def read_clear_selection : Nil
       case @active_tab
-      when :notes    then notes_controller.view.clear_selection
-      when :repeater then repeater_controller.repeater_clear_selection
-      when :fuzzer   then fuzzer_controller.fuzzer_clear_selection
-      when :decoder  then decoder_controller.decoder_clear_selection
-      when :jwt      then jwt_controller.jwt_clear_selection
-      when :issues   then issues_controller.issues_notes_clear_selection
-      when :project  then project_controller.project_desc_clear_selection
+      when :notes     then notes_controller.view.clear_selection
+      when :repeater  then repeater_controller.repeater_clear_selection
+      when :fuzzer    then fuzzer_controller.fuzzer_clear_selection
+      when :decoder   then decoder_controller.decoder_clear_selection
+      when :jwt       then jwt_controller.jwt_clear_selection
+      when :issues    then issues_controller.issues_notes_clear_selection
+      when :project   then project_controller.project_desc_clear_selection
+      when :rewriter  then rewriter_controller.rewriter_clear_selection
+      when :comparer  then comparer_controller.comparer_clear_selection
+      when :intercept then intercept_controller.intercept_preview_clear_selection
+      when :oast      then oast_controller.oast_detail_clear_selection
+      when :probe     then probe_controller.probe_detail_clear_selection
+      when :sequencer then sequencer_controller.sequencer_clear_selection
+      when :miner     then miner_controller.miner_clear_selection
       when :history
         history_controller.detail_clear_selection if @overlay.detail?
       end
@@ -5227,6 +5255,16 @@ module Gori::Tui
       when :jwt      then jwt_copy
       when :issues   then read_selection_active? ? issues_copy : issues_copy_all
       when :project  then read_selection_active? ? project_copy : project_copy_all
+        # One delegator, not the selection/all pair: the pane's own copy verb already picks
+        # between them and formats the toast, because "all" here means the whole TRANSFORM —
+        # a string that exists nowhere else, not a buffer the shell could re-read.
+      when :rewriter  then rewriter_controller.rewriter_copy
+      when :comparer  then comparer_controller.comparer_copy
+      when :intercept then intercept_controller.intercept_preview_copy
+      when :oast      then oast_controller.oast_detail_copy
+      when :probe     then probe_controller.probe_detail_copy
+      when :sequencer then sequencer_controller.sequencer_copy
+      when :miner     then miner_controller.miner_copy
       when :history
         # No whole-rendered-pane delegator exists for the detail text pane — both
         # branches fall back to the selection-or-current-line copy.

--- a/src/gori/tui/runner/comparer.cr
+++ b/src/gori/tui/runner/comparer.cr
@@ -78,4 +78,9 @@ class Gori::Tui::Runner < Gori::Verb::ExecContext
     comparer_controller.view.set_pair(a, b)
     @toast = "comparer: A ##{older} · B ##{newer} — open Comparer (^P) to view the diff"
   end
+
+  # Both flows are set — the gate for the diff's row select / copy verbs.
+  def comparer_diff_shown? : Bool
+    comparer_controller.comparer_diff_shown?
+  end
 end

--- a/src/gori/tui/runner/intercept.cr
+++ b/src/gori/tui/runner/intercept.cr
@@ -48,4 +48,9 @@ class Gori::Tui::Runner < Gori::Verb::ExecContext
   def marked_intercept_count : Int32
     intercept_controller.marked_intercept_count
   end
+
+  # The read-only held-message preview is on screen — the gate for its read verbs.
+  def intercept_preview_readable? : Bool
+    intercept_controller.intercept_preview_readable?
+  end
 end

--- a/src/gori/tui/runner/miner.cr
+++ b/src/gori/tui/runner/miner.cr
@@ -55,4 +55,9 @@ class Gori::Tui::Runner < Gori::Verb::ExecContext
       name: seed.label)
     @toast = "repeater ← miner: #{seed.label}"
   end
+
+  # The FINDING pane holds focus — the gate for its read verbs.
+  def miner_detail_readable? : Bool
+    miner_controller.miner_detail_readable?
+  end
 end

--- a/src/gori/tui/runner/oast.cr
+++ b/src/gori/tui/runner/oast.cr
@@ -64,4 +64,9 @@ class Gori::Tui::Runner < Gori::Verb::ExecContext
     Clipboard.copy(url)
     @toast = "copied OAST payload: #{url}"
   end
+
+  # A callback's detail is open — the gate for its read verbs.
+  def oast_detail_readable? : Bool
+    oast_controller.oast_detail_readable?
+  end
 end

--- a/src/gori/tui/runner/probe.cr
+++ b/src/gori/tui/runner/probe.cr
@@ -157,4 +157,9 @@ class Gori::Tui::Runner < Gori::Verb::ExecContext
   def probe_custom_rule_selected? : Bool
     probe_controller.rules_custom_selected?
   end
+
+  # A Probe issue's detail is open — the gate for its AFFECTED URLS read verbs.
+  def probe_detail_readable? : Bool
+    probe_controller.probe_detail_readable?
+  end
 end

--- a/src/gori/tui/runner/rewriter.cr
+++ b/src/gori/tui/runner/rewriter.cr
@@ -46,6 +46,11 @@ class Gori::Tui::Runner < Gori::Verb::ExecContext
     rewriter_controller.rules_sub?
   end
 
+  # The PREVIEW OUTPUT pane holds focus — the gate for its four read verbs (x / v / S / y).
+  def rewriter_preview_out? : Bool
+    rewriter_controller.rewriter_preview_out_focused?
+  end
+
   def rewriter_save_preset : Nil
     open_rule_preset_save
   end

--- a/src/gori/tui/runner/sequencer.cr
+++ b/src/gori/tui/runner/sequencer.cr
@@ -37,4 +37,9 @@ class Gori::Tui::Runner < Gori::Verb::ExecContext
   def sequence_configure : Nil
     reconfigure_sequence
   end
+
+  # The ANALYSIS report holds focus — the gate for its read verbs.
+  def sequencer_analysis_readable? : Bool
+    sequencer_controller.sequencer_analysis_readable?
+  end
 end

--- a/src/gori/tui/sequencer_view.cr
+++ b/src/gori/tui/sequencer_view.cr
@@ -2,6 +2,7 @@ require "json"
 require "./screen"
 require "./theme"
 require "./frame"
+require "./read_pane"
 require "./spark"
 require "./fmt"
 require "../store"
@@ -56,11 +57,19 @@ module Gori::Tui
       @focus = :config
       @sel = 0
       @scroll = 0
-      @analysis_scroll = 0
-      @analysis_line_count = 0
-      @analysis_h = 0
+      # The ANALYSIS report's row cursor, selection and scroll. `line_select_only`: a row here is
+      # a label/value pair drawn in two columns (or a banner, or a sparkline), so a char rectangle
+      # would address cells that are not adjacent — selection is whole rows, and the copy payload
+      # is the row projected to `"label  value"`. The pane paints its own rows (`draw_analysis_line`
+      # is kind-specific), so `ReadPane#render` is never called; `viewport_top` + `row_marked?` are.
+      # Before this, the entropy report was readable and there was no way to get it out.
+      @analysis = ReadPane.new(line_select_only: true)
+      @analysis_w = 0      # last drawn interior width — `analysis_lines` sizes its sparkline from it
       @side_by_side = true # last render layout (Samples | Analysis vs stacked)
-      @detail_scroll = 0
+      # The TOKEN pane's row cursor — same shape as ANALYSIS above, over its six `label  value`
+      # field rows. The token itself is the thing an operator reaches for, and this pane had no
+      # copy of any kind.
+      @token = ReadPane.new(line_select_only: true)
       @job_id = 0
     end
 
@@ -223,7 +232,18 @@ module Gori::Tui
     end
 
     def analysis_at_top? : Bool
-      @analysis_scroll <= 0
+      @analysis.at_top?
+    end
+
+    def analysis : ReadPane
+      @analysis
+    end
+
+    # The ANALYSIS card's interior — the rect `render_analysis` draws into, so the row cursor's
+    # click and the draw address the same rows. Empty when the pane is not on screen.
+    def analysis_body(rect : Rect) : Rect
+      _, _, an = pane_rects(rect)
+      an.empty? ? an : an.inset(1, 1)
     end
 
     # Last render put Samples and Analysis side-by-side (wide) vs stacked (narrow).
@@ -245,19 +265,148 @@ module Gori::Tui
       @sel = (@sel + d).clamp(0, @samples.size - 1)
     end
 
+    # ↑/↓ (⇧ to select) walk the report rows; the wheel scrolls the viewport and leaves the
+    # cursor put — the split every read pane in the tree makes.
     def analysis_scroll(d : Int32) : Nil
-      max = {@analysis_line_count - @analysis_h, 0}.max
-      @analysis_scroll = (@analysis_scroll + d).clamp(0, max)
+      sync_analysis
+      @analysis.move(d, 0)
+    end
+
+    def analysis_move(d : Int32, selecting : Bool) : Nil
+      sync_analysis
+      @analysis.move(d, 0, selecting: selecting)
+    end
+
+    def analysis_wheel(d : Int32) : Nil
+      sync_analysis
+      @analysis.scroll_view(d)
+    end
+
+    def analysis_motion_key(ev : Termisu::Event::Key) : Bool
+      sync_analysis
+      @analysis.motion_key(ev)
+    end
+
+    def analysis_select_line : Nil
+      sync_analysis
+      @analysis.select_line
+    end
+
+    def analysis_clear_selection : Nil
+      @analysis.clear_selection
+    end
+
+    def analysis_selection? : Bool
+      @analysis.selection?
+    end
+
+    def analysis_copy_text : String
+      sync_analysis
+      @analysis.copy_text
+    end
+
+    def analysis_copy_all : String
+      sync_analysis
+      @analysis.copy_all
+    end
+
+    def analysis_click(body : Rect, mx : Int32, my : Int32, selecting : Bool = false) : Nil
+      sync_analysis
+      @analysis.click(body, mx, my, selecting)
+    end
+
+    # Point the row cursor at the current report. Idempotent — `report` is the engine's own cached
+    # value — so every gesture and every verb can call it and none can act on a stale row count.
+    private def sync_analysis : Nil
+      ls = analysis_lines(report, {@analysis_w, 20}.max)
+      @analysis.source(ls.size, ->(i : Int32) { analysis_plain(ls[i]) })
+    end
+
+    # ONE report row projected to ONE line of text — the copy payload, 1:1 with the screen rows so
+    # row N of a paste is row N of the report. A banner and a divider carry their own words; a
+    # kv/test/spark row is `label  value`.
+    private def analysis_plain(l : ALine) : String
+      case l.kind
+      when :banner  then "#{l.a} — #{l.b}"
+      when :divider then "-- #{l.a} --"
+      when :test    then (v = l.verdict) ? "#{l.a}  #{l.b}  #{v.label}" : "#{l.a}  #{l.b}"
+      else               "#{l.a}  #{l.b}"
+      end
     end
 
     def open_detail : Nil
       return if @samples.empty?
-      @detail_scroll = 0
+      @token.reset
       @focus = :detail
     end
 
     def detail_scroll(d : Int32) : Nil
-      @detail_scroll = {@detail_scroll + d, 0}.max
+      with_token { @token.move(d, 0) }
+    end
+
+    def detail_move(d : Int32, selecting : Bool) : Nil
+      with_token { @token.move(d, 0, selecting: selecting) }
+    end
+
+    def detail_wheel(d : Int32) : Nil
+      with_token { @token.scroll_view(d) }
+    end
+
+    def detail_motion_key(ev : Termisu::Event::Key) : Bool
+      return false if selected_sample.nil?
+      sync_token
+      @token.motion_key(ev)
+    end
+
+    def detail_select_line : Nil
+      with_token { @token.select_line }
+    end
+
+    def detail_clear_selection : Nil
+      @token.clear_selection
+    end
+
+    def detail_selection? : Bool
+      @token.selection?
+    end
+
+    def detail_copy_text : String
+      return "" if selected_sample.nil?
+      sync_token
+      @token.copy_text
+    end
+
+    def detail_copy_all : String
+      return "" if selected_sample.nil?
+      sync_token
+      @token.copy_all
+    end
+
+    # The TOKEN card's interior — the rect `render_detail` draws into (it takes the whole body).
+    def detail_body(rect : Rect) : Rect
+      rect.inset(2, 1)
+    end
+
+    def detail_click(rect : Rect, mx : Int32, my : Int32, selecting : Bool = false) : Nil
+      body = detail_body(rect)
+      return if body.empty?
+      with_token { @token.click(body, mx, my, selecting) }
+    end
+
+    private def sync_token : Nil
+      smp = selected_sample
+      unless smp
+        @token.source(0, ->(_i : Int32) { "" })
+        return
+      end
+      ls = detail_lines(smp)
+      @token.source(ls.size, ->(i : Int32) { "#{ls[i][0]}  #{ls[i][1]}" })
+    end
+
+    private def with_token(&) : Nil
+      return if selected_sample.nil?
+      sync_token
+      yield
     end
 
     def close_detail : Nil
@@ -290,7 +439,7 @@ module Gori::Tui
       @report_rev = -1
       @sel = 0
       @scroll = 0
-      @analysis_scroll = 0
+      @analysis.reset
     end
 
     def finish_run : Nil
@@ -599,25 +748,23 @@ module Gori::Tui
     private def render_analysis(screen : Screen, rect : Rect, focused : Bool) : Nil
       Frame.card(screen, rect, "ANALYSIS", border: focused ? Theme.focus_gold : Theme.border, bg: Theme.bg)
       inner = rect.inset(1, 1)
-      @analysis_h = {inner.h, 0}.max
+      @analysis_w = inner.w
       return if inner.h <= 0 || inner.w <= 2
       rep = report
       if rep.usable_count == 0
-        @analysis_line_count = 1
-        @analysis_scroll = 0
+        @analysis.source(0, ->(_i : Int32) { "" })
         screen.text(inner.x + 1, inner.y, @running ? "collecting…" : "no tokens yet", Theme.muted, Theme.bg)
         return
       end
       lines = analysis_lines(rep, inner.w)
-      @analysis_line_count = lines.size
-      max_scroll = {lines.size - inner.h, 0}.max
-      @analysis_scroll = @analysis_scroll.clamp(0, max_scroll)
+      sync_analysis
+      top = @analysis.viewport_top(inner.h) # the state half of ReadPane#render — this pane draws its own rows
       inner.h.times do |i|
-        li = @analysis_scroll + i
+        li = top + i
         break if li >= lines.size
-        draw_analysis_line(screen, inner, lines[li], inner.y + i)
+        draw_analysis_line(screen, inner, lines[li], inner.y + i, focused && @analysis.row_marked?(li))
       end
-      Frame.scroll_gauge(screen, inner, lines.size, @analysis_scroll, focused)
+      Frame.scroll_gauge(screen, inner, lines.size, top, focused)
     end
 
     # A flat display line for the analysis pane. `kind` ∈ :banner :kv :divider :test :spark.
@@ -646,7 +793,12 @@ module Gori::Tui
       lines
     end
 
-    private def draw_analysis_line(screen : Screen, inner : Rect, line : ALine, py : Int32) : Nil
+    # `marked` = this row is under the row cursor or inside a selection. The whole row is tinted
+    # (never a character span): its two columns are not one run of text — see `@analysis`.
+    private def draw_analysis_line(screen : Screen, inner : Rect, line : ALine, py : Int32,
+                                   marked : Bool = false) : Nil
+      # The banner paints its own full-width fill, so a band under it would be invisible anyway.
+      screen.fill(Rect.new(inner.x, py, inner.w, 1), Theme.accent_bg) if marked && !line.kind.==(:banner)
       case line.kind
       when :banner
         color = rating_color(line.a)
@@ -702,12 +854,19 @@ module Gori::Tui
         return
       end
       lines = detail_lines(s)
-      lines.each_with_index do |(lbl, val, color), i|
-        y = inner.y + i - @detail_scroll
-        next unless inner.y <= y < inner.bottom
-        screen.text(inner.x, y, lbl, Theme.muted, Theme.bg)
-        screen.text(inner.x + 10, y, val, color, Theme.bg, width: {inner.w - 10, 1}.max)
+      sync_token
+      top = @token.viewport_top(inner.h)
+      inner.h.times do |i|
+        li = top + i
+        break if li >= lines.size
+        lbl, val, color = lines[li]
+        y = inner.y + i
+        bg = focused && @token.row_marked?(li) ? Theme.accent_bg : Theme.bg
+        screen.fill(Rect.new(inner.x, y, inner.w, 1), bg) if bg != Theme.bg
+        screen.text(inner.x, y, lbl, Theme.muted, bg)
+        screen.text(inner.x + 10, y, val, color, bg, width: {inner.w - 10, 1}.max)
       end
+      Frame.scroll_gauge(screen, inner, lines.size, top, focused)
     end
 
     private def detail_lines(s : Sequencer::Sample) : Array({String, String, Color})

--- a/src/gori/verb/context/comparer.cr
+++ b/src/gori/verb/context/comparer.cr
@@ -10,4 +10,7 @@ abstract class Gori::Verb::ExecContext
   abstract def comparer_close_subtab : Nil        # close the active comparison (keeps ≥1)
   abstract def comparer_rename_subtab : Nil       # rename the active comparison chip
   abstract def comparer_duplicate_subtab : Nil    # clone the active A/B pair
+  # Both flows are set, so there are diff rows with a cursor on them — the gate for the row
+  # select / copy verbs. A blank comparison has nothing to select.
+  abstract def comparer_diff_shown? : Bool
 end

--- a/src/gori/verb/context/intercept.cr
+++ b/src/gori/verb/context/intercept.cr
@@ -16,4 +16,8 @@ abstract class Gori::Verb::ExecContext
   abstract def intercept_mark_clear : Nil                 # drop every mark
   abstract def intercept_mark_extend(delta : Int32) : Nil # ⇧↑/⇧↓: extend a range from the anchor
   abstract def marked_intercept_count : Int32
+  # The read-only held-message preview is on screen (a queue with a selection, not editing) —
+  # the gate for its select-line / copy verbs. Its caret comes from the POINTER: the tab has no
+  # focus tier for this pane, so there is no keyboard caret to gate on.
+  abstract def intercept_preview_readable? : Bool
 end

--- a/src/gori/verb/context/miner.cr
+++ b/src/gori/verb/context/miner.cr
@@ -9,4 +9,7 @@ abstract class Gori::Verb::ExecContext
   abstract def miner_duplicate_subtab : Nil   # clone the active miner sub-tab's content into a new sibling
   abstract def miner_finding_selected? : Bool # a finding is selected in the focused miner session
   abstract def mine_repeater_selected : Nil   # send the selected miner finding to Repeater
+  # The FINDING pane holds focus — the gate for its row select / copy verbs. A mined parameter's
+  # fields are what go into a report, and the pane had no copy at all.
+  abstract def miner_detail_readable? : Bool
 end

--- a/src/gori/verb/context/oast.cr
+++ b/src/gori/verb/context/oast.cr
@@ -15,4 +15,7 @@ abstract class Gori::Verb::ExecContext
   abstract def oast_payload_available? : Bool # a listening session exists (gates the menu entries)
   abstract def oast_insert_payload : Nil      # insert a fresh payload at the editor cursor
   abstract def oast_copy_payload : Nil        # copy a fresh payload to the clipboard (History)
+  # A callback's detail is open on a row — the gate for its select-line / copy verbs. The pane
+  # holds the raw callback, which is the evidence an OAST finding rests on.
+  abstract def oast_detail_readable? : Bool
 end

--- a/src/gori/verb/context/probe.cr
+++ b/src/gori/verb/context/probe.cr
@@ -30,4 +30,6 @@ abstract class Gori::Verb::ExecContext
   abstract def probe_active_selected : Nil      # active-scan History's selected (or open) flow
   abstract def probe_active_rescan : Nil        # re-active-scan the selected Probe issue's sample flow
   abstract def probe_active_from_repeater : Nil # active-scan the current Repeater session's last send
+  # A Probe issue's detail is open — the gate for the AFFECTED URLS list's read verbs.
+  abstract def probe_detail_readable? : Bool
 end

--- a/src/gori/verb/context/rewriter.cr
+++ b/src/gori/verb/context/rewriter.cr
@@ -14,4 +14,9 @@ abstract class Gori::Verb::ExecContext
   abstract def rewriter_rules_sub? : Bool       # the RULES sub-tab is on screen (gates load-preset)
   abstract def rewriter_save_preset : Nil       # save the selected rule to the global library (name popup)
   abstract def rewriter_load_preset : Nil       # add a rule from the global library (picker popup)
+  # The PREVIEW OUTPUT pane holds focus — the read-pane gate, matching the per-tab
+  # `*_read_mode?` predicates the other read panes carry. It is the transformed sample, the one
+  # place the post-rewrite bytes exist, so it is the only Rewriter pane with a caret to select
+  # with (the rule list selects rows, the INPUT half is an editable TextArea).
+  abstract def rewriter_preview_out? : Bool
 end

--- a/src/gori/verb/context/sequencer.cr
+++ b/src/gori/verb/context/sequencer.cr
@@ -8,4 +8,7 @@ abstract class Gori::Verb::ExecContext
   abstract def sequence_run : Nil           # re-run collection for the focused Sequencer session
   abstract def sequence_stop : Nil          # stop the running collection
   abstract def sequence_configure : Nil     # reconfigure the focused session's token descriptor
+  # The ANALYSIS report holds focus — the gate for its row select / copy verbs. The report IS the
+  # randomness finding, so being unable to paste it was half a tool.
+  abstract def sequencer_analysis_readable? : Bool
 end

--- a/src/gori/verbs/oast.cr
+++ b/src/gori/verbs/oast.cr
@@ -22,7 +22,12 @@ module Gori
 
       r.register Verb::Definition.new(
         "oast.copy", "Copy payload URL", "Copy the last generated OAST payload URL to the clipboard",
-        Verb::Scope::OastCallbacks, [] of Verb::Chord, mnemonic: 'y') { |ctx| ctx.oast_copy; nil }
+        # `section: :list`, not :common: the callback DETAIL's own `y` copies what came back, and
+        # this one copies the payload gori sent — opposite directions of one interaction, and
+        # `Registry#validate_menu_keys!` refuses one letter for two meanings inside a view. The
+        # verb is also meaningless with a detail open, where there is no payload in front of you.
+        Verb::Scope::OastCallbacks, [] of Verb::Chord, mnemonic: 'y',
+        section: :list) { |ctx| ctx.oast_copy; nil }
 
       r.register Verb::Definition.new(
         "oast.filter", "Filter callbacks", "Filter the callbacks list by protocol/method/source/destination/provider",

--- a/src/gori/verbs/read_edit.cr
+++ b/src/gori/verbs/read_edit.cr
@@ -132,6 +132,141 @@ module Gori
         "project.send-to", "Send selection to…", "Send the selected text to another tool (Decoder, …)",
         Verb::Scope::ProjectDesc, available: in_sel, mnemonic: 'S') { |ctx| ctx.send_to_open; nil }
 
+      # The Rewriter's PREVIEW OUTPUT, tagged `:preview` — the tab is multi-pane, and its rule
+      # list already spends `x` on "Enable/disable" (see verbs/rewriter.cr for why every list
+      # verb moved into a `:rules` section at the same time). Two sections never render together,
+      # so `x` keeps meaning "select line" here and "toggle" there.
+      in_rewriter_out = ->(ctx : Verb::ExecContext) { ctx.current_tab == :rewriter && ctx.rewriter_preview_out? }
+      r.register Verb::Definition.new(
+        "rewriter.select-line", "Select line", "Select the entire current preview line",
+        Verb::Scope::Rewriter, [Verb::Chord.new("x")],
+        available: in_rewriter_out, mnemonic: 'x', section: :preview) { |ctx| ctx.read_select_line; nil }
+      r.register Verb::Definition.new(
+        "rewriter.clear-selection", "Clear selection", "Clear the preview text selection",
+        Verb::Scope::Rewriter, available: in_sel, mnemonic: 'v', section: :preview) { |ctx| ctx.read_clear_selection; nil }
+      r.register Verb::Definition.new(
+        "rewriter.send-to", "Send selection to…", "Send the selected text to another tool (Decoder, …)",
+        Verb::Scope::Rewriter, available: in_sel, mnemonic: 'S', section: :preview) { |ctx| ctx.send_to_open; nil }
+      r.register Verb::Definition.new(
+        "rewriter.copy", "Copy", "Copy the selected preview text, or the whole transformed sample if nothing is selected",
+        Verb::Scope::Rewriter, [Verb::Chord.new("y")],
+        available: in_rewriter_out, mnemonic: 'y', section: :preview) { |ctx| ctx.read_copy; nil }
+
+      # The Comparer's diff. Whole ROWS, never a char span: a screen row is two columns of the
+      # same diff, so `ReadPane(line_select_only: true)` is what the cursor is — see
+      # `ComparerView#unified_line` for the text a copy produces. `:common` is right here: the
+      # tab's other groups are `:subtab` / `:tab` chrome, and the diff IS its body.
+      in_comparer_diff = ->(ctx : Verb::ExecContext) { ctx.current_tab == :comparer && ctx.comparer_diff_shown? }
+      r.register Verb::Definition.new(
+        "comparer.select-line", "Select row", "Select the whole diff row under the cursor",
+        Verb::Scope::Comparer, [Verb::Chord.new("x")],
+        available: in_comparer_diff, mnemonic: 'x') { |ctx| ctx.read_select_line; nil }
+      r.register Verb::Definition.new(
+        "comparer.clear-selection", "Clear selection", "Clear the diff row selection",
+        Verb::Scope::Comparer, available: in_sel, mnemonic: 'v') { |ctx| ctx.read_clear_selection; nil }
+      r.register Verb::Definition.new(
+        "comparer.send-to", "Send selection to…", "Send the selected diff rows to another tool (Decoder, …)",
+        Verb::Scope::Comparer, available: in_sel, mnemonic: 'S') { |ctx| ctx.send_to_open; nil }
+      r.register Verb::Definition.new(
+        "comparer.copy", "Copy", "Copy the selected diff rows as unified text, or the whole diff if nothing is selected",
+        Verb::Scope::Comparer, [Verb::Chord.new("y")],
+        available: in_comparer_diff, mnemonic: 'y') { |ctx| ctx.read_copy; nil }
+
+      # The Intercept's read-only held-message preview. Mouse-placed caret (see
+      # `InterceptController#handle_click`), so `x`/`y` act on wherever the pointer left it.
+      # No chords: the queue already spends nearly every letter, and `x`/`y` there would collide
+      # with a live queue action — the menu is the discoverable route, as it is for the Project
+      # description.
+      in_icept_preview = ->(ctx : Verb::ExecContext) { ctx.current_tab == :intercept && ctx.intercept_preview_readable? }
+      r.register Verb::Definition.new(
+        "intercept.select-line", "Select line", "Select the entire current preview line",
+        Verb::Scope::Intercept, available: in_icept_preview, mnemonic: 'x') { |ctx| ctx.read_select_line; nil }
+      r.register Verb::Definition.new(
+        "intercept.clear-selection", "Clear selection", "Clear the preview text selection",
+        Verb::Scope::Intercept, available: in_sel, mnemonic: 'v') { |ctx| ctx.read_clear_selection; nil }
+      r.register Verb::Definition.new(
+        "intercept.send-to", "Send selection to…", "Send the selected text to another tool (Decoder, …)",
+        Verb::Scope::Intercept, available: in_sel, mnemonic: 'S') { |ctx| ctx.send_to_open; nil }
+      r.register Verb::Definition.new(
+        "intercept.copy", "Copy", "Copy the selected preview text, or the whole held message if nothing is selected",
+        Verb::Scope::Intercept, available: in_icept_preview, mnemonic: 'y') { |ctx| ctx.read_copy; nil }
+
+      # An OAST callback's detail. `section: :detail` (OastController#command_section answers to
+      # match): the callbacks LIST spends `y` on "copy the generated payload", and this pane's `y`
+      # copies what came back — opposite directions of one interaction, so the two views must not
+      # render together.
+      in_oast_detail = ->(ctx : Verb::ExecContext) { ctx.oast_detail_readable? }
+      r.register Verb::Definition.new(
+        "oast.select-line", "Select line", "Select the entire current callback line",
+        Verb::Scope::OastCallbacks, [Verb::Chord.new("x")],
+        available: in_oast_detail, mnemonic: 'x', section: :detail) { |ctx| ctx.read_select_line; nil }
+      r.register Verb::Definition.new(
+        "oast.clear-selection", "Clear selection", "Clear the callback text selection",
+        Verb::Scope::OastCallbacks, available: in_sel, mnemonic: 'v', section: :detail) { |ctx| ctx.read_clear_selection; nil }
+      r.register Verb::Definition.new(
+        "oast.send-to", "Send selection to…", "Send the selected text to another tool (Decoder, …)",
+        Verb::Scope::OastCallbacks, available: in_sel, mnemonic: 'S', section: :detail) { |ctx| ctx.send_to_open; nil }
+      r.register Verb::Definition.new(
+        "oast.copy-callback", "Copy callback", "Copy the selected callback text, or the whole callback if nothing is selected",
+        Verb::Scope::OastCallbacks,
+        available: in_oast_detail, mnemonic: 'y', section: :detail) { |ctx| ctx.read_copy; nil }
+
+      # A Probe issue's AFFECTED URLS. `Verb::Scope::ProbeDetail` carries no mnemonics of its own,
+      # so `x`/`v`/`S`/`y` land in `:common` with nothing to collide with.
+      in_probe_detail = ->(ctx : Verb::ExecContext) { ctx.probe_detail_readable? }
+      r.register Verb::Definition.new(
+        "probe.select-line", "Select URL", "Select the affected URL under the cursor",
+        Verb::Scope::ProbeDetail, [Verb::Chord.new("x")],
+        available: in_probe_detail, mnemonic: 'x') { |ctx| ctx.read_select_line; nil }
+      r.register Verb::Definition.new(
+        "probe.clear-selection", "Clear selection", "Clear the affected-URL selection",
+        Verb::Scope::ProbeDetail, available: in_sel, mnemonic: 'v') { |ctx| ctx.read_clear_selection; nil }
+      r.register Verb::Definition.new(
+        "probe.send-to", "Send selection to…", "Send the selected URLs to another tool (Decoder, …)",
+        Verb::Scope::ProbeDetail, available: in_sel, mnemonic: 'S') { |ctx| ctx.send_to_open; nil }
+      r.register Verb::Definition.new(
+        "probe.copy", "Copy", "Copy the selected affected URLs, or every affected URL if nothing is selected",
+        Verb::Scope::ProbeDetail, [Verb::Chord.new("y")],
+        available: in_probe_detail, mnemonic: 'y') { |ctx| ctx.read_copy; nil }
+
+      # The Sequencer's ANALYSIS report. Whole ROWS (label + value in two columns — see
+      # `SequencerView#analysis_plain` for the projection a copy produces). `x`/`v`/`S`/`y` are all
+      # free in this scope; `r`/`s`/`c` are the run/stop/configure trio.
+      in_seq_analysis = ->(ctx : Verb::ExecContext) { ctx.current_tab == :sequencer && ctx.sequencer_analysis_readable? }
+      r.register Verb::Definition.new(
+        "sequence.select-line", "Select row", "Select the analysis row under the cursor",
+        Verb::Scope::Sequencer, [Verb::Chord.new("x")],
+        available: in_seq_analysis, mnemonic: 'x') { |ctx| ctx.read_select_line; nil }
+      r.register Verb::Definition.new(
+        "sequence.clear-selection", "Clear selection", "Clear the analysis row selection",
+        Verb::Scope::Sequencer, available: in_sel, mnemonic: 'v') { |ctx| ctx.read_clear_selection; nil }
+      r.register Verb::Definition.new(
+        "sequence.send-to", "Send selection to…", "Send the selected rows to another tool (Decoder, …)",
+        Verb::Scope::Sequencer, available: in_sel, mnemonic: 'S') { |ctx| ctx.send_to_open; nil }
+      r.register Verb::Definition.new(
+        "sequence.copy", "Copy", "Copy the selected analysis rows, or the whole entropy report if nothing is selected",
+        Verb::Scope::Sequencer, [Verb::Chord.new("y")],
+        available: in_seq_analysis, mnemonic: 'y') { |ctx| ctx.read_copy; nil }
+
+      # The Miner's FINDING pane. Whole ROWS (label + value in two columns — see
+      # `MinerView#detail_plain`). `x`/`v`/`S`/`y` are free in this scope; `r`/`s`/`p` are run,
+      # stop and send-to-repeater.
+      in_miner_detail = ->(ctx : Verb::ExecContext) { ctx.current_tab == :miner && ctx.miner_detail_readable? }
+      r.register Verb::Definition.new(
+        "mine.select-line", "Select row", "Select the finding row under the cursor",
+        Verb::Scope::Miner, [Verb::Chord.new("x")],
+        available: in_miner_detail, mnemonic: 'x') { |ctx| ctx.read_select_line; nil }
+      r.register Verb::Definition.new(
+        "mine.clear-selection", "Clear selection", "Clear the finding row selection",
+        Verb::Scope::Miner, available: in_sel, mnemonic: 'v') { |ctx| ctx.read_clear_selection; nil }
+      r.register Verb::Definition.new(
+        "mine.send-to", "Send selection to…", "Send the selected rows to another tool (Decoder, …)",
+        Verb::Scope::Miner, available: in_sel, mnemonic: 'S') { |ctx| ctx.send_to_open; nil }
+      r.register Verb::Definition.new(
+        "mine.copy", "Copy", "Copy the selected finding rows, or the whole finding if nothing is selected",
+        Verb::Scope::Miner, [Verb::Chord.new("y")],
+        available: in_miner_detail, mnemonic: 'y') { |ctx| ctx.read_copy; nil }
+
       in_detail_nav = ->(ctx : Verb::ExecContext) { ctx.detail_navigable? }
       r.register Verb::Definition.new(
         "detail.select-line", "Select line", "Select the entire current line",

--- a/src/gori/verbs/rewriter.cr
+++ b/src/gori/verbs/rewriter.cr
@@ -4,35 +4,44 @@ module Gori
   module Verbs
     # The Rewriter tab's space-menu / palette actions. The body is a navigable list (not a
     # text editor), so these also bind as direct body keys in the controller; the mnemonics
-    # here drive the space menu + palette. Unique within COMMON ∪ this scope.
+    # here drive the space menu + palette.
+    #
+    # ALL of them are `section: :rules`, not :common, and `RewriterController#command_section`
+    # answers `:rules` / `:preview` to match. Two reasons, one structural and one a defect:
+    # the PREVIEW OUTPUT pane grew its own read verbs whose `x` means "select line" — the same
+    # letter this list spends on "Enable/disable", which `Registry#validate_menu_keys!` refuses
+    # inside one displayable view — and, before that, the menu offered every rule action while
+    # the preview pane held focus, acting on a row the operator was not looking at. That is the
+    # leak `Runner#rewriter_rule_selected?` documents, one axis over: it remembered `@sub` and
+    # forgot `@focus`.
     def self.register_rewriter(r : Verb::Registry) : Nil
       in_rw = ->(ctx : Verb::ExecContext) { ctx.current_tab == :rewriter }
       has_rule = ->(ctx : Verb::ExecContext) { ctx.current_tab == :rewriter && ctx.rewriter_rule_selected? }
 
       r.register Verb::Definition.new(
         "rewriter.add", "Add rule", "Open the editor to add a Match & Replace rule",
-        Verb::Scope::Rewriter, available: in_rw, mnemonic: 'a') { |ctx| ctx.rewriter_add; nil }
+        Verb::Scope::Rewriter, available: in_rw, mnemonic: 'a', section: :rules) { |ctx| ctx.rewriter_add; nil }
       r.register Verb::Definition.new(
         "rewriter.edit", "Edit rule", "Edit the selected rule in the popup editor",
-        Verb::Scope::Rewriter, available: has_rule, mnemonic: 'e') { |ctx| ctx.rewriter_edit; nil }
+        Verb::Scope::Rewriter, available: has_rule, mnemonic: 'e', section: :rules) { |ctx| ctx.rewriter_edit; nil }
       r.register Verb::Definition.new(
         "rewriter.toggle", "Enable/disable", "Toggle the selected rule on or off",
-        Verb::Scope::Rewriter, available: has_rule, mnemonic: 'x') { |ctx| ctx.rewriter_toggle; nil }
+        Verb::Scope::Rewriter, available: has_rule, mnemonic: 'x', section: :rules) { |ctx| ctx.rewriter_toggle; nil }
       r.register Verb::Definition.new(
         "rewriter.delete", "Delete rule", "Delete the selected rule (confirms first)",
-        Verb::Scope::Rewriter, available: has_rule, mnemonic: 'd') { |ctx| ctx.rewriter_delete; nil }
+        Verb::Scope::Rewriter, available: has_rule, mnemonic: 'd', section: :rules) { |ctx| ctx.rewriter_delete; nil }
       r.register Verb::Definition.new(
         "rewriter.move-up", "Move up", "Move the selected rule earlier in apply order",
-        Verb::Scope::Rewriter, available: has_rule, mnemonic: 'u') { |ctx| ctx.rewriter_move(-1); nil }
+        Verb::Scope::Rewriter, available: has_rule, mnemonic: 'u', section: :rules) { |ctx| ctx.rewriter_move(-1); nil }
       r.register Verb::Definition.new(
         "rewriter.move-down", "Move down", "Move the selected rule later in apply order",
-        Verb::Scope::Rewriter, available: has_rule, mnemonic: 'n') { |ctx| ctx.rewriter_move(1); nil }
+        Verb::Scope::Rewriter, available: has_rule, mnemonic: 'n', section: :rules) { |ctx| ctx.rewriter_move(1); nil }
       r.register Verb::Definition.new(
         "rewriter.duplicate", "Duplicate rule", "Copy the selected rule into a new one",
-        Verb::Scope::Rewriter, available: has_rule, mnemonic: 'c') { |ctx| ctx.rewriter_duplicate; nil }
+        Verb::Scope::Rewriter, available: has_rule, mnemonic: 'c', section: :rules) { |ctx| ctx.rewriter_duplicate; nil }
       r.register Verb::Definition.new(
         "rewriter.reload", "Reload rules", "Re-read rules from the project DB (pick up external edits)",
-        Verb::Scope::Rewriter, available: in_rw, mnemonic: 'r') { |ctx| ctx.rewriter_reload; nil }
+        Verb::Scope::Rewriter, available: in_rw, mnemonic: 'r', section: :rules) { |ctx| ctx.rewriter_reload; nil }
 
       # The global rule-preset library (settings.json `rewriter.presets`) — the Decoder's
       # named chains, one table over. A Match & Replace rule is a RECIPE ("strip CSP on
@@ -47,10 +56,10 @@ module Gori
       in_rules = ->(ctx : Verb::ExecContext) { ctx.current_tab == :rewriter && ctx.rewriter_rules_sub? }
       r.register Verb::Definition.new(
         "rewriter.save-preset", "Save rule to library", "Save the selected rule under a name, shared by every project",
-        Verb::Scope::Rewriter, available: has_rule, mnemonic: 's') { |ctx| ctx.rewriter_save_preset; nil }
+        Verb::Scope::Rewriter, available: has_rule, mnemonic: 's', section: :rules) { |ctx| ctx.rewriter_save_preset; nil }
       r.register Verb::Definition.new(
         "rewriter.load-preset", "Load a saved rule", "Add a rule from the global library to this project (^X deletes one)",
-        Verb::Scope::Rewriter, available: in_rules, mnemonic: 'o') { |ctx| ctx.rewriter_load_preset; nil }
+        Verb::Scope::Rewriter, available: in_rules, mnemonic: 'o', section: :rules) { |ctx| ctx.rewriter_load_preset; nil }
     end
   end
 end


### PR DESCRIPTION
Three rounds of TUI stability work on one axis: **pointer gestures and copy paths the keyboard already had.** Every finding is either spec-pinned or verified live in a real TUI (tmux, isolated `GORI_HOME`, SGR mouse injection, byte counts read off the copy toast).

## Round 1 — the wheel

`RepeaterController#handle_wheel` states the rule and cites its own counter-examples:

> "INS scrolls like NOR … every other TextArea-backed pane in the tree (Notes, the Decoder input) already wheels while in insert mode."

Notes does. The Decoder input did not. **Four panes gated the wheel on the MODE rather than the pane**, so it went dead the moment `i` was pressed: Decoder INPUT, JWT INPUT, Fuzzer TEMPLATE, and the Intercept held-message editor (where `move` bails while `@editing`). The mode test is gone from all four; `chain_pane_active?` stays on the Fuzzer arm because the ^Y sub-pane genuinely owns the wheel then, and `InterceptView#move`'s `@editing` bail stays because moving the queue selection with the editing flag up leaves keys routed into an editor that is no longer drawn.

**Intercept ignored the pointer.** Every notch went to the queue, so a notch over the held-message pane walked the QUEUE — reloading a different message under a preview that draws its own scroll gauge — and never scrolled that preview, whose only other path was PgUp/PgDn. It routes on `pane_at` now, joining Repeater/Project/Target on the `handle_wheel_at` opt-in.

**IssueForm was the one modal a click-away could not dismiss** (the base `Overlay#handle_click` gives that to the other thirty-odd), and its `severity ‹ MEDIUM ›` row was drawn and dead. Both fixed, with the interactive span bounded at the closing `›` so dead cells stay inert.

## Round 2 — the gestures

**Intercept's press and drag inverted against different rects.** `handle_click` insetted; `handle_drag` and `handle_double_click` passed the raw body rect, and `split_panes` then divided a `w` two cells too wide. Measured A/B on two builds, same gesture at the same cell (double-click mid-word, then Backspace):

- pre-fix → `X-Gamma: WODTHREE` — the double-click found no word, so **double-click never selected anything in that editor**
- post-fix → `X-Gamma: ` — the whole word under the pointer

**The Fuzzer RESULT detail was mouse-inert end to end** — a `ReadCursor`, a painted selection band, ⇧arrow growth and a `y`, and both mouse arms bailed unless the TEMPLATE was focused. Its pane chips were drawn and dead too, while the History drill-in's equivalent strip has always been clickable.

**JWT INPUT in READ mode had neither drag nor double-click** — the mode whose whole purpose is select-and-copy, advertising "⇧arrows select · y copy" — while the identical Decoder pane had both. Shipped together with the fix below on purpose: `sync_to(selecting: true)` plants its anchor with `||=`, so enabling drag over a non-collapsing press would have extended from a point nobody pressed.

**A plain click did not collapse a READ selection** in Decoder and JWT: `ReadCursor#sync` deliberately leaves the anchor ("without disturbing selection"), which is exactly why `TextReadState#click` exists and is what Repeater and Fuzzer call.

The rect audit round 1 predicted would find siblings **came out clean** — all nineteen controllers derive their pointer rects the same way their `render_body` does. One duplicate derivation removed in `HistoryController`, whose helper's own comment says it exists so the three gestures cannot drift.

## Round 3 — one home for a read pane

Three panes had grown their own copy of a scrollable read-only text pane (Decoder OUTPUT, Fuzzer detail, History detail) — ~90 lines each of the same arithmetic, and **the drift between them was already a bug**: round 1's finding was one clamping the column against the line the caret was *leaving* while the other, the same method over the same widget, clamped against the line it lands on. Six more panes were scrollable and readable with nothing selectable. One home or nine.

`Tui::ReadPane` owns the `ReadCursor`, both scroll axes, the draw (gutter, h-slice, selection band, block caret, gauge) and every gesture. Three API decisions came from the callers:

- **`(size, line_at)`, never an `Array`** — the Intercept preview reads a `Highlight::Windowed` over a megabyte-scale held body. A spec pins that one frame touches ≤12 of 5,000 lines. `Highlight.plain` (new) bridges a styled window to the text a caret addresses.
- **`styled_at` is a colour-only second provider** — the Fuzzer detail and Intercept preview draw overlays while the caret and copy read the plain line.
- **`viewport_top` / `row_marked?` are the state half of `render`** — for a pane that paints its own rows (the Comparer's two diff columns, the field lists).

**Decoder OUTPUT is migrated onto it** — the proof the API is right rather than merely sufficient for greenfield callers. `decoder_view_spec` passes unchanged, and the migration fixed two latent draw bugs for free: the hand-rolled caret and band were painted with no `- xscroll` term, so a sideways-scrolled pane put both several cells right of the glyph they addressed, or off the pane onto a neighbour.

Then seven panes got one:

| pane | shape |
| --- | --- |
| **Comparer diff** | row cursor, own two-column draw, unified-diff copy |
| Rewriter PREVIEW OUTPUT | full text pane |
| Intercept held-message preview | lazy `Highlight::Windowed`, pointer-placed caret |
| OAST callback detail | full text pane |
| Probe AFFECTED URLS | full text pane |
| Sequencer ANALYSIS | row cursor, own kind-specific draw |
| Sequencer TOKEN · Miner FINDING | row cursors over `label  value` |

### Assumptions stated, not buried

The **Comparer is line-wise only and deliberately grew no A/B column focus ring** — a screen row is two columns of one diff, so a char rectangle would address cells that are not adjacent, and the tab's ←/→ already means REQ⇄RES. Its copy payload is a projection that existed nowhere before (`  same` / `- left` / `+ right` / `~ left → right`), 1:1 with the screen rows so row N of a paste is row N of the diff. Miner FINDING and Sequencer TOKEN are field lists; their `"label  value"` projection is likewise invented here.

The **Intercept preview gets a pointer-placed caret and no keyboard one**, because that tab has no focus tier for it (Tab opens the editor, ⇧arrows are the queue's mark-range gesture). **A click there no longer starts editing** — that is the change that makes the pane selectable at all; `e`, ↵ and the `e:EDIT` badge remain the edit affordance.

## Two menu-scope defects the wiring exposed

`Registry#validate_menu_keys!` is a static guard over one displayable view. Twice it named a real problem:

- **Rewriter** kept every rule verb in `:common`, so the space menu offered "Delete rule" / "Enable/disable" while the PREVIEW pane held focus — acting on a row the operator was not looking at. That is the leak `Runner#rewriter_rule_selected?`'s own comment documents, one axis over: it remembered `@sub` and forgot `@focus`.
- **OAST** spent one `y` on both "copy the payload we sent" (the list) and "copy what came back" (the detail) — opposite directions of one interaction.

## What ameba caught that specs did not

`Lint/DuplicateWhenCondition` found a live bug **in this PR's own new code**: in `handle_preview_out_key` the `when key.escape?, key.left?` leave-arm precedes the shifted-arrow arm, so ⇧← left the pane instead of extending the selection — the later `when key.left?` was unreachable. Fixed by hoisting the shifted check above the `case`, the ordering the Comparer and Repeater already use and say why. Also removed before shipping: three `not_nil!` uses and a `set_*` accessor name.

## Verification

- **Full suite 7104 examples, 0 failures.** `spec/tui` 2137 → 2378 (+241).
- `crystal tool format --check` clean on every touched file. ameba on the 41 touched sources: 142 vs a 137 baseline — the +5 are all `Metrics/CyclomaticComplexity` on the five `case @active_tab` ladders in `runner.cr`, which grow by exactly one arm per tab wired. Every other rule count is at baseline.
- New: `spec/tui/read_pane_spec.cr` (17 examples) covering the lazy source bound, the colour-only overlay contract, all four motion keys, the `scroll_view` column clamp, h-scroll caret alignment, `line_select_only` and `reset`.
- Controllers have no unit harness (they need a `Host`), so **every controller-level change went through tmux**, reading byte counts off the copy toast: Decoder/JWT INS wheel; Intercept wheel in all three states; the Intercept double-click A/B above; Fuzzer detail (`SimpleHTTP` → 10b, drag → 4b, chip switches the card); JWT READ (drag 8b → double-click 8b → plain click 18b, proving the collapse); Comparer (`y` → 6049b, two rows → 120b); Rewriter PREVIEW OUTPUT (`y` → 102b, `x` then `y` → 18b).

## Noted, not fixed

Pointer-aware wheel in the remaining multi-pane tabs (the Repeater's own comment scopes `handle_wheel_at` as opt-in per demonstrated wrongness); `Frame.scroll_gauge` is decorative and not draggable; a list wheel moves the selection rather than the viewport, which is deliberate and consistent across every list pane.
