### PR TITLE
A selection thirteen fields never had, a band the frame that drew it erased, and the modals nothing could drag

### DIFF
--- a/spec/support/overlay_harness.cr
+++ b/spec/support/overlay_harness.cr
@@ -12,6 +12,9 @@ require "./memory_backend"
 #   * `press` / `click` mirror `Runner#dispatch_overlay_key` / `#dispatch_overlay_click`
 #     LINE FOR LINE — :cancel closes, :commit runs `commit` and closes iff it returns
 #     true, anything else stays open.
+#   * `drag` / `double_click` mirror `Runner#dispatch_drag` / `#dispatch_double_click`'s
+#     OVERLAY tier, including its `supports_drag?` gate: a modal that never opted in must
+#     see the gesture do nothing, which is what the shell does.
 #   * `open?` mirrors whether the shell still holds the modal in `@active_overlay`.
 #   * `commits` counts runs of the injected `on_commit` closure — the open-site behaviour
 #     a migrated modal no longer carries itself.
@@ -134,6 +137,47 @@ class OverlayHarness
     b = box
     raise "overlay has no box to click in (overlay_box returned nil)" unless b
     click(b.x + dx, b.y + dy)
+  end
+
+  # Pointer motion with the button held — `Runner#dispatch_drag`'s overlay tier. The shell
+  # only routes this when the press that started it landed on a modal that opted in
+  # (`Runner#drag_press_target?` → `Overlay#supports_drag?`), so this mirrors that gate
+  # rather than calling `handle_drag` unconditionally: a spec that drags a modal which never
+  # opted in must see nothing happen, exactly as the operator would.
+  #
+  # Unlike `click`, a drag has NO outcome vocabulary — the shell reads no return value, so a
+  # modal can never dismiss itself mid-drag. That asymmetry is the contract, not an omission.
+  def drag(mx : Int32, my : Int32) : Nil
+    live!
+    return unless @overlay.supports_drag?
+    @overlay.handle_drag(@area, mx, my)
+  end
+
+  def drag_in_box(dx : Int32, dy : Int32) : Nil
+    b = box
+    raise "overlay has no box to drag in (overlay_box returned nil)" unless b
+    drag(b.x + dx, b.y + dy)
+  end
+
+  # Two presses in the same cell inside the shell's double-click window. Mirrors
+  # `Runner#press_left`: the pair is dispatched to `handle_double_click` FIRST, and only a
+  # false answer falls back to the ordinary click (which, for a modal, includes the
+  # click-away dismiss). Returns whether the overlay took a word.
+  #
+  # The first press of the pair is the caller's job — the shell's real sequence is
+  # press → press, and `handle_double_click` spreads from the caret that first press left.
+  def double_click(mx : Int32, my : Int32) : Bool
+    live!
+    return false unless @overlay.supports_drag?
+    took = @overlay.handle_double_click(@area, mx, my)
+    dispatch(@overlay.handle_click(@area, mx, my)) unless took
+    took
+  end
+
+  def double_click_in_box(dx : Int32, dy : Int32) : Bool
+    b = box
+    raise "overlay has no box to double-click in (overlay_box returned nil)" unless b
+    double_click(b.x + dx, b.y + dy)
   end
 
   # A scroll-wheel notch over the modal, already ±3-scaled like Runner#handle_wheel.

--- a/spec/tui/overlay_editor_select_spec.cr
+++ b/spec/tui/overlay_editor_select_spec.cr
@@ -1,0 +1,202 @@
+require "../spec_helper"
+require "../support/memory_backend"
+require "../support/overlay_harness"
+
+include Gori::Tui
+
+# Three modals embed a real multi-line `TextArea`: the Rewriter STUB RESPONSE, the Discover
+# CUSTOM HEADERS list, and the Fuzzer SET card's value list. All three were text boxes an
+# operator could type a wordlist or an HTTP response into and could not select out of.
+#
+# TWO holes, one per input device.
+#
+# KEYBOARD. Each hand-rolled its own `case key.left? then @editor.move(0, -1)` ladder and
+# passed no `selecting:` anywhere — so ⇧arrows moved the caret like bare arrows, and there
+# was no PageUp/PageDown, no ⇧Home/⇧End, no ⌥←/→ by word, no ⌥⌫. #583 gave eight surfaces one
+# answer (`TextArea#handle_motion_key`) and these three were not among them.
+#
+# POINTER. The shell dragged nothing over a modal at all: `Runner#dispatch_drag` reached only
+# the active tab, and the predicate behind it said so out loud ("nothing else … overlays …
+# drags"). So `Overlay` grew the same three-method contract `TabController` has —
+# `supports_drag?` / `handle_drag` / `handle_double_click` — and the Runner grew an overlay
+# tier ahead of its tab tier. `OverlayHarness#drag` / `#double_click` replay that tier,
+# including its opt-in gate.
+
+# Where each card puts its buffer, as an offset from the box top-left. Both single-editor
+# cards inset by 2 columns and start one row under the border; the SET card's value list sits
+# three rows down, under the name + type rows.
+private EDITOR_DX = 2
+private EDITOR_DY = 1
+private VALUES_DY = 3
+
+private def stub_overlay(text : String) : OverlayHarness
+  OverlayHarness.new(RewriterStubOverlay.new(text), commit: true)
+end
+
+# A SET card seeded with a LIST payload and its row cursor moved onto the value buffer.
+# `for_list` opens on row 0 (the Type selector), so the ↓ here is the operator's own first
+# keystroke, not a test-only seam — `handle_values` is reachable no other way.
+private def list_overlay(values : String) : OverlayHarness
+  ov = FuzzSetOverlay.editing(SetSpec.new(:list, values), 0)
+  h = OverlayHarness.new(ov, commit: true)
+  h.press(Termisu::Input::Key::Down)
+  ov.@sel.should eq(1) # rows = [:type, :values]
+  h
+end
+
+private def headers_overlay(text : String) : OverlayHarness
+  ov = DiscoverHeadersOverlay.new(text.split('\n').compact_map { |l|
+    name, _, value = l.partition(':')
+    l.includes?(':') ? {name, value.strip} : nil
+  })
+  OverlayHarness.new(ov, commit: true)
+end
+
+describe "the multi-line overlay editors" do
+  describe "RewriterStubOverlay — the keyboard half" do
+    it "⇧→ selects, and an unmodified → collapses it" do
+      h = stub_overlay("200 OK\r\nContent-Type: text/plain\r\n\r\nhi")
+      ed = h.overlay.as(RewriterStubOverlay).@editor
+      ed.selection?.should be_false
+      h.press(Termisu::Input::Key::Right, shift: true)
+      ed.selection_text.should eq("2")
+      h.press(Termisu::Input::Key::Right)
+      ed.selection?.should be_false
+    end
+
+    it "⇧End selects to the end of the status line" do
+      h = stub_overlay("200 OK\r\nX: y")
+      h.press(Termisu::Input::Key::End, shift: true)
+      h.overlay.as(RewriterStubOverlay).@editor.selection_text.should eq("200 OK")
+    end
+
+    it "⇧↓ selects across the line break" do
+      h = stub_overlay("200 OK\r\nX: y")
+      h.press(Termisu::Input::Key::Down, shift: true)
+      sel = h.overlay.as(RewriterStubOverlay).@editor.selection_text
+      sel.should_not be_nil
+      sel.not_nil!.should contain("200 OK")
+    end
+
+    it "⌥⌫ deletes a word rather than one character" do
+      h = stub_overlay("200 OK")
+      h.press(Termisu::Input::Key::End)
+      h.press(Termisu::Input::Key::Backspace, alt: true)
+      h.overlay.as(RewriterStubOverlay).text.should eq("200 ")
+    end
+
+    it "PageDown is no longer typed into the buffer as a stray character" do
+      h = stub_overlay("200 OK")
+      before = h.overlay.as(RewriterStubOverlay).text
+      h.press(Termisu::Input::Key::PageDown)
+      h.overlay.as(RewriterStubOverlay).text.should eq(before)
+    end
+  end
+
+  describe "RewriterStubOverlay — the pointer half" do
+    it "opts into dragging" do
+      stub_overlay("200 OK").overlay.supports_drag?.should be_true
+    end
+
+    it "a press inside the card places the caret instead of doing nothing" do
+      h = stub_overlay("200 OK\r\nContent-Type: text/plain")
+      h.click_in_box(EDITOR_DX + 4, EDITOR_DY).should eq(:open)
+      h.overlay.as(RewriterStubOverlay).@editor.cursor_offset.should eq(4)
+    end
+
+    it "a drag from the press extends a selection" do
+      h = stub_overlay("200 OK\r\nContent-Type: text/plain")
+      h.click_in_box(EDITOR_DX, EDITOR_DY)
+      h.drag_in_box(EDITOR_DX + 3, EDITOR_DY)
+      h.overlay.as(RewriterStubOverlay).@editor.selection_text.should eq("200")
+    end
+
+    it "a double-click takes the word under the pointer" do
+      h = stub_overlay("200 OK\r\nContent-Type: text/plain")
+      h.click_in_box(EDITOR_DX + 4, EDITOR_DY)
+      h.double_click_in_box(EDITOR_DX + 4, EDITOR_DY).should be_true
+      h.overlay.as(RewriterStubOverlay).@editor.selection_text.should eq("OK")
+    end
+
+    it "a click OUTSIDE the card still saves and closes — the drag arm did not eat it" do
+      h = stub_overlay("200 OK")
+      h.click(0, 0).should eq(:closed)
+      h.commits.should eq(1)
+    end
+  end
+
+  describe "DiscoverHeadersOverlay" do
+    it "⇧End selects the whole header line" do
+      h = headers_overlay("Authorization: Bearer t")
+      h.press(Termisu::Input::Key::End, shift: true)
+      h.overlay.as(DiscoverHeadersOverlay).@editor.selection_text.should eq("Authorization: Bearer t")
+    end
+
+    it "⌥→ steps by word instead of one character" do
+      h = headers_overlay("Authorization: Bearer t")
+      h.press(Termisu::Input::Key::Right, alt: true)
+      h.overlay.as(DiscoverHeadersOverlay).@editor.cursor_offset.should eq("Authorization".size)
+    end
+
+    it "opts into dragging, and a drag extends from the press" do
+      h = headers_overlay("Authorization: Bearer t")
+      h.overlay.supports_drag?.should be_true
+      h.click_in_box(EDITOR_DX, EDITOR_DY)
+      h.drag_in_box(EDITOR_DX + 13, EDITOR_DY)
+      h.overlay.as(DiscoverHeadersOverlay).@editor.selection_text.should eq("Authorization")
+    end
+
+    it "a double-click takes the header NAME whole — `-` is a word char" do
+      h = headers_overlay("X-Custom-Header: v")
+      h.click_in_box(EDITOR_DX + 3, EDITOR_DY)
+      h.double_click_in_box(EDITOR_DX + 3, EDITOR_DY).should be_true
+      h.overlay.as(DiscoverHeadersOverlay).@editor.selection_text.should eq("X-Custom-Header")
+    end
+
+    it "a click outside still commits — an editable card must stay dismissible" do
+      h = headers_overlay("A: b")
+      h.click(0, 0).should eq(:closed)
+    end
+  end
+
+  describe "FuzzSetOverlay value list" do
+    it "⇧→ selects inside a value" do
+      h = list_overlay("alpha,beta")
+      h.press(Termisu::Input::Key::Right, shift: true)
+      h.overlay.as(FuzzSetOverlay).@values.selection_text.should eq("a")
+    end
+
+    it "⇧End selects the whole value line" do
+      h = list_overlay("alpha,beta")
+      h.press(Termisu::Input::Key::End, shift: true)
+      h.overlay.as(FuzzSetOverlay).@values.selection_text.should eq("alpha")
+    end
+
+    it "⇧↑ on the FIRST line stays in the buffer instead of leaving for the row above" do
+      h = list_overlay("alpha,beta")
+      h.press(Termisu::Input::Key::Up, shift: true)
+      h.overlay.as(FuzzSetOverlay).@sel.should eq(1) # still the value row
+    end
+
+    it "a BARE ↑ on the first line still leaves for the row above" do
+      h = list_overlay("alpha,beta")
+      h.press(Termisu::Input::Key::Up)
+      h.overlay.as(FuzzSetOverlay).@sel.should eq(0) # back on the Type row
+    end
+
+    it "opts into dragging, and a drag extends from the press" do
+      h = list_overlay("alpha,beta")
+      h.overlay.supports_drag?.should be_true
+      h.click_in_box(EDITOR_DX, VALUES_DY)
+      h.drag_in_box(EDITOR_DX + 5, VALUES_DY)
+      h.overlay.as(FuzzSetOverlay).@values.selection_text.should eq("alpha")
+    end
+
+    it "a double-click takes the value under the pointer" do
+      h = list_overlay("alpha,beta")
+      h.click_in_box(EDITOR_DX + 2, VALUES_DY)
+      h.double_click_in_box(EDITOR_DX + 2, VALUES_DY).should be_true
+      h.overlay.as(FuzzSetOverlay).@values.selection_text.should eq("alpha")
+    end
+  end
+end

--- a/spec/tui/rewriter_preview_select_spec.cr
+++ b/spec/tui/rewriter_preview_select_spec.cr
@@ -1,0 +1,288 @@
+require "../spec_helper"
+require "../support/memory_backend"
+require "file_utils"
+
+include Gori::Tui
+
+# The Rewriter's PREVIEW INPUT was the last `TextArea` editor still hand-rolling its own
+# arrow keys, and the hand-rolled set passed no `selecting:` anywhere.
+#
+# That left it inverted against every sibling: `RewriterController#handle_drag` and
+# `#handle_double_click` gave this exact pane a mouse selection (drag to extend, double-click
+# to take a word), and `handle_preview_in_key` gave it no way to make one from the keyboard —
+# no ⇧arrows, no Page keys, no ⇧Home/⇧End, no ⌥←/→ by word, no ⌥⌫. The OUTPUT pane one column
+# to its right had ⇧arrows the whole time (`handle_preview_out_key`), so the two halves of the
+# same preview disagreed about what shift meant.
+#
+# The fix routes everything below the three pane-crossing arms through
+# `TextArea#handle_motion_key` — the one keymap #583 gave the other eight surfaces. These
+# examples pin both halves of that: the motions now arrive, AND the crossing arms still
+# fire on a bare press while refusing to fire on a modified one (⇧↑ at the top must not
+# abandon a selection mid-build, ⌥← at column 0 is a word step this pane owns).
+
+# The narrow shell facade a controller is given. Everything here is inert except `session` —
+# the only member the Rewriter touches on construction and on every preview keystroke.
+# File-local rather than shared, matching `oast_callback_cap_spec` / `repeater_refusal_inline_spec`:
+# `Host` is ~35 abstract methods and a shared support double would be one more file to keep in
+# sync with the module every time it grows.
+private class FakeHost
+  include Gori::Tui::Host
+
+  getter statuses = [] of String
+  getter space_menus = 0
+
+  def initialize(@session : Gori::Session)
+    @jobs = Gori::Tui::Jobs.new
+    @notifications = Gori::Tui::Notifications.new
+  end
+
+  def session : Gori::Session
+    @session
+  end
+
+  def jobs : Gori::Tui::Jobs
+    @jobs
+  end
+
+  def notifications : Gori::Tui::Notifications
+    @notifications
+  end
+
+  def status(message : String) : Nil
+    @statuses << message
+  end
+
+  def request_overlay(kind : Symbol) : Nil
+  end
+
+  def request_focus(pane : Symbol) : Nil
+  end
+
+  def focus_body : Nil
+  end
+
+  def switch_tab(tab : Symbol) : Nil
+  end
+
+  def goto_tab(tab : Symbol) : Nil
+  end
+
+  def open_palette : Nil
+  end
+
+  def open_space_menu : Nil
+    @space_menus += 1
+  end
+
+  def open_fuzz_set_editor(edit_index : Int32?) : Nil
+  end
+
+  def open_fuzz_advanced_editor : Nil
+  end
+
+  def reconfigure_sequence : Nil
+  end
+
+  def open_scope_rule_editor(edit_id : Int64?, kind : String, match_type : String, pattern : String) : Nil
+  end
+
+  def open_custom_rule_editor(rule : Gori::Probe::CustomRule?) : Nil
+  end
+
+  def open_rewriter_rule_editor(rule : Gori::Store::MatchRule?) : Nil
+  end
+
+  def open_extract_rule_editor(rule : Gori::Store::ExtractRule?) : Nil
+  end
+
+  def open_chain_save : Nil
+  end
+
+  def open_chain_load : Nil
+  end
+
+  def open_oast_provider_editor(provider : Gori::Oast::ProviderConfig?) : Nil
+  end
+
+  def confirm(title : String, message : String, *, confirm_label : String, danger : Bool,
+              return_to : Symbol = :none, &action : -> Nil) : Nil
+    action.call # no modal in a spec: a confirmed action runs straight through
+  end
+
+  def overlay : Symbol
+    :none
+  end
+
+  def active_tab : Symbol
+    :rewriter
+  end
+
+  def focus : Symbol
+    :body
+  end
+
+  def reveal? : Bool
+    false
+  end
+
+  def toggle_reveal : Nil
+  end
+
+  def pretty? : Bool
+    false
+  end
+
+  def toggle_pretty : Nil
+  end
+
+  def toggle_scope_lens : Nil
+  end
+
+  def toggle_sandbox : Nil
+  end
+
+  def apply_project_network(bind_host : String, bind_port : Int32, upstream : String,
+                            connect_secs : Int32, io_secs : Int32, capture_mib : Int32) : String
+    ""
+  end
+end
+
+# The CA is the one slow part of standing a Session up (a root keypair) and no example here
+# asserts anything about it, so it is built once for the file.
+private REWRITER_SEL_CA = File.tempname("gori-rewriter-sel-ca")
+Spec.after_suite { FileUtils.rm_rf(REWRITER_SEL_CA) }
+
+private def key(k : Termisu::Input::Key, mods : Termisu::Input::Modifier = :none,
+                char : Char? = nil) : Termisu::Event::Key
+  Termisu::Event::Key.new(k, mods, char)
+end
+
+# A Rewriter controller already FOCUSED on the preview input, with the caret at (0, 0) of the
+# default sample. Focus gets there the way an operator does — a render (which is what fills
+# `@last_body`, the rect `preview_available?` measures) then ↓ off the empty rule list — rather
+# than by poking `@focus`, so the geometry gate is part of what these examples exercise.
+private def with_preview_focus(&)
+  root = File.tempname("gori-rewriter-sel")
+  Dir.mkdir_p(root)
+  project = Gori::ProjectRegistry.new(root).temp("rewritersel")
+  session = Gori::Session.open(Gori::Config.new(listen: "127.0.0.1", port: 0),
+    Gori::Proxy::Tls::CertAuthority.load_or_create(REWRITER_SEL_CA), Gori::Verbs.registry, project)
+  begin
+    host = FakeHost.new(session)
+    ctl = RewriterController.new(host)
+    backend = MemoryBackend.new(100, 40)
+    ctl.render_body(Screen.new(backend), Rect.new(0, 0, 100, 40), :body)
+    ctl.handle_body_key(key(Termisu::Input::Key::Down)) # empty rule list → ↓ enters the preview
+    ctl.@focus.should eq(:preview_in)
+    yield ctl
+  ensure
+    session.close
+    FileUtils.rm_rf(root) if Dir.exists?(root)
+  end
+end
+
+describe "Gori::Tui::RewriterController preview-input selection" do
+  describe "the keyboard half it never had" do
+    it "⇧→ selects forward from the caret" do
+      with_preview_focus do |ctl|
+        ed = ctl.@preview_input
+        ed.selection?.should be_false
+        ctl.handle_body_key(key(Termisu::Input::Key::Right, :shift))
+        ed.selection_text.should eq("G")
+        ctl.handle_body_key(key(Termisu::Input::Key::Right, :shift))
+        ed.selection_text.should eq("GE")
+      end
+    end
+
+    it "an unmodified → collapses the selection instead of extending it" do
+      with_preview_focus do |ctl|
+        ed = ctl.@preview_input
+        ctl.handle_body_key(key(Termisu::Input::Key::Right, :shift))
+        ctl.handle_body_key(key(Termisu::Input::Key::Right))
+        ed.selection?.should be_false
+      end
+    end
+
+    it "⇧End selects to the end of the line" do
+      with_preview_focus do |ctl|
+        ctl.handle_body_key(key(Termisu::Input::Key::End, :shift))
+        ctl.@preview_input.selection_text.should eq("GET /index.html HTTP/1.1")
+      end
+    end
+
+    # `word_right` lands on the START of the next word, not the end of the current one —
+    # so from column 0 of "GET /index.html …" the caret settles at 4, past the space.
+    it "⌥→ steps by word" do
+      with_preview_focus do |ctl|
+        ctl.handle_body_key(key(Termisu::Input::Key::Right, :alt))
+        ctl.@preview_input.cursor_offset.should eq("GET ".size)
+      end
+    end
+
+    it "⌥⌫ deletes the word behind the caret" do
+      with_preview_focus do |ctl|
+        ed = ctl.@preview_input
+        ctl.handle_body_key(key(Termisu::Input::Key::Right, :alt))
+        ctl.handle_body_key(key(Termisu::Input::Key::Backspace, :alt))
+        ed.lines_snapshot.first.should eq("/index.html HTTP/1.1")
+      end
+    end
+
+    it "PageDown moves the caret a screenful down" do
+      with_preview_focus do |ctl|
+        ed = ctl.@preview_input
+        ctl.handle_body_key(key(Termisu::Input::Key::PageDown))
+        ed.cursor_offset.should_not eq(0)
+      end
+    end
+  end
+
+  describe "the pane-crossing arms still claim a BARE press only" do
+    it "↑ at the top leaves for the rule list" do
+      with_preview_focus do |ctl|
+        ctl.handle_body_key(key(Termisu::Input::Key::Up))
+        ctl.@focus.should eq(:list)
+      end
+    end
+
+    it "⇧↑ at the top stays in the pane — leaving would abandon a selection mid-build" do
+      with_preview_focus do |ctl|
+        ctl.handle_body_key(key(Termisu::Input::Key::Up, :shift))
+        ctl.@focus.should eq(:preview_in)
+      end
+    end
+
+    it "← at the buffer start leaves for the rule list" do
+      with_preview_focus do |ctl|
+        ctl.handle_body_key(key(Termisu::Input::Key::Left))
+        ctl.@focus.should eq(:list)
+      end
+    end
+
+    it "⌥← at column 0 stays in the pane — it is a word step, not an exit" do
+      with_preview_focus do |ctl|
+        ctl.handle_body_key(key(Termisu::Input::Key::Left, :alt))
+        ctl.@focus.should eq(:preview_in)
+      end
+    end
+
+    it "⇧← at column 0 stays in the pane" do
+      with_preview_focus do |ctl|
+        ctl.handle_body_key(key(Termisu::Input::Key::Left, :shift))
+        ctl.@focus.should eq(:preview_in)
+      end
+    end
+  end
+
+  describe "editing still works around the new routing" do
+    it "a printable char inserts and ⌫ takes exactly one character back" do
+      with_preview_focus do |ctl|
+        ed = ctl.@preview_input
+        ctl.handle_body_key(key(Termisu::Input::Key::LowerX, :none, 'x'))
+        ed.lines_snapshot.first.should eq("xGET /index.html HTTP/1.1")
+        ctl.handle_body_key(key(Termisu::Input::Key::Backspace))
+        ed.lines_snapshot.first.should eq("GET /index.html HTTP/1.1")
+      end
+    end
+  end
+end

--- a/spec/tui/target_row_select_spec.cr
+++ b/spec/tui/target_row_select_spec.cr
@@ -1,0 +1,146 @@
+require "../spec_helper"
+require "../support/memory_backend"
+
+include Gori::Tui
+
+# The TARGET row — the single-line URL (and SNI) field at the top of the Repeater and Fuzzer
+# — is a READ pane like any other: a caret, an anchor, a painted band, `LineFieldRead`
+# behind all three. It had ⇧←/→ and two holes around them.
+#
+# ⇧Home / ⇧End. `target_home` / `target_end` ASSIGNED the caret, which never reaches the
+# anchor living in `@target_read` — so the two keys that should have grown a selection to the
+# edge of the value DROPPED it instead. This is the same defect #583 fixed in
+# `TextArea#home`/`#end_of_line`, left standing on the one field that is not a TextArea.
+#
+# THE POINTER. `handle_drag` / `handle_double_click` listed `:request` and `:response` and
+# not `:target`, so the field an operator most often wants to lift a slice out of (the URL)
+# could be clicked but never dragged across. A bare press also assigned the caret directly,
+# leaving a stale anchor behind: clicking away from a ⇧←/→ selection repainted the band from
+# the OLD anchor to the new caret.
+#
+# Both views carry the same field, so every example runs against both.
+
+private URL = "https://example.com/a/b?q=1"
+
+# A view focused on the target row, caret at column 0, in READ mode (the mode whose band
+# `draw_target_row` paints). The two constructors differ; everything after them does not.
+private def each_target_view(&)
+  rv = RepeaterView.new
+  rv.restore(URL, "GET / HTTP/1.1\r\nHost: example.com\r\n\r\n", false, true)
+  rv.focus_pane(:target)
+  rv.target_home
+  yield rv, "Repeater"
+
+  fv = FuzzerView.new
+  fv.load_request(URL, "GET / HTTP/1.1\r\nHost: example.com\r\n\r\n", false, "")
+  fv.focus_pane(:target)
+  fv.target_home
+  yield fv, "Fuzzer"
+end
+
+# The URL row of the target card: row 1 of the body, value starting at `field_base` —
+# rect.x + 2 (the card inset) + the "›" marker + 1. The same inverse the view uses, written
+# out here so a geometry drift shows up as a failing example rather than as an off-by-one
+# selection nobody notices.
+private def url_cell(col : Int32) : {Int32, Int32}
+  {4 + col, 1}
+end
+
+describe "the TARGET row selection" do
+  describe "⇧Home / ⇧End extend instead of dropping the selection" do
+    it "⇧End selects from the caret to the end of the value" do
+      each_target_view do |v, name|
+        v.target_end(true)
+        v.pane_selection?.should be_true, "#{name}: ⇧End left no selection"
+        v.target_copy_text.should eq(URL), "#{name}: ⇧End selected the wrong span"
+      end
+    end
+
+    it "⇧Home selects back to column 0" do
+      each_target_view do |v, name|
+        v.target_end        # park at the far end, unselected
+        v.target_home(true) # …and pull the selection back over the whole value
+        v.pane_selection?.should be_true, "#{name}: ⇧Home left no selection"
+        v.target_copy_text.should eq(URL), "#{name}: ⇧Home selected the wrong span"
+      end
+    end
+
+    it "a BARE Home/End still collapses the selection" do
+      each_target_view do |v, name|
+        v.target_end(true)
+        v.pane_selection?.should be_true
+        v.target_home
+        v.pane_selection?.should be_false, "#{name}: a bare Home kept the band"
+      end
+    end
+
+    it "⇧End GROWS a selection ⇧→ started rather than re-anchoring it" do
+      each_target_view do |v, name|
+        v.target_read_move(5, selecting: true) # anchor 0, caret 5 → "https"
+        v.target_copy_text.should eq(URL[0...5])
+        v.target_end(true) # caret to the end; the anchor must stay at 0
+        v.target_copy_text.should eq(URL), "#{name}: ⇧End re-anchored mid-extend"
+      end
+    end
+  end
+
+  describe "the pointer" do
+    it "a press places the caret and a drag extends from it" do
+      each_target_view do |v, name|
+        rect = Rect.new(0, 0, 120, 20)
+        px, py = url_cell(8)
+        v.target_click_to_cursor(rect, px, py)
+        v.pane_selection?.should be_false, "#{name}: a press alone made a selection"
+        dx, dy = url_cell(17)
+        v.target_drag_to_cursor(rect, dx, dy)
+        v.pane_selection?.should be_true, "#{name}: the drag did not extend"
+        v.target_copy_text.should eq(URL[8...17]), "#{name}: the drag covered the wrong span"
+      end
+    end
+
+    it "a press COLLAPSES a standing selection instead of re-anchoring it" do
+      each_target_view do |v, name|
+        rect = Rect.new(0, 0, 120, 20)
+        v.target_end(true)
+        v.pane_selection?.should be_true
+        px, py = url_cell(3)
+        v.target_click_to_cursor(rect, px, py)
+        v.pane_selection?.should be_false, "#{name}: the press left the old anchor standing"
+      end
+    end
+
+    it "a double-click takes the word the press landed on" do
+      each_target_view do |v, name|
+        rect = Rect.new(0, 0, 120, 20)
+        # column 10 is inside "example" of https://example.com/… — a word that stops at the
+        # dots either side, since `.` is punctuation under the shared word rule.
+        px, py = url_cell(10)
+        v.target_click_to_cursor(rect, px, py)
+        v.target_select_word.should be_true, "#{name}: no word taken"
+        v.target_copy_text.should eq("example"), "#{name}: wrong word"
+      end
+    end
+
+    it "a double-click on the value's trailing void takes nothing and keeps the caret" do
+      each_target_view do |v, name|
+        rect = Rect.new(0, 0, 120, 20)
+        px, py = url_cell(URL.size + 6)
+        v.target_click_to_cursor(rect, px, py)
+        v.target_select_word.should be_false, "#{name}: took a word off the end of the value"
+        v.pane_selection?.should be_false
+      end
+    end
+
+    it "a drag in INSERT mode is inert — that mode paints no band" do
+      each_target_view do |v, name|
+        rect = Rect.new(0, 0, 120, 20)
+        v.enter_target_insert!
+        px, py = url_cell(4)
+        v.target_click_to_cursor(rect, px, py)
+        dx, dy = url_cell(15)
+        v.target_drag_to_cursor(rect, dx, dy)
+        v.pane_selection?.should be_false, "#{name}: INSERT grew a selection nothing draws"
+      end
+    end
+  end
+end

--- a/spec/tui/text_field_select_spec.cr
+++ b/spec/tui/text_field_select_spec.cr
@@ -1,0 +1,259 @@
+require "../spec_helper"
+require "../support/memory_backend"
+require "../support/overlay_harness"
+
+include Gori::Tui
+
+# `TextField` — the single-line input behind thirteen modals (import + export paths, the
+# scope pattern, the match & replace and extract rule forms, the OAST provider URL, every
+# Fuzzer tuning field) — had NO selection of any kind.
+#
+# ⇧←/→ moved the caret like a bare arrow. ⇧Home/⇧End did the same. There was no ⌥←/→ by
+# word, no ⌥⌫, and no pointer route in at all: not one of the thirteen inverted a click to a
+# caret, so the only way to replace a long path or a regex was to hold ⌫ down.
+#
+# The anchor is `LineFieldRead`, the SAME model the Repeater/Fuzzer target rows use, so there
+# is one single-line selection in the tree rather than a second one written here. The word
+# rule is `TextArea#word_char?`'s, so a field and a buffer break in the same places.
+#
+# The pointer half works because the field REMEMBERS the x/y/width `render` last drew it at
+# and inverts its own clicks. The geometry of a "label value" row lives in the overlay's
+# `render` and nowhere else — the alternative was thirteen hand-written row rects, thirteen
+# chances to land the caret a column off what was drawn.
+
+private def field_key(k : Termisu::Input::Key, char : Char? = nil,
+                      shift : Bool = false, alt : Bool = false,
+                      ctrl : Bool = false) : Termisu::Event::Key
+  mods = Termisu::Input::Modifier::None
+  mods |= Termisu::Input::Modifier::Shift if shift
+  mods |= Termisu::Input::Modifier::Alt if alt
+  mods |= Termisu::Input::Modifier::Ctrl if ctrl
+  Termisu::Event::Key.new(k, mods, char)
+end
+
+# A field drawn at (0, 1) with 30 columns, so a spec can click it. Rendering is what
+# arms the pointer — an unrendered field must refuse every click.
+private def drawn_field(value : String, width : Int32 = 30) : {TextField, MemoryBackend}
+  f = TextField.new(value)
+  f.home
+  b = MemoryBackend.new(40, 3)
+  f.render(Screen.new(b), 0, 1, width, true, Theme.text, Theme.bg)
+  {f, b}
+end
+
+describe Gori::Tui::TextField do
+  describe "⇧ extends every caret motion" do
+    it "⇧→ selects forward and a bare → collapses it" do
+      f = TextField.new("hello world")
+      f.home
+      f.selection?.should be_false
+      f.handle_edit_key(field_key(Termisu::Input::Key::Right, shift: true))
+      f.selection_text.should eq("h")
+      f.handle_edit_key(field_key(Termisu::Input::Key::Right, shift: true))
+      f.selection_text.should eq("he")
+      f.handle_edit_key(field_key(Termisu::Input::Key::Right))
+      f.selection?.should be_false
+    end
+
+    it "⇧← selects backward from the end" do
+      f = TextField.new("hello")
+      f.handle_edit_key(field_key(Termisu::Input::Key::Left, shift: true))
+      f.handle_edit_key(field_key(Termisu::Input::Key::Left, shift: true))
+      f.selection_text.should eq("lo")
+    end
+
+    it "⇧End selects to the end of the value" do
+      f = TextField.new("hello world")
+      f.home
+      f.handle_edit_key(field_key(Termisu::Input::Key::End, shift: true))
+      f.selection_text.should eq("hello world")
+    end
+
+    it "⇧Home selects back to column 0" do
+      f = TextField.new("hello world")
+      f.handle_edit_key(field_key(Termisu::Input::Key::Home, shift: true))
+      f.selection_text.should eq("hello world")
+    end
+
+    it "a BARE Home collapses the selection" do
+      f = TextField.new("hello")
+      f.handle_edit_key(field_key(Termisu::Input::Key::Home, shift: true))
+      f.selection?.should be_true
+      f.handle_edit_key(field_key(Termisu::Input::Key::End))
+      f.selection?.should be_false
+    end
+  end
+
+  describe "word motion, the same rule TextArea walks" do
+    it "⌥← steps back one token of a URL, not to the start" do
+      f = TextField.new("https://example.com/a")
+      f.handle_edit_key(field_key(Termisu::Input::Key::Left, alt: true))
+      f.caret.should eq("https://example.com/".size)
+    end
+
+    it "⌃→ is accepted too — ⌥ is the macOS spelling of the same modifier" do
+      f = TextField.new("alpha beta")
+      f.home
+      f.handle_edit_key(field_key(Termisu::Input::Key::Right, ctrl: true))
+      f.caret.should eq("alpha ".size)
+    end
+
+    it "⇧⌥← extends by a whole word" do
+      f = TextField.new("alpha beta")
+      f.handle_edit_key(field_key(Termisu::Input::Key::Left, shift: true, alt: true))
+      f.selection_text.should eq("beta")
+    end
+
+    it "⌥⌫ deletes the word behind the caret in one step" do
+      f = TextField.new("alpha beta")
+      f.handle_edit_key(field_key(Termisu::Input::Key::Backspace, alt: true))
+      f.value.should eq("alpha ")
+    end
+
+    it "⌥⌫ arriving as Unknown+Alt carrying DEL is still a word delete" do
+      # A terminal sends ⌥⌫ as ESC + 0x7F; termisu maps the payload through Key.from_char,
+      # which has no name for DEL — so it lands as Unknown with the char attached.
+      f = TextField.new("alpha beta")
+      f.handle_edit_key(field_key(Termisu::Input::Key::Unknown, '\u{7F}', alt: true))
+      f.value.should eq("alpha ")
+    end
+  end
+
+  describe "editing replaces the selection" do
+    it "typing over a selection substitutes it" do
+      f = TextField.new("hello world")
+      f.home
+      5.times { f.handle_edit_key(field_key(Termisu::Input::Key::Right, shift: true)) }
+      f.handle_edit_key(field_key(Termisu::Input::Key::LowerX, 'x'))
+      f.value.should eq("x world")
+      f.selection?.should be_false
+    end
+
+    it "⌫ takes the whole selection, not one character" do
+      f = TextField.new("hello world")
+      f.home
+      6.times { f.handle_edit_key(field_key(Termisu::Input::Key::Right, shift: true)) }
+      f.handle_edit_key(field_key(Termisu::Input::Key::Backspace))
+      f.value.should eq("world")
+    end
+
+    it "Del takes the whole selection too" do
+      f = TextField.new("hello world")
+      f.home
+      6.times { f.handle_edit_key(field_key(Termisu::Input::Key::Right, shift: true)) }
+      f.handle_edit_key(field_key(Termisu::Input::Key::Delete))
+      f.value.should eq("world")
+    end
+
+    it "^Z after deleting a selection restores the run, not the already-cut buffer" do
+      f = TextField.new("hello world")
+      f.home
+      6.times { f.handle_edit_key(field_key(Termisu::Input::Key::Right, shift: true)) }
+      f.handle_edit_key(field_key(Termisu::Input::Key::Backspace))
+      f.value.should eq("world")
+      f.undo
+      f.value.should eq("hello world")
+    end
+
+    it "replacing the value drops the anchor — it indexed a string that is gone" do
+      f = TextField.new("hello world")
+      f.home
+      5.times { f.handle_edit_key(field_key(Termisu::Input::Key::Right, shift: true)) }
+      f.selection?.should be_true
+      f.set("/tmp/x")
+      f.selection?.should be_false
+    end
+  end
+
+  describe "the pointer" do
+    it "an UNRENDERED field refuses every click — nothing knows where it is yet" do
+      f = TextField.new("hello world")
+      f.click_to_cursor(3, 1).should be_false
+      f.hit?(3, 1).should be_false
+    end
+
+    it "a click places the caret at the column pointed at" do
+      f, _ = drawn_field("hello world")
+      f.click_to_cursor(6, 1).should be_true
+      f.caret.should eq(6)
+      f.selection?.should be_false
+    end
+
+    it "a click on another ROW misses the field entirely" do
+      f, _ = drawn_field("hello world")
+      f.click_to_cursor(6, 0).should be_false
+      f.click_to_cursor(6, 2).should be_false
+    end
+
+    it "a click past the field's right edge misses it" do
+      f, _ = drawn_field("hello world", width: 8)
+      f.click_to_cursor(9, 1).should be_false
+    end
+
+    it "a drag from the press extends a selection" do
+      f, _ = drawn_field("hello world")
+      f.click_to_cursor(0, 1)
+      f.click_to_cursor(5, 1, selecting: true)
+      f.selection_text.should eq("hello")
+    end
+
+    it "a press COLLAPSES a standing selection rather than re-anchoring it" do
+      f, _ = drawn_field("hello world")
+      f.handle_edit_key(field_key(Termisu::Input::Key::End, shift: true))
+      f.selection?.should be_true
+      f.click_to_cursor(2, 1)
+      f.selection?.should be_false
+    end
+
+    it "a double-click takes the word under the pointer" do
+      f, _ = drawn_field("hello world")
+      f.select_word_at(8, 1).should be_true
+      f.selection_text.should eq("world")
+    end
+
+    it "a double-click on whitespace takes nothing" do
+      f, _ = drawn_field("hello world")
+      f.select_word_at(5, 1).should be_false
+      f.selection?.should be_false
+    end
+
+    it "a double-click keeps a hyphenated token whole — `-` is a word char" do
+      f, _ = drawn_field("X-Custom-Header")
+      f.select_word_at(3, 1).should be_true
+      f.selection_text.should eq("X-Custom-Header")
+    end
+
+    it "an UNFOCUSED field is still clickable — that click is how it gets focused" do
+      f = TextField.new("hello world")
+      b = MemoryBackend.new(40, 3)
+      f.render(Screen.new(b), 0, 1, 30, false, Theme.text, Theme.bg)
+      f.click_to_cursor(6, 1).should be_true
+      f.caret.should eq(6)
+    end
+  end
+
+  describe "the band is actually on screen" do
+    # REGRESSION GUARD. `Screen#input_line` writes its own `bg` into every cell it touches,
+    # so a band painted BEFORE it was applied and erased on the same frame — which is
+    # exactly what the Repeater/Fuzzer target rows were doing, giving them a selection that
+    # copied correctly and was invisible. The band now rides inside `input_line`, between
+    # the value and the block caret.
+    it "paints the selected cells and leaves the caret cell to the caret" do
+      f, _ = drawn_field("hello world")
+      f.handle_edit_key(field_key(Termisu::Input::Key::Home))
+      5.times { f.handle_edit_key(field_key(Termisu::Input::Key::Right, shift: true)) }
+      b = MemoryBackend.new(40, 3)
+      f.render(Screen.new(b), 0, 1, 30, true, Theme.text, Theme.bg)
+      (0..4).each { |x| b.bg_grid[1][x].should eq(Theme.accent_bg) }
+      b.bg_grid[1][5].should eq(Theme.accent) # the block caret, not the band
+      b.bg_grid[1][6].should eq(Theme.bg)     # past the selection: untouched
+    end
+
+    it "draws no band when there is no selection" do
+      f, _ = drawn_field("hello world")
+      b = MemoryBackend.new(40, 3)
+      f.render(Screen.new(b), 0, 1, 30, true, Theme.text, Theme.bg)
+      (1..4).each { |x| b.bg_grid[1][x].should eq(Theme.bg) }
+    end
+  end
+end

--- a/src/gori/tui/ca_import_overlay.cr
+++ b/src/gori/tui/ca_import_overlay.cr
@@ -53,6 +53,13 @@ module Gori::Tui
       "IMPORT CA"
     end
 
+    # The single-line fields the pointer can reach — see `Overlay#text_fields`. Listing them
+    # is the whole opt-in: caret placement on a press, drag to extend, double-click for a
+    # word, all inverted by the field against the geometry `render` last drew it at.
+    def text_fields : Array(TextField)
+      @fields.values.to_a # NamedTuple on some cards, Hash on others — one shape out
+    end
+
     def hint : String
       "type to complete · ↹/↵ pick · ⇥/↑↓ field · ↵ submits · esc cancels"
     end
@@ -169,6 +176,10 @@ module Gori::Tui
         @sel = i
         @path_complete.close
       end
+      # …then the caret, if the press landed inside a drawn field. The row pick above is
+      # what focuses; this is what puts the caret where the operator pointed instead of
+      # leaving it wherever the last keystroke did (Overlay#click_text_field).
+      click_text_field(mx, my)
       :stay
     end
   end

--- a/src/gori/tui/controllers/fuzzer_controller.cr
+++ b/src/gori/tui/controllers/fuzzer_controller.cr
@@ -217,6 +217,9 @@ module Gori::Tui
       case v.focus
       when :template then v.template_drag_to_cursor(body, mx, my)
       when :detail   then v.detail_click_to_cursor(body, mx, my, selecting: true)
+        # The TARGET row is the third text pane: a single-line READ field with a caret, an
+        # anchor and a painted band (LineFieldRead). It had ⇧←/→ and no pointer route at all.
+      when :target then v.target_drag_to_cursor(body, mx, my)
       end
     end
 
@@ -230,6 +233,8 @@ module Gori::Tui
       when :detail
         return false if v.detail_chip_at(body, mx, my) # a pane chip is a button, not text
         v.detail_select_word(body, mx, my)
+      when :target
+        v.target_select_word
       else false
       end
     end
@@ -435,8 +440,8 @@ module Gori::Tui
       when key.down?  then v.pane_advance(1)
       when key.left?  then v.target_read_move(-1, selecting: selecting)
       when key.right? then v.target_read_move(1, selecting: selecting)
-      when key.home?  then v.target_home
-      when key.end?   then v.target_end
+      when key.home?  then v.target_home(selecting)
+      when key.end?   then v.target_end(selecting)
       when c && !ev.ctrl? && !ev.alt? && !c.control?
         return false # x select-line, y copy, Global breath → keymap
       end

--- a/src/gori/tui/controllers/repeater_controller.cr
+++ b/src/gori/tui/controllers/repeater_controller.cr
@@ -814,6 +814,11 @@ module Gori::Tui
       case v.focus
       when :request  then v.request_drag_to_cursor(body, mx, my)
       when :response then v.resp_drag_to_cursor(body, mx, my)
+        # The TARGET row is a single-line READ field with a caret, an anchor and a painted
+        # band (LineFieldRead) — everything a drag needs. It was missing from both pointer
+        # arms, so the one field an operator most often wants to copy a slice out of (the
+        # URL) had ⇧←/→ and nothing the mouse could do.
+      when :target then v.target_drag_to_cursor(body, mx, my)
       end
     end
 
@@ -824,9 +829,11 @@ module Gori::Tui
       body = body_rect_below_filter(rect)
       return false if v.chrome_hit(body, mx, my) # a border badge is a button, not text
       case v.focus
-      # Both spread from the caret the press placed rather than hit-testing again — see the view.
+      # All three spread from the caret the press placed rather than hit-testing again — see
+      # the view.
       when :request  then v.request_select_word
       when :response then v.resp_select_word
+      when :target   then v.target_select_word
       else                false
       end
     end
@@ -2054,8 +2061,8 @@ module Gori::Tui
       when key.down?  then view.pane_advance(1)
       when key.left?  then view.target_read_move(-1, selecting: selecting)
       when key.right? then view.target_read_move(1, selecting: selecting)
-      when key.home?  then view.target_home
-      when key.end?   then view.target_end
+      when key.home?  then view.target_home(selecting)
+      when key.end?   then view.target_end(selecting)
       when c == 'x'   then view.pane_select_line
       when c && !ev.ctrl? && !ev.alt? && !c.control?
         return false

--- a/src/gori/tui/controllers/rewriter_controller.cr
+++ b/src/gori/tui/controllers/rewriter_controller.cr
@@ -318,32 +318,43 @@ module Gori::Tui
       true
     end
 
+    # Everything below the three pane-crossing arms is `TextArea#handle_motion_key` — the ONE
+    # editor keymap (⇧arrows select, Page keys, ⇧Home/⇧End, ⌥/⌃←→ by word, ⌥⌫). This pane was
+    # the last TextArea editor still hand-rolling its own arrows, and the hand-rolled set passed
+    # no `selecting:` anywhere: it had the MOUSE half of selection (drag + double-click, below)
+    # and none of the keyboard half, while the OUTPUT pane beside it had ⇧arrows all along.
+    #
+    # A crossing arm claims only a BARE press. ⇧ means a selection is mid-build and leaving
+    # would abandon it (the same line Notes and the Project description draw), and ⌥←/⌥↑ are
+    # word/buffer motions this pane owns — routing them out would make ⌥← at column 0 jump to
+    # the rule list instead of stepping back a word.
     private def handle_preview_in_key(ev : Termisu::Event::Key) : Bool
       key = ev.key
       ed = @preview_input
+      crossing = !ev.shift? && !ev.ctrl? && !ev.alt?
       case
       when key.escape?
         @focus = :list
-      when key.up?
-        ed.at_top? ? (@focus = :list) : ed.move(-1, 0)
-      when key.down?
-        ed.at_bottom? ? (@focus = :preview_out) : ed.move(1, 0)
-      when key.left?
-        ed.at_start? ? (@focus = :list) : ed.move(0, -1)
-      when key.right?
-        ed.move(0, 1)
+      when key.up? && crossing && ed.at_top?
+        @focus = :list
+      when key.down? && crossing && ed.at_bottom?
+        @focus = :preview_out
+      when key.left? && crossing && ed.at_start?
+        @focus = :list
       when key.enter?
         ed.insert_newline
+      when ev.ctrl_z?
+        ed.undo
+        # Before plain ⌫, which would otherwise swallow the modified form as a one-character
+        # delete on a terminal that reports ⌥⌫ as Backspace+Alt.
+      when ed.word_delete_key?(ev)
+        ed.handle_motion_key(ev)
       when key.backspace?
         ed.backspace
       when key.delete?
         ed.delete
-      when key.home?
-        ed.home
-      when key.end?
-        ed.end_of_line
-      when ev.ctrl_z?
-        ed.undo
+      when ed.handle_motion_key(ev)
+        # consumed: a caret motion, with or without a selection riding along
       else
         if (c = ev.char || key.to_char) && !ev.ctrl? && !ev.alt? && !c.control?
           ed.insert(c)

--- a/src/gori/tui/custom_rule_overlay.cr
+++ b/src/gori/tui/custom_rule_overlay.cr
@@ -139,6 +139,13 @@ module Gori::Tui
       "CUSTOM RULE"
     end
 
+    # The single-line fields the pointer can reach — see `Overlay#text_fields`. Listing them
+    # is the whole opt-in: caret placement on a press, drag to extend, double-click for a
+    # word, all inverted by the field against the geometry `render` last drew it at.
+    def text_fields : Array(TextField)
+      @fields.values.to_a # NamedTuple on some cards, Hash on others — one shape out
+    end
+
     def hint : String
       "↑/↓ field · ←/→ options · type title/pattern · ↵ save · esc cancel"
     end
@@ -152,6 +159,10 @@ module Gori::Tui
         set_selected(idx)
         return :commit if on_save_row?
       end
+      # …then the caret, if the press landed inside a drawn field. The row pick above is
+      # what focuses; this is what puts the caret where the operator pointed instead of
+      # leaving it wherever the last keystroke did (Overlay#click_text_field).
+      click_text_field(mx, my)
       :stay
     end
 

--- a/src/gori/tui/discover_headers_overlay.cr
+++ b/src/gori/tui/discover_headers_overlay.cr
@@ -98,7 +98,24 @@ module Gori::Tui
       box = overlay_box(area)
       @card_drawn = !box.nil?
       return try_commit unless box
-      box.contains?(mx, my) ? :stay : try_commit
+      return try_commit unless box.contains?(mx, my)
+      @editor.click_to_cursor(editor_rect(box), mx, my) # a press inside is a caret, not a no-op
+      :stay
+    end
+
+    # --- pointer selection (see Overlay#supports_drag?) ---
+    def supports_drag? : Bool
+      true
+    end
+
+    def handle_drag(area : Rect, mx : Int32, my : Int32) : Nil
+      return unless box = overlay_box(area)
+      @editor.click_to_cursor(editor_rect(box), mx, my, selecting: true)
+    end
+
+    def handle_double_click(area : Rect, mx : Int32, my : Int32) : Bool
+      return false unless box = overlay_box(area)
+      @editor.select_word_at(editor_rect(box), mx, my)
     end
 
     # esc = save & close (:commit); every other key edits the buffer (:stay).
@@ -106,8 +123,6 @@ module Gori::Tui
       key = ev.key
       case
       when key.escape? then return try_commit
-      when key.up?     then @editor.move(-1, 0)
-      when key.down?   then @editor.move(1, 0)
       else                  edit(ev)
       end
       :stay
@@ -128,17 +143,21 @@ module Gori::Tui
     # ⏎ inserts a new header line; the rest are the usual TextArea editing/caret keys.
     # Any edit retracts a standing refusal — it is re-derived on the next commit attempt,
     # so the red line can never outlive the line it was about.
+    # ↑/↓ have no pane to cross into (the card is the whole surface), so everything below
+    # ⏎/⌫/Del is `TextArea#handle_motion_key` — the ONE editor keymap: ⇧arrows select,
+    # PageUp/PageDown, ⇧Home/⇧End, ⌥/⌃←→ by word, ⌥⌫. It hand-rolled bare ←→↑↓ and Home/End
+    # and passed no `selecting:` anywhere, so the buffer whose whole job is a list of header
+    # lines had no way to select one and retype it.
     private def edit(ev : Termisu::Event::Key) : Nil
       @refused = nil
       key = ev.key
       case
-      when key.enter?     then @editor.insert_newline
-      when key.backspace? then @editor.backspace
-      when key.delete?    then @editor.delete
-      when key.left?      then @editor.move(0, -1)
-      when key.right?     then @editor.move(0, 1)
-      when key.home?      then @editor.home
-      when key.end?       then @editor.end_of_line
+      when key.enter? then @editor.insert_newline
+        # Before plain ⌫, which would swallow the modified form as a one-character delete.
+      when @editor.word_delete_key?(ev)  then @editor.handle_motion_key(ev)
+      when key.backspace?                then @editor.backspace
+      when key.delete?                   then @editor.delete
+      when @editor.handle_motion_key(ev) then nil
       else
         ch = ev.char || key.to_char
         @editor.insert(ch) if ch && !ev.ctrl? && !ev.alt?
@@ -156,6 +175,15 @@ module Gori::Tui
       Rect.new(area.x + (area.w - w) // 2, area.y + (area.h - h) // 2, w, h)
     end
 
+    # The buffer's rect inside a drawn card. Shared by `render` and the three pointer entries
+    # so the caret cannot land on a row it wasn't drawn on — a click inverting one geometry
+    # while the draw used another is #587's shape, and here it would select the header line
+    # above or below the one pointed at.
+    private def editor_rect(box : Rect) : Rect
+      top = box.y + 1
+      Rect.new(box.x + 2, top, box.w - 4, {(box.bottom - 2) - top, 1}.max)
+    end
+
     def render(screen : Screen, area : Rect) : Nil
       box = overlay_box(area)
       @card_drawn = !box.nil? # what try_commit reads on the next key (see there)
@@ -166,9 +194,8 @@ module Gori::Tui
       # bg: Theme.bg (not the card default panel) so the embedded editor, which paints
       # on Theme.bg, doesn't two-tone against the card interior.
       Frame.card(screen, box, "CUSTOM HEADERS", bg: Theme.bg, border: Theme.border_focus)
-      top = box.y + 1
       hintline = box.bottom - 2
-      editor = Rect.new(box.x + 2, top, box.w - 4, {hintline - top, 1}.max)
+      editor = editor_rect(box)
       if @editor.line_count == 1 && @editor.text.empty?
         screen.text(editor.x, editor.y, "one header per line — e.g. Authorization: Bearer …", Theme.muted, Theme.bg, width: editor.w)
         screen.cursor(editor.x, editor.y)

--- a/src/gori/tui/export_overlay.cr
+++ b/src/gori/tui/export_overlay.cr
@@ -84,6 +84,13 @@ module Gori::Tui
       "EXPORT #{label}"
     end
 
+    # The single-line fields the pointer can reach — see `Overlay#text_fields`. Listing them
+    # is the whole opt-in: caret placement on a press, drag to extend, double-click for a
+    # word, all inverted by the field against the geometry `render` last drew it at.
+    def text_fields : Array(TextField)
+      [@field]
+    end
+
     def hint : String
       "type to complete · ↹ pick · ↑↓ browse · ↵ write · esc cancel"
     end

--- a/src/gori/tui/extract_rule_overlay.cr
+++ b/src/gori/tui/extract_rule_overlay.cr
@@ -188,6 +188,13 @@ module Gori::Tui
       "EXTRACT RULE"
     end
 
+    # The single-line fields the pointer can reach — see `Overlay#text_fields`. Listing them
+    # is the whole opt-in: caret placement on a press, drag to extend, double-click for a
+    # word, all inverted by the field against the geometry `render` last drew it at.
+    def text_fields : Array(TextField)
+      @fields.values.to_a # NamedTuple on some cards, Hash on others — one shape out
+    end
+
     def hint : String
       "↑/↓ field · ←/→ kind · type when/selector · ↵ save · esc cancel"
     end
@@ -231,6 +238,10 @@ module Gori::Tui
         set_selected(idx)
         return :commit if on_save_row?
       end
+      # …then the caret, if the press landed inside a drawn field. The row pick above is
+      # what focuses; this is what puts the caret where the operator pointed instead of
+      # leaving it wherever the last keystroke did (Overlay#click_text_field).
+      click_text_field(mx, my)
       :stay
     end
 

--- a/src/gori/tui/fuzz_advanced_overlay.cr
+++ b/src/gori/tui/fuzz_advanced_overlay.cr
@@ -91,6 +91,13 @@ module Gori::Tui
       "ADVANCED"
     end
 
+    # The single-line fields the pointer can reach — see `Overlay#text_fields`. Listing them
+    # is the whole opt-in: caret placement on a press, drag to extend, double-click for a
+    # word, all inverted by the field against the geometry `render` last drew it at.
+    def text_fields : Array(TextField)
+      @fields.values.to_a # NamedTuple on some cards, Hash on others — one shape out
+    end
+
     def hint : String
       "↑/↓/⇥ field · ←/→ edit · ␣ toggle · ↵ next · esc applies & closes"
     end
@@ -239,6 +246,10 @@ module Gori::Tui
       return :stay if i < 0 || i >= list_capacity(box)
       ri = @scroll + i
       @sel = ri if ri < ROWS.size
+      # …then the caret, if the press landed inside a drawn field. The row pick above is
+      # what focuses; this is what puts the caret where the operator pointed instead of
+      # leaving it wherever the last keystroke did (Overlay#click_text_field).
+      click_text_field(mx, my)
       :stay
     end
   end

--- a/src/gori/tui/fuzz_set_overlay.cr
+++ b/src/gori/tui/fuzz_set_overlay.cr
@@ -35,7 +35,7 @@ module Gori::Tui
     def initialize(@edit_index : Int32? = nil)
       @ptype = :list
       @preset_name = Gori::Fuzz::Presets.names.first? || "sqli" # the built-in preset selector's value
-      @sel = 0 # row cursor: 0 = the Type selector, then the type's fields
+      @sel = 0                                                  # row cursor: 0 = the Type selector, then the type's fields
       @fields = {
         :from    => TextField.new("1"),
         :to      => TextField.new("100"),
@@ -135,6 +135,13 @@ module Gori::Tui
       "PAYLOAD SET"
     end
 
+    # The single-line fields the pointer can reach — see `Overlay#text_fields`. Listing them
+    # is the whole opt-in: caret placement on a press, drag to extend, double-click for a
+    # word, all inverted by the field against the geometry `render` last drew it at.
+    def text_fields : Array(TextField)
+      @fields.values.to_a # NamedTuple on some cards, Hash on others — one shape out
+    end
+
     def hint : String
       "↑/↓/⇥ field · ←/→ type/caret · ↵ new value/next · esc applies & closes"
     end
@@ -174,11 +181,11 @@ module Gori::Tui
     private def handle_preset_name(ev : Termisu::Event::Key) : Symbol
       key = ev.key
       case
-      when key.left?             then cycle_preset(-1)
-      when key.right?            then cycle_preset(1)
-      when key.up?               then move_row(-1)
-      when key.down?             then move_row(1)
-      when key.enter?            then return :commit
+      when key.left?  then cycle_preset(-1)
+      when key.right? then cycle_preset(1)
+      when key.up?    then move_row(-1)
+      when key.down?  then move_row(1)
+      when key.enter? then return :commit
       end
       :stay
     end
@@ -212,25 +219,31 @@ module Gori::Tui
 
     private def handle_values(ev : Termisu::Event::Key) : Symbol
       key = ev.key
+      # A ROW-crossing ↑ claims only a BARE press: ⇧ means a selection is mid-build and
+      # leaving the buffer would abandon it, and ⌥↑ is a motion this editor owns. The same
+      # line the Notes and Project-description editors draw.
+      crossing = !ev.shift? && !ev.ctrl? && !ev.alt?
       case
-      when key.up?   then @values.at_top? ? move_row(-1) : @values.move(-1, 0)
-      when key.down? then @values.move(1, 0) unless @values.at_bottom?
-      else                edit_values(ev) # enter = new value line, else edit/caret
+      when key.up? && crossing && @values.at_top?      then move_row(-1)
+      when key.down? && crossing && @values.at_bottom? then nil             # the last value is the floor
+      else                                                  edit_values(ev) # enter = new value line, else edit/caret
       end
       :stay
     end
 
-    # ⏎ inserts a new value line; the rest are the usual TextArea editing/caret keys.
+    # ⏎ inserts a new value line; everything below ⌫/Del is `TextArea#handle_motion_key` —
+    # the ONE editor keymap (⇧arrows select, PageUp/PageDown, ⇧Home/⇧End, ⌥/⌃←→ by word,
+    # ⌥⌫). This buffer hand-rolled bare ←→ and Home/End and passed no `selecting:` anywhere,
+    # so the pane an operator PASTES A WORDLIST INTO had no way to select a run of it back out.
     private def edit_values(ev : Termisu::Event::Key) : Nil
       key = ev.key
       case
-      when key.enter?     then @values.insert_newline
-      when key.backspace? then @values.backspace
-      when key.delete?    then @values.delete
-      when key.left?      then @values.move(0, -1)
-      when key.right?     then @values.move(0, 1)
-      when key.home?      then @values.home
-      when key.end?       then @values.end_of_line
+      when key.enter? then @values.insert_newline
+        # Before plain ⌫, which would swallow the modified form as a one-character delete.
+      when @values.word_delete_key?(ev)  then @values.handle_motion_key(ev)
+      when key.backspace?                then @values.backspace
+      when key.delete?                   then @values.delete
+      when @values.handle_motion_key(ev) then nil
       else
         ch = ev.char || key.to_char
         @values.insert(ch) if ch && !ev.ctrl? && !ev.alt?
@@ -348,13 +361,13 @@ module Gori::Tui
 
     private def field_label(f : Symbol) : String
       case f
-      when :from    then "From"
-      when :to      then "To"
-      when :step    then "Step"
-      when :count   then "Count"
-      when :charset then "Charset"
-      when :min     then "Min"
-      when :max     then "Max"
+      when :from        then "From"
+      when :to          then "To"
+      when :step        then "Step"
+      when :count       then "Count"
+      when :charset     then "Charset"
+      when :min         then "Min"
+      when :max         then "Max"
       when :path        then "Path"
       when :preset_name then "Preset"
       else                   ""
@@ -474,10 +487,16 @@ module Gori::Tui
       nil
     end
 
-    private def render_values(screen : Screen, box : Rect) : Nil
+    # The value list's rect inside a drawn card. Shared by `render_values` and the three
+    # pointer entries so the caret cannot land on a row it wasn't drawn on — the click arm
+    # used to re-derive this expression by hand, one copy away from drifting.
+    private def values_rect(box : Rect) : Rect
       top = box.y + 3
-      h = {(box.bottom - 2) - top, 1}.max
-      editor = Rect.new(box.x + 2, top, box.w - 4, h)
+      Rect.new(box.x + 2, top, box.w - 4, {(box.bottom - 2) - top, 1}.max)
+    end
+
+    private def render_values(screen : Screen, box : Rect) : Nil
+      editor = values_rect(box)
       foc = focused == :values
       if @values.line_count == 1 && @values.text.empty?
         screen.text(editor.x, editor.y, "one value per line — paste a wordlist, it splits automatically", Theme.muted, Theme.bg, width: editor.w)
@@ -516,13 +535,34 @@ module Gori::Tui
         sync_path_complete
       elsif @ptype == :list
         @sel = rows.index(:values) || @sel
-        @values.click_to_cursor(Rect.new(box.x + 2, box.y + 3, box.w - 4, {(box.bottom - 2) - (box.y + 3), 1}.max), mx, my)
+        @values.click_to_cursor(values_rect(box), mx, my)
       else
         i = my - (box.y + 3)
         @sel = (i + 1).clamp(1, rows.size - 1) if 0 <= i < field_rows.size
         sync_path_complete
       end
       :stay
+    end
+
+    # --- pointer selection (see Overlay#supports_drag?) ---
+    # This card has BOTH kinds of text: the LIST payload type is a real multi-line `TextArea`
+    # (`@values`), every other type is single-line `TextField` rows. So each entry handles the
+    # buffer when it is showing and otherwise falls through to the base, which routes to
+    # whichever listed field was drawn under the pointer.
+    def supports_drag? : Bool
+      @ptype == :list || super
+    end
+
+    def handle_drag(area : Rect, mx : Int32, my : Int32) : Nil
+      return super unless @ptype == :list
+      return unless box = overlay_box(area)
+      @values.click_to_cursor(values_rect(box), mx, my, selecting: true)
+    end
+
+    def handle_double_click(area : Rect, mx : Int32, my : Int32) : Bool
+      return super unless @ptype == :list
+      return false unless box = overlay_box(area)
+      @values.select_word_at(values_rect(box), mx, my)
     end
 
     def move(d : Int32) : Nil

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -1590,12 +1590,24 @@ module Gori::Tui
       end
     end
 
-    def target_home : Nil
-      @target_field == :sni ? (@scx = 0) : (@tcx = 0)
+    # Home/End on the target/SNI row, ⇧ EXTENDING — the Repeater twin of these carries the
+    # reasoning: assigning the caret directly DROPPED the selection ⇧Home/⇧End was asking to
+    # grow, because the anchor lives in `@target_read` and a bare assignment never reaches it.
+    # A bare press still clears the anchor, which is what the INSERT-mode callers rely on.
+    def target_home(selecting : Bool = false) : Nil
+      if @target_field == :sni
+        @scx = @target_read.move_cx(@scx, -@scx, @sni.size, selecting: selecting)
+      else
+        @tcx = @target_read.move_cx(@tcx, -@tcx, @target.size, selecting: selecting)
+      end
     end
 
-    def target_end : Nil
-      @target_field == :sni ? (@scx = @sni.size) : (@tcx = @target.size)
+    def target_end(selecting : Bool = false) : Nil
+      if @target_field == :sni
+        @scx = @target_read.move_cx(@scx, @sni.size - @scx, @sni.size, selecting: selecting)
+      else
+        @tcx = @target_read.move_cx(@tcx, @target.size - @tcx, @target.size, selecting: selecting)
+      end
     end
 
     def target_read_move(dc : Int32, selecting : Bool = false) : Nil
@@ -2074,12 +2086,15 @@ module Gori::Tui
       screen.text(rect.x + 2, row, prefix, active ? Theme.accent : Theme.muted)
       base = field_base(rect, prefix)
       w = {rect.right - base - 1, 1}.max
+      Highlight.draw(screen, base, row, Highlight.env_line(value, Theme.text_bright), width: w)
+      # AFTER the value and before the caret — see `RepeaterView#draw_target_row`, whose note
+      # carries the reasoning: `Highlight.draw` writes its own `bg` over every cell, so a band
+      # painted first was erased on the same frame and this row's ⇧←/→ selection was invisible.
       if active && !insert
         if span = @target_read.selection_span(cx)
           paint_char_span_bg(screen, base, row, value, span[0], span[1], Theme.accent_bg)
         end
       end
-      Highlight.draw(screen, base, row, Highlight.env_line(value, Theme.text_bright), width: w)
       if active
         cursor_x = base + Screen.draw_width(value[0, cx])
         if cursor_x < rect.right - 1
@@ -2933,18 +2948,49 @@ module Gori::Tui
     # --- clicks --------------------------------------------------------------
     # Mouse: place the TARGET field caret at a click. Single-line field; the value
     # base mirrors render_target (the "›" marker at rect.x+2, the value at rect.x+4).
-    def target_click_to_cursor(rect : Rect, mx : Int32, my : Int32) : Nil
+    # `selecting` is the DRAG half — see `RepeaterView#target_click_to_cursor`, whose
+    # reasoning this mirrors: a drag never switches FIELDS (the anchor would end up measured
+    # in one value and painted over another), and even a bare press routes through `move_cx`
+    # so it COLLAPSES a standing selection instead of leaving the anchor behind.
+    def target_click_to_cursor(rect : Rect, mx : Int32, my : Int32, selecting : Bool = false) : Nil
       return unless @loaded
       # Row 2 is the SNI field when it is showing — a click there selects that field, the
       # same mapping RepeaterView#target_click_to_cursor makes, so the caret cannot land on
       # the row the click did not point at.
-      if sni_active? && my == rect.y + 2
-        @target_field = :sni
-        @scx = Screen.column_for(@sni, mx - field_base(rect, SNI_PREFIX))
+      @target_field = (sni_active? && my == rect.y + 2) ? :sni : :url unless selecting
+      if @target_field == :sni
+        to = Screen.column_for(@sni, mx - field_base(rect, SNI_PREFIX))
+        @scx = @target_read.move_cx(@scx, to - @scx, @sni.size, selecting: selecting)
       else
-        @target_field = :url
-        @tcx = Screen.column_for(@target, mx - field_base(rect, TARGET_PREFIX))
+        to = Screen.column_for(@target, mx - field_base(rect, TARGET_PREFIX))
+        @tcx = @target_read.move_cx(@tcx, to - @tcx, @target.size, selecting: selecting)
       end
+    end
+
+    # Pointer moved with the button held over the target card — READ mode only, for the
+    # reason spelled out on `RepeaterView#target_drag_to_cursor`: INSERT paints no band, so
+    # extending there would plant a selection nothing draws and `target_copy_text` would
+    # still honour it.
+    def target_drag_to_cursor(rect : Rect, mx : Int32, my : Int32) : Nil
+      return if target_insert?
+      target_click_to_cursor(rect, mx, my, selecting: true)
+    end
+
+    # Double-click: take the word the press already placed the caret on, spreading from THAT
+    # caret rather than hit-testing again. False on whitespace or an empty field, leaving the
+    # press's caret standing.
+    def target_select_word : Bool
+      return false unless @loaded && !target_insert?
+      if @target_field == :sni
+        cx = @target_read.select_word_at_cursor(@sni, @scx)
+        return false unless cx
+        @scx = cx
+      else
+        cx = @target_read.select_word_at_cursor(@target, @tcx)
+        return false unless cx
+        @tcx = cx
+      end
+      true
     end
 
     # Mouse: place the TEMPLATE editor caret at a click. Re-derives the template

--- a/src/gori/tui/import_overlay.cr
+++ b/src/gori/tui/import_overlay.cr
@@ -67,6 +67,13 @@ module Gori::Tui
       "IMPORT #{label}"
     end
 
+    # The single-line fields the pointer can reach — see `Overlay#text_fields`. Listing them
+    # is the whole opt-in: caret placement on a press, drag to extend, double-click for a
+    # word, all inverted by the field against the geometry `render` last drew it at.
+    def text_fields : Array(TextField)
+      [@field]
+    end
+
     def hint : String
       "type to complete · ↹ pick · ↑↓ browse · ↵ import · esc cancel"
     end

--- a/src/gori/tui/line_field_read.cr
+++ b/src/gori/tui/line_field_read.cr
@@ -27,6 +27,37 @@ module Gori::Tui
       end
     end
 
+    # Select the WORD at `cx` (double-click). Same boundary rule as `ReadCursor` and
+    # `TextArea#select_word_at`: a word is a run of key-ish chars (letters, digits, `_`, `-`)
+    # or a run of punctuation, so a URL breaks at every `/`, `?` and `=` while a host label
+    # stays whole. Whitespace (or past end-of-value) selects nothing.
+    #
+    # Returns the caret's NEW column, or nil when there was no word to take — a caller that
+    # gets nil leaves its caret exactly where the press put it, which is what makes a
+    # double-click on whitespace fall back to the ordinary click.
+    def select_word_at_cursor(line : String, cx : Int32) : Int32?
+      c = cx.clamp(0, line.size)
+      return nil if c >= line.size || line[c].whitespace?
+      word = word_char?(line[c])
+      a = c
+      while a > 0 && !line[a - 1].whitespace? && word_char?(line[a - 1]) == word
+        a -= 1
+      end
+      b = c
+      while b < line.size && !line[b].whitespace? && word_char?(line[b]) == word
+        b += 1
+      end
+      return nil if a == b
+      @anchor = a
+      b
+    end
+
+    # See `TextArea#word_char?` / `ReadCursor#word_char?` — all three must agree, or a
+    # double-click and ⌥←/→ would disagree about where a word ends in the same value.
+    private def word_char?(c : Char) : Bool
+      c.alphanumeric? || c == '_' || c == '-'
+    end
+
     def selection_span(cx : Int32) : {Int32, Int32}?
       return nil unless (ax = @anchor)
       x0, x1 = {ax, cx}.min, {ax, cx}.max

--- a/src/gori/tui/name_prompt_overlay.cr
+++ b/src/gori/tui/name_prompt_overlay.cr
@@ -36,6 +36,13 @@ module Gori::Tui
       OverlayKind::NamePrompt
     end
 
+    # The single-line fields the pointer can reach — see `Overlay#text_fields`. Listing them
+    # is the whole opt-in: caret placement on a press, drag to extend, double-click for a
+    # word, all inverted by the field against the geometry `render` last drew it at.
+    def text_fields : Array(TextField)
+      [@field]
+    end
+
     def hint : String
       "type a name · ↵ #{@action} · esc cancel"
     end

--- a/src/gori/tui/oast_provider_overlay.cr
+++ b/src/gori/tui/oast_provider_overlay.cr
@@ -112,6 +112,13 @@ module Gori::Tui
       "OAST PROVIDER"
     end
 
+    # The single-line fields the pointer can reach — see `Overlay#text_fields`. Listing them
+    # is the whole opt-in: caret placement on a press, drag to extend, double-click for a
+    # word, all inverted by the field against the geometry `render` last drew it at.
+    def text_fields : Array(TextField)
+      [@name, @host, @token]
+    end
+
     def hint : String
       "↑/↓ field · ←/→ scope/type · type name/host/token · ↵ save · esc cancel"
     end
@@ -125,6 +132,10 @@ module Gori::Tui
         set_selected(idx)
         return :commit if on_save_row?
       end
+      # …then the caret, if the press landed inside a drawn field. The row pick above is
+      # what focuses; this is what puts the caret where the operator pointed instead of
+      # leaving it wherever the last keystroke did (Overlay#click_text_field).
+      click_text_field(mx, my)
       :stay
     end
 

--- a/src/gori/tui/overlay.cr
+++ b/src/gori/tui/overlay.cr
@@ -1,6 +1,7 @@
 require "termisu"
 require "./screen"
 require "./geometry"
+require "./text_field"
 
 module Gori::Tui
   # Every modal state the shell's `@overlay` can hold. This was a bare `Symbol` with 33
@@ -168,7 +169,64 @@ module Gori::Tui
     # stays" behaviour; overlays with clickable rows override to also commit on a hit.
     def handle_click(area : Rect, mx : Int32, my : Int32) : Symbol
       box = overlay_box(area)
-      (box.nil? || !box.contains?(mx, my)) ? :cancel : :stay
+      return :cancel if box.nil? || !box.contains?(mx, my)
+      click_text_field(mx, my) # a press inside a drawn field is a caret, not a no-op
+      :stay
+    end
+
+    # Whether a press inside this modal can start a DRAG — pointer motion with the button
+    # held, which extends a selection from where the press landed. False by default: an
+    # overlay opts in only when its card holds text with a selection to extend.
+    #
+    # The shell dragged NOTHING over an overlay before this: `Runner#dispatch_drag` reached
+    # only the active tab, so the three modals that embed a real multi-line editor (the
+    # Rewriter stub, the Discover headers, the Fuzzer SET value list) were text an operator
+    # could type into and could not select with the pointer. The tab-side contract this
+    # mirrors is `TabController#supports_drag?` / `#handle_drag` / `#handle_double_click`,
+    # deliberately spelled the same way so the shell's two tiers read alike.
+    #
+    # All three take the SAME `area` the shell hands `handle_click` (the body rect), because
+    # an overlay hit-tests its own card: the shell owns no geometry inside it.
+    def supports_drag? : Bool
+      !text_fields.empty?
+    end
+
+    # The single-line fields this modal draws. Default empty; an overlay that lists them
+    # here gets drag-select and double-click word-select for FREE, because a `TextField`
+    # remembers the x/y/width it was last drawn at and inverts its own clicks (`hit?`).
+    #
+    # That indirection is the point: the geometry of a "label value" row lives in the
+    # overlay's `render` and nowhere else, so the alternative was thirteen hand-written row
+    # rects for the pointer to invert — thirteen chances to land the caret a column off what
+    # was drawn. The field is the only thing that already knows.
+    #
+    # The PRESS is still each overlay's own business (it also picks the focused row), which
+    # is why `handle_click` is not defaulted here.
+    def text_fields : Array(TextField)
+      [] of TextField
+    end
+
+    # Pointer moved with the button held. Extends the selection to (mx, my).
+    def handle_drag(area : Rect, mx : Int32, my : Int32) : Nil
+      text_fields.each { |f| break if f.click_to_cursor(mx, my, selecting: true) }
+    end
+
+    # Two presses in the same cell inside the double-click window. Selects the word under
+    # the pointer; return false to fall back to the ordinary single-click behaviour (which,
+    # for a modal, includes the click-away dismiss — so a modal that answers true here is
+    # also saying "this press was text, not a dismiss").
+    def handle_double_click(area : Rect, mx : Int32, my : Int32) : Bool
+      text_fields.each { |f| return true if f.select_word_at(mx, my) }
+      false
+    end
+
+    # Place the caret in whichever listed field was drawn under the pointer, collapsing any
+    # standing selection. Overlays call this from their own `handle_click` — one line, after
+    # they have picked the focused row — so a press inside a field is a caret rather than a
+    # no-op. Returns whether a field took it.
+    def click_text_field(mx : Int32, my : Int32) : Bool
+      text_fields.each { |f| return true if f.click_to_cursor(mx, my) }
+      false
     end
 
     # The modal's box within `area` — the click-away hit-test. `nil` means the card has

--- a/src/gori/tui/repeater_view.cr
+++ b/src/gori/tui/repeater_view.cr
@@ -2806,17 +2806,49 @@ module Gori::Tui
 
     # Mouse: focus the URL or SNI field of the TARGET band by which row was clicked,
     # and place that field's caret. The value bases mirror render_target (field_base).
-    def target_click_to_cursor(rect : Rect, mx : Int32, my : Int32) : Nil
+    # `selecting` is the DRAG half: it extends the read selection from wherever the press
+    # planted the anchor, and — unlike a press — it never switches FIELDS. A drag that
+    # crossed from the URL row down onto the SNI row would otherwise re-aim the anchor at a
+    # different string, so the band would be measured in one value and painted over another.
+    #
+    # A bare press goes through `move_cx` too, rather than assigning the caret: that is what
+    # COLLAPSES a standing selection. Assigning left the anchor behind, so a click after a
+    # ⇧←/→ run repainted the band from the old anchor to the new caret — a selection the
+    # operator had just clicked away from.
+    def target_click_to_cursor(rect : Rect, mx : Int32, my : Int32, selecting : Bool = false) : Nil
       return unless @loaded
       # The SNI row is at exactly rect.y+2 (bottom border is rect.y+3) — match it
       # precisely, so a click on the card's border doesn't route edits into @sni.
-      if sni_active? && my == rect.y + 2
-        @target_field = :sni
-        @scx = Screen.column_for(@sni, mx - field_base(rect, SNI_PREFIX))
-      else
-        @target_field = :url
-        @tcx = Screen.column_for(@target, mx - field_base(rect, TARGET_PREFIX))
-      end
+      @target_field = (sni_active? && my == rect.y + 2) ? :sni : :url unless selecting
+      prefix = @target_field == :sni ? SNI_PREFIX : TARGET_PREFIX
+      line = target_active_line
+      to = Screen.column_for(line, mx - field_base(rect, prefix))
+      cx = @target_read.move_cx(target_active_cx, to - target_active_cx, line.size, selecting: selecting)
+      @target_field == :sni ? (@scx = cx) : (@tcx = cx)
+    end
+
+    # Pointer moved with the button held over the target card — extend from the press.
+    #
+    # READ mode only, because that is the only mode whose band `draw_target_row` paints
+    # (`active && !insert`). Extending in INSERT would plant an anchor nothing draws and
+    # `target_copy_text` would then hand back a slice the operator never saw selected — a
+    # silent selection is worse than none. The INSERT half of this field has no selection at
+    # all yet; when it grows one, this guard is what lifts.
+    def target_drag_to_cursor(rect : Rect, mx : Int32, my : Int32) : Nil
+      return if target_insert?
+      target_click_to_cursor(rect, mx, my, selecting: true)
+    end
+
+    # Double-click: take the word the press already placed the caret on. Spreads from THAT
+    # caret rather than hit-testing again (the same rule the request/response panes follow),
+    # so the two presses of the pair cannot disagree about which character was under the
+    # pointer. False on whitespace or an empty field, leaving the press's caret standing.
+    def target_select_word : Bool
+      return false unless @loaded && !target_insert?
+      cx = @target_read.select_word_at_cursor(target_active_line, target_active_cx)
+      return false unless cx
+      @target_field == :sni ? (@scx = cx) : (@tcx = cx)
+      true
     end
 
     # Top boundary of the focused pane — the Runner pops focus to the tab bar when
@@ -3242,12 +3274,23 @@ module Gori::Tui
     end
 
     # Home/End on the single-line target/SNI field — pure caret moves, no dirty.
-    def target_home : Nil
-      @target_field == :sni ? (@scx = 0) : (@tcx = 0)
+    # Home/End on the target/SNI row, ⇧ EXTENDING like every other pane's.
+    #
+    # These two assigned the caret directly, which meant ⇧Home/⇧End DROPPED the selection the
+    # shift was asking them to grow — the read cursor's anchor lives in `@target_read` and
+    # nothing here told it anything. Same defect #583 fixed in `TextArea#home`/`#end_of_line`,
+    # left standing on the one field that is not a TextArea. Routed through `move_cx` with a
+    # delta to the line edge so the anchor rule stays in ONE place: a bare press still clears
+    # it, which is what the INSERT-mode callers (who pass no `selecting`) rely on.
+    def target_home(selecting : Bool = false) : Nil
+      cx = @target_read.move_cx(target_active_cx, -target_active_cx, target_active_line.size, selecting: selecting)
+      @target_field == :sni ? (@scx = cx) : (@tcx = cx)
     end
 
-    def target_end : Nil
-      @target_field == :sni ? (@scx = @sni.size) : (@tcx = @target.size)
+    def target_end(selecting : Bool = false) : Nil
+      len = target_active_line.size
+      cx = @target_read.move_cx(target_active_cx, len - target_active_cx, len, selecting: selecting)
+      @target_field == :sni ? (@scx = cx) : (@tcx = cx)
     end
 
     # Forward-delete the char under the caret on the target/SNI field — a content edit.
@@ -4029,12 +4072,17 @@ module Gori::Tui
       screen.text(rect.x + 2, row, prefix, active ? Theme.accent : Theme.muted)
       base = field_base(rect, prefix)
       w = {rect.right - base - 1, 1}.max
+      Highlight.draw(screen, base, row, Highlight.env_line(value, Theme.text_bright), width: w)
+      # AFTER the value, and before the caret below. `Highlight.draw` writes its own `bg`
+      # into every cell it touches, so a band painted first was applied and erased on the
+      # same frame: ⇧←/→ on this row selected, `y` copied the right slice, and the operator
+      # saw nothing. The caret still goes last, because when the selection grows LEFTWARD
+      # the caret cell is inside the span and the band would otherwise erase it.
       if active && !insert
         if span = @target_read.selection_span(cx)
           paint_char_span_bg(screen, base, row, value, span[0], span[1], Theme.accent_bg)
         end
       end
-      Highlight.draw(screen, base, row, Highlight.env_line(value, Theme.text_bright), width: w)
       if active
         # column_width — the measure paint_char_span_bg (the selection tint, a few lines up)
         # already uses on this same value in this same render, and the exact inverse of the

--- a/src/gori/tui/rewriter_rule_overlay.cr
+++ b/src/gori/tui/rewriter_rule_overlay.cr
@@ -281,6 +281,13 @@ module Gori::Tui
       "REWRITER RULE"
     end
 
+    # The single-line fields the pointer can reach — see `Overlay#text_fields`. Listing them
+    # is the whole opt-in: caret placement on a press, drag to extend, double-click for a
+    # word, all inverted by the field against the geometry `render` last drew it at.
+    def text_fields : Array(TextField)
+      @fields.values.to_a # NamedTuple on some cards, Hash on others — one shape out
+    end
+
     def hint : String
       "↑/↓ field · ←/→ options · type find/value · ↵ save · esc cancel"
     end
@@ -304,6 +311,10 @@ module Gori::Tui
         return :commit if on_save_row?
         @on_edit_stub.try(&.call) if idx == ROW_VALUE && short_circuit_op?
       end
+      # …then the caret, if the press landed inside a drawn field. The row pick above is
+      # what focuses; this is what puts the caret where the operator pointed instead of
+      # leaving it wherever the last keystroke did (Overlay#click_text_field).
+      click_text_field(mx, my)
       :stay
     end
 

--- a/src/gori/tui/rewriter_stub_overlay.cr
+++ b/src/gori/tui/rewriter_stub_overlay.cr
@@ -49,33 +49,53 @@ module Gori::Tui
     end
 
     # Nothing to cancel INTO (the rule form is still underneath), so a click outside the card
-    # saves exactly like esc.
+    # saves exactly like esc. A click INSIDE places the caret: this is a text editor, and a
+    # press that only kept the card up was the one pointer gesture it answered.
     def handle_click(area : Rect, mx : Int32, my : Int32) : Symbol
       box = overlay_box(area)
-      (box.nil? || !box.contains?(mx, my)) ? :commit : :stay
+      return :commit if box.nil? || !box.contains?(mx, my)
+      @editor.click_to_cursor(editor_rect(box), mx, my)
+      :stay
+    end
+
+    # --- pointer selection (see Overlay#supports_drag?) ---
+    def supports_drag? : Bool
+      true
+    end
+
+    def handle_drag(area : Rect, mx : Int32, my : Int32) : Nil
+      return unless box = overlay_box(area)
+      @editor.click_to_cursor(editor_rect(box), mx, my, selecting: true)
+    end
+
+    def handle_double_click(area : Rect, mx : Int32, my : Int32) : Bool
+      return false unless box = overlay_box(area)
+      @editor.select_word_at(editor_rect(box), mx, my)
     end
 
     def handle_key(ev : Termisu::Event::Key) : Symbol
       key = ev.key
       case
       when key.escape? then return :commit
-      when key.up?     then @editor.move(-1, 0)
-      when key.down?   then @editor.move(1, 0)
       else                  edit(ev)
       end
       :stay
     end
 
+    # ↑/↓ have no pane to cross into (the card is the whole surface), so everything below
+    # ⏎/⌫/Del is `TextArea#handle_motion_key` — the ONE editor keymap: ⇧arrows select,
+    # PageUp/PageDown, ⇧Home/⇧End, ⌥/⌃←→ by word, ⌥⌫. This editor hand-rolled bare ←→↑↓ and
+    # Home/End and passed no `selecting:` anywhere, so a multi-line HTTP response was a buffer
+    # with no way to select a header line and replace it.
     private def edit(ev : Termisu::Event::Key) : Nil
       key = ev.key
       case
-      when key.enter?     then @editor.insert_newline
-      when key.backspace? then @editor.backspace
-      when key.delete?    then @editor.delete
-      when key.left?      then @editor.move(0, -1)
-      when key.right?     then @editor.move(0, 1)
-      when key.home?      then @editor.home
-      when key.end?       then @editor.end_of_line
+      when key.enter? then @editor.insert_newline
+        # Before plain ⌫, which would swallow the modified form as a one-character delete.
+      when @editor.word_delete_key?(ev)  then @editor.handle_motion_key(ev)
+      when key.backspace?                then @editor.backspace
+      when key.delete?                   then @editor.delete
+      when @editor.handle_motion_key(ev) then nil
       else
         ch = ev.char || key.to_char
         @editor.insert(ch) if ch && !ev.ctrl? && !ev.alt?
@@ -93,6 +113,15 @@ module Gori::Tui
       Rect.new(area.x + (area.w - w) // 2, area.y + (area.h - h) // 2, w, h)
     end
 
+    # The buffer's rect inside a drawn card. Shared by `render` and the three pointer
+    # entries so the caret cannot land on a row it wasn't drawn on: a click that inverts one
+    # geometry while the draw used another is #587's shape, and here it would be a header
+    # line selected one row off the one the operator pointed at.
+    private def editor_rect(box : Rect) : Rect
+      top = box.y + 1
+      Rect.new(box.x + 2, top, box.w - 4, {(box.bottom - 3) - top, 1}.max)
+    end
+
     def render(screen : Screen, area : Rect) : Nil
       box = overlay_box(area)
       unless box
@@ -105,7 +134,7 @@ module Gori::Tui
       top = box.y + 1
       statusy = box.bottom - 3
       hintline = box.bottom - 2
-      editor = Rect.new(box.x + 2, top, box.w - 4, {statusy - top, 1}.max)
+      editor = editor_rect(box)
       if @editor.line_count == 1 && @editor.text.empty?
         screen.text(editor.x, editor.y, "200 OK", Theme.muted, Theme.bg, width: editor.w)
         screen.text(editor.x, editor.y + 1, "Content-Type: application/json", Theme.muted, Theme.bg, width: editor.w) if editor.h > 1

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -1400,32 +1400,59 @@ module Gori::Tui
         return
       end
       dispatch_click(layout, mx, my)
-      @dragging = body_click_target?(layout, mx, my)
+      @dragging = drag_press_target?(layout, mx, my)
     end
 
-    # Whether a press at these coords landed on a body pane that can extend a selection —
-    # i.e. whether the motion that follows means anything. Nothing else (tab bar, sub-tab
-    # strip, overlays, the bottom prompts) drags.
-    # `!modal_overlay?` and NOT `@overlay.none?`, mirroring `dispatch_click`'s own precedence:
-    # `:detail` is a History body drill-in rather than a capturing modal, so a press inside it
-    # reaches the tab — and so must the drag and the double-click that follow, or the
-    # request/response text is the one place selection works by keyboard and not by mouse.
-    private def body_click_target?(layout : Layout, mx : Int32, my : Int32) : Bool
-      return false unless @focus == :body && !modal_overlay?
+    # Whether a press at these coords landed somewhere that can extend a selection — i.e.
+    # whether the motion that follows means anything.
+    #
+    # TWO tiers, in `dispatch_click`'s order, because whatever took the PRESS is what the
+    # motion continuing it has to reach: the migrated modal on top when it opts in
+    # (`Overlay#supports_drag?`), otherwise the active tab's body pane. Everything that
+    # captures a click without owning selectable text answers false — the space menu, the
+    # copy-as / send-to pickers, the bottom prompts, and the two un-migrated modals.
+    #
+    # The overlay tier is new. It used to read "nothing else (tab bar, sub-tab strip,
+    # overlays, the bottom prompts) drags", which made the modals that embed a full
+    # multi-line editor the one class of text box where the keyboard could select and the
+    # pointer could not.
+    #
+    # `!modal_overlay?` on the TAB tier and NOT `@overlay.none?`, mirroring `dispatch_click`'s
+    # own precedence: `:detail` is a History body drill-in rather than a capturing modal, so a
+    # press inside it reaches the tab — and so must the drag and the double-click that follow,
+    # or the request/response text is the one place selection works by keyboard and not by mouse.
+    private def drag_press_target?(layout : Layout, mx : Int32, my : Int32) : Bool
       return false if @space_menu_open || copy_as_shown? || send_to_shown?
       return false if @goto_open || @search_open || @rename_open || @tag_edit_open
+      # An overlay hit-tests its own card, so the shell asks only whether it opts in — it owns
+      # no geometry inside the modal to test against.
+      if ov = active_overlay
+        return ov.supports_drag?
+      end
+      return false if modal_overlay? # palette / more menu: capture without dragging
+      return false unless @focus == :body
       layout.body.contains?(mx, my) && (@tabs[@active_tab]?.try(&.supports_drag?) || false)
     end
 
     private def dispatch_drag(layout : Layout, mx : Int32, my : Int32) : Nil
       return unless @dragging
+      # Re-resolved per motion rather than captured at the press: a modal that opened mid-drag
+      # must take the motion from the tab underneath it, not let the tab keep extending a
+      # selection the operator can no longer see.
+      if ov = active_overlay
+        ov.handle_drag(layout.body, mx, my)
+        return
+      end
       @tabs[@active_tab]?.try(&.handle_drag(layout.body, mx, my))
     end
 
     private def dispatch_double_click(layout : Layout, mx : Int32, my : Int32) : Bool
-      return false unless body_click_target?(layout, mx, my)
+      return false unless drag_press_target?(layout, mx, my)
       # The first press of the pair already placed the caret and focused the pane, so the
       # word selection lands where the operator is looking.
+      if ov = active_overlay
+        return ov.handle_double_click(layout.body, mx, my)
+      end
       @tabs[@active_tab]?.try(&.handle_double_click(layout.body, mx, my)) || false
     end
 

--- a/src/gori/tui/scope_rule_overlay.cr
+++ b/src/gori/tui/scope_rule_overlay.cr
@@ -60,6 +60,13 @@ module Gori::Tui
       "SCOPE RULE"
     end
 
+    # The single-line fields the pointer can reach — see `Overlay#text_fields`. Listing them
+    # is the whole opt-in: caret placement on a press, drag to extend, double-click for a
+    # word, all inverted by the field against the geometry `render` last drew it at.
+    def text_fields : Array(TextField)
+      [@pattern]
+    end
+
     def hint : String
       "↑/↓ field · ←/→ kind·type · type pattern · ↵ save · esc cancel"
     end
@@ -73,6 +80,10 @@ module Gori::Tui
         set_selected(idx)
         return :commit if on_save_row?
       end
+      # …then the caret, if the press landed inside a drawn field. The row pick above is
+      # what focuses; this is what puts the caret where the operator pointed instead of
+      # leaving it wherever the last keystroke did (Overlay#click_text_field).
+      click_text_field(mx, my)
       :stay
     end
 

--- a/src/gori/tui/screen.cr
+++ b/src/gori/tui/screen.cr
@@ -525,9 +525,47 @@ module Gori::Tui
     # character — so a caller can syntax-highlight what is being typed. The live IME
     # preedit always uses `fg`: it is not part of `value` yet, so nothing has classified
     # it. A short/absent array simply falls back to `fg` for the uncovered tail.
+    # Tint the background of `line[x0...x1]` — the selection band every text pane paints
+    # under its value before drawing it.
+    #
+    # Cluster-wise, matching the base draw and the caret. Summing draw_width over single
+    # CHARS is exactly the retired per-codepoint measure: it drifts right by each cluster's
+    # inflation (1 column for a skin tone, 9 for a ZWJ family), and drawing char-by-char also
+    # SHREDS a cluster across cells, stranding a bare combining mark in one of its own. Span
+    # edges snap outward so the tint covers whole glyphs.
+    #
+    # Seven views carry this as an identical private method (`paint_char_span_bg`); two of
+    # them — the WRAPPING panes, History detail and the Repeater request — carry a variant
+    # that takes a `row_start` and measures with `Wrap.row_col` instead. This is the plain
+    # one, promoted so `TextField` could paint a band without becoming an eighth copy. The
+    # existing seven are untouched: folding them in is a cleanup of its own, and the two
+    # wrap-aware ones are not this function.
+    def char_span_bg(x : Int32, y : Int32, line : String, x0 : Int32, x1 : Int32, bg : Color) : Nil
+      return if x0 >= x1
+      a = Screen.cluster_start(line, {x0, line.size}.min)
+      b = Screen.cluster_end(line, {x1, line.size}.min)
+      px = x + Screen.draw_width(line[0, a])
+      i = a
+      while i < b
+        e = Screen.cluster_end(line, i + 1)
+        seg = line[i...e]
+        text(px, y, seg, Theme.text, bg)
+        px += Screen.draw_width(seg)
+        i = e
+      end
+    end
+
+    # `sel` is a half-open {from, to} CHARACTER range into `value` to tint as the selection
+    # band. It is drawn HERE, between the value and the block caret, because those are the
+    # only two orderings that work and a caller can only reach one of them: painting before
+    # the value is what `draw_target_row` did, and `styled_run`/`Highlight.draw` both write
+    # their own `bg` over every cell they touch — so that band was applied and then erased on
+    # the same frame, leaving ⇧←/→ on the Repeater and Fuzzer target rows a selection that
+    # copied correctly and was INVISIBLE. Painting after the whole call instead would erase
+    # the caret whenever the selection grew leftward (the caret cell is inside the span then).
     def input_line(x : Int32, y : Int32, value : String, cx : Int32, preedit : String,
                    fg : Color, bg : Color = Theme.bg, width : Int32? = nil,
-                   colors : Array(Color)? = nil) : Nil
+                   colors : Array(Color)? = nil, sel : {Int32, Int32}? = nil) : Nil
       cx = cx.clamp(0, value.size)
       right = x + (width || (@width - x))
       prefix = value[0, cx]
@@ -536,6 +574,11 @@ module Gori::Tui
       px = styled_run(px, y, prefix, 0, colors, fg, bg, right) unless prefix.empty?
       px = text(px, y, preedit, fg, bg, attr: Attribute::Underline, width: {right - px, 0}.max) unless preedit.empty?
       styled_run(px, y, suffix, cx, colors, fg, bg, right) unless suffix.empty?
+      # Only meaningful with no preedit in flight: composing text shifts every column right
+      # of the caret, and a band measured against `value` would sit under the wrong glyphs.
+      if sel && preedit.empty?
+        char_span_bg(x, y, value, sel[0].clamp(0, value.size), sel[1].clamp(0, value.size), Theme.accent_bg)
+      end
       # Block caret sits just after prefix+preedit, over the suffix's first cell
       # (or a space). The terminal's own IME UI anchors at the hardware cursor.
       # draw_width, NOT display_width. `cx` is a CHARACTER index into `value` (see the

--- a/src/gori/tui/sequence_config_overlay.cr
+++ b/src/gori/tui/sequence_config_overlay.cr
@@ -103,6 +103,13 @@ module Gori::Tui
       "SEQUENCER"
     end
 
+    # The single-line fields the pointer can reach — see `Overlay#text_fields`. Listing them
+    # is the whole opt-in: caret placement on a press, drag to extend, double-click for a
+    # word, all inverted by the field against the geometry `render` last drew it at.
+    def text_fields : Array(TextField)
+      [@selector]
+    end
+
     def hint : String
       "↑/↓ field · type to edit selector · ←/→ cycle · ↵ start · esc cancel"
     end
@@ -145,6 +152,10 @@ module Gori::Tui
         set_selected(idx)
         return :commit if on_start_row?
       end
+      # …then the caret, if the press landed inside a drawn field. The row pick above is
+      # what focuses; this is what puts the caret where the operator pointed instead of
+      # leaving it wherever the last keystroke did (Overlay#click_text_field).
+      click_text_field(mx, my)
       :stay
     end
 

--- a/src/gori/tui/text_field.cr
+++ b/src/gori/tui/text_field.cr
@@ -1,6 +1,7 @@
 require "termisu"
 require "./screen"
 require "./theme"
+require "./line_field_read"
 
 module Gori::Tui
   # A minimal single-line text input: a String value plus a caret index, with the
@@ -18,6 +19,17 @@ module Gori::Tui
     def initialize(@value : String = "")
       @caret = @value.size
       @undo_stack = [] of UndoState
+      # The anchor half of the selection, shared with the Repeater/Fuzzer target rows so
+      # there is ONE single-line selection model rather than a second one written here.
+      @sel = LineFieldRead.new
+      # Where `render` last drew this field. A TextField is handed its x/y/width by the
+      # overlay that owns it, and nothing else knows that geometry — so the field remembers
+      # it and inverts its own clicks (`hit?`/`click_to_cursor`). The alternative was every
+      # one of the thirteen overlays re-deriving a "label value" row rect for the pointer,
+      # thirteen chances to land the caret a column off what was drawn.
+      @last_x = 0
+      @last_y = -1 # -1 = never rendered: `hit?` must answer false, and row 0 is real
+      @last_w = 0
     end
 
     # Replace the whole value and park the caret at its END.
@@ -34,6 +46,7 @@ module Gori::Tui
       @value = v
       @caret = v.size
       @preedit = ""
+      @sel.clear_selection # the old anchor indexes a string that no longer exists
       @undo_stack.clear
     end
 
@@ -43,13 +56,22 @@ module Gori::Tui
 
     def insert(ch : Char) : Nil
       push_undo
+      delete_selection # typing over a selection REPLACES it, as in every other editor
       c = @caret.clamp(0, @value.size)
       @value = "#{@value[0, c]}#{ch}#{@value[c..]}"
       @caret = c + 1
       @preedit = ""
     end
 
+    # A selection outranks the single character either key would otherwise take. `push_undo`
+    # runs BEFORE the cut, so ^Z restores the selected run rather than the buffer that is
+    # already missing it.
     def backspace : Nil
+      if selection?
+        push_undo
+        delete_selection
+        return
+      end
       return if @caret == 0
       push_undo
       c = @caret.clamp(0, @value.size)
@@ -58,6 +80,11 @@ module Gori::Tui
     end
 
     def delete : Nil
+      if selection?
+        push_undo
+        delete_selection
+        return
+      end
       c = @caret.clamp(0, @value.size)
       return if c >= @value.size
       push_undo
@@ -65,39 +92,182 @@ module Gori::Tui
       @caret = c
     end
 
-    def move(d : Int32) : Nil
-      @caret = (@caret + d).clamp(0, @value.size)
+    # --- selection ------------------------------------------------------------
+    # A single-line field had NO selection of any kind: ⇧←/→ moved the caret like a bare
+    # arrow, ⇧Home/⇧End did the same, and there was no pointer route in at all. Thirteen
+    # overlays' worth of fields (import paths, scope patterns, rule regexes, OAST URLs)
+    # where the only way to replace a value was to hold ⌫ down.
+    def selection? : Bool
+      !@sel.selection_span(@caret).nil?
     end
 
-    def home : Nil
-      @caret = 0
+    def selection_text : String?
+      @sel.selection_text(@value, @caret)
     end
 
-    def end_of_line : Nil
-      @caret = @value.size
+    def selection_span : {Int32, Int32}?
+      @sel.selection_span(@caret)
+    end
+
+    def clear_selection : Nil
+      @sel.clear_selection
+    end
+
+    def select_all : Nil
+      @caret = @sel.select_line(@value.size)
+    end
+
+    # Cut the selected run out and park the caret where it was. Returns whether anything
+    # went — callers gate on it exactly as `TextArea#delete_selection`'s callers do.
+    def delete_selection : Bool
+      span = @sel.selection_span(@caret)
+      return false unless span
+      x0, x1 = span
+      @value = "#{@value[0, x0]}#{@value[x1..]}"
+      @caret = x0
+      @sel.clear_selection
+      @preedit = ""
+      true
+    end
+
+    def move(d : Int32, selecting : Bool = false) : Nil
+      @caret = @sel.move_cx(@caret, d, @value.size, selecting: selecting)
+    end
+
+    def home(selecting : Bool = false) : Nil
+      @caret = @sel.move_cx(@caret, -@caret, @value.size, selecting: selecting)
+    end
+
+    def end_of_line(selecting : Bool = false) : Nil
+      @caret = @sel.move_cx(@caret, @value.size - @caret, @value.size, selecting: selecting)
+    end
+
+    # ⌥←/⌥→ — the same word rule `TextArea#word_left`/`#word_right` walk, so a field and a
+    # buffer break at the same places: `-` is inside a run and `.`/`/`/`?`/`=`/`&`/`:` are
+    # not, which makes a URL step token by token instead of end to end.
+    def word_left(selecting : Bool = false) : Nil
+      i = @caret.clamp(0, @value.size)
+      while i > 0 && @value[i - 1].whitespace?
+        i -= 1
+      end
+      if i > 0
+        word = word_char?(@value[i - 1])
+        while i > 0 && !@value[i - 1].whitespace? && word_char?(@value[i - 1]) == word
+          i -= 1
+        end
+      end
+      @caret = @sel.move_cx(@caret, i - @caret, @value.size, selecting: selecting)
+    end
+
+    def word_right(selecting : Bool = false) : Nil
+      i = @caret.clamp(0, @value.size)
+      if i < @value.size && !@value[i].whitespace?
+        word = word_char?(@value[i])
+        while i < @value.size && !@value[i].whitespace? && word_char?(@value[i]) == word
+          i += 1
+        end
+      end
+      while i < @value.size && @value[i].whitespace?
+        i += 1
+      end
+      @caret = @sel.move_cx(@caret, i - @caret, @value.size, selecting: selecting)
+    end
+
+    # ⌥⌫ — delete back to the previous word boundary as one step. Returns whether anything
+    # went, like `backspace`'s guard.
+    def delete_word_left : Bool
+      if selection?
+        push_undo
+        return delete_selection
+      end
+      return false if @caret == 0
+      push_undo
+      from = @caret
+      word_left
+      @value = "#{@value[0, @caret]}#{@value[from..]}"
+      true
+    end
+
+    # See `TextArea#word_char?` — the two must agree, or ⌥←/→ and a double-click would
+    # disagree about where a word ends in the same value.
+    private def word_char?(c : Char) : Bool
+      c.alphanumeric? || c == '_' || c == '-'
     end
 
     def blank? : Bool
       @value.strip.empty?
     end
 
-    # Apply one editing/caret key (←/→/Home/End/⌫/Del or a printable char). Returns
-    # true when consumed — the shared single-line key handler for the config overlays.
+    # Apply one editing/caret key. Returns true when consumed — the shared single-line key
+    # handler for the config overlays.
+    #
+    # This is `TextArea#handle_motion_key`'s single-line counterpart: ⇧ EXTENDS every caret
+    # motion, and ⌥/⌃ steps by word. It is written here rather than delegated because a
+    # single-line field has no rows — PageUp/PageDown and ⌃Home/⌃End have nothing to mean —
+    # but the shift rule and the word rule are the same two, deliberately.
+    #
+    # ⌥ is the macOS spelling of the word modifier and ⌃ everywhere else; both are accepted,
+    # matching `handle_motion_key`. ^Z is checked before the word branch so the undo chord is
+    # not read as a modified letter.
     def handle_edit_key(ev : Termisu::Event::Key) : Bool
       key = ev.key
+      shift = ev.shift?
+      word = ev.ctrl? || ev.alt?
       case
-      when key.left?                then move(-1)
-      when key.right?               then move(1)
-      when key.home?                then home
-      when key.end?                 then end_of_line
+      when ev.ctrl? && key.lower_z? then undo
+      when word_delete_key?(ev)     then delete_word_left
+      when word && key.left?        then word_left(shift)
+      when word && key.right?       then word_right(shift)
+      when key.left?                then move(-1, selecting: shift)
+      when key.right?               then move(1, selecting: shift)
+      when key.home?                then home(shift)
+      when key.end?                 then end_of_line(shift)
       when key.backspace?           then backspace
       when key.delete?              then delete
-      when ev.ctrl? && key.lower_z? then undo
       else
         ch = ev.char || key.to_char
         return false unless ch && !ev.ctrl? && !ev.alt?
         insert(ch)
       end
+      true
+    end
+
+    # A modified ⌫. Same shape as `TextArea#word_delete_key?`, and load-bearing for the same
+    # reason: a terminal sends ⌥⌫ as ESC + 0x7F and termisu maps the payload through
+    # `Key.from_char`, which has no name for DEL — so it arrives as Unknown + Alt carrying
+    # that char, not as Backspace.
+    def word_delete_key?(ev : Termisu::Event::Key) : Bool
+      return false unless ev.ctrl? || ev.alt?
+      return true if ev.key.backspace?
+      c = ev.char
+      !!c && (c == '\u{7F}' || c == '\b')
+    end
+
+    # --- pointer --------------------------------------------------------------
+    # Whether (mx, my) lands on this field as it was LAST DRAWN. The owning overlay knows
+    # where it put the field; this is how it asks without re-deriving the row rect.
+    def hit?(mx : Int32, my : Int32) : Bool
+      my == @last_y && mx >= @last_x && mx < @last_x + @last_w
+    end
+
+    # Place the caret under the pointer, or extend to it when `selecting` (the DRAG half).
+    # Inverts `render`'s own window + `Screen.draw_width` measure, so the caret cannot land
+    # on a character other than the one the operator pointed at — the same pairing
+    # `window_start` already had to hold with the block caret.
+    def click_to_cursor(mx : Int32, my : Int32, selecting : Bool = false) : Bool
+      return false unless hit?(mx, my)
+      start = window_start(@last_w)
+      to = start + Screen.column_for(@value[start..], mx - @last_x)
+      @caret = @sel.move_cx(@caret, to.clamp(0, @value.size) - @caret, @value.size, selecting: selecting)
+      true
+    end
+
+    # Double-click: take the word under the pointer. False when the press missed the field or
+    # landed on whitespace / past the value, leaving the caret where the click put it.
+    def select_word_at(mx : Int32, my : Int32) : Bool
+      return false unless click_to_cursor(mx, my)
+      return false unless cx = @sel.select_word_at_cursor(@value, @caret)
+      @caret = cx
       true
     end
 
@@ -119,13 +289,21 @@ module Gori::Tui
     def render(screen : Screen, x : Int32, y : Int32, width : Int32, focused : Bool,
                fg : Color, bg : Color) : Nil
       return if width <= 0
+      # Remembered BEFORE the early return, so an unfocused field is still clickable — that
+      # click is how the operator focuses it (see `hit?`).
+      @last_x, @last_y, @last_w = x, y, width
       unless focused
         screen.text(x, y, @value, fg, bg, width: width)
         return
       end
       start = window_start(width)
+      # The band rides along inside `input_line` (see there): it has to land between the
+      # value and the block caret, and only that method sits between them. Indices are
+      # rebased onto the visible window, the same shift the caret gets.
+      span = @sel.selection_span(@caret)
       screen.input_line(x, y, @value[start..], @caret.clamp(0, @value.size) - start,
-        @preedit, fg, bg, width: width)
+        @preedit, fg, bg, width: width,
+        sel: span && { {span[0] - start, 0}.max, {span[1] - start, 0}.max })
     end
 
     # First visible character index: 0 until the caret (plus any preedit, plus the caret


### PR DESCRIPTION
A sweep of every text-entry surface in the TUI for the two gestures #583 standardised: ⇧arrows to select, and the pointer to drag one. #583 gave eight surfaces one keymap (`TextArea#handle_motion_key`) plus mouse drag; this is the tail it did not reach.

## INVISIBLE

The Repeater and Fuzzer TARGET rows painted their selection band **before** the value, and `Highlight.draw` writes its own `bg` into every cell it touches — so the band was applied and erased on the same frame. ⇧←/→ selected, `y` copied the right slice, and the operator saw nothing.

The band now lands between the value and the block caret, which is the only ordering that works: after the whole draw would erase the caret whenever the selection grew leftward, since the caret cell is inside the span then. `Screen#input_line` takes a `sel:` span for the same reason — it is the one thing sitting between those two.

## THIRTEEN FIELDS

`TextField` — the single-line input behind the import/export paths, the scope pattern, the match & replace and extract rule forms, the OAST provider URL and every Fuzzer tuning field — had **no selection of any kind**, and not one of its thirteen overlays inverted a click to a caret. Replacing a long path meant holding ⌫ down.

It now carries ⇧←/→, ⇧Home/⇧End, ⌥/⌃←→ by word, ⌥⌫, selection-replacing insert/⌫/Del, and a ^Z that restores the cut run. The anchor is `LineFieldRead`, the **same** model the target rows use, so the tree has one single-line selection rather than a second one; the word rule is `TextArea#word_char?`'s, so a field and a buffer break in the same places.

The pointer half works because the field remembers the x/y/width `render` last drew it at and inverts its own clicks. The geometry of a "label value" row lives in the overlay's `render` and nowhere else, so the alternative was thirteen hand-written row rects — and thirteen chances to land the caret a column off what was drawn. An overlay opts in by listing `text_fields`; `Overlay#click_text_field` is the one line each `handle_click` adds.

## MODALS

The shell dragged nothing over an overlay at all — `Runner#dispatch_drag` reached only the active tab, and the predicate behind it said so out loud ("nothing else … overlays … drags").

`Overlay` grew the contract `TabController` already has (`supports_drag?` / `handle_drag` / `handle_double_click`), and the Runner grew an overlay tier ahead of its tab tier, in `dispatch_click`'s order: whatever took the press is what the motion continuing it must reach.

The three modals embedding a real multi-line buffer — Rewriter STUB RESPONSE, Discover CUSTOM HEADERS, Fuzzer SET value list — are wired to it, and each grew an `editor_rect` shared by `render` and all three pointer entries so a click cannot land on a row it wasn't drawn on (#587's shape). All three also hand-rolled their own arrows with no `selecting:` anywhere; they route through `handle_motion_key` now.

## TARGET ROW

`target_home`/`target_end` **assigned** the caret, which never reaches the anchor in `@target_read` — so ⇧Home/⇧End dropped the selection they were asked to grow. Same defect #583 fixed in `TextArea`, left standing on the one field that is not a TextArea.

`handle_drag`/`handle_double_click` listed `:request` and `:response` and not `:target`, so the field an operator most often lifts a slice out of could be clicked and never dragged. A bare press assigned directly too, leaving a stale anchor: clicking away from a ⇧←/→ run repainted the band from the OLD anchor to the new caret.

Drag stays READ-mode only, because INSERT paints no band and `target_copy_text` would still honour a selection nothing draws.

## REWRITER PREVIEW

The last `TextArea` editor still hand-rolling its arrows, and inverted against every sibling: `handle_drag`/`handle_double_click` gave this exact pane a mouse selection while the keyboard had none, and the OUTPUT pane one column to its right had ⇧arrows all along. Its three pane-crossing arms now claim only a **bare** press — ⇧ means a selection is mid-build, and ⌥← is a word step this pane owns.

## NOT A GAP

Comparer, Sequencer and Miner define `handle_drag` and no `handle_double_click`, which reads like an omission and is not: all three build `ReadPane.new(line_select_only: true)`, where `select_word` returns false by construction because the rows are two-column projections with no single run of text under the pointer. Left alone.

## Incidental

`Screen#char_span_bg` is the plain span painter seven views carry privately, promoted so `TextField` would not become an eighth copy. The existing seven are untouched — folding them in is a cleanup of its own, and the two wrap-aware ones are a different function.

## Verification

- Full suite: **7173 examples, 0 failures**
- 69 new examples across the four surfaces (rewriter 12 / target 9 / overlay 21 / field 27)
- `OverlayHarness` replays the new drag tier including its opt-in gate, so a modal spec cannot pass against a shell that never routes
- `crystal build src/main.cr` links; ameba on the touched files adds one finding — `TextField#handle_edit_key` at 19/12, the score its sibling `TextArea#handle_motion_key` already carries

## Known follow-ups (deliberately out of scope)

- The target row's **INSERT** mode still has no selection; only READ does.
- The seven private `paint_char_span_bg` copies are not folded in.
