### PR TITLE
A handshake its tab could ask only one question of, a key that said "fixed" and meant "refused", and the frames a flip to HTTP threw away

### DIFF
--- a/spec/repeater/handshake_as_http_spec.cr
+++ b/spec/repeater/handshake_as_http_spec.cr
@@ -1,0 +1,85 @@
+require "../spec_helper"
+
+# Sending a WebSocket upgrade through the ORDINARY h1 engine — what the TUI's `^V` override,
+# `gori run repeater send --http` and MCP `send_request` all do with a handshake.
+#
+# The claim under test is a liveness one, and it is the whole feature: a real WebSocket origin
+# answers 101 and then holds the socket open forever waiting for frames. If `Engine` framed
+# that response like any other bodyless-unknown reply it would read to EOF and block until the
+# idle timeout, and "look at this endpoint as plain HTTP" would mean "hang for `io_timeout`".
+# RFC 9110 §15.2 puts 1xx outside the body-carrying statuses, `Body.response_framing` honours
+# that, and `Engine` deliberately does NOT skip 101 as interim (it is terminal — the upgrade).
+# This pins all three together against a socket that behaves like the real thing.
+
+private def start_silent_upgrade_origin(hold : Channel(Nil)) : Int32
+  origin = TCPServer.new("127.0.0.1", 0)
+  port = origin.local_address.port
+  spawn do
+    next unless conn = origin.accept?
+    Gori::Proxy::Codec::Http1.read_head(conn)
+    conn << "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\n" \
+            "Connection: Upgrade\r\nSec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=\r\n\r\n"
+    conn.flush
+    # …and then say nothing, exactly as a WebSocket server does between frames. The socket
+    # stays open until the spec releases it, so a reader that waits for EOF waits forever.
+    hold.receive
+    conn.close
+  rescue
+  ensure
+    origin.close rescue nil
+  end
+  port
+end
+
+private HANDSHAKE_WIRE = ("GET /socket HTTP/1.1\r\n" \
+                          "Host: 127.0.0.1\r\n" \
+                          "Upgrade: websocket\r\n" \
+                          "Connection: Upgrade\r\n" \
+                          "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n" \
+                          "Sec-WebSocket-Version: 13\r\n\r\n").to_slice
+
+describe "a WebSocket handshake sent as plain HTTP" do
+  it "reads the 101 as a terminal, bodyless response instead of waiting on the open socket" do
+    hold = Channel(Nil).new
+    port = start_silent_upgrade_origin(hold)
+
+    done = Channel(Gori::Repeater::Result).new(1)
+    spawn do
+      done.send(Gori::Repeater::Engine.send(HANDSHAKE_WIRE,
+        scheme: "http", host: "127.0.0.1", port: port, verify_upstream: false))
+    rescue ex
+      # Never leave the assertion below blocking on a channel nothing will ever send to:
+      # a spec that hangs under `crystal spec` on CI produces no output at all to debug from.
+      done.send(Gori::Repeater::Result.new(Bytes.empty, nil, nil, 0_i64, "raised: #{ex.message}"))
+    end
+
+    result = select
+    when r = done.receive
+      r
+    when timeout(5.seconds)
+      hold.send(nil)
+      fail "Engine.send blocked on a 101 with the socket still open — the response was framed as body-bearing"
+    end
+
+    hold.send(nil) # release the origin fiber
+
+    result.error.should be_nil
+    result.response.not_nil!.status.should eq(101)
+    result.incomplete?.should be_false # a bodyless response is COMPLETE, not truncated
+    result.body.should be_nil
+    String.new(result.head).should contain("Sec-WebSocket-Accept")
+  end
+
+  it "refuses to pool an upgrade request or an upgraded socket" do
+    # The other half of sending a handshake through the HTTP engine: the connection is no
+    # longer HTTP/1 afterwards, so parking it would put the NEXT request into a WebSocket
+    # stream. Both guards predate this feature — pin them, because it is what newly routes
+    # 101s onto the pooled path at all.
+    Gori::Repeater::ConnPool.reusable_request?(HANDSHAKE_WIRE).should be_false
+
+    head = "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n"
+    upgraded = Gori::Repeater::Result.new(head.to_slice, nil,
+      Gori::Proxy::Codec::Http1.parse_response_head(head.to_slice), 1_i64, nil)
+    Gori::Repeater::ConnPool.reusable_response?(upgraded, "GET").should be_false
+  end
+end

--- a/spec/store_repeaters_spec.cr
+++ b/spec/store_repeaters_spec.cr
@@ -171,4 +171,40 @@ describe "Gori::Store repeater tabs (v9)" do
       store.repeaters.find!(&.id.==(id)).tags.should be_nil
     end
   end
+
+  # V11: the operator's override of WebSocket auto-detection (the TUI's `^V`). It has to
+  # survive on EVERY read path, not just the one the TUI opens with — `repeaters_meta` is the
+  # reconcile poll's source, and an override missing from it reads as a peer reverting the tab.
+  it "round-trips the V11 ws_http_only override on every read path" do
+    with_store do |store|
+      handshake = "GET /s HTTP/1.1\r\nUpgrade: websocket\r\n\r\n".to_slice
+      off = store.insert_repeater("https://ws.test", handshake, false, true, nil, 0)
+      on = store.insert_repeater("https://ws.test", handshake, false, true, nil, 1,
+        ws_http_only: true)
+
+      store.repeaters.find!(&.id.==(off)).ws_http_only?.should be_false # default: auto-detect
+      store.repeaters.find!(&.id.==(on)).ws_http_only?.should be_true
+      store.repeaters_meta.find!(&.id.==(on)).ws_http_only?.should be_true
+      store.repeaters_mcp.find!(&.id.==(on)).ws_http_only?.should be_true
+      store.get_repeater(on).not_nil!.ws_http_only?.should be_true
+      store.get_repeater_full(on).not_nil!.ws_http_only?.should be_true
+    end
+  end
+
+  it "updates the ws_http_only override without disturbing the request" do
+    with_store do |store|
+      handshake = "GET /s HTTP/1.1\r\nUpgrade: websocket\r\n\r\n".to_slice
+      id = store.insert_repeater("https://ws.test", handshake, false, true, nil, 0)
+
+      store.update_repeater(id, "https://ws.test", handshake, false, true, nil,
+        ws_keep_key: false, ws_http_only: true).should be_true
+      r = store.repeaters.find!(&.id.==(id))
+      r.ws_http_only?.should be_true
+      r.request.should eq(handshake) # the override selects an engine; it rewrites nothing
+
+      store.update_repeater(id, "https://ws.test", handshake, false, true, nil,
+        ws_keep_key: false, ws_http_only: false).should be_true
+      store.repeaters.find!(&.id.==(id)).ws_http_only?.should be_false # …and flips back
+    end
+  end
 end

--- a/spec/tui/repeater_ws_http_only_spec.cr
+++ b/spec/tui/repeater_ws_http_only_spec.cr
@@ -1,0 +1,155 @@
+require "../spec_helper"
+require "../support/memory_backend"
+
+include Gori::Tui
+
+# `^V` on a Repeater tab holding a WebSocket handshake: WS → HTTP/1.1 → HTTP/2 → WS.
+#
+# The axis these specs guard is that gori has TWO WebSocket questions, not one — what the tab
+# HOLDS (`ws_content?`, which decides what gets persisted) and what `^R` DOES with it
+# (`ws_mode?`, which decides the engine, the panes and the feature gates). Collapsing them
+# back into one flag is how a tab sent as plain HTTP loses the frames it is still holding.
+
+private HANDSHAKE = "GET /socket HTTP/1.1\r\n" \
+                    "Host: ws.test\r\n" \
+                    "Upgrade: websocket\r\n" \
+                    "Connection: Upgrade\r\n" \
+                    "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n" \
+                    "Sec-WebSocket-Version: 13\r\n\r\n"
+
+private def ws_view(*, http_only = false) : RepeaterView
+  view = RepeaterView.new
+  view.restore("https://ws.test", HANDSHAKE, false, false,
+    ws_messages: [Gori::Store::WsOutMessage.text(%({"op":"sub"})),
+                  Gori::Store::WsOutMessage.text(%({"op":"ping"}))],
+    ws_http_only: http_only)
+  view
+end
+
+describe "RepeaterView WebSocket transport override" do
+  it "auto-detects a handshake as WebSocket, and reports both facts separately" do
+    view = ws_view
+    view.ws_content?.should be_true    # it holds a handshake + frames
+    view.ws_mode?.should be_true       # …and ^R dials WsEngine
+    view.ws_http_only?.should be_false # nothing overridden
+  end
+
+  it "keeps the frames when the tab is sent as plain HTTP" do
+    # The invariant the whole split exists for. `save_current_repeater` writes the message
+    # rows off `ws_content?`; if the override made that answer false, flipping a captured WS
+    # tab to HTTP and leaving it would drop every frame the operator had captured — gori
+    # editing the test case and reporting a clean save.
+    view = ws_view(http_only: true)
+    view.ws_content?.should be_true
+    view.ws_mode?.should be_false
+    view.ws_http_only?.should be_true
+
+    msgs = view.ws_out_messages_raw
+    msgs.size.should eq(2)
+    String.new(msgs[0].payload).should eq(%({"op":"sub"}))
+    String.new(msgs[1].payload).should eq(%({"op":"ping"}))
+  end
+
+  it "cycles WS → HTTP/1.1 → HTTP/2 → WS on ^V, without touching the request bytes" do
+    view = ws_view
+    wire = view.request_text
+
+    view.cycle_ws_transport
+    view.ws_mode?.should be_false
+    view.ws_http_only?.should be_true
+    view.http2?.should be_false
+
+    view.cycle_ws_transport
+    view.ws_mode?.should be_false
+    view.http2?.should be_true
+
+    view.cycle_ws_transport
+    view.ws_mode?.should be_true # back to WebSocket
+    view.http2?.should be_false  # …which is h1 by RFC 6455
+
+    # The override selects an ENGINE. The `Upgrade:` header — and every other byte the
+    # operator authored — survives all three states untouched.
+    view.request_text.should eq(wire)
+    view.request_text.should contain("Upgrade: websocket")
+  end
+
+  it "leaves an ordinary HTTP tab on the plain two-state toggle" do
+    view = RepeaterView.new
+    view.restore("https://h.test", "GET / HTTP/1.1\r\nHost: h.test\r\n\r\n", false, false)
+    view.ws_content?.should be_false
+    view.ws_http_only?.should be_false
+    # `cycle_ws_transport` is a no-op reporter here — `repeater_toggle_http2` routes a
+    # non-handshake tab to `toggle_http2` instead, and this must not invent a third state.
+    view.cycle_ws_transport
+    view.ws_content?.should be_false
+    view.http2?.should be_false
+  end
+
+  it "unlocks the HTTP-only features that WS mode gates" do
+    # This family is the reason the override is worth having: hex edit, pretty-print, minimize,
+    # group send, Match&Replace and the h1/h2 toggle are ALL gated on `ws_mode?`, so a WS
+    # endpoint could only ever be tested as a WebSocket. `minimize_refusal` is the one that
+    # says so in words, which makes it the honest witness for the whole set.
+    ws = ws_view
+    ws.minimizable?.should be_false
+    ws.minimize_refusal.not_nil!.should contain("plain HTTP text request")
+
+    http = ws_view(http_only: true)
+    http.minimizable?.should be_true
+    http.minimize_refusal.should be_nil
+  end
+
+  it "ignores a stored override on a request that is not a handshake" do
+    # A peer edited the upgrade out of the request. The row still carries the override, but
+    # there is no WebSocket mode left to override — the tab reads as the plain HTTP tab it is
+    # rather than claiming a state it cannot be in.
+    view = RepeaterView.new
+    view.restore("https://h.test", "GET /socket HTTP/1.1\r\nHost: h.test\r\n\r\n", false, false,
+      ws_http_only: true)
+    view.ws_content?.should be_false
+    view.ws_http_only?.should be_false
+    view.ws_mode?.should be_false
+  end
+
+  it "converges the override across sessions (reconcile compare)" do
+    # `request_side_matches?` is the reconcile poll's skip test. Leaving the new field out of
+    # it made the poll read a peer's `^V` as an unchanged row, so the override never crossed
+    # sessions — the same bug shape `ws_keep_key` is in that compare to avoid.
+    view = ws_view
+    view.request_side_matches?("https://ws.test", HANDSHAKE, false, false, nil,
+      false, false).should be_true
+    view.request_side_matches?("https://ws.test", HANDSHAKE, false, false, nil,
+      false, true).should be_false
+
+    view.cycle_ws_transport # local ^V → now HTTP-only
+    view.request_side_matches?("https://ws.test", HANDSHAKE, false, false, nil,
+      false, true).should be_true
+  end
+
+  it "carries the override (and the frames) into a duplicated tab" do
+    src = ws_view(http_only: true)
+    dup = RepeaterView.new
+    dup.duplicate_from(src)
+    dup.ws_content?.should be_true
+    dup.ws_http_only?.should be_true
+    dup.ws_out_messages_raw.size.should eq(2)
+  end
+
+  it "titles the request card so the override is visible on screen" do
+    # Without this the overridden tab was indistinguishable from an ordinary REQUEST while its
+    # MESSAGES pane sat hidden — the operator could not see which engine ^R would dial.
+    rect = Rect.new(0, 0, 100, 24)
+    draw = ->(v : RepeaterView) {
+      b = MemoryBackend.new(100, 24)
+      v.render(Screen.new(b), rect)
+      b
+    }
+    draw.call(ws_view).contains?("HANDSHAKE REQUEST").should be_true
+
+    http = ws_view(http_only: true)
+    draw.call(http).contains?("HANDSHAKE (h1)").should be_true
+
+    http.cycle_ws_transport # → h2
+    draw.call(http).contains?("HANDSHAKE (h2)").should be_true
+  end
+end

--- a/src/gori/cli/run/repeater.cr
+++ b/src/gori/cli/run/repeater.cr
@@ -218,6 +218,7 @@ module Gori
         flow_id : Int64? = nil
         sni : String? = nil
         ws_keep_key = false
+        ws_http_only = false
         keep_request_line = false
 
         parser = OptionParser.new do |p|
@@ -240,6 +241,7 @@ module Gori
           p.on("--keep-request-line", "With --flow: store the flow's request line as-is — do not rewrite an absolute-form line (\"GET http://h/p\") to origin-form") { keep_request_line = true }
           p.on("--sni=HOST", "TLS SNI override") { |v| sni = v }
           p.on("--ws-keep-key", "WebSocket: send the request's own Sec-WebSocket-Key instead of a fresh one (lets an absent/short/duplicate/non-base64 key be tested)") { ws_keep_key = true }
+          p.on("--ws-http-only", "WebSocket: treat this session as plain HTTP — the upgrade handshake is sent as an ordinary request and the 101 read as a response, instead of the framed exchange. Stored on the session (the TUI's ^V); `repeater send --http` is the per-send form") { ws_http_only = true }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
           p.invalid_option { |f| abort "gori run repeater create: unknown option: #{f}\n#{p}" }
           p.missing_option { |f| abort "gori run repeater create: missing value for #{f}" }
@@ -332,7 +334,8 @@ module Gori
             flow_id: flow_id,
             position: pos.to_i32,
             sni: sni,
-            ws_keep_key: ws_keep_key
+            ws_keep_key: ws_keep_key,
+            ws_http_only: ws_http_only
           )
 
           abort "gori run repeater create: failed to create repeater session" if id == 0
@@ -465,6 +468,10 @@ module Gori
         allow_unscoped = false
         verbatim = false
         ws_keep_key = false
+        # nil = use the session's stored setting; true = this send is plain HTTP whatever it says.
+        # There is no `--websocket` counterpart: the stored default IS WebSocket unless the
+        # operator turned it off, so the only direction that needs a per-send override is this one.
+        http_only : Bool? = nil
         positional = [] of String
 
         parser = OptionParser.new do |p|
@@ -481,6 +488,7 @@ module Gori
           p.on("--message-frame=SPEC", "WebSocket: one outbound frame with an explicit shape (repeatable; mixes with --message in order). SPEC is comma-separated key=value: opcode=text|bin|cont|close|ping|pong|<0-15>, fin=0|1, rsv=0-7, mask=0|1, mask_key=<hex>, len=<declared length>, and one of hex=|b64=|text= (text= runs to the end of SPEC). Example: opcode=close,hex=03ea6279650a") { |v| ws_messages << parse_message_frame(v) }
           p.on("--ws-keep-key", "WebSocket: send the request's own Sec-WebSocket-Key instead of a fresh one (overrides the session's stored setting for this send)") { ws_keep_key = true }
           p.on("--idle-ms=N", "WebSocket: server-silence timeout after the first inbound frame (100-60000, default 3000)") { |v| idle_ms = parse_count(v, "--idle-ms").to_i64 }
+          p.on("--http", "WebSocket: send the upgrade handshake as an ordinary HTTP request and print the response, instead of performing the framed exchange (overrides the session's stored setting for this send). The bytes are unchanged — this selects the engine, not a rewrite") { http_only = true }
           p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
           p.unknown_args { |rest, _| positional = rest }
@@ -515,7 +523,11 @@ module Gori
         # Layer 1 (include list) BEFORE Layer 2 — mirrors fuzz/mine/sequence and MCP send_gate.
         abort_if_out_of_scope!(outbound, plan, "gori run repeater send")
 
-        if plan.websocket?
+        # The session's stored `ws_http_only` (the TUI's `^V`) is the default, and `--http`
+        # overrides it for this send. Both mean the same thing: dial the h1/h2 engine and read
+        # the 101 as a response. `Engine` already treats 101 as terminal and bodyless, and
+        # `ConnPool` already refuses to park an upgraded socket, so nothing else has to change.
+        if plan.websocket? && !(http_only.nil? ? rec.ws_http_only? : http_only)
           # `rec.flow_id` IS the provenance test, the same one the engine tabs and the h1
           # flow-replay path make: only a `--flow` / MCP `flow_id` seed sets it, and only a
           # seed puts CAPTURED frames in `ws_messages`. A session built from `--request-raw`

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -1236,6 +1236,7 @@ module Gori
               s.field "name", strprop("optional custom name for the repeater tab")
               s.field "ws_out_messages", ws_out_messages_prop
               s.field "ws_keep_key", boolprop("WebSocket: send this session's own Sec-WebSocket-Key instead of a fresh one (default false)")
+              s.field "ws_http_only", boolprop("WebSocket: treat this session as plain HTTP — `gori run repeater send` and the TUI send the upgrade handshake as an ordinary request and read the 101 as a response, instead of performing the framed exchange. The bytes are unchanged and the session's messages are kept (default false)")
             end
 
             tool j, "update_repeater", "Update an existing repeater tab's properties by database id." do |s|
@@ -1250,6 +1251,7 @@ module Gori
               s.field "tags", strprop("free-text tags for grouping tabs (the TUI subtab label); empty string clears them")
               s.field "ws_out_messages", ws_out_messages_prop
               s.field "ws_keep_key", boolprop("WebSocket: send this session's own Sec-WebSocket-Key instead of a fresh one")
+              s.field "ws_http_only", boolprop("WebSocket: treat this session as plain HTTP — the handshake is sent as an ordinary request and the 101 read as a response. The bytes are unchanged and the session's messages are kept")
             end
 
             tool j, "delete_repeater", "Delete a repeater tab by database id." do |s|

--- a/src/gori/mcp/tools/repeater.cr
+++ b/src/gori/mcp/tools/repeater.cr
@@ -227,7 +227,8 @@ module Gori
           flow_id: flow_id,
           position: position.to_i32,
           sni: sni.try { |s| wire_field(s) },
-          ws_keep_key: bool_arg(h, "ws_keep_key", false)
+          ws_keep_key: bool_arg(h, "ws_keep_key", false),
+          ws_http_only: bool_arg(h, "ws_http_only", false)
         )
 
         return busy("failed to persist repeater (store busy or unwritable)") if id == 0
@@ -432,6 +433,7 @@ module Gori
 
         sni = present?(h, "sni") ? str(h, "sni") : existing.sni
         ws_keep_key = bool_arg(h, "ws_keep_key", existing.ws_keep_key?)
+        ws_http_only = bool_arg(h, "ws_http_only", existing.ws_http_only?)
 
         # Masked for the REPLY only. `target`/`sni` are stored as authored (`wire_field`) —
         # this is the write that made a plain RENAME destroy them: both fall back to the
@@ -452,7 +454,8 @@ module Gori
                  http2: http2,
                  auto_cl: auto_cl,
                  sni: sni.try { |s| wire_field(s) },
-                 ws_keep_key: ws_keep_key
+                 ws_keep_key: ws_keep_key,
+                 ws_http_only: ws_http_only
                )
           return busy("repeater NOT updated (store busy or unwritable); it is unchanged")
         end

--- a/src/gori/mcp/tools/send.cr
+++ b/src/gori/mcp/tools/send.cr
@@ -65,7 +65,7 @@ module Gori
         body_cap, body_omit = body_return_opts(h)
         Result.new(send_result_json(result, recorded_flow_id, repeater_id,
           include_sensitive_headers, sc, built, wire, http2, flow_precedence_ignored(h), body_cap, body_omit, applied_rules, plan.h2_fields,
-          request_line_rewritten),
+          request_line_rewritten, plan.websocket?),
           is_error: !result.ok?)
       rescue ex : Gori::Error
         # Bad input (missing/invalid url, illegal header, …) — return a clean
@@ -556,7 +556,8 @@ module Gori
                                    ignored : Array(String), body_cap : Int32, body_omit : Bool,
                                    applied_rules : Bool = false,
                                    h2_fields : Array({String, String})? = nil,
-                                   request_line_rewritten : Bool = false) : String
+                                   request_line_rewritten : Bool = false,
+                                   websocket_handshake : Bool = false) : String
         JSON.build do |j|
           j.object do
             emit_scope(j, sc)
@@ -567,6 +568,17 @@ module Gori
             # origin-form line that actually went out). Absent means nothing was rewritten.
             j.field "request_line_rewritten", true if request_line_rewritten
             j.field "match_replace_applied", true if applied_rules
+            # `send_request` has always sent an RFC 6455 upgrade as an ordinary HTTP request —
+            # it dials `Engine`/`H2Engine` and reads the 101 as a response, where the TUI and
+            # `gori run repeater send` would perform the framed exchange. That is a useful
+            # thing to be able to do (it is what the TUI's `^V` now exposes), but it was
+            # unnamed: a caller expecting frames got a bodyless 101 and nothing said why.
+            if websocket_handshake
+              j.field "websocket_handshake", true
+              j.field "websocket_note",
+                "this request is a WebSocket upgrade; send_request performed the HTTP round-trip only " \
+                "(the response is the handshake). Use send_websocket with a repeater_id for the framed exchange."
+            end
             unless ignored.empty?
               j.field("ignored_fields") { j.array { ignored.each { |f| j.string f } } }
               j.field "precedence_warning",

--- a/src/gori/store/models.cr
+++ b/src/gori/store/models.cr
@@ -714,11 +714,16 @@ module Gori
       # Off by default — regeneration stays what every existing session does. See
       # `WsEngine.build_handshake` for why this is opt-in and not simply fixed.
       getter? ws_keep_key : Bool
+      # The operator overrode WebSocket auto-detection: send this handshake as a plain HTTP
+      # request and read the response as a response (Schema V11). Off by default — auto-detect
+      # stays what every existing session does. The request bytes are untouched either way, and
+      # the tab's `ws_messages` rows survive the override, so it is reversible without loss.
+      getter? ws_http_only : Bool
 
       def initialize(@id, @target, @request, @http2, @auto_content_length, @flow_id, @position,
                      @response_head = nil, @response_body = nil, @response_error = nil,
                      @response_duration_us = nil, @name = nil, @sni = nil,
-                     @tags = nil, @ws_keep_key = false)
+                     @tags = nil, @ws_keep_key = false, @ws_http_only = false)
       end
     end
 

--- a/src/gori/store/repeater_sessions.cr
+++ b/src/gori/store/repeater_sessions.cr
@@ -32,13 +32,13 @@ module Gori
     # (potentially multi-MB) response on each cross-session commit.
     def repeaters : Array(RepeaterRecord)
       list = [] of RepeaterRecord
-      @db.query("SELECT id, target, #{REQUEST_COL}, http2, auto_content_length, flow_id, position, response_head, response_body, response_error, response_duration_us, name, sni, tags, ws_keep_key FROM repeaters ORDER BY position, id") do |rs|
+      @db.query("SELECT id, target, #{REQUEST_COL}, http2, auto_content_length, flow_id, position, response_head, response_body, response_error, response_duration_us, name, sni, tags, ws_keep_key, ws_http_only FROM repeaters ORDER BY position, id") do |rs|
         rs.each do
           list << RepeaterRecord.new(
             rs.read(Int64), rs.read(String), rs.read(Bytes),
             rs.read(Int32) != 0, rs.read(Int32) != 0, rs.read(Int64?), rs.read(Int32),
             rs.read(Bytes?), rs.read(Bytes?), rs.read(String?), rs.read(Int64?), rs.read(String?), rs.read(String?),
-            tags: rs.read(String?), ws_keep_key: rs.read(Int32) != 0)
+            tags: rs.read(String?), ws_keep_key: rs.read(Int32) != 0, ws_http_only: rs.read(Int32) != 0)
         end
       end
       list
@@ -49,12 +49,13 @@ module Gori
     # response (responses are personal per session). Response fields stay nil.
     def get_repeater(id : Int64) : RepeaterRecord?
       @db.query(
-        "SELECT id, target, #{REQUEST_COL}, http2, auto_content_length, flow_id, position, sni, name, ws_keep_key FROM repeaters WHERE id = ?",
+        "SELECT id, target, #{REQUEST_COL}, http2, auto_content_length, flow_id, position, sni, name, ws_keep_key, ws_http_only FROM repeaters WHERE id = ?",
         id) do |rs|
         return RepeaterRecord.new(
           rs.read(Int64), rs.read(String), rs.read(Bytes),
           rs.read(Int32) != 0, rs.read(Int32) != 0, rs.read(Int64?), rs.read(Int32),
-          sni: rs.read(String?), name: rs.read(String?), ws_keep_key: rs.read(Int32) != 0) if rs.move_next
+          sni: rs.read(String?), name: rs.read(String?), ws_keep_key: rs.read(Int32) != 0,
+          ws_http_only: rs.read(Int32) != 0) if rs.move_next
       end
       nil
     end
@@ -65,14 +66,14 @@ module Gori
     def get_repeater_full(id : Int64) : RepeaterRecord?
       @db.query(
         "SELECT id, target, #{REQUEST_COL}, http2, auto_content_length, flow_id, position, " \
-        "response_head, response_body, response_error, response_duration_us, name, sni, tags, ws_keep_key " \
+        "response_head, response_body, response_error, response_duration_us, name, sni, tags, ws_keep_key, ws_http_only " \
         "FROM repeaters WHERE id = ?", id) do |rs|
         if rs.move_next
           return RepeaterRecord.new(
             rs.read(Int64), rs.read(String), rs.read(Bytes),
             rs.read(Int32) != 0, rs.read(Int32) != 0, rs.read(Int64?), rs.read(Int32),
             rs.read(Bytes?), rs.read(Bytes?), rs.read(String?), rs.read(Int64?), rs.read(String?), rs.read(String?),
-            tags: rs.read(String?), ws_keep_key: rs.read(Int32) != 0)
+            tags: rs.read(String?), ws_keep_key: rs.read(Int32) != 0, ws_http_only: rs.read(Int32) != 0)
         end
       end
       nil
@@ -80,12 +81,12 @@ module Gori
 
     def repeaters_meta : Array(RepeaterRecord)
       list = [] of RepeaterRecord
-      @db.query("SELECT id, target, #{REQUEST_COL}, http2, auto_content_length, flow_id, position, sni, ws_keep_key FROM repeaters ORDER BY position, id") do |rs|
+      @db.query("SELECT id, target, #{REQUEST_COL}, http2, auto_content_length, flow_id, position, sni, ws_keep_key, ws_http_only FROM repeaters ORDER BY position, id") do |rs|
         rs.each do
           list << RepeaterRecord.new(
             rs.read(Int64), rs.read(String), rs.read(Bytes),
             rs.read(Int32) != 0, rs.read(Int32) != 0, rs.read(Int64?), rs.read(Int32),
-            sni: rs.read(String?), ws_keep_key: rs.read(Int32) != 0)
+            sni: rs.read(String?), ws_keep_key: rs.read(Int32) != 0, ws_http_only: rs.read(Int32) != 0)
         end
       end
       list
@@ -97,14 +98,14 @@ module Gori
       list = [] of RepeaterRecord
       @db.query(
         "SELECT id, target, #{REQUEST_COL}, http2, auto_content_length, flow_id, position, sni, " \
-        "name, tags, response_head, response_error, response_duration_us, ws_keep_key FROM repeaters ORDER BY position, id") do |rs|
+        "name, tags, response_head, response_error, response_duration_us, ws_keep_key, ws_http_only FROM repeaters ORDER BY position, id") do |rs|
         rs.each do
           list << RepeaterRecord.new(
             rs.read(Int64), rs.read(String), rs.read(Bytes),
             rs.read(Int32) != 0, rs.read(Int32) != 0, rs.read(Int64?), rs.read(Int32),
             sni: rs.read(String?), name: rs.read(String?), tags: rs.read(String?),
             response_head: rs.read(Bytes?), response_error: rs.read(String?), response_duration_us: rs.read(Int64?),
-            ws_keep_key: rs.read(Int32) != 0)
+            ws_keep_key: rs.read(Int32) != 0, ws_http_only: rs.read(Int32) != 0)
         end
       end
       list
@@ -114,21 +115,22 @@ module Gori
     # 0 → nil so a later update never targets a bogus row).
     def insert_repeater(target : String, request : Bytes, http2 : Bool,
                         auto_cl : Bool, flow_id : Int64?, position : Int32, sni : String? = nil,
-                        ws_keep_key : Bool = false) : Int64
+                        ws_keep_key : Bool = false, ws_http_only : Bool = false) : Int64
       ts = now_us
       exec_task ->(c : DB::Connection) {
-        c.exec("INSERT INTO repeaters (created_at, updated_at, target, request, http2, auto_content_length, flow_id, position, sni, ws_keep_key) VALUES (?,?,?,?,?,?,?,?,?,?)",
-          ts, ts, target, request, http2 ? 1 : 0, auto_cl ? 1 : 0, flow_id, position, sni, ws_keep_key ? 1 : 0)
+        c.exec("INSERT INTO repeaters (created_at, updated_at, target, request, http2, auto_content_length, flow_id, position, sni, ws_keep_key, ws_http_only) VALUES (?,?,?,?,?,?,?,?,?,?,?)",
+          ts, ts, target, request, http2 ? 1 : 0, auto_cl ? 1 : 0, flow_id, position, sni, ws_keep_key ? 1 : 0, ws_http_only ? 1 : 0)
         nil
       }
     end
 
     # Returns whether the write committed (false = store busy/locked/closing).
     def update_repeater(id : Int64, target : String, request : Bytes, http2 : Bool, auto_cl : Bool,
-                        sni : String? = nil, ws_keep_key : Bool = false) : Bool
+                        sni : String? = nil, ws_keep_key : Bool = false,
+                        ws_http_only : Bool = false) : Bool
       exec_task_ok ->(c : DB::Connection) {
-        c.exec("UPDATE repeaters SET target = ?, request = ?, http2 = ?, auto_content_length = ?, sni = ?, ws_keep_key = ?, updated_at = ? WHERE id = ?",
-          target, request, http2 ? 1 : 0, auto_cl ? 1 : 0, sni, ws_keep_key ? 1 : 0, now_us, id)
+        c.exec("UPDATE repeaters SET target = ?, request = ?, http2 = ?, auto_content_length = ?, sni = ?, ws_keep_key = ?, ws_http_only = ?, updated_at = ? WHERE id = ?",
+          target, request, http2 ? 1 : 0, auto_cl ? 1 : 0, sni, ws_keep_key ? 1 : 0, ws_http_only ? 1 : 0, now_us, id)
         nil
       }
     end

--- a/src/gori/store/schema.cr
+++ b/src/gori/store/schema.cr
@@ -838,7 +838,28 @@ module Gori
         SQL
       ]
 
-      MIGRATIONS = [V1, V2, V3, V4, V5, V6, V7, V8, V9, V10]
+      # `repeaters.ws_http_only` is the operator's override of gori's WebSocket AUTO-DETECTION.
+      #
+      # Whether a Repeater tab is a WebSocket tab has never been stored: it is re-derived from
+      # the request bytes on every load (`WsEngine.upgrade_request?` — an `Upgrade:` header),
+      # and that verdict decides the engine `^R` dials, the split request pane, the transcript
+      # response, and — the part that is easy to miss — whether diff, pretty-print, hex edit,
+      # minimize, group send, Match&Replace and the h1/h2 toggle are available at all. They are
+      # all gated on the same flag, so a WS endpoint could only ever be tested as a WebSocket.
+      #
+      # A handshake is also an ordinary HTTP request, and "does this endpoint 101 for an
+      # unauthenticated Origin?" is an HTTP question. This column says the operator answered it:
+      # dial the h1/h2 engine, read the response as a response, stop there. It does NOT touch
+      # the bytes — the `Upgrade:` header stays exactly as authored — and it does not discard
+      # the tab's frames: `ws_messages` rows are still persisted, so `^V` back to WebSocket
+      # replays the same session.
+      #
+      # 0 on every existing row, which is what they have always done: auto-detect.
+      V11 = [
+        "ALTER TABLE repeaters ADD COLUMN ws_http_only INTEGER NOT NULL DEFAULT 0",
+      ]
+
+      MIGRATIONS = [V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11]
 
       def self.migrate!(db : DB::Database) : Nil
         db.using_connection do |conn|

--- a/src/gori/tui/controllers/repeater_controller.cr
+++ b/src/gori/tui/controllers/repeater_controller.cr
@@ -54,7 +54,7 @@ module Gori::Tui
         view.restore(r.target, request_text, r.http2?, r.auto_content_length?,
           r.response_head, r.response_body, r.response_error, r.response_duration_us,
           sni: r.sni || "", ws_messages: ws_msgs, ws_keep_key: r.ws_keep_key?,
-          evidence: !r.flow_id.nil?)
+          ws_http_only: r.ws_http_only?, evidence: !r.flow_id.nil?)
         view.name = r.name                       # custom sub-tab label survives reopen
         view.tags = Repeater::Tags.parse(r.tags) # flat tags survive reopen (V31)
         seed_repeater_original(view, r.flow_id)
@@ -264,7 +264,10 @@ module Gori::Tui
           # the footer said otherwise for both.
           "type to edit · ⇧arrows select · ^Z undo · ^G goto · ^F find · #{hex} hex · esc read · ↹ text"
         else
-          "i/↵ edit · #{read_common} · ^G goto · ^F find · #{hex} hex · ↹ pane · esc tabs"
+          # The way back on an overridden handshake tab: the MESSAGES pane is hidden there, so
+          # `^T` — the key that would otherwise reveal it — is not drawn to point at it.
+          back = v.ws_http_only? ? " · ^V websocket" : ""
+          "i/↵ edit · #{read_common} · ^G goto · ^F find · #{hex} hex#{back} · ↹ pane · esc tabs"
         end
       else
         ""
@@ -386,7 +389,9 @@ module Gori::Tui
     private def ws_hint(v : RepeaterView) : String
       sub = v.req_pane == :envelope ? "handshake request" : "messages"
       mode = v.request_insert? ? "type to edit" : "i/↵ edit · ⇧arrows select · y copy · space cmds"
-      "#{mode} #{sub} · ^T switch · ^G goto · ^F find · esc read · ↹ pane"
+      # `^V http` is listed because this key used to REFUSE here ("transport is fixed"), so
+      # nothing in the tab suggested a handshake could be sent as an ordinary request.
+      "#{mode} #{sub} · ^T switch · ^V http · ^G goto · ^F find · esc read · ↹ pane"
     end
 
     # The RESPONSE column's footer on a WS tab — the twin of `ws_hint`, naming the card being
@@ -524,13 +529,24 @@ module Gori::Tui
       end
     end
 
-    # Flip the request between HTTP/1.1 and HTTP/2 (overriding the captured protocol) so
-    # the next ^R dials the other engine. Refused for WebSocket (h1 by definition) and
-    # gRPC (rides h2) where the transport is intrinsic.
+    # Flip which engine the next ^R dials, overriding the captured protocol.
+    #
+    # Two states on an ordinary tab (HTTP/1.1 ⇄ HTTP/2); THREE on one holding a WebSocket
+    # handshake — WS → HTTP/1.1 → HTTP/2 → WS. `WsEngine`, `Engine` and `H2Engine` are three
+    # transports, and this key has always meant "the operator overrides the detected one", so
+    # the WS case belongs on it rather than on a key of its own.
+    #
+    # It used to answer "transport is fixed for WebSocket flows" and stop there. It is not
+    # fixed: a handshake is an ordinary HTTP request, and refusing here was what made "is this
+    # endpoint reachable without an Upgrade, and what does it answer?" unaskable in the tab
+    # that had the request in it. gRPC keeps the refusal — that one IS intrinsic (it rides h2
+    # by specification, and the tab's framed body has no h1 form).
     def repeater_toggle_http2 : Nil
       return unless view = current_view
-      if view.ws_mode? || view.grpc_mode?
-        @host.status("transport is fixed for #{view.ws_mode? ? "WebSocket" : "gRPC"} flows")
+      if view.grpc_mode?
+        @host.status("transport is fixed for gRPC flows (h2 by specification)")
+      elsif view.ws_content?
+        @host.status(view.cycle_ws_transport)
       else
         h2 = view.toggle_http2
         @host.status(h2 ? "transport: HTTP/2 (h2)" : "transport: HTTP/1.1")
@@ -1176,7 +1192,7 @@ module Gori::Tui
         # Only re-apply when the PERSISTED request side actually changed (data_version
         # also bumps on capture/response writes, so most polls touch an identical row).
         next if v.request_side_matches?(row.target, String.new(row.request), row.http2?,
-                  row.auto_content_length?, row.sni, row.ws_keep_key?)
+                  row.auto_content_length?, row.sni, row.ws_keep_key?, row.ws_http_only?)
         # Soft sync: request/target/flags only. Full restore() would reset focus to
         # :target and clear @result (no response BLOBs on this path) — that is the
         # "send then response vanishes / focus jumps to Target" bug.
@@ -1188,7 +1204,7 @@ module Gori::Tui
         end
         v.apply_peer_request(row.target, row_request_text, row.http2?, row.auto_content_length?,
           sni: row.sni || "", ws_messages: ws_msgs, ws_keep_key: row.ws_keep_key?,
-          evidence: !row.flow_id.nil?)
+          ws_http_only: row.ws_http_only?, evidence: !row.flow_id.nil?)
         seed_repeater_original(v, row.flow_id) # baseline may need re-seed if it was empty
       end
 
@@ -1204,7 +1220,7 @@ module Gori::Tui
         end
         view.restore(row.target, row_request_text, row.http2?, row.auto_content_length?,
           sni: row.sni || "", ws_messages: ws_msgs, ws_keep_key: row.ws_keep_key?,
-          evidence: !row.flow_id.nil?)
+          ws_http_only: row.ws_http_only?, evidence: !row.flow_id.nil?)
         seed_repeater_original(view, row.flow_id)
         @repeaters << RepeaterTab.new(view, row.flow_id, row.id)
       end
@@ -1332,7 +1348,7 @@ module Gori::Tui
               else
                 persist_new_repeater(view, nil)
               end
-      if (id = db_id) && view.ws_mode?
+      if (id = db_id) && view.ws_content? # the frames come along even on an HTTP-mode duplicate
         @host.session.store.update_repeater_ws_messages(id, view.ws_out_messages_raw)
         view.ws_out_persisted
       end
@@ -1345,7 +1361,8 @@ module Gori::Tui
     # reconcile key). A closing store returns 0 → nil, leaving the tab unsaved.
     private def persist_new_repeater(view : RepeaterView, flow_id : Int64?) : Int64?
       id = @host.session.store.insert_repeater(view.target, view.request_text.to_slice, view.http2?,
-        view.auto_content_length?, flow_id, @repeaters.size, view.sni_override)
+        view.auto_content_length?, flow_id, @repeaters.size, view.sni_override,
+        ws_keep_key: view.ws_keep_key?, ws_http_only: view.ws_http_only?)
       id == 0 ? nil : id
     end
 
@@ -1817,12 +1834,16 @@ module Gori::Tui
       return unless tab = current_repeater_tab
       return unless (id = tab.db_id) && tab.view.dirty?
       v = tab.view
-      if v.ws_mode?
+      # `ws_content?`, NOT `ws_mode?`: this asks whether there are frames to write, and a tab
+      # sent as plain HTTP (`^V`) still HAS them. Asking the send-side question here meant
+      # flipping a WS tab to HTTP and leaving the tab dropped every captured frame it held —
+      # gori silently editing the operator's test case and reporting a successful save.
+      if v.ws_content?
         # Persist the RAW handshake text (request_text = the editor's `$KEY` tokens, in the
         # line endings the editor holds), NOT ws_upgrade_bytes (env-expanded): baking the
         # expanded form in would write secrets to the DB and defeat the reconcile guard.
         @host.session.store.update_repeater(id, v.target, v.request_text.to_slice, v.http2?, v.auto_content_length?,
-          v.sni_override, ws_keep_key: v.ws_keep_key?)
+          v.sni_override, ws_keep_key: v.ws_keep_key?, ws_http_only: v.ws_http_only?)
         # Raw message lines too — the store masks secrets; env tokens re-expand on send.
         @host.session.store.update_repeater_ws_messages(id, v.ws_out_messages_raw)
         v.ws_out_persisted

--- a/src/gori/tui/help_view.cr
+++ b/src/gori/tui/help_view.cr
@@ -80,7 +80,7 @@ module Gori::Tui
         Item.new("^X", "hex-edit the request", "repeater.toggle-hex"),
         Item.new("^S", "SNI override (on the target)", "repeater.toggle-sni"),
         Item.new("^L", "toggle auto Content-Length", "repeater.toggle-auto-content-length"),
-        Item.new("^V", "toggle transport HTTP/1.1 ↔ HTTP/2", "repeater.toggle-http2"),
+        Item.new("^V", "transport: HTTP/1.1 ↔ HTTP/2 · on a WebSocket tab, WS → h1 → h2 (send the handshake as plain HTTP)", "repeater.toggle-http2"),
         Item.new("space → g", "send group: %%%-split requests on one connection"),
         Item.new("↹", "cycle target → request → response"),
         Item.new("d", "response: toggle diff", "repeater.toggle-diff"),

--- a/src/gori/tui/repeater_view.cr
+++ b/src/gori/tui/repeater_view.cr
@@ -155,10 +155,25 @@ module Gori::Tui
       @resp_alt = {0, 0, 0, 0}
       @loaded = false
       @http2 = false
-      # WebSocket repeater mode (a 101 flow): the request editor holds the editable
-      # outbound MESSAGES (one per line) and the response pane shows the TRANSCRIPT.
-      # Session-only — these tabs are never persisted/synced (db_id stays nil).
+      # WebSocket repeater CONTENT (a 101 flow): this tab holds a handshake plus an editable
+      # outbound MESSAGES list. It says what the tab IS, not what `^R` does with it — read
+      # `ws_mode?` for that, and see `@ws_http_only` for the difference.
       @ws_mode = false
+      # …and the operator's override of it: send the handshake as an ordinary HTTP request
+      # (h1 or h2, per `@http2`) and read the response as a response, instead of dialing
+      # `WsEngine` and pumping frames. `^V` cycles WS → HTTP/1.1 → HTTP/2 → WS.
+      #
+      # A handshake IS an HTTP request, and "does this endpoint 101 for an unauthenticated
+      # Origin?" is an HTTP question — one that could not be asked here, because auto-detection
+      # gated the whole tab: diff, pretty-print, hex edit, minimize, group send, Match&Replace
+      # and the h1/h2 toggle are all off in WS mode, and every one of them is a thing you want
+      # while testing a handshake. The override switches those back on by making `ws_mode?`
+      # false; `@ws_mode` stays true, so the frames are still here and still persisted.
+      #
+      # It changes NO BYTES. The `Upgrade:` header goes out exactly as authored — this is the
+      # engine gori dials, not a rewrite of the request. (In this mode `@ws_keep_key` is moot:
+      # `Engine` sends the head verbatim, so the key line in the editor is the key on the wire.)
+      @ws_http_only = false
       @ws_upgrade = nil.as(Bytes?) # the captured upgrade-request bytes (handshake source)
       @ws_result = nil.as(Repeater::WsEngine::Result?)
       @ws_lines_cache = nil.as(Array({String, Color})?)
@@ -587,7 +602,63 @@ module Gori::Tui
       reflect_content_length_in_editor if @auto_content_length
     end
 
-    getter? ws_mode : Bool
+    # Does this tab HOLD WebSocket content — a handshake and a list of outbound frames?
+    #
+    # This is the persistence question, and it is deliberately not the same one `ws_mode?`
+    # answers. Everything that would LOSE the frames by forgetting they exist asks here:
+    # `save_current_repeater`, the duplicate path's `update_repeater_ws_messages`, `dirty?`
+    # (the MESSAGES pane's own edits), and the MCP snapshot. Asking `ws_mode?` there meant
+    # flipping a tab to HTTP and closing the project silently dropped its captured frames.
+    def ws_content? : Bool
+      @ws_mode
+    end
+
+    # Does `^R` dial `WsEngine`, and does the tab RENDER as a WebSocket (split request column,
+    # transcript response, the WS badges, and the feature gates that ride with them)?
+    #
+    # WebSocket content the operator has not overridden. See `@ws_http_only`.
+    def ws_mode? : Bool
+      @ws_mode && !@ws_http_only
+    end
+
+    # The operator overrode auto-detection: a WS tab being sent as plain HTTP. False on a tab
+    # that holds no WebSocket content at all — there is nothing to override there, and the
+    # chip/`^V` cycle must not claim otherwise.
+    def ws_http_only? : Bool
+      @ws_mode && @ws_http_only
+    end
+
+    # Cycle the transport `^R` dials: WS → HTTP/1.1 → HTTP/2 → WS. Returns the new state as a
+    # label for the status line. Only a tab holding a handshake has three states; anything
+    # else keeps the plain two-state h1/h2 toggle (`toggle_http2`).
+    #
+    # The pane geometry is mode-dependent (a WS tab splits its request column and parks a
+    # second caret), so both sub-pane selections are reset to the ones the destination mode
+    # draws — otherwise the request column came back on `:decoded` with no decoded card under
+    # it, and the response cursor sat on a `:handshake` card the HTTP branch never renders.
+    def cycle_ws_transport : String
+      return @http2 ? "transport: HTTP/2 (h2)" : "transport: HTTP/1.1" unless @ws_mode
+      @dirty = true
+      if !@ws_http_only # WS → HTTP/1.1
+        @ws_http_only = true
+        @http2 = false
+      elsif !@http2 # HTTP/1.1 → HTTP/2
+        @http2 = true
+      else # HTTP/2 → WS (h2 is not a WebSocket transport here — RFC 8441 is out of scope)
+        @ws_http_only = false
+        @http2 = false
+      end
+      @req_pane = ws_mode? ? :decoded : :envelope
+      @resp_pane = :transcript
+      @resp_alt = {0, 0, 0, 0}
+      resp_wrap_reset
+      reset_result_caches
+      if ws_mode?
+        "transport: WebSocket — ^R dials WsEngine and pumps the MESSAGES pane"
+      else
+        "transport: #{@http2 ? "HTTP/2 (h2)" : "HTTP/1.1"} — the handshake is sent as a plain request (frames kept)"
+      end
+    end
 
     # Load a captured WebSocket flow (101) for repeater. The request editor is seeded
     # with the handshake upgrade request; the messages editor is seeded with the recorded
@@ -599,8 +670,9 @@ module Gori::Tui
       @evidence = true # the handshake AND the seeded frames are the capture's
       @markers_declared = false
       @ws_mode = true
-      @ws_keep_key = false # a fresh capture: the regenerated key is the default (see the ivar)
-      @http2 = false       # WebSocket is HTTP/1.1
+      @ws_http_only = false # a fresh capture starts on auto-detect; ^V is the operator's to press
+      @ws_keep_key = false  # a fresh capture: the regenerated key is the default (see the ivar)
+      @http2 = false        # WebSocket is HTTP/1.1
       @ws_upgrade = detail.request_head
       @ws_result = nil
       @ws_lines_cache = nil
@@ -662,7 +734,10 @@ module Gori::Tui
     getter? ws_keep_key : Bool
 
     def toggle_ws_keep_key : Bool
-      return @ws_keep_key unless @ws_mode
+      # `ws_mode?`, not `ws_content?`: in HTTP-only mode the head goes out verbatim through
+      # `Engine`, so the key line in the editor IS the key on the wire and there is nothing
+      # for this flag to switch. It keeps its stored value for the trip back to WebSocket.
+      return @ws_keep_key unless ws_mode?
       @dirty = true
       @ws_keep_key = !@ws_keep_key
     end
@@ -803,7 +878,12 @@ module Gori::Tui
       j.field "http2", @http2
       j.field "auto_content_length", @auto_content_length
       j.field "ws_keep_key", @ws_keep_key
+      # Both halves of the WebSocket answer, because they are two different facts and an MCP
+      # client needs each: `ws_mode` is what the tab HOLDS (a handshake + frames), `ws_http_only`
+      # is what `^R` currently DOES with it. A tab reporting `ws_mode: true, ws_http_only: true`
+      # still lists its `messages` below — they are kept, not discarded.
       j.field "ws_mode", @ws_mode
+      j.field "ws_http_only", @ws_http_only if @ws_mode
       j.field "grpc_mode", @grpc_mode
       j.field "decode_mode", decode_mode?
       if kind = @decode_kind
@@ -888,6 +968,7 @@ module Gori::Tui
       @evidence = true
       @markers_declared = false
       @grpc_mode = true
+      @ws_http_only = false # in lockstep with @ws_mode below — a gRPC tab holds no handshake
       @ws_mode = false
       @http2 = true # gRPC is HTTP/2
       @grpc_body = detail.request_body || Bytes.empty
@@ -969,6 +1050,7 @@ module Gori::Tui
       @markers_declared = false
       @decode_kind = kind
       @ws_mode = false
+      @ws_http_only = false # in lockstep with @ws_mode — a decode tab holds no handshake
       @grpc_mode = false
       @http2 = detail.http_version == "HTTP/2"
       @target = build_target(detail.row.scheme, detail.row.host, detail.row.port)
@@ -1290,7 +1372,7 @@ module Gori::Tui
     # refused a whole-buffer send. Folding hex into this predicate is what let the sharpest
     # face of the defect through on the first attempt at the fix.
     private def group_framing_applies? : Bool
-      !(@grpc_mode || @ws_mode || @decode_kind || @http2)
+      !(@grpc_mode || ws_mode? || @decode_kind || @http2)
     end
 
     # "Minimize request" removes header/cookie/param lines from the plain-text request and
@@ -1322,7 +1404,7 @@ module Gori::Tui
     # an h1 primitive), the pane already reflects the whole buffer, and there is nothing
     # chunk-scoped to misread.
     def minimize_refusal : String?
-      if @req_hex_edit || @grpc_mode || @ws_mode || @decode_kind
+      if @req_hex_edit || @grpc_mode || ws_mode? || @decode_kind
         return "minimize needs a plain HTTP text request (not hex/gRPC/WS/decode)"
       end
       unless marker_regions.empty?
@@ -1555,6 +1637,7 @@ module Gori::Tui
                 sni : String = "",
                 ws_messages : Array(Store::WsOutMessage)? = nil,
                 ws_keep_key : Bool = false,
+                ws_http_only : Bool = false,
                 evidence : Bool = false) : Nil
       @flow = nil
       # `@flow` is deliberately cleared on a restore (the FlowDetail is not persisted), so
@@ -1567,7 +1650,7 @@ module Gori::Tui
       # can defend — see `markers_live?`. (A marked-up capture reopens with its markers inert
       # and the border chip saying so; ^K re-declares.)
       @markers_declared = false
-      apply_request_fields(target, request, http2, auto_cl, sni, ws_messages, ws_keep_key)
+      apply_request_fields(target, request, http2, auto_cl, sni, ws_messages, ws_keep_key, ws_http_only)
 
       @original_lines = [] of String
       # Rebuild the persisted result: a head (success) or an error (failed send)
@@ -1598,11 +1681,12 @@ module Gori::Tui
                            sni : String = "",
                            ws_messages : Array(Store::WsOutMessage)? = nil,
                            ws_keep_key : Bool = false,
+                           ws_http_only : Bool = false,
                            evidence : Bool = false) : Nil
       @evidence = evidence
       # A peer's row carries the same two facts a restore does, so the same answer: see restore.
       @markers_declared = false
-      apply_request_fields(target, request, http2, auto_cl, sni, ws_messages, ws_keep_key)
+      apply_request_fields(target, request, http2, auto_cl, sni, ws_messages, ws_keep_key, ws_http_only)
       @req_hex_edit = nil
       # Leave @result / @prev_result / @focus / @scroll / @resp_mode / @original_lines alone.
       reflect_content_length_in_editor if @auto_content_length
@@ -1619,11 +1703,16 @@ module Gori::Tui
     # made the compare blind to a pure line-ending difference, which is a real edit now.
     # (FuzzerView#session_side_matches? still normalizes — its template is a document, not
     # a captured message, and it is persisted from `#text`.)
+    #
+    # `ws_http_only` is compared for the same reason `ws_keep_key` is: it is a stored,
+    # cross-session request-side field, so a peer's `^V` has to converge here. Leaving it out
+    # meant the poll saw the row as unchanged and the override never crossed sessions.
     def request_side_matches?(target : String, request : String, http2 : Bool, auto_cl : Bool,
-                              sni : String?, ws_keep_key : Bool = false) : Bool
+                              sni : String?, ws_keep_key : Bool = false,
+                              ws_http_only : Bool = false) : Bool
       @target == target && request_text == request &&
         @http2 == http2 && @auto_content_length == auto_cl &&
-        @ws_keep_key == ws_keep_key &&
+        @ws_keep_key == ws_keep_key && @ws_http_only == ws_http_only &&
         (sni_override || "") == (sni || "")
     end
 
@@ -1631,7 +1720,8 @@ module Gori::Tui
     private def apply_request_fields(target : String, request : String, http2 : Bool, auto_cl : Bool,
                                      sni : String,
                                      ws_messages : Array(Store::WsOutMessage)?,
-                                     ws_keep_key : Bool = false) : Nil
+                                     ws_keep_key : Bool = false,
+                                     ws_http_only : Bool = false) : Nil
       @ws_keep_key = ws_keep_key
       @http2 = http2
       @target = target
@@ -1641,6 +1731,10 @@ module Gori::Tui
       @target_field = :url
 
       is_ws = !ws_messages.nil? || Repeater::WsEngine.upgrade_request?(request)
+      # The stored override only means anything on a tab that HOLDS a handshake; a row that
+      # carries it without one (a request edited out of upgrade shape by a peer) reads as the
+      # plain HTTP tab it now is, rather than a tab claiming to override a mode it isn't in.
+      @ws_http_only = is_ws && ws_http_only
       if is_ws
         @ws_mode = true
         @ws_upgrade = request.to_slice
@@ -1653,7 +1747,10 @@ module Gori::Tui
         # wire form exactly, and slam the caret.)
         @editor.set_text(request) if @editor.wire_text != request
         seed_ws_out(ws_messages || [] of Store::WsOutMessage)
-        @req_pane = :decoded
+        # The MESSAGES card is the one the operator wants on a WS tab — but it is not DRAWN
+        # under the override (`req_split?` is false there), so parking the active sub-pane on
+        # it would leave the request column focused on a card that does not exist.
+        @req_pane = ws_mode? ? :decoded : :envelope
       else
         @ws_mode = false
         @editor.set_text(request) if @editor.wire_text != request
@@ -1730,6 +1827,7 @@ module Gori::Tui
       @name = SubtabClone.copy_name(src.@name)
 
       @ws_mode = src.@ws_mode
+      @ws_http_only = src.@ws_http_only # a duplicate opens on the transport its source is on
       @ws_upgrade = src.@ws_upgrade.try(&.dup)
       @ws_result = nil
       @ws_lines_cache = nil
@@ -1794,7 +1892,7 @@ module Gori::Tui
     # no head+body to split, and that is what `@resp_pane` distinguishes.
     def response_parts : {String, String}?
       return nil if @grpc_mode
-      return nil if @ws_mode && !resp_handshake_active?
+      return nil if ws_mode? && !resp_handshake_active?
       res = @result
       return nil unless res
       {String.new(res.head), (b = res.body) ? String.new(b) : ""}
@@ -1804,7 +1902,7 @@ module Gori::Tui
     # which rebuilds a synthetic flow from the current request + this response. nil until a send
     # lands (a response head is required), or in WS/gRPC mode where the active rules don't apply.
     def last_http_response : {Bytes, Bytes?}?
-      return nil if @ws_mode || @grpc_mode
+      return nil if ws_mode? || @grpc_mode
       res = @result
       return nil unless res
       return nil if res.head.empty?
@@ -2013,7 +2111,7 @@ module Gori::Tui
     # request-line version token to match so the editor display agrees with the wire (and
     # the verbatim h1 send doesn't ship a stray "HTTP/2"). Dirties so the choice persists.
     def toggle_http2 : Bool
-      return @http2 if @ws_mode || @grpc_mode
+      return @http2 if ws_mode? || @grpc_mode
       @http2 = !@http2
       retarget_request_version unless @req_hex_edit # hex is byte-exact — leave its bytes alone
       @dirty = true
@@ -2046,7 +2144,7 @@ module Gori::Tui
     # connection); for a single ^R the whole buffer is ONE request, so a `%%%` there is body
     # text and the lines under it must not be touched.
     def downgrade_h2_request_lines(*, group : Bool) : Bool
-      return false if @http2 || @req_hex_edit || @grpc_mode || @ws_mode
+      return false if @http2 || @req_hex_edit || @grpc_mode || ws_mode?
       changed = false
       at_request_line = true # line 0 starts a request; with `group`, so does the line after a `%%%`
       @editor.lines_snapshot.each_with_index do |line, i|
@@ -2070,7 +2168,7 @@ module Gori::Tui
 
     def pretty_print_request : String?
       return "hex mode active" if request_hex?
-      if @ws_mode && @req_pane == :decoded
+      if ws_mode? && @req_pane == :decoded
         return "websocket messages editor doesn't support pretty-printing"
       end
 
@@ -2322,7 +2420,7 @@ module Gori::Tui
     # where the send framed 34: the same display-vs-wire lie in the other direction.
     private def reflect_content_length_in_editor : Nil
       return unless @auto_content_length
-      return if @req_hex_edit || @grpc_mode || @ws_mode
+      return if @req_hex_edit || @grpc_mode || ws_mode?
       return if @decode_kind && @req_pane == :decoded
 
       wl = @editor.wire_lines
@@ -2421,7 +2519,7 @@ module Gori::Tui
     # elsewhere. Models reflect_content_length_in_editor (locate the header by content, then
     # replace_line). @dirty is already set by the target edit that triggered this.
     private def reflect_target_host_in_editor : Nil
-      return if @req_hex_edit || @ws_mode || @grpc_mode
+      return if @req_hex_edit || ws_mode? || @grpc_mode
       scheme, host, port = parse_target
       return if host.empty?
       # Shared with the engine and the CLI (build_target derives from the same call), so the
@@ -2567,7 +2665,7 @@ module Gori::Tui
       right = Rect.new(content.x + half + 1, content.y, {content.w - half - 1, 0}.max, content.h)
 
       # RESPONSE: d:diff / x:hex / p:pretty (not drawn in WS/gRPC/group transcript modes)
-      unless @ws_mode || @grpc_mode || group_mode?
+      unless ws_mode? || @grpc_mode || group_mode?
         if right.w >= 2 && my == right.y
           if hit = Frame.left_chip_hit(mx, my, right.y, right.x + 12, [
                {:diff, " d:diff "},
@@ -2595,7 +2693,7 @@ module Gori::Tui
                      b << {:req_hex, "^X", "MSG"} # click to hex-edit the unary payload
                    end
                    b
-                 elsif @ws_mode
+                 elsif ws_mode?
                    WS_BADGES # ^R:SEND + ␣K:KEY — the list render_request draws from
                  elsif @req_hex_edit
                    [{:send, "^R", "SEND"}, {:req_hex, "^X", "HEX"}] of {Symbol, String, String}
@@ -2696,7 +2794,7 @@ module Gori::Tui
     # a decode tab's envelope + payload). The predicate `req_editor`, `mark_req_edit`,
     # `render` and the hit-tests all branch on — spelled once so they cannot drift.
     private def req_split? : Bool
-      !@decode_kind.nil? || @ws_mode
+      !@decode_kind.nil? || ws_mode?
     end
 
     # Which request sub-pane the point (mx, my) falls in — `:decoded` for the lower card of a
@@ -2768,7 +2866,7 @@ module Gori::Tui
     # splits it: gRPC and a pipelined group render one transcript over the whole column.
     # `req_split?`'s counterpart, and read by the same shape of hit-test / render code.
     private def resp_split? : Bool
-      @ws_mode
+      ws_mode?
     end
 
     # Which response sub-pane owns the read cursor: `:handshake` | `:transcript`. Always
@@ -2779,7 +2877,7 @@ module Gori::Tui
     # deliberately not `transcript_rows?`, which builds (and caches, and theme-checks) the rows:
     # this is read per drawn row through `resp_navigable?`.
     private def resp_transcript? : Bool
-      @ws_mode || @grpc_mode || group_mode?
+      ws_mode? || @grpc_mode || group_mode?
     end
 
     # Whether the hex dump is what the response pane is ACTUALLY drawing. `@resp_hex` alone is
@@ -3662,7 +3760,7 @@ module Gori::Tui
     # send), else nil (a normal single response). The single source these read/copy/search
     # paths share so a new transcript mode wires into all of them at once.
     private def transcript_rows? : Array({String, Color})?
-      return ws_transcript_lines if @ws_mode
+      return ws_transcript_lines if ws_mode?
       return grpc_transcript_lines if @grpc_mode
       return group_transcript_lines if group_mode?
       nil
@@ -3972,7 +4070,7 @@ module Gori::Tui
     # decoded split pane all have their own byte semantics and CLEAR concealment, so a §
     # there is literal payload, not a marker.
     private def req_marker_editable? : Bool
-      @focus == :request && !request_hex? && !@grpc_mode && !@ws_mode &&
+      @focus == :request && !request_hex? && !@grpc_mode && !ws_mode? &&
         @decode_kind.nil? && req_editor.same?(@editor)
     end
 
@@ -4003,7 +4101,7 @@ module Gori::Tui
     # with a badge naming the codec (+ the SAML param/binding) on the top border.
     private def render_decoded(screen : Screen, rect : Rect, focused : Bool) : Nil
       return if rect.w < 2 || rect.h < 2
-      label = if @ws_mode
+      label = if ws_mode?
                 "MESSAGES"
               elsif @decode_kind == :saml
                 "DECODED · SAML XML"
@@ -4011,7 +4109,7 @@ module Gori::Tui
                 "DECODED · GraphQL"
               end
       Frame.card(screen, rect, label, bg: Theme.bg, border: pane_border(focused))
-      if @ws_mode
+      if ws_mode?
         # The seeded frames this pane cannot render as a line. Without this the operator sees
         # an empty (or short) MESSAGES pane and has no way to know a PING, a CLOSE 1002 or an
         # RSV1 frame is still in the seed and still going out — which is precisely the
@@ -4127,7 +4225,11 @@ module Gori::Tui
     end
 
     private def render_request_label : String
-      return "HANDSHAKE REQUEST" if @ws_mode
+      return "HANDSHAKE REQUEST" if ws_mode?
+      # Still a handshake — it is the transport that was overridden, not the bytes — so the
+      # card says so, and names the engine `^R` will dial. Without this the tab was
+      # indistinguishable from an ordinary REQUEST while its MESSAGES pane sat hidden.
+      return @http2 ? "HANDSHAKE (h2)" : "HANDSHAKE (h1)" if ws_http_only?
       return "GRPC REQUEST" if @grpc_mode
       return "ENVELOPE" if @decode_kind # the full request; the payload is the DECODED split below
       @http2 ? "REQUEST (h2)" : "REQUEST"
@@ -4161,7 +4263,7 @@ module Gori::Tui
         end
         return
       end
-      if @ws_mode
+      if ws_mode?
         # KEY names what happens to the `Sec-WebSocket-Key` line the operator is looking at.
         # OFF (the default) means gori drops it and appends a fresh one, so the key in this
         # editor is NOT the key on the wire — which is worth a badge on its own, because the
@@ -4374,7 +4476,7 @@ module Gori::Tui
 
     private def render_response(screen : Screen, rect : Rect, focused : Bool) : Nil
       return if rect.w < 2 || rect.h < 2
-      if @ws_mode
+      if ws_mode?
         handshake_rect, transcript_rect = ws_resp_split(rect)
         on_handshake = @resp_pane == :handshake
         render_ws_handshake(screen, handshake_rect, focused, active: on_handshake)
@@ -4810,7 +4912,7 @@ module Gori::Tui
     private def resp_line_count : Int32
       if resp_handshake_active?
         {resp_view.total, 1}.max
-      elsif @ws_mode
+      elsif ws_mode?
         {ws_transcript_lines.size, 1}.max
       elsif @grpc_mode
         {grpc_transcript_lines.size, 1}.max


### PR DESCRIPTION
A WS-detected Repeater tab could only ever be tested as a WebSocket. `^V` now cycles
**WS → HTTP/1.1 → HTTP/2 → WS** on a tab holding a handshake; schema V11
(`repeaters.ws_http_only`) persists it. No bytes change — the `Upgrade:` header goes out
exactly as authored. This selects an engine, not a rewrite.

```
╭─ HANDSHAKE REQUEST ──── ␣K:KEY  ^R:SEND ╮ ╭─ HANDSHAKE RESPONSE ─╮
│ …                │ MESSAGES split       │ │ TRANSCRIPT split      │
        ^V ↓
╭─ HANDSHAKE (h1) ─ ^U:PRETTY  ^L:CL  ^R:SEND ╮ ╭─ RESPONSE  d:diff ─ ^X:hex ─ p:pretty ─╮
```

### Why not a separate WS Repeater tab type (Burp's shape)

Burp splits because its Repeater tab cannot host a transcript. `RepeaterView` already
multiplexes five modes; a second tab type would duplicate the sub-tab strip,
`SubtabFilter`, the `repeaters` table + position, reconcile-by-view-identity, tags, links
and minimize. And the mode is not a property of the endpoint — same URL, same bytes, two
questions ("does the handshake succeed?" vs "what do frames do after it does?"), which you
flip between mid-test.

### The axis: CONTENT vs SEND

`ws_content?` (the tab HOLDS a handshake + frames) is what **persistence** asks;
`ws_mode?` (`^R` dials `WsEngine`, and the tab renders as one) is what everything else
asks. Seven of 34 `@ws_mode` reads are content, and two of them bite: on the send-side
predicate `save_current_repeater` and the duplicate path take the else-branch, which never
writes `ws_messages` and passes neither `ws_keep_key` nor `ws_http_only` — so flipping a
captured tab to HTTP and leaving it **dropped every captured frame**, and the override
could not stick to its own row.

### What this unlocks

The panes are the smaller half. Diff baseline, pretty-print, request hex, minimize, group
send, Match & Replace, auto-Content-Length and the h1/h2 toggle are all gated on the same
predicate — eight things you want while testing a handshake, none of them reachable in a
WS tab.

### Nothing new on the wire

`Engine` already treats 101 as terminal (not interim), `Body.response_framing` already
puts 1xx outside the body-carrying statuses, and `ConnPool` already refuses to pool an
`Upgrade` request (`conn_pool.cr:455`) or an upgraded socket (`:494`). All three predate
this; what is new is only that a 101 can reach them.

### Other surfaces

- `gori run repeater send --http` (per-send) · `repeater create --ws-http-only` (stored)
- MCP `create_repeater` / `update_repeater` carry `ws_http_only`
- MCP `send_request` **always** did this silently (no websocket guard, just `plan.send`) —
  it now reports `websocket_handshake` + a note pointing at `send_websocket`. The
  behaviour is not new there; the name is.

### Deliberately out of scope

`@ws_mode` is derived at load/restore/peer-sync and not while typing, so pasting
`Upgrade: websocket` into a plain tab stays HTTP this session and becomes a WS tab after a
restart. Real inconsistency, separate change — it alters what auto-detection *means*,
where this only gives the operator a way out of it.

### Verification

- `crystal spec` — **7186 examples, 8 failures**, the standing local baseline (a gori
  already bound on :8070); no new failures. 13 new specs: 9 view, 2 socket, 2 store.
- Runtime, against a Python origin that answers 101 and then **holds the socket open**
  (what a real WS server does): TUI `^V` cycle + `^R` returned **101 in 0ms** vs **15s**
  on the WS path; both CLI forms; the same endpoint asked without `Upgrade` returns its
  `426`. Save-on-leave persists the override.
