### PR TITLE
A key nothing on screen advertised, an SNI marker painted over the chip beside it, and a title so long its own card dropped the mode chip

### DIFF
--- a/spec/tui/repeater_transport_chip_spec.cr
+++ b/spec/tui/repeater_transport_chip_spec.cr
@@ -1,0 +1,188 @@
+require "../spec_helper"
+require "../support/memory_backend"
+
+include Gori::Tui
+
+# `^V` picks the transport `^R` dials — h1 ⇄ h2 on an ordinary tab, and (since the WebSocket
+# override landed) WS → h1 → h2 → WS on a tab holding a handshake. Nothing on screen said so:
+# the key was discoverable only from the footer of one pane in one mode, so a tab that could be
+# asked three different questions looked like a tab that could be asked one.
+#
+# The ` ^V:… ` chip fixes that, and it rides the TARGET band rather than the REQUEST border on
+# purpose: the request border is a HALF-width column that already carries ^R:SEND, ^L:CL,
+# ^U:PRETTY and the NOR/INS chip, and a fifth badge there pushes the mode chip past `min_x` on a
+# 100-column terminal — the badge chain drops its leftmost first. The TARGET band is full width
+# and already holds the other "how do we connect" facts (the URL, the SNI override).
+describe "RepeaterView transport chip" do
+  ws_head = "GET /ws HTTP/1.1\r\nHost: ws.test\r\nUpgrade: websocket\r\n" \
+            "Connection: Upgrade\r\nSec-WebSocket-Key: abc\r\nSec-WebSocket-Version: 13\r\n\r\n"
+
+  render = ->(view : RepeaterView, rect : Rect) {
+    b = MemoryBackend.new(rect.w, rect.h)
+    view.render(Screen.new(b), rect)
+    b
+  }
+
+  describe "an ordinary HTTP tab" do
+    it "names the transport and cycles it on a click" do
+      view = RepeaterView.new
+      view.load_blank
+      rect = Rect.new(0, 0, 100, 24)
+      b = render.call(view, rect)
+
+      row = b.row(rect.y)
+      row.should contain("^V:h1")
+      col = row.index("^V:h1").not_nil!
+      view.chrome_hit(rect, col + 1, rect.y).should eq(:transport)
+
+      view.toggle_http2.should be_true
+      render.call(view, rect).row(rect.y).should contain("^V:h2")
+    end
+
+    # The reason the chip is not on the REQUEST border: at 100 columns the request column is 49
+    # wide, and SEND+CL+PRETTY+NOR already fill it to within 3 cells of the card title.
+    #
+    # h2 is the case that pins the title cleanup: the card used to be titled "REQUEST (h2)",
+    # and those five columns moved `min_x` far enough right that the chain dropped its leftmost
+    # badge — the mode chip — on exactly this terminal. The transport lives on the band now, so
+    # the title is "REQUEST" in both states and the chip survives in both.
+    it "leaves the request border's own badges alone, in h1 and h2 alike" do
+      view = RepeaterView.new
+      view.load_blank
+      rect = Rect.new(0, 0, 100, 24)
+      border_y = rect.y + 3 # below the 3-row TARGET band
+
+      row = render.call(view, rect).row(border_y)
+      row.should contain("^R:SEND")
+      row.should contain("↵:NOR")
+      row.should_not contain("^V:")
+
+      view.toggle_http2
+      row2 = render.call(view, rect).row(border_y)
+      row2.should contain("REQUEST")
+      row2.should_not contain("(h2)")
+      row2.should contain("↵:NOR")
+    end
+
+    # The chip reports state, not on/off: its NAME is the state, so `toggle_badge`'s muted-grey
+    # "off" dress would read as a disabled control. At rest it is a filled chip; an override
+    # wears the ^R:SEND gold.
+    it "draws a filled chip at rest and the gold one while overridden" do
+      view = RepeaterView.new
+      view.load_blank
+      rect = Rect.new(0, 0, 100, 24)
+      b = render.call(view, rect)
+      col = b.row(rect.y).index("^V:h1").not_nil!
+      b.bg_at(col, rect.y).should eq(Theme.accent_bg)
+      b.bg_at(col, rect.y).should_not eq(Theme.bg)
+    end
+  end
+
+  describe "a WebSocket tab" do
+    it "cycles WS → h1 → h2 → WS and lights while overridden" do
+      view = RepeaterView.new
+      view.restore("https://ws.test", ws_head, false, true,
+        ws_messages: [Gori::Store::WsOutMessage.text("hello")])
+      rect = Rect.new(0, 0, 100, 30)
+
+      render.call(view, rect).row(rect.y).should contain("^V:WS")
+      view.transport_badge_lit?.should be_false # WS is the DETECTED transport, not an override
+
+      # Both ends, not just the destination: the request card is titled REQUEST once the
+      # override is on, so this chip is the only text left saying the tab holds a handshake.
+      view.cycle_ws_transport
+      render.call(view, rect).row(rect.y).should contain("^V:WS→h1")
+      view.transport_badge_lit?.should be_true # …h1 on a handshake tab is the operator's call
+
+      view.cycle_ws_transport
+      render.call(view, rect).row(rect.y).should contain("^V:WS→h2")
+
+      view.cycle_ws_transport
+      render.call(view, rect).row(rect.y).should contain("^V:WS")
+      view.transport_badge_lit?.should be_false
+    end
+
+    it "wears the gold while the handshake is going out as plain HTTP" do
+      view = RepeaterView.new
+      view.restore("https://ws.test", ws_head, false, true,
+        ws_messages: [Gori::Store::WsOutMessage.text("hello")])
+      rect = Rect.new(0, 0, 100, 30)
+
+      b = render.call(view, rect)
+      ws_col = b.row(rect.y).index("^V:WS").not_nil!
+      b.bg_at(ws_col, rect.y).should eq(Theme.accent_bg) # detected transport: the resting fill
+
+      view.cycle_ws_transport
+      b2 = render.call(view, rect)
+      h1_col = b2.row(rect.y).index("^V:WS→h1").not_nil!
+      b2.bg_at(h1_col, rect.y).should eq(Theme.focus_gold) # an override interrupts the glance
+    end
+
+    it "hit-tests the chip in both WS and overridden-HTTP shapes" do
+      view = RepeaterView.new
+      view.restore("https://ws.test", ws_head, false, true,
+        ws_messages: [Gori::Store::WsOutMessage.text("hello")])
+      rect = Rect.new(0, 0, 100, 30)
+
+      b = render.call(view, rect)
+      col = b.row(rect.y).index("^V:WS").not_nil!
+      view.chrome_hit(rect, col + 1, rect.y).should eq(:transport)
+
+      view.cycle_ws_transport # the pane geometry changes here; the TARGET band does not
+      b2 = render.call(view, rect)
+      row = b2.row(rect.y)
+      col2 = row.index("^V:WS→h1").not_nil!
+      view.chrome_hit(rect, col2 + 1, rect.y).should eq(:transport)
+      # The wider label must not run into its neighbour: the last cell of the chip still
+      # hit-tests as the chip, and the cell after it does not. `→` measures one column.
+      view.chrome_hit(rect, col2 + "^V:WS→h1".size, rect.y).should eq(:transport)
+      view.chrome_hit(rect, col2 + "^V:WS→h1".size + 1, rect.y).should_not eq(:transport)
+    end
+  end
+
+  describe "a gRPC tab" do
+    # gRPC rides h2 by specification and `repeater_toggle_http2` refuses it. A chip drawn where
+    # the key does nothing is worse than no chip, so this mode gets none — and nothing may
+    # hit-test as `:transport` across the whole band either.
+    it "draws no chip, because ^V refuses there" do
+      path = File.tempname("gori-transport", ".db")
+      store = Gori::Store.open(path)
+      begin
+        head = "POST /svc/M HTTP/2\r\nHost: api.test\r\ncontent-type: application/grpc\r\n\r\n"
+        id = store.insert_flow(Gori::Store::CapturedRequest.new(
+          created_at: 1_i64, scheme: "https", host: "api.test", port: 443,
+          method: "POST", target: "/svc/M", http_version: "HTTP/2",
+          head: head.to_slice, body: Bytes[0x00, 0x00, 0x00, 0x00, 0x01, 0x41]))
+        view = RepeaterView.new
+        view.load_grpc(store.get_flow(id).not_nil!)
+        rect = Rect.new(0, 0, 100, 24)
+
+        render.call(view, rect).row(rect.y).should_not contain("^V:")
+        (0...100).each { |x| view.chrome_hit(rect, x, rect.y).should_not eq(:transport) }
+      ensure
+        store.close
+        File.delete?(path)
+        File.delete?("#{path}-wal")
+        File.delete?("#{path}-shm")
+      end
+    end
+  end
+
+  # The SNI marker used to position itself at `right - " SNI ".size - 1`, which is INSIDE the
+  # NOR/INS chip's cells and drawn after it: setting an override painted over the chip's right
+  # five columns. Chaining the band's chrome — mode, then SNI, then ^V — is what makes room for
+  # the transport chip, and it fixes this at the same time.
+  it "keeps the SNI marker, the mode chip and the transport chip on separate cells" do
+    view = RepeaterView.new
+    view.restore("https://api.test/x", "GET /x HTTP/1.1\r\nHost: api.test\r\n\r\n", false, true,
+      sni: "other.test")
+    rect = Rect.new(0, 0, 100, 24)
+    row = render.call(view, rect).row(rect.y)
+
+    row.should contain("↵:NOR")
+    row.should contain("SNI")
+    row.should contain("^V:h1")
+    row.index("^V:h1").not_nil!.should be < row.index("SNI").not_nil!
+    row.index("SNI").not_nil!.should be < row.index("↵:NOR").not_nil!
+  end
+end

--- a/spec/tui/repeater_ws_http_only_spec.cr
+++ b/spec/tui/repeater_ws_http_only_spec.cr
@@ -135,9 +135,18 @@ describe "RepeaterView WebSocket transport override" do
     dup.ws_out_messages_raw.size.should eq(2)
   end
 
-  it "titles the request card so the override is visible on screen" do
+  it "shows the override on screen: the card is a REQUEST, the band says WS→h1" do
     # Without this the overridden tab was indistinguishable from an ordinary REQUEST while its
     # MESSAGES pane sat hidden — the operator could not see which engine ^R would dial.
+    #
+    # The two facts are split now. The card title says what the card IS in its pane: with the
+    # override on, `^R` sends an ordinary request and reads a response, MESSAGES is gone and
+    # the split is one card again — so it is titled REQUEST, exactly like the tab it now
+    # behaves as. The WebSocket half of the story moved to the TARGET band's chip, which names
+    # BOTH ends (` ^V:WS→h1 `) precisely so the tab is still not mistakable for a plain one.
+    #
+    # The title used to carry both facts, and the extra columns pushed the card's own ↵:NOR
+    # chip off a 100-col terminal — the badge chain measures its left stop from the title.
     rect = Rect.new(0, 0, 100, 24)
     draw = ->(v : RepeaterView) {
       b = MemoryBackend.new(100, 24)
@@ -147,9 +156,13 @@ describe "RepeaterView WebSocket transport override" do
     draw.call(ws_view).contains?("HANDSHAKE REQUEST").should be_true
 
     http = ws_view(http_only: true)
-    draw.call(http).contains?("HANDSHAKE (h1)").should be_true
+    b = draw.call(http)
+    b.contains?("HANDSHAKE").should be_false # not a handshake pane any more — a request pane
+    b.row(rect.y + 3).should contain("REQUEST")
+    b.row(rect.y).should contain("^V:WS→h1")  # …and the band is what says it was a handshake
+    b.row(rect.y + 3).should contain("↵:NOR") # the request card keeps its mode chip at 100 cols
 
     http.cycle_ws_transport # → h2
-    draw.call(http).contains?("HANDSHAKE (h2)").should be_true
+    draw.call(http).row(rect.y).should contain("^V:WS→h2")
   end
 end

--- a/src/gori/tui/controllers/repeater_controller.cr
+++ b/src/gori/tui/controllers/repeater_controller.cr
@@ -652,6 +652,12 @@ module Gori::Tui
       when :ws_key
         view.focus_pane(:request)
         repeater_toggle_ws_key
+      when :transport
+        # No `focus_pane`: the chip sits on the TARGET band but the choice belongs to the whole
+        # tab, and `cycle_ws_transport` already re-seats the request/response sub-panes it
+        # invalidates. Moving focus here would yank the caret out of whatever pane was being
+        # edited — the key (`^V`) doesn't, and the click should not differ.
+        repeater_toggle_http2 # cycles WS→h1→h2 on a handshake tab, flips h1⇄h2 elsewhere
       when :send
         view.focus_pane(:request)
         repeater_send

--- a/src/gori/tui/frame.cr
+++ b/src/gori/tui/frame.cr
@@ -140,6 +140,23 @@ module Gori::Tui
       x
     end
 
+    # A right-chained badge that reports STATE rather than an on/off toggle, so it carries its
+    # own colours instead of `toggle_badge`'s lit/muted pair. Same `" chord:NAME "` geometry, so
+    # it chains with the others and hit-tests through `right_badge_hit` unchanged.
+    #
+    # For a chip whose NAME is the state (Repeater's ` ^V:WS ` / ` ^V:h1 `), muted-when-off is
+    # the wrong dress: there is no "off", and a grey chip reads as a disabled one. Callers pass
+    # a fill so the resting state is still legible and an exceptional state can shout.
+    def self.state_badge(screen : Screen, right_edge : Int32, y : Int32, min_x : Int32,
+                         chord : String, name : String, fg : Color, bg : Color,
+                         attr : Attribute = Attribute::None) : Int32
+      text = " #{chord}:#{name} "
+      x = right_edge - text.size
+      return right_edge if x < min_x
+      screen.text(x, y, text, fg, bg, attr)
+      x
+    end
+
     # READ/INS mode chip on an editor pane's top border (Repeater REQUEST, Decoder INPUT,
     # Notes, …). NOR advertises ↵ (and i) as the way into insert; INS is a plain lit label
     # (esc exits — already in the status strip). Clickable via `mode_badge_hit`. Returns

--- a/src/gori/tui/repeater_view.cr
+++ b/src/gori/tui/repeater_view.cr
@@ -628,6 +628,36 @@ module Gori::Tui
       @ws_mode && @ws_http_only
     end
 
+    # Can `^V` change what `^R` dials on this tab? False only for gRPC, whose transport is
+    # fixed by specification (see `repeater_toggle_http2`'s refusal). Gates the `^V` badge:
+    # a chip is drawn exactly where the key does something, so a tab that shows none is a tab
+    # whose transport is not the operator's to pick.
+    def transport_switchable? : Bool
+      !@grpc_mode
+    end
+
+    # The transport `^R` will dial, as the `^V` badge names it. Only meaningful when
+    # `transport_switchable?` — a gRPC tab is always h2 and draws no badge to say so.
+    #
+    # An overridden handshake tab names BOTH ends ("WS→h1"): its request card is titled
+    # REQUEST, because that is what `^R` sends, so this chip is the only text on screen saying
+    # the tab holds a WebSocket handshake at all. Naming just the destination would put the tab
+    # back where it started — indistinguishable from an ordinary request with a hidden MESSAGES
+    # pane, which is the defect the card title used to carry alone.
+    def transport_label : String
+      return "WS" if ws_mode?
+      http = @http2 ? "h2" : "h1"
+      ws_http_only? ? "WS→#{http}" : http
+    end
+
+    # Should the `^V` badge wear the loud dress? Only when the operator overrode auto-detection
+    # — a tab holding a WebSocket handshake that `^R` will send as a plain request. h1 vs h2 on
+    # an ordinary tab is not an override (the tab has no other shape to be): it keeps the
+    # resting fill and lets the LABEL carry the state.
+    def transport_badge_lit? : Bool
+      ws_http_only?
+    end
+
     # Cycle the transport `^R` dials: WS → HTTP/1.1 → HTTP/2 → WS. Returns the new state as a
     # label for the status line. Only a tab holding a handshake has three states; anything
     # else keeps the plain two-state h1/h2 toggle (`toggle_http2`).
@@ -2572,6 +2602,36 @@ module Gori::Tui
     TARGET_PREFIX = "›"
     SNI_PREFIX    = "SNI ›"
 
+    # The TARGET band's SNI override marker (not a toggle — `^S` edits the row below).
+    SNI_BADGE = " SNI "
+
+    # Left stop for the TARGET band's right-chained chrome: one column clear of the card
+    # title, which `Frame.card` draws at `rect.x + 2`.
+    private def target_chip_min(rect : Rect) : Int32
+      rect.x + 9
+    end
+
+    # The TARGET band's right-to-left chrome after the NOR/INS mode chip: the SNI marker,
+    # then the `^V` transport chip. Returns `{sni_x, transport_right_edge}` — `sni_x` nil when
+    # no override is set or the marker doesn't fit. Pure geometry, shared by `render_target`
+    # and `chrome_hit`.
+    #
+    # The SNI marker used to place itself at `rect.right - size - 1`, which is INSIDE the mode
+    # chip's cells: setting an SNI override painted over the right five columns of " ↵:NOR ",
+    # leaving a truncated chip behind. Chaining it fixes that too.
+    private def target_chrome_chain(rect : Rect) : {Int32?, Int32}
+      min_x = target_chip_min(rect)
+      edge = rect.right - 1
+      mode = Frame.mode_badge_label(target_insert?)
+      edge -= mode.size if edge - mode.size >= rect.x + 8 # the mode chip's own stop — see render_target
+      sni_x = nil
+      if !@sni.strip.empty? && edge - SNI_BADGE.size >= min_x
+        edge -= SNI_BADGE.size
+        sni_x = edge
+      end
+      {sni_x, edge}
+    end
+
     private def field_base(rect : Rect, prefix : String) : Int32
       rect.x + 2 + prefix.size + 1
     end
@@ -2652,10 +2712,18 @@ module Gori::Tui
     def chrome_hit(rect : Rect, mx : Int32, my : Int32) : Symbol?
       return nil unless @loaded && rect.contains?(mx, my)
       target_h = {rect.h, target_card_h}.min
-      # TARGET NOR/INS chip (top band) — click toggles insert like ↵/esc.
+      # TARGET NOR/INS chip (top band) — click toggles insert like ↵/esc. The `^V` transport
+      # chip chains left of it (past the SNI marker) and cycles the transport on click.
       if my == rect.y && target_h >= 2
         if Frame.mode_badge_hit(mx, my, rect.y, rect.right - 1, rect.x + 8, target_insert?)
           return :target_mode
+        end
+        if transport_switchable?
+          _, tr_edge = target_chrome_chain(rect)
+          if hit = Frame.right_badge_hit(mx, my, rect.y, tr_edge, target_chip_min(rect),
+               [{:transport, "^V", transport_label}] of {Symbol, String, String})
+            return hit
+          end
         end
       end
       content = Rect.new(rect.x, rect.y + target_h, rect.w, {rect.h - target_h, 0}.max)
@@ -4150,12 +4218,27 @@ module Gori::Tui
       ins = focused && target_insert?
       Frame.card(screen, rect, "TARGET", bg: Theme.bg, border: pane_border(focused, insert: ins))
       Frame.mode_badge(screen, rect.right - 1, rect.y, rect.x + 8, target_insert?) # the REAL mode, not focused&&mode — see Frame.mode_badge
+      sni_x, tr_edge = target_chrome_chain(rect)
       # An at-a-glance SNI marker on the top border (right of the title) whenever an
       # override is set, so a custom SNI is visible even before the row is reached.
-      unless @sni.strip.empty?
-        badge = " SNI "
-        bx = {rect.right - badge.size - 1, rect.x + 9}.max
-        screen.text(bx, rect.y, badge, Theme.text_bright, Theme.accent_bg)
+      screen.text(sni_x, rect.y, SNI_BADGE, Theme.text_bright, Theme.accent_bg) if sni_x
+      # ` ^V:h1 ` / ` ^V:h2 ` / ` ^V:WS ` — the transport `^R` will dial, and the only thing on
+      # screen saying `^V` has anything to offer. It rides the TARGET band rather than the
+      # REQUEST border because that is where the rest of "how do we connect" already lives
+      # (the URL, the SNI override) and because the request border is a half-width column that
+      # already drops its NOR/INS chip when a fifth badge is chained onto it.
+      #
+      # Two dresses, no third: a filled chip at rest (the NAME is the state, so muted grey
+      # would read as "disabled"), and the ^R:SEND gold when the operator has overridden
+      # auto-detection — a handshake tab that will NOT speak WebSocket is the one thing on this
+      # band worth interrupting a glance for.
+      if transport_switchable?
+        fg, bg, attr = if transport_badge_lit?
+                         {Theme.ink_on(Theme.focus_gold), Theme.focus_gold, Attribute::Bold}
+                       else
+                         {Theme.text_bright, Theme.accent_bg, Attribute::None}
+                       end
+        Frame.state_badge(screen, tr_edge, rect.y, target_chip_min(rect), "^V", transport_label, fg, bg, attr)
       end
       url_active = focused && @target_field == :url
       sni_active_row = focused && @target_field == :sni
@@ -4224,15 +4307,23 @@ module Gori::Tui
       end
     end
 
+    # The request card's title says WHAT this card is in the pane it sits in. WHICH transport
+    # `^R` will dial is the TARGET band's ` ^V:… ` chip, in one place, on every tab.
+    #
+    # Both facts used to live here — "HANDSHAKE (h1)", "REQUEST (h2)" — because nothing else on
+    # screen carried the transport. That cost the card up to five columns of title, and the
+    # badge chain measures its left stop from the title: at 100 columns (a 49-wide request
+    # column) an h2 tab pushed its own ` ↵:NOR ` chip past `min_x` and drew no mode chip at all.
+    #
+    # An overridden handshake tab is titled REQUEST, not HANDSHAKE: `^R` sends it as an
+    # ordinary request and reads a response, the MESSAGES pane is gone, and the card is one
+    # card again — it IS a request pane. That the request happens to be an upgrade handshake is
+    # the ` ^V:WS→h1 ` chip's line, and the bytes' own.
     private def render_request_label : String
-      return "HANDSHAKE REQUEST" if ws_mode?
-      # Still a handshake — it is the transport that was overridden, not the bytes — so the
-      # card says so, and names the engine `^R` will dial. Without this the tab was
-      # indistinguishable from an ordinary REQUEST while its MESSAGES pane sat hidden.
-      return @http2 ? "HANDSHAKE (h2)" : "HANDSHAKE (h1)" if ws_http_only?
+      return "HANDSHAKE REQUEST" if ws_mode? # one of TWO cards here — MESSAGES is the other
       return "GRPC REQUEST" if @grpc_mode
       return "ENVELOPE" if @decode_kind # the full request; the payload is the DECODED split below
-      @http2 ? "REQUEST (h2)" : "REQUEST"
+      "REQUEST"
     end
 
     private def render_request(screen : Screen, rect : Rect, focused : Bool) : Nil


### PR DESCRIPTION
`^V` cycles WS → HTTP/1.1 → HTTP/2 on a Repeater tab holding a handshake, and h1 ⇄ h2 on
every other non-gRPC tab. Nothing drew it. The key was discoverable from the Help overlay
and from the footer of one pane in one mode, so a tab that could be asked three different
questions looked like a tab that could be asked one — the same shape as the refusal the
override itself just removed.

THE CHIP. ` ^V:WS ` / ` ^V:h1 ` / ` ^V:h2 ` on the TARGET band, naming the transport `^R`
will dial. It hit-tests as a button (`chrome_hit` → `:transport`) and cycles on click, like
every other border chip.

WHY THE BAND, NOT THE REQUEST BORDER. That border was the first try and it does not fit:
at 100 columns the request column is 49 wide, and ` ^R:SEND `, ` ^L:CL `, ` ^U:PRETTY ` and
the mode chip already fill it to within three cells of the card title. A fifth badge pushes
the chain past `min_x`, and the chain drops its LEFTMOST first — the ` ↵:NOR ` chip, which
is the one that reports whether typing will edit or navigate. The TARGET band is full
width and already holds the rest of "how do we connect": the URL and the SNI override.

THE DRESS. `Frame.state_badge` — a right-chained badge that reports STATE rather than
on/off, so it carries its own colours instead of `toggle_badge`'s lit/muted pair. For a
chip whose NAME is the state there is no "off", and muted grey reads as a disabled control.
Two dresses: the resting fill at rest, and the `^R:SEND` gold when the operator has
overridden auto-detection. A handshake tab that will NOT speak WebSocket is the one thing
on that band worth interrupting a glance for. No functional colour is spent — the palette
keeps green/yellow/red for HTTP status, and this uses the existing accent/gold vocabulary,
so all 28 themes follow for free.

THE TITLE. The request card said "HANDSHAKE (h1)" and "REQUEST (h2)" because nothing else
carried the transport. Now something does, so the title says only what the card IS in its
pane, and the transport is named once. That is not just de-duplication: the badge chain
measures its left stop FROM the title, and those five columns were exactly what pushed an
h2 tab's own ` ↵:NOR ` chip off a 100-column terminal. An overridden handshake tab is
titled REQUEST, not HANDSHAKE — `^R` sends an ordinary request and reads a response,
MESSAGES is gone, the split is one card again. The chip carries the other half by naming
both ends (` ^V:WS→h1 `), so the tab is still not mistakable for a plain one, which is what
the old title was for. `→` measures one column; the specs pin the chip's last live cell and
the dead one after it, because the badge geometry counts characters, not display width.

THE OVERLAP. The SNI marker placed itself at `right - " SNI ".size - 1` and was drawn
AFTER the mode chip — which is inside the mode chip's cells. Setting an SNI override
painted over the right five columns of ` ↵:NOR ` and left a truncated chip behind. Making
room for the transport chip meant chaining that band's chrome (mode → SNI → ^V) through one
pure geometry both the draw and `chrome_hit` read, so this went with it.

VERIFICATION. `spec/tui/repeater_transport_chip_spec.cr`: the three-state cycle, the
hit-test in both shapes, both dresses asserted against `bg_at`, the gRPC tab that draws no
chip because `^V` refuses there, the SNI/mode/transport cells staying disjoint, and the
request border keeping its own badges in h1 and h2 alike. TUI suite green; the full suite's
only failures are the eight that need port 8070 free.