### PR TITLE
A copy that reported success and reached no clipboard, a paste that ran itself as hotkeys, and a ⇧↑ that selected one newline

### DIFF
--- a/spec/tui/clipboard_spec.cr
+++ b/spec/tui/clipboard_spec.cr
@@ -6,9 +6,20 @@ describe Gori::Tui::Clipboard do
     Gori::Tui::Clipboard.osc52("hi there").should eq("\e]52;c;#{Base64.strict_encode("hi there")}\a")
   end
 
-  it "wraps in tmux DCS passthrough (ESC-doubled) when requested" do
+  # BOTH forms under tmux, bare one FIRST. The bare sequence is what default tmux
+  # (`set-clipboard external`) actually honours; the DCS wrap is gated on
+  # `allow-passthrough`, which defaults to OFF and makes tmux drop it. Sending only the
+  # wrap — what this did before — meant `y` inside tmux reported success and delivered
+  # nothing. See the Clipboard module comment.
+  it "sends the bare sequence AND the tmux DCS passthrough (ESC-doubled) under tmux" do
     b64 = Base64.strict_encode("data")
-    Gori::Tui::Clipboard.osc52("data", tmux: true).should eq("\ePtmux;\e\e]52;c;#{b64}\a\e\\")
+    bare = "\e]52;c;#{b64}\a"
+    Gori::Tui::Clipboard.osc52("data", tmux: true).should eq("#{bare}\ePtmux;\e\e]52;c;#{b64}\a\e\\")
+  end
+
+  it "starts the tmux form with the bare sequence, so a passthrough-off tmux still copies" do
+    seq = Gori::Tui::Clipboard.osc52("data", tmux: true)
+    seq.starts_with?("\e]52;c;").should be_true
   end
 
   it "round-trips arbitrary request bytes through base64" do

--- a/spec/tui/foundation_spec.cr
+++ b/spec/tui/foundation_spec.cr
@@ -137,6 +137,47 @@ describe Gori::Tui::Screen do
       end
     end
 
+    # `column_for_click` is the POINTER's inverse: same cluster grid, but a column in the FAR
+    # half of a cluster resolves to the boundary AFTER it. Flooring made the whole 2-cell
+    # footprint of a Hangul syllable resolve to the position before it, so half of every
+    # pointer position over such text landed a character short — a drag ending on the right
+    # half of `트` copied one glyph less than it covered, and a click on the right half of `한`
+    # put the caret in front of it.
+    it "column_for_click rounds a pointer to the NEAREST cluster boundary" do
+      s = "한글 선택"                                # 한 0-1, 글 2-3, space 4, 선 5-6, 택 7-8
+      Screen.column_for_click(s, 0).should eq(0) # near half of 한 → before it
+      Screen.column_for_click(s, 1).should eq(1) # FAR half of 한 → after it
+      Screen.column_for_click(s, 2).should eq(1)
+      Screen.column_for_click(s, 3).should eq(2) # far half of 글
+      Screen.column_for_click(s, 4).should eq(2) # the space (1 cell — no far half)
+      Screen.column_for_click(s, 8).should eq(5) # far half of 택 → end of string
+    end
+
+    # The ASCII half of the same rule, and the reason it could be adopted at every hit test at
+    # once: a 1-column cluster has no far half, so the two agree everywhere on ASCII and no
+    # existing click behaviour moved.
+    it "column_for_click is identical to column_for on 1-column clusters" do
+      ["hello world", "a\tb\tc", "GET /x?a=1 HTTP/1.1", "a\u{200B}b"].each do |s|
+        (-2..Screen.draw_width(s) + 2).each do |col|
+          Screen.column_for_click(s, col).should eq(Screen.column_for(s, col)) # (#{s.inspect} @ #{col})
+        end
+      end
+    end
+
+    # The double-click's companion: a pointer that rounded PAST a wide glyph has nothing to
+    # take, so the word spread steps back over that one cluster. Narrow on purpose — a 1-column
+    # cluster can never be rounded past, so "a double-click on a space takes nothing" survives.
+    it "step_back_over_wide moves off a rounded-past WIDE glyph and nothing else" do
+      s = "한글 선택"
+      Screen.step_back_over_wide(s, 2).should eq(1) # the space after 글 ← back onto 글
+      Screen.step_back_over_wide(s, 5).should eq(4) # past the end ← back onto 택
+      Screen.step_back_over_wide(s, 1).should eq(1) # 글 is not whitespace/EOL — untouched
+      a = "alpha bravo"
+      Screen.step_back_over_wide(a, 5).should eq(5) # the space stays the space
+      Screen.step_back_over_wide(a, a.size).should eq(a.size)
+      Screen.step_back_over_wide(a, 0).should eq(0)
+    end
+
     it "column_for never returns an index inside a cluster" do
       # Every column a click can produce must resolve to a cluster START, so a click can
       # never drop the caret between the `e` and the combining acute of `é`.

--- a/spec/tui/read_cursor_spec.cr
+++ b/spec/tui/read_cursor_spec.cr
@@ -20,30 +20,83 @@ describe Gori::Tui::ReadCursor do
       txt.should_not be_nil
     end
 
-    it "copies a downward selection from the anchor column to the caret column" do
+    # A VERTICAL ⇧step keeps the caret's column (clamped), so ⇧↓ ends exactly where a plain ↓
+    # would. It used to snap to the destination line's EOL, which is what made the upward case
+    # below select nothing at all — see `ReadCursor#move`.
+    it "keeps the column on a downward ⇧step, ending where a plain ↓ would" do
       down = ReadCursor.new
       down.sync(0, 2)                         # anchor at col 2 of the short top line
-      down.move(1, 0, lines, selecting: true) # Shift+Down → caret (1, EOL)
-      # Top line from col 2 to end, then the whole bottom line (caret parked at EOL).
-      down.selection_text(lines).should eq("#{lines[0][2..]}\n#{lines[1]}")
+      down.move(1, 0, lines, selecting: true) # Shift+Down → caret (1, 2)
+      down.cy.should eq(1)
+      down.cx.should eq(2)
+      down.selection_text(lines).should eq("#{lines[0][2..]}\n#{lines[1][0...2]}")
     end
 
+    # THE REGRESSION THIS PAIR EXISTS FOR. From column 0 the EOL snap made an upward ⇧step
+    # collapse to a bare "\n" with NO painted band: the boundary columns belong to their
+    # document-order lines, so the caret's column lands on the TOP line, and the caret had been
+    # parked at that line's end. Live, in the Comparer: ⇧↓⇧↓ copied 47b and ⇧↑ copied 1b.
+    it "selects a real span on an UPWARD ⇧step from column 0 (not a bare newline)" do
+      up = ReadCursor.new
+      up.sync(1, 0)
+      up.move(-1, 0, lines, selecting: true) # Shift+Up → caret (0, 0), anchor (1, 0)
+      up.selection_text(lines).should eq("#{lines[0]}\n")
+      up.highlight_spans(lines).should_not be_empty
+    end
+
+    it "paints a band for an upward ⇧step from mid-line" do
+      up = ReadCursor.new
+      up.sync(1, 3)
+      up.move(-1, 0, lines, selecting: true) # caret (0, 3), anchor (1, 3)
+      up.selection_text(lines).should eq("#{lines[0][3..]}\n#{lines[1][0...3]}")
+      up.highlight_spans(lines).map(&.[](0)).should eq([0, 1])
+    end
+
+    # Document-order boundary assignment, with the two columns DIFFERENT so a swap would show.
+    # `move_to` is the soft-wrapped panes' path (History detail, Repeater response), where the
+    # caret really can stop at a column the anchor does not share.
     it "applies the CARET column to the top line for an upward selection (not the anchor's)" do
       up = ReadCursor.new
-      up.sync(1, 3)                          # click at col 3 of the long middle line
-      up.move(-1, 0, lines, selecting: true) # Shift+Up → caret (0, EOL of the short line)
-      # Document order top→bottom is (0, EOL0) → (1, 3): the top line contributes nothing
-      # (caret at its EOL), the bottom line runs from col 0 to the anchor's col 3.
-      # The pre-fix code applied the anchor col (3) to line 0 and the caret col to line 1,
-      # copying "rt\na m" instead.
-      up.selection_text(lines).should eq("\n#{lines[1][0...3]}")
+      up.sync(1, 10)                    # caret at col 10 of the long middle line
+      up.move_to(0, 2, selecting: true) # ⇧↑ under wrap → caret (0, 2), anchor (1, 10)
+      up.selection_text(lines).should eq("#{lines[0][2..]}\n#{lines[1][0...10]}")
+      # Reversed, the top line would be sliced at 10 (past its length) and the bottom at 2.
+      up.selection_text(lines).should_not eq("\n#{lines[1][0...2]}")
     end
 
-    it "copies a clean full-line multi-line selection as whole lines" do
+    # A pane whose screen row is not one run of text (Comparer, Miner, Sequencer) asks for whole
+    # lines explicitly. Both boundary columns are set by DIRECTION, so this works upward too.
+    describe "#extend_lines" do
+      it "grows whole lines downward" do
+        rc = ReadCursor.new
+        rc.sync(0, 2) # a column the caret happened to carry in
+        rc.extend_lines(1, lines.size, ->(i : Int32) { lines[i] })
+        rc.selection_text(lines).should eq("#{lines[0]}\n#{lines[1]}")
+      end
+
+      it "grows whole lines UPWARD" do
+        rc = ReadCursor.new
+        rc.sync(1, 4)
+        rc.extend_lines(-1, lines.size, ->(i : Int32) { lines[i] })
+        rc.selection_text(lines).should eq("#{lines[0]}\n#{lines[1]}")
+        rc.selected_line_range.should eq({0, 1})
+      end
+    end
+  end
+
+  # An anchor sitting exactly on the caret selects no characters and paints no band, so it must
+  # not report a selection: `copy_text` reads `selection_text || current_line` everywhere, and
+  # a "" here defeated the fallback — `y` on an invisible selection copied nothing.
+  describe "an EMPTY selection" do
+    it "is not a selection, and copies as nil rather than an empty string" do
       rc = ReadCursor.new
-      rc.sync(0, 0)                         # start at col 0
-      rc.move(1, 0, lines, selecting: true) # Shift+Down → (1, EOL)
-      rc.selection_text(lines).should eq("#{lines[0]}\n#{lines[1]}")
+      rc.sync(1, 4)
+      rc.move(0, 1, lines, selecting: true) # ⇧→ …
+      rc.selection?.should be_true
+      rc.move(0, -1, lines, selecting: true) # … then ⇧← back onto the anchor
+      rc.selection?.should be_false
+      rc.selection_text(lines).should be_nil
+      rc.highlight_spans(lines).should be_empty
     end
   end
 

--- a/spec/tui/read_pane_spec.cr
+++ b/spec/tui/read_pane_spec.cr
@@ -91,6 +91,9 @@ describe Gori::Tui::ReadPane do
   end
 
   describe "keyboard" do
+    # A ⇧step keeps the column, so one press takes exactly one line (caret from (1,0) to (2,0))
+    # — the same place a plain ↓ lands. See `ReadCursor#move`: the EOL snap this replaced took
+    # TWO lines per press going down and NOTHING at all going up.
     it "moves the caret and grows a selection on ⇧ vertical steps" do
       pane = ReadPane.new
       pane.source(pane_source(10))
@@ -98,8 +101,20 @@ describe Gori::Tui::ReadPane do
       pane.copy_text.should eq("line1 word1") # no selection → the caret's line
       pane.move(1, 0, selecting: true)
       pane.selection?.should be_true
-      pane.copy_text.should contain("line1")
-      pane.copy_text.should contain("line2")
+      pane.copy_text.should eq("line1 word1\n")
+      pane.move(1, 0, selecting: true)
+      pane.copy_text.should eq("line1 word1\nline2 word2\n")
+    end
+
+    # ⇧↑ used to select nothing at all here: no band was painted and `y` copied one newline.
+    it "grows a selection UPWARD on a ⇧ vertical step" do
+      pane = ReadPane.new
+      pane.source(pane_source(10))
+      3.times { pane.move(1, 0) }
+      pane.move(-1, 0, selecting: true)
+      pane.selection?.should be_true
+      pane.copy_text.should eq("line2 word2\n")
+      pane.cursor.highlight_spans(pane_source(10)).should_not be_empty
     end
 
     it "selects the current line and clears it" do
@@ -203,6 +218,82 @@ describe Gori::Tui::ReadPane do
       pane.source(pane_source(6))
       render_pane(pane)
       pane.select_word(Rect.new(0, 0, 40, 6), 38, 0).should be_false
+    end
+
+    # A pointer rounds to the NEAREST cluster boundary (`Screen.column_for_click`), which is
+    # what makes a drag over Hangul/CJK include the glyph the operator is more than half way
+    # across. The cost it must NOT have: a double-click on the right half of a word's LAST
+    # glyph resolves past the word, where the spread would find no token — so
+    # `Screen.step_back_over_wide` walks back over exactly one WIDE cluster in that case.
+    # Both halves of every wide glyph, and the unchanged ASCII contract, are pinned here.
+    describe "double-click over wide glyphs" do
+      # "한글 선택 테스트" — 한 at cols 0-1, 글 2-3, space 4, 선 5-6, 택 7-8, space 9, 테 10-11.
+      it "takes the word from either half of a wide glyph" do
+        pane = ReadPane.new
+        pane.source(["한글 선택 테스트"])
+        rect = Rect.new(0, 0, 40, 3)
+        render_pane(pane, h: 3)
+        pane.select_word(rect, 5, 0).should be_true # LEFT half of 선
+        pane.copy_text.should eq("선택")
+        pane.select_word(rect, 8, 0).should be_true # RIGHT half of 택 — the word's last glyph
+        pane.copy_text.should eq("선택")
+        pane.select_word(rect, 0, 0).should be_true # left half of the line's first glyph
+        pane.copy_text.should eq("한글")
+      end
+
+      it "still takes nothing on a space, which no 1-column cell can be rounded past" do
+        pane = ReadPane.new
+        pane.source(["alpha bravo"])
+        rect = Rect.new(0, 0, 40, 3)
+        render_pane(pane, h: 3)
+        pane.select_word(rect, 4, 0).should be_true # the 'a' that ends "alpha"
+        pane.copy_text.should eq("alpha")
+        pane.select_word(rect, 5, 0).should be_false # the space after it
+      end
+    end
+
+    # `line_select_only` (Comparer diff, Miner FINDING, Sequencer ANALYSIS/TOKEN): a drag used to
+    # re-anchor on the row under the POINTER every motion event, so dragging across eight rows
+    # selected — and `y` copied — only the last one. Keyboard ⇧↓ over the same rows worked, which
+    # is how the asymmetry stayed hidden.
+    it "grows whole lines from the PRESS row when dragging in line-select mode" do
+      pane = ReadPane.new(line_select_only: true)
+      pane.source(pane_source(10))
+      rect = Rect.new(0, 0, 40, 8)
+      render_pane(pane, h: 8)
+      pane.click(rect, 2, 1) # press on row 1
+      (2..4).each { |r| pane.click(rect, 2, r, selecting: true) }
+      pane.cursor.selected_line_range.should eq({1, 4})
+      (1..4).each { |li| pane.row_marked?(li).should be_true }
+      pane.copy_text.should eq(pane_source(10)[1..4].join("\n"))
+    end
+
+    it "grows whole lines when the drag runs BACK above the press row" do
+      pane = ReadPane.new(line_select_only: true)
+      pane.source(pane_source(10))
+      rect = Rect.new(0, 0, 40, 8)
+      render_pane(pane, h: 8)
+      pane.click(rect, 2, 5)
+      pane.click(rect, 2, 2, selecting: true)
+      pane.cursor.selected_line_range.should eq({2, 5})
+      pane.copy_text.should eq(pane_source(10)[2..5].join("\n"))
+    end
+
+    # A drag that leaves the pane through the top now scrolls the view under it. It used to pin
+    # to row 0 and stop, so a selection taller than the pane could only be dragged DOWNWARD.
+    it "scrolls the view when a drag leaves the pane through the top" do
+      pane = ReadPane.new
+      pane.source(pane_source(100))
+      rect = Rect.new(0, 0, 40, 10)
+      render_pane(pane, h: 10)
+      20.times { pane.scroll_view(1) }
+      pane.scroll.should eq(20)
+      pane.click(rect, 2, 5)                   # press mid-pane
+      pane.click(rect, 2, -1, selecting: true) # …and drag out through the top
+      pane.click(rect, 2, -1, selecting: true)
+      pane.scroll.should eq(18)
+      pane.cursor.cy.should eq(18)
+      pane.cursor.selected_line_range.should eq({18, 25})
     end
   end
 

--- a/spec/tui/text_area_spec.cr
+++ b/spec/tui/text_area_spec.cr
@@ -974,6 +974,21 @@ describe Gori::Tui::TextArea do
       ta.select_word_at(rect, 3, 0).should be_true
       ta.selection_text.should eq("X-Request-Id") # the hyphen is inside a key, as word_left/right have it
     end
+
+    # The pointer rounds to the NEAREST cluster boundary, so a click past the midpoint of a
+    # 2-cell glyph resolves to the position AFTER it — which for a word's LAST glyph is where
+    # the word has already ended. `Screen.step_back_over_wide` walks back over that one
+    # cluster, and over nothing else: a 1-column cell has no far half, so the ASCII contract
+    # above ("whitespace selects nothing") is untouched. Editor-side twin of the ReadPane case.
+    it "double-click takes the word from EITHER half of a wide glyph" do
+      ta = TextArea.new("한글 선택 테스트")               # 한 0-1, 글 2-3, sp 4, 선 5-6, 택 7-8
+      ta.select_word_at(rect, 5, 0).should be_true # LEFT half of 선
+      ta.selection_text.should eq("선택")
+      ta.select_word_at(rect, 8, 0).should be_true # RIGHT half of 택 — the word's last glyph
+      ta.selection_text.should eq("선택")
+      ta.select_word_at(rect, 3, 0).should be_true # right half of 글
+      ta.selection_text.should eq("한글")
+    end
   end
 
   # ONE definition of "what do the arrow keys do in a text box", shared by every editor in

--- a/spec/tui/text_field_select_spec.cr
+++ b/spec/tui/text_field_select_spec.cr
@@ -223,6 +223,19 @@ describe Gori::Tui::TextField do
       f.selection_text.should eq("X-Custom-Header")
     end
 
+    # The single-line half of the wide-glyph pointer rule (`LineFieldRead#select_word_at_cursor`
+    # is the one home the thirteen fields share). A pointer past the midpoint of a 2-cell glyph
+    # rounds to the position AFTER it, which for a word's last glyph is past the word — so the
+    # spread steps back over that one wide cluster. ASCII is unaffected: the whitespace case
+    # above still takes nothing.
+    it "a double-click takes the word from either half of a wide glyph" do
+      f, _ = drawn_field("한글 선택")           # 한 cols 0-1, 글 2-3, sp 4, 선 5-6, 택 7-8
+      f.select_word_at(5, 1).should be_true # LEFT half of 선
+      f.selection_text.should eq("선택")
+      f.select_word_at(8, 1).should be_true # RIGHT half of 택 — the value's last glyph
+      f.selection_text.should eq("선택")
+    end
+
     it "an UNFOCUSED field is still clickable — that click is how it gets focused" do
       f = TextField.new("hello world")
       b = MemoryBackend.new(40, 3)

--- a/spec/tui/wrap_spec.cr
+++ b/spec/tui/wrap_spec.cr
@@ -140,6 +140,40 @@ describe Gori::Tui::Wrap do
       Wrap.row_index(line, nil, a, b, 0).should eq(a)
       Wrap.row_index(line, nil, a, b, 2).should eq(a + 2)
     end
+
+    # `nearest` is the POINTER's rounding — the branch the Repeater request pane and the
+    # History detail invert every click and drag through. Flooring made both cells of a
+    # 2-column glyph resolve to the position BEFORE it, so half of every pointer position over
+    # Hangul/CJK landed a character short: a drag ending on the right half of `트` copied one
+    # glyph less than it had covered. See `Screen.column_for_click`, which this mirrors.
+    it "rounds a POINTER to the nearest cluster boundary over wide glyphs" do
+      line = "한글 선택" # 한 0-1, 글 2-3, space 4, 선 5-6, 택 7-8
+      b = line.size
+      {0 => 0, 1 => 1, 2 => 1, 3 => 2, 4 => 2, 5 => 3, 6 => 4, 7 => 4, 8 => 5}.each do |col, idx|
+        Wrap.row_index(line, nil, 0, b, col, nearest: true).should eq(idx) # (col #{col})
+      end
+    end
+
+    it "is identical to the floored form on 1-column clusters" do
+      line = "GET /a?b=1 HTTP/1.1"
+      (0..Screen.draw_width(line) + 2).each do |col|
+        Wrap.row_index(line, nil, 0, line.size, col, nearest: true)
+          .should eq(Wrap.row_index(line, nil, 0, line.size, col)) # (col #{col})
+      end
+    end
+
+    # Rounding UP is the one exit that can land on a concealed run's first index (the loop's
+    # skip only guards indices it is about to measure). A `¦chain` cell is not drawn, so no
+    # click may resolve into one.
+    it "never rounds up INTO a concealed run" do
+      line = "한글¦hidden¦택"
+      conceal = [{2, 10}] # the ¦hidden¦ run
+      b = line.size
+      (0..Screen.draw_width(line) + 2).each do |col|
+        i = Wrap.row_index(line, conceal, 0, b, col, nearest: true)
+        conceal.each { |(ra, rb)| (i >= ra && i < rb).should be_false } # (col #{col} → #{i})
+      end
+    end
   end
 
   describe "mark_search" do

--- a/src/gori/tui/clipboard.cr
+++ b/src/gori/tui/clipboard.cr
@@ -7,8 +7,25 @@ module Gori::Tui
   # works locally AND over SSH, with no platform dependency. That matches gori's
   # "any terminal, headless/SSH" stance.
   #
-  # Caveat: tmux only forwards OSC 52 when `set-clipboard on`; we additionally
-  # wrap the sequence in tmux's DCS passthrough when running inside tmux.
+  # UNDER TMUX WE SEND BOTH FORMS, and that is the fix for a copy that reported
+  # success and delivered nothing. This used to send ONLY the DCS-passthrough wrap
+  # when `$TMUX` was set, on the reasoning that "tmux only forwards OSC 52 when
+  # `set-clipboard on`". Both halves of that are off:
+  #
+  # - tmux parses a BARE OSC 52 itself, and `set-clipboard` defaults to `external`
+  #   — which forwards it to the outer terminal (and `on` additionally fills tmux's
+  #   own paste buffer). So the unwrapped sequence is the one that works by default.
+  # - the DCS wrap is gated on `allow-passthrough`, which defaults to OFF (tmux 3.3+).
+  #   With it off tmux DROPS the sequence outright — it is not forwarded, so nothing
+  #   reaches the outer terminal and nothing reaches the clipboard. Measured by tapping
+  #   a nested tmux's pane with `pipe-pane`: wrapped + passthrough off → zero `ESC]52`
+  #   bytes out; wrapped + passthrough on → one.
+  #
+  # So the wrap replaced a path that works out of the box with one that is off out of
+  # the box. Both go out now, in that order, and they cover disjoint configurations:
+  # the bare one for default tmux, the wrapped one for `set-clipboard off` (where tmux
+  # ignores the bare sequence) with passthrough enabled. A terminal that honours both
+  # simply sets the same clipboard twice.
   module Clipboard
     # Ceiling on the copied payload: OSC 52 writes base64 of `data` straight to the
     # tty, so an unbounded copy (e.g. a multi-MB request/body) would flood the
@@ -16,13 +33,13 @@ module Gori::Tui
     MAX_CLIP = 64 * 1024
 
     # Builds the OSC 52 "set clipboard" sequence for `data` (base64-encoded).
-    # When `tmux` is true, wraps it in the DCS passthrough so the outer terminal
-    # receives it through tmux.
+    # When `tmux` is true, appends the DCS-passthrough copy of the SAME sequence —
+    # appends rather than substitutes, see the module comment for why.
     def self.osc52(data : String, tmux : Bool = false) : String
       core = "\e]52;c;#{Base64.strict_encode(data)}\a"
       return core unless tmux
       # tmux passthrough: ESC P tmux; <ESC-doubled core> ESC \
-      "\eP" + "tmux;" + core.gsub('\e', "\e\e") + "\e\\"
+      core + "\eP" + "tmux;" + core.gsub('\e', "\e\e") + "\e\\"
     end
 
     # Emits the sequence to the terminal. In TUI mode STDOUT is the controlling

--- a/src/gori/tui/controllers/decoder_controller.cr
+++ b/src/gori/tui/controllers/decoder_controller.cr
@@ -343,7 +343,7 @@ module Gori::Tui
       elsif regions.chain.contains?(mx, my)
         s.pane = :chain
         field = regions.chain.inset(1, 1)
-        s.chain_cx = Screen.column_for(s.chain, mx - (field.x + 2))
+        s.chain_cx = Screen.column_for_click(s.chain, mx - (field.x + 2))
         refilter_popup
       elsif regions.output.contains?(mx, my)
         s.pane = :output

--- a/src/gori/tui/controllers/history_controller.cr
+++ b/src/gori/tui/controllers/history_controller.cr
@@ -256,6 +256,13 @@ module Gori::Tui
       when key.up?, key.lower_k?          then detail_body_up
       when key.down?, key.lower_j?        then @history.scroll_detail(1)
       when ev.char == 'y' || key.lower_y? then detail_copy_selection
+        # Home/End are the LINE's edges here, like every other multi-line pane. The MODIFIED
+        # form is deliberately not claimed: ⌃/⌥+Home/End falls through to the shell's
+        # ±JUMP_ROWS and keeps the jump-to-top/bottom this pane has always had (and which
+        # used to be all Home/End did). A hex dump has no lines, so `detail_line_edge`
+        # answers false there and the plain form falls through too.
+      when key.home? && !ev.ctrl? && !ev.alt? then return @history.detail_line_edge(-1)
+      when key.end? && !ev.ctrl? && !ev.alt?  then return @history.detail_line_edge(1)
       else
         return false
       end
@@ -267,15 +274,25 @@ module Gori::Tui
       @history.detail_at_top? ? @history.set_detail_focus(:strip) : @history.scroll_detail(-1)
     end
 
-    # ⇧+arrow (or ⇧+h/j/k/l) extends the selection from the caret. Returns false for a
-    # non-arrow key so the caller falls through to the plain-nav case.
+    # ⇧+arrow (or ⇧+h/j/k/l) extends the selection from the caret. Home/End/PageUp/PageDown
+    # extend too — they used to fall through to the shell's ±JUMP_ROWS, which moved the caret
+    # to the top/bottom of the body and planted no anchor, so the two keys the footer's
+    # "⇧arrows select" most obviously implies were the two that selected nothing. Returns
+    # false for anything else (and for the ⌃/⌥ forms, which keep the buffer jump) so the
+    # caller falls through to the plain-nav case.
     private def handle_detail_body_select(ev : Termisu::Event::Key) : Bool
       key = ev.key
+      return false if ev.ctrl? || ev.alt?
+      page = @history.detail_page_rows
       case
       when key.up?, key.lower_k?    then @history.detail_move(-1, 0, selecting: true)
       when key.down?, key.lower_j?  then @history.detail_move(1, 0, selecting: true)
       when key.left?, key.lower_h?  then @history.detail_move(0, -1, selecting: true)
       when key.right?, key.lower_l? then @history.detail_move(0, 1, selecting: true)
+      when key.page_up?             then @history.detail_move(-page, 0, selecting: true)
+      when key.page_down?           then @history.detail_move(page, 0, selecting: true)
+      when key.home?                then return @history.detail_line_edge(-1, selecting: true)
+      when key.end?                 then return @history.detail_line_edge(1, selecting: true)
       else
         return false
       end

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -2959,10 +2959,10 @@ module Gori::Tui
       # the row the click did not point at.
       @target_field = (sni_active? && my == rect.y + 2) ? :sni : :url unless selecting
       if @target_field == :sni
-        to = Screen.column_for(@sni, mx - field_base(rect, SNI_PREFIX))
+        to = Screen.column_for_click(@sni, mx - field_base(rect, SNI_PREFIX))
         @scx = @target_read.move_cx(@scx, to - @scx, @sni.size, selecting: selecting)
       else
-        to = Screen.column_for(@target, mx - field_base(rect, TARGET_PREFIX))
+        to = Screen.column_for_click(@target, mx - field_base(rect, TARGET_PREFIX))
         @tcx = @target_read.move_cx(@tcx, to - @tcx, @target.size, selecting: selecting)
       end
     end

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -950,6 +950,33 @@ module Gori::Tui
       end
     end
 
+    # Home / End over the open detail: the caret to the LINE's start or end (`dir` < 0 / > 0),
+    # extending the selection when `selecting`. False when this pane is not navigable text (the
+    # hex dump), so the caller can fall through to the shell's page/jump keys.
+    #
+    # This pane had NO Home/End of its own, so both fell through to `Runner#page_nav_delta`'s
+    # ±JUMP_ROWS and jumped the caret to the top/bottom of the body — and ⇧Home/⇧End did the
+    # same and selected NOTHING, while the footer advertised "⇧arrows select". Every other
+    # multi-line pane in the tree (Repeater, Notes, Issues, Project, Decoder, Fuzzer, and
+    # `ReadPane#motion_key`) already spells Home/End as line-start/line-end with ⇧ extending;
+    # this is that same keymap, and ⌃/⌥+Home/End keeps the buffer jump (the controller lets
+    # the modified form fall through, matching `TextArea#handle_motion_key`).
+    def detail_line_edge(dir : Int32, selecting : Bool = false) : Bool
+      return false unless detail_navigable?
+      size, line_at = detail_line_source
+      return false if size <= 0
+      cy = @detail_read.cy.clamp(0, size - 1)
+      @detail_read.move_to(cy, dir < 0 ? 0 : line_at.call(cy).size, selecting: selecting)
+      ensure_detail_visible(@detail_last_h) if @detail_last_h > 0
+      true
+    end
+
+    # One screenful of the open detail, for ⇧PgUp/⇧PgDn. Same "minus a couple of rows of
+    # overlap" step `ReadPane#motion_key` uses, measured from this pane's own last drawn height.
+    def detail_page_rows : Int32
+      {@detail_last_h - 2, 1}.max
+    end
+
     # True when the detail is at its very top: caret on the FIRST VISUAL ROW of line 0
     # (navigable text) or the scroll offset pinned to 0 (hex dump). Mirrors the list's
     # at_top? so a ↑ here pops focus to the tab bar exactly as it does from the list's
@@ -1077,7 +1104,7 @@ module Gori::Tui
       # `Wrap.row_index` clamps to the row it was given, so a click past the end of a wrapped
       # row stops at the break rather than selecting the next row's first char.
       vr = rows[row]? || rows[rows.size - 1]
-      cx = Wrap.row_index(line_at.call(vr.li), nil, vr.a, vr.b, mx - (rect.x + gw))
+      cx = Wrap.row_index(line_at.call(vr.li), nil, vr.a, vr.b, mx - (rect.x + gw), nearest: true)
       if selecting
         @detail_read.move_to(vr.li, cx, selecting: true) # keeps (or plants) the anchor
       else

--- a/src/gori/tui/issue_form.cr
+++ b/src/gori/tui/issue_form.cr
@@ -104,8 +104,8 @@ module Gori::Tui
       box = overlay_box(area)
       return :cancel if box.nil? || !box.contains?(mx, my)
       if my == box.y + TITLE_ROW
-        @cx = Screen.column_for(@issue_title, mx - title_base(box)) # already clamped to the string
-        @preedit = ""                                               # a caret move ends any in-progress composition, as `insert` does
+        @cx = Screen.column_for_click(@issue_title, mx - title_base(box)) # already clamped to the string
+        @preedit = ""                                                     # a caret move ends any in-progress composition, as `insert` does
       elsif my == box.y + SEV_ROW && (lo = sev_back_x(box)) && mx >= lo && mx <= sev_forward_end(box)
         severity_cycle(mx == lo ? -1 : 1)
       end

--- a/src/gori/tui/line_field_read.cr
+++ b/src/gori/tui/line_field_read.cr
@@ -37,6 +37,11 @@ module Gori::Tui
     # double-click on whitespace fall back to the ordinary click.
     def select_word_at_cursor(line : String, cx : Int32) : Int32?
       c = cx.clamp(0, line.size)
+      # A pointer rounds to the NEAREST cluster boundary (`Screen.column_for_click`), so a
+      # double-click on the right half of a WIDE glyph resolves past it — see the same guard
+      # in `ReadCursor#select_word_at_cursor`. Only a wide cluster can be rounded past, so
+      # ASCII behaviour, including "whitespace takes nothing", is unchanged.
+      c = Screen.step_back_over_wide(line, c)
       return nil if c >= line.size || line[c].whitespace?
       word = word_char?(line[c])
       a = c

--- a/src/gori/tui/paste_newline.cr
+++ b/src/gori/tui/paste_newline.cr
@@ -39,9 +39,11 @@ module Gori
       end
 
       # True while the events being delivered came from a bracketed paste rather than the
-      # keyboard. Nothing reads it yet; it is the seam for a caller that needs to treat pasted
-      # input differently (a bulk insert without per-character work, say), and it is what
-      # makes the swallowed markers observable to a spec.
+      # keyboard — the seam for a caller that must treat pasted input differently from typing.
+      # `Runner#handle` watches its two TRANSITIONS (the markers themselves being swallowed
+      # here, they are the only signal a paste began or ended) and uses them for both things
+      # that need to know: the bulk-insert fast path, and refusing a paste whose keystrokes
+      # would otherwise run as COMMANDS at a focus that takes no text.
       def pasting? : Bool
         @in_paste
       end

--- a/src/gori/tui/read_cursor.cr
+++ b/src/gori/tui/read_cursor.cr
@@ -20,8 +20,18 @@ module Gori::Tui
       @anchor = nil.as({Int32, Int32}?)
     end
 
+    # Whether a NON-EMPTY selection is held. Emptiness matters for the same reason it does in
+    # `TextArea#selection?`, which already answers this way: an anchor sitting exactly on the
+    # caret — a drag that came back to the cell it started in, ⇧→ then ⇧← — selects no
+    # characters, so `highlight_spans` paints nothing and there is nothing on screen to say a
+    # selection exists. Reporting one anyway made `y` copy "" (the `|| current_line` fallback
+    # in every `copy_text` never fired, because `selection_text` returned "" rather than nil)
+    # and report "copied 0b to clipboard" over an invisible selection the operator could not
+    # see to clear.
     def selection? : Bool
-      !@anchor.nil?
+      a = @anchor
+      return false unless a
+      !(a[0] == @cy && a[1] == @cx)
     end
 
     def clear_selection : Nil
@@ -59,8 +69,27 @@ module Gori::Tui
       @cx = line_at.call(@cy).size
     end
 
-    # Move the caret. `extend` (shift held) grows/shrinks the selection from a fixed
-    # anchor. Vertical moves with extend select whole lines between anchor and caret.
+    # Move the caret. `selecting` (shift held) grows/shrinks the selection from a fixed anchor.
+    #
+    # A VERTICAL step KEEPS THE COLUMN, clamped to the line it lands on — exactly what the
+    # unshifted branch below does, so ⇧↓ ends where a plain ↓ would. It used to snap the caret
+    # to the destination line's END instead, and that snap was wrong in both directions:
+    #
+    # - UPWARD it selected nothing. The boundary columns belong to their document-order lines
+    #   (see `selection_text`), so a caret above the anchor puts the CARET column on the top
+    #   line — and the caret was at that line's EOL, making the top line contribute `line[EOL..]`
+    #   = "". From column 0, the whole of ⇧↑ was one "\n": `highlight_spans` painted no band at
+    #   all and `y` copied a single byte. Live: ⇧↓⇧↓ in the Comparer copied 47b, ⇧↑ copied 1b.
+    # - DOWNWARD it only LOOKED line-wise, and only when `cx` happened to be 0. Arrive on the
+    #   line by pressing → a few times first and ⇧↓ started mid-line.
+    #
+    # `move_to`, the path a soft-wrapped pane already takes, has always kept the column and
+    # states the rule this now shares: "⇧↓ has to end exactly where a plain ↓ would or the
+    # selection covers rows the operator never crossed". The History detail runs on it and is
+    # the pane where ⇧↑ works today; this is the same behaviour for everything else.
+    #
+    # A pane that wants WHOLE LINES from a vertical step wants `extend_lines`, which does it
+    # correctly in both directions rather than as a side effect of an EOL snap.
     def move(dr : Int32, dc : Int32, lines : Array(String), selecting : Bool = false) : Nil
       move(dr, dc, lines.size, ->(i : Int32) { lines[i] }, selecting)
     end
@@ -71,7 +100,7 @@ module Gori::Tui
         @anchor ||= {@cy, @cx}
         if dr != 0
           @cy = (@cy + dr).clamp(0, size - 1)
-          @cx = line_at.call(@cy).size
+          @cx = @cx.clamp(0, line_at.call(@cy).size)
         elsif dc != 0
           line = line_at.call(@cy)
           @cx = (@cx + dc).clamp(0, line.size)
@@ -103,18 +132,48 @@ module Gori::Tui
       end
     end
 
+    # Grow a WHOLE-LINE selection by `dr` rows — the vertical gesture of a pane whose screen
+    # row is not one run of text (the Comparer's two diff columns, the Miner/Sequencer field
+    # lists), where a char rectangle would address cells that are not next to each other.
+    #
+    # It assigns BOTH boundary columns by direction, which is what an EOL snap could never do:
+    # the end that is the TOP of the selection takes column 0 and the end that is the BOTTOM
+    # takes its own line's EOL, so the span is whole lines whichever way the operator travelled
+    # and whatever column the caret happened to carry in.
+    def extend_lines(dr : Int32, size : Int32, line_at : Int32 -> String) : Nil
+      return if size <= 0
+      @anchor ||= {@cy, @cx}
+      extend_lines_to(@cy + dr, size, line_at)
+    end
+
+    # `extend_lines` for a destination the owner resolved — the row a drag's pointer is over.
+    # The anchor's ROW is kept (a drag must grow from where the press landed); only the two
+    # columns are re-derived, so calling this per motion event is idempotent.
+    def extend_lines_to(cy : Int32, size : Int32, line_at : Int32 -> String) : Nil
+      return if size <= 0
+      a = (@anchor ||= {@cy, @cx})
+      ay = a[0].clamp(0, size - 1)
+      @cy = cy.clamp(0, size - 1)
+      if @cy < ay
+        @anchor = {ay, line_at.call(ay).size} # anchor is the BOTTOM end → its line's EOL
+        @cx = 0                               # caret is the TOP end → its line's start
+      else
+        @anchor = {ay, 0}
+        @cx = line_at.call(@cy).size
+      end
+    end
+
     # Put the caret on an ALREADY-RESOLVED position, applying `move`'s anchor rules: shift
     # pins the far end where the caret stands now, an unmodified move collapses the
     # selection. For a destination only the owner can compute — the visual row a soft-wrapped
     # ↑/↓ lands on, which needs a layout this class deliberately does not have (see
     # `Wrap.step_caret`, and `RepeaterView#paint_request_read_chrome` on why it has none).
     #
-    # Vertical steps through `move` snap to end-of-line; this does NOT, and that difference
-    # is the point rather than an oversight. Under wrap the caret stops mid-line at the
-    # display column it kept, and ⇧↓ has to end exactly where a plain ↓ would or the
-    # selection covers rows the operator never crossed. Both the span painter and
-    # `selection_text` handle a mid-line boundary already — the char rectangle is the model,
-    # the EOL snap was only ever what stepping whole lines happened to produce.
+    # Under wrap the caret stops mid-line at the display column it kept, and ⇧↓ has to end
+    # exactly where a plain ↓ would or the selection covers rows the operator never crossed.
+    # `move` now keeps the column on a vertical step for the same reason (it used to snap to
+    # end-of-line — see there for what that cost), so the two agree and the char rectangle is
+    # the single model. A pane that wants whole lines asks for them with `extend_lines`.
     def move_to(cy : Int32, cx : Int32, selecting : Bool = false) : Nil
       if selecting
         @anchor ||= {@cy, @cx}
@@ -148,7 +207,7 @@ module Gori::Tui
       selecting ? (@anchor ||= {@cy, @cx}) : (@anchor = nil)
       @cy = {scroll + row, size - 1}.min
       cx0 = rect.x + gutter_w
-      @cx = Screen.column_for(line_at.call(@cy), mx - cx0 + xscroll)
+      @cx = Screen.column_for_click(line_at.call(@cy), mx - cx0 + xscroll)
     end
 
     # Select the WORD under the pointer (double-click). Same boundary rule as
@@ -178,6 +237,14 @@ module Gori::Tui
       @cy = @cy.clamp(0, size - 1)
       line = line_at.call(@cy)
       cx = @cx.clamp(0, line.size)
+      # `Screen.column_for_click` rounds a POINTER to the NEAREST cluster boundary, so a
+      # double-click on the RIGHT half of a WIDE glyph — a Hangul syllable, a CJK ideograph:
+      # half of every pointer position over such text — resolves to the position AFTER it,
+      # where the word may have already ended and there is no token to take. Step back over
+      # that one glyph, and ONLY when it is wide: a 1-column cluster cannot be rounded past,
+      # so every ASCII gesture is bit-for-bit what it was (including "a double-click on a
+      # space takes nothing", which is this method's stated contract).
+      cx = Screen.step_back_over_wide(line, cx)
       return false if cx >= line.size || line[cx].whitespace?
       word = word_char?(line[cx])
       a = cx
@@ -221,6 +288,10 @@ module Gori::Tui
       return nil unless a
       return nil if size <= 0
       ay, ax = a
+      # An EMPTY selection is NO selection — nil, not "". Every `copy_text` in the tree reads
+      # `selection_text(…) || current_line(…)`, so returning "" here defeated the fallback and
+      # `y` on an invisible zero-width selection copied nothing. See `selection?`.
+      return nil if ay == @cy && ax == @cx
       y0, y1 = {ay, @cy}.min, {ay, @cy}.max
       y0 = y0.clamp(0, size - 1)
       y1 = y1.clamp(0, size - 1)

--- a/src/gori/tui/read_pane.cr
+++ b/src/gori/tui/read_pane.cr
@@ -101,9 +101,11 @@ module Gori::Tui
     def move(dr : Int32, dc : Int32, selecting : Bool = false) : Nil
       return if empty?
       if @line_select_only && dr != 0 && selecting
-        # Whole-line growth: `ReadCursor#move`'s selecting branch already parks the caret at
-        # EOL on a vertical step, which IS the line selection this mode wants.
-        @cursor.move(dr, 0, @size, @line_at, selecting: true)
+        # Whole-line growth, asked for explicitly. This used to lean on `ReadCursor#move`'s
+        # selecting branch parking the caret at EOL, which only produced a line selection
+        # going DOWN and from column 0 — see `ReadCursor#move`. `extend_lines` sets both
+        # boundary columns by direction, so ⇧↑ selects whole lines too.
+        @cursor.extend_lines(dr, @size, @line_at)
       else
         @cursor.move(dr, dc, @size, @line_at, selecting: selecting && !@line_select_only)
       end
@@ -191,9 +193,21 @@ module Gori::Tui
     # `selecting` is the drag half: the anchor stays where the press left it.
     def click(rect : Rect, mx : Int32, my : Int32, selecting : Bool = false) : Nil
       return if empty? || rect.empty?
+      # A drag that has left the pane through the TOP scrolls the view up under it, one line
+      # per motion report, so a selection can be grown past the first visible row. Downward
+      # already worked — `click_to_cursor` puts the caret past the window's last row and
+      # `ensure_visible` follows it — while upward pinned to row 0 and stopped there, so a
+      # range taller than the pane could only ever be dragged in one direction. `@scroll` is
+      # moved DIRECTLY rather than through `scroll_view`, which ends by pulling the caret into
+      # the window and would undo the placement two lines below.
+      row = my - rect.y
+      @scroll = {@scroll + row, 0}.max if row < 0 && selecting
       @cursor.click_to_cursor(rect, mx, my, @scroll, @size, @line_at, gutter_w(rect), @xscroll, selecting)
-      # A line-select pane has no meaningful column, so a drag there grows whole lines.
-      @cursor.select_line(@size, @line_at) if @line_select_only && selecting && @cursor.selection?
+      # A line-select pane has no meaningful column, so a drag there grows whole lines — from
+      # the row the PRESS landed on. It used to call `select_line`, which re-anchors at the
+      # caret's own row: every motion event destroyed the press anchor, so dragging across
+      # eight rows of the Comparer selected (and copied) only the row under the pointer.
+      @cursor.extend_lines_to(@cursor.cy, @size, @line_at) if @line_select_only && selecting
       ensure_visible
     end
 

--- a/src/gori/tui/repeater_view.cr
+++ b/src/gori/tui/repeater_view.cr
@@ -2988,7 +2988,7 @@ module Gori::Tui
       @target_field = (sni_active? && my == rect.y + 2) ? :sni : :url unless selecting
       prefix = @target_field == :sni ? SNI_PREFIX : TARGET_PREFIX
       line = target_active_line
-      to = Screen.column_for(line, mx - field_base(rect, prefix))
+      to = Screen.column_for_click(line, mx - field_base(rect, prefix))
       cx = @target_read.move_cx(target_active_cx, to - target_active_cx, line.size, selecting: selecting)
       @target_field == :sni ? (@scx = cx) : (@tcx = cx)
     end

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -938,21 +938,31 @@ module Gori::Tui
     # The bracketed paste being accumulated for a BULK insert, or nil when the paste (if any)
     # is being delivered keystroke by keystroke — see `begin_bulk_paste?`.
     @paste_buf = nil.as(String::Builder?)
+    # A bracketed paste being DROPPED because its keystrokes would run as commands — see
+    # `paste_runs_as_commands?`. Cleared at the paste's end marker.
+    @paste_dropped = false
 
     private def handle(ev : Termisu::Event::Any) : Nil
       was_pasting = @paste_newline.pasting?
       swallowed = @paste_newline.swallow?(ev)
       # PasteStart/PasteEnd are swallowed by the filter, so the transitions are the only
-      # signal that a paste began or ended. Both are read here, at the same funnel, rather
-      # than by a view that would have to guess from the shape of the keystrokes.
+      # signal that a paste began or ended. All three decisions are read here, at the same
+      # funnel, rather than by a view that would have to guess from the shape of the
+      # keystrokes: take it in bulk, deliver it as typing, or refuse it.
       if !was_pasting && @paste_newline.pasting?
-        @paste_buf = String::Builder.new if begin_bulk_paste?
+        if begin_bulk_paste?
+          @paste_buf = String::Builder.new
+        elsif paste_runs_as_commands?
+          @paste_dropped = true
+          @toast = PASTE_REFUSED
+        end
       elsif was_pasting && !@paste_newline.pasting?
-        flush_bulk_paste
+        @paste_dropped ? (@paste_dropped = false) : flush_bulk_paste
       end
       return if swallowed
       case ev
       when Termisu::Event::Key
+        return if @paste_dropped
         return if buffer_bulk_paste(ev)
         handle_key(ev)
       when Termisu::Event::Mouse
@@ -985,6 +995,45 @@ module Gori::Tui
       return false if @space_menu_open || copy_as_shown? || send_to_shown?
       return false if @goto_open || @search_open || @rename_open || @tag_edit_open
       @tabs[@active_tab]?.try(&.accepts_bulk_paste?) || false
+    end
+
+    # Shown when a paste is refused. It names the recovery, because a paste that vanishes
+    # without a word is its own bug report.
+    PASTE_REFUSED = "paste ignored — nothing focused takes text (i edits the pane, ↵ its fields)"
+
+    # Whether a bracketed paste arriving NOW would be dispatched as COMMANDS rather than typed
+    # into text — the state in which the clipboard's own bytes are hotkeys.
+    #
+    # THIS IS THE ONE THING A PASTE MUST NEVER DO, and it was the default. `begin_bulk_paste?`
+    # only buffers for an editor that is in INSERT; everything else fell through to the
+    # per-keystroke path, which is correct for a text field and catastrophic for a keymap.
+    # Pasting a request into the Repeater's REQUEST pane in READ mode ran `POST /log` as
+    # commands until the `i` of "/login" flipped the pane to INSERT, then typed the rest into
+    # the middle of the old request (Content-Length silently re-derived over the wreckage).
+    # Pasting the same thing at the tab bar ran the global breath keys: `i` turned INTERCEPT
+    # ON, so every subsequent request through the proxy was held, with nothing on screen
+    # connecting that to a paste. `c` toggles capture and `q` leaves the project from there.
+    #
+    # The test is deliberately NARROW, and errs toward delivering the paste: everything modal
+    # owns its own keymap and a stray paste inside it is contained, so only the surfaces that
+    # reach the SHELL's keymap answer true — the tab bar, the sub-tab strip, and a body that
+    # is not currently an editor. `:detail` is in that set for the same reason
+    # `drag_press_target?` puts it there: it is a History body drill-in, not a capturing modal,
+    # so its keystrokes are the tab's.
+    #
+    # `body_badge == :editor` is the controllers' own answer to "does this pane capture text",
+    # which is exactly the question (see `TabController#body_badge`) — so every field the
+    # per-keystroke path serves today keeps serving it: the Repeater TARGET/SNI rows and hex
+    # edit, the Decoder INPUT and CHAIN, Notes, the Project description, the Issues notes, the
+    # JWT input, the Fuzzer target. The sub-tab filter row reports through its own predicate.
+    private def paste_runs_as_commands? : Bool
+      return false unless @overlay.none? || @overlay.detail?
+      return false if modal_overlay? # palette / ⋯ menu / any migrated modal
+      return false if @space_menu_open || copy_as_shown? || send_to_shown?
+      return false if @goto_open || @search_open || @rename_open || @tag_edit_open
+      return false if @tabs[@active_tab]?.try(&.subtab_filter_editing?)
+      return false if @focus == :body && @tabs[@active_tab]?.try(&.body_badge) == :editor
+      true
     end
 
     # Accumulate one pasted keystroke, or false when this event is not part of a bulk paste

--- a/src/gori/tui/screen.cr
+++ b/src/gori/tui/screen.cr
@@ -261,6 +261,54 @@ module Gori::Tui
       str.size
     end
 
+    # `column_for` for a POINTER rather than for a measurement: rounds to the NEAREST cluster
+    # boundary instead of flooring to the cluster whose cell the column sits in.
+    #
+    # For a 1-column cluster the two are IDENTICAL (a single cell has no near half and far
+    # half), so every ASCII click behaves exactly as before. The difference is a WIDE glyph —
+    # a Hangul syllable, a CJK ideograph, an emoji — where flooring made the whole 2-cell
+    # footprint resolve to the position BEFORE the glyph. Half of every pointer position over
+    # such text therefore landed one character short: a drag from `선` to the right half of `트`
+    # in `한글 선택 테스트 라인` copied `선택 테스`, and a click on the right half of `한` put
+    # the caret in front of it. Every mainstream editor and terminal includes the glyph once
+    # the pointer is past its midpoint.
+    #
+    # Kept SEPARATE from `column_for` rather than replacing it, because the other callers are
+    # not pointers: `fuzzer_view` / `sitemap_view` / `comparer_view` use it to TRUNCATE a
+    # string to a column budget, where rounding up would return an index whose prefix is one
+    # column wider than the space it has to fit.
+    def self.column_for_click(str : String, target : Int32) : Int32
+      return 0 if target <= 0
+      return {target, str.size}.min if str.ascii_only? # 1 char == 1 cluster == 1 column
+      acc = 0
+      i = 0
+      str.each_grapheme do |g|
+        w = grapheme_cols(g.to_s)
+        # (w + 1) // 2 keeps a 1-wide cluster flooring (its only cell is its near half) while
+        # splitting a 2-wide one down the middle.
+        return i if target < acc + (w + 1) // 2
+        return i + g.size if target < acc + w
+        acc += w
+        i += g.size
+      end
+      str.size
+    end
+
+    # The companion to `column_for_click` for a DOUBLE-CLICK: `i` back over the preceding
+    # cluster when that cluster is WIDE and `i` itself has nothing to take (past the end of
+    # the line, or on whitespace). A pointer in the right half of a 2-cell glyph rounds to the
+    # position after it, which for a word's last glyph is where the word has already ended —
+    # so the word spread would find no token and the gesture would do nothing over exactly the
+    # text (Hangul, CJK) where it is hardest to click precisely.
+    #
+    # Deliberately narrow: a 1-column cluster can never be rounded past, so `i` is returned
+    # unchanged for all ASCII and every existing behaviour built on it survives untouched.
+    def self.step_back_over_wide(str : String, i : Int32) : Int32
+      return i unless i > 0 && (i >= str.size || str[i].whitespace?)
+      prev = cluster_start(str, i - 1)
+      draw_width(str[prev...i]) > 1 ? prev : i
+    end
+
     # Snap a character index to the START of the grapheme cluster holding it (the caret's
     # "round down"); an index already on a boundary is returned unchanged. Paired with
     # `cluster_end` this is how TextArea keeps `@cx` — which stays a CHARACTER index — off

--- a/src/gori/tui/text_area.cr
+++ b/src/gori/tui/text_area.cr
@@ -923,7 +923,7 @@ module Gori::Tui
       # start and never an unseen `¦chain` char; it clamps to the row's own end, so a click
       # past the text of a wrapped row stops at the break instead of running into the next
       # row's characters.
-      @cx = Wrap.row_index(line, cr, vr.a, vr.b, target)
+      @cx = Wrap.row_index(line, cr, vr.a, vr.b, target, nearest: true)
       snap_cx_out_of_conceal(0) # a click on the closing-§ column resolves to it; nudge to a legal rest
       break_run                 # a caret move ends the typing run — see push_undo
       env_complete_close
@@ -952,6 +952,14 @@ module Gori::Tui
       @cy = @cy.clamp(0, @lines.size - 1)
       line = @lines[@cy]
       cx = @cx.clamp(0, line.size)
+      # `Screen.column_for_click` rounds a POINTER to the NEAREST cluster boundary, so a
+      # double-click on the RIGHT half of a WIDE glyph — a Hangul syllable, a CJK ideograph:
+      # half of every pointer position over such text — resolves to the position AFTER it,
+      # where the word may have already ended and there is no token to take. Step back over
+      # that one glyph, and ONLY when it is wide: a 1-column cluster cannot be rounded past,
+      # so every ASCII gesture is bit-for-bit what it was (including "a double-click on a
+      # space takes nothing", which is this method's stated contract).
+      cx = Screen.step_back_over_wide(line, cx)
       return false if cx >= line.size || line[cx].whitespace?
       word = word_char?(line[cx])
       a = cx

--- a/src/gori/tui/text_field.cr
+++ b/src/gori/tui/text_field.cr
@@ -257,7 +257,7 @@ module Gori::Tui
     def click_to_cursor(mx : Int32, my : Int32, selecting : Bool = false) : Bool
       return false unless hit?(mx, my)
       start = window_start(@last_w)
-      to = start + Screen.column_for(@value[start..], mx - @last_x)
+      to = start + Screen.column_for_click(@value[start..], mx - @last_x)
       @caret = @sel.move_cx(@caret, to.clamp(0, @value.size) - @caret, @value.size, selecting: selecting)
       true
     end

--- a/src/gori/tui/wrap.cr
+++ b/src/gori/tui/wrap.cr
@@ -349,8 +349,22 @@ module Gori::Tui
     # past the end of a wrapped row lands on the break rather than running into the next
     # row's text, and never returns an index inside a concealed run (those cells aren't
     # drawn) nor inside a cluster (it steps by cluster, like the draw).
+    #
+    # `nearest` is what a POINTER passes: it rounds to the closer edge of the cluster the
+    # column lands in rather than always to its start, which is `Screen.column_for_click`'s
+    # rule and exists for the same reason (see there — the right half of a Hangul syllable
+    # belongs to the position after it). A 1-column cluster is unaffected either way, so this
+    # only ever moves a click over wide text. The CARET's own vertical step (`step_caret`)
+    # leaves it off: a ↓ carries a goal column, and rounding it up would drift the caret one
+    # glyph right per row over a column of CJK.
+    #
+    # ROUNDING UP is the one exit that can hand back the first index of a concealed run: the
+    # skip above only guards indices the loop is about to MEASURE, and `e` leaves before the
+    # next pass tests it. It is kept legal by hopping any run `e` opens, so the invariant above
+    # holds for both settings rather than resting on the one caller that happens to re-snap
+    # afterwards (`TextArea#click_to_cursor`'s `snap_cx_out_of_conceal`).
     def self.row_index(line : String, conceal : Array({Int32, Int32})?, a : Int32, b : Int32,
-                       target : Int32) : Int32
+                       target : Int32, nearest : Bool = false) : Int32
       lo = a.clamp(0, line.size)
       hi = b.clamp(lo, line.size)
       return lo if target <= 0
@@ -363,7 +377,11 @@ module Gori::Tui
         end
         e = {Screen.cluster_end(line, i + 1), hi}.min
         w = Screen.draw_width(line[i...e])
-        return i if target < col + w
+        return i if target < col + (nearest ? (w + 1) // 2 : w)
+        if nearest && target < col + w
+          run = conceal.try &.find { |(ra, rb)| e >= ra && e < rb }
+          return run ? {run[1], hi}.min : e
+        end
         col += w
         i = e
       end


### PR DESCRIPTION
Nine findings across the three gestures an operator spends the day in — copy out,
paste in, and select with the keyboard or the pointer. Each was reproduced against a
live TUI (isolated GORI_HOME, tmux, SGR mouse injection) before it was touched.

THE CLIPBOARD. `Clipboard.copy` wrapped OSC 52 in tmux's DCS passthrough whenever
$TMUX was set, and sent ONLY that. tmux drops a passthrough unless `allow-passthrough`
is on, and that has defaulted to OFF since 3.3 — so inside tmux `y` wrote nothing to
the clipboard while the status line said "copied 15b to clipboard". The reasoning in
the old comment ("tmux only forwards OSC 52 when set-clipboard on") had it backwards:
`set-clipboard` defaults to `external`, which means the BARE sequence is the one tmux
honours out of the box. Both forms go out now — the bare one for default tmux, the
wrap for `set-clipboard off` with passthrough enabled. Measured by tapping a nested
tmux with `pipe-pane`: wrapped + passthrough off delivers zero `ESC]52` bytes to the
outer terminal, wrapped + passthrough on delivers one. End to end on default settings,
`y` now lands as `buffer0: 15 bytes: "HTTP/1.0 200 OK"` where it used to land nowhere.

THE PASTE. `begin_bulk_paste?` buffers a bracketed paste only for a body editor that
is in INSERT. Everything else fell through to the per-keystroke path — correct for a
text field, catastrophic for a keymap. Pasting a request into the Repeater REQUEST
pane in READ mode ran `POST /log` as commands until the `i` of "/login" flipped the
pane to INSERT, then typed the remainder into the middle of the old request with
Content-Length silently re-derived over the wreckage. Pasting the same clipboard at
the tab bar ran the global breath keys: `i` turned INTERCEPT ON, so every subsequent
request through the proxy was held, with nothing on screen connecting that to a paste.
`c` toggles capture from there and `q` leaves the project.

`PasteNewline#pasting?` was already surfaced at the funnel for the bulk path, so the
third decision joins it there: `paste_runs_as_commands?` refuses a paste whose
keystrokes would reach the SHELL's keymap, and says so. The test is deliberately
narrow and errs toward delivering — everything modal owns its own keymap and a stray
paste inside it is contained, so only the tab bar, the sub-tab strip and a non-editor
body answer true. `body_badge == :editor` is the controllers' own answer to "does this
pane capture text", which is exactly the question, so every field the per-keystroke
path serves today keeps serving it (audited across all twenty controllers).

⇧↑. `ReadCursor#move` snapped the caret to the destination line's END on a vertical
extend. Because the boundary columns belong to their document-order lines, a caret
ABOVE the anchor puts the caret's column on the TOP line — and that column was the
line's end, so the top line contributed `line[EOL..]`, i.e. "". From column 0 the whole
of ⇧↑ was one "\n": `highlight_spans` painted no band at all and `y` copied a single
byte. In the Comparer, ⇧↓⇧↓ copied 47b and ⇧↑ copied 1b. Downward only LOOKED
line-wise, and only while `cx` happened to be 0.

The snap is gone; a vertical extend keeps its column, which is what `move_to` — the
soft-wrapped path the History detail already runs on, and the one pane where ⇧↑ worked
— has always done. THIS CHANGES ⇧↓: one press now takes one line instead of two. That
is the behaviour History detail has had all along and what `move_to`'s own docstring
argues for ("⇧↓ has to end exactly where a plain ↓ would or the selection covers rows
the operator never crossed"), but it is a change an existing user will feel.

A pane that genuinely wants whole lines now asks for them. `extend_lines` sets BOTH
boundary columns by direction, which an EOL snap could never do, and it is also what
fixes the drag: `ReadPane#click` kept the press anchor and then called `select_line`,
which re-anchors at the CARET's row — so every motion event destroyed the anchor and
dragging across eight Comparer rows selected, and copied, only the row under the
pointer (18b, against 170b now). Keyboard ⇧↓ over the same rows worked, which is how
the asymmetry stayed hidden.

THE POINTER OVER WIDE TEXT. `Screen.column_for` floors to the cluster whose cell the
column sits in. For a 1-column cluster that is the nearest boundary; for a Hangul
syllable or a CJK ideograph it means the whole 2-cell footprint resolves to the
position BEFORE the glyph, so half of every pointer position over such text landed a
character short. A drag from `선` to the right half of `트` copied `선택 테스` — one
glyph less than it had covered — and a click on the right half of `한` put the caret in
front of it. `column_for_click` (and `Wrap.row_index(nearest:)`, the same rule for the
wrapped panes) rounds to the nearer edge. It is a NEW method rather than a change to
`column_for`, because the other callers are truncating a string to a column budget,
where rounding up returns an index one column too wide for the space it must fit.

Rounding up has one cost and it is paid: a double-click on the right half of a word's
LAST glyph now resolves past the word, where the spread would find no token.
`Screen.step_back_over_wide` walks back over exactly one WIDE cluster in that case —
never a 1-column one, which cannot be rounded past, so every ASCII gesture is
bit-for-bit what it was, including "a double-click on a space takes nothing".

THE REST.

- History detail had no Home/End of its own, so both fell through to ±JUMP_ROWS and
  jumped the caret to the top/bottom of the body — and ⇧Home/⇧End did the same and
  selected NOTHING, while the footer advertised "⇧arrows select". They are the line's
  edges now, ⇧ extends, ⇧PgUp/PgDn extend, and ⌃/⌥ keeps the buffer jump.
- A drag that left a `ReadPane` through the TOP pinned to row 0 and stopped, so a
  selection taller than the pane could only ever be dragged downward. It scrolls now,
  one line per motion report. (`TextArea` and the History detail keep the old
  behaviour: both scroll through a wrap anchor whose `scroll_view` ends by pulling the
  caret into the window, which would undo the placement mid-drag.)
- An anchor sitting exactly on the caret reported a selection that painted nothing and
  copied "" — defeating the `selection_text || current_line` fallback every `copy_text`
  in the tree relies on, so `y` said "copied 0b" over an invisible selection the
  operator could not see to clear. `ReadCursor` now answers emptiness the way
  `TextArea#selection?` already did.
- `pasting?` no longer claims nothing reads it.