### PR TITLE
A template you had to pan sideways to read, five copies of one selection band, and the nine panes still scrolling right

### DIFF
--- a/spec/support/fake_context.cr
+++ b/spec/support/fake_context.cr
@@ -782,10 +782,6 @@ class FakeExecContext < Gori::Verb::ExecContext
     rec(:issue_edit_notes)
   end
 
-  def issue_hscroll(delta : Int32) : Nil
-    rec(:issue_hscroll, delta)
-  end
-
   def issue_edit_title : Nil
     rec(:issue_edit_title)
   end

--- a/spec/tui/decoder_view_spec.cr
+++ b/spec/tui/decoder_view_spec.cr
@@ -59,12 +59,17 @@ describe Gori::Tui::DecoderView do
   # and recalling a chain are centered modals now (NamePromptOverlay / LibraryPicker), so
   # the coverage moved to spec/tui/library_overlays_spec.cr.
 
-  it "hscroll_output scrolls a long OUTPUT line sideways into view (shift+←/→)" do
+  # Was "hscroll_output scrolls a long OUTPUT line sideways into view (shift+←/→)". The OUTPUT
+  # pane soft-wraps now, like the Repeater's RESPONSE that draws the same line, so the whole
+  # `hscroll_output` chain is retired and both ends of a long decoded line are on screen at
+  # once. Still under test: that the tail of a line wider than the pane is reachable at all —
+  # which is what the h-scroll pair existed to provide.
+  it "wraps a long OUTPUT line instead of scrolling it sideways" do
     view = DecoderView.new
     long_line = "HEAD" + ("." * 150) + "TAIL"
     # `result` (the OUTPUT content) is independent of the `input:` TextArea (the INPUT
-    # card's own display) — keep INPUT short/unrelated so its unscrolled echo of the
-    # long line's head can't be mistaken for the OUTPUT card's (scrollable) content.
+    # card's own display) — keep INPUT short/unrelated so its echo of the long line's head
+    # can't be mistaken for the OUTPUT card's content.
     result = Gori::Decoder.run(REG, long_line.to_slice, "")
     rect = Rect.new(0, 0, 80, 30)
     render_args = {
@@ -75,13 +80,34 @@ describe Gori::Tui::DecoderView do
     backend = MemoryBackend.new(80, 30)
     view.render(Screen.new(backend), rect, **render_args)
     backend.contains?("HEAD").should be_true
-    backend.contains?("TAIL").should be_false # off the right edge, clipped
+    backend.contains?("TAIL").should be_true # on a continuation row, not off the right edge
+    # …and on a LOWER row: this is a wrap, not a pane wide enough to hold the whole line.
+    head_row = (0...30).find { |y| backend.row(y).includes?("HEAD") }.not_nil!
+    tail_row = (0...30).find { |y| backend.row(y).includes?("TAIL") }.not_nil!
+    tail_row.should be > head_row
+  end
 
-    40.times { view.hscroll_output(1) } # scroll well past the line's width
-    backend2 = MemoryBackend.new(80, 30)
-    view.render(Screen.new(backend2), rect, **render_args)
-    backend2.contains?("TAIL").should be_true
-    backend2.contains?("HEAD").should be_false # scrolled off the left edge
+  # `DecoderController#handle_output` pops focus up to the CHAIN field when `output_at_top?`,
+  # so that predicate decides whether ↑ walks the pane or leaves it. Measured on the logical
+  # line alone, a caret three rows into a wrapped line 0 answers true — and ↑ would abandon the
+  # very rows it was asked to walk. `ReadPane#at_top?` measures the first VISUAL row; this pins
+  # it through the wiring that actually ships, not just on a bare pane.
+  it "is not 'at top' while the OUTPUT caret sits on a continuation row of line 0" do
+    view = DecoderView.new
+    long_line = "0123456789" * 20
+    result = Gori::Decoder.run(REG, long_line.to_slice, "")
+    rect = Rect.new(0, 0, 80, 30)
+    render_args = {
+      input: TextArea.new("unrelated"), chain: "", chain_cx: 0, chain_pre: "",
+      result: result, pane: :output, focused: true, popup: ChainComplete.new,
+    }
+    view.render(Screen.new(MemoryBackend.new(80, 30)), rect, **render_args)
+
+    view.output_at_top?.should be_true
+    view.output_move(1, 0, result) # one VISUAL row down — still on line 0
+    view.output_at_top?.should be_false
+    view.output_move(-1, 0, result)
+    view.output_at_top?.should be_true
   end
 
   it "lights only the focused section's card border gold (per-pane focus)" do
@@ -170,13 +196,18 @@ describe Gori::Tui::ChainComplete do
   end
 end
 
-describe "DecoderView OUTPUT h-scroll" do
-  # Decoding is precisely where raw control bytes surface — an unhex/base64 of a binary
-  # blob is the whole point of the tab. The OUTPUT rows draw through `screen.text`, which
-  # gives every control char a cell, but the h-scroll clamp measured them with
-  # display_width, where those chars are 0 columns. The clamp's ceiling therefore fell
-  # short of the real content and the tail of a decoded line could not be scrolled to.
-  it "scrolls a decoded line containing control bytes to its end" do
+describe "DecoderView OUTPUT control bytes" do
+  # Decoding is precisely where raw control bytes surface — an unhex/base64 of a binary blob is
+  # the whole point of the tab. The OUTPUT rows draw through `screen.text`, which gives every
+  # control char a cell, and the retired h-scroll clamp measured them with `display_width`, where
+  # those chars are 0 columns: its ceiling fell short of the real content and the tail of such a
+  # line could not be reached at all.
+  #
+  # The pane wraps now, so the clamp is gone and the same hazard lives in the WRAP measure
+  # instead — `Wrap.layout` breaks on `Screen.grapheme_cols`, the same ≥1-per-cluster measure
+  # the draw advances by. That is what this pins: a line of tabs must break at the pane's edge
+  # and its tail must land on a continuation row, not be counted as 14 columns and never wrap.
+  it "wraps a decoded line containing control bytes so its end is reachable" do
     line = "STARTTOK#{"\t" * 100}ENDTOK"
     Screen.display_width(line).should eq(14) # the raw measure: 60 tabs count for nothing
     Screen.draw_width(line).should eq(114)   # what `text` paints: one cell per tab
@@ -193,23 +224,21 @@ describe "DecoderView OUTPUT h-scroll" do
     end
 
     # Assert on the OUTPUT card ALONE: the PIPELINE card above it echoes the same decoded
-    # bytes as the unhex step's intermediate and does NOT scroll, so a whole-grid match
-    # would report the unscrolled copy (cf. the hscroll_output spec above, which keeps
-    # INPUT unrelated for the same reason).
-    out_card = ->(b : MemoryBackend) do
-      top = (0...30).index { |y| b.row(y).includes?("OUTPUT") }.not_nil!
-      (top...30).map { |y| b.row(y) }.join("\n")
-    end
-
+    # bytes as the unhex step's intermediate and does NOT wrap, so a whole-grid match would
+    # report that copy (cf. the wrap spec above, which keeps INPUT unrelated for the same
+    # reason).
+    top = 0
     at0 = MemoryBackend.new(80, 30)
     render.call(at0)
-    out_card.call(at0).should contain("STARTTOK")
-    out_card.call(at0).should_not contain("ENDTOK") # tail off to the right
-
-    15.times { view.hscroll_output(4) }
-    scrolled = MemoryBackend.new(80, 30)
-    render.call(scrolled)
-    out_card.call(scrolled).should contain("ENDTOK")       # reachable
-    out_card.call(scrolled).should_not contain("STARTTOK") # head genuinely scrolled off
+    top = (0...30).index { |y| at0.row(y).includes?("OUTPUT") }.not_nil!
+    rows = (top...30).map { |y| at0.row(y) }
+    card = rows.join("\n")
+    card.should contain("STARTTOK")
+    card.should contain("ENDTOK") # the tail wrapped onto a later row rather than being clipped
+    # …and onto a DIFFERENT row: the tabs were measured at one cell each, so the 114-column
+    # line broke at the pane's edge instead of being called 14 columns wide and left unwrapped.
+    start_row = rows.index { |r| r.includes?("STARTTOK") }.not_nil!
+    end_row = rows.index { |r| r.includes?("ENDTOK") }.not_nil!
+    end_row.should be > start_row
   end
 end

--- a/spec/tui/fuzzer_view_spec.cr
+++ b/spec/tui/fuzzer_view_spec.cr
@@ -812,7 +812,11 @@ describe Gori::Tui::FuzzerView do
     end
   end
 
-  it "hscroll_detail scrolls a long RESULT response line sideways into view (shift+←/→)" do
+  # Was "hscroll_detail scrolls a long RESULT response line sideways into view (shift+←/→)". The
+  # RESULT detail moved onto the wrapping `ReadPane`, so the whole `hscroll_detail` chain is
+  # retired and both ends of an attacker-shaped response line are on screen at once. Still under
+  # test: that the tail of a line wider than the pane is reachable — the h-scroll pair's job.
+  it "wraps a long RESULT response line instead of scrolling it sideways" do
     view = loaded_fuzzer
     long_line = "HEAD" + ("." * 100) + "TAIL"
     r = Gori::Fuzz::Result.new(0_i64, ["p0"], nil, 200, 1200_i64, 40, 5, 1000_i64, nil, false, false, nil,
@@ -824,13 +828,10 @@ describe Gori::Tui::FuzzerView do
     backend = MemoryBackend.new(80, 20)
     view.render(Screen.new(backend), rect)
     backend.contains?("HEAD").should be_true
-    backend.contains?("TAIL").should be_false # off the right edge, clipped
-
-    20.times { view.hscroll_detail(1) } # scroll well past the line's width
-    backend2 = MemoryBackend.new(80, 20)
-    view.render(Screen.new(backend2), rect)
-    backend2.contains?("TAIL").should be_true
-    backend2.contains?("HEAD").should be_false # scrolled off the left edge
+    backend.contains?("TAIL").should be_true # on a continuation row, not off the right edge
+    head_row = (0...20).find { |y| backend.row(y).includes?("HEAD") }.not_nil!
+    tail_row = (0...20).find { |y| backend.row(y).includes?("TAIL") }.not_nil!
+    tail_row.should be > head_row
   end
 end
 

--- a/spec/tui/fuzzer_wrap_spec.cr
+++ b/spec/tui/fuzzer_wrap_spec.cr
@@ -1,0 +1,396 @@
+require "../spec_helper"
+require "../support/memory_backend"
+
+include Gori::Tui
+
+# The TEMPLATE editor's content rect the view derives internally, re-derived here so a click
+# spec can aim at a real cell. Mirrors `FuzzerView#template_editor_rect`: the TARGET card band,
+# then the 45%-tall top row, then its left half, then the card's 1-cell inset.
+private def template_body_rect(rect : Gori::Tui::Rect) : Gori::Tui::Rect
+  target_h = {rect.h, 3}.min # target_card_h with no SNI override
+  rest = Gori::Tui::Rect.new(rect.x, rect.y + target_h, rect.w, {rect.h - target_h, 0}.max)
+  top_h = {rest.h * 45 // 100, 5}.max
+  top_h = rest.h if rest.h < 6
+  half = {(rest.w - 1) // 2, 1}.max
+  Gori::Tui::Rect.new(rest.x, rest.y, half, top_h).inset(1, 1)
+end
+
+private def template_view(wire : String) : Gori::Tui::FuzzerView
+  view = Gori::Tui::FuzzerView.new
+  view.load_request("https://h.test", wire, false, "")
+  view.focus_pane(:template)
+  view
+end
+
+# A request whose FIRST line is `"GET /?q=" + pad + " HTTP/1.1"` — the shape an operator
+# actually hits this with (a long query string), long enough to wrap in a half-width pane.
+private def long_query_wire(pad : String) : String
+  "GET /?q=#{pad} HTTP/1.1\r\nHost: h.test\r\n\r\n"
+end
+
+describe "Gori::Tui::FuzzerView template soft wrap" do
+  # The Burp-style contract on the Fuzzer template, the same one the Repeater request pane and
+  # the History detail carry: a line too wide for the pane spills onto continuation rows, and
+  # the line number is printed once, on the first of them.
+  it "wraps a long request line and numbers only its first visual row" do
+    Gori::Settings.show_gutter = true
+    view = template_view(long_query_wire("#{"a" * 200}TAIL"))
+    rect = Rect.new(0, 0, 120, 30)
+    b = MemoryBackend.new(120, 30)
+    view.render(Screen.new(b), rect)
+    body = template_body_rect(rect)
+    gw = Gutter.width(4) # request line, Host, blank, trailing blank
+    get_row = (0...30).find { |y| b.row(y).includes?("GET /?q=") }.not_nil!
+    b.row(get_row)[body.x, gw].should_not eq(" " * gw) # numbered
+    b.row(get_row + 1)[body.x, gw].should eq(" " * gw) # continuation: no number
+    b.contains?("TAIL").should be_true                 # on screen, not clipped off the right edge
+  ensure
+    Gori::Settings.show_gutter = true
+  end
+
+  # …and nothing runs off the right edge any more: the pane used to carry `follow_x`, so the
+  # tail of a long line was only reachable by driving the caret into it and letting the whole
+  # pane slide sideways. `wrap=` pins @xscroll at 0, so column 0 of every row is column 0 of
+  # the buffer's own row.
+  it "never scrolls the template sideways once the caret walks a long line" do
+    view = template_view(long_query_wire("b" * 300))
+    rect = Rect.new(0, 0, 120, 30)
+    b = MemoryBackend.new(120, 30)
+    view.render(Screen.new(b), rect)
+    view.enter_template_insert!
+    view.template_end # caret to the far end of the (wrapped) request line
+    b2 = MemoryBackend.new(120, 30)
+    view.render(Screen.new(b2), rect)
+    body = template_body_rect(rect)
+    gw = Gori::Settings.show_gutter ? Gutter.width(4) : 0
+    # The FIRST row still starts with the request line's own first bytes.
+    get_row = (0...30).find { |y| b2.row(y).includes?("GET /?q=") }.not_nil!
+    b2.row(get_row)[body.x + gw, 8].should eq("GET /?q=")
+  end
+
+  # The inverse of that render. Screen row N of the template WAS logical line
+  # `@editor.scroll + N`; on a wrapped line that sum names a line which is not drawn there, so
+  # a click on a continuation row placed the caret on the wrong line entirely.
+  it "round-trips a click on a continuation row of the template" do
+    view = template_view(long_query_wire("0123456789" * 20))
+    rect = Rect.new(0, 0, 120, 30)
+    b = MemoryBackend.new(120, 30)
+    view.render(Screen.new(b), rect)
+    body = template_body_rect(rect)
+    gw = Gori::Settings.show_gutter ? Gutter.width(4) : 0
+    cw = body.w - gw
+    view.template_click_to_cursor(rect, body.x + gw + 2, body.y + 1)
+    view.template_read.cy.should eq(0)      # still the request LINE …
+    view.template_read.cx.should eq(cw + 2) # … one wrapped row in, plus two columns
+  end
+
+  # ↓ steps one VISUAL row in READ mode. Stepping a logical LINE jumped the caret over every
+  # continuation row the pane was drawing — from the first row of a long request line straight
+  # to `Host:`, skipping rows that nothing else could reach.
+  it "moves the READ caret down one visual row at a time, then onto the next line" do
+    view = template_view(long_query_wire("z" * 300))
+    rect = Rect.new(0, 0, 120, 30)
+    view.render(Screen.new(MemoryBackend.new(120, 30)), rect)
+    body = template_body_rect(rect)
+    gw = Gori::Settings.show_gutter ? Gutter.width(4) : 0
+    cw = body.w - gw
+    line0 = view.template_text.lines.first
+    view.template_read.cy.should eq(0)
+    view.template_read_move(1, 0)
+    view.template_read.cy.should eq(0)  # still the same LINE …
+    view.template_read.cx.should eq(cw) # … one wrapped row into it, at the same column
+    rows = (line0.size + cw - 1) // cw
+    (rows - 2).times { view.template_read_move(1, 0) }
+    view.template_read.cy.should eq(0)
+    view.template_read.cx.should eq((rows - 1) * cw)
+    view.template_read_move(1, 0)
+    view.template_read.cy.should eq(1) # Host:, many wrapped rows below the first number
+  end
+
+  # ↑ is the exact inverse: a run of ↓ then the same number of ↑ lands back where it began.
+  it "moves the READ caret back up through the wrapped rows it came down" do
+    view = template_view(long_query_wire("z" * 300))
+    rect = Rect.new(0, 0, 120, 30)
+    view.render(Screen.new(MemoryBackend.new(120, 30)), rect)
+    4.times { view.template_read_move(1, 0) }
+    view.template_read.cy.should eq(0) # inside the wrapped line, not past it
+    view.template_read.cx.should be > 0
+    4.times { view.template_read_move(-1, 0) }
+    view.template_read.cy.should eq(0)
+    view.template_read.cx.should eq(0)
+  end
+
+  # ↑-at-the-very-top pops focus out to the TARGET pane (FuzzerController's `template_up`).
+  # Gated on the logical line alone, a caret parked three rows into a wrapped line 0 would pop
+  # instead of stepping up — skipping the very rows the arrow was asked to walk. `TextArea#at_top?`
+  # already measures the first VISUAL row; this pins it for the pane that just started wrapping.
+  it "is not 'at top' while the READ caret sits on a continuation row of line 0" do
+    view = template_view(long_query_wire("q" * 300))
+    rect = Rect.new(0, 0, 120, 30)
+    view.render(Screen.new(MemoryBackend.new(120, 30)), rect)
+    view.template_at_top?.should be_true
+    view.template_read_move(1, 0) # one VISUAL row down — still on line 0
+    view.template_read.cy.should eq(0)
+    view.template_read.cx.should be > 0
+    view.template_at_top?.should be_false # …so ↑ must step back, not pop to TARGET
+    view.template_read_move(-1, 0)
+    view.template_at_top?.should be_true
+  end
+
+  # The wheel steps DRAWN rows. With a line-indexed offset one notch jumped a whole wrapped
+  # line, so most of a long body was unreachable by scrolling.
+  it "scrolls the template by one visual row per notch" do
+    body_text = (1..6).map { |i| "#{('a' + i - 1)}" * 200 }.join("\r\n")
+    view = template_view("POST / HTTP/1.1\r\nHost: h.test\r\n\r\n#{body_text}")
+    rect = Rect.new(0, 0, 120, 30)
+    b = MemoryBackend.new(120, 30)
+    view.render(Screen.new(b), rect)
+    body = template_body_rect(rect)
+    row = ->(back : MemoryBackend, y : Int32) { back.row(y)[body.x, body.w] }
+    top = row.call(b, body.y)
+    view.template_scroll_view(1)
+    b2 = MemoryBackend.new(120, 30)
+    view.render(Screen.new(b2), rect)
+    # One notch advanced by exactly one drawn row: what was the SECOND row is now the first.
+    row.call(b2, body.y).should eq(row.call(b, body.y + 1))
+    row.call(b2, body.y).should_not eq(top)
+  end
+
+  # A READ selection that covers a wrap boundary must tint to the END of the visual row, then
+  # continue on the next one. `paint_template_read_chrome` used to clip every span to the LINE
+  # and paint it at the row of that line's FIRST visual row — so a selection running past a
+  # break was banded once, in the wrong cells.
+  it "tints a READ selection across a wrap break to the end of the row and onto the next" do
+    view = template_view(long_query_wire("0123456789" * 20))
+    rect = Rect.new(0, 0, 120, 30)
+    b = MemoryBackend.new(120, 30)
+    view.render(Screen.new(b), rect)
+    body = template_body_rect(rect)
+    gw = Gori::Settings.show_gutter ? Gutter.width(4) : 0
+    cw = body.w - gw
+    (cw + 5).times { view.template_read_move(0, 1, selecting: true) }
+    b2 = MemoryBackend.new(120, 30)
+    view.render(Screen.new(b2), rect)
+    r0 = body.y # the request line's first visual row
+    b2.bg_grid[r0][body.x + gw].should eq(Theme.accent_bg)
+    b2.bg_grid[r0][body.x + gw + cw - 1].should eq(Theme.accent_bg) # …tinted to the row's end
+    b2.bg_grid[r0 + 1][body.x + gw].should eq(Theme.accent_bg)      # …and resumed below
+    b2.bg_grid[r0 + 1][body.x + gw + 4].should eq(Theme.accent_bg)
+    # gw+5 is the caret cell itself (also accent_bg); the tint must stop right after it.
+    b2.bg_grid[r0 + 1][body.x + gw + 6].should_not eq(Theme.accent_bg)
+  end
+
+  # The READ block caret has to be drawn on the row it is actually on. With `li - scroll` it
+  # rode the line's FIRST visual row forever, so walking into a wrapped line left a caret
+  # sitting on text it was not addressing.
+  it "draws the READ caret on the continuation row it walked onto" do
+    view = template_view(long_query_wire("#{"c" * 200}NEEDLE"))
+    rect = Rect.new(0, 0, 120, 30)
+    b = MemoryBackend.new(120, 30)
+    view.render(Screen.new(b), rect)
+    line0 = view.template_text.lines.first
+    line0.index("NEEDLE").not_nil!.times { view.template_read_move(0, 1) }
+    b2 = MemoryBackend.new(120, 30)
+    view.render(Screen.new(b2), rect)
+    ny = (0...30).find { |y| b2.row(y).includes?("NEEDLE") }.not_nil!
+    nx = b2.row(ny).index("NEEDLE").not_nil!
+    b2.bg_grid[ny][nx].should eq(Theme.accent_bg) # the caret is ON the N, on NEEDLE's own row
+  end
+
+  # A double-click on a continuation row must take the word UNDER the pointer.
+  it "double-click selects the word under a continuation row of the template" do
+    view = template_view("POST / HTTP/1.1\r\nHost: h.test\r\n\r\n#{"x" * 120}NEEDLE#{"y" * 20}")
+    rect = Rect.new(0, 0, 120, 30)
+    b = MemoryBackend.new(120, 30)
+    view.render(Screen.new(b), rect)
+    body = template_body_rect(rect)
+    ny = (0...30).find { |y| b.row(y).includes?("NEEDLE") }.not_nil!
+    nx = b.row(ny).index("NEEDLE").not_nil!
+    view.template_select_word(rect, nx, ny).should be_true
+    # The run is x…xNEEDLEy…y — one unbroken word-char token, so the whole line is the word.
+    view.template_copy_text.should eq("#{"x" * 120}NEEDLE#{"y" * 20}")
+    view.template_read.cy.should eq(3)
+    body.w.should be > 0
+  end
+
+  # A `§value¦chain§` marker whose band spans a wrap break must be tinted on EVERY row it
+  # covers, and the concealed `¦chain` must stay concealed on all of them. Both fall out of
+  # `TextArea#paint_bg_regions`' per-row clipping, but this pane is THE place markers are
+  # written, so the wrap flip is pinned here.
+  it "bands a marker that straddles a wrap break on both of its rows" do
+    pad = "p" * 200
+    view = template_view("GET /?q=#{pad}§#{"m" * 90}¦b64§ HTTP/1.1\r\nHost: h.test\r\n\r\n")
+    rect = Rect.new(0, 0, 120, 30)
+    b = MemoryBackend.new(120, 30)
+    view.render(Screen.new(b), rect)
+    body = template_body_rect(rect)
+    gw = Gori::Settings.show_gutter ? Gutter.width(4) : 0
+    marker_bg = Theme.marker_bg(0)
+    banded = (0...30).select { |y| (body.x + gw...body.x + body.w).any? { |x| b.bg_grid[y][x] == marker_bg } }
+    banded.size.should be > 1           # the band continues onto the row(s) below its first
+    b.contains?("¦b64").should be_false # …and the chain stays concealed on every one of them
+  end
+end
+
+# The RESULT detail card's interior, re-derived here so a click spec can aim at a real cell.
+# Mirrors `FuzzerView#detail_card_rect` → `stack_rects`' third slice, then the card's 1-cell
+# inset: the TARGET band, then the 45%-tall top row, and the detail is what is left below.
+private def detail_body_rect(rect : Gori::Tui::Rect) : Gori::Tui::Rect
+  target_h = {rect.h, 3}.min # target_card_h with no SNI override
+  rest_h = {rect.h - target_h, 0}.max
+  rest_y = rect.y + target_h
+  top_h = {rest_h * 45 // 100, 5}.max
+  top_h = rest_h if rest_h < 6
+  Gori::Tui::Rect.new(rect.x, rest_y + top_h, rect.w, {rest_h - top_h, 0}.max).inset(1, 1)
+end
+
+# The index of the first line of `body` in the RESPONSE pane's line space. Derived from the
+# pane's own lines rather than assumed: `detail_response_lines` splits the raw head, so the
+# number of blank rows between the status line and the body follows the captured CRLFs.
+private def body_li(view : Gori::Tui::FuzzerView, marker : String) : Int32
+  view.detail_plain_lines.index { |l| l.starts_with?(marker) }.not_nil!
+end
+
+# A view with its RESULT detail open on `body`, on the RESPONSE pane.
+private def detail_view(body : String) : Gori::Tui::FuzzerView
+  view = Gori::Tui::FuzzerView.new
+  view.load_request("https://h.test", "GET / HTTP/1.1\r\nHost: h.test\r\n\r\n", false, "")
+  r = Gori::Fuzz::Result.new(0_i64, ["p0"], nil, 200, 1200_i64, 40, 5, 1000_i64, nil, false, false, nil,
+    "HTTP/1.1 200 OK\r\n\r\n".to_slice, body.to_slice)
+  view.append_result(r)
+  view.open_detail
+  view
+end
+
+describe "Gori::Tui::FuzzerView RESULT detail soft wrap" do
+  # The RESULT detail was the last of the three hand-rolled read panes still carrying its own
+  # scroll/caret/h-scroll; it is a `ReadPane` now, wrapping like every other reading surface.
+  # A fuzz response is attacker-shaped, so "one enormous line" is the normal case here.
+  it "wraps a long response line and numbers only its first visual row" do
+    Gori::Settings.show_gutter = true
+    view = detail_view("HEAD#{"." * 200}TAIL")
+    rect = Rect.new(0, 0, 100, 30)
+    b = MemoryBackend.new(100, 30)
+    view.render(Screen.new(b), rect)
+    body = detail_body_rect(rect)
+    gw = Gutter.width(view.detail_plain_lines.size)
+    head_row = (0...30).find { |y| b.row(y).includes?("HEAD") }.not_nil!
+    b.row(head_row)[body.x, gw].should_not eq(" " * gw) # numbered
+    b.row(head_row + 1)[body.x, gw].should eq(" " * gw) # continuation: no number
+    b.contains?("TAIL").should be_true                  # on screen, not clipped off the right edge
+  ensure
+    Gori::Settings.show_gutter = true
+  end
+
+  # ↓ steps one VISUAL row. It used to step a logical LINE, jumping the caret over every
+  # continuation row the pane was drawing.
+  it "moves the detail caret down one visual row at a time" do
+    view = detail_view("#{"z" * 300}\nSENTINEL")
+    rect = Rect.new(0, 0, 100, 30)
+    view.render(Screen.new(MemoryBackend.new(100, 30)), rect)
+    body = detail_body_rect(rect)
+    gw = Gutter.width(view.detail_plain_lines.size)
+    cw = body.w - gw
+    li = body_li(view, "z")
+    li.times { view.detail_move(1, 0) } # down to the 300-char body line
+    view.detail_cursor.cy.should eq(li)
+    view.detail_cursor.cx.should eq(0)
+    view.detail_move(1, 0)
+    view.detail_cursor.cy.should eq(li) # still the same LINE …
+    view.detail_cursor.cx.should eq(cw) # … one wrapped row into it
+    rows = (300 + cw - 1) // cw
+    (rows - 1).times { view.detail_move(1, 0) }
+    view.detail_cursor.cy.should eq(li + 1) # SENTINEL, several wrapped rows below
+  end
+
+  # `detail_cursor_at_top?` decides whether ↑ pops focus back to the RESULTS list. Gated on the
+  # logical line alone, a caret three rows into a wrapped line would pop instead of stepping — but
+  # here it must also stay true while the caret is genuinely on row 0 of line 0.
+  it "reports 'at top' only on the first visual row" do
+    view = detail_view("#{"q" * 300}")
+    rect = Rect.new(0, 0, 100, 30)
+    view.render(Screen.new(MemoryBackend.new(100, 30)), rect)
+    view.detail_cursor_at_top?.should be_true
+    li = body_li(view, "q")
+    li.times { view.detail_move(1, 0) } # onto the long body line
+    view.detail_cursor.cy.should eq(li)
+    view.detail_cursor_at_top?.should be_false
+    li.times { view.detail_move(-1, 0) }
+    view.detail_cursor.cy.should eq(0)
+    view.detail_cursor_at_top?.should be_true
+  end
+
+  # A click on a continuation row must resolve onto the line drawn there. The old path went
+  # through `ReadCursor#click_to_cursor`, which resolves `scroll + row`.
+  it "round-trips a click on a continuation row of the detail" do
+    view = detail_view("0123456789" * 20)
+    rect = Rect.new(0, 0, 100, 30)
+    b = MemoryBackend.new(100, 30)
+    view.render(Screen.new(b), rect)
+    body = detail_body_rect(rect)
+    gw = Gutter.width(view.detail_plain_lines.size)
+    cw = body.w - gw
+    li = body_li(view, "0123")
+    view.detail_click_to_cursor(rect, body.x + gw + 2, body.y + li + 1) # 2nd visual row of it
+    view.detail_cursor.cy.should eq(li)
+    view.detail_cursor.cx.should eq(cw + 2)
+  end
+
+  # A double-click on a continuation row takes the word UNDER the pointer.
+  it "double-click selects the word under a continuation row of the detail" do
+    view = detail_view("#{"x" * 120}NEEDLE#{"y" * 20}")
+    rect = Rect.new(0, 0, 100, 30)
+    b = MemoryBackend.new(100, 30)
+    view.render(Screen.new(b), rect)
+    ny = (0...30).find { |y| b.row(y).includes?("NEEDLE") }.not_nil!
+    nx = b.row(ny).index("NEEDLE").not_nil!
+    view.detail_select_word(rect, nx, ny).should be_true
+    view.detail_copy_text.should eq("#{"x" * 120}NEEDLE#{"y" * 20}")
+    view.detail_cursor.cy.should eq(body_li(view, "xxx"))
+  end
+
+  # ⇧←/→ used to h-scroll this pane, so it had NO way to select characters at all (plain ←/→
+  # step the pane chain). `FuzzerController#handle_detail` gives the chord to the selection now
+  # that there is nothing off to the side to pan to.
+  it "extends a character selection across a wrap break instead of h-scrolling" do
+    view = detail_view("0123456789" * 20)
+    rect = Rect.new(0, 0, 100, 30)
+    b = MemoryBackend.new(100, 30)
+    view.render(Screen.new(b), rect)
+    body = detail_body_rect(rect)
+    gw = Gutter.width(view.detail_plain_lines.size)
+    cw = body.w - gw
+    li = body_li(view, "0123")
+    li.times { view.detail_move(1, 0) }
+    view.pane_selection?.should be_false
+    (cw + 5).times { view.detail_move(0, 1, selecting: true) }
+    view.pane_selection?.should be_true
+    # The selection ran PAST the wrap break, so the copy carries both rows' worth of bytes.
+    view.detail_copy_text.size.should eq(cw + 5)
+    # …and it is tinted on the continuation row, not only on the line's first visual row.
+    b2 = MemoryBackend.new(100, 30)
+    view.render(Screen.new(b2), rect)
+    r0 = body.y + li
+    b2.bg_grid[r0][body.x + gw + cw - 1].should eq(Theme.accent_bg) # to the end of row 0 …
+    b2.bg_grid[r0 + 1][body.x + gw].should eq(Theme.accent_bg)      # … and resumed below
+  end
+
+  # The styled overlay is sliced to the SAME row the plain layout wrapped at. The two are
+  # measured on different strings (`Wrap` on the plain line, `Highlight.slice_chars` on the
+  # styled one), so if they disagreed by even one char the colours would land off the glyphs and
+  # every click on the pane would resolve to the wrong column.
+  it "keeps the styled overlay aligned with the wrapped rows it draws" do
+    src = "0123456789" * 20
+    view = detail_view(src)
+    rect = Rect.new(0, 0, 100, 30)
+    b = MemoryBackend.new(100, 30)
+    view.render(Screen.new(b), rect)
+    body = detail_body_rect(rect)
+    gw = Gutter.width(view.detail_plain_lines.size)
+    cw = body.w - gw
+    li = body_li(view, "0123")
+    # The continuation row's first cell must hold the char the wrap broke AT, not the line's
+    # first char (unsliced) and not one off it (a column-based slice).
+    b.row(body.y + li + 1)[body.x + gw].should eq(src[cw])
+  end
+end

--- a/spec/tui/intercept_view_spec.cr
+++ b/spec/tui/intercept_view_spec.cr
@@ -80,7 +80,12 @@ describe Gori::Tui::InterceptView do
     end
   end
 
-  it "hscroll_detail scrolls a long held-request header sideways into view (shift+←/→)" do
+  # Was "hscroll_detail scrolls a long held-request header sideways into view (shift+←/→)". The
+  # read-only preview soft-wraps now, like the editor behind it and like the Repeater / History
+  # panes that show the same bytes, so the whole `hscroll_detail` chain is retired. Still under
+  # test: that a header wider than the pane is fully readable — the h-scroll pair's whole job,
+  # and here it matters under a clock (a message you cannot read is one you forward blind).
+  it "wraps a long held-request header instead of scrolling it sideways" do
     tmp_interceptor do |ic|
       long_header = "X-Long: HEAD" + ("." * 80) + "TAIL"
       hold_req(ic, "acme.test", "/login", "GET /login HTTP/1.1\r\nHost: acme.test\r\n#{long_header}\r\n\r\n")
@@ -91,13 +96,10 @@ describe Gori::Tui::InterceptView do
       backend = MemoryBackend.new(100, 12)
       view.render(Screen.new(backend), rect)
       backend.contains?("HEAD").should be_true
-      backend.contains?("TAIL").should be_false # off the right edge, clipped
-
-      20.times { view.hscroll_detail(1) } # scroll well past the line's width
-      backend2 = MemoryBackend.new(100, 12)
-      view.render(Screen.new(backend2), rect)
-      backend2.contains?("TAIL").should be_true
-      backend2.contains?("HEAD").should be_false # scrolled off the left edge
+      backend.contains?("TAIL").should be_true # on a continuation row, not off the right edge
+      head_row = (0...12).find { |y| backend.row(y).includes?("HEAD") }.not_nil!
+      tail_row = (0...12).find { |y| backend.row(y).includes?("TAIL") }.not_nil!
+      tail_row.should be > head_row
     end
   end
 

--- a/spec/tui/issues_view_spec.cr
+++ b/spec/tui/issues_view_spec.cr
@@ -113,7 +113,12 @@ describe Gori::Tui::IssuesView do
     end
   end
 
-  it "hscroll_notes scrolls a long notes line sideways into view (shift+←/→)" do
+  # Was "hscroll_notes scrolls a long notes line sideways into view (shift+←/→)". The notes
+  # pane soft-wraps now, like the Repeater request pane and the History detail, so the whole
+  # `hscroll_notes` chain is retired and BOTH ends of a long line are on screen at once — with
+  # no chord to press to see the second one. Still under test: that a line wider than the pane
+  # is fully reachable, which is what the h-scroll pair existed to provide.
+  it "wraps a long notes line instead of scrolling it sideways" do
     tmp_store do |store|
       id = store.insert_issue("XSS", Gori::Store::Severity::Medium, "acme.test", nil)
       store.update_issue(id, notes: "HEAD" + ("." * 80) + "TAIL")
@@ -129,13 +134,11 @@ describe Gori::Tui::IssuesView do
       backend = MemoryBackend.new(80, 24)
       view.render(Screen.new(backend), rect, focused: true)
       backend.contains?("HEAD").should be_true
-      backend.contains?("TAIL").should be_false
-
-      30.times { view.hscroll_notes(1) }
-      backend2 = MemoryBackend.new(80, 24)
-      view.render(Screen.new(backend2), rect, focused: true)
-      backend2.contains?("TAIL").should be_true
-      backend2.contains?("HEAD").should be_false
+      backend.contains?("TAIL").should be_true # …on its continuation row, not off the edge
+      # …and on DIFFERENT rows: this is a wrap, not a pane that grew wide enough to fit.
+      head_row = (0...24).find { |y| backend.row(y).includes?("HEAD") }.not_nil!
+      tail_row = (0...24).find { |y| backend.row(y).includes?("TAIL") }.not_nil!
+      tail_row.should be > head_row
     end
   end
 

--- a/spec/tui/read_pane_wrap_spec.cr
+++ b/spec/tui/read_pane_wrap_spec.cr
@@ -1,0 +1,275 @@
+require "../spec_helper"
+require "../support/memory_backend"
+
+include Gori::Tui
+
+# `ReadPane`'s opt-in soft wrap — the same Burp-style contract the Repeater request pane, the
+# History detail and the Fuzzer template carry, reached through one component instead of a
+# hand-rolled copy per pane. Its five consumers (Decoder OUTPUT, Intercept preview, Probe
+# AFFECTED, the OAST callback detail, the Rewriter PREVIEW OUTPUT) all take it; the four that
+# self-draw through `viewport_top` deliberately do not.
+
+# One column wider than the rect: `Frame.scroll_gauge` rides the border column immediately right
+# of the content, so a rect flush to the backend's edge silently drops it (see read_pane_spec).
+private def render_wrapped(pane : Gori::Tui::ReadPane, w = 40, h = 8, focused = true,
+                           styled_at : (Int32 -> Gori::Tui::Highlight::Line)? = nil) : MemoryBackend
+  b = MemoryBackend.new(w + 1, h)
+  pane.render(Gori::Tui::Screen.new(b), Gori::Tui::Rect.new(0, 0, w, h), focused, styled_at)
+  b
+end
+
+private def wrapped_pane(lines : Array(String), gutter = false) : Gori::Tui::ReadPane
+  pane = Gori::Tui::ReadPane.new(gutter: gutter, wrap: true)
+  pane.source(lines)
+  pane
+end
+
+describe "Gori::Tui::ReadPane soft wrap" do
+  # The contract: a line too wide for the pane spills onto continuation rows, and the line
+  # number is printed once, on the first of them.
+  it "wraps a long line and numbers only its first visual row" do
+    pane = wrapped_pane(["short", "HEAD#{"." * 80}TAIL", "last"], gutter: true)
+    b = render_wrapped(pane, w: 40, h: 8)
+    gw = Gutter.width(3)
+    head_row = (0...8).find { |y| b.row(y).includes?("HEAD") }.not_nil!
+    b.row(head_row)[0, gw].should_not eq(" " * gw) # numbered
+    b.row(head_row + 1)[0, gw].should eq(" " * gw) # continuation: no number
+    b.contains?("TAIL").should be_true             # on screen, not clipped off the right edge
+    # …and the number that IS printed is the logical line's, not the drawn row's.
+    b.row(head_row)[0, gw].strip.should eq("2")
+    b.contains?("last").should be_true # the next logical line still follows below the wrap
+  end
+
+  # A wrapping pane has no sideways: `hscroll` is inert and `xscroll` stays pinned, so a stored
+  # offset the renderer no longer reads can never fight the clamp.
+  it "ignores hscroll once wrapping" do
+    pane = wrapped_pane(["HEAD#{"." * 80}TAIL"])
+    render_wrapped(pane)
+    10.times { pane.hscroll(1) }
+    pane.xscroll.should eq(0)
+    b = render_wrapped(pane)
+    b.row(0)[0, 4].should eq("HEAD") # still starts at column 0 of the buffer's own row
+  end
+
+  # ↓ steps one VISUAL row. Stepping a logical LINE jumped the caret over every continuation
+  # row the pane was drawing — rows that are on screen and that nothing but this arrow reaches.
+  it "moves the caret down one visual row at a time, then onto the next line" do
+    pane = wrapped_pane(["#{"z" * 200}", "SENTINEL"])
+    b = render_wrapped(pane, w: 40, h: 8)
+    cw = 40 # no gutter
+    b.contains?("zzz").should be_true
+    pane.cursor.cy.should eq(0)
+    pane.move(1, 0)
+    pane.cursor.cy.should eq(0)  # still the same LINE …
+    pane.cursor.cx.should eq(cw) # … one wrapped row into it, at the same column
+    rows = (200 + cw - 1) // cw
+    (rows - 2).times { pane.move(1, 0) }
+    pane.cursor.cy.should eq(0)
+    pane.cursor.cx.should eq((rows - 1) * cw)
+    pane.move(1, 0)
+    pane.cursor.cy.should eq(1) # SENTINEL, several wrapped rows below the first
+  end
+
+  # ↑ is the exact inverse: a run of ↓ then the same number of ↑ lands back where it began.
+  it "moves the caret back up through the wrapped rows it came down" do
+    pane = wrapped_pane(["#{"z" * 200}", "SENTINEL"])
+    render_wrapped(pane, w: 40, h: 8)
+    3.times { pane.move(1, 0) }
+    pane.cursor.cy.should eq(0)
+    pane.cursor.cx.should be > 0
+    3.times { pane.move(-1, 0) }
+    pane.cursor.cy.should eq(0)
+    pane.cursor.cx.should eq(0)
+  end
+
+  # `at_top?` is what a controller consults to decide whether ↑ should leave for the pane above.
+  # Gated on the logical line alone, a caret three rows into a wrapped line 0 answers true — so
+  # ↑ pops focus instead of walking the rows it was asked to walk.
+  it "is not 'at top' while the caret sits on a continuation row of line 0" do
+    pane = wrapped_pane(["#{"q" * 200}", "next"])
+    render_wrapped(pane, w: 40, h: 8)
+    pane.at_top?.should be_true
+    pane.move(1, 0)
+    pane.cursor.cy.should eq(0)
+    pane.cursor.cx.should be > 0
+    pane.at_top?.should be_false
+    pane.move(-1, 0)
+    pane.at_top?.should be_true
+  end
+
+  # Home is a LOGICAL line start, so from a caret parked several rows into a wrapped line it
+  # has to pull the ANCHOR back with it — otherwise the caret jumps to a row above the window
+  # and the next frame's `ensure_visible` is the only thing that saves it.
+  it "scrolls the anchor back when Home leaves a continuation row" do
+    pane = wrapped_pane([(0...12).map { |i| "R#{i}".ljust(40, '.') }.join])
+    render_wrapped(pane, w: 40, h: 8)
+    20.times { pane.move(1, 0) } # walk well past the first viewport of wrapped rows
+    pane.scroll_sub.should be > 0
+    pane.motion_key(Termisu::Event::Key.new(Termisu::Input::Key::Home)).should be_true
+    pane.cursor.cx.should eq(0)
+    pane.scroll_sub.should eq(0) # …and the pane is showing the row the caret is on again
+    b = render_wrapped(pane, w: 40, h: 8)
+    b.row(0)[0, 2].should eq("R0")
+  end
+
+  # The wheel steps DRAWN rows. With a line-indexed offset one notch jumped a whole wrapped
+  # line, so most of a long body was unreachable by scrolling.
+  it "scrolls by one visual row per notch" do
+    # ONE logical line, built so that every 40-column visual row starts with its own marker —
+    # otherwise the rows of a uniform filler line are textually identical and "the second row is
+    # now the first" holds vacuously.
+    pane = wrapped_pane([(0...12).map { |i| "R#{i}".ljust(40, '.') }.join])
+    b = render_wrapped(pane, w: 40, h: 8)
+    b.row(0)[0, 2].should eq("R0")
+    b.row(1)[0, 2].should eq("R1")
+    pane.scroll_view(1)
+    b2 = render_wrapped(pane, w: 40, h: 8)
+    b2.row(0)[0, 2].should eq("R1") # one notch = exactly one drawn row
+    b2.row(1)[0, 2].should eq("R2")
+    pane.scroll_view(3)
+    b3 = render_wrapped(pane, w: 40, h: 8)
+    b3.row(0)[0, 2].should eq("R4")
+  end
+
+  # …and it stops one viewport short of the end rather than scrolling the content off the top.
+  it "clamps the wheel at the last visual row" do
+    pane = wrapped_pane(["#{"m" * 400}", "ENDLINE"])
+    render_wrapped(pane, w: 40, h: 8)
+    500.times { pane.scroll_view(1) }
+    b = render_wrapped(pane, w: 40, h: 8)
+    b.contains?("ENDLINE").should be_true # the last row is on screen …
+    b.row(7)[0, 7].should eq("ENDLINE")   # … on the pane's BOTTOM line, not above it
+    b.row(0)[0, 3].should_not eq("   ")   # …and the pane is still full, not scrolled past
+  end
+
+  # A click on a continuation row must resolve to the logical line drawn there, at the column
+  # the row's own text starts from. `ReadCursor`'s own hit test resolves `scroll + row`, which
+  # on a wrapping pane names a line that is not drawn under the pointer at all.
+  it "round-trips a click on a continuation row" do
+    pane = wrapped_pane(["short", "0123456789" * 12])
+    render_wrapped(pane, w: 40, h: 8)
+    cw = 40
+    pane.click(Rect.new(0, 0, 40, 8), 2, 2) # row 2 = the second visual row of line 1
+    pane.cursor.cy.should eq(1)
+    pane.cursor.cx.should eq(cw + 2)
+  end
+
+  # A click past the end of a wrapped row stops at the break rather than running into the next
+  # row's characters — `Wrap.row_index` clamps to the row it was given.
+  it "clamps a click past the end of a wrapped row to that row's break" do
+    pane = wrapped_pane(["#{"x" * 50}"]) # wraps once: 40 cols, then 10
+    render_wrapped(pane, w: 40, h: 8)
+    pane.click(Rect.new(0, 0, 40, 8), 39, 1) # far right of the SECOND row, past its 10 chars
+    pane.cursor.cy.should eq(0)
+    pane.cursor.cx.should eq(50) # the line's end, not into a row below
+  end
+
+  # Where wrap meets #592's pointer rounding. `Screen.column_for_click` / `Wrap.row_index(
+  # nearest:)` round a POINTER to the CLOSER edge of the cluster its column lands in, so the
+  # right half of a 2-cell glyph resolves to the position AFTER it; without that, half of every
+  # pointer position over CJK or Hangul lands a character short. The wrapped click path is a
+  # second inverse of the same rule, so it has to round the same way — on a CONTINUATION row,
+  # where the columns are measured from the wrap break rather than from the line's start.
+  it "rounds a click on a wide glyph to the nearer edge on a continuation row" do
+    # 30 glyphs × 2 columns = 60, so 20 land on row 0 and 10 wrap onto row 1.
+    pane = wrapped_pane(["#{"한" * 30}"])
+    render_wrapped(pane, w: 40, h: 8)
+    rect = Rect.new(0, 0, 40, 8)
+    # Row 1 holds glyphs 20.. — its first glyph occupies columns 0-1.
+    pane.click(rect, 0, 1) # LEFT half of glyph 20 → in front of it
+    pane.cursor.cy.should eq(0)
+    pane.cursor.cx.should eq(20)
+    pane.click(rect, 1, 1) # RIGHT half of the same glyph → after it, not short of it
+    pane.cursor.cx.should eq(21)
+    pane.click(rect, 2, 1) # left half of glyph 21
+    pane.cursor.cx.should eq(21)
+  end
+
+  # A double-click on a continuation row takes the word UNDER the pointer.
+  it "double-click selects the word under a continuation row" do
+    pane = wrapped_pane(["#{"x" * 60}NEEDLE#{"y" * 10}"])
+    b = render_wrapped(pane, w: 40, h: 8)
+    ny = (0...8).find { |y| b.row(y).includes?("NEEDLE") }.not_nil!
+    nx = b.row(ny).index("NEEDLE").not_nil!
+    pane.select_word(Rect.new(0, 0, 40, 8), nx, ny).should be_true
+    # The run is x…xNEEDLEy…y — one unbroken word-char token, so the whole line is the word.
+    pane.copy_text.should eq("#{"x" * 60}NEEDLE#{"y" * 10}")
+    pane.cursor.cy.should eq(0)
+  end
+
+  # A selection covering a wrap break must tint to the END of the visual row, then resume on the
+  # next one. Clipped to the LINE instead it is painted once, at the first row's columns, and
+  # the rest of the selection reads as unselected.
+  it "tints a selection across a wrap break to the end of the row and onto the next" do
+    pane = wrapped_pane(["0123456789" * 12])
+    cw = 40
+    render_wrapped(pane, w: cw, h: 8)
+    (cw + 5).times { pane.move(0, 1, selecting: true) }
+    b = render_wrapped(pane, w: cw, h: 8)
+    b.bg_grid[0][0].should eq(Theme.accent_bg)
+    b.bg_grid[0][cw - 1].should eq(Theme.accent_bg) # …tinted to the row's end
+    b.bg_grid[1][0].should eq(Theme.accent_bg)      # …and resumed below
+    b.bg_grid[1][4].should eq(Theme.accent_bg)
+    # column 5 is the caret cell itself (also accent_bg); the tint must stop right after it.
+    b.bg_grid[1][6].should_not eq(Theme.accent_bg)
+  end
+
+  # The block caret has to be drawn on the row it is actually on. Measured from column 0 of the
+  # LINE it rides the line's first visual row forever, addressing text it is not on.
+  it "draws the caret on the continuation row it walked onto" do
+    pane = wrapped_pane(["#{"c" * 60}NEEDLE"])
+    b = render_wrapped(pane, w: 40, h: 8)
+    60.times { pane.move(0, 1) }
+    b2 = render_wrapped(pane, w: 40, h: 8)
+    ny = (0...8).find { |y| b2.row(y).includes?("NEEDLE") }.not_nil!
+    nx = b2.row(ny).index("NEEDLE").not_nil!
+    b2.bg_grid[ny][nx].should eq(Theme.accent_bg)
+    b.contains?("NEEDLE").should be_true # it was already drawn there before the caret arrived
+  end
+
+  # A STYLED pane (the Intercept preview, the Fuzzer detail overlay) must wrap on the same grid
+  # it draws: the layout is measured on the plain line while the draw slices the styled one, so
+  # the two have to agree char-for-char or the colours land a column off the glyphs.
+  it "slices a styled line to the same row the plain layout wrapped it at" do
+    text = "#{"a" * 50}RED#{"b" * 10}"
+    pane = Gori::Tui::ReadPane.new(wrap: true)
+    pane.source(1, ->(_i : Int32) { text })
+    styled = ->(_i : Int32) do
+      line = Highlight::Line.new
+      line << Highlight::Span.new("a" * 50, Theme.text)
+      line << Highlight::Span.new("RED", Theme.red)
+      line << Highlight::Span.new("b" * 10, Theme.text)
+      line
+    end
+    b = render_wrapped(pane, w: 40, h: 8, styled_at: styled)
+    # RED starts at char 50 → column 10 of the SECOND visual row, and keeps its colour there.
+    b.row(1)[10, 3].should eq("RED")
+    b.fg_at(10, 1).should eq(Theme.red)
+    b.fg_at(9, 1).should eq(Theme.text)
+  end
+
+  # A single grapheme cluster wider than the pane still gets a row of its own — `Wrap.layout`
+  # places a cluster whole or moves it whole, so it can never be cut in half.
+  it "keeps a wide cluster whole across the break" do
+    # 2 columns per glyph, so 30 glyphs are 60 columns: the line wraps at glyph 20 and the
+    # remaining 10 land on the second row. `row` gives a wide glyph its lead cell plus a blank
+    # continuation, so each glyph is ONE character of the joined row string.
+    pane = wrapped_pane(["#{"한" * 30}"])
+    b = render_wrapped(pane, w: 40, h: 8)
+    b.row(0)[0, 1].should eq("한")
+    b.row(0).count('한').should eq(20) # exactly 20 glyphs fit in 40 columns …
+    b.row(1).count('한').should eq(10) # … and the other 10 wrapped, none of them split
+    b.row(1)[0, 1].should eq("한")
+  end
+
+  # `source` re-points the pane AND drops the wrap memo: the same line index holding different
+  # bytes must not be sliced at the old line's breaks.
+  it "re-wraps after the content changes under the same line indices" do
+    pane = wrapped_pane(["#{"w" * 100}"])
+    render_wrapped(pane, w: 40, h: 8)
+    pane.source(["SHORT"])
+    b = render_wrapped(pane, w: 40, h: 8)
+    b.row(0)[0, 5].should eq("SHORT")
+    b.row(1)[0, 5].should eq("     ") # nothing left over from the wrapped line it replaced
+  end
+end

--- a/spec/verb/registry_spec.cr
+++ b/spec/verb/registry_spec.cr
@@ -729,10 +729,6 @@ private class FakeContext < ExecContext
     @calls << :issue_edit_notes
   end
 
-  def issue_hscroll(delta : Int32) : Nil
-    @calls << :issue_hscroll
-  end
-
   def issue_edit_title : Nil
     @calls << :issue_edit_title
   end

--- a/spec/verbs/issues_spec.cr
+++ b/spec/verbs/issues_spec.cr
@@ -153,17 +153,15 @@ describe "Gori::Verbs.register_issues" do
       verb_intents(r, "issue.copy").should eq([:read_copy])
     end
 
-    it "scrolls a long notes line with SHIFT+←/→, leaving plain ← to close" do
-      # issue.close owns plain ←/h; the h-scroll chords carry shift, so they don't collide.
-      r["issue.hscroll-right"].chords.should eq([Gori::Verb::Chord.new("right", shift: true)])
-      r["issue.hscroll-left"].chords.should eq([Gori::Verb::Chord.new("left", shift: true)])
+    # The ⇧←/→ h-scroll pair is retired: the notes pane soft-wraps, so nothing sits off to the
+    # side to scroll to, and `IssuesController#handle_notes_read_key` owns the chord for the
+    # character selection. What is still under test is that plain ← still closes the detail —
+    # the collision the shifted chords existed to avoid.
+    it "leaves plain ← to close the detail, with no h-scroll pair to collide with" do
       r["issue.close"].chords.should contain(Gori::Verb::Chord.new("left"))
-      ctx = FakeExecContext.new
-      r["issue.hscroll-right"].call(ctx)
-      ctx.args_for(:issue_hscroll).should eq(["1"])
-      ctx = FakeExecContext.new
-      r["issue.hscroll-left"].call(ctx)
-      ctx.args_for(:issue_hscroll).should eq(["-1"])
+      ids = r.map(&.id)
+      ids.should_not contain("issue.hscroll-right")
+      ids.should_not contain("issue.hscroll-left")
     end
 
     it "routes the detail actions to their own intents" do

--- a/src/gori/tui/controllers/decoder_controller.cr
+++ b/src/gori/tui/controllers/decoder_controller.cr
@@ -782,7 +782,6 @@ module Gori::Tui
     # Command letters defer to the keymap (rebindable copy + Global breath).
     private def handle_output(ev : Termisu::Event::Key) : Bool
       return true.tap { @host.open_space_menu } if ev.key.space? && !ev.ctrl? && !ev.alt?
-      return true if handle_output_hscroll(ev)
       s = cur
       key = ev.key
       selecting = ev.shift?
@@ -792,10 +791,10 @@ module Gori::Tui
       when key.down?, key.lower_j? then out_nav_step(s, 1, 0, selecting)
       when key.left?               then out_nav_step(s, 0, -1, selecting)
       when key.right?              then out_nav_step(s, 0, 1, selecting)
-        # Home/End/Page. ⇧←/→ stay H-SCROLL here, as they are on every read-only pane that
-        # scrolls sideways (the Repeater's RESPONSE draws the same line): an editable pane
-        # follows its caret, so there selection is strictly better — a read-only one has no
-        # caret-driven scroll to piggyback on.
+        # Home/End/Page. ⇧←/→ used to be H-SCROLL here; the pane soft-wraps now (like the
+        # Repeater's RESPONSE, which draws the same line), so there is nothing off to the side
+        # to pan to and the chord goes to the character selection every other text pane gives
+        # it — reached through the plain `key.left?`/`key.right?` arms above.
       when s.view.output_motion_key(ev, s.result) then nil
       when (c = ev.char || key.to_char) && !ev.ctrl? && !ev.alt? && !c.control?
         return false
@@ -828,19 +827,6 @@ module Gori::Tui
         s.input_read.select_word(s.input, regions.input.inset(1, 1), mx, my)
       elsif regions.output.contains?(mx, my)
         s.view.output_select_word(regions.output.inset(1, 1), mx, my, s.result)
-      else
-        false
-      end
-    end
-
-    private def handle_output_hscroll(ev : Termisu::Event::Key) : Bool
-      key = ev.key
-      if key.left? && ev.shift?
-        cur.view.hscroll_output(-1)
-        true
-      elsif key.right? && ev.shift?
-        cur.view.hscroll_output(1)
-        true
       else
         false
       end

--- a/src/gori/tui/controllers/fuzzer_controller.cr
+++ b/src/gori/tui/controllers/fuzzer_controller.cr
@@ -639,34 +639,23 @@ module Gori::Tui
       true
     end
 
+    # ⇧←/→ used to H-SCROLL this pane. It soft-wraps now, so there is nothing off to the side to
+    # pan to, and the chord goes to the CHARACTER selection instead — which this pane had no way
+    # to make at all, plain ←/→ being spoken for by the pane chain. ⇧↑/⇧↓ already selected.
     private def handle_detail(ev : Termisu::Event::Key, v : FuzzerView) : Bool
       return true.tap { @host.open_space_menu } if ev.key.space? && !ev.ctrl? && !ev.alt?
-      return true if handle_detail_hscroll(ev, v)
       key = ev.key
       selecting = ev.shift?
       case
       when key.up?, key.lower_k?
         v.detail_cursor_at_top? ? v.focus_pane(:results) : v.detail_move(-1, 0, selecting: selecting)
       when key.down?, key.lower_j? then v.detail_move(1, 0, selecting: selecting)
-      when key.left?               then v.detail_step_pane(-1)
-      when key.right?              then v.detail_step_pane(1)
+      when key.left?               then selecting ? v.detail_move(0, -1, selecting: true) : v.detail_step_pane(-1)
+      when key.right?              then selecting ? v.detail_move(0, 1, selecting: true) : v.detail_step_pane(1)
       when (c = ev.char || key.to_char) && !ev.ctrl? && !ev.alt? && !c.control?
         return false # x/y + Global breath → keymap
       end
       true
-    end
-
-    private def handle_detail_hscroll(ev : Termisu::Event::Key, v : FuzzerView) : Bool
-      key = ev.key
-      if key.left? && ev.shift?
-        v.hscroll_detail(-1)
-        true
-      elsif key.right? && ev.shift?
-        v.hscroll_detail(1)
-        true
-      else
-        false
-      end
     end
 
     def handle_click(rect : Rect, mx : Int32, my : Int32) : Bool

--- a/src/gori/tui/controllers/intercept_controller.cr
+++ b/src/gori/tui/controllers/intercept_controller.cr
@@ -89,9 +89,7 @@ module Gori::Tui
         handle_edit_key(ev)
         true
       else
-        # shift+←/→/↑/↓ (scroll the read-only preview) checked here rather than inside
-        # handle_queue_key — that dispatch is already at ameba's complexity ceiling.
-        queue_key_scroll(ev) || handle_queue_key(ev) # false for c / / (and other unhandled keys) → defer to the keymap
+        handle_queue_key(ev) # false for c / / (and other unhandled keys) → defer to the keymap
       end
     end
 
@@ -190,25 +188,11 @@ module Gori::Tui
       @host.status(n == 0 ? "selection cleared" : "selection cleared — #{n} still marked")
     end
 
-    # Shift+←/→ horizontal scroll for the read-only held-item preview — kept OUT of
-    # handle_queue_key (called from handle_body_key instead), since that dispatch is already
-    # at ameba's complexity ceiling. Bare arrows still navigate the queue.
-    #
-    # ⇧↑/⇧↓ used to scroll this preview vertically; they are now the mark-range gesture
-    # (⇧arrow = "extend the selection" everywhere else in the TUI, incl. History's list and
-    # the flow detail). Vertical reading moved to PgUp/PgDn/Home/End — see #body_scroll.
-    private def queue_key_scroll(ev : Termisu::Event::Key) : Bool
-      key = ev.key
-      return false unless ev.shift?
-      if key.left?
-        @intercept.hscroll_detail(-1)
-      elsif key.right?
-        @intercept.hscroll_detail(1)
-      else
-        return false
-      end
-      true
-    end
+    # ⇧←/→ used to h-scroll the read-only held-item preview. The preview soft-wraps now, like
+    # the editor it sits behind and like the Repeater / History panes that show the same bytes,
+    # so there is nothing off to the side to scroll to and the whole `hscroll_detail` chain is
+    # gone rather than kept as a no-op. (⇧↑/⇧↓ had already left for the mark-range gesture;
+    # vertical reading is PgUp/PgDn/Home/End — see `#body_scroll`.)
 
     # PageUp/PageDown/Home/End page the read-only held-message preview (the Runner routes
     # these here when handle_body_key declines them). The preview, not the queue: a hold

--- a/src/gori/tui/controllers/issues_controller.cr
+++ b/src/gori/tui/controllers/issues_controller.cr
@@ -53,7 +53,7 @@ module Gori::Tui
         if @issues.notes_insert_mode?
           "type to edit · esc save · ^W discard"
         elsif @issues.notes_focused?
-          "↑/↓ move · ⇧arrows select · #{y} copy · i/↵ edit · space cmds · ⇧←/→ h-scroll · esc links"
+          "↑/↓ move · ⇧arrows select · #{y} copy · i/↵ edit · space cmds · esc links"
         else
           "↑/↓ links · ↵ open · i/↵ notes · o flow · r repeater · space cmds · ←/esc back"
         end
@@ -231,10 +231,10 @@ module Gori::Tui
       true
     end
 
-    # ⇧←/→ used to h-scroll the notes pane, which shadowed the character selection every
-    # other text pane gives them. The pane has a caret and `follow_x`, so moving the caret
-    # sideways scrolls the view anyway — the selection is what the chord is for, and
-    # `hscroll_notes` stays for the wheel/other callers.
+    # ⇧←/→ used to h-scroll the notes pane, which shadowed the character selection every other
+    # text pane gives them. `handle_notes_read_key` took the chord back for the selection, and
+    # the notes pane now soft-wraps — there is nothing off to the side to scroll to — so the
+    # `hscroll_notes` chain is gone rather than kept as a no-op that still moves a caret.
 
     def set_preedit(text : String) : Bool
       if @issues.querying?
@@ -428,10 +428,6 @@ module Gori::Tui
 
     def issue_edit_notes : Nil
       @issues.enter_notes_insert!
-    end
-
-    def issue_hscroll(delta : Int32) : Nil
-      @issues.hscroll_notes(delta)
     end
 
     def issue_link_move(delta : Int32) : Nil

--- a/src/gori/tui/controllers/oast_controller.cr
+++ b/src/gori/tui/controllers/oast_controller.cr
@@ -93,7 +93,9 @@ module Gori::Tui
       # The callback detail's caret, selection, scroll and draw. This pane holds the raw callback
       # — the evidence an OAST finding rests on — and had no caret and no copy of its own: the
       # tab's `y` copies the PAYLOAD, not what came back.
-      @cb_pane = ReadPane.new
+      # Soft wrap: a callback's body / headers are the payload under inspection, and an
+      # interaction record is mostly long single lines.
+      @cb_pane = ReadPane.new(wrap: true)
       @filter = TextField.new # Callbacks free-text filter (`/`)
       @filter_editing = false
       @prov_sel = 0

--- a/src/gori/tui/controllers/rewriter_controller.cr
+++ b/src/gori/tui/controllers/rewriter_controller.cr
@@ -34,7 +34,9 @@ module Gori::Tui
       # The transformed sample: caret, selection, both scroll axes and its whole draw. No gutter
       # — these rows are a rewritten MESSAGE, and the sample's own line numbers would only
       # invite the reader to map them onto the input pane, which a head/body rewrite can shift.
-      @out = ReadPane.new
+      # Soft wrap, matching the PREVIEW INPUT editor above it: the two panes show the same
+      # message before and after a rule, so they have to agree about what a row is.
+      @out = ReadPane.new(wrap: true)
       @last_body = Rect.new(0, 0, 0, 0) # last content rect — click/wheel geometry
     end
 

--- a/src/gori/tui/decoder_view.cr
+++ b/src/gori/tui/decoder_view.cr
@@ -37,7 +37,9 @@ module Gori::Tui
     # The OUTPUT pane's caret, selection, both scroll axes and its whole draw. Gutter on: these
     # rows ARE source lines of the decoded text, and ^G-style line references only mean
     # something with numbers beside them.
-    @out = ReadPane.new(gutter: true)
+    # Soft wrap too: a decoded blob arrives as one enormous line more often than not (a base64
+    # payload, a minified JWT claim set), and the whole point of this pane is reading it.
+    @out = ReadPane.new(gutter: true, wrap: true)
 
     # Card rects for the four sections, stacked top-to-bottom. Each is a full
     # `Frame.card` (border + interior), NOT a divided slice of one outer frame —
@@ -364,11 +366,6 @@ module Gori::Tui
       !Frame.right_badge_hit(mx, my, card.y, card.right - 1, min_x, [
         {:mode, "^X", name},
       ] of {Symbol, String, String}).nil?
-    end
-
-    # Shift+←/→ over the OUTPUT card.
-    def hscroll_output(step : Int32) : Nil
-      @out.hscroll(step)
     end
 
     # Whether the OUTPUT is scrolled to the top — ↑ here pops focus up to CHAIN

--- a/src/gori/tui/fuzz_set_overlay.cr
+++ b/src/gori/tui/fuzz_set_overlay.cr
@@ -47,7 +47,11 @@ module Gori::Tui
         :path    => TextField.new(""),
       }
       @values = TextArea.new
-      @values.follow_x = true # long list values scroll horizontally to keep the caret visible
+      # Soft wrap, like the template this list feeds. One line is one payload, and a payload
+      # long enough to matter (a SQLi chain, a serialized blob) was exactly the one the
+      # `follow_x` sideways pan made unreadable — you could not see its head and its tail at
+      # the same time, in the pane whose whole job is checking what you are about to send.
+      @values.wrap = true
       @path_complete = PathComplete.new(wordlist_history: true)
     end
 

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -6,6 +6,7 @@ require "./input_mode"
 require "./text_read_state"
 require "./line_field_read"
 require "./read_cursor"
+require "./read_pane"
 require "./gutter"
 require "./traffic_empty_state"
 require "./text_area"
@@ -89,7 +90,12 @@ module Gori::Tui
       @evidence_env_names = Set(String).new
       @editor = TextArea.new
       @editor.gutter = true
-      @editor.follow_x = true     # long lines (headers, URLs, §-marked params) scroll horizontally to keep the cursor visible
+      # Soft wrap, Burp-style, exactly as the Repeater's request pane: a long header, URL or
+      # §-marked minified body spills onto continuation rows and the line number stays on the
+      # first of them. Replaces the `follow_x` horizontal scroll this pane used to carry — a
+      # request you have to pan sideways to read is a request you misread, and here the thing
+      # off the right edge is a `§…§` marker whose position IS the payload's insertion point.
+      @editor.wrap = true
       @editor.env_complete = true # `$KEY` autocomplete against the registered env vars (expanded on send)
       @editor.chain_peek = true   # tooltip revealing the concealed ¦chain of the §…§ marker under the caret
       @last_synced_config = ""    # last store config blob applied (reconcile equality)
@@ -183,11 +189,17 @@ module Gori::Tui
       @run_total = nil.as(Int64?)
       @job_id = 0
       @stop_requested = false
-      @detail_scroll = 0
-      @detail_xscroll = 0 # horizontal scroll offset for the RESULT detail (shift+←/→)
       @detail_pane = :response
-      @detail_cursor = ReadCursor.new
-      @detail_last_h = 0 # viewport height from last detail render (wheel clamp)
+      # The RESULT detail's caret, selection, scroll anchor and whole draw. This pane is one of
+      # the three hand-rolled copies `ReadPane` was extracted to replace (see its class comment)
+      # and the last to move onto it: it carried its own `@detail_scroll` / `@detail_xscroll` /
+      # `@detail_last_h` / `ReadCursor` plus its own `ensure_detail_visible`, and the drift
+      # between that copy and the Decoder's was already a documented bug.
+      #
+      # Gutter on: these rows ARE lines of the request/response under test. Wrap on: a fuzz
+      # response is attacker-shaped, so "one enormous line" is the normal case here, and the
+      # tail of it used to be reachable only by panning sideways with ⇧←/→.
+      @detail_read = ReadPane.new(gutter: true, wrap: true)
       @target_mode = InputMode::Read
       @template_mode = InputMode::Read
       @template_read = TextReadState.new
@@ -207,6 +219,9 @@ module Gori::Tui
       # (same invariant @decoded_index relies on), so this only recomputes on pane/row change.
       @detail_lines_cache = nil.as(Array(String)?)
       @detail_lines_key = nil.as({Symbol, Int64}?)
+      # The Array `@detail_read` is currently pointed at, compared by IDENTITY — see
+      # `sync_detail_source`.
+      @detail_source_lines = nil.as(Array(String)?)
       # Styled overlay for the detail lines (syntax highlighting), keyed by pane/row +
       # theme revision so a palette switch rebuilds it. Held in lockstep with the plain
       # @detail_lines_cache; the plain lines still back the gutter/cursor/selection math.
@@ -479,7 +494,20 @@ module Gori::Tui
     # --- READ / INS input modes (target + template panes) ---
     getter target_mode : InputMode
     getter template_mode : InputMode
-    getter detail_cursor : ReadCursor
+
+    # The RESULT detail's caret + selection. Read off the pane that owns them now, rather than
+    # being a second cursor beside it.
+    def detail_cursor : ReadCursor
+      @detail_read.cursor
+    end
+
+    # The READ-mode caret/selection over the TEMPLATE pane. Exposed like
+    # `HistoryView#detail_read` so a wrap example can assert where a visual-row step landed in
+    # BUFFER coordinates — the one thing a screen-cell assertion cannot distinguish from a
+    # caret that stopped on the right cell of the wrong line.
+    def template_read : ReadCursor
+      @template_read.cursor
+    end
 
     def target_insert? : Bool
       @target_mode == InputMode::Insert
@@ -810,7 +838,11 @@ module Gori::Tui
       @results_rev += 1
       # A fresh run reuses result indices from 0, so drop the {pane, index}-keyed detail
       # cache — otherwise an old row's lines could survive under a colliding new index.
+      # `@detail_source_lines` goes with it: dropping the cache alone would already force a
+      # rebuild (and so a re-source, the Array being new), but tying the two together keeps
+      # the "the pane is pointed at THAT Array" invariant readable in one place.
       @detail_lines_cache = nil
+      @detail_source_lines = nil
       @detail_lines_key = nil
       @detail_styled_cache = nil
       @detail_styled_key = nil
@@ -1297,38 +1329,25 @@ module Gori::Tui
     def open_detail : Nil
       return if sorted_results.empty?
       @focus = :detail
-      @detail_scroll = 0
-      @detail_xscroll = 0
       @detail_pane = :response
-      @detail_cursor.reset
+      @detail_read.reset
       decode_detail # parse the decoded-protocol panes for the row we're opening
     end
 
     def detail_cursor_at_top? : Bool
-      @detail_cursor.cy == 0 && @detail_scroll == 0
+      @detail_read.at_top?
     end
 
     def detail_move(dr : Int32, dc : Int32, selecting : Bool = false) : Nil
       return unless detail_navigable?
-      lines = detail_plain_lines
-      return if lines.empty?
-      @detail_cursor.move(dr, dc, lines, selecting: selecting)
-      ensure_detail_visible(@detail_last_h) if @detail_last_h > 0
+      sync_detail_source
+      @detail_read.move(dr, dc, selecting: selecting)
     end
 
     def detail_scroll_view(step : Int32) : Nil
       return unless detail_navigable?
-      lines = detail_plain_lines
-      return if @detail_last_h <= 0 || lines.size <= @detail_last_h
-      max = lines.size - @detail_last_h
-      @detail_scroll = (@detail_scroll + step).clamp(0, max)
-      lo = @detail_scroll
-      hi = {@detail_scroll + @detail_last_h - 1, lines.size - 1}.min
-      # Clamp cy into range BEFORE indexing `lines`: while a run streams, a live re-sort
-      # (non-index sort) can swap the fixed @sel onto a shorter result, leaving cy stale
-      # and larger than the new `lines` — a bare `lines[cy]` would then raise IndexError.
-      cy = @detail_cursor.cy.clamp(lo, hi)
-      @detail_cursor.sync(cy, @detail_cursor.cx.clamp(0, lines[cy].size))
+      sync_detail_source
+      @detail_read.scroll_view(step)
     end
 
     def detail_plain_lines : Array(String)
@@ -1338,13 +1357,34 @@ module Gori::Tui
     end
 
     def detail_copy_text : String
-      lines = detail_plain_lines
-      return "" if lines.empty?
-      @detail_cursor.selection_text(lines) || @detail_cursor.current_line(lines)
+      sync_detail_source
+      @detail_read.copy_text
     end
 
     def detail_copy_all_text : String
       detail_plain_lines.join("\n")
+    end
+
+    # Point the detail pane at the OPEN result's lines. Cheap and idempotent — `detail_lines`
+    # is memoized on {pane, row} — so every gesture can call it and none can act on a pane
+    # sourced from a row the list has since re-sorted away underneath it. That re-source is
+    # also what keeps the old hand-rolled `cy` clamp honest: while a run streams, a live
+    # re-sort can swap the fixed `@sel` onto a SHORTER result, and `ReadPane` clamps the caret
+    # against the text it is pointed at.
+    #
+    # A stale cache hit cannot survive that swap, because the memo key holds `r.index` and
+    # `Fuzz::Result#index` is the run's request ORDINAL — `Generator#emit` hands out `idx` once
+    # per emitted job, so no two rows of one run share it. Indices DO restart at 0 on the next
+    # run, and `begin_run` drops the cache for exactly that.
+    private def sync_detail_source : Nil
+      lines = detail_plain_lines
+      prev = @detail_source_lines
+      # IDENTITY, not equality: `detail_lines` hands back the very same Array while its
+      # {pane, row} key holds, and `ReadPane#source` drops the wrap memo — so comparing by
+      # value here would re-wrap the visible window on every keystroke over a body that can
+      # reach multiple MiB, which is exactly what the memo exists to prevent.
+      @detail_read.source(lines) unless prev && lines.same?(prev)
+      @detail_source_lines = lines
     end
 
     # --- mouse over the RESULT detail ---------------------------------------
@@ -1353,8 +1393,8 @@ module Gori::Tui
     # double-click arms both bailed unless the focused pane was the template, and its click arm
     # had no `:detail` branch, so a click focused the card and left the caret where it was.
     # Compare the History drill-in, which has had all four (chips, caret, drag, word) since it
-    # grew a read cursor. The inverse is `DecoderView#output_click_to_cursor`'s: `ReadCursor`
-    # owns the mapping, the pane supplies the scroll anchor, the gutter and the h-scroll.
+    # grew a read cursor. The hit test itself is `ReadPane`'s now — it owns the wrap layout and
+    # the gutter, and a second inverse here would drift from the caret the click lands on.
 
     # The card `render_bottom` hands `render_detail`, so every gesture inverts against exactly
     # the rect that was drawn. nil unless the detail is what is actually on screen there.
@@ -1364,31 +1404,27 @@ module Gori::Tui
       bottom.h > 0 ? bottom : nil
     end
 
-    # The detail card's interior + its gutter width, or nil when there is nothing to hit-test.
-    private def detail_hit_geometry(rect : Rect) : {Rect, Array(String), Int32}?
+    # The detail card's interior, or nil when there is nothing to hit-test. The gutter width is
+    # no longer computed here: `ReadPane` derives it from the size it was sourced with, and two
+    # derivations of it would be two answers about where the text column starts.
+    private def detail_hit_geometry(rect : Rect) : Rect?
       return nil unless detail_navigable?
       card = detail_card_rect(rect)
       return nil unless card
-      lines = detail_plain_lines
-      return nil if lines.empty?
+      sync_detail_source
+      return nil if @detail_read.empty?
       inner = card.inset(1, 1)
-      return nil if inner.empty?
-      {inner, lines, {Gutter.width(lines.size), inner.w}.min}
+      inner.empty? ? nil : inner
     end
 
     def detail_click_to_cursor(rect : Rect, mx : Int32, my : Int32, selecting : Bool = false) : Nil
-      inner, lines, gw = detail_hit_geometry(rect) || return
-      @detail_cursor.click_to_cursor(inner, mx, my, @detail_scroll, lines, gw, @detail_xscroll, selecting)
-      ensure_detail_visible(inner.h)
+      inner = detail_hit_geometry(rect) || return
+      @detail_read.click(inner, mx, my, selecting)
     end
 
     def detail_select_word(rect : Rect, mx : Int32, my : Int32) : Bool
-      hit = detail_hit_geometry(rect)
-      return false unless hit
-      inner, lines, gw = hit
-      took = @detail_cursor.select_word_at(inner, mx, my, @detail_scroll, lines, gw, @detail_xscroll)
-      ensure_detail_visible(inner.h)
-      took
+      inner = detail_hit_geometry(rect) || return false
+      @detail_read.select_word(inner, mx, my)
     end
 
     # The pane chip under (mx, my) on the detail card's TOP BORDER, or nil. Inverts
@@ -1425,12 +1461,6 @@ module Gori::Tui
       detail_step_pane(i - (panes.index(@detail_pane) || 0))
     end
 
-    # Horizontal companion to `detail_scroll` (shift+←/→). Floored at 0 here; the
-    # render loop clamps the upper bound to the widest row actually on screen.
-    def hscroll_detail(delta : Int32) : Nil
-      @detail_xscroll = {@detail_xscroll + delta * 4, 0}.max
-    end
-
     # ←/→ in the RESULT detail: step through the pane chain (request → response →
     # whichever decoded-protocol panes the row carries), clamped — no wrap, so ← past
     # the first / → past the last is a no-op (esc leaves the detail).
@@ -1439,9 +1469,8 @@ module Gori::Tui
       i = (panes.index(@detail_pane) || 0) + dir
       return if i < 0 || i >= panes.size
       @detail_pane = panes[i]
-      @detail_scroll = 0
-      @detail_xscroll = 0
-      @detail_cursor.reset
+      @detail_read.reset
+      @detail_source_lines = nil
       @detail_lines_cache = nil
       @detail_lines_key = nil
       @detail_styled_cache = nil
@@ -1833,7 +1862,7 @@ module Gori::Tui
       case @focus
       when :template then !pane_insert?(:template) && @template_read.selection?
       when :target   then !pane_insert?(:target) && @target_read.selection?
-      when :detail   then detail_navigable? && @detail_cursor.selection?
+      when :detail   then detail_navigable? && @detail_read.selection?
       else                false
       end
     end
@@ -1848,10 +1877,8 @@ module Gori::Tui
         @tcx = @target_read.select_line(@target.size)
       when :detail
         return unless detail_navigable?
-        lines = detail_plain_lines
-        return if lines.empty?
-        @detail_cursor.select_line(lines)
-        ensure_detail_visible(@detail_last_h) if @detail_last_h > 0
+        sync_detail_source
+        @detail_read.select_line
       end
     end
 
@@ -1859,7 +1886,7 @@ module Gori::Tui
       case @focus
       when :template then @template_read.clear_selection
       when :target   then @target_read.clear_selection
-      when :detail   then @detail_cursor.clear_selection
+      when :detail   then @detail_read.clear_selection
       end
     end
 
@@ -2164,28 +2191,11 @@ module Gori::Tui
     # The copy was right all along (it reads buffer coordinates), so the band highlighted different
     # bytes than `y` copied. See the READ-mode over-paint seam in `text_area.cr`.
     #
-    # `scroll`-relative rows are correct here where they would not be in the Repeater: this editor
-    # does not soft-wrap (no `wrap = true`), so one logical line is one drawn row.
+    # The shared over-paint — `TextReadState#paint_chrome`, which inverts the row list the
+    # editor actually drew instead of the `li - scroll` sum this method used to carry. That sum
+    # stopped being the screen row the moment this pane started soft-wrapping.
     private def paint_template_read_chrome(screen : Screen, rect : Rect, active : Bool) : Nil
-      return unless active
-      lines = @editor.lines_snapshot
-      return if lines.empty?
-      @template_read.sync_from(@editor)
-      scr = @editor.scroll
-      gw = @editor.gutter? ? Gutter.width(lines.size) : 0
-      cw = {rect.w - gw, 0}.max
-      @template_read.cursor.highlight_spans(lines).each do |(li, x0, x1)|
-        next unless li >= scr && li < scr + rect.h
-        @editor.paint_read_band(screen, rect.x + gw, rect.y + (li - scr), li, x0, x1, 0, -1, cw)
-      end
-      cy, cx = @editor.cy, @editor.cx
-      return unless cy >= scr && cy < scr + rect.h
-      col, ch = @editor.read_caret_cell(cy, cx)
-      px = rect.x + gw + col
-      if px < rect.x + rect.w
-        screen.cell(px, rect.y + (cy - scr), ch, Theme.bg, Theme.accent_bg)
-        screen.cursor(px, rect.y + (cy - scr))
-      end
+      @template_read.paint_chrome(screen, rect, @editor, active)
     end
 
     private def paint_char_span_bg(screen : Screen, x : Int32, y : Int32, line : String,
@@ -2206,16 +2216,6 @@ module Gori::Tui
         screen.text(px, y, seg, Theme.text, bg)
         px += Screen.draw_width(seg)
         i = e
-      end
-    end
-
-    private def ensure_detail_visible(view_h : Int32) : Nil
-      return if view_h <= 0
-      cy = @detail_cursor.cy
-      if cy < @detail_scroll
-        @detail_scroll = cy
-      elsif cy >= @detail_scroll + view_h
-        @detail_scroll = cy - view_h + 1
       end
     end
 
@@ -2670,48 +2670,13 @@ module Gori::Tui
       inner = rect.inset(1, 1)
       lines = detail_lines(r)
       styled = detail_styled(r, lines)
-      @detail_last_h = inner.h
-      ensure_detail_visible(inner.h) if focused
-      @detail_scroll = @detail_scroll.clamp(0, {lines.size - inner.h, 0}.max)
-      gw = {Gutter.width(lines.size), inner.w}.min
-      cw = {inner.w - gw, 0}.max
-      rows = (0...inner.h).compact_map { |i| lines[@detail_scroll + i]? }
-      # draw_width, not display_width: these rows are drawn per grapheme (Highlight.draw on
-      # the styled overlay, `screen.text` on the plain fallback), so a control char in a
-      # fuzz response holds a cell the raw measure scores 0 and the clamp stopped short of
-      # the content. _upto keeps the early exit — this runs every frame over response lines
-      # that are attacker-shaped and can be arbitrarily long.
-      @detail_xscroll = @detail_xscroll.clamp(0, {(rows.max_of? { |l| Screen.draw_width_upto(l, @detail_xscroll + cw + 1) } || 0) - cw, 0}.max)
-      # Selection spans for the WHOLE buffer, built once per frame. This used to sit inside
-      # paint_detail_line_chrome, i.e. rebuilt and thrown away once per drawn row — O(rows ×
-      # selection length) tuple appends, plus a fresh Array per row even with nothing selected.
-      spans = focused && detail_navigable? ? @detail_cursor.highlight_spans(lines) : nil
-      rows.each_with_index do |line, i|
-        li = @detail_scroll + i
-        Gutter.draw(screen, inner.x, inner.y + i, li, gw, current: focused && li == @detail_cursor.cy)
-        # Draw the styled overlay; the plain `line` still drives the cursor/selection chrome.
-        sline = styled[li]? || [Highlight::Span.new(line, Theme.text)]
-        sline = Highlight.slice_left(sline, @detail_xscroll) if @detail_xscroll > 0
-        Highlight.draw(screen, inner.x + gw, inner.y + i, sline, bg: Theme.bg, width: cw)
-        paint_detail_line_chrome(screen, inner.x + gw, inner.y + i, li, line, spans)
-      end
-      Frame.scroll_gauge(screen, inner, lines.size, @detail_scroll, focused)
-    end
-
-    # `spans` is the frame's selection-span list (nil when the pane isn't focused/navigable),
-    # built once by render_detail rather than per row.
-    private def paint_detail_line_chrome(screen : Screen, x : Int32, y : Int32, li : Int32, line : String,
-                                         spans : Array({Int32, Int32, Int32})?) : Nil
-      return unless spans
-      spans.each do |(l, x0, x1)|
-        paint_char_span_bg(screen, x, y, line, x0, x1, Theme.accent_bg) if l == li
-      end
-      return unless li == @detail_cursor.cy
-      cx = @detail_cursor.cx.clamp(0, line.size)
-      px = x + Screen.draw_width(line[0, cx])
-      ch = cx < line.size ? line[cx] : ' '
-      screen.cell(px, y, ch, Theme.bg, Theme.accent_bg)
-      screen.cursor(px, y)
+      sync_detail_source
+      # `styled_at` is COLOUR ONLY — its span texts concatenate back to the same `lines[li]` the
+      # pane addresses, which is what lets the caret, the selection band and the wrap layout be
+      # measured on the plain line while the draw paints the coloured one. A row the overlay has
+      # no entry for falls back to the plain text in `Theme.text`, exactly as before.
+      @detail_read.render(screen, inner, focused && detail_navigable?,
+        styled_at: ->(li : Int32) { styled[li]? || Highlight::Line{Highlight::Span.new(lines[li]? || "", Theme.text)} })
     end
 
     # The detail sub-panes in order: REQUEST → RESPONSE → decoded-protocol panes (each

--- a/src/gori/tui/intercept_view.cr
+++ b/src/gori/tui/intercept_view.cr
@@ -44,8 +44,13 @@ module Gori::Tui
       @selected = 0
       @scroll = 0
       @editor = TextArea.new
-      @editor.gutter = true   # line numbers in the held-message editor (pairs with ^G)
-      @editor.follow_x = true # long lines (headers, URLs) scroll horizontally to keep the cursor visible
+      @editor.gutter = true # line numbers in the held-message editor (pairs with ^G)
+      # Soft wrap, Burp-style, exactly as the Repeater's request pane and the Fuzzer template:
+      # a long header, URL or minified body spills onto continuation rows with its line number
+      # on the first of them. These are the same bytes those panes hold, and here they are
+      # under a clock — a held message you have to pan sideways to read is one you forward
+      # without having read it.
+      @editor.wrap = true
       @editing = false
       # Filter bar: the catch direction + on/off mirror the Interceptor (captured on
       # reload, rendered as chips); the condition query is a local edit buffer pushed
@@ -88,7 +93,9 @@ module Gori::Tui
       # from the item's `Highlight::Windowed` LAZILY — a held body runs to megabytes and this is
       # the pane that must not materialise it. `Highlight.plain` is the bridge from the styled
       # window to the text the caret and a copy address; the window itself paints.
-      @preview = ReadPane.new
+      # Soft wrap, matching the editor beside it (and the Repeater / History panes showing the
+      # same bytes): READ and EDIT must not disagree about what a row is in one pane.
+      @preview = ReadPane.new(wrap: true)
       @reload_rev = -1 # Interceptor#revision the queue snapshot was last taken at (-1 ⇒ never)
       # Multi-select marks (#442's model, ported to the hold queue), keyed by ITEM ID rather
       # than row index: a forward/drop of an earlier entry shifts every index below it, so an
@@ -1071,16 +1078,9 @@ module Gori::Tui
       @preview.source(win.total, ->(i : Int32) { Highlight.plain(win.line_at(i)) })
     end
 
-    # Nudge the read-only held-item preview sideways (shift+←/→). No-op while
-    # editing — the TextArea editor's own follow_x already handles that case.
-    def hscroll_detail(delta : Int32) : Nil
-      return if @editing
-      @preview.hscroll(delta)
-    end
-
-    # Vertical companion to hscroll_detail (shift+↑/↓): scroll the read-only preview so a
-    # held body taller than the pane is fully readable WITHOUT entering edit mode (which
-    # risks mutating byte-exact held bytes). Floored at 0 here; render clamps the upper bound.
+    # Scroll the read-only preview so a held body taller than the pane is fully readable WITHOUT
+    # entering edit mode (which risks mutating byte-exact held bytes). Floored at 0 here; render
+    # clamps the upper bound. The pane wraps, so this is the only scroll axis it has left.
     def vscroll_detail(delta : Int32) : Nil
       return if @editing
       with_preview { @preview.scroll_view(delta) }

--- a/src/gori/tui/issues_view.cr
+++ b/src/gori/tui/issues_view.cr
@@ -45,7 +45,10 @@ module Gori::Tui
       @notes_mode = InputMode::Read
       @notes_read = TextReadState.new
       @notes = TextArea.new
-      @notes.follow_x = true # long note lines scroll horizontally to keep the cursor visible
+      # Soft wrap, like every other reading surface in the tree. An issue's notes are prose —
+      # a pasted payload or a paragraph of reproduction steps is one logical line — so the
+      # `follow_x` sideways pan this used to carry showed one screenful and hid the rest.
+      @notes.wrap = true
       @loaded = false
       # The `/` filter bar (mirrors History's QL bar but matches in memory).
       @query = ""
@@ -285,14 +288,6 @@ module Gori::Tui
       return false unless idx = @issues.index { |f| f.id == id }
       select_index(idx)
       open_detail(store)
-    end
-
-    # Nudge the notes viewport sideways (shift+←/→ in READ). Pans by moving the read
-    # cursor so follow_x keeps the window aligned (TextArea ensure_visible_x otherwise
-    # resets a bare @xscroll when the caret sits at column 0).
-    def hscroll_notes(delta : Int32) : Nil
-      return if notes_insert_mode?
-      @notes_read.move(@notes, 0, delta * 4)
     end
 
     def close_detail : Nil
@@ -971,48 +966,11 @@ module Gori::Tui
       notes_card_rect(rect).inset(1, 1)
     end
 
+    # The shared over-paint — see `TextReadState#paint_chrome`. This pane's own copy also
+    # skipped the `sync_from` its four siblings carry, so an MCP `update_issue` shrinking the
+    # notes under a stale read cursor could index off the end of the buffer mid-render.
     private def paint_notes_read_chrome(screen : Screen, rect : Rect, active : Bool) : Nil
-      return unless active
-      lines = @notes.lines_snapshot
-      return if lines.empty?
-      scr = @notes.scroll
-      sel_bg = Theme.accent_bg
-      @notes_read.cursor.highlight_spans(lines).each do |(li, x0, x1)|
-        next unless li >= scr && li < scr + rect.h
-        row = li - scr
-        paint_char_span_bg(screen, rect.x, rect.y + row, lines[li], x0, x1, sel_bg)
-      end
-      cy, cx = @notes_read.cursor.cy, @notes_read.cursor.cx
-      return unless cy >= scr && cy < scr + rect.h
-      row = cy - scr
-      line = lines[cy]
-      px = rect.x + Screen.draw_width(line[0, cx])
-      if px < rect.x + rect.w
-        ch = cx < line.size ? line[cx] : ' '
-        screen.cell(px, rect.y + row, ch, Theme.bg, Theme.accent_bg)
-        screen.cursor(px, rect.y + row)
-      end
-    end
-
-    private def paint_char_span_bg(screen : Screen, x : Int32, y : Int32, line : String,
-                                   x0 : Int32, x1 : Int32, bg : Color) : Nil
-      return if x0 >= x1
-      # Cluster-wise, matching the base draw and the caret. Summing draw_width over single
-      # CHARS is exactly the retired per-codepoint measure: it drifts right by each
-      # cluster's inflation (1 column for a skin tone, 9 for a ZWJ family), and drawing
-      # char-by-char also SHREDS a cluster across cells, stranding a bare combining mark in
-      # one of its own. Span edges snap outward so the tint covers whole glyphs.
-      a = Screen.cluster_start(line, {x0, line.size}.min)
-      b = Screen.cluster_end(line, {x1, line.size}.min)
-      px = x + Screen.draw_width(line[0, a])
-      i = a
-      while i < b
-        e = Screen.cluster_end(line, i + 1)
-        seg = line[i...e]
-        screen.text(px, y, seg, Theme.text, bg)
-        px += Screen.draw_width(seg)
-        i = e
-      end
+      @notes_read.paint_chrome(screen, rect, @notes, active)
     end
 
     # A filled "chip": ` LABEL ` painted with `color` as the background. Returns the

--- a/src/gori/tui/notes_view.cr
+++ b/src/gori/tui/notes_view.cr
@@ -34,7 +34,11 @@ module Gori::Tui
 
       def initialize(@id : Int64, text : String = "")
         @area = TextArea.new(text)
-        @area.follow_x = true # long lines scroll horizontally to keep the cursor visible (like the Project description)
+        # Soft wrap, like every other reading surface in the tree (the Repeater's request pane,
+        # the History detail, the Fuzzer template). A note is prose — a paragraph typed as one
+        # logical line is the NORMAL case here, not the exception — so the `follow_x` sideways
+        # pan this used to carry hid all but one screenful of nearly every note it held.
+        @area.wrap = true
       end
 
       # Sub-tab label: the note's title (first non-blank line, trimmed) truncated
@@ -433,56 +437,11 @@ module Gori::Tui
       paint_read_chrome(screen, area, ed, focused && !insert_mode?) if !insert_mode?
     end
 
+    # The shared over-paint — see `TextReadState#paint_chrome`, which carries the reasoning
+    # (including the `sync_from` that keeps a peer edit shrinking the note under a stale cursor
+    # from taking the render down).
     private def paint_read_chrome(screen : Screen, rect : Rect, ed : TextArea, focused : Bool) : Nil
-      return unless focused
-      lines = ed.lines_snapshot
-      return if lines.empty?
-      # Re-sync the read cursor from the editor before painting. A peer edit (2nd session or MCP
-      # update_note) can reload a shorter note via soft_merge_from, which resets the editor's
-      # clamped caret but deliberately leaves @read alone — a stale @read.cursor.cy past the new
-      # end would make the lines[cy] below raise IndexError and crash the TUI render. Mirrors
-      # RepeaterView#paint_request_read_chrome.
-      @read.sync_from(ed)
-      scr = ed.scroll
-      sel_bg = Theme.accent_bg
-      @read.cursor.highlight_spans(lines).each do |(li, x0, x1)|
-        next unless li >= scr && li < scr + rect.h
-        row = li - scr
-        gw = ed.gutter? ? Gutter.width(lines.size) : 0
-        paint_char_span_bg(screen, rect.x + gw, rect.y + row, lines[li], x0, x1, sel_bg)
-      end
-      cy, cx = @read.cursor.cy, @read.cursor.cx
-      return unless cy >= scr && cy < scr + rect.h
-      row = cy - scr
-      gw = ed.gutter? ? Gutter.width(lines.size) : 0
-      line = lines[cy]
-      px = rect.x + gw + Screen.draw_width(line[0, cx])
-      if px < rect.x + rect.w
-        ch = cx < line.size ? line[cx] : ' '
-        screen.cell(px, rect.y + row, ch, Theme.bg, Theme.accent_bg)
-        screen.cursor(px, rect.y + row)
-      end
-    end
-
-    private def paint_char_span_bg(screen : Screen, x : Int32, y : Int32, line : String,
-                                   x0 : Int32, x1 : Int32, bg : Color) : Nil
-      return if x0 >= x1
-      # Cluster-wise, matching the base draw and the caret. Summing draw_width over single
-      # CHARS is exactly the retired per-codepoint measure: it drifts right by each
-      # cluster's inflation (1 column for a skin tone, 9 for a ZWJ family), and drawing
-      # char-by-char also SHREDS a cluster across cells, stranding a bare combining mark in
-      # one of its own. Span edges snap outward so the tint covers whole glyphs.
-      a = Screen.cluster_start(line, {x0, line.size}.min)
-      b = Screen.cluster_end(line, {x1, line.size}.min)
-      px = x + Screen.draw_width(line[0, a])
-      i = a
-      while i < b
-        e = Screen.cluster_end(line, i + 1)
-        seg = line[i...e]
-        screen.text(px, y, seg, Theme.text, bg)
-        px += Screen.draw_width(seg)
-        i = e
-      end
+      @read.paint_chrome(screen, rect, ed, focused)
     end
 
     # Sub-tab chip labels (one per note), sourced by the Runner's shared strip: each

--- a/src/gori/tui/probe_view.cr
+++ b/src/gori/tui/probe_view.cr
@@ -34,7 +34,9 @@ module Gori::Tui
       # The AFFECTED URLS list in the detail: caret, selection, scroll and draw. The list is the
       # finding's evidence and had no caret and no copy — the one thing an operator wants out of a
       # scan issue is the URLs it fired on.
-      @affected = ReadPane.new
+      # Soft wrap: these rows are URLs, and a URL long enough to matter is exactly the one the
+      # right edge used to eat.
+      @affected = ReadPane.new(wrap: true)
       @query = ""
       @qcx = 0
       @preedit_q = ""

--- a/src/gori/tui/project_view.cr
+++ b/src/gori/tui/project_view.cr
@@ -53,7 +53,10 @@ module Gori::Tui
       @status_counts = [] of {Int32?, Int64}
       @sev_tally = StaticArray(Int64, 5).new(0_i64)
       @desc_area = TextArea.new
-      @desc_area.follow_x = true # long description lines scroll horizontally to keep the cursor visible
+      # Soft wrap, like every other reading surface in the tree. A description is prose typed
+      # as one logical line per paragraph, so the `follow_x` sideways pan this used to carry
+      # showed one screenful of each and hid the rest behind ⇧←/→.
+      @desc_area.wrap = true
       @desc_dirty = false
       @desc_mode = InputMode::Read
       @desc_read = TextReadState.new
@@ -1306,53 +1309,11 @@ module Gori::Tui
       insert ? Theme.accent : Frame.pane_border(true)
     end
 
+    # The shared over-paint — see `TextReadState#paint_chrome`, which carries the reasoning
+    # (including the `sync_from` that keeps `^E`'s external editor shrinking the description
+    # under a stale read cursor from taking the render down).
     private def paint_desc_read_chrome(screen : Screen, rect : Rect, active : Bool) : Nil
-      return unless active
-      lines = @desc_area.lines_snapshot
-      return if lines.empty?
-      # Re-sync the read cursor from the editor before painting: replace_desc (^E external editor)
-      # can shrink the description without touching @desc_read, leaving a stale cursor past the new
-      # end so the lines[cy] below would raise IndexError and crash the TUI render. Mirrors the
-      # notes_view / repeater_view / fuzzer_view read-chrome paint paths.
-      @desc_read.sync_from(@desc_area)
-      scr = @desc_area.scroll
-      sel_bg = Theme.accent_bg
-      @desc_read.cursor.highlight_spans(lines).each do |(li, x0, x1)|
-        next unless li >= scr && li < scr + rect.h
-        row = li - scr
-        paint_char_span_bg(screen, rect.x, rect.y + row, lines[li], x0, x1, sel_bg)
-      end
-      cy, cx = @desc_read.cursor.cy, @desc_read.cursor.cx
-      return unless cy >= scr && cy < scr + rect.h
-      row = cy - scr
-      line = lines[cy]
-      px = rect.x + Screen.draw_width(line[0, cx])
-      if px < rect.x + rect.w
-        ch = cx < line.size ? line[cx] : ' '
-        screen.cell(px, rect.y + row, ch, Theme.bg, Theme.accent_bg)
-        screen.cursor(px, rect.y + row)
-      end
-    end
-
-    private def paint_char_span_bg(screen : Screen, x : Int32, y : Int32, line : String,
-                                   x0 : Int32, x1 : Int32, bg : Color) : Nil
-      return if x0 >= x1
-      # Cluster-wise, matching the base draw and the caret. Summing draw_width over single
-      # CHARS is exactly the retired per-codepoint measure: it drifts right by each
-      # cluster's inflation (1 column for a skin tone, 9 for a ZWJ family), and drawing
-      # char-by-char also SHREDS a cluster across cells, stranding a bare combining mark in
-      # one of its own. Span edges snap outward so the tint covers whole glyphs.
-      a = Screen.cluster_start(line, {x0, line.size}.min)
-      b = Screen.cluster_end(line, {x1, line.size}.min)
-      px = x + Screen.draw_width(line[0, a])
-      i = a
-      while i < b
-        e = Screen.cluster_end(line, i + 1)
-        seg = line[i...e]
-        screen.text(px, y, seg, Theme.text, bg)
-        px += Screen.draw_width(seg)
-        i = e
-      end
+      @desc_read.paint_chrome(screen, rect, @desc_area, active)
     end
 
     # NETWORK card: the scope-lens + sandbox toggles over the three inline-editable network

--- a/src/gori/tui/read_pane.cr
+++ b/src/gori/tui/read_pane.cr
@@ -5,6 +5,7 @@ require "./gutter"
 require "./highlight"
 require "./read_cursor"
 require "./geometry"
+require "./wrap"
 
 module Gori::Tui
   # A scrollable READ-ONLY text pane: the state (`ReadCursor` + vertical scroll + horizontal
@@ -39,15 +40,35 @@ module Gori::Tui
   # precisely because the two agree. A provider that changed the characters would put a different
   # letter in the caret cell than in the row around it.
   class ReadPane
+    # Ceiling on the per-line wrap memo — mirrors `TextArea::WRAP_CACHE_CAP` and exists for the
+    # same reason: a viewport is tens of rows, so this covers it many times over while a pane
+    # scrolled through a huge body can never accumulate an entry per line.
+    WRAP_CACHE_CAP = 512
+
     getter cursor : ReadCursor
-    # First visible line, clamped by `render` against the height it actually drew.
+    # First visible line, clamped by `render` against the height it actually drew. Under wrap it
+    # is the first half of the `(line, sub-row)` anchor — see `scroll_sub`.
     getter scroll : Int32 = 0
+    # Which VISUAL row of line `scroll` sits on the pane's top line. Always 0 without wrap.
+    #
+    # The pair is the anchor rather than a flat visual-row index for the reason `Wrap`'s header
+    # gives: a flat index can only be produced by wrapping every line from the top of the
+    # document, an O(document) pass on every width change over bodies that reach multiple MB.
+    # Every walk below is O(the rows it is asked to move).
+    getter scroll_sub : Int32 = 0
     # Horizontal offset in display columns (⇧←/→). Clamped by `render` to the widest row on
-    # screen, so a pane whose long line scrolls off can always be scrolled back.
+    # screen, so a pane whose long line scrolls off can always be scrolled back. Pinned at 0
+    # for good on a wrapping pane — there is nothing off to the side of a wrapped row.
     getter xscroll : Int32 = 0
     # Interior height of the last `render`. `0` before the first frame — every gesture that
     # needs a viewport (page, wheel) is inert until then, which is what the panes did already.
     getter last_h : Int32 = 0
+    # Content width (past the gutter) of the last `render`. The wrap mappings that run OUTSIDE
+    # render — a caret step, a wheel notch, `at_top?` — all need it, and guessing one would put
+    # the caret on a different row than the draw did.
+    getter last_cw : Int32 = 0
+    # The rows `render` last laid down, for a caller that needs to invert the draw.
+    getter last_rows : Array(Wrap::Row) = [] of Wrap::Row
 
     @size = 0
     @line_at : (Int32 -> String) = ->(_i : Int32) { "" }
@@ -60,16 +81,35 @@ module Gori::Tui
     # but a selection is always whole lines and a double-click takes nothing. For a pane whose
     # screen row is not one run of text — the Comparer draws TWO columns per row — a char
     # rectangle would address cells that are not next to each other on screen.
-    def initialize(*, @gutter : Bool = false, @line_select_only : Bool = false)
+    #
+    # `wrap` turns on Burp-style soft wrap: a line too wide for the pane spills onto
+    # continuation rows and the line number rides the first of them. It is opt-in, and it is
+    # mutually exclusive with the `viewport_top` self-drawing shape below — those panes place
+    # their own rows from a logical line index, so a wrapped anchor would name a row they never
+    # draw. Every pane that calls `render` should take it; the four that self-draw must not.
+    def initialize(*, @gutter : Bool = false, @line_select_only : Bool = false,
+                   @wrap : Bool = false)
       @cursor = ReadCursor.new
+      # Per-line wrap memo, keyed on the content width it was built for. Dropped by `source`
+      # (the content is different text now) and by a width change.
+      @wrap_cache = {} of Int32 => Wrap::Layout
+      @wrap_w = -1
     end
 
     # Point the pane at its text. Call this when the CONTENT changes (a recompute, a new
     # selection in the list above, a mode flip), not every frame: it is the one place the
     # caret's bounds come from, and `reset_cursor` is how a pane says "this is different text".
+    #
+    # It also drops the wrap memo, which is why "not every frame" is worth more than style here:
+    # a pane that re-points itself each frame re-wraps its visible window each frame. That is
+    # still correct and still bounded by the viewport — the three panes that do it hold a URL
+    # list, a callback dump and a preview sample — but the two that can hold megabytes (the
+    # Decoder output, the Intercept preview) call this only when the bytes actually change, and
+    # they are the ones the memo is for.
     def source(size : Int32, line_at : Int32 -> String) : Nil
       @size = {size, 0}.max
       @line_at = line_at
+      drop_wrap_cache
     end
 
     def source(lines : Array(String)) : Nil
@@ -93,7 +133,9 @@ module Gori::Tui
     def reset : Nil
       @cursor.reset
       @scroll = 0
+      @scroll_sub = 0
       @xscroll = 0
+      drop_wrap_cache
     end
 
     # --- keyboard -------------------------------------------------------------
@@ -105,7 +147,16 @@ module Gori::Tui
         # selecting branch parking the caret at EOL, which only produced a line selection
         # going DOWN and from column 0 — see `ReadCursor#move`. `extend_lines` sets both
         # boundary columns by direction, so ⇧↑ selects whole lines too.
+        #
+        # This arm is checked FIRST, and it never wraps: a `line_select_only` pane draws its
+        # own rows through `viewport_top`, so `wrapping?` is false there by construction.
         @cursor.extend_lines(dr, @size, @line_at)
+      elsif dr != 0 && (target = visual_row_target(dr))
+        # ↑/↓ step one VISUAL row under wrap, matching what the arrow does in every other
+        # wrapped pane. Stepping a logical LINE would jump the caret over every continuation
+        # row the pane is drawing between one line number and the next — rows that are on
+        # screen and that nothing but this arrow could reach.
+        @cursor.move_to(target[0], target[1], selecting: selecting && !@line_select_only)
       else
         @cursor.move(dr, dc, @size, @line_at, selecting: selecting && !@line_select_only)
       end
@@ -114,6 +165,15 @@ module Gori::Tui
 
     # Home / End / PageUp / PageDown, with ⇧ extending. Returns false when `ev` is none of
     # them, so a caller can fall through to its own keymap.
+    #
+    # Home/End are LOGICAL line ends, not visual row ends — matching `TextArea#home` /
+    # `#end_of_line`, so the two modes of a pane that has both agree. On a wrapped line that
+    # means End lands on its LAST row and Home on its first, and the shared `ensure_visible`
+    # below scrolls the anchor to whichever visual row the caret ended up on.
+    #
+    # The two page arms `return true` early ON PURPOSE: they go through `move`, which already
+    # ran `ensure_visible` (and, on a wrapping pane, paged by DRAWN rows rather than logical
+    # lines — the reason ↑/↓ step visual rows too). Falling through would run it twice.
     def motion_key(ev : Termisu::Event::Key) : Bool
       return false if empty?
       key = ev.key
@@ -122,8 +182,8 @@ module Gori::Tui
       case
       when key.home?      then @cursor.move_to(@cursor.cy, 0, selecting: shift)
       when key.end?       then @cursor.move_to(@cursor.cy, line(@cursor.cy.clamp(0, @size - 1)).size, selecting: shift)
-      when key.page_up?   then @cursor.move(-page, 0, @size, @line_at, selecting: shift)
-      when key.page_down? then @cursor.move(page, 0, @size, @line_at, selecting: shift)
+      when key.page_up?   then move(-page, 0, selecting: shift); return true
+      when key.page_down? then move(page, 0, selecting: shift); return true
       else                     return false
       end
       ensure_visible
@@ -168,7 +228,12 @@ module Gori::Tui
     # into the window BEFORE `cx` is measured, so the column is measured against the line the
     # caret lands on — the `IndexError` `FuzzerView#detail_scroll_view` documents.
     def scroll_view(step : Int32) : Nil
-      return if @last_h <= 0 || @size <= @last_h
+      return if @last_h <= 0
+      if wrapping?
+        scroll_view_wrapped(step)
+        return
+      end
+      return if @size <= @last_h
       @scroll = (@scroll + step).clamp(0, @size - @last_h)
       lo = @scroll
       hi = {@scroll + @last_h - 1, @size - 1}.min
@@ -177,14 +242,23 @@ module Gori::Tui
     end
 
     # ⇧←/→. Floored at 0 here; `render` clamps the upper bound to the widest row on screen.
+    # Inert on a wrapping pane: nothing sits off to the side of a wrapped row, and a stored
+    # offset the renderer no longer reads would only fight the clamp every frame.
     def hscroll(step : Int32) : Nil
+      return if @wrap
       @xscroll = {@xscroll + step * 4, 0}.max
     end
 
     # At the top of the pane — the test a controller uses to decide whether ↑ should leave for
     # the pane above rather than move the caret.
+    #
+    # Under wrap that is the first VISUAL row, not the first logical line: a caret three rows
+    # into a wrapped line 0 still has three rows above it inside this pane, and stealing its ↑
+    # would make exactly those rows unreachable from the keyboard.
     def at_top? : Bool
-      @scroll <= 0 && @cursor.cy <= 0
+      return false unless @scroll <= 0 && @scroll_sub <= 0 && @cursor.cy <= 0
+      return true unless wrapping?
+      layout_of(0, @last_cw).row_of(@cursor.cx) == 0
     end
 
     # --- mouse ----------------------------------------------------------------
@@ -193,16 +267,26 @@ module Gori::Tui
     # `selecting` is the drag half: the anchor stays where the press left it.
     def click(rect : Rect, mx : Int32, my : Int32, selecting : Bool = false) : Nil
       return if empty? || rect.empty?
-      # A drag that has left the pane through the TOP scrolls the view up under it, one line
-      # per motion report, so a selection can be grown past the first visible row. Downward
-      # already worked — `click_to_cursor` puts the caret past the window's last row and
-      # `ensure_visible` follows it — while upward pinned to row 0 and stopped there, so a
-      # range taller than the pane could only ever be dragged in one direction. `@scroll` is
-      # moved DIRECTLY rather than through `scroll_view`, which ends by pulling the caret into
-      # the window and would undo the placement two lines below.
+      # A drag that has left the pane through the TOP scrolls the view up under it, one row per
+      # motion report, so a selection can be grown past the first visible row. Downward already
+      # worked — the hit test puts the caret past the window's last row and `ensure_visible`
+      # follows it — while upward pinned to row 0 and stopped there, so a range taller than the
+      # pane could only ever be dragged in one direction. The anchor is moved DIRECTLY rather
+      # than through `scroll_view`, which ends by pulling the caret into the window and would
+      # undo the placement two lines below.
+      #
+      # Under wrap the step is in VISUAL rows, walked through the anchor: `@scroll + row` is a
+      # logical line index, and on a wrapped pane that skips a whole line's worth of rows per
+      # motion report instead of one.
       row = my - rect.y
-      @scroll = {@scroll + row, 0}.max if row < 0 && selecting
-      @cursor.click_to_cursor(rect, mx, my, @scroll, @size, @line_at, gutter_w(rect), @xscroll, selecting)
+      if row < 0 && selecting
+        if wrapping?
+          @scroll, @scroll_sub = Wrap.step_back(@scroll, @scroll_sub, -row, layout_fn(@last_cw))
+        else
+          @scroll = {@scroll + row, 0}.max
+        end
+      end
+      place_caret_at(rect, mx, my, selecting)
       # A line-select pane has no meaningful column, so a drag there grows whole lines — from
       # the row the PRESS landed on. It used to call `select_line`, which re-anchors at the
       # caret's own row: every motion event destroyed the press anchor, so dragging across
@@ -215,9 +299,51 @@ module Gori::Tui
     # there is no single run of text under the pointer to take.
     def select_word(rect : Rect, mx : Int32, my : Int32) : Bool
       return false if empty? || rect.empty? || @line_select_only
-      took = @cursor.select_word_at(rect, mx, my, @scroll, @size, @line_at, gutter_w(rect), @xscroll)
+      # The hit test is `place_caret_at`'s, not `ReadCursor#select_word_at`'s: that one resolves
+      # the row as `scroll + row`, which on a wrapping pane names a line that is not drawn
+      # there — so a double-click on a continuation row took a word out of the wrong line.
+      place_caret_at(rect, mx, my, false)
+      took = @cursor.select_word_at_cursor(@size, @line_at)
       ensure_visible
       took
+    end
+
+    # The caret half of both mouse gestures. Without wrap this is `ReadCursor`'s own hit test;
+    # with it, the row list the draw laid down is inverted instead.
+    private def place_caret_at(rect : Rect, mx : Int32, my : Int32, selecting : Bool) : Nil
+      gw = gutter_w(rect)
+      unless wrapping?
+        @cursor.click_to_cursor(rect, mx, my, @scroll, @size, @line_at, gw, @xscroll, selecting)
+        return
+      end
+      row = my - rect.y
+      # A drag above the pane pins to its first visible row (the pointer left the top edge with
+      # the button down); a plain click there belongs to whatever is drawn above.
+      if row < 0
+        return unless selecting
+        row = 0
+      end
+      # Rebuilt from the same rect and the same anchor `render` used rather than read off
+      # `last_rows`, so the mapping also holds for a click that arrives before the first frame
+      # and there is exactly one definition of where a row begins.
+      rows = visible_rows({rect.w - gw, 0}.max, rect.h)
+      return if rows.empty?
+      vr = rows[row]? || rows[rows.size - 1]
+      # `Wrap.row_index` is the exact inverse of `Wrap.row_col`, the measure the draw, the
+      # caret and the band all share — so a click lands on the cell the caret would paint, on
+      # a continuation row as much as on a first one. It clamps to the row's own end, so a
+      # click past the text of a wrapped row stops at the break instead of running into the
+      # next row's characters.
+      #
+      # `nearest: true` because this is a POINTER: it rounds to the closer edge of the cluster
+      # the column lands in, so the right half of a wide glyph resolves to the position AFTER
+      # it. Without it half of every pointer position over CJK or Hangul lands a character
+      # short. Same rule the unwrapped branch gets from `Screen.column_for_click`, and the same
+      # one `TextArea#click_to_cursor` passes; the caret's own ↓ deliberately does not (a goal
+      # column rounded up drifts one glyph right per row).
+      @cursor.move_to(vr.li,
+        Wrap.row_index(line(vr.li), nil, vr.a, vr.b, mx - (rect.x + gw), nearest: true),
+        selecting: selecting)
     end
 
     # --- render ---------------------------------------------------------------
@@ -229,7 +355,9 @@ module Gori::Tui
     # text — so they call this where `render` would have gone, then read `scroll` and `cursor` to
     # place their own rows and their own band.
     #
-    # Returns the first visible line, which is what such a painter loops from.
+    # Returns the first visible line, which is what such a painter loops from. A pane on this
+    # path must not enable `wrap`: it maps a logical line index straight onto a screen row, and
+    # under wrap that mapping is exactly the one that stops holding.
     def viewport_top(h : Int32) : Int32
       @last_h = h
       @scroll = @scroll.clamp(0, {@size - h, 0}.max)
@@ -255,51 +383,112 @@ module Gori::Tui
                styled_at : (Int32 -> Highlight::Line)? = nil,
                fg : Color = Theme.text, bg : Color = Theme.bg) : Nil
       return if rect.empty?
-      viewport_top(rect.h)
+      @last_h = rect.h
       gw = gutter_w(rect)
       cw = {rect.w - gw, 0}.max
+      @last_cw = cw
+      clamp_anchor(cw, rect.h)
       ensure_visible if focused
 
-      shown = (0...rect.h).compact_map { |i| (li = @scroll + i) < @size ? li : nil }
-      # draw_width_upto, not display_width: these rows go out through `screen.text` /
-      # `Highlight.draw`, which advance ≥1 cell per grapheme. A control byte scores 0 on the raw
-      # measure, which used to pin the clamp short and leave the tail of such a line
-      # unreachable. `_upto` keeps the per-frame early exit on a huge single line.
-      widest = shown.max_of? { |li| Screen.draw_width_upto(@line_at.call(li), @xscroll + cw + 1) } || 0
-      @xscroll = @xscroll.clamp(0, {widest - cw, 0}.max)
-
+      rows = visible_rows(cw, rect.h)
+      @last_rows = rows
+      clamp_xscroll(rows, cw)
       # Built ONCE per frame rather than per row: this used to sit inside the per-row chrome
       # painter in two of the panes, i.e. rebuilt and thrown away `rect.h` times.
       spans = focused && @cursor.selection? ? @cursor.highlight_spans(@size, @line_at) : nil
-      shown.each_with_index do |li, i|
-        y = rect.y + i
-        plain = @line_at.call(li)
-        Gutter.draw(screen, rect.x, y, li, gw, current: focused && li == @cursor.cy) if gw > 0
-        if styled_at
-          sl = styled_at.call(li)
-          sl = Highlight.slice_left(sl, @xscroll) if @xscroll > 0
-          Highlight.draw(screen, rect.x + gw, y, sl, bg: bg, width: cw)
-        else
-          text = @xscroll > 0 ? Highlight.slice_left_text(plain, @xscroll) : plain
-          screen.text(rect.x + gw, y, text, fg, bg, width: cw)
+      # `line_at` is called once per LOGICAL line, not once per drawn row: a wrapped line can
+      # fill the whole viewport, and materialising it per row would multiply the cost of the one
+      # case wrap exists to display.
+      cached_li = -1
+      cached_line = ""
+      rows.each_with_index do |vr, i|
+        if vr.li != cached_li
+          cached_li = vr.li
+          cached_line = @line_at.call(vr.li)
         end
-        paint_chrome(screen, rect.x + gw, y, li, plain, spans, focused, cw)
+        draw_row(screen, rect, rect.y + i, vr, cached_line, gw, cw, focused, styled_at, fg, bg)
+        paint_chrome(screen, rect.x + gw, rect.y + i, vr, cached_line, spans, focused, cw)
       end
+      # The gauge stays in LOGICAL lines under wrap — a deliberate approximation, matching
+      # `TextArea#render`: it is a proportion indicator, not a coordinate.
       Frame.scroll_gauge(screen, rect, @size, @scroll, focused, bg: bg)
     end
 
+    # The vertical anchor, clamped to the text: a plain line index without wrap, the
+    # `(line, sub-row)` pair with it.
+    private def clamp_anchor(cw : Int32, h : Int32) : Nil
+      if wrapping?
+        @xscroll = 0 # `wrap` has no sideways — pinned here as well as in `hscroll`
+        clamp_wrapped_anchor(cw, h)
+      else
+        @scroll = @scroll.clamp(0, {@size - h, 0}.max)
+      end
+    end
+
+    # The h-scroll ceiling: the widest row currently on screen, so a pane whose long line
+    # scrolled off can always be scrolled back. Inert under wrap (nothing is off to the side).
+    #
+    # draw_width_upto, not display_width: these rows go out through `screen.text` /
+    # `Highlight.draw`, which advance ≥1 cell per grapheme. A control byte scores 0 on the raw
+    # measure, which used to pin the clamp short and leave the tail of such a line unreachable.
+    # `_upto` keeps the per-frame early exit on a huge single line.
+    private def clamp_xscroll(rows : Array(Wrap::Row), cw : Int32) : Nil
+      return if wrapping?
+      widest = rows.max_of? { |vr| Screen.draw_width_upto(@line_at.call(vr.li), @xscroll + cw + 1) } || 0
+      @xscroll = @xscroll.clamp(0, {widest - cw, 0}.max)
+    end
+
+    # One drawn row: its gutter cell and its slice of `plain`, coloured through `styled_at` when
+    # the caller supplied one. The chrome (band + caret) goes over the top of it separately.
+    private def draw_row(screen : Screen, rect : Rect, y : Int32, vr : Wrap::Row, plain : String,
+                         gw : Int32, cw : Int32, focused : Bool,
+                         styled_at : (Int32 -> Highlight::Line)?, fg : Color, bg : Color) : Nil
+      if gw > 0
+        # The line number rides the FIRST visual row of a logical line and nothing else (Burp
+        # style). A continuation row gets a blank of the same width rather than no write at all,
+        # so the text column stays put and no stale digits survive there.
+        if vr.sub == 0
+          Gutter.draw(screen, rect.x, y, vr.li, gw, current: focused && vr.li == @cursor.cy)
+        else
+          screen.text(rect.x, y, " " * {gw - 1, 0}.max, Theme.muted, width: gw)
+        end
+      end
+      whole = vr.a == 0 && vr.b >= plain.size
+      if styled_at
+        sl = styled_at.call(vr.li)
+        # Char offsets, not columns: `Wrap::Layout` decided the break by walking clusters and
+        # handed back char indices, so slicing by column here would re-derive it with a second
+        # measure — and the colours would land off the glyphs they belong to.
+        sl = Highlight.slice_chars(sl, vr.a, vr.b) unless whole
+        sl = Highlight.slice_left(sl, @xscroll) if @xscroll > 0
+        Highlight.draw(screen, rect.x + gw, y, sl, bg: bg, width: cw)
+      else
+        text = whole ? plain : plain[vr.a...vr.b]
+        text = Highlight.slice_left_text(text, @xscroll) if @xscroll > 0
+        screen.text(rect.x + gw, y, text, fg, bg, width: cw)
+      end
+    end
+
     # The selection band + the block caret for one drawn row, over whatever the base draw put
-    # there. Both measure the PLAIN line with `Screen.draw_width`, which is what `screen.text`
-    # and `Highlight.draw` advance by — so the tint covers the glyphs it addresses.
-    private def paint_chrome(screen : Screen, x : Int32, y : Int32, li : Int32, plain : String,
+    # there. Both measure the PLAIN line with `Wrap.row_col`, which is what `screen.text` and
+    # `Highlight.draw` advance by — so the tint covers the glyphs it addresses.
+    private def paint_chrome(screen : Screen, x : Int32, y : Int32, vr : Wrap::Row, plain : String,
                              spans : Array({Int32, Int32, Int32})?, focused : Bool, cw : Int32) : Nil
       return unless focused
+      # Each span is clipped to the ROW, so a selection crossing a wrap break tints to the end
+      # of one row and resumes on the next; clipped to the LINE it would be painted once, at
+      # the first row's columns, and the rest would read as unselected.
       spans.try &.each do |(l, x0, x1)|
-        paint_span_bg(screen, x, y, plain, x0, x1, cw) if l == li
+        next unless l == vr.li
+        paint_span_bg(screen, x, y, plain, {x0, vr.a}.max, {x1, vr.b}.min, vr.a, cw)
       end
-      return unless li == @cursor.cy
+      return unless vr.li == @cursor.cy
       cx = @cursor.cx.clamp(0, plain.size)
-      px = x + Screen.draw_width(plain[0, cx]) - @xscroll
+      # The caret belongs to exactly one row: the one whose slice contains it, with the end of
+      # a wrapped row losing to the row it starts (`Wrap::Layout#row_of`'s rule, spelled out
+      # here because `ReadCursor` holds no layout of its own).
+      return unless cx >= vr.a && (cx < vr.b || vr.b >= plain.size)
+      px = x + Wrap.row_col(plain, nil, vr.a, cx) - @xscroll
       return if px < x || px >= x + cw
       ch = cx < plain.size ? plain[cx] : ' '
       screen.cell(px, y, ch, Theme.bg, Theme.accent_bg)
@@ -310,12 +499,16 @@ module Gori::Tui
     # CHARS is the retired per-codepoint measure: it drifts right by each cluster's inflation
     # (1 column for a skin tone, 9 for a ZWJ family) and drawing char-by-char also shreds a
     # cluster across cells. Span edges snap outward so the tint covers whole glyphs.
+    #
+    # `row_start` is the char index the drawn row begins at — 0 for an unwrapped line, the wrap
+    # break for a continuation row. Columns are measured from THERE, so a tint on a
+    # continuation row starts at the pane's left edge like the text it covers.
     private def paint_span_bg(screen : Screen, x : Int32, y : Int32, plain : String,
-                              x0 : Int32, x1 : Int32, cw : Int32) : Nil
+                              x0 : Int32, x1 : Int32, row_start : Int32, cw : Int32) : Nil
       return if x0 >= x1
       a = Screen.cluster_start(plain, {x0, plain.size}.min)
       b = Screen.cluster_end(plain, {x1, plain.size}.min)
-      px = x + Screen.draw_width(plain[0, a]) - @xscroll
+      px = x + Wrap.row_col(plain, nil, row_start, a) - @xscroll
       i = a
       while i < b
         e = Screen.cluster_end(plain, i + 1)
@@ -334,6 +527,13 @@ module Gori::Tui
     # Keep the caret's line inside the window. Selection-follow, like every list in the tree.
     private def ensure_visible : Nil
       return if @last_h <= 0
+      if wrapping?
+        cw = @last_cw
+        @scroll = @scroll.clamp(0, {@size - 1, 0}.max)
+        csub = layout_of(@cursor.cy, cw).row_of(@cursor.cx)
+        @scroll, @scroll_sub = Wrap.ensure_visible(@scroll, @scroll_sub, @cursor.cy, csub, @last_h, layout_fn(cw))
+        return
+      end
       cy = @cursor.cy
       if cy < @scroll
         @scroll = cy
@@ -341,6 +541,108 @@ module Gori::Tui
         @scroll = cy - @last_h + 1
       end
       @scroll = @scroll.clamp(0, {@size - @last_h, 0}.max)
+    end
+
+    # --- soft-wrap layout ------------------------------------------------------
+    # Everything below is inert (or trivially one-row-per-line) while `wrap` is off.
+
+    # Wrap is only meaningful once a render has told us how wide the content column is — every
+    # mapping outside render needs that width, and guessing one would put the caret on a
+    # different row than the draw did.
+    private def wrapping? : Bool
+      @wrap && @last_cw > 0 && @size > 0
+    end
+
+    private def drop_wrap_cache : Nil
+      @wrap_cache.clear
+      @wrap_w = -1
+    end
+
+    # The wrap of line `li` at content width `cw`, memoized on (content, cw). See `source` for
+    # what invalidates it and why the invalidation is the caller's to time.
+    private def layout_of(li : Int32, cw : Int32) : Wrap::Layout
+      if @wrap_w != cw
+        @wrap_cache.clear
+        @wrap_w = cw
+      end
+      if hit = @wrap_cache[li]?
+        return hit
+      end
+      @wrap_cache.clear if @wrap_cache.size >= WRAP_CACHE_CAP
+      @wrap_cache[li] = Wrap.layout(line(li), cw)
+    end
+
+    private def layout_fn(cw : Int32) : Int32 -> Wrap::Layout
+      ->(i : Int32) { layout_of(i, cw) }
+    end
+
+    # The rows the pane shows, top to bottom. Without wrap this is the identity it always was:
+    # one row per logical line from `@scroll`, `sub` 0, the whole line.
+    private def visible_rows(cw : Int32, h : Int32) : Array(Wrap::Row)
+      unless wrapping?
+        rows = Array(Wrap::Row).new({h, 0}.max)
+        return rows if h <= 0
+        (0...h).each do |i|
+          li = @scroll + i
+          break if li >= @size
+          rows << Wrap::Row.new(li, 0, 0, line(li).size)
+        end
+        return rows
+      end
+      @scroll = @scroll.clamp(0, @size - 1)
+      Wrap.rows(@scroll, @scroll_sub, h, @size, layout_fn(cw))
+    end
+
+    # The wrapped equivalent of clamping `@scroll` to `size - h`: refuse an anchor further down
+    # than the one that puts the buffer's LAST visual row on the pane's bottom line. Found by
+    # walking back one viewport from that row, so it costs O(h) and never counts the document.
+    private def clamp_wrapped_anchor(cw : Int32, h : Int32) : Nil
+      @scroll = @scroll.clamp(0, @size - 1)
+      mli, msub = Wrap.max_anchor(@size, h, layout_fn(cw))
+      if @scroll > mli || (@scroll == mli && @scroll_sub > msub)
+        @scroll = mli
+        @scroll_sub = msub
+      end
+    end
+
+    # Wheel under soft wrap: `step` is VISUAL rows, so one notch moves one drawn row even when
+    # that row is the middle of a wrapped line. The anchor walks; nothing counts the buffer's
+    # total rows.
+    private def scroll_view_wrapped(step : Int32) : Nil
+      cw = @last_cw
+      return if cw <= 0
+      fn = layout_fn(cw)
+      @scroll, @scroll_sub = if step < 0
+                               Wrap.step_back(@scroll, @scroll_sub, -step, fn)
+                             else
+                               Wrap.step_forward(@scroll, @scroll_sub, step, @size, fn)
+                             end
+      clamp_wrapped_anchor(cw, @last_h)
+      # Pull the caret into the new window so `render`'s `ensure_visible` doesn't snap the view
+      # straight back (mirrors the unwrapped branch). The comparison has to be in VISUAL rows: a
+      # caret on line 0 is "inside" a window starting at row 3 of line 0 only by logical-line
+      # arithmetic, and that arithmetic is what made the wheel fight `ensure_visible` to a halt.
+      rows = visible_rows(cw, @last_h)
+      return if rows.empty?
+      first = rows[0]
+      last = rows[rows.size - 1]
+      cy, cx = @cursor.cy, @cursor.cx
+      if cy < first.li || (cy == first.li && cx < first.a)
+        cy, cx = first.li, first.a
+      elsif cy > last.li || (cy == last.li && layout_of(last.li, cw).row_of(cx) > last.sub)
+        cy, cx = last.li, last.a
+      end
+      @cursor.sync(cy, cx.clamp(0, line(cy).size))
+    end
+
+    # Where the caret would land `dr` VISUAL rows away, or nil when this pane has nothing to
+    # wrap (soft wrap off, or no render has measured the content width yet) — in which case a
+    # visual row IS a logical line and the caller's plain step is already right.
+    private def visual_row_target(dr : Int32) : {Int32, Int32}?
+      return nil unless wrapping?
+      return nil if dr == 0
+      cw = @last_cw
+      Wrap.step_caret(@cursor.cy, @cursor.cx, dr, @size, @line_at, layout_fn(cw))
     end
   end
 end

--- a/src/gori/tui/repeater_view.cr
+++ b/src/gori/tui/repeater_view.cr
@@ -4402,50 +4402,16 @@ module Gori::Tui
       paint_request_read_chrome(screen, inner, @editor, focused && !ins)
     end
 
-    # READ-mode over-paint (selection tint + block caret) on top of the frame the editor
-    # just drew. It inverts `TextArea#last_rows` — the rows that were ACTUALLY laid down —
-    # rather than re-deriving `line - scroll`: under soft wrap a screen row is no longer a
-    # logical line, and the two derivations drifting apart is precisely how a selection ends
-    # up tinting the wrong text. Every span is clipped to its row, so a selection crossing a
-    # wrap break is painted on each row it covers.
+    # READ-mode over-paint (selection tint + block caret) on top of the frame the editor just
+    # drew — `TextReadState#paint_chrome`, which carries the reasoning for every line of it.
+    #
     # `ed` is passed in rather than read from `req_editor`: the caller knows which card it is
     # drawing, and a split column has two. Deriving it here meant that painting the DECODED
     # card while the ENVELOPE was the active sub-pane would invert the ENVELOPE's `last_rows`
-    # into the DECODED rect — the exact "two derivations drifting apart" this method's own
-    # comment warns about, one level up. The `active` gate happens to make that unreachable
-    # today; the parameter makes it unrepresentable.
+    # into the DECODED rect — two derivations of the same rows, drifting apart. The `active`
+    # gate happens to make that unreachable today; the parameter makes it unrepresentable.
     private def paint_request_read_chrome(screen : Screen, rect : Rect, ed : TextArea, active : Bool) : Nil
-      return unless active
-      lines = ed.lines_snapshot
-      return if lines.empty?
-      @req_read.sync_from(ed)
-      rows = ed.last_rows
-      return if rows.empty?
-      gw = ed.gutter? ? Gutter.width(lines.size) : 0
-      cw = {rect.w - gw, 0}.max
-      spans = @req_read.cursor.highlight_spans(lines)
-      cy, cx = ed.cy, ed.cx
-      rows.each_with_index do |vr, row|
-        y = rect.y + row
-        line = lines[vr.li]? || ""
-        # The band and the caret both go through the EDITOR, which owns the concealed-run map:
-        # `§value¦chain§` hides the `¦chain` in this very pane, and measuring the span here on the
-        # raw line put the tint N columns right of its text while re-drawing the raw segment
-        # unconcealed the chain (see the READ-mode over-paint seam in `text_area.cr`).
-        spans.each do |(li, x0, x1)|
-          next unless li == vr.li
-          ed.paint_read_band(screen, rect.x + gw, y, li, x0, x1, vr.a, vr.b, cw)
-        end
-        # The caret belongs to exactly one row: the one whose slice contains it, with the
-        # end of a wrapped row losing to the row it starts (Wrap::Layout#row_of's rule,
-        # spelled out here because ReadCursor holds no layout of its own).
-        next unless vr.li == cy && cx >= vr.a && (cx < vr.b || vr.b >= line.size)
-        col, ch = ed.read_caret_cell(vr.li, cx, vr.a)
-        px = rect.x + gw + col
-        next unless px < rect.x + rect.w
-        screen.cell(px, y, ch, Theme.bg, Theme.accent_bg)
-        screen.cursor(px, y)
-      end
+      @req_read.paint_chrome(screen, rect, ed, active)
     end
 
     # `row_start` is the char index the drawn row begins at — 0 for an unwrapped line, the

--- a/src/gori/tui/runner/issues.cr
+++ b/src/gori/tui/runner/issues.cr
@@ -143,10 +143,6 @@ class Gori::Tui::Runner < Gori::Verb::ExecContext
     issues_controller.issues_copy_all
   end
 
-  def issue_hscroll(delta : Int32) : Nil
-    issues_controller.issue_hscroll(delta)
-  end
-
   # Re-open the create form seeded from the open issue (title + severity), in
   # edit mode — commit updates instead of inserting (create_issue_from_form).
   # Stays in the shell: it opens the issue-form OVERLAY (shell-owned).

--- a/src/gori/tui/text_area.cr
+++ b/src/gori/tui/text_area.cr
@@ -1756,9 +1756,9 @@ module Gori::Tui
     # drift the tint left of the cells). Multi-line regions clamp to [0, line.size): first
     # line tints col→EOL, fully-covered lines 0→size, last line BOL→col; the '\n' offset
     # has no cell. Region columns are computed against the FULL (unscrolled) line, then
-    # shifted left by @xscroll and clipped to the visible window — a no-op when
-    # @xscroll == 0 (the common case, since only the Fuzzer template sets bg_regions and
-    # it doesn't enable follow_x).
+    # shifted left by @xscroll and clipped to the visible window — always a no-op today, since
+    # the only editors that set bg_regions (the Fuzzer template, the Repeater request pane)
+    # soft-wrap, and `wrap=` pins @xscroll at 0 for good.
     #
     # `rs`/`re` bound the VISUAL ROW being painted: the whole line without wrap, one wrapped
     # slice of it with. A region is clipped to the row, so a marker that spans a wrap break

--- a/src/gori/tui/text_read_state.cr
+++ b/src/gori/tui/text_read_state.cr
@@ -1,5 +1,6 @@
 require "./read_cursor"
 require "./text_area"
+require "./gutter"
 
 module Gori::Tui
   # Read-mode navigation + selection for a TextArea (shared by Repeater, Fuzzer, Notes, …).
@@ -8,6 +9,61 @@ module Gori::Tui
 
     def initialize
       @cursor = ReadCursor.new
+    end
+
+    # --- the READ-mode over-paint ----------------------------------------------
+    # The NORMAL-mode selection band + block caret, drawn on top of the frame the editor just
+    # laid down. It lives HERE because all five owners of a read-mode editor — the Repeater's
+    # request pane, the Fuzzer template, Notes, an Issue's notes, the Project description —
+    # had grown their own copy of exactly this loop, and the copies had already drifted: two
+    # measured the band on the raw line (blind to the concealed `¦chain` runs, see the
+    # READ-mode over-paint seam in `text_area.cr`), one omitted the `sync_from` the other four
+    # carry against a peer edit shrinking the buffer under a stale cursor, and every one of
+    # them derived the screen row as `li - editor.scroll`.
+    #
+    # That last sum is what soft wrap retires. A wrapped logical line is N drawn rows, so
+    # `li - scroll` names the row the line STARTS on and paints every one of its rows there —
+    # the band and the caret drifting further off with each wrap above them. `last_rows` is
+    # the row list the editor ACTUALLY drew, so inverting it cannot disagree with the draw.
+    #
+    # `rect` must be the same interior the editor was rendered into. Both the band and the
+    # caret go through the EDITOR (`paint_read_band` / `read_caret_cell`), which owns the
+    # concealed-run map and the column measure the base draw advanced by.
+    def paint_chrome(screen : Screen, rect : Rect, editor : TextArea, active : Bool = true) : Nil
+      return unless active
+      lines = editor.lines_snapshot
+      return if lines.empty?
+      # Before painting, not after: a peer edit (a 2nd session, an MCP `update_note`, `^E`'s
+      # external editor) can reload a shorter buffer, which re-clamps the EDITOR's caret and
+      # deliberately leaves this cursor alone — a stale `cy` past the new end then indexes
+      # off the end of `lines` and takes the whole render down.
+      sync_from(editor)
+      rows = editor.last_rows
+      return if rows.empty?
+      gw = editor.gutter? ? Gutter.width(lines.size) : 0
+      cw = {rect.w - gw, 0}.max
+      spans = @cursor.highlight_spans(lines)
+      cy, cx = editor.cy, editor.cx
+      rows.each_with_index do |vr, row|
+        y = rect.y + row
+        line = lines[vr.li]? || ""
+        # Every span is clipped to its ROW, so a selection crossing a wrap break is tinted to
+        # the end of one row and resumed on the next — clipping to the LINE instead paints it
+        # once, at the first row's columns, and the rest reads as unselected.
+        spans.each do |(li, x0, x1)|
+          next unless li == vr.li
+          editor.paint_read_band(screen, rect.x + gw, y, li, x0, x1, vr.a, vr.b, cw)
+        end
+        # The caret belongs to exactly one row: the one whose slice contains it, with the end
+        # of a wrapped row losing to the row it starts (`Wrap::Layout#row_of`'s rule, spelled
+        # out here because `ReadCursor` holds no layout of its own).
+        next unless vr.li == cy && cx >= vr.a && (cx < vr.b || vr.b >= line.size)
+        col, ch = editor.read_caret_cell(vr.li, cx, vr.a)
+        px = rect.x + gw + col
+        next unless px < rect.x + rect.w
+        screen.cell(px, y, ch, Theme.bg, Theme.accent_bg)
+        screen.cursor(px, y)
+      end
     end
 
     def clear_selection : Nil
@@ -33,9 +89,9 @@ module Gori::Tui
     # "down" means in the one pane that wraps.
     #
     # The destination comes from the editor because the editor owns the wrap layout;
-    # `visual_row_target` is nil for every non-wrapping owner (Notes, the project
-    # description, the Fuzzer template), which then keeps the plain logical step it always
-    # had. Horizontal moves are unaffected: a wrapped row has no sideways.
+    # `visual_row_target` is nil for every non-wrapping owner, which then keeps the plain
+    # logical step it always had. Horizontal moves are unaffected: a wrapped row has no
+    # sideways.
     def move(editor : TextArea, dr : Int32, dc : Int32, selecting : Bool = false) : Nil
       lines = editor.lines_snapshot
       return if lines.empty?

--- a/src/gori/verb/context/issues.cr
+++ b/src/gori/verb/context/issues.cr
@@ -36,11 +36,9 @@ abstract class Gori::Verb::ExecContext
   abstract def issue_set_severity : Nil # open the severity colour picker
   abstract def issue_set_status : Nil   # open the triage-status colour picker
   abstract def issue_edit_notes : Nil
-  abstract def issues_notes_read_mode? : Bool # detail open, notes not in INS (gates y/copy)
-  abstract def issues_copy : Nil              # copy selection from issue notes (READ)
-  abstract def issues_copy_all : Nil          # copy all issue notes (space menu)
-  # Horizontal scroll (shift+←/→) for notes in READ (no-op in INS — follow_x tracks the caret).
-  abstract def issue_hscroll(delta : Int32) : Nil
+  abstract def issues_notes_read_mode? : Bool       # detail open, notes not in INS (gates y/copy)
+  abstract def issues_copy : Nil                    # copy selection from issue notes (READ)
+  abstract def issues_copy_all : Nil                # copy all issue notes (space menu)
   abstract def issue_edit_title : Nil               # rename + set severity via the form overlay
   abstract def issue_open_flow : Nil                # open the linked flow's detail in History
   abstract def issue_repeater_flow : Nil            # send the linked flow to Repeater

--- a/src/gori/verbs/issues.cr
+++ b/src/gori/verbs/issues.cr
@@ -155,15 +155,9 @@ module Gori
         "issue.edit-notes", "Edit notes", "Edit the issue notes inline (i/↵/e)", Verb::Scope::IssuesDetail,
         [Verb::Chord.new("e")]) { |ctx| ctx.issue_edit_notes; nil }
 
-      # Shift+←/→ scroll a long notes line sideways. `issue.close` (registered
-      # above) owns plain ← — a distinct chord (shift: true), so no collision.
-      r.register Verb::Definition.new(
-        "issue.hscroll-right", "Scroll notes right", "Scroll a long notes line right", Verb::Scope::IssuesDetail,
-        [Verb::Chord.new("right", shift: true)], hidden: true) { |ctx| ctx.issue_hscroll(1); nil }
-
-      r.register Verb::Definition.new(
-        "issue.hscroll-left", "Scroll notes left", "Scroll a long notes line left", Verb::Scope::IssuesDetail,
-        [Verb::Chord.new("left", shift: true)], hidden: true) { |ctx| ctx.issue_hscroll(-1); nil }
+      # There is no ⇧←/→ h-scroll pair here any more: the notes pane soft-wraps, so nothing
+      # sits off to the side to scroll to, and `IssuesController#handle_notes_read_key` had
+      # already taken the chord back for the character selection every other text pane gives it.
 
       r.register Verb::Definition.new(
         "issue.delete", "Delete issue", "Delete this issue", Verb::Scope::IssuesDetail,


### PR DESCRIPTION
The Repeater's request pane stopped scrolling sideways in cd2503b1 and the History detail
followed in 5e269e3b: a long header or a minified body wraps, one logical line becomes N
visual rows, and the gutter numbers the FIRST row only. Everything else was left on the old
model. The Fuzzer TEMPLATE — the one pane in the tool where an operator WRITES `§value¦chain§`,
and where the thing off the right edge is the marker whose position IS the payload's insertion
point — was reachable only by driving the caret into it and letting the whole pane slide.

`TextArea` and `Wrap` already had every piece. What this change is really about is that the
flag was the small half.

THE TEMPLATE. `follow_x` out, `wrap = true` in. The one real defect it exposed:
`paint_template_read_chrome` derived its screen row as `li - @editor.scroll`, and that sum
stops being the screen row the moment a line is more than one row — the READ band and the block
caret would have ridden the line's FIRST visual row forever, drifting further off with every
wrap above them. Verified against a live TUI (isolated GORI_HOME, tmux): ⇧→ ×50 from a
continuation row tints columns 7–57 of THAT row and `y` reports `copied 50b`, so the band and
the copy address the same bytes.

FIVE COPIES OF THE SAME LOOP, now one. The Repeater request pane, the Fuzzer template, Notes,
an Issue's notes and the Project description had each grown their own READ-mode over-paint, and
the copies had already drifted three ways: two measured the band on the raw line (blind to the
concealed `¦chain` runs — the seam in `text_area.cr` exists to stop exactly that), Issues
omitted the `sync_from` its four siblings carry against a peer edit shrinking the buffer under a
stale cursor, and all five derived the row as `li - scroll`. `TextReadState#paint_chrome` is the
single implementation; it inverts `TextArea#last_rows`, the rows the editor ACTUALLY drew, so
inverting cannot disagree with the draw. The Repeater was re-pointed at it and re-verified live:
identical band columns, identical `copied 50b`.

`ReadPane` LEARNED TO WRAP, opt-in. One change lights up the Decoder OUTPUT, the Intercept
preview, Probe AFFECTED, the OAST callback detail and the Rewriter PREVIEW OUTPUT. The anchor is
`(scroll, scroll_sub)` — Vim's topline+skipcol, not a flat visual-row index, for the reason
`wrap.cr`'s header gives: a flat index costs an O(document) pass on every width change over
bodies that reach MiB. Arrows step visual rows through `Wrap.step_caret`, the wheel walks the
anchor, `at_top?` measures the first VISUAL row (`DecoderController` pops focus to CHAIN on that
predicate — gated on the logical line, ↑ would abandon the rows it was asked to walk), and the
click inverts the row list the draw laid down instead of `scroll + row`.

It is OPT-IN because four consumers must NOT take it: the Comparer draws two aligned columns per
row and the Miner / Probe / Sequencer details paint label-and-value fields. They go through
`viewport_top` and map a logical line straight onto a screen row, which is precisely the mapping
wrap retires. Wrapping the Comparer would desync its two sides; h-scroll is the correct
affordance there and stays.

THE FUZZER RESULT DETAIL was the third hand-rolled read pane named in `ReadPane`'s own class
comment as one it was extracted to replace, and the last still carrying `@detail_scroll`,
`@detail_xscroll`, `@detail_last_h`, its own `ReadCursor` and its own `ensure_detail_visible`. It
is a `ReadPane` now. `sync_detail_source` compares the lines Array by IDENTITY, not value:
`detail_lines` memoizes on `{pane, r.index}` and `source` drops the wrap memo, so a value
compare would re-wrap the visible window on every keystroke over a body the memo exists to
protect. A stale hit cannot survive a live re-sort — `Fuzz::Result#index` is the run's request
ordinal, handed out once per job by `Generator#emit` — and indices restart at 0 on the next run,
which is what `begin_run` already drops the cache for.

FOUR ⇧←/→ H-SCROLL CHAINS ARE GONE, not kept as no-ops, following 5e269e3b: a stored offset the
renderer no longer reads only fights the clamp every frame. Issues (view, controller, runner, the
abstract def in `verb/context/issues.cr`, two verb registrations, two spec doubles, and the
footer hint that advertised it), the Decoder OUTPUT, the Intercept preview and the Fuzzer RESULT
detail. Two of those hand the chord back to something better: the Decoder OUTPUT and the Fuzzer
detail get the character selection every other text pane has, and the Fuzzer detail had NO way
to select characters at all, plain ←/→ being spoken for by the pane chain.

The Issues chain was already dead: `handle_notes_read_key` had taken ⇧←/→ for the selection, so
the verb only fired with the notes UNFOCUSED, where it moved a caret in a pane the operator was
not in.

SPECS. `fuzzer_wrap_spec.cr` (23) and `read_pane_wrap_spec.cr` (16), in the shape
`repeater_wrap_spec.cr` / `history_wrap_spec.cr` established — one file per wrapped pane,
enumerating the failure modes wrap actually introduces: the numbered first row, the arrow that
steps rows, the click that lands on the row it was drawn on, the band clipped per row, the wide
cluster that survives the break, and the styled overlay sliced on the same grid the plain layout
wrapped at. Both were control-run with wrap disabled — 10/11 and 13/16 fail — so they test the
change rather than passing vacuously. Four pre-existing h-scroll specs were flipped rather than
deleted, each carrying a note on what is still under test; the Decoder's control-byte one is
worth naming, since the tab-measuring hazard it pinned moved from the h-scroll clamp into the
WRAP measure and is pinned there now.

REBASED ONTO #592, which touched the same three files. Its `ReadPane` fixes are carried into the
rewritten one rather than lost to it: `extend_lines` / `extend_lines_to` for the whole-line
gestures (the EOL snap only ever produced a line selection going DOWN, and `select_line`
re-anchored on every motion event so a Comparer drag copied one row), and the upward drag-scroll
— translated to VISUAL rows here, since `@scroll + row` skips a whole line's worth of rows per
motion report on a wrapping pane. The wrapped click path also takes `Wrap.row_index(nearest:
true)`, #592's pointer rounding, because it is a second inverse of the same rule: without it half
of every pointer position over CJK or Hangul lands a character short. That intersection —
rounding on a CONTINUATION row, where columns are measured from the break — is the one thing
neither change covered alone, so it is pinned in `read_pane_wrap_spec.cr`.

