### PR TITLE
A response the origin sent and gori threw away, a scope filter that bound the wrong pattern, and a settings file its own loader overwrote

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,8 +61,9 @@ parity with it, and every parity gap found so far has been in a surface, not an 
     src/gori/{store,probe,fuzz,miner,discover,sequencer,oast}.cr
   ```
 
-  Today that returns exactly one hit, a comment in `src/gori/probe/group.cr`. A comment may
-  point at a caller; code may not.
+  Today that returns four hits, all of them comments: `src/gori/store/models.cr` (×2),
+  `src/gori/probe/group.cr`, `src/gori/fuzz/types.cr`. A comment may point at a caller; code
+  may not — so the check is "every hit is a comment", not a hit count.
 - Every gori-originated request goes through the `Gori::Outbound` chokepoint
   (`src/gori/outbound.cr`). It is a required constructor argument on `Fuzz::Sender` and
   `Repeater::Sender`, so an ungated sender is a compile error. Layer 1 (`check`) is the only

--- a/spec/cookie_spec.cr
+++ b/spec/cookie_spec.cr
@@ -33,12 +33,39 @@ describe Gori::Cookie do
       # Rack's `--<40 hex>` is the strongest signal; check it wins the ordering.
       Gori::Cookie.detect(RACK).should eq("rack")
     end
+
+    it "detects a Flask/Django cookie whose base64url payload contains a '--' run" do
+      # base64url's alphabet includes '-', so two adjacent '-' occur naturally in ~2% of
+      # payloads. Rejecting them as "Rack punctuation" made real cookies undetectable, and
+      # every surface (CLI/MCP/TUI) then aborts with "unrecognized cookie format" — even
+      # when the operator supplies the right secret. Rack is still disambiguated by being
+      # tested first and by its 40-hex tail, which neither of these has.
+      Gori::Cookie.detect("eyJhIjoxfQ--x.am71Yg.gd2MWkbBsGdhg4rScrYWBdGoj-Q").should eq("flask")
+      Gori::Cookie.detect("eyJhIjoxfQ--x:1wqQs6:ofPm07XfGfVUimPfVs9Bdy5M7H0").should eq("django")
+    end
   end
 
   describe "shared helpers" do
     it "base62 round-trips a unix second" do
       Gori::Cookie.base62_encode(1785656674_i64).should eq("1wqQs6")
       Gori::Cookie.base62_decode("1wqQs6").should eq(1785656674_i64)
+    end
+
+    it "base62_decode answers nil (not OverflowError) on a segment past Int64" do
+      # A crafted Django cookie can carry an arbitrarily long timestamp segment. The
+      # accumulator is Int64 and Crystal's arithmetic is overflow-checked, so this used to
+      # raise out of decode_text/decode_json and escape as an unhandled crash. `nil` is the
+      # channel the callers already speak — they render "(invalid base62 …)" — and it is
+      # what the non-base62 character case has always returned. Same contract as the
+      # `unix_to_s` rescue immediately below it in the source.
+      Gori::Cookie.base62_decode("zzzzzzzzzzzzzzzzzzzzzzzz").should be_nil
+      Gori::Cookie.base62_decode("!!!").should be_nil
+    end
+
+    it "decodes a Django cookie carrying an oversized timestamp instead of crashing" do
+      oversized = "eyJhIjoxfQ:zzzzzzzzzzzzzzzzzzzzzzzz:8BooTFI1B28NGHSf42JyGt1Or-0"
+      Gori::Cookie.decode(oversized, "django").should contain("invalid base62")
+      Gori::Cookie.decode_json(oversized, "django").should contain(%("timestamp":null))
     end
 
     it "int_to_b64 is the itsdangerous timestamp codec (plain unix, minimal big-endian)" do

--- a/spec/mcp_spec.cr
+++ b/spec/mcp_spec.cr
@@ -2401,6 +2401,36 @@ describe Gori::MCP::RequestBuilder do
       .should eq("GET /v HTTP/1.1\r\nHost: h.test\r\nX-B: lf\r\n\r\n")
   end
 
+  # An `as_h?`-only read answered nil for every non-object shape and the caller skipped the
+  # loop, so the request went out with ZERO caller headers and still reported success —
+  # discover_start echoes no request at all, so an authenticated crawl could run
+  # unauthenticated with no signal anywhere. Accept the shapes an agent actually sends.
+  it "accepts a stringified headers object" do
+    args = JSON.parse({"url" => "http://h.test/x", "headers" => %({"Authorization":"Bearer T"})}.to_json).as_h
+    String.new(Gori::MCP::RequestBuilder.build(args).bytes).should contain("Authorization: Bearer T\r\n")
+  end
+
+  it "accepts headers as an array of [name, value] pairs" do
+    args = JSON.parse({"url" => "http://h.test/x", "headers" => [["Authorization", "Bearer T"]]}.to_json).as_h
+    String.new(Gori::MCP::RequestBuilder.build(args).bytes).should contain("Authorization: Bearer T\r\n")
+  end
+
+  # BEHAVIOUR CHANGE, pinned deliberately: an unusable `headers` must RAISE, never vanish.
+  # Silently dropping it is what made the bug invisible on both surfaces.
+  it "raises rather than silently dropping an unusable headers value" do
+    ["not-json-at-all", "42"].each do |bad|
+      args = JSON.parse({"url" => "http://h.test/x", "headers" => bad}.to_json).as_h
+      expect_raises(Gori::Error, /headers/) { Gori::MCP::RequestBuilder.build(args) }
+    end
+    args = JSON.parse({"url" => "http://h.test/x", "headers" => [["only-one"]]}.to_json).as_h
+    expect_raises(Gori::Error, /headers/) { Gori::MCP::RequestBuilder.build(args) }
+  end
+
+  it "still treats an absent headers key as no headers" do
+    args = JSON.parse({"url" => "http://h.test/x"}.to_json).as_h
+    String.new(Gori::MCP::RequestBuilder.build(args).bytes).should eq("GET /x HTTP/1.1\r\nHost: h.test\r\n\r\n")
+  end
+
   it "keeps the bare LF byte-exact under verbatim" do
     raw = "GET /v HTTP/1.1\r\nHost: h.test\nX-B: lf\n\r\n"
     args = JSON.parse({"url" => "http://h.test/", "raw" => raw, "verbatim" => true}.to_json).as_h

--- a/spec/probe_spec.cr
+++ b/spec/probe_spec.cr
@@ -3626,6 +3626,18 @@ describe "Gori::Probe::Active::HostHeaderInjection" do
     end
   end
 
+  it "survives a Cache-Control max-age past Int32 (hand-rolled accumulator overflowed)" do
+    # `positive_max_age?` accumulated digits into an Int32 with checked arithmetic, so a
+    # 10-digit delta-seconds (here a 100-year max-age, which RFC 9111 §1.2.2 says to clamp)
+    # raised OverflowError out of `gate`. Nothing rescues between there and the TUI event
+    # loop, so the `A` keypress took the whole process down. No "public" token, so the
+    # `||` cannot short-circuit before the accumulator runs.
+    with_store do |store|
+      detail = capture_flow(store, "HTTP/1.1 200 OK\r\nCache-Control: max-age=3153600000\r\n\r\n", target: "/page")
+      probe.plan(detail).should_not be_nil
+    end
+  end
+
   it "does not fire on a bare mention, a path segment, or a longer hostname" do
     with_store do |store|
       detail = capture_flow(store, "HTTP/1.1 200 OK\r\nCache-Control: public\r\n\r\n", target: "/page")

--- a/spec/repeater/h2_engine_spec.cr
+++ b/spec/repeater/h2_engine_spec.cr
@@ -151,6 +151,35 @@ end
 # A cleartext-h2 origin that sends HEADERS(:status) + one DATA frame WITHOUT
 # END_STREAM, then drops the connection — a truncated response the client must
 # flag as incomplete (no END_STREAM ever arrives).
+# Sibling of `start_h2_origin_truncated` that closes STRICTLY INSIDE a frame rather than on
+# its boundary: it writes a complete HEADERS + DATA, then 5 bytes of a 9-byte frame header
+# and hangs up. `Frame.read` -> `read_exact` answers that with `Gori::Error`, NOT `IO::Error`
+# — so it used to escape both rescue arms and destroy the fully decoded 200 + body. The
+# boundary helper cannot reach this path: there `Frame.read` returns nil.
+private def start_h2_origin_truncated_midframe(status : Int32, partial : String) : Int32
+  origin = TCPServer.new("127.0.0.1", 0)
+  port = origin.local_address.port
+  spawn do
+    next unless conn = origin.accept?
+    conn.read_timeout = 5.seconds
+    Frame.read_preface(conn)
+    send_server_preface(conn)
+    loop do
+      f = Frame.read(conn)
+      break if f.nil?
+      break if f.frame_type.in?(Frame::Type::Headers, Frame::Type::Data) && f.end_stream?
+    end
+    block = HPACK::Encoder.new.encode([{":status", status.to_s}])
+    conn.write(Frame::Header.new(Frame::Type::Headers.value, Frame::END_HEADERS, 1_u32, block).to_bytes)
+    conn.write(Frame::Header.new(Frame::Type::Data.value, 0_u8, 1_u32, partial.to_slice).to_bytes)
+    # A PARTIAL frame header — 5 of the 9 bytes — then close. EOF lands mid-frame.
+    conn.write(Bytes[0, 0, 8, 0, 0])
+    conn.flush
+    conn.close
+  end
+  port
+end
+
 private def start_h2_origin_truncated(status : Int32, partial : String) : Int32
   origin = TCPServer.new("127.0.0.1", 0)
   port = origin.local_address.port
@@ -999,6 +1028,23 @@ describe Gori::Repeater::H2Engine do
 
     receive_within(seen).should eq("GET /f body=")
     result.ok?.should be_true
+  end
+
+  it "keeps a response whose origin hung up MID-FRAME, not just on a frame boundary" do
+    # One wire event used to split three ways: boundary EOF -> kept; RST -> kept; mid-frame
+    # FIN -> everything destroyed, because `Frame.read` raises Gori::Error there and only
+    # IO::Error was rescued. The status and body below plainly arrived, so they must
+    # survive — "a response that arrived keeps its head and body regardless".
+    port = start_h2_origin_truncated_midframe(200, "partial")
+
+    request = "GET /midframe HTTP/2\r\n\r\n".to_slice
+    result = Gori::Repeater::H2Engine.send(request, scheme: "http", host: "127.0.0.1", port: port, verify_upstream: false)
+
+    result.error.should be_nil
+    result.ok?.should be_true
+    result.response.not_nil!.status.should eq(200)
+    String.new(result.body.not_nil!).should eq("partial")
+    result.incomplete?.should be_true # no END_STREAM ever arrived
   end
 
   it "flags an h2 response cut short before END_STREAM as incomplete" do

--- a/spec/scope_spec.cr
+++ b/spec/scope_spec.cr
@@ -240,6 +240,33 @@ describe Gori::Scope do
     end
   end
 
+  it "SQL filter agrees with in_scope_url? when an EXCLUDE rule was stored before the INCLUDE" do
+    # #filter emits placeholders include-first, exclude-second, but used to bind values in
+    # rule-id order. Add the exclude first and the two orders diverge: the include's `?`
+    # takes the exclude's pattern and vice versa, so History/Sitemap silently show a
+    # different set than in_scope_url? computes. Rule ORDER, not rule content, is the
+    # trigger — the existing parity test above adds its include first and cannot see it.
+    with_store do |store|
+      flows = [
+        {"https", "api.acme.test", "/v1/users"},
+        {"https", "api.acme.test", "/static/app.js"},
+        {"https", "other.test", "/v1/users"},
+      ]
+      flows.each { |(sc, h, t)| capture(store, h, t, sc) }
+
+      scope = Gori::Scope.load(store)
+      scope.add("exclude", "string", "/static/") # exclude FIRST — lower rule id
+      scope.add("include", "host", "acme.test")
+      scope.enable
+
+      sql_set = store.search(scope.filter, 50).map { |r| {r.scheme, r.host, r.target} }.to_set
+      mem_set = flows.select { |(sc, h, t)| scope.in_scope_url?(url_of(sc, h, t), h) }
+        .map { |(sc, h, t)| {sc, h, t} }.to_set
+      sql_set.should eq(mem_set)
+      mem_set.should eq([{"https", "api.acme.test", "/v1/users"}].to_set)
+    end
+  end
+
   it "SQL filter agrees with in_scope_url? over Store#search (host/string/regex, incl/excl)" do
     with_store do |store|
       flows = [

--- a/spec/update_spec.cr
+++ b/spec/update_spec.cr
@@ -746,6 +746,19 @@ describe Gori::Update do
       end
     end
 
+    it "raises a clean Gori::Error for valid JSON whose root is not an object" do
+      # `data["tag_name"]?` on a non-Hash JSON::Any raises a BARE Exception, which no
+      # rescue on the `gori update` path catches (cli.cr rescues Gori::Error), so the
+      # operator got an unhandled backtrace instead of the intended message. Any 200 whose
+      # body is valid JSON with a non-object root reaches this — a captive proxy, a GHE
+      # mirror, or GORI_UPDATE_API_URL pointed at a list endpoint.
+      {"[]", "null", %("a string"), "42"}.each do |body|
+        expect_raises(Gori::Error, /could not parse release information/) do
+          Gori::Update.parse_release(body)
+        end
+      end
+    end
+
     it "update_binary surfaces the same clean error for a non-JSON release response" do
       io = IO::Memory.new
       expect_raises(Gori::Error, /could not parse release information/) do

--- a/src/gori/cookie.cr
+++ b/src/gori/cookie.cr
@@ -176,10 +176,19 @@ module Gori
       end
     end
 
+    # nil on anything that isn't a base62 unix second — an out-of-alphabet character OR a
+    # run long enough to overflow the accumulator. A crafted cookie chooses this segment
+    # freely, and Crystal's arithmetic is overflow-checked, so an unguarded `n * 62` raised
+    # OverflowError straight out of Django's decode_text/decode_json. Callers already
+    # render nil as "(invalid base62 …)" / a null field, which is the honest answer for
+    # both cases (same reasoning as `unix_to_s`'s rescue below).
     def base62_decode(s : String) : Int64?
       n = 0_i64
       s.each_char do |c|
         idx = BASE62.index(c) || return nil
+        # Checked BEFORE the multiply: a wrap-and-test would miss a value that wraps twice
+        # and lands positive again.
+        return nil if n > (Int64::MAX - idx) // 62
         n = n * 62 + idx
       end
       n

--- a/src/gori/cookie/django.cr
+++ b/src/gori/cookie/django.cr
@@ -28,11 +28,15 @@ module Gori
         ts_seg : String,      # base62 unix second
         signature : String
 
-      # `Cookie.detect`: a ":"-separated cookie with exactly three parts and no Rack "--".
-      # Django's segments (base64url / base62 / base64url) never contain ":", so an exact
-      # 3-way split is a reliable signal.
+      # `Cookie.detect`: a ":"-separated cookie with exactly three parts. Django's segments
+      # (base64url / base62 / base64url) never contain ":", so an exact 3-way split is a
+      # reliable signal.
+      #
+      # Deliberately does NOT reject "--": base64url uses '-', so a genuine Django payload
+      # can contain a "--" run, and rejecting it made those cookies undetectable. Rack is
+      # already separated — `detect` tests it first, and Rack's strict-base64 body plus hex
+      # tail contains no ':' at all, so it can never reach a count of two.
       def looks_like?(s : String) : Bool
-        return false if s.includes?("--")
         s.count(':') == 2
       end
 

--- a/src/gori/cookie/flask.cr
+++ b/src/gori/cookie/flask.cr
@@ -25,9 +25,15 @@ module Gori
         signature : String
 
       # Cheap structural test for `Cookie.detect`: two dot-separated tail segments and no
-      # Rack "--" / Django ":" punctuation. Deliberately loose — a real parse validates.
+      # Django ":" punctuation. Deliberately loose — a real parse validates.
+      #
+      # Deliberately does NOT reject "--": base64url's alphabet contains '-', so a genuine
+      # Flask payload carries a "--" run often enough to matter, and rejecting it made
+      # those cookies undetectable on every surface. Rack cannot be confused with Flask
+      # here — `detect` tests Rack first, and Rack's own predicate needs a 40-hex tail
+      # after the "--", while Rack's strict-base64 body has no '.' to reach `count`.
       def looks_like?(s : String) : Bool
-        return false if s.includes?("--") || s.includes?(':')
+        return false if s.includes?(':')
         s.count('.') >= 2
       end
 

--- a/src/gori/mcp/request_builder.cr
+++ b/src/gori/mcp/request_builder.cr
@@ -15,6 +15,38 @@ module Gori
     module RequestBuilder
       record Built, bytes : Bytes, scheme : String, host : String, port : Int32
 
+      # `headers` as name→value pairs, in the caller's order.
+      #
+      # An `as_h?`-only read answered nil for every non-object shape and the caller then
+      # skipped the loop entirely — so a JSON-encoded string or a pair array meant the
+      # request went out with ZERO caller headers and still reported success. An entire
+      # authenticated crawl could run unauthenticated with no signal anywhere. Accept the
+      # shapes an agent actually sends, and RAISE on anything else rather than vanish —
+      # same contract as `parse_h2_fields`, which already takes object-or-encoded-string.
+      def self.header_pairs(raw : JSON::Any?) : Array({String, String})
+        return [] of {String, String} if raw.nil? || raw.raw.nil?
+        node = raw
+        if s = raw.as_s?
+          # A whole object handed over as a JSON string — common when an agent stringifies.
+          parsed = (JSON.parse(s) rescue nil)
+          raise Gori::Error.new(
+            "invalid 'headers' (expected an object of name->value, got an unparseable string)") unless parsed
+          node = parsed
+        end
+
+        if h = node.as_h?
+          return h.map { |k, v| {k, v.as_s? || v.to_s} }
+        end
+        if arr = node.as_a?
+          return arr.map do |item|
+            pair = item.as_a?
+            raise Gori::Error.new("invalid 'headers' (array form must hold [name, value] pairs)") unless pair && pair.size == 2
+            {pair[0].as_s? || pair[0].to_s, pair[1].as_s? || pair[1].to_s}
+          end
+        end
+        raise Gori::Error.new("invalid 'headers' (expected an object of name->value)")
+      end
+
       # `args` is the tool's `arguments` object (a parsed JSON hash).
       def self.build(args : Hash(String, JSON::Any)) : Built
         uri, scheme, host, port = parse_origin(args)
@@ -167,12 +199,10 @@ module Gori
         reject_token_breakers(target, "request target")
 
         headers = [] of {String, String}
-        if h = args["headers"]?.try(&.as_h?)
-          h.each do |k, v|
-            value = Env.expand(v.as_s? || v.to_s)
-            validate_header(k, value)
-            headers << {k, value}
-          end
+        RequestBuilder.header_pairs(args["headers"]?).each do |(k, v)|
+          value = Env.expand(v)
+          validate_header(k, value)
+          headers << {k, value}
         end
 
         unless headers.any? { |(k, _)| k.compare("host", case_insensitive: true) == 0 }

--- a/src/gori/mcp/tools/discover.cr
+++ b/src/gori/mcp/tools/discover.cr
@@ -131,11 +131,11 @@ module Gori
       # `{"headers": {"X-A": "1"}}` as raw `Name: Value` lines. `$VAR` in a value is left
       # alone here — the builder expands it (and re-applies the CRLF guard afterwards).
       private def discover_header_lines(h) : Array(String)
-        lines = [] of String
-        if hm = h["headers"]?.try(&.as_h?)
-          hm.each { |k, v| lines << "#{k}: #{v.as_s? || v.to_s}" }
-        end
-        lines
+        # Shares RequestBuilder.header_pairs with send_request: a stringified or
+        # pair-array `headers` used to be dropped here too, and discover_start echoes no
+        # request at all, so an unauthenticated crawl of an authenticated surface was
+        # completely silent.
+        RequestBuilder.header_pairs(h["headers"]?).map { |(k, v)| "#{k}: #{v}" }
       end
 
       # MCP's wording for a plan the args can't produce — the builder reports the

--- a/src/gori/oast/provider.cr
+++ b/src/gori/oast/provider.cr
@@ -111,7 +111,26 @@ module Gori::Oast
       when String
         Time.parse_rfc3339(v) rescue (Time.parse_utc(v, "%Y-%m-%dT%H:%M:%S") rescue Time.utc)
       when Int64, Int32
-        Time.unix(v.to_i64)
+        # Scale-detect before constructing: `Time.unix` raises ArgumentError past
+        # 315_537_897_599, and a millisecond epoch (~1.7e12) is three orders past that.
+        # postb.in's `inserted` field is epoch MILLIseconds, so the shipped "Public
+        # PostBin" preset raised on every callback — and Postbin#poll shifts
+        # destructively, so the raise discarded interactions already consumed from the
+        # bin. The String branch beside this one has always been rescue-guarded; this one
+        # was the only unguarded field, because every other value routes through `field()`
+        # and reaches that guarded path as a string.
+        n = v.to_i64
+        begin
+          if n.abs >= 100_000_000_000_000 # microseconds
+            Time.unix(n // 1_000_000)
+          elsif n.abs >= 100_000_000_000 # milliseconds
+            Time.unix_ms(n)
+          else
+            Time.unix(n)
+          end
+        rescue ArgumentError
+          Time.utc
+        end
       else
         Time.utc
       end

--- a/src/gori/probe/active/host_header_injection.cr
+++ b/src/gori/probe/active/host_header_injection.cr
@@ -103,17 +103,20 @@ module Gori
           cc.includes?("public") || positive_max_age?(cc)
         end
 
+        # Overflow-safe like the other three max-age readers in the probe engine
+        # (security_headers.cr, cookies.cr, cacheable_api.cr all use `to_i64?`). The
+        # hand-rolled Int32 accumulator this replaces raised OverflowError on any
+        # delta-seconds past Int32::MAX — a 100-year `max-age=3153600000` is enough — and
+        # `gate` is called from `Analyzer#active_estimate` with no rescue between it and
+        # the TUI event loop, so one hostile Cache-Control header ended the process.
+        # RFC 9111 §1.2.2 says to clamp an oversized delta-seconds, so a value we cannot
+        # represent still counts as a positive max-age rather than silently reading false.
         private def positive_max_age?(cc : String) : Bool
           idx = cc.index("max-age=") || return false
-          i = idx + 8
-          n = 0
-          seen = false
-          while i < cc.size && cc[i].ascii_number?
-            n = n * 10 + (cc[i].ord - '0'.ord)
-            seen = true
-            i += 1
-          end
-          seen && n > 0
+          digits = cc[(idx + 8)..].each_char.take_while(&.ascii_number?).join
+          return false if digits.empty?
+          # nil == more digits than Int64 holds, which is unambiguously a positive age.
+          (digits.to_i64? || Int64::MAX) > 0
         end
 
         private def body_reflects?(result : Repeater::Result) : Bool

--- a/src/gori/repeater/h2_engine.cr
+++ b/src/gori/repeater/h2_engine.cr
@@ -475,7 +475,14 @@ module Gori
           Frame.read(io)
         rescue IO::TimeoutError
           return false # idle, not dead — the caller decides whether that is fatal
-        rescue IO::Error
+        rescue IO::Error | Gori::Error
+          # `Gori::Error` here is `read_exact`'s "unexpected EOF mid-frame" — a FIN that
+          # landed inside a frame rather than on its boundary. That is end-of-data, not a
+          # reason to raise: `Gori::Error < Exception`, not `IO::Error`, so it used to
+          # escape `pump_once`, escape `write_data`'s stall loop and `await_settings`, and
+          # unwind out of `write_request` before `read_response` could drain the complete
+          # response already sitting in `flow.pending` — the exact lie `write_data`'s
+          # comment below swore off. Treated like the reset socket it is.
           flow.eof = true
           return false
         end
@@ -769,18 +776,30 @@ module Gori
             # An IO error mid-response (connection reset — e.g. an origin that closed
             # right after a non-END_STREAM DATA) is end-of-data, not a hard failure:
             # treat it like a clean EOF and return what arrived, flagged incomplete
-            # (mirrors the h1 engine). A Gori::Error from Frame.read (oversized/corrupt
-            # frame — a real protocol violation) is NOT swallowed: it propagates to the
-            # outer rescue and surfaces as a failed repeater, since the workbench exists to
-            # reveal exactly that. An idle TIMEOUT is separated from a closed socket: "the
-            # origin sent nothing" and "the origin hung up" are different findings and only
-            # one of them is worth retrying.
+            # (mirrors the h1 engine). An idle TIMEOUT is separated from a closed socket:
+            # "the origin sent nothing" and "the origin hung up" are different findings and
+            # only one of them is worth retrying.
+            #
+            # `Gori::Error` is swallowed the same way. This arm once deliberately let it
+            # propagate, on the stated ground that it meant an oversized/corrupt frame —
+            # a real protocol violation worth surfacing. That ground was void: `len` is
+            # three bytes (max 16777215) and the default MAX_PAYLOAD is exactly 16777215,
+            # and no caller here passes a tighter cap, so `Frame.read`'s `len > max_payload`
+            # guard cannot fire. The only Gori::Error reaching this line is `read_exact`'s
+            # "unexpected EOF mid-frame", and letting THAT propagate destroyed a fully
+            # decoded status + headers + body over a FIN that happened to land inside a
+            # frame instead of on its boundary — splitting one wire event three ways
+            # (boundary EOF → kept; RST → kept; mid-frame FIN → destroyed). Only the third
+            # was destructive, against this file's own rule that "a response that arrived
+            # keeps its head and body regardless". If a discriminable protocol violation is
+            # ever wanted here, give `Frame.read` a distinct subtype for it rather than
+            # resting on a guard that cannot trip.
             frame = begin
               Frame.read(io)
             rescue IO::TimeoutError
               timed_out = true
               nil
-            rescue IO::Error
+            rescue IO::Error | Gori::Error
               nil
             end
             break if frame.nil?

--- a/src/gori/scope.cr
+++ b/src/gori/scope.cr
@@ -307,15 +307,26 @@ module Gori
         return QL::EMPTY unless active_unlocked?
         inc_conds = [] of String
         exc_conds = [] of String
-        args = [] of DB::Any
+        # Bucket the values with their conditions. The SQL below is assembled
+        # includes-then-excludes, but @rules is in rule-id order, so a single flat array
+        # bound an exclude's pattern to an include's `?` (and vice versa) whenever an
+        # exclude rule was stored first — the filter then silently described a different
+        # set than `in_scope_url?`. Same placeholder/value discipline QL.tree_sql documents.
+        inc_args = [] of DB::Any
+        exc_args = [] of DB::Any
         @rules.each do |rule|
           cond, cargs = rule_cond(rule)
-          (rule.include? ? inc_conds : exc_conds) << cond
-          args.concat(cargs)
+          if rule.include?
+            inc_conds << cond
+            inc_args.concat(cargs)
+          else
+            exc_conds << cond
+            exc_args.concat(cargs)
+          end
         end
         inc_sql = inc_conds.empty? ? "1" : "(#{inc_conds.join(" OR ")})"
         exc_sql = exc_conds.empty? ? "" : " AND NOT (#{exc_conds.join(" OR ")})"
-        QL::Filter.new("(#{inc_sql}#{exc_sql})", args)
+        QL::Filter.new("(#{inc_sql}#{exc_sql})", inc_args + exc_args)
       end
     end
 

--- a/src/gori/settings.cr
+++ b/src/gori/settings.cr
@@ -98,16 +98,37 @@ module Gori
     # Split out of load so load stays a small read → parse → apply flow.
     # Not private: import_document reuses it, so a profile import runs the SAME per-section
     # readers as a normal load rather than a parallel implementation that could drift.
+    # An Int32 field that cannot raise. `JSON::Any#as_i?` is `as?(Int).try(&.to_i)`, and
+    # `to_i` on an Int64 outside Int32 raises OverflowError — so a value in the
+    # Int32::MAX < |v| <= Int64::MAX band (larger fails in JSON.parse and takes the
+    # documented .corrupt path) aborted apply_sections partway. Everything after the
+    # raising line then kept its factory default, and the next `save` wrote those defaults
+    # over the operator's file: `merge_with_disk` short-circuits on `disk == base` and
+    # returns `mine`, so the 3-way merge never gets a chance to preserve the lost sections.
+    # Out-of-range reads as absent, which is what every caller's `|| default` already means.
+    protected def self.int_field(node : JSON::Any, key : String) : Int32?
+      node[key]?.try(&.as_i?)
+    rescue OverflowError
+      nil
+    end
+
+    # Same guard for the sections that have already unwrapped their node to a Hash.
+    protected def self.int_field(node : Hash(String, JSON::Any), key : String) : Int32?
+      node[key]?.try(&.as_i?)
+    rescue OverflowError
+      nil
+    end
+
     protected def self.apply_sections(root : JSON::Any) : Nil
       if net = root["network"]?
         self.bind_host = net["bind_host"]?.try(&.as_s?) || bind_host
-        self.bind_port = net["bind_port"]?.try(&.as_i?) || bind_port
+        self.bind_port = int_field(net, "bind_port") || bind_port
         self.upstream_proxy = net["upstream_proxy"]?.try(&.as_s?) || upstream_proxy
         self.verify_upstream = load_bool(net, "verify_upstream", verify_upstream?)
         self.serve_landing = load_bool(net, "serve_landing", serve_landing?)
-        net["connect_timeout_secs"]?.try(&.as_i?).try { |v| self.connect_timeout_secs = {v, 1}.max }
-        net["io_timeout_secs"]?.try(&.as_i?).try { |v| self.io_timeout_secs = {v, 1}.max }
-        net["capture_max_mib"]?.try(&.as_i?).try { |v| self.capture_max_mib = v.clamp(1, MAX_CAPTURE_MAX_MIB) }
+        int_field(net, "connect_timeout_secs").try { |v| self.connect_timeout_secs = {v, 1}.max }
+        int_field(net, "io_timeout_secs").try { |v| self.io_timeout_secs = {v, 1}.max }
+        int_field(net, "capture_max_mib").try { |v| self.capture_max_mib = v.clamp(1, MAX_CAPTURE_MAX_MIB) }
         parse_tls_passthrough(net)
         net["http2"]?.try(&.as_s?).try { |v| self.http2 = v if HTTP2_MODES.includes?(v) }
       end

--- a/src/gori/settings/discover.cr
+++ b/src/gori/settings/discover.cr
@@ -22,8 +22,8 @@ module Gori::Settings
     end
     self.discover_prefs_saved = true
     obj["containment"]?.try(&.as_s?).try { |s| self.discover_containment = s }
-    obj["max_depth"]?.try(&.as_i?).try { |n| self.discover_max_depth = n }
-    obj["concurrency"]?.try(&.as_i?).try { |n| self.discover_concurrency = n }
+    int_field(obj, "max_depth").try { |n| self.discover_max_depth = n }
+    int_field(obj, "concurrency").try { |n| self.discover_concurrency = n }
     obj["spider"]?.try(&.as_bool?).try { |b| self.discover_spider = b }
     obj["bruteforce"]?.try(&.as_bool?).try { |b| self.discover_bruteforce = b }
     obj["extensions"]?.try(&.as_bool?).try { |b| self.discover_extensions = b }

--- a/src/gori/settings/display.cr
+++ b/src/gori/settings/display.cr
@@ -110,7 +110,7 @@ module Gori::Settings
     if ord = o["history_list_order"]?.try(&.as_s?)
       self.history_list_order = normalize_history_list_order(ord)
     end
-    if d = o["sitemap_expand_depth"]?.try(&.as_i?)
+    if d = int_field(o, "sitemap_expand_depth")
       self.sitemap_expand_depth = normalize_sitemap_depth(d)
     end
   end
@@ -122,7 +122,7 @@ module Gori::Settings
     if cmd = o["command"]?.try(&.as_s?)
       self.statusline_command = cmd
     end
-    if iv = o["interval"]?.try(&.as_i?)
+    if iv = int_field(o, "interval")
       self.statusline_interval = {iv, 1}.max
     end
   end
@@ -138,7 +138,7 @@ module Gori::Settings
       self.history_time_format = v == "relative" ? "relative" : "absolute"
     end
     self.show_gutter = load_bool_h(o, "show_gutter", show_gutter)
-    if v = o["preview_body_kib"]?.try(&.as_i?)
+    if v = int_field(o, "preview_body_kib")
       self.preview_body_kib = v.clamp(1, MAX_PREVIEW_BODY_KIB)
     end
     self.resource_meter = load_bool_h(o, "resource_meter", resource_meter?)
@@ -157,7 +157,7 @@ module Gori::Settings
     return unless o = node.try(&.as_h?)
     self.notify_bell = load_bool_h(o, "bell", notify_bell?)
     self.notify_toast = load_bool_h(o, "toast", notify_toast?)
-    if v = o["retention"]?.try(&.as_i?)
+    if v = int_field(o, "retention")
       self.notify_retention = {v, 1}.max
     end
   end

--- a/src/gori/settings/listeners.cr
+++ b/src/gori/settings/listeners.cr
@@ -169,11 +169,11 @@ module Gori::Settings
     arr.each do |e|
       next unless o = e.as_h?
       host = o["host"]?.try(&.as_s?).try(&.strip)
-      port = o["port"]?.try(&.as_i?)
+      port = int_field(o, "port")
       next if host.nil? || host.empty? || port.nil? || !(0 <= port <= 65535)
       mode = o["mode"]?.try(&.as_s?).try(&.strip.downcase) || "proxy"
       next unless LISTENER_MODES.includes?(mode)
-      target = o["target_port"]?.try(&.as_i?) || 0
+      target = int_field(o, "target_port") || 0
       target = 0 unless 0 <= target <= 65535
       origin = o["origin"]?.try(&.as_s?).try(&.strip) || ""
       rewrite_host = o["rewrite_host"]?.try(&.as_bool?) || false

--- a/src/gori/settings/miner.cr
+++ b/src/gori/settings/miner.cr
@@ -21,7 +21,7 @@ module Gori::Settings
     if locs = obj["locations"]?.try(&.as_a?)
       self.mine_locations = locs.compact_map(&.as_s?).map(&.downcase.strip).reject(&.empty?)
     end
-    obj["concurrency"]?.try(&.as_i?).try { |n| self.mine_concurrency = n }
+    int_field(obj, "concurrency").try { |n| self.mine_concurrency = n }
     obj["notify"]?.try(&.as_s?).try { |s| self.mine_notify = s }
   end
 

--- a/src/gori/settings/retention.cr
+++ b/src/gori/settings/retention.cr
@@ -28,7 +28,7 @@ module Gori::Settings
 
   private def self.parse_retention(node : JSON::Any?) : Nil
     return unless h = node.try(&.as_h?)
-    h["max_flows"]?.try(&.as_i?).try { |v| self.retention_max_flows = v < 0 ? 0 : v }
+    int_field(h, "max_flows").try { |v| self.retention_max_flows = v < 0 ? 0 : v }
   end
 
   # Omitted at the factory default, like the other optional sections, so an untouched install

--- a/src/gori/store/entity_links.cr
+++ b/src/gori/store/entity_links.cr
@@ -36,7 +36,12 @@ module Gori
       return 0 if refs.empty?
       ts = now_us
       inserted = 0
-      exec_task ->(c : DB::Connection) {
+      # exec_task_ok, not exec_task: the tally accumulates inside the transaction, so a
+      # batch that later rolls back still produced a nonzero count and the caller toasted
+      # "linked N" for rows that never committed. (exec_task's own Int64 reply cannot
+      # stand in — on a committed batch where every INSERT OR IGNORE was ignored,
+      # last_insert_rowid is a stale nonzero, so it can't discriminate either.)
+      ok = exec_task_ok ->(c : DB::Connection) {
         refs.each do |(ref_kind, ref_id)|
           c.exec(
             "INSERT OR IGNORE INTO entity_links (owner_kind, owner_id, ref_kind, ref_id, created_at) VALUES (?,?,?,?,?)",
@@ -45,7 +50,7 @@ module Gori
         end
         nil
       }
-      inserted
+      ok ? inserted : 0
     end
 
     def link_id(owner_kind : LinkOwnerKind, owner_id : Int64, ref_kind : LinkRefKind, ref_id : Int64) : Int64?

--- a/src/gori/store/issues.cr
+++ b/src/gori/store/issues.cr
@@ -4,10 +4,18 @@ module Gori
   class Store
     # --- issues ------------------------------------------------------------
 
+    # 0 == not persisted. Three callers guard on that, so the id must come from the
+    # COMMITTED signal, not from the local the closure captured: the closure runs inside
+    # the transaction, but the batch can still roll back afterwards (a COMMIT-time
+    # SQLITE_FULL/IOERR, or an unrelated co-submitted write raising — writer_loop batches
+    # up to BATCH_MAX ops from every fiber into one transaction). Returning the captured
+    # id there handed out the rowid of an issue that does not exist, and because
+    # `issues.id` is INTEGER PRIMARY KEY without AUTOINCREMENT the next issue created is
+    # handed that same id and silently adopts any entity_links written against it.
     def insert_issue(title : String, severity : Severity, host : String?, flow_id : Int64?) : Int64
       ts = now_us
       issue_id = 0_i64
-      exec_task ->(c : DB::Connection) {
+      ok = exec_task_ok ->(c : DB::Connection) {
         c.exec("INSERT INTO issues (created_at, updated_at, title, severity, host, flow_id, notes) VALUES (?,?,?,?,?,?,'')",
           ts, ts, title, severity.value, host, flow_id)
         # Capture the issue's own id BEFORE the entity_links insert below overwrites
@@ -21,7 +29,7 @@ module Gori
         end
         nil
       }
-      issue_id
+      ok ? issue_id : 0_i64
     end
 
     # Returns whether the write committed (false = store busy/locked/closing). An empty

--- a/src/gori/update.cr
+++ b/src/gori/update.cr
@@ -470,11 +470,18 @@ module Gori
       rescue ex : JSON::ParseException
         raise Error.new("could not parse release information (server did not return valid JSON): #{ex.message}")
       end
-      tag = data["tag_name"]?.try(&.as_s?)
+      # Valid JSON with a non-object root ([], null, a bare string/number) would otherwise
+      # make `data["tag_name"]?` raise a BARE Exception — not a Gori::Error — and nothing
+      # on the `gori update` path rescues that, so the operator got a backtrace instead of
+      # a message. Reachable from any 200 carrying such a body: a captive portal, a GHE
+      # mirror, or GORI_UPDATE_API_URL aimed at a list endpoint.
+      obj = data.as_h? || raise Error.new(
+        "could not parse release information (expected a JSON object, got #{data.raw.class})")
+      tag = obj["tag_name"]?.try(&.as_s?)
       raise Error.new("release JSON missing tag_name") unless tag
 
       assets = [] of Asset
-      if arr = data["assets"]?.try(&.as_a?)
+      if arr = obj["assets"]?.try(&.as_a?)
         arr.each do |item|
           name = item["name"]?.try(&.as_s?) || next
           url = item["browser_download_url"]?.try(&.as_s?) || next


### PR DESCRIPTION
Twelve fixes from an audit of the subsystems the last hundred commits didn't touch. Every oracle
AGENTS.md hands you came back clean first — the layering grep, `request_token_safe?`'s single
home, `PlanError::Reason` exhaustiveness, `spawn` loop capture — so everything here is logic.
Most of it is one of two shapes: **an exception nobody rescued**, or **a count reported before
the thing it counted had committed**.

Full reasoning per fix is in the commit message. Summary:

| Site | Defect |
| --- | --- |
| `repeater/h2_engine.cr` (×2) | `Frame.read` raises `Gori::Error` on a truncated frame, which is **not** an `IO::Error` — it escaped both rescue arms and destroyed a fully decoded response. Boundary EOF kept it, RST kept it, mid-frame FIN destroyed it. `read_response`'s comment justified this on an **unreachable** branch (`len` is 3 bytes; `MAX_PAYLOAD` is exactly its max), so the comment is rewritten too. |
| `scope.cr` | Placeholders emitted include-then-exclude, values bound in rule-id order → any exclude stored first swapped the patterns. SQL answered `Set{}` where `in_scope_url?` answered correctly. **Display path only** (History/Sitemap); the in-memory gates read `@rules` directly, so this is *not* a containment bypass. |
| `settings.cr` + 5 siblings | `as_i?` raises `OverflowError` in the `Int32::MAX..Int64::MAX` band, aborting `apply_sections` partway; the next `save` then wrote factory defaults over the user's file, because `merge_with_disk` short-circuits on `disk == base` and returns `mine`. 14 sites now use a non-raising `int_field`. |
| `probe/active/host_header_injection.cr` | Hand-rolled Int32 accumulator overflowed on a large `max-age`; `gate` is reached from `active_estimate` on `A` with no rescue before the TUI event loop, which `runner.cr:568-572` warns ends the process. Now uses `to_i64?` like its three siblings. |
| `oast/provider.cr` | `Time.unix` on a millisecond epoch raises. postb.in's `inserted` **is** ms, so the shipped "Public PostBin" preset never reported a callback — and `Postbin#poll` shifts destructively, so the raise discarded interactions already taken off the bin. |
| `store/issues.cr`, `store/entity_links.cr` | Both returned a value captured inside the transaction even when the batch rolled back. `issues.id` has no AUTOINCREMENT, so the next issue reuses that id and adopts any `entity_links` written against it. |
| `mcp/request_builder.cr`, `mcp/tools/discover.cr` | `headers` read via `as_h?` alone → a stringified object or pair array was silently dropped, the request went out with zero caller headers, and the tool reported success. `discover_start` echoes no request at all, so an authenticated-surface crawl could run unauthenticated with no signal. |
| `cookie.cr` | `base62_decode` overflowed on a crafted Django timestamp, crashing decode — where `unix_to_s` two lines below already rescues this exact class. |
| `cookie/{flask,django}.cr` | Both rejected any cookie containing `--`, but base64url uses `-`, so genuine cookies were undetectable and every surface said "unrecognized cookie format" even given the right secret. |
| `update.cr` | Valid JSON with a non-object root raised a bare `Exception`, which nothing on the `gori update` path rescues → unhandled backtrace instead of a message. |
| `AGENTS.md` | The layering self-check claimed the grep returns "exactly one hit". It returns four, all comments, which the contract permits. The invariant is "every hit is a comment", not a count. |

## Intentional behaviour change

Per CONTRIBUTING: **`RequestBuilder.header_pairs` now raises on an unusable `headers` value**
instead of silently returning none. It accepts object, JSON-encoded object, and `[name, value]`
pairs; anything else is a clean `Gori::Error`. Silently dropping it is what made the bug
invisible on both surfaces. Pinned by a spec so it isn't reverted as a "fix".

## Verification

- **7249 → 7260 examples, no regressions.** 11 new specs, each confirmed to fail before its fix
  and pass after.
- The h2 spec needed a new origin helper: `start_h2_origin_truncated` closes on a frame
  boundary, where `Frame.read` returns nil, so it cannot reach the raising path. Its mid-frame
  sibling writes 5 of 9 header bytes and hangs up. Reverting just the two rescue arms turns that
  spec red with `h2: unexpected EOF mid-frame` and the 200 gone.
- ameba unchanged at **893**; `crystal tool format --check` clean on every changed file.
- The 8 red specs before *and* after are the `Gori::Session` port-bind set — they fail because a
  live `gori` holds `127.0.0.1:8070`, not because of anything here.

## Found but deliberately not fixed

Three were quarantined on purpose:

- **`proxy/codec/http1.cr:343` `framing_ambiguous?`** — reported as comparing framing header
  values but never the head *boundary*, so a bare-LF blank line could desync a keep-alive
  connection. AGENTS.md names "making the response framing rule as strict as the request rule" as
  an explicit trap. If pursued, add a *separate* head-boundary check; do not tighten the value
  comparison.
- **`proxy/conn/client_conn.cr:550` `serve_short_circuit`** — unbounded request-body buffering. A
  cap is a policy decision about what an operator's stub accepts, not a bug fix.
- **`pretty.cr:498`** — a display-only projection can be fed back as the request body the
  Repeater/Fuzzer sends. Any fix must bail on a non-native `res.kind`, **not** sanitize bytes (P7).

~25 further findings were reported by the audit but **not independently confirmed**, so treat
their severity as unreviewed. The strongest-looking is **`import/burp.cr:137`**: the hand-rolled
XML scanner is not CDATA-aware, so a captured response body containing `</item>` truncates the
record, silently drops the response, and inflates the skip count — reproduced against a
standalone harness. Others cluster in `discover/` (a query-only `?page=2` href resolving against
the base's *directory*; a hard 404/5xx recorded as a brute-force hit at confidence 1.0),
`decoder/codecs.cr`, `ql.cr` (`header:` compiles to a LIKE over `CAST(head AS TEXT)`, which stops
at the first NUL), `sitemap.cr` (`stamp_node_tags` still natively recursive), `fuzz/template.cr`
(`clear_markers` writes an un-escaped `§` back), and `mcp/server.cr` (a JSON-RPC batch answered
with one `id: null` error, so every request in it hangs). Happy to file these as issues.
