### PR TITLE
Every h2 request on one connection stamped with the same time, a repeater body the origin read as empty, and a rule that rewrote bytes it could not read

### DIFF
--- a/spec/cli/run/replay_reconstruct_spec.cr
+++ b/spec/cli/run/replay_reconstruct_spec.cr
@@ -164,8 +164,10 @@ describe "replay reconstruct (P7) — Content-Length re-sync" do
       .should eq("POST /u HTTP/1.1\r\nHost: h\r\nContent-Length: 5\r\n\r\nhello")
   end
 
-  it "never ADDS a Content-Length to a request that has none" do
-    # A bodyless GET must stay clean, and a chunked request must keep its framing.
+  it "adds no Content-Length to a bodyless or chunked request" do
+    # A bodyless GET must stay clean, and a chunked request must keep its framing. (A request
+    # that DOES carry a body and no CL is completed instead — see flow_request_spec — because
+    # leaving it unframed made the origin read a zero-length body.)
     get = "GET / HTTP/1.1\r\nHost: h\r\n\r\n".to_slice
     String.new(Gori::Repeater::FlowRequest.resync_content_length(get)).should eq(String.new(get))
 

--- a/spec/repeater/flow_request_spec.cr
+++ b/spec/repeater/flow_request_spec.cr
@@ -57,8 +57,43 @@ describe Gori::Repeater::FlowRequest do
       out.should contain("Content-Length: 10\r\n")
     end
 
-    it "never adds a header (a GET with no Content-Length is untouched)" do
+    it "adds no header to a BODYLESS request (a GET with no Content-Length is untouched)" do
       wire = "GET /x HTTP/1.1\r\nHost: t\r\n\r\n".to_slice
+      Gori::Repeater::FlowRequest.resync_content_length(wire).should eq(wire)
+    end
+
+    # The auto-CL toggle's whole job: an operator edits a repeater request, types a body, and
+    # leaves the Content-Length out. Returning the bytes unchanged (the pre-fix behaviour) sent
+    # a framing-ambiguous request that a spec-conforming origin reads as a ZERO-length body —
+    # silently, while gori's own captured `request_body` still displayed the typed text.
+    it "adds a Content-Length when a body has none" do
+      wire = "POST /x HTTP/1.1\r\nHost: t\r\n\r\na=1&b=2".to_slice
+      String.new(Gori::Repeater::FlowRequest.resync_content_length(wire))
+        .should eq("POST /x HTTP/1.1\r\nHost: t\r\nContent-Length: 7\r\n\r\na=1&b=2")
+    end
+
+    # The captured-flow REPLAY path (and MCP `send_request{apply_rules}`, which runs past the
+    # point `auto_content_length` was honoured) opts out: a capture that carried no CL — an
+    # h2/gRPC streamed POST is stored exactly that way — is evidence, not a draft to complete.
+    it "adds nothing when add_if_missing is false" do
+      wire = "POST /x HTTP/1.1\r\nHost: t\r\n\r\na=1&b=2".to_slice
+      Gori::Repeater::FlowRequest.resync_content_length(wire, add_if_missing: false).should eq(wire)
+    end
+
+    # A bare-LF header line makes `split("\r\n")` merge it into the line before, so the
+    # Transfer-Encoding guard cannot see a TE that is really there. Adding a CL beside it would
+    # hand back a CL.TE desync probe the operator never wrote, with the length counting the
+    # CHUNKED wire bytes.
+    it "refuses to add when a bare-LF line hides a Transfer-Encoding" do
+      wire = "POST / HTTP/1.1\r\nHost: x\nTransfer-Encoding: chunked\r\n\r\n5\r\nHELLO\r\n0\r\n\r\n".to_slice
+      Gori::Repeater::FlowRequest.resync_content_length(wire).should eq(wire)
+    end
+
+    # An LF-framed head means the first `\r\n\r\n` can occur inside the BODY — here inside a
+    # smuggled inner request — so the "head" runs past the real terminator and the appended
+    # header would land in the middle of the smuggled bytes.
+    it "refuses to add when the CRLFCRLF terminator lands inside the body" do
+      wire = "POST /x HTTP/1.1\nHost: v\n\nGET /admin HTTP/1.1\r\nHost: v\r\n\r\nX".to_slice
       Gori::Repeater::FlowRequest.resync_content_length(wire).should eq(wire)
     end
 

--- a/src/gori/cli/run/compare.cr
+++ b/src/gori/cli/run/compare.cr
@@ -62,7 +62,7 @@ module Gori
         if pane == :request
           Repeater::MessageLines.of(d.request_head, d.request_body, decode: false)
         else
-          Repeater::MessageLines.of(d.response_head, d.response_body, decode: true)
+          Repeater::MessageLines.of(d.response_head, d.response_body, decode: true, error: d.error)
         end
       end
 

--- a/src/gori/cookie/django.cr
+++ b/src/gori/cookie/django.cr
@@ -12,9 +12,10 @@ module Gori
     #               key, NOT an HMAC-derived one (that's Flask's scheme).
     #
     # salt defaults to "django.core.signing"; the cookie-session backend uses
-    # "django.contrib.sessions.backends.signed_cookies" (the "signed-with-salt" variant).
-    # algorithm defaults to SHA-256 (Django ≥ 3.1); older apps used SHA-1. Both salt and
-    # algorithm are pinned to golden vectors from real Django in the spec.
+    # "django.contrib.sessions.backends.signed_cookies" (SESSION_SALT below) — which, as of
+    # Django 6.0, also wraps the secret with a fixed prefix before deriving the key (see
+    # `derive_key`). algorithm defaults to SHA-256 (Django ≥ 3.1); older apps used SHA-1.
+    # Both salt and algorithm are pinned to golden vectors from real Django in the spec.
     module Django
       extend self
 
@@ -129,8 +130,19 @@ module Gori
 
       # --- internals ----------------------------------------------------------
 
+      # Django 6.0 added a purpose-specific wrap around the secret, but only for
+      # `django.core.signing.get_cookie_signer()` — the factory `signed_cookies`
+      # (SESSION_SALT) calls internally to build its Signer: `key = b"django.http.cookies"
+      # + secret_key`, and THAT wrapped key is what feeds the normal salt+"signer"
+      # derivation below. The generic `signing.dumps()`/`Signer` API (any other salt,
+      # including DEFAULT_SALT) never goes through `get_cookie_signer` and is unaffected.
+      # Confirmed byte-for-byte against real Django 6.0.8 — see
+      # `django.core.signing._cookie_signer_key`.
+      COOKIE_SIGNER_PREFIX = "django.http.cookies"
+
       private def derive_key(salt : String, secret : String, algorithm : String) : Bytes
-        material = "#{salt}signer#{secret}"
+        key = salt == SESSION_SALT ? "#{COOKIE_SIGNER_PREFIX}#{secret}" : secret
+        material = "#{salt}signer#{key}"
         case algorithm
         when "sha1"   then Digest::SHA1.digest(material)
         when "sha256" then Digest::SHA256.digest(material)

--- a/src/gori/mcp/tools/compare.cr
+++ b/src/gori/mcp/tools/compare.cr
@@ -102,7 +102,7 @@ module Gori
         if pane == :request
           Repeater::MessageLines.of(redacted_head(d.request_head, include_sensitive), d.request_body, decode: false)
         else
-          Repeater::MessageLines.of(redacted_head(d.response_head, include_sensitive), d.response_body, decode: true)
+          Repeater::MessageLines.of(redacted_head(d.response_head, include_sensitive), d.response_body, decode: true, error: d.error)
         end
       end
 

--- a/src/gori/mcp/tools/send.cr
+++ b/src/gori/mcp/tools/send.cr
@@ -543,8 +543,17 @@ module Gori
         return {plan, false} unless bool_arg(h, "apply_rules", false)
         rules = Gori::Rules.load(store)
         return {plan, false} unless rules.active?
+        # `add_if_missing: false` — this runs AFTER `Plan.build`, so it is past the point where
+        # `auto_content_length` was honoured, and the two plan shapes that reach here with that
+        # flag deliberately OFF (a `flow_id` capture and a `raw`/verbatim request, both built
+        # below with `auto_content_length: false`) are the ones this must not re-frame. A
+        # capture that carried no Content-Length is evidence — an h2/gRPC streamed POST is
+        # stored exactly that way — and inventing framing for it here would undo the very
+        # thing those call sites turned the flag off for. Rules may still CHANGE the body, so
+        # an EXISTING Content-Length is still re-synced; only the ADD is withheld.
         rewritten = Repeater::FlowRequest.resync_content_length(
-          rules.transform_message(String.new(plan.bytes), Store::RuleTarget::Request, plan.host).to_slice)
+          rules.transform_message(String.new(plan.bytes), Store::RuleTarget::Request, plan.host).to_slice,
+          add_if_missing: false)
         return {plan, false} if rewritten == plan.bytes
         {plan.with_requests([rewritten]), true}
       end

--- a/src/gori/proxy/codec/content_decode.cr
+++ b/src/gori/proxy/codec/content_decode.cr
@@ -3,6 +3,7 @@ require "compress/deflate"
 require "compress/zlib"
 require "./brotli"
 require "./zstd"
+require "./http1" # Http1.obfuscated_header? — see content_encoded?
 require "../../ascii_bytes"
 
 module Gori::Proxy::Codec
@@ -101,6 +102,32 @@ module Gori::Proxy::Codec
     # header at all? (Byte scan for either full name, case-insensitively.)
     private def self.head_has_encoding?(head : Bytes) : Bool
       AsciiBytes.contains_ci?(head, CE_NEEDLE) || AsciiBytes.contains_ci?(head, TE_NEEDLE)
+    end
+
+    # Whether `head` declares a real (non-identity) Content-Encoding — gzip/br/deflate/zstd,
+    # as opposed to Transfer-Encoding (chunked), which the caller de-chunks separately.
+    # Content-Encoding is never inflated on the live wire path (only for DISPLAY, above) —
+    # a Match&Replace body rule matching against still-compressed bytes can incidentally hit
+    # inside the compressed stream and corrupt it (a short/common literal pattern needs no
+    # more than a byte-value coincidence), so callers on that path use this to refuse rather
+    # than risk it. See `ClientConn#apply_body_rewrite`.
+    # This is a WIRE gate, not a display read, so it must fail CLOSED where the tolerant parser
+    # below cannot see a value. `encoding_headers` walks whole lines and skips any without a
+    # colon, so an obs-folded header (RFC 7230 §3.2.4, `Content-Encoding:\r\n gzip`) parses as an
+    # EMPTY value and the real `gzip` on the continuation line is never seen — which would hand
+    # a compressed body straight to the rule engine, the one outcome this predicate exists to
+    # prevent. `Http1.obfuscated_header?` is the codebase's single home for "this head is folded
+    # or otherwise not cleanly parseable" (see AGENTS.md §1), so ask it rather than re-deriving
+    # the scan here. Response framing deliberately lets obs-folds through byte-exact (see
+    # `Http1.framing_ambiguous?`), so such a head really does reach this gate.
+    def self.content_encoded?(head : Bytes) : Bool
+      return false unless AsciiBytes.contains_ci?(head, CE_NEEDLE)
+      _, ce_values = encoding_headers(head)
+      return true if ce_values.flat_map(&.split(',')).map(&.strip.downcase).any? { |e| !e.empty? && e != "identity" }
+      # A Content-Encoding field-name IS present (a bare `Vary: Content-Encoding` yields no
+      # entry here at all, so it still returns false) but no readable token came back: refuse
+      # only when the head is folded/obfuscated, which is the shape that hides one.
+      !ce_values.empty? && Http1.obfuscated_header?(head)
     end
 
     # `chunked` frames the body only when it's the FINAL transfer-coding (RFC 7230

--- a/src/gori/proxy/conn/client_conn.cr
+++ b/src/gori/proxy/conn/client_conn.cr
@@ -1807,9 +1807,17 @@ module Gori::Proxy
     # it is de-chunked to the entity before matching. `yield entity` runs the rule engine
     # (rewrite_request_body / rewrite_response_body), which returns the SAME bytes when
     # nothing matched. On no change we return the ORIGINAL head + wire body byte-exact
-    # (P7) — so an unmatched flow, including a compressed body a literal pattern can't
-    # touch, is never re-framed. On a change we re-frame the head to Content-Length (the
-    # new entity length, Transfer-Encoding dropped) and forward the rewritten entity.
+    # (P7) — so an unmatched flow is never re-framed. On a change we re-frame the head to
+    # Content-Length (the new entity length, Transfer-Encoding dropped) and forward the
+    # rewritten entity.
+    #
+    # A real (non-identity) Content-Encoding is refused BEFORE the rule ever sees the
+    # entity: gzip/br/deflate/zstd are never inflated on this wire path (only for
+    # DISPLAY — see `ContentDecode`), so a literal/regex match runs against opaque
+    # compressed bytes. A short or common pattern (a single byte is enough) can
+    # incidentally match INSIDE the compressed stream purely by chance and corrupt it —
+    # silently: no error, no advisory, Content-Length still recalculated to look
+    # consistent. Refusing keeps the response byte-exact (P7) instead of guessing wrong.
     #
     # The two returned halves are always FRAMED CONSISTENTLY with each other, and #501's
     # extract observer depends on that: it is handed the same pair and lets
@@ -1818,6 +1826,7 @@ module Gori::Proxy
     private def apply_body_rewrite(head : Bytes, wire_body : Bytes?, framing : Codec::BodyFraming,
                                    & : Bytes -> Bytes) : {Bytes, Bytes?}
       return {head, wire_body} if wire_body.nil? || wire_body.empty?
+      return {head, wire_body} if Codec::ContentDecode.content_encoded?(head)
       entity = framing.chunked? ? Codec::ContentDecode.dechunk(wire_body) : wire_body
       rewritten = yield entity
       return {head, wire_body} if rewritten == entity # nothing matched → byte-exact (P7)

--- a/src/gori/proxy/h2/assembler.cr
+++ b/src/gori/proxy/h2/assembler.cr
@@ -80,6 +80,11 @@ module Gori::Proxy::H2
       # is stamped when the stream is first seen; `resp_first_at` on the first
       # response HEADERS/DATA frame (time-to-first-byte).
       getter started_at : Time::Instant = Time.instant
+      # Wall-clock capture time for THIS stream. A persistent h2 connection carries many
+      # requests over its lifetime (the common case: gori advertises h2 to the client
+      # whenever the origin offers it), so this must be stamped per-stream, not inherited
+      # from the connection's own open time — the same mistake `started_at` above avoids.
+      getter created_at : Int64 = (Time.utc - Time::UNIX_EPOCH).total_microseconds.to_i64
       property resp_first_at : Time::Instant? = nil
       # The stream whose PUSH_PROMISE invented this request, when the client never sent it.
       # A pushed flow was indistinguishable in History / QL / the Sitemap from one the client
@@ -95,7 +100,10 @@ module Gori::Proxy::H2
       getter advisories = [] of String
     end
 
-    def initialize(@sink : FlowSink, @host : String, @port : Int32, @created_at : Int64,
+    # `connection_created_at` is kept as a positional argument for call-site compatibility
+    # (the connection's own open time) but is deliberately NOT stored or used for a flow's
+    # `created_at` — see `Stream#created_at`, which each request stamps for itself.
+    def initialize(@sink : FlowSink, @host : String, @port : Int32, connection_created_at : Int64,
                    @conn_id : Int64 = 0_i64)
       @mutex = Mutex.new
       @streams = {} of UInt32 => Stream
@@ -433,7 +441,7 @@ module Gori::Proxy::H2
       head = synth_request_head(headers, authority, stream.req.trailer_names, stream.pushed_by,
         pseudo(headers, ":protocol"))
       captured = Store::CapturedRequest.new(
-        created_at: @created_at, scheme: scheme, host: host, port: port,
+        created_at: stream.created_at, scheme: scheme, host: host, port: port,
         method: method, target: path, http_version: "HTTP/2", head: head, body: body,
         body_truncated: cap.truncated?, body_size: cap.total,
         h2_conn_id: @conn_id, h2_stream_id: stream_id.to_i64,

--- a/src/gori/repeater/flow_request.cr
+++ b/src/gori/repeater/flow_request.cr
@@ -106,22 +106,27 @@ module Gori
         end.to_slice
       end
 
-      # Rewrite an EXISTING Content-Length to match the actual body length of a wire-form
-      # request. Used after env-var expansion changes body bytes (a `$KEY` in the body):
-      # `build` framed the CL over the pre-expansion body, so re-sync it or the origin
-      # over/under-reads. Never ADDS a header (GETs stay clean) and leaves chunked/h2
-      # bodies (no Content-Length) untouched. Shared by the TUI Repeater editor and the
-      # headless CLI/MCP repeater-send paths so they can't disagree.
+      # Keep Content-Length matching the actual body length of a wire-form request: rewrite
+      # an EXISTING header (e.g. after env-var expansion changes body bytes — a `$KEY` in the
+      # body means `build` framed the CL over the pre-expansion body, so re-sync it or the
+      # origin over/under-reads), and — when `add_if_missing` (the repeater's own default-on
+      # auto-CL toggle, as opposed to the captured-flow-replay caller below) — ADD one when a
+      # non-empty body has none at all: an operator editing a repeater's raw request text and
+      # leaving out Content-Length entirely otherwise sends a framing-ambiguous request that
+      # most origins read as a zero-length body, silently, with gori's own recorded evidence
+      # still showing the edited body text. A bodyless request (GETs stay clean) never gets a
+      # header added. Shared by the TUI Repeater editor and the headless CLI/MCP
+      # repeater-send paths so they can't disagree.
       #
-      # A head carrying `Transfer-Encoding` is left ALONE, Content-Length or not. RFC 7230
-      # §3.3.3 forbids sending both, so a message with both is a CL.TE / TE.CL smuggling
-      # probe — the two headers disagreeing IS the test — and "correcting" the CL over the
-      # chunked wire form turns it into a different probe with no notice. This is the rule
-      # `build_single_flow_request` already applies on the sibling flow-replay path
-      # (`!explicit_cl && !has_te && body_override`); it was missing here, so `repeater
-      # create` + `send` under the default auto-CL rewrote exactly the requests it exists
-      # to replay.
-      def self.resync_content_length(bytes : Bytes) : Bytes
+      # A head carrying `Transfer-Encoding` is left ALONE, Content-Length or not (added or
+      # existing). RFC 7230 §3.3.3 forbids sending both, so a message with both is a CL.TE /
+      # TE.CL smuggling probe — the two headers disagreeing IS the test — and "correcting"
+      # the CL over the chunked wire form turns it into a different probe with no notice.
+      # This is the rule `build_single_flow_request` already applies on the sibling
+      # flow-replay path (`!explicit_cl && !has_te && body_override`); it was missing here,
+      # so `repeater create` + `send` under the default auto-CL rewrote exactly the requests
+      # it exists to replay.
+      def self.resync_content_length(bytes : Bytes, add_if_missing : Bool = true) : Bytes
         text = String.new(bytes)
         sep = text.index("\r\n\r\n")
         return bytes unless sep
@@ -130,8 +135,25 @@ module Gori
         lines = head.split("\r\n")
         return bytes if lines.any? { |l| l.lstrip[0, 18]?.try(&.downcase) == "transfer-encoding:" }
         idx = lines.index { |l| l.lstrip.downcase.starts_with?("content-length:") }
-        return bytes unless idx
-        lines[idx] = "Content-Length: #{body.bytesize}"
+        if idx
+          lines[idx] = "Content-Length: #{body.bytesize}"
+        elsif add_if_missing && body.bytesize > 0
+          # ADD only into a head this function actually parsed. `split("\r\n")` collapses a
+          # bare-LF-terminated line into the one before it, and both consequences are the exact
+          # corruption this function exists to avoid:
+          #   * a `Transfer-Encoding` hiding inside such a merged line is invisible to the guard
+          #     above, so a pure TE probe would come back framed BOTH ways — a CL.TE desync test
+          #     the operator never wrote, with the length counting the chunked wire bytes;
+          #   * when the head is LF-framed, `\r\n\r\n` can first occur inside the BODY, so `head`
+          #     runs past the real terminator and the new header lands INSIDE a smuggled request.
+          # A leftover `\n` in any line means exactly that, so leave the bytes as written (P7).
+          # Rewriting an EXISTING Content-Length keeps its pre-existing behaviour: this guard is
+          # only about ADDING framing to bytes we could not parse.
+          return bytes if lines.any?(&.includes?('\n'))
+          lines << "Content-Length: #{body.bytesize}"
+        else
+          return bytes
+        end
         "#{lines.join("\r\n")}\r\n\r\n#{body}".to_slice
       end
 
@@ -148,11 +170,16 @@ module Gori
       # after expansion the header under-counts a body the operator did not author, and the
       # origin over/under-reads. Detect that by the BODY LENGTH changing — an expansion that
       # only touched the head must not be allowed to overwrite a deliberately-wrong CL.
+      #
+      # `add_if_missing: false` — a captured flow with NO Content-Length at all (relying on
+      # close-delimited framing, or itself a smuggling probe) is evidence same as a wrong one;
+      # this path only ever RESYNCS an existing header, it does not invent framing the
+      # operator's capture never had.
       def self.resync_content_length_if_body_changed(before : Bytes, after : Bytes) : Bytes
         b = body_bytesize(before)
         a = body_bytesize(after)
         return after if b.nil? || a.nil? || b == a
-        resync_content_length(after)
+        resync_content_length(after, add_if_missing: false)
       end
 
       # Body length of a wire-form request, or nil when there is no CRLFCRLF terminator.

--- a/src/gori/repeater/message_lines.cr
+++ b/src/gori/repeater/message_lines.cr
@@ -18,9 +18,16 @@ module Gori
       # text: rendering raw non-UTF-8 bytes here (Comparer + the Repeater response diff)
       # reintroduced PR#86's terminal corruption — accidental wide/emoji graphemes among
       # the bytes desync the terminal's cursor tracking. Text lines are scrubbed too.
-      def of(head : Bytes?, body : Bytes?, *, decode : Bool) : Array(String)
+      #
+      # `error` (a flow's `state: error` reason — Sandbox-blocked, connection refused, etc.)
+      # is prepended as its own line, same placement as `gori run show`'s "error: …" line.
+      # Without it, an errored flow has no head/body at all and this returns an empty array,
+      # so a diff against it renders as an unexplained "response removed" — every line of the
+      # OTHER side deleted, with no hint why — instead of showing the actual, more useful fact.
+      def of(head : Bytes?, body : Bytes?, *, decode : Bool, error : String? = nil) : Array(String)
         b = decode ? display_body(head, body) : body
-        lines = bytes_to_lines(head)
+        lines = error ? ["error: #{error}"] : [] of String
+        lines.concat(bytes_to_lines(head))
         if b && !b.empty?
           lines << ""
           if binary?(b)

--- a/src/gori/repeater/plan.cr
+++ b/src/gori/repeater/plan.cr
@@ -297,8 +297,9 @@ module Gori::Repeater
       # `Upgrade: websocket` header would pick the h1 engine and silently exchange nothing.
       websocket = WsEngine.upgrade_request?(String.new(wires.first))
       # A handshake carries no body, and all three surfaces have always sent it verbatim —
-      # `resync_content_length` never ADDS a header, but a captured upgrade that happened to
-      # carry a Content-Length would be rewritten, so skip the pass rather than rely on that.
+      # `resync_content_length` never touches a bodyless request either way (no ADD, and an
+      # existing header still gets rewritten), but a captured upgrade that happened to carry
+      # a Content-Length would still be resynced, so skip the pass rather than rely on that.
       if !websocket
         if options.auto_content_length?
           wires = wires.map { |b| FlowRequest.resync_content_length(b) }

--- a/src/gori/sequencer/stats.cr
+++ b/src/gori/sequencer/stats.cr
@@ -434,6 +434,23 @@ module Gori::Sequencer
         end
         return {false, "non-monotonic"}
       end
+      # Hex path — same correlation idea as the general path below, but decodes each
+      # token's hex DIGITS to their numeric value first instead of reading raw ASCII
+      # bytes. `leading_value` (the general path) treats the string's own bytes as the
+      # magnitude, which silently distorts hex text: ASCII '9' (0x39) to 'a' (0x61) is a
+      # 40-point jump for what is logically a +1 step, so a straightforward incrementing
+      # hex counter can land well under the 0.9 threshold and be missed entirely —
+      # confirmed: `2..301` formatted as zero-padded `%08x` scores corr=0.774 under the
+      # general path despite being a textbook sequential counter. Decoding nibbles first
+      # keeps the magnitude linear in the counter's real value, matching the numeric fast
+      # path's precision for decimal tokens above.
+      if tokens.all? { |t| !t.empty? && t.each_char.all? { |c| c.ascii_number? || ('a'..'f').includes?(c) || ('A'..'F').includes?(c) } }
+        skip = common_prefix_len(tokens)
+        xs = Array(Float64).new(n, &.to_f)
+        ys = tokens.map { |t| hex_leading_value(t, skip) }
+        r = pearson(xs, ys)
+        return {r.abs > 0.9, "corr=#{fmt(r)}"}
+      end
       # General path — correlation of arrival order with a leading-byte magnitude. Shares
       # the same order-dependency the numeric fast path had above (arrival order can be
       # shuffled by concurrency), but isn't fixed here — a coordinate-only fix couldn't
@@ -481,6 +498,21 @@ module Gori::Sequencer
       slice = t.to_slice
       start = {skip, slice.size}.min
       slice[start, {8, slice.size - start}.min].each { |b| v = v * 256.0 + b }
+      v
+    end
+
+    # Like `leading_value`, but for hex text: decodes each character to its NIBBLE value
+    # (0-15) instead of using the character's raw ASCII byte — see the hex path in
+    # `detect_sequential` for why the distinction matters. Window widened to 16 chars (64
+    # bits of hex) to match `leading_value`'s 8-BYTE window at one hex digit per nibble.
+    private def self.hex_leading_value(t : String, skip : Int32 = 0) : Float64
+      v = 0.0
+      chars = t.chars
+      start = {skip, chars.size}.min
+      chars[start, {16, chars.size - start}.min].each do |c|
+        nibble = c.ascii_number? ? (c.ord - '0'.ord) : (c.downcase.ord - 'a'.ord + 10)
+        v = v * 16.0 + nibble
+      end
       v
     end
 

--- a/src/gori/tui/comparer_view.cr
+++ b/src/gori/tui/comparer_view.cr
@@ -380,7 +380,7 @@ module Gori::Tui
       if @pane == :request
         Repeater::MessageLines.of(d.request_head, d.request_body, decode: false)
       else
-        Repeater::MessageLines.of(d.response_head, d.response_body, decode: true)
+        Repeater::MessageLines.of(d.response_head, d.response_body, decode: true, error: d.error)
       end
     end
 

--- a/src/gori/tui/repeater_view.cr
+++ b/src/gori/tui/repeater_view.cr
@@ -2423,12 +2423,13 @@ module Gori::Tui
       "marking works on the REQUEST pane — ↹ to it"
     end
 
-    # When enabled, rewrite an existing `Content-Length` header so it matches the
-    # actual edited body length (the part after the blank line). Common when
-    # tampering with a captured body — you change the JSON and the length should
-    # follow. Only an EXISTING header is updated (never added, so GETs stay clean);
-    # chunked/h2 bodies have no Content-Length and are left untouched. Shared with the
-    # headless CLI/MCP repeater-send paths via FlowRequest so they can't drift apart.
+    # When enabled, keep `Content-Length` matching the actual edited body length (the
+    # part after the blank line): rewrite an existing header, or ADD one when a non-empty
+    # body has none at all (leaving the header out entirely otherwise sends a
+    # framing-ambiguous request most origins read as an empty body). A bodyless request
+    # (GETs stay clean) never gets a header added; chunked/h2 bodies have no
+    # Content-Length and are left untouched. Shared with the headless CLI/MCP
+    # repeater-send paths via FlowRequest so they can't drift apart.
     private def sync_content_length(raw : Bytes) : Bytes
       Repeater::FlowRequest.resync_content_length(raw)
     end


### PR DESCRIPTION
Found by building gori and using it for 20 rounds against local origins (a Python HTTP/SSE server, a Node h2 server, a `grpcio` server, a WS echo, real `oast.pro`, and real Flask/Rack/Django/PyJWT vectors). Six defects, each reproduced before the fix and re-verified after.

### h2 capture timestamps
`Assembler` took the connection's open time once and stamped every stream with it, so every request on a persistent h2 connection shared one `created_at` while `duration_us` stayed correctly per-stream. gori offers h2 whenever the origin does, so this is most HTTPS traffic: a browser tab open for minutes puts dozens of requests in History under one timestamp, breaking chronological ordering and `time:` QL filters. Each `Stream` now stamps its own.

Repro: three sequential requests over one connection shared `created_at=1785928031526067` with durations 6574/787/187µs. Fresh connections were always correct, which is what scoped it to the connection lifetime.

### Repeater Content-Length
Auto Content-Length re-synced an **existing** header but never added a missing one. Editing a request to carry a body and leaving the header out sent a body the origin read as zero-length, silently, while gori's own `request_body` and `form_params` still displayed the typed text. It now adds one.

Two call sites opt out with `add_if_missing: false`: the captured-flow replay path, and MCP `send_request{apply_rules}` (which runs past where `auto_content_length` was honoured, so it would otherwise re-frame the `flow_id` and `raw` plans that deliberately set it off). A capture with no Content-Length is evidence — an h2/gRPC streamed POST is stored exactly that way — not a draft to complete.

The add is also withheld when a bare-LF line leaves the head unparseable: `split("\r\n")` merges such a line into the one before it, which hid a `Transfer-Encoding` from the guard (handing back a CL.TE probe nobody wrote, length counting the chunked wire bytes) and, when the head is LF-framed, let `\r\n\r\n` first occur inside the body so the header landed inside a smuggled request.

### Match & Replace on compressed bodies
A body rule ran against still-compressed bytes. A short literal could match inside a gzip stream by coincidence and corrupt it — no advisory, no log line, and a recalculated Content-Length that looked consistent. Confirmed with a single-byte `x` rule against a gzip endpoint.

The rule is now refused on a real (non-identity) Content-Encoding, which is what `docs/content/guide/proxy.md` already promised ("isn't decompressed, so a literal pattern won't match it"). An obs-folded `Content-Encoding:\r\n gzip` hid the encoding from the tolerant parser, so the check asks `Http1.obfuscated_header?` rather than re-deriving that scan. `Vary: Content-Encoding` still correctly does not trip it.

### Sequencer sequential detection
The Sequential test only took its exact path for pure-decimal tokens. Anything with a hex letter fell to a correlation over raw ASCII bytes, where the 40-point jump from `'9'` (0x39) to `'a'` (0x61) depressed the score: `2..301` as `%08x` scored 0.774 against a 0.9 threshold and reported "none" for a textbook counter. Hex digits now decode to nibbles first (same range now scores 1.0). Random tokens still pass with no new false positive.

### Django session cookies
`verify`/`crack`/`forge` missed session cookies: `get_cookie_signer()` wraps the secret with `b"django.http.cookies"` before the salt derivation, and the `signed_cookies` backend goes through it. Confirmed byte-for-byte against real Django **4.2 LTS, 5.2 and 6.0**. The generic `signing.dumps` API does not go through that factory and is untouched (regression-checked).

### Comparer error state
A diff against an errored flow rendered as an unexplained "response removed" — every line of the other side deleted, no reason — because only `show` read `flows.error`. The shared `MessageLines` now carries it, so the CLI, MCP and TUI comparers all say why (e.g. `error: blocked by sandbox (out of scope)`).

---

Two candidate findings were **retracted** rather than shipped: a "rule reload does not reach a running capture" (the test raced the documented 2s poll) and a "`probe --active` never persists findings" (that scan is a stateless rescan by design; persistence is `probe mode active` + the live analyzer, verified by setting the mode before capture starts).

Verification: `crystal spec` → 7264 examples, 0 failures, 0 errors. `crystal build --no-codegen src/main.cr` clean. ameba reports no offence inside any changed hunk. Includes 4 new regression specs; two existing spec titles that this change made false were corrected.