### PR TITLE
Four motion keys the Repeater response pane swallowed, and an ↑ that left the pane with rows still above the caret

### DIFF
--- a/spec/tui/repeater_wrap_spec.cr
+++ b/spec/tui/repeater_wrap_spec.cr
@@ -263,3 +263,93 @@ describe "Gori::Tui::RepeaterView soft wrap" do
     view.resp_cursor.cx.should be > 0
   end
 end
+
+# A response whose STATUS LINE is long enough to wrap — the shape that makes line 0 span
+# several visual rows without any help from the operator. A hostile (or merely verbose)
+# origin picks the reason phrase, so this is ordinary captured traffic, not a synthetic case.
+private def wrapped_head_view : Gori::Tui::RepeaterView
+  view = Gori::Tui::RepeaterView.new
+  view.load_blank
+  view.focus_pane(:response)
+  hdr = "HTTP/1.1 200 OK #{"Y" * 300}\r\nContent-Type: text/plain\r\n\r\n"
+  view.apply(Gori::Repeater::Result.new(hdr.to_slice, ("body line\n" * 40).to_slice, nil, 1000_i64))
+  view
+end
+
+describe "Gori::Tui::RepeaterView response read motion" do
+  # THE REGRESSION for `at_top?`. The caret one visual row into a wrapped line 0 still has a
+  # row above it inside the pane, and the controller turns `at_top?` into "↑ leaves for the
+  # tab bar" — so answering true there made every continuation row of line 0 unreachable by
+  # ↑. `TextArea#at_top?` (the request pane beside it), `HistoryView#detail_at_top?` and
+  # `ReadPane#at_top?` all test the sub-row; this pane was the last one that did not.
+  it "is not at_top? while the caret sits on a continuation row of a wrapped line 0" do
+    view = wrapped_head_view
+    rect = Rect.new(0, 0, 80, 20)
+    view.render(Screen.new(MemoryBackend.new(80, 20)), rect)
+    view.at_top?.should be_true # caret on line 0, first visual row
+
+    view.resp_move(1, 0) # one VISUAL row down — still inside line 0
+    view.resp_cursor.cy.should eq(0)
+    view.at_top?.should be_false
+
+    view.resp_move(-1, 0) # and back up to the first row, which IS the top
+    view.at_top?.should be_true
+  end
+
+  # Home/End are the LOGICAL line's edges, not the visual row's — the rule `ReadPane#
+  # motion_key` states and `HistoryView#detail_line_edge` follows, so End on a wrapped line
+  # lands on its LAST row rather than at the first wrap break.
+  it "puts End at the logical end of a wrapped line and Home back at its start" do
+    view = wrapped_head_view
+    rect = Rect.new(0, 0, 80, 20)
+    view.render(Screen.new(MemoryBackend.new(80, 20)), rect)
+    len = view.resp_plain_lines[0].size
+    len.should be > 300 # the status line really does wrap at this width
+
+    view.resp_line_edge(1).should be_true
+    view.resp_cursor.cy.should eq(0)
+    view.resp_cursor.cx.should eq(len) # the LINE's end, not the first row's
+
+    view.resp_line_edge(-1).should be_true
+    view.resp_cursor.cx.should eq(0)
+  end
+
+  # ⇧Home/⇧End extend rather than just move — the footer advertises "⇧arrows select", and
+  # before this the two keys reached no arm at all and selected nothing.
+  it "extends the selection when Home/End are given shift" do
+    view = wrapped_head_view
+    rect = Rect.new(0, 0, 80, 20)
+    view.render(Screen.new(MemoryBackend.new(80, 20)), rect)
+    view.resp_cursor.selection?.should be_false
+
+    view.resp_line_edge(1, selecting: true).should be_true
+    view.resp_cursor.selection?.should be_true
+    view.resp_copy_text.should eq(view.resp_plain_lines[0])
+  end
+
+  # The page step is measured from THIS pane's drawn height, not the shell's body height:
+  # the response column carries its own header and borders, so paging by the body's height
+  # would step past the end of what the operator is looking at. Same `-2` overlap as
+  # `ReadPane#motion_key` and `HistoryView#detail_page_rows`.
+  it "pages by its own drawn height, with a couple of rows of overlap" do
+    view = wrapped_head_view
+    rect = Rect.new(0, 0, 80, 20)
+    view.render(Screen.new(MemoryBackend.new(80, 20)), rect)
+    body_h = resp_body_rect(rect).h
+    view.resp_page_rows.should eq({body_h - 2, 1}.max)
+    view.resp_page_rows.should be < body_h # an overlap, not a clean jump
+  end
+
+  # A hex dump has no lines to have edges, so `resp_line_edge` DECLINES — that false is what
+  # lets the controller fall through to the shell's ±JUMP_ROWS and reach
+  # `RepeaterController#body_scroll`, which jumps the dump to top/bottom instead. Answering
+  # true here would swallow the key and leave hex Home/End dead.
+  it "declines Home/End on a hex dump so the buffer jump can claim them" do
+    view = wrapped_head_view
+    rect = Rect.new(0, 0, 80, 20)
+    view.render(Screen.new(MemoryBackend.new(80, 20)), rect)
+    view.toggle_resp_hex
+    view.resp_line_edge(1).should be_false
+    view.resp_line_edge(-1).should be_false
+  end
+end

--- a/src/gori/tui/controllers/repeater_controller.cr
+++ b/src/gori/tui/controllers/repeater_controller.cr
@@ -693,6 +693,24 @@ module Gori::Tui
       handle_wheel(step)
     end
 
+    # PageUp/PageDown/Home/End that `handle_body_key` did NOT claim: the response pane's hex
+    # dump (no lines, so `resp_line_edge` declines) and every ⌃/⌥-modified form (deferred to
+    # the keymap before the focus dispatch ever runs). Both land here, and both mean "move the
+    # dump" — the twin of the `history_controller.scroll_detail(delta)` fallthrough the Runner
+    # does for the History detail overlay.
+    #
+    # The `:response` guard is the mechanism, not a comment: it is what keeps this from moving
+    # a pane the operator is not in. The request and target panes do consume these keys
+    # themselves (`handle_repeater_request_read` / `edit_motion_key` in both modes, and a
+    # single-line target has no page to turn), but the guard holds even where they do not —
+    # including the CHAIN pane, which `chain_pane_active?` scopes to `:request` anyway.
+    def body_scroll(delta : Int32) : Bool
+      v = current_view
+      return false unless v && v.focus == :response
+      v.scroll(delta)
+      true
+    end
+
     def handle_wheel(step : Int32) : Bool
       v = current_view
       return true unless v
@@ -2150,6 +2168,26 @@ module Gori::Tui
       when key.down?, key.lower_j? then resp_nav_step(view, 1, 0, selecting, nav)
       when key.left?               then resp_nav_step(view, 0, -1, selecting, nav)
       when key.right?              then resp_nav_step(view, 0, 1, selecting, nav)
+        # Page/line-edge keys, ⇧ extending — the set every other read pane in the tree has
+        # (`ReadPane#motion_key`, `HistoryView#detail_line_edge`/`#detail_page_rows`, and the
+        # request editor beside this one). They sat in NO arm before, so the trailing `true`
+        # swallowed all four and they moved nothing.
+        #
+        # ABOVE the `transcript` arm on purpose: a WS/gRPC/group transcript is navigable text
+        # with a caret, exactly like a plain response — the same reasoning the ←/→ comment
+        # above gives. Only the d/x/p TOOLS are transcript-less.
+        #
+        # A page step goes through `resp_move`, so on a split column it crosses cards only
+        # when the caret is ALREADY on the boundary line — the same condition a single ↓ has
+        # to meet. From mid-card it pages within the card.
+      when key.page_up?   then resp_nav_step(view, -view.resp_page_rows, 0, selecting, nav)
+      when key.page_down? then resp_nav_step(view, view.resp_page_rows, 0, selecting, nav)
+        # Home/End return FALSE on a hex dump (no lines to have edges) so the shell's
+        # ±JUMP_ROWS reaches `body_scroll` and jumps the dump to top/bottom — History's hex
+        # fallthrough. The MODIFIED form never arrives here at all (`handle_body_key` defers
+        # every ctrl/alt chord to the keymap), and lands on that same buffer jump.
+      when key.home? then return view.resp_line_edge(-1, selecting: selecting)
+      when key.end?  then return view.resp_line_edge(1, selecting: selecting)
       when transcript
         # Transcript: no d/x/p tools; still let Global breath / copy through.
         return false if c && !ev.ctrl? && !ev.alt? && !c.control?

--- a/src/gori/tui/repeater_view.cr
+++ b/src/gori/tui/repeater_view.cr
@@ -3046,7 +3046,13 @@ module Gori::Tui
         if resp_split? && @resp_pane == :transcript
           false
         elsif resp_navigable?
-          @resp_cursor.cy == 0 && @scroll == 0
+          # The sub-row half is not decoration: under wrap a caret parked three rows into a
+          # wrapped line 0 still has three rows above it INSIDE this pane, and popping focus
+          # from there makes exactly those rows unreachable by ↑. A long status reason phrase
+          # wraps line 0 on its own, so this was reachable with no help from the operator.
+          # `TextArea#at_top?` (the request pane beside it), `HistoryView#detail_at_top?` and
+          # `ReadPane#at_top?` all already test it; this pane was the last one that did not.
+          @resp_cursor.cy == 0 && @scroll == 0 && resp_caret_sub == 0
         else
           @scroll == 0
         end
@@ -3540,6 +3546,42 @@ module Gori::Tui
       ensure_resp_visible(@resp_last_h) if @resp_last_h > 0
     end
 
+    # Home / End in the response pane: the LOGICAL line's edges, with ⇧ extending.
+    #
+    # This pane had NO Home/End, and no PgUp/PgDn either: all four reached
+    # `handle_repeater_response`, matched none of its arms, and were swallowed by the
+    # trailing `true` — so the four keys did nothing at all, and ⇧Home/⇧End selected nothing
+    # while the footer advertised "⇧arrows select". Every other multi-line pane in the tree
+    # (the request editor beside it via `TextArea#handle_motion_key`, `HistoryView#
+    # detail_line_edge`, and `ReadPane#motion_key` for the other nine) already spells them
+    # this way; the response pane was the lone hold-out.
+    #
+    # Logical line ends, not visual row ends — the rule `ReadPane#motion_key` states, so a
+    # wrapped line's End lands on its last row and Home on its first, with the shared
+    # `ensure_resp_visible` scrolling to whichever row that turned out to be.
+    #
+    # False on a hex dump: it has no lines to have edges. The controller then returns false
+    # too, and the shell's ±JUMP_ROWS reaches `RepeaterController#body_scroll` — the same
+    # top/bottom buffer jump History's hex dump falls through to.
+    def resp_line_edge(dir : Int32, selecting : Bool = false) : Bool
+      return false unless resp_navigable?
+      size, line_at = resp_line_source
+      return false if size <= 0
+      cy = @resp_cursor.cy.clamp(0, size - 1)
+      @resp_cursor.move_to(cy, dir < 0 ? 0 : line_at.call(cy).size, selecting: selecting)
+      ensure_resp_visible(@resp_last_h) if @resp_last_h > 0
+      true
+    end
+
+    # One screenful of the response pane, for PgUp/PgDn. The same "minus a couple of rows of
+    # overlap" step `ReadPane#motion_key` and `HistoryView#detail_page_rows` use, measured
+    # from THIS pane's own last drawn height rather than the shell's `@body_h`: the response
+    # column is half the body's width but carries its own header and borders, so the body's
+    # height pages past the end of what the operator is looking at.
+    def resp_page_rows : Int32
+      {@resp_last_h - 2, 1}.max
+    end
+
     # A vertical step off the end of one response card crosses into the other — ↓ off the
     # HANDSHAKE RESPONSE bottom lands on the TRANSCRIPT's first line, ↑ off the TRANSCRIPT top
     # lands on the handshake's last — so the column reads as one document, exactly as
@@ -3977,6 +4019,22 @@ module Gori::Tui
       fn = resp_layout_fn(cw, line_at)
       csub = fn.call(cy).row_of(@resp_cursor.cx + off)
       @scroll, @scroll_sub = Wrap.ensure_visible(@scroll, @scroll_sub, cy, csub, view_h, fn)
+    end
+
+    # The caret's visual row WITHIN its logical line, or 0 when nothing has been laid out yet
+    # (hex, or before the first frame published a content width) — `at_top?`'s wrap half, the
+    # twin of `HistoryView#detail_caret_sub`.
+    #
+    # Measured on the DRAWN line and with `cx + off`, exactly as `ensure_resp_visible` above
+    # does: in diff mode every row carries a `"+ "`/`"- "` decoration, so the bare column the
+    # cursor holds sits `off` cells left of the one the wrap was computed on.
+    private def resp_caret_sub : Int32
+      cw = @resp_last_cw
+      return 0 if resp_hex_active? || cw <= 0
+      size, drawn_at, off = resp_drawn_source
+      cy = @resp_cursor.cy
+      return 0 if size <= 0 || cy >= size
+      resp_layout(cy, cw, drawn_at).row_of(@resp_cursor.cx + off)
     end
 
     # --- response soft wrap ----------------------------------------------------


### PR DESCRIPTION
Two findings in the one read pane the tree's three keymap sweeps all missed. Both were
reproduced against a live TUI (isolated GORI_HOME, tmux, caret read back with
`display-message`) and re-verified A/B against a pre-fix binary.

WHY THIS PANE. `handle_repeater_response` covers the only multi-line read surface that is
neither a `TextArea`, nor a `ReadPane` user, nor the History detail — and each of the three
sweeps that spread this keymap was scoped by exactly one of those. #583 ("ONE KEYMAP") routed
eight surfaces through `TextArea#handle_motion_key` and its message notes "PageUp/PageDown
(nothing had it)"; all eight are text boxes. #588 gave nine read-only panes
`ReadPane#motion_key`; this pane is hand-rolled and was not migrated, and that commit's only
touch here was a wheel comment. #592 gave the History detail `detail_line_edge`, and its
comment enumerates "every other multi-line pane in the tree (Repeater, Notes, Issues, Project,
Decoder, Fuzzer, and `ReadPane#motion_key`)" — the "Repeater" in that list is the REQUEST pane.
The response pane was invisible in the enumeration all three times.

FOUR DEAD KEYS. Home, End, PageUp and PageDown matched no arm of `handle_repeater_response`,
so its trailing `true` reported them handled and they moved nothing — and because it answered
true, the Runner's `page_nav_delta` → `body_scroll` fallback never ran either. ⇧Home/⇧End
selected nothing while the footer advertised "⇧arrows select". No verb could have wanted the
keys: `Keybind.from_event` encodes enter/escape/tab/arrows/backspace/space/ASCII only, so
Home/End/Page cannot be spelled as a `Verb::Chord` at all.

`resp_line_edge` is the line-edge half — LOGICAL line ends, so End on a wrapped line lands on
its last row, `ReadPane#motion_key`'s rule — and `resp_page_rows` the page half, measured from
this pane's own drawn height rather than the shell's `@body_h` because the response column
carries its own header and borders. Both arms sit ABOVE the `transcript` arm: a WS/gRPC/group
transcript is navigable text with a caret, the same reasoning the ←/→ comment beside them
already gives. On a hex dump `resp_line_edge` DECLINES, and that false is load-bearing — it
lets the key fall through to `RepeaterController#body_scroll`, the new twin of the History
detail's `scroll_detail(delta)` fallthrough, which jumps the dump to top/bottom. That same
fallthrough catches every ⌃/⌥-modified form, which never reaches the handler at all.

AN ↑ THAT EJECTED. `at_top?` answered `cy == 0 && @scroll == 0` for the response, ignoring the
caret's wrapped SUB-ROW — and the controller turns `at_top?` into "↑ leaves for the tab bar".
So from any continuation row of a wrapped line 0 the ↑ ejected the pane instead of walking up
one row, making exactly those rows unreachable from the keyboard. A verbose status reason
phrase wraps line 0 on its own, so this needed no help from the operator: against a 300-char
reason the caret walked rows 15→16→17 on ↓↓ and then jumped clean out of the pane on ↑.
`TextArea#at_top?` (the request pane beside it), `HistoryView#detail_at_top?` and
`ReadPane#at_top?` all already test the sub-row. `resp_caret_sub` is this pane's, measured on
the DRAWN line with `cx + off` so diff mode's "+ "/"- " decoration lands on the grid the wrap
was computed on — the coordinates `ensure_resp_visible` already uses.

VERIFIED. Normal, diff (the `off` path) and hex (the fallthrough path); ⇧ extending on all
four keys, where copy reports a 1072b selection against copy-all's 2418b; the request pane
unchanged in READ and INSERT with the response pane not moving under it. The `at_top?` spec
fails on the pre-fix source, so it is a regression test and not a description. NOT exercised:
the split (WebSocket) response column — a page step routes through `resp_move`, so by code
reading it crosses cards only when the caret is already on the boundary line, the same
condition a single ↓ has to meet, but the harness had no WS flow to prove it.

7264 -> 7269 examples, no regressions. The eight red specs before and after are the
`Gori::Session` port-bind set, which fail because a live gori holds the port, not because of
anything here. Format clean on every changed file; ameba unchanged at 40 on them.
