### PR TITLE
Five data-flow defects across the tui / mcp / run surfaces, found by diffing them against each other

### DIFF
--- a/spec/cli/run/history_spec.cr
+++ b/spec/cli/run/history_spec.cr
@@ -158,17 +158,86 @@ describe "gori run history — CLI::Output rows" do
   # CLI::Output is the shape `gori run history --format json`, `gori run capture`'s
   # JSON-Lines stream, and the MCP list_history tool all mirror. A field added to one
   # serializer and not the other is a silent three-surface drift, and nothing else in the
-  # tree compares them. The ONE deliberate difference is the timestamp field name.
+  # tree compares them. The ONE remaining difference is the CLI's extra human `time`.
+  #
+  # This used to subtract `time` from one side and `created_at_iso` from the other and assert
+  # neither carried both, which made the pin PASS while the two surfaces rendered the same
+  # instant as different strings — `time` is local at second precision, `created_at_iso` is
+  # UTC at millisecond. The keys matched and the values could not be compared. Now the CLI
+  # carries both and the shared key is asserted on VALUE, not just presence.
   it "keeps the flow-row JSON keys in lockstep with the MCP serializer" do
     row = flow_row(target: "/a", host: "h", status: 200, state: Gori::Store::FlowState::Complete)
     cli = JSON.parse(Gori::CLI::Output.flow_row_json(row)).as_h.keys
     mcp = JSON.parse(JSON.build { |j| Gori::MCP::Serialize.flow_row(j, row) }).as_h.keys
 
     # Sorted: the point is a missing/extra FIELD, not the emission order.
-    (cli - ["time"]).sort!.should eq((mcp - ["created_at_iso"]).sort!)
-    cli.should contain("time")               # CLI names it `time`
-    mcp.should contain("created_at_iso")     # MCP names it `created_at_iso`
-    cli.should_not contain("created_at_iso") # …and neither carries both
+    (cli - ["time"]).sort!.should eq(mcp.sort!)
+    cli.should contain("time")           # the CLI's extra, human-facing, local
+    cli.should contain("created_at_iso") # …alongside the machine-readable one MCP names
+  end
+
+  # The half the key-set pin cannot see. `Output.iso_time_utc` is a reimplementation of
+  # `Serialize.unix_micros_iso` (CLI::Output deliberately takes no dependency on MCP::), so
+  # nothing but this assertion stops the two from drifting.
+  it "renders created_at_iso byte-for-byte the same as the MCP serializer" do
+    row = Gori::Store::FlowRow.new(
+      id: 1_i64, created_at: 1_700_000_000_123_456_i64, scheme: "https", method: "GET",
+      host: "h", port: 443, target: "/a", status: 200, size: 0_i64,
+      state: Gori::Store::FlowState::Complete)
+    cli = JSON.parse(Gori::CLI::Output.flow_row_json(row))
+    mcp = JSON.parse(JSON.build { |j| Gori::MCP::Serialize.flow_row(j, row) })
+    cli["created_at_iso"].as_s.should eq(mcp["created_at_iso"].as_s)
+    # UTC, milliseconds, Z — and the sub-second micros `time` drops are kept here.
+    cli["created_at_iso"].as_s.should eq("2023-11-14T22:13:20.123Z")
+    Gori::CLI::Output.iso_time_utc(1_700_000_000_123_456_i64)
+      .should eq(Gori::MCP::Serialize.unix_micros_iso(1_700_000_000_123_456_i64))
+  end
+
+  # The class this round closed: `JSON::Builder#string` escapes JSON metacharacters but writes
+  # raw bytes through, so ONE non-UTF-8 byte in a captured field makes the whole document
+  # unparseable to a strict reader (python's json.loads raises UnicodeDecodeError) — and in the
+  # JSON-Lines stream, every later line with it. Proven reachable end-to-end: `flows.host` /
+  # `flows.target` round-trip such a byte through SQLite unchanged.
+  it "emits valid UTF-8 for a captured target and host holding a non-UTF-8 byte" do
+    row = Gori::Store::FlowRow.new(
+      id: 1_i64, created_at: 0_i64, scheme: "https", method: "GET",
+      host: String.new(Bytes[104, 255, 120]), port: 443,
+      target: String.new(Bytes[47, 97, 255, 98]), status: 200, size: 0_i64,
+      state: Gori::Store::FlowState::Complete,
+      content_type: String.new(Bytes[116, 255]))
+    json = Gori::CLI::Output.flow_row_json(row)
+    json.valid_encoding?.should be_true
+    parsed = JSON.parse(json)
+    parsed["target"].as_s.should eq("/a�b")
+    parsed["host"].as_s.should eq("h�x")
+    parsed["content_type"].as_s.should eq("t�")
+    # …and the MCP row for the same flow was already clean, which is what made this a drift.
+    JSON.build { |j| Gori::MCP::Serialize.flow_row(j, row) }.valid_encoding?.should be_true
+  end
+
+  it "emits valid UTF-8 for a fuzz row whose extract captured non-UTF-8 response bytes" do
+    bad = String.new(Bytes[115, 61, 255, 254])
+    r = Gori::Fuzz::Result.new(0_i64, ["p"], 0, 200, 10_i64, 2, 1, 100_i64, nil, true, false, bad)
+    Gori::CLI::Output.fuzz_row_json(r).valid_encoding?.should be_true
+    JSON.parse(Gori::CLI::Output.fuzz_row_json(r))["extracted"].as_s.should eq("s=��")
+
+    # …and the same for `error`, the sibling field the `payloads` fix did not cover.
+    e = Gori::Fuzz::Result.new(1_i64, ["p"], 0, nil, 0_i64, 0, 0, 5_i64, bad, false, false, nil)
+    Gori::CLI::Output.fuzz_row_json(e).valid_encoding?.should be_true
+  end
+
+  it "emits valid UTF-8 for a discover finding and a sequencer sample" do
+    bad = String.new(Bytes[47, 255])
+    f = Gori::Discover::Finding.new(
+      url: "http://h/#{bad}", method: "GET", status: 200, length: 1_i64,
+      content_type: bad, source: Gori::Discover::Source::Crawled, depth: 0,
+      confidence: 1.0, note: nil)
+    Gori::CLI::Output.discover_row_json(f).valid_encoding?.should be_true
+
+    s = Gori::Sequencer::Sample.new(
+      index: 0, token: bad, status: 200, length: 2, duration_us: 1_i64, error: nil)
+    Gori::CLI::Output.sequence_sample_json(s).valid_encoding?.should be_true
+    JSON.parse(Gori::CLI::Output.sequence_sample_json(s))["token"].as_s.should eq("/�")
   end
 
   # The same lockstep for the field this round added, since a conditional field is exactly

--- a/spec/cli/run/intercept_spec.cr
+++ b/spec/cli/run/intercept_spec.cr
@@ -216,3 +216,96 @@ describe "held-item edit refusal on the read surfaces" do
     obj.has_key?("head_only_note").should be_false
   end
 end
+
+# `head_and_body` backs BOTH read surfaces — MCP `intercept_list`/`intercept_get` and
+# `gori run intercept list`/`show` — and it used to scan for `\r\n\r\n` alone and slice the
+# body at a hard-coded `sep + 4`. A bare-LF header terminator is *the* CL/TE desync primitive
+# (P7 keeps it byte-exact), so the one message class an operator holds precisely BECAUSE of its
+# framing was the one whose framing these projections got wrong: the body was reported inside
+# `head` with `body_size: 0`, while the EDIT path on the same bytes split it correctly through
+# `Env.head_body_boundary`. `body_size` is the only body signal `intercept_get` gives without
+# `include_sensitive`, and `intercept show` gates its raw-bytes hint on `body.empty?`.
+private def desync_held(raw : String) : Gori::Store::HeldRow
+  Gori::Store::HeldRow.new(
+    session_token: "t", item_id: 3_i64, kind: "request", method: "POST", host: "h",
+    port: 80, scheme: "http", target: "/x", raw: raw.to_slice, held_at_ms: 0_i64)
+end
+
+describe "Gori::MCP::Serialize.head_and_body" do
+  it "splits a bare-LF-terminated head (LFLF) and keeps the body byte-exact" do
+    head, body = Gori::MCP::Serialize.head_and_body(
+      "POST /x HTTP/1.1\nHost: h\nContent-Length: 8\n\nSMUGGLED".to_slice)
+    head.should eq("POST /x HTTP/1.1\nHost: h\nContent-Length: 8")
+    String.new(body).should eq("SMUGGLED")
+  end
+
+  it "splits the mixed `\\n\\r\\n` spelling too" do
+    head, body = Gori::MCP::Serialize.head_and_body("POST /x HTTP/1.1\nHost: h\n\r\nBODY".to_slice)
+    head.should eq("POST /x HTTP/1.1\nHost: h")
+    String.new(body).should eq("BODY")
+  end
+
+  it "is unchanged on a conformant CRLF message" do
+    head, body = Gori::MCP::Serialize.head_and_body("POST /x HTTP/1.1\r\nHost: h\r\n\r\nBODY".to_slice)
+    head.should eq("POST /x HTTP/1.1\r\nHost: h")
+    String.new(body).should eq("BODY")
+  end
+
+  # The leftmost terminator wins, so a CRLFCRLF sitting INSIDE a smuggled body cannot pull the
+  # split past the real one — the failure mode `Env.head_body_separator` is ordered to avoid.
+  it "takes the earliest terminator when the body itself contains a CRLFCRLF" do
+    head, body = Gori::MCP::Serialize.head_and_body(
+      "POST /x HTTP/1.1\nCL: 1\n\nGET /smuggled HTTP/1.1\r\nHost: h\r\n\r\n".to_slice)
+    head.should eq("POST /x HTTP/1.1\nCL: 1")
+    String.new(body).should eq("GET /smuggled HTTP/1.1\r\nHost: h\r\n\r\n")
+  end
+
+  it "treats a message with no terminator as all head" do
+    head, body = Gori::MCP::Serialize.head_and_body("GET / HTTP/1.1".to_slice)
+    head.should eq("GET / HTTP/1.1")
+    body.size.should eq(0)
+  end
+
+  it "reports the body on the intercept detail projection, not a phantom empty one" do
+    row = desync_held("POST /x HTTP/1.1\nHost: h\nContent-Length: 8\n\nSMUGGLED")
+    obj = JSON.parse(JSON.build { |j| Gori::MCP::Serialize.intercept_item_detail(j, row, false, 0_i64) })
+    obj["body_size"].as_i.should eq(8)
+    obj["raw_size"].as_i.should eq(52)
+    obj["head"].as_s.should_not contain("SMUGGLED")
+  end
+
+  it "keeps the head preview on the list projection free of body bytes" do
+    row = desync_held("POST /x HTTP/1.1\nHost: h\nContent-Length: 8\n\nSMUGGLED")
+    obj = JSON.parse(JSON.build { |j| Gori::MCP::Serialize.intercept_item_row(j, row, false, 0_i64) })
+    obj["head_preview"]?.try(&.as_s).try(&.should_not(contain("SMUGGLED")))
+  end
+end
+
+# The scanner both shapes come from. `head_body_boundary` (body start) and
+# `head_body_separator` ({offset, width}) must never disagree, because a caller that renders
+# the head as TEXT needs the offset and cannot derive it by subtracting a fixed 4.
+describe "Gori::Env.head_body_separator" do
+  it "agrees with head_body_boundary on every terminator spelling" do
+    {
+      "GET / HTTP/1.1\nHost: h\n\nbody",
+      "GET / HTTP/1.1\r\nHost: h\r\n\r\nbody",
+      "GET / HTTP/1.1\nHost: h\n\r\nbody",
+    }.each do |wire|
+      bytes = wire.to_slice
+      offset, width = Gori::Env.head_body_separator(bytes).not_nil!
+      (offset + width).should eq(Gori::Env.head_body_boundary(bytes))
+    end
+  end
+
+  it "reports the width of each spelling" do
+    Gori::Env.head_body_separator("a\n\nb".to_slice).should eq({1, 2})
+    Gori::Env.head_body_separator("a\n\r\nb".to_slice).should eq({1, 3})
+    Gori::Env.head_body_separator("a\r\n\r\nb".to_slice).should eq({1, 4})
+  end
+
+  it "is nil — and head_body_boundary is the full size — when there is no terminator" do
+    bytes = "GET / HTTP/1.1\r\nHost: h\r\n".to_slice
+    Gori::Env.head_body_separator(bytes).should be_nil
+    Gori::Env.head_body_boundary(bytes).should eq(bytes.size)
+  end
+end

--- a/spec/mcp_agent_surface_spec.cr
+++ b/spec/mcp_agent_surface_spec.cr
@@ -455,6 +455,12 @@ describe "MCP job-tool parity knobs" do
         {"discover_start", %({"url":"http://127.0.0.1:1/","throttle_ms":5})},
         {"probe_scan", %({"insecure":true})},
         {"intercept_forward_edit", %({"item_id":1,"raw":"GET / HTTP/1.1\\r\\n\\r\\n","update_content_length":false})},
+        # `send_request` was the LAST send surface with no route to an SNI: the schema declared
+        # none and the code only ever read a stored one off a flow/repeater row, so an agent
+        # could not run the vhost-confusion test that every sibling tool's own description
+        # names — and replaying a flow dialled with a ClientHello `gori run repeater
+        # <flow-id> --sni` could change and this could not.
+        {"send_request", %({"url":"http://127.0.0.1:1/","sni":"x"})},
       }.each do |(tool, args)|
         result_text(drive(store, call_line(tool, args))[0])
           .should_not contain("unknown argument")

--- a/spec/mcp_spec.cr
+++ b/spec/mcp_spec.cr
@@ -3520,8 +3520,11 @@ describe "MCP intercept_forward_edit" do
       end
 
       queued = queued_intercept_bytes(store)
-      sep = Gori::MCP::Serialize.head_body_split(queued).not_nil!
-      queued[(sep + 4)..].should eq body # untouched, 0x0A and 0xFF included
+      # `Env.head_body_separator` — the one scanner. The `+ 4` this used to hard-code beside
+      # a CRLFCRLF-only scan is the bug `head_and_body` carried; take the width from the
+      # scanner so the assertion holds whichever spelling terminates the head.
+      offset, width = Gori::Env.head_body_separator(queued).not_nil!
+      queued[(offset + width)..].should eq body # untouched, 0x0A and 0xFF included
     end
   end
 

--- a/spec/scope_spec.cr
+++ b/spec/scope_spec.cr
@@ -197,6 +197,38 @@ describe Gori::Scope do
     end
   end
 
+  # `validation_error`'s `case match_type` had no `else`, so an unrecognised type returned nil
+  # and `valid?` said yes — `Scope#add` stored it and `Rule#matches?` (whose own case DOES end
+  # in `else false`) then never matched it. The dangerous direction is EXCLUDE: a typo'd
+  # `exclude strng logout` sat in the operator's listed scope and excluded nothing, which is
+  # fail-OPEN, and is exactly the "silent dead rule" the host:port check above exists to stop.
+  # Every write path validates membership itself today, so this is the guarantee
+  # `validation_error`'s own doc already claimed rather than a live hole being closed.
+  it "refuses a match_type outside TYPES instead of storing a rule that can never match" do
+    Gori::Scope.valid?("strng", "logout").should be_false
+    Gori::Scope.validation_error("strng", "logout").not_nil!
+      .should contain("unknown match type")
+    # …and it names what IS accepted, so the message is actionable.
+    Gori::Scope::TYPES.each do |t|
+      Gori::Scope.validation_error("strng", "x").not_nil!.should contain(t)
+    end
+    # All three real types still pass through untouched.
+    Gori::Scope.valid?("host", "acme.test").should be_true
+    Gori::Scope.valid?("string", "logout").should be_true
+    Gori::Scope.valid?("regex", "^/api/").should be_true
+  end
+
+  it "keeps a dead-on-arrival exclude rule out of the store" do
+    with_store do |store|
+      scope = Gori::Scope.load(store)
+      scope.add("exclude", "strng", "logout").should be_false
+      scope.rules.should be_empty
+      # The correctly-spelled rule is unaffected.
+      scope.add("exclude", "string", "logout").should be_true
+      scope.rules.map(&.match_type).should eq(["string"])
+    end
+  end
+
   it "normalizes IPv6 brackets so [::1] and ::1 match a host rule interchangeably" do
     # The CONNECT/tunnel path (the dominant HTTPS-MITM case) stores the flow host bare,
     # so a bracketed rule (the form the old suggestion recommended) must still match it —

--- a/src/gori/cli/output.cr
+++ b/src/gori/cli/output.cr
@@ -47,7 +47,7 @@ module Gori
           # a rule that structurally could not run on it, a request the ORIGIN invented in a
           # PUSH_PROMISE. Emitted only when there is one, so a script keying off field
           # presence is not broken by a field it never asked for — the same discipline
-          # `emit_ws_shape_json` uses.
+          # `Store::WsMessage#emit_shape_json` uses.
           advisories = row.advisories
           unless advisories.empty?
             j.field("advisory") { j.array { advisories.each { |l| j.string(term_safe(l)) } } }
@@ -108,19 +108,6 @@ module Gori
         return "(no payload)" if m.payload.empty?
         body = String.new(m.payload)
         body.valid_encoding? ? term_safe(body) : "0x#{m.payload.hexstring}"
-      end
-
-      # The shape fields, for a JSON reader. Only what departs from the default is emitted,
-      # so an ordinary message's object is exactly the shape it was before V7 — a script
-      # keying off field presence is not broken by a feature it did not ask for.
-      def self.emit_ws_shape_json(j : JSON::Builder, m : Store::WsMessage) : Nil
-        s = m.shape
-        j.field "fin", false unless s.fin
-        j.field "rsv", s.rsv if s.rsv != 0
-        s.masked.try { |mk| j.field "masked", mk unless mk }
-        j.field "frames", s.frames if s.frames > 1
-        m.close_code.try { |c| j.field "close_code", c }
-        m.close_reason.try { |r| j.field "close_reason", String.new(r).scrub }
       end
 
       # "#42  GET   https  example.com:443/users  200  1.2kB  3ms  [Complete]"

--- a/src/gori/cli/output.cr
+++ b/src/gori/cli/output.cr
@@ -28,17 +28,26 @@ module Gori
           j.field "id", row.id
           j.field "created_at", row.created_at
           j.field "time", iso_time(row.created_at)
-          j.field "scheme", row.scheme
-          j.field "method", row.method
-          j.field "host", row.host
+          # `created_at_iso` beside `time`, because the two surfaces named and rendered the
+          # same instant differently: `time` is LOCAL at second precision (it drops the
+          # sub-second micros `created_at` carries), while MCP's `flow_row` emits
+          # `created_at_iso` in UTC at millisecond precision. A script correlating
+          # `gori run history --format json` against `list_history` could not compare the two
+          # as strings, and the CLI carried no RFC3339 field anywhere in the tree. Additive:
+          # `time` keeps its exact spelling and value, so nothing reading it breaks.
+          j.field "created_at_iso", iso_time_utc(row.created_at)
+          # Wire-derived, every one of them — see `json_captured`.
+          json_captured(j, "scheme", row.scheme)
+          json_captured(j, "method", row.method)
+          json_captured(j, "host", row.host)
           j.field "port", row.port
-          j.field "target", row.target
+          json_captured(j, "target", row.target)
           j.field "status", row.status
           j.field "state", row.state.to_s.downcase
           j.field "size", row.size
           j.field "response_size", row.response_size
           j.field "duration_us", row.duration_us
-          j.field "content_type", row.content_type
+          json_captured(j, "content_type", row.content_type)
           # Kept in lockstep with MCP::Serialize.flow_row (spec/cli/run/history_spec.cr pins
           # the two key sets against each other): a consumer of either feed has no other way
           # to tell a gori-authored stub response from one the origin actually sent (#511).
@@ -53,6 +62,34 @@ module Gori
             j.field("advisory") { j.array { advisories.each { |l| j.string(term_safe(l)) } } }
           end
         end
+      end
+
+      # Emit `name` carrying a CAPTURED string, scrubbed to U+FFFD. The JSON counterpart of
+      # `term_safe`, and the ONE seam every wire-derived string field on this surface goes
+      # through — the point being that a field added later cannot be added unscrubbed.
+      #
+      # `JSON::Builder#string` escapes JSON metacharacters but writes raw bytes through, and
+      # a captured host / path / header / body-derived value can be invalid UTF-8 without
+      # carrying a single control byte (`term_safe`'s doc names the hazard). One such byte
+      # makes the WHOLE document invalid, not just its own field: `python3 json.loads` fails
+      # outright with UnicodeDecodeError, and in a JSON-Lines stream every later line is lost
+      # with it. This was fixed field-by-field as each instance was found — fuzz `payloads`
+      # (`fuzz_row_fields`), every sitemap label, `grpc_message` in three emitters — while
+      # `flow_row_fields`, `discover_finding_fields`, `sequence_sample_json` and the `error`
+      # fields kept emitting raw. `MCP::Serialize.text` is the same decision on the agent
+      # surface; this is its name here.
+      #
+      # NOT `term_safe`: control bytes are legitimate content in a JSON string (they are
+      # escaped as \u00XX and no terminal ever sees them raw), so replacing them with '·'
+      # would corrupt a value a script is meant to read. Only the invalid-UTF-8 half applies.
+      #
+      # Scope is WIRE-DERIVED values. Operator-authored config that happens to be a string —
+      # a rule's name/host, a project name, an OAST provider host, a saved repeater's
+      # target/name — deliberately stays raw here, because MCP emits those raw too
+      # (`tools/rules.cr`, `tools/repeater.cr`) and matching it is the point. Scrub where the
+      # bytes came off a socket; leave alone where the two surfaces already agree.
+      def self.json_captured(j : JSON::Builder, name : String, s : String?) : Nil
+        j.field name, s.try(&.scrub)
       end
 
       # Neutralize terminal control bytes in an untrusted CAPTURED string before it is
@@ -167,7 +204,10 @@ module Gori
           j.field "lines", r.lines
           j.field "duration_us", r.duration_us
           j.field "matched", r.matched?
-          j.field "error", r.error
+          # A send failure's text can quote bytes the ORIGIN chose (a status line, a header a
+          # codec refused), so it is captured data like `payloads` two fields up. MCP's
+          # `Serialize.fuzz_result` has always wrapped this in `text()`.
+          json_captured(j, "error", r.error)
           # A declared `¦chain` that could not run on this payload — the payload went out
           # UNTRANSFORMED. Emitted (and only when set) so a script never reads `"error":null`
           # for a request that sent a different test than the operator asked for. `.scrub` for
@@ -187,7 +227,10 @@ module Gori
           if gm = r.grpc_message
             j.field "grpc_message", gm.scrub
           end
-          j.field "extracted", r.extracted
+          # `--extract` is a regex capture out of the RESPONSE BODY, so this is arbitrary
+          # origin bytes BY CONSTRUCTION — the sharpest instance of the class in this file,
+          # and the one the `payloads` fix above did not cover. MCP wraps it in `text()`.
+          json_captured(j, "extracted", r.extracted)
           # Only when true. This is an exception rather than a per-row property, and a `false`
           # on every row of every clean run would bury the one row that matters.
           j.field "retried", true if r.retried?
@@ -223,7 +266,10 @@ module Gori
 
       def self.mine_finding_fields(j : JSON::Builder, f : Miner::Finding) : Nil
         j.object do
-          j.field "name", f.name
+          # A mined parameter name comes from a wordlist FILE the operator supplied, so it can
+          # be arbitrary bytes — the same argument `fuzz_row_fields` makes for `payloads`.
+          # (`canary` below is gori-generated and fixed-length, so it needs nothing.)
+          json_captured(j, "name", f.name)
           j.field "location", f.location.label
           j.field "evidence", f.evidence.label
           j.field "confidence", f.confidence.label
@@ -279,9 +325,15 @@ module Gori
           j.object do
             j.field "index", s.index
             j.field "status", s.status
-            j.field "token", s.token
+            # Extracted from the RESPONSE by the token descriptor — origin bytes by
+            # construction, exactly like the fuzzer's `extracted`. This emitter is a JSONL
+            # STREAM, so one invalid byte does not just break its own line: a reader that
+            # stops at the first parse error loses every sample after it. There is no MCP
+            # counterpart to compare against (`sequence_results` returns only the report),
+            # which is why this one went unnoticed longest.
+            json_captured(j, "token", s.token)
             j.field "length", s.length
-            j.field "error", s.error
+            json_captured(j, "error", s.error)
             # The gRPC CALL's outcome. `status` above is 200 for every gRPC response, so
             # without these a collection against a target denying every call read as healthy.
             # Emitted only when the response actually carried them, so a non-gRPC sample's
@@ -309,11 +361,15 @@ module Gori
 
       def self.discover_finding_fields(j : JSON::Builder, f : Discover::Finding) : Nil
         j.object do
-          j.field "url", f.url
-          j.field "method", f.method
+          # A crawled URL is built from a page's own `<a href>` and `content_type` is a
+          # response header, so both are outside-origin. `Discover::Url.parse` percent-encodes
+          # the octets `<= 0x20` / `0x7F` (#394) but nothing above 0x7F, so a high byte reaches
+          # here intact. MCP's `discover_finding_json` wraps all three in `Serialize.text`.
+          json_captured(j, "url", f.url)
+          json_captured(j, "method", f.method)
           j.field "status", f.status
           j.field "length", f.length
-          j.field "content_type", f.content_type
+          json_captured(j, "content_type", f.content_type)
           j.field "source", f.source.label
           j.field "depth", f.depth
           j.field "confidence", f.confidence.round(2)
@@ -667,9 +723,31 @@ module Gori
         "#{round1(ms / 1000.0)}s"
       end
 
-      # Local ISO-8601 from unix micros (the store's created_at unit).
+      # Local ISO-8601 from unix micros (the store's created_at unit). Lossy on purpose: this
+      # is the field a human reads off a terminal, so it stays in the operator's timezone and
+      # drops the micros. `iso_time_utc` is the machine-readable one.
       def self.iso_time(micros : Int64) : String
         Time.unix(micros // 1_000_000).to_local.to_s("%Y-%m-%dT%H:%M:%S%:z")
+      end
+
+      # RFC3339 UTC at millisecond precision from unix micros — the `*_iso` convention the
+      # MCP surface uses everywhere and the CLI used nowhere (`grep -rn '_iso' src/gori/cli/`
+      # returned zero while MCP had fifteen). Byte-for-byte identical to
+      # `MCP::Serialize.unix_micros_iso`, which `spec/cli/run/history_spec.cr` pins against
+      # this — the same lockstep-by-spec arrangement `emit_body_json` and
+      # `emit_trailers_json` already have with their MCP counterparts.
+      #
+      # Reimplemented rather than called: `CLI::Output` has no dependency on `MCP::` and
+      # should not gain one for four lines. The dependency between these two surfaces is
+      # one-way but still UNDECLARED: `cli/run/{intercept,history}.cr` call `MCP::Serialize.*`
+      # with no `require` of their own (they link because `src/gori.cr` pulls in both). That is
+      # the direction DESIGN.md §2.1 already documents and tolerates; the reverse edge — MCP
+      # reaching into `CLI::Output` for the WS shape — is gone, moved onto the model that owns
+      # the data (`Store::WsMessage#emit_shape_json`). Reimplementing here keeps `CLI::Output`
+      # itself free of `MCP::` rather than adding the first such call to this file.
+      def self.iso_time_utc(micros : Int64) : String
+        sec, micro = micros.divmod(1_000_000)
+        (Time.utc(1970, 1, 1) + sec.seconds + micro.microseconds).to_s("%Y-%m-%dT%H:%M:%S.%LZ")
       end
 
       private def self.round1(n : Float64) : String

--- a/src/gori/cli/run/history.cr
+++ b/src/gori/cli/run/history.cr
@@ -501,7 +501,10 @@ module Gori
               CLI::Output.flow_row_fields(j, detail.row)
             end
             j.field "http_version", detail.http_version
-            j.field "error", detail.error
+            # `Serialize.flow_detail` wraps this same field in `text()`; here it was raw. A
+            # capture failure's text quotes bytes the origin sent (a malformed status line, a
+            # header the codec refused), so it is captured data — see `Output.json_captured`.
+            CLI::Output.json_captured(j, "error", detail.error)
             emit_decoded_json(j, detail, req, resp)
             if req
               j.field "request" do

--- a/src/gori/cli/run/history.cr
+++ b/src/gori/cli/run/history.cr
@@ -531,7 +531,7 @@ module Gori
                           j.object do
                             j.field "direction", m.direction
                             j.field "opcode", m.opcode
-                            Output.emit_ws_shape_json(j, m)
+                            m.emit_shape_json(j)
                             if m.text?
                               j.field "text", String.new(m.payload).scrub
                               # See emit_ws_result: JSON cannot carry a byte that is not valid

--- a/src/gori/cli/run/repeater.cr
+++ b/src/gori/cli/run/repeater.cr
@@ -44,6 +44,7 @@ module Gori
         insecure = false
         allow_unscoped = false
         format = :text
+        timeout : Time::Span? = nil
 
         parser = OptionParser.new do |p|
           p.banner = "Usage: gori run repeater h2 --target URL --fields FILE [options]\n\n" \
@@ -54,6 +55,7 @@ module Gori
           p.on("-tURL", "--target=URL", "Dial origin (scheme://host[:port]); :authority/:scheme in the fields may differ") { |v| target = v }
           p.on("--fields=FILE", "JSON file with the ordered HPACK field list (and optional body)") { |v| fields_file = v }
           p.on("-k", "--insecure-upstream", "Do not verify the upstream TLS certificate") { insecure = true }
+          p.on("--timeout=SEC", "Per-operation connect + idle timeout (seconds)") { |v| timeout = parse_count(v, "--timeout").seconds }
           p.on("--allow-unscoped", "Send even if the target is outside the project scope (Sandbox/exclude still apply)") { allow_unscoped = true }
           p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
@@ -81,7 +83,7 @@ module Gori
         plan = begin
           Repeater::Plan.build(Repeater::PlanOptions.new(
             h2_fields: fields, h2_body: body, target: tgt,
-            http2: true, verify: !insecure, overrides: overrides), outbound)
+            http2: true, verify: !insecure, timeout: timeout, overrides: overrides), outbound)
         rescue ex : Repeater::PlanError
           repeater_plan_abort("gori run repeater h2", ex)
         end
@@ -399,9 +401,11 @@ module Gori
       # Content-Length on every replay, and no `Plan`-level spec would notice.
       private def self.session_plan_options(rec : Store::RepeaterRecord, insecure : Bool,
                                             overrides : Gori::HostOverrides?,
-                                            verbatim : Bool = false) : Repeater::PlanOptions
+                                            verbatim : Bool = false,
+                                            timeout : Time::Span? = nil) : Repeater::PlanOptions
         Repeater::PlanOptions.new([rec.request],
           default_target: rec.target, http2: rec.http2?, sni: rec.sni,
+          timeout: timeout,
           expand_request: !verbatim,
           # …and on an h2 session it used to change NOTHING the encoder does: the flag
           # promised "the stored bytes EXACTLY" while `H2Engine` still lowercased every field
@@ -460,6 +464,7 @@ module Gori
         insecure = false
         do_diff = false
         format = :text
+        timeout : Time::Span? = nil
         # `--message` and `--message-frame` share ONE list so their relative ORDER is the send
         # order. A WebSocket exchange is a sequence, and two lists merged afterwards would
         # silently reorder a fragment ahead of the CONT that finishes it.
@@ -481,6 +486,7 @@ module Gori
           p.on("--project=NAME", "Project to read (default: most-recently-active)") { |v| project_name = v }
           p.on("--db=PATH", "Explicit SQLite db file to read") { |v| db_path = v }
           p.on("-k", "--insecure-upstream", "Do not verify the upstream TLS certificate") { insecure = true }
+          p.on("--timeout=SEC", "Per-operation connect + idle timeout (seconds). Ignored on the WebSocket path, which paces itself with --idle-ms") { |v| timeout = parse_count(v, "--timeout").seconds }
           p.on("--diff", "Diff the new response against the session's last stored response") { do_diff = true }
           p.on("--allow-unscoped", "Send even if the target is outside the project scope (Sandbox/exclude still apply)") { allow_unscoped = true }
           p.on("--verbatim", "Send the stored bytes EXACTLY: no $VAR expansion, no bare-LF→CRLF promotion, no Content-Length resync, no HTTP/2→1.1 version fix, and on h2 no field-name lowercasing") { verbatim = true }
@@ -515,7 +521,7 @@ module Gori
         outbound = project_outbound(project_name, db_path, allow_unscoped)
 
         plan = begin
-          Repeater::Plan.build(session_plan_options(rec, insecure, host_overrides, verbatim), outbound)
+          Repeater::Plan.build(session_plan_options(rec, insecure, host_overrides, verbatim, timeout), outbound)
         rescue ex : Repeater::PlanError
           repeater_plan_abort("gori run repeater send", ex, "session ##{id}")
         end
@@ -1139,6 +1145,7 @@ module Gori
         body_override : String? = nil
         allow_unscoped = false
         keep_request_line = false
+        timeout : Time::Span? = nil
         positional = [] of String
 
         parser = OptionParser.new do |p|
@@ -1156,6 +1163,7 @@ module Gori
           p.on("--http1", "Force HTTP/1.1 — downgrades an h2-captured flow (default follows how the flow was captured)") { http2_override = false }
           p.on("--no-http2", "Alias for --http1") { http2_override = false }
           p.on("--sni=HOST", "TLS SNI override") { |v| sni_override = v }
+          p.on("--timeout=SEC", "Per-operation connect + idle timeout (seconds)") { |v| timeout = parse_count(v, "--timeout").seconds }
           p.on("-k", "--insecure-upstream", "Do not verify the upstream TLS certificate") { insecure = true }
           p.on("--diff", "Diff the new response against the captured one") { do_diff = true }
           p.on("-HHEADER", "--header=HEADER", "Custom header to overwrite/add. Repeat the SAME name to send duplicate header lines. An explicit Content-Length is honored verbatim (no auto-resync) for CL-mismatch testing") { |v| headers << v }
@@ -1277,7 +1285,7 @@ module Gori
             # operator's OWN `-H`/`-b`/`--target` above, so nothing downstream needs to (and
             # nothing downstream can still tell the operator's bytes from the capture's).
             evidence: true,
-            verify: !insecure, overrides: host_overrides), outbound)
+            verify: !insecure, timeout: timeout, overrides: host_overrides), outbound)
         rescue ex : Repeater::PlanError
           repeater_plan_abort("gori run repeater", ex)
         end

--- a/src/gori/cli/run/repeater.cr
+++ b/src/gori/cli/run/repeater.cr
@@ -747,7 +747,7 @@ module Gori
               j.field "upgraded", result.upgraded?
               j.field "duration_us", result.duration_us
               j.field "close_code", result.close_code
-              j.field "error", result.error
+              CLI::Output.json_captured(j, "error", result.error)
               j.field "note", result.note
               # The inbound transcript stopped SHORT of the server at a cap. A synthetic row
               # already sits in `messages` below; this is the summary half so a script reading
@@ -1308,7 +1308,9 @@ module Gori
             j.field "ok", result.ok?
             j.field "status", result.response.try(&.status)
             j.field "duration_us", result.duration_us
-            j.field "error", result.error
+            # A send failure quotes origin bytes — see `Output.json_captured`. The WS sibling
+            # above takes the same treatment.
+            CLI::Output.json_captured(j, "error", result.error)
             # …and WHY it is incomplete. `incomplete` alone conflates an origin that closed
             # early with gori's own capture ceiling; a reader that assumed the first blamed
             # the target for something gori did.

--- a/src/gori/discover/plan.cr
+++ b/src/gori/discover/plan.cr
@@ -64,10 +64,17 @@ module Gori::Discover
     # Verify upstream TLS certificates.
     property? verify : Bool
     # TLS SNI override — the name presented in the ClientHello (and, under verify, the name
-    # the certificate is checked against) WITHOUT changing the dialed host:port. Mirrors
+    # the certificate is checked against) WITHOUT changing the dialed host:port. Same field as
     # `Miner::PlanOptions#sni` / `Fuzz` / `Sequencer`; discover was the one engine of the four
     # that could not carry it, which made an IP-direct sweep of a name-based vhost
     # inexpressible (the crawler also owns its `Host:` header, so there was no second way in).
+    #
+    # Reached from `gori run discover --sni` and MCP `discover_start{sni}` ONLY. The Discover TAB
+    # cannot set it — `DiscoverController#build_engine` passes neither this nor `http2`, and
+    # `Discover::Config` has no field to hold either, while the Fuzzer/Miner/Sequencer/Repeater
+    # views all carry `sni_override` + `@http2`. That is where the rollout stopped on purpose
+    # (the commit adding these scoped itself to "CLI and to `discover_start`"), not an oversight;
+    # said here because "Mirrors Fuzz/Miner/Sequencer" used to read as settled on all three.
     property sni : String?
     # Send over HTTP/2 (TLS + ALPN `h2`, or h2c prior-knowledge on http://). `Discover::Sender`
     # has always had the field; nothing could set it, so an h2-only origin was unreachable

--- a/src/gori/env.cr
+++ b/src/gori/env.cr
@@ -755,11 +755,34 @@ module Gori
     # `\r\n\r\n` alone and REFUSED to send a bare-LF-terminated request — the exact
     # payload its `verbatim` flag advertises.
     def self.head_body_boundary(bytes : Bytes) : Int32
+      if sep = head_body_separator(bytes)
+        offset, width = sep
+        offset + width
+      else
+        bytes.size
+      end
+    end
+
+    # `{offset of the blank-line separator, its width in bytes}`, or nil when the message
+    # carries none. The SCANNING half of `head_body_boundary`, and the only place the
+    # three terminator spellings are enumerated.
+    #
+    # Two shapes exist because callers want two different things and deriving one from the
+    # other needs the width. `head_body_boundary` wants where the BODY starts (to normalize
+    # or expand the head and copy the body through untouched). A projection that renders the
+    # head as text wants the head WITHOUT its terminator, which is `bytes[0, offset]` — and
+    # it cannot recover that from the boundary alone, because subtracting a fixed 4 is only
+    # right for `\r\n\r\n`. `MCP::Serialize.head_and_body` hard-coded that 4 alongside its own
+    # CRLFCRLF-only scan, so a bare-LF-terminated held message — a CL/TE desync primitive gori
+    # stores byte-exact (P7) — reported its whole body as part of the head with `body_size: 0`,
+    # on MCP `intercept_get`/`intercept_list` AND `gori run intercept show`/`list`, while the
+    # edit path on the same bytes split it correctly.
+    def self.head_body_separator(bytes : Bytes) : {Int32, Int32}?
       n = bytes.size
       i = 0
       while i < n
         if bytes[i] == 0x0A_u8 && i + 1 < n && bytes[i + 1] == 0x0A_u8
-          return i + 2
+          return {i, 2}
         end
         # `\n\r\n` (0x0A 0x0D 0x0A): a bare-LF header terminator followed by a CRLF blank
         # line. The two neighboring checks both miss it — LFLF needs `bytes[i+1]==0x0A`
@@ -767,15 +790,15 @@ module Gori
         # all-head and the body's bare LFs get promoted to CRLF. Body starts at i+3.
         if bytes[i] == 0x0A_u8 && i + 2 < n &&
            bytes[i + 1] == 0x0D_u8 && bytes[i + 2] == 0x0A_u8
-          return i + 3
+          return {i, 3}
         end
         if bytes[i] == 0x0D_u8 && i + 3 < n &&
            bytes[i + 1] == 0x0A_u8 && bytes[i + 2] == 0x0D_u8 && bytes[i + 3] == 0x0A_u8
-          return i + 4
+          return {i, 4}
         end
         i += 1
       end
-      n
+      nil
     end
 
     # Byte-level equivalent of `gsub(/\r?\n/, "\r\n")`: inserts `\r` before any

--- a/src/gori/fuzz/plan.cr
+++ b/src/gori/fuzz/plan.cr
@@ -107,7 +107,16 @@ module Gori::Fuzz
     property? http2 : Bool
     # Payload sources, in position order. `Plan.build` pairs each with `processors`.
     property sources : Array(PayloadSource)
-    # The processing pipeline applied to EVERY set (all three surfaces share one list).
+    # The processing pipeline applied to EVERY set — one list, shared by every set rather than
+    # declared per set.
+    #
+    # Set by `gori run fuzz` (`--prefix/--suffix/--encode/--case/--hash/--regex-replace`) and by
+    # MCP `fuzz_start{processors}`. NOT by the TUI: `FuzzerView#build_engine` passes none and the
+    # Fuzzer tab has never had a processor UI (`Fuzz::Processor` appears nowhere under
+    # `src/gori/tui/`). This comment used to claim "all three surfaces share one list", which was
+    # false in the commit that wrote it — the same #366 change added the CLI/MCP wiring and
+    # touched `tui/fuzzer_view.cr` without wiring it. Recorded rather than quietly widened, per
+    # DESIGN.md's preamble; closing it is a TUI feature, not a rewording.
     property processors : Array(Processor)
     # Mode / concurrency / rps / throttle / retries / timeout / follow_redirects /
     # auto_calibrate / keep_bodies (the evidence policy) / max_requests.

--- a/src/gori/mcp/serialize.cr
+++ b/src/gori/mcp/serialize.cr
@@ -1,5 +1,6 @@
 require "json"
 require "base64"
+require "../env"
 require "../store"
 require "../issues_export"
 require "../repeater/engine"
@@ -126,21 +127,30 @@ module Gori
 
       # --- #123 held intercept item projections --------------------------------
 
-      # Offset of the CRLFCRLF head/body separator in a raw HTTP message, or nil.
-      def self.head_body_split(raw : Bytes) : Int32?
-        i = 0
-        while i + 3 < raw.size
-          return i if raw[i] == 13 && raw[i + 1] == 10 && raw[i + 2] == 13 && raw[i + 3] == 10
-          i += 1
-        end
-        nil
-      end
-
       # {scrubbed head text, body bytes} for a held raw message; whole message as head
       # (empty body) when there is no separator.
+      #
+      # `Env.head_body_separator`, not a local scan: this used to roll its own CRLFCRLF-only
+      # loop and slice the body at a hard-coded `sep + 4`, which made it the one splitter in
+      # the tree that neither handled a bare-LF-terminated head nor refused it. `Env`'s
+      # accepts `\n\n` / `\n\r\n` / `\r\n\r\n` (leftmost wins) and `Fuzz::ContentLength` scans
+      # the same three; `Repeater::FlowRequest.resync_content_length` stays CRLF-only but
+      # deliberately NO-OPS rather than mis-framing. This one reported a wrong split instead:
+      # a held CL/TE desync probe (`…Content-Length: 8\n\nSMUGGLED`) came back with its body
+      # inside `head` and `body_size: 0`, so `intercept_get`'s only body signal said there was
+      # none, and `gori run intercept show` — which gates its "[N bytes of body — use
+      # --format json --include-sensitive …]" hint on `body.empty?` — never told the operator
+      # the body existed or how to fetch its bytes. The intercept EDIT path on the same bytes
+      # already split at the right offset (`Env.head_body_boundary`), so one held message had
+      # two framings inside one feature.
+      #
+      # The width matters and is why `Env` exposes the separator rather than only the
+      # boundary: the head is rendered as TEXT here, so it must exclude the terminator, and
+      # `boundary - 4` is only correct for the CRLF spelling.
       def self.head_and_body(raw : Bytes) : {String, Bytes}
-        if sep = head_body_split(raw)
-          {String.new(raw[0, sep]).scrub, raw[(sep + 4)..]}
+        if sep = Env.head_body_separator(raw)
+          offset, width = sep
+          {String.new(raw[0, offset]).scrub, raw[(offset + width)..]}
         else
           {String.new(raw).scrub, Bytes.empty}
         end

--- a/src/gori/mcp/serialize.cr
+++ b/src/gori/mcp/serialize.cr
@@ -481,8 +481,10 @@ module Gori
                     # existed; MCP did not, so the agent surface was the one place a captured
                     # RSV1 frame, an unmasked client frame, or a close code was invisible —
                     # and a close code is the most diagnostic thing a failed WebSocket test
-                    # produces. Shared emitter, so the two projections cannot drift.
-                    CLI::Output.emit_ws_shape_json(j, m)
+                    # produces. The MODEL's own emitter, so the two projections cannot drift —
+                    # and, unlike the `CLI::Output` call this replaced, without MCP depending on
+                    # the CLI surface (see `WsMessage#emit_shape_json`).
+                    m.emit_shape_json(j)
                     if m.text?
                       raw = String.new(m.payload)
                       s = raw.scrub

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -1190,6 +1190,7 @@ module Gori
               s.field "h2_fields", h2fieldsprop
               s.field "http2", boolprop("use real HTTP/2; defaults to the flow's version when flow_id is set)")
               s.field "timeout_ms", intprop("per-operation connect + idle (read/write) timeout in milliseconds; a timeout surfaces as a network-error result with error_kind (1-600000)")
+              s.field "sni", strprop("TLS SNI override, independent of the Host header — the vhost-confusion / domain-fronting test (mirrors CLI --sni). OVERRIDES the SNI a flow_id/repeater_id source carries, the way `gori run repeater <flow-id> --sni` does; omit to keep the stored one.")
               s.field "insecure", boolprop("skip upstream TLS verification (default false)")
               s.field "apply_rules", boolprop("apply the project's enabled Match & Replace rules (REQUEST side only) to the outgoing request before sending, matching the live proxy; default false — direct sends are byte-exact")
               s.field "record_history", boolprop("record the outbound request and response in History for audit/evidence (default true)")

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -2074,7 +2074,16 @@ module Gori
       private def emit_audit(j : JSON::Builder, a : JobAudit, ended_at_ms : Int64?) : Nil
         j.field "audit" do
           j.object do
-            j.field "target", a.target
+            # `Serialize.text`, matching what all four `list_jobs` rows already do with this
+            # exact value (`tools/jobs.cr`) — it was raw only here. For fuzz/mine/sequence the
+            # target is `"#{scheme}://#{host}:#{port}"` built from the plan's origin, and a
+            # flow-seeded job takes that host off a capture: `flows.host` round-trips a byte
+            # above 0x7F (nothing rejects it — `Import::Builder::HOST_INVALID` covers only
+            # `[\x00-\x20\x7f]`) and `FlowRequest.parse_target` passes it through, so
+            # `fuzz_status` could put invalid UTF-8 on the wire while `list_jobs` for the same
+            # job stayed clean. This surface is stdio JSON-RPC, where that is a transport-level
+            # protocol violation rather than a display glitch (see `Serialize.issue`).
+            j.field "target", Serialize.text(a.target)
             j.field "rate", a.rate
             j.field "concurrency", a.concurrency
             j.field "max_requests", a.max_requests

--- a/src/gori/mcp/tools/send.cr
+++ b/src/gori/mcp/tools/send.cr
@@ -204,6 +204,25 @@ module Gori
         sc
       end
 
+      # The TLS SNI for one send: an explicit `sni` argument OVERRIDES whatever the stored source
+      # carries (`stored` is `flow.sni` / `rec.sni`, or nil on the direct-dial branch). That is
+      # the rule `gori run repeater <flow-id> --sni` already applies
+      # (`sni_override.presence || built.sni`).
+      #
+      # Until this argument existed, `send_request` was the one send surface in gori with no
+      # route to an SNI at all — every sibling takes it and their schemas name it "the
+      # vhost-confusion / domain-fronting test" (`create_repeater`, `update_repeater`,
+      # `fuzz_start`, `mine_start`, `sequence_start`, `discover_start`, `gori run
+      # repeater/fuzz/mine/sequence/discover --sni`, four TUI tabs). So replaying a flow dialled
+      # with a ClientHello the CLI could change and an agent could not: same stored bytes, two
+      # different handshakes depending on the surface.
+      #
+      # `.presence` so an empty string means "no override" rather than an empty ServerName. One
+      # function rather than the expression inlined per branch, so the precedence is stated once.
+      private def send_sni(h, stored : String? = nil) : String?
+        str(h, "sni").presence || stored
+      end
+
       # Per-operation (connect + idle read/write) timeout for a one-shot send, from
       # timeout_ms; nil = the engine defaults. Mirrors fuzz_timeout's bounds.
       private def send_timeout(h) : Time::Span?
@@ -375,8 +394,8 @@ module Gori
         flow_id = int(h, "flow_id") || recorded_flow_id
         # Masked for the PROBE SCAN only, exactly like `masked_req` below — never for the row.
         # `target` is a WIRE field: it is the dial tuple, and it supplies the TLS ClientHello
-        # ServerName whenever `sni` is absent (which it always is on this save-from-send path,
-        # `sni: nil`). See `stored_request` for the seam; the two extra facts that make masking
+        # ServerName whenever `sni` is absent. See `stored_request` for the seam; the two extra
+        # facts that make masking
         # it destructive rather than merely cosmetic:
         #
         #   * The two ends do not share a vocabulary. `mask_secrets` resolves against
@@ -417,7 +436,13 @@ module Gori
           auto_cl: true,
           flow_id: flow_id,
           position: store.repeaters_meta.size.to_i32,
-          sni: nil
+          # The SNI the send actually used, so re-sending the saved row reproduces the same
+          # ClientHello. Hard-coded `nil` until `send_request` gained the argument — harmless
+          # while there was nothing to lose, a silent fidelity hole the moment there was: the
+          # row would dial the vhost by `target`'s own name while the send that produced the
+          # evidence presented a different one. Through `send_sni`, so the row stores exactly
+          # what `send_plan_options` handed the sender.
+          sni: send_sni(h)
         )
         return nil unless repeater_id > 0
 
@@ -994,7 +1019,7 @@ module Gori
           # Respect the repeater's auto-Content-Length setting (the TUI Repeater does):
           # only recompute CL when it's on, so a deliberately hand-set CL is preserved.
           return {Repeater::PlanOptions.new([rec.request], default_target: rec.target,
-            http2: bool_arg(h, "http2", rec.http2?), sni: rec.sni,
+            http2: bool_arg(h, "http2", rec.http2?), sni: send_sni(h, rec.sni),
             auto_content_length: rec.auto_content_length?, verify: verify,
             timeout: timeout, overrides: overrides), false}
         end
@@ -1050,7 +1075,7 @@ module Gori
           {Repeater::PlanOptions.new([flow.bytes], default_target: flow.target,
             expand_request: false, evidence: true,
             auto_content_length: false,
-            http2: bool_arg(h, "http2", flow.http2), sni: flow.sni, verify: verify,
+            http2: bool_arg(h, "http2", flow.http2), sni: send_sni(h, flow.sni), verify: verify,
             timeout: timeout, overrides: overrides), flow.rewrote_request_line}
         else
           # `RequestBuilder` already expanded, framed and range-checked this one, with
@@ -1070,6 +1095,11 @@ module Gori
             # copy-paste artifact to repair. See `PlanOptions#preserve_field_case?`.
             preserve_field_case: verbatim,
             origin: Repeater::Origin.new(built.scheme, built.host, built.port),
+            # The direct-dial branch carried no SNI at all, so the domain-fronting test this
+            # argument exists for — an IP or a fronting host in `url`, a different name in the
+            # ClientHello — was unreachable even with the argument present. `Repeater::Plan`
+            # owns the `Env.expand` over it (`PlanOptions#sni`), so it goes in raw.
+            sni: send_sni(h),
             http2: bool_arg(h, "http2", false), verify: verify,
             timeout: timeout, overrides: overrides), false}
         end

--- a/src/gori/mcp/tools/send.cr
+++ b/src/gori/mcp/tools/send.cr
@@ -597,7 +597,11 @@ module Gori
             j.field "saved_repeater_id", repeater_id if repeater_id && repeater_id > 0
             unless result.ok?
               kind = network_error_kind(result.error)
-              j.field "error", result.error
+              # `Serialize.text`: a send failure quotes bytes the ORIGIN chose (a malformed
+              # status line, a header the codec refused), so it is captured data — which is why
+              # `Serialize.fuzz_result` and `Serialize.flow_detail` both already wrap their own
+              # `error`. Raw here would put invalid UTF-8 on a stdio JSON-RPC line.
+              j.field "error", Serialize.text(result.error)
               j.field "error_kind", kind
               # Structured-error contract inside the payload (the payload IS the
               # structuredContent) so a caller can apply policy without string-matching the

--- a/src/gori/scope.cr
+++ b/src/gori/scope.cr
@@ -401,6 +401,16 @@ module Gori
     # add`, the History add-host quick-action) — gate on Scope.valid?, defined below in
     # terms of this, so a rejection here keeps a dead rule out of the store regardless of
     # which entry point created it.
+    #   match_type — must be one of TYPES. This case had no `else`, so any other string fell
+    #           through to nil and `valid?` said yes: `Scope#add` stored it, and `Rule#matches?`
+    #           (whose own `case` DOES end in `else false`) then never matched it. A typo'd
+    #           `exclude strng logout` was listed in the operator's scope and silently excluded
+    #           nothing — fail-OPEN on the exclude gate, and precisely the "silent dead rule"
+    #           the host:port check below exists to prevent. Every write path happens to check
+    #           membership itself today (MCP `tools/scope.cr`, `gori run project scope
+    #           add`/`update`, and the TUI overlay, which can only cycle an index into TYPES),
+    #           so this closes no live hole — it makes the guarantee this comment already
+    #           claimed actually hold for the next caller.
     #   regex — must compile (the SQLite REGEXP callback + the proxy hot path both call
     #           Regex.new and would otherwise raise).
     #   host  — must NOT carry a :PORT. A host rule matches the BARE host on any port
@@ -414,8 +424,12 @@ module Gori
           "host rule must not include a port — a host rule already matches every port; " \
           "use the bare host #{host_without_port(pattern).inspect} (matches any port)"
         end
+      when "string"
+        nil
       when "regex"
         "invalid regex (failed to compile)" unless valid_regex?(pattern)
+      else
+        "unknown match type #{match_type.inspect} (expected #{TYPES.join(", ")})"
       end
     end
 

--- a/src/gori/store/models.cr
+++ b/src/gori/store/models.cr
@@ -1,3 +1,4 @@
+require "json"
 require "../ascii_bytes"
 require "../url"
 require "../token_extract"
@@ -266,6 +267,34 @@ module Gori
       def close_reason : Bytes?
         return nil unless @opcode == 8 && @payload.size > 2
         @payload[2, @payload.size - 2]
+      end
+
+      # This message's frame SHAPE as JSON fields, emitted into an open object. Only what
+      # departs from the default is written, so an ordinary message's object is exactly the
+      # shape it was before V7 — a script keying off field presence is not broken by a feature
+      # it did not ask for. The JSON sibling of `WsOutMessage#shape_label` / `ws_shape_note`.
+      #
+      # Lives on the MODEL, the way `Probe.group_json` and `Jwt.decode_json` do, because two
+      # surfaces render it and neither owns it: `gori run show --format json` and MCP's
+      # `emit_ws_messages`. It used to live in `CLI::Output`, which `MCP::Serialize` then called
+      # — and since `cli/run/{intercept,history}.cr` already call `MCP::Serialize.*`, that made
+      # the two surfaces MUTUALLY dependent, with none of the files declaring the require (it
+      # links only because `src/gori.cr` happens to pull in both). DESIGN.md §2.1 documents the
+      # CLI→MCP direction and prescribes exactly this move.
+      #
+      # This removes the `CLI::Output` edge, NOT the whole cycle: `MCP::Serialize` and
+      # `mcp/tools/{send,repeater}.cr` still reach into `CLI::Run` for `incomplete_reason`,
+      # `ws_seed_rows`, `seed_shape` and `ws_notice_dropped_note` — four more pure functions
+      # over `Repeater::Result` / `Store::WsMessage` that belong under `Repeater::` by the same
+      # argument. Moving them is the rest of this job.
+      def emit_shape_json(j : JSON::Builder) : Nil
+        s = shape
+        j.field "fin", false unless s.fin
+        j.field "rsv", s.rsv if s.rsv != 0
+        s.masked.try { |mk| j.field "masked", mk unless mk }
+        j.field "frames", s.frames if s.frames > 1
+        close_code.try { |c| j.field "close_code", c }
+        close_reason.try { |r| j.field "close_reason", String.new(r).scrub }
       end
     end
 


### PR DESCRIPTION
Analysis of the TUI / `gori run` / `gori mcp` data-flow seams, then the fixes it justified. Method: diff the three surfaces wherever two implementations of one thing exist — `PlanOptions` construction (5 tools × 3 surfaces), `Env.expand` call sites, `Outbound` variants, every JSON emitter, all four head/body splitters, all 12 `*_iso` conversions, enum label/parse round-trips, and the scope/rules validation paths.

Each commit is one finding with its own repro. Five commits, deliberately not squashed — they are independent defects.

### 1. Intercept read surfaces mis-framed a bare-LF-terminated held message · `f6af738`

`MCP::Serialize.head_body_split` scanned CRLFCRLF only and sliced the body at a hard-coded `sep + 4`. Its four callers are the whole intercept display path on **both** surfaces (`cli/run/intercept.cr` calls the same function). A bare-LF header terminator is *the* CL/TE desync primitive P7 keeps byte-exact, so the one message class held *because* of its framing was the one whose framing these projections got wrong:

```
held: POST /x HTTP/1.1\nHost: h\nContent-Length: 8\n\nSMUGGLED   (52 B)
before → intercept_get: body_size = 0, head = all 52 bytes
after  → intercept_get: body_size = 8, head excludes the body
```

`intercept_get`'s `body_size` is the only body signal without `include_sensitive`, and it said none. `gori run intercept show` gates its raw-bytes hint on `body.empty?`, so it never printed. The intercept **edit** path split the same bytes correctly all along — two framings of one message inside one feature.

Three of the four splitters already agreed; `FlowRequest.resync_content_length` stays CRLF-only but deliberately **no-ops** rather than mis-framing. This one neither handled the case nor declined it. Consolidated onto `Env.head_body_separator`, now the only place the three spellings are enumerated.

### 2. MCP borrowed the WS frame-shape emitter from the CLI · `8217066`

`MCP::Serialize` called `CLI::Output.emit_ws_shape_json`. Since `cli/run/{intercept,history}.cr` already call `MCP::Serialize.*`, that edge made the two **surfaces** mutually dependent — and none of the files declares the require; it links only because `src/gori.cr` pulls in mcp (L52) then cli (L89). Moved onto the model that owns the data (`Store::WsMessage#emit_shape_json`), where `Probe.group_json` and `Jwt.decode_json` already live. DESIGN.md §2.1 prescribes exactly this.

Removes that edge, **not** the whole cycle — the four remaining `CLI::Run` calls are named in the new method's comment rather than left to be rediscovered.

### 3. Captured bytes made `--format json` unparseable · `67053fb`

MCP wraps every origin-derived string in `Serialize.text`; the CLI wrapped only the fields whose bug had been found individually — 3 of 8 sites. `JSON::Builder#string` writes raw bytes through, so one invalid byte breaks the **whole** document, and in a JSONL stream every later line with it:

```
flow with target /a\xFFb, inserted and read back through the real Store
before → python3 json.loads(cli_row) → UnicodeDecodeError: 0xff invalid start byte
         python3 json.loads(mcp_row) → OK
after  → both OK
```

`extracted` and `token` are the sharpest — both are *by construction* a regex capture out of a response body. New `CLI::Output.json_captured` is the single seam, so a field added later cannot be added unscrubbed. Two MCP sites had the same defect on the agent surface, where invalid UTF-8 is a JSON-RPC transport violation: `emit_audit` emitted `audit.target` raw while all four `list_jobs` rows scrubbed the *same value*.

Also: the CLI carried no RFC3339 field anywhere (`grep -rn '_iso' src/gori/cli/` → 0; MCP had 15). `time` is local/second-precision, MCP's `created_at_iso` is UTC/millisecond, so the two feeds' timestamps could not be compared as strings. `created_at_iso` now sits beside `time`, which is unchanged.

**The "lockstep" spec had encoded this divergence as intentional** (`cli.should_not contain("created_at_iso")`), so it passed while one instant rendered two ways. It now asserts the shared key on *value*.

### 4. The only send tool with no SNI, and the one replay path with no timeout · `ffcbdd0`

`send_request` declared no `sni` and only ever read a stored one, so the direct-dial branch had none at all — while every sibling takes it and their own descriptions call it "the vhost-confusion / domain-fronting test". Replaying a flow dialled with a ClientHello `gori run repeater <flow-id> --sni` could change and an agent could not: same bytes, two handshakes. Schema declaration is load-bearing, not docs — `unknown_args` derives from it. `persist_send_repeater`'s hard-coded `sni: nil` became a fidelity hole the moment the argument existed, and now stores what the send used.

`gori run repeater` had no `--timeout` while `run fuzz/mine/sequence/discover` and MCP `timeout_ms` all did. Added to all three send paths, verified against a socket that accepts and never answers (`--timeout=2` → `duration_us: 2003203`; `--timeout=6` → `6002264`).

### 5. A scope rule stored to never match, and three false-parity comments · `3269330`

`Scope.validation_error`'s `case match_type` had no `else`, so any unrecognised type returned nil, `valid?` said yes, `Scope#add` persisted it — and `Rule#matches?` (whose case *does* end in `else false`) never matched it. `exclude strng logout` sat in the listed scope and excluded nothing: fail-**open** on the gate §3 says fails closed. Not currently reachable (all three write paths validate membership themselves), so it closes no live hole — it makes the guarantee the comment already claimed actually hold.

Plus two comments describing a system that does not exist, the defect class §7's #357 entry exists for: `Fuzz::PlanOptions#processors` claimed "all three surfaces share one list" (the TUI passes none, and the commit that wrote the sentence also touched `tui/fuzzer_view.cr` without wiring it), and `Discover::PlanOptions#sni` read as settled on all three surfaces (the Discover tab can set neither `sni` nor `http2`). Both now state where the field is actually reachable from; neither is widened to fit.

---

### Verification

- `crystal build` clean. Full suite **7285 examples, 0 errors, 8 failures** — all 8 the known environmental `Gori::Session` port-bind set (a live `gori` holding 127.0.0.1:8070), confirmed to fail identically on a clean tree.
- `ameba` per-file counts identical to baseline on every changed file. One new finding appeared mid-work (`send_plan_options` complexity 13/12 from two `||`); extracting `send_sni` returned it to baseline and states the override precedence once instead of twice.
- 19 new examples. Every commit type-checks and passes its own specs in isolation; the five together reconstruct the verified working tree byte-for-byte.

### Analysed, found clean (not defects)

`Outbound` variants are correctly placed per surface; `Env.expand` runs exactly once per tool on all three; the `Plan` split is complete for all five engines; intercept *edit* agrees across surfaces; `Repeater::MessageLines` scrubs at source so the comparer is safe; `Probe.group_json` / `Jwt.*_json` are genuinely shared emitters — the counter-example that makes #3 a fixable inconsistency rather than a style preference.

### Left open, each its own change

TUI SNI/http2 and fuzz processors (feature work); `fuzz_runs`/`fuzz_results` half-wired persistence (needs a wire-or-delete decision); the four remaining `MCP → CLI::Run` edges; the CLI's remaining `*_iso` and `ws_messages` fields.