### PR TITLE
Coverage-driven audit: scope holes, silent filter inversions, and evidence that lied

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,9 +61,10 @@ parity with it, and every parity gap found so far has been in a surface, not an 
     src/gori/{store,probe,fuzz,miner,discover,sequencer,oast}.cr
   ```
 
-  Today that returns four hits, all of them comments: `src/gori/store/models.cr` (×2),
+  Today that returns eight hits, all of them comments: `src/gori/store/models.cr` (×6),
   `src/gori/probe/group.cr`, `src/gori/fuzz/types.cr`. A comment may point at a caller; code
-  may not — so the check is "every hit is a comment", not a hit count.
+  may not — so the check is "every hit is a comment", not a hit count. (The count drifts as
+  those comments are edited; that is fine, and is why it is not the check.)
 - Every gori-originated request goes through the `Gori::Outbound` chokepoint
   (`src/gori/outbound.cr`). It is a required constructor argument on `Fuzz::Sender` and
   `Repeater::Sender`, so an ungated sender is a compile error. Layer 1 (`check`) is the only

--- a/spec/cli_run_spec.cr
+++ b/spec/cli_run_spec.cr
@@ -961,3 +961,76 @@ describe "gori run --bind-from — Layer-1 scope gate on the SEED's host" do
     end
   end
 end
+
+# `split_ql_negations` pulls `-field:value` out of argv before OptionParser can abort it as an
+# unknown option — so a negation term is a filter the CLI reclassified on the operator's behalf,
+# not a positional they chose. `query ||= (positional + neg_terms).join` threw those terms away
+# whenever `--query` was also given, silently BROADENING the result set (measured: with 3 flows,
+# `history 'host:x' '-path:/b'` returned 2 and `history --query='host:x' '-path:/b'` returned 3)
+# and skipping `warn_query_terms`, the apparatus built to shout about exactly that.
+describe "CLI::Run.compose_history_query" do
+  it "ANDs negation terms into an explicit --query instead of dropping them" do
+    q, dropped = Gori::CLI::Run.compose_history_query("host:x", [] of String, ["-path:/b"])
+    q.should eq("host:x -path:/b")
+    dropped.should be_nil
+  end
+
+  it "reports nothing swallowed when --query stands alone" do
+    # The warning must fire ONLY when something was actually dropped: `gori run history
+    # --format=har --query=… > out.har` is piped, so a line on STDERR every time would be new
+    # noise in an existing workflow.
+    Gori::CLI::Run.compose_history_query("host:x", [] of String, [] of String)
+      .should eq({"host:x", nil})
+  end
+
+  it "keeps --query winning over a plain positional, but reports what it swallowed" do
+    q, dropped = Gori::CLI::Run.compose_history_query("host:x", ["status:404"], [] of String)
+    q.should eq("host:x")
+    dropped.should eq("status:404") # the caller warns; silence is what made this a bug
+  end
+
+  it "ANDs negations AND reports the swallowed positional when both are present" do
+    q, dropped = Gori::CLI::Run.compose_history_query("host:x", ["status:404"], ["-path:/b", "-method~PO"])
+    q.should eq("host:x -path:/b -method~PO")
+    dropped.should eq("status:404")
+  end
+
+  it "joins positionals and negations when there is no --query (unchanged)" do
+    q, dropped = Gori::CLI::Run.compose_history_query(nil, ["host:x"], ["-path:/b"])
+    q.should eq("host:x -path:/b")
+    dropped.should be_nil
+  end
+
+  it "is nil — match everything — only when the operator asked for nothing" do
+    Gori::CLI::Run.compose_history_query(nil, [] of String, [] of String).should eq({nil, nil})
+    # A negation ALONE is still a query: `history -status:404` must not dump every flow.
+    Gori::CLI::Run.compose_history_query(nil, [] of String, ["-status:404"]).should eq({"-status:404", nil})
+  end
+end
+
+# `gori run rewriter --project=t1 rm 1` — a global flag BEFORE the verb, the ordering every other
+# `gori run` command accepts. The dispatcher sees a first token starting with '-', assumes the rest
+# are list options, and routes to the list command, whose OptionParser had no `unknown_args`
+# handler: the verb and its id were dropped, the rules printed, exit 0. A destructive mutation that
+# silently no-ops with a SUCCESS status. Verified against the built binary for all three list
+# commands; this pins the shared decision and message, which `abort` cannot be spec'd for.
+describe "CLI::Run.list_leftover_error" do
+  it "is nil when a list command got no positionals (the ordinary list)" do
+    Gori::CLI::Run.list_leftover_error([] of String, "rewriter", "add, rm").should be_nil
+  end
+
+  it "names the discarded verb, the ordering, and the real verbs" do
+    msg = Gori::CLI::Run.list_leftover_error(["rm", "1"], "rewriter", "add, rm/delete, enable")
+    msg.should_not be_nil
+    m = msg.not_nil!
+    m.should contain("unknown subcommand 'rm'") # the token that was about to be swallowed
+    m.should contain("global flags go AFTER")   # the fix the operator has to apply
+    m.should contain("gori run rewriter rm")    # the corrected invocation, spelled out
+    m.should contain("add, rm/delete, enable")  # what they could have meant
+  end
+
+  it "names only the FIRST leftover — the verb, not its arguments" do
+    Gori::CLI::Run.list_leftover_error(["disable", "custom_p_1"], "probe rules", "add, enable")
+      .not_nil!.should contain("unknown subcommand 'disable'")
+  end
+end

--- a/spec/cli_run_spec.cr
+++ b/spec/cli_run_spec.cr
@@ -906,3 +906,58 @@ describe "gori run repeater — WebSocket frame shape round trip" do
     Gori::CLI::Run.seed_shape(ordinary).default?.should be_true
   end
 end
+
+# `--bind-from FLOW-ID` replays somebody else's captured request so an extract rule can mint a
+# `$SESSION` token before the sweep starts. Each command already guards its own `--target` with
+# `guard_outbound`, but the seed dials a SECOND, unrelated host — whatever that capture was taken
+# from — and that send ran with Layer 1 never applied: a configured project scope was silently
+# inert for it, and only Sandbox/excludes (Layer 2, inside `Repeater::Sender`) could stop gori
+# replaying a captured request, cookies included, to an out-of-scope host the very same
+# invocation would have refused as a `--target`. Same gap and same fix as #406 gave
+# `gori run repeater`. `bind_from_scope_triple` is what `guard_outbound` is handed.
+module Gori::CLI::Run
+  def self.bind_from_scope_triple_for_spec(built : Gori::Repeater::FlowRequest::Built)
+    bind_from_scope_triple(built)
+  end
+end
+
+private def seed_built(raw : String, target : String) : Gori::Repeater::FlowRequest::Built
+  Gori::Repeater::FlowRequest::Built.new(target: target, bytes: raw.to_slice,
+    http2: false, sni: nil, rewrote_request_line: false)
+end
+
+describe "gori run --bind-from — Layer-1 scope gate on the SEED's host" do
+  it "judges the seed's own scheme/host/target, recovering the target from the raw bytes" do
+    built = seed_built("GET /admin?q=1 HTTP/1.1\r\nHost: seed.test\r\n\r\n", "http://seed.test/admin?q=1")
+    Gori::CLI::Run.bind_from_scope_triple_for_spec(built).should eq({"http", "seed.test", "/admin?q=1"})
+    # An irregular request line must not degrade the gate to an empty path (the shape
+    # `Outbound.request_target` exists for) — the seed's bytes are a CAPTURE, so gori did not
+    # author them and cannot assume they are well-formed.
+    doubled = seed_built("GET  /admin HTTP/1.1\r\nHost: seed.test\r\n\r\n", "http://seed.test/admin")
+    Gori::CLI::Run.bind_from_scope_triple_for_spec(doubled).should eq({"http", "seed.test", "/admin"})
+  end
+
+  it "refuses an out-of-scope seed under a configured scope, and honours --allow-unscoped" do
+    path = File.tempname("gori-bindscope", ".db")
+    store = Gori::Store.open(path)
+    begin
+      scope = Gori::Scope.load(store)
+      scope.add("include", "host", "in.test") # seed.test is NOT in scope
+      built = seed_built("GET /login HTTP/1.1\r\nHost: seed.test\r\n\r\n", "http://seed.test/login")
+      s, h, t = Gori::CLI::Run.bind_from_scope_triple_for_spec(built)
+
+      # Layer 1 (Gate::Configured) refuses the replay — this is what `guard_outbound` aborts on.
+      Gori::Outbound.cli(scope, false).check_request(s, h, t).blocked?.should be_true
+      # ...and the operator waiver lets it through, exactly as it does for the sweep's target.
+      Gori::Outbound.cli(scope, true).check_request(s, h, t).blocked?.should be_false
+
+      # An in-scope seed is never refused.
+      ok = seed_built("GET /login HTTP/1.1\r\nHost: in.test\r\n\r\n", "http://in.test/login")
+      os, oh, ot = Gori::CLI::Run.bind_from_scope_triple_for_spec(ok)
+      Gori::Outbound.cli(scope, false).check_request(os, oh, ot).blocked?.should be_false
+    ensure
+      store.close
+      File.delete?(path); File.delete?("#{path}-wal"); File.delete?("#{path}-shm")
+    end
+  end
+end

--- a/spec/decoder_spec.cr
+++ b/spec/decoder_spec.cr
@@ -280,8 +280,8 @@ describe Gori::Decoder do
     # intact (matching Python idna, which nameprep-maps only non-ASCII labels).
     it "punycode-encode leaves an all-lowercase IDN and a pure-ASCII label exactly as before" do
       conv("punycode-encode", "münchen.de").should eq "xn--mnchen-3ya.de" # all-lowercase: same as today
-      conv("punycode-encode", "PAYPAL.com").should eq "PAYPAL.com"         # pure ASCII: case preserved
-      conv("punycode-encode", "Example.COM").should eq "Example.COM"       # pure ASCII, mixed: untouched
+      conv("punycode-encode", "PAYPAL.com").should eq "PAYPAL.com"        # pure ASCII: case preserved
+      conv("punycode-encode", "Example.COM").should eq "Example.COM"      # pure ASCII, mixed: untouched
     end
   end
 
@@ -797,6 +797,15 @@ describe Gori::Decoder do
         reg["selfref"].unusable.not_nil!.should contain "recursive"
         # A built-in is never unusable.
         reg["upper"].unusable.should be_nil
+      end
+    end
+
+    it "marks a saved chain with an unknown converter token unusable" do
+      # Left as typed, this registered with unusable:nil so Fuzz::Plan's pre-dial
+      # refusal never fired and apply_chains sent the payload untransformed.
+      with_library([{"myenc", "url-encode > nosuchthing"}]) do |reg|
+        reg["myenc"].unusable.not_nil!.should contain "unknown converter"
+        reg["myenc"].unusable.not_nil!.should contain "nosuchthing"
       end
     end
 

--- a/spec/filter_ast_spec.cr
+++ b/spec/filter_ast_spec.cr
@@ -183,6 +183,28 @@ describe Gori::FilterAst do
       taken.map(&.negate?).should eq([false])
       residual.should eq("NOT host:a")
     end
+
+    it "carries a NOT before a parenthesised group onto every taken term inside" do
+      # LParen has term==nil, so the bare-term NOT branch used to miss and take tag:a
+      # unnegated while residual `NOT ( )` folded away — Sitemap `NOT (tag:done)` then
+      # showed ONLY the tagged nodes. Polarity must ride into the group.
+      taken, residual = Gori::FilterAst.partition("NOT (tag:a) b") { |t| t.text.starts_with?("tag:") }
+      taken.map { |t| {t.text, t.negate?} }.should eq([{"tag:a", true}])
+      # Group shells and non-matching words stay; empty-group residue is fine (QL folds it).
+      residual.should contain("(")
+      residual.should contain(")")
+      residual.should contain("b")
+      residual.includes?("tag:a").should be_false
+
+      both, _ = Gori::FilterAst.partition("NOT (tag:a OR tag:b)") { |t| t.text.starts_with?("tag:") }
+      both.map { |t| {t.text, t.negate?} }.should eq([{"tag:a", true}, {"tag:b", true}])
+
+      # Even run cancels; dash inside XORs with the outer run.
+      even, _ = Gori::FilterAst.partition("NOT NOT (tag:x)") { |t| t.text.starts_with?("tag:") }
+      even.map(&.negate?).should eq([false])
+      dash, _ = Gori::FilterAst.partition("NOT (-tag:x)") { |t| t.text.starts_with?("tag:") }
+      dash.map(&.negate?).should eq([false])
+    end
   end
 
   describe ".spans" do

--- a/spec/fuzz/conn_pool_spec.cr
+++ b/spec/fuzz/conn_pool_spec.cr
@@ -180,6 +180,68 @@ describe F::ConnPool do
         req("POST /a HTTP/1.1\r\nHost: h\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n")).should be_false
     end
 
+    it "refuses a chunked body whose DATA forges the zero-chunk suffix" do
+      # The whole reason `reusable_request?` walks the chunk framing instead of comparing a
+      # 5-byte suffix. Chunk size 5, data `AB0\r\n`: the wire ends with `0\r\n\r\n` and carries
+      # NO terminating zero-chunk, so the origin sits waiting for the next chunk-size line and
+      # reads whatever gori pipelines next as this body's continuation — gori smuggling a
+      # request into its own target, out of its own pool.
+      F::ConnPool.reusable_request?(
+        req("POST /a HTTP/1.1\r\nHost: h\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nAB0\r\n\r\n")).should be_false
+      # Same forgery one chunk further in, after an honest chunk has been walked.
+      F::ConnPool.reusable_request?(
+        req("POST /a HTTP/1.1\r\nHost: h\r\nTransfer-Encoding: chunked\r\n\r\n" \
+            "2\r\nhi\r\n5\r\nAB0\r\n\r\n")).should be_false
+    end
+
+    it "refuses a chunked body with bytes AFTER its terminator" do
+      # Trailing octets are the mirror smuggle: the origin stops at the zero-chunk and the
+      # remainder becomes the head of the next request on the socket.
+      F::ConnPool.reusable_request?(
+        req("POST /a HTTP/1.1\r\nHost: h\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n\r\nGET /x HTTP/1.1\r\n\r\n")).should be_false
+    end
+
+    it "refuses a chunk-size line the origin would read differently" do
+      # `parse_chunk_size`'s rules, reached through the walker: a signed size, a non-hex size,
+      # a size larger than the body actually carries, and one that does not even fit Int32 —
+      # `parse_chunk_size` accepts any non-negative Int64 hex, so the walker has to reject an
+      # over-long size rather than walk its cursor past the buffer.
+      {
+        "+5\r\nhello\r\n0\r\n\r\n",
+        "z\r\nhello\r\n0\r\n\r\n",
+        "99\r\nhello\r\n0\r\n\r\n",
+        "7FFFFFFFFF\r\nhello\r\n0\r\n\r\n",
+        "7FFFFFFFFFFFFFFF\r\nhello\r\n0\r\n\r\n",
+      }.each do |body|
+        F::ConnPool.reusable_request?(
+          req("POST /a HTTP/1.1\r\nHost: h\r\nTransfer-Encoding: chunked\r\n\r\n#{body}")).should be_false
+      end
+    end
+
+    it "answers an over-long chunk size without raising out of the codec" do
+      # `reusable_request?` has a blanket rescue, so an escaping OverflowError would still read as
+      # "not reusable" there — but `Codec::Body.chunked_complete?` is public on the codec now and
+      # a caller without that rescue must not inherit a crash.
+      Gori::Proxy::Codec::Body.chunked_complete?(
+        "7FFFFFFFFFFFFFFF\r\nhello\r\n0\r\n\r\n".to_slice).should be_false
+      Gori::Proxy::Codec::Body.chunked_complete?("5\r\nhello\r\n0\r\n\r\n".to_slice).should be_true
+    end
+
+    it "still accepts the legitimate chunked shapes the walker has to keep passing" do
+      # Regression guard on the tightening: chunk extensions, a trailer field, multiple chunks
+      # and a bare-LF chunk terminator are all things `copy_chunked` frames successfully, so
+      # refusing them would have quietly dropped the pool back to one connection per request.
+      {
+        "5;name=v\r\nhello\r\n0\r\n\r\n",
+        "5\r\nhello\r\n0\r\nX-Sum: 1\r\n\r\n",
+        "2\r\nhi\r\n3\r\nthe\r\n0\r\n\r\n",
+        "5\nhello\n0\n\n",
+      }.each do |body|
+        F::ConnPool.reusable_request?(
+          req("POST /a HTTP/1.1\r\nHost: h\r\nTransfer-Encoding: chunked\r\n\r\n#{body}")).should be_true
+      end
+    end
+
     it "refuses bytes with no complete head" do
       F::ConnPool.reusable_request?(req("GET /a HTTP/1.1\r\nHost: h\r\n")).should be_false
     end

--- a/spec/fuzz_spec.cr
+++ b/spec/fuzz_spec.cr
@@ -622,10 +622,10 @@ describe F::Engine do
     results.size.should eq(3)
 
     by_payload = results.index_by { |r| r.payloads.first }
-    by_payload["a'b"].chain_error.should be_nil  # shell-escape ran
-    by_payload["c;d"].chain_error.should be_nil  # shell-escape ran
+    by_payload["a'b"].chain_error.should be_nil # shell-escape ran
+    by_payload["c;d"].chain_error.should be_nil # shell-escape ran
     failed = by_payload[binary]
-    failed.chain_error.should_not be_nil         # shell-escape refused this payload
+    failed.chain_error.should_not be_nil # shell-escape refused this payload
     failed.chain_error.not_nil!.should contain("shell-escape")
 
     # The run's tally counts the swallowed chain — it is NOT hidden inside "0 errors".
@@ -658,6 +658,24 @@ describe F::Engine do
     backend = FakeBackend.new(F::Origin.new("http", "h", 80)) { |_b| ok_result(200, "x") }
     results, _ = drain(F::Engine.new(gen, F::Matcher.new, backend, cfg))
     results.size.should eq(3) # all sent — a 0 cap must not break at @dispatched >= 0
+  end
+
+  it "skips calibration at max_requests=1 so the sweep still gets a send" do
+    # Math.max(cap-1, 1) used to want 1 calibration sample at cap=1, leaving zero for the
+    # sweep despite the comment promising the opposite.
+    set = F::PayloadSet.new(F::InlineList.new(["only"]))
+    cfg = F::Config.new(mode: F::Mode::Sniper, concurrency: 1, max_requests: 1_i64,
+      auto_calibrate: true)
+    gen = F::Generator.new(base, [set], cfg)
+    backend = FakeBackend.new(F::Origin.new("http", "h", 80)) { |_b| ok_result(200, "x") }
+    matcher = F::Matcher.new(auto_calibrate: true)
+    engine = F::Engine.new(gen, matcher, backend, cfg)
+    engine.auto_calibrate?.should be_true
+    engine.calibrate_baseline # must send nothing under cap=1
+    backend.sent.should eq(0)
+    results, _ = drain(engine)
+    results.size.should eq(1)
+    backend.sent.should eq(1)
   end
 
   it "enforces max_requests as a hard cap on real sends (retries count)" do
@@ -768,8 +786,8 @@ describe Gori::CLI::Output do
   it "emits valid JSON for a non-UTF-8 payload (row and array)" do
     binary = String.new(Bytes[0xff_u8, 0xfe_u8])
     r = F::Result.new(1_i64, [binary], nil, 200, 3_i64, 1, 1, 10_i64, nil, true, false, nil)
-    row = Gori::CLI::Output.fuzz_row_json(r)         # jsonl path
-    arr = Gori::CLI::Output.fuzz_array_json([r])     # json path
+    row = Gori::CLI::Output.fuzz_row_json(r)     # jsonl path
+    arr = Gori::CLI::Output.fuzz_array_json([r]) # json path
     # `valid_encoding?`, not `JSON.parse`: Crystal's parser tolerates its own invalid-UTF-8
     # output, but jq / python's json / every other consumer rejects a document with a raw
     # \xff in a string — which is exactly what the finding reproduced. The emitted bytes must

--- a/spec/import/import_spec.cr
+++ b/spec/import/import_spec.cr
@@ -993,6 +993,21 @@ describe Gori::Import::Builder do
       head.should contain("Transfer-Encoding: chunked\r\n")
     end
 
+    it "does not invent a Content-Length on a response that stated no framing" do
+      empty = Gori::Import::Builder::Headers.new
+      # Close-delimited / bodyless 304 / HTTP/2 DATA-framed: no CL on the wire.
+      head = String.new(Gori::Import::Builder.response_head("HTTP/1.1", 304, "Not Modified",
+        empty, nil))
+      head.should_not contain("Content-Length")
+      head = String.new(Gori::Import::Builder.response_head("HTTP/1.1", 200, "OK", empty,
+        "<html>".to_slice))
+      head.should_not contain("Content-Length")
+      head = String.new(Gori::Import::Builder.response_head("HTTP/2", 200, "", empty,
+        %({"a":1}).to_slice))
+      head.should_not contain("Content-Length")
+      head.should eq("HTTP/2 200\r\n\r\n") # no trailing space on empty reason
+    end
+
     # The complements: each framing ALONE keeps the behaviour the surrounding comments
     # describe, so "keep both" cannot be read as "keep whatever the source said".
     it "still drops a Content-Length that stands alone and re-states the real one" do
@@ -1105,7 +1120,8 @@ describe Gori::Import::Builder do
     it "does NOT rescue a body that was never chunk framing to begin with" do
       # The complement, and the reason the relaxation is bounded: a DECODED body a
       # third-party HAR shipped under a Transfer-Encoding header still loses the header,
-      # truncation flag or no truncation flag.
+      # truncation flag or no truncation flag. No CL is invented either — fabricating one
+      # would change a close-delimited (or unframed) entity into length-framed (P7).
       headers = Gori::Import::Builder::Headers.new
       headers << {"Transfer-Encoding", "chunked"}
       empty = Gori::Import::Builder::Headers.new
@@ -1114,7 +1130,7 @@ describe Gori::Import::Builder do
         headers, "hello world".to_slice, "text/plain", nil, nil, 5_000_i64)
       head = String.new(pair.response.not_nil!.head)
       head.should_not contain("Transfer-Encoding")
-      head.should contain("Content-Length: 11\r\n")
+      head.should_not contain("Content-Length")
     end
 
     it "does NOT relax the walk for an UNtruncated body" do

--- a/spec/mcp_spec.cr
+++ b/spec/mcp_spec.cr
@@ -1524,6 +1524,27 @@ describe Gori::MCP::Server do
       end
     end
 
+    it "save_as_repeater keeps the source SNI and does not force auto_content_length on" do
+      with_store do |store|
+        port = start_mcp_http_origin("ok")
+        # Seed a repeater with an SNI and auto_cl OFF (byte-exact / CL-desync probe).
+        rid = store.insert_repeater(
+          target: "http://127.0.0.1:#{port}",
+          request: "GET / HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n".to_slice,
+          http2: false, auto_cl: false, flow_id: nil, position: 0,
+          sni: "backend.internal.example.com")
+        call = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"send_request","arguments":{"repeater_id":#{rid},"save_as_repeater":true,"allow_unscoped":true}}})
+        resp = drive(store, call, verify_upstream: false)[0]
+        resp["result"]["isError"].as_bool.should be_false
+        # New row is the last repeater; source row kept.
+        saved = store.repeaters_meta.last
+        saved.id.should_not eq(rid)
+        rec = store.get_repeater(saved.id).not_nil!
+        rec.sni.should eq("backend.internal.example.com")
+        rec.auto_content_length?.should be_false
+      end
+    end
+
     it "includes effective_request on a url send (no ignored fields)" do
       with_store do |store|
         port = start_mcp_http_origin("ok")

--- a/spec/miner/engine_spec.cr
+++ b/spec/miner/engine_spec.cr
@@ -242,6 +242,27 @@ describe Gori::Miner::Engine do
       engine.first_error.should be_nil
       engine.successful_sends.should be > 0
     end
+
+    it "does not retry an exclude-rule refusal (Layer 2 is permanent)" do
+      # permanent_refusal? used to list only CAP and SANDBOX — exclude burned retries and
+      # the request cap for a refusal that cannot change between attempts.
+      reason = Gori::Outbound::EXCLUDE_SWEEP_ERROR
+      backend = BlockedBackend.new(F::Origin.new("http", "h", 80), reason)
+      c = cfg
+      c.retries = 5
+      c.retry_pause = 0.milliseconds
+      c.concurrency = 1
+      c.stability_rounds = 1
+      c.confirm_rounds = 1
+      base = "GET /api?a=1 HTTP/1.1\r\nHost: h\r\n\r\n".to_slice
+      engine = M::Engine.new(base, http2: false, names: ["alpha"], backend: backend, config: c)
+      engine.run { }
+      # One send per planned attempt — never (1 + retries) per attempt.
+      backend.sent.should be <= 4 # baseline + a few buckets, all single-shot
+      # If exclude were retried, retries=5 would multiply every send by 6.
+      backend.sent.should be < 12
+      engine.first_error.should eq(reason)
+    end
   end
 
   # Names the wordlist supplied that a location cannot carry. Dropping them is CORRECT — a

--- a/spec/oast/engine_spec.cr
+++ b/spec/oast/engine_spec.cr
@@ -322,4 +322,35 @@ describe Gori::Oast do
       O::ProviderKind.parse?("custom http").should be_nil
     end
   end
+
+  describe O::WebhookSite do
+    it "keeps the payload nonce on an empty-body callback" do
+      # generate_payload mints …/{uuid}/{nonce}; a GET with content:"" used to set
+      # raw_request="" and full_id=request-uuid, so the nonce vanished from every surface.
+      token = "tok-uuid-aaaa"
+      nonce = "n0nc3payld"
+      hit = "https://webhook.site/#{token}/#{nonce}"
+      body = {
+        "data" => [{
+          "uuid"       => "req-bbbb",
+          "method"     => "GET",
+          "ip"         => "203.0.113.5",
+          "content"    => "",
+          "url"        => hit,
+          "created_at" => "2024-01-01T00:00:00Z",
+        }],
+      }.to_json
+      provider = O::WebhookSite.new("https://webhook.site")
+      session = O::Session.new(0_i64, O::ProviderKind::WebhookSite,
+        "https://webhook.site", token, "", registered: true)
+      results = provider.poll(FakeHttp.new("/token/", body), session)
+      results.size.should eq(1)
+      i = results[0]
+      i.unique_id.should eq("req-bbbb")
+      i.full_id.should eq(hit)
+      i.raw_request.should eq(hit)
+      i.raw_request.should contain(nonce)
+      i.method.should eq("GET")
+    end
+  end
 end

--- a/spec/outbound_spec.cr
+++ b/spec/outbound_spec.cr
@@ -120,6 +120,38 @@ describe Gori::Outbound do
       Gori::Outbound.allowlist(nil).allows?(URL, "acme.test").should be_false
     end
 
+    it "check_request uses the port-less scope URL, so a non-default port stays allowlisted" do
+      # FlowRow#url embeds :8443; string/regex includes are written against the port-less
+      # form Scope.request_url / QL::URL_EXPR use. Probe Layer 1 must call check_request
+      # (or scope_url), not allows?(row.url, …), or every active probe on a non-default
+      # port is silently skipped while History still shows the flow in-scope.
+      with_scope do |scope, _store|
+        scope.add("include", "string", "https://acme.test/")
+        ob = Gori::Outbound.allowlist(scope)
+        portful = "https://acme.test:8443/admin"
+        # Documents the wrong form: a port-bearing URL misses the string include.
+        ob.allows?(portful, "acme.test").should be_false
+        # The form every other gate builds — and check_request.
+        ob.allows?(Gori::Outbound.scope_url("https", "acme.test", "/admin"), "acme.test").should be_true
+        ob.check_request("https", "acme.test", "/admin").blocked?.should be_false
+        # host rules never cared about port; pin that still holds.
+        scope2_path = File.tempname("gori-outbound-host", ".db")
+        store2 = Gori::Store.open(scope2_path)
+        begin
+          s2 = Gori::Scope.load(store2)
+          s2.add("include", "host", "acme.test")
+          o2 = Gori::Outbound.allowlist(s2)
+          o2.check_request("https", "acme.test", "/admin").blocked?.should be_false
+          o2.allows?(portful, "acme.test").should be_true # host match ignores URL port
+        ensure
+          store2.close
+          File.delete?(scope2_path)
+          File.delete?("#{scope2_path}-wal")
+          File.delete?("#{scope2_path}-shm")
+        end
+      end
+    end
+
     # Regression: Unscoped(NoProject) waives BOTH layers, so it is only ever correct when
     # there genuinely is no project. `gori run repeater send <id>` reads its session out of
     # the most-recently-active project even with no --project flag, and briefly built its
@@ -397,7 +429,7 @@ describe Gori::Outbound do
       Gori::Outbound.request_target("\r\nGET /admin/x HTTP/1.1\r\nHost: h\r\n\r\n").should eq("/admin/x")
       Gori::Outbound.request_target("\nGET /admin/x HTTP/1.1\r\n".to_slice).should eq("/admin/x")
       Gori::Outbound.request_target("\r\n\r\nGET /admin/x HTTP/1.1\r\n").should eq("/admin/x") # doubled leading blank
-      Gori::Outbound.request_target("\r\nPOST  /a/b\tHTTP/1.1\r\n").should eq("/a/b")           # blank line + irregular ws
+      Gori::Outbound.request_target("\r\nPOST  /a/b\tHTTP/1.1\r\n").should eq("/a/b")          # blank line + irregular ws
     end
 
     it "keeps the scope gate honest against a doubled-space request line" do

--- a/spec/probe_spec.cr
+++ b/spec/probe_spec.cr
@@ -1719,6 +1719,21 @@ describe "Gori::Probe::Active::ForbiddenBypass" do
     end
   end
 
+  it "dedup_key distinguishes ACTIVE from AGGRESSIVE so the wider header set is not suppressed" do
+    with_store do |store|
+      forbidden = capture_flow(store, "HTTP/1.1 403 Forbidden\r\n\r\n", target: "/admin", status: 403, content_type: nil)
+      base_key = probe.dedup_key(forbidden, Gori::Probe::Active::Options::DEFAULT).not_nil!
+      aggr_opts = Gori::Probe::Active::Options.new(allow_unsafe: true, aggressive: true)
+      aggr_key = probe.dedup_key(forbidden, aggr_opts).not_nil!
+      base_key.should_not eq(aggr_key)
+      base_key.should contain("|base")
+      aggr_key.should contain("|aggr")
+      # plan and dedup_key stay identical for each mode.
+      probe.plan(forbidden).not_nil!.dedup_key.should eq(base_key)
+      probe.plan(forbidden, aggr_opts).not_nil!.dedup_key.should eq(aggr_key)
+    end
+  end
+
   it "flags a possible bypass (Medium) only when the probe flips to 2xx and the control still denies" do
     with_store do |store|
       forbidden = capture_flow(store, "HTTP/1.1 403 Forbidden\r\n\r\n", target: "/admin", status: 403, content_type: nil)

--- a/spec/protocol_decode_spec.cr
+++ b/spec/protocol_decode_spec.cr
@@ -142,6 +142,15 @@ describe Gori::Jwt do
       found[0].brief.not_nil!.should contain("exp ")
     end
 
+    it "strips a case-insensitive Bearer scheme (RFC 7235)" do
+      # Only "Bearer "/"bearer " were stripped; BEARER left the whole value and jwt? dropped it.
+      {"Bearer", "bearer", "BEARER", "BeArEr"}.each do |scheme|
+        found = Gori::Jwt.from_flow("/", head("GET / HTTP/1.1", "Authorization: #{scheme} #{token}"), nil, nil, nil)
+        found.size.should eq(1), "scheme #{scheme.inspect}"
+        found[0].token.should eq(token)
+      end
+    end
+
     it "finds a token embedded in a JSON response body" do
       found = Gori::Jwt.from_flow("/", head("GET / HTTP/1.1"), nil,
         head("HTTP/1.1 200 OK"), %({"access_token":"#{token}"}).to_slice)

--- a/spec/proxy/codec/body_spec.cr
+++ b/spec/proxy/codec/body_spec.cr
@@ -163,6 +163,20 @@ describe Gori::Proxy::Codec::Body do
       Body.response_framing(ok, "HEAD").should eq({BodyFraming::None, 0_i64})
     end
 
+    it "treats a 2xx CONNECT response as bodyless but frames a non-2xx CONNECT entity" do
+      # RFC 7230 §3.3.3 / RFC 9112 §6.3: only a successful CONNECT is bodyless.
+      ok = Http1.parse_response_head("HTTP/1.1 200 Connection Established\r\n\r\n".to_slice)
+      Body.response_framing(ok, "CONNECT").should eq({BodyFraming::None, 0_i64})
+
+      auth = Http1.parse_response_head(
+        "HTTP/1.1 407 Proxy Authentication Required\r\nContent-Length: 12\r\n\r\n".to_slice)
+      Body.response_framing(auth, "CONNECT").should eq({BodyFraming::Length, 12_i64})
+
+      err = Http1.parse_response_head(
+        "HTTP/1.1 502 Bad Gateway\r\nContent-Type: text/plain\r\n\r\n".to_slice)
+      Body.response_framing(err, "CONNECT").should eq({BodyFraming::CloseDelimited, 0_i64})
+    end
+
     it "falls back to close-delimited when a response has neither CL nor chunked" do
       resp = Http1.parse_response_head("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\n".to_slice)
       Body.response_framing(resp, "GET").should eq({BodyFraming::CloseDelimited, 0_i64})

--- a/spec/proxy/codec/http1_spec.cr
+++ b/spec/proxy/codec/http1_spec.cr
@@ -166,4 +166,68 @@ describe Gori::Proxy::Codec::Http1 do
       Http1.request_token_safe?("/검색 ?q=값").should be_false
     end
   end
+
+  describe ".gate_target" do
+    # The target the SCOPE gate reads. `parse_request_head`'s strict `split(' ')` must stay
+    # strict (it feeds resolve_forward/rewrite_request_line, whose `version` is parts[2]), so
+    # the leniency lives here — and ONLY here. See `Http1.gate_target`.
+
+    it "returns the parsed target unchanged for a well-formed request line" do
+      req = Http1.parse_request_head(bytes("GET /admin?q=1 HTTP/1.1\r\nHost: h\r\n\r\n"))
+      req.malformed?.should be_false
+      Http1.gate_target(req).should eq("/admin?q=1")
+      # Same object identity as the parse: the common path allocates nothing new (P6).
+      Http1.gate_target(req).should be(req.target)
+    end
+
+    it "recovers the target a DOUBLED SPACE hid from the strict parse" do
+      # `split(' ')` yields ["GET", "", "/admin", "HTTP/1.1"] — size 4, so `malformed?`, and
+      # `parts[1]?` is the EMPTY string. The gate then evaluated `http://host`, missing an
+      # `exclude string:/admin` that an origin collapsing the whitespace still honours.
+      req = Http1.parse_request_head(bytes("GET  /admin HTTP/1.1\r\nHost: h\r\n\r\n"))
+      req.target.should eq("") # the strict parse is unchanged...
+      req.malformed?.should be_true
+      Http1.gate_target(req).should eq("/admin") # ...and the gate no longer reads it
+    end
+
+    it "recovers the target a TAB hid, which the strict parse turned into garbage" do
+      # Nastier than the empty case: ["GET\t/admin", "HTTP/1.1"] makes `parts[1]?` the
+      # VERSION, so the gate evaluated `http://hostHTTP/1.1` — a string a `string:` rule can
+      # match in ways nobody intended, in either direction.
+      req = Http1.parse_request_head(bytes("GET\t/admin HTTP/1.1\r\nHost: h\r\n\r\n"))
+      req.target.should eq("HTTP/1.1")
+      Http1.gate_target(req).should eq("/admin")
+    end
+
+    it "reads past LEADING BLANK LINES rather than gating an innocuous \"/\"" do
+      # RFC 9112 §2.2 tells a recipient to ignore an empty line before the request-line, so the
+      # real target reaches the origin while the first line the strict parse read was "".
+      req = Http1.parse_request_head(bytes("\r\n\r\nGET /admin HTTP/1.1\r\nHost: h\r\n\r\n"))
+      req.target.should eq("")
+      Http1.gate_target(req).should eq("/admin")
+    end
+
+    it "degrades to \"/\" when the request line carries no target at all" do
+      # Pinned, not incidental: `""` would make the scope URL `http://host` and `"/"` makes it
+      # `http://host/`, which is a different answer for an anchored regex rule. `"/"` is the
+      # value `Outbound.request_target` has always returned, and the two must not disagree.
+      Http1.gate_target(Http1.parse_request_head(bytes("GET\r\nHost: h\r\n\r\n"))).should eq("/")
+      Http1.gate_target(Http1.parse_request_head(bytes("\r\n\r\n"))).should eq("/")
+    end
+
+    it "answers identically to Outbound.request_target on every shape" do
+      # One predicate, one home: `Outbound.request_target` delegates here, so an active send
+      # (fuzz/mine/repeater) and the proxy gate can never grade the same bytes differently.
+      {
+        "GET /a HTTP/1.1\r\nHost: h\r\n\r\n",
+        "GET  /a HTTP/1.1\r\nHost: h\r\n\r\n",
+        "GET\t/a HTTP/1.1\r\nHost: h\r\n\r\n",
+        "\r\nGET /a HTTP/1.1\r\nHost: h\r\n\r\n",
+        "GET\r\nHost: h\r\n\r\n",
+      }.each do |raw|
+        Http1.gate_target(Http1.parse_request_head(bytes(raw)))
+          .should eq(Gori::Outbound.request_target(raw))
+      end
+    end
+  end
 end

--- a/spec/proxy/server_spec.cr
+++ b/spec/proxy/server_spec.cr
@@ -1090,6 +1090,105 @@ describe Gori::Proxy::Server do
     sink.responses.first.error.should eq("blocked by sandbox (out of scope)")
   end
 
+  it "sandbox blocks a request whose doubled-space request line hid the excluded path" do
+    # The scope gate used to read `parse_request_head`'s strict `split(' ')` target, which for
+    # `GET  /admin HTTP/1.1` is the EMPTY string — so the gate evaluated `http://127.0.0.1:p`,
+    # missed `exclude string:/admin`, and forwarded. An origin that collapses the whitespace
+    # reads `/admin` all the same, so this was a Sandbox bypass, not a cosmetic parse gap.
+    # `Codec::Http1.gate_target` closes it; the bytes still reach the origin byte-exact (P7).
+    seen = Channel(String).new(2)
+    done = Channel(Nil).new(2)
+    origin_port = start_origin("ok", seen)
+
+    store_path = File.tempname("gori-sbx-ws", ".db")
+    store = Gori::Store.open(store_path)
+    scope = Gori::Scope.load(store)
+    scope.add("include", "host", "127.0.0.1")
+    scope.add("exclude", "string", "/admin")
+    scope.enable_sandbox
+    interceptor = Gori::Interceptor.new(scope)
+
+    sink = RecordingSink.new(done)
+    proxy = Gori::Proxy::Server.new("127.0.0.1", 0, sink, interceptor: interceptor)
+    proxy.start
+
+    # Control: the well-formed request line is blocked by the exclude rule.
+    plain = TCPSocket.new("127.0.0.1", proxy.port)
+    plain << "GET /admin HTTP/1.1\r\nHost: 127.0.0.1:#{origin_port}\r\n\r\n"
+    plain.flush
+    plain_resp = plain.gets_to_end
+    plain.close
+    done.receive
+
+    # The bypass shape: same path, one extra space.
+    doubled = TCPSocket.new("127.0.0.1", proxy.port)
+    doubled << "GET  /admin HTTP/1.1\r\nHost: 127.0.0.1:#{origin_port}\r\n\r\n"
+    doubled.flush
+    doubled_resp = doubled.gets_to_end
+    doubled.close
+    done.receive
+
+    # And the tab shape, which handed the gate the VERSION as the target.
+    tabbed = TCPSocket.new("127.0.0.1", proxy.port)
+    tabbed << "GET\t/admin HTTP/1.1\r\nHost: 127.0.0.1:#{origin_port}\r\n\r\n"
+    tabbed.flush
+    tabbed_resp = tabbed.gets_to_end
+    tabbed.close
+    done.receive
+
+    proxy.stop
+    store.close
+    File.delete?(store_path)
+    File.delete?("#{store_path}-wal")
+    File.delete?("#{store_path}-shm")
+
+    plain_resp.should contain("403 Forbidden")
+    doubled_resp.should contain("403 Forbidden")
+    tabbed_resp.should contain("403 Forbidden")
+    # Nothing was dialled: every attempt is an Aborted flow, and the origin's 200 never arrives
+    # (a forwarded request would have made these responses Ok with a body instead).
+    sink.responses.size.should eq(3)
+    sink.responses.each do |r|
+      r.state.should eq(Gori::Store::FlowState::Aborted)
+      r.error.should eq("blocked by sandbox (out of scope)")
+    end
+  end
+
+  it "still forwards a doubled-space request line byte-exact when the scope allows it" do
+    # The gate got stricter; the WIRE did not. gori is a proxy for malformed bytes (P7), so the
+    # origin must receive the operator's octets unchanged — doubled space included.
+    seen = Channel(String).new(1)
+    done = Channel(Nil).new(1)
+    origin_port = start_origin("ok", seen)
+
+    store_path = File.tempname("gori-sbx-wsok", ".db")
+    store = Gori::Store.open(store_path)
+    scope = Gori::Scope.load(store)
+    scope.add("include", "host", "127.0.0.1")
+    scope.enable_sandbox
+    interceptor = Gori::Interceptor.new(scope)
+
+    sink = RecordingSink.new(done)
+    proxy = Gori::Proxy::Server.new("127.0.0.1", 0, sink, interceptor: interceptor)
+    proxy.start
+
+    client = TCPSocket.new("127.0.0.1", proxy.port)
+    client << "GET  /hello HTTP/1.1\r\nHost: 127.0.0.1:#{origin_port}\r\n\r\n"
+    client.flush
+    body = client.gets_to_end
+    client.close
+
+    done.receive
+    proxy.stop
+    store.close
+    File.delete?(store_path)
+    File.delete?("#{store_path}-wal")
+    File.delete?("#{store_path}-shm")
+
+    seen.receive.should eq("GET  /hello HTTP/1.1") # both spaces survived the proxy
+    body.should contain("200 OK")
+  end
+
   it "answers 400 (not a silent empty close) when it refuses a request's framing" do
     # gori is right to refuse CL+TE on the live MITM path (DESIGN P7) — but it used to do it
     # by closing with ZERO bytes, which on the wire is indistinguishable from the ORIGIN

--- a/spec/proxy/upstream_spec.cr
+++ b/spec/proxy/upstream_spec.cr
@@ -272,6 +272,54 @@ describe Gori::Proxy::Upstream do
       Gori::Proxy::Upstream.addresses_self?("127.0.0.1", 8080, {"127.0.0.1", 8080}).should be_true
     end
 
+    # The resolver's grammar is `inet_aton`'s, not `inet_pton`'s: every spelling below was
+    # MEASURED reaching a real 127.0.0.1 TCPServer on this platform, while
+    # `Socket::IPAddress.new(h, 0)` raises for all of them. So the classifiers were blind to
+    # them and gori forwarded a request aimed at its own listener to itself, accepted it as a
+    # fresh client, and dialled again — the accept-loop wedge `reaches_self?` exists to stop.
+    it "recognises numeric and rooted loopback spellings inet_pton rejects" do
+      {"2130706433", "0x7f000001", "017700000001", "127.1", "127.0.1", "localhost."}.each do |h|
+        Gori::Proxy::Upstream.addresses_self?(h, 8080, {"127.0.0.1", 8080})
+          .should be_true, file: __FILE__, line: __LINE__
+      end
+    end
+
+    # `unspecified?`'s own comment claims "the all-zero address in ANY spelling"; these three
+    # are all-zero, all reach loopback, and none of them parse as a literal.
+    it "recognises short all-zero spellings as the unspecified address" do
+      {"0", "0.0", "0.0.0"}.each do |h|
+        Gori::Proxy::Upstream.addresses_self?(h, 8080, {"127.0.0.1", 8080})
+          .should be_true, file: __FILE__, line: __LINE__
+      end
+    end
+
+    # The false-positive boundary: a 502 for legitimate traffic is worse than the loop, so the
+    # numeric reader must refuse anything that is not exactly inet_aton's grammar, and must not
+    # claim a non-127 address.
+    it "does not mistake a hostname or a non-loopback numeric host for self" do
+      {"example.com", "12345.com", "0x", "1.2.3.4.5", "256.1",
+       "16777217", "8.8.8.8", "notlocalhost"}.each do |h|
+        Gori::Proxy::Upstream.addresses_self?(h, 8080, {"127.0.0.1", 8080})
+          .should be_false, file: __FILE__, line: __LINE__
+      end
+      # `127.0.0.256` is out-of-range for inet_aton too, so the numeric reader also refuses it —
+      # but the PRE-EXISTING `starts_with?("127.")` fallback still claims it, and deliberately
+      # (see `loopback?`: dropping the prefix test would regress `127.1`). Pinned as unchanged
+      # rather than omitted: refusing an unroutable `127.` host as self is the safe side.
+      Gori::Proxy::Upstream.addresses_self?("127.0.0.256", 8080, {"127.0.0.1", 8080}).should be_true
+    end
+
+    # A dual-stack `::` bind reports an accepted IPv4 connection's local address v4-mapped, so
+    # `local_host` never matched the dotted `Host` the client actually sent — the one input the
+    # parameter was added for.
+    it "matches a v4-mapped local_host against the dotted Host the client sent" do
+      Gori::Proxy::Upstream.addresses_self?(
+        "192.168.1.5", 8080, {"::", 8080}, local_host: "::ffff:192.168.1.5").should be_true
+      # …and the mirror spelling, a client that writes the mapped form itself.
+      Gori::Proxy::Upstream.addresses_self?(
+        "[::ffff:192.168.1.5]", 8080, {"::", 8080}, local_host: "192.168.1.5").should be_true
+    end
+
     # Gap 1: the OS routes a connect() to the all-zero address onto loopback, so a
     # wildcard TARGET reaches us wherever a loopback target would.
     it "treats a 0.0.0.0 target as self against a loopback bind" do

--- a/spec/proxy/ws_spec.cr
+++ b/spec/proxy/ws_spec.cr
@@ -1521,6 +1521,20 @@ describe "Gori::Proxy::WS::Relay frame shape capture (V7)" do
     rows[0][3].fin.should be_true  # ... and the last of them did FIN
   end
 
+  it "records the re-framed shape (1 frame) when a rewrite collapses fragmentation" do
+    # Re-framing replaces multi-fragment wire bytes with ONE frame; capture must not keep
+    # the arrived frames=2 / RSV / mask key. emit_message used to pass `arrived` into the
+    # gate branch (and `emitted` was a dead store); the direct path already used emitted.
+    wire = client_frame(Gori::Proxy::WS::OP_TEXT, "hi ".to_slice, fin: false) +
+           client_frame(Gori::Proxy::WS::OP_CONT, "there".to_slice)
+    rows = shape_capture(wire, WsRewriter.new(to_server: {"hi there", "bye"}))
+    rows.size.should eq(1)
+    rows[0][2].should eq("bye")
+    rows[0][3].frames.should eq(1) # gori's one frame, not the peer's two
+    rows[0][3].fin.should be_true
+    rows[0][3].rsv.should eq(0)
+  end
+
   it "marks a message that ended with no FIN at all" do
     rows = shape_capture(client_frame(Gori::Proxy::WS::OP_TEXT, "never-ends".to_slice, fin: false))
     rows.size.should eq(1)

--- a/spec/ql_spec.cr
+++ b/spec/ql_spec.cr
@@ -218,10 +218,36 @@ describe Gori::QL do
   end
 
   it "compiles header: as a case-insensitive substring over the head bytes" do
+    # Long needles use a case-insensitive literal REGEXP (SafeRegexp is NUL-transparent);
+    # CAST+LIKE truncated at the first NUL and missed headers stored after an embedded 0x00.
     f = Gori::QL.parse("header:Set-Cookie")
-    f.sql.should eq("((lower(CAST(request_head AS TEXT)) LIKE ? ESCAPE '\\' OR " \
-                    "(response_head IS NOT NULL AND lower(CAST(response_head AS TEXT)) LIKE ? ESCAPE '\\')))")
-    f.args.should eq(["%set-cookie%", "%set-cookie%"]) # lowercased, substring
+    f.sql.should eq("((CAST(request_head AS TEXT) REGEXP ? OR " \
+                    "(response_head IS NOT NULL AND CAST(response_head AS TEXT) REGEXP ?)))")
+    f.args.should eq(["(?i)Set\\-Cookie", "(?i)Set\\-Cookie"])
+  end
+
+  it "compiles a short header: needle via byte-wise instr (NUL-transparent)" do
+    f = Gori::QL.parse("header:ab")
+    # case permutations of "ab" → ab/aB/Ab/AB, each against request + response head
+    f.sql.includes?("instr(request_head").should be_true
+    f.sql.includes?("instr(response_head").should be_true
+    f.args.size.should eq(8)
+  end
+
+  it "matches header: past an embedded NUL in the stored head bytes" do
+    # CAST AS TEXT LIKE stopped at the first NUL; the REGEXP/instr path must not.
+    tmp_store do |store|
+      head = "HTTP/1.1 200 OK\r\nX-Trace: a\u0000b\r\nSet-Cookie: sid=1\r\n\r\n".to_slice
+      id = store.insert_flow(Gori::Store::CapturedRequest.new(
+        created_at: 1_i64, scheme: "http", host: "acme.test", port: 80,
+        method: "GET", target: "/", http_version: "HTTP/1.1",
+        head: "GET / HTTP/1.1\r\nHost: acme.test\r\n\r\n".to_slice, body: nil))
+      store.update_response(Gori::Store::CapturedResponse.new(
+        flow_id: id, status: 200, head: head))
+      store.flush
+      store.search(Gori::QL.parse("header:Set-Cookie"), 50).map(&.id).should eq([id])
+      store.search(Gori::QL.parse("header:set-cookie"), 50).map(&.id).should eq([id]) # case-insensitive
+    end
   end
 
   it "compiles the ~ operator to a REGEXP over text fields" do

--- a/spec/settings_profile_spec.cr
+++ b/spec/settings_profile_spec.cr
@@ -276,3 +276,41 @@ describe "settings profiles" do
     end
   end
 end
+
+# #594 fixed a settings loader that overwrote the operator's own file: one `as_i?` OverflowError
+# aborted `apply_sections` partway, every section BELOW it kept its factory default, and the next
+# `save` wrote those defaults to disk. The same failure was still reachable through a different
+# coercion — `JSON::Any#[]?(String)` RAISES on a non-object ("Expected Hash for #[]?(key : String),
+# not String"), and four sections dereferenced their node with no `as_h?` guard. `"editor": "nvim"`
+# is enough, and `gori settings import` accepts such a profile after validating only the TOP level.
+#
+# `mine` is the probe: `parse_mine_prefs(root["mine"]?)` is declared AFTER all four guarded
+# sections, so it is applied only if none of them aborted the pass.
+describe "Settings.apply_sections — a non-object section must not abandon the rest" do
+  {"editor", "network", "decoder", "rewriter"}.each do |section|
+    {"\"not-an-object\"", "null", "42", "[1,2]"}.each do |bad|
+      it "survives #{section} = #{bad} and still applies the sections after it" do
+        with_config_home do
+          prev = Gori::Settings.mine_concurrency
+          begin
+            Gori::Settings.mine_concurrency = 3
+            Gori::Settings.import_document(%({"#{section}": #{bad}, "mine": {"concurrency": 7}}))
+            Gori::Settings.mine_concurrency.should eq(7)
+          ensure
+            Gori::Settings.mine_concurrency = prev
+          end
+        end
+      end
+    end
+  end
+
+  it "still reads a well-formed editor and network section (regression guard)" do
+    with_config_home do
+      Gori::Settings.import_document(
+        %({"editor": {"command": "nvim"}, "network": {"bind_port": 9123}, "theme": "goriday"}))
+      Gori::Settings.editor.should eq("nvim")
+      Gori::Settings.bind_port.should eq(9123)
+      Gori::Settings.theme.should eq("goriday")
+    end
+  end
+end

--- a/spec/settings_profile_spec.cr
+++ b/spec/settings_profile_spec.cr
@@ -314,3 +314,29 @@ describe "Settings.apply_sections — a non-object section must not abandon the 
     end
   end
 end
+
+describe "Settings.import_document — absent mine/discover leave overlay prefs alone" do
+  it "does not clear mine_prefs_saved when the profile omits mine" do
+    with_config_home do
+      Gori::Settings.save_mine_prefs(["query", "headers"], 12, "always")
+      Gori::Settings.mine_prefs_saved?.should be_true
+      Gori::Settings.mine_concurrency.should eq(12)
+      # network-only import used to call parse_mine_prefs(nil) and wipe the saved flag.
+      Gori::Settings.import_document(%({"network":{"bind_port":9199}}), ["network"])
+      Gori::Settings.mine_prefs_saved?.should be_true
+      Gori::Settings.mine_concurrency.should eq(12)
+      Gori::Settings.mine_locations.should eq(["query", "headers"])
+    end
+  end
+
+  it "does not clear discover_prefs_saved when the profile omits discover" do
+    with_config_home do
+      Gori::Settings.save_discover_prefs("strict", 3, 8, true, false, true, true)
+      Gori::Settings.discover_prefs_saved?.should be_true
+      Gori::Settings.import_document(%({"theme":"goriday"}), ["theme"])
+      Gori::Settings.discover_prefs_saved?.should be_true
+      Gori::Settings.discover_max_depth.should eq(3)
+      Gori::Settings.discover_concurrency.should eq(8)
+    end
+  end
+end

--- a/spec/store/retention_prune_spec.cr
+++ b/spec/store/retention_prune_spec.cr
@@ -1,0 +1,88 @@
+require "../spec_helper"
+
+# `Store#prune` used to seek its cutoff arithmetically — `MAX(id) - @retention_flows` — which is
+# "the newest N flows" only on a GAP-FREE id space. `flows.id` is monotonic but not gapless:
+# `delete_flow`/`delete_flows` remove arbitrary mid-history ids (the History tab's multi-select,
+# MCP `delete_flow`, `gori run history delete`), so an operator who prunes by hand leaves holes.
+# The sweep then destroyed flows it was explicitly asked to keep, silently and irreversibly,
+# logged as an ordinary retention drop. `Store::Compact.prune_old_flows` already documented and
+# fixed this exact arithmetic; these specs pin the two sweeps to one definition of "the newest N".
+
+private def prune_store(retention, prune_interval, &)
+  path = File.tempname("gori-retention-prune", ".db")
+  db = DB.open("sqlite3:#{path}?journal_mode=wal&busy_timeout=5000")
+  Gori::Store::Schema.migrate!(db)
+  store = Gori::Store.new(db, nil, retention_flows: retention, prune_interval: prune_interval)
+  begin
+    yield store
+  ensure
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+private def pruned_request(target : String) : Gori::Store::CapturedRequest
+  Gori::Store::CapturedRequest.new(
+    created_at: 1_000_i64, scheme: "http", host: "acme.test", port: 80,
+    method: "GET", target: target, http_version: "HTTP/1.1",
+    head: "GET #{target} HTTP/1.1\r\nHost: acme.test\r\n\r\n".to_slice, body: nil)
+end
+
+describe "Store#prune retention cutoff" do
+  it "keeps every flow when the surviving row count is under the cap, despite gapped ids" do
+    # 10 captures, 6 hand-deleted from the middle (survivors 1, 2, 9, 10), then 15 more captures:
+    # 19 rows against a cap of 20, so the sweep must drop NOTHING. The old arithmetic computed
+    # `25 - 20 = 5` and destroyed flows 1 and 2.
+    prune_store(20, 2) do |store|
+      ids = (1..10).map { |i| store.insert_flow(pruned_request("/#{i}")) }
+      store.flush
+      store.delete_flows(ids[2..7])
+      store.flush
+      survivors = ids.select { |id| store.flow_row(id) }
+      survivors.size.should eq(4) # the hand-delete landed as intended
+
+      (11..25).each { |i| store.insert_flow(pruned_request("/#{i}")) }
+      store.flush
+
+      ids.select { |id| store.flow_row(id) }.should eq(survivors)
+    end
+  end
+
+  it "still drops the oldest flows once the cap is genuinely exceeded" do
+    # The regression guard on the tightening: retention must keep sweeping. 12 captures under a
+    # cap of 5 leaves exactly the newest 5.
+    prune_store(5, 2) do |store|
+      ids = (1..12).map { |i| store.insert_flow(pruned_request("/#{i}")) }
+      store.flush
+      ids.select { |id| store.flow_row(id) }.should eq(ids.last(5))
+    end
+  end
+
+  it "counts surviving ROWS, not id distance, when the cap is exceeded on a gapped space" do
+    # Both halves at once: gaps present AND the cap exceeded. 10 captures, ids 3..8 hand-deleted
+    # (survivors 1, 2, 9, 10), then 8 more (ids 11..18) — 12 rows against a cap of 6, so exactly
+    # the newest 6 by ROW ORDER survive: 13..18. The old arithmetic would have kept 13..18 too
+    # only by coincidence of the numbers; what it could never do is stop at a row count.
+    prune_store(6, 2) do |store|
+      ids = (1..10).map { |i| store.insert_flow(pruned_request("/#{i}")) }
+      store.flush
+      store.delete_flows(ids[2..7])
+      store.flush
+      more = (11..18).map { |i| store.insert_flow(pruned_request("/#{i}")) }
+      store.flush
+      alive = (ids + more).select { |id| store.flow_row(id) }
+      alive.size.should eq(6)
+      alive.should eq(more.last(6))
+    end
+  end
+
+  it "is a no-op for a store with fewer flows than the cap" do
+    prune_store(100, 2) do |store|
+      ids = (1..6).map { |i| store.insert_flow(pruned_request("/#{i}")) }
+      store.flush
+      ids.select { |id| store.flow_row(id) }.should eq(ids)
+    end
+  end
+end

--- a/spec/tui/tutorial_pet_spec.cr
+++ b/spec/tui/tutorial_pet_spec.cr
@@ -164,3 +164,30 @@ describe Gori::Tui::Tutorial do
     end
   end
 end
+
+# The tour's fake palette is filterable, so its row list can be EMPTY — and the ↑ arm took its
+# modulo before checking, so `gori tutorial` → palette step → `^P` → type a non-matching
+# character → ↑ died with an unhandled DivisionByZeroError. Both arrows now go through one
+# helper; these are the cases that used to differ between them.
+describe "Gori::Tui::Tutorial.wrap_sel" do
+  it "returns 0 for an empty list instead of dividing by zero" do
+    Gori::Tui::Tutorial.wrap_sel(0, -1, 0).should eq(0)  # the crash
+    Gori::Tui::Tutorial.wrap_sel(0, +1, 0).should eq(0)  # the arm that was already guarded
+    Gori::Tui::Tutorial.wrap_sel(7, -1, 0).should eq(0)  # a stale selection, list filtered away
+    Gori::Tui::Tutorial.wrap_sel(3, +1, -1).should eq(0) # defensive: n can never be < 0, but 0 is the answer
+  end
+
+  it "wraps both directions over a non-empty list" do
+    Gori::Tui::Tutorial.wrap_sel(0, -1, 4).should eq(3) # floored %, so ↑ from the top goes to the end
+    Gori::Tui::Tutorial.wrap_sel(3, +1, 4).should eq(0)
+    Gori::Tui::Tutorial.wrap_sel(1, -1, 4).should eq(0)
+    Gori::Tui::Tutorial.wrap_sel(1, +1, 4).should eq(2)
+  end
+
+  it "lands in range even when the selection is already past the end" do
+    # `render_fake_palette` clamps for drawing, but the state itself must not stay out of range.
+    Gori::Tui::Tutorial.wrap_sel(9, +1, 3).should be < 3
+    Gori::Tui::Tutorial.wrap_sel(9, -1, 3).should be < 3
+    Gori::Tui::Tutorial.wrap_sel(1, +1, 1).should eq(0)
+  end
+end

--- a/src/gori/cli/run.cr
+++ b/src/gori/cli/run.cr
@@ -394,6 +394,16 @@ module Gori
       # would ship a token minutes-to-days stale into the run and produce the page of 401s the
       # feature exists to remove.
 
+      # The {scheme, host, target} `guard_outbound` judges a `--bind-from` seed by. Named rather
+      # than inlined so the decision is spec-able without a live send, the way
+      # `repeater_out_of_scope?` is for `gori run repeater`. The target comes from
+      # `Outbound.request_target` — the one home for reading a request-target off raw bytes,
+      # which recovers it from an irregular request line instead of gating an empty path.
+      private def self.bind_from_scope_triple(built : Repeater::FlowRequest::Built) : {String, String, String}
+        scheme, host, _port = Repeater::FlowRequest.parse_target(built.target)
+        {scheme, host, Gori::Outbound.request_target(built.bytes)}
+      end
+
       # Replay flow `flow_id` through `Repeater::Sender` — the one extraction source — so its
       # response can fill the binding table before the sweep starts. Aborts on anything that
       # leaves the table unfilled: a seed that silently did nothing would hand the operator
@@ -419,6 +429,17 @@ module Gori
         if err = bind_from_blocker(bindings)
           abort "#{cmd}: #{err}"
         end
+        # Layer 1, on the SEED's own host — which is not the sweep's. Each command guards its
+        # `--target` with `guard_outbound` before it gets here, but `--bind-from FLOW-ID` names
+        # a second, unrelated destination: whatever host that capture was taken from. Without
+        # this the seed replayed a full captured request — cookies and all — to an out-of-scope
+        # host that the very same invocation would have refused as a `--target`, and only
+        # Sandbox/excludes (Layer 2, inside `Repeater::Sender`) could stop it. `Outbound` exists
+        # so no active request leaves gori without a scope decision; a replay is an active
+        # request. `--allow-unscoped` still waives it, exactly as it does for the sweep.
+        # Same gap, same shape, and the same fix as #406 gave `gori run repeater`.
+        gs, gh, gt = bind_from_scope_triple(built)
+        guard_outbound(outbound, gs, gh, gt, "#{cmd}: --bind-from")
         # `evidence: true` is not conditional here and cannot be: `built` is
         # `Repeater::FlowRequest.build(detail)`, which reads `request_head`/`request_body` and
         # nothing else, and the operator supplied one integer. There is no draft on this path

--- a/src/gori/cli/run.cr
+++ b/src/gori/cli/run.cr
@@ -556,6 +556,33 @@ module Gori
         {hits, rest}
       end
 
+      # The QL `gori run history`/`ls` actually runs, plus the positional terms an explicit
+      # `--query` swallowed (nil when none were).
+      #
+      # `--query` wins over a POSITIONAL query — but NOT over a negation term, and the difference
+      # is provenance. A positional is a second spelling of the same argument, so letting the
+      # explicit flag win is a choice. A `-path:/b` is not: OptionParser would have aborted it as
+      # an unknown option, so `split_ql_negations` reclassified it out of argv on the operator's
+      # behalf — and the old `query ||= (positional + neg_terms).join` then threw it away
+      # whenever `--query` was also given. Measured with 3 flows: `history 'host:x' '-path:/b'`
+      # returned the two that match, `history --query='host:x' '-path:/b'` returned all three.
+      # A silently BROADER result set is the one outcome `warn_query_terms` exists to shout
+      # about, and the dropped term never reached it either. Spaces are QL's AND, which the
+      # positional join already assumed.
+      #
+      # Returned rather than aborted so the caller owns the message, and named rather than
+      # inlined so the precedence is spec-able without a store or a tty.
+      def self.compose_history_query(query : String?, positional : Array(String),
+                                     neg_terms : Array(String)) : {String?, String?}
+        if q = query
+          combined = neg_terms.empty? ? q : ([q] + neg_terms).join(' ')
+          {combined, positional.empty? ? nil : positional.join(' ')}
+        else
+          pq = (positional + neg_terms).join(' ')
+          {pq.empty? ? nil : pq, nil}
+        end
+      end
+
       # QL negation terms ("-field:value" / "-field~rx") begin with '-', so OptionParser
       # aborts them as unknown options before the positional-query join ever runs. Pull
       # them out first so they join the query like any other positional term. A single-
@@ -592,6 +619,31 @@ module Gori
           end
         end
         out
+      end
+
+      # Refuse the positionals a LIST command was handed. A `list` takes none, but every
+      # `rewriter`/`probe rules` dispatcher routes a first token starting with '-' straight to
+      # its list command on the assumption that the rest are list options — so a global flag
+      # written BEFORE the verb (`rewriter --project=t1 rm 1`, the ordering every other
+      # `gori run` command accepts) discarded the verb AND its id, listed the rules, and exited
+      # 0. A destructive mutation that silently no-ops with a SUCCESS status is the failure this
+      # file's own header (see the `verb_token?` guards) calls the worst one a scripted surface
+      # can have, so it becomes a usage error that names the ordering.
+      private def self.refuse_list_leftovers(leftover : Array(String), sub : String,
+                                             verbs : String) : Nil
+        (msg = list_leftover_error(leftover, sub, verbs)) && abort(msg)
+      end
+
+      # The sentence `refuse_list_leftovers` aborts with, or nil to proceed. Split out so the
+      # decision AND the message are spec-able — `abort` is not, and this is the one fix of the
+      # three whose blast radius is several call sites (`cmd_rewriter_list`, `cmd_extract_list`,
+      # `cmd_probe_rules_list`) plus one DELIBERATE exclusion: `cmd_probe_scan` takes a positional
+      # QL query (`gori run probe [QL query]`), so a leftover there is the operator's filter, not
+      # a discarded verb. Do not add this to it.
+      def self.list_leftover_error(leftover : Array(String), sub : String, verbs : String) : String?
+        return nil if leftover.empty?
+        "gori run #{sub}: unknown subcommand '#{leftover[0]}' — global flags go AFTER " \
+        "the subcommand (`gori run #{sub} #{leftover[0]} … --project=NAME`). Verbs: #{verbs}"
       end
 
       private def self.take_flow_id(rest : Array(String), sub : String) : Int64

--- a/src/gori/cli/run/history.cr
+++ b/src/gori/cli/run/history.cr
@@ -33,8 +33,14 @@ module Gori
         end
         parser.parse(args)
 
-        id_s = positional.first? || abort("gori run history delete: <id> is required")
-        id = id_s.to_i64? || abort("gori run history delete: invalid flow id #{id_s.inspect}")
+        # `take_flow_id`, not a hand-rolled `first?`: it supplies the too-many-arguments abort
+        # this one path was missing, so `history delete 1 2 3` no longer deletes ONLY flow #1
+        # and exits 0 with nothing said about #2 and #3. The TUI has multi-select delete and the
+        # store exposes `delete_flows`, so trying the list form is natural — and an operator who
+        # believes three captures are gone when two are still on disk has been told a lie by a
+        # destructive command. Every sibling id-taking delete (project, scope, env,
+        # host-override, `history show`) already goes through this helper.
+        id = take_flow_id(positional, "history delete")
 
         store = open_store(resolve_read_project(project_name, db_path))
         begin
@@ -110,9 +116,12 @@ module Gori
         parser.parse(opt_args)
         # Accept a positional QL too ("gori run history status:404" / "-status:404"),
         # mirroring the TUI's `/` bar — otherwise a positional query was silently dropped
-        # and EVERY flow dumped. An explicit --query wins. Terms join with spaces (QL ANDs).
-        positional_query = (positional + neg_terms).join(' ')
-        query ||= positional_query unless positional_query.empty?
+        # and EVERY flow dumped.
+        query, dropped = Run.compose_history_query(query, positional, neg_terms)
+        if dropped
+          STDERR.puts "gori run history: --query given, so the positional query term(s) " \
+                      "#{dropped.inspect} were ignored"
+        end
 
         store = open_store(resolve_read_project(project_name, db_path))
         begin

--- a/src/gori/cli/run/probe.cr
+++ b/src/gori/cli/run/probe.cr
@@ -371,6 +371,7 @@ module Gori
         project_name : String? = nil
         kind : String? = nil
         format = :text
+        leftover = [] of String
 
         parser = OptionParser.new do |p|
           p.banner = "Usage: gori run probe rules [list] [options]\n\n" \
@@ -382,10 +383,12 @@ module Gori
           p.on("--kind=KIND", "Only list rules of this kind (passive|active|custom)") { |v| kind = parse_rule_kind(v) }
           p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
+          p.unknown_args { |rest, _| leftover = rest }
           p.invalid_option { |f| abort "gori run probe rules: unknown option: #{f}\n#{p}" }
           p.missing_option { |f| abort "gori run probe rules: missing value for #{f}" }
         end
         parser.parse(args)
+        refuse_list_leftovers(leftover, "probe rules", "add, enable, disable, delete/rm")
 
         store = open_store(resolve_read_project(project_name, db_path))
         entries, mode = begin

--- a/src/gori/cli/run/rewriter.cr
+++ b/src/gori/cli/run/rewriter.cr
@@ -64,15 +64,18 @@ module Gori
         db_path : String? = nil
         project_name : String? = nil
         format = :text
+        leftover = [] of String
         parser = OptionParser.new do |p|
           p.banner = "Usage: gori run rewriter extract [list] [options]"
           p.on("--project=NAME", "Project to read (default: most-recently-active)") { |v| project_name = v }
           p.on("--db=PATH", "Explicit SQLite db file to read") { |v| db_path = v }
           p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
+          p.unknown_args { |rest, _| leftover = rest }
           p.invalid_option { |f| abort "gori run rewriter extract: unknown option: #{f}\n#{p}" }
         end
         parser.parse(args)
+        refuse_list_leftovers(leftover, "rewriter extract", "add, rm/delete, enable, disable")
 
         store = open_store(resolve_read_project(project_name, db_path))
         begin
@@ -293,6 +296,7 @@ module Gori
         db_path : String? = nil
         project_name : String? = nil
         format = :text
+        leftover = [] of String
 
         parser = OptionParser.new do |p|
           p.banner = "Usage: gori run rewriter [options]\n\n" \
@@ -304,10 +308,12 @@ module Gori
           p.on("--db=PATH", "Explicit SQLite db file to read") { |v| db_path = v }
           p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
+          p.unknown_args { |rest, _| leftover = rest }
           p.invalid_option { |f| abort "gori run rewriter: unknown option: #{f}\n#{p}" }
           p.missing_option { |f| abort "gori run rewriter: missing value for #{f}" }
         end
         parser.parse(args)
+        refuse_list_leftovers(leftover, "rewriter", "add, rm/delete, enable, disable, preview, extract, bindings")
 
         project = resolve_read_project(project_name, db_path)
         store = open_store(project)

--- a/src/gori/decoder/library.cr
+++ b/src/gori/decoder/library.cr
@@ -71,8 +71,12 @@ module Gori::Decoder
     # visible stack rather than a hang in a fuzz worker. Returns nil when the entry is
     # unusable (cycle, or past MAX_TOKENS), with the reason in `why`.
     #
-    # A token that is neither a built-in nor a saved name is left ALONE: `run` then reports it
-    # as an unknown converter, which is the same answer typing it directly would give.
+    # A token that is neither a built-in nor a saved name makes the chain unusable: leaving
+    # it "as typed" registered the entry with `unusable: nil`, so `Fuzz::Plan`'s up-front
+    # `refuse_unusable_chains` never fired and `Template#apply_chains` sent the payload
+    # untransformed (a typo'd `url-encode > nosuchthing` put a raw space on the wire).
+    # Marking it here surfaces the same "unknown converter" answer the plan gate already
+    # knows how to report — before the first dial.
     #
     # `r` MUST be the pristine built-in registry here — see `register_all`'s two passes. If a
     # saved entry has already been registered into it, `r[tok]?` answers true for that name and
@@ -91,11 +95,16 @@ module Gori::Decoder
       failed = false
       Decoder.parse_spec(specs[nk][1]).each do |tok|
         tk = Registry.normalize(tok)
-        # A built-in wins (register_all never lets a saved name shadow one), and an unknown
-        # token stays as typed. Everything else is a saved name and gets spliced — in EITHER
-        # direction, because `r` holds no saved entry at this point.
-        if r[tok]? || !specs.has_key?(tk)
+        # A built-in wins (register_all never lets a saved name shadow one). An unknown
+        # token fails the chain as unusable (see comment above). Everything else is a
+        # saved name and gets spliced — in EITHER direction, because `r` holds no saved
+        # entry at this point.
+        if r[tok]?
           out << tok
+        elsif !specs.has_key?(tk)
+          failed = true
+          why[nk] = "unknown converter \"#{tok}\""
+          break
         else
           inner = flatten(tk, specs, r, flat, why, stack)
           if inner.nil?

--- a/src/gori/filter_ast.cr
+++ b/src/gori/filter_ast.cr
@@ -363,6 +363,36 @@ module Gori
           i += run + 1
           next
         end
+        # `NOT (tag:x)` — same desugar, but the NOT sits before a GROUP. An LParen lexeme
+        # has `term == nil`, so the branch above never fired and the inner `tag:x` was
+        # taken UNNEGATED while `NOT ( )` fell into residual and folded away — Sitemap
+        # `NOT (tag:done)` then showed ONLY the tagged nodes, silently inverted, with no
+        # "invalid filter" note. Walk the group, apply the run's polarity to every taken
+        # term inside (XOR with a dash already on the leaf), and leave non-matching
+        # structure in the residual. Empty residual groups fold the same way as before.
+        if run > 0 && nxt && nxt.tok.l_paren?
+          j = i + run
+          depth = 0
+          while j < lexemes.size
+            lx = lexemes[j]
+            if lx.tok.l_paren?
+              depth += 1
+              kept << query[lx.start, lx.size]
+            elsif lx.tok.r_paren?
+              depth -= 1
+              kept << query[lx.start, lx.size]
+              j += 1
+              break if depth == 0
+            elsif (t = lx.term) && yield t
+              taken << (run.odd? ? t.negated : t)
+            else
+              kept << query[lx.start, lx.size]
+            end
+            j += 1
+          end
+          i = j
+          next
+        end
         lx = lexemes[i]
         t = lx.term
         if t && yield t

--- a/src/gori/fuzz/engine.cr
+++ b/src/gori/fuzz/engine.cr
@@ -503,6 +503,13 @@ module Gori::Fuzz
       @total
     end
 
+    # Whether Config asked for auto-calibration. Surfaces that own their start path
+    # (CLI, TUI) call `calibrate_baseline` themselves; MCP's job fiber asks this so the
+    # documented `auto_calibrate` flag is not a silent no-op.
+    def auto_calibrate? : Bool
+      @config.auto_calibrate?
+    end
+
     # Seed the matcher's calibration set from CALIBRATION_SAMPLES synthetic,
     # randomly-payloaded requests (see Generator#calibration_requests and
     # Matcher.reflects_length?) — replaces the old single-snapshot baseline, which a
@@ -510,12 +517,17 @@ module Gori::Fuzz
     # reflected parameter) trivially defeated. Optional; call before `start`. Every
     # send routes through @backend like any other, so calibration sends still count
     # against a configured max_requests cap; under a tight cap, sample count is
-    # trimmed so at least one send is left for the sweep itself. A failed/empty
-    # calibration is non-fatal — auto_calibrate then simply suppresses nothing.
+    # trimmed so at least one send is left for the sweep itself (at max_requests=1
+    # calibration is skipped entirely — the old `Math.max(cap - 1, 1)` still wanted 1
+    # sample and left zero for the sweep, despite the comment promising the opposite).
+    # A failed/empty calibration is non-fatal — auto_calibrate then simply suppresses
+    # nothing.
     def calibrate_baseline : Nil
       wanted = CALIBRATION_SAMPLES
-      if (cap = @config.max_requests) && cap > 0 && cap - 1 < wanted
-        wanted = Math.max(cap - 1, 1_i64).to_i32
+      if (cap = @config.max_requests) && cap > 0
+        room = cap - 1
+        return if room <= 0
+        wanted = Math.min(wanted.to_i64, room).to_i32
       end
       samples = [] of BaselineSample
       @generator.calibration_requests(wanted).each do |bytes, payload_len|

--- a/src/gori/import/builder.cr
+++ b/src/gori/import/builder.cr
@@ -362,8 +362,14 @@ module Gori
         reject_inject!(reason, "reason phrase")
         reject_header_injection!(headers)
         String.build do |b|
-          b << http_version << ' ' << status << ' ' << reason << "\r\n"
-          has_cl = false
+          # HTTP/2 status lines carry no reason phrase on the wire; inventing "OK" (or a
+          # trailing space after an empty reason) broke the export→import fixed point for
+          # every h2 flow. Omit the phrase when empty rather than force a space.
+          if reason.empty?
+            b << http_version << ' ' << status << "\r\n"
+          else
+            b << http_version << ' ' << status << ' ' << reason << "\r\n"
+          end
           wire_chunked = wire_chunked?(headers, body, truncated)
           # A response stating both framings keeps both, for the reason `both_framings?`
           # gives: the pair is the operator's evidence, and a response desync is the same
@@ -371,11 +377,13 @@ module Gori
           both = both_framings?(headers)
           headers.each do |k, v|
             next if !both && !wire_chunked && transfer_encoding?(k)
-            has_cl = true if !has_cl && k.compare("content-length", case_insensitive: true) == 0
             b << k << ": " << v << "\r\n"
           end
-          # See `wire_chunked?`: a length only where the body is not chunk-framed as stored.
-          b << "Content-Length: " << (body.try(&.size) || 0) << "\r\n" unless has_cl || wire_chunked
+          # Do NOT invent a Content-Length the source never stated. Close-delimited replies,
+          # bodyless 304/204, and every HTTP/2 head (DATA-framed, no CL) had one fabricated
+          # here, so re-import silently changed framing (P7) and broke export→import. An
+          # incoming CL is kept by the headers loop above; chunked bodies keep TE via
+          # wire_chunked; truncation is already carried by body_size on the DTO.
           b << "\r\n"
         end.to_slice
       end

--- a/src/gori/import/har.cr
+++ b/src/gori/import/har.cr
@@ -69,7 +69,18 @@ module Gori
         end
 
         status = resp["status"]?.try(&.as_i).try(&.to_i32) || 0
-        reason = resp["statusText"]?.to_s.presence || status_reason(status)
+        # Prefer the HAR's own statusText. Only invent a phrase for HTTP/1.x when the
+        # field is absent — HTTP/2 has no reason phrase on the wire, and inventing "OK"
+        # (or a trailing space on an empty phrase) broke the export→import fixed point.
+        resp_version = normalize_http_version(resp["httpVersion"]?.to_s.presence || http_version)
+        raw_reason = resp["statusText"]?.to_s
+        reason = if raw_reason.presence
+                   raw_reason
+                 elsif resp_version.starts_with?("HTTP/2")
+                   ""
+                 else
+                   status_reason(status)
+                 end
         resp_headers = headers_list(resp["headers"]?)
         resp_body, mime_type, resp_declared = response_body(resp)
         # Prefer the ACTUAL Content-Type response HEADER over HAR content.mimeType, matching how

--- a/src/gori/jwt.cr
+++ b/src/gori/jwt.cr
@@ -118,7 +118,15 @@ module Gori
         value = l[(colon + 1)..].strip
         case name
         when "authorization"
-          tok = value.lchop?("Bearer ") || value.lchop?("bearer ") || value
+          # RFC 7235: the auth scheme is case-insensitive. Only "Bearer "/"bearer " were
+          # stripped, so `BEARER` / mixed-case schemes left the whole value in place and
+          # jwt? rejected it — tokens present on the wire were silently dropped from the
+          # scan. A 7-char case-insensitive prefix match covers every spelling.
+          tok = if value.size >= 7 && value[0, 7].compare("Bearer ", case_insensitive: true) == 0
+                  value[7..]
+                else
+                  value
+                end
           yield "#{pfx}Authorization", tok.strip
         when "cookie", "set-cookie"
           label = name == "cookie" ? "Cookie" : "Set-Cookie"

--- a/src/gori/mcp/tools/fuzz.cr
+++ b/src/gori/mcp/tools/fuzz.cr
@@ -49,6 +49,10 @@ module Gori
       # never leave the job wedged at :running, which would hang a polling client
       # forever and keep jobs_running? true (blocking switch_project/delete_project).
       private def run_fuzz_job(fjob : FuzzJob, engine : Fuzz::Engine) : Nil
+        # CLI (`--ac`) and the TUI both call calibrate_baseline before the sweep.
+        # fuzz_config already set Config/Matcher.auto_calibrate from the arg, but nothing
+        # here ever sampled — so auto_calibrate:true was a documented silent no-op.
+        engine.calibrate_baseline if engine.auto_calibrate?
         engine.run { |ev| drain_fuzz_event(fjob, ev) }
       rescue ex
         Log.error(exception: ex) { "fuzz job #{fjob.id} crashed" }

--- a/src/gori/mcp/tools/send.cr
+++ b/src/gori/mcp/tools/send.cr
@@ -60,7 +60,8 @@ module Gori
         Log.info { "send_request #{built.scheme}://#{built.host}:#{built.port} http2=#{http2} scope=#{sc.decision} flow_id=#{recorded_flow_id || "none"} -> #{result.ok? ? "ok" : result.error}" }
 
         repeater_id = persist_send_repeater(h, save, built, http2, result,
-          issue_id, recorded_flow_id, plan.h2_fields)
+          issue_id, recorded_flow_id, plan.h2_fields,
+          sni: plan.sni, auto_cl: send_persist_auto_cl(h))
 
         body_cap, body_omit = body_return_opts(h)
         Result.new(send_result_json(result, recorded_flow_id, repeater_id,
@@ -381,10 +382,25 @@ module Gori
         code == "NETWORK_ERROR" && !delivered
       end
 
+      # The auto-Content-Length flag to persist on a save_as_repeater row. Hard-coded true
+      # re-framed every later replay of a CL-desync evidence capture. Prefer the source
+      # session's setting when replaying a repeater; otherwise default OFF (byte-exact),
+      # overridable by an explicit auto_content_length arg.
+      private def send_persist_auto_cl(h) : Bool
+        if present?(h, "auto_content_length")
+          return bool_arg(h, "auto_content_length", false)
+        end
+        if present?(h, "repeater_id") && (id = int(h, "repeater_id")) && (rec = store.get_repeater(id))
+          return rec.auto_content_length?
+        end
+        false
+      end
+
       private def persist_send_repeater(h, save : Bool, built : RequestBuilder::Built,
                                         http2 : Bool, result : Repeater::Result,
                                         issue_id : Int64?, recorded_flow_id : Int64?,
-                                        h2_fields : Array({String, String})? = nil) : Int64?
+                                        h2_fields : Array({String, String})? = nil,
+                                        *, sni : String? = nil, auto_cl : Bool = false) : Int64?
         return nil unless save
         port_suffix = ((built.scheme == "https" && built.port == 443) ||
                        (built.scheme == "http" && built.port == 80)) ? "" : ":#{built.port}"
@@ -429,20 +445,21 @@ module Gori
         # and `RepeaterView#evidence?` sends `$NAME` literally — so this row went out one way
         # from the TUI and another from MCP. Same seam as `Tools#stored_request`.
         masked_req = Env.mask_secrets(String.new(saved_bytes))
+        # Prefer the Plan's expanded SNI (what the send actually used); fall back through
+        # send_sni so an explicit arg still wins. Bare `send_sni(h)` dropped the stored SNI
+        # because it passed no `stored` argument.
+        effective_sni = sni.presence || send_sni(h)
         repeater_id = store.insert_repeater(
           target: target_url,
           request: saved_bytes,
           http2: http2,
-          auto_cl: true,
+          auto_cl: auto_cl,
           flow_id: flow_id,
           position: store.repeaters_meta.size.to_i32,
           # The SNI the send actually used, so re-sending the saved row reproduces the same
-          # ClientHello. Hard-coded `nil` until `send_request` gained the argument — harmless
-          # while there was nothing to lose, a silent fidelity hole the moment there was: the
-          # row would dial the vhost by `target`'s own name while the send that produced the
-          # evidence presented a different one. Through `send_sni`, so the row stores exactly
-          # what `send_plan_options` handed the sender.
-          sni: send_sni(h)
+          # ClientHello. Through the effective value above, not a hard-coded nil / arg-only
+          # read that silently dropped the source's SNI.
+          sni: effective_sni
         )
         return nil unless repeater_id > 0
 

--- a/src/gori/mcp/tools/sequence.cr
+++ b/src/gori/mcp/tools/sequence.cr
@@ -32,7 +32,10 @@ module Gori
         # token list is sequence_analyze's job and builds no engine at all).
         origin = plan.origin!
         goal = plan.goal
-        sc = ob.check("#{origin.scheme}://#{origin.host}/", origin.host)
+        # Gate on the plan's real request-target, not a bare `/`. A path-scoped include
+        # (string/regex on `/api/...`) used to refuse an in-scope run that `gori run sequence`
+        # accepted, because Layer 1 was asked about `https://host/` instead of the template.
+        sc = ob.check_request(origin.scheme, origin.host, plan.request_target)
         return scope_blocked(sc) if sc.blocked?
         @job_seq += 1
         id = "sq_#{@job_seq}"

--- a/src/gori/miner/engine.cr
+++ b/src/gori/miner/engine.cr
@@ -458,10 +458,14 @@ module Gori::Miner
       end
     end
 
-    # Refusals no retry can change: the request budget is spent, or the sandbox says no. Both
-    # are decided from state that does not move between two calls a `retry_pause` apart.
+    # Refusals no retry can change: the request budget is spent, or Layer 2 says no. Cap,
+    # sandbox, and exclude are all decided from state that does not move between two calls
+    # a `retry_pause` apart. Exclude was previously omitted, so an EXCLUDE_SWEEP_ERROR was
+    # retried `retries` times — burning the request cap and stalling the run for nothing.
     private def permanent_refusal?(err : String?) : Bool
-      err == Fuzz::CappedBackend::CAP_ERROR || err == Gori::Outbound::SANDBOX_SWEEP_ERROR
+      err == Fuzz::CappedBackend::CAP_ERROR ||
+        err == Gori::Outbound::SANDBOX_SWEEP_ERROR ||
+        err == Gori::Outbound::EXCLUDE_SWEEP_ERROR
     end
 
     private def pace_interval : Time::Span?

--- a/src/gori/oast/providers/webhook_site.cr
+++ b/src/gori/oast/providers/webhook_site.cr
@@ -49,8 +49,22 @@ module Gori::Oast
     private def to_interaction(it : JSON::Any) : Interaction?
       return nil unless it.as_h?
       uid = field(it, "uuid") || Crypto.random_id(16)
-      raw = field(it, "content") || it.to_json
-      Interaction.new(uid, "http", field(it, "method"), field(it, "ip"), uid, raw, nil,
+      # The hit URL carries the per-payload nonce `generate_payload` minted
+      # (`…/{uuid}/{nonce}`). `full_id` is "the destination sub-id shown in the table",
+      # so prefer the URL over the request uuid. An empty-body GET — the canonical blind
+      # SSRF callback — arrives with `content: ""`; `field` returns that empty string
+      # (only JSON null is skipped), so `|| it.to_json` never fired and both raw_request
+      # and full_id lost the nonce. Fall back to the URL (then the item JSON) when the
+      # body is absent or blank so attribution survives.
+      hit_url = field(it, "url")
+      content = field(it, "content")
+      raw = if content.nil? || content.empty?
+              hit_url.presence || it.to_json
+            else
+              content
+            end
+      full_id = hit_url.presence || uid
+      Interaction.new(uid, "http", field(it, "method"), field(it, "ip"), full_id, raw, nil,
         parse_time(it["created_at"]?))
     end
   end

--- a/src/gori/outbound.cr
+++ b/src/gori/outbound.cr
@@ -1,6 +1,7 @@
 require "uri"
 require "./scope"
 require "./store"
+require "./proxy/codec/http1"
 
 module Gori
   # THE outbound chokepoint for gori-originated ("active") traffic.
@@ -281,41 +282,22 @@ module Gori
     # request-target is recovered from a malformed request line. (The bytes themselves still
     # go on the wire byte-exact — P7 — this only feeds the scope decision.)
     #
-    # SCOPE OF THIS FIX: `Outbound` only — repeater/fuzz/mine/sequence/discover/active-probe.
-    # The PROXY path does not come through here: ClientConn passes
-    # `Codec::Http1.parse_request_head`'s `target` (a plain `split(' ')[1]?`) straight to
-    # `Interceptor#sandbox_blocks?` / `#intercepts_request?` / `#intercepts_response?`
-    # (client_conn.cr:241, :267, :494), so the same doubled-space/tab line still yields an
-    # empty target there. Verified against 0.2.0: with `include host:…` + `exclude string:/x`
-    # and Sandbox ON, `GET  /x  HTTP/1.1` reaches the origin while `GET /x HTTP/1.1` is 403'd;
-    # with a URL-keyed include it inverts and fails closed. Do not read this comment as
-    # covering the proxy gate.
+    # It ALSO reads from the first NON-BLANK line rather than blindly the first: a raw request
+    # may arrive with leading blank line(s) — an operator's authored bytes, or a peer that emits
+    # an empty line before the request-line — and reading the first line blindly gates the
+    # innocuous "/" while the REAL target sits on a later line and goes on the wire.
+    #
+    # ONE HOME: the recovery itself now lives on `Codec::Http1.request_target_line`, because the
+    # PROXY gate needs the identical predicate (`Codec::Http1.gate_target` — read its comment
+    # for the bypass it closes) and re-deriving a request-line rule next to a new caller is the
+    # shape AGENTS.md flags as thrice-recurring (#390/#394/#397). `Outbound` keeps these two
+    # names because ~20 active-send call sites and `spec/outbound_spec.cr` speak them.
     def self.request_target(bytes : Bytes) : String
-      request_target_line(String.new(bytes))
+      Proxy::Codec::Http1.request_target_line(String.new(bytes))
     end
 
     def self.request_target(text : String) : String
-      request_target_line(text)
-    end
-
-    # Read the request-TARGET off the request line — but from the first NON-BLANK line,
-    # not blindly the first line. A raw request may arrive with LEADING BLANK LINE(S)
-    # (an operator's authored bytes, or a peer that emits an empty line before the
-    # request-line); `each_line.first?` would then read an empty ("" / bare "\r") first
-    # line, `split[1]?` it to nil, and gate the innocuous "/" while the REAL target sits
-    # on a later line and goes on the wire — a scope/Sandbox bypass, the same failure mode
-    # as the doubled-space case below. So skip leading blank / whitespace-only lines, then
-    # split. The no-arg `split` still collapses whitespace runs (doubled space / tab) and
-    # drops empty parts, and tolerates a stray trailing "\r", so the malformed-first-line
-    # recovery is unchanged; a line with no target (or an all-blank input) still degrades
-    # to "/". The bytes themselves reach the wire byte-exact (P7) — only what the gate
-    # READS changes. (Still `Outbound`-only; see the proxy-gate caveat above.)
-    private def self.request_target_line(text : String) : String
-      text.each_line do |line|
-        next if line.strip.empty? # skip a leading blank / whitespace-only line (incl. a bare "\r")
-        return line.split[1]? || "/"
-      end
-      "/"
+      Proxy::Codec::Http1.request_target_line(text)
     end
 
     # The URL the gate evaluates, ALWAYS anchored on the DIAL target (the scheme/host the

--- a/src/gori/probe/active/forbidden_bypass.cr
+++ b/src/gori/probe/active/forbidden_bypass.cr
@@ -92,7 +92,7 @@ module Gori
           return nil if malformed
           return nil unless method_allowed?(method.upcase, opts)
           return nil unless denied_status?(detail.row.status)
-          key_string(detail, method.upcase, target)
+          key_string(detail, method.upcase, target, opts.aggressive)
         end
 
         # probe (spoofed headers) + control (the request UNCHANGED).
@@ -111,7 +111,7 @@ module Gori
           # two legs differ in exactly one thing: whether our forged values are present.
           control = rebuild_with_bypass_headers(detail.request_head, detail.request_body,
             opts.aggressive, insert: false)
-          Plan.new(request, [] of Param, key_string(detail, req.method.upcase, req.target), [control])
+          Plan.new(request, [] of Param, key_string(detail, req.method.upcase, req.target, opts.aggressive), [control])
         end
 
         # results = [probe, control]. Flag only when the spoofed request succeeded AND the control
@@ -155,9 +155,14 @@ module Gori
 
         # The single key expression both `plan` and `dedup_key` use, so they can't drift. Query is
         # stripped (a client-IP gate is per-endpoint, not per-query-value) → one probe per
-        # (host, method, path); host:PORT so the same host on another service is a distinct surface.
-        private def key_string(detail : Store::FlowDetail, method_upcase : String, target : String) : String
-          "forbidden_bypass|#{detail.row.host}:#{detail.row.port}|#{method_upcase}|#{path_key(target)}"
+        # (host, method, path, header-set); host:PORT so the same host on another service is a
+        # distinct surface. The aggressive tag is load-bearing: without it, a surface already
+        # probed in ACTIVE mode never received the wider AGGRESSIVE IP-header set, because
+        # both modes shared one key and the first win suppressed the second forever.
+        private def key_string(detail : Store::FlowDetail, method_upcase : String, target : String,
+                               aggressive : Bool) : String
+          tag = aggressive ? "aggr" : "base"
+          "forbidden_bypass|#{detail.row.host}:#{detail.row.port}|#{method_upcase}|#{path_key(target)}|#{tag}"
         end
 
         private def path_key(target : String) : String

--- a/src/gori/probe/analyzer.cr
+++ b/src/gori/probe/analyzer.cr
@@ -387,12 +387,13 @@ module Gori
         # is the refusal that matters and would reject this job anyway (#511).
         return if detail.row.short_circuited?
         row = detail.row
-        url = row.url
         # Active probes only on hosts/paths covered by Project scope INCLUDE rules
         # (the Outbound ALLOWLIST gate — lens-independent; requires ≥1 include so
         # excludes-only never means "probe everything"). in_scope_url? is wrong here: it is
         # permissive when the ⇧S display lens is off. AGGRESSIVE never widens this.
-        return unless @outbound.allows?(url, row.host)
+        # Gate on the port-less scope URL (check_request), not FlowRow#url — a non-default
+        # port in the latter made string/regex includes miss every active probe on that origin.
+        return if @outbound.check_request(row.scheme, row.host, row.target).blocked?
         opts = active_opts
         Active::RULES.each { |rule| enqueue_probe(rule, detail, opts) unless Probe.rule_disabled?(rule.info.id, @disabled) }
       rescue Channel::ClosedError

--- a/src/gori/probe/scan.cr
+++ b/src/gori/probe/scan.cr
@@ -164,7 +164,11 @@ module Gori
               detections.concat(Passive.analyze(detail, ws, disabled: cfg.disabled, custom: cfg.custom))
               # `!cfg.degraded`: the disabled-rule set could not be read, so gori does not
               # know which ACTIVE rules the operator switched off — see `RuleConfig`.
-              if active && !cfg.degraded && outbound.allows?(detail.row.url, detail.row.host) && budget.take?
+              # Gate on the port-less scope URL Layer 2 / History / SQL already share —
+              # `FlowRow#url` embeds a non-default port, so a string/regex include of
+              # `https://acme.test/` would miss `https://acme.test:8443/…` and silently
+              # skip every active probe on that origin while the lens still shows it in-scope.
+              if active && !cfg.degraded && allows_row?(outbound, detail.row) && budget.take?
                 detections.concat(Active.analyze(detail, verify_upstream, outbound: outbound, opts: opts,
                   disabled: cfg.disabled, on_error: on_error))
               end
@@ -204,7 +208,7 @@ module Gori
             Passive.analyze(detail, ws, disabled: cfg.disabled, custom: cfg.custom).each do |d|
               detections << Probe.with_source(d, flow_id: rec.flow_id, repeater_id: rec.id)
             end
-            if active && !cfg.degraded && outbound.allows?(detail.row.url, detail.row.host) && budget.take?
+            if active && !cfg.degraded && allows_row?(outbound, detail.row) && budget.take?
               Active.analyze(detail, verify_upstream, outbound: outbound, opts: opts,
                 disabled: cfg.disabled, on_error: on_error).each do |d|
                 detections << Probe.with_source(d, flow_id: rec.flow_id, repeater_id: rec.id)
@@ -225,6 +229,12 @@ module Gori
       # against, so it probes nothing unless allow_unscoped — same as before, but explicit.
       private def outbound_for(scope : Scope?, allow_unscoped : Bool) : Outbound
         allow_unscoped ? Outbound.waived(scope, Outbound::Reason::Operator) : Outbound.allowlist(scope)
+      end
+
+      # Layer 1 on the same URL shape every other gate builds (port omitted). ONE home so
+      # scan_flows / scan_repeaters cannot drift apart again.
+      private def allows_row?(outbound : Outbound, row : Store::FlowRow) : Bool
+        !outbound.check_request(row.scheme, row.host, row.target).blocked?
       end
     end
   end

--- a/src/gori/proxy/codec/body.cr
+++ b/src/gori/proxy/codec/body.cr
@@ -195,11 +195,17 @@ module Gori::Proxy::Codec
       # explicitly sanctions refusing a message here rather than guessing.
       raise Gori::Error.new("ambiguous framing headers (a lenient recipient would frame this response differently)") if Http1.framing_ambiguous?(resp.raw_head, resp.headers)
       # Allocation-free case-insensitive match (per response); `.upcase` allocated a String.
-      if request_method.compare("HEAD", case_insensitive: true) == 0 ||
-         request_method.compare("CONNECT", case_insensitive: true) == 0
+      if request_method.compare("HEAD", case_insensitive: true) == 0
         return {BodyFraming::None, 0_i64}
       end
       s = resp.status
+      # RFC 7230 §3.3.3 / RFC 9112 §6.3: a response to CONNECT is bodyless only for 2xx
+      # (the tunnel is open). Non-2xx (407 Proxy Auth Required, 502, …) may carry an
+      # entity the client must read; treating EVERY CONNECT reply as bodyless left that
+      # entity on the wire to misframe the next message on a reused upstream.
+      if request_method.compare("CONNECT", case_insensitive: true) == 0 && (200..299).includes?(s)
+        return {BodyFraming::None, 0_i64}
+      end
       return {BodyFraming::None, 0_i64} if (s >= 100 && s < 200) || s == 204 || s == 304
 
       te = resp.headers.has?("Transfer-Encoding") ? resp.headers.get_all("Transfer-Encoding") : EMPTY_TE

--- a/src/gori/proxy/codec/body.cr
+++ b/src/gori/proxy/codec/body.cr
@@ -437,7 +437,7 @@ module Gori::Proxy::Codec
           end
           return true # terminating chunk reached
         end
-        return false unless copy_n(src, dst, tee, size, cbuf)             # truncated mid-chunk
+        return false unless copy_n(src, dst, tee, size, cbuf)              # truncated mid-chunk
         return false unless copy_chunk_terminator(src, dst, tee, line_buf) # bad/absent chunk-data terminator → desync
       end
     end
@@ -511,6 +511,82 @@ module Gori::Proxy::Codec
     # request. Check content (terminator octets only), not length.
     private def self.blank_line?(line : Bytes) : Bool
       line.all? { |b| b == 0x0d_u8 || b == 0x0a_u8 }
+    end
+
+    # Does this IN-MEMORY chunked body contain one COMPLETE chunked message and nothing
+    # after it? For a buffer gori is about to write onto a socket it intends to REUSE — the
+    # Repeater/Fuzz connection pool's `reusable_request?`.
+    #
+    # It exists because the cheap test that shape invites — "the bytes end with 0\r\n\r\n" —
+    # is FORGEABLE by the chunk data itself. A single chunk `5\r\nAB0\r\n\r\n` (size 5, data
+    # `AB0\r\n`) ends with those five octets while carrying no terminating zero-chunk at all,
+    # so the origin is left mid-body waiting for the next chunk-size line: the NEXT request
+    # gori pipelines onto that socket is read as this one's continuation. That is a request
+    # smuggle gori would be committing against its own target, from its own pool.
+    #
+    # Framing rules mirror `copy_chunked` exactly — `parse_chunk_size` (pure hex, chunk-ext
+    # after ';', no sign), and a chunk-data terminator of "\r\n" or a bare "\n" — with one
+    # DELIBERATE tightening: `copy_chunked` tolerates a clean EOF standing in for the trailer
+    # section, because there it means the peer hung up and the connection dies anyway. Here
+    # the whole question is whether the connection SURVIVES, and a missing final CRLF is
+    # precisely the state that leaves the origin's parser open. So the trailer section must be
+    # present and the buffer must end exactly on it; anything else is unprovable, hence false.
+    #
+    # It lives HERE, beside `copy_chunked`, despite having one caller (P0 would otherwise put it
+    # in `ConnPool`): it must answer "is this chunked message complete" the same way the streaming
+    # reader frames one, and a copy in the pool is a copy that drifts. `ConnPool`'s job is the
+    # reuse POLICY; the framing rule is the codec's.
+    def self.chunked_complete?(body : Bytes) : Bool
+      pos = 0
+      while pos < body.size
+        eol = line_end(body, pos)
+        return false unless eol # no LF: an unterminated size line, not a framing gori can trust
+        size = parse_chunk_size(body[pos, eol - pos])
+        return false if size.nil?
+        pos = eol
+        return trailer_ends_body?(body, pos) if size == 0
+        # Bounds-check BEFORE advancing, so `pos` (Int32) can never be walked past the buffer by
+        # an Int64 chunk-size a hostile/garbled line declared — `parse_chunk_size` accepts any
+        # non-negative hex that fits Int64, so `7FFFFFFFFF` is a "valid" size. A size larger than
+        # what is actually here is unprovable anyway, so it returns false rather than overflowing.
+        remaining = (body.size - pos).to_i64
+        return false if size > remaining # chunk declares more data than is here
+        pos += size.to_i32
+        # …then the chunk-data terminator, and JUST it (see copy_chunk_terminator).
+        tend = line_end(body, pos)
+        return false unless tend
+        term = body[pos, tend - pos]
+        return false unless term.size <= 2 && (term.size == 1 || term[0] == 0x0d_u8)
+        pos = tend
+      end
+      false # a chunked body that never reached its zero-chunk
+    end
+
+    # After a zero-chunk: does the trailer section close, with the body ending exactly on its
+    # blank line? Trailing octets past that line are the mirror smuggle of a missing terminator
+    # — the origin stops reading at the zero-chunk, so the remainder becomes the head of the
+    # next request on the socket.
+    private def self.trailer_ends_body?(body : Bytes, pos : Int32) : Bool
+      while pos < body.size
+        tend = line_end(body, pos)
+        return false unless tend
+        line = body[pos, tend - pos]
+        pos = tend
+        return pos == body.size if blank_line?(line)
+      end
+      false # ran out of bytes before the blank line closed the trailer section
+    end
+
+    # Index just PAST the next LF at or after `from`, or nil when there is none. The scanning
+    # counterpart of `read_crlf_line`: an "up to and including the LF" line, so a bare-LF
+    # terminator reads the same here as it does on the streaming path.
+    private def self.line_end(body : Bytes, from : Int32) : Int32?
+      i = from
+      while i < body.size
+        return i + 1 if body.unsafe_fetch(i) == 0x0a_u8
+        i += 1
+      end
+      nil
     end
   end
 end

--- a/src/gori/proxy/codec/http1.cr
+++ b/src/gori/proxy/codec/http1.cr
@@ -168,6 +168,47 @@ module Gori::Proxy::Codec::Http1
     {parts[0]? || "", parts[1]? || "", parts.size != 3 || start == H2_PREFACE_LINE}
   end
 
+  # The request-target the SCOPE GATE reads — NOT what goes on the wire.
+  #
+  # `parse_request_head`'s strict `split(' ')` is right for the forwarding path and must stay:
+  # it feeds `resolve_forward`/`rewrite_request_line`, whose `version` is `parts[2]`, so making
+  # the parse lenient would rebuild a doubled-space `GET  http://x/y HTTP/1.1` as
+  # `GET /y http://x/y` — gori corrupting the operator's bytes (P7). But the same strictness
+  # hands the GATE a target of `""` (doubled space / leading blank line) or of `"HTTP/1.1"`
+  # (a tab between method and target), and an origin that collapses whitespace still reads the
+  # real path. That gap is a Sandbox/scope BYPASS: with `include host:acme.test` +
+  # `exclude string:/admin` and Sandbox on, `GET  /admin HTTP/1.1` evaluated as
+  # `http://acme.test` misses the exclude and reaches the origin, while `GET /admin HTTP/1.1`
+  # is 403'd. Verified end-to-end against 0.2.0.
+  #
+  # `Outbound` fixed exactly this on the gori-originated side (#491); this is the same
+  # predicate's ONE home, which `Outbound.request_target` now delegates to rather than
+  # re-deriving next to its own caller (the shape AGENTS.md flags as thrice-recurring).
+  # The bytes still reach the wire byte-exact — only what the gate READS changes.
+  #
+  # Recovery is skipped on the common path: a well-formed line's `target` is returned as-is,
+  # so the gate stays allocation-free (P6).
+  def self.gate_target(req : RawRequest) : String
+    return req.target unless req.malformed? || req.target.empty?
+    request_target_line(String.new(req.raw_head))
+  end
+
+  # Read the request-TARGET off the request line — but from the first NON-BLANK line, not
+  # blindly the first line. A raw request may arrive with LEADING BLANK LINE(S) (an operator's
+  # authored bytes, or a peer that emits an empty line before the request-line, which RFC 9112
+  # §2.2 tells a recipient to ignore); reading the first line blindly then gates the innocuous
+  # "/" while the REAL target sits on a later line and goes on the wire.
+  #
+  # The no-arg `split` collapses whitespace RUNS and drops empty parts, so a doubled space or a
+  # tab recovers the real target; a line with no target (or an all-blank input) degrades to "/".
+  def self.request_target_line(text : String) : String
+    text.each_line do |line|
+      next if line.strip.empty? # skip a leading blank / whitespace-only line (incl. a bare "\r")
+      return line.split[1]? || "/"
+    end
+    "/"
+  end
+
   def self.parse_response_head(raw : Bytes) : RawResponse
     first_crlf = index_crlf(raw, 0)
     start = String.new(raw[0, first_crlf || raw.size])

--- a/src/gori/proxy/conn/client_conn.cr
+++ b/src/gori/proxy/conn/client_conn.cr
@@ -890,8 +890,16 @@ module Gori::Proxy
         # RFC 9110 §15.2 / RFC 7231: a proxy MUST NOT forward a 1xx to an HTTP/1.0
         # client (it can't parse it). Read past it for everyone; forward only to 1.1.
         if req.version == "HTTP/1.1"
-          @io.write(resp_head) # forward byte-exact (P6/P7); no rewrite on interim
-          @io.flush
+          begin
+            @io.write(resp_head) # forward byte-exact (P6/P7); no rewrite on interim
+            @io.flush
+          rescue
+            # Client gone mid-1xx (Stop / max-time / RST). Every other exit from this
+            # method records on_response; an unguarded raise left the flow Pending forever.
+            @sink.on_response(FlowMapper.error_response(flow_id, "connection closed while forwarding interim 1xx response"))
+            release_upstream
+            return nil
+          end
         end
         resp_head = safe_read_head(upstream)
         if resp_head.nil?
@@ -1149,28 +1157,41 @@ module Gori::Proxy
       # forwarded unedited (whose Content-Length describes the entity, not the bytes).
       out_head, out_body = split_message(decision.bytes)
       sent_resp = Codec::Http1.parse_response_head(out_head)
-      @io.write(out_head)
-      @io.write(out_body) if out_body
-      @io.flush
-      # The operator's bytes are what the client got, so they are what a binding must agree
-      # with (P4) — and a DROPPED response never reaches here at all, because the client never
-      # received it. `decision.bytes` is a complete message, so its body half is already the
-      # entity (the editor synced Content-Length); an empty one is a body we have, not a body
-      # gori withheld, hence `Bytes.empty` rather than nil.
-      observe_delivered(extract_ref_for(sent_req, host, scheme, sent_resp.status, flow_id),
-        out_head, out_body || Bytes.empty)
+      delivered = true
+      begin
+        @io.write(out_head)
+        @io.write(out_body) if out_body
+        @io.flush
+      rescue
+        # Client gone while we held the response (navigated away / Stop). The non-held
+        # stream path already rescues this as Aborted; without the rescue the raise
+        # unwound to run's blanket rescue and left the flow Pending forever — the
+        # invariant this file states four times ("record + close, never unwind").
+        delivered = false
+      end
       stored, trunc, size = capped(out_body)
-      @sink.on_response(FlowMapper.response(sent_resp,
-        flow_id: flow_id, body: stored, ttfb_us: ttfb, duration_us: duration,
-        body_truncated: trunc, body_size: size))
+      if delivered
+        # The operator's bytes are what the client got, so they are what a binding must agree
+        # with (P4) — and a DROPPED response never reaches here at all, because the client never
+        # received it. `decision.bytes` is a complete message, so its body half is already the
+        # entity (the editor synced Content-Length); an empty one is a body we have, not a body
+        # gori withheld, hence `Bytes.empty` rather than nil.
+        observe_delivered(extract_ref_for(sent_req, host, scheme, sent_resp.status, flow_id),
+          out_head, out_body || Bytes.empty)
+        @sink.on_response(FlowMapper.response(sent_resp,
+          flow_id: flow_id, body: stored, ttfb_us: ttfb, duration_us: duration,
+          body_truncated: trunc, body_size: size))
+      else
+        @sink.on_response(FlowMapper.response(sent_resp,
+          flow_id: flow_id, body: stored, ttfb_us: ttfb, duration_us: duration,
+          body_truncated: trunc, body_size: size,
+          state: Store::FlowState::Aborted, error: "connection closed while forwarding held response"))
+      end
       # Reuse the upstream iff we read the WHOLE body cleanly AND the origin kept its
       # side alive. Origin side keys on sent_req (what the origin received); the CLIENT
       # keep-alive (return value) uses the edited resp.
       update_upstream_reuse(resp_complete && origin_keep_alive?(sent_req, resp, resp_framing))
-      # A truncated upstream body was forwarded short — close the client connection so it
-      # sees end-of-response instead of blocking for the missing bytes while we read its
-      # next keep-alive request (mirrors the non-held path's resp_complete guard).
-      return false unless resp_complete
+      return false unless delivered && resp_complete
       # The human may have edited the held response into conflicting framing (CL+TE); the
       # response was already forwarded + recorded above, so recompute the client-side framing
       # defensively — a raw response_framing raise here would unwind to run's blanket rescue

--- a/src/gori/proxy/conn/client_conn.cr
+++ b/src/gori/proxy/conn/client_conn.cr
@@ -344,6 +344,19 @@ module Gori::Proxy
         end
       end
 
+      # The target every SCOPE/INTERCEPT gate below reads, from the ACTUALLY-SENT head (post
+      # Match&Replace). `Codec::Http1.gate_target` is `sent_req.target` on the common path and
+      # only recovers when the strict `split(' ')` could not frame the request line — a doubled
+      # space, a tab, or a leading blank line otherwise hands the gate `""` (or `"HTTP/1.1"`)
+      # while an origin that collapses whitespace still reads the real path, which is a Sandbox
+      # bypass. Read that method's comment; the wire bytes are untouched (P7).
+      #
+      # The RECORDED projection (`sent_req.target`, below) deliberately stays on the strict
+      # parse — `request_head` is byte-exact and `target` is a derived column — so for a
+      # malformed request line the History row's `target` does NOT reproduce this gate's input.
+      # That is the one case where the live gate and the Scope SQL filter over History disagree.
+      gate_target = Codec::Http1.gate_target(sent_req)
+
       # Sandbox: the hard scope gate. When enabled, ONLY requests the scope ALLOWS reach
       # upstream — everything else, including ALL traffic when no include rule is set, is
       # blocked HERE, before we touch (or even dial) the origin. Keyed on the ACTUALLY-SENT
@@ -351,7 +364,7 @@ module Gori::Proxy
       # We record the attempt as an aborted flow (visible in History) and answer the client
       # a distinct 403 so a sandbox block never reads like an upstream failure. The scope
       # URL is built lazily inside the interceptor, only while the sandbox is on.
-      if (ic = @interceptor) && ic.sandbox_blocks?(scheme, host, sent_req.target)
+      if (ic = @interceptor) && ic.sandbox_blocks?(scheme, host, gate_target)
         record_blocked_request(sent_req, scheme, host, port, created_at)
         write_sandbox_block
         return false
@@ -397,11 +410,12 @@ module Gori::Proxy
       # Intercept (request): hold only when enabled AND in scope. Holding buffers
       # the full body (vs streaming) so the human can see/edit it; the non-hold
       # path keeps zero-buffer streaming (P6). The gate builds the scope URL lazily
-      # (scheme || '://' || host || <stored target>, matching the Scope SQL filter over
-      # the SAME captured target) only when intercept + Scope are both on, so the common
+      # (scheme || '://' || host || <gate target>, which for a well-formed request line IS
+      # the captured target the Scope SQL filter sees — see `gate_target` above for the one
+      # case they part company) only when intercept + Scope are both on, so the common
       # capture-only path spends nothing here.
       if (ic = @interceptor) && ic.intercepts_request?(
-           method: sent_req.method, host: host, target: sent_req.target, scheme: scheme)
+           method: sent_req.method, host: host, target: gate_target, scheme: scheme)
         return handle_held_request(ic, req, sent_req, sent_head, host, port, scheme,
           created_at, started, req_framing, req_len)
       end
@@ -747,7 +761,8 @@ module Gori::Proxy
       # request that was captured + scope-gated), not the original `req`, so a `method:`/`path:`
       # rule that holds the request also holds its response when M&R changed the request line.
       if (ic = @interceptor) && ic.intercepts_response?(
-           method: sent_req.method, host: host, target: sent_req.target, scheme: scheme, status: resp.status) &&
+           method: sent_req.method, host: host, target: Codec::Http1.gate_target(sent_req),
+           scheme: scheme, status: resp.status) &&
          !resp_framing.close_delimited? && !sse?(resp) && resp.status != 101
         return handle_held_response(ic, upstream, req, sent_req, flow_id, host, port, scheme,
           resp, sent_resp_head, resp_framing, resp_len, ttfb, started)
@@ -803,8 +818,12 @@ module Gori::Proxy
           # scope on — a WebSocket message has no authority, scheme or path of its own. The
           # relay asks each lens ONCE, here, whether it can reach this host; a socket that
           # answers "no" to both keeps the byte-exact pump (P6/P7).
+          # `target` here is what `Interceptor#intercepts_ws?` scopes every message on, so it
+          # takes the same gate-side recovery as the two HTTP gates (see `gate_target`) —
+          # otherwise a handshake with a malformed request line hands the WS message gate an
+          # empty path and every frame on that socket escapes a path-scoped rule.
           ws_ctx = WS::Context.new(host: host, port: port, scheme: scheme,
-            method: sent_req.method, target: sent_req.target)
+            method: sent_req.method, target: Codec::Http1.gate_target(sent_req))
           # frames until close
           WS::Relay.run(@io, upstream, flow_id, @sink, @rewriter, ws_ctx, @interceptor, notice: ws_notice)
         else

--- a/src/gori/proxy/upstream.cr
+++ b/src/gori/proxy/upstream.cr
@@ -170,7 +170,63 @@ module Gori::Proxy
 
     private def self.normalize_host(h : String) : String
       h = h[1...-1] if h.starts_with?('[') && h.ends_with?(']') # strip IPv6 brackets
+      # Unwrap a v4-mapped literal, the same rule (and reason) as `OrigDst.dial_host`. Under a
+      # dual-stack `::` bind the kernel reports an accepted IPv4 connection's local address as
+      # `::ffff:192.168.1.5` while the client's `Host` says `192.168.1.5`, so the `local_host`
+      # comparisons in `loops_to_self?`/`addresses_self?` — the whole reason that parameter
+      # exists ("a Host that matches the LAN/interface IP the client connected through") — could
+      # never match, and a LAN device got neither the CA-download page nor the self-loop refusal.
+      h = h.lchop("::ffff:") if h.starts_with?("::ffff:") && h.count('.') == 3
       h.downcase
+    end
+
+    # `h` with one trailing root dot removed: `localhost.` is the same name as `localhost` to
+    # every resolver (verified: it dials a 127.0.0.1 listener), but to a string compare it is not.
+    private def self.strip_root_dot(h : String) : String
+      h.size > 1 && h.ends_with?('.') ? h.rchop('.') : h
+    end
+
+    # `h` read as `inet_aton` reads it, folded to a u32 — or nil when it is not that grammar.
+    #
+    # `parse_ip` is `inet_pton`, which accepts only the full dotted-quad. The RESOLVER every
+    # dial goes through is `inet_aton`-flavoured and accepts far more, all of which reach a
+    # 127.0.0.1 listener (measured on this platform): a bare 32-bit decimal (`2130706433`), a
+    # hex or octal form (`0x7f000001`, `017700000001`), and the short dotted forms where the last
+    # part fills the remaining low bytes (`127.1`, `0.0`, `0`). So `unspecified?` returned false
+    # for `0` and `0.0` — both all-zero spellings its own comment claims to cover — and
+    # `loopback?`'s string fallback knew only the literal `127.` prefix. A client naming gori's
+    # own port as `Host: 0:8080` therefore walked past `loops_to_self?` and gori forwarded to
+    # itself, accepted that as a fresh client, re-derived the same target, and dialled again:
+    # verbatim the accept-loop wedge `reaches_self?` exists to stop.
+    #
+    # String-local on purpose — no DNS on this path (see `parse_ip`) — and STRICT, because a
+    # false positive here 502s legitimate traffic: every part must be numeric and in range, so a
+    # hostname (`example.com`, `12345.com`) yields nil rather than an address.
+    private def self.inet_aton_u32?(h : String) : UInt32?
+      return nil if h.empty?
+      parts = h.split('.')
+      return nil if parts.size > 4
+      vals = [] of UInt32
+      parts.each do |p|
+        return nil if p.empty?
+        v = if p.starts_with?("0x") || p.starts_with?("0X")
+              p[2..]?.presence.try(&.to_u32?(16))
+            elsif p.size > 1 && p.starts_with?('0')
+              p[1..].to_u32?(8)
+            else
+              p.to_u32?(10)
+            end
+        return nil unless v
+        vals << v
+      end
+      last = vals[-1]
+      lead = vals[0...(vals.size - 1)]
+      return nil if lead.any? { |v| v > 0xff }
+      # inet_aton: with n parts, the last one fills the low `4 - (n - 1)` bytes.
+      return nil if last.to_u64 > (1_u64 << (8 * (4 - lead.size))) - 1
+      acc = 0_u32
+      lead.each_with_index { |v, i| acc |= v << (8 * (3 - i)) }
+      acc | last
     end
 
     # `h` parsed as an IP literal, or nil when it is a hostname ("localhost",
@@ -193,10 +249,15 @@ module Gori::Proxy
     # literal), so dropping the prefix test would regress the exact case it guards.
     # Parsing additionally buys the v4-mapped forms (::ffff:127.0.0.1) for free.
     private def self.loopback?(h : String) : Bool
+      h = strip_root_dot(h)
       if ip = parse_ip(h)
         return ip.loopback?
       end
-      h == "localhost" || h.starts_with?("127.")
+      return true if h == "localhost"
+      if v = inet_aton_u32?(h)
+        return (v >> 24) == 127 # the whole 127/8 block, however it was spelled
+      end
+      h.starts_with?("127.")
     end
 
     # The all-zero address in ANY spelling (0.0.0.0, ::, ::0, 0:0:0:0:0:0:0:0, 0000:…).
@@ -205,7 +266,9 @@ module Gori::Proxy
     # bind the loopback/wildcard conjunct collapsed to false for every loopback target
     # and BOTH the self-page (CA download) and the self-loop refusal disappeared.
     private def self.unspecified?(h : String) : Bool
-      !!parse_ip(h).try(&.unspecified?)
+      h = strip_root_dot(h)
+      return true if parse_ip(h).try(&.unspecified?)
+      inet_aton_u32?(h) == 0_u32 # `0`, `0.0`, `0.0.0`, `0x0` — all-zero, none of them inet_pton
     end
 
     # A BIND that answers on every interface: the all-zero address, plus the empty string

--- a/src/gori/proxy/ws/relay.cr
+++ b/src/gori/proxy/ws/relay.cr
@@ -943,10 +943,14 @@ module Gori::Proxy::WS
           # It gets the message's frames in both forms because only IT knows which applies:
           # written through, the peer's own interleave goes back on the wire; parked on a
           # hold, the control frames are split back out and sent now (see `WS::RawFrames`).
+          # Pass `emitted`, not `arrived`: when re-framing, MessageGate records the shape
+          # on write, and the arrived multi-fragment RSV/mask is a lie about what goes out
+          # (one frame, gori's key). `emitted` was already computed above and was a dead
+          # store on this branch.
           gate.submit(@opcode, rewritten,
             reusable ? WS::RawFrames.new(interleaved: interleaved_raw.dup,
               data_only: @raw.to_slice.dup, controls: parked_bytes) : nil,
-            arrived)
+            emitted)
         else
           write_direct(reusable ? interleaved_raw : WS.encode(@opcode, rewritten, mask: @mask, fin: true))
           # Record what gori WROTE rather than what arrived, the way #513 keeps P7 on h2: the

--- a/src/gori/ql.cr
+++ b/src/gori/ql.cr
@@ -468,11 +468,30 @@ module Gori
     # the whole head, so it also sees the request/status line (rare false hit; fine).
     # request_head is NOT NULL; response_head is guarded so a response-less flow
     # contributes no match (and `-header:x` correctly keeps it).
-    private def self.header_cond(value : String) : {String, Array(DB::Any)}
-      p = like(value)
-      {"(lower(CAST(request_head AS TEXT)) LIKE ? ESCAPE '\\' OR " \
-       "(response_head IS NOT NULL AND lower(CAST(response_head AS TEXT)) LIKE ? ESCAPE '\\'))",
-       [p, p] of DB::Any}
+    #
+    # BYTE-wise, not `CAST(... AS TEXT) LIKE`: SQLite truncates a BLOB→TEXT cast at the
+    # first NUL, so a head that stored an embedded NUL (header-injection / smuggling
+    # cases — the codec keeps the octets, P7) made every header after the NUL invisible
+    # to `header:` while `header~` (SafeRegexp over the full blob) still found it. Same
+    # trap `body_cond` already routed around. `instr` is case-SENSITIVE, so OR every case
+    # permutation of a short needle; longer needles go through a case-insensitive literal
+    # REGEXP, which SafeRegexp already makes NUL-transparent.
+    private def self.header_cond(value : String) : {String, Array(DB::Any)}?
+      value = value.chars.reject(&.control?).join
+      return nil if value.empty?
+      if value.size < 3
+        conds = [] of String
+        params = [] of DB::Any
+        case_permutations(value).each do |v|
+          conds << "COALESCE(instr(request_head, CAST(? AS BLOB)), 0) > 0"
+          conds << "COALESCE(instr(response_head, CAST(? AS BLOB)), 0) > 0"
+          params << v << v
+        end
+        return {"(#{conds.join(" OR ")})", params}
+      end
+      pat = "(?i)#{Regex.escape(value)}"
+      return {"0", [] of DB::Any} unless valid_regex?(pat)
+      header_regex_cond(pat)
     end
 
     # The `~` operator: case-sensitive regex (SQLite REGEXP, the same shard-provided

--- a/src/gori/repeater/conn_pool.cr
+++ b/src/gori/repeater/conn_pool.cr
@@ -467,9 +467,13 @@ module Gori::Repeater
         # mid-message, so whatever runs next on this connection is misframed.
         body.to_i64 == len
       in Proxy::Codec::BodyFraming::Chunked
-        # A chunked body is reusable only if it actually terminates here. Cheap exact test:
-        # the wire form must end with the zero-chunk + (empty) trailer section.
-        ends_with?(bytes, "0\r\n\r\n".to_slice)
+        # A chunked body is reusable only if it actually terminates here — WALKED, not
+        # suffix-matched. `ends_with?(bytes, "0\r\n\r\n")` looks like an exact test and is a
+        # forgery: a chunk whose own DATA ends `0\r\n` (e.g. `5\r\nAB0\r\n\r\n`) produces that
+        # suffix with no zero-chunk anywhere, so the origin stayed mid-body and the next
+        # request off this pooled socket became its continuation chunks. See
+        # `Codec::Body.chunked_complete?`, which frames by the same rules `copy_chunked` uses.
+        Proxy::Codec::Body.chunked_complete?(bytes[head_len, body])
       in Proxy::Codec::BodyFraming::CloseDelimited
         false # responses only, but the enum is exhaustive
       end
@@ -540,11 +544,6 @@ module Gori::Repeater
         i += 1
       end
       nil
-    end
-
-    private def self.ends_with?(bytes : Bytes, suffix : Bytes) : Bool
-      return false if bytes.size < suffix.size
-      bytes[(bytes.size - suffix.size), suffix.size] == suffix
     end
   end
 end

--- a/src/gori/settings.cr
+++ b/src/gori/settings.cr
@@ -119,8 +119,28 @@ module Gori
       nil
     end
 
+    # The section node at `key`, but ONLY when it is a JSON OBJECT — nil for a scalar, an array
+    # or null. `JSON::Any#[]?(String)` RAISES on a non-object ("Expected Hash for
+    # #[]?(key : String), not String"), and a raise inside `apply_sections` abandons every
+    # section BELOW it: `Settings.load`'s blanket rescue then returns with `env` (vars AND their
+    # token VALUES), `hostname_overrides`, `scan_rules`, `oast_providers`, `hotkeys`, `listeners`,
+    # `retention` and the rest at factory defaults, and the first later `save` writes those
+    # defaults OVER the operator's file. That is the shipped failure #594 fixed, reached through a
+    # different coercion: one `"editor": "nvim"` — or a `gori settings import` of a profile with
+    # one, since `CLI` validates only that the TOP level is an object — was enough.
+    #
+    # Returns `JSON::Any` rather than the unwrapped Hash so the section bodies and their
+    # `load_bool` / `parse_tls_passthrough` helpers keep their existing signatures. The sections
+    # whose parse helper already begins `node.try(&.as_h?)` were never exposed; these four
+    # dereferenced the node directly.
+    private def self.object_section(root : JSON::Any, key : String) : JSON::Any?
+      node = root[key]?
+      node && node.as_h? ? node : nil
+    end
+
     protected def self.apply_sections(root : JSON::Any) : Nil
-      if net = root["network"]?
+      # All four of these dereference their node directly — see `object_section`.
+      if net = object_section(root, "network")
         self.bind_host = net["bind_host"]?.try(&.as_s?) || bind_host
         self.bind_port = int_field(net, "bind_port") || bind_port
         self.upstream_proxy = net["upstream_proxy"]?.try(&.as_s?) || upstream_proxy
@@ -135,7 +155,7 @@ module Gori
       self.theme = root["theme"]?.try(&.as_s?) || theme # validated against the known themes by Theme.apply
       self.mouse = load_bool(root, "mouse", mouse)
       self.pretty_bodies_default = load_bool(root, "pretty_bodies", pretty_bodies_default)
-      if ed = root["editor"]?
+      if ed = object_section(root, "editor")
         self.editor = ed["command"]?.try(&.as_s?) || editor
         self.editor_markdown = load_bool(ed, "markdown", editor_markdown)
       end
@@ -149,11 +169,11 @@ module Gori
       self.scan_rules = parse_scan_rules(root["scan_rules"]?)
       self.oast_providers = parse_oast_providers(root["oast_providers"]?)
       parse_hotkeys(root["hotkeys"]?)
-      if cv = root["decoder"]?
+      if cv = object_section(root, "decoder")
         self.decoder_sessions = parse_decoder_sessions(cv["sessions"]?)
         self.decoder_chains = parse_decoder_chains(cv["chains"]?)
       end
-      if rw = root["rewriter"]?
+      if rw = object_section(root, "rewriter")
         self.rewriter_presets = parse_rewriter_presets(rw["presets"]?)
       end
       parse_mine_prefs(root["mine"]?)

--- a/src/gori/settings/discover.cr
+++ b/src/gori/settings/discover.cr
@@ -15,7 +15,10 @@ module Gori::Settings
   class_property? discover_prefs_saved : Bool = false
 
   private def self.parse_discover_prefs(node : JSON::Any?) : Nil
-    obj = node.try(&.as_h?)
+    # ABSENT (nil) leaves the live prefs alone — same import_document hole as mine
+    # (see parse_mine_prefs). Present-but-not-an-object still clears.
+    return if node.nil?
+    obj = node.as_h?
     unless obj
       self.discover_prefs_saved = false
       return

--- a/src/gori/settings/miner.cr
+++ b/src/gori/settings/miner.cr
@@ -12,7 +12,12 @@ module Gori::Settings
   class_property? mine_prefs_saved : Bool = false
 
   private def self.parse_mine_prefs(node : JSON::Any?) : Nil
-    obj = node.try(&.as_h?)
+    # ABSENT (nil) leaves the live prefs alone — import_document filters to selected
+    # sections then reuses apply_sections, so a profile without `mine` used to clear
+    # mine_prefs_saved and the next save erased the operator's Mine overlay choices.
+    # Present-but-not-an-object still clears (malformed section, not "untouched").
+    return if node.nil?
+    obj = node.as_h?
     unless obj
       self.mine_prefs_saved = false
       return

--- a/src/gori/store.cr
+++ b/src/gori/store.cr
@@ -543,16 +543,30 @@ module Gori
       end
     end
 
-    # Retention sweep: keep only the newest `@retention_flows` flows (by id, which
-    # is monotonic), cascading to their ws messages and orphaned h2 frames/conns.
+    # Retention sweep: keep only the newest `@retention_flows` flows, cascading to their ws
+    # messages and orphaned h2 frames/conns.
     # A failure here must not kill the writer or lose the just-committed batch, so
     # it runs in its own transaction and swallows errors (the next sweep, after
     # another PRUNE_INTERVAL inserts, simply tries again).
+    #
+    # The cutoff is the id of the OLDEST flow that SURVIVES, seeked from the rows that actually
+    # exist — deliberately not `MAX(id) - @retention_flows`. `flows.id` is monotonic but NOT
+    # gapless (INTEGER PRIMARY KEY without AUTOINCREMENT, and `delete_flow`/`delete_flows` remove
+    # arbitrary mid-history ids from the History tab, MCP and `gori run history`), and that
+    # arithmetic is "the newest N" only on a gap-free space. With 10 flows of which 6
+    # mid-history ones were hand-deleted (1, 2, 9, 10 survive) and 15 more captured, a cap of 20
+    # computed `cutoff = 25 - 20 = 5` and destroyed flows 1 and 2 — out of 19 rows, under a cap
+    # of 20, where nothing at all should have been dropped. Irreversible, and reported as an
+    # ordinary retention drop. `Compact.prune_old_flows` already documents and fixes this exact
+    # arithmetic; the two sweeps now share one definition of "the newest N".
     private def prune(conn : DB::Connection) : Nil
       return if @retention_flows <= 0
-      max_id = conn.query_one?("SELECT MAX(id) FROM flows", as: Int64?)
-      return unless max_id
-      cutoff = max_id - @retention_flows
+      # Served by the primary key: a rightmost-leaf descending scan of @retention_flows rows.
+      oldest_kept = conn.query_one?(
+        "SELECT MIN(id) FROM (SELECT id FROM flows ORDER BY id DESC LIMIT ?)",
+        @retention_flows, as: Int64?)
+      return unless oldest_kept # no flows at all
+      cutoff = oldest_kept - 1  # everything strictly below the oldest survivor goes
       return if cutoff <= 0
       dropped = 0_i64
       conn.transaction do |tx|

--- a/src/gori/tui/tutorial.cr
+++ b/src/gori/tui/tutorial.cr
@@ -541,12 +541,19 @@ module Gori::Tui
 
       case @overlay
       when :palette
+        # ONE `rows.size` for both arrows. The ↑ arm used to take the modulo BEFORE its
+        # empty-list guard — `(@pal_sel - 1) % 0` — so typing a character that matches no
+        # PALETTE_ROWS label and then pressing ↑ killed the tour with an unhandled
+        # DivisionByZeroError, while the ↓ arm three lines below had always computed `n`
+        # first. `render_fake_palette` already paints "(no matches)" and `footer_hint`
+        # advertises ↑/↓ in exactly that state, so the empty list was expected everywhere
+        # except on that one line. Hoisted rather than re-guarded so the two cannot drift
+        # apart again. (Crystal's `%` is floored, so -1 wraps to the last row.)
+        n = filtered_palette.size
         if key.up? || ev.char == 'k'
-          @pal_sel = (@pal_sel - 1) % filtered_palette.size
-          @pal_sel = 0 if filtered_palette.empty?
+          @pal_sel = Tutorial.wrap_sel(@pal_sel, -1, n)
         elsif key.down? || ev.char == 'j'
-          n = filtered_palette.size
-          @pal_sel = n == 0 ? 0 : (@pal_sel + 1) % n
+          @pal_sel = Tutorial.wrap_sel(@pal_sel, +1, n)
         elsif key.backspace?
           @pal_query = @pal_query[0...-1] unless @pal_query.empty?
           @pal_sel = 0
@@ -896,6 +903,22 @@ module Gori::Tui
     # so that range is reachable — and the failure would be a mascot painted on top of the
     # tab-bar mock, not a missing one. She stands down instead, and #pet_band then returns
     # 0 so the card takes the full width it would have had if she were off.
+    # Move a wrapping selection by `delta` over `n` rows, and 0 when there are none.
+    #
+    # A class method rather than two inline expressions because the two arrows had already
+    # drifted: ↑ took `(@pal_sel - 1) % filtered_palette.size` BEFORE its empty-list guard, so
+    # filtering the tour's fake palette down to no matches and pressing ↑ (or `k`) killed the
+    # process with an unhandled DivisionByZeroError — on the first-run path that is after
+    # `SetupWizard#finish` has written settings.json, so the tour never auto-launched again.
+    # ↓ three lines below had always computed the size first. `render_fake_palette` clamps for
+    # an empty list and paints "(no matches)", and `footer_hint` advertises ↑/↓ in exactly that
+    # state, so the empty list was expected everywhere but that one line. One home, spec-able
+    # without a tty. (Crystal's `%` is floored, so -1 wraps to the last row.)
+    def self.wrap_sel(sel : Int32, delta : Int32, n : Int32) : Int32
+      return 0 if n <= 0
+      (sel + delta) % n
+    end
+
     def self.pet_place(w : Int32, h : Int32) : Rect?
       return nil unless rect = Pet.place(pet_stage(w, h))
       # Her plate claims a column left of the sprite (Pet.draw), so that — not rect.x — is

--- a/src/gori/update.cr
+++ b/src/gori/update.cr
@@ -717,7 +717,18 @@ module Gori
 
     private def self.http_client(host : String, port : Int32, tls : Bool,
                                  timeout : Time::Span = HTTP_TIMEOUT) : HTTP::Client
-      client = HTTP::Client.new(host, port, tls)
+      # When tls is a bare `true`, HTTP::Client builds OpenSSL::SSL::Context::Client.new
+      # with only the compiled-in OPENSSLDIR store. A static-musl release binary's store
+      # is often empty (#323/#333) — exactly the environment `gori update` exists to
+      # serve (Channel::Binary). Apply the same system-trust repair the proxy uses so
+      # GitHub HTTPS verification works out of the box; additive and rescue-guarded.
+      client = if tls
+                 ctx = OpenSSL::SSL::Context::Client.new
+                 Proxy::Upstream.apply_system_trust(ctx)
+                 HTTP::Client.new(host, port, ctx)
+               else
+                 HTTP::Client.new(host, port, false)
+               end
       client.connect_timeout = timeout
       client.read_timeout = timeout
       client


### PR DESCRIPTION
## Summary

Coverage-driven audit of under-tested surfaces, fixing confirmed defects that inverted filters, skipped gates, stranded flows, or rewrote captured evidence. **29 fixes across 5 commits** on this branch (19 from this session on top of 10 earlier).

### Scope / security
- Proxy sandbox bypass via doubled-space / tab request lines (`gate_target` as one home)
- `--bind-from` missing Layer 1; probe Layer 1 on port-bearing `FlowRow#url`
- Loopback self-loop blind spots (`0`, hex forms, `::ffff:` dual-stack)
- CONNECT non-2xx body framing (RFC 7230 §3.3.3)

### Silent inversions / data loss
- Sitemap `FilterAst.partition` dropping `NOT` before a group
- Settings loader empty-section wipe; import clearing mine/discover prefs
- Retention prune on gapped ids; history multi-delete / `--query`+negation broaden
- `rewriter`/`probe rules` flag-before-verb silent no-op list

### Evidence fidelity
- Held response / interim 1xx unguarded client write → Pending forever
- WS re-frame recorded arrived shape instead of emitted
- HAR inventing Content-Length / h2 reason phrases
- MCP `save_as_repeater` dropping SNI and forcing `auto_cl:true`
- header: NUL truncation; webhook empty-body nonce loss; decoder unknown tokens marked usable

### Surface parity / tooling
- MCP `auto_calibrate` never sampled; `sequence_start` gated on bare `/`
- Fuzz calibrate budget at `max_requests=1`; miner exclude retried forever
- JWT Bearer case-insensitive; forbidden_bypass ACTIVE vs AGGRESSIVE dedup
- Update system-trust for static-musl; tutorial palette `↑` `% 0` abort

## Test plan
- [x] Targeted specs for each fix (fail-before / pass-after where practical)
- [x] `filter_ast`, `ql`, `decoder`, `outbound`, `oast`, `update`, `probe`, `fuzz`, `import`, `ws`, `mcp`, `miner` areas exercised
- [ ] CI full suite on the PR