### PR TITLE
fix: invent response CL only when a lying TE was stripped; reset mine prefs after profile specs

### DIFF
--- a/spec/import/import_spec.cr
+++ b/spec/import/import_spec.cr
@@ -1120,8 +1120,8 @@ describe Gori::Import::Builder do
     it "does NOT rescue a body that was never chunk framing to begin with" do
       # The complement, and the reason the relaxation is bounded: a DECODED body a
       # third-party HAR shipped under a Transfer-Encoding header still loses the header,
-      # truncation flag or no truncation flag. No CL is invented either — fabricating one
-      # would change a close-delimited (or unframed) entity into length-framed (P7).
+      # truncation flag or no truncation flag. CL is restated so framing matches the
+      # stored body (the TE-strip case) — not invented when the source stated no framing.
       headers = Gori::Import::Builder::Headers.new
       headers << {"Transfer-Encoding", "chunked"}
       empty = Gori::Import::Builder::Headers.new
@@ -1130,7 +1130,7 @@ describe Gori::Import::Builder do
         headers, "hello world".to_slice, "text/plain", nil, nil, 5_000_i64)
       head = String.new(pair.response.not_nil!.head)
       head.should_not contain("Transfer-Encoding")
-      head.should_not contain("Content-Length")
+      head.should contain("Content-Length: 11\r\n")
     end
 
     it "does NOT relax the walk for an UNtruncated body" do

--- a/spec/settings_profile_spec.cr
+++ b/spec/settings_profile_spec.cr
@@ -22,6 +22,13 @@ private def with_config_home(&)
     Gori::Settings.upstream_rules = [] of Gori::Settings::UpstreamRule
     Gori::Settings.theme = Gori::Settings::DEFAULT_THEME
     Gori::Settings.env_vars = [] of {String, String}
+    # Overlay scratch must not leak into MineConfigOverlay / Discover specs that run later
+    # in the same process (class_properties, not the temp settings.json).
+    Gori::Settings.mine_locations = [] of String
+    Gori::Settings.mine_concurrency = 10
+    Gori::Settings.mine_notify = "when-found"
+    Gori::Settings.mine_prefs_saved = false
+    Gori::Settings.discover_prefs_saved = false
     FileUtils.rm_rf(dir)
   end
 end

--- a/src/gori/import/builder.cr
+++ b/src/gori/import/builder.cr
@@ -375,15 +375,22 @@ module Gori
           # gives: the pair is the operator's evidence, and a response desync is the same
           # primitive read from the other end.
           both = both_framings?(headers)
+          had_te = false
+          has_cl = false
           headers.each do |k, v|
+            had_te = true if transfer_encoding?(k)
             next if !both && !wire_chunked && transfer_encoding?(k)
+            has_cl = true if !has_cl && k.compare("content-length", case_insensitive: true) == 0
             b << k << ": " << v << "\r\n"
           end
-          # Do NOT invent a Content-Length the source never stated. Close-delimited replies,
-          # bodyless 304/204, and every HTTP/2 head (DATA-framed, no CL) had one fabricated
-          # here, so re-import silently changed framing (P7) and broke export→import. An
-          # incoming CL is kept by the headers loop above; chunked bodies keep TE via
-          # wire_chunked; truncation is already carried by body_size on the DTO.
+          # Invent a Content-Length only when we stripped a lying Transfer-Encoding (decoded
+          # body under a chunked header) so framing still matches the stored bytes. Never
+          # invent one for a source that stated no framing at all — close-delimited, bodyless
+          # 304/204, and HTTP/2 DATA-framed heads must stay without a fabricated CL (P7 /
+          # export→import fixed point). Incoming CL and true chunked bodies are kept above.
+          if body && !has_cl && !wire_chunked && had_te
+            b << "Content-Length: " << body.size << "\r\n"
+          end
           b << "\r\n"
         end.to_slice
       end


### PR DESCRIPTION
## Summary

Follow-up to #600. That PR merged before CI finished; two suite failures remain on main:

1. **HAR response framing** — the blanket "never invent Content-Length" change broke third-party HARs where a decoded body sits under `Transfer-Encoding: chunked`. TE is correctly dropped, but CL must restate the body length so framing matches the bytes. Invent only when `had_te && !wire_chunked`; close-delimited / 304 / HTTP/2 still get no fabricated CL.

2. **Mine overlay prefs pollution** — `with_config_home` left `mine_prefs_saved` / locations on class properties, so full-suite runs after `settings_profile_spec` poisoned `MineConfigOverlay` defaults.

## Test plan
- [x] `spec/export/har_spec.cr:249`
- [x] `spec/import/import_spec.cr`
- [x] `spec/settings_profile_spec.cr` + `spec/tui/mine_config_overlay_spec.cr` (ordered pollution check)