### PR TITLE
Mine every location through one work queue, calibrate the baseline concurrently, and reuse the connection

### DIFF
--- a/bench/miner_perf_bench.cr
+++ b/bench/miner_perf_bench.cr
@@ -1,0 +1,124 @@
+# Param-miner end-to-end benchmark — what a mine costs that is NOT per-response CPU.
+#
+# `miner_inject_bench` and `miner_reflect_bench` already cover the per-request code paths
+# (they are microseconds). A real mine waits on its TRANSPORT: every send dialed a fresh
+# connection, so an N-request mine paid N TCP handshakes and, on https, N TLS handshakes.
+# Same fact `fuzz_keepalive_bench` measured for the sweep senders; the miner was left on
+# `keep_alive: false`. The two columns below are that, with everything else held equal.
+#
+# The wall-clock TOTAL also carries the run's SCHEDULE — every location's buckets share one
+# work queue, so the mine is not serialised per location and the 1-2-bucket tail of a
+# bisection no longer idles the pool. That half is not an A/B here (it is not a flag); to
+# measure it, run this binary against the previous build of the engine.
+#
+# Both costs are LATENCY, so a loopback origin understates them: with RTT ~ 0 a handshake is
+# only syscalls plus (for https) crypto, and an idle worker costs nothing a stopwatch on
+# localhost can see. The last origin below adds a fixed per-request server delay to stand in
+# for the round trip a real target charges; read all three.
+#
+# Build: crystal build bench/miner_perf_bench.cr -o bin/miner_perf_bench --release
+# Run:   bin/miner_perf_bench
+require "benchmark"
+require "socket"
+require "openssl"
+require "http/server"
+
+# `Gori::Error` (src/gori.cr) is what the codec/decoder requires below raise; declare it
+# first, as the other benches do, instead of pulling the whole binary in.
+module Gori
+  class Error < Exception; end
+end
+
+require "../src/gori/bindings"
+require "../src/gori/fuzz"
+require "../src/gori/miner"
+require "../src/gori/outbound"
+
+alias M = Gori::Miner
+
+CONCURRENCY = 20
+BODY        = "x" * 2048
+
+# Parameters the origin secretly accepts — they make the run BISECT, which is what a real
+# mine's request count is made of. Names taken from the built-in wordlist.
+SECRETS = {"debug", "admin", "callback", "redirect_url", "template"}
+
+private def self_signed : {String, String}
+  dir = File.tempname("gori-bench-tls")
+  Dir.mkdir_p(dir)
+  cert = File.join(dir, "cert.pem")
+  key = File.join(dir, "key.pem")
+  ok = Process.run("openssl", ["req", "-x509", "-newkey", "rsa:2048", "-keyout", key,
+                               "-out", cert, "-days", "1", "-nodes", "-subj", "/CN=localhost"],
+    output: Process::Redirect::Close, error: Process::Redirect::Close).success?
+  abort "openssl is required to generate the bench's TLS cert" unless ok
+  {cert, key}
+end
+
+# An origin that reacts to a secret parameter at ANY of the three mined locations: query,
+# header, cookie. A hit lengthens the body, which is the metric-diff signal the miner
+# bisects for; everything else gets the identical baseline page.
+private def start_origin(tls : Bool, delay : Time::Span) : Int32
+  server = HTTP::Server.new do |ctx|
+    sleep delay if delay > Time::Span.zero
+    hits = 0
+    q = ctx.request.query_params
+    SECRETS.each { |s| hits += 1 if q.has_key?(s) }
+    ctx.request.headers.each { |name, _| hits += 1 if SECRETS.includes?(name.downcase) }
+    if cookie = ctx.request.headers["Cookie"]?
+      SECRETS.each { |s| hits += 1 if cookie.includes?("#{s}=") }
+    end
+    ctx.response.content_type = "text/html"
+    ctx.response.print BODY
+    hits.times { ctx.response.print "\nsecret parameter accepted\n" }
+  end
+  port = if tls
+           cert, key = self_signed
+           tls_ctx = OpenSSL::SSL::Context::Server.new
+           tls_ctx.certificate_chain = cert
+           tls_ctx.private_key = key
+           server.bind_tls("127.0.0.1", 0, tls_ctx).port
+         else
+           server.bind_tcp("127.0.0.1", 0).port
+         end
+  spawn { server.listen }
+  port
+end
+
+private def mine(scheme : String, port : Int32, keep_alive : Bool) : {Int64, Int32, Gori::Repeater::ConnPool?}
+  request = "GET /?q=1 HTTP/1.1\r\nHost: 127.0.0.1:#{port}\r\nAccept: */*\r\nCookie: sid=1\r\n\r\n"
+  config = M::Config.new(
+    locations: [M::Location::Query, M::Location::Headers, M::Location::Cookies],
+    concurrency: CONCURRENCY, keep_alive: keep_alive)
+  options = M::PlanOptions.new(request,
+    target: "#{scheme}://127.0.0.1:#{port}/", locations: config.locations, config: config, verify: false)
+  plan = M::Plan.build(options, Gori::Outbound.waived(nil, Gori::Outbound::Reason::NoProject))
+  sent = 0_i64
+  found = 0
+  plan.engine.run do |ev|
+    case ev
+    when M::DoneEvent then sent = ev.progress.sent; found = ev.progress.found
+    end
+  end
+  plan.sender.close
+  {sent, found, plan.sender.pool}
+end
+
+# One warm-up mine per origin: the first run of the process pays lazy wordlist parsing and
+# the TLS context setup, which would otherwise land entirely on whichever column runs first.
+{ {"http", 0.milliseconds}, {"https", 0.milliseconds}, {"http", 2.milliseconds} }.each do |(scheme, delay)|
+  port = start_origin(scheme == "https", delay)
+  sleep 200.milliseconds # let the listener come up
+  mine(scheme, port, true)
+
+  sent, found, _ = mine(scheme, port, false)
+  puts "\n== #{scheme} · origin delay #{delay.total_milliseconds}ms · concurrency #{CONCURRENCY} " \
+       "· query/headers/cookies · #{sent} requests · #{found} params found"
+  Benchmark.bm do |x|
+    x.report("dial-per-request") { mine(scheme, port, false) }
+    x.report("keep-alive pool ") { mine(scheme, port, true) }
+  end
+  if pool = mine(scheme, port, true)[2]
+    puts "   handshakes: #{pool.dialed} dialed, #{pool.reused} served off a parked socket"
+  end
+end

--- a/docs/content/guide/scanning.ko.md
+++ b/docs/content/guide/scanning.ko.md
@@ -57,6 +57,8 @@ gori run mine <flow-id> \
   --bucket 50
 ```
 
+마이닝은 CPU가 아니라 지연 시간에 묶여 있습니다. 버킷을 보내고 기다리고, 이분 탐색하고 또 기다리므로 비용의 대부분이 왕복 횟수입니다. 이를 줄이는 장치가 두 가지입니다. 프로브 사이에 연결을 재사용하고(프로브마다가 아니라 워커마다 TCP, https라면 TLS 핸드셰이크를 한 번씩만 치릅니다. 대상이 연결 단위로 동작한다면 **reuse connections** 체크박스나 `--no-keep-alive`, `keep_alive: false`로 끕니다), 모든 location을 하나의 워커 풀에서 함께 처리합니다. 그래서 location 세 개가 하나의 세 배가 되지 않고, 이분 탐색의 끝자락이 혼자 돌지도 않습니다.
+
 > Miner 탭은 기본적으로 숨겨져 있습니다. 필요할 때 커맨드 팔레트(`Ctrl-P`)에서 활성화하세요.
 
 ## Discover: 스파이더 & 브루트포스 {#discover-spider-brute-force}

--- a/docs/content/guide/scanning.md
+++ b/docs/content/guide/scanning.md
@@ -57,6 +57,8 @@ gori run mine <flow-id> \
   --bucket 50
 ```
 
+A mine is latency-bound rather than CPU-bound — it sends a bucket, waits, bisects, waits — so what it mostly costs is round trips. Two things keep that count down: the run reuses one connection across its probes (one TCP, and on https one TLS, handshake per worker instead of one per probe — turn it off with the **reuse connections** checkbox, `--no-keep-alive`, or `keep_alive: false` when the target behaves per-connection), and every location is mined through one shared pool of workers, so three locations do not cost three times one location and the tail of a bisection no longer runs alone.
+
 > The Miner tab is hidden by default. Enable it from the command palette (`Ctrl-P`) when you need it.
 
 ## Discover: Spider & Brute-Force

--- a/docs/content/reference/cli.ko.md
+++ b/docs/content/reference/cli.ko.md
@@ -232,7 +232,10 @@ gori run mine <flow-id> --locations query,headers --wordlist params.txt
 | `--locations=LIST` | `query`, `form`, `json`, `headers`, `cookies` |
 | `--wordlist`, `--bucket=N` | 후보 이름과 버킷 크기 |
 | `--concurrency` (10), `--rate`, `--throttle`, `--timeout`, `--retries` (1), `--max-requests=N` | 속도 제어 |
+| `--no-keep-alive` | 연결 재사용 대신 프로브마다 새로 연결 |
 | `--format` | `text`, `json`, 또는 `jsonl` |
+
+기본적으로 연결을 재사용합니다. 마이닝 한 번이 프로브마다가 아니라 워커마다 TCP(https라면 TLS) 핸드셰이크를 한 번씩만 치릅니다. 실행이 끝날 때 나오는 `connections · N dialed · M reused` 줄에서 대상이 이를 지켰는지 확인할 수 있습니다. 대상이 연결 단위로 동작한다면 `--no-keep-alive`로 끕니다.
 
 ### run sequence {#run-sequence}
 

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -233,8 +233,11 @@ gori run mine <flow-id> --locations query,headers --wordlist params.txt
 | `--locations=LIST` | `query`, `form`, `multipart`, `json`, `headers`, `cookies` (multipart off by default, pass it explicitly) |
 | `--wordlist`, `--bucket=N` | Candidate names and bucket size |
 | `--concurrency` (10), `--rate`, `--throttle`, `--timeout`, `--retries` (1), `--max-requests=N` | Rate control |
+| `--no-keep-alive` | Dial a fresh connection per probe instead of reusing one |
 | `--bind-from=FLOW-ID` | Replay that captured flow first so its response fills the project's `$NAME` session bindings for the rest of the run |
 | `--format` | `text`, `json`, or `jsonl` |
+
+Connections are reused by default, so a mine pays one TCP (and on https one TLS) handshake per worker rather than one per probe — the `connections · N dialed · M reused` line at the end of a run is where you see whether the target honoured it. Turn it off with `--no-keep-alive` when the target behaves per-connection.
 
 ### run sequence
 

--- a/spec/miner/engine_spec.cr
+++ b/spec/miner/engine_spec.cr
@@ -80,6 +80,57 @@ private class BlockedBackend < F::Backend
   end
 end
 
+# Reacts to a magic name at the QUERY *and* at the HEADER location, and yields inside every
+# send so the scheduler can interleave — which is what makes the in-flight measurements below
+# real rather than always 1.
+#
+#   max_in_flight     — the most sends outstanding at one moment.
+#   mixed_in_flight   — a QUERY bucket and a HEADER bucket were outstanding TOGETHER, which
+#                       a per-location schedule can never produce.
+#   closed            — the end-of-run release of the send backend (the pool's sockets).
+private class MultiLocationBackend < F::Backend
+  getter origin : F::Origin
+  getter sent : Int32 = 0
+  getter closed : Bool = false
+  getter max_in_flight : Int32 = 0
+  getter mixed_in_flight : Bool = false
+
+  def initialize(@origin : F::Origin, @magic : String)
+    @in_flight = 0
+    @query_in_flight = 0
+    @header_in_flight = 0
+  end
+
+  def send(bytes : Bytes) : Gori::Repeater::Result
+    text = String.new(bytes)
+    line = text.lines.first? || ""
+    # A canary is "gq" + 8 hex, injected as `name=gqXXXXXXXX` in the query and as
+    # `name: gqXXXXXXXX` in a header — so the request itself says which bucket this is.
+    query = line.includes?("=gq")
+    header = text.includes?(": gq")
+    @sent += 1
+    @in_flight += 1
+    @query_in_flight += 1 if query
+    @header_in_flight += 1 if header
+    @max_in_flight = @in_flight if @in_flight > @max_in_flight
+    @mixed_in_flight = true if @query_in_flight > 0 && @header_in_flight > 0
+    Fiber.yield
+    @in_flight -= 1
+    @query_in_flight -= 1 if query
+    @header_in_flight -= 1 if header
+    hit = line.includes?("#{@magic}=gq") || text.includes?("\r\n#{@magic}: gq")
+    body = "BASELINE BODY CONTENT"
+    body += " XXXXXXXXXXXXXXXXXXXXXXXXXXXXXX" if hit
+    head = "HTTP/1.1 200 OK\r\nContent-Length: #{body.bytesize}\r\n\r\n".to_slice
+    resp = Gori::Proxy::Codec::Http1.parse_response_head(head)
+    Gori::Repeater::Result.new(head, body.to_slice, resp, 1000_i64)
+  end
+
+  def close : Nil
+    @closed = true
+  end
+end
+
 private def mine(backend : F::Backend, names : Array(String), config : M::Config) : Array(M::Finding)
   base = "GET /api HTTP/1.1\r\nHost: h\r\n\r\n".to_slice
   engine = M::Engine.new(base, http2: false, names: names, backend: backend, config: config)
@@ -165,6 +216,49 @@ describe Gori::Miner::Engine do
     end
     saw_baseline.should be_true
     saw_done.should be_true
+  end
+
+  it "mines every configured location in ONE pass, not one location after another" do
+    # The scheduler runs all locations through a single work queue, so the mine is not
+    # serialised per location and the tail of one bisection no longer idles the pool while
+    # another location's untouched buckets wait behind a barrier. What must NOT change is
+    # the verdict: the same name is still isolated at each location it applies to.
+    backend = MultiLocationBackend.new(F::Origin.new("http", "h", 80), "secret")
+    c = cfg
+    c.locations = [M::Location::Query, M::Location::Headers]
+    c.concurrency = 8
+    names = ["alpha", "beta", "gamma", "secret", "delta", "epsilon", "zeta", "eta"]
+    findings = mine(backend, names, c)
+    findings.map(&.name).uniq.should eq(["secret"])
+    findings.map(&.location).sort_by(&.value).should eq([M::Location::Query, M::Location::Headers])
+    # Buckets from BOTH locations were in flight together — under the old per-location
+    # loop the second location could not start until the first had finished entirely.
+    backend.mixed_in_flight.should be_true
+  end
+
+  it "releases the send backend (the keep-alive pool's sockets) when the run ends" do
+    backend = MultiLocationBackend.new(F::Origin.new("http", "h", 80), "secret")
+    mine(backend, ["alpha", "secret"], cfg)
+    backend.closed.should be_true
+  end
+
+  it "calibrates the baseline concurrently, and one at a time when the run is paced" do
+    # Calibration is `stability_rounds + locations` round trips of dead air at the head of
+    # every mine, and the probes do not depend on each other.
+    c = cfg
+    c.stability_rounds = 4
+    c.concurrency = 4
+    base = "GET /api HTTP/1.1\r\nHost: h\r\n\r\n".to_slice
+    backend = MultiLocationBackend.new(F::Origin.new("http", "h", 80), "secret")
+    M::Baseline.new(backend, base, c).calibrate([M::Location::Query])
+    backend.max_in_flight.should be > 1
+
+    # …but a paced run asked for one request per interval, and the FIRST thing the target
+    # sees from a mine must not be a burst of them.
+    c.throttle_ms = 50
+    paced = MultiLocationBackend.new(F::Origin.new("http", "h", 80), "secret")
+    M::Baseline.new(paced, base, c).calibrate([M::Location::Query])
+    paced.max_in_flight.should eq(1)
   end
 
   it "enforces max_requests as a hard cap that counts baseline calibration too" do

--- a/spec/miner/plan_spec.cr
+++ b/spec/miner/plan_spec.cr
@@ -194,6 +194,30 @@ describe Gori::Miner::Plan do
     File.delete?(path) if path
   end
 
+  describe "transport" do
+    it "gives the run a keep-alive pool, sized to its concurrency" do
+      cfg = config(concurrency: 7)
+      plan = M::Plan.build(M::PlanOptions.new(CRLF_RAW, target: "http://t.test", config: cfg), ungated)
+      # One parked socket per worker fiber is the most that can ever be checked out at once.
+      plan.pool.should_not be_nil
+      plan.sender.pool.should be(plan.pool)
+    end
+
+    it "runs connection-per-send when keep-alive is off" do
+      cfg = config
+      cfg.keep_alive = false
+      plan = M::Plan.build(M::PlanOptions.new(CRLF_RAW, target: "http://t.test", config: cfg), ungated)
+      plan.pool.should be_nil
+    end
+
+    it "runs connection-per-send on h2, whatever the knob says" do
+      # H2Engine frames its own connection per send — `Fuzz::Sender` excludes h2 from pooling.
+      plan = M::Plan.build(M::PlanOptions.new(CRLF_RAW, target: "https://t.test",
+        http2: true, config: config), ungated)
+      plan.pool.should be_nil
+    end
+  end
+
   describe "locations" do
     it "detects the applicable defaults when the surface named none" do
       # A GET with no body: Form/Json cannot apply, so the default is query only.

--- a/spec/tui/mine_config_overlay_spec.cr
+++ b/spec/tui/mine_config_overlay_spec.cr
@@ -32,7 +32,7 @@ describe Gori::Tui::MineConfigOverlay do
 
   it "cycles max-requests, concurrency and notification on their rows and reports the Start row" do
     ov = MineConfigOverlay.new(seed([Gori::Miner::Location::Query], [Gori::Miner::Location::Query]))
-    # rows: [0]=query, [1]=max requests, [2]=concurrency, [3]=notification, [4]=start
+    # rows: [0]=query, [1]=max requests, [2]=concurrency, [3]=notification, [4]=keep-alive, [5]=start
     ov.build_config.max_requests.should be_nil # uncapped is the first choice, and the default
     ov.move(1)                                 # max requests row
     ov.adjust(1)
@@ -43,8 +43,21 @@ describe Gori::Tui::MineConfigOverlay do
     ov.move(1)                                # notification row
     ov.adjust(1)
     ov.build_config.notify.should eq(Gori::Miner::NotifyMode::Off)
+    ov.move(1) # keep-alive row
+    ov.on_start_row?.should be_false
     ov.move(1) # start row
     ov.on_start_row?.should be_true
+  end
+
+  it "reuses connections by default and turns pooling off from its own row" do
+    ov = MineConfigOverlay.new(seed([Gori::Miner::Location::Query], [Gori::Miner::Location::Query]))
+    ov.build_config.keep_alive?.should be_true
+    ov.set_selected(4) # the keep-alive row for a one-location seed
+    ov.toggle
+    ov.build_config.keep_alive?.should be_false
+    # ←/→ flips it too, so the row behaves like the cyclers it sits under.
+    ov.adjust(1)
+    ov.build_config.keep_alive?.should be_true
   end
 
   it "defaults notification to when-found" do
@@ -56,6 +69,7 @@ describe Gori::Tui::MineConfigOverlay do
     Gori::Settings.mine_locations = ["query", "json"]
     Gori::Settings.mine_concurrency = 20
     Gori::Settings.mine_notify = "always"
+    Gori::Settings.mine_keep_alive = false
     Gori::Settings.mine_prefs_saved = true
     ov = MineConfigOverlay.new(seed(
       [Gori::Miner::Location::Query, Gori::Miner::Location::Json, Gori::Miner::Location::Headers],
@@ -64,10 +78,12 @@ describe Gori::Tui::MineConfigOverlay do
     cfg.locations.should eq([Gori::Miner::Location::Query, Gori::Miner::Location::Json])
     cfg.concurrency.should eq(20)
     cfg.notify.should eq(Gori::Miner::NotifyMode::Always)
+    cfg.keep_alive?.should be_false
   ensure
     Gori::Settings.mine_locations = [] of String
     Gori::Settings.mine_concurrency = 10
     Gori::Settings.mine_notify = "when-found"
+    Gori::Settings.mine_keep_alive = true
     Gori::Settings.mine_prefs_saved = false
   end
 

--- a/spec/tui/overlay_dispatch_spec.cr
+++ b/spec/tui/overlay_dispatch_spec.cr
@@ -425,8 +425,8 @@ describe "Overlay seam — MineConfigOverlay (laggard: keys were shell-owned; cl
   it "commits from the Start row through the generic dispatch" do
     ov = MineConfigOverlay.new(mseed)
     h = OverlayHarness.new(ov)
-    # rows: [Query, Json, max requests, concurrency, notify, Start] → 5 downs to Start.
-    5.times { h.press(Termisu::Input::Key::Down) }
+    # rows: [Query, Json, max requests, concurrency, notify, keep-alive, Start] → 6 downs.
+    6.times { h.press(Termisu::Input::Key::Down) }
     ov.on_start_row?.should be_true
     h.press(Termisu::Input::Key::Enter).should eq(:closed)
     h.commits.should eq(1)
@@ -435,7 +435,7 @@ describe "Overlay seam — MineConfigOverlay (laggard: keys were shell-owned; cl
   it "keeps the form open when the commit closure rejects (no location selected)" do
     ov = MineConfigOverlay.new(mseed)
     h = OverlayHarness.new(ov, commit: false) # e.g. any_checked? was false
-    ov.set_selected(5)                        # Start row
+    ov.set_selected(6)                        # Start row
     h.press(Termisu::Input::Key::Enter).should eq(:open)
   end
 
@@ -450,8 +450,8 @@ describe "Overlay seam — MineConfigOverlay (laggard: keys were shell-owned; cl
 
   it "click on Start commits; a click outside dismisses" do
     h = OverlayHarness.new(MineConfigOverlay.new(mseed))
-    # Start is row index 5; its screen row is box.y + 3 + 5.
-    h.click_in_box(3, 8).should eq(:closed)
+    # Start is row index 6; its screen row is box.y + 3 + 6.
+    h.click_in_box(3, 9).should eq(:closed)
     h.commits.should eq(1)
 
     away = OverlayHarness.new(MineConfigOverlay.new(mseed))

--- a/src/gori/cli/run/mine.cr
+++ b/src/gori/cli/run/mine.cr
@@ -23,6 +23,7 @@ module Gori
         timeout : Time::Span? = nil
         retries = 1
         max_requests : Int64? = nil
+        keep_alive = true
         format = :text
         allow_unscoped = false
         bind_from : Int64? = nil
@@ -47,6 +48,7 @@ module Gori
           p.on("--timeout=SEC", "Per-request connect + idle timeout (seconds)") { |v| timeout = parse_count(v, "--timeout").seconds }
           p.on("--retries=N", "Retries on a network error") { |v| retries = parse_nonneg(v, "--retries") }
           p.on("--max-requests=N", "Hard cap on total requests sent") { |v| max_requests = parse_count(v, "--max-requests").to_i64 }
+          p.on("--no-keep-alive", "Dial a fresh connection for every probe (default: reuse)") { keep_alive = false }
           p.on("--bind-from=FLOW-ID", "Replay this captured flow FIRST so its response fills session bindings ($NAME)") { |v| bind_from = parse_flow_id(v, "gori run mine") }
           p.on("--allow-unscoped", "Send even if the target is outside the project scope (Sandbox/exclude still apply)") { allow_unscoped = true }
           p.on("--format=FMT", "Output: text (default) | json | jsonl") { |v| format = parse_format(v, [:text, :json, :jsonl]) }
@@ -75,6 +77,7 @@ module Gori
         config.retries = retries
         config.max_requests = max_requests
         config.user_wordlist = wordlist
+        config.keep_alive = keep_alive
         # `--locations=` with no usable value (empty, or only blanks/commas) is an operator
         # mistake, not a request to auto-detect — abort instead of silently mining defaults.
         if (loc = locations) && loc.empty?
@@ -115,7 +118,7 @@ module Gori
           # invocation, so `--bind-from` replays one here. An unseeded `$NAME` ships literally
           # rather than refusing the sweep (see `Env.unbound`).
           (fid = bind_from) && seed_bindings(fid, project_name, db_path, outbound, insecure, "gori run mine")
-          run_mine_stream(plan.engine, origin.scheme, origin.host, origin.port, plan.config, format)
+          run_mine_stream(plan.engine, origin.scheme, origin.host, origin.port, plan.config, format, plan.pool)
         ensure
           outbound.close
         end
@@ -204,7 +207,8 @@ module Gori
       end
 
       private def self.run_mine_stream(engine : Miner::Engine, scheme : String, host : String,
-                                       port : Int32, config : Miner::Config, format : Symbol) : Nil
+                                       port : Int32, config : Miner::Config, format : Symbol,
+                                       pool : Fuzz::ConnPool? = nil) : Nil
         total = engine.total_names
         STDERR.puts "mining #{scheme}://#{host}:#{port} · #{config.locations.map(&.label).join("/")} · #{total} names"
         # Names the wordlist supplied that this location cannot carry. Dropping them is
@@ -222,7 +226,7 @@ module Gori
           when Miner::BaselineEvent then mine_baseline(ev)
           when Miner::FindingEvent  then findings << ev.finding; emit_mine_finding(ev.finding, format)
           when Miner::ProgressEvent then mine_progress(ev, total)
-          when Miner::DoneEvent     then mine_done(ev, findings.size, config)
+          when Miner::DoneEvent     then mine_done(ev, findings.size, config); mine_connections(pool)
           when Miner::ErrorEvent    then had_error = true; STDERR.puts "mine error: #{ev.message}"
           end
         end
@@ -289,6 +293,18 @@ module Gori
         # operator never passed would send them after the wrong thing.
         why = config.max_requests ? "budget exhausted — raise or drop --max-requests" : "incomplete"
         STDERR.puts "#{why} · #{left} of #{p.names_total} names never tested"
+      end
+
+      # Handshakes actually paid for. Worth a line for the same reason `gori run fuzz` prints
+      # it: it is how an operator sees whether the origin honoured keep-alive at all (dialed ≈
+      # sent means it closed after every response, or the probes were too odd to share a socket
+      # — see ConnPool). Nothing is printed for a --no-keep-alive or h2 run, which has no pool.
+      private def self.mine_connections(pool : Fuzz::ConnPool?) : Nil
+        return unless pool && pool.dialed > 0
+        STDERR.puts "connections · #{pool.dialed} dialed · #{pool.reused} reused" \
+                    "#{pool.stale_retries > 0 ? " · #{pool.stale_retries} re-sent on a closed connection" : ""}" \
+                    "#{pool.unsafe_stale > 0 ? " · #{pool.unsafe_stale} not re-sent (non-idempotent method)" : ""}" \
+                    "#{pool.pooling? ? "" : " · keep-alive gave up (origin closes every connection)"}"
       end
     end
   end

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -1538,6 +1538,7 @@ module Gori
               s.field "throttle_ms", intprop("fixed delay between requests in ms — an alternative to 'rate' for a target that rate-limits on inter-request gap rather than throughput (mirrors CLI --throttle)")
               s.field "sni", strprop("TLS SNI override, independent of the Host header — the vhost-confusion / domain-fronting test (mirrors CLI --sni)")
               s.field "max_requests", intprop("caller cap on total requests")
+              s.field "keep_alive", boolprop("reuse one HTTP/1.1 connection across the mine's probes (default true) — one TCP/TLS handshake per worker instead of per probe, which is most of a mine's wall clock. Set false to dial a fresh connection per probe, which is what you want when the target behaves per-connection (connection-scoped rate limits, a load balancer pinning by connection).")
               s.field "allow_unscoped", boolprop("run even when the target host is outside the project's configured scope — REQUIRED to run against an out-of-scope target, or when no scope is configured at all (active requests are refused by default without a matching scope)")
             end
 

--- a/src/gori/mcp/tools/mine.cr
+++ b/src/gori/mcp/tools/mine.cr
@@ -193,6 +193,7 @@ module Gori
         config.max_requests = cap ? {cap, MINE_MAX_REQUESTS}.min : MINE_MAX_REQUESTS
         config.user_wordlist = str(h, "wordlist").presence
         int(h, "throttle_ms").try { |v| config.throttle_ms = v.clamp(0_i64, 600_000_i64).to_i }
+        config.keep_alive = bool_arg(h, "keep_alive", true)
         options = Miner::PlanOptions.new(text,
           # A `flow_id` template is CAPTURED evidence; a `template` string is the caller's
           # draft. See `Miner::PlanOptions#evidence?`.

--- a/src/gori/miner/baseline.cr
+++ b/src/gori/miner/baseline.cr
@@ -42,12 +42,23 @@ module Gori::Miner
     end
 
     def calibrate(locations : Array(Location)) : Report
-      probes = [] of Probe
       rounds = {@config.stability_rounds, 1}.max
-      rounds.times do
+      # Calibration is pure round-trip time and it runs BEFORE a single candidate is tested,
+      # so on a real target its cost is `stability_rounds + locations` RTTs of dead air at the
+      # head of every mine — on a 100ms origin that is most of a second before the run does
+      # anything. The probes do not depend on each other (the stability rounds are N copies of
+      # the same request; the controls are one independent bucket per location), so they go out
+      # concurrently, in two waves: the tolerance bands the controls are judged against come
+      # from the stability wave.
+      #
+      # Indexed writes, not appends: `probes.first` is the round the whole report is built
+      # from, so the answer must not depend on which fiber finished first.
+      slots = Array(Probe?).new(rounds, nil)
+      in_parallel(rounds) do |i|
         raw = @backend.send(@base)
-        probes << Fingerprint.probe(raw) if raw.error.nil?
+        slots[i] = Fingerprint.probe(raw) if raw.error.nil?
       end
+      probes = slots.compact
       return unreachable if probes.empty?
 
       base = probes.first
@@ -68,8 +79,12 @@ module Gori::Miner
 
       reflection_only = Hash(Location, Bool).new
       reflects_all = Hash(Location, Bool).new
-      locations.each do |loc|
-        reacts, echoes = control_signals(loc, base, length_tol, words_tol, lines_tol)
+      signals = Array({Bool, Bool}?).new(locations.size, nil)
+      in_parallel(locations.size) do |i|
+        signals[i] = control_signals(locations[i], base, length_tol, words_tol, lines_tol)
+      end
+      locations.each_with_index do |loc, i|
+        reacts, echoes = signals[i] || {false, false}
         reflection_only[loc] = reacts
         reflects_all[loc] = echoes
       end
@@ -77,6 +92,54 @@ module Gori::Miner
       Report.new(base.metrics.status, length_tol, words_tol, lines_tol,
         base.metrics.length, base.metrics.words, base.metrics.lines,
         stable, reflection_only, reflects_all, baseline_warning(stable, statuses, reflects_all))
+    end
+
+    # Call the block for `0...count` through at most `concurrency` fibers, and return only
+    # once every call has finished.
+    #
+    # SEQUENTIAL when the run is paced (`--rate` / `--throttle`): calibration has never
+    # charged itself against the pacer, which was invisible while it also sent one request at
+    # a time. Firing `stability_rounds` at once would turn "1 request per second, please" into
+    # a burst on the very first thing the target sees from a mine — the opposite of what the
+    # operator asked for, and the calibration is a handful of requests either way.
+    #
+    # An exception inside the block is re-raised on THIS fiber rather than escaping on a
+    # worker's: an unhandled exception in a spawned fiber takes the process down, and until
+    # this ran concurrently every raise here landed inside `Engine#orchestrate`'s rescue and
+    # became an ErrorEvent. The first one wins; the rest are already-failed work.
+    private def in_parallel(count : Int32, &block : Int32 ->) : Nil
+      return if count <= 0
+      workers = {count, {@config.concurrency, 1}.max}.min
+      workers = 1 if @config.rps || @config.throttle_ms
+      if workers <= 1
+        count.times { |i| block.call(i) }
+        return
+      end
+
+      jobs = Channel(Int32).new
+      done = Channel(Nil).new(workers)
+      failure = nil.as(Exception?)
+      workers.times do
+        spawn(name: "miner-baseline") do
+          begin
+            while i = jobs.receive?
+              begin
+                block.call(i)
+              rescue ex
+                failure ||= ex
+              end
+            end
+          ensure
+            done.send(nil)
+          end
+        end
+      end
+      count.times { |i| jobs.send(i) }
+      jobs.close
+      workers.times { done.receive }
+      if ex = failure
+        raise ex
+      end
     end
 
     # Inject a bucket of random non-existent names ONCE per location. Returns

--- a/src/gori/miner/engine.cr
+++ b/src/gori/miner/engine.cr
@@ -12,9 +12,10 @@ module Gori::Miner
 
   # Drives a parameter-mining run: calibrate a baseline, then for each location stuff
   # candidate names into buckets, diff vs baseline, and BINARY-SEARCH each interesting
-  # bucket to isolate the responsible name. Concurrency = level-synchronized BFS per
-  # location: the current frontier of buckets runs concurrently through a bounded worker
-  # pool, children (bisection halves) are collected, then the next frontier runs.
+  # bucket to isolate the responsible name. Concurrency = ONE work queue for the whole run,
+  # drained by a bounded worker pool: every location's buckets go in together and a
+  # bisection's halves are pushed straight back, so nothing waits on a round barrier or on
+  # another location finishing. See `drain`.
   #
   # Single-threaded fiber scheduler (no -Dpreview_mt): plain ivar increments and array
   # appends never yield mid-op, so the counters and per-round outcome array need no locks.
@@ -49,6 +50,11 @@ module Gori::Miner
     @names_done : Int64
     @names_total : Int64
     @last_dispatch : Time::Instant
+    # Buckets dispatched to a worker and not yet accounted for, and the 1-slot channel a
+    # worker pokes when one lands. Together they are the mine's "is there still work?"
+    # answer — see `drain` / `wait_for_worker`.
+    @inflight : Int32
+    @idle : Channel(Nil)
 
     # The first per-send failure reason of the run. `@errors` counts refusals and drops the
     # string, which is how a scope-blocked run could report "0 found" and exit 0 with the
@@ -96,6 +102,8 @@ module Gori::Miner
       @names_done = 0_i64
       @names_total = 0_i64
       @last_dispatch = Time.instant
+      @inflight = 0
+      @idle = Channel(Nil).new(1)
     end
 
     # The number of distinct (name × location) tests this run will perform — the stable
@@ -142,56 +150,75 @@ module Gori::Miner
       @report = report
       @events.send(BaselineEvent.new(report.stable, report.warning))
 
-      @config.locations.each do |loc|
-        break if @state.stopped?
-        frontier = initial_buckets(loc, valid_names_for(loc))
-        until frontier.empty? || @state.stopped?
-          frontier = run_round(frontier).flat_map { |children| children }
-        end
-      end
+      work = Deque(Task).new
+      @config.locations.each { |loc| initial_buckets(loc, valid_names_for(loc)).each { |t| work << t } }
+      drain(work)
       @events.send(DoneEvent.new(snapshot, @state.stopped?))
     rescue ex
       @events.send(ErrorEvent.new(ex.message || "miner error"))
       @events.send(DoneEvent.new(snapshot, @state.stopped?))
     ensure
+      # Every worker has left `drain` by here, so no fiber can be holding a checked-out
+      # socket: release the keep-alive pool's parked ones instead of waiting for GC to
+      # finalize them (a stopped 40-worker run would otherwise sit on 40 fds). Same close
+      # `Fuzz::Engine#coordinate` performs, at the miner's equivalent seam.
+      @backend.close
       @events.close
     end
 
-    # Run one frontier concurrently; returns each task's children (next frontier).
-    private def run_round(tasks : Array(Task)) : Array(Array(Task))
-      outcomes = [] of Array(Task)
-      return outcomes if tasks.empty?
-      # Never spawn more workers than there are tasks: the tail bisection/isolation rounds carry
-      # 1–2 tasks, so a fixed pool of @concurrency (up to 100) would spawn dozens of fibers that
-      # only see the closed channel and exit. Capping keeps full parallelism with no idle churn.
-      workers = {@concurrency, tasks.size}.min
-      jobs = Channel(Task).new(workers)
+    # Run every bucket of the whole mine through ONE bounded worker pool, feeding each
+    # task's bisection children straight back into the queue.
+    #
+    # It used to be a level-synchronised BFS per location: `locations.each` ran the locations
+    # one after another, and inside each, a round dispatched the frontier, waited for ALL of
+    # it, then dispatched the children. Both halves of that idled the pool, and a mine is
+    # LATENCY-bound — its request count is small (bucket + bisect + confirm) and almost all of
+    # its wall clock is time-of-flight — so an idle worker is time nobody gets back:
+    #
+    #   * the tail of a bisection is 1-2 tasks wide (that is what isolating one name MEANS),
+    #     so the last log₂(bucket) rounds ran at a concurrency of 1-2 no matter what the
+    #     operator set. Meanwhile the OTHER buckets' subtrees, which are entirely independent,
+    #     sat in a later round waiting on the barrier;
+    #   * a three-location mine took three times as long as its slowest location, for no
+    #     reason at all: query/headers/cookies share nothing but the baseline report.
+    #
+    # A queue removes both without changing what is sent: the tasks are exactly the same
+    # tasks, each still decided against the same calibrated baseline, and a bisection child
+    # still cannot run before its parent — it does not EXIST before its parent. Only the
+    # order of independent work changes, so findings can now interleave across locations.
+    #
+    # Concurrency: single-threaded fiber scheduler (no `-Dpreview_mt`). `Deque#push`/`#shift?`
+    # never yield mid-op, so workers and this fiber can share the queue with no lock, the same
+    # reasoning the counters already rely on.
+    private def drain(work : Deque(Task)) : Nil
+      return if work.empty?
+      # The pool is spawned ONCE for the run, so an idle worker is a fiber parked on a receive
+      # rather than the per-round spawn/exit churn the old code capped against — and the cap
+      # it used (`min(concurrency, frontier.size)`) cannot be computed here anyway: the queue
+      # grows as buckets bisect, and sizing the pool to the first frontier would pin a
+      # 40-worker run to its 4 initial buckets for the whole mine.
+      workers = @concurrency
+      # UNBUFFERED on purpose: a send parks until a worker actually TAKES the task, which is
+      # what keeps `@inflight` bounded by the pool size instead of by the queue's length.
+      jobs = Channel(Task).new
       finished = Channel(Nil).new(workers)
       interval = pace_interval
-
-      spawn(name: "miner-dispatch") do
-        begin
-          tasks.each do |task|
-            break if @state.stopped?
-            park_if_paused
-            break if @state.stopped?
-            # Early-out once the hard cap is hit — the CappedBackend also refuses any
-            # send that slips past this racy check, so the network count never exceeds it.
-            break if @backend.cap_reached?
-            pace(interval)
-            jobs.send(task)
-          end
-        ensure
-          jobs.close
-        end
-      end
+      @inflight = 0
 
       workers.times do |i|
         spawn(name: "miner-worker-#{i}") do
           begin
             while task = jobs.receive?
-              next if @state.stopped? # drain buffered tasks without sending on stop
-              outcomes << process_bucket(task)
+              # Children are queued BEFORE the task is counted out, so the "queue empty and
+              # nothing in flight" test below is a true end-of-work and never races a child in.
+              process_bucket(task).each { |child| work << child } unless @state.stopped?
+              @inflight -= 1
+              # Non-blocking: a worker must never park reporting completion (the dispatcher
+              # only listens while it is idle). Dropping a poke is safe — see `wait_for_worker`.
+              select
+              when @idle.send(nil)
+              else
+              end
             end
           ensure
             finished.send(nil)
@@ -199,8 +226,38 @@ module Gori::Miner
         end
       end
 
+      until @state.stopped?
+        if task = work.shift?
+          park_if_paused
+          break if @state.stopped?
+          # Early-out once the hard cap is hit — the CappedBackend also refuses any
+          # send that slips past this racy check, so the network count never exceeds it.
+          break if @backend.cap_reached?
+          pace(interval)
+          @inflight += 1
+          jobs.send(task)
+        elsif @inflight > 0
+          wait_for_worker # a bucket is still out; its children may refill the queue
+        else
+          break # queue drained and nothing outstanding — the mine is complete
+        end
+      end
+      jobs.close
       workers.times { finished.receive }
-      outcomes
+    end
+
+    # Park until a worker reports a finished bucket.
+    #
+    # A DROPPED poke cannot lose a wake-up, because the only place this is called from tests
+    # `@inflight > 0` and then parks with no yield point in between: the fiber scheduler is
+    # single-threaded and cooperative, so a worker that is still out at the moment of the test
+    # can only run — and only poke — once this receive is already parked, and a parked receiver
+    # is handed the value directly rather than through the buffer. The 1-slot buffer is there
+    # for the reverse case (a poke that lands while the dispatcher is busy dispatching), where
+    # collapsing several into one is exactly right: the dispatcher re-reads the queue and the
+    # counter after every wake, so a wake means "look again", never "one task finished".
+    private def wait_for_worker : Nil
+      @idle.receive
     end
 
     # ── the bucketing + bisection core ──────────────────────────────────────────────

--- a/src/gori/miner/plan.cr
+++ b/src/gori/miner/plan.cr
@@ -148,6 +148,7 @@ module Gori::Miner
     getter request_target : String
     # The candidate parameter names (built-in list + the user wordlist).
     getter names : Array(String)
+
     # Resolved locations that `Detect` says do NOT apply to this request — a surface can
     # only reach these by naming them explicitly, and `gori run mine` warns per location
     # rather than dropping them silently.
@@ -157,6 +158,14 @@ module Gori::Miner
                    @origin : Fuzz::Origin, @http2 : Bool, @request : Bytes,
                    @request_target : String, @names : Array(String),
                    @inapplicable : Array(Location))
+    end
+
+    # The run's keep-alive pool, or nil when it runs connection-per-send (h2, or
+    # `config.keep_alive?` off). Surfaces read its counters to report how many handshakes the
+    # run actually paid for — the one directly observable measure of what pooling bought.
+    # Same accessor `Fuzz::Plan` publishes, so the two CLI reporters stay one shape.
+    def pool : Fuzz::ConnPool?
+      @sender.pool
     end
 
     # The number of distinct (name × location) tests this run performs — the progress
@@ -212,8 +221,12 @@ module Gori::Miner
       # untouched captured request, and `Baseline#calibrate` sends it raw before any
       # injection at all. Reproduced: `gori run mine <flow> --bind-from <flow>` put the live
       # session token on the wire in 6 of 8 requests.
+      #
+      # `idle_conns: concurrency` — one parked socket per worker fiber is the most that can
+      # ever be checked out at once, so a larger pool would only hold dead sockets open.
       sender = Fuzz::Sender.new(origin, outbound, http2: options.http2?, verify: options.verify?,
         sni: options.sni, timeout: config.timeout, overrides: options.overrides,
+        keep_alive: config.keep_alive?, idle_conns: config.concurrency,
         evidence: options.evidence?)
       new(engine: Engine.new(request, options.http2?, names, sender, config), sender: sender,
         config: config, origin: origin, http2: options.http2?, request: request,

--- a/src/gori/miner/types.cr
+++ b/src/gori/miner/types.cr
@@ -187,6 +187,17 @@ module Gori
       property? add_content_length_when_missing : Bool
       property user_wordlist : String?
       property notify : NotifyMode
+      # Reuse one HTTP/1.1 connection across the run's sends (`Repeater::ConnPool`, wired in
+      # `Plan.build`) instead of dialing a fresh one per probe. ON by default, as it is for the
+      # Fuzzer and Discover: a mine is a sweep — baseline calibration, one request per bucket,
+      # then a bisection tree and `confirm_rounds` per finding — all at ONE origin, so without
+      # pooling every one of those pays a TCP handshake and, on https, a TLS handshake before a
+      # payload byte moves. Off is the right answer when the target behaves per-connection
+      # (connection-scoped rate limits, a load balancer pinning by connection) or when the
+      # keep-alive handling is itself what is being probed. Reuse is still opt-in PER MESSAGE
+      # inside the pool — a bucket whose wire body disagrees with its declared length always
+      # gets a fresh socket (see `ConnPool.reusable_request?`).
+      property? keep_alive : Bool
 
       # Per-Burp ceilings; query/form are additionally clamped by the URL byte budget
       # in Inject so a stuffed line can't exceed common request-line limits.
@@ -205,7 +216,7 @@ module Gori
                      @timeout = nil, @retries = 1, @retry_pause = 500.milliseconds,
                      @stability_rounds = 4, @confirm_rounds = 2, @max_requests = nil,
                      @add_content_length_when_missing = false, @user_wordlist = nil,
-                     @notify = NotifyMode::WhenFound)
+                     @notify = NotifyMode::WhenFound, @keep_alive = true)
       end
 
       def bucket_for(loc : Location) : Int32

--- a/src/gori/settings/miner.cr
+++ b/src/gori/settings/miner.cr
@@ -9,6 +9,10 @@ module Gori::Settings
   class_property mine_locations : Array(String) = [] of String
   class_property mine_concurrency : Int32 = 10
   class_property mine_notify : String = "when-found"
+  # Reuse one connection across the mine's probes. Mirrors `Settings.discover_keep_alive?`,
+  # including the `!= false` read below: a settings file written before this key existed must
+  # come back as the default ON, not as an opt-out the operator never chose.
+  class_property? mine_keep_alive : Bool = true
   class_property? mine_prefs_saved : Bool = false
 
   private def self.parse_mine_prefs(node : JSON::Any?) : Nil
@@ -28,13 +32,16 @@ module Gori::Settings
     end
     int_field(obj, "concurrency").try { |n| self.mine_concurrency = n }
     obj["notify"]?.try(&.as_s?).try { |s| self.mine_notify = s }
+    self.mine_keep_alive = obj["keep_alive"]?.try(&.as_bool?) != false
   end
 
   # Persist the overlay's last confirmed choices (called when mining starts).
-  def self.save_mine_prefs(locations : Array(String), concurrency : Int32, notify : String) : Nil
+  def self.save_mine_prefs(locations : Array(String), concurrency : Int32, notify : String,
+                           keep_alive : Bool = true) : Nil
     self.mine_locations = locations.map(&.downcase.strip).reject(&.empty?)
     self.mine_concurrency = concurrency
     self.mine_notify = notify
+    self.mine_keep_alive = keep_alive
     self.mine_prefs_saved = true
     save
   end
@@ -48,6 +55,7 @@ module Gori::Settings
           end
           j.field "concurrency", mine_concurrency
           j.field "notify", mine_notify
+          j.field "keep_alive", mine_keep_alive?
         end
       end
     end

--- a/src/gori/tui/mine_config_overlay.cr
+++ b/src/gori/tui/mine_config_overlay.cr
@@ -49,6 +49,7 @@ module Gori::Tui
       @conc_idx = CONC_CHOICES.index(10) || 1
       @notify_idx = NOTIFY_CHOICES.index(Miner::NotifyMode::WhenFound) || 0
       @maxreq_idx = 0
+      @keep_alive = true
       @selected = 0
       restore_saved_prefs
     end
@@ -57,7 +58,7 @@ module Gori::Tui
     def save_prefs : Nil
       locs = @seed.applicable.select { |l| @checked[l]? }.map(&.label)
       notify = NOTIFY_CHOICES[@notify_idx].token
-      Settings.save_mine_prefs(locs, CONC_CHOICES[@conc_idx], notify)
+      Settings.save_mine_prefs(locs, CONC_CHOICES[@conc_idx], notify, @keep_alive)
     end
 
     private def restore_saved_prefs : Nil
@@ -72,12 +73,13 @@ module Gori::Tui
       if mode = Miner::NotifyMode.parse?(Settings.mine_notify)
         @notify_idx = NOTIFY_CHOICES.index(mode) || @notify_idx
       end
+      @keep_alive = Settings.mine_keep_alive?
     end
 
     # Rows: one per applicable location, then max-requests + concurrency + notification
-    # cyclers, then Start.
+    # cyclers, then the keep-alive checkbox, then Start.
     private def row_count : Int32
-      @seed.applicable.size + 4
+      @seed.applicable.size + 5
     end
 
     private def maxreq_row : Int32
@@ -92,8 +94,14 @@ module Gori::Tui
       @seed.applicable.size + 2
     end
 
-    private def start_row : Int32
+    # Reuse one connection across the run's probes — a checkbox rather than a cycler
+    # because it is a plain on/off, matching the Discover overlay's own keep-alive row.
+    private def keepalive_row : Int32
       @seed.applicable.size + 3
+    end
+
+    private def start_row : Int32
+      @seed.applicable.size + 4
     end
 
     def on_start_row? : Bool
@@ -157,9 +165,10 @@ module Gori::Tui
 
     def adjust(d : Int32) : Nil
       case @selected
-      when maxreq_row then @maxreq_idx = (@maxreq_idx + d) % MAX_REQ_CHOICES.size
-      when conc_row   then @conc_idx = (@conc_idx + d) % CONC_CHOICES.size
-      when notify_row then @notify_idx = (@notify_idx + d) % NOTIFY_CHOICES.size
+      when maxreq_row    then @maxreq_idx = (@maxreq_idx + d) % MAX_REQ_CHOICES.size
+      when conc_row      then @conc_idx = (@conc_idx + d) % CONC_CHOICES.size
+      when notify_row    then @notify_idx = (@notify_idx + d) % NOTIFY_CHOICES.size
+      when keepalive_row then @keep_alive = !@keep_alive
       end
     end
 
@@ -168,6 +177,8 @@ module Gori::Tui
       if @selected < @seed.applicable.size
         loc = @seed.applicable[@selected]
         @checked[loc] = !(@checked[loc]? || false)
+      elsif @selected == keepalive_row
+        @keep_alive = !@keep_alive
       elsif @selected == maxreq_row || @selected == conc_row || @selected == notify_row
         adjust(1)
       end
@@ -179,6 +190,7 @@ module Gori::Tui
       c.concurrency = CONC_CHOICES[@conc_idx]
       c.notify = NOTIFY_CHOICES[@notify_idx]
       c.max_requests = MAX_REQ_CHOICES[@maxreq_idx].try(&.to_i64)
+      c.keep_alive = @keep_alive
       c
     end
 
@@ -235,15 +247,23 @@ module Gori::Tui
       x = box.x + 3
       if i < @seed.applicable.size
         loc = @seed.applicable[i]
-        on = @checked[loc]? || false
-        screen.text(x, py, on ? "[x]" : "[ ]", on ? Theme.green : Theme.muted, bg)
-        screen.text(x + 4, py, "#{loc.label} mining", sel ? Theme.text_bright : Theme.text, bg)
+        draw_check(screen, x, py, bg, sel, @checked[loc]? || false, "#{loc.label} mining")
+      elsif i == keepalive_row
+        draw_check(screen, x, py, bg, sel, @keep_alive, "reuse connections (keep-alive)")
       elsif i == start_row
         label = any_checked? ? "[ Start mining ]" : "[ select a location ]"
         screen.text(x, py, label, any_checked? ? Theme.accent : Theme.muted, bg, Attribute::Bold)
       else
         draw_cycler(screen, x, py, bg, sel, i)
       end
+    end
+
+    # One ␣-toggled checkbox row — the location rows and the keep-alive row are the same
+    # widget, so they draw through the same three lines rather than two copies of them.
+    private def draw_check(screen : Screen, x : Int32, py : Int32, bg : Color,
+                           sel : Bool, on : Bool, label : String) : Nil
+      screen.text(x, py, on ? "[x]" : "[ ]", on ? Theme.green : Theme.muted, bg)
+      screen.text(x + 4, py, label, sel ? Theme.text_bright : Theme.text, bg)
     end
 
     # The three ←/›-cycled rows, split out of draw_row so adding a knob does not keep

--- a/src/gori/tui/miner_view.cr
+++ b/src/gori/tui/miner_view.cr
@@ -425,6 +425,7 @@ module Gori::Tui
           j.field "concurrency", @config.concurrency
           j.field "max_requests", @config.max_requests
           j.field "notify", @config.notify.token
+          j.field "keep_alive", @config.keep_alive?
           j.field "stability_rounds", @config.stability_rounds
           j.field "confirm_rounds", @config.confirm_rounds
           j.field "buckets" do
@@ -448,6 +449,10 @@ module Gori::Tui
       # Absent (an older row) reads as nil ⇒ uncapped, which is what those runs were.
       @config.max_requests = any["max_requests"]?.try(&.as_i64?)
       any["notify"]?.try(&.as_s?).try { |s| Miner::NotifyMode.parse?(s) }.try { |m| @config.notify = m }
+      # `!= false`, not `|| false`: a session persisted before this key existed has no
+      # `keep_alive` field at all, and reading a missing key as "off" would silently opt an
+      # old session out of the default the overlay shows it as having.
+      @config.keep_alive = any["keep_alive"]?.try(&.as_bool?) != false
       any["stability_rounds"]?.try(&.as_i?).try { |n| @config.stability_rounds = n }
       any["confirm_rounds"]?.try(&.as_i?).try { |n| @config.confirm_rounds = n }
       if buckets = any["buckets"]?.try(&.as_h?)


### PR DESCRIPTION
A mine is **latency-bound, not request-bound**. It sends a couple of hundred requests and spends its wall clock waiting: bucket, wait, bisect, wait. So the number worth optimising is *serial round trips*, and three things were spending them.

## What was slow

- **Locations ran one after another.** `locations.each` meant a three-location mine cost three times one location, for no reason — query/headers/cookies share nothing but the baseline report.
- **A barrier between bisection rounds.** The tail of a bisection is 1-2 buckets wide by definition (that is what isolating one name *means*), so the last log₂(bucket) rounds ran at a concurrency of 1-2 whatever the operator set, while every other bucket's subtree waited behind the barrier.
- **Calibration was dead air.** `Baseline#calibrate` was `stability_rounds + locations` sequential round trips before the first candidate went out.
- **No connection reuse.** The miner was the sweep sender still left on `keep_alive: false`, so every probe paid a TCP handshake and, on https, a TLS handshake.

## What changed

`Engine#drain` replaces the per-location level-synchronised BFS with **one work queue for the whole run**: every location's buckets go in together and a bisection's halves are pushed straight back. Nothing about *what is sent* changes — the same tasks, each still decided against the same calibrated baseline, and a child still cannot run before the parent that creates it. Only the order of independent work changes, so **findings can now interleave across locations**.

Calibration probes do not depend on each other, so they go out in two waves (the controls need the stability wave's tolerance bands). A **paced run stays sequential**: firing four at once would turn "one request per second, please" into a burst on the first thing the target ever sees from us.

Transport pools like the Fuzzer and Discover do — `--no-keep-alive`, MCP `keep_alive`, a **reuse connections** checkbox, a `connections · N dialed · M reused` line at the end of a CLI run — and the engine releases the pool when a run ends.

## Measured

`bench/miner_perf_bench.cr` (212 requests, 17 params found, 3 locations, conc 20) plus an out-of-process origin at 2ms/request, best of 5:

| | before | after |
|---|---|---|
| 3 locations, conc 20 | 83.1 ms (41 RTT) | **35.2 ms (17.6 RTT)** — 2.4x |
| 3 locations, conc 60 | 84.6 ms | **27.0 ms** — 3.1x (the old schedule could not use the extra workers at all) |
| query only, conc 20 | 36.2 ms | 27.8 ms |
| https, keep-alive on/off | 172 ms · 167 ms user CPU | **36 ms · 28 ms**, 20 handshakes instead of 212 |

Same 212 requests and same 17 findings in every cell.

## Verification

- Full suite: 7384 examples, 8 failures — all of them the usual `capture_status` / `project_registry` pair that fails against a gori already holding :8070 locally.
- The three new engine specs were **control-run against the previous engine and fail there** (buckets from two locations in flight together; the backend released at end of run; calibration concurrency, and its sequential fallback under pacing).
- `crystal build --no-codegen`, format on touched files only, ameba with no new findings. The CLI path was exercised end to end against a local origin.