### PR TITLE
The one project model nobody reloads, a host rule shaped like a URL, and three adds that could not tell a rolled-back write from a stored one

### DIFF
--- a/spec/host_overrides_spec.cr
+++ b/spec/host_overrides_spec.cr
@@ -327,4 +327,57 @@ describe Gori::Proxy::Upstream do
       Gori::Proxy::Upstream.loops_to_self?("evil.test", 8070, ov, {"127.0.0.1", 8070}).should be_false
     end
   end
+
+  # Scope and Rules both expose `reload` and are pulled by the TUI's data_version poll
+  # (Runner#apply_external_change) and headless capture's reload fiber (App#spawn_reload_loop);
+  # HostOverrides — read on the SAME dial path, written by the SAME external surfaces
+  # (`gori run project host-override`, MCP add/update/delete_host_override) — had no such
+  # method, so a running session kept dialing the old address for the rest of its life while
+  # the writing surface reported success. `peer` here stands in for that other process.
+  describe "#reload (external writes by a peer process against the same db)" do
+    it "picks up an add, an update and a delete a peer made" do
+      with_store do |store|
+        live = Gori::HostOverrides.load(store) # the running session's proxy + Project pane
+        peer = Gori::HostOverrides.load(store) # `gori run project host-override …`
+
+        peer.add("staging.acme.test", "10.0.0.1").should be_true
+        live.connect_address("staging.acme.test").should be_nil # stale: the whole bug
+        live.reload
+        live.connect_address("staging.acme.test").should eq("10.0.0.1")
+        live.size.should eq(1)
+
+        peer.update(peer.entries.first.id, "staging.acme.test", "10.0.0.2:8443").should be_true
+        live.reload
+        live.connect_address("staging.acme.test").should eq("10.0.0.2:8443")
+
+        peer.remove(peer.entries.first.id).should be_true
+        live.reload
+        live.connect_address("staging.acme.test").should be_nil
+        live.size.should eq(0)
+      end
+    end
+
+    # The stale list also broke the WRITE path, not just lookups: `add` dedupes against its own
+    # in-memory entries, so against a stale list it issued an INSERT the store's
+    # `UNIQUE(host)` + `INSERT OR IGNORE` silently dropped — and the post-write reload then
+    # surfaced the PEER's address under an "override added" toast. Reloading first turns that
+    # into the honest duplicate answer the caller already knows how to report.
+    it "reports a peer-created host as the duplicate it is instead of claiming the write landed" do
+      with_store do |store|
+        live = Gori::HostOverrides.load(store)
+        peer = Gori::HostOverrides.load(store)
+        peer.add("staging.acme.test", "10.0.0.1").should be_true
+
+        # Even WITHOUT a reload first — the in-memory dedupe can't see the peer's row, so the
+        # INSERT OR IGNORE is dropped by UNIQUE(host). `add` used to return true anyway and the
+        # caller announced an override at 10.9.9.9 that the proxy would never dial.
+        live.add("staging.acme.test", "10.9.9.9").should be_false
+        live.connect_address("staging.acme.test").should eq("10.0.0.1") # peer's value, unclaimed
+
+        live.reload
+        live.add("staging.acme.test", "10.9.9.9").should be_false
+        live.connect_address("staging.acme.test").should eq("10.0.0.1")
+      end
+    end
+  end
 end

--- a/spec/scope_spec.cr
+++ b/spec/scope_spec.cr
@@ -595,6 +595,72 @@ describe Gori::Scope do
   end
 end
 
+# A host rule matches the BARE host, so a pattern carrying a scheme/path/userinfo/whitespace
+# can never fire — the same silent-dead-rule failure the :PORT check prevents, reached by the
+# same mistake (pasting a URL where a host goes). Only the port shape was checked, so
+# `include host https://acme.test/admin` was stored, listed as configured scope, and matched
+# nothing: fail-CLOSED under the Sandbox (every request blocked while include_count stays
+# non-zero, so even the "blocks everything" warning stays quiet) and fail-OPEN as an exclude.
+describe "Gori::Scope host-rule shape validation" do
+  it "proves the URL-shaped host pattern it now rejects could never have matched" do
+    # Built directly (bypassing validation), the way a pre-existing stored row would be.
+    rule = Gori::Scope::Rule.new(1_i64, "include", "host", "https://acme.test/admin")
+    rule.matches?("https://acme.test/admin", "acme.test").should be_false
+    rule.matches?("https://acme.test/", "acme.test").should be_false
+  end
+
+  it "rejects a scheme/path/userinfo/whitespace host pattern and names the bare host to use" do
+    {
+      "https://acme.test"           => "acme.test",
+      "http://acme.test/admin"      => "acme.test",
+      "acme.test/admin"             => "acme.test",
+      "https://user@acme.test/x"    => "acme.test",
+      "https://acme.test:8443/api"  => "acme.test", # scheme AND port peeled for the suggestion
+      "https://[::1]:8443/api"      => "::1",       # bare IPv6 form, matching the port check's advice
+      "acme.test?q=1"               => "acme.test",
+      "https://*.acme.test/"        => "*.acme.test", # a glob survives the peel
+    }.each do |pattern, suggestion|
+      Gori::Scope.valid?("host", pattern).should be_false
+      err = Gori::Scope.validation_error("host", pattern).not_nil!
+      err.should contain("bare host")
+      err.should contain(suggestion.inspect)
+      # The suggestion is itself storable — following the advice must not land on a second
+      # rejection (this is what the :PORT check's "use the bare host" contract already promises).
+      Gori::Scope.valid?("host", suggestion).should be_true
+    end
+  end
+
+  it "rejects whitespace but suggests nothing rather than guessing which half was meant" do
+    err = Gori::Scope.validation_error("host", "acme.test admin").not_nil!
+    err.should contain("whitespace")
+    err.should contain("string or regex") # points at the rule types that CAN match a URL
+    err.should_not contain("\"acme.test\"")
+  end
+
+  it "leaves every legitimate host pattern (and string/regex rules) alone" do
+    ["acme.test", "*.acme.test", "api.acme.test", "127.0.0.1", "::1", "fe80::1", "[::1]",
+     "under_score.test", "xn--9n2bp8q.test", "한국.test"].each do |p|
+      Gori::Scope.validation_error("host", p).should be_nil
+    end
+    # string/regex rules match the whole URL, so URL syntax is exactly what belongs there.
+    Gori::Scope.valid?("string", "https://acme.test/admin").should be_true
+    Gori::Scope.valid?("regex", "^https://acme\\.test/admin").should be_true
+  end
+
+  it "keeps the dead rule out of the store on add AND on update" do
+    with_store do |store|
+      scope = Gori::Scope.load(store)
+      scope.add("include", "host", "https://acme.test/admin").should be_false
+      store.scope_rules.should be_empty
+
+      scope.add("include", "host", "acme.test").should be_true
+      id = scope.rules.first.id
+      scope.update(id, "include", "host", "https://acme.test/admin").should be_false
+      scope.rules.first.pattern.should eq("acme.test") # still gating traffic, unchanged
+    end
+  end
+end
+
 describe Gori::QL do
   it "ANDs two filters and absorbs the empty filter" do
     a = Gori::QL::Filter.new("host = ?", ["x"] of DB::Any)

--- a/spec/tui/scope_rule_overlay_spec.cr
+++ b/spec/tui/scope_rule_overlay_spec.cr
@@ -93,7 +93,51 @@ describe "ProjectView#commit_scope_rule" do
       view.commit_scope_rule("include", "host", "").should eq(:empty)
       view.commit_scope_rule("include", "regex", "(bad").should eq(:invalid)
       view.commit_scope_rule("include", "host", "127.0.0.1:9091").should eq(:invalid) # host+port can never match
-      view.commit_scope_rule("exclude", "string", "/admin").should eq(:dup)           # same triple, new add
+      view.commit_scope_rule("include", "host", "https://acme.test/x").should eq(:invalid) # URL-shaped host: dead rule
+      view.commit_scope_rule("exclude", "string", "/admin").should eq(:dup)                # same triple, new add
+
+      # A no-op self-edit is NOT a duplicate — the popup re-committing the rule it was seeded
+      # from must not be rejected by the pre-write dup check that splits :dup from :failed.
+      view.commit_scope_rule("exclude", "string", "/admin", updated.id).should eq(:ok)
+    ensure
+      store.close
+      File.delete?(path)
+      File.delete?("#{path}-wal")
+      File.delete?("#{path}-shm")
+    end
+  end
+end
+
+# The HOST OVERRIDES inline row serves BOTH add and edit, but reported one `:ok` that the
+# controller toasted as "host override added" even after an edit — and folded a store refusal
+# into `:dup`, telling an operator who was already editing to "edit it (e)".
+describe "ProjectView#ov_commit" do
+  it "distinguishes an add from an edit, and a real duplicate from either" do
+    path = File.tempname("gori-ov-commit", ".db")
+    store = Gori::Store.open(path)
+    begin
+      overrides = Gori::HostOverrides.load(store)
+      view = ProjectView.new(Gori::Scope.load(store), overrides)
+
+      view.ov_add_start
+      "10.0.0.1 staging.acme.test".each_char { |c| view.ov_input(c) }
+      view.ov_commit.should eq(:ok)
+      overrides.connect_address("staging.acme.test").should eq("10.0.0.1")
+
+      # Re-committing the row the edit was SEEDED from is a no-op self-edit, not a duplicate —
+      # the pre-write dup check that splits :dup from :failed has to skip the row being edited.
+      view.ov_edit_start
+      view.ov_commit.should eq(:updated)
+      overrides.connect_address("staging.acme.test").should eq("10.0.0.1")
+
+      view.ov_add_start
+      "10.0.0.9 staging.acme.test".each_char { |c| view.ov_input(c) }
+      view.ov_commit.should eq(:dup) # a DIFFERENT row already maps that host
+      overrides.connect_address("staging.acme.test").should_not eq("10.0.0.9")
+
+      view.ov_add_start
+      "not-an-ip host.test".each_char { |c| view.ov_input(c) }
+      view.ov_commit.should eq(:invalid)
     ensure
       store.close
       File.delete?(path)

--- a/src/gori/app.cr
+++ b/src/gori/app.cr
@@ -385,6 +385,14 @@ module Gori
             rescue ex
               Log.error(exception: ex) { "scope rule reload failed" }
             end
+            begin
+              # The per-project /etc/hosts is read on the SAME dial path as the two above and
+              # is edited by the same external surfaces (`gori run project host-override`,
+              # MCP add/update/delete_host_override), so it goes stale the same way.
+              session.host_overrides.reload
+            rescue ex
+              Log.error(exception: ex) { "host override reload failed" }
+            end
           end
         end
       end

--- a/src/gori/cli/run/project.cr
+++ b/src/gori/cli/run/project.cr
@@ -487,7 +487,8 @@ module Gori
           scope = Scope.load(store)
           unless scope.add(kind, match_type, pat)
             store.close
-            abort "gori run project scope add: failed to add rule (duplicate, empty, or invalid)"
+            abort "gori run project scope add: rule NOT added (duplicate, empty, invalid, " \
+                  "or the store was busy/unwritable); the scope is unchanged"
           end
           puts "Scope rule added successfully."
         ensure
@@ -954,7 +955,8 @@ module Gori
           ov = HostOverrides.load(store)
           unless ov.add(h, i)
             store.close
-            abort "gori run project host-override add: failed to add override (duplicate host, empty, or invalid)"
+            abort "gori run project host-override add: override NOT added (duplicate host, empty, " \
+                  "invalid, or the store was busy/unwritable); nothing was created"
           end
           entry = ov.entries.find { |e| e.host == h.strip.downcase }
           if e = entry

--- a/src/gori/host_overrides.cr
+++ b/src/gori/host_overrides.cr
@@ -66,7 +66,16 @@ module Gori
     end
 
     # Add an override (validates, lowercases the host, dedupes on host). Returns false
-    # (no-op) on an empty/invalid pair or a host that's already mapped (edit it instead).
+    # (no-op) on an empty/invalid pair, a host that's already mapped (edit it instead) — or a
+    # store write that did not commit.
+    #
+    # That last case used to return TRUE: unlike update/remove (exec_task_ok) the INSERT goes
+    # through exec_task, which reports nothing, so a busy/locked/closing store rolled the batch
+    # back and `add` still said yes — the caller then reported an override the proxy would
+    # never dial. The `INSERT OR IGNORE` behind it can also drop the row when a PEER process
+    # created the same host since this object last loaded, which the in-memory dedupe above
+    # cannot see. The reload right below already fetches the truth: present with THIS address
+    # ⇒ stored. (Address, not just host — a peer's colliding row must not be read as our write.)
     def add(host : String, ip : String) : Bool
       host = host.strip.downcase
       ip = ip.strip
@@ -75,8 +84,8 @@ module Gori
         return false if @entries.any? { |e| e.host == host }
         @store.add_host_override(host, ip)
         reload_entries_unlocked
+        @entries.any? { |e| e.host == host && e.ip == ip }
       end
-      true
     end
 
     # Edit an override in place (by id). Dedupes the host against OTHER entries so a
@@ -131,6 +140,24 @@ module Gori
       host = parts[1].strip
       return nil unless valid?(host, ip)
       {host.downcase, ip}
+    end
+
+    # Re-read the entries from the store after an EXTERNAL change — another process
+    # (`gori run project host-override add/rm`, an MCP `add_host_override`) or another
+    # instance's TUI writing to the SAME db. Mirrors Scope#reload / Rules#reload, and for
+    # the same reason: every consumer already holds a reference to THIS object (the proxy's
+    # `Upstream.connect_target` via each listener, the Project tab's HOST OVERRIDES pane),
+    # so refreshing it in place is enough — no re-wiring needed.
+    #
+    # Without it a running gori kept dialing the OLD address for the rest of the session
+    # while the writing surface reported success, and the TUI pane deduped its own adds
+    # against a stale list — `INSERT OR IGNORE` then dropped the write (host is UNIQUE) and
+    # the reload surfaced the OTHER process's value under an "override added" toast.
+    #
+    # Pulled by the same two call sites Scope#reload has: the TUI's data_version poll
+    # (Runner#apply_external_change) and headless capture's reload fiber (App#spawn_reload_loop).
+    def reload : Nil
+      @mutex.synchronize { reload_entries_unlocked }
     end
 
     private def reload_entries_unlocked : Nil

--- a/src/gori/mcp/tools/host_overrides.cr
+++ b/src/gori/mcp/tools/host_overrides.cr
@@ -27,17 +27,20 @@ module Gori
         return err("invalid host/ip (host hostname-shaped; ip an IPv4/IPv6 literal, optionally IP:PORT or [v6]:PORT)", "INVALID_ARGUMENT") unless HostOverrides.valid?(host, ip)
         ov = HostOverrides.load(store)
         normalized = host.strip.downcase
-        # host/ip are already validated above and HostOverrides#add reports NOTHING about the
-        # store write, so its only remaining false is a DUPLICATE — a deterministic condition
-        # that can never succeed on retry. Reporting it as retryable PROJECT_BUSY made an agent
-        # that trusts `retryable` loop forever (the #414 shape, fixed there in add_scope_rule).
+        # The DUPLICATE question is deterministic and can never succeed on retry, so answer it
+        # here as a non-retryable INVALID_ARGUMENT — reporting it as retryable PROJECT_BUSY made
+        # an agent that trusts `retryable` loop forever (the #414 shape, fixed there in
+        # add_scope_rule).
         if ov.entries.any? { |e| e.host == normalized }
           return err("a host override for '#{normalized}' already exists (update it by id with update_host_override)",
             "INVALID_ARGUMENT", field: "host")
         end
         unless ov.add(host, ip)
-          return err("host override rejected (host must be hostname-shaped; ip an IPv4/IPv6 literal, optionally IP:PORT or [v6]:PORT)",
-            "INVALID_ARGUMENT", field: "host")
+          # host/ip were validated above and the duplicate is answered above, so what is left is
+          # the store refusing the write — which `add` only started reporting once it verified
+          # the row landed. Before that it returned true here and this tool emitted `{"id": null}`
+          # as success for an override the proxy would never dial.
+          return busy("host override NOT added (store busy or unwritable); no override was created")
         end
         entry = ov.entries.find { |e| e.host == normalized }
         Result.new(JSON.build do |j|

--- a/src/gori/mcp/tools/scope.cr
+++ b/src/gori/mcp/tools/scope.cr
@@ -17,13 +17,22 @@ module Gori
           return err(e, "INVALID_ARGUMENT", field: "pattern")
         end
         scope = Scope.load(store)
-        unless scope.add(kind, match_type, pattern)
-          # kind/match_type/pattern are already validated above, so a false here means the rule
-          # is a DUPLICATE — a deterministic condition that will never succeed on retry. Report it
-          # as a non-retryable INVALID_ARGUMENT, not PROJECT_BUSY/retryable (which made an agent
-          # that trusts `retryable` loop forever, #414).
+        # Answer the DUPLICATE question here, before the write, the way add_host_override does.
+        # It is deterministic and will never succeed on retry, so it must be a non-retryable
+        # INVALID_ARGUMENT — reporting it as PROJECT_BUSY/retryable made an agent that trusts
+        # `retryable` loop forever (#414).
+        if scope.rules.any? { |r| r.kind == kind && r.match_type == match_type && r.pattern == pattern }
           return err("scope rule already exists (identical kind/match_type/pattern)",
             "INVALID_ARGUMENT", field: "pattern")
+        end
+        unless scope.add(kind, match_type, pattern)
+          # Everything deterministic is now ruled out above (kind/match_type/pattern validated,
+          # duplicate answered), so the remaining false is the store refusing the write — which
+          # `add` only started reporting once it verified the row landed. Before that it returned
+          # true here and this tool emitted `{"id": null}` as success for a rule that does not
+          # exist and gates nothing. A racing peer that created the same rule in between lands
+          # here too; the retry then gets the deterministic duplicate answer above.
+          return busy("scope rule NOT added (store busy or unwritable); the scope is unchanged")
         end
         # Scope#add reloads @rules from the store before returning, so this lookup
         # already sees the freshly assigned id.

--- a/src/gori/scope.cr
+++ b/src/gori/scope.cr
@@ -331,7 +331,15 @@ module Gori
     end
 
     # Add a rule (validates regex, dedupes on the kind/type/pattern triple). Returns
-    # false (no-op) on an empty pattern, an invalid regex, or a duplicate.
+    # false (no-op) on an empty pattern, an invalid regex, a duplicate — or a store write
+    # that did not commit.
+    #
+    # That last case used to return TRUE: unlike update/remove (exec_task_ok) the INSERT goes
+    # through exec_task, which reports nothing, so a busy/locked/closing store rolled the
+    # batch back and `add` still said yes. The rule then wasn't in the store OR in @rules, and
+    # every caller reported a rule that gates traffic but does not exist — MCP even emitted
+    # `{"id": null}` as ordinary success. The reload right above already fetches the truth, so
+    # the answer is simply to look: present ⇒ stored.
     def add(kind : String, match_type : String, pattern : String) : Bool
       pattern = pattern.strip
       return false if pattern.empty? || !Scope.valid?(match_type, pattern)
@@ -339,8 +347,8 @@ module Gori
         return false if @rules.any? { |r| r.kind == kind && r.match_type == match_type && r.pattern == pattern }
         @store.add_scope_rule(kind, match_type, pattern)
         reload_rules_unlocked
+        @rules.any? { |r| r.kind == kind && r.match_type == match_type && r.pattern == pattern }
       end
-      true
     end
 
     # Edit a rule in place (by id). Same validation; dedupes against OTHER rules so a
@@ -413,14 +421,18 @@ module Gori
     #           claimed actually hold for the next caller.
     #   regex — must compile (the SQLite REGEXP callback + the proxy hot path both call
     #           Regex.new and would otherwise raise).
-    #   host  — must NOT carry a :PORT. A host rule matches the BARE host on any port
-    #           (Rule#host_match? compares the port-less host, and the scope URL built by
-    #           request_url carries no port for origin-form flows), so "127.0.0.1:9091"
-    #           could NEVER match and would sit in the store as a silent dead rule.
+    #   host  — must be a BARE host: no scheme, path, userinfo, query/fragment or whitespace
+    #           (host_pattern_shape_error), and no :PORT. A host rule matches the BARE host on
+    #           any port (Rule#host_match? compares the port-less host, and the scope URL built
+    #           by request_url carries no port for origin-form flows), so "127.0.0.1:9091" or
+    #           "https://acme.test/admin" could NEVER match and would sit in the store as a
+    #           silent dead rule.
     def self.validation_error(match_type : String, pattern : String) : String?
       case match_type
       when "host"
-        if host_pattern_has_port?(pattern)
+        if e = host_pattern_shape_error(pattern)
+          e
+        elsif host_pattern_has_port?(pattern)
           "host rule must not include a port — a host rule already matches every port; " \
           "use the bare host #{host_without_port(pattern).inspect} (matches any port)"
         end
@@ -437,6 +449,53 @@ module Gori
     # callers use (Scope#add/#update gate, the overlay's Save-button + commit path).
     def self.valid?(match_type : String, pattern : String) : Bool
       validation_error(match_type, pattern).nil?
+    end
+
+    # Characters a request host can NEVER contain, so a host-type pattern carrying one can
+    # never fire. Deliberately a BLACKLIST, not a hostname whitelist: an IDN target typed in
+    # its unicode form, or a name with an underscore, is the operator's business — only the
+    # shapes that are provably dead are rejected.
+    HOST_PATTERN_FORBIDDEN = {'/', '\\', '?', '#', '@'}
+
+    # A host rule matches the BARE host of a request (Rule#host_match? / host_cond both
+    # compare against the `host` column alone), so a pattern carrying a scheme, a path,
+    # userinfo, a query/fragment or whitespace is a rule that matches NOTHING while sitting
+    # in the operator's scope list looking configured. That is worse than a typo in both
+    # directions: a dead INCLUDE under the Sandbox blocks ALL traffic while `include_count`
+    # stays non-zero, so even the "blocks everything" warning stays quiet; a dead EXCLUDE
+    # fails OPEN and carves out nothing. Same silent-dead-rule failure the :PORT check below
+    # prevents, and the same mistake that produces it — pasting a URL where a host goes.
+    private def self.host_pattern_shape_error(pattern : String) : String?
+      offender = pattern.each_char.find { |c| c.whitespace? || c.in?(HOST_PATTERN_FORBIDDEN) }
+      return nil unless offender
+      shown = offender.whitespace? ? "whitespace" : offender.to_s.inspect
+      base = "host rule must be a bare host — #{pattern.inspect} contains #{shown}, " \
+             "which a request host never does"
+      if suggestion = host_from_urlish(pattern)
+        "#{base}; use #{suggestion.inspect} (a host rule already matches every scheme, port and path)"
+      else
+        "#{base} (use a string or regex rule to match a URL)"
+      end
+    end
+
+    # Best-effort "what the operator meant": the host of a URL-ish pattern, with the scheme,
+    # userinfo, path/query/fragment and :PORT peeled off. nil when what's left still isn't
+    # host-shaped (e.g. "acme.test admin", where guessing which half was meant would be
+    # worse than saying nothing), so the message degrades to the plain complaint rather than
+    # suggesting a pattern that is itself dead.
+    private def self.host_from_urlish(pattern : String) : String?
+      s = pattern.strip
+      if i = s.index("://")
+        s = s[(i + 3)..]
+      end
+      s = s.split(/[\/?#]/, 2).first
+      if at = s.rindex('@')
+        s = s[(at + 1)..]
+      end
+      return nil if s.empty?
+      return nil if s.each_char.any? { |c| c.whitespace? || c.in?(HOST_PATTERN_FORBIDDEN) }
+      s = host_without_port(s) if host_pattern_has_port?(s)
+      bare_host(s).presence
     end
 
     # True ⇔ a host-type pattern carries an explicit :PORT suffix a host rule can never

--- a/src/gori/tui/controllers/project_controller.cr
+++ b/src/gori/tui/controllers/project_controller.cr
@@ -324,6 +324,14 @@ module Gori::Tui
       @project_view.reload(@host.session.project, @host.session.store)
     end
 
+    # Runner#apply_external_change already refreshed the live Scope / HostOverrides objects
+    # this view renders straight out of; all that is left is to pull the two list selections
+    # back inside a list another process may have SHRUNK, so the highlight doesn't sit on a
+    # row that no longer exists.
+    def on_external_change : Nil
+      @project_view.clamp_selections
+    end
+
     def save : Nil
       @project_view.save(@host.session.store)
     end
@@ -503,6 +511,12 @@ module Gori::Tui
       when :dup
         @host.status("scope: duplicate rule")
         false
+      when :failed
+        # The store refused the write (busy/locked/closing). Distinct from :dup on purpose —
+        # the scope is UNCHANGED and still gating traffic, and a retry is worth making, which
+        # is the opposite of what "duplicate rule" tells the operator to do.
+        @host.status("scope rule NOT saved (store busy or unwritable) — the scope is unchanged")
+        false
       when :ok
         n = @host.session.scope.size
         edited = !edit_id.nil?
@@ -630,6 +644,8 @@ module Gori::Tui
       when :empty   then @host.status("host override: empty")
       when :invalid then @host.status(%(host override: need "IP host" — a valid IP + a hostname))
       when :dup     then @host.status("host override: host already mapped — edit it (e)")
+      when :failed  then @host.status("host override NOT saved (store busy or unwritable) — nothing changed")
+      when :updated then @host.status("host override updated — #{@host.session.host_overrides.size} total")
       when :ok      then @host.status("host override added — #{@host.session.host_overrides.size} total")
       end
     end

--- a/src/gori/tui/project_view.cr
+++ b/src/gori/tui/project_view.cr
@@ -576,17 +576,25 @@ module Gori::Tui
       @scope.rules[@sel]?
     end
 
-    # Commit from the SCOPE popup. Returns :ok | :empty | :invalid | :dup for toasts.
+    # Commit from the SCOPE popup. Returns :ok | :empty | :invalid | :dup | :failed for toasts.
+    # :dup and :failed are answered separately because they send the operator to different
+    # places — "you already have this rule" vs "the store refused the write, the scope is
+    # unchanged". Scope#add/#update collapse both into one false, so the duplicate is settled
+    # HERE (against the same rules the popup was seeded from) and whatever false survives that
+    # is the store.
     def commit_scope_rule(kind : String, match_type : String, pattern : String, edit_id : Int64? = nil) : Symbol
       pattern = pattern.strip
       return :empty if pattern.empty?
       return :invalid unless Scope.valid?(match_type, pattern)
+      if @scope.rules.any? { |r| r.id != edit_id && r.kind == kind && r.match_type == match_type && r.pattern == pattern }
+        return :dup
+      end
       ok = if id = edit_id
              @scope.update(id, kind, match_type, pattern)
            else
              @scope.add(kind, match_type, pattern)
            end
-      return :dup unless ok
+      return :failed unless ok
       clamp_sel
       :ok
     end
@@ -598,6 +606,15 @@ module Gori::Tui
       @scope.remove(rule.id)
       clamp_sel
       rule.pattern
+    end
+
+    # Pull BOTH list selections back inside their (possibly externally shrunk) lists. Called
+    # by the controller after Runner#apply_external_change reloaded the live Scope /
+    # HostOverrides — this view renders straight out of those objects, so a peer process
+    # deleting the last rule would otherwise leave the highlight past the end.
+    def clamp_selections : Nil
+      clamp_sel
+      clamp_ov_sel
     end
 
     private def clamp_sel : Nil
@@ -667,24 +684,33 @@ module Gori::Tui
     end
 
     # Commit the add/edit row. Parses "IP host" (/etc/hosts order — IP first). Returns
-    # :ok | :empty | :invalid | :dup so the controller toasts.
+    # :ok | :updated | :empty | :invalid | :dup | :failed so the controller toasts.
+    #
+    # :ok vs :updated because this row serves BOTH actions and the one toast it had said
+    # "added" after an edit. :dup vs :failed for the same reason commit_scope_rule splits
+    # them: HostOverrides#add/#update collapse "that host is already mapped" and "the store
+    # refused the write" into one false, and on the EDIT path the duplicate reading was
+    # simply wrong — it told an operator fixing an address to "edit it (e)", which is what
+    # they were already doing.
     def ov_commit : Symbol
       text = @ov_input.strip
       return :empty if text.empty?
       parsed = HostOverrides.parse_line(text)
       return :invalid unless parsed
       host, ip = parsed
-      ok = if id = @ov_edit_id
-             @host_overrides.update(id, host, ip)
-           else
-             added = @host_overrides.add(host, ip)
-             @ov_sel = @host_overrides.entries.size - 1 if added # select the new row, like ENV add
-             added
-           end
-      return :dup unless ok
-      cancel_ov_add
-      clamp_ov_sel
-      :ok
+      return :dup if @host_overrides.entries.any? { |e| e.id != @ov_edit_id && e.host == host }
+      if id = @ov_edit_id
+        return :failed unless @host_overrides.update(id, host, ip)
+        cancel_ov_add
+        clamp_ov_sel
+        :updated
+      else
+        return :failed unless @host_overrides.add(host, ip)
+        @ov_sel = @host_overrides.entries.size - 1 # select the new row, like ENV add
+        cancel_ov_add
+        clamp_ov_sel
+        :ok
+      end
     end
 
     # Removes the selected override, returning its host (for the toast) or nil.

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -907,6 +907,13 @@ module Gori::Tui
       # markers (and Sandbox enforcement, which reads the SAME live object) from going stale
       # after an external `gori run project scope add/rm` against this project's db.
       @session.scope.reload
+      # Same discipline for the per-project /etc/hosts: the proxy's dial path and the Project
+      # tab's HOST OVERRIDES pane read this ONE live object, so an external
+      # `gori run project host-override add` / MCP `add_host_override` against this db has to
+      # land here or the session dials the old address for the rest of its life. The pane's
+      # own inline add/edit row is a separate buffer and is untouched by this (only the
+      # underlying list changes), so there is nothing to clobber — same as Scope above.
+      @session.host_overrides.reload
       # Reload a store-backed view only when it's the ACTIVE tab (others reload on
       # tab entry via on_enter_tab) — avoids re-querying History's page ~1.3×/sec
       # while the user is elsewhere. Own-session captures also arrive via flow_events.


### PR DESCRIPTION
Audit of the Project tab's configuration surfaces (SCOPE, HOST OVERRIDES). Three defects, all surfaced by comparing siblings rather than reading a file: each is a guarantee that two of three call sites already keep.

## 1. `HostOverrides` had no `#reload`

`Rules#reload` and `Scope#reload` are pulled by the two external-change sites — the TUI's `data_version` poll (`Runner#apply_external_change`) and headless capture's reload fiber (`App#spawn_reload_loop`). The third per-project model read on the **same dial path**, written by the **same external surfaces** (`gori run project host-override`, MCP `add_host_override`), had no such method.

So an override added against a running session never reached the proxy: it kept dialing the old address for the rest of the session while the writing surface reported success. The Project pane went stale with it — and deduped its own adds against that stale list, so `INSERT OR IGNORE` dropped the write (`host` is `UNIQUE`) and the post-write reload surfaced the *other* process's value under an "override added" toast.

Adds the method plus both call sites, and clamps the pane's two list selections after a peer shrinks a list.

## 2. A `host` scope rule was checked for a `:PORT` and nothing else

A host rule matches the **bare host**, so `https://acme.test/admin` — a URL pasted where a host goes — stored fine and matched nothing. Worse than a typo in both directions:

- a dead **INCLUDE** under the Sandbox blocks **all** traffic while `include_count` stays non-zero, so even the "blocks everything" warning stays quiet;
- a dead **EXCLUDE** fails **open** and carves out nothing.

Same silent-dead-rule failure the `:PORT` check exists to prevent, reached by the same mistake. The new check is a **blacklist** of what a host can never contain (`/ \ ? # @` and whitespace), not a hostname whitelist — a unicode IDN target or an underscore name still passes. The rejection names the bare host to use, peeling scheme, userinfo, path, query and port: `"https://user@acme.test:8443/api"` → `"acme.test"`.

## 3. Every `add` path reported a rolled-back store write as success

`update`/`remove` go through `exec_task_ok` and answer whether the batch **committed**; `add_scope_rule` / `add_host_override` go through `exec_task`, which answers nothing — so `Scope#add` and `HostOverrides#add` returned `true` unconditionally. On a busy/locked/closing store the rule was in neither the store nor memory and every caller announced a rule that gates traffic and does not exist. MCP emitted `{"id": null}` as ordinary success.

Both adds now confirm the row landed in the reload they already perform (host overrides check host **and** address: an `INSERT OR IGNORE` dropped by a peer's colliding `UNIQUE(host)` row must not be read as our write). Callers that must split *duplicate* from *busy* answer the duplicate question themselves before the write — MCP already did this for host overrides, `add_scope_rule` now does too — so whatever `false` survives is the store, reported retryable, never #414's infinite-retry mix-up.

### TUI fallout of (3)

`ov_commit` serves both add and edit but returned one `:ok` the controller printed as "host override **added**" after an edit, and read a store refusal as "host already mapped — edit it (e)" to someone who was already editing. It now answers `:ok | :updated | :dup | :failed`; `commit_scope_rule` likewise gained `:failed`.

## Verification

- `crystal build --no-codegen src/main.cr` clean
- `crystal spec` → **7385 examples, 8 failures**, all of them the port-bound baseline from a gori already listening on `:8070` (`project_registry` ×5, `capture_status` ×3). No new failures.
- New specs: the URL-shaped host rule is proven never to have matched; peer-process add/update/delete now land; a peer collision makes `add` answer `false`; the TUI's `:ok` / `:updated` / `:dup` split.
