### PR TITLE
Probe passive rules: an evidence list that drifted, two body caps for one document, and a sink that matched itself

### DIFF
--- a/bench/probe_passive_bench.cr
+++ b/bench/probe_passive_bench.cr
@@ -116,6 +116,35 @@ JS_I18N_BODY = begin
   io.to_slice.dup
 end
 
+# A LARGE HTML document — past Context::BODY_CAP (64 KiB), up against CLIENT_BODY_CAP (256 KiB).
+# Ordinary content-heavy pages (a docs page, a product listing, a dashboard with server-rendered
+# rows) land here routinely, and this is the fixture that actually exercises BodyLeaks' HTML sink
+# checks at their real width: they read `client_body_text`, not the 64 KiB `body_text` the leak
+# scans use, so the 40 KiB HTML_BODY above cannot show their cost at all.
+#
+# It carries NO cleartext URL, no `javascript:` and no `_blank` — that is the point. This is the
+# common case, and it measures whether the literal prefilters really keep a clean page off the
+# regex passes. A fixture that tripped every check would only measure the rare page.
+BIG_HTML_BODY = begin
+  io = IO::Memory.new
+  io << "<!doctype html><html><head><title>Docs</title>"
+  io << %(<link rel="stylesheet" href="https://cdn.example.com/app.css">)
+  io << "</head><body>\n"
+  i = 0
+  while io.bytesize < 200 * 1024
+    io << %(<section class="row"><h2>Section ) << i << "</h2>"
+    io << %(<p>ordinary paragraph text, entirely unremarkable, number ) << i << "</p>"
+    io << %(<a href="/docs/page) << i << %(">next</a></section>) << "\n"
+    i += 1
+  end
+  io << "</body></html>\n"
+  io.to_slice.dup
+end
+
+BIG_HTML_FLOW = flow("GET", "/docs", "text/html; charset=utf-8",
+  ("GET /docs HTTP/1.1\r\nHost: app.example.com\r\n\r\n").to_slice, nil,
+  HTML_RESP_HEAD, BIG_HTML_BODY)
+
 JS_RESP_HEAD = ("HTTP/1.1 200 OK\r\nContent-Type: application/javascript\r\n" \
                 "Server: nginx/1.24.0\r\nCache-Control: max-age=31536000\r\n\r\n").to_slice
 
@@ -139,6 +168,7 @@ puts "  (detections: json=#{Gori::Probe::Passive.analyze(JSON_FLOW).size}" \
 Benchmark.ips do |x|
   x.report("JSON API POST flow ") { Gori::Probe::Passive.analyze(JSON_FLOW) }
   x.report("HTML document flow ") { Gori::Probe::Passive.analyze(HTML_FLOW) }
+  x.report("HTML doc, 200 KiB  ") { Gori::Probe::Passive.analyze(BIG_HTML_FLOW) }
   x.report("JS bundle flow     ") { Gori::Probe::Passive.analyze(JS_FLOW) }
   # Must stay in the SAME order of magnitude as the plain JS bundle. A large gap here means the
   # non-ASCII slow path is back.

--- a/spec/probe_custom_rule_spec.cr
+++ b/spec/probe_custom_rule_spec.cr
@@ -181,3 +181,59 @@ describe "Gori::Probe.custom_rules merge" do
     end
   end
 end
+
+# A custom finding used to store `evidence: nil`, so every surface could say a rule fired on a
+# host but never what tripped it — the operator had to re-run the pattern by hand against the
+# sample flow. A regex rule now reports its match.
+describe "Gori::Probe::CustomRule evidence" do
+  it "reports capture group 1 when the pattern defines one" do
+    with_store do |store|
+      dets = matches?(store, rule(kind: "regex", pattern: "build-id:\\s*([0-9a-f]{8})"),
+        body: "meta build-id: deadbeef end")
+      dets.size.should eq(1)
+      dets.first.evidence.should eq("deadbeef")
+    end
+  end
+
+  it "reports the whole match when the pattern has no group" do
+    with_store do |store|
+      dets = matches?(store, rule(kind: "regex", pattern: "internal-[a-z]+\\.corp"),
+        body: "host is internal-billing.corp today")
+      dets.first.evidence.should eq("internal-billing.corp")
+    end
+  end
+
+  # A string rule's match is byte-identical to its own pattern, which every surface already
+  # shows next to the rule, so reporting it again would be pure duplication.
+  it "reports no evidence for a string rule" do
+    with_store do |store|
+      dets = matches?(store, rule(kind: "string", pattern: "SECRET"), body: "a SECRET here")
+      dets.size.should eq(1)
+      dets.first.evidence.should be_nil
+    end
+  end
+
+  it "caps a greedy pattern so it cannot write a whole body into the issue row" do
+    with_store do |store|
+      dets = matches?(store, rule(kind: "regex", pattern: "A.*"), body: "A#{"z" * 500}")
+      ev = dets.first.evidence.not_nil!
+      ev.size.should be <= Gori::Probe::CustomRule::EVIDENCE_CAP + 1
+      ev.should end_with("…")
+    end
+  end
+
+  it "strips control bytes out of the captured text before it reaches storage or the TUI" do
+    with_store do |store|
+      bel = 7.chr
+      dets = matches?(store, rule(kind: "regex", pattern: "tag:(.+)"),
+        body: "tag:val#{bel}ue")
+      dets.first.evidence.should eq("val ue")
+    end
+  end
+
+  it "still degrades a bad pattern to no match instead of raising" do
+    with_store do |store|
+      matches?(store, rule(kind: "regex", pattern: "([unclosed"), body: "anything").should be_empty
+    end
+  end
+end

--- a/spec/probe_spec.cr
+++ b/spec/probe_spec.cr
@@ -4119,3 +4119,302 @@ describe "Gori::Probe::Triage" do
     end
   end
 end
+
+# The in-memory fold (`gori run probe`, MCP probe_scan) and the SQL upsert (TUI/capture) must
+# agree on which codes accumulate their evidence. They did not: Group kept its own three-code
+# copy of the list while Store's had grown to five, so a headless scan reported ONE of a host's
+# third-party hosts and dropped the rest. Both now read Store::ACCUMULATING_EVIDENCE_CODES.
+describe "Gori::Probe evidence accumulation (Group ↔ Store parity)" do
+  # Build N detections of one code on one host, each carrying a different evidence label.
+  private_labels = ->(code : String, labels : Array(String)) do
+    labels.map_with_index do |label, i|
+      Gori::Probe::Detection.new(code, "headers", "acme.test", "https://acme.test/#{i}",
+        "t", Gori::Store::Severity::Low, label)
+    end
+  end
+
+  it "accumulates missing_sri third-party hosts in a headless fold, not just the first" do
+    dets = private_labels.call("missing_sri", ["cdn.a.test", "cdn.b.test", "cdn.c.test"])
+    g = Gori::Probe.group(dets)
+    g.size.should eq(1)
+    ev = g.first.evidence.not_nil!
+    ev.should contain("cdn.a.test")
+    ev.should contain("cdn.b.test")
+    ev.should contain("cdn.c.test")
+  end
+
+  it "accumulates cookie names so a host with several unflagged cookies names them all" do
+    dets = private_labels.call("cookie_no_httponly", ["sid", "csrf", "pref"])
+    ev = Gori::Probe.group(dets).first.evidence.not_nil!
+    %w[sid csrf pref].each { |n| ev.should contain(n) }
+  end
+
+  it "folds evidence identically in memory and in the DB" do
+    with_store do |store|
+      dets = private_labels.call("missing_sri", ["cdn.a.test", "cdn.b.test"])
+      dets.each { |d| store.upsert_probe_issue(d) }
+      stored = store.probe_issues.find(&.code.==("missing_sri")).not_nil!
+      stored.evidence.should eq(Gori::Probe.group(dets).first.evidence)
+    end
+  end
+
+  it "keeps a first-wins sample for a code that is NOT in the accumulating set" do
+    dets = private_labels.call("weak_csp", ["first", "second"])
+    ev = Gori::Probe.group(dets).first.evidence.not_nil!
+    ev.should eq("first")
+  end
+
+  # merge_evidence dedups by splitting the stored string on ", ", so a per-cookie requirement
+  # list joined the same way would be torn into fragments that read as other cookies' evidence.
+  it "joins one cookie's unmet prefix requirements with ' + ' so the merge cannot split them" do
+    with_store do |store|
+      head = "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n" \
+             "Set-Cookie: __Host-sid=a; Domain=acme.test\r\n\r\n"
+      hit = analyze(store, resp_head: head).find(&.code.==("cookie_prefix_violation")).not_nil!
+      ev = hit.evidence.not_nil!
+      ev.should contain("Secure + Path=/ + no Domain")
+      # Two violating cookies on one host merge into two whole labels, not five fragments.
+      other = Gori::Probe::Detection.new("cookie_prefix_violation", "cookies", "acme.test",
+        "https://acme.test/2", "t", Gori::Store::Severity::Medium, "__Secure-tok: needs Secure")
+      merged = Gori::Probe.group([hit, other]).first.evidence.not_nil!
+      merged.split(", ").size.should eq(2)
+    end
+  end
+end
+
+# The tag-shaped HTML sink checks share their subject with Sri — the tags of one document — so
+# they must share its reach. They used to read the 64 KiB body_text while Sri read the 256 KiB
+# client_body_text, which on a large page reported the unhashed third-party script and stayed
+# silent about the cleartext one beside it.
+describe "Gori::Probe::Passive::BodyLeaks (HTML sinks reach the client body cap)" do
+  # An HTML document whose interesting tag sits PAST the 64 KiB body_text prefix but inside
+  # the 256 KiB client_body_text one.
+  padded = ->(tag : String) do
+    String.build do |io|
+      io << "<html><body>"
+      io << ("<p>filler filler filler</p>" * 4000) # ~104 KiB, past BODY_CAP
+      io << tag << "</body></html>"
+    end
+  end
+
+  it "finds active mixed content past the 64 KiB prefix" do
+    with_store do |store|
+      body = padded.call(%(<script src="http://cdn.acme.test/a.js"></script>))
+      body.bytesize.should be > Gori::Probe::Passive::Context::BODY_CAP
+      codes_of(analyze(store, resp_head: "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n",
+        body: body)).should contain("mixed_content")
+    end
+  end
+
+  it "finds an insecure form action past the 64 KiB prefix" do
+    with_store do |store|
+      codes_of(analyze(store, resp_head: "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n",
+        body: padded.call(%(<form action="http://acme.test/login">)))).should contain("insecure_form_action")
+    end
+  end
+
+  # The prefilters are ASCII case-INSENSITIVE byte scans; a case-sensitive includes? would have
+  # silently stopped matching the uppercase markup the /i regexes were written to catch.
+  it "still matches uppercase markup through the literal prefilters" do
+    with_store do |store|
+      found = codes_of(analyze(store, resp_head: "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n",
+        body: %(<A TARGET="_BLANK" HREF="/x">x</A><IMG SRC="HTTP://acme.test/i.png">)))
+      found.should contain("reverse_tabnabbing")
+      found.should contain("mixed_passive")
+    end
+  end
+end
+
+describe "Gori::Probe.cwe" do
+  # A CWE key that no rule emits is dead metadata nobody would ever notice — a typo'd code
+  # ("secret_in_urls") maps forever and shows up nowhere. REMEDIATION is the de-facto registry
+  # of emitted codes, so every CWE key must appear there.
+  it "maps only codes that findings actually carry" do
+    stray = Gori::Probe::CWE.keys.reject { |c| Gori::Probe::REMEDIATION.has_key?(c) }
+    stray.should be_empty
+  end
+
+  # The inverse: a documented code with no CWE must be one of the deliberate exclusions, so a
+  # newly added rule cannot quietly ship unclassified. Update this list ONLY with the reason.
+  it "leaves exactly the deliberately unmapped codes without a CWE" do
+    unmapped = Gori::Probe::REMEDIATION.keys.reject { |c| Gori::Probe::CWE.has_key?(c) }
+    # jwt_in_body/jwt_in_ws are Info notes on where tokens flow — handing the client its own
+    # token is the design, not a weakness (see Passive::Secrets::JWT).
+    unmapped.sort.should eq(["jwt_in_body", "jwt_in_ws"])
+  end
+
+  it "renders the canonical CWE-<id> identifier and name" do
+    Gori::Probe.cwe_id("dom_xss").should eq("CWE-79")
+    Gori::Probe.cwe_name("cookie_no_httponly").should eq("Sensitive Cookie Without 'HttpOnly' Flag")
+    Gori::Probe.cwe_id("tech_server").should be_nil
+    Gori::Probe.cwe_id("custom_p_1").should be_nil
+  end
+
+  it "emits cwe fields in the shared JSON shape, and omits them when unmapped" do
+    mapped = Gori::Probe::Detection.new("dom_xss", "client", "acme.test", "https://acme.test/",
+      "t", Gori::Store::Severity::Medium)
+    json = Gori::CLI::Output.probe_group_json(Gori::Probe.group([mapped]).first)
+    JSON.parse(json)["cwe"].as_s.should eq("CWE-79")
+    JSON.parse(json)["cwe_name"].as_s.should contain("Cross-site Scripting")
+
+    tech = Gori::Probe::Detection.new("tech_server", "tech", "acme.test", "https://acme.test/",
+      "t", Gori::Store::Severity::Info)
+    parsed = JSON.parse(Gori::CLI::Output.probe_group_json(Gori::Probe.group([tech]).first))
+    parsed.as_h.has_key?("cwe").should be_false
+    parsed.as_h.has_key?("cwe_name").should be_false
+  end
+end
+
+describe "Gori::Probe::Passive::Secrets (provider shapes)" do
+  private_hit = ->(s : String) do
+    Gori::Probe::Passive::Secrets::PATTERNS.select { |(re, _)| re.matches?(s) }.map { |(_, l)| l }
+  end
+
+  it "matches the added provider key shapes" do
+    private_hit.call("sk-ant-api03-#{"a" * 95}").should contain("Anthropic API key")
+    private_hit.call("sk-proj-#{"B" * 60}").should contain("OpenAI project key")
+    private_hit.call("xapp-1-A01BCDEFG-1234567890123-#{"0123456789abcdef" * 4}").should contain("Slack app-level token")
+    private_hit.call("shpat_#{"0" * 32}").should contain("Shopify access token")
+    private_hit.call("123456789:AA#{"F" * 33}").should contain("Telegram bot token")
+    private_hit.call("AccountKey=#{"A" * 86}==").should contain("Azure Storage account key")
+  end
+
+  it "flags a database URI carrying real inline credentials" do
+    private_hit.call("mongodb+srv://root:S3cretPassw0rd@cluster0.abcd.mongodb.net")
+      .should contain("database URI with inline credentials")
+  end
+
+  # The docs/tutorial shape is what a naive scheme://user:pass@host pattern would drown in:
+  # a placeholder password, a loopback host, or a reserved example domain.
+  it "does not flag a documentation-style connection string" do
+    ["postgres://user:pass@localhost:5432/dev",
+     "postgres://user:password@db.example.com/app",
+     "redis://admin:changeme@127.0.0.1:6379",
+     "our keys start with sk-ant- as a prefix"].each do |s|
+      private_hit.call(s).should be_empty
+    end
+  end
+
+  it "reaches the response body through BodyLeaks" do
+    with_store do |store|
+      body = %({"db":"postgres://svc:Hunter2Hunter2@db.internal.acme:5432/main"})
+      codes_of(analyze(store, resp_head: "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n",
+        content_type: "application/json", body: body)).should contain("secret_in_body")
+    end
+  end
+end
+
+describe "Gori::Probe::Passive::JsScan (navigation + parsing sinks)" do
+  private_pairs = ->(src : String) do
+    Gori::Probe::Passive::JsScan.source_sink_pairs(Gori::Probe::Passive::JsScan.strip(src))
+  end
+
+  # The window is searched as the two sides AROUND the sink, never across the sink's own text.
+  # Without that, `location.href =` (a sink) pairs with `location.href` (a source) matched in
+  # those very bytes, and every ordinary SPA redirect reports a DOM-XSS lead against itself.
+  it "does not pair a navigation sink with its own text" do
+    private_pairs.call(%(location.href = "/dashboard";)).should be_empty
+    private_pairs.call(%(window.location = "/login";)).should be_empty
+    private_pairs.call(%(if (location.href === x) { go(); })).should be_empty
+  end
+
+  it "pairs a navigation sink with a real taint source" do
+    private_pairs.call(%(location.href = document.referrer;)).should_not be_empty
+    private_pairs.call(%(location.replace(location.hash.slice(1));)).should_not be_empty
+    private_pairs.call(%(window.open(location.search, "_blank");)).should_not be_empty
+    private_pairs.call(%(window.open("/help", "_blank");)).should be_empty
+  end
+
+  it "pairs the HTML-parsing sinks" do
+    private_pairs.call(%(el.appendChild(r.createContextualFragment(location.hash));)).should_not be_empty
+    private_pairs.call(%(new DOMParser().parseFromString(document.URL, "text/html");)).should_not be_empty
+  end
+
+  # The split must not regress the sinks that predate it, including the one whose source sits
+  # INSIDE the sink's arguments (that source is on the POST side, which is still searched).
+  it "keeps the pre-existing pairs" do
+    private_pairs.call(%(o.innerHTML = location.hash;)).should_not be_empty
+    private_pairs.call(%(document.write(document.URL);)).should_not be_empty
+    private_pairs.call(%(o.innerHTML = "<b>static</b>";)).should be_empty
+  end
+end
+
+describe Gori::Probe::Passive::ExposedConfig do
+  private_plain = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\n"
+  private_html = "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n"
+
+  it "flags a served .git/config" do
+    with_store do |store|
+      body = "[core]\n\trepositoryformatversion = 0\n\tbare = false\n[remote \"origin\"]\n\turl = git@github.com:acme/app.git\n"
+      dets = analyze(store, resp_head: private_plain, content_type: "text/plain", body: body)
+      hit = dets.find(&.code.==("exposed_config")).not_nil!
+      hit.evidence.should eq(".git/config")
+      hit.severity.should eq(Gori::Store::Severity::High)
+    end
+  end
+
+  it "flags a served .env but not an HTML page documenting the same keys" do
+    with_store do |store|
+      env = "APP_ENV=production\nDB_PASSWORD=s3cr3t-value\nMAIL_PASSWORD=hunter2\n"
+      codes_of(analyze(store, resp_head: private_plain, content_type: "text/plain", body: env))
+        .should contain("exposed_config")
+      # The same key names inside a deployment guide are documentation, not the file.
+      doc = "<html><body><pre>DB_PASSWORD=your-password-here</pre><p>Set these in .env</p></body></html>"
+      codes_of(analyze(store, resp_head: private_html, content_type: "text/html", body: doc))
+        .should_not contain("exposed_config")
+    end
+  end
+
+  it "flags phpinfo(), .htpasswd, wp-config credentials, and actuator env" do
+    with_store do |store|
+      [
+        {"<html><head><title>phpinfo()</title></head><body>PHP Version 8.2.1</body></html>", "text/html", "phpinfo() output"},
+        {"admin:$apr1$abcd1234$0123456789abcdefghijkl\n", "text/plain", ".htpasswd credentials"},
+        {"<?php define('DB_PASSWORD', 'p4ssw0rd'); ?>", "text/plain", "wp-config.php credentials"},
+        {"{\"activeProfiles\":[\"prod\"],\"propertySources\":[{\"name\":\"systemEnvironment\"}]}",
+         "application/json", "Spring actuator env"},
+      ].each do |(body, ct, label)|
+        head = "HTTP/1.1 200 OK\r\nContent-Type: #{ct}\r\n\r\n"
+        hit = analyze(store, resp_head: head, content_type: ct, body: body).find(&.code.==("exposed_config"))
+        hit.not_nil!.evidence.should eq(label)
+      end
+    end
+  end
+
+  # The FP that actually matters: a page that TALKS ABOUT the artifact. Each signature is
+  # anchored on the artifact's own structure, so prose naming it must not match.
+  it "does not flag documentation that merely names these artifacts" do
+    with_store do |store|
+      [
+        "Run phpinfo() to inspect your build; see the phpinfo() docs for details.",
+        "Edit the [core] section of your repository configuration to set autocrlf.",
+        "Generate a .htpasswd with htpasswd -c, then point AuthUserFile at it.",
+        "The propertySources concept in Spring lets you layer configuration.",
+      ].each do |prose|
+        codes_of(analyze(store, resp_head: private_html, content_type: "text/html", body: prose))
+          .should_not contain("exposed_config")
+      end
+    end
+  end
+
+  it "ignores a non-2xx page that echoes the requested path" do
+    with_store do |store|
+      body = "[core]\n\trepositoryformatversion = 0\n"
+      codes_of(analyze(store, resp_head: "HTTP/1.1 404 Not Found\r\nContent-Type: text/plain\r\n\r\n",
+        content_type: "text/plain", body: body, status: 404)).should_not contain("exposed_config")
+    end
+  end
+
+  it "accumulates every artifact a host serves rather than pinning to the first" do
+    with_store do |store|
+      git = analyze(store, resp_head: private_plain, content_type: "text/plain",
+        target: "/.git/config", body: "[core]\n\trepositoryformatversion = 0\n")
+      env = analyze(store, resp_head: private_plain, content_type: "text/plain",
+        target: "/.env", body: "DB_PASSWORD=s3cr3t-value\n")
+      (git + env).each { |d| store.upsert_probe_issue(d) }
+      ev = store.probe_issues.find(&.code.==("exposed_config")).not_nil!.evidence.not_nil!
+      ev.should contain(".git/config")
+      ev.should contain(".env file")
+    end
+  end
+end

--- a/src/gori/cli/output.cr
+++ b/src/gori/cli/output.cr
@@ -400,14 +400,22 @@ module Gori
         Probe.group_json(j, g) # shared field shape (also used by the MCP probe_scan tool)
       end
 
-      # "[high]      secret_in_url             api.test   ×3   token"
+      # "[high]      secret_in_url             api.test   ×3   CWE-598   token"
       # plus an indented representative affected URL ("(+N more)" when capped).
+      #
+      # The CWE goes BEFORE the evidence, not after: evidence is the one variable-width field
+      # here (an accumulating code's is a whole ", "-joined list), so appending after it would
+      # push the id off the right of a terminal on exactly the findings that have the most to
+      # say. An unmapped code (tech_*, jwt_in_*, custom_*) contributes nothing — see Probe::CWE.
       def self.probe_group_text(g : Probe::Group) : String
         String.build do |io|
           io << "[#{g.severity.label}]".ljust(11)
           io << g.code.ljust(28)
           io << "  " << term_safe(g.host)
           io << "  ×" << g.hit_count
+          if cwe = Probe.cwe_id(g.code)
+            io << "  " << cwe
+          end
           if ev = g.evidence
             io << "  " << term_safe(ev)
           end
@@ -425,8 +433,9 @@ module Gori
         JSON.build { |j| j.array { issues.each { |i| Probe.issue_json(j, i) } } }
       end
 
-      # "12   [high]      secret_in_url   api.test   ×3   open   token"
-      # Leads with the id, because every triage subcommand addresses a finding by it.
+      # "12   [high]      secret_in_url   api.test   ×3   open   CWE-598   token"
+      # Leads with the id, because every triage subcommand addresses a finding by it. CWE sits
+      # ahead of the variable-width evidence for the same reason as probe_group_text.
       def self.probe_issue_text(i : Store::ProbeIssue) : String
         String.build do |io|
           io << i.id.to_s.ljust(5)
@@ -435,6 +444,9 @@ module Gori
           io << "  " << term_safe(i.host)
           io << "  ×" << i.hit_count
           io << "  " << i.status.label
+          if cwe = Probe.cwe_id(i.code)
+            io << "  " << cwe
+          end
           if ev = i.evidence
             io << "  " << term_safe(ev)
           end

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -657,7 +657,9 @@ module Gori
             "hard-block). Returns " \
             "{flows_scanned, repeaters_scanned, issue_count, issues:[{code, category, host, " \
             "title, severity, hit_count, affected, affected_count, evidence, sample_flow_id, " \
-            "sample_repeater_id, remediation}]}, highest-severity first. Writes nothing." do |s|
+            "sample_repeater_id, remediation, cwe, cwe_name}]}, highest-severity first. " \
+            "`cwe`/`cwe_name` are OMITTED for a code with no meaningful CWE — a technology " \
+            "fingerprint, an informational jwt_in_* note, or a custom rule. Writes nothing." do |s|
             s.field "query", strprop("gori QL filter applied to History flows only; empty scans all (Repeater tabs are always scanned)")
             s.field "active", boolprop("also run active checks that SEND probe requests (default false = passive, request-free); requires write access + a configured scope")
             s.field "severity", strprop("only return issues at/above this level (info|low|medium|high|critical)")

--- a/src/gori/probe/custom_rule.cr
+++ b/src/gori/probe/custom_rule.cr
@@ -60,9 +60,10 @@ module Gori
         return if pattern.empty?
         text = region_text(ctx)
         return if text.nil? || text.empty?
-        return unless matches?(text)
+        hit, evidence = match_evidence(text)
+        return unless hit
         acc << Detection.new(code, Category::CUSTOM, ctx.host, ctx.url, title, severity,
-          evidence: nil, flow_id: ctx.fid)
+          evidence: evidence, flow_id: ctx.fid)
       end
 
       # The scrubbed text for this rule's side × region (nil when that region is absent, e.g. a
@@ -89,16 +90,42 @@ module Gori
         "#{head}\r\n#{body}"
       end
 
-      # Byte-safe match: text is pre-scrubbed; a bad user regex (compile raise) degrades to no
-      # match rather than dropping the whole flow's detections.
-      private def matches?(text : String) : Bool
+      # Byte-safe match returning {matched?, evidence}. Text is pre-scrubbed; a bad user regex
+      # (compile raise) degrades to no match rather than dropping the whole flow's detections.
+      #
+      # A regex rule now REPORTS WHAT IT MATCHED. Every custom finding used to store
+      # `evidence: nil`, so the Probe detail pane, `gori run probe`, and the MCP tools could all
+      # say a rule fired on a host but not what tripped it — the operator had to re-run the
+      # pattern by hand against the sample flow to find out. Capture group 1 wins when the
+      # pattern defines one (that is how you say "report THIS part" — the id out of a URL, the
+      # version out of a banner); otherwise the whole match is reported.
+      #
+      # A STRING rule reports nothing, deliberately: its match is byte-identical to its own
+      # `pattern`, which every surface already shows next to the rule, so the field would be
+      # pure duplication.
+      private def match_evidence(text : String) : {Bool, String?}
         if kind == "regex"
-          SafeRegexp.compile(pattern).matches?(text)
+          m = SafeRegexp.compile(pattern).match(text)
+          return {false, nil} unless m
+          {true, safe_evidence(m[1]? || m[0])}
         else
-          text.includes?(pattern)
+          {text.includes?(pattern), nil}
         end
       rescue
-        false
+        {false, nil}
+      end
+
+      # The captured text is CONTENT — server bytes, or the operator's own traffic — landing in
+      # a stored row and in the TUI, so it gets the same treatment every other rule gives
+      # content-derived evidence (cf. Passive::Sri#safe_host, SourceMap#safe_ref): printable
+      # ASCII only, and capped. The cap also keeps a greedy user pattern (`.*`) from writing a
+      # whole 64 KiB body into the issue row.
+      EVIDENCE_CAP = 120
+
+      private def safe_evidence(raw : String) : String?
+        cleaned = raw.scrub.gsub(/[^\x20-\x7e]/, " ").strip
+        return nil if cleaned.empty?
+        cleaned.size > EVIDENCE_CAP ? "#{cleaned[0, EVIDENCE_CAP]}…" : cleaned
       end
     end
 

--- a/src/gori/probe/group.cr
+++ b/src/gori/probe/group.cr
@@ -47,10 +47,13 @@ module Gori
           # shows a lower-severity title (reflected_param: non-HTML Low vs HTML Medium). A
           # fixed-title code is unaffected.
           title = d.severity.value > g.severity.value ? d.title : g.title
-          # Type-labeled infoleak codes accumulate every distinct type seen (so a body
-          # or host leaking several secret/error types surfaces them all); others keep
-          # the first representative sample. Mirrors Store#upsert_probe_issue.
-          evidence = accumulate_evidence?(d.code) ? merge_evidence(g.evidence, d.evidence) : (g.evidence || d.evidence)
+          # Type-labeled codes accumulate every distinct label seen (so a host leaking several
+          # secret/error types, or shipping several unflagged cookies, surfaces them all);
+          # others keep the first representative sample. Both the decision and the merge come
+          # from Store so this in-memory fold and the SQL upsert CANNOT drift — they did once,
+          # when missing_sri/jwt_sensitive_claims were added to Store's list and not to a copy
+          # that used to live here, which made a headless scan report one third-party host.
+          evidence = Store.accumulate_evidence?(d.code) ? Store.merge_evidence(g.evidence, d.evidence) : (g.evidence || d.evidence)
           acc[key] = Group.new(g.code, g.category, g.host, title, sev, g.hit_count + 1,
             urls, evidence, g.sample_flow_id, g.sample_repeater_id)
         else
@@ -59,19 +62,6 @@ module Gori
         end
       end
       finish_group_sort(acc)
-    end
-
-    # Codes whose evidence is a TYPE label (not a one-off sample) — see Store.
-    private def self.accumulate_evidence?(code : String) : Bool
-      code == "secret_in_body" || code == "error_stack_leak" || code == "secret_in_ws"
-    end
-
-    private def self.merge_evidence(existing : String?, incoming : String?) : String?
-      return existing if incoming.nil? || incoming.empty?
-      return incoming if existing.nil? || existing.empty?
-      parts = existing.split(", ").map(&.strip).reject(&.empty?)
-      return existing if parts.includes?(incoming) || parts.size >= Store::PROBE_EVIDENCE_CAP
-      (parts << incoming).join(", ")
     end
 
     private def self.finish_group_sort(acc : Hash({String, String}, Group)) : Array(Group)
@@ -105,7 +95,18 @@ module Gori
         j.field "first_seen", i.first_seen
         j.field "last_seen", i.last_seen
         j.field "remediation", Probe.remediation(i.code)
+        cwe_fields(j, i.code)
       end
+    end
+
+    # `cwe`/`cwe_name`, emitted only for a code that HAS a mapping. Absent rather than null:
+    # tech fingerprints, the informational jwt_in_* notes, and custom rules are unmapped on
+    # purpose (see Probe::CWE), and a null would read as "we tried and failed to classify it".
+    private def self.cwe_fields(j : JSON::Builder, code : String) : Nil
+      return unless entry = Probe.cwe(code)
+      id, name = entry
+      j.field "cwe", "CWE-#{id}"
+      j.field "cwe_name", name
     end
 
     # The canonical JSON object for one grouped issue — the single source of the field shape
@@ -125,6 +126,7 @@ module Gori
         j.field "sample_flow_id", g.sample_flow_id
         j.field "sample_repeater_id", g.sample_repeater_id
         j.field "remediation", Probe.remediation(g.code)
+        cwe_fields(j, g.code)
       end
     end
   end

--- a/src/gori/probe/issue.cr
+++ b/src/gori/probe/issue.cr
@@ -157,6 +157,7 @@ module Gori
       "jwt_sensitive_claims"           => "JWT payloads are base64url, not encrypted — anything in them is readable by the client and by anyone who sees the token. Keep roles/permissions and personal data server-side (or in an encrypted JWE) and reference them by an opaque subject id.",
       "sourcemap_exposed"              => "The script points at its source map, from which the original, unminified sources are reconstructable. Stop deploying .map files to production (or serve them only to authenticated/internal clients) and drop the sourceMappingURL comment from production builds.",
       "missing_sri"                    => "A cross-origin script/stylesheet is loaded with no integrity hash, so whoever controls that third party controls this page. Add integrity=\"sha384-…\" plus crossorigin=\"anonymous\", pin the exact version, or self-host the asset.",
+      "exposed_config"                 => "A server-side configuration or diagnostic artifact is being served to clients (the evidence names which). Remove it from the web root or block it at the edge, then treat every credential it contained as compromised and rotate it: a readable .env / wp-config / .htpasswd hands over live secrets outright, a .git/config lets the whole repository be reconstructed, and phpinfo() / Spring actuator env expose paths, versions, and environment variables that make every other attack cheaper. Deny dotfiles and VCS directories at the reverse proxy rather than relying on the application not to route them.",
       "directory_listing"              => "The server auto-generated a directory index, enumerating every file in it (backups, editor leftovers, old releases). Turn the listing off (Apache `Options -Indexes`, nginx `autoindex off;`) and add an index file where a directory must stay browsable.",
       "dom_xss"                        => "A DOM taint source reaches an execution sink in one statement — review and sanitize: assign text via textContent, build nodes with the DOM API, or run untrusted HTML through a sanitizer (DOMPurify) before it touches innerHTML/write/eval. Heuristic; confirm the data path in a browser.",
       "dom_clobbering"                 => "Don't trust globals that HTML id/name attributes can define: declare variables with let/const, look elements up defensively, and avoid the window.X = window.X || … fallback. A strict CSP and sanitizing injected markup (dropping id/name) also mitigate clobbering.",
@@ -174,6 +175,112 @@ module Gori
 
     def self.remediation(code : String) : String
       REMEDIATION[code]? || (code.starts_with?("tech_") ? TECH_REMEDIATION : "")
+    end
+
+    # The CWE each finding code maps to: {numeric id, CWE name}. This is the vocabulary every
+    # downstream consumer already speaks — a report template, a Jira field, a scanner-comparison
+    # spreadsheet, an agent asked "does this codebase have any CWE-79" — and gori was the only
+    # part of that chain that could not answer it.
+    #
+    # One CWE per code, chosen as the weakness the finding IS rather than the attack it enables:
+    # `missing_hsts` is cleartext transmission (319), not "clickjacking"; `cookie_no_httponly` has
+    # its own precise entry (1004) and does not get filed under a generic 200. Where CWE genuinely
+    # has no better entry than the abstract "a protection mechanism is absent or ineffective",
+    # 693 is used deliberately rather than forcing a specific-sounding but wrong id.
+    #
+    # DELIBERATELY UNMAPPED, and not an oversight:
+    #   * `tech_*` — a fingerprint is a project fact, not a weakness; there is nothing to file.
+    #   * `jwt_in_body` / `jwt_in_ws` — Info notes on where tokens flow. Handing the client its
+    #     own token is the design (see Secrets::JWT), so stamping a CWE on it would re-create the
+    #     exact "a High that fires everywhere" problem splitting these codes out was meant to fix.
+    #   * `custom_*` — the operator's own rule; only they know what it means.
+    # `cwe` returns nil for these, and every surface omits the field rather than inventing one.
+    CWE = {
+      # --- transport / headers -----------------------------------------------------------
+      "missing_hsts"                   => {319, "Cleartext Transmission of Sensitive Information"},
+      "short_hsts"                     => {319, "Cleartext Transmission of Sensitive Information"},
+      "insecure_basic_auth"            => {319, "Cleartext Transmission of Sensitive Information"},
+      "mixed_content"                  => {319, "Cleartext Transmission of Sensitive Information"},
+      "mixed_passive"                  => {319, "Cleartext Transmission of Sensitive Information"},
+      "insecure_form_action"           => {319, "Cleartext Transmission of Sensitive Information"},
+      "missing_csp"                    => {693, "Protection Mechanism Failure"},
+      "csp_report_only"                => {693, "Protection Mechanism Failure"},
+      "weak_csp"                       => {693, "Protection Mechanism Failure"},
+      "missing_x_content_type_options" => {693, "Protection Mechanism Failure"},
+      "missing_permissions_policy"     => {693, "Protection Mechanism Failure"},
+      "weak_permissions_policy"        => {693, "Protection Mechanism Failure"},
+      "missing_x_frame_options"        => {1021, "Improper Restriction of Rendered UI Layers or Frames"},
+      "missing_referrer_policy"        => {200, "Exposure of Sensitive Information to an Unauthorized Actor"},
+      "weak_referrer_policy"           => {200, "Exposure of Sensitive Information to an Unauthorized Actor"},
+      "cacheable_json"                 => {524, "Use of Cache Containing Sensitive Information"},
+      # --- cookies -----------------------------------------------------------------------
+      "cookie_no_secure"              => {614, "Sensitive Cookie in HTTPS Session Without 'Secure' Attribute"},
+      "cookie_no_httponly"            => {1004, "Sensitive Cookie Without 'HttpOnly' Flag"},
+      "cookie_no_samesite"            => {1275, "Sensitive Cookie with Improper SameSite Attribute"},
+      "cookie_samesite_none_insecure" => {1275, "Sensitive Cookie with Improper SameSite Attribute"},
+      "cookie_prefix_violation"       => {693, "Protection Mechanism Failure"},
+      # --- CORS / origin -----------------------------------------------------------------
+      "cors_wildcard"          => {942, "Permissive Cross-domain Policy with Untrusted Domains"},
+      "cors_null_origin"       => {942, "Permissive Cross-domain Policy with Untrusted Domains"},
+      "cors_reflected_origin"  => {942, "Permissive Cross-domain Policy with Untrusted Domains"},
+      "cors_arbitrary_origin"  => {942, "Permissive Cross-domain Policy with Untrusted Domains"},
+      "postmessage_no_origin"  => {346, "Origin Validation Error"},
+      "document_domain_set"    => {346, "Origin Validation Error"},
+      "postmessage_wildcard"   => {200, "Exposure of Sensitive Information to an Unauthorized Actor"},
+      # --- information disclosure --------------------------------------------------------
+      "private_ip_leak"      => {200, "Exposure of Sensitive Information to an Unauthorized Actor"},
+      "secret_in_body"       => {200, "Exposure of Sensitive Information to an Unauthorized Actor"},
+      "secret_in_ws"         => {200, "Exposure of Sensitive Information to an Unauthorized Actor"},
+      "graphql_introspection" => {200, "Exposure of Sensitive Information to an Unauthorized Actor"},
+      "jwt_sensitive_claims"  => {200, "Exposure of Sensitive Information to an Unauthorized Actor"},
+      "error_stack_leak"      => {209, "Generation of Error Message Containing Sensitive Information"},
+      "secret_in_url"         => {598, "Use of GET Request Method With Sensitive Query Strings"},
+      "sourcemap_exposed"     => {540, "Inclusion of Sensitive Information in Source Code"},
+      "directory_listing"     => {548, "Exposure of Information Through Directory Listing"},
+      "exposed_config"        => {538, "Insertion of Sensitive Information into Externally-Accessible File or Directory"},
+      # --- client-side execution ---------------------------------------------------------
+      "reflected_param"           => {79, "Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"},
+      "dom_xss"                   => {79, "Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"},
+      "inline_js_uri"             => {79, "Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"},
+      "prototype_pollution"       => {1321, "Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution')"},
+      "prototype_pollution_param" => {1321, "Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution')"},
+      "dom_clobbering"            => {913, "Improper Control of Dynamically-Managed Code Resources"},
+      "reverse_tabnabbing"        => {1022, "Use of Web Link to Untrusted Target with window.opener Access"},
+      "missing_sri"               => {494, "Download of Code Without Integrity Check"},
+      # --- injection / traversal ---------------------------------------------------------
+      "lfi_param_traversal"  => {22, "Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')"},
+      "nginx_alias_traversal" => {22, "Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')"},
+      "open_redirect"         => {601, "URL Redirection to Untrusted Site ('Open Redirect')"},
+      "crlf_injection"        => {113, "Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Request/Response Splitting')"},
+      "ssti"                  => {1336, "Improper Neutralization of Special Elements Used in a Template Engine"},
+      "backslash_powered"     => {20, "Improper Input Validation"},
+      "host_header_injection" => {20, "Improper Input Validation"},
+      "request_smuggling_clte" => {444, "Inconsistent Interpretation of HTTP Requests ('HTTP Request/Response Smuggling')"},
+      "request_smuggling_tecl" => {444, "Inconsistent Interpretation of HTTP Requests ('HTTP Request/Response Smuggling')"},
+      "request_smuggling_tete" => {444, "Inconsistent Interpretation of HTTP Requests ('HTTP Request/Response Smuggling')"},
+      # --- authn / authz / crypto --------------------------------------------------------
+      "forbidden_bypass"          => {290, "Authentication Bypass by Spoofing"},
+      "path_normalization_bypass" => {288, "Authentication Bypass Using an Alternate Path or Channel"},
+      "url_rewrite_bypass"        => {288, "Authentication Bypass Using an Alternate Path or Channel"},
+      "nextjs_action_no_auth"     => {306, "Missing Authentication for Critical Function"},
+      "jwt_alg_none"              => {347, "Improper Verification of Cryptographic Signature"},
+      "jwt_weak_alg"              => {327, "Use of a Broken or Risky Cryptographic Algorithm"},
+      "jwt_no_expiry"             => {613, "Insufficient Session Expiration"},
+    }
+
+    # {id, name} for a finding code, or nil when the code is deliberately unmapped (see CWE).
+    def self.cwe(code : String) : {Int32, String}?
+      CWE[code]?
+    end
+
+    # The canonical "CWE-79" identifier for a finding code, or nil. This is the string every
+    # surface prints and every export field carries, so the "CWE-" prefix is spelled ONCE.
+    def self.cwe_id(code : String) : String?
+      CWE[code]?.try { |(id, _)| "CWE-#{id}" }
+    end
+
+    def self.cwe_name(code : String) : String?
+      CWE[code]?.try { |(_, name)| name }
     end
 
     # Codes whose product name is fixed (protocol/framework identity, not carried in a value).

--- a/src/gori/probe/issue.cr
+++ b/src/gori/probe/issue.cr
@@ -263,6 +263,7 @@ module Gori
       "path_normalization_bypass" => {288, "Authentication Bypass Using an Alternate Path or Channel"},
       "url_rewrite_bypass"        => {288, "Authentication Bypass Using an Alternate Path or Channel"},
       "nextjs_action_no_auth"     => {306, "Missing Authentication for Critical Function"},
+      "ssrf_oast"                 => {918, "Server-Side Request Forgery (SSRF)"},
       "jwt_alg_none"              => {347, "Improper Verification of Cryptographic Signature"},
       "jwt_weak_alg"              => {327, "Use of a Broken or Risky Cryptographic Algorithm"},
       "jwt_no_expiry"             => {613, "Insufficient Session Expiration"},

--- a/src/gori/probe/passive.cr
+++ b/src/gori/probe/passive.cr
@@ -14,6 +14,7 @@ require "./passive/jwt"
 require "./passive/sourcemap"
 require "./passive/sri"
 require "./passive/directory_listing"
+require "./passive/exposed_config"
 require "./passive/ws_payloads"
 require "./passive/secrets"
 require "./passive/js_scan"
@@ -47,6 +48,7 @@ module Gori
         SourceMap.new,
         Sri.new,
         DirectoryListing.new,
+        ExposedConfig.new,
         WsPayloads.new,
         DomXss.new,
         DomClobbering.new,

--- a/src/gori/probe/passive/body_leaks.cr
+++ b/src/gori/probe/passive/body_leaks.cr
@@ -1,5 +1,6 @@
 require "./rule"
 require "./secrets"
+require "../../ascii_bytes"
 
 module Gori
   module Probe
@@ -93,6 +94,17 @@ module Gori
         # safe — a guaranteed false positive on any uppercase markup.
         REL_NOOPENER = /\bno(?:opener|referrer)\b/i
 
+        # Allocation-free literal prefilters for the HTML sink checks, one per group, each a
+        # NECESSARY condition of every regex it guards: the five mixed-content/insecure-form
+        # patterns all end in `http://`, INLINE_JS_URI contains `javascript:`, and ANCHOR_BLANK
+        # contains `_blank`. All those regexes are /i, so the tests are ASCII case-INSENSITIVE
+        # byte scans (AsciiBytes wants an already-lowercase needle) — a case-sensitive
+        # `String#includes?` would have quietly stopped matching `HTTP://` and `_BLANK`.
+        # Held as constants so the slices are built once for the process, not per flow.
+        private HTTP_NEEDLE   = "http://".to_slice
+        private JS_URI_NEEDLE = "javascript:".to_slice
+        private BLANK_NEEDLE  = "_blank".to_slice
+
         def check(ctx : Context, acc : Array(Detection)) : Nil
           return unless ctx.response
           return unless texty?(ctx.content_type)
@@ -133,32 +145,55 @@ module Gori
           # client its own token is the normal design, not a disclosure (see Secrets::JWT).
           acc << leak(ctx, "jwt_in_body", "JSON Web Token in a response body",
             Store::Severity::Info, nil) if Secrets::JWT[0].matches?(text)
-          check_html_sinks(ctx, acc, text) if ctx.html?
+          # The tag-shaped checks read the LARGER prefix (client_body_text, CLIENT_BODY_CAP) —
+          # see check_html_sinks. It is nil only when the body is empty, which `text` above has
+          # already ruled out for this branch, so the fallback is belt-and-braces.
+          check_html_sinks(ctx, acc, ctx.client_body_text || text) if ctx.html?
         end
 
         # HTML-only client-side sink checks: mixed content (active/passive), insecure form
         # actions, javascript: URLs, and reverse-tabnabbing links. Split out of check so each
         # method stays under the complexity budget.
+        #
+        # These read `client_body_text` (CLIENT_BODY_CAP, 256 KiB), NOT the 64 KiB `body_text`
+        # the leak scans above use. A tag is a tag wherever it sits in the document, and the
+        # sibling rule that walks the very same tags — Sri — has always read the larger prefix:
+        # on a 120 KiB page that split reported the unhashed third-party <script> and stayed
+        # silent about the plain-http one beside it. The larger text costs no extra decode (it
+        # is one slice of the same shared buffer, already materialised for every HTML flow by
+        # the client-side rules), so only the SCAN grows — and each check now gates on an
+        # allocation-free literal first, which more than pays that back on a clean page.
+        #
+        # The leak scans (private IP / error / secret) deliberately stay on the 64 KiB prefix:
+        # that is the shared BODY_CAP every non-client rule works from, and widening a content
+        # scan is a different, measurable trade from widening a tag scan.
         private def check_html_sinks(ctx : Context, acc : Array(Detection), text : String) : Nil
-          if ctx.scheme == "https"
-            if MIXED_ACTIVE.matches?(text) || MIXED_ACTIVE_LINK.matches?(text) || MIXED_ACTIVE_OBJECT.matches?(text)
-              acc << Detection.new("mixed_content", Category::HEADERS, ctx.host, ctx.url,
-                "Active mixed content (http:// sub-resource on an HTTPS page)", Store::Severity::Low, nil, ctx.fid)
-            end
-            if MIXED_PASSIVE.matches?(text)
-              acc << Detection.new("mixed_passive", Category::HEADERS, ctx.host, ctx.url,
-                "Passive mixed content (http:// image/media on an HTTPS page)", Store::Severity::Info, nil, ctx.fid)
-            end
-            if INSECURE_FORM.matches?(text)
-              acc << Detection.new("insecure_form_action", Category::HEADERS, ctx.host, ctx.url,
-                "Form on an HTTPS page submits over cleartext http://", Store::Severity::Medium, nil, ctx.fid)
-            end
-          end
-          if INLINE_JS_URI.matches?(text)
+          bytes = text.to_slice
+          check_mixed_content(ctx, acc, text) if ctx.scheme == "https" &&
+                                                 AsciiBytes.contains_ci?(bytes, HTTP_NEEDLE)
+          if AsciiBytes.contains_ci?(bytes, JS_URI_NEEDLE) && INLINE_JS_URI.matches?(text)
             acc << Detection.new("inline_js_uri", Category::CLIENT, ctx.host, ctx.url,
               "javascript: URL in an HTML attribute", Store::Severity::Low, nil, ctx.fid)
           end
-          flag_reverse_tabnabbing(ctx, acc, text)
+          flag_reverse_tabnabbing(ctx, acc, text) if AsciiBytes.contains_ci?(bytes, BLANK_NEEDLE)
+        end
+
+        # The three cleartext-subresource findings on an HTTPS page. Reached only once the
+        # `http://` prefilter has passed, so a page with no cleartext URL at all pays one byte
+        # scan instead of five PCRE passes.
+        private def check_mixed_content(ctx : Context, acc : Array(Detection), text : String) : Nil
+          if MIXED_ACTIVE.matches?(text) || MIXED_ACTIVE_LINK.matches?(text) || MIXED_ACTIVE_OBJECT.matches?(text)
+            acc << Detection.new("mixed_content", Category::HEADERS, ctx.host, ctx.url,
+              "Active mixed content (http:// sub-resource on an HTTPS page)", Store::Severity::Low, nil, ctx.fid)
+          end
+          if MIXED_PASSIVE.matches?(text)
+            acc << Detection.new("mixed_passive", Category::HEADERS, ctx.host, ctx.url,
+              "Passive mixed content (http:// image/media on an HTTPS page)", Store::Severity::Info, nil, ctx.fid)
+          end
+          if INSECURE_FORM.matches?(text)
+            acc << Detection.new("insecure_form_action", Category::HEADERS, ctx.host, ctx.url,
+              "Form on an HTTPS page submits over cleartext http://", Store::Severity::Medium, nil, ctx.fid)
+          end
         end
 
         # A target="_blank" anchor with no rel=noopener/noreferrer lets the opened page repoint

--- a/src/gori/probe/passive/cookies.cr
+++ b/src/gori/probe/passive/cookies.cr
@@ -112,9 +112,14 @@ module Gori
           end
         end
 
+        # The unmet requirements are joined with " + ", NOT ", ": every cookie code accumulates
+        # its evidence across a (code, host) group, and that merge splits the stored string on
+        # ", " to dedup (Store.merge_evidence). A ", "-joined requirement list would be torn into
+        # bogus fragments ("Path=/" as if it were another cookie's evidence), so the separator
+        # inside one cookie's label has to be something the merge does not split on.
         private def emit_prefix(ctx : Context, name : String, missing : Array(String), acc : Array(Detection)) : Nil
           acc << cookie(ctx, "cookie_prefix_violation", "Cookie violates its #{name.starts_with?(HOST_PREFIX) ? "__Host-" : "__Secure-"} prefix rules",
-            Store::Severity::Medium, "#{name}: needs #{missing.join(", ")}")
+            Store::Severity::Medium, "#{name}: needs #{missing.join(" + ")}")
         end
 
         private def cookie(ctx : Context, code : String, title : String, sev : Store::Severity, name : String) : Detection

--- a/src/gori/probe/passive/exposed_config.cr
+++ b/src/gori/probe/passive/exposed_config.cr
@@ -1,0 +1,139 @@
+require "./rule"
+
+module Gori
+  module Probe
+    module Passive
+      # Server-side configuration and diagnostic artifacts served to the client (category
+      # "infoleak"). These are not "a secret happened to appear in a page" — the sibling
+      # `secret_in_body` rule covers that. This is the whole FILE being readable: a deployed
+      # `.env`, a `.git/config`, a `phpinfo()` page, an `.htpasswd`, a Spring `/actuator/env`.
+      # One of these is usually the shortest path from recon to credentials, and every one of
+      # them is a deployment mistake rather than a code bug, so the finding is actionable on
+      # its own.
+      #
+      # PRECISION over recall, deliberately. Every signature is anchored on the exact structural
+      # shape the artifact has — `[core]` immediately followed by `repositoryformatversion`, a
+      # `<title>phpinfo()</title>`, an Apache MD5 crypt hash — never on a keyword that a page
+      # ABOUT the artifact would also carry. The FP that matters here is a tutorial, a docs
+      # site, or a config reference showing the same text, and that is what the two-marker /
+      # structural anchoring (the `directory_listing` pattern) is for.
+      #
+      # Every signature is prefiltered by an allocation-free literal, so a body that cannot
+      # match is rejected without ever entering PCRE — this rule scans the body of every
+      # texty 2xx response.
+      class ExposedConfig < Rule
+        def info : RuleInfo
+          RuleInfo.new("exposed_config", "Exposed configuration files",
+            "Detects server configuration and diagnostic artifacts served to clients: .env, " \
+            ".git/config, phpinfo(), .htpasswd, wp-config credentials, and Spring actuator env.",
+            Category::INFOLEAK)
+        end
+
+        # {literal prefilter, confirming pattern, evidence label, severity}.
+        #
+        # The prefilter must be a NECESSARY condition of the pattern beside it, and is matched
+        # case-sensitively where the artifact's own casing is fixed (`[core]`, `phpinfo()`,
+        # SCREAMING_SNAKE env keys all are).
+        SIGNATURES = [
+          # A `.git/config`: the `[core]` section header is immediately followed by the
+          # repository format version. A prose mention of "[core]" cannot produce that pair.
+          {"repositoryformatversion",
+           /\[core\][^\[]{0,80}repositoryformatversion\s*=/,
+           ".git/config", Store::Severity::High},
+          # phpinfo() output. The <title> is emitted by the function itself and is not something
+          # a page merely DISCUSSING phpinfo would carry; the PHP Version table row confirms it.
+          {"phpinfo()",
+           /<title>phpinfo\(\)<\/title>/i,
+           "phpinfo() output", Store::Severity::Medium},
+          # An Apache/nginx password file: `user:$apr1$…` (or bcrypt / SHA-512 crypt). The hash
+          # prefix is the anchor — a bare `user:password` line would match nothing here.
+          # The prefilter is `:$`, the adjacency the pattern requires, NOT a bare `$`: a lone
+          # dollar sign is in every jQuery-shaped body on the web and would filter nothing,
+          # leaving the regex (whose own first-byte set is just `\n`) to walk every response.
+          {":$",
+           /(?:\A|\n)[\w.\-]{1,64}:\$(?:apr1|2[aby]|5|6)\$[^\s:]{8,}/,
+           ".htpasswd credentials", Store::Severity::High},
+          # wp-config.php served as source instead of executed: the DB password define().
+          {"DB_PASSWORD",
+           /define\s*\(\s*['"]DB_PASSWORD['"]\s*,/,
+           "wp-config.php credentials", Store::Severity::High},
+          # Spring Boot Actuator /env (or /configprops): the response envelope is distinctive.
+          {"propertySources",
+           /"propertySources"\s*:\s*\[/,
+           "Spring actuator env", Store::Severity::Medium},
+        ]
+
+        # A `.env` file is the one artifact with no structural envelope — it is just
+        # `KEY=value` lines, which is also what a great many ordinary text responses look like.
+        # So it is keyed on a SECRET-BEARING key at the start of a line, and gated separately
+        # on the response NOT being a document (below): an HTML page listing these key names is
+        # a deployment guide, whereas a text/plain body that opens a line with `DB_PASSWORD=`
+        # and a non-empty value is the file itself.
+        # No literal prefilter here on purpose: every candidate literal (`=`, `_`) is in
+        # essentially every response body, so one would cost a full byte scan and reject
+        # nothing. The content-type gate below is the real filter, and after it PCRE's own
+        # first-byte set (the key initials following a newline) does the skipping.
+        DOTENV = /(?:\A|\n)(?:DB_PASSWORD|DB_USERNAME|DATABASE_URL|APP_KEY|APP_SECRET|SECRET_KEY|SECRET_KEY_BASE|AWS_SECRET_ACCESS_KEY|STRIPE_SECRET_KEY|JWT_SECRET|MAIL_PASSWORD|REDIS_PASSWORD)\s*=\s*\S/
+
+        # Every artifact here DECLARES ITSELF in its opening bytes: `[core]` opens a git config,
+        # `<title>phpinfo()</title>` is in the document head, an `.htpasswd` record is line one,
+        # the actuator envelope keys are the outermost JSON object, and a `.env`'s keys sit at
+        # the top. So the scan is bounded to this prefix instead of the full 64 KiB `body_text`.
+        #
+        # This is a real cost, not a hypothetical one: the rule runs on EVERY texty 2xx response
+        # and its literal prefilters are substring searches, so scanning the whole prefix cost
+        # ~0.4ms per flow on the shared passive fiber (measured, bench/probe_passive_bench) —
+        # for bytes that structurally cannot hold the signal. A body already under the bound is
+        # used as-is and copies nothing.
+        SCAN_PREFIX = 16 * 1024
+
+        def check(ctx : Context, acc : Array(Detection)) : Nil
+          return unless resp = ctx.response
+          # Only a SERVED artifact counts. A 403/404 error page can echo the requested path
+          # (".../.git/config") and a redirect body carries nothing — same gate as
+          # directory_listing, and for the same reason.
+          return unless (200..299).includes?(resp.status)
+          full = ctx.body_text
+          return if full.nil? || full.empty?
+          text = head_of(full)
+
+          SIGNATURES.each do |(needle, pattern, label, severity)|
+            next unless text.includes?(needle)
+            next unless pattern.matches?(text)
+            acc << det(ctx, label, severity)
+          end
+          check_dotenv(ctx, acc, text)
+        end
+
+        # `.env` is checked only for a NON-document response. An HTML page that lists
+        # `DB_PASSWORD=…` is documentation (a README render, a deployment guide, a paste site);
+        # the file served raw is text/plain, octet-stream, or type-less. Excluding HTML here is
+        # what makes the loose `KEY=value` shape safe to match at all.
+        private def check_dotenv(ctx : Context, acc : Array(Detection), text : String) : Nil
+          return if ctx.html? || ctx.js?
+          return unless DOTENV.matches?(text)
+          acc << det(ctx, ".env file", Store::Severity::High)
+        end
+
+        # The first SCAN_PREFIX bytes, scrubbed. The cut can land mid-codepoint, and PCRE RAISES
+        # on invalid UTF-8 — which here would take out the whole flow's detections, not just
+        # this rule's — so the slice is scrubbed before any pattern sees it.
+        private def head_of(text : String) : String
+          return text if text.bytesize <= SCAN_PREFIX
+          String.new(text.to_slice[0, SCAN_PREFIX]).scrub
+        end
+
+        # One code for the whole family: these are the same finding ("a server-side artifact is
+        # readable") and an operator acts on them together, so they group and are dismissed
+        # together. The artifact NAME rides in `evidence`, which accumulates per host (see
+        # Store::ACCUMULATING_EVIDENCE_CODES), so a host serving both a .env and a phpinfo page
+        # names both rather than pinning to whichever was captured first. The title is FIXED so
+        # the severity-driven title adoption in upsert_probe_issue has nothing to swap.
+        private def det(ctx : Context, label : String, severity : Store::Severity) : Detection
+          Detection.new("exposed_config", Category::INFOLEAK, ctx.host, ctx.url,
+            "Server configuration or diagnostic file exposed", severity, label, ctx.fid)
+        end
+      end
+    end
+  end
+end

--- a/src/gori/probe/passive/js_scan.cr
+++ b/src/gori/probe/passive/js_scan.cr
@@ -66,6 +66,17 @@ module Gori
           {/\bset(?:Timeout|Interval)\s*\(/, "setTimeout/setInterval"},
           {/\bdangerouslySetInnerHTML\b/, "dangerouslySetInnerHTML"},
           {/\.html\s*\(/, "jQuery.html()"},
+          # Navigation sinks. A tainted navigation target is how `javascript:`-URL XSS and
+          # client-side open redirect both land, and neither is reachable through the HTML/eval
+          # sinks above. The bare-`location` form deliberately also matches `document.location =`
+          # and `window.location =` (the `\b` holds after the dot); `(?!=)` keeps `==`/`===` out.
+          {/\b(?:window\.)?location(?:\.href)?\s*=(?!=)/, "location assignment"},
+          {/\blocation\.(?:replace|assign)\s*\(/, "location.replace/assign"},
+          {/\bwindow\.open\s*\(/, "window.open"},
+          # HTML-parsing sinks: both turn a string into live nodes, which is the same capability
+          # as innerHTML once the result is inserted.
+          {/\.createContextualFragment\s*\(/, "createContextualFragment"},
+          {/\bparseFromString\s*\(/, "DOMParser.parseFromString"},
         ] of {Regex, String}
 
         # A random-access `Char` view over ASCII bytes, used instead of `String#chars` on the
@@ -441,10 +452,21 @@ module Gori
             end
             j += 1
           end
-          # A window edge can land mid-char, so scrub before handing the slice to PCRE (invalid
-          # UTF-8 makes the match raise). Bounded to ~2*WINDOW bytes, so this costs nothing.
-          seg = String.new(bytes[lo, hi - lo]).scrub
-          SOURCES.each { |(re, label)| return label if re.matches?(seg) }
+          # The statement is searched as the two sides AROUND the sink — [lo, from) and [to, hi) —
+          # never as one span covering the sink's own matched text. A sink whose pattern CONTAINS
+          # a source spelling would otherwise pair with itself: `location.href =` is a navigation
+          # sink, and the `location.href` source matches those very bytes, so every ordinary
+          # `location.href = "/dashboard"` in every SPA would have reported a DOM-XSS lead with
+          # itself as the taint. Splitting is behaviour-identical for the sinks that came before
+          # (none of `.innerHTML=`, `document.write(`, `eval(`, `.html(` contains a source), and a
+          # source really inside the sink's arguments still sits in the POST side, which is where
+          # `document.write(document.URL)` has always been read from.
+          #
+          # A window edge can land mid-char, so scrub before handing a slice to PCRE (invalid
+          # UTF-8 makes the match raise). Both slices are bounded by WINDOW, so this costs nothing.
+          pre = String.new(bytes[lo, from - lo]).scrub
+          post = String.new(bytes[to, hi - to]).scrub
+          SOURCES.each { |(re, label)| return label if re.matches?(pre) || re.matches?(post) }
           nil
         end
       end

--- a/src/gori/probe/passive/secrets.cr
+++ b/src/gori/probe/passive/secrets.cr
@@ -27,6 +27,34 @@ module Gori
           {/\b(?:pk|sk)\.eyJ[\w\-]{20,}\.[\w\-]{20,}\b/, "Mapbox token"},
           {/\bhttps:\/\/hooks\.slack\.com\/services\/T[0-9A-Za-z]+\/B[0-9A-Za-z]+\/[0-9A-Za-z]{16,}/, "Slack webhook url"},
           {/\bSK[0-9a-f]{32}\b/, "Twilio api key"},
+          # LLM provider keys. Both vendors' formats are prefix-anchored and long, so the
+          # prefix alone is already the discriminator — the length floors just stop a prose
+          # mention of the prefix ("keys start with sk-ant-") from matching.
+          {/\bsk-ant-(?:api|admin)\d{2}-[A-Za-z0-9_\-]{40,}/, "Anthropic API key"},
+          {/\bsk-proj-[A-Za-z0-9_\-]{40,}/, "OpenAI project key"},
+          # Slack app-level token (`xapp-`), a shape the existing xox[baprs]- pattern does not
+          # cover: different prefix, different body (version-counter, app id, 64 hex chars).
+          {/\bxapp-\d-[A-Z0-9]+-\d+-[a-f0-9]{64}\b/, "Slack app-level token"},
+          {/\bshp(?:at|ss|ca|pa)_[0-9a-f]{32}\b/, "Shopify access token"},
+          {/\bsq0(?:atp|csp)-[A-Za-z0-9_\-]{20,}/, "Square access token"},
+          # Telegram bot token: the `<numeric id>:AA…` shape is the distinctive part.
+          {/\b\d{8,10}:AA[A-Za-z0-9_\-]{32,35}\b/, "Telegram bot token"},
+          {/\bpypi-AgEIcHlwaS5vcmc[A-Za-z0-9_\-]{50,}/, "PyPI API token"},
+          # Azure Storage connection string — AccountKey is the credential; the surrounding
+          # DefaultEndpointsProtocol/AccountName literals make it unmistakable.
+          {/AccountKey=[A-Za-z0-9+\/]{86}==/, "Azure Storage account key"},
+          # A database/broker URI carrying inline credentials — the single most common shape a
+          # leaked config file or a stack trace exposes. Guarded twice against the tutorial /
+          # docs-page false positive that a bare `scheme://user:pass@host` would produce: the
+          # password must be at least 8 characters (placeholder passwords in documentation are
+          # `pass`, `pwd`, `secret`, `password`, `changeme`, all shorter or excluded below), and
+          # the host must not be a loopback or a reserved example domain. Those two together are
+          # what keep this out of the "every page that documents a connection string" trap.
+          {/\b(?:postgres(?:ql)?|mysql|mariadb|mongodb(?:\+srv)?|redis|rediss|amqps?|clickhouse):\/\/
+            [^\s:@\/]{1,64}:
+            (?!password@|changeme@|secret@|yourpass)[^\s:@\/]{8,}
+            @(?!localhost|127\.0\.0\.1|\[::1\]|example\.(?:com|org|net)\b)[\w.\-]+/x,
+           "database URI with inline credentials"},
         ]
 
         # A JSON Web Token, held OUT of PATTERNS on purpose.

--- a/src/gori/store/probe_issues.cr
+++ b/src/gori/store/probe_issues.cr
@@ -43,7 +43,7 @@ module Gori
           # for this (code, host) group so a later flow's different secret/error type
           # isn't masked by the first-wins COALESCE. Other codes keep their first
           # representative sample.
-          new_evidence = accumulate_evidence?(d.code) ? merge_evidence(prev_evidence, d.evidence) : (prev_evidence || d.evidence)
+          new_evidence = Store.accumulate_evidence?(d.code) ? Store.merge_evidence(prev_evidence, d.evidence) : (prev_evidence || d.evidence)
           c.exec("UPDATE probe_issues SET hit_count = hit_count + 1, affected = ?, severity = ?, " \
                  "title = ?, evidence = ?, last_seen = ? WHERE id = ?",
             urls.to_json, new_sev, new_title, new_evidence, ts, id)
@@ -60,22 +60,34 @@ module Gori
       bump_probe_generation if wrote # after commit (exec_task blocks until writer replies)
     end
 
-    # Codes whose evidence is a TYPE label (not a one-off sample), so a (code, host)
-    # group should list every distinct type seen rather than pin to the first. `missing_sri`
-    # and `jwt_sensitive_claims` belong here for the same reason: one host's third-party hosts
-    # (and one host's sensitive claim names) are a SET that only the union describes.
-    private def accumulate_evidence?(code : String) : Bool
-      case code
-      when "secret_in_body", "error_stack_leak", "secret_in_ws",
-           "missing_sri", "jwt_sensitive_claims"
-        true
-      else
-        false
-      end
+    # Codes whose evidence is a TYPE LABEL drawn from a small vocabulary (a secret kind, an
+    # error class, a third-party host, a cookie name, a claim name) rather than a one-off
+    # sample. For these, a (code, host) group is only described by the UNION of what it saw:
+    # first-wins would report one of a host's five insecure cookies, or one of its third
+    # parties, and silently drop the rest.
+    #
+    # THIS IS THE ONE LIST. `Probe::Group` folds detections in memory for the headless
+    # `gori run probe` / MCP `probe_scan` path and must fold them identically, so it reads
+    # this set rather than keeping its own copy — which is exactly how `missing_sri` and
+    # `jwt_sensitive_claims` came to accumulate in the DB but not in a headless scan.
+    #
+    # Membership requires the evidence string to survive a `", "` split/re-join round trip
+    # (see merge_evidence): a label that embeds its own ", " would be split into fragments.
+    # `jwt_sensitive_claims` is already a ", "-joined claim list, which is idempotent here;
+    # `cookie_prefix_violation` joins its unmet requirements with " + " for the same reason.
+    ACCUMULATING_EVIDENCE_CODES = Set{
+      "secret_in_body", "error_stack_leak", "secret_in_ws",
+      "missing_sri", "jwt_sensitive_claims", "secret_in_url", "exposed_config",
+      "cookie_no_secure", "cookie_no_httponly", "cookie_no_samesite",
+      "cookie_samesite_none_insecure", "cookie_prefix_violation",
+    }
+
+    def self.accumulate_evidence?(code : String) : Bool
+      ACCUMULATING_EVIDENCE_CODES.includes?(code)
     end
 
     # Union of distinct evidence labels for one issue group, ", "-joined and capped.
-    private def merge_evidence(existing : String?, incoming : String?) : String?
+    def self.merge_evidence(existing : String?, incoming : String?) : String?
       return existing if incoming.nil? || incoming.empty?
       return incoming if existing.nil? || existing.empty?
       parts = existing.split(", ").map(&.strip).reject(&.empty?)

--- a/src/gori/tui/probe_view.cr
+++ b/src/gori/tui/probe_view.cr
@@ -498,7 +498,13 @@ module Gori::Tui
     private def preview_lines(issue : Store::ProbeIssue) : Array({Color, String})
       lines = [] of {Color, String}
       lines << {Theme.text_bright, "#{severity_badge(issue.severity)}  #{issue.title}"}
-      lines << {Theme.muted, "#{issue.host}  ·  #{issue.category}  ·  #{issue.status.label}  ·  ×#{Fmt.count(issue.hit_count)}"}
+      meta = "#{issue.host}  ·  #{issue.category}  ·  #{issue.status.label}  ·  ×#{Fmt.count(issue.hit_count)}"
+      # A code with no CWE (tech fingerprint, the informational jwt_in_* notes, a custom rule)
+      # is unmapped on purpose — append nothing rather than a placeholder.
+      if id = Probe.cwe_id(issue.code)
+        meta = "#{meta}  ·  #{id}"
+      end
+      lines << {Theme.muted, meta}
       if ev = issue.evidence
         lines << {Theme.muted, "detail  #{ev}"}
       end
@@ -650,7 +656,14 @@ module Gori::Tui
       cx = rect.x + 1
       cx = chip(screen, cx, rect.y + 1, " #{severity_badge(issue.severity)} ", severity_color(issue.severity))
       cx = chip(screen, cx + 1, rect.y + 1, " #{issue.status.label} ", status_color(issue.status))
-      chip(screen, cx + 1, rect.y + 1, " #{issue.category} ", Theme.muted)
+      cx = chip(screen, cx + 1, rect.y + 1, " #{issue.category} ", Theme.muted)
+      # CWE last, and only when the whole chip fits: `chip` draws through screen.text with no
+      # width cap, so an unguarded one on a narrow pane would run past the pane's right edge and
+      # paint over the neighbouring column. Dropping it is the right degradation — the id is also
+      # on the preview meta line and in every export.
+      if (id = Probe.cwe_id(issue.code)) && cx + 1 + id.size + 2 <= rect.right
+        chip(screen, cx + 1, rect.y + 1, " #{id} ", Theme.muted)
+      end
 
       hint = detail_hint(issue.code)
       screen.text(rect.x + 1, rect.y + 2, hint, Theme.muted, width: w) unless hint.empty?


### PR DESCRIPTION
Four axes over `src/gori/probe/passive/` — accuracy, result quality, coverage, and custom-rule
expressiveness. Three of the changes fix defects that were live; each was confirmed by running
the old code, not by reading it.

## Defects

**The evidence list existed twice, and had drifted.** `Probe::Group.accumulate_evidence?` folds
detections in memory for `gori run probe` and MCP `probe_scan`; `Store#accumulate_evidence?`
does the same fold in SQL for the TUI. Both kept their own copy of "which codes accumulate their
evidence", both carried a comment claiming they mirrored each other, and they had not since
`missing_sri` / `jwt_sensitive_claims` were added to one of them. A headless scan reported ONE
of a host's third-party hosts and dropped the rest. There is now one list and Group reads it.

The cookie codes join it: their evidence is a cookie NAME, so a host shipping five unflagged
cookies described itself by whichever was captured first. `cookie_prefix_violation` switches to
" + " for its own requirement list, because the merge dedups by splitting on ", " and would
otherwise tear one cookie's label into fragments reading as another's.

**Two body caps for one document.** `BodyLeaks`' HTML sink checks read the 64 KiB `body_text`
while `Sri` — walking the same tags of the same page — read the 256 KiB `client_body_text`. On a
120 KiB page that reported the third-party script with no integrity hash and stayed silent about
the plain-`http://` one beside it. The tag checks now read the larger prefix; the content scans
(private IP, error traces, secrets) stay at 64 KiB, since widening a tag scan and widening a
content scan are different trades. Each check first gates on an allocation-free literal, matched
case-**in**sensitively — every regex it guards is `/i`, so `String#includes?` would have quietly
stopped matching `HTTP://`.

**A sink that matched itself.** Adding `location.href =` as a DOM-XSS sink made every ordinary
SPA redirect a finding: `JsScan.source_in_window` searched one span *covering the sink's own
matched bytes*, and the `location.href` source pattern matched those bytes. It now searches the
two sides around the sink — behaviour-identical for the nine pre-existing sinks (none contains a
source spelling), and `document.write(document.URL)` still pairs because its source is on the
post side.

## CWE

There was no CWE anywhere in the tree, so gori was the only link in the chain — report template,
ticket field, scanner comparison — that could not speak the vocabulary. `Probe::CWE` maps each
code to the weakness it *is* rather than the attack it enables. `tech_*`, the informational
`jwt_in_*` notes, and `custom_*` are unmapped on purpose and the field is **omitted**, never
null. Two specs pin that in both directions, so a typo'd key cannot become dead metadata and a
new rule cannot ship unclassified — which it immediately proved on rebase, catching #609's
`ssrf_oast` (now CWE-918, second commit).

Surfaced in `group_json`/`issue_json`, a width-guarded TUI chip, the preview meta line, and both
CLI text formats ahead of the variable-width evidence column.

## Coverage

**New rule `exposed_config`** (CWE-538): `.env`, `.git/config`, `phpinfo()`, `.htpasswd`,
wp-config credentials, Spring actuator env. Every signature is anchored on the artifact's own
structure, never a keyword a page *about* it would carry, and each has a spec for that false
positive. One code for the family — same finding, acted on together — with the artifact name in
accumulating evidence. `.env` is the only one with no structural envelope, so it is also gated
on the response not being a document: an HTML page listing `DB_PASSWORD=` is a deployment guide,
the raw file is `text/plain`.

Ten `Secrets::PATTERNS` (Anthropic, OpenAI, Slack app-level, Shopify, Square, Telegram, PyPI,
Azure Storage, and a database URI with inline credentials). The database URI is the one needing
*guarding* rather than anchoring — a real-length password, no loopback or reserved example host
— or every page documenting a connection string becomes a High finding.

Five `JsScan` sinks: navigation (`location` assignment, `location.replace/assign`,
`window.open`) and HTML-parsing (`createContextualFragment`, `parseFromString`).

## Custom rules

Every custom finding stored `evidence: nil`, so all three surfaces could say a rule fired on a
host but not what tripped it. A regex rule now reports capture group 1 when the pattern defines
one, else the whole match — sanitised to printable ASCII and capped so a greedy `.*` cannot
write a body into the issue row. String rules still report nothing: their match is byte-identical
to the pattern every surface already displays.

Not done, and deliberately out of scope: a suppression / `not_pattern` field. That needs a store
schema column plus the TUI editor, CLI, and MCP surfaces in one change.

## Cost, measured

`bench/probe_passive_bench` gains a 200 KiB HTML fixture — the existing one is 40 KiB, below
`BODY_CAP`, so it could not reach the HTML-sink branch it was supposed to guard.

| flow | before | after |
| --- | --- | --- |
| HTML, 200 KiB | 2.84 ms | 2.98 ms (+5%) |
| JS bundle, 256 KiB | 10.10 ms | 11.21 ms (+11%) |

The +11% is the five new sinks. Merging the two `location` patterns into one alternation
recovered ~3% — inside the noise — and cost the label precision that tells an analyst which
shape to look for, so they stay separate.

`exposed_config` cost ~0.4 ms/flow before being bounded to a 16 KiB prefix; every artifact it
looks for declares itself in its opening bytes. A prefilter also has to be *selective* to earn
its scan: `.htpasswd`'s was `$` (in every jQuery-shaped body on the web) and is now the `:$`
adjacency the pattern requires; `.env`'s was `=`, which filtered nothing, and is gone in favour
of the content-type gate.

## Not done, on purpose

- Widening `Tech#check_frameworks` to 256 KiB. The markers that matter (`/_next/static/`,
  `/_nuxt/`, `react-dom.js`, `ng-version`, `jquery.js`) all sit in the document head, so the
  false negative is theoretical while six more regexes over 4× the bytes is not.
- A suspected `jwt.cr` bug — `Base64.decode` on a base64**url** payload silently losing
  `jwt_no_expiry`. Ran it: Crystal's `Base64.decode` handles the urlsafe alphabet and missing
  padding. Retracted.

## Verification

+37 specs. Six of the new ones were control-run against the pre-fix source and fail there; the
rest are invariant guards that hold both ways. Full suite green apart from the 8 pre-existing
`project_registry`/`capture_status` failures caused by a gori already bound to :8070 locally.
