### PR TITLE
Stop measuring a token's structural skeleton as if it were secret, and give the verdict a way out of the session

### DIFF
--- a/docs/content/guide/sequencer.ko.md
+++ b/docs/content/guide/sequencer.ko.md
@@ -45,9 +45,31 @@ session cookie, CSRF token, 비밀번호 리셋 코드, API key가 예측 가능
 | **Weak** | >= 30 bits |
 | **Critical** | below 30 bits |
 
-**중복**되거나 **순차적인** token이 하나라도 있으면 entropy가 아무리 높아 보여도 판정이 곧바로 Critical로 떨어집니다. 내부적으로 gori는 일련의 통계 테스트(monobit, poker, runs, longest-run, 그리고 token의 심볼 bitstream에 대한 per-bit 편향)와, 알파벳의 entropy 하한과 대조하는 압축 검사, per-position 문자 분포를 실행합니다. 샘플이 작으면(사용 가능한 token이 약 20개 미만) 확실히 판단할 데이터가 부족하므로, 강한 실패를 경고로 완화하고 등급의 상한을 제한합니다.
+**중복**되거나 **순차적인** token이 하나라도 있으면 entropy가 아무리 높아 보여도 판정이 곧바로 Critical로 떨어집니다. 내부적으로 gori는 token의 심볼 bitstream에 대해 일련의 통계 테스트(monobit, poker, runs, longest-run, per-bit 편향, cumulative sums, approximate entropy, spectral)를 실행하고, byte 빈도에 대한 chi-square, lag-1 serial correlation, 알파벳의 entropy 하한과 대조하는 압축 검사를 함께 수행합니다. p-value로 판정하는 테스트들은 Bonferroni 보정된 임계값을 공유하므로, 테스트가 늘어나도 정상적인 token이 잘못 걸릴 확률은 올라가지 않습니다.
+
+샘플이 작으면(사용 가능한 token이 약 20개 미만) 확실히 판단할 데이터가 부족하므로, 강한 실패를 경고로 완화하고 등급의 상한을 제한합니다.
+
+### 구조는 비밀이 아닙니다 {#structure-is-not-secret}
+
+실제 token에는 대개 뼈대가 있습니다. `sess_v1_` 같은 접두사, 버전 byte, base64 padding 같은 것들입니다. **Structure** 행은 샘플 전체에서 한 번도 변하지 않는 위치가 몇 개인지 보여주고, 모든 byte 단위 테스트는 그 다음부터 *변하는* 영역만 측정합니다.
+
+이 구분이 등급을 좌우합니다. `sess_v1_` 뒤에 무작위 hex 24자가 붙은 token은 접두사까지 세면 알파벳 크기가 19가 되는데, 이는 2의 거듭제곱이 아니므로 비트 테스트 전체가 "해당 없음"으로 꺼집니다. 그러면 chi-square와 압축 검사는 순전히 접두사 때문에 치우친 분포를 보고 실패합니다. 변하는 영역만 측정하면 같은 샘플이 원래 모습대로 나옵니다. lower-hex 알파벳에 전체 비트 테스트가 활성화되고 모든 행이 통과합니다.
+
+무작위 부분이 가변 길이 머리 뒤의 *접미사*인 token(`123-<random>`)이라면, gori는 per-position 창을 entropy가 더 많은 쪽 끝에 맞추므로 머리 부분이 추정치를 끌어내리지 않습니다.
 
 패널은 **CONFIG**(소스와 token 위치), **SAMPLES**(수집된 token), **ANALYSIS**(등급과 테스트별 분석)로 구성되며, 개별 샘플에 대한 상세 보기가 함께 제공됩니다.
+
+## 판정 결과 내보내기 {#getting-the-verdict-out}
+
+수집된 token은 살아 있는 자격 증명이므로 디스크에 절대 기록되지 않고 세션과 함께 사라집니다. 판정 결과까지 사라져서는 안 됩니다.
+
+| 동작 | 키 | 기록 대상 |
+|------|-----|-----------|
+| Export report | `⇧E` | 직접 지정한 경로의 Markdown 리포트 |
+| Export report (JSON) | 팔레트 | 동일한 리포트의 JSON |
+| File as issue | `Space` → `i` | Issues 탭의 Issue |
+
+**File as issue**는 등급을 Issues 리포트에 기록하며 Critical은 `critical`, Weak은 `high`, Moderate는 `medium`, Secure는 `info`로 매핑합니다. Issue 본문에는 대상, token 디스크립터, entropy 수치, 전체 테스트 표가 담기고 근거로 시드가 된 flow가 연결됩니다. 내보낸 파일과 Issue 어느 쪽에도 token 값은 들어가지 않습니다. 리포트는 빈도표와 판정만으로 만들어지므로 애초에 유출될 샘플이 들어 있지 않습니다.
 
 ## 헤드리스 {#headless}
 
@@ -60,7 +82,7 @@ gori run sequence --tokens tokens.txt
 cat tokens.txt | gori run sequence --tokens -
 ```
 
-token 위치는 정확히 하나만 고르고(`--cookie` / `--header` / `--regex` / `--position` / `--jsonpath`), 요청은 `--flow`, `--request FILE`, 또는 stdin에서 가져옵니다. 속도 및 전송 관련 플래그는 Fuzzer와 동일합니다(`--concurrency`, `--rate`, `--throttle`, `--timeout`, `--target`, `--http2`, …). 출력 형식은 `text`, `json`, `jsonl`입니다. 전체 플래그는 [CLI Reference](/ko/reference/cli/#run-sequence)에 있습니다.
+token 위치는 정확히 하나만 고르고(`--cookie` / `--header` / `--regex` / `--position` / `--jsonpath`), 요청은 `--flow`, `--request FILE`, 또는 stdin에서 가져옵니다. 속도 및 전송 관련 플래그는 Fuzzer와 동일합니다(`--concurrency`, `--rate`, `--throttle`, `--timeout`, `--target`, `--http2`, …). 출력 형식은 `text`, `json`, `jsonl`, `markdown`입니다(`markdown`은 TUI의 **Export report**가 쓰는 문서와 동일합니다). 전체 플래그는 [CLI Reference](/ko/reference/cli/#run-sequence)에 있습니다.
 
 MCP에서는 `sequence_analyze`가 token 목록을 인라인으로 등급 매기고, `sequence_start` / `sequence_status` / `sequence_results` / `sequence_stop`이 라이브 수집을 백그라운드 작업으로 구동합니다. 결과는 항상 **리포트**를 반환하며 raw token은 절대 반환하지 않습니다.
 

--- a/docs/content/guide/sequencer.md
+++ b/docs/content/guide/sequencer.md
@@ -45,9 +45,31 @@ The headline is **effective entropy** in bits: a conservative estimate of how mu
 | **Weak** | >= 30 bits |
 | **Critical** | below 30 bits |
 
-Any **duplicate** or **sequential** token drops the verdict straight to Critical, however high the entropy looks. Underneath, gori runs a battery of statistical tests (monobit, poker, runs, longest-run, and per-bit bias over the token's symbol bitstream), a compression check against the alphabet's entropy floor, and a per-position character distribution. A small sample (fewer than ~20 usable tokens) softens hard failures to warnings and caps the rating, since there isn't enough data to be sure.
+Any **duplicate** or **sequential** token drops the verdict straight to Critical, however high the entropy looks. Underneath, gori runs a battery of statistical tests over the token's symbol bitstream (monobit, poker, runs, longest-run, per-bit bias, cumulative sums, approximate entropy, and a spectral test), a chi-square on byte frequencies, a lag-1 serial correlation, and a compression check against the alphabet's entropy floor. The tests judged on a p-value share a Bonferroni-corrected threshold, so a clean token is no likelier to be flagged as the battery grows.
+
+A small sample (fewer than ~20 usable tokens) softens hard failures to warnings and caps the rating, since there isn't enough data to be sure.
+
+### Structure Is Not Secret
+
+Real tokens usually carry a skeleton: a `sess_v1_` prefix, a version byte, base64 padding. The **Structure** row reports how many positions never vary across the sample, and every byte-level test then measures the *varying* region only.
+
+That distinction decides the grade. A token of `sess_v1_` plus 24 random hex characters looks like a 19-character alphabet if you count the prefix, which is not a power of two, which switches off the entire bit-test battery as not-applicable; chi-square and compression then fail on a distribution skewed purely by the prefix. Measured against the varying region instead, the same sample is what it actually is: lower-hex, full battery active, every row passing.
+
+For a token whose random part is a *suffix* behind a variable-length head (`123-<random>`), gori anchors the per-position window to whichever end carries more entropy, so the head does not drag the estimate down.
 
 The panes are **CONFIG** (source and token location), **SAMPLES** (the collected tokens), and **ANALYSIS** (the grade and the per-test breakdown), with a detail view for any one sample.
+
+## Getting the Verdict Out
+
+Collected tokens are live credentials, so they are never written to disk and vanish with the session. The verdict should not.
+
+| Action | Key | Writes |
+|--------|-----|--------|
+| Export report | `⇧E` | A Markdown report at a path you choose |
+| Export report (JSON) | palette | The same report as JSON |
+| File as issue | `Space` → `i` | An Issue in the Issues tab |
+
+**File as issue** records the grade in the Issues report, mapping Critical to `critical`, Weak to `high`, Moderate to `medium`, and Secure to `info`. The Issue carries the target, the token descriptor, the entropy figures, and the full test table as its body, plus the seeding flow as evidence. Neither the export nor the Issue contains a token value: the report is built from frequency tables and verdicts, so there is no sample in it to leak.
 
 ## Headless
 
@@ -60,7 +82,7 @@ gori run sequence --tokens tokens.txt
 cat tokens.txt | gori run sequence --tokens -
 ```
 
-Pick exactly one token location (`--cookie` / `--header` / `--regex` / `--position` / `--jsonpath`), and source the request from `--flow`, `--request FILE`, or stdin. Rate and transport flags mirror the Fuzzer (`--concurrency`, `--rate`, `--throttle`, `--timeout`, `--target`, `--http2`, …). Output is `text`, `json`, or `jsonl`. Full flags are in the [CLI Reference](/reference/cli/#run-sequence).
+Pick exactly one token location (`--cookie` / `--header` / `--regex` / `--position` / `--jsonpath`), and source the request from `--flow`, `--request FILE`, or stdin. Rate and transport flags mirror the Fuzzer (`--concurrency`, `--rate`, `--throttle`, `--timeout`, `--target`, `--http2`, …). Output is `text`, `json`, `jsonl`, or `markdown` (the same document the TUI's **Export report** writes). Full flags are in the [CLI Reference](/reference/cli/#run-sequence).
 
 Over MCP, `sequence_analyze` grades a token list inline, and `sequence_start` / `sequence_status` / `sequence_results` / `sequence_stop` drive a live collection as a background job. Results return the **report**, never the raw tokens.
 

--- a/docs/content/reference/cli.ko.md
+++ b/docs/content/reference/cli.ko.md
@@ -251,7 +251,7 @@ gori run sequence --tokens tokens.txt          # '-' reads stdin
 | `--count=N` | 목표 토큰 개수(기본값 500) |
 | `--target`, `--http2`, `--sni`, `-k` | 트랜스포트(`--request`/stdin에는 target 필요) |
 | `--concurrency` (1), `--rate`, `--throttle`, `--timeout`, `--retries`, `--max-requests=N` | 속도 제어(상태 기반 토큰을 위해 concurrency는 1 유지) |
-| `--format` | `text`, `json`, 또는 `jsonl` |
+| `--format` | `text`, `json`, `jsonl`, 또는 `markdown`(TUI의 Export가 쓰는 리포트) |
 
 ### run probe {#run-probe}
 

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -254,7 +254,7 @@ gori run sequence --tokens tokens.txt          # '-' reads stdin
 | `--target`, `--http2`, `--sni`, `-k` | Transport (target required for `--request`/stdin) |
 | `--concurrency` (1), `--rate`, `--throttle`, `--timeout`, `--retries`, `--max-requests=N` | Rate control (concurrency stays 1 for stateful tokens) |
 | `--bind-from=FLOW-ID` | Replay that captured flow first so its response fills the project's `$NAME` session bindings for the rest of the run |
-| `--format` | `text`, `json`, or `jsonl` |
+| `--format` | `text`, `json`, `jsonl`, or `markdown` (the report the TUI's Export writes) |
 
 ### run probe
 

--- a/spec/sequencer/present_spec.cr
+++ b/spec/sequencer/present_spec.cr
@@ -41,6 +41,7 @@ private JSON_FIELDS = %w[
   rating rationale sample_count usable_count
   effective_entropy_bits shannon_bits_per_char
   charset_size charset min_len max_len variable_length
+  constant_positions entropy_alignment
   uniqueness duplicate_count sequential tests
 ]
 
@@ -229,6 +230,82 @@ describe Gori::Sequencer::Present do
       text = P.report_text(S.analyze(tokens))
       text.should contain("rating:    ")
       text.should contain("charset:   ")
+    end
+  end
+
+  describe ".report_markdown" do
+    subject = P::Subject.new(descriptor: "cookie \"SID\"", origin: "https://example.com:443",
+      mode: "live replay", session: "login")
+
+    it "renders the subject, the entropy table and one row per test" do
+      rep = S.analyze(random_hex(60, 32))
+      md = P.report_markdown(rep, subject, heading: "Token randomness")
+      md.should start_with("# Token randomness\n")
+      md.should contain("**#{rep.rating.label}** — #{rep.rationale}")
+      md.should contain("| Target | https://example.com:443 |")
+      md.should contain("| Token | cookie \"SID\" |")
+      md.should contain("| Mode | live replay |")
+      md.should contain("| Session | login |")
+      md.should contain("| Samples | 60 usable / 60 collected |")
+      md.should contain("| effective entropy | #{rep.effective_entropy.round(1)} bits |")
+      md.should contain("| structure | 0/32 fixed positions (from token start) |")
+      # Every verdict row makes it into the table.
+      rep.tests.each { |t| md.should contain("| #{t.name} | ") }
+      md.lines.count(&.starts_with?("| ")).should be >= rep.tests.size
+    end
+
+    it "omits the heading and the optional subject rows when they are absent" do
+      md = P.report_markdown(S.analyze(random_hex(30, 16)), P::Subject.new(descriptor: "header X-Token"))
+      md.should_not start_with("#")
+      md.should contain("| Target | — |") # a manual paste has no origin
+      md.should_not contain("| Mode |")
+      md.should_not contain("| Session |")
+    end
+
+    it "never leaks a token value into the report" do
+      # The property that lets this be written to an operator-chosen path: a Stats::Report
+      # holds frequency tables and verdicts, so there is no sample for the renderer to print.
+      tokens = random_hex(40, 24)
+      md = P.report_markdown(S.analyze(tokens), subject)
+      tokens.each { |t| md.should_not contain(t) }
+    end
+
+    it "escapes a pipe in a descriptor so it cannot split the table row" do
+      # `regex /a|b/` is an ordinary token location; unescaped it would end the cell early
+      # and silently drop the rest of the row.
+      md = P.report_markdown(S.analyze(random_hex(30, 16)), P::Subject.new(descriptor: "regex /a|b/"))
+      md.should contain("| Token | regex /a\\|b/ |")
+    end
+
+    it "keeps invalid UTF-8 in a descriptor byte-exact" do
+      # Byte-wise escaping, not gsub: a one-byte needle walks the subject as chars and would
+      # turn every invalid byte into U+FFFD on a report that gets stored as an Issue's notes.
+      raw = String.new(Bytes[0x68_u8, 0xff_u8, 0x7c_u8, 0x69_u8]) # "h\xFF|i"
+      md = P.report_markdown(S.analyze(random_hex(30, 16)), P::Subject.new(descriptor: raw))
+      hay = md.to_slice
+      want = Bytes[0x68_u8, 0xff_u8, 0x5c_u8, 0x7c_u8, 0x69_u8] # 0xFF survives, the pipe gains a backslash
+      (0..hay.size - want.size).any? { |i| hay[i, want.size] == want }.should be_true
+    end
+  end
+
+  describe "issue promotion mapping" do
+    it "leads the title with the grade and names the descriptor" do
+      rep = build_report(rating: S::Rating::Critical)
+      P.issue_title(rep, P::Subject.new(descriptor: "cookie \"SID\"")).should eq("Critical token randomness: cookie \"SID\"")
+    end
+
+    it "maps every rating to a severity the store can parse" do
+      # `issue_severity_label` returns a STRING so Present stays free of the db layer. That
+      # indirection is only safe while every value round-trips — this is the pin.
+      {
+        S::Rating::Critical => Gori::Store::Severity::Critical,
+        S::Rating::Weak     => Gori::Store::Severity::High,
+        S::Rating::Moderate => Gori::Store::Severity::Medium,
+        S::Rating::Secure   => Gori::Store::Severity::Info,
+      }.each do |rating, severity|
+        label = P.issue_severity_label(build_report(rating: rating))
+        Gori::Store::Severity.parse?(label).should eq(severity)
+      end
     end
   end
 end

--- a/spec/sequencer/stats_spec.cr
+++ b/spec/sequencer/stats_spec.cr
@@ -290,8 +290,13 @@ describe Gori::Sequencer::Stats do
   end
 
   it "renders plural 'N tests failed' rationale when several tests fail without dup/seq" do
-    pref = random_hex(60, 60, 99_u64).map { |s| "abcd" + s[4..] } # constant prefix, random tail
-    report = S.analyze(pref)
+    # A corpus whose bias switches halfway through: distinct, non-sequential, and genuinely
+    # broken in more than one way (drift and periodicity).
+    rng = Random.new(7_u64)
+    drift = Array.new(200) do |i|
+      String.build { |io| 32.times { io << "0123456789abcdef"[(i < 100 ? 0 : 8) + rng.rand(8)] } }
+    end
+    report = S.analyze(drift)
     report.duplicate_count.should eq(0)
     report.sequential.should be_false
     fails = report.tests.count(&.verdict.fail?)
@@ -383,6 +388,158 @@ describe Gori::Sequencer::Stats do
     report = S.analyze(["", "abcd", "", "efgh", "ijkl"])
     report.sample_count.should eq(5)
     report.usable_count.should eq(3)
+  end
+
+  # ── NIST-style bitstream tests: each must fire on the defect it exists for ─────────
+
+  # Nibbles drawn only from the low or high half of the hex alphabet, switching halfway
+  # through the corpus. Every symbol's HIGH BIT is 0 for the first half and 1 for the second,
+  # so the ones total over the whole stream is balanced (Monobit sees nothing) while the
+  # random walk drifts thousands of steps off zero.
+  private_hex = "0123456789abcdef"
+  drifting = begin
+    rng = Random.new(7_u64)
+    Array.new(200) do |i|
+      String.build { |io| 32.times { io << private_hex[(i < 100 ? 0 : 8) + rng.rand(8)] } }
+    end
+  end
+
+  # Each nibble emitted twice: an 8-bit period, with per-position entropy, charset and
+  # single-bit frequencies all untouched.
+  doubled = begin
+    rng = Random.new(11_u64)
+    Array.new(200) do
+      String.build { |io| 16.times { c = private_hex[rng.rand(16)]; io << c << c } }
+    end
+  end
+
+  it "catches a mid-stream bias with Cusum that Monobit cannot see" do
+    report = S.analyze(drifting)
+    # The premise: the defect is invisible to the existing frequency test.
+    report.tests.find { |t| t.name == "Monobit" }.not_nil!.verdict.should eq(S::Verdict::Pass)
+    cusum = report.tests.find { |t| t.name == "Cusum" }.not_nil!
+    cusum.verdict.should eq(S::Verdict::Fail)
+    cusum.detail.should contain("max excursion")
+  end
+
+  it "passes Cusum, Approx entropy and Spectral on a clean high-entropy corpus" do
+    report = S.analyze(random_hex(300, 32))
+    %w[Cusum Approx\ entropy Spectral].each do |name|
+      report.tests.find { |t| t.name == name }.not_nil!.verdict.should eq(S::Verdict::Pass)
+    end
+  end
+
+  it "sizes the Approx entropy block to the sample so a repeat wider than 2 bits is seen" do
+    # Regression for a FIXED m=2: an 8-bit repeat has perfectly uniform 2- and 3-bit block
+    # statistics, and the test scored the ideal ApEn (0.693) on this corpus. m is now derived
+    # from the bit count — 200×32 hex chars = 25600 bits → floor(log2 n) - 6 = 8.
+    apen = S.analyze(doubled).tests.find { |t| t.name == "Approx entropy" }.not_nil!
+    apen.detail.should contain("m=8")
+    apen.verdict.should eq(S::Verdict::Fail)
+  end
+
+  it "flags a periodic bitstream with the spectral test" do
+    S.analyze(doubled).tests.find { |t| t.name == "Spectral" }.not_nil!.verdict.should eq(S::Verdict::Fail)
+  end
+
+  it "reports insufficient rather than grading when a corpus is too small for a bit test" do
+    # 5 tokens × 4 hex chars = 80 bits: under every floor these three carry.
+    report = S.analyze(random_hex(5, 4))
+    %w[Cusum Approx\ entropy Spectral].each do |name|
+      row = report.tests.find { |t| t.name == name }.not_nil!
+      row.verdict.should eq(S::Verdict::Info)
+      row.detail.should eq("insufficient sample")
+    end
+  end
+
+  # ── Bonferroni family ────────────────────────────────────────────────────────────
+
+  it "splits the p-value thresholds across exactly the tests that use them" do
+    # If a p-value test is added without bumping P_VALUE_TESTS, the family-wise correction is
+    # silently wrong — every test in the family becomes more likely to raise a false FAIL.
+    # This pins the roster against the constant the split is computed from.
+    p_value_rows = ["Monobit", "Poker", "Runs", "Chi-square", "Cusum", "Approx entropy", "Spectral"]
+    p_value_rows.size.should eq(S::P_VALUE_TESTS)
+    names = S.analyze(random_hex(300, 32)).tests.map(&.name)
+    p_value_rows.each { |n| names.should contain(n) }
+    S::ALPHA_FAIL.should be_close(0.01 / S::P_VALUE_TESTS, 1e-12)
+    S::ALPHA_WARN.should be_close(0.05 / S::P_VALUE_TESTS, 1e-12)
+  end
+
+  # ── window alignment + structure ─────────────────────────────────────────────────
+
+  it "anchors the per-position window to the token END when that is where the entropy is" do
+    # A variable-length structural head in front of a random tail: aligned to the START, the
+    # columns mix bytes from different logical fields and the strong tail reads far weaker
+    # than it is.
+    rng = Random.new(3_u64)
+    tokens = Array.new(200) { |i| "u#{i}-" + String.build { |io| 32.times { io << "0123456789abcdef"[rng.rand(16)] } } }
+    report = S.analyze(tokens)
+    report.variable_length.should be_true
+    report.aligned_from_end.should be_true
+    # 32 random hex chars ≈ 128 bits, which only the end-anchored window can account for.
+    report.effective_entropy.should be > 120.0
+  end
+
+  it "keeps the start anchor for a fixed-length corpus (both windows are the same bytes)" do
+    report = S.analyze(random_hex(60, 32))
+    report.variable_length.should be_false
+    report.aligned_from_end.should be_false
+  end
+
+  # ── the variable region: structural bytes must not be measured as if they were secret ──
+
+  it "measures the byte-level tests over the varying columns only" do
+    # Regression, measured: the 8-byte `sess_v1_` prefix dragged 5 extra characters into the
+    # alphabet, so charset read 19 — not a power of two, which gated EVERY bit test off as
+    # "n/a" — while chi-square and compression failed on a distribution skewed purely by that
+    # prefix. The verdict was WEAK on 96 bits of perfectly good hex, from tests that had never
+    # looked at it.
+    rng = Random.new(5_u64)
+    tokens = Array.new(300) { "sess_v1_" + String.build { |io| 24.times { io << "0123456789abcdef"[rng.rand(16)] } } }
+    report = S.analyze(tokens)
+
+    report.charset_size.should eq(16) # the prefix's s/e/_/v/1 are excluded
+    report.charset_label.should eq("lower-hex")
+    report.constant_positions.should eq(8)
+    # A power-of-two alphabet, so nothing is gated: the full battery actually ran…
+    report.tests.none? { |t| t.detail.includes?("n/a for non-power-of-2 alphabet") }.should be_true
+    # …and it passes, because the varying region genuinely is 24 random hex characters.
+    report.tests.count(&.verdict.fail?).should eq(0)
+    report.effective_entropy.should be_close(96.0, 0.001)
+  end
+
+  it "falls back to every byte when no column varies at all" do
+    # An all-identical corpus has no varying column; excluding the constant ones would leave
+    # nothing to measure, so the unfiltered bytes are the honest answer.
+    report = S.analyze(Array.new(50, "aaaaaaaaaaaaaaaa"))
+    report.charset_size.should eq(1)
+    report.constant_positions.should eq(16)
+    report.bits_per_char.should eq(0.0)
+    report.rating.should eq(S::Rating::Critical) # 50 duplicates — still the right verdict
+  end
+
+  it "does not count a constant column's bits as bit bias" do
+    # A constant column's ones-count is 0 or n by definition, so each of its bits scores
+    # |z| = √n: unfiltered, a corpus with a fixed prefix reported 85 of 160 positions biased
+    # while its varying region was flawless.
+    rng = Random.new(13_u64)
+    tokens = Array.new(200) { "0000" + String.build { |io| 28.times { io << "0123456789abcdef"[rng.rand(16)] } } }
+    row = S.analyze(tokens).tests.find { |t| t.name == "Bit bias" }.not_nil!
+    row.verdict.should eq(S::Verdict::Pass)
+    row.value.should eq("0/112") # 28 varying chars × 4 bits — the 4 fixed chars contribute none
+  end
+
+  it "counts never-varying positions and reports them as INFO, never as a failure" do
+    # A constant 8-char prefix in front of a random 24-char tail, fixed length throughout.
+    rng = Random.new(5_u64)
+    tokens = Array.new(200) { "sess_v1_" + String.build { |io| 24.times { io << "0123456789abcdef"[rng.rand(16)] } } }
+    report = S.analyze(tokens)
+    report.constant_positions.should eq(8)
+    row = report.tests.find { |t| t.name == "Structure" }.not_nil!
+    row.value.should eq("8/32 fixed")
+    row.verdict.should eq(S::Verdict::Info)               # already priced into effective_entropy — never charged twice
+    report.effective_entropy.should be_close(96.0, 0.001) # 24 hex chars × 4 bits; the prefix adds 0
   end
 
   it "handles a large single-byte corpus and invalid-UTF-8 bytes without raising" do

--- a/spec/support/fake_context.cr
+++ b/spec/support/fake_context.cr
@@ -451,6 +451,23 @@ class FakeExecContext < Gori::Verb::ExecContext
     rec(:sequence_configure)
   end
 
+  def sequence_export(format : Symbol) : Nil
+    rec(:sequence_export)
+    @sequence_export_format = format
+  end
+
+  getter sequence_export_format : Symbol? = nil
+
+  def sequence_promote : Nil
+    rec(:sequence_promote)
+  end
+
+  property? sequence_report_ready = false
+
+  def sequence_report_ready? : Bool
+    @sequence_report_ready
+  end
+
   def miner_duplicate_subtab : Nil
     rec(:miner_duplicate_subtab)
   end

--- a/spec/tui/sequencer_view_spec.cr
+++ b/spec/tui/sequencer_view_spec.cr
@@ -135,4 +135,35 @@ describe Gori::Tui::SequencerView do
       end
     end
   end
+
+  # The report SUBJECT: what an exported file and an Issue promoted from the same verdict say
+  # the run was about. Both renderings read it from here, so a mapping bug would make the two
+  # describe the run differently — the one thing having a single renderer is meant to prevent.
+  describe "#subject / #target_host" do
+    it "names the live-replay origin, the descriptor and the operator's session name" do
+      view = Gori::Tui::SequencerView.new
+      cfg = Q::Config.new(token_loc: Q::TokenLoc.cookie("SID"))
+      view.load("http://example.com:8080", "GET / HTTP/1.1\r\nHost: h\r\n\r\n".to_slice, false, nil, cfg)
+      view.name = "  login  " # trimmed, so an all-blank name does not become a blank row
+      subject = view.subject
+      subject.descriptor.should eq("cookie \"SID\"")
+      subject.origin.should eq("http://example.com:8080")
+      subject.mode.should eq("live replay")
+      subject.session.should eq("login")
+      view.target_host.should eq("example.com")
+    end
+
+    it "carries no origin or host for a manual paste" do
+      view = Gori::Tui::SequencerView.new
+      cfg = Q::Config.new(mode: Q::Mode::Manual, token_loc: Q::TokenLoc.cookie("SID"),
+        manual_tokens: ["aa"])
+      # A manual session still holds the seed's target; the subject must not claim the run
+      # reached it, and `insert_issue` must get a nil host rather than an unvisited one.
+      view.load("http://example.com:8080", Bytes.empty, false, nil, cfg)
+      view.subject.origin.should be_nil
+      view.subject.mode.should eq("manual")
+      view.subject.session.should be_nil
+      view.target_host.should be_nil
+    end
+  end
 end

--- a/spec/verb/registry_spec.cr
+++ b/spec/verb/registry_spec.cr
@@ -412,6 +412,18 @@ private class FakeContext < ExecContext
     @calls << :sequence_configure
   end
 
+  def sequence_export(format : Symbol) : Nil
+    @calls << :sequence_export
+  end
+
+  def sequence_promote : Nil
+    @calls << :sequence_promote
+  end
+
+  def sequence_report_ready? : Bool
+    false
+  end
+
   def miner_duplicate_subtab : Nil
     @calls << :miner_duplicate_subtab
   end

--- a/src/gori/cli/run/sequence.cr
+++ b/src/gori/cli/run/sequence.cr
@@ -60,7 +60,7 @@ module Gori
           p.on("--max-requests=N", "Hard cap on total requests sent") { |v| max_requests = parse_count(v, "--max-requests").to_i64 }
           p.on("--bind-from=FLOW-ID", "Replay this captured flow FIRST so its response fills session bindings ($NAME)") { |v| bind_from = parse_flow_id(v, "gori run sequence") }
           p.on("--allow-unscoped", "Send even if the target is outside the project scope (Sandbox/exclude still apply)") { allow_unscoped = true }
-          p.on("--format=FMT", "Output: text (default) | json | jsonl") { |v| format = parse_format(v, [:text, :json, :jsonl]) }
+          p.on("--format=FMT", "Output: text (default) | json | jsonl | markdown") { |v| format = parse_format(v, [:text, :json, :jsonl, :markdown]) }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
           p.unknown_args { |rest, _| positional = rest }
           p.invalid_option { |f| abort "gori run sequence: unknown option: #{f}\n#{p}" }
@@ -72,7 +72,11 @@ module Gori
         if tf = tokens_file
           tokens = read_token_list(tf)
           abort "gori run sequence: no tokens to analyze" if tokens.empty?
-          emit_sequence_report(Sequencer::Stats.analyze(tokens), format)
+          # A pasted list has no origin and no descriptor — name the FILE, so a markdown report
+          # written from one still says where its corpus came from.
+          subject = Sequencer::Present::Subject.new(
+            descriptor: tf == "-" ? "token list (stdin)" : "token list #{tf}", mode: "manual")
+          emit_sequence_report(Sequencer::Stats.analyze(tokens), format, subject)
           return
         end
 
@@ -211,6 +215,8 @@ module Gori
         STDERR.puts "sequencing #{scheme}://#{host}:#{port} · #{loc.label} · goal #{goal}"
         tokens = [] of String
         had_error = false
+        subject = Sequencer::Present::Subject.new(
+          descriptor: loc.label, origin: "#{scheme}://#{host}:#{port}", mode: "live replay")
         engine.run do |ev|
           case ev
           when Sequencer::SampleEvent
@@ -222,7 +228,7 @@ module Gori
           when Sequencer::ErrorEvent    then had_error = true; STDERR.puts "sequence error: #{ev.message}"
           end
         end
-        emit_sequence_report(Sequencer::Stats.analyze(tokens), format)
+        emit_sequence_report(Sequencer::Stats.analyze(tokens), format, subject)
         exit 1 if had_error
         # Collecting NO token because every replay was refused is a failure, not a clean
         # "0 collected" — `had_error` only fires on an orchestration raise. Gated on
@@ -250,10 +256,14 @@ module Gori
       end
 
       # In jsonl mode the samples already streamed, so append the final report as a JSON
-      # line; text prints the human table, json prints the report object.
-      private def self.emit_sequence_report(rep : Sequencer::Stats::Report, format : Symbol) : Nil
+      # line; text prints the human table, json prints the report object, markdown prints the
+      # same document the TUI's "Export report" writes (`gori run sequence … --format markdown
+      # > report.md` and the TUI export are byte-identical for one verdict).
+      private def self.emit_sequence_report(rep : Sequencer::Stats::Report, format : Symbol,
+                                            subject : Sequencer::Present::Subject) : Nil
         case format
         when :json, :jsonl then puts Sequencer::Present.report_json(rep)
+        when :markdown     then puts Sequencer::Present.report_markdown(rep, subject, heading: "Token randomness")
         else                    puts Sequencer::Present.report_text(rep)
         end
       end

--- a/src/gori/sequencer/present.cr
+++ b/src/gori/sequencer/present.cr
@@ -6,6 +6,17 @@ module Gori::Sequencer
   # --format json` and the MCP sequence_results tool — so the two can't drift. Pure over
   # a Stats::Report (no Store/TUI dependency).
   module Present
+    # What the report is ABOUT. A `Stats::Report` is pure over a token list and deliberately
+    # carries none of this, but a file on disk or an Issue in the report has to say which
+    # target and which descriptor produced the verdict — a bare "CRITICAL, 41 bits" is
+    # unactionable a week later. Every surface that writes a report out supplies one, so the
+    # Markdown export and the Issue it can be promoted to describe the run in the same words.
+    record Subject,
+      descriptor : String,    # the TokenLoc label — `cookie "SID"`, `header X-CSRF-Token`
+      origin : String? = nil, # scheme://host:port; nil for a manual paste (no network)
+      mode : String? = nil,
+      session : String? = nil
+
     def self.report_json(rep : Stats::Report) : String
       JSON.build { |j| report_object(j, rep) }
     end
@@ -23,6 +34,10 @@ module Gori::Sequencer
         j.field "min_len", rep.min_len
         j.field "max_len", rep.max_len
         j.field "variable_length", rep.variable_length
+        j.field "constant_positions", rep.constant_positions
+        # Which end of the token the per-position window was anchored to — without it a
+        # consumer cannot tell WHICH `min_len` bytes `constant_positions` counted.
+        j.field "entropy_alignment", rep.aligned_from_end ? "end" : "start"
         j.field "uniqueness", rep.uniqueness
         j.field "duplicate_count", rep.duplicate_count
         j.field "sequential", rep.sequential
@@ -50,12 +65,95 @@ module Gori::Sequencer
         io << rep.bits_per_char.round(2) << " bits/char\n"
         io << "charset:   " << rep.charset_size << " (" << rep.charset_label << ")\n"
         io << "length:    " << (rep.variable_length ? "#{rep.min_len}-#{rep.max_len} (variable)" : "#{rep.min_len} (fixed)") << "\n"
+        io << "structure: " << structure_line(rep) << "\n"
         io << "unique:    " << rep.duplicate_count << " duplicate(s)\n"
         io << "\ntests:\n"
         rep.tests.each do |t|
           io << "  " << t.verdict.label.ljust(5) << " " << t.name.ljust(14) << " " << t.value
           io << "  (" << t.detail << ")" unless t.detail.empty?
           io << "\n"
+        end
+      end
+    end
+
+    # The Markdown report — the TUI's "Export report" file and, minus its heading, the body of
+    # an Issue promoted from a verdict. ONE renderer for both so a filed Issue and the file
+    # attached next to it cannot describe the same run differently.
+    #
+    # It carries NO token values, and cannot: a `Stats::Report` holds frequency tables and
+    # verdicts, never the sample. That is the property that lets this be written to an operator-
+    # chosen path and pasted into a report without leaking live session credentials.
+    def self.report_markdown(rep : Stats::Report, subject : Subject, heading : String? = nil) : String
+      String.build do |io|
+        io << "# " << heading << "\n\n" if heading
+        io << "**" << rep.rating.label << "** — " << rep.rationale << "\n\n"
+        io << "| | |\n| --- | --- |\n"
+        row(io, "Target", subject.origin || "—")
+        row(io, "Token", subject.descriptor)
+        subject.mode.try { |m| row(io, "Mode", m) }
+        subject.session.try { |s| row(io, "Session", s) }
+        row(io, "Samples", "#{rep.usable_count} usable / #{rep.sample_count} collected")
+        io << "\n## Entropy\n\n| measure | value |\n| --- | --- |\n"
+        row(io, "effective entropy", "#{rep.effective_entropy.round(1)} bits")
+        row(io, "shannon", "#{rep.bits_per_char.round(2)} bits/char")
+        row(io, "charset", "#{rep.charset_size} (#{rep.charset_label})")
+        row(io, "length", rep.variable_length ? "#{rep.min_len}-#{rep.max_len} (variable)" : "#{rep.min_len} (fixed)")
+        row(io, "structure", structure_line(rep))
+        row(io, "unique", "#{(rep.uniqueness * 100).round(1)}% (#{rep.duplicate_count} duplicate#{rep.duplicate_count == 1 ? "" : "s"})")
+        io << "\n## Tests\n\n| test | result | detail | verdict |\n| --- | --- | --- | --- |\n"
+        rep.tests.each do |t|
+          io << "| " << cell(t.name) << " | " << cell(t.value) << " | " << cell(t.detail)
+          io << " | " << t.verdict.label << " |\n"
+        end
+      end
+    end
+
+    # Title for an Issue filed from a verdict. Leads with the grade and names the descriptor,
+    # so the Issues list reads as findings rather than as five identical "Sequencer" rows.
+    def self.issue_title(rep : Stats::Report, subject : Subject) : String
+      "#{rep.rating.label.capitalize} token randomness: #{subject.descriptor}"
+    end
+
+    # `Store::Severity#label` for a rating. Spelled as a STRING because this module is pure
+    # over a Stats::Report and pulling `Store::Severity` in would drag the whole db layer into
+    # the CLI/MCP report path. `spec/sequencer/present_spec.cr` pins every value against
+    # `Store::Severity.parse?`, so the indirection cannot silently rot into a label the store
+    # does not know.
+    #
+    # A Secure verdict maps to `info`, not to "no issue": an operator who explicitly promotes
+    # one is recording that the token WAS tested, which is worth having in the report.
+    def self.issue_severity_label(rep : Stats::Report) : String
+      case rep.rating
+      in Stats::Rating::Critical then "critical"
+      in Stats::Rating::Weak     then "high"
+      in Stats::Rating::Moderate then "medium"
+      in Stats::Rating::Secure   then "info"
+      end
+    end
+
+    private def self.structure_line(rep : Stats::Report) : String
+      return "—" if rep.min_len <= 0
+      anchor = rep.aligned_from_end ? "from token end" : "from token start"
+      "#{rep.constant_positions}/#{rep.min_len} fixed positions (#{anchor})"
+    end
+
+    private def self.row(io : IO, label : String, value : String) : Nil
+      io << "| " << cell(label) << " | " << cell(value) << " |\n"
+    end
+
+    # A pipe inside a cell would split it into two columns and silently drop the rest of the
+    # row. Reachable from a real descriptor: `regex /a|b/` is an ordinary token location.
+    #
+    # Byte-wise, not `gsub`: a one-byte needle makes Crystal's gsub walk the subject as CHARS,
+    # and a descriptor built from a response header name is not guaranteed valid UTF-8 — every
+    # invalid byte would come back U+FFFD. This report can be written to a file and stored as
+    # an Issue's notes, so it must not be the thing that rewrites bytes.
+    private def self.cell(s : String) : String
+      return s unless s.to_slice.includes?(0x7c_u8) # '|'
+      String.build do |io|
+        s.to_slice.each do |b|
+          io.write_byte(0x5c_u8) if b == 0x7c_u8 # '\'
+          io.write_byte(b)
         end
       end
     end

--- a/src/gori/sequencer/stats.cr
+++ b/src/gori/sequencer/stats.cr
@@ -19,6 +19,45 @@ module Gori::Sequencer
     # single largest allocation in the report.
     COMPRESS_SCAN_CAP = 256 * 1024
 
+    # How many rows in one report take their verdict from a p-value: Monobit, Poker, Runs,
+    # Chi-square, Cusum, Approx entropy, Spectral. Their thresholds below are Bonferroni-split
+    # by this count.
+    #
+    # Without the split, adding a test makes a GENUINELY RANDOM token more likely to be
+    # demoted: `rate` costs a tier per FAIL, so at a flat α=0.01 each, seven independent tests
+    # give a clean token a 1-0.99^7 ≈ 6.8% chance of one spurious FAIL — and every future test
+    # would push that higher. Splitting α across the family holds the family-wise false-alarm
+    # rate at the ~1% a single test carried, which is what makes the family safe to grow.
+    # Real weakness is unaffected: a broken generator's p-values are ~0, orders below either
+    # threshold. The four rows judged on a hand-set effect size instead (Long run, Serial corr,
+    # Compression, Bit bias) are not part of this family and keep their own bands.
+    P_VALUE_TESTS = 7
+    ALPHA_FAIL    = 0.01 / P_VALUE_TESTS
+    ALPHA_WARN    = 0.05 / P_VALUE_TESTS
+
+    # Approximate-entropy block length, chosen per corpus as floor(log2 n) - 6 within these
+    # bounds (NIST wants m < log2(n) - 5; one further bit of headroom keeps ~64 observations per
+    # pattern, so the chi-square is not read off a sparse table).
+    #
+    # A FIXED small m is the trap here: at m=2 the test only sees 2- and 3-bit blocks, and a
+    # stream built by repeating each nibble — an 8-bit period — has perfectly uniform statistics
+    # at that width. Measured, it scored ApEn=0.693, the ideal, on a corpus three other rows
+    # flagged. The block has to be wide enough to contain the repeat before this test can see it.
+    APEN_M_MIN    =    2
+    APEN_M_MAX    =    8
+    APEN_MIN_BITS = 1000
+
+    # The spectral test needs a power-of-two length for the radix-2 FFT, so the bitstream is
+    # truncated to the largest one it covers. The cap bounds an O(n log n) pass that the TUI
+    # re-runs on a throttle: 2^16 bits is ~1M butterfly ops, and the peak-count statistic is
+    # settled long before a full multi-megabit sample.
+    DFT_MIN_BITS = 1024
+    DFT_MAX_BITS = 1 << 16
+
+    # Above this the Cusum p-value series would run more terms than the answer is worth. A
+    # max excursion that small over that many bits is not a near-miss — see `cusum_p`.
+    CUSUM_MAX_TERMS = 10_000
+
     enum Verdict
       Pass
       Warn
@@ -55,6 +94,55 @@ module Gori::Sequencer
     # One row of the analysis table.
     record TestRow, name : String, value : String, detail : String, verdict : Verdict
 
+    # Which bytes of a token the byte-level tests may read — see the variable region in
+    # `analyze`. Every column of the aligned window that never varies is skipped; every byte
+    # outside the window is kept (a corpus of mixed lengths has no column evidence out there,
+    # so nothing is known to be constant). `full` keeps everything.
+    struct Region
+      def initialize(@min_len : Int32, @constant : Array(Bool), @from_end : Bool, @all : Bool = false)
+      end
+
+      def self.full : Region
+        new(0, [] of Bool, false, all: true)
+      end
+
+      # The corpus flattened to the bytes the tests may read, in token order. Built ONCE and
+      # shared by the frequency table, the symbol bitstream, the symbol sequence and the
+      # compression input, all of which used to re-walk `usable` themselves.
+      def bytes(usable : Array(String)) : Bytes
+        dropped = @constant.count(true)
+        return flatten(usable) if @all || @min_len <= 0 || dropped == 0
+        # `min_len` IS the shortest token's length, so the window fits inside every token and
+        # each one loses exactly `dropped` bytes — the size is known without a counting pass.
+        buf = Bytes.new(usable.sum(&.bytesize) - usable.size * dropped)
+        off = 0
+        usable.each do |t|
+          sl = t.to_slice
+          w0 = @from_end ? sl.size - @min_len : 0
+          i = 0
+          while i < sl.size
+            unless i >= w0 && i - w0 < @min_len && @constant.unsafe_fetch(i - w0)
+              buf.unsafe_put(off, sl.unsafe_fetch(i))
+              off += 1
+            end
+            i += 1
+          end
+        end
+        buf
+      end
+
+      private def flatten(usable : Array(String)) : Bytes
+        buf = Bytes.new(usable.sum(&.bytesize))
+        off = 0
+        usable.each do |t|
+          sl = t.to_slice
+          sl.copy_to(buf.to_unsafe + off, sl.size)
+          off += sl.size
+        end
+        buf
+      end
+    end
+
     record Report,
       sample_count : Int32,
       usable_count : Int32,
@@ -77,7 +165,15 @@ module Gori::Sequencer
       len_min : Int32,
       len_max : Int32,
       per_pos_entropy : Array(Float64),
-      bit_bias : Array(Float64) do
+      bit_bias : Array(Float64),
+      # Positions in the aligned window that NEVER vary — a token's structural skeleton (a
+      # `sess_` prefix, a version byte, base64 padding). They contribute exactly 0 to
+      # `effective_entropy` already; naming the count is what tells an operator that a
+      # 40-character token is really a 24-character one.
+      constant_positions : Int32 = 0,
+      # Whether the per-position window was anchored to the END of each token rather than its
+      # start — see `analyze`. Always false for a fixed-length corpus, where the two agree.
+      aligned_from_end : Bool = false do
       # A one-line rationale for the rating banner.
       def rationale : String
         return "no usable tokens" if usable_count == 0
@@ -103,33 +199,26 @@ module Gori::Sequencer
       len_max = lengths.max
       min_len = len_min
 
-      # Global byte-frequency table (drives Shannon/char-set/chi-square/char chart).
+      # Per-position entropy + the headline effective-entropy budget
+      # (Σ log2(distinct bytes seen at each position over a fixed window of min_len positions).
+      #
+      # It runs BEFORE the byte-frequency pass because its output decides which bytes that pass
+      # is allowed to look at — see the variable region below.
+      per_pos, effective, const_mask, aligned_from_end =
+        aligned_positions(usable, min_len, n, variable_length: len_min != len_max)
+      shannon_total = per_pos.sum
+      constant_positions = const_mask.count(true)
+
+      region_bytes = variable_region(usable, min_len, const_mask, aligned_from_end)
+      total_bytes = region_bytes.size.to_i64
+
       gcounts = Array(Int32).new(256, 0)
-      total_bytes = 0_i64
-      usable.each do |t|
-        t.to_slice.each do |b|
-          gcounts[b] += 1
-          total_bytes += 1
-        end
-      end
+      region_bytes.each { |b| gcounts[b] += 1 }
       present = [] of UInt8
       gcounts.each_with_index { |c, i| present << i.to_u8 if c > 0 }
       charset_size = present.size
       charset_label = classify(present)
       bits_per_char = shannon(gcounts, total_bytes)
-
-      # Per-position entropy + the headline effective-entropy budget
-      # (Σ log2(distinct bytes seen at each position over the common prefix)).
-      per_pos = Array(Float64).new(min_len, 0.0)
-      effective = 0.0
-      (0...min_len).each do |p|
-        col = Array(Int32).new(256, 0)
-        usable.each { |t| col[t.to_slice[p]] += 1 }
-        distinct = col.count(&.positive?)
-        per_pos[p] = shannon(col, n.to_i64)
-        effective += Math.log2(distinct.to_f) if distinct > 0
-      end
-      shannon_total = per_pos.sum
 
       lcounts = Hash(Int32, Int32).new(0)
       lengths.each { |l| lcounts[l] += 1 }
@@ -164,36 +253,51 @@ module Gori::Sequencer
       # bit tests would FAIL a genuinely-random token. Gate their FAIL contribution below.
       pow2 = charset_size > 0 && (charset_size & (charset_size - 1)) == 0
 
-      # Per-symbol-bit bias over the fixed common prefix (feeds the chart + a test).
-      prefix_bits = min_len * bps
-      ones_at = Array(Int32).new(prefix_bits, 0)
+      # Per-symbol-bit bias over the fixed window (feeds the chart + a test). Anchored to the
+      # same end as the per-position pass above — a suffix-aligned corpus measured from the
+      # start would score every column's bias against bytes from different logical fields.
+      window_bits = min_len * bps
+      ones_at = Array(Int32).new(window_bits, 0)
       if bps > 0
         usable.each do |t|
           sl = t.to_slice
           (0...min_len).each do |p|
-            v = idx_of.unsafe_fetch(sl[p])
+            v = idx_of.unsafe_fetch(sl[aligned_from_end ? sl.size - min_len + p : p])
             (0...bps).each { |k| ones_at[p * bps + k] += 1 if (v >> (bps - 1 - k)) & 1 == 1 }
           end
         end
       end
       bit_bias = ones_at.map { |c| (c.to_f / n - 0.5).abs }
 
-      bits = symbol_bits(usable, idx_of, bps, total_bytes)
-      sym_seq = symbol_seq(usable, idx_of, total_bytes)
+      bits = symbol_bits(region_bytes, idx_of, bps)
+      sym_seq = symbol_seq(region_bytes, idx_of)
+      # Over the WHOLE tokens, not the region: whether one value follows another is a property
+      # of the value an operator was issued, and a counter hidden behind a constant prefix is
+      # exactly what `detect_sequential` already goes out of its way to find.
       seq, seq_detail = detect_sequential(usable)
 
       tests = [] of TestRow
       tests << uniqueness_test(unique, n, duplicate_count)
       tests << TestRow.new("Sequential", seq ? "detected" : "none", seq_detail,
         seq ? Verdict::Fail : Verdict::Pass)
+      tests << structure_test(constant_positions, min_len, aligned_from_end)
       tests << gate_bits(monobit_test(bits, small), pow2)
       tests << gate_bits(poker_test(bits, small), pow2)
       tests << gate_bits(runs_test(bits, small), pow2)
       tests << gate_bits(longrun_test(bits, small), pow2)
       tests << chi_square_test(gcounts, present, total_bytes, small)
       tests << serial_test(sym_seq, small)
-      tests << compression_test(usable, total_bytes, charset_size, small)
-      tests << gate_bits(bit_bias_test(ones_at, n, small), pow2)
+      tests << compression_test(region_bytes, total_bytes, charset_size, small)
+      tests << gate_bits(bit_bias_test(ones_at, n, small, const_mask, bps), pow2)
+      # The three NIST-style additions. Each reads the SAME symbol bitstream the four classic
+      # bit tests do, so each is gated on a power-of-two alphabet for the same reason, and each
+      # catches a failure the existing table cannot: Cusum a drift that shows up only partway
+      # through the stream (the monobit total stays balanced), Approx entropy a repeating block
+      # structure (frequencies stay uniform), Spectral a periodicity — the signature of an LCG
+      # or a time-seeded counter, which passes every frequency-and-runs test there is.
+      tests << gate_bits(cusum_test(bits, small), pow2)
+      tests << gate_bits(approx_entropy_test(bits, small), pow2)
+      tests << gate_bits(spectral_test(bits, small), pow2)
 
       rating = rate(effective, duplicate_count, seq, tests, small)
 
@@ -206,7 +310,78 @@ module Gori::Sequencer
         uniqueness: uniqueness, duplicate_count: duplicate_count,
         sequential: seq, rating: rating, tests: tests,
         char_counts: char_counts, len_hist: len_hist, len_min: len_min, len_max: len_max,
-        per_pos_entropy: per_pos, bit_bias: bit_bias)
+        per_pos_entropy: per_pos, bit_bias: bit_bias,
+        constant_positions: constant_positions, aligned_from_end: aligned_from_end)
+    end
+
+    # The per-position pass, anchored to whichever END of the token carries more entropy.
+    #
+    # Anchoring to the START unconditionally — which is all this did — silently under-reports
+    # every token whose random part is a SUFFIX behind a variable-length structural head
+    # (`v2.<random>` / `<user-id>-<random>`): the columns then mix bytes from different logical
+    # fields, distinct counts collapse toward the shared structure, and a strong token reads
+    # Weak. Both alignments are the same measurement of the same corpus, so taking the larger
+    # keeps the figure conservative (still capped by min(N, alphabet) per column) without letting
+    # an arbitrary anchor choice decide the grade. A fixed-length corpus yields identical
+    # windows, so it never pays for the second pass.
+    private def self.aligned_positions(usable : Array(String), min_len : Int32, n : Int32,
+                                       variable_length : Bool) : {Array(Float64), Float64, Array(Bool), Bool}
+      per_pos, effective, mask = positional(usable, min_len, n, from_end: false)
+      return {per_pos, effective, mask, false} unless variable_length
+      s_pos, s_eff, s_mask = positional(usable, min_len, n, from_end: true)
+      s_eff > effective ? {s_pos, s_eff, s_mask, true} : {per_pos, effective, mask, false}
+    end
+
+    # THE VARIABLE REGION: every byte except those sitting at a window column that never varies.
+    # Everything byte-level in `analyze` — the alphabet, Shannon, the char chart, chi-square, the
+    # symbol bitstream all eight bit tests read, and compression — is measured over these bytes
+    # and no others.
+    #
+    # Reading the structural bytes too does not merely add noise, it disables the analysis.
+    # Measured on 300 tokens of `sess_v1_` + 24 random hex chars: the eight prefix bytes drag
+    # five extra characters into the alphabet, so charset reads 19 instead of 16 — NOT a power of
+    # two, which gates every bit test off as "n/a"; chi-square then fails on a byte distribution
+    # skewed purely by the constant prefix, compression fails because the repeated prefix
+    # deflates, and what is left is a WEAK grade on 96 bits of perfectly good hex, produced by
+    # tests that never looked at it. Excluded, the same corpus is what it actually is: a
+    # lower-hex alphabet with the full bit-test battery active and every row passing.
+    #
+    # A constant column carries exactly zero information — `effective_entropy` already scores it
+    # 0 — so dropping it removes nothing a test could have used. The `Region.full` fallback is
+    # for a corpus with NO varying column (an all-identical sample): there the exclusion would
+    # leave nothing to measure at all, and the honest answer is the one the unfiltered bytes give.
+    private def self.variable_region(usable : Array(String), min_len : Int32,
+                                     const_mask : Array(Bool), from_end : Bool) : Bytes
+      bytes = Region.new(min_len, const_mask, from_end).bytes(usable)
+      bytes.empty? ? Region.full.bytes(usable) : bytes
+    end
+
+    # Per-position byte entropy over a fixed window of `min_len` positions, with the
+    # effective-entropy budget (Σ log2 distinct) and a mask marking the columns that never vary.
+    # `from_end` reads position p as the p-th byte from the END of each token; both returned
+    # arrays are in token order (left to right within the window), so a caller charting them
+    # never has to know which anchor won.
+    #
+    # One 256-entry column table, refilled per position rather than reallocated: this runs
+    # twice for a variable-length corpus and min_len reaches the hundreds.
+    private def self.positional(usable : Array(String), min_len : Int32, n : Int32,
+                                from_end : Bool) : {Array(Float64), Float64, Array(Bool)}
+      per_pos = Array(Float64).new(min_len, 0.0)
+      constant = Array(Bool).new(min_len, false)
+      effective = 0.0
+      col = Array(Int32).new(256, 0)
+      (0...min_len).each do |p|
+        col.fill(0)
+        usable.each do |t|
+          sl = t.to_slice
+          col[sl.unsafe_fetch(from_end ? sl.size - min_len + p : p)] += 1
+        end
+        distinct = col.count(&.positive?)
+        per_pos[p] = shannon(col, n.to_i64)
+        effective += Math.log2(distinct.to_f) if distinct > 0
+        constant[p] = distinct == 1
+      end
+      {per_pos, effective, constant}
     end
 
     # A raw fixed-width bit test (monobit/poker/runs/long-run/bit-bias) only measures true
@@ -359,15 +534,15 @@ module Gori::Sequencer
     # Deflate ratio vs the token alphabet's own entropy floor (log2(charset)/8). A random
     # token compresses to ~its floor; a ratio well below it means real structure. Judging
     # against a flat 1.0 would wrongly fail every hex/base64 token for its encoding.
-    private def self.compression_test(tokens : Array(String), bytes : Int64,
+    private def self.compression_test(region : Bytes, bytes : Int64,
                                       charset_size : Int32, small : Bool) : TestRow
       return insufficient("Compression", "#{bytes} bytes") if bytes < 64
       # Cap the deflate input. The ratio is a stable statistic long before the whole sample is
-      # consumed, but `tokens.join` over a full 50k-token sample built a multi-MB String (from
-      # a String.build starting at capacity 64, so a realloc chain on top) and then deflated
-      # every byte of it — on a path the TUI re-runs on a throttle and every MCP poll re-runs
-      # from scratch. Whole tokens only, so a token is never split mid-value.
-      raw = join_capped(tokens, COMPRESS_SCAN_CAP)
+      # consumed, but a full 50k-token sample is multiple megabytes to deflate — on a path the
+      # TUI re-runs on a throttle and every MCP poll re-runs from scratch. A prefix of the
+      # region buffer, so the constant columns a structural prefix contributes (which deflate to
+      # nothing and would drag the ratio under any floor) are already out of it.
+      raw = region[0, {region.size, COMPRESS_SCAN_CAP}.min]
       io = IO::Memory.new(raw.size // 2)
       Compress::Deflate::Writer.open(io, &.write(raw))
       ratio = io.size.to_f / raw.size
@@ -385,14 +560,196 @@ module Gori::Sequencer
       TestRow.new("Compression", fmt(ratio), detail, verdict)
     end
 
-    private def self.bit_bias_test(ones_at : Array(Int32), n : Int32, small : Bool) : TestRow
-      total = ones_at.size
-      return insufficient("Bit bias", "no fixed prefix") if total == 0 || n < SMALL_SAMPLE
+    # How much of the token is skeleton rather than secret. INFO, never a FAIL: these columns
+    # already contribute 0 to `effective_entropy`, so grading them again would charge the same
+    # weakness twice — this row exists to explain a low headline figure, not to lower it.
+    private def self.structure_test(constant : Int32, min_len : Int32, from_end : Bool) : TestRow
+      return TestRow.new("Structure", "—", "no fixed window", Verdict::Info) if min_len <= 0
+      anchor = from_end ? "aligned to token end" : "aligned to token start"
+      detail = constant == 0 ? "every position varies · #{anchor}" : "#{min_len - constant} varying · #{anchor}"
+      TestRow.new("Structure", "#{constant}/#{min_len} fixed", detail, Verdict::Info)
+    end
+
+    # NIST SP 800-22 §2.13 (forward cumulative sums). The bits walk ±1 and the statistic is the
+    # largest absolute excursion. A generator whose bias appears only partway through the stream
+    # — a counter that rolls over, a pool that degrades once it drains — keeps a balanced ONES
+    # TOTAL and sails through Monobit while walking far off zero here.
+    private def self.cusum_test(bits : Array(UInt8), small : Bool) : TestRow
+      n = bits.size
+      return insufficient("Cusum", "#{n} bits") if n < 100
+      s = 0
+      z = 0
+      bits.each do |b|
+        s += b == 1_u8 ? 1 : -1
+        a = s.abs
+        z = a if a > z
+      end
+      # A walk that never leaves zero is not a near-miss — it is a perfectly alternating stream.
+      return TestRow.new("Cusum", "z=0", "walk never leaves 0", small ? Verdict::Warn : Verdict::Fail) if z == 0
+      p = cusum_p(z, n)
+      TestRow.new("Cusum", "z=#{z}", "max excursion · expected ~#{Math.sqrt(n.to_f).round.to_i}", grade(p, small))
+    end
+
+    # The forward-cusum p-value: 1 - Σ[Φ((4k+1)z/√n) - Φ((4k-1)z/√n)] + Σ[Φ((4k+3)z/√n) -
+    # Φ((4k+1)z/√n)], both series over k ≈ ±n/(4z). For a random walk z ≈ √n, so the term count
+    # is ≈ √n/2 — a few hundred terms even on a multi-megabit stream. A z small enough to blow
+    # that budget (n/z past CUSUM_MAX_TERMS·4) means an excursion orders of magnitude under the
+    # random expectation, which is itself decisive: report 0 rather than spend the series
+    # confirming it.
+    private def self.cusum_p(z : Int32, n : Int32) : Float64
+      return 0.0 if n.to_f / z > 4.0 * CUSUM_MAX_TERMS
+      sq = Math.sqrt(n.to_f)
+      zf = z.to_f
+      kmax = ((n.to_f / zf - 1.0) / 4.0).floor.to_i
+      sum1 = 0.0
+      k = ((-n.to_f / zf + 1.0) / 4.0).ceil.to_i
+      while k <= kmax
+        sum1 += phi(((4 * k + 1) * zf) / sq) - phi(((4 * k - 1) * zf) / sq)
+        k += 1
+      end
+      sum2 = 0.0
+      k = ((-n.to_f / zf - 3.0) / 4.0).ceil.to_i
+      while k <= kmax
+        sum2 += phi(((4 * k + 3) * zf) / sq) - phi(((4 * k + 1) * zf) / sq)
+        k += 1
+      end
+      (1.0 - sum1 + sum2).clamp(0.0, 1.0)
+    end
+
+    # NIST SP 800-22 §2.12. Compares the pattern-frequency entropy of m-bit blocks with that of
+    # (m+1)-bit blocks: for a random stream the extra bit buys a full ln2 of surprise. A stream
+    # built from a repeating block — a nonce reused across a chunk of the token, a PRNG with a
+    # short cycle — keeps every SINGLE-bit frequency uniform (so Monobit/Poker pass) while the
+    # transition structure gives it away here.
+    private def self.approx_entropy_test(bits : Array(UInt8), small : Bool) : TestRow
+      n = bits.size
+      return insufficient("Approx entropy", "#{n} bits") if n < APEN_MIN_BITS
+      m = (Math.log2(n.to_f).floor.to_i - 6).clamp(APEN_M_MIN, APEN_M_MAX)
+      apen = block_phi(bits, m) - block_phi(bits, m + 1)
+      chi = 2.0 * n * (Math.log(2.0) - apen)
+      p = chi2_sf(chi, 1 << m)
+      TestRow.new("Approx entropy", "ApEn=#{fmt(apen)}", "m=#{m} · ideal #{fmt(Math.log(2.0))}", grade(p, small))
+    end
+
+    # φ^(m): Σ π ln π over the 2^m block patterns of the CIRCULARLY extended bitstream (the
+    # last m-1 bits wrap onto the first), so all n windows exist and the two φ values are
+    # comparable. A flat 2^m counter array, rolled with a shift-and-mask.
+    private def self.block_phi(bits : Array(UInt8), m : Int32) : Float64
+      n = bits.size
+      counts = Array(Int32).new(1 << m, 0)
+      mask = (1 << m) - 1
+      v = 0
+      (0...(m - 1)).each { |i| v = ((v << 1) | bits.unsafe_fetch(i)) & mask }
+      n.times do |i|
+        v = ((v << 1) | bits.unsafe_fetch((i + m - 1) % n)) & mask
+        counts[v] += 1
+      end
+      total = n.to_f
+      s = 0.0
+      counts.each do |c|
+        next if c == 0
+        pr = c / total
+        s += pr * Math.log(pr)
+      end
+      s
+    end
+
+    # NIST SP 800-22 §2.6 (discrete Fourier transform). Counts how many spectral peaks fall
+    # under the 95% height threshold; a periodic component pushes peaks above it. This is the
+    # test that catches a linear-congruential or time-seeded generator — such a stream has
+    # uniform bit frequencies, well-behaved runs and near-ideal compression, and every other
+    # row in this table passes it.
+    private def self.spectral_test(bits : Array(UInt8), small : Bool) : TestRow
+      avail = {bits.size, DFT_MAX_BITS}.min
+      return insufficient("Spectral", "#{bits.size} bits") if avail < DFT_MIN_BITS
+      n = 1 << Math.log2(avail.to_f).floor.to_i # radix-2 FFT wants a power-of-two length
+      re = Array(Float64).new(n) { |i| bits.unsafe_fetch(i) == 1_u8 ? 1.0 : -1.0 }
+      im = Array(Float64).new(n, 0.0)
+      fft(re, im)
+      threshold = Math.sqrt(Math.log(1.0 / 0.05) * n)
+      half = n // 2
+      below = 0
+      half.times { |i| below += 1 if Math.sqrt(re[i] * re[i] + im[i] * im[i]) < threshold }
+      expected = 0.95 * half
+      d = (below - expected) / Math.sqrt(n * 0.95 * 0.05 / 4.0)
+      # Say so when the spectrum came from a prefix, so the number is never silently a different
+      # measurement from the one the sample size implies (same rule as the compression row).
+      scope = n < bits.size ? " · first #{n} bits" : ""
+      TestRow.new("Spectral", "d=#{fmt(d)}", "#{below}/#{half} peaks under T#{scope}", grade(two_sided(d), small))
+    end
+
+    # In-place iterative radix-2 Cooley-Tukey FFT. `re`/`im` must share a power-of-two length.
+    # The twiddle factor is advanced by recurrence rather than recomputed per butterfly: the
+    # accumulated drift over the 2^16-bit cap is far below the resolution of a peak COUNT
+    # against a fixed threshold, and per-step trig would cost a million calls.
+    private def self.fft(re : Array(Float64), im : Array(Float64)) : Nil
+      n = re.size
+      j = 0
+      (1...n).each do |i|
+        bit = n >> 1
+        while j & bit != 0
+          j ^= bit
+          bit >>= 1
+        end
+        j |= bit
+        if i < j
+          re.swap(i, j)
+          im.swap(i, j)
+        end
+      end
+      len = 2
+      while len <= n
+        ang = -2.0 * Math::PI / len
+        wr = Math.cos(ang)
+        wi = Math.sin(ang)
+        half = len // 2
+        i = 0
+        while i < n
+          cr = 1.0
+          ci = 0.0
+          half.times do |k|
+            ur = re.unsafe_fetch(i + k)
+            ui = im.unsafe_fetch(i + k)
+            xr = re.unsafe_fetch(i + k + half)
+            xi = im.unsafe_fetch(i + k + half)
+            vr = xr * cr - xi * ci
+            vi = xr * ci + xi * cr
+            re.unsafe_put(i + k, ur + vr)
+            im.unsafe_put(i + k, ui + vi)
+            re.unsafe_put(i + k + half, ur - vr)
+            im.unsafe_put(i + k + half, ui - vi)
+            ncr = cr * wr - ci * wi
+            ci = cr * wi + ci * wr
+            cr = ncr
+          end
+          i += len
+        end
+        len <<= 1
+      end
+    end
+
+    # Standard normal CDF, for the cusum series.
+    private def self.phi(x : Float64) : Float64
+      0.5 * Math.erfc(-x / Math.sqrt(2.0))
+    end
+
+    # `constant`/`bps` locate the window columns that never vary, whose bits are skipped. A
+    # constant column's ones-count is 0 or n by definition, so every one of its bits scores
+    # |z| = √n and counted as "biased" — a token behind an 8-character prefix reported 85 of 160
+    # positions biased on a corpus whose varying region was flawless. Structure is reported by
+    # its own INFO row; this row is about the bits that were supposed to be random.
+    private def self.bit_bias_test(ones_at : Array(Int32), n : Int32, small : Bool,
+                                   constant : Array(Bool), bps : Int32) : TestRow
+      return insufficient("Bit bias", "no fixed window") if ones_at.empty? || n < SMALL_SAMPLE
+      total = 0
       biased = 0
-      ones_at.each do |c|
+      ones_at.each_with_index do |c, i|
+        next if bps > 0 && constant[i // bps]? == true
+        total += 1
         z = (2.0 * c - n) / Math.sqrt(n.to_f)
         biased += 1 if z.abs > 2.58
       end
+      return insufficient("Bit bias", "no varying column") if total == 0
       frac = biased.to_f / total
       verdict = if frac > 0.05
                   small ? Verdict::Warn : Verdict::Fail
@@ -539,50 +896,26 @@ module Gori::Sequencer
 
     # ── shared numeric helpers ──────────────────────────────────────────────────────
 
-    # The concatenated symbol bitstream: each byte → its alphabet index → `bps` bits
+    # The symbol bitstream over the variable region: each byte → its alphabet index → `bps` bits
     # (MSB-first). Empty when the alphabet has ≤ 1 symbol (no bits to test).
-    # Concatenated token bytes, stopping at the first WHOLE token that would cross `cap` (so a
-    # token is never split mid-value). Presized, unlike `tokens.join`.
-    private def self.join_capped(tokens : Array(String), cap : Int32) : Bytes
-      total = 0
-      taken = 0
-      tokens.each do |t|
-        break if total + t.bytesize > cap && taken > 0
-        total += t.bytesize
-        taken += 1
-      end
-      buf = Bytes.new(total)
-      off = 0
-      taken.times do |i|
-        sl = tokens.unsafe_fetch(i).to_slice
-        sl.copy_to(buf.to_unsafe + off, sl.size)
-        off += sl.size
-      end
-      buf
-    end
-
-    # Presized: the final length is known exactly (total sample bytes × bps), and growing from
+    #
+    # Presized: the final length is known exactly (region bytes × bps), and growing from
     # capacity 0 to the millions of elements a full sample produces means ~20 doubling reallocs,
     # each copying everything written so far.
-    private def self.symbol_bits(tokens : Array(String), idx_of : Array(Int32), bps : Int32,
-                                 total_bytes : Int64) : Array(UInt8)
+    private def self.symbol_bits(region : Bytes, idx_of : Array(Int32), bps : Int32) : Array(UInt8)
       return [] of UInt8 if bps <= 0
-      bits = Array(UInt8).new((total_bytes * bps).to_i)
-      tokens.each do |t|
-        t.to_slice.each do |b|
-          v = idx_of.unsafe_fetch(b)
-          (bps - 1).downto(0) { |k| bits << ((v >> k) & 1).to_u8 }
-        end
+      bits = Array(UInt8).new(region.size * bps)
+      region.each do |b|
+        v = idx_of.unsafe_fetch(b)
+        (bps - 1).downto(0) { |k| bits << ((v >> k) & 1).to_u8 }
       end
       bits
     end
 
-    # The concatenated sequence of alphabet indices (for serial correlation). Presized for the
-    # same reason as symbol_bits.
-    private def self.symbol_seq(tokens : Array(String), idx_of : Array(Int32),
-                                total_bytes : Int64) : Array(Int32)
-      seq = Array(Int32).new(total_bytes.to_i)
-      tokens.each { |t| t.to_slice.each { |b| seq << idx_of.unsafe_fetch(b) } }
+    # The sequence of alphabet indices (for serial correlation). Presized for the same reason.
+    private def self.symbol_seq(region : Bytes, idx_of : Array(Int32)) : Array(Int32)
+      seq = Array(Int32).new(region.size)
+      region.each { |b| seq << idx_of.unsafe_fetch(b) }
       seq
     end
 
@@ -645,10 +978,12 @@ module Gori::Sequencer
       0.5 * Math.erfc(z / Math.sqrt(2.0))
     end
 
+    # Verdict for a p-value test. The bands are Bonferroni-split across the family — see
+    # `P_VALUE_TESTS` for why a per-test α would make every added test cost accuracy.
     private def self.grade(p : Float64, small : Bool) : Verdict
-      if p < 0.01
+      if p < ALPHA_FAIL
         small ? Verdict::Warn : Verdict::Fail
-      elsif p < 0.05
+      elsif p < ALPHA_WARN
         Verdict::Warn
       else
         Verdict::Pass

--- a/src/gori/tui/controllers/sequencer_controller.cr
+++ b/src/gori/tui/controllers/sequencer_controller.cr
@@ -128,6 +128,10 @@ module Gori::Tui
         return true
       end
       return false if (ev.ctrl? || ev.alt?) && !ev.key.escape? # ^R/^X → keymap verb
+      # ⇧E → sequence.export, dispatched by the keymap. The line below swallows every key
+      # this body does not itself use, so a SHIFTED chord (which is neither ctrl nor alt)
+      # never reaches the keymap unless it is declined here by name.
+      return false if c == 'E'
       ev.key.escape? ? handle_escape(v) : handle_pane_key(ev, v)
       true
     end
@@ -311,6 +315,76 @@ module Gori::Tui
       written = Clipboard.copy(text)
       note = Clipboard.note(written, text)
       @host.status(sel ? "copied #{written}b to clipboard#{note}" : "copied all (#{written}b)#{note}")
+    end
+
+    # --- report out: export to a file, or file the verdict as an Issue ---
+
+    # Whether there is a verdict to report at all — the availability gate both verbs share, so
+    # neither shows up on a session that has collected nothing.
+    def sequencer_report_ready? : Bool
+      current_view.try { |v| v.report.usable_count > 0 } || false
+    end
+
+    # Write this session's randomness report to `path` (the destination came from
+    # ExportOverlay). Returns whether the shell should CLOSE the popup: a correctable failure
+    # returns false so the card stays up with the typed path intact, the same rule
+    # `issues_export_to` follows.
+    #
+    # The trailing newline matches the Issues/Notes exports and `gori run sequence`, so the
+    # same verdict written from the TUI and from the CLI produces byte-identical files.
+    def sequencer_export_to(format : Symbol, path : String) : Bool
+      v = current_view
+      unless v
+        @host.status("no sequencer session")
+        return true
+      end
+      rep = v.report
+      if rep.usable_count == 0
+        @host.status("nothing to export — collect tokens first (^R)")
+        return true
+      end
+      content = if format == :json
+                  Sequencer::Present.report_json(rep)
+                else
+                  Sequencer::Present.report_markdown(rep, v.subject, heading: "Token randomness")
+                end
+      File.write(path, content.ends_with?('\n') ? content : "#{content}\n")
+      msg = "exported #{rep.rating.label} report · #{rep.usable_count} tokens → #{path}"
+      # Only warn when the report landed INSIDE the ephemeral project dir — a file written to
+      # the operator's cwd outlives the project just fine (same rule as issues_export_to).
+      msg += "  ⚠ temp project — copy it before closing" if @host.session.project.ephemeral? && path.starts_with?(@host.session.project.dir)
+      @host.status(msg)
+      true
+    rescue ex
+      @host.status("export failed: #{ex.message}")
+      false
+    end
+
+    # File the current verdict in the Issues report — the Sequencer's counterpart to
+    # `Probe::Triage.promote`. Until this existed a CRITICAL grade lived and died inside the
+    # session: collected tokens are never persisted, so closing the tab took the finding with
+    # it. The Issue carries the Markdown report as its notes and the seeding flow as evidence,
+    # and no token value (see `Present.report_markdown`).
+    def sequencer_promote : Nil
+      tab = current_tab_obj
+      v = tab.try(&.view)
+      return @host.status("no sequencer session") unless tab && v
+      rep = v.report
+      return @host.status("nothing to file — collect tokens first (^R)") if rep.usable_count == 0
+      store = @host.session.store
+      severity = Store::Severity.parse?(Sequencer::Present.issue_severity_label(rep)) || Store::Severity::Info
+      id = store.insert_issue(Sequencer::Present.issue_title(rep, v.subject), severity, v.target_host, tab.flow_id)
+      # insert_issue returns 0 — NOT nil — when the write never committed (busy/locked/closing
+      # store), and 0 is TRUTHY in Crystal. Reporting success there would tell the operator a
+      # finding is recorded when nothing was written; the same trap Probe::Triage.promote names.
+      return @host.status("could not file the issue (store busy) — nothing was written, try again") if id == 0
+      # A failed notes update leaves the Issue standing with its title and severity, which is
+      # still the finding — say which half landed rather than claim the whole thing did.
+      if store.update_issue(id, notes: Sequencer::Present.report_markdown(rep, v.subject))
+        @host.status("filed issue ##{id} (#{severity.label}) — see the Issues tab")
+      else
+        @host.status("filed issue ##{id} (#{severity.label}), but the report body did not save — store busy")
+      end
     end
 
     def handle_wheel(step : Int32) : Bool

--- a/src/gori/tui/export_overlay.cr
+++ b/src/gori/tui/export_overlay.cr
@@ -59,19 +59,23 @@ module Gori::Tui
     # the popup and the toast can't disagree about what was written.
     def label : String
       case @kind
-      when :note        then "note"
-      when :issues_md   then "issues (Markdown)"
-      when :issues_json then "issues (JSON)"
-      else                   "file"
+      when :note          then "note"
+      when :issues_md     then "issues (Markdown)"
+      when :issues_json   then "issues (JSON)"
+      when :sequence_md   then "randomness report (Markdown)"
+      when :sequence_json then "randomness report (JSON)"
+      else                     "file"
       end
     end
 
     private def blurb : String
       case @kind
-      when :note        then "Write the current note's text to a Markdown file."
-      when :issues_md   then "Write the Markdown issue report to a file."
-      when :issues_json then "Write every issue to a JSON file."
-      else                   "Write the export to a file."
+      when :note          then "Write the current note's text to a Markdown file."
+      when :issues_md     then "Write the Markdown issue report to a file."
+      when :issues_json   then "Write every issue to a JSON file."
+      when :sequence_md   then "Write this session's token-randomness report to a Markdown file (no token values)."
+      when :sequence_json then "Write this session's token-randomness report to a JSON file (no token values)."
+      else                     "Write the export to a file."
       end
     end
 

--- a/src/gori/tui/runner/sequencer.cr
+++ b/src/gori/tui/runner/sequencer.cr
@@ -38,6 +38,27 @@ class Gori::Tui::Runner < Gori::Verb::ExecContext
     reconfigure_sequence
   end
 
+  # Open the destination-path popup, then write the randomness report there. `format` is
+  # :markdown | :json — the same pair `issues_export` offers, and the same overlay.
+  def sequence_export(format : Symbol) : Nil
+    return (@toast = "open a sequencer session first") unless sequencer_controller.current_view
+    json = format == :json
+    kind = json ? :sequence_json : :sequence_md
+    open_export(kind, File.join(Dir.current, "sequence-report.#{json ? "json" : "md"}")) do |p|
+      sequencer_controller.sequencer_export_to(format, p)
+    end
+  end
+
+  def sequence_promote : Nil
+    sequencer_controller.sequencer_promote
+  end
+
+  # A session with a finished analysis is open — the gate for the export / file-as-issue verbs,
+  # so neither offers itself on an empty tab where it could only report "nothing to export".
+  def sequence_report_ready? : Bool
+    sequencer_controller.sequencer_report_ready?
+  end
+
   # The ANALYSIS report holds focus — the gate for its read verbs.
   def sequencer_analysis_readable? : Bool
     sequencer_controller.sequencer_analysis_readable?

--- a/src/gori/tui/sequencer_view.cr
+++ b/src/gori/tui/sequencer_view.cr
@@ -205,6 +205,26 @@ module Gori::Tui
       @target
     end
 
+    # The host an Issue filed from this session belongs to. nil for a manual paste, which has
+    # no origin at all — `insert_issue` takes a nilable host for exactly that case.
+    def target_host : String?
+      return nil if @config.mode.manual?
+      _, host, _ = Repeater::FlowRequest.parse_target(@target)
+      host.empty? ? nil : host
+    end
+
+    # What this session's report is ABOUT — see `Sequencer::Present::Subject`. Built here
+    # because the view is the only place holding the descriptor, the origin and the operator's
+    # name for the session at once, so the exported file and an Issue promoted from the same
+    # verdict cannot describe the run differently.
+    def subject : Sequencer::Present::Subject
+      Sequencer::Present::Subject.new(
+        descriptor: @config.token_loc.label,
+        origin: @config.mode.manual? ? nil : target_origin,
+        mode: @config.mode.label,
+        session: @name.try(&.strip).presence)
+    end
+
     # --- focus ring ---
     def focus_pane(pane : Symbol) : Nil
       @focus = pane if PANE_ORDER.includes?(pane)

--- a/src/gori/verb/context/sequencer.cr
+++ b/src/gori/verb/context/sequencer.cr
@@ -8,6 +8,11 @@ abstract class Gori::Verb::ExecContext
   abstract def sequence_run : Nil           # re-run collection for the focused Sequencer session
   abstract def sequence_stop : Nil          # stop the running collection
   abstract def sequence_configure : Nil     # reconfigure the focused session's token descriptor
+  # Write the focused session's randomness report to a file (:markdown | :json — the
+  # destination comes from the export popup), or file its verdict in the Issues report.
+  abstract def sequence_export(format : Symbol) : Nil
+  abstract def sequence_promote : Nil
+  abstract def sequence_report_ready? : Bool # a collected verdict exists — gates the two above
   # The ANALYSIS report holds focus — the gate for its row select / copy verbs. The report IS the
   # randomness finding, so being unable to paste it was half a tool.
   abstract def sequencer_analysis_readable? : Bool

--- a/src/gori/verbs/sequencer.cr
+++ b/src/gori/verbs/sequencer.cr
@@ -40,6 +40,25 @@ module Gori
         "sequence.configure", "Configure token", "Set the token location (cookie/header/regex/position/jsonpath) + goal",
         Verb::Scope::Sequencer, [Verb::Chord.new("c")], available: in_sequencer, mnemonic: 'c') { |ctx| ctx.sequence_configure; nil }
 
+      # Getting the verdict OUT. A randomness grade used to live and die inside the session —
+      # collected tokens are secrets and are never persisted, so closing the tab took the
+      # finding with it. Both are gated on there being a verdict at all, so neither offers
+      # itself on a session that has collected nothing.
+      has_report = ->(ctx : Verb::ExecContext) { ctx.current_tab == :sequencer && ctx.sequence_report_ready? }
+      # ⇧E, matching notes.export / issues.export-key — export is one key across the tree.
+      # `Chord.new("E")` would be DEAD: a shifted letter is ("e", shift: true).
+      r.register Verb::Definition.new(
+        "sequence.export", "Export report…", "Write this session's randomness report to a Markdown file (asks for the path)",
+        Verb::Scope::Sequencer, [Verb::Chord.new("e", shift: true)], available: has_report,
+        mnemonic: 'E') { |ctx| ctx.sequence_export(:markdown); nil }
+      r.register Verb::Definition.new(
+        "sequence.export-json", "Export report (JSON)…", "Write this session's randomness report to a JSON file (asks for the path)",
+        Verb::Scope::Sequencer, [] of Verb::Chord, available: has_report) { |ctx| ctx.sequence_export(:json); nil }
+      r.register Verb::Definition.new(
+        "sequence.promote", "File as issue", "Record this randomness verdict in the Issues report (no token values)",
+        Verb::Scope::Sequencer, [] of Verb::Chord, available: has_report,
+        mnemonic: 'i') { |ctx| ctx.sequence_promote; nil }
+
       r.register Verb::Definition.new(
         "sequence.find-subtab", "Search sub-tabs", "Filter the open sequencing sessions and jump to one",
         Verb::Scope::Sequencer,


### PR DESCRIPTION
Two things the Sequencer could not do.

## The byte-level analysis read structure as if it were secret

`Stats.analyze` measured every byte of every token. Measured on 300 tokens of `sess_v1_` plus 24 random hex characters:

| | before | after |
|---|---|---|
| charset | 19 (base64url) | 16 (lower-hex) |
| bit tests | all gated off as `n/a` | all active |
| verdict | **WEAK**, 2 tests failed | **SECURE**, all tests passed |

The eight prefix bytes drag five extra characters into the alphabet, so charset reads 19 instead of 16. That is not a power of two, which makes `gate_bits` switch the entire bit-test battery off as not-applicable; chi-square then fails on a distribution skewed purely by the prefix, and compression fails because the repeated prefix deflates. The verdict was WEAK on 96 bits of perfectly good hex, produced by tests that had never looked at it.

`analyze` now derives a **variable region** first (the columns of the aligned window that actually vary) and measures the alphabet, Shannon, the char chart, chi-square, the symbol bitstream and compression over those bytes only. A constant column carries exactly zero information and `effective_entropy` already scores it 0, so charging it a second time was the whole defect; the columns that never vary get their own INFO **Structure** row instead. `Region.full` falls back to every byte for a corpus with no varying column at all, where the exclusion would leave nothing to measure.

Bit bias had the same disease: a constant column's ones-count is 0 or n by definition, so each of its bits scores `|z| = √n` and counts as biased. It reported 85 of 160 positions biased on a corpus whose varying region was flawless.

`detect_sequential` deliberately stays on whole tokens: a counter hidden behind a constant prefix is exactly what it already goes out of its way to find.

## Window alignment

The per-position window anchored to the start of the token unconditionally, which under-reports any token whose random part is a suffix behind a variable-length head (`123-<random>`). It now runs both anchors and takes the larger, and the bit-bias scan follows the same anchor.

## Three NIST-style rows, and a correction that makes the battery safe to grow

- **Cusum** for a bias that appears only partway through the stream. The monobit total stays balanced and passes; the walk drifts thousands of steps off zero.
- **Approximate entropy** for a repeating block. It sizes `m` to the sample rather than fixing `m=2` — at that width an 8-bit repeat has perfectly uniform statistics, and it scored the ideal ApEn on a corpus three other rows flagged.
- **Spectral** (DFT) for periodicity, over an in-tree radix-2 FFT capped at 2^16 bits.

All three read the same symbol bitstream the classic four do, so all three are gated on a power-of-two alphabet for the same reason.

`rate` costs a tier per FAIL, so at a flat α=0.01 each, seven independent p-value tests give a clean token a ~6.8% chance of one spurious demotion, and every future test would push that higher. The p-value family now shares a **Bonferroni-corrected** threshold, holding the family-wise false-alarm rate at the ~1% a single test carried. A spec pins the roster against the constant so a future p-value test cannot silently break the correction.

## Getting the verdict out

Collected tokens are credentials and are never persisted, so closing the tab took the finding with it.

- `⇧E` exports the report as Markdown (JSON from the palette).
- **File as issue** files it in the Issues report, mapping Critical/Weak/Moderate/Secure to critical/high/medium/info, with the seeding flow as evidence and the report as the Issue body.
- `gori run sequence --format markdown` emits the same document.

One renderer backs all three, so a filed Issue and the file next to it cannot describe the same run differently. None of them can carry a token value: a `Stats::Report` holds frequency tables and verdicts, so there is no sample in it to leak.

## Verification

Live in the TUI over tmux: 500 tokens collected off a local cookie server → SECURE, charset 16, Bit bias 1/96. `⇧E` wrote the Markdown report (zero token occurrences in the file); `Space → i` filed issue #1 with the flow linked as evidence and the report as its notes.

Each new test was control-run against a corpus built for the defect it targets (a corpus whose bias switches halfway, one with doubled nibbles, an LCG) and against a clean one, before being turned into a regression spec.

Full suite green apart from the known port-conflict set and one `h2_engine_spec` flake that passes in isolation. No new ameba finding in any touched file.