### PR TITLE
Finish two `gori run` fixes that had only reached a third of their call sites

### DIFF
--- a/spec/cli/run/bind_from_disabled_rule_spec.cr
+++ b/spec/cli/run/bind_from_disabled_rule_spec.cr
@@ -142,7 +142,13 @@ describe "gori run --bind-from — the pre-plan refusal" do
       Gori::CLI::Run.bind_from_blocker_for_spec(Gori::Bindings.load(store))
         .should eq(Gori::CLI::Run::BIND_FROM_NO_RULES)
     end
-    # No project at all (--request/stdin) — same answer, one sentence.
+    # A nil layer keeps the no-rules answer HERE, and only here: this blocker is also what
+    # `seed_bindings` reaches, AFTER its own `open_store`, where nil means the load failed rather
+    # than "no project was named". The preflight caller no longer shares that answer — it routes
+    # through `preflight_bind_from_blocker`, which returns BIND_FROM_NO_PROJECT instead, because a
+    # nil layer there means `--request`/stdin was run with no --project/--db and telling that
+    # operator their project "declares no extract rules" was measurably false. Do not merge the two
+    # back together; see spec/cli_run_spec.cr's "no project vs no rules".
     Gori::CLI::Run.bind_from_blocker_for_spec(nil).should eq(Gori::CLI::Run::BIND_FROM_NO_RULES)
   end
 

--- a/spec/cli_run_spec.cr
+++ b/spec/cli_run_spec.cr
@@ -1034,3 +1034,41 @@ describe "CLI::Run.list_leftover_error" do
       .not_nil!.should contain("unknown subcommand 'disable'")
   end
 end
+
+# `--bind-from` refused a run in a project that DOES declare extract rules, with the sentence for a
+# project that declares none. `preflight_bind_from` reads `Env.layer`, hydrated only by
+# `open_store`, and on the `--request`/stdin path with no --project/--db nothing has opened a
+# project by then — so a nil layer means "no project in play", not "no rules". Measured: a project
+# holding an enabled `$SESSION` rule was told to run `rewriter extract add` and write it again.
+#
+# Asserted through `preflight_bind_from_blocker`, the function that MAKES the choice — not through
+# the constants alone. Constant-only assertions all stay green if the classification is deleted,
+# which is exactly the coverage gap that let this ship. (`bind_from_blocker_for_spec` already
+# exists in spec/cli/run/bind_from_disabled_rule_spec.cr; do not redefine it here — two reopens of
+# one module silently let the later-parsed body win.)
+describe "gori run --bind-from — no project vs no rules" do
+  it "classifies a nil layer as NO PROJECT, not as a project without rules" do
+    # The fix itself: delete the nil branch in preflight_bind_from_blocker and only this fails.
+    Gori::CLI::Run.preflight_bind_from_blocker(nil)
+      .should eq(Gori::CLI::Run::BIND_FROM_NO_PROJECT)
+  end
+
+  it "sends the no-project case to name the project, NOT to add a rule it may already have" do
+    msg = Gori::CLI::Run.preflight_bind_from_blocker(nil).not_nil!
+    msg.should contain("no project is in play")
+    msg.should contain("--project")
+    # The wrong remedy is the whole bug: following it persists a duplicate rule and the run is
+    # still refused, because the project was never named.
+    msg.should_not contain("rewriter extract add")
+    msg.should_not eq(Gori::CLI::Run::BIND_FROM_NO_RULES)
+  end
+
+  it "still defers to the blocker for a project that IS loaded" do
+    with_store do |store|
+      # An opened project with no rules keeps the add-a-rule remedy, so the split did not swallow
+      # the case the sentence was written for.
+      Gori::CLI::Run.preflight_bind_from_blocker(Gori::Bindings.load(store))
+        .should eq(Gori::CLI::Run::BIND_FROM_NO_RULES)
+    end
+  end
+end

--- a/src/gori/cli/run.cr
+++ b/src/gori/cli/run.cr
@@ -478,6 +478,25 @@ module Gori
       BIND_FROM_NO_RULES = "--bind-from: this project declares no extract rules, so a replay has " \
                            "nothing to bind — add one with `gori run rewriter extract add`"
 
+      # The refusal for a `--bind-from` run with NO PROJECT in play, which is a different fact from
+      # the sentence above and used to be told as that one.
+      #
+      # `Env.layer` is hydrated by `open_store`, and on the `--request`/stdin path with no
+      # --project/--db nothing has opened a project by preflight time (`hydrate_project_env` is
+      # skipped, the source is a file, `cli_host_overrides` returns nil without opening). So the
+      # layer is nil, `bind_from_blocker(nil)` said "this project declares no extract rules", and
+      # that was measurably FALSE — the ambient project may declare several — while sending the
+      # operator to `rewriter extract add` to write a rule that already exists. The action they
+      # actually need is to NAME the project.
+      #
+      # Deliberately not fixed by hydrating the ambient project here: binding a standalone run to
+      # the ambient project is the product call `optional_project_outbound` defers on #354, and it
+      # would also silently pull that project's Sandbox/scope into a run this surface announces as
+      # UNSCOPED. One fact, one sentence; the behaviour change stays with #354.
+      BIND_FROM_NO_PROJECT = "--bind-from: no project is in play (--request/stdin without " \
+                             "--project/--db), so no extract rules are loaded and a replay has " \
+                             "nothing to bind — name the project with --project NAME (or --db PATH)"
+
       private def self.bind_from_blocker(bindings : Gori::Bindings?) : String?
         return BIND_FROM_NO_RULES if bindings.nil?
         return nil unless bindings.declared.empty?
@@ -498,8 +517,22 @@ module Gori
       # the time it runs, so it can move ahead of the plan without the store or the outbound.
       private def self.preflight_bind_from(bind_from : Int64?, cmd : String) : Nil
         return unless bind_from
-        err = bind_from_blocker(Env.layer.as?(Gori::Bindings))
+        err = preflight_bind_from_blocker(Env.layer.as?(Gori::Bindings))
         abort "#{cmd}: #{err}" if err
+      end
+
+      # Why `--bind-from` cannot bind at PREFLIGHT time, or nil to go ahead. Split from the abort
+      # for the same reason `bind_from_blocker` is: a decision reached only through `abort` is
+      # untestable by construction, and every spec of it stays green if the line is deleted.
+      #
+      # The one difference from `bind_from_blocker` is the nil case, and it is the whole fix: a nil
+      # layer HERE means no project was ever opened (`Env.layer` is hydrated by `open_store`, which
+      # the `--request`/stdin path with no --project/--db never calls), not a project without rules.
+      # `bind_from_blocker` keeps its own nil branch on the no-rules sentence because `seed_bindings`
+      # reaches it AFTER an `open_store`, where nil is a genuine load failure instead.
+      def self.preflight_bind_from_blocker(layer : Gori::Bindings?) : String?
+        return BIND_FROM_NO_PROJECT if layer.nil?
+        bind_from_blocker(layer)
       end
 
       # One sentence for every `gori run` tool whose builder refused an env token that
@@ -583,6 +616,42 @@ module Gori
         end
       end
 
+      # The two warnings every positional-QL surface owes its operator, beside the composer whose
+      # `dropped` half feeds the first. Shared because the alternative is what it replaced: the
+      # sentence copy-pasted per command (three copies, one word apart) and the SECOND warning
+      # present on `history` alone.
+      #
+      # That second one is the whole reason this is not cosmetic. `compose_history_query`'s own
+      # docstring justifies itself with "A silently BROADER result set is the one outcome
+      # `warn_query_terms` exists to shout about" — but probe and sitemap only ever ran the
+      # invalid-regex half, never `QL.analyze(q).ignored`, so on those two surfaces the thing it
+      # exists to shout about went out silent. Measured before/after on all three:
+      # `--query='path:/keep size:>bogus'` — a KNOWN field whose value will not compile, so
+      # `size_cond` returns nil, `analyze` reports it ignored, the filter collapses to `path:/keep`
+      # and the result is broader than asked. `QL::EMPTY` does not catch it, because `path:/keep`
+      # compiles fine.
+      #
+      # An unknown field NAME (`hostt:x`) is NOT this case and must not be expected here: ql.cr's
+      # `field_cond` else-branch deliberately free-texts the whole token so a typo "matches nothing
+      # real", which means it DID compile and `analyze` rightly does not call it ignored. Negating
+      # one (`-hostt:x`) therefore matches every row — a real sharp edge, but it belongs to that
+      # design decision in ql.cr, not to this warning.
+      def self.warn_dropped_query_terms(cmd : String, dropped : String?) : Nil
+        return unless dropped
+        STDERR.puts "gori run #{cmd}: --query given, so the positional query term(s) " \
+                    "#{dropped.inspect} were ignored"
+      end
+
+      def self.warn_query_terms(cmd : String, q : String) : Nil
+        QL.invalid_regex_terms(q).each do |t|
+          STDERR.puts "gori run #{cmd}: warning: invalid regex in #{t.inspect} — that term matches nothing"
+        end
+        ignored = QL.analyze(q).ignored
+        return if ignored.empty?
+        STDERR.puts "gori run #{cmd}: warning: ignored #{ignored.map(&.inspect).join(", ")} " \
+                    "— unrecognized or invalid, so the result is BROADER than the query asks for"
+      end
+
       # QL negation terms ("-field:value" / "-field~rx") begin with '-', so OptionParser
       # aborts them as unknown options before the positional-query join ever runs. Pull
       # them out first so they join the query like any other positional term. A single-
@@ -630,18 +699,34 @@ module Gori
       # file's own header (see the `verb_token?` guards) calls the worst one a scripted surface
       # can have, so it becomes a usage error that names the ordering.
       private def self.refuse_list_leftovers(leftover : Array(String), sub : String,
-                                             verbs : String) : Nil
-        (msg = list_leftover_error(leftover, sub, verbs)) && abort(msg)
+                                             verbs : String, read_verb : String = "list") : Nil
+        (msg = list_leftover_error(leftover, sub, verbs, read_verb)) && abort(msg)
       end
 
       # The sentence `refuse_list_leftovers` aborts with, or nil to proceed. Split out so the
-      # decision AND the message are spec-able — `abort` is not, and this is the one fix of the
-      # three whose blast radius is several call sites (`cmd_rewriter_list`, `cmd_extract_list`,
-      # `cmd_probe_rules_list`) plus one DELIBERATE exclusion: `cmd_probe_scan` takes a positional
-      # QL query (`gori run probe [QL query]`), so a leftover there is the operator's filter, not
-      # a discarded verb. Do not add this to it.
-      def self.list_leftover_error(leftover : Array(String), sub : String, verbs : String) : String?
+      # decision AND the message are spec-able — `abort` is not — and now the single seam for
+      # twelve call sites, which is what makes `read_verb` belong here rather than in each of them.
+      # One DELIBERATE exclusion: `cmd_probe_scan` takes a positional QL query (`gori run probe
+      # [QL query]`), so a leftover there is the operator's filter, not a discarded verb. Do not
+      # add this to it.
+      #
+      # `read_verb` is the command's OWN read verb, and a lone one is NOT refused. The guard exists
+      # for "a destructive mutation that silently no-ops with a SUCCESS status" (see
+      # refuse_list_leftovers above); the read verb is neither destructive nor a no-op — it is
+      # precisely what this command was about to do anyway. Without this, the leading-flag route
+      # turned every `<cmd> --project=X list` into a usage error, because that route hands the list
+      # command its own name as a leftover (`cmd_issues` → `verb_token?("--project=X")` is false →
+      # `cmd_issues_list(["--project=X", "list"])`, leftover `["list"]`). The message was
+      # self-refuting too: it called `list` an unknown subcommand while listing `list` among the
+      # verbs. `gori run project sandbox` passes "status" — the only one of the twelve whose read
+      # verb is not spelled `list`.
+      #
+      # Exactly one token, and exactly that word: `issues --project=X list rm 3` still names `list`
+      # as the discarded-verb position, because there a real second verb followed it.
+      def self.list_leftover_error(leftover : Array(String), sub : String, verbs : String,
+                                   read_verb : String = "list") : String?
         return nil if leftover.empty?
+        return nil if leftover.size == 1 && leftover[0] == read_verb
         "gori run #{sub}: unknown subcommand '#{leftover[0]}' — global flags go AFTER " \
         "the subcommand (`gori run #{sub} #{leftover[0]} … --project=NAME`). Verbs: #{verbs}"
       end

--- a/src/gori/cli/run/history.cr
+++ b/src/gori/cli/run/history.cr
@@ -118,17 +118,14 @@ module Gori
         # mirroring the TUI's `/` bar — otherwise a positional query was silently dropped
         # and EVERY flow dumped.
         query, dropped = Run.compose_history_query(query, positional, neg_terms)
-        if dropped
-          STDERR.puts "gori run history: --query given, so the positional query term(s) " \
-                      "#{dropped.inspect} were ignored"
-        end
+        Run.warn_dropped_query_terms("history", dropped)
 
         store = open_store(resolve_read_project(project_name, db_path))
         begin
           rows =
             if q = query
               filter = QL.parse(q)
-              warn_query_terms(q)
+              Run.warn_query_terms("history", q)
               # A query that fails to compile to ANY clause (e.g. `status:>=foo`)
               # yields the match-all EMPTY filter — silently dumping every flow,
               # the opposite of what the user asked. Refuse it instead.
@@ -175,23 +172,6 @@ module Gori
       # STDOUT stays a pure HAR document (pipe it straight to a file); every caveat — flows
       # skipped, bodies capped — goes to STDERR, because a silently short export is exactly
       # the failure this file keeps having to fix.
-      # Both ways a typed term can fail to do what it says, on STDERR so `--format=json` stays
-      # machine-readable. An invalid regex matches NOTHING (indistinguishable from a genuinely
-      # empty result); a term gori could not compile at all is DROPPED, and a dropped term
-      # BROADENS — `QL::REFERENCE` calls that the dangerous direction. MCP has had `strict:true`
-      # and `ql_explain` for the second case from the start; the CLI had neither and no warning,
-      # so `history -q 'path:/graphql size:>bogus'` printed every /graphql flow with exit 0 and
-      # nothing to suggest the size filter had not been applied.
-      private def self.warn_query_terms(q : String) : Nil
-        QL.invalid_regex_terms(q).each do |t|
-          STDERR.puts "gori run history: warning: invalid regex in #{t.inspect} — that term matches nothing"
-        end
-        ignored = QL.analyze(q).ignored
-        return if ignored.empty?
-        STDERR.puts "gori run history: warning: ignored #{ignored.map(&.inspect).join(", ")} " \
-                    "— unrecognized or invalid, so the result is BROADER than the query asks for"
-      end
-
       private def self.emit_har(store : Store, rows : Array(Store::FlowRow), query : String?,
                                 limit : Int32) : Nil
         details = rows.reverse.each.compact_map { |r| store.get_flow(r.id) }

--- a/src/gori/cli/run/intercept.cr
+++ b/src/gori/cli/run/intercept.cr
@@ -105,6 +105,7 @@ module Gori
         project_name : String? = nil
         format = :text
         include_sensitive = false
+        leftover = [] of String
 
         parser = OptionParser.new do |p|
           p.banner = "Usage: gori run intercept [list] [options]"
@@ -113,10 +114,16 @@ module Gori
           p.on("--include-sensitive", "Show Authorization/Cookie/etc header values instead of [REDACTED]") { include_sensitive = true }
           p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
+          p.unknown_args { |rest, _| leftover = rest }
           p.invalid_option { |f| abort "gori run intercept: unknown option: #{f}\n#{p}" }
           p.missing_option { |f| abort "gori run intercept: missing value for #{f}" }
         end
         parser.parse(args)
+        # Both this and the mutating verbs report "no live capturing instance", so the swallowed
+        # `intercept --project=X drop 3` was indistinguishable from a real drop that found no TUI
+        # — the held request stayed held and the client stayed hung, under exit 0.
+        refuse_list_leftovers(leftover, "intercept",
+          "get, forward, drop, edit, enable, disable, filter, direction, list")
 
         project = resolve_read_project(project_name, db_path)
         store = open_store(project)

--- a/src/gori/cli/run/issues.cr
+++ b/src/gori/cli/run/issues.cr
@@ -27,6 +27,7 @@ module Gori
         project_name : String? = nil
         format = :text
         export_path : String? = nil
+        leftover = [] of String
 
         parser = OptionParser.new do |p|
           p.banner = "Usage: gori run issues [options]\n\n" \
@@ -39,10 +40,12 @@ module Gori
           p.on("--format=FMT", "Output: text (default) | json | markdown") { |v| format = parse_format(v, [:text, :json, :markdown]) }
           p.on("--export=PATH", "Write to PATH instead of STDOUT") { |v| export_path = v }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
+          p.unknown_args { |rest, _| leftover = rest }
           p.invalid_option { |f| abort "gori run issues: unknown option: #{f}\n#{p}" }
           p.missing_option { |f| abort "gori run issues: missing value for #{f}" }
         end
         parser.parse(args)
+        refuse_list_leftovers(leftover, "issues", "create, update, delete/rm, list")
 
         project = resolve_read_project(project_name, db_path)
         store = open_store(project)

--- a/src/gori/cli/run/links.cr
+++ b/src/gori/cli/run/links.cr
@@ -27,6 +27,7 @@ module Gori
         owner_s = "issue"
         owner_id : Int64? = nil
         format = :text
+        leftover = [] of String
 
         parser = OptionParser.new do |p|
           p.banner = "Usage: gori run links [list] --owner=issue|note --id=N\n\n" \
@@ -43,10 +44,15 @@ module Gori
           p.on("--id=N", "Owner issue/note id (required)") { |v| owner_id = parse_link_id(v, "--id") }
           p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
+          p.unknown_args { |rest, _| leftover = rest }
           p.invalid_option { |f| abort "gori run links: unknown option: #{f}\n#{p}" }
           p.missing_option { |f| abort "gori run links: missing value for #{f}" }
         end
         parser.parse(args)
+        # Only ever masked here by a flag mismatch: the COMPLETE mutate form aborts on `--ref`,
+        # which the list parser does not own, but `links --project=X --owner=issue --id=1 delete`
+        # listed and exited 0 with the verb discarded.
+        refuse_list_leftovers(leftover, "links", "add, delete/rm, list")
 
         owner_kind = Store::LinkOwnerKind.parse(owner_s) ||
                      abort("gori run links: invalid --owner '#{owner_s}' (issue|note)")
@@ -104,6 +110,7 @@ module Gori
         owner_id : Int64? = nil
         ref_s : String? = nil
         ref_id : Int64? = nil
+        leftover = [] of String
 
         parser = OptionParser.new do |p|
           p.banner = "Usage: gori run links #{verb} --owner=issue|note --id=N --ref=KIND --ref-id=M\n\n" \
@@ -115,10 +122,28 @@ module Gori
           p.on("--ref=KIND", "Target kind: flow|repeater|fuzz|miner (required)") { |v| ref_s = v.strip.downcase }
           p.on("--ref-id=M", "Target id (required)") { |v| ref_id = parse_link_id(v, "--ref-id") }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
+          p.unknown_args { |rest, _| leftover = rest }
           p.invalid_option { |f| abort "gori run links #{verb}: unknown option: #{f}\n#{p}" }
           p.missing_option { |f| abort "gori run links #{verb}: missing value for #{f}" }
         end
         parser.parse(args)
+        # Every end of a link is named by a FLAG, so a positional here is always a mistake — most
+        # likely a `--ref`/`--id` value the operator meant to attach to its flag. Silently dropping
+        # it would file (or fail to remove) a different link than the one written.
+        #
+        # Refused AFTER `parse`, never inside the `unknown_args` block: Crystal's OptionParser runs
+        # that callback BEFORE its `starts_with?('-')` → `invalid_option` sweep, and an unrecognized
+        # flag is still sitting in the leftovers at that point. Aborting from inside therefore
+        # pre-empted `invalid_option` and misdiagnosed a typo — `--refid=3` came back as "unexpected
+        # argument" instead of "unknown option: --refid" plus the help listing the real flag names,
+        # which is the one thing that tells the operator they dropped a dash. Deferring lets the
+        # sweep win for flags and leaves this to catch genuine positionals (which is also why the
+        # twelve `refuse_list_leftovers` sites were never exposed to it — they all defer too).
+        unless leftover.empty?
+          abort "gori run links #{verb}: unexpected argument#{leftover.size == 1 ? "" : "s"} " \
+                "#{leftover.join(" ").inspect} — every end is named by a flag " \
+                "(--owner, --id, --ref, --ref-id)"
+        end
 
         owner_kind = Store::LinkOwnerKind.parse(owner_s) ||
                      abort("gori run links #{verb}: invalid --owner '#{owner_s}' (issue|note)")

--- a/src/gori/cli/run/oast.cr
+++ b/src/gori/cli/run/oast.cr
@@ -90,6 +90,7 @@ module Gori
         project_name : String? = nil
         show_tokens = false
         format = :text
+        leftover = [] of String
 
         parser = OptionParser.new do |p|
           p.banner = "Usage: gori run oast providers [list] [options]\n\n" \
@@ -100,10 +101,13 @@ module Gori
           p.on("--show-tokens", "Print provider auth tokens instead of [REDACTED]") { show_tokens = true }
           p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
+          p.unknown_args { |rest, _| leftover = rest }
           p.invalid_option { |f| abort "gori run oast providers: unknown option: #{f}\n#{p}" }
           p.missing_option { |f| abort "gori run oast providers: missing value for #{f}" }
         end
         parser.parse(args)
+        refuse_list_leftovers(leftover, "oast providers",
+          "add, update, enable, disable, delete/rm, list")
 
         store = open_store(resolve_read_project(project_name, db_path))
         configs = begin

--- a/src/gori/cli/run/probe.cr
+++ b/src/gori/cli/run/probe.cr
@@ -80,16 +80,22 @@ module Gori
         neg_terms, opt_args = split_ql_negations(args)
         parser.parse(opt_args)
         # A positional QL is accepted too ("gori run probe status:>=500" / "-status:200"),
-        # mirroring history; an explicit --query wins. Terms join with spaces (QL ANDs them).
-        positional_query = (positional + neg_terms).join(' ')
-        query ||= positional_query unless positional_query.empty?
+        # mirroring history. `compose_history_query` owns the precedence, and it is shared rather
+        # than re-spelled here because the local `query ||= (positional + neg_terms).join` this
+        # replaces silently DISCARDED both halves whenever --query was also given: measured,
+        # `probe --query='host:x' '-path:/drop'` scanned 2 flows where the positional form scanned
+        # 1, and the summary line below printed the TRUNCATED query, so the widening was invisible
+        # in the output. A negation is not even the operator's second spelling of an argument —
+        # `split_ql_negations` reclassified it out of argv on their behalf.
+        query, dropped = Run.compose_history_query(query, positional, neg_terms)
+        Run.warn_dropped_query_terms("probe", dropped)
 
         filter : QL::Filter? = nil
         if q = query
           parsed = QL.parse(q)
-          QL.invalid_regex_terms(q).each do |t|
-            STDERR.puts "gori run probe: warning: invalid regex in #{t.inspect} — that term matches nothing"
-          end
+          # Both halves, not just invalid-regex: an UNRECOGNIZED field is dropped by QL and
+          # broadens the scan, which is the direction that matters here — see Run.warn_query_terms.
+          Run.warn_query_terms("probe", q)
           # A query that compiles to NOTHING (e.g. `status:>=foo`) becomes the match-all EMPTY
           # filter — here that would scan every flow, the opposite of what was asked. Refuse it.
           if !q.strip.empty? && parsed == QL::EMPTY

--- a/src/gori/cli/run/project.cr
+++ b/src/gori/cli/run/project.cr
@@ -66,14 +66,18 @@ module Gori
 
       private def self.cmd_project_list(args : Array(String)) : Nil
         format = :text
+        leftover = [] of String
         parser = OptionParser.new do |p|
           p.banner = "Usage: gori run project [list] [options]"
           p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
+          p.unknown_args { |rest, _| leftover = rest }
           p.invalid_option { |f| abort "gori run project: unknown option: #{f}\n#{p}" }
           p.missing_option { |f| abort "gori run project: missing value for #{f}" }
         end
         parser.parse(args)
+        refuse_list_leftovers(leftover, "project",
+          "list, create, delete/rm, scope, sandbox, env, host-override")
 
         registry = ProjectRegistry.new(Paths.projects_dir)
         projects = registry.list
@@ -342,6 +346,7 @@ module Gori
         db_path : String? = nil
         project_name : String? = nil
         format = :text
+        leftover = [] of String
 
         parser = OptionParser.new do |p|
           p.banner = "Usage: gori run project scope [options]\n\n" \
@@ -354,10 +359,13 @@ module Gori
           p.on("--db=PATH", "Explicit SQLite db file to read") { |v| db_path = v }
           p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
+          p.unknown_args { |rest, _| leftover = rest }
           p.invalid_option { |f| abort "gori run project scope: unknown option: #{f}\n#{p}" }
           p.missing_option { |f| abort "gori run project scope: missing value for #{f}" }
         end
         parser.parse(args)
+        refuse_list_leftovers(leftover, "project scope",
+          "add, update/edit, delete/rm, enable, disable, list")
 
         project = resolve_read_project(project_name, db_path)
         store = open_store(project)
@@ -607,6 +615,7 @@ module Gori
         db_path : String? = nil
         project_name : String? = nil
         format = :text
+        leftover = [] of String
 
         parser = OptionParser.new do |p|
           p.banner = "Usage: gori run project sandbox [options]\n\n" \
@@ -619,10 +628,16 @@ module Gori
           p.on("--db=PATH", "Explicit SQLite db file to read") { |v| db_path = v }
           p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
+          p.unknown_args { |rest, _| leftover = rest }
           p.invalid_option { |f| abort "gori run project sandbox: unknown option: #{f}\n#{p}" }
           p.missing_option { |f| abort "gori run project sandbox: missing value for #{f}" }
         end
         parser.parse(args)
+        # The one in this family where the silent no-op is a CONTAINMENT failure: `project
+        # sandbox --project=X on` printed the status, left the gate OFF and exited 0, so a CI
+        # bootstrap believed its traffic was contained when it was not.
+        refuse_list_leftovers(leftover, "project sandbox", "on/enable, off/disable, status",
+          read_verb: "status")
 
         project = resolve_read_project(project_name, db_path)
         store = open_store(project)
@@ -710,6 +725,7 @@ module Gori
         db_path : String? = nil
         project_name : String? = nil
         format = :text
+        leftover = [] of String
 
         parser = OptionParser.new do |p|
           p.banner = "Usage: gori run project env [options]\n\n" \
@@ -722,10 +738,12 @@ module Gori
           p.on("--db=PATH", "Explicit SQLite db file to read") { |v| db_path = v }
           p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
+          p.unknown_args { |rest, _| leftover = rest }
           p.invalid_option { |f| abort "gori run project env: unknown option: #{f}\n#{p}" }
           p.missing_option { |f| abort "gori run project env: missing value for #{f}" }
         end
         parser.parse(args)
+        refuse_list_leftovers(leftover, "project env", "set, delete/rm, list")
 
         project = resolve_read_project(project_name, db_path)
         store = open_store(project)
@@ -863,6 +881,7 @@ module Gori
         db_path : String? = nil
         project_name : String? = nil
         format = :text
+        leftover = [] of String
 
         parser = OptionParser.new do |p|
           p.banner = "Usage: gori run project host-override [options]\n\n" \
@@ -877,10 +896,12 @@ module Gori
           p.on("--db=PATH", "Explicit SQLite db file to read") { |v| db_path = v }
           p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
+          p.unknown_args { |rest, _| leftover = rest }
           p.invalid_option { |f| abort "gori run project host-override: unknown option: #{f}\n#{p}" }
           p.missing_option { |f| abort "gori run project host-override: missing value for #{f}" }
         end
         parser.parse(args)
+        refuse_list_leftovers(leftover, "project host-override", "add, update, delete/rm, list")
 
         project = resolve_read_project(project_name, db_path)
         store = open_store(project)

--- a/src/gori/cli/run/sequence.cr
+++ b/src/gori/cli/run/sequence.cr
@@ -15,8 +15,6 @@ module Gori
         insecure = false
         kind : Sequencer::ExtractKind? = nil
         selector = ""
-        pos_a = 0
-        pos_b = 0
         count = 500
         concurrency = 1
         rate : Float64? = nil
@@ -70,6 +68,35 @@ module Gori
 
         # Manual mode — analyze a token list, no network.
         if tf = tokens_file
+          # This branch returns before EVERY check below — the arity check, the token-location
+          # requirement, `preflight_bind_from` and `seed_bindings` — so anything that only matters
+          # to a live replay was silently discarded. `sequence 5 --tokens=f.txt` analyzed the file
+          # and never said the `5` had gone; worse, `--tokens=f.txt --bind-from=3` printed a full
+          # report at exit 0 with `--bind-from` a no-op, which is the very defect class (a
+          # `--bind-from` discarded before it could speak) that CLI::Run.preflight_bind_from exists
+          # to close — left open one branch away from it.
+          #
+          # Read off the PARSED state rather than re-scanning argv for flag names, so the list
+          # cannot drift from the parser above. The three numeric collection knobs (--count,
+          # --concurrency, --retries) are deliberately absent: they carry non-nil defaults, so
+          # "was it passed" is not recoverable from state, and each only sizes a collection that is
+          # not happening. Every flag that would put a REQUEST on the wire, and every token-location
+          # flag (redundant against a list of already-extracted tokens), is named.
+          live = [] of String
+          live << "<flow-id> #{positional.join(" ").inspect}" unless positional.empty?
+          live << "--flow" if flow_id
+          live << "--request" if request_file
+          live << "--target" if target_override
+          live << "--sni" if sni
+          live << "--http2" if force_h2
+          live << "--insecure-upstream" if insecure
+          live << "--bind-from" if bind_from
+          live << "--allow-unscoped" if allow_unscoped
+          live << "a token location (--cookie/--header/--regex/--position/--jsonpath)" if kind
+          unless live.empty?
+            abort "gori run sequence: --tokens analyzes a pasted list and sends nothing, so it " \
+                  "cannot be combined with #{live.join(", ")} — drop one"
+          end
           tokens = read_token_list(tf)
           abort "gori run sequence: no tokens to analyze" if tokens.empty?
           # A pasted list has no origin and no descriptor — name the FILE, so a markdown report

--- a/src/gori/cli/run/sitemap.cr
+++ b/src/gori/cli/run/sitemap.cr
@@ -126,9 +126,13 @@ module Gori
         neg_terms, opt_args = split_ql_negations(args)
         parser.parse(opt_args)
         # Accept a positional QL too ("gori run sitemap host:api" / "-status:404"), mirroring
-        # history's `/` bar; an explicit --query wins. Terms join with spaces (QL ANDs).
-        positional_query = (positional + neg_terms).join(' ')
-        query ||= positional_query unless positional_query.empty?
+        # history's `/` bar. Shared with history through `compose_history_query` rather than
+        # re-spelled: the local `query ||= (positional + neg_terms).join` this replaces threw both
+        # halves away whenever --query was given, so `sitemap --query='host:x' '-path:/drop'`
+        # printed the /drop endpoint the term excluded — a silently BROADER tree, with nothing on
+        # STDERR to say a term had gone.
+        query, dropped = Run.compose_history_query(query, positional, neg_terms)
+        Run.warn_dropped_query_terms("sitemap", dropped)
 
         # Parse/validate the QL BEFORE opening the store: abort skips ensure blocks, so a
         # bad query must not leave a store handle open.
@@ -151,9 +155,9 @@ module Gori
       private def self.sitemap_filter(query : String?) : QL::Filter
         return QL::EMPTY unless q = query
         filter = QL.parse(q)
-        QL.invalid_regex_terms(q).each do |t|
-          STDERR.puts "gori run sitemap: warning: invalid regex in #{t.inspect} — that term matches nothing"
-        end
+        # Both halves — an unrecognized field is dropped and BROADENS the tree. See
+        # Run.warn_query_terms.
+        Run.warn_query_terms("sitemap", q)
         if !q.strip.empty? && filter == QL::EMPTY
           abort "gori run sitemap: query #{q.inspect} did not match any field (check syntax, e.g. host:example.com method:POST path:/api status:>=500)"
         end


### PR DESCRIPTION
Two bug classes in `gori run` were each diagnosed, given a shared spec'd helper, and then wired to only some of their call sites. The helper's presence and its confident docstring are what kept the rest invisible.

Found by auditing `src/gori/cli/run.cr` (893 lines) + `src/gori/cli/run/*.cr` (23 files, 8.6k lines). Every finding below was reproduced against a binary built from this tree, driven with an isolated `GORI_HOME`.

## 1. A global flag before the verb turned 9 mutating commands into a silent no-op, exit 0

`refuse_list_leftovers` (run.cr) was wired to 3 of 14 list commands. The rest routed a leading `-` token straight to a list command whose `OptionParser` had **no `unknown_args` handler** — Crystal silently discards leftover positionals in that case, so the verb and its arguments vanished and the command exited 0.

| invocation | before | now |
|---|---|---|
| `project sandbox --project=X on` | printed status, **containment stayed OFF**, rc=0 | rc=1 |
| `project scope --project=X delete 1` | listed rules, #1 still there | rc=1 |
| `project scope --project=X enable`/`disable` | listed, flag unchanged | rc=1 |
| `project env --project=X set K=v` / `delete K` | listed | rc=1 |
| `project host-override --project=X delete 1` | listed | rc=1 |
| `issues --project=X delete 1` | listed issues | rc=1 |
| `oast providers --project=X delete p_1` | listed providers | rc=1 |
| `intercept --project=X drop 3` | ran the LIST command | rc=1 |
| `links --project=X --owner=issue --id=1 delete` | listed | rc=1 |
| `project --format=text delete X` | listed projects | rc=1 |

**`project sandbox on` is the headline** — sandbox is the hard-containment gate, and this command exists specifically as the headless CI bootstrap. A pipeline got exit 0 and believed traffic was contained when it was not.

`intercept` needed a discriminator: list *and* drop both report "no live capturing instance". `--format=json` proves which ran — the flag-before-verb form emitted the list object byte-identical to `intercept list`.

`cmd_repeater_list` / `cmd_decoder_list` are **deliberately untouched**: they dispatch on an exact verb with no leading-flag fallthrough, so they were never in the class (`repeater --project=X list` → `rc=1 invalid flow id 'list'`), and the shared message would misdirect there.

## 2. `--query` silently discarded QL terms on `probe` and `sitemap`

`compose_history_query` was made public and spec'd for exactly this; only `history` called it. Both others kept `query ||= positional_query`, dropping **negations and plain positionals**.

```
probe --query='host:x' '-path:/drop'    scanned 2 flows   (positional form: 1)
  summary: no issues in flows matching "host:x"           ← truncated, so invisible
sitemap --query='host:x' '-path:/drop'  printed the /drop endpoint the term excluded
```

Both now route through the shared composer and warn on the swallowed half. `warn_query_terms` moves to `run.cr` with it — probe and sitemap had only ever run its invalid-regex half, never the `QL.analyze(q).ignored` half that names a **BROADENING** result, which is the outcome the composer's own docstring cites as its reason to exist. Verified: `--query='path:/keep size:>bogus'` now warns on all three surfaces; before, only `history` did.

## 3. `--bind-from` told the no-project case as the no-rules case

`preflight_bind_from` reads `Env.layer`, hydrated only by `open_store`. On `--request`/stdin with no `--project`/`--db` nothing has opened a project by then, so a project holding an **enabled** `$SESSION` rule was told it "declares no extract rules" and sent to `rewriter extract add` to write it again.

Split into `BIND_FROM_NO_PROJECT`, behind a new `preflight_bind_from_blocker` so the classification is spec-able instead of reachable only through `abort`. Not fixed by hydrating the ambient project — that is the #354 product call, and it would pull that project's Sandbox/scope into a run this surface announces as UNSCOPED.

## Also

- **`read_verb` on the shared guard.** The naive guard refused the command's own read verb, so `<cmd> --project=X list` (and `project sandbox … status`) became a usage error whose message called `list` unknown *while listing `list` among the verbs*. A lone read verb is neither destructive nor a no-op — it is what the command was about to do anyway. This repairs the 3 pre-existing sites too, which had the same flaw before this branch.
- **`sequence --tokens`** returned before every source check, so `--bind-from`, `--target`, `--sni`, `--http2`, `-k`, `--allow-unscoped`, a token location, and any positional were silently discarded on the documented no-network path. `--tokens --bind-from=3` printed a full report at exit 0 with the replay never happening.
- **`links add`/`delete`** refuse a stray positional — *after* `parse`, never inside `unknown_args`, because OptionParser runs that callback before its own invalid-option sweep, and aborting from inside misdiagnosed a typo'd flag (`--refid=3`) as an unexpected argument instead of naming the unknown option.
- Dead `pos_a`/`pos_b` locals removed; the `dropped` warning sentence stops being copy-pasted three times.

## Verification

- `crystal build src/main.cr` clean.
- Specs **7524 → 7527**, same 8 failures both before and after — the known-environmental `Gori::Session` port-bind examples in `project_registry_spec` / `capture_status_spec`. No new failures.
- 3 new examples assert the `--bind-from` split through `preflight_bind_from_blocker`, the function that makes the choice; constant-only assertions would stay green if the classification were deleted, which is the coverage gap that let this ship.
- All 11 flag-before-verb forms now `rc=1`; all 12 `<cmd> … list` forms `rc=0`; `--help`/`-h` still `rc=0` on all 9 touched commands; the mutations themselves verified to actually mutate (`sandbox on` → `status: ENABLED`).