### PR TITLE
Stop `gori settings` from calling a section unknown just because this machine has no value for it

### DIFF
--- a/docs/content/reference/cli.ko.md
+++ b/docs/content/reference/cli.ko.md
@@ -690,24 +690,36 @@ gori settings import FILE          # 프로필의 섹션들을 적용
 
 ```bash
 gori settings export --sections network,scan_rules -o team-profile.json
-gori settings import team-profile.json --dry-run     # 무엇이 바뀔지 미리 보기
+gori settings import team-profile.json --dry-run     # 무엇이 적용될지 미리 보기
 gori settings import team-profile.json --sections network
 ```
 
+`gori settings sections`는 gori가 아는 모든 섹션을 나열하고, 이 설치본에 아직 값이 없는 것을 표시합니다:
+
+```
+network
+scan_rules  (not set — at its default)
+env  (holds secrets — excluded unless named; not set — at its default)
+```
+
+*not set*으로 표시된 섹션도 `--sections`에 쓸 수 있는 정상적인 이름입니다. export하면 담을 값이 없을 뿐이고(그 사실을 stderr로 알려줍니다), import하면 그 섹션이 처음으로 기록됩니다.
+
 | 플래그 | 대상 | 설명 |
 |------|-----------|-------------|
-| `--sections a,b` | 공통 | 쉼표로 구분한 섹션 이름. export 기본값은 비밀을 담은 섹션을 제외한 전부, import 기본값은 파일에 있는 전부 |
+| `--sections a,b` | 공통 | 쉼표로 구분한 섹션 이름, 최소 하나. export 기본값은 비밀을 담은 섹션을 제외한 전부, import 기본값은 파일에 있는 전부 |
 | `-o`, `--out FILE` | export | stdout 대신 파일로 기록 |
-| `--dry-run` | import | 바뀔 섹션만 출력하고 아무것도 쓰지 않고 종료 |
+| `--dry-run` | import | 적용될 섹션만 출력하고 아무것도 쓰지 않고 종료 |
 
 선택하지 않았거나 프로필에 없는 섹션은 **그대로 남습니다**. `--sections`가 고르는 것이 바로 이 경계입니다. 프로필이 실제로 담고 있는 섹션 안에서는:
 
 - **리스트/테이블 섹션은 통째 교체됩니다**: `upstream_rules`, `outbound_tls`, `listeners`, `scan_rules`, `hostname_overrides`, `tabs` 등. `"upstream_rules": []`를 담은 프로필은 테이블을 비웁니다 — "규칙 없음"을 그렇게 표현합니다.
 - **스칼라 오브젝트 섹션은 키 단위로 적용됩니다**: `network`, `editor`, `probe`. 프로필이 생략한 키는 현재 값을 유지하므로, `network.upstream_proxy`만 지정한 팀 프로필이 언급한 적도 없는 `bind_port`까지 기본값으로 되돌리지 않습니다.
 
-`export`는 공장 기본값 상태인 섹션을 아예 쓰지 않으므로, 프로필은 설정 전체의 스냅샷이 아니라 *적용할 값들의 묶음*입니다 — 어떤 값이 기본값인 머신에서 export해도, 그 값이 기본값이 아닌 머신에서 되돌려지지 않습니다. import가 실제로 무엇을 건드릴지는 `--dry-run`으로 확인하세요.
+`export`는 공장 기본값 상태인 섹션을 아예 쓰지 않으므로, 프로필은 설정 전체의 스냅샷이 아니라 *적용할 값들의 묶음*입니다 — 어떤 값이 기본값인 머신에서 export해도, 그 값이 기본값이 아닌 머신에서 되돌려지지 않습니다. import가 무엇을 건드릴지는 `--dry-run`으로 확인하세요 — 목록에 넣는 쪽으로 넉넉하게 판단하므로, 거기 없는 섹션은 확실히 아무 변화도 없습니다.
 
-import는 TUI와 동일한 저장 경로를 거치므로 원자적 쓰기가 유지되고, 동시에 실행 중인 gori가 건드리지 않은 섹션에 한 편집을 덮어쓰지 않습니다. 파일에 있는 알 수 없는 섹션은 보고하고 무시합니다.
+import는 TUI와 동일한 저장 경로를 거치므로 원자적 쓰기가 유지되고, 동시에 실행 중인 gori가 건드리지 않은 섹션에 한 편집이나 삭제를 덮어쓰지 않습니다. 파일에 있는 알 수 없는 섹션은 보고하고 무시합니다 — 실행 중인 설정에도, 파일에도 반영되지 않습니다.
+
+gori가 `settings.json`을 읽지 못하는 상태 — 파싱 실패, 권한 문제, `--config`가 열 수 없는 대상을 가리키는 경우 — 라면 `export`와 `import` 모두 진행하지 않고 거부합니다. 그 시점의 gori는 모든 섹션이 공장 기본값이므로, import는 프로필이 언급하지 않은 섹션 전부를 기본값으로 디스크에 박고, export는 그 기본값을 당신의 설정인 양 파일로 내보내기 때문입니다. 먼저 파일을 고치거나 지우세요 — 파싱되지 않은 원본은 옆에 `settings.json.corrupt`로 보관됩니다. `--dry-run`은 예외입니다: 아무것도 쓰지 않으므로 그대로 실행되고, 비교 대상이 기본값이라는 사실을 stderr로 알려줍니다.
 
 `env`와 `decoder`는 export에서 기본 제외됩니다 — `env`는 토큰 값을, `decoder`는 마지막 입력과 저장된 세션을 담기 때문입니다. 명시적으로 이름을 적는 것(`--sections env`)이 포함에 대한 동의입니다. `upstream_rules`는 공유해도 안전합니다 — 사용자명과 환경변수 *이름*만 저장하고 비밀번호는 담지 않습니다.
 

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -710,24 +710,36 @@ gori settings import FILE          # apply a profile's sections
 
 ```bash
 gori settings export --sections network,scan_rules -o team-profile.json
-gori settings import team-profile.json --dry-run     # show what would change
+gori settings import team-profile.json --dry-run     # show what would be applied
 gori settings import team-profile.json --sections network
 ```
 
+`gori settings sections` lists every section gori knows, marking the ones this install has no value for yet:
+
+```
+network
+scan_rules  (not set — at its default)
+env  (holds secrets — excluded unless named; not set — at its default)
+```
+
+A section marked *not set* is still a valid name for `--sections`: exporting it simply carries nothing (gori says so on stderr), and importing one writes it for the first time.
+
 | Flag | Applies to | Description |
 |------|-----------|-------------|
-| `--sections a,b` | both | Comma-separated section names. Export defaults to everything except secret-bearing sections; import defaults to every section in the file |
+| `--sections a,b` | both | Comma-separated section names; at least one. Export defaults to everything except secret-bearing sections; import defaults to every section in the file |
 | `-o`, `--out FILE` | export | Write to a file instead of stdout |
-| `--dry-run` | import | Print which sections would change, then exit without writing |
+| `--dry-run` | import | Print which sections would be applied, then exit without writing |
 
 A section you do not select — or that the profile does not carry — is left **exactly as it was**. That is the guarantee `--sections` is choosing between. Within a section the profile *does* carry:
 
 - **List and table sections replace wholesale**: `upstream_rules`, `outbound_tls`, `listeners`, `scan_rules`, `hostname_overrides`, `tabs`, and the rest. A profile carrying `"upstream_rules": []` clears the table — that is how "no rules" is stated.
 - **Object-of-scalars sections apply key by key**: `network`, `editor`, `probe`. A key the profile omits keeps its current value, so a team profile that pins `network.upstream_proxy` does not also reset everyone's `bind_port` to a default it never mentioned.
 
-Note that `export` omits a section sitting at its factory default, so a profile is a set of values to *apply*, not a snapshot of a whole configuration: exporting from a machine where a value is default will not reset that value on a machine where it is not. Pass `--dry-run` to see exactly which sections an import would touch.
+Note that `export` omits a section sitting at its factory default, so a profile is a set of values to *apply*, not a snapshot of a whole configuration: exporting from a machine where a value is default will not reset that value on a machine where it is not. Pass `--dry-run` to see which sections an import would touch — it errs on the side of listing one, so a section it does *not* name is guaranteed to be a no-op.
 
-Import goes through the same writer the TUI uses, so it keeps the atomic write and cannot clobber a concurrently-running gori's edit to a section it did not touch. Unrecognised sections in the file are reported and ignored.
+Import goes through the same writer the TUI uses, so it keeps the atomic write and cannot clobber a concurrently-running gori's edit to — or deletion of — a section it did not touch. Unrecognised sections in the file are reported and ignored: they reach neither the live settings nor the file.
+
+If gori cannot load your `settings.json` — unparseable, unreadable, or a `--config` pointing at something it cannot open — both `export` and `import` refuse rather than proceeding. Every section is at its factory default at that point, so an import would persist those defaults over every section the profile does not name, and an export would write them out as if they were yours. Fix or remove the file first; an unparseable one is kept alongside it as `settings.json.corrupt`. `--dry-run` is the exception: it writes nothing, so it still runs, and says on stderr that the comparison is against defaults.
 
 `env` and `decoder` are excluded from an export by default: `env` holds token values and `decoder` holds your last input and saved sessions. Naming one explicitly (`--sections env`) is how you consent to include it. Note that `upstream_rules` is safe to share — it stores a username and an environment-variable *name*, never a password.
 

--- a/spec/cli_spec.cr
+++ b/spec/cli_spec.cr
@@ -12,6 +12,21 @@ module Gori::CLI
     _, subargs = split_subcommand(argv)
     global_version_flag?(subargs)
   end
+
+  # `gori settings` helpers. Only the PURE ones are reachable: the guards themselves end in
+  # `abort`, which calls `exit` and is not catchable, so each of these is the decision the
+  # abort is made on rather than the abort itself.
+  def self.unknown_settings_verb_for_spec(args : Array(String)) : Bool
+    unknown_settings_verb?(args)
+  end
+
+  def self.parse_sections_value_for_spec(value : String) : Array(String)
+    parse_sections_value(value)
+  end
+
+  def self.unknown_sections_for_spec(list : Array(String)) : Array(String)
+    unknown_sections(list)
+  end
 end
 
 describe "gori — global version flag" do
@@ -95,5 +110,62 @@ describe "gori — global version flag" do
     Gori::CLI.global_version_flag_for_spec(["--verbose"]).should be_false
     Gori::CLI.global_version_flag_for_spec(["-vv"]).should be_false
     Gori::CLI.global_version_flag_for_spec(["run", "decoder", "--input", "-vsomething"]).should be_false
+  end
+end
+
+# `gori settings` argv guards. Each one closes a silent-no-op-carrying-SUCCESS hole — the
+# failure mode the `global_version_flag?` comment above condemns at length, which `gori
+# settings` was reproducing on a typo'd verb, an empty `--sections`, and a misspelt one.
+describe "gori settings — subcommand dispatch" do
+  it "rejects a bare word that is not one of the three verbs" do
+    # `gori settings expor -o profile.json` used to print the settings path and exit 0: no
+    # export, no file, and `… || die` never fires.
+    Gori::CLI.unknown_settings_verb_for_spec(["expor"]).should be_true
+    Gori::CLI.unknown_settings_verb_for_spec(["expor", "-o", "p.json"]).should be_true
+    Gori::CLI.unknown_settings_verb_for_spec(["blahblah", "nonsense"]).should be_true
+  end
+
+  it "accepts the three verbs and every flag-only form" do
+    Gori::CLI.unknown_settings_verb_for_spec(["export"]).should be_false
+    Gori::CLI.unknown_settings_verb_for_spec(["import", "p.json"]).should be_false
+    Gori::CLI.unknown_settings_verb_for_spec(["sections"]).should be_false
+    # Bare `gori settings`, and the flag forms it has always taken.
+    Gori::CLI.unknown_settings_verb_for_spec([] of String).should be_false
+    Gori::CLI.unknown_settings_verb_for_spec(["--edit"]).should be_false
+    Gori::CLI.unknown_settings_verb_for_spec(["-h"]).should be_false
+  end
+end
+
+describe "gori settings — --sections parsing" do
+  it "trims and drops empties" do
+    Gori::CLI.parse_sections_value_for_spec("network, theme ").should eq(["network", "theme"])
+    Gori::CLI.parse_sections_value_for_spec("network,,theme").should eq(["network", "theme"])
+  end
+
+  # The caller aborts on an empty result. It has to check emptiness explicitly: `[] of String`
+  # is TRUTHY in Crystal, so `if list = sections` used to pass with nothing in it, and
+  # `--sections=""` exported `{}` / imported nothing at exit 0 — where a shell expanding an
+  # unset variable lands.
+  it "yields nothing for an empty or all-comma value" do
+    Gori::CLI.parse_sections_value_for_spec("").should be_empty
+    Gori::CLI.parse_sections_value_for_spec(",,,").should be_empty
+    Gori::CLI.parse_sections_value_for_spec("  ").should be_empty
+  end
+end
+
+describe "gori settings — section-name validation" do
+  # Static SECTION_KEYS, never `document_keys`: a section at its factory default is absent from
+  # the latter, which is how `--sections network,scan_rules` (the example in the CLI reference)
+  # aborted as "unknown" on every fresh install.
+  it "accepts a known section this install has no value for" do
+    Gori::CLI.unknown_sections_for_spec(["network", "scan_rules"]).should be_empty
+    Gori::CLI.unknown_sections_for_spec(Gori::Settings::SECTION_KEYS).should be_empty
+  end
+
+  it "names the ones gori does not know" do
+    # Import used not to validate at all, so `--sections netwrok` selected nothing and reported
+    # "imported 0 section(s)" with exit 0.
+    Gori::CLI.unknown_sections_for_spec(["netwrok"]).should eq(["netwrok"])
+    Gori::CLI.unknown_sections_for_spec(["network", "bogus", "theme"]).should eq(["bogus"])
   end
 end

--- a/spec/settings_profile_spec.cr
+++ b/spec/settings_profile_spec.cr
@@ -33,6 +33,120 @@ private def with_config_home(&)
   end
 end
 
+# A profile that puts a NON-DEFAULT value in every one of Settings::SECTION_KEYS, so
+# `document_keys` (derived from `serialize`, which omits a section at its default) can be
+# compared against SECTION_KEYS exactly rather than as a one-way subset. Every entry here is
+# shaped to survive its section's tolerant parser — a rejected entry leaves the section empty,
+# the section then does not serialize, and the guard silently weakens instead of failing.
+private MAXIMAL_PROFILE = <<-JSON
+  {
+    "theme": "goriday",
+    "mouse": false,
+    "pretty_bodies": false,
+    "layout": { "history_preview": true, "history_list_order": "oldest" },
+    "statusline": { "command": "echo hi" },
+    "display": { "history_time_format": "relative" },
+    "pet": { "enabled": true, "notices": false },
+    "notifications": { "bell": true, "toast": false },
+    "general": { "confirm_quit": false, "clipboard_osc52": false },
+    "update": { "notified_version": "9.9.9" },
+    "network": { "bind_port": 9191 },
+    "upstream_rules": [ { "host": "*.corp", "kind": "direct" } ],
+    "outbound_tls": [ { "host": "a.test", "min_version": "tls1.2" } ],
+    "retention": { "max_flows": 4242 },
+    "listeners": [ { "host": "127.0.0.1", "port": 8099, "mode": "proxy" } ],
+    "editor": { "command": "nvim" },
+    "tabs": [ { "id": "history", "visible": true } ],
+    "hostname_overrides": [ { "host": "api.corp", "ip": "10.0.0.5" } ],
+    "env": { "vars": [ { "key": "TOKEN", "value": "v" } ] },
+    "scan_rules": [ { "id": "r1", "title": "t", "pattern": "p", "enabled": false } ],
+    "oast_providers": [ { "id": "o1", "name": "p1", "kind": "interactsh", "host": "x.test" } ],
+    "hotkeys": { "os": "linux" },
+    "mine": { "locations": ["query"], "concurrency": 11 },
+    "fuzzer": { "recent_wordlists": ["/tmp/w.txt"] },
+    "probe": { "active_notify": "always" },
+    "discover": { "containment": "strict", "max_depth": 3 },
+    "decoder": { "chains": [ { "name": "c1", "spec": "base64-decode" } ] },
+    "rewriter": { "next_rule_id": 2, "rules": [] }
+  }
+  JSON
+
+# Settings are class_properties — process-global, not per-example — so an example that
+# populates all 28 sections would leak every one of them into whatever spec file runs next.
+# `with_config_home` already resets the handful its own examples touch; this restores the rest
+# by SNAPSHOT rather than by naming defaults, so it stays correct whatever state it inherits.
+private def with_every_section_populated(&)
+  pretty = Gori::Settings.pretty_bodies_default
+  mouse = Gori::Settings.mouse
+  hist_preview = Gori::Settings.history_preview
+  hist_order = Gori::Settings.history_list_order
+  statusline = Gori::Settings.statusline_command
+  time_format = Gori::Settings.history_time_format
+  pet = Gori::Settings.pet?
+  pet_notices = Gori::Settings.pet_notices?
+  bell = Gori::Settings.notify_bell?
+  toast = Gori::Settings.notify_toast?
+  osc52 = Gori::Settings.clipboard_osc52?
+  confirm_quit = Gori::Settings.confirm_quit?
+  notified = Gori::Settings.update_notified_version
+  outbound = Gori::Settings.outbound_tls
+  retention = Gori::Settings.retention_max_flows
+  listeners = Gori::Settings.listeners
+  editor = Gori::Settings.editor
+  tabs = Gori::Settings.tab_prefs
+  overrides = Gori::Settings.hostname_overrides
+  scan_rules = Gori::Settings.scan_rules
+  oast = Gori::Settings.oast_providers
+  keymap_os = Gori::Settings.keymap_os
+  wordlists = Gori::Settings.fuzz_recent_wordlists
+  probe_notify = Gori::Settings.probe_active_notify
+  containment = Gori::Settings.discover_containment
+  depth = Gori::Settings.discover_max_depth
+  chains = Gori::Settings.decoder_chains
+  rules = Gori::Settings.rewriter_rules
+  next_id = Gori::Settings.rewriter_next_rule_id
+  # `parse_mine_prefs`/`parse_discover_prefs` end with `keep_alive = obj["keep_alive"]? != false`,
+  # so a mine/discover block that omits the key forces BOTH to true — a leak this helper exists
+  # to prevent, and one no other reset in this file covers.
+  mine_keep_alive = Gori::Settings.mine_keep_alive?
+  discover_keep_alive = Gori::Settings.discover_keep_alive?
+  begin
+    yield
+  ensure
+    Gori::Settings.pretty_bodies_default = pretty
+    Gori::Settings.mouse = mouse
+    Gori::Settings.history_preview = hist_preview
+    Gori::Settings.history_list_order = hist_order
+    Gori::Settings.statusline_command = statusline
+    Gori::Settings.history_time_format = time_format
+    Gori::Settings.pet = pet
+    Gori::Settings.pet_notices = pet_notices
+    Gori::Settings.notify_bell = bell
+    Gori::Settings.notify_toast = toast
+    Gori::Settings.clipboard_osc52 = osc52
+    Gori::Settings.confirm_quit = confirm_quit
+    Gori::Settings.update_notified_version = notified
+    Gori::Settings.outbound_tls = outbound
+    Gori::Settings.retention_max_flows = retention
+    Gori::Settings.listeners = listeners
+    Gori::Settings.editor = editor
+    Gori::Settings.tab_prefs = tabs
+    Gori::Settings.hostname_overrides = overrides
+    Gori::Settings.scan_rules = scan_rules
+    Gori::Settings.oast_providers = oast
+    Gori::Settings.keymap_os = keymap_os
+    Gori::Settings.fuzz_recent_wordlists = wordlists
+    Gori::Settings.probe_active_notify = probe_notify
+    Gori::Settings.discover_containment = containment
+    Gori::Settings.discover_max_depth = depth
+    Gori::Settings.decoder_chains = chains
+    Gori::Settings.rewriter_rules = rules
+    Gori::Settings.rewriter_next_rule_id = next_id
+    Gori::Settings.mine_keep_alive = mine_keep_alive
+    Gori::Settings.discover_keep_alive = discover_keep_alive
+  end
+end
+
 describe "settings profiles" do
   describe ".path resolution" do
     it "prefers --config over $GORI_CONFIG over GORI_HOME" do
@@ -188,17 +302,32 @@ describe "settings profiles" do
       with_config_home do
         Gori::Settings.theme = "goridark"
         raw = %({"theme":"goriday","mouse":#{Gori::Settings.mouse},"bogus":{"a":1}})
-        changed, unknown = Gori::Settings.import_preview(raw)
+        applicable, changed, unknown = Gori::Settings.import_preview(raw)
+        applicable.should eq(["theme", "mouse"]) # both recognised, both would be applied
         changed.should contain("theme")
         changed.should_not contain("mouse") # identical to current → not a change
         unknown.should eq(["bogus"])
       end
     end
 
+    # `applicable` is what BOTH `--dry-run` and the real run report, so the two commands agree
+    # on the count. Reporting `changed` from one and `applied` from the other let a six-section
+    # profile preview as "would apply 1 section(s)" and then import as "imported 6".
+    it "returns the set a real import would apply, not just the differing subset" do
+      with_config_home do
+        Gori::Settings.theme = "goridark"
+        raw = %({"theme":"goridark","network":{"bind_port":9999}})
+        applicable, changed, _ = Gori::Settings.import_preview(raw)
+        changed.should eq(["network"])             # theme already matches
+        applicable.should eq(["theme", "network"]) # …but both are still applied
+        Gori::Settings.import_document(raw).should eq(applicable)
+      end
+    end
+
     it "honours a section filter" do
       with_config_home do
         raw = %({"theme":"goriday","network":{"bind_port":9999}})
-        changed, _ = Gori::Settings.import_preview(raw, ["network"])
+        _, changed, _ = Gori::Settings.import_preview(raw, ["network"])
         changed.should eq(["network"])
       end
     end
@@ -318,6 +447,128 @@ describe "Settings.apply_sections — a non-object section must not abandon the 
       Gori::Settings.editor.should eq("nvim")
       Gori::Settings.bind_port.should eq(9123)
       Gori::Settings.theme.should eq("goriday")
+    end
+  end
+end
+
+# `document_keys` is derived from `serialize`, so a section sitting at its factory default is
+# absent from it. Using it as the VALIDITY oracle made a section's NAME valid or invalid
+# depending on the machine: `gori settings export --sections network,scan_rules` — the example
+# in docs/reference/cli.md — aborted with "unknown section(s): scan_rules" on any install where
+# scan_rules was untouched, and `gori settings import` called a well-known section
+# "unrecognised … ignored" and then applied it anyway. Settings::SECTION_KEYS is the static
+# answer to "does gori know this name?"; these pin the two apart.
+describe "Settings::SECTION_KEYS" do
+  it "matches every key `serialize` can emit, in both directions" do
+    with_every_section_populated do
+      with_config_home do
+        # The RETURN value matters as much as the on-disk keys: import_document filters
+        # `selected` through SECTION_KEYS, so a name missing from the registry is silently
+        # dropped on the way IN — it would never reach `apply_sections` and would never show up
+        # in document_keys either, leaving the comparison below trivially satisfied.
+        applied = Gori::Settings.import_document(MAXIMAL_PROFILE)
+        applied.sort.should eq(Gori::Settings::SECTION_KEYS.sort)
+
+        keys = Gori::Settings.document_keys
+        # A section added to `serialize` without a SECTION_KEYS entry — the regression that
+        # reintroduces the export abort and the bogus "unrecognised" warning.
+        (keys - Gori::Settings::SECTION_KEYS).should be_empty
+        # A SECTION_KEYS entry naming nothing real (a typo, or a section since removed), which
+        # would advertise a name in `gori settings sections` that export then silently drops.
+        (Gori::Settings::SECTION_KEYS - keys).should be_empty
+      end
+    end
+  end
+
+  it "still knows a section this install has never touched" do
+    with_config_home do
+      Gori::Settings.document_keys.should_not contain("scan_rules") # at its default → not serialized
+      Gori::Settings::SECTION_KEYS.should contain("scan_rules")     # …but gori knows the name
+    end
+  end
+end
+
+describe "Settings.import_preview / import_document — recognised vs applied" do
+  # The headline: a valid section at its factory default was reported "unrecognised … ignored"
+  # and then written anyway. `env` is the sharp case — on a fresh config it is empty, so gori
+  # told the operator the credential-bearing section had been ignored while writing the token
+  # values to disk.
+  it "does not call a valid-but-default section unrecognised, and counts it as applied" do
+    with_config_home do
+      raw = %({"env":{"vars":[{"key":"TOKEN","value":"leaked"}]}})
+      applicable, changed, unknown = Gori::Settings.import_preview(raw, ["env"])
+      unknown.should be_empty
+      applicable.should eq(["env"])
+      changed.should eq(["env"])
+
+      Gori::Settings.import_document(raw, ["env"]).should eq(["env"])
+      Gori::Settings.env_vars.should eq([{"TOKEN", "leaked"}])
+    end
+  end
+
+  it "reports a genuinely unknown section AND leaves it out of the applied set" do
+    with_config_home do
+      raw = %({"network":{"bind_port":9191},"bogus":{"a":1}})
+      applicable, changed, unknown = Gori::Settings.import_preview(raw)
+      unknown.should eq(["bogus"])
+      applicable.should eq(["network"]) # the unknown key is not offered for application
+      changed.should eq(["network"])
+
+      # "ignored" has to be TRUE: the key is dropped before apply_sections, so it reaches
+      # neither the live settings nor the file, and the returned list is exactly what landed.
+      Gori::Settings.import_document(raw).should eq(["network"])
+      JSON.parse(File.read(Gori::Settings.path)).as_h.has_key?("bogus").should be_false
+    end
+  end
+end
+
+# The 3-way merge exists so persisting one field cannot discard a concurrent writer's edit to
+# an unrelated one. It got EDITS right and DELETIONS wrong: a `disk_h[k]? || cur_v` fallback
+# treated "the peer removed this section" as "the peer has nothing to say about it" and wrote
+# our stale copy back. Sections vanish from `serialize` the moment they are emptied, so
+# clearing your env vars in one gori window and saving anything in another resurrected the
+# token values.
+describe "Settings.save — merging against a concurrent writer" do
+  it "honours a peer's deletion of a section this process did not change" do
+    with_config_home do
+      Gori::Settings.env_vars = [{"TOKEN", "super-secret"}]
+      Gori::Settings.upstream_rules = [Gori::Settings::UpstreamRule.new("*.corp", "http", "proxy:3128")]
+      Gori::Settings.save
+      Gori::Settings.load # this read is the merge BASE
+
+      # A peer clears both sections (they stop serializing) and changes something of its own.
+      peer = JSON.parse(File.read(Gori::Settings.path)).as_h
+      peer.delete("env")
+      peer.delete("upstream_rules")
+      peer["theme"] = JSON::Any.new("goriday")
+      File.write(Gori::Settings.path, peer.to_pretty_json)
+
+      Gori::Settings.mouse = !Gori::Settings.mouse # an unrelated change of ours
+      Gori::Settings.save
+
+      on_disk = JSON.parse(File.read(Gori::Settings.path)).as_h
+      on_disk.has_key?("env").should be_false
+      on_disk.has_key?("upstream_rules").should be_false
+      on_disk["theme"].as_s.should eq("goriday") # their EDIT still merges through
+    end
+  end
+
+  it "still lets a section THIS process changed win over disk" do
+    with_config_home do
+      Gori::Settings.save
+      Gori::Settings.load
+      peer = JSON.parse(File.read(Gori::Settings.path)).as_h
+      peer.delete("env")
+      peer["theme"] = JSON::Any.new("goriday")
+      File.write(Gori::Settings.path, peer.to_pretty_json)
+
+      # We add env AFTER loading, so mine != base for it — the deletion rule must not eat it.
+      Gori::Settings.env_vars = [{"TOKEN", "ours"}]
+      Gori::Settings.save
+
+      on_disk = JSON.parse(File.read(Gori::Settings.path)).as_h
+      on_disk["env"].to_json.should contain("ours")
+      on_disk["theme"].as_s.should eq("goriday")
     end
   end
 end

--- a/src/gori/cli.cr
+++ b/src/gori/cli.cr
@@ -221,25 +221,74 @@ module Gori
     # — the same file the TUI's settings:* + ^E editor write); `--edit` opens it in
     # $EDITOR. Lazily created with current defaults on first invocation. ("config"
     # the word is reserved for the runtime Config struct — flags/effective config.)
+    private SETTINGS_USAGE = "Usage: gori settings [--edit]\n" \
+                             "       gori settings sections\n" \
+                             "       gori settings export [--sections a,b] [-o FILE]\n" \
+                             "       gori settings import FILE [--sections a,b] [--dry-run]"
+
+    private SETTINGS_VERBS = {"export", "import", "sections"}
+
+    # A leading BARE WORD that is not one of the three verbs is a typo, not a flag. Letting it
+    # fall through to `run_settings`'s own parser dropped it — OptionParser ignores leftover
+    # positionals with no `unknown_args` handler — so `gori settings expor -o profile.json`
+    # printed the settings path and exited 0: no export, no file, and `… || die` never fires.
+    # That is the silent-no-op-carrying-SUCCESS failure this very file refuses for version flags
+    # (see global_version_flag?), and `run_ca` below already rejects the identical shape.
+    private def self.unknown_settings_verb?(args : Array(String)) : Bool
+      return false unless first = args[0]?
+      !first.starts_with?('-') && !SETTINGS_VERBS.includes?(first)
+    end
+
+    # Parse, then refuse any leftover positional. OptionParser silently DROPS unclaimed bare
+    # words when no `unknown_args` handler is installed, and every `gori settings` verb but
+    # `import` takes none — so `gori settings --edit export` opened the editor and dropped
+    # `export`, `gori settings sections --help` printed the section list and never saw `--help`,
+    # and `gori settings export team-profile.json` (a forgotten `-o`) dumped the profile to
+    # stdout, created no file, and exited 0. `import` parses on its own because it does take a
+    # positional; its own `rest.size > 1` guard is the same rule.
+    private def self.reject_stray_args!(cmd : String, parser : OptionParser, args : Array(String)) : Nil
+      rest = [] of String
+      parser.unknown_args { |before, _| rest = before }
+      parser.parse(args)
+      return if rest.empty?
+      label = cmd.empty? ? "gori settings" : "gori settings #{cmd}"
+      abort "#{label}: unexpected argument(s): #{rest.join(", ")}\n#{parser}"
+    end
+
+    # Refuse to read or write a profile against settings gori could not load. Every section is
+    # at its factory default at that point, so an EXPORT writes those defaults out under the
+    # operator's name — into a file that outlives the stderr warning and gets committed or
+    # shared — and an IMPORT persists them back over the real file (the 3-way merge has no base;
+    # see Settings.load_degraded?). Both directions turn a recoverable local problem into a
+    # permanent one, so neither is worth guessing at.
+    private def self.abort_on_degraded_settings!(cmd : String) : Nil
+      return unless Settings.load_degraded?
+      abort "gori settings #{cmd}: #{Settings.path} could not be loaded (see the warning above, " \
+            "if any), so every section is at its factory default right now — this would #{cmd} " \
+            "those defaults, not your settings.\nFix or remove that file, then re-run."
+    end
+
     private def self.run_settings(args : Array(String)) : Nil
       case args[0]?
       when "export"   then return run_settings_export(args[1..])
       when "import"   then return run_settings_import(args[1..])
-      when "sections" then return run_settings_sections
+      when "sections" then return run_settings_sections(args[1..])
+      end
+      if unknown_settings_verb?(args)
+        STDERR.puts "unknown settings subcommand: #{args[0]}"
+        STDERR.puts SETTINGS_USAGE
+        exit 1
       end
 
       edit = false
       parser = OptionParser.new do |p|
-        p.banner = "Usage: gori settings [--edit]\n" \
-                   "       gori settings sections\n" \
-                   "       gori settings export [--sections a,b] [-o FILE]\n" \
-                   "       gori settings import FILE [--sections a,b] [--dry-run]"
+        p.banner = SETTINGS_USAGE
         p.on("--edit", "Open the settings file in your editor (Settings: Editor / $VISUAL / $EDITOR / vi)") { edit = true }
         p.on("-h", "--help", "Show this help") { puts p; exit 0 }
         p.invalid_option { |flag| abort "unknown option: #{flag}\n#{p}" }
         p.missing_option { |flag| abort "missing value for #{flag}" }
       end
-      parser.parse(args)
+      reject_stray_args!("", parser, args)
 
       Paths.ensure_dirs
       Settings.load                                    # pick up the persisted editor pref + existing values
@@ -261,17 +310,46 @@ module Gori
       end
 
       cmd = Settings.editor_command
-      status = Process.run(cmd[0], cmd[1..] + [path],
-        input: Process::Redirect::Inherit, output: Process::Redirect::Inherit, error: Process::Redirect::Inherit)
+      status =
+        begin
+          Process.run(cmd[0], cmd[1..] + [path],
+            input: Process::Redirect::Inherit, output: Process::Redirect::Inherit, error: Process::Redirect::Inherit)
+        rescue File::NotFoundError
+          # Process.run RAISES when the program isn't on PATH, and CLI.run's rescue catches only
+          # Gori::Error — so a stale $EDITOR, or an `"editor": {"command": …}` naming something
+          # this box doesn't have, printed a Crystal backtrace at the user. ExternalEditor (the
+          # TUI's ^E path) has always handled this properly; match its wording.
+          abort "gori settings --edit: editor not found: #{cmd[0]}\n" \
+                "Set one with 'Settings: Editor' in the TUI, or via $VISUAL / $EDITOR."
+        rescue ex
+          abort "gori settings --edit: could not run the editor (#{cmd.join(' ')}): #{ex.message}"
+        end
       abort "gori settings: editor (#{cmd.join(' ')}) exited #{status.exit_code}" unless status.success?
     end
 
-    # `gori settings sections` — the top-level keys export/import operate on. Derived from the
-    # live serialization, so a newly added section appears here with no list to update.
-    private def self.run_settings_sections : Nil
+    # `gori settings sections` — the top-level keys export/import operate on.
+    #
+    # Lists Settings::SECTION_KEYS (every section gori knows), not `document_keys` (the ones
+    # this install happens to have a value for). Listing the latter meant a fresh config
+    # advertised 6 of 28 sections, and the ones it hid were exactly the ones export then
+    # rejected as "unknown" — so the message pointing here for "the list" pointed at a list that
+    # did not contain the name. The "not set" annotation keeps the information that was
+    # genuinely useful about the old output.
+    private def self.run_settings_sections(args : Array(String)) : Nil
+      parser = OptionParser.new do |p|
+        p.banner = "Usage: gori settings sections"
+        p.on("-h", "--help", "Show this help") { puts p; exit 0 }
+        p.invalid_option { |flag| abort "unknown option: #{flag}\n#{p}" }
+      end
+      reject_stray_args!("sections", parser, args)
+
       Settings.load
-      Settings.document_keys.each do |k|
-        puts Settings::SECRET_SECTIONS.includes?(k) ? "#{k}  (holds secrets — excluded unless named)" : k
+      present = Settings.document_keys
+      Settings::SECTION_KEYS.each do |k|
+        notes = [] of String
+        notes << "holds secrets — excluded unless named" if Settings::SECRET_SECTIONS.includes?(k)
+        notes << "not set — at its default" unless present.includes?(k)
+        puts notes.empty? ? k : "#{k}  (#{notes.join("; ")})"
       end
     end
 
@@ -281,18 +359,24 @@ module Gori
       out = nil.as(String?)
       parser = OptionParser.new do |p|
         p.banner = "Usage: gori settings export [--sections a,b] [-o FILE]"
-        p.on("--sections=LIST", "Comma-separated top-level sections (default: all but #{Settings::SECRET_SECTIONS.join('/')})") { |v| sections = split_sections(v) }
+        p.on("--sections=LIST", "Comma-separated top-level sections (default: all but #{Settings::SECRET_SECTIONS.join('/')})") { |v| sections = split_sections("export", v) }
         p.on("-o FILE", "--out=FILE", "Write here instead of stdout") { |v| out = v }
         p.on("-h", "--help", "Show this help") { puts p; exit 0 }
         p.invalid_option { |flag| abort "unknown option: #{flag}\n#{p}" }
         p.missing_option { |flag| abort "missing value for #{flag}" }
       end
-      parser.parse(args)
+      reject_stray_args!("export", parser, args)
 
       Settings.load
+      abort_on_degraded_settings!("export")
       if list = sections
-        unknown = list - Settings.document_keys
-        abort "gori settings export: unknown section(s): #{unknown.join(", ")}\nRun 'gori settings sections' for the list." unless unknown.empty?
+        # Names were already validated against SECTION_KEYS in split_sections. What is left is
+        # informational: a KNOWN section this install never touched is omitted by `serialize`,
+        # so it is simply absent from the profile — correct (there is no value to carry), but
+        # silently handing back `{}` for `--sections scan_rules` reads as a bug. Say it, on
+        # STDERR so a piped profile stays clean, and keep exit 0: nothing went wrong.
+        at_default = list - Settings.document_keys
+        STDERR.puts "note: at their default, nothing to export: #{at_default.join(", ")}" unless at_default.empty?
       end
       doc = Settings.export_document(sections)
       if path = out
@@ -345,8 +429,8 @@ module Gori
       dry = false
       parser = OptionParser.new do |p|
         p.banner = "Usage: gori settings import FILE [--sections a,b] [--dry-run]"
-        p.on("--sections=LIST", "Comma-separated top-level sections to apply (default: every section in FILE)") { |v| sections = split_sections(v) }
-        p.on("--dry-run", "Print which sections would change, then exit without writing") { dry = true }
+        p.on("--sections=LIST", "Comma-separated top-level sections to apply (default: every section in FILE)") { |v| sections = split_sections("import", v) }
+        p.on("--dry-run", "Print which sections would be applied, then exit without writing") { dry = true }
         p.on("-h", "--help", "Show this help") { puts p; exit 0 }
         p.invalid_option { |flag| abort "unknown option: #{flag}\n#{p}" }
         p.missing_option { |flag| abort "missing value for #{flag}" }
@@ -357,6 +441,10 @@ module Gori
 
       file = rest[0]?
       abort "gori settings import: needs a file\n#{parser}" unless file
+      # One profile per run. Taking rest[0] and dropping the rest turned a typo — a missing
+      # `--sections`, a glob that matched two files — into a half-done import reported as a
+      # full success.
+      abort "gori settings import: one file at a time (got #{rest.size}: #{rest.join(", ")})" if rest.size > 1
       raw = begin
         File.read(file)
       rescue ex
@@ -372,26 +460,84 @@ module Gori
       end
 
       Settings.load
-      changed, unknown = Settings.import_preview(raw, sections)
+      # Settings gori could not load leave EVERY section at its factory default and the 3-way
+      # merge without a base, so the `save` inside import_document writes those defaults over
+      # the operator's real file — theme, env token values, hostname overrides, upstream rules,
+      # the TLS pass-through list — while the summary names only the section they asked for.
+      # `load_root` promises the fallback lasts "for this run"; an import is the surface that
+      # would make it permanent. `--dry-run` writes nothing, so it may proceed — but the
+      # comparison it prints is against defaults, and saying so is the whole point of the note.
+      if dry
+        STDERR.puts "note: the comparison below is against DEFAULTS, not your real settings" if Settings.load_degraded?
+      else
+        abort_on_degraded_settings!("import")
+      end
+
+      applicable, changed, unknown = Settings.import_preview(raw, sections)
       STDERR.puts "warning: unrecognised section(s) ignored: #{unknown.join(", ")}" unless unknown.empty?
 
       if dry
-        if changed.empty?
-          puts "no changes — the selected sections already match #{Settings.path}"
+        if applicable.empty?
+          puts "nothing to apply — #{file} carries none of the selected sections"
+        elsif changed.empty?
+          # Only say "already match" when something really was compared. With no applicable
+          # section this line claimed a match that was never tested.
+          puts "no changes — the #{applicable.size} selected section(s) already match #{Settings.path}"
         else
-          puts "would replace #{changed.size} section(s) in #{Settings.path}:"
-          changed.each { |k| puts "  #{k}" }
+          # This list is EXACTLY what a real run reports as imported, so the two commands agree
+          # on the count; the `(unchanged)` marks carry what printing only the differing subset
+          # used to convey. "apply", not "replace": apply_sections merges the object-of-scalars
+          # sections key by key, and `changed` is an over-approximation of what differs (see
+          # Settings.import_preview) — a marked section may prove a no-op, an unmarked one is
+          # guaranteed to be.
+          puts "would apply #{applicable.size} section(s) to #{Settings.path}:"
+          applicable.each { |k| puts changed.includes?(k) ? "  #{k}" : "  #{k}  (unchanged)" }
         end
         return
       end
 
+      # import_document drops unrecognised keys itself and raises if the write fails, so what it
+      # returns IS what was handed to the settings. Subtracting `unknown` from it here was the
+      # second half of the miscount: with a valid section wrongly classed unknown, the summary
+      # read "imported 0 section(s)" over a write that had just happened.
       applied = Settings.import_document(raw, sections)
-      known = applied - unknown
-      puts "imported #{known.size} section(s) into #{Settings.path}#{known.empty? ? "" : ": #{known.join(", ")}"}"
+      puts "imported #{applied.size} section(s) into #{Settings.path}#{applied.empty? ? "" : ": #{applied.join(", ")}"}"
     end
 
-    private def self.split_sections(value : String) : Array(String)
+    # Split a `--sections` value into names. Pure, so the suite can exercise it — `abort` calls
+    # `exit`, which is not catchable, so the aborts stay at the call site below.
+    private def self.parse_sections_value(value : String) : Array(String)
       value.split(',').compact_map(&.strip.presence)
+    end
+
+    # The names in `list` gori does not know. Static SECTION_KEYS, never `document_keys` — the
+    # latter made this reject a name gori knows perfectly well but has no value for yet, which
+    # is how the documented `--sections network,scan_rules` example failed on a fresh install.
+    private def self.unknown_sections(list : Array(String)) : Array(String)
+      list - Settings::SECTION_KEYS
+    end
+
+    # `--sections` takes at least one KNOWN name, on both export and import.
+    #
+    # Two silent-success holes met here. An empty or all-commas value compact_map'd down to
+    # `[] of String` — TRUTHY in Crystal — so it sailed past the unknown-section check with
+    # nothing to check and then matched nothing: `--sections=""` exported `{}` and imported
+    # nothing, both exit 0, which is where a shell expanding an unset variable lands. And only
+    # export validated the names at all, so `gori settings import p.json --sections netwrok`
+    # selected nothing and reported "imported 0 section(s)" — or, with `--dry-run`, the flatly
+    # wrong "no changes — the selected sections already match".
+    private def self.split_sections(cmd : String, value : String) : Array(String)
+      list = parse_sections_value(value)
+      if list.empty?
+        abort "gori settings #{cmd}: --sections needs at least one section name\n" \
+              "Run 'gori settings sections' for the list."
+      end
+      unknown = unknown_sections(list)
+      unless unknown.empty?
+        abort "gori settings #{cmd}: unknown section(s): #{unknown.join(", ")}\n" \
+              "Run 'gori settings sections' for the list."
+      end
+      list
     end
 
     # `gori ca` is the CA utility surface:

--- a/src/gori/settings.cr
+++ b/src/gori/settings.cr
@@ -199,6 +199,20 @@ module Gori
       nil
     end
 
+    # A settings file EXISTS but this process could not use it, so every section is sitting at
+    # its factory default AND the 3-way merge has no base — meaning the next `save` writes those
+    # defaults over the operator's file. Only meaningful after a `load`.
+    #
+    # Deliberately NOT `load_warning != nil`. That covers one of the two ways in: `load_root`'s
+    # rescue (present but unparseable) sets the warning, but `load_raw`'s rescue above sets
+    # nothing and swallows every READ failure — EACCES on a settings.json left root-owned by a
+    # `sudo gori`, a `--config` pointing at a directory, a transient I/O error. A guard keyed on
+    # the warning therefore misses exactly the cases that leave no trace at all, which is how
+    # `gori settings import` still replaced a live config with defaults and reported success.
+    def self.load_degraded? : Bool
+      @@loaded_raw.nil? && File.exists?(path)
+    end
+
     # Why the last load fell back to defaults, or nil when it did not. Read by the TUI to
     # put it on the project picker; every headless surface has already had it on STDERR
     # (see load_root). Cleared by a load that parses, so it never outlives the problem.
@@ -351,9 +365,24 @@ module Gori
         j.object do
           keys.each do |k|
             cur_v = cur_h[k]?
-            # I changed this section (mine != base) → mine wins; else take disk's (a
-            # concurrent writer's value, or unchanged). Drop a section absent from both.
-            chosen = cur_v != base_h[k]? ? cur_v : (disk_h[k]? || cur_v)
+            # I changed this section (mine != base) → mine wins; else take disk's, INCLUDING
+            # when disk no longer has the key at all.
+            #
+            # That last clause is the whole point. A `disk_h[k]? || cur_v` fallback sat here,
+            # and it silently undid a concurrent instance's DELETION: sections vanish from
+            # `serialize` the moment they are emptied (`env`, `upstream_rules`, `outbound_tls`,
+            # `listeners`, `scan_rules`, `oast_providers`, `hostname_overrides`, `tabs`,
+            # `hotkeys`, `decoder`, `fuzzer`, `retention` at default, `mine`/`discover` unsaved
+            # — nearly every optional one), so "the operator cleared their env vars in the other
+            # gori window" reached this line as an absent key, and `|| cur_v` wrote our stale
+            # copy — token VALUES and all — straight back. Their EDITS merged correctly the
+            # whole time; only their deletions came back, which is the harder failure to notice.
+            #
+            # Dropping the fallback is the entire fix, because the remaining case it covered is
+            # already handled: if disk lacks the key AND we did not change the section, then
+            # `cur_v == base_h[k]?`, so either base had it (they deleted it → drop, correct) or
+            # nobody ever had it (`cur_v` is nil → dropped anyway, same result).
+            chosen = cur_v != base_h[k]? ? cur_v : disk_h[k]?
             j.field k, chosen if chosen
           end
         end
@@ -377,8 +406,33 @@ module Gori
     # environment-variable NAME, never a password (see settings/upstream_rules.cr).
     SECRET_SECTIONS = ["env", "decoder"]
 
-    # Every top-level key the current settings would write. Also the answer to
-    # `gori settings sections`.
+    # Every top-level key gori KNOWS, whether or not this install currently has a value for one.
+    #
+    # `document_keys` cannot answer that question and must not be used to: it is derived from
+    # `serialize`, and every optional section's `serialize_*` omits itself at its factory
+    # default. Using it as the VALIDITY oracle made a section's NAME valid or invalid depending
+    # on the machine — `gori settings export --sections network,scan_rules` (verbatim the
+    # example in docs/reference/cli.md) aborted with "unknown section(s): scan_rules" on any
+    # install where scan_rules was untouched, and `gori settings import` reported a perfectly
+    # well-known section as "unrecognised … ignored" and then applied it anyway. The `env` case
+    # was the sharp one: on a fresh config `env` is empty, so importing a profile carrying
+    # `env` printed "ignored: env" / "imported 0 section(s)" while writing the token VALUES to
+    # disk — the tool telling the operator a credential section had been ignored when it had not.
+    #
+    # Hand-maintained, deliberately: this is the set of keys the `serialize` dispatcher at the
+    # bottom of this file can emit and `apply_sections` can read, and no runtime expression
+    # produces it without a fully-populated settings object. Add a section → add its key here.
+    # The `document_keys - SECTION_KEYS` guard in spec/settings_profile_spec.cr catches a
+    # rename, and catches an addition as soon as any example populates the new section.
+    SECTION_KEYS = %w(
+      theme mouse pretty_bodies layout statusline display pet notifications general update
+      network upstream_rules outbound_tls retention listeners editor tabs hostname_overrides
+      env scan_rules oast_providers hotkeys mine fuzzer probe discover decoder rewriter
+    )
+
+    # Every top-level key the current settings would write — i.e. which sections this install
+    # actually has a value for. NOT the list of valid names (see SECTION_KEYS): a section
+    # sitting at its factory default is absent from here on purpose.
     def self.document_keys : Array(String)
       (JSON.parse(serialize).as_h?.try(&.keys) || [] of String)
     end
@@ -409,16 +463,35 @@ module Gori
       end
     end
 
-    # The top-level keys in `raw` that would actually CHANGE the current settings, and the keys
-    # it carries that gori does not recognise. Import is destructive at section granularity, so
-    # `--dry-run` prints this before anything is written.
-    def self.import_preview(raw : String, only : Array(String)? = nil) : {Array(String), Array(String)}
+    # What `import_document` would do with `raw`, as three lists: the sections it would APPLY
+    # (selected ∩ recognised), the subset of those whose value differs from the current
+    # settings, and the keys gori does not recognise. `--dry-run` prints this before anything
+    # is written.
+    #
+    # The first list exists because the caller must be able to report the SAME set the real run
+    # reports. Printing only the differing subset made `--dry-run` and the actual import
+    # disagree on the count for identical input — "would apply 1 section(s)", then "imported 6"
+    # — and the count is the one thing `--dry-run` is run to learn.
+    #
+    # "Recognised" is decided by SECTION_KEYS, not by `document_keys` — see SECTION_KEYS for
+    # what using the latter cost. An unrecognised key is reported and then genuinely skipped by
+    # `import_document`, so the two halves of this tuple no longer overlap.
+    #
+    # The first half is an OVER-approximation, and the caller's wording ("would apply") is
+    # chosen to match: a section whose value differs wholesale is compared as a unit, but
+    # `apply_sections` merges the object-of-scalars sections key by key, so a profile pinning
+    # `network.upstream_proxy` to the value already in effect still shows up here. Erring this
+    # way is the safe direction — a section listed here might turn out to be a no-op, but one
+    # NOT listed is guaranteed to be, which is what "no changes" has to mean to be worth
+    # anything. Narrowing it further would need per-section merge semantics restated here (they
+    # differ: `network` preserves an omitted key, `hotkeys` and `env` reset one), i.e. a second
+    # description of `apply_sections` that could silently drift out of step with it.
+    def self.import_preview(raw : String, only : Array(String)? = nil) : {Array(String), Array(String), Array(String)}
       incoming = JSON.parse(raw).as_h
       current = JSON.parse(serialize).as_h
-      known = document_keys
       selected = incoming.keys.select { |k| only.nil? || only.includes?(k) }
-      changed = selected.select { |k| current[k]? != incoming[k] }
-      {changed, selected.reject { |k| known.includes?(k) }}
+      applicable, unknown = selected.partition { |k| SECTION_KEYS.includes?(k) }
+      {applicable, applicable.select { |k| current[k]? != incoming[k] }, unknown}
     end
 
     # Apply the selected sections of `raw` to the live settings and persist. Returns the keys
@@ -447,12 +520,34 @@ module Gori
     # goes through `save`, NOT a raw write: that keeps the atomic temp+rename and the 3-way
     # merge, so an import cannot clobber a concurrent instance's edit to a section it did not
     # touch.
+    # A key gori does not recognise is dropped here rather than passed through to
+    # `apply_sections` (which would ignore it anyway) — so the "unrecognised section(s) ignored"
+    # `import_preview` reports is TRUE. The caller printed a summary derived by subtracting one
+    # list from the other, which was wrong in both directions once `document_keys` decided what
+    # "recognised" meant.
+    #
+    # Returns the sections HANDED to `apply_sections`, which is not quite the same as the ones
+    # that took effect: the per-section parsers are tolerant by design, so a section whose value
+    # is the wrong shape (`"editor": "nvim"` — the #594 guard) is a no-op and still appears here.
+    # Narrowing this to "actually changed something" is not available cheaply: re-serializing
+    # around the apply cannot tell a rejected section from one imported with the value already
+    # in effect, and would report the second as skipped.
     def self.import_document(raw : String, only : Array(String)? = nil) : Array(String)
       incoming = JSON.parse(raw).as_h
-      selected = incoming.keys.select { |k| only.nil? || only.includes?(k) }
+      selected = incoming.keys.select do |k|
+        (only.nil? || only.includes?(k)) && SECTION_KEYS.includes?(k)
+      end
       filtered = JSON.build { |j| j.object { selected.each { |k| j.field k, incoming[k] } } }
       apply_sections(JSON.parse(filtered))
-      save
+      # `save` REPORTS failure rather than raising, because a failed write must not crash the
+      # TUI. Discarding that here meant a full disk, a read-only filesystem or an unwritable
+      # config directory printed "imported N section(s)" and exited 0 with nothing persisted —
+      # the silent-success shape `gori settings` was just fixed to stop producing elsewhere.
+      # There is no TUI on this path; Gori::Error is the CLI's expected-error type and CLI.run
+      # turns it into a clean abort.
+      unless save
+        raise Error.new("settings were applied in memory but could not be written to #{path}")
+      end
       selected
     end
 


### PR DESCRIPTION
## The bug

`Settings.document_keys` is derived from `serialize`, and every optional section's `serialize_*` omits itself at its factory default. It was being used as the **validity** oracle for `export` / `import` / `sections` — which made a section *name* valid or invalid depending on the machine. On a fresh config it answers with 6 of the 28 sections that exist.

Both directions failed, and both reported success:

```console
$ echo '{"env":{"vars":[{"key":"TOKEN","value":"leaked"}]}}' > creds.json
$ gori settings import creds.json --sections env
warning: unrecognised section(s) ignored: env
imported 0 section(s) into ~/.gori/settings.json          # exit 0
$ grep -A3 '"env"' ~/.gori/settings.json
  "env": { "vars": [ { "key": "TOKEN", "value": "leaked" } ] }   # ← written
```

gori reports that the credential-bearing section was ignored and that nothing was imported, then writes the token value. `SECRET_SECTIONS` gates the *export* default only.

```console
$ gori settings export --sections network,scan_rules -o team-profile.json
gori settings export: unknown section(s): scan_rules
Run 'gori settings sections' for the list.                # exit 1
```

That is verbatim the example in `docs/content/reference/cli.md`. It fails on any install where `scan_rules` is untouched, and `gori settings sections` never listed the name either — it was derived from the same list.

## The fix

`Settings::SECTION_KEYS` is now the static answer to *"does gori know this name?"*; `document_keys` keeps its real job, *"does this install have a value for it?"*. `gori settings sections` lists all 28, marking the ones at their default. Hand-maintained deliberately — no runtime expression produces that set without a fully-populated settings object — with a both-directions spec guard over a profile that populates every section.

## Also on this surface

- **The 3-way merge resurrected a section a concurrent instance *deleted*.** Sections vanish from `serialize` the moment they are emptied, so `disk_h[k]? || cur_v` read *"the peer cleared their env vars"* as *"the peer has nothing to say about it"* and wrote our stale copy — token values and all — back. Their **edits** merged correctly the whole time; only **deletions** came back, which is the harder failure to notice.
- **Silent successes.** `gori settings expor -o p.json` printed the settings path and exited 0. So did a forgotten `-o`, a trailing token after `sections` / `--edit`, `--sections=""` (an empty array is truthy in Crystal), a misspelt section name, a second positional file, and a failed `save`. Each did nothing and returned 0, so `… || die` never fires — the failure mode `global_version_flag?` already condemns at length in this same file, and which `run_ca` already rejects correctly.
- **Export/import against settings gori could not *load*** — unparseable, unreadable (EACCES from a `sudo gori`), a `--config` it cannot open — now refuse. Every section is at factory defaults there and the merge has no base, so import persisted those defaults over the real file and export wrote them out as the operator's profile. `--dry-run` still runs and says what it is comparing against.
- **`--edit` backtraced** when the editor binary was missing; `ExternalEditor` (the TUI's `^E` path) always handled it.
- **`--dry-run` and the real run reported different counts** for identical input — "would apply 1 section(s)", then "imported 6".

## Testing

- `crystal spec` → **7537 examples, 8 failures** — the known environmental `Gori::Session` port-bind failures in `project_registry` / `capture_status` (live gori processes hold the port), unchanged from before this branch.
- New specs confirmed to **fail against the old code** before being kept.
- Every case above reproduced by hand against a built binary, before and after.
- `crystal tool format --check` clean on the four changed `.cr` files.

## Deliberately not taken

- `import_document` still reports a section whose value is the wrong shape (`"editor": "nvim"` — the #594 guard makes it a no-op). Re-serializing around the apply cannot distinguish that from a section imported with the value already in effect, and would report the second as skipped — a worse error in the more common direction. The comment was corrected instead.
- `SECTION_KEYS` is a third hand-maintained list; a single key→serializer→parser table driving `serialize`, `apply_sections` and `SECTION_KEYS` is the right end state, but that is a refactor of those two, not of this fix.
- The corrupt-load → persist-defaults path is still reachable from the TUI settings editor and `gori wizard`. Guarding there would break the one flow an operator would use to fix the file.