### PR TITLE
Let the tour's mock outrank its prose, and stop teaching a mode name nothing shows

### DIFF
--- a/docs/static/images/tui/fuzzer.svg
+++ b/docs/static/images/tui/fuzzer.svg
@@ -51,8 +51,8 @@
 <text x="36.00" y="173.68" textLength="1152.00" lengthAdjust="spacingAndGlyphs" fill="#2a2a30" xml:space="preserve">│──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────│</text>
 <text x="36.00" y="191.68" textLength="27.00" lengthAdjust="spacingAndGlyphs" fill="#2a2a30" xml:space="preserve">│╭─</text>
 <text x="72.00" y="191.68" textLength="54.00" lengthAdjust="spacingAndGlyphs" fill="#fafafa" font-weight="700" xml:space="preserve">TARGET</text>
-<text x="135.00" y="191.68" textLength="972.00" lengthAdjust="spacingAndGlyphs" fill="#2a2a30" xml:space="preserve">────────────────────────────────────────────────────────────────────────────────────────────────────────────</text>
-<text x="1116.00" y="191.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">↵:NOR</text>
+<text x="135.00" y="191.68" textLength="963.00" lengthAdjust="spacingAndGlyphs" fill="#2a2a30" xml:space="preserve">───────────────────────────────────────────────────────────────────────────────────────────────────────────</text>
+<text x="1107.00" y="191.68" textLength="54.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">↵:READ</text>
 <text x="1170.00" y="191.68" textLength="18.00" lengthAdjust="spacingAndGlyphs" fill="#2a2a30" xml:space="preserve">╮│</text>
 <text x="36.00" y="209.68" textLength="18.00" lengthAdjust="spacingAndGlyphs" fill="#2a2a30" xml:space="preserve">││</text>
 <text x="63.00" y="209.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">›</text>

--- a/docs/static/images/tui/light/fuzzer.svg
+++ b/docs/static/images/tui/light/fuzzer.svg
@@ -65,8 +65,8 @@
 <text x="36.00" y="209.68" textLength="1152.00" lengthAdjust="spacingAndGlyphs" fill="#a89a86" xml:space="preserve">│──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────│</text>
 <text x="36.00" y="227.68" textLength="27.00" lengthAdjust="spacingAndGlyphs" fill="#a89a86" xml:space="preserve">│╭─</text>
 <text x="72.00" y="227.68" textLength="54.00" lengthAdjust="spacingAndGlyphs" fill="#111110" font-weight="700" xml:space="preserve">TARGET</text>
-<text x="135.00" y="227.68" textLength="972.00" lengthAdjust="spacingAndGlyphs" fill="#a89a86" xml:space="preserve">────────────────────────────────────────────────────────────────────────────────────────────────────────────</text>
-<text x="1116.00" y="227.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6b6454" xml:space="preserve">↵:NOR</text>
+<text x="135.00" y="227.68" textLength="963.00" lengthAdjust="spacingAndGlyphs" fill="#a89a86" xml:space="preserve">───────────────────────────────────────────────────────────────────────────────────────────────────────────</text>
+<text x="1107.00" y="227.68" textLength="54.00" lengthAdjust="spacingAndGlyphs" fill="#6b6454" xml:space="preserve">↵:READ</text>
 <text x="1170.00" y="227.68" textLength="18.00" lengthAdjust="spacingAndGlyphs" fill="#a89a86" xml:space="preserve">╮│</text>
 <text x="36.00" y="245.68" textLength="18.00" lengthAdjust="spacingAndGlyphs" fill="#a89a86" xml:space="preserve">││</text>
 <text x="63.00" y="245.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#6b6454" xml:space="preserve">›</text>

--- a/docs/static/images/tui/light/repeater.svg
+++ b/docs/static/images/tui/light/repeater.svg
@@ -66,8 +66,8 @@
 <text x="36.00" y="209.68" textLength="1152.00" lengthAdjust="spacingAndGlyphs" fill="#a89a86" xml:space="preserve">│──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────│</text>
 <text x="36.00" y="227.68" textLength="27.00" lengthAdjust="spacingAndGlyphs" fill="#a89a86" xml:space="preserve">│╭─</text>
 <text x="72.00" y="227.68" textLength="54.00" lengthAdjust="spacingAndGlyphs" fill="#111110" font-weight="700" xml:space="preserve">TARGET</text>
-<text x="135.00" y="227.68" textLength="972.00" lengthAdjust="spacingAndGlyphs" fill="#a89a86" xml:space="preserve">────────────────────────────────────────────────────────────────────────────────────────────────────────────</text>
-<text x="1116.00" y="227.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6b6454" xml:space="preserve">↵:NOR</text>
+<text x="135.00" y="227.68" textLength="963.00" lengthAdjust="spacingAndGlyphs" fill="#a89a86" xml:space="preserve">───────────────────────────────────────────────────────────────────────────────────────────────────────────</text>
+<text x="1107.00" y="227.68" textLength="54.00" lengthAdjust="spacingAndGlyphs" fill="#6b6454" xml:space="preserve">↵:READ</text>
 <text x="1170.00" y="227.68" textLength="18.00" lengthAdjust="spacingAndGlyphs" fill="#a89a86" xml:space="preserve">╮│</text>
 <text x="36.00" y="245.68" textLength="18.00" lengthAdjust="spacingAndGlyphs" fill="#a89a86" xml:space="preserve">││</text>
 <text x="63.00" y="245.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#6b6454" xml:space="preserve">›</text>
@@ -78,8 +78,8 @@
 <text x="45.00" y="281.68" textLength="18.00" lengthAdjust="spacingAndGlyphs" fill="#8a6a28" xml:space="preserve">╭─</text>
 <text x="72.00" y="281.68" textLength="63.00" lengthAdjust="spacingAndGlyphs" fill="#111110" font-weight="700" xml:space="preserve">REQUEST</text>
 <text x="144.00" y="281.68" textLength="36.00" lengthAdjust="spacingAndGlyphs" fill="#111110" font-weight="700" xml:space="preserve">(h2)</text>
-<text x="189.00" y="281.68" textLength="99.00" lengthAdjust="spacingAndGlyphs" fill="#8a6a28" xml:space="preserve">───────────</text>
-<text x="297.00" y="281.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6b6454" xml:space="preserve">↵:NOR</text>
+<text x="189.00" y="281.68" textLength="90.00" lengthAdjust="spacingAndGlyphs" fill="#8a6a28" xml:space="preserve">──────────</text>
+<text x="288.00" y="281.68" textLength="54.00" lengthAdjust="spacingAndGlyphs" fill="#6b6454" xml:space="preserve">↵:READ</text>
 <text x="360.00" y="281.68" textLength="81.00" lengthAdjust="spacingAndGlyphs" fill="#6b6454" xml:space="preserve">^U:PRETTY</text>
 <text x="459.00" y="281.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#111110" xml:space="preserve">^L:CL</text>
 <text x="522.00" y="281.68" textLength="63.00" lengthAdjust="spacingAndGlyphs" fill="#fafafa" font-weight="700" xml:space="preserve">^R:SEND</text>

--- a/docs/static/images/tui/repeater.svg
+++ b/docs/static/images/tui/repeater.svg
@@ -63,8 +63,8 @@
 <text x="36.00" y="209.68" textLength="1152.00" lengthAdjust="spacingAndGlyphs" fill="#2a2a30" xml:space="preserve">│──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────│</text>
 <text x="36.00" y="227.68" textLength="27.00" lengthAdjust="spacingAndGlyphs" fill="#2a2a30" xml:space="preserve">│╭─</text>
 <text x="72.00" y="227.68" textLength="54.00" lengthAdjust="spacingAndGlyphs" fill="#fafafa" font-weight="700" xml:space="preserve">TARGET</text>
-<text x="135.00" y="227.68" textLength="972.00" lengthAdjust="spacingAndGlyphs" fill="#2a2a30" xml:space="preserve">────────────────────────────────────────────────────────────────────────────────────────────────────────────</text>
-<text x="1116.00" y="227.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">↵:NOR</text>
+<text x="135.00" y="227.68" textLength="963.00" lengthAdjust="spacingAndGlyphs" fill="#2a2a30" xml:space="preserve">───────────────────────────────────────────────────────────────────────────────────────────────────────────</text>
+<text x="1107.00" y="227.68" textLength="54.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">↵:READ</text>
 <text x="1170.00" y="227.68" textLength="18.00" lengthAdjust="spacingAndGlyphs" fill="#2a2a30" xml:space="preserve">╮│</text>
 <text x="36.00" y="245.68" textLength="18.00" lengthAdjust="spacingAndGlyphs" fill="#2a2a30" xml:space="preserve">││</text>
 <text x="63.00" y="245.68" textLength="9.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">›</text>
@@ -75,8 +75,8 @@
 <text x="45.00" y="281.68" textLength="18.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">╭─</text>
 <text x="72.00" y="281.68" textLength="63.00" lengthAdjust="spacingAndGlyphs" fill="#fafafa" font-weight="700" xml:space="preserve">REQUEST</text>
 <text x="144.00" y="281.68" textLength="36.00" lengthAdjust="spacingAndGlyphs" fill="#fafafa" font-weight="700" xml:space="preserve">(h2)</text>
-<text x="189.00" y="281.68" textLength="99.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">───────────</text>
-<text x="297.00" y="281.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">↵:NOR</text>
+<text x="189.00" y="281.68" textLength="90.00" lengthAdjust="spacingAndGlyphs" fill="#d9c28b" xml:space="preserve">──────────</text>
+<text x="288.00" y="281.68" textLength="54.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">↵:READ</text>
 <text x="360.00" y="281.68" textLength="81.00" lengthAdjust="spacingAndGlyphs" fill="#6e6e76" xml:space="preserve">^U:PRETTY</text>
 <text x="459.00" y="281.68" textLength="45.00" lengthAdjust="spacingAndGlyphs" fill="#fafafa" xml:space="preserve">^L:CL</text>
 <text x="522.00" y="281.68" textLength="63.00" lengthAdjust="spacingAndGlyphs" fill="#111111" font-weight="700" xml:space="preserve">^R:SEND</text>

--- a/spec/tui/mouse_spec.cr
+++ b/spec/tui/mouse_spec.cr
@@ -261,14 +261,17 @@ describe "Frame.left_chip_hit / right_badge_hit" do
     Frame.right_badge_hit(28, y, y, right, 20, badges).should eq(:mark)
   end
 
-  it "hits the NOR/INS mode badge and chains left of right-aligned badges" do
+  it "hits the READ/INS mode badge and chains left of right-aligned badges" do
     y = 2
     right = 40
-    # NOR label is " ↵:NOR " (7 cells) → [right-7, right).
+    # The chip spans [right - label.size, right). Measured from the label rather than a
+    # hardcoded width: the two labels are DIFFERENT widths on purpose, and this hit-test
+    # exists because a caller once drew one over the other's rect.
+    nw = Frame.mode_badge_label(false).size
     Frame.mode_badge_hit(right - 2, y, y, right, 0, false).should be_true
-    Frame.mode_badge_hit(right - 7, y, y, right, 0, false).should be_true # inclusive start
-    Frame.mode_badge_hit(right, y, y, right, 0, false).should be_false    # exclusive end
-    Frame.mode_badge_hit(right - 8, y, y, right, 0, false).should be_false
+    Frame.mode_badge_hit(right - nw, y, y, right, 0, false).should be_true # inclusive start
+    Frame.mode_badge_hit(right, y, y, right, 0, false).should be_false     # exclusive end
+    Frame.mode_badge_hit(right - nw - 1, y, y, right, 0, false).should be_false
     # INS is " INS " (5 cells) → [right-5, right).
     Frame.mode_badge_hit(right - 2, y, y, right, 0, true).should be_true
     Frame.mode_badge_hit(right - 6, y, y, right, 0, true).should be_false
@@ -298,7 +301,7 @@ describe "RepeaterView#chrome_hit" do
     view.chrome_hit(rect, resp.x + 12 + 9, resp.y).should eq(:hex) # past " d:diff " + gap
     view.chrome_hit(rect, resp.x + 12 + 9 + 9, resp.y).should eq(:pretty)
 
-    # REQUEST right-chain: rightmost is SEND, then CL, PRETTY, then NOR/INS
+    # REQUEST right-chain: rightmost is SEND, then CL, PRETTY, then READ/INS
     send_label = " ^R:SEND "
     send_x = (req.right - 1) - send_label.size
     view.chrome_hit(rect, send_x + 1, req.y).should eq(:send)
@@ -308,11 +311,11 @@ describe "RepeaterView#chrome_hit" do
     pretty_label = " ^U:PRETTY "
     pretty_x = cl_x - pretty_label.size
     view.chrome_hit(rect, pretty_x + 1, req.y).should eq(:pretty_req)
-    mode_label = Frame.mode_badge_label(false) # " ↵:NOR "
+    mode_label = Frame.mode_badge_label(false) # the READ label
     mode_x = pretty_x - mode_label.size
     view.chrome_hit(rect, mode_x + 1, req.y).should eq(:mode)
 
-    # TARGET NOR/INS on the top band
+    # TARGET READ/INS on the top band
     view.chrome_hit(rect, rect.right - 3, rect.y).should eq(:target_mode)
 
     # Body click (not on border chrome) → nil so caret path still runs

--- a/spec/tui/read_chrome_badge_parity_spec.cr
+++ b/spec/tui/read_chrome_badge_parity_spec.cr
@@ -8,16 +8,16 @@ include Gori::Tui
 # hit-test it is drawn for. Every one of them is a place where the screen and the clipboard, or
 # the screen and the click, told the operator different things.
 #
-#   A. FuzzerView drew the `§N` marker-count badge 4 cells INSIDE the 7-cell NOR/INS chip, so the
+#   A. FuzzerView drew the `§N` marker-count badge 4 cells INSIDE the READ/INS chip, so the
 #      TEMPLATE border read "↵: §2" — the mode chip destroyed and the count ambiguous.
 #   B. FuzzerView#template_home/end and JwtSession's Home/End moved the EDITOR caret without
 #      adopting it into the READ cursor. Symptoms differ because the painters differ: the Fuzzer
 #      (which `sync_from`s every frame) kept a phantom band whose ends had crossed, so `y` copied
 #      ""; JWT (which paints purely from its read cursor) moved a caret nobody could see.
-#   C. Every NOR/INS chip was drawn from `focused && insert?` while its hit-test and its click
+#   C. Every READ/INS chip was drawn from `focused && insert?` while its hit-test and its click
 #      handler read `insert?` alone. A pane that retained INS while focus moved away drew the
-#      7-cell " ↵:NOR " over a 5-cell " INS " hit rect — two dead cells — and clicking a chip
-#      that said "↵:NOR" turned insert OFF.
+#      wider " ↵:READ " chip over a 5-cell " INS " hit rect — dead cells on its left — and clicking a chip
+#      that said "↵:READ" turned insert OFF.
 #   D. The READ band and block caret measured the RAW line in the two panes that CONCEAL text
 #      (`§value¦chain§`), so both landed N columns right of what they addressed, and the band —
 #      which re-draws its own text — put the hidden `¦chain` back on screen. Copy was correct
@@ -29,7 +29,7 @@ describe "READ-mode chrome + border badge parity" do
   content_y = 4
 
   describe "A · fuzzer §N badge" do
-    it "chains the marker count clear of the NOR/INS chip" do
+    it "chains the marker count clear of the READ/INS chip" do
       view = FuzzerView.new
       view.load_request("https://h", "GET /?x=§1§&y=§2§ HTTP/1.1\r\nHost: h\r\n\r\n", false, "")
       view.focus_pane(:template)
@@ -38,9 +38,9 @@ describe "READ-mode chrome + border badge parity" do
       row = b.row(border_y)
 
       # Both are legible and neither is inside the other.
-      row.should contain("↵:NOR")
+      row.should contain("↵:READ")
       row.should contain("§2")
-      row.index("§2").not_nil!.should be < row.index("↵:NOR").not_nil! # count chains LEFT
+      row.index("§2").not_nil!.should be < row.index("↵:READ").not_nil! # count chains LEFT
       row.should_not contain("↵: §")                                   # the overlap's signature
     end
 
@@ -51,7 +51,7 @@ describe "READ-mode chrome + border badge parity" do
       rect = Rect.new(0, 0, 120, 30)
       b = MemoryBackend.new(120, 30)
       view.render(Screen.new(b), rect)
-      col = b.row(border_y).index("↵:NOR").not_nil!
+      col = b.row(border_y).index("↵:READ").not_nil!
       view.template_chrome_hit(rect, col + 1, border_y).should eq(:mode)
     end
   end
@@ -104,7 +104,7 @@ describe "READ-mode chrome + border badge parity" do
     end
   end
 
-  describe "C · the NOR/INS chip states the pane's real mode" do
+  describe "C · the READ/INS chip states the pane's real mode" do
     # `Frame.mode_badge`'s two labels are different widths, and `chrome_hit` is called from a
     # click handler with no idea which pane had focus when the frame was drawn.
     it "draws INS on an unfocused Repeater pane that retained it, and hit-tests the same cells" do
@@ -120,7 +120,7 @@ describe "READ-mode chrome + border badge parity" do
       view.render(Screen.new(b), rect)
       row = b.row(border_y)
       row.should contain("INS")
-      row.should_not contain("↵:NOR") # the label no longer lies about the mode
+      row.should_not contain("↵:READ") # the label no longer lies about the mode
 
       # Every cell of the drawn chip hit-tests as :mode, and the run is exactly " INS " wide.
       hits = (0...120).select { |x| view.chrome_hit(rect, x, border_y) == :mode }

--- a/spec/tui/repeater_grpc_framing_spec.cr
+++ b/spec/tui/repeater_grpc_framing_spec.cr
@@ -105,10 +105,10 @@ describe "RepeaterView gRPC framing failure" do
 
   # The GRPC REQUEST head is a mode-switched text editor (`i`/esc, READ selection, and — since
   # the READ over-paint reached this branch — a visible NORMAL block caret), so it carries the
-  # NOR/INS chip like every other non-hex request card. Draw and hit-test share
+  # READ/INS chip like every other non-hex request card. Draw and hit-test share
   # `Frame.right_badge_edge` over one badge list; this pins them together, because a chip that
   # is drawn but not hit-testable (or the reverse) is the exact defect `␣K:KEY` had.
-  it "draws a clickable NOR/INS mode chip on the request head" do
+  it "draws a clickable READ/INS mode chip on the request head" do
     grpc_tmp_store do |store|
       view = def_view.call(store)
       view.focus_pane(:request)
@@ -119,8 +119,8 @@ describe "RepeaterView gRPC framing failure" do
       # The request card's top border: below the 3-row TARGET band.
       border_y = rect.y + 3
       row = b.row(border_y)
-      row.should contain("↵:NOR")
-      col = row.index("↵:NOR").not_nil!
+      row.should contain("↵:READ")
+      col = row.index("↵:READ").not_nil!
       view.chrome_hit(rect, col + 1, border_y).should eq(:mode)
 
       # And it reports the mode it is in, rather than a fixed label.
@@ -143,7 +143,7 @@ describe "RepeaterView gRPC framing failure" do
       view.toggle_request_hex.should be_true
       b = MemoryBackend.new(160, 24)
       view.render(Screen.new(b), rect)
-      b.row(border_y).should_not contain("↵:NOR")
+      b.row(border_y).should_not contain("↵:READ")
       (0...160).each { |x| view.chrome_hit(rect, x, border_y).should_not eq(:mode) }
     end
   end

--- a/spec/tui/repeater_transport_chip_spec.cr
+++ b/spec/tui/repeater_transport_chip_spec.cr
@@ -10,7 +10,7 @@ include Gori::Tui
 #
 # The ` ^V:… ` chip fixes that, and it rides the TARGET band rather than the REQUEST border on
 # purpose: the request border is a HALF-width column that already carries ^R:SEND, ^L:CL,
-# ^U:PRETTY and the NOR/INS chip, and a fifth badge there pushes the mode chip past `min_x` on a
+# ^U:PRETTY and the READ/INS chip, and a fifth badge there pushes the mode chip past `min_x` on a
 # 100-column terminal — the badge chain drops its leftmost first. The TARGET band is full width
 # and already holds the other "how do we connect" facts (the URL, the SNI override).
 describe "RepeaterView transport chip" do
@@ -40,7 +40,7 @@ describe "RepeaterView transport chip" do
     end
 
     # The reason the chip is not on the REQUEST border: at 100 columns the request column is 49
-    # wide, and SEND+CL+PRETTY+NOR already fill it to within 3 cells of the card title.
+    # wide, and SEND+CL+PRETTY+the mode chip already fill it to within a couple of cells of the card title.
     #
     # h2 is the case that pins the title cleanup: the card used to be titled "REQUEST (h2)",
     # and those five columns moved `min_x` far enough right that the chain dropped its leftmost
@@ -54,14 +54,14 @@ describe "RepeaterView transport chip" do
 
       row = render.call(view, rect).row(border_y)
       row.should contain("^R:SEND")
-      row.should contain("↵:NOR")
+      row.should contain("↵:READ")
       row.should_not contain("^V:")
 
       view.toggle_http2
       row2 = render.call(view, rect).row(border_y)
       row2.should contain("REQUEST")
       row2.should_not contain("(h2)")
-      row2.should contain("↵:NOR")
+      row2.should contain("↵:READ")
     end
 
     # The chip reports state, not on/off: its NAME is the state, so `toggle_badge`'s muted-grey
@@ -169,7 +169,7 @@ describe "RepeaterView transport chip" do
   end
 
   # The SNI marker used to position itself at `right - " SNI ".size - 1`, which is INSIDE the
-  # NOR/INS chip's cells and drawn after it: setting an override painted over the chip's right
+  # READ/INS chip's cells and drawn after it: setting an override painted over the chip's right
   # five columns. Chaining the band's chrome — mode, then SNI, then ^V — is what makes room for
   # the transport chip, and it fixes this at the same time.
   it "keeps the SNI marker, the mode chip and the transport chip on separate cells" do
@@ -179,10 +179,10 @@ describe "RepeaterView transport chip" do
     rect = Rect.new(0, 0, 100, 24)
     row = render.call(view, rect).row(rect.y)
 
-    row.should contain("↵:NOR")
+    row.should contain("↵:READ")
     row.should contain("SNI")
     row.should contain("^V:h1")
     row.index("^V:h1").not_nil!.should be < row.index("SNI").not_nil!
-    row.index("SNI").not_nil!.should be < row.index("↵:NOR").not_nil!
+    row.index("SNI").not_nil!.should be < row.index("↵:READ").not_nil!
   end
 end

--- a/spec/tui/repeater_view_spec.cr
+++ b/spec/tui/repeater_view_spec.cr
@@ -1957,7 +1957,7 @@ describe Gori::Tui::RepeaterView do
     view.request_insert?.should be_false
     backend2 = MemoryBackend.new(120, 24)
     view.render(Screen.new(backend2), Rect.new(0, 0, 120, 24))
-    backend2.contains?("↵:NOR").should be_true
+    backend2.contains?("↵:READ").should be_true
   end
 
   it "resp_move + selection returns plain text for copy" do

--- a/spec/tui/repeater_ws_editor_parity_spec.cr
+++ b/spec/tui/repeater_ws_editor_parity_spec.cr
@@ -316,12 +316,12 @@ describe "RepeaterView WebSocket editor parity" do
       view.chrome_hit(rect, col + 2, border_y).should eq(:ws_key)
     end
 
-    it "hit-tests the NOR/INS mode badge on the HANDSHAKE card" do
+    it "hit-tests the READ/INS mode badge on the HANDSHAKE card" do
       rect = Rect.new(0, 0, 100, 30)
       view, b = render_ws.call(rect, true)
       env, _ = sub_rects.call(view, rect)
       border_y = env.y - 1
-      col = col_of.call(b, border_y, "↵:NOR")
+      col = col_of.call(b, border_y, "↵:READ")
       view.chrome_hit(rect, col + 1, border_y).should eq(:mode)
     end
 

--- a/spec/tui/repeater_ws_http_only_spec.cr
+++ b/spec/tui/repeater_ws_http_only_spec.cr
@@ -145,7 +145,7 @@ describe "RepeaterView WebSocket transport override" do
     # behaves as. The WebSocket half of the story moved to the TARGET band's chip, which names
     # BOTH ends (` ^V:WS→h1 `) precisely so the tab is still not mistakable for a plain one.
     #
-    # The title used to carry both facts, and the extra columns pushed the card's own ↵:NOR
+    # The title used to carry both facts, and the extra columns pushed the card's own ↵:READ
     # chip off a 100-col terminal — the badge chain measures its left stop from the title.
     rect = Rect.new(0, 0, 100, 24)
     draw = ->(v : RepeaterView) {
@@ -160,7 +160,7 @@ describe "RepeaterView WebSocket transport override" do
     b.contains?("HANDSHAKE").should be_false # not a handshake pane any more — a request pane
     b.row(rect.y + 3).should contain("REQUEST")
     b.row(rect.y).should contain("^V:WS→h1")  # …and the band is what says it was a handshake
-    b.row(rect.y + 3).should contain("↵:NOR") # the request card keeps its mode chip at 100 cols
+    b.row(rect.y + 3).should contain("↵:READ") # the request card keeps its mode chip at 100 cols
 
     http.cycle_ws_transport # → h2
     draw.call(http).row(rect.y).should contain("^V:WS→h2")

--- a/spec/tui/tutorial_pet_spec.cr
+++ b/spec/tui/tutorial_pet_spec.cr
@@ -191,3 +191,98 @@ describe "Gori::Tui::Tutorial.wrap_sel" do
     Gori::Tui::Tutorial.wrap_sel(1, +1, 1).should eq(0)
   end
 end
+
+# The fake palette had no scrolling and a hard 8-row overlay cap, so its FIFTH row could not
+# be drawn at any terminal size — while ↑/↓ still selected it, the ▎ marker vanished off the
+# bottom and ↵ ran a command that had never been on screen. The click path bounded the row by
+# `rows.size` rather than by what was painted, so a click on the overlay's own bottom border
+# ran an undrawn row. Draw, scroll and hit-test now share these two.
+describe "Gori::Tui::Tutorial palette window" do
+  # border + query + divider + rows + border, so an n-row list needs n + 4.
+  it "counts only the rows between the divider and the bottom border" do
+    Gori::Tui::Tutorial.palette_rows_visible(Gori::Tui::Rect.new(0, 0, 30, 9)).should eq(5)
+    Gori::Tui::Tutorial.palette_rows_visible(Gori::Tui::Rect.new(0, 0, 30, 6)).should eq(2)
+    Gori::Tui::Tutorial.palette_rows_visible(Gori::Tui::Rect.new(0, 0, 30, 4)).should eq(0)
+    Gori::Tui::Tutorial.palette_rows_visible(Gori::Tui::Rect.new(0, 0, 30, 1)).should eq(0)
+  end
+
+  it "does not scroll while the whole list fits" do
+    (0..4).each { |sel| Gori::Tui::Tutorial.palette_scroll(sel, 5, 5).should eq(0) }
+    Gori::Tui::Tutorial.palette_scroll(4, 5, 8).should eq(0)
+  end
+
+  # The bug, in one line: at a 6-row overlay only 2 of 5 rows draw, and sel 4 must still be
+  # one of them.
+  it "keeps the selection inside the window" do
+    (0..4).each do |sel|
+      top = Gori::Tui::Tutorial.palette_scroll(sel, 5, 2)
+      sel.should be >= top
+      sel.should be < top + 2
+    end
+  end
+
+  it "never scrolls past the end of the list" do
+    Gori::Tui::Tutorial.palette_scroll(4, 5, 2).should eq(3)
+    Gori::Tui::Tutorial.palette_scroll(9, 5, 2).should eq(3) # stale selection, list filtered down
+  end
+
+  it "returns 0 for an empty window or an empty list" do
+    Gori::Tui::Tutorial.palette_scroll(0, 5, 0).should eq(0)
+    Gori::Tui::Tutorial.palette_scroll(0, 0, 4).should eq(0)
+  end
+
+end
+
+# The card MIN_CARD_H admits is three rows shorter than CONTENT_ROWS asks for, and the lessons
+# used to walk a FIXED prose height down it — so at an 80x16 terminal (the size the tour's own
+# "too small" message names as its minimum) the shell was left 4 rows, one under render_shell's
+# floor, and Navigate and Practice painted an EMPTY card under "roam the mock". At 13 and 14
+# rows the FLOWS pane showed 1 and 2 of its 3 rows, teaching "↓ list" over a list that could
+# not move. The prose gives way now; these pin the whole reachable band, not one height.
+describe "Gori::Tui::Tutorial.lesson_split" do
+  # box.h at terminal heights 16..22 — step_card gives min(CONTENT_ROWS + 3, max(h - 4, 3)).
+  card = ->(bh : Int32) { Gori::Tui::Rect.new(0, 2, 74, bh) }
+
+  it "gives the mock its rows at every card height the tour will render" do
+    (Gori::Tui::Tutorial::MIN_CARD_H..18).each do |bh|
+      box = card.call(bh)
+      # Navigate / Palette / SpaceMenu / Edit: headline + try line, muted detail rows tradeable.
+      _, sy = Gori::Tui::Tutorial.lesson_split(box, fixed: 2, detail: 2)
+      shell_h = box.bottom - 1 - sy
+      shell_h.should be >= Gori::Tui::Tutorial::SHELL_ROWS
+    end
+  end
+
+  # Practice carries the six goal chips, so it is the tightest lesson — and the one whose key
+  # line teaches "↓ list". One-row chips (fixed: 2) must still clear SHELL_ROWS at the floor.
+  it "clears the mock's rows on Practice once its goal chips fold to one row" do
+    box = card.call(Gori::Tui::Tutorial::MIN_CARD_H)
+    pad = Gori::Tui::Tutorial.prose_gaps(box, 2 + Gori::Tui::Tutorial::SHELL_ROWS, 1)
+    _, sy = Gori::Tui::Tutorial.lesson_split(box, fixed: 2, detail: 0, pad: pad)
+    (box.bottom - 1 - pad - sy).should be >= Gori::Tui::Tutorial::SHELL_ROWS
+  end
+
+  it "spends its spare rows on the prose once the card is tall enough" do
+    box = card.call(18)
+    keep, _ = Gori::Tui::Tutorial.lesson_split(box, fixed: 2, detail: 2)
+    keep.should eq(2) # nothing dropped when there is room for both
+    box12 = card.call(Gori::Tui::Tutorial::MIN_CARD_H)
+    Gori::Tui::Tutorial.lesson_split(box12, fixed: 2, detail: 2)[0].should eq(0)
+  end
+end
+
+# Welcome and Done wrote eleven rows into a card that can hold ten, and the eleventh painted
+# straight over the bottom border ("╰─Re-run this tour anytime: gori tutorial──╯" at 80x16).
+describe "Gori::Tui::Tutorial.prose_gaps" do
+  it "drops spacers before text, and keeps every row inside the card" do
+    [{9, 2}, {8, 2}].each do |(content, want)|
+      (Gori::Tui::Tutorial::MIN_CARD_H..18).each do |bh|
+        box = Gori::Tui::Rect.new(0, 2, 74, bh)
+        gaps = Gori::Tui::Tutorial.prose_gaps(box, content, want)
+        gaps.should be <= want
+        last = Gori::Tui::Tutorial.prose_top(box) + content + gaps - 1
+        last.should be < box.bottom - 1 # never the border row
+      end
+    end
+  end
+end

--- a/src/gori/tui/frame.cr
+++ b/src/gori/tui/frame.cr
@@ -158,17 +158,17 @@ module Gori::Tui
     end
 
     # READ/INS mode chip on an editor pane's top border (Repeater REQUEST, Decoder INPUT,
-    # Notes, …). NOR advertises ↵ (and i) as the way into insert; INS is a plain lit label
+    # Notes, …). READ advertises ↵ (and i) as the way into insert; INS is a plain lit label
     # (esc exits — already in the status strip). Clickable via `mode_badge_hit`. Returns
     # the badge's left x for chaining, or `right_edge` when it doesn't fit.
     #
     # `insert` must be the pane's REAL mode — never `focused && insert?`. The two labels are
-    # different WIDTHS (" ↵:NOR " is 7 cells, " INS " is 5), and `mode_badge_hit` is called from a
+    # different WIDTHS (" ↵:READ " is 8 cells, " INS " is 5), and `mode_badge_hit` is called from a
     # click handler that has no idea which pane had focus when the frame was drawn; every caller's
     # hit-test therefore passes the bare mode. Gating the label on focus desynchronised the two:
     # a pane that retained INS while focus moved away (no view exits insert on a focus change)
-    # drew the 7-cell NOR chip over a 5-cell hit rect — two dead cells on its left — and a click
-    # on a chip reading "↵:NOR" ran the INS branch and turned insert OFF. Focus belongs in the
+    # drew the wider READ chip over a 5-cell hit rect — dead cells on its left — and a click
+    # on a chip reading "↵:READ" ran the INS branch and turned insert OFF. Focus belongs in the
     # BORDER (`Frame.pane_border(focused, insert:)`), not in this label.
     def self.mode_badge(screen : Screen, right_edge : Int32, y : Int32, min_x : Int32,
                         insert : Bool) : Int32
@@ -183,9 +183,18 @@ module Gori::Tui
       x
     end
 
-    # Label drawn by `mode_badge` / measured by `mode_badge_hit`. Keep geometry in one place.
+    # Label drawn by `mode_badge` / measured by `mode_badge_hit`. Keep geometry in one place —
+    # every caller derives its x, its hit rect and its chained neighbours from this string, so
+    # the width is free to change here and nowhere else.
+    #
+    # READ, not the "NOR" this used to paint. The rest of gori — the Help tab, the tutorial, the
+    # CLI's own `--help` — has always called this mode READ, in seventeen user-facing strings,
+    # while the only place a user ever SAW the name spelled it NOR. The tutorial is where the
+    # two met: its Edit lesson teaches "Editors open in READ … esc returns to READ" with this
+    # badge painted a few cells away reading "↵:NOR", which is a poor first lesson in a
+    # vocabulary. One name, and it is the one the prose already uses.
     def self.mode_badge_label(insert : Bool) : String
-      insert ? " INS " : " ↵:NOR "
+      insert ? " INS " : " ↵:READ "
     end
 
     # Hit-test for a single `mode_badge` at the same geometry as draw. Miss → false.

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -2149,12 +2149,12 @@ module Gori::Tui
       pretty_x = Frame.toggle_badge(screen, run_x, rect.y, min_x, "^U", "PRETTY", false)
       # The mode chip states the pane's REAL mode, not `focused && …`: `template_chrome_hit` and
       # `apply_chrome_click` both read `template_insert?` alone, so gating the LABEL on focus made
-      # an unfocused pane that had retained INS draw " ↵:NOR " (7 cols) over a 5-col " INS " hit
-      # rect — two dead cells on the left of the chip — and a click on a chip reading "↵:NOR" then
+      # an unfocused pane that had retained INS draw " ↵:READ " (8 cols) over a 5-col " INS " hit
+      # rect — dead cells on the left of the chip — and a click on a chip reading "↵:READ" then
       # EXITED insert mode. Focus is still carried, by the border colour below.
       mode_x = Frame.mode_badge(screen, pretty_x, rect.y, min_x, template_insert? || @chain_focused)
       # …and `§N` chains off the mode chip's left edge. It used to be drawn at `pretty_x - 4`,
-      # which is INSIDE the 7-cell mode badge — so it overwrote "NOR " and the border read
+      # which is INSIDE the mode badge — so it overwrote the label's tail and the border read
       # "↵: §2", destroying the mode chip and leaving the marker count ambiguous. Every other
       # badge on every other pane chains off its neighbour's returned left x; this one did not.
       badge_x = mode_x - badge.size

--- a/src/gori/tui/repeater_view.cr
+++ b/src/gori/tui/repeater_view.cr
@@ -2639,13 +2639,13 @@ module Gori::Tui
       rect.x + 9
     end
 
-    # The TARGET band's right-to-left chrome after the NOR/INS mode chip: the SNI marker,
+    # The TARGET band's right-to-left chrome after the READ/INS mode chip: the SNI marker,
     # then the `^V` transport chip. Returns `{sni_x, transport_right_edge}` — `sni_x` nil when
     # no override is set or the marker doesn't fit. Pure geometry, shared by `render_target`
     # and `chrome_hit`.
     #
     # The SNI marker used to place itself at `rect.right - size - 1`, which is INSIDE the mode
-    # chip's cells: setting an SNI override painted over the right five columns of " ↵:NOR ",
+    # chip's cells: setting an SNI override painted over the right columns of the mode label,
     # leaving a truncated chip behind. Chaining it fixes that too.
     private def target_chrome_chain(rect : Rect) : {Int32?, Int32}
       min_x = target_chip_min(rect)
@@ -4399,7 +4399,7 @@ module Gori::Tui
     # Both facts used to live here — "HANDSHAKE (h1)", "REQUEST (h2)" — because nothing else on
     # screen carried the transport. That cost the card up to five columns of title, and the
     # badge chain measures its left stop from the title: at 100 columns (a 49-wide request
-    # column) an h2 tab pushed its own ` ↵:NOR ` chip past `min_x` and drew no mode chip at all.
+    # column) an h2 tab pushed its own ` ↵:READ ` chip past `min_x` and drew no mode chip at all.
     #
     # An overridden handshake tab is titled REQUEST, not HANDSHAKE: `^R` sends it as an
     # ordinary request and reads a response, the MESSAGES pane is gone, and the card is one

--- a/src/gori/tui/tutorial.cr
+++ b/src/gori/tui/tutorial.cr
@@ -48,6 +48,12 @@ module Gori::Tui
     HEADER_ROWS  =  2 # brand + progress rail
     FOOTER_ROWS  =  2 # hint + Prev/Next buttons
 
+    # Rows the mock wants: the tab bar, the keyhint row under it, and panes tall enough to
+    # show every FLOW_ROWS row. `render_shell` refuses to draw at all below 5 (its panes are
+    # clamped to 3 rows and would spill past the rect), and `lesson_split` hands it these
+    # rows BEFORE the prose so it can never fall through that floor.
+    SHELL_ROWS = 7
+
     # Columns Miss Ring's stand claims at the right edge, when she is on: the sprite, the
     # GUTTER Pet.place already keeps clear of it, and ONE more for the plate strip
     # Pet.draw paints at `rect.x - 1`.
@@ -126,6 +132,9 @@ module Gori::Tui
       @edit_typed = ""
       # Once the user touches keys on Navigate, stop the auto-demo and hand over.
       @nav_live = false
+      # esc at the top level arms the leave-the-tour prompt; a second esc leaves. See
+      # #handle_escape for why one press is not enough.
+      @esc_armed = false
 
       # Hit-test rects rebuilt every frame for mouse (0-based screen coords).
       @prev_btn = Rect.new(0, 0, 0, 0)
@@ -261,6 +270,10 @@ module Gori::Tui
         return
       end
 
+      # Anything but esc disarms the leave-the-tour confirmation (see #handle_escape). Set
+      # here rather than per-branch so a key handled deep in an overlay still counts.
+      @esc_armed = false unless key.escape?
+
       # Tour navigation is independent of the mock — available so the user can
       # never get stuck (n/b, ⇧⇥). Letter keys are suppressed while typing.
       if tour_nav_key?(ev)
@@ -338,13 +351,19 @@ module Gori::Tui
     # menu that owns its own keys), n/b are NOT tour nav — the overlay consumes
     # them (the palette types them; the space menu ignores non-mnemonics) instead
     # of snapping the lesson forward/back. ⇧⇥ still escapes (checked first).
+    #
+    # Body focus in the mock does NOT suppress them, though it used to "to prevent
+    # accidental jumps". Nothing in the mock's body binds n or b — the shell reads arrows,
+    # hjkl, ⇥, ↵, i, space, ^P, digits and [ ] — so the suppression protected no gesture and
+    # only made two advertised keys dead: `footer_hint` goes on printing "n next · b back" in
+    # exactly that state, and on a short terminal, where the mock does not draw at all, one ↓
+    # left the user pressing them at a blank card with nothing to explain why. Free keys, and
+    # this whole method exists so a lesson can never trap anyone.
     private def tour_nav_key?(ev : Termisu::Event::Key) : Bool
       return true if ev.key.back_tab?
       return false if @edit_insert
       return false unless @overlay == :none
       return false if ev.ctrl? || ev.alt? # leave ^P etc. alone
-      # Suppress n/b shortcuts when navigating inside body to prevent accidental jumps
-      return false if live_shell? && @p_level == :body
       ch = ev.char
       ch == 'n' || ch == 'N' || ch == 'b' || ch == 'B'
     end
@@ -360,20 +379,36 @@ module Gori::Tui
       end
     end
 
+    # Reached only with INS closed and no overlay open — `handle_key` dispatches both of those
+    # ahead of this, and each owns its own esc (leave INS / close the overlay). This is the
+    # rest: pop one level of the mock, or leave the tour.
     private def handle_escape : Nil
-      if @edit_insert
-        @edit_insert = false
-        @tried_edit = true
-        return
-      end
       if live_shell? && @p_level == :body
         @p_level = :menu
         @p_up = true
         @tried_nav = true if @step.navigate?
         return
       end
-      # Esc exits the tour when back at the top-level tab bar or on any step
-      @running = false
+      # Top level, where esc leaves the tour — but only on a DELIBERATE second press.
+      #
+      # This tour spends two steps teaching esc as "go back" and Practice names `esc back` as
+      # one of its six goals, so the press that arrives here is nearly always someone who
+      # meant back and had already run out of levels: one step too far in Practice, or the
+      # second half of the double-tap that dismisses an overlay (^P, esc to close, esc). A
+      # single press ended the whole tour on the spot, and on the first-run path that is
+      # permanent — App offers it only while settings.json is absent (which the wizard has
+      # just written), and the Done step it discards is the only screen that names
+      # `gori tutorial` as the way back.
+      #
+      # `footer_hint` announces the armed state, and any other key disarms it (#handle_key,
+      # #handle_mouse), so this can't strand anyone in a mode they can't see — which is also
+      # why the resize-and-retry screen, the one path that paints no footer, opts out.
+      return @running = false if too_small?
+      if @esc_armed
+        @running = false
+      else
+        @esc_armed = true
+      end
     end
 
     private def live_shell? : Bool
@@ -678,6 +713,7 @@ module Gori::Tui
 
     private def handle_mouse(ev : Termisu::Event::Mouse) : Nil
       return unless ev.press? && !ev.wheel?
+      @esc_armed = false # a click is intent to stay (see #handle_escape)
       mx, my = ev.x - 1, ev.y - 1 # termisu mouse coords are 1-based
 
       # Footer buttons always win (never stuck — Skip/Next/Finish/Prev).
@@ -721,11 +757,16 @@ module Gori::Tui
     private def handle_overlay_click(mx : Int32, my : Int32) : Nil
       case @overlay
       when :palette
-        # Click a row → select + run (same as ↵).
-        row = my - (@palette_rect.y + 3)
+        # Click a row → select + run (same as ↵). Bounded by the rows actually PAINTED and
+        # offset by the same scroll window `render_fake_palette` used, not by `rows.size`:
+        # the two disagreed, so a click on the overlay's bottom border ran a command the user
+        # could not see.
         rows = filtered_palette
-        if row >= 0 && row < rows.size
-          @pal_sel = row
+        vis = Tutorial.palette_rows_visible(@palette_rect)
+        top = Tutorial.palette_scroll(@pal_sel.clamp(0, {rows.size - 1, 0}.max), rows.size, vis)
+        row = my - (@palette_rect.y + 3)
+        if row >= 0 && row < {vis, rows.size - top}.min
+          @pal_sel = top + row
           run_overlay_selection
         end
       when :space
@@ -822,8 +863,8 @@ module Gori::Tui
       # on every 50ms poll — calling it for the guard and again for the card doubled that
       # work ~20x/second to answer a question whose inputs had not changed.
       box = step_card(w, h)
-      unless Layout.usable?(w, h) && box.h >= MIN_CARD_H
-        screen.text(0, 0, "terminal too small for tutorial — min 80x16, resize & retry (esc to leave)", Theme.red)
+      if too_small?(w, h)
+        screen.text(0, 0, "terminal too small for tutorial — min 40x16, resize & retry (esc to leave)", Theme.red)
         @term.hide_cursor
         flush
         return
@@ -866,6 +907,22 @@ module Gori::Tui
     private def flush : Nil
       @backend.flush(sync: @resized)
       @resized = false
+    end
+
+    # Whether `render` will paint the resize-and-retry line instead of the tour.
+    #
+    # Shared with `handle_escape`, which must not arm its leave-the-tour confirmation on that
+    # screen: `footer_hint` is what announces the armed state and this path returns before
+    # `render_footer`, so a first esc there would change nothing a user could see while the
+    # red line goes on advertising "esc to leave". Nothing on that screen is a lesson worth
+    # protecting from an accidental press, so esc simply leaves.
+    private def too_small?(w : Int32, h : Int32) : Bool
+      !(Layout.usable?(w, h) && Tutorial.step_card(w, h, pet_band(w, h)).h >= MIN_CARD_H)
+    end
+
+    private def too_small? : Bool
+      w, h = @backend.size
+      too_small?(w, h)
     end
 
     # Card sits between the 2-row header and the 2-row footer, centred in whatever width
@@ -917,6 +974,33 @@ module Gori::Tui
     def self.wrap_sel(sel : Int32, delta : Int32, n : Int32) : Int32
       return 0 if n <= 0
       (sel + delta) % n
+    end
+
+    # Rows `render_fake_palette` can actually paint in `rect`: its interior between the query
+    # divider (rect.y + 2) and the bottom border.
+    #
+    # ONE home for the draw loop, the scroll window and the click hit-test, which had drifted
+    # apart. `draw_palette_overlay` capped the overlay at 8 rows — four short of what five
+    # PALETTE_ROWS need — and there was no scrolling, so "Open Help" could not be drawn at any
+    # terminal size while ↑/↓ still selected it: the ▎ marker simply vanished off the bottom
+    # and ↵ ran a command that had never been on screen. The click path was worse, bounding
+    # the row by `rows.size` instead of by what was painted, so a click on the card's own
+    # bottom border ran an undrawn row. In the one lesson whose subject is "↑/↓ move · ↵ run".
+    def self.palette_rows_visible(rect : Rect) : Int32
+      {rect.h - 4, 0}.max
+    end
+
+    # First row of the scroll window that keeps `sel` on screen.
+    #
+    # Stateless, so the selection rides the window's BOTTOM edge once the list is scrolled at
+    # all: moving up one row scrolls the list up with it rather than leaving it parked. A
+    # sticky window (keep the previous top unless `sel` would fall outside it) would move less,
+    # but it needs the previous top carried across frames, and this is a five-row fake palette
+    # in a tutorial — the thing worth guaranteeing here is that draw, click and ↑/↓ agree on
+    # one window, which they can only do if any of them can recompute it.
+    def self.palette_scroll(sel : Int32, n : Int32, visible : Int32) : Int32
+      return 0 if visible <= 0 || n <= visible
+      { {sel - visible + 1, 0}.max, n - visible }.min
     end
 
     def self.pet_place(w : Int32, h : Int32) : Rect?
@@ -1067,11 +1151,17 @@ module Gori::Tui
     # Contextual mock hint; tour nav (n/b · Prev/Next · rail click) is separate.
     private def footer_hint : String
       tour = "n next · b back"
+      # The armed esc outranks every lesson's hint: it is the only state in the tour where
+      # the next keystroke can end it, and it lasts exactly until the next key or click.
+      # The three hints that name the exit spell it "esc esc" for the same reason — a footer
+      # promising what one press does when it takes two is the defect this whole change is
+      # about, just pointed the other way.
+      return "esc again to leave the tour · any other key stays" if @esc_armed
       case @step
       when Step::Welcome
-        "↵/n start · click Start · esc leave"
+        "↵/n start · click Start · esc esc leave"
       when Step::Done
-        "↵/n finish · click Finish · esc leave"
+        "↵/n finish · click Finish · esc esc leave"
       when Step::Practice
         if @overlay != :none
           "↑/↓ · ↵ run · esc close · #{tour}"
@@ -1115,30 +1205,77 @@ module Gori::Tui
           "try i · #{tour} to skip"
         end
       else
-        "#{tour} · click Prev/Next · esc leave"
+        "#{tour} · click Prev/Next · esc esc leave"
       end
     end
 
     # --- lessons -------------------------------------------------------------
 
+    # Split a lesson's interior between its prose and its mock.
+    #
+    # THE MOCK IS THE LESSON, so it claims SHELL_ROWS off the bottom first and the prose
+    # gives way — the muted key-hint rows restate what `footer_hint` already says, while a
+    # lesson whose mock did not draw teaches nothing. The old fixed walk did the opposite,
+    # and the card MIN_CARD_H admits is three rows shorter than CONTENT_ROWS asks for: at a
+    # 12-row card (an 80x16 terminal — the size the "too small" message NAMES as the
+    # minimum) it left the shell 4 rows, one under `render_shell`'s floor, so Navigate and
+    # Practice painted an EMPTY card under "roam the mock" and "Try: switch a tab, enter
+    # body". At 13 and 14 rows the FLOWS pane showed 1 and 2 of its 3 rows, teaching "↓ list"
+    # over a list that could not move.
+    #
+    # Returns {rows of `detail` the prose may keep, the row the mock starts on}. `fixed` is
+    # prose rows the lesson always draws (headline, try line, goal chips); `pad` is rows it
+    # keeps BELOW the mock.
+    # Class methods, like step_card and wrap_sel, so a spec can sweep them over card heights
+    # without a tty — this is geometry, and the way it breaks is silently, at one end of a
+    # size range nobody renders by hand.
+    def self.lesson_split(box : Rect, fixed : Int32, detail : Int32, pad : Int32 = 0) : {Int32, Int32}
+      floor = box.bottom - 1 - pad
+      keep = { {floor - SHELL_ROWS - prose_top(box) - fixed, 0}.max, detail }.min
+      y = prose_top(box) + fixed + keep
+      y += 1 if y + 1 + SHELL_ROWS <= floor # blank spacer, only when the mock keeps its rows
+      {keep, y}
+    end
+
+    # Blank spacer rows a lesson can still afford, given the `content` rows it always draws.
+    #
+    # The prose lessons (Welcome / Done) call this for their own spacing — what they overran
+    # was the card's bottom border, which their eleventh row painted straight over
+    # ("╰─Re-run this tour anytime: gori tutorial──╯" at 80x16). Practice calls it for the
+    # status row UNDER its mock, passing `fixed + SHELL_ROWS` as content: same question, since
+    # that row is spacing the mock's list rows outrank.
+    def self.prose_gaps(box : Rect, content : Int32, want : Int32) : Int32
+      { {box.bottom - 1 - prose_top(box) - content, 0}.max, want }.min
+    end
+
+    # First interior row a lesson writes on — one blank under the card's top border. ONE home
+    # for it: both helpers above measure from here, and they disagreeing is how the card grew
+    # a row past its own frame the last time.
+    def self.prose_top(box : Rect) : Int32
+      box.y + 2
+    end
+
     private def render_welcome(screen : Screen, box : Rect) : Nil
       ix = box.x + 2
       iw = {box.w - 4, 1}.max
       y = box.y + 2
-      screen.text(ix, y, "Welcome to gori — a keyboard-driven HTTP/HTTPS proxy.", Theme.text_bright, Theme.panel, width: iw)
-      y += 2
-      screen.text(ix, y, "You'll learn the four moves you'll use every session:", Theme.text, Theme.panel, width: iw)
-      y += 1
-      [
+      moves = [
         "1.  tabs & panes     ←/→  ·  ↓  ·  esc  ·  ⇥",
         Hotkeys.retag("2.  command palette  ^P   — jump to any action"),
         "3.  action menu      space — commands for this pane",
         "4.  edit mode        READ / INS — browse, then type",
-      ].each do |ln|
+      ]
+      gaps = Tutorial.prose_gaps(box, moves.size + 4, 2)
+      screen.text(ix, y, "Welcome to gori — a keyboard-driven HTTP/HTTPS proxy.", Theme.text_bright, Theme.panel, width: iw)
+      y += 1
+      y += 1 if gaps > 0
+      screen.text(ix, y, "You'll learn the four moves you'll use every session:", Theme.text, Theme.panel, width: iw)
+      y += 1
+      moves.each do |ln|
         screen.text(ix + 2, y, ln, Theme.text, Theme.panel, width: {iw - 2, 1}.max)
         y += 1
       end
-      y += 1
+      y += 1 if gaps > 1
       screen.text(ix, y, "Each step demos a move, then lets you try it on a live mock.", Theme.muted, Theme.panel, width: iw)
       y += 1
       screen.text(ix, y, "Tour nav: n next · b back · click Prev/Next · click the step rail.", Theme.muted, Theme.panel, width: iw)
@@ -1148,18 +1285,20 @@ module Gori::Tui
       ix = box.x + 2
       iw = {box.w - 4, 1}.max
       y = box.y + 2
+      detail = [
+        "←/→ on the bar · [ / ] from anywhere · 1-9 jump",
+        "↓ or ↵ into the body · ↑ back to tabs · ↓ list · esc · ⇥ panes",
+      ]
+      keep, sy = Tutorial.lesson_split(box, fixed: 2, detail: detail.size)
       screen.text(ix, y, "Every screen is a tab; most tabs split into panes.", Theme.text_bright, Theme.panel, width: iw)
       y += 1
-      screen.text(ix, y, "←/→ on the bar · [ / ] from anywhere · 1-9 jump",
-        Theme.muted, Theme.panel, width: iw)
-      y += 1
-      screen.text(ix, y, "↓ or ↵ into the body · ↑ back to tabs · ↓ list · esc · ⇥ panes",
-        Theme.muted, Theme.panel, width: iw)
-      y += 1
+      detail[0, keep].each do |ln|
+        screen.text(ix, y, ln, Theme.muted, Theme.panel, width: iw)
+        y += 1
+      end
       draw_try_line(screen, ix, y, iw, "Try: switch a tab, enter body, ↑ back to tabs.", @tried_nav)
-      y += 2
 
-      shell = Rect.new(box.x + 2, y, box.w - 4, {box.bottom - 1 - y, 3}.max)
+      shell = Rect.new(box.x + 2, sy, box.w - 4, {box.bottom - 1 - sy, 3}.max)
       if @nav_live
         render_shell(screen, shell, @p_tab, @p_level == :body, @p_pane, "",
           flow: @p_flow, insert: false, typed: "")
@@ -1177,15 +1316,17 @@ module Gori::Tui
       ix = box.x + 2
       iw = {box.w - 4, 1}.max
       y = box.y + 2
+      keep, sy = Tutorial.lesson_split(box, fixed: 2, detail: 1)
       screen.text(ix, y, "Jump to any action without hunting tabs or memorizing chords.", Theme.text_bright, Theme.panel, width: iw)
       y += 1
-      screen.text(ix, y, Hotkeys.retag("^P opens it · type to fuzzy-filter · ↑/↓ move · ↵ run · esc close"),
-        Theme.muted, Theme.panel, width: iw)
-      y += 1
+      if keep > 0
+        screen.text(ix, y, Hotkeys.retag("^P opens it · type to fuzzy-filter · ↑/↓ move · ↵ run · esc close"),
+          Theme.muted, Theme.panel, width: iw)
+        y += 1
+      end
       draw_try_line(screen, ix, y, iw, Hotkeys.retag("Try: press ^P, filter, ↵ to run a command."), @tried_palette)
-      y += 2
 
-      shell = Rect.new(box.x + 2, y, box.w - 4, {box.bottom - 1 - y, 3}.max)
+      shell = Rect.new(box.x + 2, sy, box.w - 4, {box.bottom - 1 - sy, 3}.max)
       render_shell(screen, shell, @p_tab, false, 0, "", flow: 0)
       # Demo auto-overlay only until the user has tried — after they close it,
       # leave a clean shell so it doesn't look like the palette is still open.
@@ -1200,15 +1341,17 @@ module Gori::Tui
       ix = box.x + 2
       iw = {box.w - 4, 1}.max
       y = box.y + 2
+      keep, sy = Tutorial.lesson_split(box, fixed: 2, detail: 1)
       screen.text(ix, y, "space opens actions for whatever area has focus.", Theme.text_bright, Theme.panel, width: iw)
       y += 1
-      screen.text(ix, y, "each row has a mnemonic key — press it to run · ↑/↓ move · esc dismiss",
-        Theme.muted, Theme.panel, width: iw)
-      y += 1
+      if keep > 0
+        screen.text(ix, y, "each row has a mnemonic key — press it to run · ↑/↓ move · esc dismiss",
+          Theme.muted, Theme.panel, width: iw)
+        y += 1
+      end
       draw_try_line(screen, ix, y, iw, "Try: press space, move with ↑/↓, run with a letter or ↵.", @tried_space)
-      y += 2
 
-      shell = Rect.new(box.x + 2, y, box.w - 4, {box.bottom - 1 - y, 3}.max)
+      shell = Rect.new(box.x + 2, sy, box.w - 4, {box.bottom - 1 - sy, 3}.max)
       render_shell(screen, shell, 0, true, 0, "", flow: 0)
       if @overlay == :space
         draw_space_overlay(screen, shell, live: true)
@@ -1221,15 +1364,17 @@ module Gori::Tui
       ix = box.x + 2
       iw = {box.w - 4, 1}.max
       y = box.y + 2
+      keep, sy = Tutorial.lesson_split(box, fixed: 2, detail: 1)
       screen.text(ix, y, "Editors open in READ — navigate, select, copy, open the menu.", Theme.text_bright, Theme.panel, width: iw)
       y += 1
-      screen.text(ix, y, "press i or ↵ to enter INS and type · esc returns to READ (safe by default)",
-        Theme.muted, Theme.panel, width: iw)
-      y += 1
+      if keep > 0
+        screen.text(ix, y, "press i or ↵ to enter INS and type · esc returns to READ (safe by default)",
+          Theme.muted, Theme.panel, width: iw)
+        y += 1
+      end
       draw_try_line(screen, ix, y, iw, "Try: press i, type a username, esc back to READ.", @tried_edit)
-      y += 2
 
-      shell = Rect.new(box.x + 2, y, box.w - 4, {box.bottom - 1 - y, 3}.max)
+      shell = Rect.new(box.x + 2, sy, box.w - 4, {box.bottom - 1 - sy, 3}.max)
       screen.fill(shell, Theme.bg)
 
       if @edit_insert || @tried_edit
@@ -1256,19 +1401,31 @@ module Gori::Tui
       ix = box.x + 2
       iw = {box.w - 4, 1}.max
       y = box.y + 2
+      goals = [
+        {"switch", @p_switch}, {"enter", @p_enter}, {"esc back", @p_up},
+        {Hotkeys.retag("^P"), @p_palette}, {"space", @p_space}, {"i INS", @p_edit},
+      ]
+      # Practice carries two rows of prose the other lessons don't — the six goal chips — and
+      # at the shortest card that costs the mock a FLOWS row, on the one step whose key line
+      # teaches "↓ list". So the chips fold onto one row when they fit there, and the status
+      # row under the mock (which restates those same chips, and `footer_hint` under it) is
+      # what goes next. Both are spacing around the mock; the mock is the lesson.
+      one_row = goals.sum { |(label, _)| label.size + 4 } - 2 <= iw
+      fixed = one_row ? 2 : 3
+      pad = Tutorial.prose_gaps(box, fixed + SHELL_ROWS, 1)
+      _, sy = Tutorial.lesson_split(box, fixed: fixed, detail: 0, pad: pad)
+
       screen.text(ix, y, "Your turn — complete each move once (or Skip anytime).", Theme.text_bright, Theme.panel, width: iw)
       y += 1
 
-      gx = draw_goal(screen, ix, y, "switch", @p_switch)
-      gx = draw_goal(screen, gx + 2, y, "enter", @p_enter)
-      draw_goal(screen, gx + 2, y, "esc back", @p_up)
-      y += 1
-      gx = draw_goal(screen, ix, y, Hotkeys.retag("^P"), @p_palette)
-      gx = draw_goal(screen, gx + 2, y, "space", @p_space)
-      draw_goal(screen, gx + 2, y, "i INS", @p_edit)
-      y += 2
+      per_row = one_row ? goals.size : 3
+      goals.each_slice(per_row) do |slice|
+        gx = ix
+        slice.each { |(label, done)| gx = draw_goal(screen, gx, y, label, done) + 2 }
+        y += 1
+      end
 
-      shell = Rect.new(box.x + 2, y, box.w - 4, {box.bottom - 2 - y, 3}.max)
+      shell = Rect.new(box.x + 2, sy, box.w - 4, {box.bottom - 1 - pad - sy, 3}.max)
       render_shell(screen, shell, @p_tab, @p_level == :body, @p_pane, "",
         flow: @p_flow, insert: @edit_insert, typed: @edit_typed)
 
@@ -1277,6 +1434,7 @@ module Gori::Tui
       when :space   then draw_space_overlay(screen, shell, live: true)
       end
 
+      return if pad == 0
       msg = if practice_done?
               "✓ Nicely done — click Next or press ↵."
             elsif @overlay != :none
@@ -1306,20 +1464,23 @@ module Gori::Tui
       ix = box.x + 2
       iw = {box.w - 4, 1}.max
       y = box.y + 2
-      screen.text(ix, y, "That's the tour — here's a first real session:", Theme.text_bright, Theme.panel, width: iw)
-      y += 2
-      [
+      steps = [
         {"1.", "run  gori  — start the TUI (proxy on your bind address)"},
         {"2.", "browse via Project, or point a client at the proxy"},
         {"3.", "History — pick a captured flow"},
         {"4.", "^R — send it to Repeater · edit (i) · send again"},
         {"5.", "Help tab — full cheat-sheet anytime"},
-      ].each do |(num, desc)|
+      ]
+      gaps = Tutorial.prose_gaps(box, steps.size + 3, 2)
+      screen.text(ix, y, "That's the tour — here's a first real session:", Theme.text_bright, Theme.panel, width: iw)
+      y += 1
+      y += 1 if gaps > 0
+      steps.each do |(num, desc)|
         screen.text(ix, y, num, Theme.accent, Theme.panel, width: 3)
         screen.text(ix + 3, y, desc, Theme.text, Theme.panel, width: {iw - 3, 1}.max)
         y += 1
       end
-      y += 1
+      y += 1 if gaps > 1
       screen.text(ix, y, Hotkeys.retag("Cheat-sheet:  ^P palette · space menu · i/↵ INS · esc READ/back"), Theme.muted, Theme.panel, width: iw)
       y += 1
       screen.text(ix, y, "Re-run this tour anytime:  gori tutorial", Theme.muted, Theme.panel, width: iw)
@@ -1439,7 +1600,10 @@ module Gori::Tui
 
     private def draw_palette_overlay(screen : Screen, shell : Rect, *, live : Bool) : Nil
       pw = { {shell.w - 8, 36}.min, 24 }.max
-      ph = { {shell.h - 1, 8}.min, 6 }.max
+      # Tall enough for every row when the shell can spare it: border + query + divider +
+      # rows + border. The old cap of 8 was fixed at four rows short of PALETTE_ROWS, so the
+      # fifth was unreachable even on a 200-row terminal — see `palette_rows_visible`.
+      ph = { {shell.h - 1, PALETTE_ROWS.size + 4}.min, 6 }.max
       px = shell.x + {(shell.w - pw) // 2, 0}.max
       py = shell.y + {(shell.h - ph) // 2, 0}.max
       rect = Rect.new(px, py, pw, ph)
@@ -1480,10 +1644,11 @@ module Gori::Tui
             else
               (@tick // 10) % PALETTE_ROWS.size
             end
+      vis = Tutorial.palette_rows_visible(rect)
+      top = Tutorial.palette_scroll(sel, rows.size, vis)
       yy = rect.y + 3
-      rows.each_with_index do |(sig, label), i|
-        break if yy >= rect.bottom - 1
-        s = i == sel
+      rows[top, vis].each_with_index do |(sig, label), i|
+        s = top + i == sel
         bg = s ? Theme.accent_bg : Theme.panel
         screen.fill(Rect.new(rect.x + 1, yy, rect.w - 2, 1), bg)
         screen.cell(rect.x + 1, yy, s ? '▎' : ' ', Theme.accent, bg)
@@ -1491,6 +1656,15 @@ module Gori::Tui
         screen.text(rect.x + 5, yy, label, s ? Theme.text_bright : Theme.text, bg,
           width: {rect.right - 1 - (rect.x + 5), 1}.max)
         yy += 1
+      end
+      # A scrolled list says so, on the border row it is covering — otherwise a window showing
+      # 2 of 5 reads as a palette with only 2 commands in it. Rows BELOW the window, not rows
+      # hidden in total: it is painted at the bottom edge, so it can only be read as "more
+      # that way", and it went on claiming "+3" with the user parked on the last row.
+      below = rows.size - top - vis
+      if vis > 0 && below > 0
+        more = "+#{below}"
+        screen.text({rect.right - 1 - more.size, rect.x + 1}.max, rect.bottom - 1, more, Theme.muted, Theme.panel)
       end
       if live && rows.empty? && yy < rect.bottom - 1
         screen.text(rect.x + 3, yy, "(no matches)", Theme.muted, Theme.panel)


### PR DESCRIPTION
Six defects in `gori tutorial`, all confirmed on a real binary under tmux (isolated `GORI_HOME`, `capture-pane`).

## The mock vanished across the tour's own bottom three heights

`MIN_CARD_H` admits a card three rows shorter than `CONTENT_ROWS` asks for, and every lesson walked a **fixed** prose height down it. At 80x16 — the size the "too small" message itself named as the minimum — the shell was left 4 rows, one under `render_shell`'s floor:

| terminal h | before | after |
|---|---|---|
| 16 | **no mock at all** (empty card under "roam the mock") | 3 of 3 flow rows |
| 17 | 1 of 3 flow rows | 3 of 3 |
| 18 | 2 of 3 flow rows | 3 of 3 |

`lesson_split` inverts the priority: the mock claims `SHELL_ROWS` first and the muted key-hint rows give way, since `footer_hint` already says what they say. Practice folds its six goal chips onto one row and drops the status line under its mock — both restate the chips or the footer.

## `n`/`b` died while the mock held body focus, at every size

`tour_nav_key?` suppressed them "to prevent accidental jumps", but nothing in the mock's body binds either key. It protected no gesture and only made two keys `footer_hint` goes on advertising dead — and on a short terminal, where the mock did not draw at all, one `↓` left the user pressing them at a blank card.

## One `esc` ended the whole tour

At the top level of a tour that spends two steps teaching `esc` as "go back" and names `esc back` as one of Practice's six goals. The press that arrived there was nearly always someone one step past the tab bar, or the second half of the double-tap that dismisses an overlay (`^P`, esc, esc). On the first-run path it was permanent: App offers the tour only while `settings.json` is absent, and the Done step it discarded is the only screen naming `gori tutorial`.

It now arms with a footer prompt, and any other key or click disarms. The three hints that name the exit say `esc esc leave`. The resize-and-retry screen — the one path that paints no footer, and has no lesson to protect — still leaves on one press.

## The palette's fifth row could not be drawn at any size

The overlay capped four rows short of `PALETTE_ROWS` with no scrolling, so "Open Help" was undrawable while `↑/↓` still selected it: the `▎` marker vanished off the bottom and `↵` ran a command that had never been on screen (verified — Help tab lit). The click path bounded the row by `rows.size` rather than by what was painted, so a click on the overlay's own bottom border ran an undrawn row.

`palette_rows_visible` / `palette_scroll` are now the single home for draw, scroll and hit-test, with a `+N` marker counting the rows **below** the window.

## Welcome and Done overran the card

Eleven rows into a ten-row card; the eleventh painted over the bottom border — `╰─Re-run this tour anytime: gori tutorial──╯`.

## The Edit lesson taught a name nothing on screen showed

Card title, body, caption and the Done cheat-sheet all say READ, with the mock's badge a few cells away reading `↵:NOR` — the only place a user ever *saw* the name, against seventeen user-facing strings (Help tab, tutorial, CLI `--help`) that call it READ.

`Frame.mode_badge_label` says READ now. Every call site derives its x, hit rect and chained neighbours from that string, so 7→8 cells needed no other geometry change. The docs screenshots carrying the old chip are patched to match.

**Known trade:** the badge chain drops its leftmost badge first when it does not fit, by design. One cell widens that band on the Repeater REQUEST border from widths 60-70/79-92 to 60-72/79-94. The TARGET band carries its own chip throughout.

## Verification

- Full suite **7533 examples, 8 failures** — the known environmental `Gori::Session` port-bind failures (live `gori` processes hold the port), unchanged from baseline.
- **10 new specs.** `lesson_split`, `prose_gaps` and the two palette-window helpers are class methods, like `step_card` and `wrap_sel`, so specs sweep them over card heights without a tty. Seven spec files asserted the old badge literal; `mouse_spec`'s width assertions now derive from `Frame.mode_badge_label` instead of hardcoding.
- **tmux** at 80x16/17/18/19 and 100x24, pet on and off, Practice with `^P`/space overlays on the `pad == 0` path, and the live Repeater (`↵:READ` on both bands, INS toggle).
- ameba unchanged from baseline (8 pre-existing `Metrics/CyclomaticComplexity`).