### PR TITLE
Let the setup wizard finish what it starts, and stop a one-run bind from moving in

### DIFF
--- a/spec/settings_cli_bind_override_spec.cr
+++ b/spec/settings_cli_bind_override_spec.cr
@@ -1,0 +1,89 @@
+require "./spec_helper"
+require "file_utils"
+
+# `-l` / `-p` (`gori tui`, `gori run capture`) are documented as a ONE-RUN override — by
+# `gori tui --help`, by `gori wizard --help`, and on screen by the wizard's own NETWORK step
+# ("-l/-p one run"). They used to be assigned straight into `Settings.bind_host` /
+# `bind_port`, which ARE the persisted global, so any `Settings.save` the session happened to
+# make — the update-check stamp, tab prefs, the pet toggle, the first-run wizard's own commit —
+# flushed the flag to settings.json and every future launch inherited it. `gori tui -l 0.0.0.0`
+# on a fresh install left the proxy bound to every interface for good.
+#
+# `Settings.cli_bind_*` is the layer that keeps a one-run value out of the persisted one. These
+# examples pin both halves of that: the precedence it resolves at, and that it never serializes.
+private def with_bind_layers(&)
+  prev_host, prev_port = Gori::Settings.bind_host, Gori::Settings.bind_port
+  prev_cli_host, prev_cli_port = Gori::Settings.cli_bind_host, Gori::Settings.cli_bind_port
+  prev_proj_host, prev_proj_port = Gori::Settings.project_bind_host, Gori::Settings.project_bind_port
+  begin
+    Gori::Settings.bind_host = "127.0.0.1"
+    Gori::Settings.bind_port = 8070
+    Gori::Settings.cli_bind_host = nil
+    Gori::Settings.cli_bind_port = nil
+    Gori::Settings.project_bind_host = nil
+    Gori::Settings.project_bind_port = nil
+    yield
+  ensure
+    Gori::Settings.bind_host = prev_host
+    Gori::Settings.bind_port = prev_port
+    Gori::Settings.cli_bind_host = prev_cli_host
+    Gori::Settings.cli_bind_port = prev_cli_port
+    Gori::Settings.project_bind_host = prev_proj_host
+    Gori::Settings.project_bind_port = prev_proj_port
+  end
+end
+
+describe Gori::Settings do
+  it "resolves a CLI bind override above the persisted global and below a project pin" do
+    with_bind_layers do
+      # Nothing overridden → the persisted global, for both the effective and startup views.
+      Gori::Settings.effective_bind_host.should eq("127.0.0.1")
+      Gori::Settings.effective_bind_port.should eq(8070)
+      Gori::Settings.startup_bind_host.should eq("127.0.0.1")
+      Gori::Settings.startup_bind_port.should eq(8070)
+
+      # A flag beats the global...
+      Gori::Settings.cli_bind_host = "0.0.0.0"
+      Gori::Settings.cli_bind_port = 9999
+      Gori::Settings.effective_bind_host.should eq("0.0.0.0")
+      Gori::Settings.effective_bind_port.should eq(9999)
+      Gori::Settings.startup_bind_host.should eq("0.0.0.0")
+      Gori::Settings.startup_bind_port.should eq(9999)
+      # ...WITHOUT touching it. This is the whole point: the wizard prefills from these two,
+      # and every `Settings.save` serializes them.
+      Gori::Settings.bind_host.should eq("127.0.0.1")
+      Gori::Settings.bind_port.should eq(8070)
+
+      # ...and a project pin beats the flag, which is the precedence the flag has always had:
+      # it used to reach the proxy through `bind_host`, and `project_bind_*` already won there.
+      Gori::Settings.project_bind_host = "127.0.0.2"
+      Gori::Settings.project_bind_port = 7000
+      Gori::Settings.effective_bind_host.should eq("127.0.0.2")
+      Gori::Settings.effective_bind_port.should eq(7000)
+      # `startup_*` is the BEFORE-any-project view (what App seeds Config from), so it keeps
+      # ignoring the pin — otherwise opening a second project would carry the first one's bind.
+      Gori::Settings.startup_bind_host.should eq("0.0.0.0")
+      Gori::Settings.startup_bind_port.should eq(9999)
+    end
+  end
+
+  it "never serializes a CLI bind override into settings.json" do
+    dir = File.tempname("gori-cli-bind-override")
+    Dir.mkdir_p(dir)
+    prev_home = ENV["GORI_HOME"]?
+    begin
+      ENV["GORI_HOME"] = dir
+      with_bind_layers do
+        Gori::Settings.cli_bind_host = "0.0.0.0"
+        Gori::Settings.cli_bind_port = 9999
+        Gori::Settings.save.should be_true
+        net = JSON.parse(File.read(File.join(dir, "settings.json")))["network"]
+        net["bind_host"].as_s.should eq("127.0.0.1")
+        net["bind_port"].as_i.should eq(8070)
+      end
+    ensure
+      prev_home ? (ENV["GORI_HOME"] = prev_home) : ENV.delete("GORI_HOME")
+      FileUtils.rm_rf(dir)
+    end
+  end
+end

--- a/spec/tui/setup_wizard_floor_spec.cr
+++ b/spec/tui/setup_wizard_floor_spec.cr
@@ -1,0 +1,37 @@
+require "../spec_helper"
+
+private alias SW = Gori::Tui::SetupWizard
+
+# The wizard's minimum terminal height used to be checked PER STEP, against each step's own
+# `content_rows`. The steps don't agree — BIND needs 14 terminal rows, PET 13, REVIEW 15 — so a
+# 14-row terminal rendered BIND, THEME and PET and then replaced REVIEW with "terminal too
+# small". REVIEW is the only step that can commit, and input runs regardless of the render
+# guard, so ↵ still saved from a screen that said it couldn't draw. `MIN_H` is now derived from
+# the tallest step; these examples pin that derivation from BOTH sides, so a step that grows a
+# row can't quietly push the real floor past the advertised one again.
+describe Gori::Tui::SetupWizard do
+  it "gives every fixed-layout step a card that fits at MIN_H" do
+    {SW::BIND_ROWS, SW::PET_ROWS, SW::REVIEW_ROWS}.each do |rows|
+      # `rows + 3` = top border + pad row + content + bottom border, which is exactly the
+      # invariant render_* rely on: they draw at fixed offsets down to `box.y + 2 + rows - 1`.
+      SW.card_h(SW::MIN_H, rows).should be >= rows + 3
+    end
+  end
+
+  it "sets MIN_H no higher than the tallest step actually needs" do
+    # One row below the floor the tallest step must NOT fit — otherwise MIN_H is padded and the
+    # wizard turns away terminals it could have served.
+    tallest = {SW::BIND_ROWS, SW::PET_ROWS, SW::REVIEW_ROWS}.max
+    SW.card_h(SW::MIN_H - 1, tallest).should be < tallest + 3
+  end
+
+  it "advertises the width that Layout.usable? actually rejects at" do
+    # `fits?` takes its width test entirely from Layout.usable?; MIN_W exists only to be the
+    # number in the on-screen "min 40x15" message. So the pair that matters is: the advertised
+    # width is accepted, and one column under it is not. The second assertion is the load-bearing
+    # one — it fails if Layout's floor moves and the message is left promising a size that no
+    # longer works.
+    Gori::Tui::Layout.usable?(SW::MIN_W, SW::MIN_H).should be_true
+    Gori::Tui::Layout.usable?(SW::MIN_W - 1, SW::MIN_H).should be_false
+  end
+end

--- a/src/gori/app.cr
+++ b/src/gori/app.cr
@@ -188,7 +188,12 @@ module Gori
         # theme setup once. Inside `begin` so the `ensure term.close` restores
         # the terminal if it raises. The wizard persists settings.json (even on skip),
         # so it never auto-launches again.
-        Tui::SetupWizard.new(term).run unless File.exists?(Settings.path)
+        #
+        # It stages `Settings.bind_host`/`bind_port` — the PERSISTED global, which a `-l`/`-p`
+        # flag deliberately no longer touches (Settings.cli_bind_host). That separation is what
+        # keeps the wizard from writing a one-run override into settings.json as the permanent
+        # default, while this session still binds where the flag said.
+        wizard_error = File.exists?(Settings.path) ? nil : Tui::SetupWizard.new(term).run
         # `notice` is the picker's one-line "here is why you are looking at this screen".
         # A failed open used to fall through to the picker in SILENCE, its reason reachable
         # only by knowing to read ~/.gori/gori.log, so an operator who typo'd `--db` saw
@@ -198,7 +203,13 @@ module Gori
         # A corrupt settings.json starts on the row and a failed --db open then displaces
         # it, being the more immediate explanation of what is on screen. Neither is lost:
         # the settings warning also went to STDERR and names the `.corrupt` copy it kept.
-        notice = settings_warning
+        #
+        # A failed wizard persist outranks both, and unlike the others it never touched STDERR —
+        # the wizard hands it back precisely because its own screen was about to be wiped. It is
+        # specifically the SKIP path's failure: a failed `finish` keeps the user on REVIEW to
+        # retry, so what reaches here is "settings.json could not be materialised at all", whose
+        # only other symptom is the wizard silently re-opening on every launch.
+        notice = wizard_error.try { |e| "setup wizard: #{e}" } || settings_warning
         if open_db_path
           outcome, db_error = open_and_run(project_for_db_path(open_db_path), term)
           return if outcome == :quit
@@ -281,9 +292,12 @@ module Gori
     # which are :back, and only one of which is worth putting on screen.
     private def open_and_run(project : Project, term : Termisu) : {Symbol, String?}
       # Pick up any bind address / verify-upstream toggle changed via Settings since startup
-      # (the previous session kept its values; this one opens on the new ones).
-      @config.listen = Settings.bind_host
-      @config.port = Settings.bind_port
+      # (the previous session kept its values; this one opens on the new ones). `startup_*`,
+      # not the bare globals: a `-l`/`-p` flag lives in its own layer now, and dropping it here
+      # would silently un-apply the override on the second project opened in a session.
+      # Session.open then layers the project's own pin on top (effective_bind_*).
+      @config.listen = Settings.startup_bind_host
+      @config.port = Settings.startup_bind_port
       @config.insecure_upstream = !Settings.verify_upstream?
       session =
         begin

--- a/src/gori/cli.cr
+++ b/src/gori/cli.cr
@@ -182,13 +182,20 @@ module Gori
       ca_dir = Paths.default_ca_dir
       insecure = false
 
+      # Tracked separately from `listen`/`port` (which are pre-seeded from Settings and so can't
+      # say whether a flag was actually GIVEN), because only an actual flag goes into the
+      # process-only override layer below. See Settings.cli_bind_host.
+      listen_flag = nil.as(String?)
+      port_flag = nil.as(Int32?)
+
       parser = OptionParser.new do |p|
         p.banner = "Usage: gori tui [options]"
-        p.on("-lHOST", "--listen=HOST", "Listen address (default #{Settings.bind_host})") { |v| listen = v }
+        p.on("-lHOST", "--listen=HOST", "Listen address (default #{Settings.bind_host})") { |v| listen = v; listen_flag = v }
         p.on("-pPORT", "--port=PORT", "Listen port (default #{Settings.bind_port})") do |v|
           parsed = v.to_i?
           abort "gori: invalid --port '#{v}' (expected 0-65535)" unless parsed && 0 <= parsed <= 65535
           port = parsed
+          port_flag = parsed
         end
         p.on("--db=PATH", "SQLite database path (opens it directly, skipping the project picker)") { |v| db_path = v; db_explicit = true }
         p.on("--ca-dir=PATH", "Directory for the root CA") { |v| ca_dir = v }
@@ -202,13 +209,18 @@ module Gori
       parser.parse(args)
 
       Paths.ensure_dirs
-      # Reflect the active bind (after any CLI override) in the settings UI; the
-      # upstream proxy was already loaded by Settings.load.
-      Settings.bind_host = listen
-      Settings.bind_port = port
-      # --insecure-upstream is a launch override of the persisted verify toggle (mirrors the
-      # bind override above): force verify off for this session so the settings:network editor
-      # reflects the active state; toggling it there re-syncs the live proxy + persists.
+      # Publish the bind override into its OWN runtime layer, NOT into Settings.bind_host /
+      # bind_port. Those are the persisted global, so assigning them here handed every later
+      # `Settings.save` in the session a one-run flag to write to disk — see
+      # Settings.cli_bind_host for the whole story. `effective_bind_*` (what the proxy binds,
+      # and what every surface displays) picks the override up from there.
+      Settings.cli_bind_host = listen_flag
+      Settings.cli_bind_port = port_flag
+      # --insecure-upstream stays a write into the PERSISTED property, deliberately unlike the
+      # bind above: it carries no one-run promise to break (nothing documents it as temporary),
+      # and the settings:network editor is expected to show verification as actually off so
+      # toggling it back re-syncs the live proxy. Giving it an override layer too would be a
+      # behaviour change, not a bug fix.
       Settings.verify_upstream = false if insecure
       config = Config.new(listen, port, db_path, ca_dir, !Settings.verify_upstream?)
       # Settings.load already put any corrupt-file warning on STDERR, which the alt screen
@@ -583,6 +595,43 @@ module Gori
       Run.dispatch(args)
     end
 
+    # `gori wizard` and `gori tutorial` take no arguments at all. `unknown_args` runs BEFORE
+    # `invalid_option` (both fire for an undeclared flag), so this is what actually reports one
+    # — the `invalid_option` handlers below are the fallback, not the primary path. A stray flag
+    # and a stray word are named apart so `gori wizard --port 9000` reads as the misplaced
+    # `gori tui` flag it actually is.
+    #
+    # `after` is the run following a `--` separator, which OptionParser strips and hands over
+    # separately. It has to be rejected too: discarding it left `gori wizard -- --port 9000`
+    # launching with the flag silently dropped, which is the whole failure this replaced.
+    private def self.reject_extra_args(cmd : String, rest : Array(String), after : Array(String),
+                                       parser : OptionParser) : Nil
+      return if (first = (rest + after).first?).nil?
+      abort "unknown option: #{first}\n#{parser}" if first.starts_with?('-')
+      abort "gori #{cmd} takes no arguments (got #{first.inspect})\n#{parser}"
+    end
+
+    # Run `body` against a terminal `Tui.open_terminal` has just switched into raw mode + the
+    # alternate screen, and restore it on every way out — including a DELIVERED SIGNAL, which
+    # never reaches an `ensure` at all (the default disposition kills the process with no
+    # stack unwind). `gori wizard` and `gori tutorial` were the only two surfaces that opened
+    # a terminal without this: an SSH drop's SIGHUP, or `pkill gori`, handed the operator's
+    # pane back in raw mode with the alternate screen up and mouse reporting on, recoverable
+    # only with `reset`. App#run_tui has armed the same guard for the TUI all along — see
+    # App::SignalGuard for why it restores and re-raises rather than nudging a channel.
+    private def self.with_tui_terminal(term : Termisu, &)
+      App::SignalGuard.new(-> { term.close; nil }).install
+      begin
+        yield
+      ensure
+        term.close # restore the terminal even on error
+        # Disarmed AFTER the close, in that order for the reason App#run_tui gives: until the
+        # terminal is actually restored the guard is the only thing between a delivered
+        # signal and a wrecked tty, and afterwards it would only re-close a closed Termisu.
+        App::TUI_SIGNALS.each(&.reset)
+      end
+    end
+
     # `gori wizard` launches the interactive, step-by-step setup wizard (bind
     # address → theme). It also runs automatically on first launch
     # (App#run_tui, when settings.json doesn't exist yet); this command re-runs it
@@ -590,14 +639,23 @@ module Gori
     # its own terminal directly instead of going through App (which eagerly loads
     # the CA).
     private def self.run_wizard(args : Array(String)) : Nil
-      if args.any? { |a| ["-h", "--help"].includes?(a) }
-        puts "Usage: gori wizard"
-        puts "  Interactive setup wizard: global proxy bind (default for projects), TUI theme, Miss Ring."
-        puts "  Runs automatically on first launch; use this to re-run it anytime."
-        puts "  Bind is the shared default — pin a different address per project in the Project tab;"
-        puts "  --listen/--port override settings for one run only (not written to disk)."
-        return
+      # A real OptionParser, not a hand-rolled scan for -h: this used to IGNORE everything it
+      # didn't recognise, so `gori wizard --port 9000` — which the help text below all but
+      # invites, and which belongs to `gori tui` — was a silent no-op. Every other subcommand
+      # aborts on an unknown flag; this one now does too.
+      parser = OptionParser.new do |p|
+        p.banner = "Usage: gori wizard\n" \
+                   "  Interactive setup wizard: global proxy bind (default for projects), TUI theme, Miss Ring.\n" \
+                   "  Runs automatically on first launch; use this to re-run it anytime.\n" \
+                   "  Bind is the shared default — pin a different address per project in the Project tab;\n" \
+                   "  `gori tui --listen/--port` override settings for one run only (not written to disk)."
+        p.on("-h", "--help", "Show this help") { puts p; exit 0 }
+        p.invalid_option { |flag| abort "unknown option: #{flag}\n#{p}" }
+        p.missing_option { |flag| abort "missing value for #{flag}" }
+        p.unknown_args { |rest, after| reject_extra_args("wizard", rest, after, p) }
       end
+      parser.parse(args)
+
       Paths.ensure_dirs
       Settings.load
       Tui::Theme.load_custom           # register user themes before the theme step
@@ -606,12 +664,20 @@ module Gori
       # while a real terminal is still present), so the guard lives at the shared
       # Tui.open_terminal construction point (same as App#run_tui).
       term = Tui.open_terminal("run the wizard directly, not under CI or a detached/background job")
-      term.enable_enhanced_keyboard       # Kitty disambiguation for IME/Unicode (mirrors App#run_tui)
-      term.enable_mouse if Settings.mouse # SGR-1006 click + scroll-wheel nav
-      begin
+      # The wizard hands a failed persist back rather than printing onto a screen that is
+      # about to be wiped — report it here, on the restored terminal, and fail the command.
+      # Silently exiting 0 having written nothing was the worst version of this.
+      err = with_tui_terminal(term) do
+        # INSIDE the guarded block, mirroring App#run_tui: a signal delivered while these run
+        # would otherwise leave the tty raw with the alternate screen up, and an enable_* that
+        # raises needs the `ensure term.close` to cover it.
+        term.enable_enhanced_keyboard       # Kitty disambiguation for IME/Unicode
+        term.enable_mouse if Settings.mouse # SGR-1006 click + scroll-wheel nav
         Tui::SetupWizard.new(term).run
-      ensure
-        term.close # restore the terminal even on error
+      end
+      if err
+        STDERR.puts "gori: setup wizard: #{err}"
+        exit 1
       end
     end
 
@@ -621,26 +687,29 @@ module Gori
     # / first launch; this command repeaters it anytime. Like the wizard it drives
     # /dev/tty directly, so it sets up its own terminal instead of going through App.
     private def self.run_tutorial(args : Array(String)) : Nil
-      if args.any? { |a| ["-h", "--help"].includes?(a) }
-        puts "Usage: gori tutorial"
-        puts "  Interactive tour of gori's TUI on a mock UI: tab/pane navigation,"
-        puts "  the command palette (^P), the action menu (space), and edit mode"
-        puts "  (READ/INS). Each lesson asks you to try the key; a final practice"
-        puts "  step covers all four moves, then a first-session checklist."
-        puts "  Also offered at the end of `gori wizard`; safe to re-run anytime."
-        return
+      parser = OptionParser.new do |p| # same reasoning as run_wizard's: no silent no-ops
+        p.banner = "Usage: gori tutorial\n" \
+                   "  Interactive tour of gori's TUI on a mock UI: tab/pane navigation,\n" \
+                   "  the command palette (^P), the action menu (space), and edit mode\n" \
+                   "  (READ/INS). Each lesson asks you to try the key; a final practice\n" \
+                   "  step covers all four moves, then a first-session checklist.\n" \
+                   "  Also offered at the end of `gori wizard`; safe to re-run anytime."
+        p.on("-h", "--help", "Show this help") { puts p; exit 0 }
+        p.invalid_option { |flag| abort "unknown option: #{flag}\n#{p}" }
+        p.missing_option { |flag| abort "missing value for #{flag}" }
+        p.unknown_args { |rest, after| reject_extra_args("tutorial", rest, after, p) }
       end
+      parser.parse(args)
+
       Paths.ensure_dirs
       Settings.load
       Tui::Theme.load_custom           # honour user themes so the mock matches the real UI
       Tui::Theme.apply(Settings.theme) # render the tour in the persisted theme
       term = Tui.open_terminal("run the tutorial directly, not under CI or a detached/background job")
-      term.enable_enhanced_keyboard # Kitty disambiguation (mirrors the wizard)
-      term.enable_mouse             # always on for the tour: Prev/Next buttons + mock clicks
-      begin
+      with_tui_terminal(term) do
+        term.enable_enhanced_keyboard # Kitty disambiguation (mirrors the wizard)
+        term.enable_mouse             # always on for the tour: Prev/Next buttons + mock clicks
         Tui::Tutorial.new(term).run
-      ensure
-        term.close # restore the terminal even on error
       end
     end
 

--- a/src/gori/cli/run/capture.cr
+++ b/src/gori/cli/run/capture.cr
@@ -6,6 +6,10 @@ module Gori
         Settings.load # persisted bind is the default; flags override
         listen = Settings.bind_host
         port = Settings.bind_port
+        # Only an actual flag reaches the runtime override layer below — `listen`/`port` are
+        # pre-seeded from Settings and so can't say whether one was given.
+        listen_flag = nil.as(String?)
+        port_flag = nil.as(Int32?)
         db_path : String? = nil
         project_name : String? = nil
         insecure = false
@@ -15,8 +19,8 @@ module Gori
 
         parser = OptionParser.new do |p|
           p.banner = "Usage: gori run capture [options]\n\nRun the proxy and stream captured flows to STDOUT until Ctrl-C (or --for / --max)."
-          p.on("-lHOST", "--listen=HOST", "Listen address (default #{listen})") { |v| listen = v }
-          p.on("-pPORT", "--port=PORT", "Listen port (default #{port})") { |v| port = parse_port(v) }
+          p.on("-lHOST", "--listen=HOST", "Listen address (default #{listen})") { |v| listen = listen_flag = v }
+          p.on("-pPORT", "--port=PORT", "Listen port (default #{port})") { |v| port = port_flag = parse_port(v) }
           p.on("--project=NAME", "Capture into project NAME (created if missing; default 'default')") { |v| project_name = v }
           p.on("--db=PATH", "Capture into an explicit SQLite db file") { |v| db_path = v }
           p.on("-k", "--insecure-upstream", "Do not verify upstream TLS certificates") { insecure = true }
@@ -33,8 +37,11 @@ module Gori
         parser.parse(args)
 
         Paths.ensure_dirs
-        Settings.bind_host = listen
-        Settings.bind_port = port
+        # The process-only override layer, not the persisted global: Session.open reads
+        # `effective_bind_*`, and any `Settings.save` this run makes must not promote a `-l`/`-p`
+        # into settings.json. See Settings.cli_bind_host.
+        Settings.cli_bind_host = listen_flag
+        Settings.cli_bind_port = port_flag
         project = resolve_capture_project(project_name, db_path)
         config = Config.new(listen, port, project.db_path, Paths.default_ca_dir,
           insecure_upstream: insecure)

--- a/src/gori/settings/network.cr
+++ b/src/gori/settings/network.cr
@@ -311,11 +311,57 @@ module Gori::Settings
     self.project_capture_max_mib = store.setting(PROJECT_CAPTURE_MAX_KEY).try(&.to_i?)
   end
 
+  # A `-l` / `-p` (`gori tui`, `gori run capture`) override for THIS PROCESS only, nil when the
+  # flag wasn't given. Its own layer rather than an assignment into `bind_host`/`bind_port`,
+  # because those two ARE the persisted global: writing a flag there meant any later
+  # `Settings.save` in the session flushed it to settings.json — the pet toggle, tab prefs, the
+  # update-check stamp, the first-run wizard's own commit — silently promoting a one-run
+  # override into the permanent default that every future project then inherits. Which is
+  # precisely the invariant `Runner.port_fallback` spells out for the startup port fallback;
+  # the CLI flag is the same kind of value and belongs on the same side of the line.
+  #
+  # `gori tui --help`, `gori wizard --help` and the wizard's own NETWORK step all promise this
+  # is temporary; before this layer existed, `gori tui -p 9999 -l 0.0.0.0` on a fresh install
+  # left every later launch bound to every interface.
+  #
+  # Ordered BELOW a project pin and above the persisted global — the precedence the flag has
+  # always had, since it used to reach the proxy by way of `bind_host` itself.
+  class_property cli_bind_host : String? = nil
+  class_property cli_bind_port : Int32? = nil
+
   def self.effective_bind_host : String
-    project_bind_host || bind_host
+    project_bind_host || cli_bind_host || bind_host
   end
 
   def self.effective_bind_port : Int32
+    project_bind_port || cli_bind_port || bind_port
+  end
+
+  # The bind before any project is open: the persisted global with this run's flag on top.
+  # What `Config` is seeded from, and what a "no project yet" surface should report.
+  def self.startup_bind_host : String
+    cli_bind_host || bind_host
+  end
+
+  def self.startup_bind_port : Int32
+    cli_bind_port || bind_port
+  end
+
+  # The bind this project is CONFIGURED for, deliberately excluding the process-only CLI layer:
+  # its own pin if it has one, else the persisted global. What the Project pane displays and
+  # compares against, for two reasons that pull the same way:
+  #
+  #   - the pane labels each row "· project" or "· global" off `project_bind_*`, so seeding it
+  #     from `effective_*` showed a `-l`/`-p` value under a "· global" marker while the actual
+  #     global was something else — the pane asserting a shared default that isn't one;
+  #   - the same value is the baseline `apply_project_network` reads as "unchanged means
+  #     inherit", and against `effective_*` the port the operator is RUNNING ON becomes
+  #     impossible to pin: typing it matches the baseline and clears the key instead.
+  def self.configured_bind_host : String
+    project_bind_host || bind_host
+  end
+
+  def self.configured_bind_port : Int32
     project_bind_port || bind_port
   end
 

--- a/src/gori/tui/project_view.cr
+++ b/src/gori/tui/project_view.cr
@@ -128,10 +128,15 @@ module Gori::Tui
     # (Re)load the PROJECT SETTINGS network fields from the effective config — the project
     # override when pinned, else the global default (Session.open populated Settings.project_*
     # from this project's DB on open). @set_overridden drives the "· project/global" marker.
+    #
+    # The bind pair uses `configured_bind_*`, NOT `effective_bind_*`: those two differ only by
+    # the process-only `-l`/`-p` layer, which is neither a project pin nor the global — so it
+    # would be shown here under a "· global" marker that misnames it, and would become an
+    # inherit-baseline that makes the running port unpinnable. See Settings.configured_bind_host.
     private def load_settings_values : Nil
       @set_values = [
-        Settings.effective_bind_host,
-        Settings.effective_bind_port.to_s,
+        Settings.configured_bind_host,
+        Settings.configured_bind_port.to_s,
         Settings.effective_upstream_proxy,
         Settings.effective_connect_timeout_secs.to_s,
         Settings.effective_io_timeout_secs.to_s,

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -5479,6 +5479,12 @@ module Gori::Tui
     # override layer, then rebinds the live proxy (the upstream is already live via effective_*).
     def apply_project_network(bind_host : String, bind_port : Int32, upstream : String,
                               connect_secs : Int32, io_secs : Int32, capture_mib : Int32) : String
+      # The bind pair compares against the bare GLOBAL, which is exactly what ProjectView seeded
+      # the pane with for an unpinned project (`Settings.configured_bind_*`) — so "unchanged
+      # means inherit" tracks what the operator was shown. A `-l`/`-p` override is in neither
+      # value, which is what keeps a one-run flag from being pinned into this project's DB the
+      # next time someone saves this pane for an unrelated reason: the mistake
+      # `Runner.port_fallback` describes, one layer down.
       set_or_clear(Settings::PROJECT_BIND_HOST_KEY, bind_host, Settings.bind_host)
       set_or_clear(Settings::PROJECT_BIND_PORT_KEY, bind_port.to_s, Settings.bind_port.to_s)
       set_or_clear(Settings::PROJECT_UPSTREAM_KEY, upstream, Settings.upstream_proxy)

--- a/src/gori/tui/settings_view.cr
+++ b/src/gori/tui/settings_view.cr
@@ -684,6 +684,17 @@ module Gori::Tui
         @status = "invalid TLS passthrough host"
         return err
       end
+      # An explicit bind edit HERE supersedes a `-l`/`-p` launch override. That override is
+      # process-only and invisible on this screen, and the rebind Runner#apply_settings performs
+      # compares `effective_bind_*` — where the override wins — so leaving it in place made this
+      # edit report "settings saved" while the proxy stayed on the flag's address, with no
+      # in-session way to clear it. Only on an actual CHANGE: a save that left the bind alone
+      # (an upstream-proxy or timeout edit) must not silently drop the override and yank the
+      # proxy off the port the operator launched it on.
+      if @values[0].strip != Settings.bind_host || port != Settings.bind_port
+        Settings.cli_bind_host = nil
+        Settings.cli_bind_port = nil
+      end
       Settings.bind_host = @values[0].strip
       Settings.bind_port = port
       Settings.upstream_proxy = up

--- a/src/gori/tui/setup_wizard.cr
+++ b/src/gori/tui/setup_wizard.cr
@@ -33,6 +33,41 @@ module Gori::Tui
     LIST_MIN        = 24 # minimum theme-list width before the preview is dropped
     THEME_VP_MAX    = 10 # most theme rows shown at once
 
+    # Interior content rows each FIXED-LAYOUT step draws, below the card's top border + 1 pad
+    # row. Each must match what the matching render_* actually draws at its fixed offsets, and
+    # NOTHING CHECKS THAT — the spec pins MIN_H against these numbers, not these numbers against
+    # the renderers, because SetupWizard builds its own TermisuBackend and can't be rendered
+    # headless. So they are load-bearing by hand: at MIN_H the tallest step has exactly ZERO
+    # spare rows (its content ends on `box.bottom - 2`), which means one row added to a render_*
+    # without bumping its constant here draws straight over the card's bottom border, and one
+    # row added to REVIEW raises the real floor above the "min 40x15" the guard advertises.
+    # Count the offsets in the renderer when you touch either.
+    # (Appearance isn't here — it scrolls, so its viewport follows the card height rather than
+    # demanding one; see `content_rows`.)
+    BIND_ROWS   = 8 # heading, gap, ip, port, gap, 2 info lines, status
+    PET_ROWS    = 7 # heading, gap, 2 offer rows, gap, motion row, info line
+    REVIEW_ROWS = 9 # title, gap, 4 recap rows, gap, 2 offer rows
+
+    # ONE size floor for every step, DERIVED from the tallest rather than hand-counted. It used
+    # to be checked per step against each step's own rows, and the steps don't agree — BIND
+    # wanted 14 terminal rows, PET 13, REVIEW 15 — so a 14-row terminal drew BIND, THEME and PET
+    # and then refused to draw REVIEW, the one step where `finish` lives. Input is handled
+    # regardless of that guard, so a blind ↵ still committed; the user simply had no way to know
+    # it would. One floor means the wizard refuses at step 1 or not at all.
+    #
+    # `+ 6`: a card needs `rows + 3` (top border, pad row, content, bottom border) and
+    # `card_h` can only reach `h - 3`. See the spec, which pins the derivation in both
+    # directions so a new REVIEW row can't quietly raise the real floor past this number.
+    MIN_W = 40 # Layout.usable?'s width floor; step_card clamps to 34 columns inside it
+    MIN_H = {BIND_ROWS, PET_ROWS, REVIEW_ROWS}.max + 6
+
+    # The card height `step_card` settles on for a terminal of height `h` and a step wanting
+    # `rows` of content. Pulled out as a pure class method so the MIN_H invariant above is
+    # checkable without standing up a terminal.
+    def self.card_h(h : Int32, rows : Int32) : Int32
+      {rows + 6, {h - 3, 3}.max}.min
+    end
+
     enum Step
       Bind       # bind ip/port
       Appearance # theme (named Appearance to avoid clashing with the Theme module)
@@ -45,8 +80,10 @@ module Gori::Tui
       # Held as the base Backend: TermisuBackend is generic over the terminal type.
       @backend = TermisuBackend.new(@term).as(Backend)
       @step = Step::Bind
-      # Bind step — staged values prefilled from the live Settings (which already
-      # reflect any `gori tui --port` flag).
+      # Bind step — staged values prefilled from the PERSISTED global, which is deliberately
+      # NOT where a `gori tui -l/-p` override lives (that is `Settings.cli_bind_*`, a
+      # process-only layer). Staging the flag here is what used to promote a documented
+      # one-run value into the permanent default on finish.
       @ip = Settings.bind_host
       @port = Settings.bind_port.to_s
       @bind_field = :ip  # :ip | :port
@@ -80,11 +117,20 @@ module Gori::Tui
       # first-run chance to pick ⌥ before hitting a terminal that eats Ctrl+digit. Kept on
       # ←/→ rather than the ↑/↓ offer ring, so Review needs no focus ring.
       @modifier = Settings.command_modifier
+      # Non-nil once a persist attempt has FAILED: drawn in the footer in place of the key
+      # hint, and returned by `run` so the caller can put it somewhere that outlives the alt
+      # screen. `Settings.save` rescues everything and reports failure as a plain `false`,
+      # which both commit paths used to discard — so an unwritable settings.json meant the
+      # wizard walked the user through four steps, accepted "finish", and exited 0 having
+      # written nothing. Worse on the first-run path, whose auto-launch gate is that file's
+      # existence: the wizard then re-opened on every launch with nothing saying why.
+      @save_error = nil.as(String?)
     end
 
-    # Run the wizard to completion (finish) or skip. Returns when the user is done;
-    # the caller (App#run_tui or `gori wizard`) continues afterward.
-    def run : Nil
+    # Run the wizard to completion (finish) or skip. Returns nil, or a one-line reason the
+    # settings could not be persisted — reporting that is the caller's job (App#run_tui puts
+    # it on the picker, `gori wizard` on STDERR), because this screen is about to be wiped.
+    def run : String?
       Theme.load_custom # pick up any user themes dropped under <GORI_HOME>/themes
       @theme_name = Theme.canonical(@theme_name)
       @theme_baseline = Theme.active_name
@@ -105,8 +151,25 @@ module Gori::Tui
         break unless @running
       end
       # Opted into the tour on the Review step → run it now, reusing this terminal
-      # (already enhanced-keyboard + mouse enabled). Skip/Esc leaves it false.
-      Tutorial.new(@term).run if @launch_tutorial
+      # (already in raw mode with enhanced keyboard on). Skip/Esc leaves it false.
+      launch_tour if @launch_tutorial
+      @save_error
+    end
+
+    # Hand this terminal to the guided tour. `gori tutorial` enables the mouse
+    # UNCONDITIONALLY — the tour's Prev/Next buttons and its mock clicks are mouse-driven —
+    # while both wizard callers gate `enable_mouse` on Settings.mouse. So the same tour had
+    # live buttons or dead ones depending on which door the user came through. Borrow the
+    # mouse for the tour when the caller left it off, then hand the terminal back exactly as
+    # it arrived (the picker and Runner that follow honour Settings.mouse themselves).
+    private def launch_tour : Nil
+      borrowed = !Settings.mouse
+      @term.enable_mouse if borrowed
+      begin
+        Tutorial.new(@term).run
+      ensure
+        @term.disable_mouse if borrowed
+      end
     end
 
     # --- input ---------------------------------------------------------------
@@ -118,6 +181,13 @@ module Gori::Tui
         skip # Esc / ^C exits the wizard (revert preview, persist defaults)
         return
       end
+      # Below the floor NOTHING but the two keys above is accepted. `fits?` gates rendering, and
+      # while it was the only gate the "terminal too small" screen stayed fully navigable: four
+      # blind ↵ presses walked Bind → Pet → Review → `finish` and committed a bind/theme/pet the
+      # operator never saw a single frame of. A screen that says it cannot draw the choices must
+      # not accept them either — resizing brings the wizard back with nothing lost, since every
+      # answer is staged in this object.
+      return unless fits?(*@backend.size)
       case @step
       when Step::Bind       then handle_bind_key(ev)
       when Step::Appearance then handle_theme_key(ev)
@@ -203,6 +273,10 @@ module Gori::Tui
         @modifier = @modifier == "alt" ? "ctrl" : "alt"
       elsif key.back_tab?
         @step = Step::Pet
+        # The failed-save footer says "↵ retry", and ↵ only retries HERE (elsewhere it
+        # advances), so the notice doesn't follow the user off this step. A still-blocked write
+        # sets it again on the next ↵, and `skip` reports its own failure independently.
+        @save_error = nil
       end
     end
 
@@ -288,7 +362,16 @@ module Gori::Tui
     end
 
     # Commit the staged choices and persist. The live palette is already @theme_name.
+    #
+    # Every field is snapshotted first so a FAILED write can be rolled back: the wizard has
+    # to stay on REVIEW in that case (nowhere else can report it), and while it is there Esc
+    # must still mean what it says — "leaves Settings untouched". Without the rollback, a
+    # failed finish followed by Esc would have `skip` persist the committed values under the
+    # one keystroke that promises not to.
     private def finish : Nil
+      prev_host, prev_port = Settings.bind_host, Settings.bind_port
+      prev_theme, prev_modifier = Settings.theme, Settings.command_modifier
+      prev_pet, prev_motion = Settings.pet?, Settings.pet_motion
       Settings.bind_host = effective_ip
       Settings.bind_port = @port.strip.to_i? || Settings.bind_port
       Settings.theme = @theme_name
@@ -300,9 +383,28 @@ module Gori::Tui
       # factory-default).
       Settings.pet = @pet_enabled
       Settings.pet_motion = Settings.normalize_pet_motion(@pet_motion) if @pet_enabled
-      Settings.save
-      @launch_tutorial = @offer == :tour # `run` launches the tour after the loop
-      @running = false
+      if Settings.save
+        @save_error = nil
+        @launch_tutorial = @offer == :tour # `run` launches the tour after the loop
+        @running = false
+        return
+      end
+      Settings.bind_host = prev_host
+      Settings.bind_port = prev_port
+      Settings.theme = prev_theme
+      Settings.command_modifier = prev_modifier
+      Settings.pet = prev_pet
+      Settings.pet_motion = prev_motion
+      # Held on REVIEW: the staged choices live on in this object's own fields, so ↵ retries
+      # the write once the user has unblocked it (a full disk, a read-only --config path).
+      # "esc DISCARD", not "esc leave": Esc runs `skip`, which saves the rolled-back values, so
+      # leaving from here throws every answer away. Saying "leave" invited reading it as
+      # "dismiss this error" and losing four screens of work to a keystroke that looked inert.
+      #
+      # This string is FOOTER-ONLY and never reaches a caller: `finish` leaves @running true, so
+      # the loop can exit only through a successful finish (which nils it) or `skip` (which
+      # overwrites it) — see `run`'s return.
+      @save_error = "save failed: could not write #{Settings.path} · ↵ retry · esc discard"
     end
 
     # Exit without committing: revert the live theme preview to the baseline, leave
@@ -311,7 +413,12 @@ module Gori::Tui
     private def skip : Nil
       Theme.apply(@theme_baseline)
       @resized = true
-      Settings.save
+      # Esc means leave, so unlike `finish` a failed write cannot hold the user here — it is
+      # reported through `run`'s return instead. It matters even though nothing was staged:
+      # the file not appearing is exactly what makes the first-run wizard re-open next launch.
+      # Unprefixed: this is the ONE string `run` can return, and each caller frames it for where
+      # it lands ("gori: setup wizard: …" on STDERR, "setup wizard: …" on the picker).
+      @save_error = Settings.save ? nil : "could not write #{Settings.path}"
       @running = false
     end
 
@@ -324,7 +431,8 @@ module Gori::Tui
 
     private def handle_mouse(ev : Termisu::Event::Mouse) : Nil
       return unless ev.press? || ev.wheel?
-      mx, my = ev.x - 1, ev.y - 1 # termisu mouse coords are 1-based
+      return unless fits?(*@backend.size) # same reason handle_key bails: nothing is on screen to hit
+      mx, my = ev.x - 1, ev.y - 1         # termisu mouse coords are 1-based
       if ev.wheel?
         if @step.appearance? && (ev.button.wheel_up? || ev.button.wheel_down?)
           cycle_theme(ev.button.wheel_up? ? -1 : 1)
@@ -340,6 +448,11 @@ module Gori::Tui
       w, h = @backend.size
       box = step_card(w, h)
       return unless box.contains?(mx, my)
+      # The LIST's own columns only. `box.contains?` also covers the live preview panel, the
+      # gap beside it and the card's two border columns, and with `mx` otherwise unused a
+      # click anywhere on a row silently re-picked the theme sitting at it — including a
+      # click on the preview the user had gone there to look at.
+      return unless box.x < mx <= box.x + theme_list_w(box)
       names = Theme.available
       return if names.empty?
       vp = {box.h - 6, 1}.max
@@ -367,34 +480,48 @@ module Gori::Tui
       inner = {w - 4, cols}.min
       cw = {inner, 34}.max
       avail = {h - 3, 3}.max # rows between the header (y0-1) and the hint (y h-1)
-      ch = {content_rows + 6, avail}.min
+      ch = SetupWizard.card_h(h, content_rows)
       cx = {(w - cw) // 2, 0}.max
       cy = 2 + {(avail - ch) // 2, 0}.max
       Rect.new(cx, cy, cw, ch)
     end
 
+    # Columns the theme LIST occupies inside `box`; the rest goes to the preview panel, or
+    # back to the list on a card too narrow to hold both. The ONE source of that split —
+    # render and the click hit-test share it, so a click can't land on a row the list
+    # doesn't own.
+    private def theme_list_w(box : Rect) : Int32
+      full = box.w - 2
+      full >= LIST_MIN + PREVIEW_GAP + PREVIEW_W ? full - PREVIEW_GAP - PREVIEW_W : full
+    end
+
     # Interior content rows a step draws (below the card's top border + 1 pad row).
-    # Must be ACCURATE for the fixed-layout steps: `step_fits?` rejects a terminal too
-    # short to hold them, and render_* draw at fixed offsets up to `box.y + 2 + this`.
+    # Must be ACCURATE for the fixed-layout steps: MIN_H is derived from the largest of
+    # them, and render_* draw at fixed offsets up to `box.y + 2 + this`.
     private def content_rows : Int32
       case @step
-      when Step::Bind   then 8 # heading, gap, ip, port, gap, 2 info lines, status
-      when Step::Pet    then 7 # heading, gap, 2 offer rows, gap, motion row, info line
-      when Step::Review then 9 # title, gap, 4 recap rows, gap, 2 offer rows
-      # ≥7 so the preview panel (header + 3 status rows) is never clipped, capped so a
-      # long theme list scrolls (the list viewport derives from the card height) instead
-      # of demanding the whole screen.
+      when Step::Bind   then BIND_ROWS
+      when Step::Pet    then PET_ROWS
+      when Step::Review then REVIEW_ROWS
+        # ≥7 so the preview panel (header + 3 status rows) is never clipped, capped so a
+        # long theme list scrolls (the list viewport derives from the card height) instead
+        # of demanding the whole screen.
       else { {Theme.available.size, 7}.max, THEME_VP_MAX }.min # appearance
       end
     end
 
-    # Whether the current step's card can hold its content at height `h`. The theme
-    # step scrolls (its viewport derives from the card height) so it fits any usable
-    # size; the fixed-layout steps draw at fixed offsets and need `content_rows` rows
-    # below the top border + pad, i.e. a card height of at least `content_rows + 3`.
-    private def step_fits?(h : Int32) : Bool
-      return true if @step.appearance?
-      step_card(@backend.size[0], h).h - 3 >= content_rows
+    # Whether the wizard can draw AT ALL at `w`×`h`. Deliberately step-independent: the
+    # fixed-layout steps each need `content_rows` rows below their card's top border + pad
+    # (a card height of `content_rows + 3`), and honouring that per step is what let the
+    # wizard accept a terminal at BIND and then dead-end at REVIEW. See MIN_H.
+    #
+    # Also the input gate (handle_key / handle_mouse): a screen that can't draw the choices must
+    # not accept them. Width comes entirely from `Layout.usable?` — MIN_W equals its floor, so a
+    # separate `w >= MIN_W` conjunct here would never reject anything the first term didn't;
+    # MIN_W's job is to be the number in the on-screen message, and the spec pins the two
+    # together so the message can't drift from what actually rejects.
+    private def fits?(w : Int32, h : Int32) : Bool
+      Layout.usable?(w, h) && h >= MIN_H
     end
 
     # --- rendering -----------------------------------------------------------
@@ -404,10 +531,13 @@ module Gori::Tui
       w, h = screen.width, screen.height
       screen.fill(Rect.new(0, 0, w, h), Theme.bg)
 
-      # Below the global minimum, or too short for THIS step's card (the fixed-layout
-      # steps would otherwise draw their lower rows over the card border / footer).
-      unless Layout.usable?(w, h) && step_fits?(h)
-        screen.text(0, 0, "terminal too small for the setup wizard — resize and retry", Theme.red)
+      # Below the wizard's floor. Two rows, both inside MIN_W so neither is ellipsized at
+      # the narrowest terminal that CAN run it: the size actually needed (a bare "resize and
+      # retry" left the user guessing by how much) and the fact that Esc still works — input
+      # is live behind this screen, which is the only thing that makes it escapable.
+      unless fits?(w, h)
+        screen.text(0, 0, "terminal too small for the setup wizard", Theme.red, Theme.bg)
+        screen.text(0, 1, "min #{MIN_W}x#{MIN_H} · resize, or esc to skip", Theme.muted, Theme.bg)
         @term.hide_cursor
         flush
         return
@@ -465,6 +595,13 @@ module Gori::Tui
     end
 
     private def render_footer(screen : Screen, w : Int32, h : Int32) : Nil
+      # A failed write displaces the key hint rather than taking a card row of its own:
+      # REVIEW's interior is already exactly `content_rows` tall, so a row there would push
+      # MIN_H from 15 to 16 and lock out terminals that can otherwise finish setup.
+      if err = @save_error
+        screen.text({(w - err.size) // 2, 0}.max, h - 1, err, Theme.red, Theme.bg)
+        return
+      end
       hint = case @step
              when Step::Bind       then "↵ next · ↑/↓ field · esc skip"
              when Step::Appearance then "↑/↓ pick theme · ↵ next · ⇧⇥ back · esc skip"
@@ -523,9 +660,8 @@ module Gori::Tui
       return if names.empty?
       sel = names.index(@theme_name) || 0
       vp = {box.h - 6, 1}.max
-      list_full = box.w - 2
-      two_col = list_full >= LIST_MIN + PREVIEW_GAP + PREVIEW_W
-      list_w = two_col ? list_full - PREVIEW_GAP - PREVIEW_W : list_full
+      list_w = theme_list_w(box)
+      two_col = list_w < box.w - 2 # theme_list_w gives the list everything when it can't fit both
 
       # Scroll-follow: clamp to a valid window, then keep `sel` on screen.
       @theme_scroll = @theme_scroll.clamp(0, {names.size - vp, 0}.max)
@@ -616,13 +752,17 @@ module Gori::Tui
     private def render_pet(screen : Screen, box : Rect) : Nil
       ix = box.x + 3
       # Hold the sprite's column band back before laying out the text, so a line can never
-      # run under her — the same order Tutorial.step_card reserves her band in.
+      # run under her — the same order Tutorial.step_card reserves her band in. But ONLY while
+      # she is actually standing there: every consumer of that reservation (the text width here,
+      # the accent band below, draw_pet_preview at the end) is gated the same way, so under
+      # "No mascot" the step uses the card's full interior instead of ellipsizing its copy and
+      # clipping its rows 14 columns short of an edge with nothing behind it.
       px = box.right - 2 - PET_PREVIEW_W
-      iw = {px - PET_PREVIEW_GAP - ix, 1}.max
+      iw = @pet_enabled ? {px - PET_PREVIEW_GAP - ix, 1}.max : {box.right - 1 - ix, 1}.max
       screen.text(ix, box.y + 2, "A mascot in the corner, off unless you want her.",
         Theme.text, Theme.panel, width: iw)
       ry = box.y + 4
-      band = px - PET_PREVIEW_GAP # the accent band stops short of her plate
+      band = @pet_enabled ? px - PET_PREVIEW_GAP : nil
       render_offer_row(screen, box, ry, "Show Miss Ring", @pet_enabled, band)
       render_offer_row(screen, box, ry + 1, "No mascot", !@pet_enabled, band)
       # Only while she is on — a motion row under "No mascot" offers a setting for
@@ -674,10 +814,10 @@ module Gori::Tui
       # No prompt line above the offer: the two rows below say "Take the guided tour" /
       # "Skip — finish setup" in full, so "New to gori? Take a quick tour of the TUI:" was
       # restating them. Dropping it is what keeps the Miss Ring recap row free — adding a
-      # fourth recap row otherwise pushed content_rows from 9 to 10, which moved the whole
-      # step's minimum height from 15 rows to 16. That is the worst row to lose: REVIEW is
-      # where `finish` lives, so a 15-row terminal could no longer commit the wizard at
-      # all (Esc skips without committing). Net rows are unchanged and the floor holds.
+      # fourth recap row otherwise pushed content_rows from 9 to 10, which moved this step's
+      # minimum height from 15 rows to 16 and, since REVIEW is the tallest step, MIN_H along
+      # with it. That is the worst row to lose: `finish` lives here, so every row added
+      # locks another terminal size out of completing setup. Net rows are unchanged.
       render_offer_row(screen, box, y, "Take the guided tour", @offer == :tour); y += 1
       render_offer_row(screen, box, y, "Skip — finish setup", @offer == :skip)
     end


### PR DESCRIPTION
Eight defects in the `gori wizard` path, found by walking the command step by step. Each was reproduced against a built binary (tmux, isolated `GORI_HOME`, SGR mouse injection) before the fix and re-verified after.

## The wizard could not report its own failure

`Settings.save` rescues everything and returns a plain `false`; both commit paths threw it away. With an unwritable config path the wizard walked all four steps, accepted "finish", and **exited 0 having written nothing** — and on the first-run path, whose auto-launch gate is that file's existence, silently re-opened on every launch.

`run` now returns the reason. `finish` snapshots what it stages and, on failure, **rolls the commit back and holds on REVIEW** with the error in the footer — the rollback is what keeps Esc's "leaves Settings untouched" promise true, and the staged answers live on so ↵ retries once the write is unblocked. `skip` reports through the return instead. The message is unprefixed so each caller frames it: `gori: setup wizard: …` on STDERR, `setup wizard: …` on the picker.

Verified: footer error → `chmod` → ↵ persists (0600), exit 0; Esc → STDERR + exit 1; first-run → picker notice.

## The height floor was per step, and the steps disagreed

BIND needed 14 terminal rows, PET 13, REVIEW 15. So **at exactly 14 rows** the wizard drew BIND, THEME and PET and then replaced REVIEW — the only step that can commit — with "terminal too small". Input runs regardless of the render guard, so a blind ↵ still saved.

`MIN_H` is now *derived* from the tallest step, `card_h` is a pure class method so the invariant is testable, and `fits?` also gates `handle_key`/`handle_mouse`: a screen that cannot draw the choices no longer accepts them. The message names the size and that Esc works.

Verified 80x13 / 80x14 / 80x15; at 80x12 five ↵ presses now write nothing and a resize brings the wizard back with everything staged.

## `-l`/`-p` were documented as one-run and behaved as permanent

They were assigned into `Settings.bind_host`/`bind_port` — which **are** the persisted global — so *any* `Settings.save` during the session promoted them: the update-check stamp, tab prefs, the wizard's own commit. `gori tui -l 0.0.0.0` on a fresh install left the proxy bound to every interface for every later launch, from a flag `gori tui --help`, `gori wizard --help` and the wizard's own NETWORK copy all call temporary.

`Settings.cli_bind_*` is a process-only layer, resolved `project || cli || global` (the precedence the flag always had) — the same line `Runner.port_fallback` already draws for the startup port fallback. `gori run capture` gets it too. Three consequences handled in the same change:

- the Project pane reads `configured_bind_*` (project pin, else global), so its value matches its own `· global` marker and **the running port is pinnable again** — against `effective_*` typing it cleared the key instead;
- an explicit settings:network bind edit clears the override, because `apply_settings` rebinds on `effective_*` and the flag would otherwise veto the edit while reporting success, with no in-session way to clear it. Only on an actual change, so an upstream-proxy save doesn't yank the proxy off the launch port;
- `App#open_and_run` seeds `Config` from `startup_bind_*`, so the override survives opening a second project.

Verified: wizard prefills the factory default; settings.json stays `127.0.0.1:8070` after a full session (an `update` section proves saves ran); socket is `TCP *:9999`; the Project pane pins 9999 on request and writes nothing when untouched; a settings:network edit rebinds to 8090.

## Also

- **`SignalGuard`** for `gori wizard` / `gori tutorial` — the only two surfaces opening a terminal without one, so a SIGHUP or `pkill` handed the pane back in raw mode with the alternate screen up. `#{alternate_on}` after SIGTERM: `1` → `0` for both now. The `enable_*` calls moved inside the guarded block, mirroring `App#run_tui`.
- **Real `OptionParser`s** for both commands, which had been ignoring every argument — `gori wizard --port 9000` was a silent no-op while the help text mentioned the flag. Post-`--` args rejected too.
- **Theme clicks bounded to the list** via one shared `theme_list_w`, so clicking the live PREVIEW panel stops re-picking a theme.
- **The tour borrows the mouse** it needs and hands it back, so its Prev/Next buttons work whichever door you came through.
- **Miss Ring's column reservation** is gated on her actually being there — both the accent band and the text width, so the copy no longer ellipsizes for a sprite that isn't drawn.

## Verification

- 7529 examples, 0 new failures. The 8 `Gori::Session` port-bind failures are environmental (a live gori holds 8070) and confirmed identical on a stashed baseline.
- New: `spec/settings_cli_bind_override_spec.cr` (layer precedence + non-serialization), `spec/tui/setup_wizard_floor_spec.cr` (pins the `MIN_H` derivation from both sides — hard-coding `MIN_H = 14` fails it).
- `crystal tool format --check` clean on every touched file; all were clean on the baseline.

One thing deliberately left: `--insecure-upstream` still writes the persisted property. It carries no one-run promise, and settings:network is expected to show verification as actually off so toggling it back re-syncs the proxy — giving it a layer would be a behaviour change, not a bug fix.
