### PR TITLE
Five latent-bug fixes across the cookie, filter, env, minimizer, and HPACK layers

### DIFF
--- a/spec/cookie_spec.cr
+++ b/spec/cookie_spec.cr
@@ -74,6 +74,16 @@ describe Gori::Cookie do
       Gori::Cookie.int_to_b64(Gori::Cookie.b64_to_int(seg)).should eq(seg)
     end
 
+    it "b64_to_int? answers nil (not raise) on an invalid or oversized segment" do
+      # The tolerant DECODE sibling of b64_to_int, mirroring the nil contract base62_decode
+      # already gives Django, so a mangled Flask timestamp renders "(invalid …)"/null instead
+      # of raising CookieError and refusing the whole cookie.
+      seg = FLASK.split('.')[1]
+      Gori::Cookie.b64_to_int?(seg).should eq(Gori::Cookie.b64_to_int(seg)) # a real ts still decodes
+      Gori::Cookie.b64_to_int?("@@@bad@@@").should be_nil                    # not valid base64
+      Gori::Cookie.b64_to_int?("AAAAAAAAAAAAAAAA").should be_nil             # decodes to > 8 bytes
+    end
+
     it "secure_compare is length- and content-exact" do
       Gori::Cookie.secure_compare("abc", "abc").should be_true
       Gori::Cookie.secure_compare("abc", "abd").should be_false
@@ -111,6 +121,16 @@ describe Gori::Cookie do
       forged = Gori::Cookie::Flask.forge(%({"admin":true}), SECRET, 1785656674_i64)
       Gori::Cookie::Flask.verify(forged, SECRET).should be_true
       Gori::Cookie::Flask.verify(forged, "other").should be_false
+    end
+
+    it "decodes a cookie with a mangled timestamp instead of crashing (Django parity)" do
+      # A crafted timestamp segment must not refuse the whole cookie: the payload and
+      # signature are perfectly readable, and Django already degrades this gracefully.
+      bad_ts = FLASK.sub(FLASK.split('.')[1], "@@@bad@@@")
+      txt = Gori::Cookie.decode(bad_ts, "flask")
+      txt.should contain("invalid timestamp")
+      txt.should contain("alice") # the payload is still shown
+      JSON.parse(Gori::Cookie.decode_json(bad_ts, "flask"))["timestamp"].raw.should be_nil
     end
   end
 

--- a/spec/env_spec.cr
+++ b/spec/env_spec.cr
@@ -92,6 +92,18 @@ describe Gori::Env do
     Gori::Settings.env_prefix = "$"
   end
 
+  it "expand does not let a $NAME read INTO a verbatim span (a fuzz payload stays untouched)" do
+    vars = {"ADMIN" => "SECRET"}
+    # "x=$ADMIN": the `$` at index 2 is OUTSIDE the payload span; the name reaches into it.
+    # The read used to run to end-of-buffer, so the payload ADMIN — declared verbatim, the
+    # thing under test — was consumed and substituted, splicing a live credential into it.
+    Gori::Env.expand("x=$ADMIN", vars, "$", [{3, 8}]).should eq("x=$ADMIN")
+    # A name FULLY before the span still resolves; the payload after it is copied through.
+    Gori::Env.expand("$ADMIN|PAY", vars, "$", [{7, 10}]).should eq("SECRET|PAY")
+    # The `$$` escape must not reach into the span either (payload keeps its leading `$`).
+    Gori::Env.expand("a$$X", {} of String => String, "$", [{2, 4}], Gori::Env::Escape::Consume).should eq("a$$X")
+  end
+
   it "expand_wire does not raise and still normalizes CRLF when the text has invalid UTF-8" do
     Gori::Settings.env_prefix = "$"
     Gori::Settings.env_vars = [] of {String, String}

--- a/spec/filter_ast_spec.cr
+++ b/spec/filter_ast_spec.cr
@@ -205,6 +205,44 @@ describe Gori::FilterAst do
       dash, _ = Gori::FilterAst.partition("NOT (-tag:x)") { |t| t.text.starts_with?("tag:") }
       dash.map(&.negate?).should eq([false])
     end
+
+    it "keeps the NOT for a group made ENTIRELY of the other backend's terms" do
+      # A NOT-group with no OWNED (tag:) term used to be decomposed anyway: the inner terms
+      # went to the residual and the leading NOT was DROPPED, so Sitemap's residual for
+      # `NOT (host:evil)` came back as `( host:evil )` and QL then SHOWED only evil — the
+      # negation silently inverted. A term-less group can't feed `taken`, so keep it verbatim.
+      taken, residual = Gori::FilterAst.partition("NOT (host:evil)") { |t| t.text.starts_with?("tag:") }
+      taken.should be_empty
+      residual.should eq("NOT (host:evil)")
+
+      # The module's own documented example, all-residual for a tag: backend.
+      _, res2 = Gori::FilterAst.partition("NOT (host:cdn OR host:static)") { |t| t.text.starts_with?("tag:") }
+      res2.should eq("NOT (host:cdn OR host:static)")
+
+      # A tag term alongside still splits out; the residual NOT-group keeps its negation.
+      tk, res3 = Gori::FilterAst.partition("tag:done NOT (host:evil)") { |t| t.text.starts_with?("tag:") }
+      tk.map(&.text).should eq(["tag:done"])
+      res3.should eq("NOT (host:evil)")
+    end
+
+    it "makes NOT tag:x and -tag:x identical INSIDE a group (the grammar's core equivalence)" do
+      # An inner NOT keyword before an owned term used to fall into the residual, so the term
+      # took only the OUTER run's polarity: `NOT (NOT tag:a)` excluded what `NOT (-tag:a)`
+      # included. Inner and dash negation must compose the same way.
+      %w(a b).each do |x|
+        {"NOT (NOT tag:#{x})", "NOT (-tag:#{x})"}.tap do |kw, dash|
+          kwp = Gori::FilterAst.partition(kw) { |t| t.text.starts_with?("tag:") }[0].map(&.negate?)
+          dp = Gori::FilterAst.partition(dash) { |t| t.text.starts_with?("tag:") }[0].map(&.negate?)
+          kwp.should eq(dp)
+        end
+      end
+      # NOT (NOT tag:a) is a double negation → positive.
+      Gori::FilterAst.partition("NOT (NOT tag:a)") { |t| t.text.starts_with?("tag:") }[0]
+        .map(&.negate?).should eq([false])
+      # NOT (tag:a NOT tag:b): outer negates a, inner+outer cancel on b.
+      Gori::FilterAst.partition("NOT (tag:a NOT tag:b)") { |t| t.text.starts_with?("tag:") }[0]
+        .map { |t| {t.text, t.negate?} }.should eq([{"tag:a", true}, {"tag:b", false}])
+    end
   end
 
   describe ".spans" do

--- a/spec/proxy/h2/hpack_spec.cr
+++ b/spec/proxy/h2/hpack_spec.cr
@@ -57,6 +57,24 @@ describe Gori::Proxy::H2::HPACK do
     expect_raises(Gori::Error, /dynamic index/) { HPACK::Decoder.new.decode(hexb("be")) }
   end
 
+  it "raises Gori::Error (not IndexError) on a literal field truncated before its value" do
+    # `0x50` = literal with incremental indexing, static name index 16, and the block ends —
+    # so the value string's length byte is off the end. `read_string` used to index past the
+    # block and raise a raw IndexError, escaping every caller that rescues only Gori::Error
+    # (the repeater h2 engine's response decode among them → a truncated-HPACK origin response
+    # crashed the exchange). Must be a named Gori::Error now.
+    expect_raises(Gori::Error, /truncated/) { HPACK::Decoder.new.decode_fields(hexb("50")) }
+    expect_raises(Gori::Error, /truncated/) { HPACK::Decoder.new.decode_fields(hexb("40")) } # index 0 → literal NAME, also truncated
+    # And it stays a Gori::Error across every single-byte block (no raw IndexError anywhere).
+    256.times do |i|
+      begin
+        HPACK::Decoder.new.decode_fields(Bytes[i.to_u8])
+      rescue Gori::Error
+        # fine — the sanctioned channel
+      end
+    end
+  end
+
   it "Huffman round-trips arbitrary bytes" do
     ["www.example.com", "Mon, 21 Oct 2013 20:13:21 GMT", "ABCxyz0189-_/:%", ""].each do |s|
       HPACK.huffman_decode(HPACK.huffman_encode(s)).should eq(s)

--- a/spec/repeater/minimize_spec.cr
+++ b/spec/repeater/minimize_spec.cr
@@ -182,6 +182,29 @@ describe Gori::Repeater::Minimize do
     report.sends.should be > 0
   end
 
+  it "strips cosmetic crumbs from a SECOND Cookie header even when the first is load-bearing" do
+    # HTTP/2 splits cookies across multiple `cookie` field lines (RFC 9113 §8.2.2). The crumb
+    # remover used to target the FIRST Cookie header only, so once a crumb there was load-bearing
+    # (keeping that header un-emptied and un-deleted, hence perpetually "first"), every crumb in a
+    # later Cookie header was silently unremovable — the minimizer under-minimized and said so.
+    text = [
+      "GET /p HTTP/1.1",
+      "Host: h",
+      "X-Keep: yes",
+      "Cookie: sid=abc123",     # load-bearing → header 1 is never emptied/deleted
+      "Cookie: junk=1; trash=2", # cosmetic → must still be reachable and removed
+    ].join("\n")
+
+    report = minimize(FakeOrigin.new, text)
+    report.aborted.should be_false
+    labels = report.removed.map(&.label)
+    labels.should contain("junk")
+    labels.should contain("trash")
+    report.minimized_text.should contain("sid=abc123")
+    report.minimized_text.should_not contain("junk")
+    report.minimized_text.should_not contain("trash")
+  end
+
   it "removes an unused body param and re-lengths, keeping a load-bearing one (auto-CL on)" do
     text = [
       "POST /submit HTTP/1.1",

--- a/src/gori/cookie.cr
+++ b/src/gori/cookie.cr
@@ -137,6 +137,24 @@ module Gori
       n
     end
 
+    # Tolerant sibling of `b64_to_int` for the DECODE path (Crystal's raise-vs-`?`
+    # convention): nil when the segment isn't valid base64 OR decodes to more than 8 bytes
+    # (no real itsdangerous unix second is that wide). A crafted Flask cookie chooses this
+    # segment freely, so `Flask.decode_text`/`decode_json` must render "(invalid …)"/null
+    # rather than let `b64_to_int`'s raise refuse the whole cookie — hiding the perfectly
+    # readable payload and signature. This is the exact contract `base62_decode` already
+    # gives Django's timestamp (see spec: "decodes a cookie carrying an oversized/invalid
+    # timestamp instead of crashing"); Flask had been left the odd sibling out.
+    def b64_to_int?(seg : String) : Int64?
+      bytes = b64decode(seg)
+      return nil if bytes.size > 8
+      n = 0_i64
+      bytes.each { |byte| n = n << 8 | byte }
+      n
+    rescue CookieError
+      nil
+    end
+
     # zlib-inflate a compressed cookie payload (Flask's leading-"." / Django's compress=True).
     # 4 MiB cap: a session cookie is tiny, so anything larger is a crafted zip-bomb — stop
     # rather than drain it. CookieError on a bad stream, so the decode path reports cleanly.

--- a/src/gori/cookie/flask.cr
+++ b/src/gori/cookie/flask.cr
@@ -109,11 +109,12 @@ module Gori
 
       def decode_text(cookie : String) : String
         p = parse(cookie)
+        ts = Cookie.b64_to_int?(p.ts_seg)
         String.build do |io|
           io << "// format: flask (itsdangerous secure cookie)\n"
           io << "// payload" << (p.payload_seg.starts_with?('.') ? " (zlib-compressed)\n" : "\n")
           io << payload_pretty(p) << "\n\n"
-          io << "// timestamp: " << Cookie.unix_to_s(Cookie.b64_to_int(p.ts_seg)) << "\n"
+          io << "// timestamp: " << (ts ? Cookie.unix_to_s(ts) : "(invalid timestamp #{p.ts_seg.inspect})") << "\n"
           io << "// signature (not verified): " << p.signature
         end
       end
@@ -125,7 +126,7 @@ module Gori
             j.field "format", "flask"
             j.field "payload" { j.raw(payload_json_or_null(p)) }
             j.field "compressed", p.payload_seg.starts_with?('.')
-            j.field "timestamp", Cookie.b64_to_int(p.ts_seg)
+            j.field "timestamp", Cookie.b64_to_int?(p.ts_seg)
             j.field "signature", p.signature
           end
         end

--- a/src/gori/env.cr
+++ b/src/gori/env.cr
@@ -567,14 +567,23 @@ module Gori
           end
         end
         if i + plen <= n && prefix_bytes.each_with_index.all? { |b, j| bytes[i + j] == b }
-          if prefix_at?(bytes, prefix_bytes, i + plen)
+          # A verbatim span starting ahead of `i` caps how far a token opened here may read:
+          # its NAME (and the second `$` of an escape) must stop at the span, never reach INTO
+          # it. Without the cap a `$NAME` whose `$` sits just before a fuzz payload consumed
+          # and substituted the payload's leading bytes — the exact splice `verbatim` exists to
+          # prevent (a live credential spliced into the payload under test). vi already points
+          # past every span ending at/behind `i`, and we are NOT inside one (that branch ran
+          # above), so `verbatim[vi]` is the next span ahead. No verbatim → `key_end == n`, the
+          # unchanged common path.
+          key_end = (verbatim && vi < verbatim.size) ? verbatim[vi][0] : n
+          if i + 2 * plen <= key_end && prefix_at?(bytes, prefix_bytes, i + plen)
             # `$$` — one escaped literal `$`. Both prefixes are consumed and the token behind
             # them is never read, which is what makes the escape mean the same thing whether
             # or not the name after it happens to resolve.
             buf << prefix
             buf << prefix if escape.preserve?
             i += 2 * plen
-          elsif parsed = read_key_bytes(bytes, i + plen, n)
+          elsif parsed = read_key_bytes(bytes, i + plen, key_end)
             key, consumed = parsed
             if val = vars[key]?
               buf << val
@@ -708,11 +717,15 @@ module Gori
           end
         end
         if i + plen <= n && prefix_bytes.each_with_index.all? { |b, j| bytes[i + j] == b }
-          if prefix_at?(bytes, prefix_bytes, i + plen)
+          # Cap the token at the next verbatim span exactly as `expand` does — the two MUST
+          # agree about where a token ends (see the note there), so a `$NAME` reaching into a
+          # payload span is neither substituted by `expand` nor reported here.
+          key_end = (verbatim && vi < verbatim.size) ? verbatim[vi][0] : n
+          if i + 2 * plen <= key_end && prefix_at?(bytes, prefix_bytes, i + plen)
             # `$$` — an escape, not a reference. Same advance as `expand`'s escape branch, so
             # the two agree about where the NEXT token starts.
             i += 2 * plen
-          elsif parsed = read_key_bytes(bytes, i + plen, n)
+          elsif parsed = read_key_bytes(bytes, i + plen, key_end)
             key, consumed = parsed
             if vars.has_key?(key)
               i += plen + consumed

--- a/src/gori/filter_ast.cr
+++ b/src/gori/filter_ast.cr
@@ -364,13 +364,51 @@ module Gori
           next
         end
         # `NOT (tag:x)` — same desugar, but the NOT sits before a GROUP. An LParen lexeme
-        # has `term == nil`, so the branch above never fired and the inner `tag:x` was
-        # taken UNNEGATED while `NOT ( )` fell into residual and folded away — Sitemap
-        # `NOT (tag:done)` then showed ONLY the tagged nodes, silently inverted, with no
-        # "invalid filter" note. Walk the group, apply the run's polarity to every taken
-        # term inside (XOR with a dash already on the leaf), and leave non-matching
-        # structure in the residual. Empty residual groups fold the same way as before.
+        # has `term == nil`, so the run-before-term branch never fires for it.
         if run > 0 && nxt && nxt.tok.l_paren?
+          # First locate the matching `)` and learn whether the group holds ANY owned term.
+          scan = i + run
+          depth = 0
+          has_taken = false
+          close = scan # last lexeme index that belongs to this group (unclosed ⇒ to EOF)
+          while scan < lexemes.size
+            lx = lexemes[scan]
+            if lx.tok.l_paren?
+              depth += 1
+            elsif lx.tok.r_paren?
+              depth -= 1
+              if depth == 0
+                close = scan
+                break
+              end
+            elsif (t = lx.term) && yield t
+              has_taken = true
+            end
+            close = scan
+            scan += 1
+          end
+
+          unless has_taken
+            # No owned term in the group → keep the WHOLE `NOT ( … )` verbatim in the residual
+            # (source spans, so the parens and NOTs survive) rather than decomposing it. The old
+            # walk emitted only the inner terms + parens and DROPPED the leading NOT, so a group
+            # made entirely of the OTHER backend's terms lost its negation: Sitemap's residual for
+            # `NOT (host:cdn OR host:static)` — the module's own example — came back as
+            # `( host:cdn OR host:static )` and `QL.parse` then SHOWED only cdn/static, the exact
+            # inversion the surrounding fixes exist to prevent. A term-less group can't feed
+            # `taken` anyway, so verbatim is both correct and lossless here.
+            first = lexemes[i]
+            last = lexemes[close]
+            kept << query[first.start, (last.start + last.size) - first.start]
+            i = close + 1
+            next
+          end
+
+          # The group DOES own terms: decompose it, pushing the run's polarity down to each
+          # taken term (De Morgan holds because `taken` is ANDed). `NOT (tag:done)` used to
+          # take `tag:done` UNNEGATED; now the run negates it. XOR with a `-` already on the
+          # leaf. Non-owned structure stays in the residual (a MIXED group can't round-trip
+          # through a flat AND — documented — but a homogeneous all-owned group is exact).
           j = i + run
           depth = 0
           while j < lexemes.size
@@ -378,17 +416,34 @@ module Gori
             if lx.tok.l_paren?
               depth += 1
               kept << query[lx.start, lx.size]
+              j += 1
             elsif lx.tok.r_paren?
               depth -= 1
               kept << query[lx.start, lx.size]
               j += 1
               break if depth == 0
-            elsif (t = lx.term) && yield t
-              taken << (run.odd? ? t.negated : t)
             else
-              kept << query[lx.start, lx.size]
+              # Consume a run of INNER `NOT` keywords the same way the top-level loop does, so
+              # the grammar's `-x == NOT x` equivalence holds inside the group too: an inner
+              # `NOT` lexeme (term "NOT", rejected by the field predicate) used to fall into the
+              # residual and the term took ONLY the outer run's polarity — so `NOT (NOT tag:a)`
+              # EXCLUDED what `NOT (-tag:a)` included. Combine the inner run with `run`, negate once.
+              inner = 0
+              while j + inner < lexemes.size && lexemes[j + inner].tok.not?
+                inner += 1
+              end
+              nx = lexemes[j + inner]?
+              if inner > 0 && nx && (t = nx.term) && yield t
+                taken << ((run + inner).odd? ? t.negated : t)
+                j += inner + 1
+              elsif inner == 0 && (t = lx.term) && yield t
+                taken << (run.odd? ? t.negated : t)
+                j += 1
+              else
+                kept << query[lx.start, lx.size]
+                j += 1
+              end
             end
-            j += 1
           end
           i = j
           next

--- a/src/gori/proxy/h2/hpack.cr
+++ b/src/gori/proxy/h2/hpack.cr
@@ -431,6 +431,14 @@ module Gori::Proxy::H2
 
       # HPACK string (§5.2): H-bit + length, then raw or Huffman-coded octets.
       private def read_string(block : Bytes, pos : Int32) : {String, Int32}
+        # A block that ends exactly at a string boundary (a literal field with no value byte,
+        # e.g. the single byte `0x50` — a static name index and nothing after it) reached this
+        # `block[pos]` out of bounds and raised a raw `IndexError`, breaking the module's "hostile
+        # input raises only Gori::Error" contract (`read_int` above states it). It escaped every
+        # caller that rescues only `Gori::Error`/`IO::Error` — the repeater h2 engine's response
+        # decode (`absorb`) among them, so a truncated-HPACK ORIGIN response crashed the exchange
+        # — and the assembler papered over it by widening its rescue to `IndexError`. Fail by name.
+        raise Gori::Error.new("hpack: truncated string length") if pos >= block.size
         huffman = block[pos] & 0x80 != 0
         len, pos = read_int(block, pos, 7)
         raise Gori::Error.new("hpack: string overruns block") if pos + len > block.size

--- a/src/gori/repeater/minimize.cr
+++ b/src/gori/repeater/minimize.cr
@@ -331,12 +331,18 @@ module Gori::Repeater
     private def self.cookie_candidate(crumb : String) : Candidate
       Candidate.new(Kind::Cookie, crumb.split('=', 2).first, ->(text : String) {
         hl, body, sep = split_text(text)
-        idx = (1...hl.size).find { |k| header_name(hl[k]).downcase == "cookie" }
+        # Find the Cookie header that CONTAINS this crumb, not merely the FIRST one. HTTP/2
+        # routinely splits cookies across several `cookie` field lines (RFC 9113 §8.2.2), and a
+        # `.find` on the first header could never excise a crumb living in a later one: once a
+        # crumb in the first header was load-bearing (so that header was never emptied and
+        # deleted), every crumb in every SUBSEQUENT Cookie header was silently unremovable.
+        idx = (1...hl.size).find do |k|
+          header_name(hl[k]).downcase == "cookie" && cookie_crumbs(hl[k]).includes?(crumb)
+        end
         return nil unless idx
         colon = hl[idx].index(':').not_nil!
         prefix = hl[idx][0...colon]
         crumbs = hl[idx][(colon + 1)..].strip.split(/;\s*/).reject(&.empty?)
-        return nil unless crumbs.includes?(crumb)
         crumbs.delete(crumb)
         if crumbs.empty?
           hl.delete_at(idx)


### PR DESCRIPTION
A source-analysis pass over the pure-logic and parser layers, hunting latent bugs with differential
fuzzing and sibling comparison. Five fixes, each with a repro-backed spec; the full suite stays green
(only the 8 known environmental port-bind failures).

## Fixes

- **Flask cookie: timestamp decode refused the whole cookie** (`cookie/flask.cr`, `cookie.cr`). A
  mangled timestamp segment made `decode_text`/`decode_json` raise out of `b64_to_int`, failing the
  ENTIRE decode (CLI rc=1 / MCP is_error / Decoder step-error) even though payload + signature were
  readable — while the Django sibling already degraded to `(invalid …)`/null. Added `b64_to_int?`
  (nil on non-base64 or > 8 bytes, the same contract `base62_decode` gives Django) and routed Flask
  through it. `b64_to_int` stays for the forge round-trip.

- **Scope filter dropped its own NOT and inverted the group it handed on** (`filter_ast.cr`).
  `partition` (Sitemap's `tag:` extractor) decomposed a NOT-group made entirely of the OTHER
  backend's terms and DROPPED the leading NOT into the residual, so `NOT (host:evil)` — and the
  module's own example `NOT (host:cdn OR host:static)` — came back as an un-negated residual that
  `QL.parse` then SHOWED. Now a term-less NOT-group is kept verbatim. Also: an inner `NOT` keyword
  before an owned term was dropped (breaking `-x == NOT x`); it now composes with the outer run.

- **A `$NAME` ate the fuzz payload it sat next to** (`env.cr`). `expand` copies `verbatim` byte
  ranges (a fuzz payload — the thing under test) through untouched, but the guard only skipped a `$`
  INSIDE a span; a `$` just OUTSIDE one still read its name to end-of-buffer, so a name reaching into
  the span consumed and substituted the payload's leading bytes — splicing a live session credential
  into the request under test. The token read is now capped at the next verbatim boundary in both
  `expand` and `scan_unresolved` (they must agree on where a token ends).

- **The cookie minimizer could only reach the first Cookie header** (`repeater/minimize.cr`). The
  crumb remover keyed on the FIRST `Cookie:` header via `.find`; once a crumb there was load-bearing
  (so that header was never emptied and deleted), every crumb in a later Cookie header — HTTP/2 splits
  cookies across multiple `cookie` field lines (RFC 9113 §8.2.2) — was silently unremovable. It now
  finds the header that actually CONTAINS the crumb.

- **HPACK indexed off the end of a truncated field** (`proxy/h2/hpack.cr`). `read_string` read the
  string's length byte with no bounds check, so a block ending at a string boundary (a literal field
  with a table name index and no value, e.g. the single byte `0x50`) raised a raw `IndexError` —
  breaking the module's "hostile input raises only Gori::Error" contract. The capture Assembler had
  papered over it, but the repeater h2 engine's response decode (`absorb`→`decode`) is not
  IndexError-guarded, so a truncated-HPACK ORIGIN response crashed the exchange. Now it fails by name.

## How they were found

Sibling comparison (Flask vs Django, `env`/`fuzz` CL siblings), differential fuzzing against an
independent oracle (parse's pushed-down NOT polarity; verbatim-invariant; encode↔decode round-trips),
and never-crash fuzzing of attacker-controlled parsers (HPACK, WS frames, chunked, codecs). ~35 areas
were reviewed or fuzzed; the rest were clean or already fixed since the last hunt.
