### PR TITLE
Six bugs in the `gori mcp` command surface: dropped install flags and an unspoken JSON-RPC batch

### DIFF
--- a/docs/content/guide/mcp.ko.md
+++ b/docs/content/guide/mcp.ko.md
@@ -71,11 +71,14 @@ gori는 널리 쓰이는 클라이언트의 MCP 설정을 대신 작성해 줍�
 gori mcp --install-claude-code
 gori mcp --install-codex
 gori mcp --install-grok
+gori mcp --install-claude-code --install-codex  # 한 번에 여러 클라이언트
 ```
 
-Codex와 Grok은 JSON이 아니라 `[mcp_servers.gori]` 테이블이 있는 TOML을 사용합니다. 설치 후 클라이언트를 재시작하거나 세션을 다시 열어 MCP 서버를 다시 로드하세요.
+Codex와 Grok은 JSON이 아니라 `[mcp_servers.gori]` 테이블이 있는 TOML을 사용합니다. 설치 후 클라이언트를 재시작하거나 세션을 다시 열어 MCP 서버를 다시 로드하세요. 기존 설정 파일은 제자리에서 갱신됩니다. 다른 서버·테이블·주석은 그대로 두고, 파일 권한도 유지하며, 교체는 원자적이라 설치가 중간에 끊겨도 파일이 잘려 나가지 않습니다.
 
 클라이언트가 리포지토리 디렉터리 밖에서 MCP를 시작해도 서버는 unbound로 연결되며, 에이전트가 도구로 프로젝트를 고르거나 만들 수 있습니다. 설치 시점에 고정 engagement를 박아 두려면 선택자를 넘기세요. 예: `gori mcp --project my-engagement --install-codex`.
+
+`--install-*`과 함께 넘긴 플래그는 모두 설치되는 커맨드에 그대로 기록됩니다. 선택자(`--project`, `--db`, `--no-project`, `--use-active-project`)는 물론 `--read-only`, `--insecure-upstream`, `--config`까지 포함되므로 클라이언트가 띄우는 커맨드가 입력한 그대로가 됩니다. 경로는 절대 경로로 변환됩니다. 클라이언트는 사용자가 고르지 않은 작업 디렉터리에서 서버를 실행하기 때문입니다.
 
 ## 도구 {#tools}
 

--- a/docs/content/guide/mcp.md
+++ b/docs/content/guide/mcp.md
@@ -71,11 +71,14 @@ gori can write the MCP configuration for common clients for you:
 gori mcp --install-claude-code
 gori mcp --install-codex
 gori mcp --install-grok
+gori mcp --install-claude-code --install-codex  # several clients in one run
 ```
 
-Codex and Grok use TOML with an `[mcp_servers.gori]` table (not JSON). Restart the client (or re-open the session) after installing so it reloads MCP servers.
+Codex and Grok use TOML with an `[mcp_servers.gori]` table (not JSON). Restart the client (or re-open the session) after installing so it reloads MCP servers. Existing config files are updated in place: other servers, tables and comments are preserved, the file's permissions are kept, and the replacement is atomic so an interrupted install can never truncate it.
 
 If a client starts MCP outside your repository directory, the server starts unbound and the agent can pick or create a project over tools. To pin a fixed engagement at install time instead, pass a selector, for example `gori mcp --project my-engagement --install-codex`.
+
+Every flag you pass alongside `--install-*` is written into the installed command, so what the client spawns matches what you typed — selectors (`--project`, `--db`, `--no-project`, `--use-active-project`), `--read-only`, `--insecure-upstream`, and `--config`. Paths are made absolute, because the client spawns the server from a working directory you did not choose.
 
 ## Tools
 

--- a/docs/content/reference/cli.ko.md
+++ b/docs/content/reference/cli.ko.md
@@ -622,6 +622,8 @@ MCP stdio 서버입니다. 도구 세부사항은 [MCP 가이드](/ko/guide/mcp/
 | `--install-agy` | Antigravity `~/.gemini/antigravity-cli/mcp_config.json` 기록 |
 | `--install-grok` | Grok `~/.grok/config.toml` `[mcp_servers.gori]` 기록 |
 
+`--install-*`은 한 번에 여러 개 지정할 수 있습니다. 클라이언트마다 따로 설정하고 따로 보고하며, 하나가 실패해도 나머지는 그대로 진행됩니다. 커맨드라인의 다른 플래그(`--db`, `--project`, `--no-project`, `--use-active-project`, `--read-only`, `--insecure-upstream`, 전역 `--config`)는 모두 설치되는 커맨드에 기록되고, 경로는 절대 경로로 바뀝니다. 기존 설정 파일은 제자리에서 갱신됩니다. 다른 항목·테이블·주석은 유지되고, 권한도 보존되며, 교체는 원자적입니다.
+
 ## gori ca {#gori-ca}
 
 ```bash

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -642,6 +642,8 @@ MCP stdio server. See the [MCP guide](/guide/mcp/) for tool details.
 | `--install-agy` | Write Antigravity `~/.gemini/antigravity-cli/mcp_config.json` |
 | `--install-grok` | Write Grok `~/.grok/config.toml` `[mcp_servers.gori]` |
 
+Several `--install-*` flags may be given in one run; each named client is configured and reported separately, and one unwritable config does not stop the others. Every other flag on the command line — `--db`, `--project`, `--no-project`, `--use-active-project`, `--read-only`, `--insecure-upstream`, and the global `--config` — is written into the installed command, with paths made absolute. Existing config files are updated in place: other entries, tables and comments survive, permissions are preserved, and the replacement is atomic.
+
 ## gori ca
 
 ```bash

--- a/spec/mcp_install_spec.cr
+++ b/spec/mcp_install_spec.cr
@@ -35,6 +35,37 @@ describe Gori::MCP::Install do
       Gori::MCP::Install.build_args(use_active_project: true).should eq(
         ["mcp", "--use-active-project"])
     end
+
+    it "carries --no-project into the installed argv" do
+      # Dropped here, the installed server path-binds to whatever workspace the client
+      # spawns it in — the opposite of the flag the user typed and gori validated.
+      Gori::MCP::Install.build_args(no_project: true).should eq(["mcp", "--no-project"])
+      Gori::MCP::Install.build_args(no_project: true, read_only: true).should eq(
+        ["mcp", "--no-project", "--read-only"])
+    end
+
+    it "carries --config into the installed argv, absolute" do
+      # The client spawns this command from a directory the user never chose, so a
+      # relative --config would resolve against the wrong tree (or not at all).
+      args = Gori::MCP::Install.build_args(config_path: "./ci-settings.json")
+      args.size.should eq(2)
+      args[0].should eq("mcp")
+      args[1].should eq("--config=#{File.expand_path("./ci-settings.json")}")
+    end
+
+    it "expands a quoted tilde instead of writing it as a literal directory" do
+      # `gori mcp --db '~/e.db' --install-codex`: the shell never expanded it, and a `~`
+      # joined onto the CWD becomes a permanent wrong path inside the client's config.
+      home = ENV["HOME"]? || Path.home.to_s
+      args = Gori::MCP::Install.build_args("~/e.db", config_path: "~/gori.json")
+      args.should eq(["mcp", "--config=#{File.join(home, "gori.json")}",
+                      "--db=#{File.join(home, "e.db")}"])
+    end
+
+    it "emits no selector flags when none were asked for" do
+      Gori::MCP::Install.build_args(no_project: false, config_path: nil).should eq(["mcp"])
+      Gori::MCP::Install.build_args(config_path: "").should eq(["mcp"])
+    end
   end
 
   describe ".upsert_toml_table" do
@@ -129,6 +160,86 @@ describe Gori::MCP::Install do
           File.read(bad).should eq("not-json{")
         ensure
           old_home ? (ENV["HOME"] = old_home) : ENV.delete("HOME")
+        end
+      end
+    end
+
+    it "keeps the existing config's permissions and leaves no temp file behind" do
+      # ~/.claude.json holds auth and every other MCP server: an update must not widen a
+      # 0600 file to the umask default, nor litter the directory with partial writes.
+      Dir.tempdir.try do |base|
+        home = File.join(base, "home-perm-#{Random::Secure.hex(4)}")
+        dir = File.join(home, ".gemini", "antigravity-cli")
+        Dir.mkdir_p(dir)
+        config = File.join(dir, "mcp_config.json")
+        File.write(config, %({"other":{"keep":true}}))
+        File.chmod(config, 0o600)
+        old_home = ENV["HOME"]?
+        ENV["HOME"] = home
+        begin
+          Gori::MCP::Install.install("agy", exe_path: "/opt/gori")
+          File.info(config).permissions.should eq(File::Permissions.new(0o600))
+          JSON.parse(File.read(config))["other"]["keep"].as_bool.should be_true
+          Dir.children(dir).sort.should eq(["mcp_config.json"])
+        ensure
+          old_home ? (ENV["HOME"] = old_home) : ENV.delete("HOME")
+        end
+      end
+    end
+
+    it "writes through a symlinked config instead of detaching it" do
+      # Dotfiles are routinely symlinked into a dotfiles repo. Renaming over the LINK would
+      # leave the client reading a plain file while the repo copy silently went stale.
+      Dir.tempdir.try do |base|
+        home = File.join(base, "home-link-#{Random::Secure.hex(4)}")
+        dotfiles = File.join(base, "dotfiles-#{Random::Secure.hex(4)}")
+        Dir.mkdir_p(home)
+        Dir.mkdir_p(dotfiles)
+        real = File.join(dotfiles, "claude.json")
+        File.write(real, %({"other":{"keep":true}}))
+        link = File.join(home, ".claude.json")
+        File.symlink(real, link)
+        old_home = ENV["HOME"]?
+        ENV["HOME"] = home
+        begin
+          Gori::MCP::Install.install("claude-code", exe_path: "/opt/gori")
+          File.symlink?(link).should be_true # still a link, not replaced by a file
+          parsed = JSON.parse(File.read(real))
+          parsed["other"]["keep"].as_bool.should be_true
+          parsed["mcpServers"]["gori"]["command"].as_s.should eq("/opt/gori")
+          Dir.children(dotfiles).sort.should eq(["claude.json"])
+        ensure
+          old_home ? (ENV["HOME"] = old_home) : ENV.delete("HOME")
+        end
+      end
+    end
+
+    it "installs every target and keeps going past one that fails" do
+      # `gori mcp --install-claude-code --install-codex` with a hand-broken ~/.claude.json:
+      # the client that CAN be configured still is, the one that cannot is named, and which
+      # clients end up installed does not depend on the order the flags were typed in.
+      Dir.tempdir.try do |base|
+        home = File.join(base, "home-multi-#{Random::Secure.hex(4)}")
+        Dir.mkdir_p(File.join(home, ".codex"))
+        broken = File.join(home, ".claude.json")
+        File.write(broken, "not-json{")
+        old_home = ENV["HOME"]?
+        old_codex = ENV["CODEX_HOME"]?
+        ENV["HOME"] = home
+        ENV.delete("CODEX_HOME")
+        begin
+          outcomes = Gori::MCP::Install.install_all(
+            ["claude-code", "codex", "codex"], exe_path: "/opt/gori")
+          outcomes.map(&.target).should eq(["claude-code", "codex"]) # deduped, order kept
+          outcomes[0].ok?.should be_false
+          outcomes[0].error.to_s.should contain("Refusing to overwrite")
+          outcomes[1].ok?.should be_true
+          # The failing target left its file alone; the healthy one was written anyway.
+          File.read(broken).should eq("not-json{")
+          File.read(File.join(home, ".codex", "config.toml")).should contain("[mcp_servers.gori]")
+        ensure
+          old_home ? (ENV["HOME"] = old_home) : ENV.delete("HOME")
+          old_codex ? (ENV["CODEX_HOME"] = old_codex) : ENV.delete("CODEX_HOME")
         end
       end
     end

--- a/spec/mcp_spec.cr
+++ b/spec/mcp_spec.cr
@@ -271,6 +271,114 @@ describe Gori::MCP::Server do
         out.should be_empty
       end
     end
+
+    it "answers a message carrying no method at all, id or not" do
+      with_store do |store|
+        # Silence is for a NOTIFICATION — no id, but a method. An object naming no method is
+        # malformed, and JSON-RPC answers it at null rather than dropping it on the floor.
+        out = drive(store, %({"jsonrpc":"2.0","params":{}}))
+        out.size.should eq(1)
+        out[0]["id"].raw.should be_nil
+        out[0]["error"]["code"].as_i.should eq(-32600)
+      end
+    end
+  end
+
+  # SUPPORTED_VERSIONS advertises 2025-03-26 — the one MCP revision that REQUIRES receiving
+  # JSON-RPC batches (2025-06-18 removed batching again). A batch used to come back as a
+  # single `Invalid Request` at id null, so a client tracking one promise per request in the
+  # batch resolved none of them and hung on a revision the server had just claimed.
+  describe "JSON-RPC batches" do
+    it "answers a batch with one array, correlated per member id" do
+      with_store do |store|
+        batch = %([{"jsonrpc":"2.0","id":1,"method":"ping"},) +
+                %({"jsonrpc":"2.0","method":"notifications/initialized"},) +
+                %({"jsonrpc":"2.0","id":"two","method":"ping"}])
+        out = drive(store, batch)
+        out.size.should eq(1) # one framed line, not three
+        arr = out[0].as_a
+        # The notification contributes nothing; the two requests keep their own id types.
+        arr.size.should eq(2)
+        arr[0]["id"].as_i.should eq(1)
+        arr[0]["result"].as_h.should be_empty
+        arr[1]["id"].as_s.should eq("two")
+        arr[1]["result"].as_h.should be_empty
+      end
+    end
+
+    it "answers a bad member beside its siblings instead of voiding the batch" do
+      with_store do |store|
+        batch = %([{"jsonrpc":"2.0","id":1,"method":"ping"},"garbage",) +
+                %({"jsonrpc":"2.0","id":9,"method":"nope"}])
+        arr = drive(store, batch)[0].as_a
+        arr.size.should eq(3)
+        arr[0]["result"].as_h.should be_empty
+        arr[1]["id"].raw.should be_nil # a non-object member has no id to answer with
+        arr[1]["error"]["code"].as_i.should eq(-32600)
+        arr[2]["id"].as_i.should eq(9)
+        arr[2]["error"]["code"].as_i.should eq(-32601)
+      end
+    end
+
+    it "stays silent for an all-notification batch" do
+      with_store do |store|
+        # `[]` back would be a protocol violation of its own, not a harmless empty answer.
+        batch = %([{"jsonrpc":"2.0","method":"notifications/initialized"},) +
+                %({"jsonrpc":"2.0","method":"notifications/cancelled"}])
+        drive(store, batch).should be_empty
+      end
+    end
+
+    it "answers an unparseable batch at id null, not at its first member's id" do
+      with_store do |store|
+        # `1e400` is legal JSON that Crystal's Float64 parser refuses, so the whole LINE
+        # fails to parse. recover_id scrapes the first `"id"` it sees — in a batch that id
+        # belongs to member 1, and answering the batch under it resolves exactly one of the
+        # client's promises while every other member hangs.
+        batch = %([{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"limit":1e400}},) +
+                %({"jsonrpc":"2.0","id":2,"method":"ping"}])
+        out = drive(store, batch)
+        out.size.should eq(1)
+        out[0]["id"].raw.should be_nil
+        out[0]["error"]["code"].as_i.should eq(-32700)
+      end
+    end
+
+    it "answers a member with neither method nor id, keeping the array aligned" do
+      with_store do |store|
+        # A client correlating responses to members BY POSITION needs one element per
+        # member; a silently skipped member shifts every response after it.
+        batch = %([{"jsonrpc":"2.0","id":1,"method":"ping"},{"jsonrpc":"2.0","params":{}}])
+        arr = drive(store, batch)[0].as_a
+        arr.size.should eq(2)
+        arr[0]["id"].as_i.should eq(1)
+        arr[1]["id"].raw.should be_nil
+        arr[1]["error"]["code"].as_i.should eq(-32600)
+      end
+    end
+
+    it "rejects an empty batch with a single null-id error" do
+      with_store do |store|
+        out = drive(store, "[]")
+        out.size.should eq(1)
+        out[0]["id"].raw.should be_nil
+        out[0]["error"]["code"].as_i.should eq(-32600)
+      end
+    end
+
+    it "runs real tool calls inside a batch" do
+      with_store do |store|
+        seed_flow(store, "ex.com", "GET", "/a", 200)
+        batch = %([{"jsonrpc":"2.0","id":1,"method":"tools/call",) +
+                %("params":{"name":"list_history","arguments":{"limit":1}}},) +
+                %({"jsonrpc":"2.0","id":2,"method":"tools/list"}])
+        arr = drive(store, batch)[0].as_a
+        arr.size.should eq(2)
+        arr[0]["result"]["isError"].as_bool.should be_false
+        JSON.parse(arr[0]["result"]["content"][0]["text"].as_s).as_a.size.should eq(1)
+        arr[1]["result"]["tools"].as_a.should_not be_empty
+      end
+    end
   end
 
   describe "tools/list" do

--- a/src/gori/cli.cr
+++ b/src/gori/cli.cr
@@ -870,7 +870,12 @@ module Gori
       read_only = false
       use_active_project = false
       no_project = false
-      install_target = nil.as(String?)
+      # A LIST, not a single slot: `gori mcp --install-claude-code --install-codex` is what
+      # someone who runs two agents types, and the last-one-wins slot this used to be
+      # configured Codex alone and said nothing about the client it skipped — the same
+      # "accepted, then quietly discarded" failure MCP::Install.build_args documents for the
+      # selector flags, spent on a whole client instead of one flag.
+      install_targets = [] of String
 
       parser = OptionParser.new do |p|
         p.banner = "Usage: gori mcp [options]\n\n" \
@@ -885,11 +890,11 @@ module Gori
         p.on("--no-project", "Start unbound even inside a Git workspace (agent picks via list/create/switch)") { no_project = true }
         p.on("--insecure-upstream", "send_request: skip upstream TLS verification") { insecure_upstream = true }
         p.on("--read-only", "Disable action tools (send_request, create/update_issue)") { read_only = true }
-        p.on("--install-agy", "Install gori as an MCP server in Antigravity (~/.gemini/antigravity-cli/mcp_config.json)") { install_target = "agy" }
-        p.on("--install-codex", "Install gori as an MCP server in Codex (~/.codex/config.toml)") { install_target = "codex" }
-        p.on("--install-claude", "Install gori as an MCP server in Claude Desktop config") { install_target = "claude" }
-        p.on("--install-claude-code", "Install gori as an MCP server in Claude Code (~/.claude.json)") { install_target = "claude-code" }
-        p.on("--install-grok", "Install gori as an MCP server in Grok (~/.grok/config.toml)") { install_target = "grok" }
+        p.on("--install-agy", "Install gori as an MCP server in Antigravity (~/.gemini/antigravity-cli/mcp_config.json)") { install_targets << "agy" }
+        p.on("--install-codex", "Install gori as an MCP server in Codex (~/.codex/config.toml)") { install_targets << "codex" }
+        p.on("--install-claude", "Install gori as an MCP server in Claude Desktop config") { install_targets << "claude" }
+        p.on("--install-claude-code", "Install gori as an MCP server in Claude Code (~/.claude.json)") { install_targets << "claude-code" }
+        p.on("--install-grok", "Install gori as an MCP server in Grok (~/.grok/config.toml)") { install_targets << "grok" }
         p.on("-h", "--help", "Show this help") { puts p; exit 0 }
         p.invalid_option { |flag| abort "unknown option: #{flag}\n#{p}" }
         p.missing_option { |flag| abort "missing value for #{flag}" }
@@ -903,9 +908,12 @@ module Gori
         abort "gori mcp: --no-project cannot be combined with --db/--project/--use-active-project"
       end
 
-      if target = install_target
-        install_mcp_config(target, db_path, project, read_only, insecure_upstream, use_active_project)
-        exit 0
+      unless install_targets.empty?
+        # Settings.path_override is `--config`, already stripped from argv by CLI.run before
+        # dispatch — so run_mcp never sees the flag and can only read it back from here.
+        ok = install_mcp_config(install_targets, db_path, project, read_only, insecure_upstream,
+          use_active_project, no_project, Settings.path_override)
+        exit(ok ? 0 : 1)
       end
 
       # Logs to STDERR ONLY — STDOUT is reserved for the JSON-RPC stream.
@@ -960,17 +968,36 @@ module Gori
       end
     end
 
-    private def self.install_mcp_config(target : String, db_path : String?, project : String?, read_only : Bool,
-                                        insecure_upstream : Bool, use_active_project : Bool) : Nil
-      path = MCP::Install.install(target, db_path: db_path, project: project,
-        read_only: read_only, insecure_upstream: insecure_upstream,
-        use_active_project: use_active_project)
+    # Writes the MCP entry into every named client config. Returns false if ANY target
+    # failed — reported per target, and never as an abort partway through, which would have
+    # made "which clients did gori configure?" depend on the order the flags were typed in.
+    private def self.install_mcp_config(targets : Array(String), db_path : String?, project : String?,
+                                        read_only : Bool, insecure_upstream : Bool,
+                                        use_active_project : Bool, no_project : Bool,
+                                        settings_path : String?) : Bool
       exe = MCP::Install.executable_path
-      args = MCP::Install.build_args(db_path, project, read_only, insecure_upstream, use_active_project)
-      puts "Successfully installed gori MCP server configuration to #{path}"
-      puts "Command: #{exe} #{args.join(" ")}"
+      outcomes = MCP::Install.install_all(targets, exe_path: exe, db_path: db_path, project: project,
+        read_only: read_only, insecure_upstream: insecure_upstream,
+        use_active_project: use_active_project, no_project: no_project,
+        settings_path: settings_path)
+      outcomes.each do |outcome|
+        if path = outcome.path
+          puts "Successfully installed gori MCP server configuration to #{path}"
+        else
+          STDERR.puts "Failed to install MCP config for #{outcome.target}: #{outcome.error}"
+        end
+      end
+      # Once, and read back off an Outcome: the argv is identical for every target, and this
+      # is the array the installs actually wrote rather than a second build of it.
+      outcomes.first?.try { |first| puts "Command: #{exe} #{first.args.join(" ")}" }
+      outcomes.all?(&.ok?)
     rescue ex
-      abort "Failed to install MCP config for #{target}: #{ex.message}"
+      # `executable_path` (gori invoked through a PATH entry that has since moved) and
+      # `build_args` (a deleted working directory) both raise before any target is attempted.
+      # Neither is a Gori::Error, so CLI.run's narrow rescue lets them out as a backtrace —
+      # they were covered by this method's own rescue before it grew a loop, and a setup
+      # failure affecting every target still belongs here rather than in an Outcome.
+      abort "Failed to install MCP config: #{ex.message.presence || ex.class}"
     end
 
     private def self.resolve_mcp_project(db : String?, project : String?, *, workspace_project : Bool,

--- a/src/gori/mcp/install.cr
+++ b/src/gori/mcp/install.cr
@@ -8,6 +8,17 @@ module Gori
     module Install
       SERVER_NAME = "gori"
 
+      # What one `--install-*` target did. `error` is nil on success and carries the failure
+      # sentence otherwise — COLLECTED rather than raised, because a run naming several
+      # clients must not let the first broken config file decide the fate of the rest.
+      # `args` is the argv actually written, carried back so the caller PRINTS the same array
+      # the install wrote instead of rebuilding it from the same inputs at a second site.
+      record Outcome, target : String, path : String?, error : String?, args : Array(String) do
+        def ok? : Bool
+          error.nil?
+        end
+      end
+
       # Returns the absolute config path for *target* (`agy`, `codex`, `claude`,
       # `claude-code`, `grok`). Raises on unknown targets.
       def self.config_path(target : String) : String
@@ -42,14 +53,32 @@ module Gori
       end
 
       # Build the argv passed to the gori binary after the executable path.
+      #
+      # EVERY flag `gori mcp` accepts alongside an `--install-*` has to be reproduced here:
+      # the installed entry is the only thing the client ever spawns, so a flag this method
+      # does not emit is a flag the user typed, gori validated, and then silently discarded
+      # into a config file nobody re-reads. `--no-project` and `--config` were both dropped
+      # that way — the first left a server that path-binds to whatever workspace the client
+      # happens to launch in (the exact opposite of what was asked for), the second left one
+      # reading the default settings.json.
       def self.build_args(db_path : String? = nil, project : String? = nil,
                           read_only : Bool = false, insecure_upstream : Bool = false,
-                          use_active_project : Bool = false) : Array(String)
+                          use_active_project : Bool = false, no_project : Bool = false,
+                          config_path : String? = nil) : Array(String)
         args = ["mcp"]
-        # expand_path (not realpath): the db need not exist yet — `gori mcp` creates it on
-        # first serve. realpath raises File::NotFoundError on a fresh path and aborts install.
-        args << "--db=#{File.expand_path(db_path)}" if db_path && !db_path.empty?
+        # expand_path throughout (not realpath): neither the db nor the config need exist yet
+        # — `gori mcp` creates the db on first serve, and realpath raises File::NotFoundError
+        # on a fresh path and aborts the install. Absolute either way, because the client
+        # spawns this command from a working directory the user never chose.
+        #
+        # `home: true` because a QUOTED tilde reaches us unexpanded (`--db '~/e.db'`), and
+        # without it the leading `~` is kept as a literal directory name joined onto the CWD.
+        # Anywhere else that is a one-run mistake; written into a client config it is a
+        # permanent one, and the server silently falls back to defaults on every launch.
+        args << "--config=#{File.expand_path(config_path, home: true)}" if config_path && !config_path.empty?
+        args << "--db=#{File.expand_path(db_path, home: true)}" if db_path && !db_path.empty?
         args << "--project=#{project}" if project && !project.empty?
+        args << "--no-project" if no_project
         args << "--read-only" if read_only
         args << "--insecure-upstream" if insecure_upstream
         args << "--use-active-project" if use_active_project
@@ -64,12 +93,23 @@ module Gori
       end
 
       # Install gori into the target client's config. Returns the path written.
+      # *settings_path* is `gori --config PATH` (the gori settings file the installed server
+      # should read); it is named apart from the local `config_path`, which is the CLIENT's
+      # config file this method writes.
       def self.install(target : String, *, exe_path : String = executable_path,
                        db_path : String? = nil, project : String? = nil,
                        read_only : Bool = false, insecure_upstream : Bool = false,
-                       use_active_project : Bool = false) : String
+                       use_active_project : Bool = false, no_project : Bool = false,
+                       settings_path : String? = nil) : String
+        install_argv(target, exe_path, build_args(db_path, project, read_only, insecure_upstream,
+          use_active_project, no_project, settings_path))
+      end
+
+      # Write *args* into *target*'s config file, returning the path written. The argv is
+      # passed IN rather than rebuilt, so `install_all` hands the caller the very array it
+      # installed and the command gori prints cannot drift from the one it wrote.
+      private def self.install_argv(target : String, exe_path : String, args : Array(String)) : String
         config_path = config_path(target)
-        args = build_args(db_path, project, read_only, insecure_upstream, use_active_project)
         Dir.mkdir_p(File.dirname(config_path)) unless Dir.exists?(File.dirname(config_path))
 
         if toml_target?(target)
@@ -78,6 +118,33 @@ module Gori
           install_json(config_path, exe_path, args)
         end
         config_path
+      end
+
+      # Install into EVERY named target (deduped, order preserved), one Outcome each.
+      #
+      # Deliberately does not raise. `install` refuses a config file it cannot parse, and one
+      # hand-broken `~/.claude.json` must not decide whether the Codex entry beside it gets
+      # written: letting that failure out of the loop would stop after some targets were
+      # already on disk, so WHICH clients ended up configured would depend on the order the
+      # flags happened to be typed in, and the targets never reached would go unmentioned.
+      # Every target is attempted and reported by name; the caller sets the exit status
+      # from `ok?`.
+      def self.install_all(targets : Array(String), *, exe_path : String = executable_path,
+                           db_path : String? = nil, project : String? = nil,
+                           read_only : Bool = false, insecure_upstream : Bool = false,
+                           use_active_project : Bool = false, no_project : Bool = false,
+                           settings_path : String? = nil) : Array(Outcome)
+        # Built once, outside the loop: every target writes the identical argv, and building
+        # it here is what lets each Outcome carry exactly what was installed.
+        args = build_args(db_path, project, read_only, insecure_upstream, use_active_project,
+          no_project, settings_path)
+        targets.uniq.map do |target|
+          begin
+            Outcome.new(target, install_argv(target, exe_path, args), nil, args)
+          rescue ex
+            Outcome.new(target, nil, ex.message.presence || ex.class.to_s, args)
+          end
+        end
       end
 
       # --- JSON clients (Claude Desktop, Claude Code, Antigravity) -------------
@@ -113,7 +180,7 @@ module Gori
         mcp_servers[SERVER_NAME] = JSON::Any.new(gori_entry)
         config["mcpServers"] = JSON::Any.new(mcp_servers)
 
-        File.write(config_path, config.to_pretty_json)
+        write_atomic(config_path, config.to_pretty_json)
       end
 
       # --- TOML clients (Codex, Grok) ------------------------------------------
@@ -125,7 +192,71 @@ module Gori
           io << "command = #{toml_string(exe_path)}\n"
           io << "args = #{toml_string_array(args)}\n"
         end
-        File.write(config_path, upsert_toml_table(existing, table, body))
+        write_atomic(config_path, upsert_toml_table(existing, table, body))
+      end
+
+      # --- Durable writes -------------------------------------------------------
+
+      # Replace *path*'s contents with no window in which it is truncated or half-written.
+      #
+      # These are the user's files, not gori's: `~/.claude.json` is Claude Code's entire CLI
+      # state (projects, auth, every other MCP server), `~/.codex/config.toml` is Codex's.
+      # install_json already refuses to clobber one it cannot parse — but a plain File.write
+      # truncates FIRST and fills after, so a crash, a full disk, or a SIGINT between those
+      # two steps destroys exactly what that check exists to protect, and the installer that
+      # was only adding one entry is what destroyed it.
+      #
+      # Temp file in the SAME directory (rename is atomic only within a filesystem), fsync
+      # before the rename so the rename cannot land ahead of the bytes, and carry the
+      # original's permissions across — a credential-bearing config found at 0600 must not
+      # come back 0644 because gori recreated it under the umask.
+      #
+      # Resolve a symlink to its target FIRST. These paths are dotfiles, which people
+      # routinely symlink into a dotfiles repo; File.write wrote THROUGH the link, and a
+      # rename over the link itself would quietly detach it — the client would then read a
+      # plain file while the repo copy it was linked to went stale, with nothing to show
+      # for it in `git status`. A HARDLINKED config is not detectable this way and does get
+      # detached (rename installs a new inode); that is the standing cost of an atomic
+      # replace, and it is the trade every durable writer in this repo already makes.
+      private def self.write_atomic(path : String, content : String) : Nil
+        target = resolve_symlink(path)
+        dir = File.dirname(target)
+        # The mode to land on: the file's own if it has one, else private — these hold auth
+        # and are nobody else's business.
+        perm = File.info?(target).try(&.permissions) || File::Permissions.new(0o600)
+        # Randomized, not pid-derived: a pid repeats, and a temp left behind by a killed run
+        # would then be re-opened (mode intact, since `perm` only applies on CREATE) and
+        # renamed into place at whatever mode it was abandoned with.
+        tmp = File.tempname(".#{File.basename(target)}.gori", ".tmp", dir: dir)
+        begin
+          # Create at the final mode rather than widening under the umask and narrowing
+          # after: the content is written before any chmod could run, so a 0644 temp holding
+          # an auth-bearing ~/.claude.json is a window the in-place File.write never opened.
+          File.open(tmp, "w", perm: perm) do |file|
+            file.print(content)
+            file.flush
+            file.fsync
+          end
+          File.chmod(tmp, perm)
+          File.rename(tmp, target)
+        rescue ex
+          # `rescue nil` on the cleanup: an unwritable directory or a read-only filesystem
+          # makes the delete raise too, and that exception would REPLACE the ENOSPC (or
+          # whatever actually failed) with a permission complaint about a temp file the user
+          # has never heard of. The cause is what install_all is about to report.
+          File.delete?(tmp) rescue nil
+          raise ex
+        end
+      end
+
+      # The path a symlink points at, or *path* itself. A broken link (or an unreadable
+      # one) resolves to itself, so the write replaces the dangling link with a real file
+      # rather than failing the install over it.
+      private def self.resolve_symlink(path : String) : String
+        return path unless File.symlink?(path)
+        File.realpath(path)
+      rescue
+        path
       end
 
       # Replace or append a TOML table named *header* (without brackets), including any

--- a/src/gori/mcp/server.cr
+++ b/src/gori/mcp/server.cr
@@ -41,6 +41,9 @@ module Gori
         # Set when the output pipe breaks (client vanished mid-write): the loop then
         # stops rather than thrashing on a dead stream or raising an unhandled error.
         @closed = false
+        # Non-nil only while a batch is being dispatched: `send` collects into it instead of
+        # writing, so the members' responses leave as the one array the batch is owed.
+        @batch = nil.as(Array(String)?)
       end
 
       # Reads until EOF on `input` (client closed the pipe). Each line is parsed
@@ -60,7 +63,6 @@ module Gori
       end
 
       private def handle_line(line : String) : Nil
-        id = nil.as(JSON::Any?)
         root = begin
           JSON.parse(line)
         rescue ex : JSON::ParseException
@@ -73,6 +75,47 @@ module Gori
           return write_error(recover_id(line), -32700, "Parse error: #{ex.message}")
         end
 
+        if batch = root.as_a?
+          handle_batch(batch)
+        else
+          handle_message(root)
+        end
+      end
+
+      # A JSON-RPC 2.0 batch: an ARRAY of messages, answered by ONE array of the responses
+      # the member requests produced.
+      #
+      # SUPPORTED_VERSIONS advertises `2025-03-26`, the one MCP revision where receiving
+      # batches is mandatory (2025-06-18 removed it again) — and we echo that version back
+      # whenever a client asks for it. Without this, every batch fell through to
+      # handle_message's object check and came back as a SINGLE `Invalid Request` at id
+      # `null`: not one of the ids in the batch, so a client holding a promise per request
+      # resolved none of them and the session hung on a revision we had just claimed.
+      #
+      # Members are dispatched in order through the same path a lone line takes, so a bad
+      # member yields its own error object beside its siblings' results rather than voiding
+      # the batch.
+      private def handle_batch(items : Array(JSON::Any)) : Nil
+        # An empty batch names no request to answer, so the single null-id error IS the
+        # spec's answer here (unlike the case above, where ids existed and were thrown away).
+        return write_error(nil, -32600, "Invalid Request: empty batch") if items.empty?
+
+        collected = [] of String
+        @batch = collected
+        begin
+          items.each { |item| handle_message(item) }
+        ensure
+          @batch = nil
+        end
+
+        # All-notification batches get no response at all — sending `[]` back is explicitly
+        # forbidden, and a client that reads one as a malformed frame drops the connection.
+        return if collected.empty?
+        send("[#{collected.join(',')}]")
+      end
+
+      private def handle_message(root : JSON::Any) : Nil
+        id = nil.as(JSON::Any?)
         obj = root.as_h?
         return write_error(nil, -32600, "Invalid Request") unless obj
 
@@ -81,8 +124,13 @@ module Gori
         params = obj["params"]?
 
         unless method
-          write_error(id, -32600, "Invalid Request: missing method") if id
-          return
+          # No `method` at all is a MALFORMED message, not a notification — a notification is
+          # one that omits `id` while still naming a method, and this one may omit both. It is
+          # answered at whatever id it carried, or at null when it carried none. Staying silent
+          # for the id-less case cost a batch one array element, and a client that correlates
+          # responses to members BY POSITION then pairs every later response with the wrong
+          # request — worse than the error it was trying not to send.
+          return write_error(id, -32600, "Invalid Request: missing method")
         end
 
         if id
@@ -266,6 +314,13 @@ module Gori
       # inside a tool ARGUMENT (get_flow's own `id`, an issue id, …) from being mistaken for
       # the envelope's. Nil when nothing matches: a wrong id is worse than none.
       private def recover_id(line : String) : JSON::Any?
+        # A line that OPENS as an array is a BATCH, and its first `"id"` belongs to the first
+        # MEMBER — there is no envelope id to recover. Answering the whole unparseable batch
+        # under that one id resolves exactly one of the client's pending promises and strands
+        # every other member: the same hang batch support exists to prevent, arrived at from
+        # the other side. A batch parse error is answered at id null, which is also what
+        # JSON-RPC asks for when the request cannot be read.
+        return nil if line.lstrip.starts_with?('[')
         head = line[0, {line.index(%("method")) || line.size, line.index(%("params")) || line.size}.min]
         m = head.match(/"id"\s*:\s*(?:(-?\d{1,18})|"([^"\\]{0,128})")/)
         return nil unless m
@@ -290,6 +345,15 @@ module Gori
 
       private def send(payload : String) : Nil
         return if @closed
+        # Inside a batch this is one member's response, not a frame: buffer it for
+        # handle_batch, which emits the array through this same method once. Deliberately
+        # NOT wire_safe'd here — the joined array gets one pass below, and `[`, `,` and `]`
+        # cannot introduce invalid UTF-8, so scanning each member too would walk a
+        # multi-megabyte batch twice for the same answer.
+        if batch = @batch
+          batch << payload
+          return
+        end
         @output.puts(wire_safe(payload)) # newline framing
         @output.flush                    # or the client blocks on the unterminated line
       rescue ex : IO::Error

--- a/src/gori/settings.cr
+++ b/src/gori/settings.cr
@@ -69,6 +69,14 @@ module Gori
       @@path_override = p.try(&.presence)
     end
 
+    # The `--config PATH` this process was started with, or nil. Distinct from `path`, which
+    # answers where settings live after every fallback: a surface that has to REPRODUCE the
+    # invocation (`gori mcp --install-*` writing the argv a client will spawn) must carry only
+    # what was explicitly asked for, not bake in a default that should stay a default.
+    def self.path_override : String?
+      @@path_override
+    end
+
     def self.path : String
       @@path_override || ENV["GORI_CONFIG"]?.presence || File.join(Paths.home_dir, "settings.json")
     end


### PR DESCRIPTION
An audit of the `gori mcp` command layer — `cli.cr:run_mcp`, `mcp/install.cr`, `mcp/server.cr`, `mcp/project_resolver.cr`. Six bugs, each reproduced against a real binary before and after. Two commits, one per bug class.

## The install path dropped flags it had already validated

`--install-*` writes the argv a client spawns forever, so a flag `build_args` doesn't emit is one the user typed, gori parsed, gori conflict-checked, and gori then discarded into a file nobody re-reads.

1. **`--no-project`** — parsed, validated against `--db`/`--project`/`--use-active-project`, then absent from `build_args`. `gori mcp --no-project --install-claude-code` wrote `["mcp"]`, and the installed server path-binds to whatever workspace the client launches in: the exact opposite of the flag.
2. **`--config`** — stripped in `CLI.run` before dispatch, so `run_mcp` never saw it. The installed server read the default `settings.json`.
3. **A whole client** — `install_target` was a single slot, so `--install-claude-code --install-codex` configured only Codex and never mentioned the one it skipped.

Fixing (3) opened a partial-failure path: one hand-broken `~/.claude.json` must not decide whether the Codex entry beside it gets written. `MCP::Install.install_all` attempts every target, reports each by name, and lets the caller set the exit status — so *which* clients end up configured no longer depends on the order the flags were typed in.

4. **A quoted tilde** — `--config '~/corp.json'` became `$PWD/~/corp.json`. A one-run mistake anywhere else; permanent inside a client config.

Also here: the client config write is now atomic. `install_json` refuses to clobber a config it can't parse — `~/.claude.json` is Claude Code's entire CLI state — but `File.write` truncates first and fills after, so a crash or a full disk destroys exactly what that check protects. Temp + fsync + rename, created at the final mode, permissions preserved, symlinks followed to their target.

## The server advertised a revision whose batch support it didn't have

5. **JSON-RPC batches.** `SUPPORTED_VERSIONS` advertises `2025-03-26` and echoes it back on request — the one MCP revision where receiving batches is mandatory (2025-06-18 removed batching). `handle_line` only looked for an object, so every batch came back as a single `Invalid Request` at id `null`. Not one of the ids in the batch: a client holding a promise per member resolved **none** of them and hung, on a revision the server had claimed two messages earlier.

6. **Two correlation bugs a batch exposes.** An unparseable batch line went through `recover_id`, which scraped the first `"id"` — belonging to member 1 — and answered the whole batch under it, resolving one promise and stranding the rest. And a member naming no `method` produced no array element at all, so a client correlating by position mis-paired every response after the gap.

## Verification

- All six reproduced against the built binary, then re-run after the fix.
- +15 specs (7 server, 8 installer).
- Full suite: **7599 examples, 8 failures** — the 8 are the known environmental `Gori::Session` port-bind cases in `project_registry`/`capture_status`, identical to the pre-change baseline.
- `crystal tool format --check` clean; guide and CLI reference updated, en + ko.

## Considered and declined

- **Repo-wide durable-write helper.** `write_atomic` is the sixth independent temp+rename here; the other five (`settings.cr`, `paths.cr`, `capture_status.cr`, `settings/decoder.cr`, `update.cr`, `cert_authority.cr`) lack the symlink and permission handling. Real, but a separate change well outside this command.

  **Worth naming as a follow-up, not just a refactor:** `Settings.save` renames over `Settings.path` with no symlink resolution, so `gori --config ~/dotfiles/gori.json` + a settings write detaches that symlink — the exact failure this PR guards against on the installer side. This PR makes it *more* reachable, since `--config` is now written into installed client configs. Not fixed here (it's a different file with its own write path and its own specs), but it should be.
- **Carrying `GORI_CONFIG` into the installed argv.** Baking an environment variable's value into a config file is surprising; the rule is to reproduce only what was explicitly asked for.
- **`"id": null` treated as a request.** Spec-defensible — JSON-RPC defines a notification by the *absence* of `id`.
- **Hardlinked configs detach on rename.** The standing cost of an atomic replace; noted in the code.
- **Unbounded batch buffering.** Any member cap would be arbitrary; MCP specifies none.
