### PR TITLE
gori run: a minimize that saved a per-send flag onto the session, and four writes that claimed success without asking

### DIFF
--- a/spec/probe_custom_rule_spec.cr
+++ b/spec/probe_custom_rule_spec.cr
@@ -154,6 +154,46 @@ describe "Gori::Store custom-rule config" do
       store.probe_custom_rules.empty?.should be_true
     end
   end
+
+  # Both scan-rule writers report whether the toggle COMMITTED, so `gori run probe rules
+  # enable/disable` can refuse instead of printing "Rule 'x' is now disabled." over a
+  # busy/locked project that kept the old setting. They used to return Nil — the settings one
+  # while already holding the answer, since set_setting/delete_setting are both exec_task_ok.
+  # A `true` here means the batch COMMITTED, which is not the same as "a row matched" — so the
+  # state is asserted beside every return value. Without that second half the example would
+  # still pass for a bogus id, i.e. it would certify exactly the weakness the guard is meant to
+  # close.
+  it "reports whether a scan-rule toggle committed, and commits it" do
+    with_store do |store|
+      store.set_probe_disabled_rules(Set{"cookies"}).should be_true
+      store.probe_disabled_rules.should eq(Set{"cookies"})
+      store.set_probe_disabled_rules(Set(String).new).should be_true # the delete_setting branch
+      store.probe_disabled_rules.empty?.should be_true
+
+      id = store.insert_probe_custom_rule("t", "d", "response", "body", "string", "x", Gori::Store::Severity::Low)
+      store.set_probe_custom_rule_enabled(id, false).should be_true
+      store.probe_custom_rules.first.enabled?.should be_false
+      store.set_probe_custom_rule_enabled(id, true).should be_true
+      store.probe_custom_rules.first.enabled?.should be_true
+    end
+  end
+
+  it "reports a scan-rule toggle as NOT committed once the store is closing" do
+    path = File.tempname("gori-custom-closed", ".db")
+    # Open + seed INSIDE the begin, like `with_store` does: a raise in Store.open or the insert
+    # would otherwise leak the temp db and its -wal/-shm siblings.
+    begin
+      store = Gori::Store.open(path)
+      id = store.insert_probe_custom_rule("t", "d", "response", "body", "string", "x", Gori::Store::Severity::Low)
+      store.close
+      store.set_probe_disabled_rules(Set{"cookies"}).should be_false
+      store.set_probe_custom_rule_enabled(id, false).should be_false
+    ensure
+      File.delete?(path)
+      File.delete?("#{path}-wal")
+      File.delete?("#{path}-shm")
+    end
+  end
 end
 
 describe "Gori::Probe.custom_rules merge" do

--- a/src/gori/cli/run/oast.cr
+++ b/src/gori/cli/run/oast.cr
@@ -201,13 +201,18 @@ module Gori
                                                   token : String?, enabled : Bool?) : Nil
         existing = store.oast_providers.find { |p| p.id == row }
         abort "gori run oast providers update: no project OAST provider with id 'p_#{row}'" if existing.nil?
-        store.update_oast_provider(row,
+        # The store answers whether the write COMMITTED, and this was the one provider verb
+        # that dropped it — `enable/disable`, `delete` and `add` in this same file all check
+        # theirs. So a busy/locked project printed "updated." over a provider whose host or
+        # token was unchanged, and the next `oast` listen went out against the old one.
+        ok = store.update_oast_provider(row,
           name.try(&.strip).presence || existing.name,
           kind.try(&.label) || existing.kind,
           host.try(&.strip).presence || existing.host,
           # See the MCP twin: `--token=` with an empty value is a CLEAR, not an omission.
           token.nil? ? existing.token : token.strip.presence,
           enabled.nil? ? existing.enabled? : enabled)
+        abort "gori run oast providers update: NOT applied (project busy) — the provider is unchanged" unless ok
         puts "OAST provider p_#{row} updated."
       end
 

--- a/src/gori/cli/run/probe.cr
+++ b/src/gori/cli/run/probe.cr
@@ -438,17 +438,24 @@ module Gori
         begin
           entry = Probe::RuleCatalog.load(store).find { |e| e.id == id } ||
                   abort("gori run probe rules #{verb}: no scan rule with id '#{id}' (see `gori run probe rules`)")
-          if entry.kind == "custom"
-            abort "gori run probe rules #{verb}: '#{id}' is a GLOBAL custom rule (stored in settings.json, shared across projects) — it cannot be toggled per project" if entry.scope == "global"
-            row_id = probe_custom_row_id(id) || abort("gori run probe rules #{verb}: malformed custom rule id '#{id}'")
-            store.set_probe_custom_rule_enabled(row_id, enabled)
-          else
-            disabled = store.probe_disabled_rules
-            # `set_rule_enabled` (not a bare delete/add) so a DEFAULT-OFF rule toggles correctly:
-            # for those ids the stored-set membership is INVERTED — see Probe::DEFAULT_DISABLED_RULES.
-            Probe.set_rule_enabled(disabled, id, enabled)
-            store.set_probe_disabled_rules(disabled)
-          end
+          # Both writers now answer whether the toggle COMMITTED, so this stops claiming a
+          # scan rule was muted (or unmuted) over a busy/locked project that kept the old
+          # setting — the same refusal `probe dismiss` and `probe delete` already make in this
+          # file. A silently-ignored `disable` leaves a rule firing on every later scan; a
+          # silently-ignored `enable` leaves a class of finding switched off.
+          ok =
+            if entry.kind == "custom"
+              abort "gori run probe rules #{verb}: '#{id}' is a GLOBAL custom rule (stored in settings.json, shared across projects) — it cannot be toggled per project" if entry.scope == "global"
+              row_id = probe_custom_row_id(id) || abort("gori run probe rules #{verb}: malformed custom rule id '#{id}'")
+              store.set_probe_custom_rule_enabled(row_id, enabled)
+            else
+              disabled = store.probe_disabled_rules
+              # `set_rule_enabled` (not a bare delete/add) so a DEFAULT-OFF rule toggles correctly:
+              # for those ids the stored-set membership is INVERTED — see Probe::DEFAULT_DISABLED_RULES.
+              Probe.set_rule_enabled(disabled, id, enabled)
+              store.set_probe_disabled_rules(disabled)
+            end
+          abort "gori run probe rules #{verb}: NOT applied (project busy) — rule '#{id}' is unchanged" unless ok
           puts "Rule '#{id}' is now #{enabled ? "enabled" : "disabled"}."
         ensure
           store.close

--- a/src/gori/cli/run/project.cr
+++ b/src/gori/cli/run/project.cr
@@ -46,7 +46,7 @@ module Gori
           list               List known projects (default when no subcommand)
           create <name>      Create (or reopen) a project by name
           delete|rm <name>   Delete a project and everything captured in it
-          scope              Manage scope rules (list, add, delete, enable/disable)
+          scope              Manage scope rules (list, add, update, delete, enable/disable)
           sandbox            Get/set the hard-containment sandbox gate (status, on, off)
           env                Manage project env vars ($KEY substitution)
           host-override      Manage host overrides (list, add, update, delete)
@@ -336,7 +336,7 @@ module Gori
             cmd_scope_list(args)
           else
             STDERR.puts "gori run project scope: unknown subcommand '#{sub}'"
-            STDERR.puts "Usage: gori run project scope [list options] | add | delete|rm | enable | disable"
+            STDERR.puts "Usage: gori run project scope [list options] | add | update|edit <rule-id> | delete|rm <rule-id> | enable | disable"
             exit 1
           end
         end
@@ -352,6 +352,7 @@ module Gori
           p.banner = "Usage: gori run project scope [options]\n\n" \
                      "Or run with a subcommand:\n" \
                      "  gori run project scope add --kind=include/exclude --type=host/string/regex --pattern=...\n" \
+                     "  gori run project scope update|edit <rule-id> [--kind=... --type=... --pattern=...]\n" \
                      "  gori run project scope delete|rm <rule-id>\n" \
                      "  gori run project scope enable\n" \
                      "  gori run project scope disable"
@@ -450,6 +451,17 @@ module Gori
           if err = Scope.validation_error(new_type, new_pattern)
             abort "gori run project scope update: #{err}"
           end
+          # `scope_rules` carries UNIQUE(kind, match_type, pattern) (store/schema.cr), and this
+          # command writes straight through the store rather than via `Scope#update`, which
+          # dedupes. Without this pre-check the constraint violation rolled the writer batch
+          # back, `update_scope_rule` returned false, and the busy-store abort below reported a
+          # duplicate as "store busy or unwritable" — sending the operator to hunt for a lock.
+          # `scope add` already names the duplicate; this makes the two agree.
+          if scope.rules.any? { |r| r.id != id && r.kind == new_kind && r.match_type == new_type && r.pattern == new_pattern }
+            store.close
+            abort "gori run project scope update: rule ##{id} NOT updated — #{new_kind} #{new_type} #{new_pattern} " \
+                  "already exists as another rule; the scope is unchanged"
+          end
           unless store.update_scope_rule(id, new_kind, new_type, new_pattern)
             abort "gori run project scope update: rule NOT updated (store busy or unwritable); it is unchanged and still gates traffic"
           end
@@ -545,7 +557,14 @@ module Gori
             store.close
             abort "gori run project scope delete: no scope rule with id #{id}"
           end
-          scope.remove(id)
+          # `Scope#remove` now hands back `remove_scope_rule`'s committed flag (it is
+          # `exec_task_ok`, so the answer always existed). Without this a busy/locked project
+          # reported a security rule "deleted successfully" while it was still gating traffic —
+          # the failure mode `scope enable/disable` and `sandbox on/off` already refuse to have.
+          unless scope.remove(id)
+            store.close
+            abort "gori run project scope delete: rule ##{id} NOT deleted (project busy) — try again"
+          end
           puts "Scope rule ##{id} deleted successfully."
           warn_scope_blackhole(scope, "gori run project scope delete")
         ensure

--- a/src/gori/cli/run/repeater_minimize.cr
+++ b/src/gori/cli/run/repeater_minimize.cr
@@ -38,7 +38,14 @@ module Gori
         id_s = positional.first? || abort("gori run repeater minimize: <repeater-id> is required")
         id = id_s.to_i64? || abort("gori run repeater minimize: invalid repeater id #{id_s.inspect}")
 
-        store = open_store(resolve_read_project(project_name, db_path))
+        # Resolved ONCE and reused by the `--apply` write below. `resolve_read_project` with no
+        # --project/--db falls through to `registry.list.first`, and that list is sorted by each
+        # project's DB-file MTIME (`Project#last_modified`) — so the "most-recently-active"
+        # project can change identity while this command runs, and a minimize is minutes long
+        # (up to SEND_CAP real sends). Re-resolving at apply time therefore let a peer's write
+        # steer the UPDATE into a DIFFERENT project's `repeaters` row #id.
+        project = resolve_read_project(project_name, db_path)
+        store = open_store(project)
         # HostOverrides.load snapshots rows into memory, so it is safe to keep past the close.
         # Loaded from the SAME open that fetched `rec` rather than via cli_host_overrides,
         # which returns nil without an explicit --project/--db — a repeater session always
@@ -83,13 +90,40 @@ module Gori
         STDERR.print "\r\e[K" if meter
         outbound.close
 
-        if apply && !report.aborted && !report.removed.empty?
-          w = open_store(resolve_read_project(project_name, db_path))
+        # `--apply` writes the minimized REQUEST back — and only that. `auto_cl` above folds in
+        # `--verbatim`, which is a PER-SEND choice ("same meaning as `repeater send
+        # --verbatim`", per its own help), so persisting it here turned one
+        # `minimize --apply --verbatim` into a PERMANENT Auto-Content-Length OFF on the
+        # session: `session_plan_options` reads `rec.auto_content_length?`, so every later
+        # non-verbatim `repeater send <id>` — and the TUI — silently stopped resyncing
+        # Content-Length after `$KEY` expansion, framing an expanded body under the stale
+        # length. Confirmed on the binary (`auto_content_length` 1 → 0). The MCP twin already
+        # writes the stored value and says so in a parenthetical (mcp/tools/minimize.cr); this
+        # makes the two agree.
+        #
+        # The store also answers whether the write COMMITTED, and dropping that let a
+        # busy/locked project print "saved back to session #N" — and report `"applied": true`
+        # to a script — over a session still holding the un-minimized request. Same reason
+        # `history delete`, `issues delete` and `project scope enable` all check theirs.
+        applied = false
+        wanted_apply = apply && !report.aborted && !report.removed.empty?
+        if wanted_apply
+          w = open_store(project)
           begin
-            w.update_repeater(id: id, target: rec.target, request: report.minimized_text.to_slice,
-              http2: rec.http2?, auto_cl: auto_cl, sni: rec.sni)
+            # EVERY column `update_repeater` writes comes off the stored row. Its SQL sets
+            # ws_keep_key and ws_http_only unconditionally and its signature defaults both to
+            # false, so omitting them CLEARS them — and a session can hold either flag with a
+            # request that is not a WebSocket upgrade (`repeater create --ws-http-only -f
+            # plain.txt`), which is exactly the shape `minimize_target_or_abort` lets through.
+            applied = w.update_repeater(id: id, target: rec.target, request: report.minimized_text.to_slice,
+              http2: rec.http2?, auto_cl: rec.auto_content_length?, sni: rec.sni,
+              ws_keep_key: rec.ws_keep_key?, ws_http_only: rec.ws_http_only?)
           ensure
             w.close
+          end
+          unless applied
+            STDERR.puts "gori run repeater minimize: --apply did NOT commit (project busy) — " \
+                        "session ##{id} still holds the original request"
           end
         end
         # The report is rendered through the SAME resolver the search used, so the request
@@ -99,8 +133,11 @@ module Gori
         # search nor what a later `repeater send` would produce. `--apply` still stores the
         # source form (that is what the session row holds, and re-resolving it on every send
         # is the point of storing it).
-        report_repeater_minimize(id, report, format, apply, resolve)
-        exit 1 if report.aborted
+        report_repeater_minimize(id, report, format, applied, resolve)
+        # A refused `--apply` is a failed mutation, so it must not exit 0 — but the report is
+        # printed first either way: the search already spent real sends, and throwing its
+        # result away would cost the operator the run as well as the write.
+        exit 1 if report.aborted || (wanted_apply && !applied)
       end
 
       # The editor-text → wire-bytes step `Minimize` sends through, and the ONE thing
@@ -236,6 +273,10 @@ module Gori
 
       # `resolve` is the SAME proc the search sent through, so `minimized_request` is the
       # request that was actually tested rather than the pre-resolution source text.
+      #
+      # `applied` is the OUTCOME of the write, not the `--apply` flag: the caller already
+      # folded in "aborted", "nothing removed" AND "the store committed it", so re-deriving
+      # the first two here would report a refused write as a successful one.
       private def self.report_repeater_minimize(id : Int64, report : Repeater::Minimize::Report,
                                                 format : Symbol, applied : Bool,
                                                 resolve : Proc(String, Bytes)) : Nil
@@ -255,7 +296,7 @@ module Gori
                 end
               end
               j.field "removed_count", report.removed.size
-              j.field "applied", applied && !report.aborted && !report.removed.empty?
+              j.field "applied", applied
               # The RESOLVED wire, plus the source form the session stores, because they are
               # different questions and the operator needs both: the first is what was sent,
               # the second is what `--apply` writes back and what a later send re-resolves.
@@ -273,7 +314,7 @@ module Gori
         end
         STDERR.puts "#{report.note} · #{report.sends} send#{report.sends == 1 ? "" : "s"}"
         report.removed.each { |r| STDERR.puts "  - [#{r.kind.to_s.downcase}] #{r.label}" }
-        STDERR.puts "saved back to session ##{id}" if applied && !report.aborted && !report.removed.empty?
+        STDERR.puts "saved back to session ##{id}" if applied
         STDOUT.write(wire)
         STDOUT.puts unless wire.empty? || wire[-1] == 0x0A_u8
       end

--- a/src/gori/mcp/tools/minimize.cr
+++ b/src/gori/mcp/tools/minimize.cr
@@ -97,9 +97,13 @@ module Gori
 
         applied = false
         if apply && !report.aborted && !report.removed.empty?
+          # ws_keep_key/ws_http_only for the reason the CLI twin gives: update_repeater's SQL
+          # sets both columns unconditionally and its signature defaults them to false, so
+          # omitting them CLEARS a session that carried either.
           applied = store.update_repeater(id: id, target: rec.target,
             request: report.minimized_text.to_slice, http2: rec.http2?,
-            auto_cl: rec.auto_content_length?, sni: rec.sni)
+            auto_cl: rec.auto_content_length?, sni: rec.sni,
+            ws_keep_key: rec.ws_keep_key?, ws_http_only: rec.ws_http_only?)
         end
 
         Result.new(JSON.build do |j|

--- a/src/gori/mcp/tools/probe.cr
+++ b/src/gori/mcp/tools/probe.cr
@@ -226,14 +226,20 @@ module Gori
           end
           row_id = custom_rule_row_id(id)
           return err("malformed custom rule id '#{id}'", "INVALID_ARGUMENT", field: "id") unless row_id
-          store.set_probe_custom_rule_enabled(row_id, enabled)
+          ok = store.set_probe_custom_rule_enabled(row_id, enabled)
         else
           disabled = store.probe_disabled_rules
           # `set_rule_enabled` (not a bare delete/add) so a DEFAULT-OFF rule toggles correctly:
           # for those ids the stored-set membership is INVERTED — see `Probe::DEFAULT_DISABLED_RULES`.
           Probe.set_rule_enabled(disabled, id, enabled)
-          store.set_probe_disabled_rules(disabled)
+          ok = store.set_probe_disabled_rules(disabled)
         end
+        # Both writers report whether the toggle COMMITTED. Returning `{enabled: false}` over a
+        # rolled-back batch tells an agent a scan rule is muted while it keeps firing on every
+        # later scan — the same refusal the CLI twin makes (cli/run/probe.cr).
+        # `busy`, not a bare `err`: a rolled-back batch is transient, so the Result must carry
+        # `retryable: true` the way every other PROJECT_BUSY refusal in this server does.
+        return busy("scan rule '#{id}' NOT updated (store busy or unwritable); it is unchanged") unless ok
         Result.new({"id" => id, "enabled" => enabled, "kind" => entry.kind}.to_json)
       end
 

--- a/src/gori/scope.cr
+++ b/src/gori/scope.cr
@@ -364,10 +364,20 @@ module Gori
       true
     end
 
-    def remove(id : Int64) : Nil
+    # Returns whether the DELETE COMMITTED (false = store busy/locked/closing).
+    #
+    # Unlike `add` above — where `add_scope_rule` goes through `exec_task` and genuinely
+    # reports nothing, so looking at the reloaded list is the only answer available —
+    # `remove_scope_rule` is `exec_task_ok` and has had the answer all along. Dropping it made
+    # every caller claim a security rule was deleted while it was still gating traffic, and
+    # each surface invented its own workaround: MCP bypassed `Scope` entirely to reach the
+    # flag, and the CLI re-read the reloaded rule list. One dropped return value, three
+    # treatments — so it is returned here instead.
+    def remove(id : Int64) : Bool
       @mutex.synchronize do
-        @store.remove_scope_rule(id)
+        ok = @store.remove_scope_rule(id)
         reload_rules_unlocked
+        ok
       end
     end
 

--- a/src/gori/store/probe_rules.cr
+++ b/src/gori/store/probe_rules.cr
@@ -42,7 +42,10 @@ module Gori
       out
     end
 
-    def set_probe_disabled_rules(ids : Set(String)) : Nil
+    # Returns whether the write COMMITTED (false = store busy/locked/closing). Both branches
+    # already had the answer — `set_setting`/`delete_setting` are `exec_task_ok` — and this
+    # threw it away, so every caller that toggles a scan rule had to claim success blind.
+    def set_probe_disabled_rules(ids : Set(String)) : Bool
       if ids.empty?
         delete_setting(PROBE_DISABLED_KEY)
       else
@@ -85,8 +88,12 @@ module Gori
       }
     end
 
-    def set_probe_custom_rule_enabled(id : Int64, enabled : Bool) : Nil
-      exec_task ->(c : DB::Connection) { c.exec("UPDATE probe_custom_rules SET enabled = ? WHERE id = ?", enabled ? 1 : 0, id); nil }
+    # `exec_task_ok`, not `exec_task`: an UPDATE reports nothing through last_insert_rowid, so
+    # this is the only way a caller can tell a committed toggle from a rolled-back one — and
+    # this one mutes or unmutes a security scan rule. Same reason `set_rule_enabled` (Match &
+    # Replace) and `update_probe_issue_status` already return Bool.
+    def set_probe_custom_rule_enabled(id : Int64, enabled : Bool) : Bool
+      exec_task_ok ->(c : DB::Connection) { c.exec("UPDATE probe_custom_rules SET enabled = ? WHERE id = ?", enabled ? 1 : 0, id); nil }
     end
 
     def delete_probe_custom_rule(id : Int64) : Nil

--- a/src/gori/tui/controllers/probe_controller.cr
+++ b/src/gori/tui/controllers/probe_controller.cr
@@ -436,12 +436,30 @@ module Gori::Tui
         # add/delete): a DEFAULT-OFF rule inverts the stored-set membership — see
         # Gori::Probe::DEFAULT_DISABLED_RULES.
         Gori::Probe.set_rule_enabled(dis, row.rule_id, !row.enabled?)
-        store.set_probe_disabled_rules(dis)
+        # Both scan-rule writers report whether the toggle COMMITTED. Without this the status
+        # bar said `disabled rule "X"` while the very next `reload_rules` re-drew the row as
+        # still enabled — two lines of UI contradicting each other with no way to tell which
+        # was true. Same refusal as the CLI/MCP twins.
+        unless store.set_probe_disabled_rules(dis)
+          @host.status("rule \"#{row.title}\" NOT changed (project busy)")
+          return
+        end
         @host.status(row.enabled? ? "disabled rule \"#{row.title}\"" : "enabled rule \"#{row.title}\"")
       when :custom
         c = row.custom.not_nil!
         on = !c.enabled
-        c.global? ? Settings.set_scan_rule_enabled(c.id, on) : store.set_probe_custom_rule_enabled(c.id.to_i64, on)
+        ok = if c.global?
+               # settings.json, not the project DB — there is no transaction and so no commit
+               # flag to read. Only the PROJECT writer can report a rolled-back batch.
+               Settings.set_scan_rule_enabled(c.id, on)
+               true
+             else
+               store.set_probe_custom_rule_enabled(c.id.to_i64, on)
+             end
+        unless ok
+          @host.status("rule \"#{c.title}\" NOT changed (project busy)")
+          return
+        end
         @host.status(on ? "enabled rule \"#{c.title}\"" : "disabled rule \"#{c.title}\"")
       else
         return

--- a/src/gori/tui/controllers/project_controller.cr
+++ b/src/gori/tui/controllers/project_controller.cr
@@ -480,8 +480,14 @@ module Gori::Tui
     end
 
     def scope_delete_rule : Nil
+      # Read the selection BEFORE the delete so a refused write can be told apart from an
+      # empty list: `scope_delete` returns nil for both, and staying silent about the first
+      # leaves the rule on screen with no hint that the keypress did nothing.
+      selected = @project_view.selected_rule
       if pat = @project_view.scope_delete
         @host.status("removed scope rule: #{pat}#{scope_blackhole_note}")
+      elsif selected
+        @host.status("scope rule NOT removed (project busy) — it still gates traffic")
       end
     end
 

--- a/src/gori/tui/project_view.cr
+++ b/src/gori/tui/project_view.cr
@@ -608,7 +608,10 @@ module Gori::Tui
     def scope_delete : String?
       rule = selected_rule
       return nil unless rule
-      @scope.remove(rule.id)
+      # `Scope#remove` now reports whether the DELETE committed. A rolled-back batch must not
+      # produce a "removed scope rule: <pattern>" toast over a rule that is still gating
+      # traffic; the caller turns this nil into a busy message instead.
+      return nil unless @scope.remove(rule.id)
       clamp_sel
       rule.pattern
     end


### PR DESCRIPTION
## Summary

A `gori run` audit. One behavioural bug — `repeater minimize --apply --verbatim` persisting a
per-send flag onto the session row — plus the **commit-confirmation class** it sat in: mutations
that throw away the store's "did this write COMMIT?" answer and print success anyway.

`Store` has two write helpers: `exec_task` (rowid; cannot tell a committed non-INSERT from a
rollback) and `exec_task_ok` (**Bool** = the batch committed). A `false` is transient — a
cross-process SQLite busy/lock, or the store closing — so a mutating command is supposed to
refuse, not claim success. Several didn't.

## The bug

`cli/run/repeater_minimize.cr` wrote `auto_cl: auto_cl`, where `auto_cl` is
`!verbatim && rec.auto_content_length?`. `--verbatim` is a **per-send** choice — its own help
says "same meaning as `repeater send --verbatim`" — so `--apply` was persisting it:

```
$ sqlite3 gori.db 'select id,auto_content_length from repeaters'
1|1
$ gori run repeater minimize 1 --apply --verbatim
saved back to session #1
$ sqlite3 gori.db 'select id,auto_content_length from repeaters'
1|0      # ← permanently off
```

`session_plan_options` reads `rec.auto_content_length?`, so from then on every non-verbatim
`repeater send <id>` — and the TUI — silently skipped the Content-Length resync, framing a
`$KEY`-expanded body under the stale length.

Three witnesses agreed: the flag's own help text, `--apply`'s ("writes the request"), and
`mcp/tools/minimize.cr`, whose twin writes `rec.auto_content_length?` and documents the choice
in a parenthetical. One word to fix. After: `1|1` stays `1|1`.

## The class — swept across CLI, MCP and TUI

| site | was |
|---|---|
| `cli/run/repeater_minimize.cr` | `--apply` ignored `update_repeater`'s Bool → `"applied": true` |
| `cli/run/oast.cr` | the only provider verb not checking; `enable/disable`, `delete`, `add` all did |
| `cli/run/project.cr` scope delete | printed "deleted successfully" over a rule still gating traffic |
| `cli/run/probe.cr` probe rules | needed the store changed first (below) |
| `mcp/tools/probe.cr` | returned `{enabled:false}` as ordinary success → now `busy(...)`, retryable |
| `tui/.../probe_controller.cr` | status said `disabled rule "X"` while `reload_rules` re-drew it enabled |

Two store methods gained the return they already had: `set_probe_disabled_rules` (its branches
are `set_setting`/`delete_setting`, both `exec_task_ok`) and `set_probe_custom_rule_enabled`
(`exec_task` → `exec_task_ok`).

`Scope#remove` likewise — `remove_scope_rule` is `exec_task_ok`, and dropping the flag had led
all three surfaces to invent a different workaround. (`Scope#add` is *not* the same case:
`add_scope_rule` uses `exec_task`, so looking at the reloaded list really is the only answer
there.) The TUI's global custom-rule branch keeps `ok = true` on purpose — `Settings.set_scan_rule_enabled`
writes settings.json, not a transaction, so there is no commit flag to read.

## From code review — adopted

- **`--apply` re-resolved the project after the search.** `registry.list` is sorted by DB-file
  MTIME and a minimize runs minutes (up to `SEND_CAP` sends), so a peer's write could steer the
  UPDATE into a *different* project's `repeaters` row. Resolve once at the top, reuse. *(Confirmed:
  `project_registry.cr:107` sorts on `Project#last_modified`, which stats mtime.)*
- **`update_repeater` omitting `ws_keep_key`/`ws_http_only`** — its signature defaults both to
  false and its SQL sets both columns unconditionally, so omitting them clears a session that
  carried either. Reachable without any WS request: `repeater create --ws-http-only -f plain.txt`
  passes minimize's upgrade check. Fixed in the CLI and the MCP twin. Verified `6|1|1|1` → `6|1|1|1`.
- **`Scope#remove` should return the Bool** rather than have the CLI re-read the reloaded list.
  *(Confirmed: `remove_scope_rule` is `exec_task_ok`, `add_scope_rule` is `exec_task`.)*
- **`scope update` bypassed `Scope#update`'s dedupe** into a `UNIQUE(kind, match_type, pattern)`
  table, so a duplicate rolled back and was reported as "store busy or unwritable". Now names the
  duplicate, like `scope add` does. A self no-op update is still allowed.

## From code review — rejected

`probe.cr` / `oast.cr`'s new guards `abort` inside `begin/ensure` without `store.close` first.
Their own files' existing siblings do the same (`probe.cr:251`/`:255`, `oast.cr:273`); it is
`project.cr` that closes first. The new guards match the file they live in.

## Deferred (not in this PR)

- The probe-rule builtin branch read-modify-writes over `probe_disabled_rules`, the **tolerant**
  read that rescues corrupt JSON to an empty set — so one toggle over a corrupt value re-enables
  every other disabled rule *and commits*, which the new guard reports as success. Shared by
  CLI/MCP/TUI; wants its own change alongside `probe_disabled_rules_strict`.
- TUI `persist_repeater_tab` (`repeater_controller.cr`) discards `update_repeater`'s Bool then
  calls `clear_dirty`, losing a minimized request with no retry.
- `exec_task_ok` reports COMMITTED, not rows-matched — every guard of this class (including the
  pre-existing ones) reports success for an UPDATE that matched zero rows.
- No CLI-level regression spec for the `auto_content_length` fix; it is pinned by the binary
  repro above and a long comment at the call site, the same way this file's prior `abort`-wiring
  fixes were landed.
- Under `--format=json` a refused `--apply` is only on STDERR + the exit code; `applied:false` is
  in-band but indistinguishable from "nothing to apply".

Also: `project scope update|edit` existed but was missing from three help strings.

## Verification

- Specs **7586 examples / 8 failures / 0 errors** — the same 8 environmental `Gori::Session`
  port-bind failures as the pre-change baseline (7584/8/0); +2 from the new store examples.
- Binary: `auto_content_length` and the two WS columns preserved through `--apply` (both
  `--verbatim` and not); `probe rules enable/disable` on builtin **and** custom rules, both
  directions; `oast providers update`; `scope add/update/delete` incl. duplicate + repeat-delete;
  `--help` still exits 0 on every touched command.
- Not exercised end-to-end: the `applied == false` branch (needs a busy store). The store half is
  pinned by the new closed-store example; the CLI wiring is inference from the code.

## Behaviour changes a script could notice

- `repeater minimize --apply` now exits **1** when the write is refused (was silently 0).
- `probe rules enable/disable`, `oast providers update` and `project scope delete` now exit 1
  instead of printing success when the write does not commit.
- MCP `set_probe_rule_enabled` can now return a retryable `PROJECT_BUSY` error.
