### PR TITLE
gori update: an updater whose likeliest failure — no network — answered with a stack trace

### DIFF
--- a/spec/update_spec.cr
+++ b/spec/update_spec.cr
@@ -20,6 +20,33 @@ end
 # ubuntu-latest runner (non-root), so the negative cases below do execute there;
 # this guard is for someone running the suite inside a root container. Probe the
 # actual behaviour rather than guessing from the uid.
+# A response body that yields a few chunks and then dies, the way a connection
+# reset part-way through a release asset does.
+private class BurstThenResetIO < IO
+  def initialize(@chunks : Int32)
+  end
+
+  def read(slice : Bytes) : Int32
+    raise IO::Error.new("connection reset by peer") if @chunks <= 0
+    @chunks -= 1
+    slice.fill(0x61_u8)
+    slice.size
+  end
+
+  def write(slice : Bytes) : Nil
+  end
+end
+
+# A port nothing is listening on: bind to 0 so the OS picks a free one, then
+# close it, so a connect there is REFUSED rather than left to time out (which
+# would make the network examples below take HTTP_TIMEOUT each).
+private def dead_port : Int32
+  server = TCPServer.new("127.0.0.1", 0)
+  port = server.local_address.port
+  server.close
+  port
+end
+
 private def mode_enforced?(dir : String) : Bool
   probe = File.join(dir, ".gori-perm-probe")
   File.write(probe, "x")
@@ -27,6 +54,17 @@ private def mode_enforced?(dir : String) : Bool
   false
 rescue
   true
+end
+
+# `verify_download!` is private and only ever called from inside update_binary's
+# tempdir block, where the redirect fallback it disclaims for cannot be reached
+# without talking to github.com. Expose it the way the other specs expose privates
+# (spec/cli_spec.cr does the same for split_subcommand / global_version_flag?).
+module Gori::Update
+  def self.verify_download_for_spec(dest : String, asset : Asset, got : Int64, io : IO, *,
+                                    announce_skip : Bool) : Nil
+    verify_download!(dest, asset, got, io, announce_skip: announce_skip)
+  end
 end
 
 describe Gori::Update do
@@ -1484,6 +1522,251 @@ describe Gori::Update do
           Gori::Update.fetch_latest_release_json(server.api_url)
           server.last_api_headers.not_nil!["Authorization"]?.should be_nil
         end
+      end
+    end
+  end
+
+  # CLI.run's rescue is deliberately narrow: a non-Gori::Error reaches the top of
+  # the process as a Crystal backtrace, "because those are bugs and want a trace"
+  # (cli.cr). Being offline is not a bug — it is the likeliest way an updater
+  # fails — and every network path here used to answer it with exactly that
+  # trace. `gori update` on a machine with no route out printed
+  # `Unhandled exception: ... (Socket::ConnectError)`.
+  describe "I/O failures surface as Gori::Error, never a backtrace (Bug C)" do
+    it "wraps a refused connection to the releases API" do
+      url = "http://127.0.0.1:#{dead_port}/repos/hahwul/gori/releases/latest"
+      expect_raises(Gori::Error, /could not reach 127\.0\.0\.1/) do
+        Gori::Update.fetch_latest_release_json(url)
+      end
+    end
+
+    # fetch_latest_release_json_with_fallback re-raises whatever the API fetch
+    # threw once the redirect fallback has nothing to offer (or is not eligible).
+    # That re-raise is only as clean as the original exception.
+    it "keeps the re-raise from the fallback path a Gori::Error too" do
+      url = "http://127.0.0.1:#{dead_port}/repos/hahwul/gori/releases/latest"
+      expect_raises(Gori::Error, /could not reach/) do
+        Gori::Update.fetch_latest_release_json_with_fallback(url)
+      end
+    end
+
+    it "wraps a refused connection while downloading an asset" do
+      url = "http://127.0.0.1:#{dead_port}/download/gori-v99.0.0-linux-x86_64"
+      dest = File.tempname("gori-dl-")
+      begin
+        expect_raises(Gori::Error, /could not download/) do
+          Gori::Update.download_to(url, dest)
+        end
+      ensure
+        File.delete?(dest)
+      end
+    end
+
+    it "wraps a file that cannot be read for checksumming" do
+      expect_raises(Gori::Error, /could not read .* to checksum it/) do
+        Gori::Update.file_sha256(File.join(File.tempname("gori-absent-", ""), "nope"))
+      end
+    end
+
+    # install_dir_writable? deliberately passes a directory that does not exist
+    # yet, on the grounds that atomic_install creates it — so the mkdir is the
+    # first place the layout can actually be rejected, and it sat outside
+    # atomic_install's own rescue.
+    it "wraps an install directory that cannot be created" do
+      root = File.tempname("gori-mkdir-")
+      Dir.mkdir_p(root)
+      begin
+        blocker = File.join(root, "prefix")
+        File.write(blocker, "a file, not a directory")
+        source = File.join(root, "new-gori")
+        File.write(source, "new")
+
+        # install_dir_writable? says yes (the dir simply is not there yet).
+        Gori::Update.install_dir_writable?(File.join(blocker, "bin", "gori")).should be_true
+        expect_raises(Gori::Error, /could not create the install directory/) do
+          Gori::Update.atomic_install(source, File.join(blocker, "bin", "gori"))
+        end
+      ensure
+        FileUtils.rm_rf(root) if File.exists?(root)
+      end
+    end
+
+    # Process.run RAISES File::NotFoundError when the binary is absent rather
+    # than returning a failed status, so `tar list failed` never got a chance to
+    # run on a minimal image — the macOS archive install backtraced instead.
+    it "wraps a missing tar" do
+      expect_raises(Gori::Error, /could not run tar/) do
+        with_env({"PATH" => File.tempname("gori-empty-path-", "")}) do
+          Gori::Update.list_tar_entries("/nonexistent.tar.gz")
+        end
+      end
+    end
+  end
+
+  describe ".run --exec on channels with no single command" do
+    # package_action deliberately returns `command: nil` for pacman/deb/rpm/nix:
+    # which one is right depends on the AUR helper / how nix installed it, and
+    # the rest need sudo. But the whole acknowledgement lived inside
+    # `if cmd = action[:command]`, so `--exec` printed NOTHING about itself on
+    # those channels and read as though it had run the upgrade.
+    it "says --exec had nothing to run instead of staying silent" do
+      {
+        {"/usr/bin/gori", Gori::Update::OwnerResult::Pacman, Gori::Update::OsFamily::ArchLike, "pacman"},
+        {"/usr/bin/gori", Gori::Update::OwnerResult::Dpkg, Gori::Update::OsFamily::DebianLike, "deb"},
+        {"/usr/bin/gori", Gori::Update::OwnerResult::Rpm, Gori::Update::OsFamily::RhelLike, "rpm"},
+        {"/nix/store/0fhkwk15n3ya0llfr0754awcldpz4x54-gori-0.1.3/bin/gori",
+         Gori::Update::OwnerResult::None, Gori::Update::OsFamily::Unknown, "nix"},
+      }.each do |(path, owner, family, channel)|
+        io = IO::Memory.new
+        Gori::Update.run(io, io, exe_path: path, exec_package_commands: true,
+          owner: owner, os_family: family)
+        out = io.to_s
+        out.should contain("install channel: #{channel}")
+        out.should contain("--exec has nothing to run on the #{channel} channel")
+        # Still no claim that anything was executed.
+        out.should_not contain("Running:")
+      end
+    end
+
+    it "stays quiet about --exec on those channels when it was not passed" do
+      io = IO::Memory.new
+      Gori::Update.run(io, io, exe_path: "/usr/bin/gori",
+        owner: Gori::Update::OwnerResult::Pacman,
+        os_family: Gori::Update::OsFamily::ArchLike)
+      io.to_s.should_not contain("--exec")
+    end
+
+    # The channels that DO carry a command keep the hint they always had.
+    it "leaves the Homebrew/Snap hint alone" do
+      io = IO::Memory.new
+      Gori::Update.run(io, io, exe_path: "/opt/homebrew/Cellar/gori/0.1.0/bin/gori")
+      out = io.to_s
+      out.should contain("Re-run with --exec to run the command above automatically.")
+      out.should_not contain("has nothing to run")
+    end
+  end
+
+  describe ".copy_with_progress on a failed transfer" do
+    # The clear used to sit AFTER the copy loop, so an exception skipped it: the
+    # last bar stayed on screen and `gori update: …` was then printed onto that
+    # same line, right after the transfer rate.
+    it "clears the progress line even when the download raises" do
+      term = IO::Memory.new
+      dest = File.tempname("gori-progress-")
+      begin
+        expect_raises(IO::Error, /connection reset/) do
+          Gori::Update.copy_with_progress(BurstThenResetIO.new(2), dest, 10_000_000_i64,
+            progress_io: term, force_progress: true)
+        end
+        drawn = term.to_s
+        drawn.should contain("%") # a bar really was drawn
+        drawn.should end_with("\r\e[K")
+      ensure
+        File.delete?(dest)
+      end
+    end
+  end
+
+  describe ".atomic_install leftover sweep" do
+    # atomic_install's `rescue` only runs when the copy RAISES. Crystal's default
+    # SIGINT terminates without unwinding, so Ctrl-C during the copy (or a kill,
+    # or a power loss) stranded a full ~40 MB duplicate of the binary in the
+    # operator's install directory, and every retry added another. lib/ already
+    # swept its own leftovers; the binary did not.
+    it "clears .gori-update.* temps stranded by an interrupted run" do
+      dir = File.tempname("gori-sweep-")
+      Dir.mkdir_p(dir)
+      begin
+        target = File.join(dir, "gori")
+        File.write(target, "#!/bin/sh\necho old\n")
+        File.chmod(target, 0o755)
+        File.write(File.join(dir, ".gori-update.4242.deadbeef"), "a" * 4096)
+        File.write(File.join(dir, ".gori-update.4243.cafebabe"), "a" * 4096)
+        # Neither the installed binary nor an unrelated sibling may be touched.
+        File.write(File.join(dir, "gori-notes.txt"), "keep me")
+
+        source = File.join(dir, "new-gori")
+        File.write(source, "#!/bin/sh\necho new\n")
+
+        Gori::Update.atomic_install(source, target)
+
+        # Dir.children, not Dir.glob: glob skips dotfiles, so it reports empty
+        # even when the orphans are right there.
+        Dir.children(dir).select(&.starts_with?(".gori-update.")).should be_empty
+        File.read(target).should contain("echo new")
+        File.read(File.join(dir, "gori-notes.txt")).should eq("keep me")
+      ensure
+        FileUtils.rm_rf(dir) if File.exists?(dir)
+      end
+    end
+
+    # Matched by prefix over Dir.children rather than by Dir.glob, for the reason
+    # sweep_lib_leftovers gives: the install path belongs to the operator.
+    it "treats glob metacharacters in the install path as literal" do
+      root = File.tempname("gori-sweep-glob-")
+      dir = File.join(root, "gori[1]*?")
+      Dir.mkdir_p(dir)
+      begin
+        target = File.join(dir, "gori")
+        File.write(target, "old")
+        File.write(File.join(dir, ".gori-update.7.abcd1234"), "stale")
+        source = File.join(root, "new-gori")
+        File.write(source, "new")
+
+        Gori::Update.atomic_install(source, target)
+
+        Dir.children(dir).select(&.starts_with?(".gori-update.")).should be_empty
+        File.read(target).should eq("new")
+      ensure
+        FileUtils.rm_rf(root) if File.exists?(root)
+      end
+    end
+  end
+
+  describe "redirect-fallback checksum notice" do
+    # The "no SHA256SUMS, so verification is skipped" line used to be printed
+    # BEFORE the download, off the versioned asset. But the versioned name on the
+    # redirect path is a GUESS from a tag, and download_asset swaps in the
+    # version-less alias when that guess 404s — and the alias carries its own
+    # SHA256SUMS entry. So the operator was told verification was skipped for an
+    # asset that was never fetched, while the one that was actually installed got
+    # verified. The notice now reads off the asset that came down.
+    it "reports on the asset that was actually downloaded, not the one first guessed" do
+      wrong = Gori::Update::Asset.new("gori-v9.9.9-linux-x86_64", "http://127.0.0.1/x", 0_i64, nil)
+      verified = Gori::Update::Asset.new("gori-linux-x86_64", "http://127.0.0.1/y", 0_i64,
+        "sha256:#{"b" * 64}")
+
+      payload = File.tempname("gori-notice-")
+      begin
+        File.write(payload, "body")
+        real = Gori::Update.file_sha256(payload)
+        good = Gori::Update::Asset.new(verified.name, verified.browser_download_url, 0_i64,
+          "sha256:#{real}")
+
+        io = IO::Memory.new
+        Gori::Update.verify_download_for_spec(payload, good, 4_i64, io, announce_skip: true)
+        out = io.to_s
+        out.should contain("Verifying sha256 checksum")
+        out.should_not contain("verification is skipped")
+
+        # And the genuine no-digest case still says so, naming that same asset.
+        io2 = IO::Memory.new
+        Gori::Update.verify_download_for_spec(payload, wrong, 4_i64, io2, announce_skip: true)
+        io2.to_s.should contain("#{wrong.name} has no SHA256SUMS entry")
+
+        # Off the redirect path there is nothing to disclaim: the API always
+        # hands over a per-asset digest, so silence there is not a skipped check.
+        io3 = IO::Memory.new
+        Gori::Update.verify_download_for_spec(payload, wrong, 4_i64, io3, announce_skip: false)
+        io3.to_s.should be_empty
+
+        # A digest that is present but wrong still fails, notice or not.
+        expect_raises(Gori::Error, /checksum mismatch/) do
+          Gori::Update.verify_download_for_spec(payload, verified, 4_i64, IO::Memory.new,
+            announce_skip: true)
+        end
+      ensure
+        File.delete?(payload)
       end
     end
   end

--- a/src/gori/cli.cr
+++ b/src/gori/cli.cr
@@ -1029,6 +1029,12 @@ module Gori
           exit 0
         end
         p.invalid_option { |flag| abort "unknown option: #{flag}\n#{p}" }
+        # `gori update` takes no positional arguments, and `--exec` is its only
+        # flag — so a `--` separator has nothing legitimate to protect. Without
+        # this, `gori update -- --exec` parsed clean and silently dropped the
+        # flag, and `gori update whatever` ran a full self-update on a typo. Same
+        # failure, same guard, as `gori wizard` / `gori tutorial`.
+        p.unknown_args { |rest, after| reject_extra_args("update", rest, after, p) }
       end
       parser.parse(args)
       begin

--- a/src/gori/update.cr
+++ b/src/gori/update.cr
@@ -652,29 +652,35 @@ module Gori
       downloaded = 0_i64
       buf = Bytes.new(PROGRESS_CHUNK)
 
-      File.open(dest, "w") do |file|
-        loop do
-          n = body_io.read(buf)
-          break if n == 0
-          file.write(buf[0, n])
-          downloaded += n
-          on_progress.try &.call(downloaded, total)
+      begin
+        File.open(dest, "w") do |file|
+          loop do
+            n = body_io.read(buf)
+            break if n == 0
+            file.write(buf[0, n])
+            downloaded += n
+            on_progress.try &.call(downloaded, total)
 
-          if show && progress_io
-            now = Time.instant
-            if now - last_draw >= PROGRESS_MIN_INTERVAL || (total > 0 && downloaded >= total)
-              line = format_progress_line(downloaded, total, elapsed: started.elapsed)
-              progress_io.print "\r\e[K  #{line}"
-              progress_io.flush
-              last_draw = now
+            if show && progress_io
+              now = Time.instant
+              if now - last_draw >= PROGRESS_MIN_INTERVAL || (total > 0 && downloaded >= total)
+                line = format_progress_line(downloaded, total, elapsed: started.elapsed)
+                progress_io.print "\r\e[K  #{line}"
+                progress_io.flush
+                last_draw = now
+              end
             end
           end
         end
-      end
-
-      if show && progress_io
-        progress_io.print "\r\e[K"
-        progress_io.flush
+      ensure
+        # In an `ensure`, not after the loop: a reset mid-transfer left the last
+        # bar standing and the error message was then printed onto that same
+        # line, right after the rate — the one moment the operator most needs to
+        # read it. The line belongs to this method either way it exits.
+        if show && progress_io
+          progress_io.print "\r\e[K"
+          progress_io.flush
+        end
       end
       downloaded
     end
@@ -722,12 +728,14 @@ module Gori
     # Streamed SHA256 of a file as lowercase hex (constant memory).
     def self.file_sha256(path : String) : String
       digest = Digest::SHA256.new
-      File.open(path) do |file|
-        buf = Bytes.new(PROGRESS_CHUNK)
-        loop do
-          n = file.read(buf)
-          break if n == 0
-          digest.update(buf[0, n])
+      io_guard("could not read #{path} to checksum it") do
+        File.open(path) do |file|
+          buf = Bytes.new(PROGRESS_CHUNK)
+          loop do
+            n = file.read(buf)
+            break if n == 0
+            digest.update(buf[0, n])
+          end
         end
       end
       digest.hexfinal
@@ -750,10 +758,40 @@ module Gori
     # CLI orchestration + I/O
     # ---------------------------------------------------------------------------
 
+    # Turn the I/O failures an updater actually MEETS — no route to GitHub, DNS
+    # that does not resolve, a TLS store that cannot verify (#323/#333), a
+    # connection reset mid-transfer, a `tar` that is not installed — into the
+    # project's expected-error type.
+    #
+    # CLI.run's rescue is deliberately narrow (see cli.cr): anything that is not
+    # a Gori::Error reaches the top of the process as a Crystal backtrace,
+    # "because those are bugs and want a trace". Being offline is not a bug, and
+    # it is the single likeliest way `gori update` fails — yet that is exactly
+    # what it answered with. Only the I/O families are converted here, so a
+    # genuine bug still gets its trace.
+    #
+    # Gori::Error descends straight from Exception, so the errors this module
+    # raises on purpose (including AssetNotFound, which the alias retry rescues
+    # by type) pass through untouched.
+    private def self.io_guard(what : String, &)
+      yield
+    rescue ex : IO::Error | OpenSSL::Error
+      raise Error.new("#{what}: #{ex.message.presence || ex.class}")
+    end
+
     def self.resolve_executable_path : String
       path = Process.executable_path
       raise Error.new("could not determine the running gori executable path") unless path
       File.realpath(path)
+    rescue ex : File::Error
+      # The running binary was moved or deleted underneath us (a package manager
+      # upgrading it, a concurrent `gori update`). File::Error is not a
+      # Gori::Error, so this used to be the first thing `gori update` did and the
+      # first way it could backtrace.
+      raise Error.new(
+        "could not resolve the running gori executable: #{ex.message.presence || ex.class} " \
+        "(it may have been moved or deleted while running)"
+      )
     end
 
     private def self.http_client(host : String, port : Int32, tls : Bool,
@@ -965,7 +1003,9 @@ module Gori
       tls = uri.scheme == "https"
       client = http_client(host, port, tls, timeout)
       begin
-        response = client.get(uri.request_target, headers: headers)
+        response = io_guard("could not reach #{host}") do
+          client.get(uri.request_target, headers: headers)
+        end
         raise api_error(response.status_code, response.body) unless response.status_code == 200
         response.body
       ensure
@@ -991,40 +1031,45 @@ module Gori
         # Capture result outside the HTTP block (block return is not always the method return).
         result = 0_i64
         redirect_url : String? = nil
-        client.get(uri.request_target, headers: headers) do |response|
-          code = response.status_code
-          if {301, 302, 303, 307, 308}.includes?(code)
-            location = response.headers["Location"]?
-            raise Error.new("redirect without Location from #{url}") unless location
-            response.body_io.gets_to_end
-            # Resolve relative redirects against the current URL.
-            redirect_url = location.starts_with?("http://") || location.starts_with?("https://") ? location : URI.parse(url).resolve(location).to_s
-            next
-          end
-          unless code == 200
-            response.body_io.gets_to_end
-            # 404 gets its own type: it is the one status that means "this exact
-            # name is not in the release", which is the only thing worth retrying
-            # under the version-less alias.
-            raise AssetNotFound.new("download failed HTTP 404 for #{url}") if code == 404
-            raise Error.new("download failed HTTP #{code} for #{url}")
-          end
-          cl = response.headers["Content-Length"]?.try(&.to_i64?) || 0_i64
-          total = cl > 0 ? cl : expected_size
-          result = copy_with_progress(response.body_io, dest, total,
-            progress_io: progress_io,
-            on_progress: on_progress,
-            force_progress: force_progress)
-          # Verify against the ACTUAL HTTP Content-Length header, not just whatever
-          # size the (unauthenticated) release JSON claims. A truncated/interrupted
-          # transfer must never be silently accepted just because the JSON's `size`
-          # field is 0 or wrong — this is the one completeness signal the server
-          # can't lie about without also lying to every other HTTP client.
-          if cl > 0 && result != cl
-            File.delete?(dest)
-            raise Error.new(
-              "download truncated for #{url}: expected #{cl} bytes (Content-Length) but received #{result}"
-            )
+        # Guards the whole streamed exchange, not just the connect: a reset or a
+        # read timeout part-way through tens of MB is the commonest way this
+        # fails, and it surfaces from inside the block.
+        io_guard("could not download #{url}") do
+          client.get(uri.request_target, headers: headers) do |response|
+            code = response.status_code
+            if {301, 302, 303, 307, 308}.includes?(code)
+              location = response.headers["Location"]?
+              raise Error.new("redirect without Location from #{url}") unless location
+              response.body_io.gets_to_end
+              # Resolve relative redirects against the current URL.
+              redirect_url = location.starts_with?("http://") || location.starts_with?("https://") ? location : URI.parse(url).resolve(location).to_s
+              next
+            end
+            unless code == 200
+              response.body_io.gets_to_end
+              # 404 gets its own type: it is the one status that means "this exact
+              # name is not in the release", which is the only thing worth retrying
+              # under the version-less alias.
+              raise AssetNotFound.new("download failed HTTP 404 for #{url}") if code == 404
+              raise Error.new("download failed HTTP #{code} for #{url}")
+            end
+            cl = response.headers["Content-Length"]?.try(&.to_i64?) || 0_i64
+            total = cl > 0 ? cl : expected_size
+            result = copy_with_progress(response.body_io, dest, total,
+              progress_io: progress_io,
+              on_progress: on_progress,
+              force_progress: force_progress)
+            # Verify against the ACTUAL HTTP Content-Length header, not just whatever
+            # size the (unauthenticated) release JSON claims. A truncated/interrupted
+            # transfer must never be silently accepted just because the JSON's `size`
+            # field is 0 or wrong — this is the one completeness signal the server
+            # can't lie about without also lying to every other HTTP client.
+            if cl > 0 && result != cl
+              File.delete?(dest)
+              raise Error.new(
+                "download truncated for #{url}: expected #{cl} bytes (Content-Length) but received #{result}"
+              )
+            end
           end
         end
         if next_url = redirect_url
@@ -1059,8 +1104,19 @@ module Gori
     # part-way with, say, IO::Error would otherwise strand `tmp` next to the binary.
     def self.atomic_install(source : String, target : String) : Nil
       dir = File.dirname(target)
-      Dir.mkdir_p(dir)
-      tmp = File.join(dir, ".gori-update.#{Process.pid}.#{Random::Secure.hex(4)}")
+      # Outside the `begin` below, so it needs its own guard: install_dir_writable?
+      # deliberately passes a directory that does not exist yet ("atomic_install
+      # creates it"), and creating it fails for real — an unwritable parent, or a
+      # plain file sitting at that path.
+      io_guard("could not create the install directory #{dir}") { Dir.mkdir_p(dir) }
+      # Before staging a new one, clear temps an earlier run never got to rename.
+      # The `rescue` below only runs when the copy raises — Crystal's default
+      # SIGINT terminates without unwinding, so a Ctrl-C during the copy (or a
+      # kill, or a power loss) strands a full ~40 MB duplicate of the binary in
+      # the operator's install directory, and every retry adds another. lib/
+      # already sweeps its own leftovers; this is the same sweep for the binary.
+      sweep_install_leftovers(dir)
+      tmp = File.join(dir, "#{INSTALL_TMP_PREFIX}#{Process.pid}.#{Random::Secure.hex(4)}")
       begin
         FileUtils.cp(source, tmp)
         File.chmod(tmp, 0o755)
@@ -1072,6 +1128,25 @@ module Gori
           "(the binary already installed there was left untouched)"
         )
       end
+    end
+
+    # Remove `.gori-update.*` siblings stranded by an interrupted run.
+    #
+    # Matched by prefix over Dir.children rather than by Dir.glob, for the reason
+    # sweep_lib_leftovers gives: the install path is the operator's, and a `[`,
+    # `*` or `?` in it would make a glob both miss the real leftovers and rm
+    # entries it was never meant to see. The prefix starts with a dot and the
+    # installed binary is `gori`, so the target itself can never match.
+    #
+    # A concurrent `gori update` could have its in-flight temp swept here. That
+    # costs the loser a clean "failed to install" — the installed binary is never
+    # touched — which is the right trade against leaving the copies to pile up.
+    private def self.sweep_install_leftovers(dir : String) : Nil
+      Dir.children(dir).each do |name|
+        File.delete?(File.join(dir, name)) if name.starts_with?(INSTALL_TMP_PREFIX)
+      end
+    rescue
+      # A leftover we cannot clear is cosmetic; never fail an update over it.
     end
 
     # `atomic_install` renames a sibling temp file over the target, so replacing
@@ -1087,18 +1162,32 @@ module Gori
     # Crystal has no Dir.mktmpdir; create a unique dir under Dir.tempdir and clean up.
     private def self.with_tempdir(prefix : String, &)
       dir = File.tempname(prefix, "")
-      Dir.mkdir_p(dir)
+      # A TMPDIR that has been removed, or points somewhere unwritable, is an
+      # operator condition and gets a message like every other one.
+      io_guard("could not create a temporary directory under #{File.dirname(dir)}") do
+        Dir.mkdir_p(dir)
+      end
       begin
         yield dir
       ensure
-        FileUtils.rm_rf(dir) if File.exists?(dir)
+        # Rescued so a tempdir we cannot clear — which is cosmetic — never
+        # replaces the real exception on the way out.
+        begin
+          FileUtils.rm_rf(dir) if File.exists?(dir)
+        rescue
+        end
       end
     end
 
+    # `tar` is assumed present, and on a minimal image it is not: Process.run
+    # raises File::NotFoundError rather than returning a failed status, which is
+    # not a Gori::Error and so backtraced out of the macOS archive install.
     def self.list_tar_entries(archive : String) : String
       listing = IO::Memory.new
       tar_err = IO::Memory.new
-      status = Process.run("tar", ["tzf", archive], output: listing, error: tar_err)
+      status = io_guard("could not run tar") do
+        Process.run("tar", ["tzf", archive], output: listing, error: tar_err)
+      end
       raise Error.new("tar list failed: #{tar_err}") unless status.success?
       listing.to_s
     end
@@ -1106,13 +1195,17 @@ module Gori
     def self.extract_tar(archive : String, dest_dir : String) : Nil
       assert_safe_tar_listing(list_tar_entries(archive))
       tar_err = IO::Memory.new
-      status = Process.run("tar", ["xzf", archive, "-C", dest_dir],
-        output: Process::Redirect::Close, error: tar_err)
+      status = io_guard("could not run tar") do
+        Process.run("tar", ["xzf", archive, "-C", dest_dir],
+          output: Process::Redirect::Close, error: tar_err)
+      end
       raise Error.new("tar extract failed: #{tar_err}") unless status.success?
     end
 
     LIB_BACKUP_SUFFIX  = ".gori-old."
     LIB_STAGING_SUFFIX = ".gori-new."
+    # Sibling temp atomic_install renames over the target (see sweep_install_leftovers).
+    INSTALL_TMP_PREFIX = ".gori-update."
 
     # Replace lib/ only at a verified-safe destination. Stages to a temp name then renames.
     #
@@ -1124,7 +1217,7 @@ module Gori
       raise Error.new("refusing to install lib/ at unsafe path: #{lib_dst}") if forbidden_lib_destination?(lib_dst)
 
       parent = File.dirname(lib_dst)
-      Dir.mkdir_p(parent)
+      io_guard("could not create #{parent} for the bundled lib/") { Dir.mkdir_p(parent) }
 
       # Half-copied staging trees are always garbage, so they go unconditionally.
       # Backups do NOT: if a previous run died between renaming lib/ aside and
@@ -1270,7 +1363,8 @@ module Gori
     # Post-download integrity gate: non-empty, matches the size the release
     # advertised, and matches its sha256 when the API supplied a digest. The
     # digest is absent on the redirect fallback, where verify_sha256! no-ops.
-    private def self.verify_download!(dest : String, asset : Asset, got : Int64, io : IO) : Nil
+    private def self.verify_download!(dest : String, asset : Asset, got : Int64, io : IO, *,
+                                      announce_skip : Bool = false) : Nil
       raise Error.new("downloaded asset is empty: #{asset.name}") unless got > 0
       if asset.size > 0 && got != asset.size
         raise Error.new("downloaded size mismatch for #{asset.name}: expected #{asset.size} bytes, got #{got}")
@@ -1278,6 +1372,13 @@ module Gori
       if expected_sha = parse_sha256_digest(asset.digest)
         io.puts "Verifying sha256 checksum"
         verify_sha256!(dest, expected_sha, asset.name)
+      elsif announce_skip
+        # Said HERE rather than beside the "resolved via redirect" note, because
+        # only here is `asset` the one that actually came down. download_asset
+        # can swap in the version-less alias, which carries its own SHA256SUMS
+        # entry — so the note used to be read off an asset that was never
+        # installed and could claim a skip for a download it then verified.
+        io.puts "Note: #{asset.name} has no SHA256SUMS entry in this release, so sha256 verification is skipped."
       end
     end
 
@@ -1358,9 +1459,6 @@ module Gori
       if via_redirect
         io.puts "Note: the GitHub release API was unavailable (rate limit or outage);"
         io.puts "      resolved #{display_version(release.tag_name)} from #{RELEASES_LATEST_URL} instead."
-        unless parse_sha256_digest(asset.digest)
-          io.puts "      #{display_version(release.tag_name)} publishes no SHA256SUMS, so sha256 verification is skipped."
-        end
       end
 
       io.puts "Updating #{display_version(VERSION)} → #{display_version(ver)}"
@@ -1370,7 +1468,7 @@ module Gori
       with_tempdir("gori-dl-") do |dir|
         started = Time.instant
         dest, asset, got = download_asset(release, asset, dir, io, force_progress: force_progress)
-        verify_download!(dest, asset, got, io)
+        verify_download!(dest, asset, got, io, announce_skip: via_redirect)
         io.puts "Downloaded #{format_size(got)} in #{format_duration(started.elapsed)}"
         install_from_download(dest, target_path, asset_is_archive?(asset.name))
       end
@@ -1414,7 +1512,9 @@ module Gori
             tool = cmd.split.first
             if Process.find_executable(tool)
               io.puts "Running: #{cmd}"
-              status = Process.run(cmd, shell: true, output: io, error: err)
+              status = io_guard("could not run #{cmd}") do
+                Process.run(cmd, shell: true, output: io, error: err)
+              end
               unless status.success?
                 raise Error.new("#{cmd} failed (exit #{status.exit_code})")
               end
@@ -1422,8 +1522,16 @@ module Gori
               io.puts "(#{tool} not found on PATH — run the command above yourself)"
             end
           else
-            io.puts "Re-run with --exec to run the command above automatically." if cmd
+            io.puts "Re-run with --exec to run the command above automatically."
           end
+        elsif exec_package_commands
+          # pacman/deb/rpm/nix deliberately carry no single auto-runnable command
+          # (which of them is right depends on the AUR helper / how nix installed
+          # it, and the others need sudo). That left `--exec` printing NOTHING
+          # about itself on those channels, so it read as having run something.
+          io.puts ""
+          io.puts "(--exec has nothing to run on the #{channel.to_s.downcase} channel: " \
+                  "the upgrade needs a privileged or interactive command, so run one of the lines above yourself.)"
         end
       else
         io.puts action[:message]


### PR DESCRIPTION
Six defects in `gori update`, each found with a repro and fixed with specs.

| # | Defect | Symptom |
|---|---|---|
| 1 | Every I/O failure escaped as a non-`Gori::Error` | `gori update` offline printed `Unhandled exception: … (Socket::ConnectError)` |
| 2 | No `unknown_args` guard | `gori update -- --exec` silently dropped the flag; `gori update <typo>` ran a full self-update |
| 3 | `--exec` unacknowledged on pacman/deb/rpm/nix | printed nothing about itself — read as though it had run the upgrade |
| 4 | Progress bar not cleared on error | the error message landed on the bar's own line, right after the transfer rate |
| 5 | Checksum notice computed pre-retry | could announce "verification skipped" for an asset it then verified |
| 6 | No sweep for `.gori-update.*` | a Ctrl-C during install stranded a ~40 MB copy of the binary, one per retry |

### 1 — the headline

`CLI.run`'s rescue is deliberately narrow (`cli.cr:72-79`): anything that is not a `Gori::Error` reaches the top of the process as a Crystal backtrace, *"because those are bugs and want a trace"*. Being offline is not a bug — it is the single likeliest way an updater fails.

Rather than a blanket `rescue ex` in `run_update` (which would contradict that documented policy and swallow genuine bugs), the I/O families are converted **at each site** through a new `io_guard`, so a real bug still gets its trace:

- the releases-API `GET`
- the asset download — the whole streamed exchange, so a reset part-way through tens of MB is covered, not just the connect
- `File.realpath` on the running binary (moved/deleted underneath us)
- `file_sha256`
- both `tar` invocations — **`Process.run` RAISES `File::NotFoundError` when the binary is absent** rather than returning a failed status, so `tar list failed` never got to run on a minimal image
- the three `Dir.mkdir_p` calls that sat outside their methods' own rescues

The fallback path matters as much as the direct one: `fetch_latest_release_json_with_fallback` re-raises whatever the API fetch threw once the redirect fallback has nothing to offer, so that re-raise is only as clean as the original exception.

### Before / after

```
$ gori update            # unreachable releases API
- Unhandled exception: Error connecting to '…': Connection refused (Socket::ConnectError)
+ gori update: could not reach 127.0.0.1: Error connecting to '127.0.0.1:1': Connection refused

$ gori update -- --exec
- gori v0.2.0 … (proceeds, --exec silently dropped)
+ unknown option: --exec

$ gori update garbage
- gori v0.2.0 … (proceeds with a full self-update)
+ gori update takes no arguments (got "garbage")

$ gori update --exec     # on Arch
  pacman/AUR install detected. Upgrade with your AUR helper …
+ (--exec has nothing to run on the pacman channel: the upgrade needs a
+  privileged or interactive command, so run one of the lines above yourself.)
```

### Notes

- #2 uses `reject_extra_args`, which takes **both** `unknown_args` arrays — the post-`--` run has to be rejected too, same guard as `gori wizard` / `gori tutorial`.
- #6 matches by prefix over `Dir.children` rather than by `Dir.glob`, for the reason `sweep_lib_leftovers` already documents: the install path is the operator's, and a `[`, `*` or `?` in it would make a glob both miss the real leftovers and remove entries it was never meant to see.
- Verified end to end against `scripts/mock_update_server.cr` with a real tarball: download → lib/ swap → binary install, with a pre-seeded stranded temp confirmed swept.

### Deliberately out of scope

- **`HTTP_PROXY` support** — a feature, and `Proxy::Upstream.dial` is driven by gori's own Settings rather than the environment, so there is no clean precedent to borrow.
- **`version_cmp` prerelease handling** — it collapses `-rc1`/`+build` suffixes, but all six release tags are bare `vX.Y.Z` and `VERSION` is bare, so it is theoretical.
- **Tar symlink escape** — `assert_safe_tar_listing` vets entry names, and `tar tzf` does not show link targets. `update.cr` already concedes it does not defend against an attacker who controls the release itself; closing this needs signed checksums, which is release-side infra.

### Testing

- `crystal spec spec/update_spec.cr` — **123 examples, 0 failures** (14 new)
- `crystal spec` — 7661 examples, 8 failures, all of them the pre-existing environmental `Gori::Session` port-bind cases (`project_registry_spec`, `capture_status_spec`)
- `crystal tool format --check` clean on the changed files; ameba reports no new findings (per-file counts unchanged vs. baseline)