### PR TITLE
A string argument that was not a string: the MCP string readers finish a class the bool/int/header readers closed one at a time

### DIFF
--- a/spec/mcp_str_args_spec.cr
+++ b/spec/mcp_str_args_spec.cr
@@ -1,0 +1,425 @@
+require "./spec_helper"
+require "socket"
+
+# Every MCP STRING argument, driven with the shapes a client actually sends:
+#   "text"        — the legal one
+#   42 / true     — a JSON scalar: unambiguous, so COERCED ("42"), never dropped
+#   [] / {}       — a container: REFUSED BY NAME (JSON::Any#to_s renders a Hash in
+#                   Crystal syntax, `{"a" => 1}`, so coercing puts text on the wire
+#                   or in the store that the caller never wrote)
+#   null          — absent, exactly as `present?` means it everywhere else
+#
+# `h[key]?.try(&.as_s?)` answered nil for EVERY non-string shape, and every caller read
+# that nil as "the caller did not pass it". So the argument was accepted, validated
+# against nothing, and discarded: `send_request{method:123}` sent a GET, `{body:{…}}` sent
+# no body and no Content-Length, `{raw:[…]}` fell through to a structured GET,
+# `create_repeater{request_base64:1234}` stored the non-byte-exact `request` instead, and
+# `add_scope_rule{pattern:8080}` refused with "missing required 'pattern'" for a value it
+# had just been handed. All with `isError:false` where a send was involved.
+#
+# The sibling primitives closed this one at a time — `bool_value` (a `1` is refused by
+# name), `optional_int_arg`, `RequestBuilder.header_pairs` ("RAISE on anything else rather
+# than vanish"), `ws_out_messages_arg` (`compact_map` used to store 2 of 4 frames) — and
+# the string readers were what was left.
+
+private def with_store(&)
+  path = File.tempname("gori-mcp-strs", ".db")
+  store = Gori::Store.open(path)
+  begin
+    yield store
+  ensure
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+private def str_tools(store) : Gori::MCP::Tools
+  Gori::MCP::Tools.new(store, allow_actions: true, verify_upstream: false)
+end
+
+private def str_json(tools : Gori::MCP::Tools, name : String, args : String) : JSON::Any
+  r = tools.call(name, JSON.parse(args))
+  fail "tool #{name}#{args} errored: #{r.text}" if r.is_error
+  JSON.parse(r.text)
+end
+
+# A container in a string slot must be refused, and the refusal must NAME the argument —
+# an unnamed "invalid arguments" would leave the caller no better off than the silent drop.
+private def refuses_container(tools : Gori::MCP::Tools, name : String, field : String,
+                              args : Proc(String, String))
+  ["[1,2]", %({"a":1})].each do |bad|
+    r = tools.call(name, JSON.parse(args.call(bad)))
+    unless r.is_error
+      fail "#{name}{#{field}: #{bad}} was accepted (#{r.text[0, 200]})"
+    end
+    r.text.should contain("'#{field}'")
+  end
+end
+
+private def seed_str_flow(store, host = "acme.test", target = "/x") : Int64
+  store.insert_flow(Gori::Store::CapturedRequest.new(
+    created_at: 1_i64, scheme: "http", host: host, port: 80,
+    method: "GET", target: target, http_version: "HTTP/1.1",
+    head: "GET #{target} HTTP/1.1\r\nHost: #{host}\r\n\r\n".to_slice, body: nil))
+end
+
+# Records the raw request bytes of the next `count` connections into `sink`, answering 204.
+private def start_str_recording_origin(sink : Channel(Bytes), count : Int32) : Int32
+  origin = TCPServer.new("127.0.0.1", 0)
+  port = origin.local_address.port
+  spawn do
+    count.times do
+      break unless conn = origin.accept?
+      buf = IO::Memory.new
+      begin
+        conn.read_timeout = 300.milliseconds
+        tmp = Bytes.new(4096)
+        while (n = conn.read(tmp)) > 0
+          buf.write(tmp[0, n])
+        end
+      rescue
+        # idle — everything the client meant to send has arrived
+      end
+      sink.send(buf.to_slice)
+      conn << "HTTP/1.1 204 No Content\r\n\r\n" rescue nil
+      conn.flush rescue nil
+      conn.close rescue nil
+    end
+    origin.close
+  rescue
+    origin.close rescue nil
+  end
+  port
+end
+
+describe "MCP string arguments — the wire fields of send_request" do
+  it "refuses a non-string method instead of silently sending GET" do
+    with_store do |store|
+      tools = str_tools(store)
+      # The dead port proves nothing was sent: the refusal has to come from the builder,
+      # before any dial. `method: 123` used to become the DEFAULT "GET".
+      r = tools.call("send_request", JSON.parse(
+        %({"url":"http://127.0.0.1:1/","method":123,"allow_unscoped":true})))
+      r.is_error.should be_true
+      r.text.should contain("'method'")
+      r.text.should_not contain("connection refused")
+      refuses_container(tools, "send_request", "method", ->(bad : String) {
+        %({"url":"http://127.0.0.1:1/","method":#{bad},"allow_unscoped":true})
+      })
+    end
+  end
+
+  it "refuses a JSON-object body instead of sending a bodiless request and reporting success" do
+    with_store do |store|
+      tools = str_tools(store)
+      # The shape an LLM reaches for on any JSON API. It used to send `POST /` with NO
+      # body and NO Content-Length, and answer isError:false with the origin's 400.
+      r = tools.call("send_request", JSON.parse(
+        %({"url":"http://127.0.0.1:1/","method":"POST","body":{"user":"admin"},"allow_unscoped":true})))
+      r.is_error.should be_true
+      r.text.should contain("'body'")
+      refuses_container(tools, "send_request", "body_base64", ->(bad : String) {
+        %({"url":"http://127.0.0.1:1/","body_base64":#{bad},"allow_unscoped":true})
+      })
+      # A numeric body is a container-free scalar, but this field IS the message, so it is
+      # refused too rather than guessed at (same reasoning as `base64_arg`'s).
+      num = tools.call("send_request", JSON.parse(
+        %({"url":"http://127.0.0.1:1/","method":"POST","body":42,"allow_unscoped":true})))
+      num.is_error.should be_true
+      num.text.should contain("'body'")
+    end
+  end
+
+  it "refuses a non-string raw instead of falling through to a structured GET" do
+    with_store do |store|
+      tools = str_tools(store)
+      refuses_container(tools, "send_request", "raw", ->(bad : String) {
+        %({"url":"http://127.0.0.1:1/","raw":#{bad},"allow_unscoped":true})
+      })
+      refuses_container(tools, "send_request", "raw_base64", ->(bad : String) {
+        %({"url":"http://127.0.0.1:1/","raw_base64":#{bad},"allow_unscoped":true})
+      })
+    end
+  end
+
+  it "names 'url' when the url is not a string (not 'url is required')" do
+    with_store do |store|
+      tools = str_tools(store)
+      r = tools.call("send_request", JSON.parse(%({"url":8080,"allow_unscoped":true})))
+      r.is_error.should be_true
+      r.text.should contain("'url'")
+    end
+  end
+
+  it "still sends a string body byte-for-byte, and still treats a null body as absent" do
+    sink = Channel(Bytes).new(2)
+    port = start_str_recording_origin(sink, 2)
+    with_store do |store|
+      tools = str_tools(store)
+      str_json(tools, "send_request", %({"url":"http://127.0.0.1:#{port}/p","method":"POST",) +
+                                      %("body":"{\\"user\\":\\"admin\\"}","allow_unscoped":true,"record_history":false}))
+      sent = String.new(sink.receive)
+      sent.should start_with("POST /p HTTP/1.1\r\n")
+      sent.should contain("Content-Length: 16\r\n")
+      sent.should end_with(%({"user":"admin"}))
+
+      # `null` is what an LLM emits for "no body"; it must stay ABSENT, not become "null".
+      str_json(tools, "send_request", %({"url":"http://127.0.0.1:#{port}/q","body":null,) +
+                                      %("allow_unscoped":true,"record_history":false}))
+      bodiless = String.new(sink.receive)
+      bodiless.should end_with("\r\n\r\n")
+      bodiless.should_not contain("Content-Length")
+    end
+  end
+end
+
+describe "MCP string arguments — the shared str() reader" do
+  it "coerces a JSON scalar rather than reporting the argument missing" do
+    with_store do |store|
+      tools = str_tools(store)
+      # `pattern: 8080` used to come back "missing required 'pattern'" for a value the
+      # caller had just sent. A bare number in a string slot is unambiguous.
+      str_json(tools, "add_scope_rule", %({"match_type":"string","pattern":8080}))
+      Gori::Scope.load(store).rules.map(&.pattern).should contain("8080")
+
+      note = str_json(tools, "create_note", %({"text":42}))["id"].as_i64
+      Gori::Notes.load(store).notes.find { |n| n.id == note }.not_nil!.text.should eq("42")
+    end
+  end
+
+  it "refuses a container in a string slot, naming the argument" do
+    with_store do |store|
+      seed_str_flow(store)
+      tools = str_tools(store)
+      refuses_container(tools, "add_scope_rule", "pattern", ->(bad : String) {
+        %({"match_type":"string","pattern":#{bad}})
+      })
+      refuses_container(tools, "create_note", "text", ->(bad : String) { %({"text":#{bad}}) })
+      # A dropped `query` is the sharpest one: list_history answered with the WHOLE
+      # history, and the agent reasoned over a set it never asked for.
+      refuses_container(tools, "list_history", "query", ->(bad : String) { %({"query":#{bad}}) })
+      refuses_container(tools, "create_issue", "title", ->(bad : String) {
+        %({"title":#{bad},"severity":"low"})
+      })
+    end
+  end
+
+  it "reads a null string argument as absent" do
+    with_store do |store|
+      seed_str_flow(store)
+      tools = str_tools(store)
+      # `query: null` is "no filter", the same as omitting it — not the string "null".
+      both = str_json(tools, "list_history", %({"query":null})).as_a.size
+      both.should eq(str_json(tools, "list_history", "{}").as_a.size)
+      both.should be > 0
+    end
+  end
+end
+
+describe "MCP string arguments — byte-exact base64 fields are strict" do
+  it "refuses a non-string request_base64 instead of falling back to `request`" do
+    with_store do |store|
+      tools = str_tools(store)
+      # `base64_str` answered nil, so `|| str(h, "request")` won and create_repeater stored
+      # the NON-byte-exact request while reporting success. A caller reaching for a
+      # `*_base64` argument is asking for exact bytes.
+      r = tools.call("create_repeater", JSON.parse(
+        %({"target":"http://acme.test","request_base64":1234,) +
+        %("request":"GET / HTTP/1.1\\r\\nHost: acme.test\\r\\n\\r\\n"})))
+      r.is_error.should be_true
+      r.text.should contain("'request_base64'")
+      store.repeaters.size.should eq(0)
+    end
+  end
+end
+
+describe "MCP string arguments — list readers keep every entry" do
+  it "cookie_crack takes a bare string as one candidate, and does not drop a numeric one" do
+    with_store do |store|
+      tools = str_tools(store)
+      forged = str_json(tools, "cookie_forge",
+        %({"format":"flask","secret":"12345","payload":"{\\"user\\":\\"admin\\"}"}))["cookie"].as_s
+
+      # A numeric secret used to be dropped by `compact_map(&.as_s?)`, so the crack tried
+      # 1 of the 2 candidates and answered `found:false` with isError:false — a false
+      # negative the caller cannot see.
+      hit = str_json(tools, "cookie_crack",
+        %({"cookie":"#{forged}","format":"flask","secrets":["nope",12345]}))
+      hit["found"].as_bool.should be_true
+      hit["secret"].as_s.should eq("12345")
+
+      # A single secret sent as a bare string is the shape a caller reaches for; it used to
+      # become an empty list and come back "provide 'secrets' (array) and/or 'wordlist'".
+      bare = str_json(tools, "cookie_crack",
+        %({"cookie":"#{forged}","format":"flask","secrets":"12345"}))
+      bare["found"].as_bool.should be_true
+      # …and a bare NUMBER is the same one candidate, not a shape to refuse — the scalar rule
+      # has to read the same on a whole list argument as it does on one entry of it.
+      scalar = str_json(tools, "cookie_crack",
+        %({"cookie":"#{forged}","format":"flask","secrets":12345}))
+      scalar["found"].as_bool.should be_true
+      # A container in the list slot still has no reading, and the refusal names that shape.
+      obj = tools.call("cookie_crack", JSON.parse(%({"cookie":"#{forged}","secrets":{"a":1}})))
+      obj.is_error.should be_true
+      obj.text.should contain("'secrets'")
+      obj.text.should contain("an object")
+
+      # The complement: a genuinely wrong candidate list still reports no match.
+      miss = str_json(tools, "cookie_crack",
+        %({"cookie":"#{forged}","format":"flask","secrets":["nope","also-nope"]}))
+      miss["found"].as_bool.should be_false
+
+      refuses_container(tools, "cookie_crack", "secrets", ->(bad : String) {
+        %({"cookie":"#{forged}","format":"flask","secrets":[#{bad}]})
+      })
+    end
+  end
+
+  it "sequence_analyze analyzes every token it was handed, or refuses" do
+    with_store do |store|
+      tools = str_tools(store)
+      # 2 of the 3 tokens used to reach the analyzer, so the randomness verdict described a
+      # sample the caller never submitted — the `create_repeater` "stored 2 of 4 frames"
+      # bug, spent on a report instead of a send.
+      r = str_json(tools, "sequence_analyze", %({"tokens":["aaaa","bbbb",1234]}))
+      r["sample_count"].as_i.should eq(3)
+      refuses_container(tools, "sequence_analyze", "tokens", ->(bad : String) {
+        %({"tokens":["aaaa",#{bad}]})
+      })
+    end
+  end
+
+  it "create_repeater refuses an OBJECT ws_out_messages instead of storing zero frames" do
+    with_store do |store|
+      tools = str_tools(store)
+      # An actual upgrade request: `ws_out_messages` is only read when the stored bytes are
+      # a WebSocket handshake.
+      handshake = "GET /ws HTTP/1.1\\r\\nHost: acme.test\\r\\nUpgrade: websocket\\r\\n" \
+                  "Connection: Upgrade\\r\\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\\r\\n" \
+                  "Sec-WebSocket-Version: 13\\r\\n\\r\\n"
+      base = %("target":"ws://acme.test","request":"#{handshake}")
+      # The array branch was tried first and the object fell through to the string branch,
+      # which answered nil — so the repeater was stored with an EMPTY frame list and
+      # reported success.
+      r = tools.call("create_repeater", JSON.parse(%({#{base},"ws_out_messages":{"payload":"hi"}})))
+      r.is_error.should be_true
+      r.text.should contain("'ws_out_messages'")
+
+      # Both documented shapes still work: the array form and the newline-string form.
+      arr = str_json(tools, "create_repeater", %({#{base},"ws_out_messages":["a","b"]}))
+      arr["ws_out_message_count"].as_i.should eq(2)
+      lines = str_json(tools, "create_repeater", %({#{base},"ws_out_messages":"a\\nb\\nc"}))
+      lines["ws_out_message_count"].as_i.should eq(3)
+    end
+  end
+end
+
+describe "MCP string arguments — the fuzz payload/processor/matcher grammar" do
+  # `fuzz_start` builds the whole plan before the scope gate and before any send, so every
+  # refusal here happens with nothing on the wire.
+  private_base = %("template":"GET /?q=§x§ HTTP/1.1\\r\\nHost: 127.0.0.1\\r\\n\\r\\n",) +
+                 %("url":"http://127.0.0.1:1","allow_unscoped":true)
+
+  it "coerces a scalar payload entry but refuses a container one" do
+    with_store do |store|
+      tools = str_tools(store)
+      # `x.as_s? || x.to_s` stringified a nested object in CRYSTAL syntax (`{"a" => 1}`), so
+      # every request built from it carried a payload nobody wrote.
+      ok = str_json(tools, "fuzz_start", %({#{private_base},"payloads":[{"list":[1,2]}]}))
+      ok["total"].as_i.should eq(2)
+      bad = tools.call("fuzz_start", JSON.parse(%({#{private_base},"payloads":[{"list":[{"a":1}]}]})))
+      bad.is_error.should be_true
+      bad.text.should contain("'list'")
+    end
+  end
+
+  it "refuses a non-string replacement instead of deleting every match" do
+    with_store do |store|
+      tools = str_tools(store)
+      # `strict_jstr(…) || ""` turned `replacement: 123` into an empty replacement, so the
+      # processor STRIPPED the match rather than substituting the value the caller named.
+      r = tools.call("fuzz_start", JSON.parse(%({#{private_base},"payloads":[{"list":["a"]}],) +
+                                              %("processors":[{"type":"regex_replace","pattern":"a","replacement":123}]})))
+      r.is_error.should be_true
+      r.text.should contain("'replacement'")
+    end
+  end
+
+  it "refuses a non-string matcher regex instead of dropping the matcher" do
+    with_store do |store|
+      tools = str_tools(store)
+      # Both condition sets go through the same reader, so both are pinned.
+      {"match", "filter"}.each do |arg|
+        r = tools.call("fuzz_start", JSON.parse(%({#{private_base},"payloads":[{"list":["a"]}],) +
+                                                %("#{arg}":{"regex":[1]}})))
+        r.is_error.should be_true
+        r.text.should contain("'regex'")
+      end
+    end
+  end
+
+  it "refuses a non-string preset file instead of running without the merged wordlist" do
+    with_store do |store|
+      tools = str_tools(store)
+      r = tools.call("fuzz_start", JSON.parse(%({#{private_base},"payloads":[{"preset":"sqli","file":42}]})))
+      r.is_error.should be_true
+      r.text.should contain("'file'")
+    end
+  end
+end
+
+# --- the transport layer: `arguments` that is not an object ----------------------
+
+private def drive_str(store, *lines) : Array(JSON::Any)
+  input = IO::Memory.new(lines.join('\n') + "\n")
+  output = IO::Memory.new
+  Gori::MCP::Server.new(store, allow_actions: true, verify_upstream: false,
+    input: input, output: output).run
+  output.to_s.each_line.reject(&.strip.empty?).map { |l| JSON.parse(l) }.to_a
+end
+
+describe "MCP tools/call — a stringified `arguments` object" do
+  it "parses arguments sent as a JSON string instead of dropping every one of them" do
+    with_store do |store|
+      flow = seed_str_flow(store)
+      # `as_h?` answered nil and `Tools#call` substituted an empty hash, so a client that
+      # stringifies its arguments — which happens, and which `header_pairs` already accepts
+      # one level down — was told "missing required 'id'" for a call that named it.
+      resp = drive_str(store,
+        %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_flow","arguments":"{\\"id\\":#{flow}}"}}))
+      resp.size.should eq(1)
+      resp[0]["result"]["isError"].as_bool.should be_false
+      JSON.parse(resp[0]["result"]["content"][0]["text"].as_s)["id"].as_i64.should eq(flow)
+    end
+  end
+
+  it "refuses a non-object `arguments` at the protocol level rather than running with none" do
+    with_store do |store|
+      resp = drive_str(store,
+        %({"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"get_flow","arguments":[1,2]}}),
+        %({"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"get_flow","arguments":"not json"}}))
+      resp.size.should eq(2)
+      resp[0]["id"].as_i.should eq(2)
+      resp[0]["error"]["code"].as_i.should eq(-32602)
+      resp[0]["error"]["message"].as_s.should contain("arguments")
+      resp[1]["id"].as_i.should eq(3)
+      resp[1]["error"]["code"].as_i.should eq(-32602)
+    end
+  end
+
+  it "still treats an absent, null, or blank `arguments` as no arguments" do
+    with_store do |store|
+      resp = drive_str(store,
+        %({"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"list_history"}}),
+        %({"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"list_history","arguments":null}}),
+        %({"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"list_history","arguments":""}}))
+      resp.size.should eq(3)
+      resp.each do |r|
+        r["error"]?.should be_nil
+        r["result"]["isError"].as_bool.should be_false
+      end
+    end
+  end
+end

--- a/src/gori/mcp/request_builder.cr
+++ b/src/gori/mcp/request_builder.cr
@@ -47,6 +47,32 @@ module Gori
         raise Gori::Error.new("invalid 'headers' (expected an object of name->value)")
       end
 
+      # A string argument that IS the message: `url`, `raw`, `method`, `body`, and the
+      # `*_base64` pair. `args[…]?.try(&.as_s?)` answered nil for every other shape and each
+      # caller read that nil as "absent", so a mistyped argument was accepted and then thrown
+      # away — with `isError:false` and an `effective_request` echo of a request that never
+      # existed:
+      #
+      #   * `method: 123`   → fell back to the DEFAULT and sent a GET. The caller measured a
+      #                       target's handling of a verb it never sent.
+      #   * `body: {…}`     → the shape an LLM reaches for on any JSON API — sent NO body and
+      #                       no Content-Length.
+      #   * `raw: […]`      → fell through to the structured builder and sent a bare GET to
+      #                       `url` instead of the request the caller wrote.
+      #
+      # STRICT, unlike `Tools#str`'s scalar coercion, for the reason `strict_jstr` gives in
+      # fuzz.cr: only a genuine JSON string is ever a sane input for a value spliced straight
+      # onto the wire, and GUESSING at one is the failure `base64_arg` already refuses —
+      # serializing an object body would invent a Content-Type and a length the caller never
+      # stated. `header_pairs` (which accepts the encoded-object form) is the exception, and
+      # it can be: a header set has one unambiguous JSON spelling. A body does not.
+      private def self.wire_str(args : Hash(String, JSON::Any), name : String,
+                                hint : String = "") : String?
+        v = args[name]?
+        return nil if v.nil? || v.raw.nil?
+        v.as_s? || raise Gori::Error.new("invalid '#{name}' (expected a JSON string#{hint})")
+      end
+
       # `args` is the tool's `arguments` object (a parsed JSON hash).
       def self.build(args : Hash(String, JSON::Any)) : Built
         uri, scheme, host, port = parse_origin(args)
@@ -56,7 +82,7 @@ module Gori
             # A base64 input IS the wire: the caller encoded the exact octets it wants sent,
             # so there is nothing to normalise and nothing to expand. See `verbatim?`.
             b64
-          elsif (raw = args["raw"]?.try(&.as_s?)) && !raw.empty?
+          elsif (raw = wire_str(args, "raw", "; use raw_base64 for exact octets")) && !raw.empty?
             # `verbatim` means the operator's bytes ARE the message: no `$VAR` expansion and no
             # bare-LF promotion. `normalize_raw` exists so a hand-typed request still frames,
             # but a bare-LF header terminator is a standard front-end/back-end desync
@@ -82,7 +108,7 @@ module Gori
       end
 
       private def self.parse_origin(args : Hash(String, JSON::Any)) : {URI, String, String, Int32}
-        url = args["url"]?.try(&.as_s?)
+        url = wire_str(args, "url")
         raise Gori::Error.new("'url' is required") if url.nil? || url.empty?
         url = Env.expand(url)
 
@@ -149,7 +175,7 @@ module Gori
       # refuses an unintelligible value through `Tools#bool_arg`; this one now does too.
       # `Gori::Error` is what the tools rescue into a clean caller-facing message.
       def self.verbatim?(args : Hash(String, JSON::Any)) : Bool
-        return true if args["raw_base64"]?.try(&.as_s?).try { |s| !s.empty? }
+        return true if wire_str(args, "raw_base64").try { |s| !s.empty? }
         v = args["verbatim"]?
         return false if v.nil? || v.raw.nil?
         b = v.as_bool?
@@ -172,7 +198,7 @@ module Gori
       # caller reaching for this argument is asking for exact bytes, and quietly sending
       # different ones is the failure it came here to avoid.
       private def self.base64_arg(args : Hash(String, JSON::Any), name : String) : Bytes?
-        s = args[name]?.try(&.as_s?)
+        s = wire_str(args, name)
         return nil if s.nil? || s.empty?
         begin
           Base64.decode(s)
@@ -183,13 +209,14 @@ module Gori
 
       private def self.build_from_parts(uri : URI, scheme : String, host : String, port : Int32,
                                         args : Hash(String, JSON::Any)) : Bytes
-        method = (args["method"]?.try(&.as_s?) || "GET").upcase
+        method = (wire_str(args, "method") || "GET").upcase
         validate_method(method)
         # `body_base64` wins over `body`: it is the byte-exact form, and a caller that sent
         # both meant the precise one. It is NOT env-expanded — the caller already decided
         # every octet, and expanding would change the length it encoded.
         body = base64_arg(args, "body_base64") ||
-               args["body"]?.try(&.as_s?).try { |b| Env.expand(b).to_slice }
+               wire_str(args, "body", "; stringify JSON yourself, or use body_base64 for exact octets")
+                 .try { |b| Env.expand(b).to_slice }
 
         path = uri.path
         path = "/" if path.empty?

--- a/src/gori/mcp/server.cr
+++ b/src/gori/mcp/server.cr
@@ -224,7 +224,9 @@ module Gori
       private def handle_tools_call(id : JSON::Any, params : JSON::Any?) : Nil
         name = obj_field(params, "name").try(&.as_s?)
         return write_error(id, -32602, "tools/call: missing 'name'") unless name
-        args = obj_field(params, "arguments") || EMPTY_ARGS
+        args = tool_arguments(params)
+        return write_error(id, -32602,
+          "tools/call: 'arguments' must be an object (or a JSON-encoded one)") unless args
         result = @tools.call(name, args)
         write_result(id) do |j|
           j.object do
@@ -243,6 +245,31 @@ module Gori
             j.field "isError", result.is_error
           end
         end
+      end
+
+      # `params.arguments` as the object the tools layer reads, or nil when it is a shape that
+      # is not an argument list at all.
+      #
+      # An `as_h?`-only read answered nil for every other shape, and `Tools#call` substituted
+      # an EMPTY hash for it — so a client that stringifies its arguments (which happens, and
+      # which `RequestBuilder.header_pairs` already accepts one level down) had every argument
+      # silently dropped and was told "missing required 'id'" for a call that named `id`. The
+      # agent then "fixed" an argument it had sent correctly, in a loop. Parse the encoded
+      # form; refuse anything else HERE, as a protocol error, rather than run a tool with none
+      # of the arguments it was called with.
+      #
+      # Absent / null / blank all stay "no arguments" — a tool with only optional arguments is
+      # legitimately called that way, and `""` is what an LLM emits for it.
+      private def tool_arguments(params : JSON::Any?) : JSON::Any?
+        raw = obj_field(params, "arguments")
+        return EMPTY_ARGS if raw.nil? || raw.raw.nil?
+        return raw if raw.as_h?
+        if s = raw.as_s?
+          return EMPTY_ARGS if s.strip.empty?
+          parsed = (JSON.parse(s) rescue nil)
+          return parsed if parsed && parsed.as_h?
+        end
+        nil
       end
 
       # The structured-error contract: {error_code, message, field?, retryable,

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -2187,8 +2187,98 @@ module Gori
         j.field "effective_host", Serialize.text(sc.host)
       end
 
+      # A string-shaped argument, held to the same "lenient, but never SILENT" contract every
+      # other primitive on this surface already has.
+      #
+      # `h[key]?.try(&.as_s?)` alone answered nil for EVERY non-string shape, and each of the
+      # ~180 callers reads a nil as "the caller did not pass it". So a mistyped argument was
+      # accepted, checked against nothing, and discarded: `add_scope_rule{pattern: 8080}` came
+      # back "missing required 'pattern'" for a value it had just been handed, and
+      # `create_note{text: [1,2]}` stored an EMPTY note and reported success. The same nil
+      # reaching a tool with a documented default silently ran the default instead — the
+      # failure `bool_value` describes for `probe_scan{active: 1}`, spent on a string.
+      #
+      # A JSON scalar is COERCED, matching `header_pairs`' `v.as_s? || v.to_s` for header
+      # values and `int`'s acceptance of a numeric string: an unquoted `8080` in a string slot
+      # says one thing only. An array/object is REFUSED BY NAME — `JSON::Any#to_s` renders a
+      # Hash in CRYSTAL syntax (`{"a" => 1}`, not JSON), so coercing one would put text the
+      # caller never wrote into the store or onto the wire, which is worse than the drop. A
+      # JSON null stays ABSENT, which is what `present?` already means everywhere else.
+      #
+      # Raising is safe at every call site: `call` rescues `Gori::Error` into a clean
+      # INVALID_ARGUMENT. The one argument read BOTH ways — `ws_out_messages`, string or
+      # array — tries its array branch first, so only the object shape reaches here, and
+      # refusing that is the point (it used to store zero frames).
       private def str(h, key : String) : String?
-        h[key]?.try(&.as_s?)
+        v = h[key]?
+        return nil if v.nil? || v.raw.nil?
+        if s = v.as_s?
+          return s
+        end
+        if shape = container_shape(v)
+          raise Gori::Error.new("invalid '#{key}' (expected a string, got #{shape})")
+        end
+        v.to_s
+      end
+
+      # A string argument that is NOT coerced: only a genuine JSON string will do. For the
+      # `*_base64` arguments, whose whole contract is "these exact octets" — `base64_str`
+      # answered nil for a non-string, so `base64_str(h, "request_base64") || str(h, "request")`
+      # silently stored the NON-byte-exact request and reported success. Coercing would be
+      # worse than the drop here: `1234` would `to_s` into a string that DECODES (3 octets),
+      # so gori would send bytes the caller never named at all.
+      private def strict_str(h, key : String) : String?
+        v = h[key]?
+        return nil if v.nil? || v.raw.nil?
+        v.as_s? || raise Gori::Error.new("invalid '#{key}' (expected a base64 string)")
+      end
+
+      # "an array" / "an object", or nil for a scalar — the shapes `str` must refuse.
+      private def container_shape(v : JSON::Any) : String?
+        return "an array" if v.as_a?
+        return "an object" if v.as_h?
+        nil
+      end
+
+      # One entry of a string LIST, under `str`'s rule: a scalar is coerced, a container is
+      # refused by name. `arr.compact_map(&.as_s?)` silently DROPPED the entry instead, so
+      # `cookie_crack{secrets:["nope",12345]}` tried 1 of the 2 candidates and answered
+      # `found:false` — a false negative with `isError:false` — and `sequence_analyze` rated
+      # the randomness of a sample two thirds the size of the one submitted. Same fix, same
+      # reason as `ws_out_messages_arg`'s (its `compact_map` stored 2 of 4 frames and called
+      # it a clean send).
+      private def str_entry(v : JSON::Any, key : String) : String
+        if s = v.as_s?
+          return s
+        end
+        if (shape = container_shape(v)) || v.raw.nil?
+          raise Gori::Error.new("invalid '#{key}' entry #{v.to_json} (expected a string, got #{shape || "null"})")
+        end
+        v.to_s
+      end
+
+      # A list-of-strings argument in any shape a client sends: a real array, a JSON-ENCODED
+      # array (LLM clients stringify — `fuzz_marks` accepts the same two), or a BARE string as
+      # a one-element list, which is what a caller with a single secret reaches for and which
+      # used to become an empty list and an error naming the argument it had just supplied.
+      # Anything else is refused rather than silently emptied.
+      private def str_list(h, key : String) : Array(String)
+        raw = h[key]?
+        return [] of String if raw.nil? || raw.raw.nil?
+        if s = raw.as_s?
+          return [] of String if s.strip.empty?
+          if s.lstrip.starts_with?('[') && (parsed = (JSON.parse(s) rescue nil)) && (arr = parsed.as_a?)
+            return arr.map { |v| str_entry(v, key) }
+          end
+          return [s]
+        end
+        # A bare SCALAR is one candidate, exactly as a bare string is: `secrets: 12345` is a
+        # single numeric secret, which is the same shape as the numeric ENTRY this reader was
+        # fixed to stop dropping. Only a container in a list slot has no reading, and
+        # `str_entry` is what says so — naming the shape actually sent, rather than telling a
+        # caller who wrote a number that it passed an object.
+        arr = raw.as_a? || return [str_entry(raw, key)]
+        arr.map { |v| str_entry(v, key) }
       end
 
       # A `*_base64` argument decoded into the exact bytes it names, as a String (Crystal
@@ -2201,7 +2291,7 @@ module Gori
       # rather than falling back: a caller reaching for this argument wants exact bytes, and
       # silently sending different ones is the failure it came here to avoid.
       private def base64_str(h, key : String) : String?
-        s = h[key]?.try(&.as_s?)
+        s = strict_str(h, key)
         return nil if s.nil? || s.empty?
         begin
           String.new(Base64.decode(s))

--- a/src/gori/mcp/tools/cookie.cr
+++ b/src/gori/mcp/tools/cookie.cr
@@ -135,12 +135,8 @@ module Gori
         end
       end
 
-      private def str_list(h, key : String) : Array(String)
-        raw = h[key]?
-        return [] of String unless raw
-        arr = raw.as_a? || return [] of String
-        arr.compact_map(&.as_s?)
-      end
+      # `str_list` lives in tools.cr now: `secrets` and `tokens` had two near-identical readers
+      # that BOTH dropped a non-string entry, and one grammar gets one behaviour.
     end
   end
 end

--- a/src/gori/mcp/tools/fuzz.cr
+++ b/src/gori/mcp/tools/fuzz.cr
@@ -467,7 +467,7 @@ module Gori
         pattern = strict_jstr(obj, "pattern")
         raise FuzzArgError.new(%(processor "regex_replace" needs a non-empty 'pattern' string)) if pattern.nil? || pattern.empty?
         regex = Regex.new(pattern) rescue raise FuzzArgError.new("invalid processors.regex_replace pattern '#{pattern}'")
-        Fuzz::RegexReplace.new(regex, strict_jstr(obj, "replacement") || "")
+        Fuzz::RegexReplace.new(regex, demanded_jstr(obj, "replacement", %(processor "regex_replace")) || "")
       end
 
       # Like `jstr`, but WITHOUT its `v.to_s` fallback: a JSON null/array/object stays nil
@@ -509,7 +509,11 @@ module Gori
 
       private def fuzz_source_from(obj : Hash(String, JSON::Any), spec : JSON::Any) : Fuzz::PayloadSource
         if list = obj["list"]?.try(&.as_a?)
-          Fuzz::InlineList.new(list.map { |x| x.as_s? || x.to_s })
+          # `x.as_s? || x.to_s` coerced a nested array/object too, and `JSON::Any#to_s`
+          # renders those in CRYSTAL syntax (`{"a" => 1}`) — so a mistyped entry became a
+          # payload nobody wrote and every request built from it was wasted. Scalars still
+          # coerce (`list: [1,2]` means "1","2"); a container is refused by name.
+          Fuzz::InlineList.new(list.map { |x| str_entry(x, "list") })
         elsif b64 = obj["list_base64"]?.try(&.as_a?)
           # The byte-exact payload list. `list` entries are JSON strings put on the wire as
           # their UTF-8 encoding, so `é` went out as 2 bytes and a byte-level set (0x00-0xFF,
@@ -524,7 +528,7 @@ module Gori
           # on the server's disk ("file": built-in first, de-duped). Reject a typo up front
           # with the list, rather than let it surface as an empty run.
           raise FuzzArgError.new("unknown preset #{preset.inspect} (available: #{Fuzz::Presets.names.join(", ")})") unless Fuzz::Presets.exists?(preset)
-          Fuzz::PresetSource.new(preset, obj["file"]?.try(&.as_s?).presence)
+          Fuzz::PresetSource.new(preset, demanded_jstr(obj, "file", "payload set").try(&.presence))
         elsif nums = obj["numbers"]?
           fuzz_numbers(nums)
         elsif (nul = obj["null"]?) && (n = (nul.as_i64? || nul.as_s?.try(&.to_i64?)))
@@ -648,11 +652,28 @@ module Gori
           end
         {status: jstr(obj, "status"), grpc: jstr(obj, "grpc"), size: jstr(obj, "size"),
          words: jstr(obj, "words"), lines: jstr(obj, "lines"),
-         regex: obj["regex"]?.try(&.as_s?)}
+         regex: demanded_jstr(obj, "regex", which)}
       end
 
+      # A matcher/filter condition as text. `status: 500` means "500" — that leniency is the
+      # point of the `to_s` — but a CONTAINER used to stringify too, and `JSON::Any#to_s`
+      # renders one in Crystal syntax (`{"a" => 1}`), which then failed the condition grammar
+      # under a message naming a value the caller never wrote. `str_entry` is the one rule.
       private def jstr(obj : Hash(String, JSON::Any), key : String) : String?
-        obj[key]?.try { |v| v.as_s? || v.to_s }
+        obj[key]?.try { |v| v.raw.nil? ? nil : str_entry(v, key) }
+      end
+
+      # `strict_jstr`, except that a PRESENT non-string raises instead of reading as absent —
+      # `Tools#str`'s rule, for the three fuzz arguments that were still falling back
+      # silently. Each one quietly changed the sweep the caller then read as complete: a
+      # non-string `replacement` became `""` (so the processor DELETED every match instead of
+      # replacing it), a non-string `file` dropped the user's merged wordlist from the run, and
+      # a non-string `regex` dropped a whole MATCHER while the results were reported as
+      # filtered.
+      private def demanded_jstr(obj : Hash(String, JSON::Any), key : String, which : String) : String?
+        v = obj[key]?
+        return nil if v.nil? || v.raw.nil?
+        v.as_s? || raise FuzzArgError.new("#{which} '#{key}' must be a string")
       end
 
       private def fuzz_regex(s : String?, which : String) : Regex?

--- a/src/gori/mcp/tools/sequence.cr
+++ b/src/gori/mcp/tools/sequence.cr
@@ -18,11 +18,12 @@ module Gori
         Result.new(Sequencer::Present.report_json(Sequencer::Stats.analyze(tokens)))
       end
 
+      # Through the shared `str_list`: a numeric token is a token (it is COERCED, not dropped),
+      # and a non-string entry is refused by name. `compact_map(&.as_s?)` discarded it, so a
+      # 3-token sample was rated as a 2-token one and the report described a set the caller
+      # never submitted.
       private def sequence_token_list(h) : Array(String)
-        raw = h["tokens"]?
-        return [] of String unless raw
-        arr = raw.as_a? || return [] of String
-        arr.compact_map(&.as_s?).map(&.strip).reject(&.empty?)
+        str_list(h, "tokens").map(&.strip).reject(&.empty?)
       end
 
       private def sequence_start(h) : Result


### PR DESCRIPTION
`h[key]?.try(&.as_s?)` answered nil for **every** non-string shape, and all ~180 callers on the MCP surface read a nil as *"the caller did not pass it."* So a mistyped argument was accepted, checked against nothing, and discarded — and where a send was involved, the call still came back `isError:false` with an `effective_request` echo of a request that never existed.

Every one below was reproduced through the built binary over stdio before the fix, and each has a failing-then-passing example in `spec/mcp_str_args_spec.cr`.

| call | what gori actually did |
|---|---|
| `send_request{method: 123}` | fell back to the default and sent a **GET** — the caller measured a verb it never sent |
| `send_request{body: {"user":"admin"}}` | sent **no body and no Content-Length** (the shape an LLM reaches for on any JSON API) |
| `send_request{raw: [...]}` | fell through to the structured builder and sent a bare GET to `url` |
| `create_repeater{request_base64: 1234}` | `base64_str` answered nil, so `\|\| str(h, "request")` won and the **non-byte-exact** request was stored as if it were the octets asked for |
| `add_scope_rule{pattern: 8080}` | `"missing required 'pattern'"` — for a value it had just been handed |
| `create_note{text: [1,2]}` | stored an **empty** note, reported success |
| `cookie_crack{secrets: ["nope", 12345]}` | tried 1 of 2 candidates, answered `found:false` — a false negative the caller cannot see |
| `sequence_analyze{tokens: ["a","b",1234]}` | rated the randomness of a **2**-token sample when 3 were submitted |
| `tools/call{arguments: "{\"id\":1}"}` | a client that stringifies its arguments had **every** one dropped, then was told `"missing required 'id'"` |

## The class this finishes

The sibling primitives closed this one at a time — `bool_value` (a `1` is refused by name), `optional_int_arg`, `RequestBuilder.header_pairs` (*"RAISE on anything else rather than vanish"*), `ws_out_messages_arg` (whose `compact_map` stored 2 of 4 frames and called it a clean send). The string readers were what was left.

**One rule, at every site.** A JSON scalar is **coerced** — matching `header_pairs`' `v.as_s? || v.to_s` for header values and `int`'s acceptance of a numeric string, because an unquoted `8080` in a string slot says one thing only. An array/object is **refused by name**: `JSON::Any#to_s` renders a Hash in *Crystal* syntax (`{"a" => 1}`, not JSON), so coercing one would put text the caller never wrote into the store or onto the wire — worse than the drop. A JSON `null` stays **absent**, which is what `present?` already means everywhere else.

Two deliberate exceptions, both strict (a present non-string raises, no coercion):

- **The wire fields** (`url`, `raw`, `method`, `body`, `raw_base64`, `body_base64`) — the reason `strict_jstr` already gives in `fuzz.cr`: these values *are* the message. Serializing an object body would invent a Content-Type and a length the caller never stated, so it says so and lets the agent retry.
- **`base64_str`** — coercing here would be worse than the drop: `1234` would `to_s` into a string that *decodes* to 3 octets, so gori would send bytes the caller never named.

## Why `str` centrally, and how the blast radius was checked

`str` is the lever: one edit covers all ~180 tool arguments and cannot drift from them. The one argument read **both** ways, `ws_out_messages`, tries its array branch first, so only the object shape reaches `str` — and refusing that is the point, since it used to store zero frames and report success. Checked the other direction too: of every argument the schema declares as a non-string (`headers`, `marks`, `payloads`, `processors`, `tokens`, `secrets`, `messages`, `filter`, `h2_fields`, `list*`), none but `ws_out_messages` is read through `str` at all.

Also folded in, same class:

- `secrets` and `tokens` had two near-identical list readers that **both** dropped a non-string entry. They share `str_list` now — array, JSON-encoded array, or a bare string as a one-element list (the shape a caller with a single secret reaches for, which used to become an empty list and an error naming the argument it had just supplied). One grammar, one behaviour.
- Three fuzz arguments still fell back silently, each quietly changing the sweep the caller then read as complete: a non-string `replacement` became `""` (the processor **deleted** every match instead of substituting), a non-string `file` dropped the user's merged wordlist, a non-string `regex` dropped a whole **matcher**. `jstr` stringified containers too.
- At the transport, a non-object `arguments` is a protocol error (`-32602`) rather than a tool run with none of the arguments it was called with; the JSON-encoded object form is accepted, as `header_pairs` already accepts it one level down. Absent / null / blank still mean "no arguments".

## Verification

- `spec/mcp_str_args_spec.cr`, in the shape `mcp_bool_args_spec.cr` established: every refusal asserted to **name** its argument, with a complement beside each one proving the leniency and the documented shapes still work — a string body still goes out byte-for-byte with its `Content-Length`, `body: null` is still bodiless, the array and newline-string forms of `ws_out_messages` still store 2 and 3 frames, a genuinely wrong candidate list still reports no match. **19 examples; all 11 pre-existing behaviours failed before this change.**
- Full suite: **7667 examples, 8 failures** — the known-environmental `Gori::Session` port-bind set (a live gori process holds the port), identical before and after, and untouched here.
- `crystal tool format --check` clean on every changed file; `ameba` finds **16** findings on these files before and after — zero added.
- End-to-end through the built binary over stdio: `method: 123` → `invalid 'method' (expected a JSON string)`, `body: {…}` → names `body` and points at `body_base64`, `arguments: [1,2]` → `-32602`, and a stringified `arguments` carrying `pattern: 8080` now stores `"8080"`.