### PR TITLE
One vocabulary for the TUI: chrome, colour, wording, the pointer, and the keys

### DIFF
--- a/spec/support/fake_context.cr
+++ b/spec/support/fake_context.cr
@@ -376,6 +376,14 @@ class FakeExecContext < Gori::Verb::ExecContext
     rec(:fuzz_automark)
   end
 
+  def fuzz_mark_word : Nil
+    rec(:fuzz_mark_word)
+  end
+
+  def fuzz_insert_marker : Nil
+    rec(:fuzz_insert_marker)
+  end
+
   def fuzz_attach_chain : Nil
     rec(:fuzz_attach_chain)
   end

--- a/spec/support/fake_context.cr
+++ b/spec/support/fake_context.cr
@@ -476,6 +476,22 @@ class FakeExecContext < Gori::Verb::ExecContext
     @sequence_report_ready
   end
 
+  def miner_rename_subtab : Nil
+    rec(:miner_rename_subtab)
+  end
+
+  def miner_close_subtab : Nil
+    rec(:miner_close_subtab)
+  end
+
+  def sequencer_rename_subtab : Nil
+    rec(:sequencer_rename_subtab)
+  end
+
+  def sequencer_close_subtab : Nil
+    rec(:sequencer_close_subtab)
+  end
+
   def miner_duplicate_subtab : Nil
     rec(:miner_duplicate_subtab)
   end
@@ -1179,6 +1195,14 @@ class FakeExecContext < Gori::Verb::ExecContext
 
   def rewriter_rules_sub? : Bool
     @rewriter_rules_sub
+  end
+
+  # Defaults to "the list has focus" so every existing rule-verb expectation keeps its
+  # meaning; a test that wants a preview pane focused sets it false.
+  property rewriter_rule_list_focused = true
+
+  def rewriter_rule_list_focused? : Bool
+    @rewriter_rules_sub && @rewriter_rule_list_focused
   end
 
   def rewriter_preview_out? : Bool

--- a/spec/tui/color_semantics_spec.cr
+++ b/spec/tui/color_semantics_spec.cr
@@ -83,3 +83,69 @@ describe "state signals carry a word or a glyph" do
     offenders.should be_empty
   end
 end
+
+# Two axes, one ladder. Severity (CRIT/HIGH/MED/LOW/INFO) and triage status
+# (conf/fp/done/open) are drawn five columns apart on every row of the Issues and Probe
+# lists, and both used to draw from red/accent/muted — so `CRIT conf` was two reds meaning
+# two different things and `LOW open` two accents. On a list whose entire job is "scan for
+# red", three of five reds could be triage state.
+describe "severity and triage status" do
+  it "do not share a colour ladder" do
+    root = File.join(__DIR__, "..", "..", "src", "gori", "tui")
+    # The hues severity owns. A status branch reaching for any of them is the collision.
+    severity_hues = ["Theme.red", "Theme.orange", "Theme.yellow", "Theme.accent"]
+    offenders = [] of String
+    {"issues_view.cr", "probe_view.cr"}.each do |name|
+      src = File.read(File.join(root, name))
+      body = src[/def status_color\(s : Store::Status\).*?\n    end/m]?
+      body.should_not be_nil
+      severity_hues.each do |hue|
+        offenders << "#{name} — status_color uses #{hue}" if body.not_nil!.includes?(hue)
+      end
+    end
+    # The picker teaches what a status colour MEANS, so it must not contradict the lists.
+    picker = File.read(File.join(root, "choice_picker.cr"))
+    status_block = picker[/def self\.for_status.*?\n    end/m].not_nil!
+    severity_hues.each do |hue|
+      offenders << "choice_picker.cr — for_status uses #{hue}" if status_block.includes?(hue)
+    end
+    offenders.should be_empty
+  end
+end
+
+# `theme.cr` sanctions exactly two jobs for `focus_gold`: the brand mark, and the focus
+# outline. Everything else that reached for it made one of those two unreadable — the
+# Repeater's transport chip rides the same card border that goes gold on focus, and the
+# chain overlay borrowed it (through `marker_accent`) to mean provenance.
+describe "focus_gold" do
+  it "does not fill a chip that rides a focusable card's own border" do
+    # The Repeater's `^V:h2` transport chip fills when the operator has overridden transport
+    # auto-detection, and it sits ON the TARGET card's top border — the same border that goes
+    # `focus_gold` when the card has focus. Filling it gold put two golds on one edge and
+    # "gold means focus is here" stopped being readable. It is a bold ACCENT pill now: still
+    # the loudest thing on the band, no longer competing with the focus outline.
+    src = File.read(File.join(__DIR__, "..", "..", "src", "gori", "tui", "repeater_view.cr"))
+    chip = src[/if transport_badge_lit\?.*?end/m].not_nil!
+    chip.should_not contain("focus_gold")
+  end
+
+  it "does not stand in for provenance on the chain overlay" do
+    # `marker_accent` IS `focus_gold` under another name, documented for one job: the closing
+    # § of a marker that hides a ¦chain. The step list borrowed it to mean "this resolved to a
+    # SAVED library chain" — provenance, which is the question `env_known` already answers for
+    # a `$TOKEN` that resolved.
+    # Match the STEP-STATE line, not a guessed spelling of the expression: the first attempt
+    # asserted `category.saved? ? Theme.marker_accent` and the real code reads
+    # `try(&.category.saved?) ?`, so the control run reintroducing the bug passed.
+    src = File.read(File.join(__DIR__, "..", "..", "src", "gori", "tui", "chain_overlay.cr"))
+    step_line = src.lines.find(&.includes?("category.saved?")).not_nil!
+    step_line.should_not contain("marker_accent")
+  end
+
+  # NOT asserted here, and deliberately: `RepeaterView#pane_border` returns `accent` instead of
+  # `focus_gold` while a focused pane is in INSERT mode, so the most active pane in the app is
+  # the one that is not gold. That reads like the same defect — two axes (focus, mode) sharing
+  # one channel, with the mode already stated by the `↵:READ`/`INS` badge on the same border —
+  # but it is long-standing behaviour the Fuzzer copies, and changing it moves the most-used
+  # pane in gori. It wants its own decision, not a spec smuggled in beside two settled ones.
+end

--- a/spec/tui/color_semantics_spec.cr
+++ b/spec/tui/color_semantics_spec.cr
@@ -1,0 +1,85 @@
+require "../spec_helper"
+
+include Gori::Tui
+
+# `theme.cr` states the intent in its own header: "Only HTTP status keeps functional colour",
+# and every one of the 28 palettes annotates its three semantic slots the same way —
+# green 2xx, yellow 4xx, red 5xx/error. `Theme.status_color` is that ladder as code.
+#
+# The Repeater then hand-rolled the mapping twice, twenty lines apart in one file, and got two
+# different answers for the same fact: `st >= 400 ? red : text` on the gRPC transcript and
+# `st >= 400 ? yellow : green` on the head line. So a 404 was RED in one pane and yellow in
+# the next — red being the colour every other surface reserves for 5xx.
+describe "HTTP status colour" do
+  it "comes from Theme.status_color, never a local >= 400 test" do
+    root = File.join(__DIR__, "..", "..", "src", "gori", "tui")
+    offenders = [] of String
+    Dir.glob(File.join(root, "**", "*.cr")).sort.each do |path|
+      next if File.basename(path) == "theme.cr" # the ladder itself
+      File.read(path).lines.each_with_index do |line, i|
+        # A status threshold deciding a colour on the same line — the shape both Repeater
+        # sites had. Comparisons only: `status:>=500` inside the Intercept filter bar's
+        # EXAMPLE string is prose about the query language, not a colour decision, and it
+        # sits on a line that also names a Theme colour for the bar itself.
+        next unless line.matches?(/[a-z_]\s*>=?\s*(400|500|200|300)\b/)
+        next unless line.matches?(/\?.*Theme\.|Theme\..*:/)
+        offenders << "#{File.basename(path)}:#{i + 1} — #{line.strip}"
+      end
+    end
+    offenders.should be_empty
+  end
+
+  it "keeps the ladder's four rungs distinct in intent" do
+    # Not a rendering assertion — the palettes are free to collapse rungs (19 of 28 make
+    # `accent` equal `text` or `text_bright`, which is why every one of these cells also
+    # carries the NUMBER). This pins the mapping itself, which is what the hand-rolled
+    # versions got wrong: one collapsed 3xx into green, the other 4xx into red.
+    Theme.apply("goridark")
+    Theme.status_color(204).should eq(Theme.green)
+    Theme.status_color(301).should eq(Theme.accent)
+    Theme.status_color(404).should eq(Theme.yellow)
+    Theme.status_color(503).should eq(Theme.red)
+    Theme.status_color(nil).should eq(Theme.muted)
+  end
+end
+
+# A state an operator acts on must be readable WITHOUT colour. gori ships HIGH_CONTRAST (where
+# accent, text and text_bright are all `#ffffff`) and palettes like MATRIX where the semantic
+# hues sit close together, so a hue-only signal is not merely an accessibility nicety here —
+# it is invisible on themes the app itself offers.
+describe "state signals carry a word or a glyph" do
+  it "says whether capture is running, in words" do
+    # Both states used to render the byte-identical `● 127.0.0.1:8070`, differing only by
+    # green-vs-muted. The project picker already wrote `off`; the top bar now does too.
+    src = File.read(File.join(__DIR__, "..", "..", "src", "gori", "tui", "chrome.cr"))
+    body = src[/def self\.listen_chip.*?\n    end/m]?.should_not be_nil
+    src[/def self\.listen_chip.*?\n    end/m].not_nil!.should contain("off")
+  end
+
+  it "marks a hotkey rebind's outcome with a glyph, not just a hue" do
+    # `✓` / `✗` — the notification centre's vocabulary. Both outcomes used to print `•` and
+    # differ only by green-vs-yellow, the closest pair in several shipped palettes.
+    src = File.read(File.join(__DIR__, "..", "..", "src", "gori", "tui", "hotkeys_overlay.cr"))
+    footer = src[/def render_footer.*?\n    end/m].not_nil!
+    footer.should contain("'✓'")
+    footer.should contain("'✗'")
+  end
+
+  it "spells :error the same colour wherever the symbol is used" do
+    # `:error` was yellow in the Hotkeys footer and red in the notification centre — one
+    # symbol name, one meaning, two hues.
+    root = File.join(__DIR__, "..", "..", "src", "gori", "tui")
+    offenders = [] of String
+    Dir.glob(File.join(root, "**", "*.cr")).sort.each do |path|
+      File.read(path).lines.each_with_index do |line, i|
+        # Colour branches only. `:error` is also a key in the mascot's FACE table and the
+        # pet's mood map, where it selects a glyph and an animation — different channels,
+        # and neither names a colour.
+        next unless line.matches?(/when :error\s+then.*Theme\./)
+        next if line.includes?("Theme.red")
+        offenders << "#{File.basename(path)}:#{i + 1} — #{line.strip}"
+      end
+    end
+    offenders.should be_empty
+  end
+end

--- a/spec/tui/color_semantics_spec.cr
+++ b/spec/tui/color_semantics_spec.cr
@@ -149,3 +149,35 @@ describe "focus_gold" do
   # but it is long-standing behaviour the Fuzzer copies, and changing it moves the most-used
   # pane in gori. It wants its own decision, not a spec smuggled in beside two settled ones.
 end
+
+# A pane's border answers ONE question: does this pane have focus. The mode it is in — READ or
+# INS — is answered by the badge riding that same border, and putting both on the outline made
+# the most active pane in the app the one that was not gold.
+#
+# Three views carried a private `pane_border` with a third dress for "focused and typing"
+# (`insert ? Theme.accent : Theme.focus_gold`) while four insert-capable panes — Decoder, JWT,
+# Issues, Intercept — never had one. It cost legibility too: `accent` equals `text_bright` on
+# nine of the 28 palettes, so the pane being typed into outlined itself in the brightest colour
+# the theme has.
+describe "pane borders" do
+  it "are drawn by Frame.pane_border alone" do
+    # No local copy, not even a pass-through: a private `pane_border` that merely forwards is
+    # exactly the seam the third dress grew in, and four files had one.
+    root = File.join(__DIR__, "..", "..", "src", "gori", "tui")
+    offenders = [] of String
+    Dir.glob(File.join(root, "**", "*.cr")).sort.each do |path|
+      next if File.basename(path) == "frame.cr"
+      File.read(path).lines.each_with_index do |line, i|
+        next unless line.matches?(/def [a-z_]*pane_border/)
+        offenders << "#{File.basename(path)}:#{i + 1} — #{line.strip}"
+      end
+    end
+    offenders.should be_empty
+  end
+
+  it "take focus as their only input" do
+    Theme.apply("goridark")
+    Frame.pane_border(true).should eq(Theme.focus_gold)
+    Frame.pane_border(false).should eq(Theme.border)
+  end
+end

--- a/spec/tui/colormarker_view_spec.cr
+++ b/spec/tui/colormarker_view_spec.cr
@@ -1,0 +1,86 @@
+require "../spec_helper"
+
+include Gori::Tui
+
+# The Colormarker list's geometry, which is really ONE invariant stated three times:
+# `render`, `row_capacity` and `row_at` must agree about whether the interior's bottom row
+# belongs to the rules or to the "first enabled match wins" note.
+#
+# They did not. `render` stole that row whenever a second rule existed, while capacity
+# reported the full interior and `row_at` mapped every row inside it — so the last rule
+# scrolled underneath the note with no way to reach it, and a click on the prose selected a
+# rule that was not under the pointer. The twin next door (`RewriterView#list_row_capacity` /
+# `#row_at`) had always subtracted its own stolen row; this list was the copy that never
+# caught up. These examples exist to keep the three answers in step.
+describe Gori::Tui::ColormarkerView do
+  view = Gori::Tui::ColormarkerView.new
+
+  # A card whose framed interior is `h` rows tall — `render` insets by 1 on every side.
+  card = ->(h : Int32) { Rect.new(0, 0, 60, h + 2) }
+
+  describe "#row_capacity" do
+    it "keeps the whole interior when a lone rule cannot contend with anything" do
+      # The note only means something once two rules can both match, so with 0 or 1 rules
+      # `render` draws no note and the list is free to use every row.
+      view.row_capacity(card.call(6), 0).should eq(6)
+      view.row_capacity(card.call(6), 1).should eq(6)
+    end
+
+    it "gives the note its row back once two rules can contend" do
+      view.row_capacity(card.call(6), 2).should eq(5)
+    end
+
+    it "keeps every row in a card too short to spare one for the note" do
+      # `render` skips the note at an interior of 2 or less rather than leave a single
+      # rule row, so capacity must not subtract one either.
+      view.row_capacity(card.call(2), 5).should eq(2)
+      view.row_capacity(card.call(1), 5).should eq(1)
+    end
+  end
+
+  describe "#row_at" do
+    it "maps interior rows to rule indices from the scroll offset" do
+      rect = card.call(6)
+      view.row_at(rect, 1, 0, 4).should eq(0)
+      view.row_at(rect, 3, 0, 4).should eq(2)
+      view.row_at(rect, 1, 2, 4).should eq(2)
+    end
+
+    it "refuses the note's row instead of resolving it to a rule" do
+      # Interior spans y 1..6 and the note takes y 6, leaving five rows for rules. With five
+      # rules every one of them is reachable and the note is still not: clicking the prose
+      # used to select whatever index that row happened to land on.
+      rect = card.call(6)
+      view.row_at(rect, 5, 0, 5).should eq(4)
+      view.row_at(rect, 6, 0, 5).should be_nil
+    end
+
+    it "refuses a row past the last rule" do
+      # Six rows of interior, two rules: rows 3..5 are empty canvas, not rule 2/3/4.
+      rect = card.call(6)
+      view.row_at(rect, 3, 0, 2).should be_nil
+    end
+
+    it "refuses anything outside the framed interior" do
+      rect = card.call(6)
+      view.row_at(rect, 0, 0, 4).should be_nil # the top border
+      view.row_at(rect, 7, 0, 4).should be_nil # the bottom border
+    end
+
+    it "never resolves a row the capacity does not admit" do
+      # The invariant the two methods broke, stated directly: every row `row_at` accepts has
+      # to be one `row_capacity` claimed exists, at every size the card can take.
+      (1..8).each do |h|
+        rect = card.call(h)
+        [0, 1, 2, 5].each do |count|
+          cap = view.row_capacity(rect, count)
+          (rect.y...rect.bottom).each do |my|
+            next unless idx = view.row_at(rect, my, 0, count)
+            idx.should be < cap
+            idx.should be < count
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/tui/confirm_wording_spec.cr
+++ b/spec/tui/confirm_wording_spec.cr
@@ -1,0 +1,47 @@
+require "../spec_helper"
+
+# How a confirm dialog is DRESSED, which had split into two conventions.
+#
+# `ConfirmDialog` renders both strings verbatim — the heading through `Frame.card`, the
+# button through `render_button` — so the two spellings really did reach the screen. Eleven
+# dialogs shouted an uppercase noun over a lowercase button (`DELETE ISSUE` / `delete`),
+# matching every card title in gori; six newer ones used sentence case with a capitalised
+# button (`Delete rule` / `Delete`), which also put a `Delete` next to the `cancel` that
+# `ConfirmDialog` supplies by default — mixed case inside one dialog.
+#
+# The rule: the heading names the subject in caps, the buttons are lowercase verbs.
+describe "confirm dialog wording" do
+  root = File.join(__DIR__, "..", "..", "src", "gori", "tui")
+
+  it "gives every dialog an UPPERCASE heading" do
+    offenders = [] of String
+    Dir.glob(File.join(root, "**", "*.cr")).sort.each do |path|
+      File.read(path).lines.each_with_index do |line, i|
+        next unless m = line.match(/\bconfirm\("([^"]+)"/)
+        heading = m[1]
+        # Interpolated headings are built at runtime; only literal prose is checkable here.
+        next if heading.includes?("\#{")
+        next if heading == heading.upcase
+        offenders << "#{File.basename(path)}:#{i + 1} — #{heading}"
+      end
+    end
+    offenders.should be_empty
+  end
+
+  it "gives every dialog lowercase button verbs" do
+    # Both buttons, because the pair is what an operator reads at once: `confirm_label` is
+    # per-site and `cancel_label` defaults to `cancel`, so a capitalised confirm verb is the
+    # one that breaks the pair.
+    offenders = [] of String
+    Dir.glob(File.join(root, "**", "*.cr")).sort.each do |path|
+      File.read(path).lines.each_with_index do |line, i|
+        line.scan(/(?:confirm|cancel)_label: "([^"]+)"/) do |m|
+          label = m[1]
+          next if label == label.downcase
+          offenders << "#{File.basename(path)}:#{i + 1} — #{label}"
+        end
+      end
+    end
+    offenders.should be_empty
+  end
+end

--- a/spec/tui/discover_headers_overlay_spec.cr
+++ b/spec/tui/discover_headers_overlay_spec.cr
@@ -112,12 +112,13 @@ describe Gori::Tui::DiscoverHeadersOverlay do
   it "does not hold the operator behind a refusal the card has no room to draw" do
     # THE TRAP. `try_commit` is this sub-editor's ONLY exit, and it refuses while any line
     # is unusable — but the refusal is drawn on the render branch that needs a card, and
-    # `overlay_box` bails below w 34 / h 8. `Layout.usable?` admits 40x8, so the whole
-    # 8–17-row band is live-but-unrenderable: esc → :stay, click-away → :stay, and the one
+    # `overlay_box` bails below a 34x8 card, which a modal's 4x2 inset puts at a 38x10 area.
+    # `Layout.usable?` admits 40x8, so 40x8 and 40x9 are live-but-unrenderable: a body in that
+    # band gets esc → :stay, click-away → :stay, and the one
     # line that DOES draw advertises "esc to close", a key that never fires. Only ^C/^D
     # (quitting gori outright) or a resize got out. A refusal nobody can read is a lock,
     # not a guard, so it may only hold while the card that explains it is on screen.
-    band = Gori::Tui::Rect.new(0, 0, 40, 10)
+    band = Gori::Tui::Rect.new(0, 0, 40, 9)
     ov = DiscoverHeadersOverlay.new([] of {String, String})
     ov.overlay_box(band).should be_nil
     h = OverlayHarness.new(ov, area: band)

--- a/spec/tui/discover_runs_pane_spec.cr
+++ b/spec/tui/discover_runs_pane_spec.cr
@@ -39,7 +39,11 @@ describe "Discover RUNS list" do
     backend.contains?("http://a.test/").should be_true
     backend.contains?("http://b.test/").should be_true
     backend.contains?("http://c.test/").should be_true
-    backend.contains?("RUNS (3)").should be_true
+    # The count moved out of the card TITLE and onto `Frame.border_meta`: the run badge's
+    # `min_x` is derived from the title's width, so `RUNS (9)` → `RUNS (10)` shifted the chrome.
+    # Still on the border, still says how many — just right-aligned and independent of the title.
+    backend.row(0).should contain("RUNS")
+    backend.row(0).should contain("3")
     # Each row carries its own status, so "which one is still sending" is readable at a glance.
     row_of(backend, "http://b.test/").should_not eq(-1)
     backend.row(row_of(backend, "http://b.test/")).should contain("paused")
@@ -82,7 +86,11 @@ describe "Discover RUNS list" do
     backend = render_runs(view)
     # The newest run is selected, so the window must have followed the selection down.
     backend.contains?("http://h19.test/").should be_true
-    backend.contains?("RUNS (20)").should be_true
+    # The count moved out of the card TITLE and onto `Frame.border_meta`: the run badge's
+    # `min_x` is derived from the title's width, so `RUNS (9)` → `RUNS (10)` shifted the chrome.
+    # Still on the border, still says how many — just right-aligned and independent of the title.
+    backend.row(0).should contain("RUNS")
+    backend.row(0).should contain("20")
 
     view.move_run(-19) # back to the first run
     top = render_runs(view)

--- a/spec/tui/esc_destination_spec.cr
+++ b/spec/tui/esc_destination_spec.cr
@@ -1,0 +1,68 @@
+require "../spec_helper"
+
+# `esc tabs` is a PROMISE about where escape lands, and on nine surfaces it was wrong.
+#
+# `Runner#focus_pane` downgrades `:subtabs` to `:menu` only when no strip is shown
+# (`runner.cr`, "never strand focus on an absent strip"). Sitemap, Discover, OAST, Notes,
+# Decoder, JWT and Probe's Rules list all show one, so escape stopped at the sub-tab strip
+# while their hints said it went to the tab bar — one level further than it goes. The Project
+# tab had the right wording all along (`esc sub-tabs`), which is what this pins the rest to.
+#
+# Checked against the CODE rather than a list of strings: a controller that sends escape to
+# `:subtabs` must not promise `esc tabs` in the same file. That way a new tab inherits the
+# rule instead of a hand-maintained exemption list.
+describe "the esc hint names where esc actually goes" do
+  it "never says `esc tabs` where EVERY escape lands on the sub-tab strip" do
+    # The condition is "every", not "any", and that is what makes this checkable without an
+    # exemption list. A tab may legitimately route escape both ways: Probe sends it to the
+    # strip on the Rules sub-tab (`probe_controller`) and to the tab bar on Findings
+    # (`verbs/probe.cr`, `probe.leave`), so `esc tabs` is true on one of its two hints. A
+    # controller with NO route to `:menu` has no such defence — every `esc tabs` in it is a
+    # promise nothing keeps.
+    root = File.join(__DIR__, "..", "..", "src", "gori")
+    offenders = [] of String
+    Dir.glob(File.join(root, "tui", "controllers", "*.cr")).sort.each do |path|
+      src = File.read(path)
+      # `esc sub-tabs` contains `esc tabs` as a substring; the preceding char separates them.
+      next unless src.matches?(/[^-]esc tabs/)
+      # BOTH files decide where escape goes, and which one owns it varies: Sitemap and
+      # Discover route it from their verbs, Probe and OAST from their controllers. Reading
+      # only the controller made this check silently miss the two verb-routed tabs — it
+      # passed a control run that reintroduced Sitemap's wrong hint.
+      name = File.basename(path).sub("_controller.cr", ".cr")
+      verbs_path = File.join(root, "verbs", name)
+      verbs = File.exists?(verbs_path) ? File.read(verbs_path) : ""
+      # File-level, not line-level. An escape handler is routinely several lines from the
+      # focus call it ends in (`jwt_controller`: `commit` then `request_focus(:subtabs)` inside
+      # an else-branch), so a one-line regex saw only the terse `when key.escape? then …`
+      # controllers and let the multi-line ones through — it passed a control run that
+      # reintroduced JWT's wrong hint. The cost of the looser test is that a `:menu` route
+      # reached by some key OTHER than escape counts as a defence; that is acceptable here,
+      # because it can only ever make this check quieter, never wrong about a file it flags.
+      # CODE only. Reading whole files means comments count too, and the comment in
+      # `verbs/oast.cr` explaining why its `focus_pane(:menu)` verbs were REMOVED read as a
+      # live `:menu` route and shielded OAST from this very check.
+      code = ->(text : String) do
+        text.lines.reject(&.lstrip.starts_with?('#')).join('\n')
+      end
+      src_code = code.call(src)
+      verbs_code = code.call(verbs)
+      routes = ->(pane : String) do
+        src_code.includes?("request_focus(:#{pane})") || verbs_code.includes?("focus_pane(:#{pane})")
+      end
+      next unless routes.call("subtabs")
+      offenders << File.basename(path) unless routes.call("menu")
+    end
+    offenders.should be_empty
+  end
+
+  it "leaves no escape verb registered where a controller already claims the key" do
+    # `Verb` registrations for escape are unreachable on any scope whose controller answers
+    # escape and returns true. Two sat on the OAST sub-tabs saying `focus_pane(:menu)` while
+    # the live handler went to `:subtabs` — dead code that also documented the wrong
+    # destination, which is how the hint came to say it too.
+    verbs_dir = File.join(__DIR__, "..", "..", "src", "gori", "verbs")
+    oast = File.read(File.join(verbs_dir, "oast.cr"))
+    oast.should_not contain(%(Verb::Chord.new("escape")))
+  end
+end

--- a/spec/tui/fuzz_advanced_overlay_spec.cr
+++ b/spec/tui/fuzz_advanced_overlay_spec.cr
@@ -150,12 +150,13 @@ describe Gori::Tui::FuzzAdvancedOverlay do
     #
     # Production hands `layout.body`, which is what makes this reachable: the card clips to
     # 14 rows there, so only 11 of the 17 ROWS are drawn. Under the harness's 80x24 default
-    # every row fits and `visible == ROWS.size` hides the whole bug.
-    body = Gori::Tui::Rect.new(2, 4, 76, 18)
+    # every row fits and `visible == ROWS.size` hides the whole bug. The 16-row body is what
+    # yields that 14-row card now that every modal insets from its area by 2.
+    body = Gori::Tui::Rect.new(2, 4, 76, 16)
     ov = FuzzAdvancedOverlay.new(blank_snapshot)
     h = OverlayHarness.new(ov, area: body)
     box = h.box.not_nil!
-    box.y.should eq(6) # rows run box.y+1 (7) .. 17; hint on 18, border on 19
+    box.y.should eq(5) # rows run box.y+1 (6) .. 16; hint on 17, border on 18
 
     h.click_in_box(2, 12).should eq(:open) # the hint row
     h.click_in_box(2, 13).should eq(:open) # the bottom border
@@ -175,12 +176,12 @@ describe Gori::Tui::FuzzAdvancedOverlay do
   end
 
   it "offsets a click by the scroll position once the list has scrolled" do
-    # Production hands an overlay `layout.body` — 6 rows shorter and offset from the screen —
-    # so this 18-row card renders clipped to 14 and the row list must scroll to reach the
+    # Production hands an overlay `layout.body` — shorter than the screen and offset from it —
+    # so this 16-row body renders a card clipped to 14 and the row list must scroll to reach the
     # bottom fields. That scroll is what makes handle_click's `@scroll + i` load-bearing:
     # @scroll only ever advances inside `render`, so a click example that never renders
     # leaves it at 0, where `@scroll + i` and plain `i` are indistinguishable.
-    body = Gori::Tui::Rect.new(2, 4, 76, 18)
+    body = Gori::Tui::Rect.new(2, 4, 76, 16)
     ov = FuzzAdvancedOverlay.new(blank_snapshot)
     h = OverlayHarness.new(ov, area: body)
     h.box.should_not be_nil

--- a/spec/tui/fuzz_set_overlay_spec.cr
+++ b/spec/tui/fuzz_set_overlay_spec.cr
@@ -96,8 +96,8 @@ describe Gori::Tui::FuzzSetOverlay do
     spec = ov.build_spec.not_nil!
     spec.kind.should eq(:preset)
     Gori::Fuzz::Presets.names.should contain(spec.value) # a real preset name
-    ov.handle_key(okey(Termisu::Input::Key::Down))  # Type row → the Preset selector
-    ov.handle_key(okey(Termisu::Input::Key::Right)) # cycle to the next preset
+    ov.handle_key(okey(Termisu::Input::Key::Down))       # Type row → the Preset selector
+    ov.handle_key(okey(Termisu::Input::Key::Right))      # cycle to the next preset
     ov.build_spec.not_nil!.value.should_not eq(spec.value)
   end
 
@@ -241,11 +241,12 @@ describe Gori::Tui::FuzzSetOverlay do
   end
 
   it "hit-tests rows against the rect the shell passes (layout.body)" do
-    # Production hands an overlay `layout.body` — 6 rows shorter and offset from the screen,
+    # Production hands an overlay `layout.body` — shorter than the screen and offset from it,
     # so this 20-row card renders clipped to 14 and sits lower. Only CLICKS can tell the two
     # areas apart: handle_key never sees `area`, so driving keys through a smaller rect would
-    # be a byte-for-byte copy of the DEFAULT_AREA examples above.
-    body = Gori::Tui::Rect.new(2, 4, 76, 18)
+    # be a byte-for-byte copy of the DEFAULT_AREA examples above. A 16-row body is what yields
+    # the 14-row card now that every modal insets from its area by 2.
+    body = Gori::Tui::Rect.new(2, 4, 76, 16)
     ov = FuzzSetOverlay.for_list
     h = OverlayHarness.new(ov, area: body)
     box = h.box.not_nil!

--- a/spec/tui/fuzzer_target_chrome_spec.cr
+++ b/spec/tui/fuzzer_target_chrome_spec.cr
@@ -1,0 +1,71 @@
+require "../spec_helper"
+require "../support/memory_backend"
+
+include Gori::Tui
+
+# The Fuzzer's TARGET border carries two things on its right: the mode chip `Frame` draws, and
+# an `SNI` marker shown when an override is set. The marker used to place itself at
+# `rect.right - size - 1` — inside the mode chip's own cells — so setting an override painted
+# over the right of ` ↵:READ ` and left `↵: SNI ` on the border. The hit-test still measured
+# the whole mode rect underneath, so a press on the letters an operator could SEE saying SNI
+# toggled insert mode.
+#
+# Repeater met this first and chained the marker left of the chip instead
+# (`repeater_view.cr#target_chrome_chain`, whose comment describes exactly this). These pin
+# the ported fix in both halves — what is drawn, and what a press does — and locate the marker
+# by READING the rendered row rather than by asking the view, so a geometry that renders one
+# way and hit-tests another cannot satisfy both examples.
+private def sni_fuzzer(sni : String) : FuzzerView
+  view = FuzzerView.new
+  view.load_request("https://1.2.3.4", "GET / HTTP/1.1\r\nHost: vhost.test\r\n\r\n", false, sni)
+  view
+end
+
+private def border_row(view : FuzzerView, rect : Rect) : String
+  backend = MemoryBackend.new(rect.right, rect.bottom)
+  view.render(Screen.new(backend), rect, focused: false)
+  backend.row(rect.y)
+end
+
+describe "FuzzerView TARGET border chrome" do
+  rect = Rect.new(0, 0, 60, 20)
+
+  it "leaves the mode chip intact when an SNI override is set" do
+    row = border_row(sni_fuzzer("alt.example.com"), rect)
+    row.should contain("SNI")
+    # `↵:READ` in full. Before the fix the row read `↵: SNI `, the marker having eaten the
+    # chip's last three cells.
+    row.should contain(Frame.mode_badge_label(false).strip)
+    row.should_not contain("↵: SNI")
+  end
+
+  it "does not answer the mode chip for a press on the SNI marker" do
+    view = sni_fuzzer("alt.example.com")
+    row = border_row(view, rect)
+    x = row.index("SNI").not_nil!
+    # Every cell of the marker is inert: it reports what it IS, it is not a control.
+    ((x - 1)...(x + 4)).each do |mx|
+      view.target_chrome_hit(rect, mx, rect.y).should be_nil
+    end
+  end
+
+  it "still answers the mode chip on the chip's own cells" do
+    # The positive control — without it the example above also passes for a hit-test that has
+    # simply stopped working.
+    view = sni_fuzzer("alt.example.com")
+    row = border_row(view, rect)
+    mode_x = row.index("↵:READ").not_nil!
+    view.target_chrome_hit(rect, mode_x, rect.y).should eq(:mode)
+  end
+
+  it "shows no marker at all without an override" do
+    border_row(sni_fuzzer(""), rect).should_not contain("SNI")
+  end
+
+  it "drops the marker rather than overlapping when the card is too narrow" do
+    # `Frame`'s badges drop out when they do not fit; the hand-rolled marker clamped with
+    # `.max` and drew over the card title instead.
+    row = border_row(sni_fuzzer("alt.example.com"), Rect.new(0, 0, 18, 20))
+    row.should_not contain("SNI")
+  end
+end

--- a/spec/tui/help_view_spec.cr
+++ b/spec/tui/help_view_spec.cr
@@ -6,8 +6,8 @@ include Gori::Tui
 describe Gori::Tui::HelpView do
   it "renders the grouped shortcut sections" do
     view = HelpView.new
-    backend = MemoryBackend.new(100, 120) # tall enough for every row (grows as tabs are added)
-    view.render(Screen.new(backend), Rect.new(0, 0, 100, 120))
+    backend = MemoryBackend.new(100, 240) # tall enough for every row (grows as tabs are added)
+    view.render(Screen.new(backend), Rect.new(0, 0, 100, 240))
 
     backend.contains?("GLOBAL").should be_true
     backend.contains?("command palette").should be_true
@@ -15,6 +15,19 @@ describe Gori::Tui::HelpView do
     backend.contains?("REPEATER").should be_true
     backend.contains?("rename").should be_true  # the new sub-tab rename shortcut is documented
     backend.contains?("DECODER").should be_true # the Decoder tab cheat-sheet
+  end
+
+  it "gives every workbench tab a section" do
+    # Miner, JWT and OAST had none, while Sequencer — also default-hidden — had a full one,
+    # so "it's a hidden tab" was never the rule. Three tabs whose whole keyboard surface was
+    # missing from the one screen that exists to answer "what can I press here".
+    #
+    # Title-matched rather than rendered, so a section that scrolls off a short terminal still
+    # counts: this is about the CONTENT existing, not about it fitting.
+    titles = HelpView::SECTIONS.map { |(t, _)| t }
+    %w(REPEATER FUZZER MINER SEQUENCER JWT OAST DECODER COMPARER REWRITER COLORMARKER).each do |tab|
+      titles.should contain(tab)
+    end
   end
 
   it "scrolls — the first section leaves and the last arrives" do

--- a/spec/tui/intercept_content_length_spec.cr
+++ b/spec/tui/intercept_content_length_spec.cr
@@ -101,7 +101,7 @@ describe "InterceptView Content-Length sync toggle" do
       view = def_edited.call(ic)
       backend = MemoryBackend.new(120, 14)
       view.render(Screen.new(backend), Rect.new(0, 0, 120, 14))
-      backend.contains?("^l:CL").should be_true
+      backend.contains?("^L:CL").should be_true # uppercase, like every other chord badge
     end
   end
 end

--- a/spec/tui/intercept_view_spec.cr
+++ b/spec/tui/intercept_view_spec.cr
@@ -47,7 +47,11 @@ describe Gori::Tui::InterceptView do
       view.reload(ic)
       backend = MemoryBackend.new(100, 12)
       view.render(Screen.new(backend), Rect.new(0, 0, 100, 12))
-      backend.contains?("QUEUE (1)").should be_true # framed queue pane title
+      # The count left the TITLE for the border's right edge (`Frame.border_meta`), so it is
+      # no longer contiguous with the word — a count baked into a title makes the title's
+      # width a moving target for anything else riding that border.
+      queue_row = (0...backend.size[1]).find { |y| backend.row(y).includes?("QUEUE") }.not_nil!
+      backend.row(queue_row).should contain("1") # the count, right-aligned on the same border
       backend.contains?("REQ").should be_true
       backend.contains?("acme.test/login").should be_true
     end
@@ -634,12 +638,12 @@ describe "Intercept filter bar" do
 
       backend = MemoryBackend.new(100, 12)
       view.render(Screen.new(backend), Rect.new(0, 0, 100, 12))
-      idle_row = (0...12).find { |y| backend.row(y).includes?("QUEUE (1)") }
+      idle_row = (0...12).find { |y| backend.row(y).includes?("QUEUE") }
 
       view.start_query
       backend = MemoryBackend.new(100, 12)
       view.render(Screen.new(backend), Rect.new(0, 0, 100, 12))
-      query_row = (0...12).find { |y| backend.row(y).includes?("QUEUE (1)") }
+      query_row = (0...12).find { |y| backend.row(y).includes?("QUEUE") }
 
       idle_row.should_not be_nil
       query_row.should eq(idle_row.not_nil! + 1)
@@ -697,7 +701,7 @@ describe "Intercept filter bar" do
       backend = MemoryBackend.new(100, 12)
       view.render(Screen.new(backend), Rect.new(0, 0, 100, 12))
       backend.row(0).includes?("c:ALL").should be_true # bar on the top row
-      backend.contains?("QUEUE (1)").should be_true    # queue card still drawn below
+      backend.contains?("QUEUE").should be_true        # queue card still drawn below
       backend.contains?("acme.test/login").should be_true
     end
   end

--- a/spec/tui/mode_badge_contract_spec.cr
+++ b/spec/tui/mode_badge_contract_spec.cr
@@ -1,0 +1,62 @@
+require "../spec_helper"
+
+# `Frame.mode_badge`'s doc-comment states the rule in its own words: "`insert` must be the
+# pane's REAL mode — never `focused && insert?`." It says why, too — the two labels are
+# different WIDTHS (` ↵:READ ` is 8 cells, ` INS ` is 5), and every caller's hit-test passes
+# the bare mode, because a click handler has no idea which pane had focus when the frame was
+# drawn. Gate the draw on focus and the two geometries stop describing the same rectangle.
+#
+# Two callers broke it anyway, and the Issues one broke it in the worst available way: in
+# insert-but-unfocused NOTHING was painted on the border while the controller went on
+# hit-testing a five-cell INS rect, so clicking blank border cells turned insert off. Nothing
+# exits insert on a focus change, so that state is ordinary rather than exotic.
+#
+# The rule is checkable in source and cheap to check, which is the whole reason to: a comment
+# that has already been ignored twice is not a guard.
+describe "Frame.mode_badge callers" do
+  it "pass the pane's real mode, never a focus-gated one" do
+    root = File.join(__DIR__, "..", "..", "src", "gori", "tui")
+    offenders = [] of String
+    Dir.glob(File.join(root, "**", "*.cr")).sort.each do |path|
+      next if File.basename(path) == "frame.cr"
+      src = File.read(path)
+      src.lines.each_with_index do |line, i|
+        next unless line.includes?("Frame.mode_badge(")
+        # The mode is the last argument. A `focused && …` there is the exact shape the
+        # contract forbids; so is a local whose own definition ANDs focus in, which is how
+        # all three of these were written (`ins = focused && insert_mode?`).
+        #
+        # Strip the trailing comment FIRST: the Repeater's call carries the words
+        # "not focused&&mode — see Frame.mode_badge" after it, and splitting on the last comma
+        # of the raw line took the comment's tail for the argument. And match `focused` as a
+        # WORD — the Fuzzer passes `template_insert? || @chain_focused`, which is a different
+        # flag whose name merely ends in it.
+        code = line.split('#')[0]
+        arg = code.rpartition(',')[2].strip.rstrip(')')
+        bad = arg.matches?(/(^|[^a-z_])focused\b/) ||
+              src.matches?(/\b#{Regex.escape(arg)}\s*=\s*focused\s*&&/)
+        offenders << "#{File.basename(path)}:#{i + 1} — #{arg}" if bad
+      end
+    end
+    offenders.should be_empty
+  end
+
+  it "draw the badge unconditionally, so the hit rect is never on a blank border" do
+    # The second half of the same defect: `if focused` around the CALL leaves the controller's
+    # hit-test live over cells with nothing drawn on them. A caller may of course return early
+    # for a card too small to draw — that is `mode_badge`'s own `min_x` drop — but focus must
+    # not decide whether the chip exists.
+    root = File.join(__DIR__, "..", "..", "src", "gori", "tui")
+    offenders = [] of String
+    Dir.glob(File.join(root, "**", "*.cr")).sort.each do |path|
+      next if File.basename(path) == "frame.cr"
+      lines = File.read(path).lines
+      lines.each_with_index do |line, i|
+        next unless line.includes?("Frame.mode_badge(")
+        prev = lines[i - 1]?.try(&.strip) || ""
+        offenders << "#{File.basename(path)}:#{i + 1}" if prev.matches?(/^if\s+.*\bfocused\b/)
+      end
+    end
+    offenders.should be_empty
+  end
+end

--- a/spec/tui/mouse_geometry_spec.cr
+++ b/spec/tui/mouse_geometry_spec.cr
@@ -239,6 +239,35 @@ describe "marker actions across the two template editors" do
     end
   end
 
+  # The space-menu letter is the thing a hand learns, so the two panes must not disagree on
+  # it. Three of the five did — auto-mark was 'a' in the Repeater and 'm' in the Fuzzer, and
+  # attach-chain / clear-marks were 'c'/'e' against 'e'/'c', i.e. SWAPPED: pressing the letter
+  # you know from one pane ran a DIFFERENT action in the other, which is worse than a no-op.
+  # Aligned on the Repeater's letters, where the muscle memory is.
+  {
+    {"repeater.auto-mark", "fuzz.automark"},
+    {"repeater.mark-word", "fuzz.mark-word"},
+    {"repeater.insert-marker", "fuzz.insert-marker"},
+    {"repeater.clear-marks", "fuzz.clear-marks"},
+    {"repeater.attach-chain", "fuzz.attach-chain"},
+    {"repeater.pretty-request", "fuzz.pretty-template"},
+    {"repeater.toggle-http2", "fuzz.toggle-http2"},
+  }.each do |(rep, fuzz)|
+    it "gives #{rep.split('.').last} the same menu letter in both panes" do
+      registry[rep].menu_key.should eq(registry[fuzz].menu_key)
+    end
+  end
+
+  it "leaves the SNI pair apart, because the Fuzzer cannot have the Repeater's letter" do
+    # NOT drift, and the one pair deliberately left unmatched: the space menu shows COMMON
+    # plus the focused section, and `fuzz.stop` already owns 's' in the Fuzzer's COMMON —
+    # the Repeater has no stop verb, so 's' was free there. Aligning would raise at boot.
+    registry["repeater.toggle-sni"].menu_key.should eq('s')
+    registry["fuzz.toggle-sni"].menu_key.should_not eq('s')
+    registry.find { |v| v.scope == Gori::Verb::Scope::Fuzzer && v.section == :common && v.menu_key == 's' }
+      .should_not be_nil
+  end
+
   it "gives every marker action a space-menu entry in both panes" do
     # `menu_key` nil ⇒ the verb is EXCLUDED from the space menu. That is what the Fuzzer's
     # two `chord_action` arms amounted to: no verb, so nothing to list.

--- a/spec/tui/mouse_geometry_spec.cr
+++ b/spec/tui/mouse_geometry_spec.cr
@@ -280,3 +280,37 @@ describe "marker actions across the two template editors" do
     end
   end
 end
+
+# Review findings, each pinned so the fix is a rule rather than a patch.
+describe "code-review fixes" do
+  it "keeps the ^T:MARK badge off a decode split, where ^T means something else" do
+    # `repeater.toggle-decoded` is context-sensitive: on a SAML/GraphQL tab `^T` switches
+    # ENVELOPE ⇄ DECODED instead of inserting a §. `req_split?` routes those through the SAME
+    # `render_request`, so the badge was drawn — and clickable — reading `^T:MARK` while the
+    # key it names did something unrelated. Draw and hit are gated together.
+    src = File.read(File.join(__DIR__, "..", "..", "src", "gori", "tui", "repeater_view.cr"))
+    draw = src[/# …and NOT on a decode split.*?end/m].not_nil!
+    draw.should contain("!decode_mode?")
+    hit = src[/` \^T:MARK ` chains LEFT.*?return :mark/m].not_nil!
+    hit.should contain("!decode_mode?")
+  end
+
+  it "makes a rule-list click SELECT, never toggle, in all three lists" do
+    # `probe-rules.toggle` gave up its `↵` because "a reflex carried from any other rule list
+    # silently disabled a scanning rule here" — and the pointer path kept exactly that hazard,
+    # toggling on a second click while neither sibling does.
+    root = File.join(__DIR__, "..", "..", "src", "gori", "tui", "controllers")
+    {"probe_controller.cr", "rewriter_controller.cr", "colormarker_controller.cr"}.each do |f|
+      src = File.read(File.join(root, f))
+      body = src[/def handle_click.*?\n    end/m].not_nil!
+      body.should_not match(/selected_index == idx \? \w*toggle/)
+    end
+  end
+
+  it "snaps the Probe Rules gauge to a row that can actually take the selection" do
+    # `@rows` interleaves three `:header` rows and an `:empty` placeholder; `select_index`
+    # refuses them, so a raw proportional hit was a silent no-op on ~4 of ~40 track positions.
+    src = File.read(File.join(__DIR__, "..", "..", "src", "gori", "tui", "probe_rules_view.cr"))
+    src[/def gauge_row_at.*?\n    end/m].not_nil!.should contain("nearest_selectable")
+  end
+end

--- a/spec/tui/mouse_geometry_spec.cr
+++ b/spec/tui/mouse_geometry_spec.cr
@@ -171,20 +171,83 @@ describe "Runner double-click dispatch" do
   end
 end
 
-# A key printed on a badge or in a hint must be a key that does something. The Repeater's
-# ` ^K:MARK ` badge and two hint strings advertised ctrl-K, which is bound nowhere in the app —
-# legacy from a marking flow that `^T` replaced. (The Fuzzer's `^K`/`^T` are live: that
-# controller handles them directly in `chord_action` rather than through the verb registry,
-# which is why a registry-only search reads them as dead.)
+# A key printed on a badge or in a hint must be a key that DOES something. The Repeater's
+# ` ^K:MARK ` badge and two hint strings advertised ctrl-K, which at the time was bound
+# nowhere in the app — legacy from a marking flow `^T` had replaced. Nothing failed; the key
+# simply did nothing, and only a hand audit would ever notice.
+#
+# So: every `^<letter>` this pane PRINTS must be reachable in it. The two panes answer that
+# question by different routes — the Repeater defers every ctrl chord to the keymap, the
+# Fuzzer claims a few directly in `chord_action` — so the check unions both.
 describe "advertised chords" do
-  it "leaves no ^K in the Repeater, which binds none" do
-    src = File.read(File.join(__DIR__, "..", "..", "src", "gori", "tui", "repeater_view.cr"))
-    src.should_not contain("^K")
+  registry = Gori::Verbs.registry
+
+  # Ctrl letters a scope can actually receive: registry bindings, plus the letters the
+  # controller intercepts itself before the keymap sees them.
+  reachable = ->(scope : Gori::Verb::Scope, controller : String) do
+    keys = Set(String).new
+    registry.each { |v| v.chords.each { |c| keys << c.key if c.ctrl && v.scope == scope } }
+    src = File.read(File.join(__DIR__, "..", "..", "src", "gori", "tui", "controllers", controller))
+    if body = src[/private def chord_action.*?\n    end/m]?
+      body.scan(/key\.lower_([a-z])\?/) { |m| keys << m[1] }
+    end
+    # Plus the shell's own — ^G goto, ^F find, ^B reveal and friends are dispatched in
+    # `Runner#handle_key` before any tab sees them, so a hint naming one is telling the truth.
+    # Derived, not listed: a hard-coded set would rot the moment the shell grew a chord.
+    shell = File.read(File.join(__DIR__, "..", "..", "src", "gori", "tui", "runner.cr"))
+    shell.scan(/ev\.ctrl\? && ev\.key\.lower_([a-z])\?/) { |m| keys << m[1] }
+    keys.concat(%w(p w z n)) # palette / close sub-tab / undo / new, claimed per-controller
+    keys
   end
 
-  it "still finds ctrl-K live in the Fuzzer, so the check above is about the Repeater alone" do
-    src = File.read(File.join(__DIR__, "..", "..", "src", "gori", "tui",
-      "controllers", "fuzzer_controller.cr"))
-    src[/private def chord_action.*?\n    end/m].not_nil!.should contain("lower_k?")
+  # Ctrl letters PRINTED by a file — badge labels and hint strings alike.
+  advertised = ->(file : String) do
+    out = Set(String).new
+    File.read(File.join(__DIR__, "..", "..", "src", "gori", "tui", file)).each_line do |line|
+      next if line.matches?(/^\s*#/) # prose, not a label
+      line.scan(/\^([A-Z])/) { |m| out << m[1].downcase }
+    end
+    out
+  end
+
+  {
+    {"repeater_view.cr", "repeater_controller.cr", Gori::Verb::Scope::Repeater},
+    {"fuzzer_view.cr", "fuzzer_controller.cr", Gori::Verb::Scope::Fuzzer},
+  }.each do |(view, controller, scope)|
+    it "prints only chords #{view.split('_').first} can actually receive" do
+      have = reachable.call(scope, controller)
+      # `^C`/`^D` are the terminal's, and the hex editors print `^X`-style prose about BYTES.
+      shown = advertised.call(view) - Set{"c", "d"}
+      (shown - have).should be_empty
+    end
+  end
+end
+
+describe "marker actions across the two template editors" do
+  registry = Gori::Verbs.registry
+
+  {"mark-word" => "k", "insert-marker" => "t"}.each do |action, chord|
+    it "binds ^#{chord.upcase} to #{action} in BOTH panes" do
+      # `repeater.insert-marker` is the exception the pair does not break: `^T` there is
+      # `repeater.toggle-decoded`, one context-sensitive key that switches envelope/decoded on
+      # a SAML/GraphQL/WS tab and inserts a § everywhere else. Same keystroke, same gesture.
+      fuzz = registry["fuzz.#{action}"]
+      fuzz.chords.any? { |c| c.key == chord && c.ctrl }.should be_true
+      next if action == "insert-marker"
+      rep = registry["repeater.#{action}"]
+      rep.chords.any? { |c| c.key == chord && c.ctrl }.should be_true
+    end
+  end
+
+  it "gives every marker action a space-menu entry in both panes" do
+    # `menu_key` nil ⇒ the verb is EXCLUDED from the space menu. That is what the Fuzzer's
+    # two `chord_action` arms amounted to: no verb, so nothing to list.
+    %w(mark-word insert-marker automark clear-marks).each do |a|
+      fuzz_id = a == "automark" ? "fuzz.automark" : "fuzz.#{a}"
+      registry[fuzz_id].menu_key.should_not be_nil
+    end
+    %w(mark-word insert-marker auto-mark clear-marks).each do |a|
+      registry["repeater.#{a}"].menu_key.should_not be_nil
+    end
   end
 end

--- a/spec/tui/mouse_geometry_spec.cr
+++ b/spec/tui/mouse_geometry_spec.cr
@@ -1,0 +1,190 @@
+require "../spec_helper"
+
+include Gori::Tui
+
+# What gori DRAWS and what it HIT-TESTS, held to each other.
+#
+# This axis has produced real defects three times over: the Fuzzer's SNI badge overpainted the
+# mode chip so clicking the visible `SNI` letters toggled insert; `Frame.mode_badge` was passed
+# `focused && insert?` in three views, so an unfocused-but-inserting pane drew nothing while a
+# five-cell click target stayed live; and the Issues RELATED list drew its selection bar only
+# when active. Every rule below is a shape that has actually shipped broken.
+describe Gori::Tui::Frame do
+  # `toggle_badge` returns its `right_edge` UNCHANGED when a badge does not fit, so the chain
+  # keeps going and a SHORTER badge further left still draws at that same edge. The hit-test
+  # used to `break` out of the loop while its own doc comment claimed "(same as draw)".
+  describe ".right_badge_hit" do
+    it "skips a badge that does not fit and keeps testing the shorter ones, like the draw" do
+      # ` ^R:SEND ` is 9 cells and ` ^L:CL ` is 7. At a width where SEND cannot be drawn but CL
+      # can, CL is on screen — and used to be un-clickable.
+      badges = [{:send, "^R", "SEND"}, {:cl, "^L", "CL"}] of {Symbol, String, String}
+      right_edge = 20
+      min_x = 13 # SEND would start at 11 (< min_x); CL starts at 13 (fits)
+      Frame.right_badge_hit(14, 0, 0, right_edge, min_x, badges).should eq(:cl)
+    end
+
+    it "returns the same edge the draw does, so the next badge chains correctly" do
+      badges = [{:send, "^R", "SEND"}, {:cl, "^L", "CL"}] of {Symbol, String, String}
+      # SEND skipped (edge unchanged at 20), CL drawn at 13 → the next badge's edge is 13.
+      Frame.right_badge_edge(20, 13, badges).should eq(13)
+    end
+  end
+
+  # `Frame.chip` does not clip itself, so a caller that stops drawing at a limit must tell the
+  # hit-test — the Repeater's RESPONSE cluster is half-width and used to run through its own
+  # '╮' on the draw side only.
+  describe ".left_chip_hit" do
+    chips = [{:diff, " d:diff "}, {:hex, " ^X:hex "}] of {Symbol, String}
+
+    it "stops at the first chip that would cross the limit" do
+      # d:diff spans 10..17, ^X:hex 19..26. A limit of 20 means ^X:hex was never drawn.
+      Frame.left_chip_hit(20, 0, 0, 10, chips, limit: 20).should be_nil
+      Frame.left_chip_hit(12, 0, 0, 10, chips, limit: 20).should eq(:diff)
+    end
+
+    it "walks the whole run when no limit is given" do
+      Frame.left_chip_hit(20, 0, 0, 10, chips).should eq(:hex)
+    end
+  end
+
+  # The gauge is the one piece of chrome an operator reflexively grabs, and for 46 draw sites
+  # there was no hit-test of any kind.
+  describe ".scroll_gauge_top" do
+    content = Rect.new(0, 0, 10, 10) # gauge column is x == 10 (content.right)
+
+    it "refuses when the draw would refuse — a body that fits has no gauge to click" do
+      Frame.scroll_gauge_top(content, 10, 10, 0).should be_nil
+      Frame.scroll_gauge_top(Rect.new(0, 0, 10, 1), 100, 10, 0).should be_nil
+    end
+
+    it "refuses anywhere but the gauge column" do
+      Frame.scroll_gauge_top(content, 100, 9, 5).should be_nil
+      Frame.scroll_gauge_top(content, 100, 11, 5).should be_nil
+    end
+
+    it "puts the clicked cell in the MIDDLE of the thumb, and clamps at both ends" do
+      Frame.scroll_gauge_top(content, 100, 10, 0).should eq(0)
+      Frame.scroll_gauge_top(content, 100, 10, 9).should eq(90) # total - track
+      mid = Frame.scroll_gauge_top(content, 100, 10, 5).not_nil!
+      (0 < mid < 90).should be_true
+    end
+  end
+
+  describe ".scroll_gauge_row" do
+    content = Rect.new(0, 0, 10, 10)
+
+    it "maps the track's ends onto the FIRST and LAST rows" do
+      Frame.scroll_gauge_row(content, 100, 10, 0).should eq(0)
+      Frame.scroll_gauge_row(content, 100, 10, 9).should eq(99)
+    end
+
+    it "refuses off the gauge column and when nothing overflows" do
+      Frame.scroll_gauge_row(content, 100, 9, 5).should be_nil
+      Frame.scroll_gauge_row(content, 10, 10, 5).should be_nil
+    end
+  end
+end
+
+# A mode badge states its pane's OWN mode and is drawn unconditionally. `Frame.mode_badge`'s
+# contract says so and spells out the failure; three views broke it once and were fixed, then
+# the Decoder and JWT INPUT cards were found doing the same thing by gating the whole DRAW on
+# focus while their controllers hit-tested the bare mode. A click on blank border flipped the
+# editor into insert.
+describe "mode badges" do
+  it "are never drawn behind a focus gate" do
+    root = File.join(__DIR__, "..", "..", "src", "gori", "tui")
+    offenders = [] of String
+    Dir.glob(File.join(root, "**", "*.cr")).sort.each do |path|
+      next if File.basename(path) == "frame.cr" # the helper itself
+      lines = File.read(path).lines
+      lines.each_with_index do |line, i|
+        # CODE only. The first pass matched `focused&&mode` inside the Repeater's own comment
+        # saying NOT to do that — the third time a source-grep spec here has been fooled by the
+        # prose explaining the very rule it enforces.
+        code = line.sub(/\s#.*$/, "")
+        next unless code.includes?("Frame.mode_badge(")
+        # The two shapes that gate it: a `focused &&`-style argument on the call itself, and an
+        # `if <focus-ish>` on the line above wrapping the call.
+        offenders << "#{File.basename(path)}:#{i + 1} — #{code.strip}" if code.matches?(/Frame\.mode_badge\(.*\b(focused|active|reading)\b\s*&&/)
+        prev = lines[i - 1]?.try(&.sub(/\s#.*$/, ""))
+        next unless prev
+        offenders << "#{File.basename(path)}:#{i} — gated by #{prev.strip}" if prev.matches?(/^\s*if\s+(focused|active|reading)\b/)
+      end
+    end
+    offenders.should be_empty
+  end
+end
+
+# A hit-test must not accept a row the render RESERVED for something else. Three lists had this
+# and each was found separately: the Colormarker note row, the Sitemap tag prompt, and the
+# Probe Rules description footer. In every case a sibling on the same render pass (the gauge)
+# already had the geometry right.
+describe "reserved rows" do
+  it "are subtracted by the hit-test wherever the draw subtracts them" do
+    root = File.join(__DIR__, "..", "..", "src", "gori", "tui")
+    {"colormarker_view.cr" => "list_h",
+     "sitemap_view.cr"     => "@tagging",
+     "probe_rules_view.cr" => "list_h"}.each do |file, token|
+      src = File.read(File.join(root, file))
+      body = src[/def row_at\(.*?\n    end/m]?
+      body.should_not be_nil
+      body.not_nil!.should contain(token)
+    end
+  end
+end
+
+# A hit-test derived from a rect the renderer did not draw. `results_rect` backs both the
+# Fuzzer's RESULTS badge hits and its row hits, and had no `@focus == :detail` gate — while
+# `render_bottom` hands the whole band to the DETAIL card in exactly that state. A click on the
+# detail card's top border toggled DIST/MATCH/sort *and* threw the operator out of the detail.
+describe "FuzzerView#results_rect" do
+  it "is nil while the RESULT DETAIL card owns the band" do
+    src = File.read(File.join(__DIR__, "..", "..", "src", "gori", "tui", "fuzzer_view.cr"))
+    body = src[/private def results_rect\(rect : Rect\) : Rect\?.*?\n    end/m].not_nil!
+    # CODE lines only. The first control run PASSED with the gate removed, because the comment
+    # explaining the gate names the very expression being looked for — the same way the mode-badge
+    # check above was fooled. A source-grep spec has to read what RUNS.
+    code = body.lines.map(&.sub(/\s*#.*$/, "")).join("\n")
+    code.should contain("return nil if @focus == :detail")
+  end
+end
+
+# The shell used to gate `handle_double_click` on `supports_drag?`, which conflates "can extend
+# a text selection" with "can receive a double-click". Colormarker implements the gesture (it
+# opens the rule editor) and, being a list with no text, answers `supports_drag?` false — so
+# the shell never asked and a double-click read as two selects. Silent, and invisible from the
+# controller alone.
+describe "Runner double-click dispatch" do
+  it "does not require drag support" do
+    src = File.read(File.join(__DIR__, "..", "..", "src", "gori", "tui", "runner.cr"))
+    body = src[/private def dispatch_double_click.*?\n    end/m].not_nil!
+    body.should_not contain("drag_press_target?")
+    body.should contain("double_click_target?")
+  end
+
+  it "keeps the same context rejections as the drag tier" do
+    # Both must refuse the space menu, the pickers and the bottom prompts. Shared, so they
+    # cannot drift: the whole point of splitting them was to change ONE of the two questions.
+    src = File.read(File.join(__DIR__, "..", "..", "src", "gori", "tui", "runner.cr"))
+    src[/private def drag_press_target?.*?\n    end/m].not_nil!.should contain("pointer_capture_elsewhere?")
+    src[/private def double_click_target?.*?\n    end/m].not_nil!.should contain("pointer_capture_elsewhere?")
+  end
+end
+
+# A key printed on a badge or in a hint must be a key that does something. The Repeater's
+# ` ^K:MARK ` badge and two hint strings advertised ctrl-K, which is bound nowhere in the app —
+# legacy from a marking flow that `^T` replaced. (The Fuzzer's `^K`/`^T` are live: that
+# controller handles them directly in `chord_action` rather than through the verb registry,
+# which is why a registry-only search reads them as dead.)
+describe "advertised chords" do
+  it "leaves no ^K in the Repeater, which binds none" do
+    src = File.read(File.join(__DIR__, "..", "..", "src", "gori", "tui", "repeater_view.cr"))
+    src.should_not contain("^K")
+  end
+
+  it "still finds ctrl-K live in the Fuzzer, so the check above is about the Repeater alone" do
+    src = File.read(File.join(__DIR__, "..", "..", "src", "gori", "tui",
+      "controllers", "fuzzer_controller.cr"))
+    src[/private def chord_action.*?\n    end/m].not_nil!.should contain("lower_k?")
+  end
+end

--- a/spec/tui/overlay_c5_spec.cr
+++ b/spec/tui/overlay_c5_spec.cr
@@ -210,7 +210,9 @@ describe "C5 · HostsOverlay on the Overlay seam" do
       h.press(ENTER).should eq(:open) # ↵ commits the ROW, never the modal
       ov.to_overrides.should eq([{"staging.acme.test", "10.0.0.1"}])
       saves.size.should eq(1)
-      toasts.last.should eq("host override saved — 1 total")
+      # `added` / `updated`, the distinction the Project pane editing the same list already
+      # made — the overlay holds `@edit_index` and simply never said which it had done.
+      toasts.last.should eq("host override added — 1 total")
     end
   end
 
@@ -416,7 +418,7 @@ describe "C5 · EnvOverlay on the Overlay seam" do
       h.press(ENTER).should eq(:open)
       ov.to_config[1].should eq([{"HOST", "api.example.com"}])
       saves.size.should eq(1)
-      toasts.last.should eq("env var saved — 1 total")
+      toasts.last.should eq("env var added — 1 total")
     end
   end
 
@@ -435,7 +437,7 @@ describe "C5 · EnvOverlay on the Overlay seam" do
       mnemonic(h, 'a')
       h.type("HOST other")
       h.press(ENTER)
-      toasts.last.should eq("env var: KEY already defined")
+      toasts.last.should eq("env var: KEY already defined — edit it (e)")
       ov.to_config[1].should eq([{"HOST", "api.example.com"}]) # unchanged
     end
   end

--- a/spec/tui/overlay_c5_spec.cr
+++ b/spec/tui/overlay_c5_spec.cr
@@ -306,7 +306,7 @@ describe "C5 · HostsOverlay on the Overlay seam" do
       mnemonic(h, 'd')
       ov.to_overrides.should eq([{"beta.test", "10.0.0.2"}])
       saves.size.should eq(1)
-      toasts.last.should eq("removed host override: acme.test")
+      toasts.last.should eq("host override deleted: acme.test")
     end
   end
 
@@ -487,7 +487,9 @@ describe "C5 · EnvOverlay on the Overlay seam" do
       mnemonic(h, 'd')
       ov.to_config[1].should eq([{"HOST", "a"}])
       saves.size.should eq(1)
-      toasts.last.should eq("removed env: TOKEN")
+      # `<noun> deleted: <name>` — the shape every delete-success toast uses now, so it reads
+      # in parallel with its own failure line.
+      toasts.last.should eq("env var deleted: TOKEN")
     end
   end
 

--- a/spec/tui/overlay_hint_placement_spec.cr
+++ b/spec/tui/overlay_hint_placement_spec.cr
@@ -1,0 +1,68 @@
+require "../spec_helper"
+
+# WHERE a modal's key hint is allowed to live.
+#
+# The shell already draws the open modal's `hint` in the bottom status strip
+# (`Runner#key_hints` → `active_overlay.hint`), so a card that also painted a hint band was
+# showing the same advice twice — and the two copies had drifted, because only one of them
+# was the method every other surface reads. Six forms carried a literal that no longer
+# matched their own `hint`, one of them with a `←/›` typo that could not be seen from the
+# method at all.
+#
+# The rule that replaced them: a modal states KEYS in `hint` and nowhere else. What a card
+# may still say on a band is what the operator cannot infer from the form itself — a match
+# preview, a format rule, a refusal.
+#
+# Two placements are deliberately NOT covered here:
+#   · the degraded "needs a larger window · esc to close" line, which draws from `area` when
+#     the card cannot be drawn at all. It is the only thing on screen, so it names its escape.
+#   · a per-row affordance like a cycler's `‹/›`, which marks the key where the key applies.
+describe "Overlay key hints" do
+  it "are not painted onto the card by any modal" do
+    dir = File.join(__DIR__, "..", "..", "src", "gori", "tui")
+    # Vocabulary that only ever appears in a KEY hint. `esc to close` is absent on purpose:
+    # it belongs to the degraded line, which draws from `area` and is exempt below.
+    keyish = /esc cancel|esc close|esc saves|↵ save|↑\/↓ field|←\/→/
+    offenders = [] of String
+    Dir.glob(File.join(dir, "*.cr")).sort.each do |path|
+      src = File.read(path)
+      next unless src.includes?("< Overlay")
+      src.lines.each_with_index do |line, i|
+        # `box.` is what makes it a band on the DRAWN card; the degraded line uses `area.`.
+        next unless line.matches?(/screen\.text\(\s*box\./)
+        next unless line.matches?(keyish)
+        offenders << "#{File.basename(path)}:#{i + 1}"
+      end
+    end
+    offenders.should be_empty
+  end
+
+  it "spell the ←/→ clause the one way wherever it cycles options" do
+    # Six spellings had accumulated for one gesture — `options` / `kind` / `kind·type` /
+    # `scope/type` / `adjust` / `cycle` — which is exactly the drift an operator feels when
+    # two rule forms sit one keystroke apart.
+    #
+    # Scoped to hint STRINGS (a hint always names its escape, which is what `esc` selects
+    # for) and to forms that cycle: `←/→ edit` in the Fuzzer's advanced panel is NOT drift,
+    # because there the arrows step a value rather than walk a list of choices. A rule that
+    # forced one verb on both gestures would make the hint lie.
+    dir = File.join(__DIR__, "..", "..", "src", "gori", "tui")
+    cyclers = %w[
+      colormarker_rule_overlay custom_rule_overlay extract_rule_overlay
+      mine_config_overlay oast_provider_overlay rewriter_rule_overlay
+      scope_rule_overlay sequence_config_overlay
+    ]
+    offenders = [] of String
+    cyclers.each do |name|
+      path = File.join(dir, "#{name}.cr")
+      File.read(path).lines.each_with_index do |line, i|
+        line.scan(/"([^"]*←\/→ ([^ ·"]+)[^"]*)"/) do |m|
+          next unless m[1].includes?("esc") # a hint names its escape; prose does not
+          next if m[2] == "options"
+          offenders << "#{name}.cr:#{i + 1} — ←/→ #{m[2]}"
+        end
+      end
+    end
+    offenders.should be_empty
+  end
+end

--- a/spec/tui/project_view_spec.cr
+++ b/spec/tui/project_view_spec.cr
@@ -363,7 +363,10 @@ describe "ProjectView NETWORK pane" do
       b = MemoryBackend.new(120, 30)
       view.render(Screen.new(b), Rect.new(0, 0, 120, 30), focused: true)
       b.contains?("NETWORK").should be_true
-      b.contains?("ENV").should be_true # the chip strip still names every sub-tab
+      # The chip strip still names every sub-tab. Title Case since the strips were unified:
+      # four of the six in gori already read `Findings`/`Callbacks`/`Sitemap`, and this one
+      # shouted while the Rewriter's whispered — the renderer draws labels verbatim.
+      b.contains?("Env").should be_true
       b.contains?("Scope lens").should be_true
       b.contains?("Sandbox").should be_true
       b.contains?("Bind IP").should be_true

--- a/spec/tui/project_view_spec.cr
+++ b/spec/tui/project_view_spec.cr
@@ -209,8 +209,10 @@ describe "ProjectView SCOPE list" do
       view.focus_pane(:scope)
       b = MemoryBackend.new(120, 30)
       view.render(Screen.new(b), Rect.new(0, 0, 120, 30), focused: true)
-      b.contains?("no rules").should be_true
-      b.contains?("a to add").should be_true
+      # The wording every empty list in gori uses: what is missing, then `press a to add`.
+      # This pane used to say `(no rules — a to add)`, in parentheses and with a bare key.
+      b.contains?("no scope rules").should be_true
+      b.contains?("press a to add").should be_true
     end
   end
 end

--- a/spec/tui/repeater_transport_chip_spec.cr
+++ b/spec/tui/repeater_transport_chip_spec.cr
@@ -102,7 +102,7 @@ describe "RepeaterView transport chip" do
       view.transport_badge_lit?.should be_false
     end
 
-    it "wears the gold while the handshake is going out as plain HTTP" do
+    it "fills with accent while the handshake is going out as plain HTTP" do
       view = RepeaterView.new
       view.restore("https://ws.test", ws_head, false, true,
         ws_messages: [Gori::Store::WsOutMessage.text("hello")])
@@ -115,7 +115,12 @@ describe "RepeaterView transport chip" do
       view.cycle_ws_transport
       b2 = render.call(view, rect)
       h1_col = b2.row(rect.y).index("^V:WS→h1").not_nil!
-      b2.bg_at(h1_col, rect.y).should eq(Theme.focus_gold) # an override interrupts the glance
+      # ACCENT, not `focus_gold`. An override still has to interrupt the glance — that part
+      # was right — but this chip rides the TARGET card's own top border, and that border IS
+      # `focus_gold` when the card has focus. Filling it gold put two golds on one edge, so
+      # "gold means focus is here" stopped being readable on exactly the card an operator is
+      # most often typing into. Gold is focus and the brand mark; nothing else.
+      b2.bg_at(h1_col, rect.y).should eq(Theme.accent)
     end
 
     it "hit-tests the chip in both WS and overridden-HTTP shapes" do

--- a/spec/tui/selection_bar_spec.cr
+++ b/spec/tui/selection_bar_spec.cr
@@ -1,0 +1,34 @@
+require "../spec_helper"
+
+# The `▎` selection bar is the one glyph that has to read identically in every list gori
+# draws, because it answers the same question everywhere: you are here.
+#
+# Two lists had given it a second job. The Listeners overlay tinted it by the row's
+# status (red/green/muted) and the Passthrough overlay painted it `Theme.yellow` — so the
+# marker changed colour between two modals an operator opens from the same menu. Neither
+# tint carried information the row did not already state in words, and the status one could
+# not even be read: the glyph is drawn only on the SELECTED row (the rest get a space, where
+# a foreground colour renders nothing), so it coloured exactly one row at a time.
+describe "the ▎ selection bar" do
+  it "is drawn in Theme.accent by every list" do
+    root = File.join(__DIR__, "..", "..", "src", "gori", "tui")
+    offenders = [] of String
+    Dir.glob(File.join(root, "**", "*.cr")).sort.each do |path|
+      File.read(path).lines.each_with_index do |line, i|
+        # The selection-bar idiom specifically: glyph-or-space on a per-row flag, which is
+        # what makes the cell a MARKER COLUMN the list owns on every row. A bare `'▎'` is a
+        # different device — the Fuzzer draws one in `Theme.marker_hue` beside a `→N` chip to
+        # tie a row to its payload marker, and that one is meant to carry a colour.
+        next unless line.includes?("? '▎' : ' '")
+        next unless line.includes?("screen.cell")
+        # `pal.accent` is the wizard's THEME PREVIEW, which paints a sample row in the palette
+        # being previewed rather than the one in force. It is the only legitimate exception:
+        # drawing that row in the active theme would defeat the preview.
+        next if line.includes?("pal.accent")
+        next if line.includes?("Theme.accent")
+        offenders << "#{File.basename(path)}:#{i + 1}"
+      end
+    end
+    offenders.should be_empty
+  end
+end

--- a/spec/tui/shared_chrome_spec.cr
+++ b/spec/tui/shared_chrome_spec.cr
@@ -111,6 +111,23 @@ describe "shared card chrome" do
     offenders.should be_empty
   end
 
+  it "phrases an add-me-something empty state one way" do
+    # Five spellings for one sentence, split by which file drew it: the Project panes wrote
+    # `(no vars — a to add)` in parentheses with a bare key, the tab views wrote
+    # `no rules — press a to add` without them. Same list, same absence, same instruction.
+    offenders = [] of String
+    Dir.glob(File.join(root, "**", "*.cr")).sort.each do |path|
+      File.read(path).lines.each_with_index do |line, i|
+        # Keyed on the `a` KEY specifically: a settings opener row saying `↵ to add` is a
+        # different affordance, and "no flows left to add" is a toast, not an empty state.
+        next unless line.includes?("a to add")
+        next if line.includes?("press a to add")
+        offenders << "#{File.basename(path)}:#{i + 1} — #{line.strip}"
+      end
+    end
+    offenders.should be_empty
+  end
+
   it "leaves the scroll affordance to Frame.scroll_gauge" do
     # The Settings theme list painted ▲ / ▼ / ↕ into its own last interior column — an
     # affordance no other list in gori had, which said "there is more" without saying how

--- a/spec/tui/shared_chrome_spec.cr
+++ b/spec/tui/shared_chrome_spec.cr
@@ -36,6 +36,31 @@ describe "shared card chrome" do
     offenders.should be_empty
   end
 
+  it "leaves the ‹/› cycler to Frame.option_cycle" do
+    # Three dialects had grown for one control: the full strip (four rule forms, byte-identical
+    # private copies), the lit value alone (OAST provider, the Scope form's `kind:` row), and a
+    # value with the cue in its own colour drawn on every row whether focused or not (Miner,
+    # Sequencer, Probe active, Compact, Discover). The middle one is the costly one — a form
+    # whose entire first question is "include or exclude?" showed only the current answer.
+    #
+    # Colormarker's colour row is the sole exception and draws its own: each option carries a
+    # hue swatch, which no generic renderer can place. It is required to spell the cue the
+    # same way, which is what this check enforces for it.
+    offenders = [] of String
+    Dir.glob(File.join(root, "**", "*.cr")).sort.each do |path|
+      next if File.basename(path) == "frame.cr"
+      File.read(path).lines.each_with_index do |line, i|
+        next unless line.includes?("‹/›")
+        next unless line.includes?("screen.text")
+        # The one hand-drawn cue left, and it must match `option_cycle`'s exactly.
+        next if File.basename(path) == "colormarker_rule_overlay.cr" &&
+                line.includes?(%[" ‹/›", Theme.muted, bg) if row_sel])
+        offenders << "#{File.basename(path)}:#{i + 1}"
+      end
+    end
+    offenders.should be_empty
+  end
+
   it "leaves the scroll affordance to Frame.scroll_gauge" do
     # The Settings theme list painted ▲ / ▼ / ↕ into its own last interior column — an
     # affordance no other list in gori had, which said "there is more" without saying how
@@ -79,6 +104,66 @@ describe Gori::Tui::Frame do
       backend = MemoryBackend.new(40, 10)
       Frame.border_meta(Screen.new(backend), card, "SCOPE", "")
       backend.contains?("SCOPE").should be_false # nothing drawn at all — card() draws the title
+    end
+  end
+
+  describe ".option_cycle" do
+    it "draws the whole strip when there is room for it" do
+      # The point of a strip: the alternatives are visible without pressing anything.
+      backend = MemoryBackend.new(60, 4)
+      Frame.option_cycle(Screen.new(backend), 0, 0, 60, Theme.panel,
+        "kind:", ["include", "exclude"], 0, false)
+      backend.row(0).should contain("include")
+      backend.row(0).should contain("exclude")
+    end
+
+    it "falls back to the chosen value alone when the strip will not fit" do
+      # `MAX_REQ_CHOICES` is eight numbers plus `uncapped`; on a narrow card the strip would
+      # run off the row. The fallback is a WIDTH decision made here, which is what lets every
+      # caller use one renderer — the Miner and Sequencer configs used to hard-code it.
+      backend = MemoryBackend.new(30, 4)
+      opts = ["uncapped", "100", "250", "500", "1000", "2500", "5000", "10000"]
+      Frame.option_cycle(Screen.new(backend), 0, 0, 30, Theme.panel,
+        "max requests:", opts, 2, false)
+      backend.row(0).should contain("250")
+      backend.row(0).should_not contain("uncapped")
+      backend.row(0).should_not contain("10000")
+    end
+
+    it "shows the ‹/› cue only while the row has focus" do
+      # Several forms drew it on every row at once, which advertises keys that do nothing
+      # unless that row is the selected one.
+      focused = MemoryBackend.new(60, 4)
+      Frame.option_cycle(Screen.new(focused), 0, 0, 60, Theme.panel,
+        "kind:", ["include", "exclude"], 0, true)
+      focused.row(0).should contain("‹/›")
+
+      resting = MemoryBackend.new(60, 4)
+      Frame.option_cycle(Screen.new(resting), 0, 0, 60, Theme.panel,
+        "kind:", ["include", "exclude"], 0, false)
+      resting.row(0).should_not contain("‹/›")
+    end
+
+    it "reserves room for the cue, so focusing a row cannot push the strip off the edge" do
+      # A width that fits the strip but NOT the strip plus the cue must take the fallback,
+      # or selecting the row would silently truncate the last option.
+      opts = ["alpha", "bravo", "charlie"]
+      # label 5 + 1, strip = 7 + 7 + 9 = 23 → 29; the cue is 4 more.
+      backend = MemoryBackend.new(40, 4)
+      Frame.option_cycle(Screen.new(backend), 0, 0, 31, Theme.panel,
+        "kind:", opts, 1, true)
+      backend.row(0).should contain("bravo")
+      backend.row(0).should_not contain("charlie")
+    end
+
+    it "returns the x past what it drew, for a caller placing something after it" do
+      # The Colormarker style row puts a live sample two cells past the cycler and used to
+      # re-derive that x from the label width, the option padding and the cue width.
+      backend = MemoryBackend.new(60, 4)
+      stop = Frame.option_cycle(Screen.new(backend), 0, 0, 60, Theme.panel,
+        "style:", ["full row", "strip"], 0, false)
+      # "style:" (6) + 1 + " full row " (10) + " strip " (7) = 24
+      stop.should eq(24)
     end
   end
 end

--- a/spec/tui/shared_chrome_spec.cr
+++ b/spec/tui/shared_chrome_spec.cr
@@ -259,3 +259,62 @@ describe "fixed sub-tab strip labels" do
     offenders.should be_empty
   end
 end
+
+# The last of the hand-rolled chrome: a right-anchored run of bare text chips on a filter bar,
+# a count baked into a card TITLE, and the `▎` marker used as a trailing glyph.
+describe "the last hand-rolled chrome" do
+  root = File.join(__DIR__, "..", "..", "src", "gori", "tui")
+
+  it "leaves the filter bar's right cluster to Frame.right_text_chain" do
+    # Four views wrote this out — History (`count · ⇧S scope · f:follow · N marked`), Sitemap
+    # (`… g:fold …`), and the bare pair in Issues and Probe. The tell is the hand-rolled
+    # right-to-left cursor: `rx = rect.right - 1` followed by `rx -= …`. They had already
+    # drifted on the gap, stepping TWO columns after the count and ONE between the chips in
+    # the same method.
+    offenders = [] of String
+    Dir.glob(File.join(root, "**", "*.cr")).sort.each do |path|
+      src = File.read(path)
+      # Filter BARS only. `probe_view` runs the same right-to-left cursor INSIDE a list row
+      # to right-align `status · host · ×N` — a per-row column layout, not a bar cluster, and
+      # no shared helper covers it.
+      next if File.basename(path) == "probe_view.cr"
+      src.lines.each_with_index do |line, i|
+        next unless line.matches?(/^\s+rx -= \w+\.size \+ \d/)
+        offenders << "#{File.basename(path)}:#{i + 1} — #{line.strip}"
+      end
+    end
+    offenders.should be_empty
+  end
+
+  it "keeps counts out of card titles" do
+    # A count in the title makes the title's WIDTH a moving target, and two views derive a
+    # badge's `min_x` from exactly that width — so the chrome shifted as the number gained a
+    # digit. `Frame.border_meta` is the slot, right-aligned and independent of the title.
+    offenders = [] of String
+    Dir.glob(File.join(root, "**", "*.cr")).sort.each do |path|
+      File.read(path).lines.each_with_index do |line, i|
+        next unless line.includes?("Frame.card(")
+        # A COUNT, specifically — `"FINDINGS (#{n})"`, `"ATTACKS · #{n}"`. A title that
+        # interpolates WHAT the card is showing is not the same thing and stays: `RESULT #3`,
+        # `SETTINGS · NETWORK`, `PICK FLOW REPEATER`, `IMPORT HAR · source path`. The tell is
+        # a bare size/count expression, not a name.
+        next unless line.matches?(/Frame\.card\([^,]+,\s*[^,]+,\s*"[^"]*#\{[^}]*\.size[^}]*\}/)
+        offenders << "#{File.basename(path)}:#{i + 1} — #{line.strip}"
+      end
+    end
+    offenders.should be_empty
+  end
+
+  it "uses ▎ as a leading marker, never a trailing one" do
+    # Every list in gori writes `▎` in the row's marker column. History's preview titles were
+    # the one place it followed its label instead.
+    offenders = [] of String
+    Dir.glob(File.join(root, "**", "*.cr")).sort.each do |path|
+      File.read(path).lines.each_with_index do |line, i|
+        next unless line.matches?(/"[^"]*\S\s*▎"/)
+        offenders << "#{File.basename(path)}:#{i + 1} — #{line.strip}"
+      end
+    end
+    offenders.should be_empty
+  end
+end

--- a/spec/tui/shared_chrome_spec.cr
+++ b/spec/tui/shared_chrome_spec.cr
@@ -61,6 +61,56 @@ describe "shared card chrome" do
     offenders.should be_empty
   end
 
+  it "insets every modal from the body by the same margin" do
+    # Eight overlays sat `area.w - 6` / `area.h - 4` against everyone else's `- 4` / `- 2`, and
+    # the group was not a group: a one-line name prompt shared the wider margin with the export
+    # sheet. It showed most where it mattered least to have it — the Rewriter stub editor opens
+    # FROM the Rewriter rule form, so on any terminal narrower than 78 the card jumped in by a
+    # column on each side when you pressed ↵ on `response:`.
+    # Scoped to `overlay_box`, which is where a modal states its CARD geometry. The same
+    # `area.w - N` shape appears in three other places that are not that: a confirm dialog
+    # sized to its own text, a "terminal too small" degraded card, and a row-count fit — and
+    # holding those to a card's margin would be meaningless.
+    offenders = [] of String
+    Dir.glob(File.join(root, "**", "*.cr")).sort.each do |path|
+      src = File.read(path)
+      next unless body = src[/def overlay_box.*?\n    end/m]?
+      # ConfirmDialog is the one modal that sizes to its CONTENT (`content + 6`) rather than
+      # filling out to a cap; its `area.w - 2` is the ceiling on that, not a margin from the
+      # body. A dialog three lines tall has no card edge to align with anything.
+      next if File.basename(path) == "confirm_dialog.cr"
+      body.each_line do |line|
+        next unless line.matches?(/\{area\.w - (?!4\b)\d+,|\{area\.h - (?!2\b)\d+,/)
+        offenders << "#{File.basename(path)} — #{line.strip}"
+      end
+    end
+    offenders.should be_empty
+  end
+
+  it "gives every add/edit-one-rule form the same card" do
+    # Six forms for one kind of task, reached from adjacent tabs. Opening two in a row must not
+    # resize the card under the operator, so all six take their width and floors from the
+    # `RULE_FORM_*` constants rather than a number typed into their own `overlay_box`.
+    forms = %w[
+      rewriter_rule_overlay colormarker_rule_overlay custom_rule_overlay
+      extract_rule_overlay scope_rule_overlay oast_provider_overlay
+    ]
+    offenders = [] of String
+    forms.each do |name|
+      src = File.read(File.join(root, "#{name}.cr"))
+      body = src[/def overlay_box.*?\n    end/m]? || ""
+      # Not "does it use the right constants" — the whole computation belongs to
+      # `Overlay.rule_form_box`, so the form should state only its ROW COUNT and whether it
+      # carries a preview band. A form that spells any of the arithmetic here has started its
+      # own copy, which is where the six drifted apart the first time.
+      unless body.matches?(/Overlay\.rule_form_box\(area, (ROW_COUNT|row_count)(, preview: true)?\)/)
+        offenders << "#{name}: overlay_box does not delegate to Overlay.rule_form_box"
+      end
+      offenders << "#{name}: re-derives card arithmetic" if body.includes?("area.w -") || body.includes?("area.h -")
+    end
+    offenders.should be_empty
+  end
+
   it "leaves the scroll affordance to Frame.scroll_gauge" do
     # The Settings theme list painted ▲ / ▼ / ↕ into its own last interior column — an
     # affordance no other list in gori had, which said "there is more" without saying how

--- a/spec/tui/shared_chrome_spec.cr
+++ b/spec/tui/shared_chrome_spec.cr
@@ -1,0 +1,84 @@
+require "../spec_helper"
+require "../support/memory_backend"
+
+include Gori::Tui
+
+# `frame.cr` owns the card chrome — the rounded card, the tee'd divider, the scroll gauge, the
+# annotation that rides a top border. The workbench tabs (Repeater, Fuzzer, Discover, Miner,
+# Sequencer, …) had always drawn through it. The policy and settings pages had not: they
+# hand-rolled the same three devices per file, and the copies drifted.
+#
+# These examples pin the two drifts that were measurable in source, so the next card added to
+# this family inherits the shared geometry instead of a fresh copy of it.
+describe "shared card chrome" do
+  root = File.join(__DIR__, "..", "..", "src", "gori", "tui")
+
+  it "puts no hand-rolled border annotation where Frame.border_meta belongs" do
+    # The tell: a `screen.text` positioned by `rect.right - meta.size - N` — the right-aligned
+    # meta each card used to place itself. Six files carried one, with five different guard
+    # constants (+10 / +14 / +16 / +18 / +20) for the same layout, so sibling cards dropped
+    # their count at different widths. None of the numbers was derived from the title they
+    # were protecting; `Frame.border_meta` derives it.
+    offenders = [] of String
+    Dir.glob(File.join(root, "**", "*.cr")).sort.each do |path|
+      next if File.basename(path) == "frame.cr"
+      File.read(path).lines.each_with_index do |line, i|
+        next unless line.includes?("screen.text")
+        next unless line.matches?(/\.right\s*-\s*meta\./)
+        # Only a TOP-BORDER annotation, which is what the helper owns: the y argument is the
+        # card's own `.y`. A right-aligned meta on a LIST ROW (project_picker draws each
+        # project's flow count that way) is a different device at a per-row `y`, and forcing it
+        # through a border helper would be the opposite mistake.
+        next unless line.matches?(/,\s*\w+\.y\s*,/)
+        offenders << "#{File.basename(path)}:#{i + 1}"
+      end
+    end
+    offenders.should be_empty
+  end
+
+  it "leaves the scroll affordance to Frame.scroll_gauge" do
+    # The Settings theme list painted ▲ / ▼ / ↕ into its own last interior column — an
+    # affordance no other list in gori had, which said "there is more" without saying how
+    # much, and cost a column the swatch wanted. The gauge answers both on the hairline.
+    offenders = [] of String
+    Dir.glob(File.join(root, "**", "*.cr")).sort.each do |path|
+      File.read(path).lines.each_with_index do |line, i|
+        next unless line.includes?("screen.cell")
+        next unless line.includes?("'▲'") || line.includes?("'▼'") || line.includes?("'↕'")
+        offenders << "#{File.basename(path)}:#{i + 1}"
+      end
+    end
+    offenders.should be_empty
+  end
+end
+
+describe Gori::Tui::Frame do
+  describe ".border_meta" do
+    # 40 wide, title ` SCOPE ` from x+2 → the title ends at x + 2 + 5 + 2 = x + 9.
+    card = Rect.new(0, 0, 40, 10)
+
+    it "right-aligns the annotation two cells inside the card's right edge" do
+      backend = MemoryBackend.new(40, 10)
+      Frame.border_meta(Screen.new(backend), card, "SCOPE", "7 rules")
+      # "7 rules" is 7 cells ending at x = 37, so it starts at 31 — two clear of the edge, which
+      # is where `Frame.card` puts its right border and corner.
+      backend.row(0)[31, 7].should eq("7 rules")
+    end
+
+    it "draws nothing rather than landing on the title" do
+      # A card too narrow to hold both drops the meta — the title is the one that must survive,
+      # since it says WHAT the card is. The hand-rolled versions clamped instead, which is how
+      # a count could end up written over the title's last letters.
+      backend = MemoryBackend.new(40, 10)
+      narrow = Rect.new(0, 0, 14, 10)
+      Frame.border_meta(Screen.new(backend), narrow, "HOST OVERRIDES", "12 entries")
+      backend.contains?("12 entries").should be_false
+    end
+
+    it "ignores an empty annotation" do
+      backend = MemoryBackend.new(40, 10)
+      Frame.border_meta(Screen.new(backend), card, "SCOPE", "")
+      backend.contains?("SCOPE").should be_false # nothing drawn at all — card() draws the title
+    end
+  end
+end

--- a/spec/tui/shared_chrome_spec.cr
+++ b/spec/tui/shared_chrome_spec.cr
@@ -293,12 +293,17 @@ describe "the last hand-rolled chrome" do
     offenders = [] of String
     Dir.glob(File.join(root, "**", "*.cr")).sort.each do |path|
       File.read(path).lines.each_with_index do |line, i|
-        next unless line.includes?("Frame.card(")
         # A COUNT, specifically — `"FINDINGS (#{n})"`, `"ATTACKS · #{n}"`. A title that
         # interpolates WHAT the card is showing is not the same thing and stays: `RESULT #3`,
         # `SETTINGS · NETWORK`, `PICK FLOW REPEATER`, `IMPORT HAR · source path`. The tell is
         # a bare size/count expression, not a name.
-        next unless line.matches?(/Frame\.card\([^,]+,\s*[^,]+,\s*"[^"]*#\{[^}]*\.size[^}]*\}/)
+        inline = line.includes?("Frame.card(") &&
+                 line.matches?(/Frame\.card\([^,]+,\s*[^,]+,\s*"[^"]*#\{[^}]*\.size[^}]*\}/)
+        # …and the same title BOUND FIRST and passed on the next line, which is the form this
+        # check originally missed: Discover built `title = "RUNS (#{@runs.size})"` a line above
+        # its `Frame.card`, so the inline pattern never saw it and the audit found it by hand.
+        bound = line.matches?(/^\s*\w*title\w* = "[^"]*#\{[^}]*\.size[^}]*\}/)
+        next unless inline || bound
         offenders << "#{File.basename(path)}:#{i + 1} — #{line.strip}"
       end
     end

--- a/spec/tui/shared_chrome_spec.cr
+++ b/spec/tui/shared_chrome_spec.cr
@@ -234,3 +234,28 @@ describe Gori::Tui::Frame do
     end
   end
 end
+
+# The sub-tab strip is the same chrome on six tabs, and its labels are drawn VERBATIM
+# (`Chrome.render_tab_strip`), so three spellings reached the screen: Project shouted
+# `DESCRIPTION`/`SCOPE`, the Rewriter whispered `rules`/`extract`, and the other four used
+# Title Case. Moving between tabs, the same strip in the same place read three ways.
+describe "fixed sub-tab strip labels" do
+  it "are Title Case everywhere" do
+    root = File.join(__DIR__, "..", "..", "src", "gori")
+    offenders = [] of String
+    Dir.glob(File.join(root, "tui", "**", "*.cr")).sort.each do |path|
+      File.read(path).lines.each_with_index do |line, i|
+        next unless line.matches?(/^\s+(SUBTABS|SUB_LABELS|PANE_LABELS|PAGE_LABELS|SUBS)\s*=\s*\[/)
+        line.scan(/"([^"]+)"/) do |m|
+          label = m[1]
+          # First letter upper, and not SHOUTED — `Host overrides` is right, `HOST OVERRIDES`
+          # and `rules` are not. A one-word acronym label would be a fair exception; there is
+          # none today, so the rule stays simple until there is.
+          ok = label[0].uppercase? && label != label.upcase
+          offenders << "#{File.basename(path)}:#{i + 1} — #{label}" unless ok
+        end
+      end
+    end
+    offenders.should be_empty
+  end
+end

--- a/spec/tui/space_menu_spec.cr
+++ b/spec/tui/space_menu_spec.cr
@@ -27,8 +27,10 @@ describe Gori::Tui::SpaceMenu do
     menu.verb_for('y').try(&.id).should eq("history.copy")
     menu.verb_for('Y').try(&.id).should eq("history.copy-as") # pairs with 'y' (was 'F')
     menu.verb_for('r').try(&.id).should eq("history.repeater")
-    menu.verb_for('X').try(&.id).should eq("history.delete")
-    menu.verb_for('C').try(&.id).should eq("history.clear")
+    # `D` deletes the row and `X` wipes the tab — the pairing Probe already had.
+    menu.verb_for('D').try(&.id).should eq("history.delete")
+    menu.verb_for('X').try(&.id).should eq("history.clear")
+    menu.verb_for('C').should be_nil # freed: 'C' is Send to Comparer in the Repeater/Fuzzer
     menu.verb_for('Q').should be_nil # no entry bound to this key
   end
 
@@ -93,7 +95,9 @@ describe Gori::Tui::SpaceMenu do
     menu.verb_for('r').try(&.id).should eq("detail.repeater")
     menu.verb_for('x').try(&.id).should eq("detail.select-line")
     menu.verb_for('e').try(&.id).should eq("detail.toggle-hex")
-    menu.verb_for('X').try(&.id).should eq("detail.delete")
+    # 'D' here too, so the drill-in does not read `X` as "this one" while the list one
+    # keystroke away reads it as "all of them".
+    menu.verb_for('D').try(&.id).should eq("detail.delete")
   end
 
   it "lists the scope-rule actions in the Project scope pane (space replaced the lens toggle)" do

--- a/spec/tui/space_menu_spec.cr
+++ b/spec/tui/space_menu_spec.cr
@@ -485,7 +485,11 @@ describe Gori::Tui::SpaceMenu do
     ctx.miner_has_issue = true
     menu.open(Gori::Verb::Scope::Miner, :common, ctx)
     menu.entries.map(&.id).should contain("mine.repeater")
-    menu.verb_for('p').try(&.id).should eq("mine.repeater")
+    # 'R', not 'p': `fuzz.repeater` also had to move off `r` and its comment names 'R' as
+    # "the letter the other tabs use for Repeater" — the two tabs with the same collision had
+    # picked different answers.
+    menu.verb_for('R').try(&.id).should eq("mine.repeater")
+    Gori::Verbs.registry["fuzz.repeater"].menu_key.should eq('R')
   end
 
   it "hides the scope rule edit/delete entries when no rule is selected" do

--- a/spec/tui/space_menu_spec.cr
+++ b/spec/tui/space_menu_spec.cr
@@ -343,7 +343,9 @@ describe Gori::Tui::SpaceMenu do
     ids.should contain("fuzz.run")      # COMMON
     ids.should contain("fuzz.new")      # Round 5: New moved into COMMON, so it's here too
     ids.should contain("fuzz.automark") # :template
-    menu.verb_for('m').try(&.id).should eq("fuzz.automark")
+    # 'a', matching `repeater.auto-mark`. It was 'm' here while the Repeater — the pane most
+    # operators learn first — has always used 'a' for the same action.
+    menu.verb_for('a').try(&.id).should eq("fuzz.automark")
 
     # Round 5: fuzz.new moved :tab → :common, so Fuzzer no longer has any :tab-only
     # verbs — the tab bar now falls back to a flat COMMON-only render (same rule that

--- a/spec/tui/theme_spec.cr
+++ b/spec/tui/theme_spec.cr
@@ -326,7 +326,11 @@ describe "SettingsView theme list" do
       area = Rect.new(0, 0, 80, 24)
       view.render(Screen.new(backend), area)
       box = view.overlay_box(area)
-      tick_x = box.right - 9 # first swatch tick = the theme's accent (see draw_swatch)
+      # First swatch tick = the theme's accent. The swatch is 7 cells ending on the last
+      # interior column, so it starts at `box.right - 8` and `draw_swatch` puts tick 0 one
+      # cell in. It gained a column when the per-row ▲/▼/↕ scroll marker that used to hold
+      # `box.right - 2` was replaced by `Frame.scroll_gauge` on the card's hairline.
+      tick_x = box.right - 7
       # The on-screen row for a theme index, via field_at's inverse (robust to scroll).
       screen_row = ->(idx : Int32) do
         (box.y + 2...box.y + box.h).find { |y| view.field_at(box, box.x + 5, y) == idx } ||

--- a/spec/tui/toast_wording_spec.cr
+++ b/spec/tui/toast_wording_spec.cr
@@ -1,0 +1,100 @@
+require "../spec_helper"
+
+include Gori::Tui
+
+# What gori SAYS back, held to the same standard as what it draws.
+#
+# `Runner#status`, `@toast = …` and an overlay's `on_toast` all land on one strip, so they are
+# one vocabulary — and it had drifted into three shapes for a delete, two for a refusal, two
+# quoting styles, and `cannot`/`can't` split by module rather than by meaning.
+describe "status-strip wording" do
+  root = File.join(__DIR__, "..", "..", "src", "gori", "tui")
+
+  it "reports a delete as `<noun> deleted: <name>`" do
+    # Noun-first, so the success line reads in parallel with the failure template it shares a
+    # keypress with (`colour rule NOT deleted (project busy) — …`), and NAMED, so a fast
+    # sequence of deletes can be checked afterwards. The `removed <noun>:` and
+    # `deleted <noun> "<name>"` variants are the two this replaced.
+    offenders = [] of String
+    Dir.glob(File.join(root, "**", "*.cr")).sort.each do |path|
+      File.read(path).lines.each_with_index do |line, i|
+        next unless line.matches?(/(status|toast)\(.*"removed /)
+        offenders << "#{File.basename(path)}:#{i + 1} — #{line.strip}"
+      end
+    end
+    offenders.should be_empty
+  end
+
+  it "refuses with `<noun> NOT <verbed> (<cause>) — <consequence>`" do
+    # The template says what is STILL TRUE, which is the part an operator acts on. Two sites
+    # abandoned it for `delete failed — project busy, marks kept; try again` — the corpus's
+    # only `<verb> failed` refusal, its only semicolon, and `—` introducing the cause where
+    # every peer puts the consequence.
+    offenders = [] of String
+    Dir.glob(File.join(root, "**", "*.cr")).sort.each do |path|
+      File.read(path).lines.each_with_index do |line, i|
+        next unless line.matches?(/(status|toast)\(.*"[a-z ]*delete failed/)
+        offenders << "#{File.basename(path)}:#{i + 1}"
+      end
+    end
+    offenders.should be_empty
+  end
+
+  it "quotes a user value in confirm bodies only, and curly" do
+    # Two tiers, one rule each: a confirm body is a SENTENCE and quotes the name; a toast is a
+    # one-line report where `deleted: <name>` already marks what follows. The straight-quoted
+    # `\"…\"` form was in both, including two confirms — so DELETE FLOW and DELETE ISSUE wore
+    # a different quote from every other dialog.
+    offenders = [] of String
+    Dir.glob(File.join(root, "**", "*.cr")).sort.each do |path|
+      File.read(path).lines.each_with_index do |line, i|
+        next unless line.includes?("confirm(")
+        next unless line.matches?(/\\"#\{/)
+        offenders << "#{File.basename(path)}:#{i + 1}"
+      end
+    end
+    offenders.should be_empty
+  end
+
+  it "says can't, not cannot" do
+    # Near-even (13 vs 15) and split by MODULE, not by meaning: engine controllers said
+    # `cannot`, the shell and pickers `can't`. Confirms have always said "This can't be undone."
+    offenders = [] of String
+    Dir.glob(File.join(root, "**", "*.cr")).sort.each do |path|
+      File.read(path).lines.each_with_index do |line, i|
+        next unless line.matches?(/(status|toast|@toast =)\(?.*"[^"]*\bcannot\b/)
+        offenders << "#{File.basename(path)}:#{i + 1}"
+      end
+    end
+    offenders.should be_empty
+  end
+end
+
+# `Runner#format_status_message` prefixes the strip with a spinner / ✓ / ✗ by MATCHING THE
+# MESSAGE TEXT. That makes it the one place where renaming a toast silently changes how it
+# looks — and it did: `fuzz error:` became `fuzzer error:` for the sake of one noun per engine,
+# and the ✗ simply stopped appearing. Nothing failed; the mark was gone.
+describe "status glyph prefixes" do
+  it "cover every engine's error toast" do
+    root = File.join(__DIR__, "..", "..", "src", "gori", "tui")
+    # Only what reaches the STRIP. The same `<x> error:` shape is also used for text drawn
+    # INTO a pane — `config error:` in the Fuzzer/Miner config bodies, `upstream error:` in a
+    # History detail line, `wordlist error:` as a returned string — and those are not status
+    # messages, so no glyph applies to them.
+    emitted = [] of String
+    Dir.glob(File.join(root, "**", "*.cr")).sort.each do |path|
+      File.read(path).lines.each do |line|
+        next unless line.matches?(/(status\(|@toast =|toast\()/)
+        line.scan(/"([a-z]+ error): #\{/) { |m| emitted << m[1] }
+      end
+    end
+    emitted.uniq.sort.should eq(["discover error", "fuzzer error", "miner error",
+                                 "probe error", "repeater error", "sequencer error"])
+    # Every one of them must be in the table that earns the ✗.
+    runner = File.read(File.join(root, "runner.cr"))
+    table = runner[/ERROR_PREFIXES = \[(.*?)\]/m]?.should_not be_nil
+    emitted.uniq.each do |prefix|
+      runner.should contain(%("#{prefix}:"))
+    end
+  end
+end

--- a/spec/verb/registry_spec.cr
+++ b/spec/verb/registry_spec.cr
@@ -324,6 +324,14 @@ private class FakeContext < ExecContext
     @calls << :fuzz_automark
   end
 
+  def fuzz_mark_word : Nil
+    @calls << :fuzz_mark_word
+  end
+
+  def fuzz_insert_marker : Nil
+    @calls << :fuzz_insert_marker
+  end
+
   def fuzz_attach_chain : Nil
     @calls << :fuzz_attach_chain
   end

--- a/spec/verb/registry_spec.cr
+++ b/spec/verb/registry_spec.cr
@@ -432,6 +432,22 @@ private class FakeContext < ExecContext
     false
   end
 
+  def miner_rename_subtab : Nil
+    @calls << :miner_rename_subtab
+  end
+
+  def miner_close_subtab : Nil
+    @calls << :miner_close_subtab
+  end
+
+  def sequencer_rename_subtab : Nil
+    @calls << :sequencer_rename_subtab
+  end
+
+  def sequencer_close_subtab : Nil
+    @calls << :sequencer_close_subtab
+  end
+
   def miner_duplicate_subtab : Nil
     @calls << :miner_duplicate_subtab
   end
@@ -1146,6 +1162,10 @@ private class FakeContext < ExecContext
   end
 
   def rewriter_rules_sub? : Bool
+    true
+  end
+
+  def rewriter_rule_list_focused? : Bool
     true
   end
 

--- a/spec/verbs/comparer_spec.cr
+++ b/spec/verbs/comparer_spec.cr
@@ -38,9 +38,13 @@ describe "Gori::Verbs.register_comparer" do
     end
   end
 
-  it "keeps New in :common and the chip actions on :subtab" do
+  it "keeps New and Close in :common, the chip-only actions on :subtab" do
+    # Close joined New in COMMON: the space menu renders COMMON ∪ the FOCUSED PANE's section,
+    # so a `:subtab` close is invisible from the body and reachable only after moving focus to
+    # the strip — the thing Decoder and JWT had already fixed for themselves.
     r["comparer.new"].section.should eq(:common)
-    %w[comparer.rename-subtab comparer.close-subtab comparer.duplicate-subtab].each do |id|
+    r["comparer.close-subtab"].section.should eq(:common)
+    %w[comparer.rename-subtab comparer.duplicate-subtab].each do |id|
       r[id].section.should eq(:subtab)
     end
   end

--- a/spec/verbs/history_spec.cr
+++ b/spec/verbs/history_spec.cr
@@ -284,10 +284,15 @@ describe "Gori::Verbs.register_history" do
 
     it "gates the Fuzzer-scope actions on the Fuzzer tab" do
       ctx = on(:fuzzer)
-      {"fuzz.run"             => :fuzz_run,
-       "fuzz.stop"            => :fuzz_stop,
-       "fuzz.new"             => :fuzz_new,
-       "fuzz.automark"        => :fuzz_automark,
+      {"fuzz.run"      => :fuzz_run,
+       "fuzz.stop"     => :fuzz_stop,
+       "fuzz.new"      => :fuzz_new,
+       "fuzz.automark" => :fuzz_automark,
+       # ^K / ^T. Verbs since the Fuzzer's `chord_action` stopped claiming them — which is
+       # what kept them off the space menu and out of the keymap while their four siblings
+       # were here all along.
+       "fuzz.mark-word"       => :fuzz_mark_word,
+       "fuzz.insert-marker"   => :fuzz_insert_marker,
        "fuzz.attach-chain"    => :fuzz_attach_chain,
        "fuzz.list-paste"      => :fuzz_list_paste,
        "fuzz.pretty-template" => :fuzz_pretty_template,

--- a/spec/verbs/history_spec.cr
+++ b/spec/verbs/history_spec.cr
@@ -129,11 +129,19 @@ describe "Gori::Verbs.register_history" do
 
     it "keeps the destructive list verbs menu-only, on capitals that don't shadow a chord" do
       # 'x' is select-line and 'c' is compare in the same Body COMMON view, so delete/clear
-      # take 'X'/'C'. A lowercase mnemonic here would silently shadow one of those.
+      # take capitals. A lowercase mnemonic here would silently shadow one of those.
+      #
+      # WHICH capitals matters: `X` wipes the tab and `D` deletes the row, matching Probe's
+      # `probe.clear` / `probe.delete-selected`. History had them inverted — `X` was one flow
+      # here and every issue one tab over — and `C` collided with Send to Comparer, which is
+      # `C` in both the Repeater and the Fuzzer.
       r["history.delete"].chords.should be_empty
-      r["history.delete"].menu_key.should eq('X')
+      r["history.delete"].menu_key.should eq('D')
       r["history.clear"].chords.should be_empty
-      r["history.clear"].menu_key.should eq('C')
+      r["history.clear"].menu_key.should eq('X')
+      r["probe.clear"].menu_key.should eq('X')      # the pairing this now follows
+      r["repeater.compare"].menu_key.should eq('C') # and the letter it stopped colliding with
+      r["history.clear"].menu_key.should_not eq(r["repeater.compare"].menu_key)
       r["history.probe-active"].menu_key.should eq('A')
       verb_intents(r, "history.probe-active").should eq([:probe_active_selected])
     end

--- a/spec/verbs/oast_spec.cr
+++ b/spec/verbs/oast_spec.cr
@@ -32,12 +32,19 @@ describe "Gori::Verbs.register_oast" do
     }.each { |id, intent| verb_intents(r, id).should eq([intent]) }
   end
 
-  it "escapes back to the tab menu from either sub-tab" do
-    %w[oast.callbacks-to-menu oast.providers-to-menu].each do |id|
-      ctx = FakeExecContext.new
-      r[id].call(ctx)
-      ctx.args_for(:focus_pane).should eq(["menu"])
-      r[id].hidden?.should be_true
+  # Escape belongs to the CONTROLLER on both sub-tabs (`handle_callbacks_key` /
+  # `handle_providers_key` claim it and return true), so a verb registration for it can never
+  # run. Two used to sit here saying `focus_pane(:menu)` while the live handler goes to
+  # `:subtabs` — a spec that asserted the dead path and passed, over a hint (`esc tabs`) that
+  # described the dead path too. What is worth pinning is that nothing re-registers it.
+  it "registers no escape verb on either sub-tab — the controller owns that key" do
+    [Gori::Verb::Scope::OastCallbacks, Gori::Verb::Scope::OastProviders].each do |scope|
+      escapes = [] of String
+      r.each do |v|
+        next unless v.scope == scope
+        escapes << v.id if v.chords.any? { |c| c.key == "escape" }
+      end
+      escapes.should be_empty
     end
   end
 

--- a/spec/verbs/probe_spec.cr
+++ b/spec/verbs/probe_spec.cr
@@ -28,11 +28,17 @@ describe "Gori::Verbs.register_probe" do
        "probe.repeater-evidence" => "r",
        "probe.promote-selected"  => "p",
        "probe.delete-selected"   => "d",
-       "probe.clear"             => "x",
       }.each do |id, key|
         r[id].scope.should eq(Gori::Verb::Scope::Probe)
         r[id].chords.should eq([Gori::Verb::Chord.new(key)])
       end
+      # `probe.clear` deliberately claims NO chord. It deletes every issue in the project, and
+      # it used to answer a bare `x` — the same unmodified letter that is a harmless enable
+      # toggle one sub-tab to the right, and one that no Probe hint ever named. It keeps a
+      # space-menu handle so the action stays reachable by key, just not by reflex.
+      r["probe.clear"].chords.should be_empty
+      r["probe.clear"].menu_key.should eq('X')
+
       r["probe.open"].chords.first.should eq(Gori::Verb::Chord.new("enter"))
       r["probe.open"].menu_key.should eq('v') # 'o' is reserved for open-evidence
       r["probe.scope-toggle"].chords.should eq([Gori::Verb::Chord.new("s", shift: true)])
@@ -94,7 +100,14 @@ describe "Gori::Verbs.register_probe" do
       ctx = FakeExecContext.new
       r["probe-rules.toggle"].available?(ctx).should be_true
       r["probe-rules.add"].available?(ctx).should be_true
-      r["probe-rules.toggle"].menu_key.should eq('t') # enter/x are its chords
+      # `x` for the chord AND the menu key — the letter the Rewriter and Colormarker rule
+      # lists already use for this action, where this one used to say `t` in the menu.
+      r["probe-rules.toggle"].chords.should eq([Gori::Verb::Chord.new("x")])
+      r["probe-rules.toggle"].menu_key.should eq('x')
+      # ↵ belongs to EDIT here, as it does in every other rule list in gori. Bound to toggle,
+      # it meant a reflex carried from any of them silently disabled a scanning rule.
+      r["probe-rules.toggle"].chords.map(&.key).should_not contain("enter")
+      r["probe-rules.edit"].chords.map(&.key).should contain("enter")
       verb_intents(r, "probe-rules.toggle").should eq([:probe_rule_toggle])
       verb_intents(r, "probe-rules.add").should eq([:probe_rule_add])
     end

--- a/spec/verbs/registry_reach_spec.cr
+++ b/spec/verbs/registry_reach_spec.cr
@@ -169,3 +169,30 @@ describe "Rewriter rule keys" do
     r["colormarker.toggle"].chords.should contain(Gori::Verb::Chord.new("x"))
   end
 end
+
+# `^E` is `Hotkeys::CLAIMED_CTRL_LETTERS` — the shell's open-in-$EDITOR, claimed before any
+# tab sees it. JWT hardcoded it for its lens switch, which WORKED (the shell's ^E branch has
+# no `:jwt` arm and falls through) but could never be a registered chord: `keymap_spec`'s
+# "no rebindable default chord that is reserved" check refuses it, and did. So the key was
+# unbindable, and it spent the letter that would one day give this tab's INPUT pane an
+# external editor.
+#
+# That reserved rule lives in `keymap_spec` and is not repeated here — it already exempts the
+# four verbs that ARE the claimed handlers (`app.palette` ^P, `view.reveal-ws` ^B, the two
+# `*.new` ^N) via `Hotkeys.rebindable?`. This pins only where JWT landed.
+describe "JWT's lens switch" do
+  it "is on ^T, the Repeater's letter for the same gesture" do
+    r = Gori::Verbs.registry
+    ctrl_t = Gori::Verb::Chord.new("t", ctrl: true)
+    r["jwt.toggle-mode"].chords.should contain(ctrl_t)
+    # `repeater.toggle-decoded` is "switch which representation this pane shows" — the same
+    # question, and it has held ^T all along.
+    r["repeater.toggle-decoded"].chords.should contain(ctrl_t)
+  end
+
+  it "no longer claims a letter the shell reserves" do
+    Gori::Verbs.registry["jwt.toggle-mode"].chords.each do |c|
+      Gori::Hotkeys::CLAIMED_CTRL_LETTERS.should_not contain(c.key) if c.ctrl
+    end
+  end
+end

--- a/spec/verbs/registry_reach_spec.cr
+++ b/spec/verbs/registry_reach_spec.cr
@@ -1,0 +1,32 @@
+require "../spec_helper"
+
+# Every registered verb must be reachable from SOME keyboard surface. `sequence.export-json`
+# was not: no chord, no `mnemonic:`, so `Definition#menu_key` returned nil, `SpaceMenu#open`
+# filters on `menu_key`, and the palette only queries `Scope::Global`. A shipped export with
+# a handler, an `ExecContext` method and no way to invoke it.
+#
+# The three surfaces, and the whole rule:
+#   • a chord      → the keymap fires it
+#   • a menu_key   → the space menu lists it (explicit `mnemonic:`, else a plain 1-char chord)
+#   • Scope::Global → the palette lists it regardless
+describe "verb reachability" do
+  it "leaves no verb without a keyboard path" do
+    unreachable = [] of String
+    Gori::Verbs.registry.each do |v|
+      next if v.hidden?                            # a gesture, not a listed command
+      next if v.scope == Gori::Verb::Scope::Global # the palette lists these by scope alone
+      next unless v.chords.empty?
+      next if v.menu_key
+      unreachable << v.id
+    end
+    unreachable.should be_empty
+  end
+
+  it "keeps a hidden verb's chord, since hidden means unlisted rather than unbound" do
+    # The exemption above is only safe while `hidden: true` implies a chord — a hidden verb
+    # with neither would be just as unreachable, and the check would wave it through.
+    Gori::Verbs.registry.each do |v|
+      v.chords.should_not be_empty if v.hidden?
+    end
+  end
+end

--- a/spec/verbs/registry_reach_spec.cr
+++ b/spec/verbs/registry_reach_spec.cr
@@ -196,3 +196,34 @@ describe "JWT's lens switch" do
     end
   end
 end
+
+# A letter that changes meaning one `↵` into a drill-in is the sharpest kind of drift: the
+# list and its detail are the same workflow, and nothing on screen says the vocabulary moved.
+describe "list vs drill-in letters" do
+  r = Gori::Verbs.registry
+
+  it "keeps `O` meaning OAST payload, and only that" do
+    # Three scopes agree; HistoryDetail carries no OAST verb, so its `O` (Copy flow) was the
+    # letter re-pointing under the operator between the History list and its own detail.
+    %w(history.oast-copy repeater.oast-insert fuzzer.oast-insert).each do |id|
+      r[id].menu_key.should eq('O')
+    end
+    r.each do |v|
+      next if v.id.includes?("oast")
+      v.menu_key.should_not eq('O')
+    end
+  end
+
+  # NOT asserted, and deliberately — two more the audit surfaced where the KEYS already agree
+  # and only the menu letter differs, each with its reasoning already in the source:
+  #
+  #   `t`  Issues list = mark, Issues detail = edit title (issues.cr:73 — the detail is a modal
+  #        drill-in and `t` = mark is the cross-tab convention across four list tabs, so that
+  #        one wins; the detail's rename is reversible and marks are meaningless there).
+  #   `o`  Issues menu = open row, Probe menu = open EVIDENCE flow (probe.cr:18 — `probe.open`
+  #        keeps the family's enter/l/right chords, so the keys an operator presses agree;
+  #        only the menu letter moved, to 'v').
+  #
+  # Both are judgement calls that were made once with a written reason. Pinning them here
+  # would freeze the reason as a rule, which is not the same thing.
+end

--- a/spec/verbs/registry_reach_spec.cr
+++ b/spec/verbs/registry_reach_spec.cr
@@ -128,6 +128,29 @@ describe "sub-tab verbs" do
     end
   end
 
+  # WHERE close lands in the menu. `SpaceMenu#open` renders COMMON ∪ the focused pane's
+  # section, so a `:subtab` close is invisible from the body — an operator editing in a pane
+  # has to move focus to the strip first. Decoder and JWT fixed that for themselves ("Round 4",
+  # decoder_spec) and the rest inherited the old placement, which read as the majority.
+  it "files close under COMMON, so it is reachable from the body" do
+    {"decoder.close", "jwt.close", "comparer.close-subtab",
+     "mine.close-subtab", "sequence.close-subtab"}.each do |id|
+      r[id].section.should eq(:common)
+    end
+  end
+
+  it "leaves Repeater and Fuzzer out, because `w` is taken in their editor sections" do
+    # NOT drift: `repeater.mark-word` / `fuzz.mark-word` own 'w' in `:request` / `:template`,
+    # and a COMMON entry renders alongside them — `Registry#validate_menu_keys!` would raise
+    # at boot. `^W` still closes from anywhere; only the menu row is strip-only there.
+    r["repeater.close-subtab"].section.should eq(:subtab)
+    r["fuzz.close-subtab"].section.should eq(:subtab)
+    r["repeater.mark-word"].menu_key.should eq('w')
+    r["repeater.mark-word"].section.should eq(:request)
+    r["fuzz.mark-word"].menu_key.should eq('w')
+    r["fuzz.mark-word"].section.should eq(:template)
+  end
+
   it "puts rename on `e` everywhere it can" do
     # One letter across the family. JWT is the documented exception: `jwt.toggle-mode` owns
     # 'e' in its COMMON group, and the menu shows COMMON plus the focused section.

--- a/spec/verbs/registry_reach_spec.cr
+++ b/spec/verbs/registry_reach_spec.cr
@@ -99,3 +99,73 @@ describe "hex and whitespace letters" do
     r["repeater.toggle-resp-hex"].menu_key.should eq('h')
   end
 end
+
+# Every multi-session tab's sub-tab strip supports rename and close — `Runner#renameable_subtabs?`
+# and `#subtab_close` list :miner and :sequencer alongside the rest. Only the VERBS were
+# missing, so Miner's `:subtab` menu group held Duplicate alone and the Sequencer had no
+# `:subtab` group at all, and neither key could be rebound in either.
+describe "sub-tab verbs" do
+  r = Gori::Verbs.registry
+
+  # {tab prefix, close verb id} — Decoder and JWT spell theirs `*.close` in `:common` while
+  # the rest use `*.close-subtab` in `:subtab`. NOT unified here on purpose: a verb id is what
+  # a saved keybinding stores, so renaming one silently drops the operator's binding. The
+  # split is a naming inconsistency worth its own migration, not a drive-by rename.
+  {
+    {"repeater", "repeater.close-subtab"},
+    {"fuzz", "fuzz.close-subtab"},
+    {"comparer", "comparer.close-subtab"},
+    {"decoder", "decoder.close"},
+    {"jwt", "jwt.close"},
+    {"mine", "mine.close-subtab"},
+    {"sequence", "sequence.close-subtab"},
+  }.each do |(prefix, close_id)|
+    it "gives #{prefix} both a rename and a close" do
+      r["#{prefix}.rename-subtab"]?.should_not be_nil
+      r["#{prefix}.rename-subtab"].menu_key.should_not be_nil
+      r[close_id]?.should_not be_nil
+      r[close_id].menu_key.should eq('w')
+    end
+  end
+
+  it "puts rename on `e` everywhere it can" do
+    # One letter across the family. JWT is the documented exception: `jwt.toggle-mode` owns
+    # 'e' in its COMMON group, and the menu shows COMMON plus the focused section.
+    {"repeater", "fuzz", "comparer", "decoder", "mine", "sequence"}.each do |prefix|
+      r["#{prefix}.rename-subtab"].menu_key.should eq('e')
+    end
+    r["jwt.rename-subtab"].menu_key.should eq('r')
+    r["jwt.toggle-mode"].menu_key.should eq('e')
+  end
+end
+
+# The Rewriter's rule list moved onto the keymap — with ONE key held back, for a structural
+# reason worth pinning so nobody "fixes" it later.
+describe "Rewriter rule keys" do
+  r = Gori::Verbs.registry
+
+  it "binds every rule action except toggle" do
+    plain = ->(k : String) { Gori::Verb::Chord.new(k) }
+    r["rewriter.add"].chords.should contain(plain.call("a"))
+    r["rewriter.edit"].chords.should contain(plain.call("e"))
+    r["rewriter.delete"].chords.should contain(plain.call("d"))
+    r["rewriter.scope"].chords.should contain(plain.call("s"))
+    r["rewriter.move-up"].chords.should contain(Gori::Verb::Chord.new("k", shift: true))
+    r["rewriter.toggle-default"].chords.should contain(Gori::Verb::Chord.new("x", shift: true))
+  end
+
+  it "leaves `x` to the controller, because the KEYMAP has no focus dimension" do
+    # `rewriter.select-line` binds bare `x` in this same SCOPE for the preview pane. Two
+    # `section:`s never render together so the space menu is fine with `x` meaning two
+    # things — but `Keymap#lookup` is keyed by scope alone and returns ONE id, so a chord on
+    # `rewriter.toggle` would shadow one of them. `RewriterController#handle_list_key` runs
+    # only when the LIST has focus, which is the disambiguation the keymap cannot express.
+    r["rewriter.toggle"].chords.should be_empty
+    r["rewriter.select-line"].chords.should contain(Gori::Verb::Chord.new("x"))
+    r["rewriter.toggle"].menu_key.should eq('x') # still the letter, in its own section
+    r["rewriter.select-line"].section.should eq(:preview)
+    r["rewriter.toggle"].section.should eq(:rules)
+    # Colormarker COULD take the chord: it has no read pane, so nothing else claims `x`.
+    r["colormarker.toggle"].chords.should contain(Gori::Verb::Chord.new("x"))
+  end
+end

--- a/spec/verbs/registry_reach_spec.cr
+++ b/spec/verbs/registry_reach_spec.cr
@@ -65,3 +65,37 @@ describe "rule-list keys" do
     r["colormarker.toggle-default"].menu_key.should eq('X')
   end
 end
+
+# `b` is the whitespace letter across the app: the global reveal is ^B (`view.reveal-ws`) and
+# the History detail binds bare `b` to `detail.toggle-ws`. The Repeater's space menu spent it
+# on hex — one keystroke away from a pane where the same letter reveals whitespace — while its
+# own chord for hex was ^X all along.
+describe "hex and whitespace letters" do
+  r = Gori::Verbs.registry
+
+  it "never spends `b` on hex" do
+    r.each do |v|
+      next unless v.id.includes?("hex")
+      v.menu_key.should_not eq('b')
+    end
+  end
+
+  it "keeps hex on ^X wherever it has a chord at all" do
+    ctrl_x = Gori::Verb::Chord.new("x", ctrl: true)
+    r.each do |v|
+      next unless v.id.includes?("hex")
+      next if v.chords.empty? # the response-pane dump is menu-only; ^X reaches it pane-dispatched
+      v.chords.should contain(ctrl_x)
+    end
+  end
+
+  it "leaves the two that CANNOT take `x`, and says why" do
+    # Not drift — a real collision in each displayable view:
+    #   HistoryDetail   `x` is `detail.select-line`      → `detail.toggle-hex` stays 'e'
+    #   Repeater :response `x` is `repeater.select-line` → `repeater.toggle-resp-hex` stays 'h'
+    r["repeater.toggle-hex"].menu_key.should eq('x')
+    r["detail.toggle-hex"].menu_key.should eq('e')
+    r["detail.select-line"].menu_key.should eq('x')
+    r["repeater.toggle-resp-hex"].menu_key.should eq('h')
+  end
+end

--- a/spec/verbs/registry_reach_spec.cr
+++ b/spec/verbs/registry_reach_spec.cr
@@ -30,3 +30,38 @@ describe "verb reachability" do
     end
   end
 end
+
+# A rule list's actions belong to the KEYMAP, not to a hand-rolled `case` in its controller.
+# Four of the six deferred (Scope, Env, Host overrides, Probe rules); Rewriter and Colormarker
+# hardcoded `a / ↵,e / d / x / ⇧X / s / ⇧J / ⇧K` and registered every verb with `[] of Chord`,
+# so those two lists alone could not be rebound and their keys never met the `available?` gate
+# the space menu uses.
+describe "rule-list keys" do
+  it "are real chords on the verbs, for every rule list" do
+    r = Gori::Verbs.registry
+    {
+      "scope.add-rule", "env.add-var", "hostoverride.add-entry", "probe-rules.add",
+      "colormarker.add",
+    }.each do |id|
+      r[id].chords.should_not be_empty
+    end
+  end
+
+  it "gives Colormarker the same key set its controller used to hardcode" do
+    r = Gori::Verbs.registry
+    plain = ->(k : String) { Gori::Verb::Chord.new(k) }
+    shift = ->(k : String) { Gori::Verb::Chord.new(k, shift: true) }
+    r["colormarker.add"].chords.should contain(plain.call("a"))
+    r["colormarker.edit"].chords.should contain(plain.call("e"))
+    r["colormarker.edit"].chords.should contain(plain.call("enter"))
+    r["colormarker.delete"].chords.should contain(plain.call("d"))
+    r["colormarker.toggle"].chords.should contain(plain.call("x"))
+    r["colormarker.scope"].chords.should contain(plain.call("s"))
+    r["colormarker.toggle-default"].chords.should contain(shift.call("x"))
+    r["colormarker.move-down"].chords.should contain(shift.call("j"))
+    r["colormarker.move-up"].chords.should contain(shift.call("k"))
+    # …and the menu letter now names the key. It was 'g', which matched neither the verb
+    # ("Enable/disable everywhere") nor its ⇧X binding.
+    r["colormarker.toggle-default"].menu_key.should eq('X')
+  end
+end

--- a/spec/verbs/sitemap_spec.cr
+++ b/spec/verbs/sitemap_spec.cr
@@ -113,14 +113,21 @@ describe "Gori::Verbs.register_sitemap" do
     clear.available?(ctx).should be_true
   end
 
-  it "gives `t` to marking and moves tagging to ⇧T (with an explicit menu key)" do
-    # The two lists agree on `t` = mark; a shifted chord yields no menu key on its own, so the
-    # tag entry carries 'T' explicitly.
+  it "gives `t` to marking and leaves ⇧T unbound, with tagging menu-only" do
+    # The lists agree on `t` = mark. ⇧T is where they STOPPED agreeing: History, Issues and
+    # Intercept all read it as "mark all", so a hand that learnt the `t`/⇧T pair there opened
+    # a text prompt here. Tagging is a space-menu entry now, like `sitemap.mark-clear`, and
+    # ⇧T is deliberately left free rather than reassigned — a tree has no useful "mark every
+    # row" today (see sitemap.mark-toggle), and this keeps the letter for the day it does.
     r["sitemap.mark-toggle"].chords.should eq([Gori::Verb::Chord.new("t")])
     r["sitemap.mark-toggle"].menu_key.should eq('t')
     tag = r["sitemap.tag"]
-    tag.chords.should eq([Gori::Verb::Chord.new("t", shift: true)])
+    tag.chords.should be_empty
     tag.menu_key.should eq('T')
+    shift_t = Gori::Verb::Chord.new("t", shift: true)
+    sitemap_verbs = [] of Gori::Verb::Definition
+    r.each { |v| sitemap_verbs << v if v.scope.sitemap? }
+    sitemap_verbs.none? { |v| v.chords.includes?(shift_t) }.should be_true
   end
 
   it "extends the range on ⇧arrows without shadowing plain tree nav" do

--- a/src/gori/tui/ca_import_overlay.cr
+++ b/src/gori/tui/ca_import_overlay.cr
@@ -123,8 +123,8 @@ module Gori::Tui
     LABEL_W = 14 # value column offset (widest label "Private key" + padding)
 
     def overlay_box(area : Rect) : Rect?
-      w = {area.w - 6, 72}.min
-      h = {area.h - 4, 11}.min
+      w = {area.w - 4, 72}.min
+      h = {area.h - 2, 11}.min
       return nil if w < 40 || h < 8
       Rect.new(area.x + (area.w - w) // 2, area.y + (area.h - h) // 2, w, h)
     end

--- a/src/gori/tui/chain_overlay.cr
+++ b/src/gori/tui/chain_overlay.cr
@@ -105,7 +105,12 @@ module Gori::Tui
       when .ok?
         bytes = step.output
         shown = bytes ? Decoder.display(bytes)[0] : ""
-        {step.converter.try(&.category.saved?) ? Theme.marker_accent : Theme.text, Theme.green, shown}
+        # `env_known`, not `marker_accent`. That accessor is `focus_gold` under another name,
+        # documented for exactly one job (the closing § of a marker hiding a ¦chain), and gold
+        # is focus + brand. What this cell means is PROVENANCE — the step resolved to a chain
+        # from the saved library rather than an inline converter — which is the same question
+        # `env_known` answers for a `$TOKEN` that resolved.
+        {step.converter.try(&.category.saved?) ? Theme.env_known : Theme.text, Theme.green, shown}
       when .skipped?
         {Theme.muted, Theme.muted, "(skipped)"}
       else # failed / unknown

--- a/src/gori/tui/choice_picker.cr
+++ b/src/gori/tui/choice_picker.cr
@@ -40,11 +40,15 @@ module Gori::Tui
 
     # The coloured triage-status picker, opened on the current status.
     def self.for_status(current : Int32) : ChoicePicker
+      # Live vs handled, the same two-tier the Issues and Probe lists use — NOT the severity
+      # hues. This picker is where an operator learns what a status colour means, so teaching
+      # `confirmed = red` here and then showing red-for-CRITICAL in the list beside it is how
+      # the two axes came to look like one.
       new("SET STATUS", [
-        Choice.new("open", 'o', Theme.accent, 0),
-        Choice.new("confirmed", 'c', Theme.red, 1),
+        Choice.new("open", 'o', Theme.text, 0),
+        Choice.new("confirmed", 'c', Theme.text, 1),
         Choice.new("false-positive", 'f', Theme.muted, 2),
-        Choice.new("resolved", 'r', Theme.green, 3),
+        Choice.new("resolved", 'r', Theme.muted, 3),
       ], current, :status)
     end
 

--- a/src/gori/tui/chrome.cr
+++ b/src/gori/tui/chrome.cr
@@ -288,9 +288,18 @@ module Gori::Tui
       end
     end
 
+    # `· off` in WORDS when capture is paused, not hue alone. Both states used to render the
+    # byte-identical `● 127.0.0.1:8070` and differ only by green-vs-muted — the single most
+    # consequential state in gori, carried by a colour. It fails in three ways: on MATRIX the
+    # two hues are both phosphor green, on HIGH_CONTRAST the palette is deliberately flat, and
+    # a colour is not a thing you can read at a glance in peripheral vision anyway.
+    #
+    # The project picker already does this (`● off · host:port`), and the Listeners overlay
+    # states the rule for itself: "the status is already stated in words on this row".
     private def self.listen_chip(listen : String, capturing : Bool, write_failures : Int32) : {String, Color}
       return {"● #{listen} (#{write_failures})", Theme.red} if write_failures > 0
-      {"● #{listen}", capturing ? Theme.green : Theme.muted}
+      return {"● #{listen}", Theme.green} if capturing
+      {"● #{listen} · off", Theme.muted}
     end
 
     # The drawn rect of a tagged top-bar chip (or nil if absent) — rebuilds the SAME

--- a/src/gori/tui/colormarker_rule_overlay.cr
+++ b/src/gori/tui/colormarker_rule_overlay.cr
@@ -325,9 +325,9 @@ module Gori::Tui
       fg = sel ? Theme.text_bright : Theme.text
       case i
       when ROW_NAME  then draw_field(screen, box, py, bg, fg, sel, "name:", @fields[:name])
-      when ROW_SCOPE then draw_cycle(screen, x, py, bg, fg, "scope:", SCOPE_LABELS, @scope_i, sel)
+      when ROW_SCOPE then Frame.option_cycle(screen, x, py, box.right - 2, bg, "scope:", SCOPE_LABELS, @scope_i, sel)
       when ROW_COLOR then draw_color_cycle(screen, x, py, bg, sel)
-      when ROW_STYLE then draw_style_cycle(screen, x, py, bg, fg, sel)
+      when ROW_STYLE then draw_style_cycle(screen, box, x, py, bg, sel)
       when ROW_WHEN  then draw_field(screen, box, py, bg, fg, sel, "when:", @fields[:when])
       else
         ok = valid?
@@ -349,16 +349,23 @@ module Gori::Tui
         col = lit ? (row_sel ? Theme.text_bright : Theme.accent) : Theme.muted
         tx = screen.text(tx + 1, py, "#{opt} ", col, bg, lit ? Attribute::Bold : Attribute::None)
       end
-      screen.text(tx, py, "‹/›", Theme.muted, bg) if row_sel
+      # ` ‹/›` with the leading space, matching `Frame.option_cycle` — this row keeps its own
+      # renderer because each option carries a swatch, but it must not read differently from
+      # the cyclers directly above and below it.
+      screen.text(tx, py, " ‹/›", Theme.muted, bg) if row_sel
     end
 
     # The style row carries a live SAMPLE of what the choice does, drawn against `Theme.bg` —
     # NOT against the row's own `bg`. The focused row is filled with `accent_bg`, and previewing
     # a canvas tint on top of the selection band would be a lie about how History will look.
-    private def draw_style_cycle(screen : Screen, x : Int32, py : Int32, bg : Color, fg : Color,
+    private def draw_style_cycle(screen : Screen, box : Rect, x : Int32, py : Int32, bg : Color,
                                  row_sel : Bool) : Nil
-      draw_cycle(screen, x, py, bg, fg, "style:", STYLE_LABELS, @style_i, row_sel)
-      sx = x + 8 + STYLE_LABELS.sum { |s| Screen.draw_width(s) + 2 } + (row_sel ? 4 : 0) + 2
+      # The sample sits two cells past whatever the cycler drew. `option_cycle` returns that x,
+      # so the offset is READ rather than re-derived — the hand-rolled `x + 8 + sum + (sel ? 4
+      # : 0) + 2` restated the label width, the per-option padding and the cue width a second
+      # time, which is three chances to disagree with the row above it.
+      sx = Frame.option_cycle(screen, x, py, box.right - 2, bg,
+        "style:", STYLE_LABELS, @style_i, row_sel) + 2
       hue = Theme.mark_color(color.to_sym)
       if style.full?
         screen.text(sx, py, " sample row ", Theme.text_bright, Theme.row_tint(hue, Theme.bg))
@@ -366,18 +373,6 @@ module Gori::Tui
         screen.cell(sx, py, '█', hue, Theme.bg)
         screen.text(sx + 1, py, " sample row ", Theme.text, Theme.bg)
       end
-    end
-
-    private def draw_cycle(screen : Screen, x : Int32, py : Int32, bg : Color, fg : Color,
-                           label : String, opts : Array(String), sel_i : Int32, row_sel : Bool) : Nil
-      screen.text(x, py, label, Theme.muted, bg)
-      tx = x + label.size + 1
-      opts.each_with_index do |opt, oi|
-        lit = oi == sel_i
-        col = lit ? (row_sel ? Theme.text_bright : Theme.accent) : Theme.muted
-        tx = screen.text(tx, py, " #{opt} ", col, bg, lit ? Attribute::Bold : Attribute::None)
-      end
-      screen.text(tx, py, " ‹/›", Theme.muted, bg) if row_sel
     end
 
     private def draw_field(screen : Screen, box : Rect, py : Int32, bg : Color, fg : Color,

--- a/src/gori/tui/colormarker_rule_overlay.cr
+++ b/src/gori/tui/colormarker_rule_overlay.cr
@@ -274,10 +274,7 @@ module Gori::Tui
     end
 
     def overlay_box(area : Rect) : Rect?
-      w = {area.w - 4, 72}.min
-      h = {area.h - 2, ROW_COUNT + 5}.min # title + rows + preview/suggestions + hint + padding
-      return nil if w < 40 || h < 10
-      Rect.new(area.x + (area.w - w) // 2, area.y + (area.h - h) // 2, w, h)
+      Overlay.rule_form_box(area, ROW_COUNT, preview: true)
     end
 
     def render(screen : Screen, area : Rect) : Nil

--- a/src/gori/tui/colormarker_rule_overlay.cr
+++ b/src/gori/tui/colormarker_rule_overlay.cr
@@ -304,8 +304,8 @@ module Gori::Tui
           screen.text(box.x + 2, pv_y, band, Theme.muted, Theme.panel, width: box.w - 4)
         end
       end
-      hint_y = box.bottom - 1
-      screen.text(box.x + 2, hint_y, hint, Theme.muted, Theme.panel, width: box.w - 4) if hint_y > first
+      # No key hint on the bottom border — the shell draws `hint` in the status strip for the
+      # open modal (Runner#key_hints). See RewriterRuleOverlay#render for the whole argument.
     end
 
     private def completion_band : String

--- a/src/gori/tui/colormarker_view.cr
+++ b/src/gori/tui/colormarker_view.cr
@@ -52,9 +52,7 @@ module Gori::Tui
       # pay border width to be told "0 global".
       globals = rules.count(&.global?)
       meta = "#{globals} global · #{meta}" if globals > 0
-      if rect.w > meta.size + 18
-        screen.text({rect.right - meta.size - 2, rect.x + 16}.max, rect.y, meta, Theme.muted, Theme.bg)
-      end
+      Frame.border_meta(screen, rect, "COLORMARKER", meta)
       inner = rect.inset(1, 1)
       return if inner.empty?
 
@@ -82,6 +80,11 @@ module Gori::Tui
         break if idx >= rules.size
         render_row(screen, inner, rules[idx], list_top + i, idx == sel, focused)
       end
+      # Tracks the LIST viewport, not the interior — the note row below it is prose, not a
+      # row you can scroll to. `rows` is already the note-aware height, so the gauge and the
+      # hit-test read the same geometry.
+      Frame.scroll_gauge(screen, Rect.new(inner.x, list_top, inner.w, rows),
+        rules.size, scroll, focused)
     end
 
     private def render_row(screen : Screen, rect : Rect, rule : Store::ColorRule, py : Int32,

--- a/src/gori/tui/colormarker_view.cr
+++ b/src/gori/tui/colormarker_view.cr
@@ -42,6 +42,16 @@ module Gori::Tui
       idx < count ? idx : nil
     end
 
+    # The row a click on the scroll gauge asks for. The gauge rides the frame's right hairline,
+    # one column outside the list rect, so `row_at` cannot answer it — and `@scroll` here is
+    # DERIVED from the selection, so the answer is a selection. See `Frame.scroll_gauge_row`.
+    def gauge_row_at(rect : Rect, mx : Int32, my : Int32, count : Int32) : Int32?
+      inner = rect.inset(1, 1)
+      return nil if inner.empty?
+      Frame.scroll_gauge_row(Rect.new(inner.x, inner.y, inner.w, list_h(inner, count)),
+        count, mx, my)
+    end
+
     def render(screen : Screen, rect : Rect, rules : Array(Store::ColorRule),
                sel : Int32, scroll : Int32, enabled_count : Int32, focused : Bool) : Nil
       return if rect.w < 6 || rect.h < LIST_MIN_H

--- a/src/gori/tui/colormarker_view.cr
+++ b/src/gori/tui/colormarker_view.cr
@@ -11,17 +11,35 @@ module Gori::Tui
   class ColormarkerView
     LIST_MIN_H = 3
 
+    # Whether `render` steals the interior's bottom row for the resolution-rule note.
+    # Capacity and hit-testing MUST ask this the same way render does, or the two drift:
+    # a capacity that counts the note's row scrolls the last rule underneath it, and a
+    # hit-test that accepts that row resolves a click on prose to a rule that isn't there.
+    # `h` is the interior height BEFORE the note is subtracted, which is what render tests.
+    private def note_row?(count : Int32, h : Int32) : Bool
+      count > 1 && h > 2
+    end
+
+    # Rows the list can actually draw, once the note has taken its share.
+    private def list_h(inner : Rect, count : Int32) : Int32
+      h = inner.h
+      h -= 1 if note_row?(count, h)
+      {h, 0}.max
+    end
+
     # Visible row count inside the list card, for scroll clamping.
-    def row_capacity(rect : Rect) : Int32
-      inner = rect.inset(1, 1)
-      {inner.h, 0}.max
+    def row_capacity(rect : Rect, count : Int32) : Int32
+      list_h(rect.inset(1, 1), count)
     end
 
     # Which row index sits under `my`, or nil. Y-only, like every other list here.
-    def row_at(rect : Rect, my : Int32, scroll : Int32) : Int32?
+    def row_at(rect : Rect, my : Int32, scroll : Int32, count : Int32) : Int32?
       inner = rect.inset(1, 1)
-      return nil if inner.empty? || my < inner.y || my >= inner.bottom
-      scroll + (my - inner.y)
+      return nil if inner.empty?
+      i = my - inner.y
+      return nil if i < 0 || i >= list_h(inner, count)
+      idx = scroll + i
+      idx < count ? idx : nil
     end
 
     def render(screen : Screen, rect : Rect, rules : Array(Store::ColorRule),
@@ -41,15 +59,17 @@ module Gori::Tui
       return if inner.empty?
 
       list_top = inner.y
-      list_h = inner.h
       # A one-line reminder of the resolution rule, stolen from the bottom when there is more
       # than one rule. It is the single thing about this list an operator most often gets wrong
       # (rewrite rules next door COMPOSE), and it only matters once two rules can contend.
-      if rules.size > 1 && list_h > 2
-        screen.text(inner.x, inner.bottom - 1, "first enabled match wins — u/n reorder",
+      # It names no key: the reorder chord lives in the status bar (`body_hint`), and spelling
+      # it twice is how the two got out of step — this line advertised `u/n`, which are the
+      # space-menu mnemonics, while the list itself has only ever answered ⇧J/⇧K.
+      if note_row?(rules.size, inner.h)
+        screen.text(inner.x, inner.bottom - 1, "first enabled match wins",
           Theme.muted, Theme.bg, width: inner.w)
-        list_h -= 1
       end
+      rows = list_h(inner, rules.size)
 
       if rules.empty?
         screen.text(inner.x, list_top, "no colour rules — press a to add",
@@ -57,7 +77,7 @@ module Gori::Tui
         return
       end
 
-      (0...list_h).each do |i|
+      (0...rows).each do |i|
         idx = scroll + i
         break if idx >= rules.size
         render_row(screen, inner, rules[idx], list_top + i, idx == sel, focused)

--- a/src/gori/tui/compact_overlay.cr
+++ b/src/gori/tui/compact_overlay.cr
@@ -158,8 +158,8 @@ module Gori::Tui
         size = bytes > 0 ? Fmt.size(bytes) : "—"
         screen.text(box.right - size.size - 2, py, size, bytes > 0 ? Theme.muted : Theme.border, bg)
       elsif i == keep_row
-        screen.text(x, py, "keep newest flows:", Theme.muted, bg)
-        screen.text(x + 19, py, "#{keep_label}  ‹/›", sel ? Theme.text_bright : Theme.text, bg)
+        Frame.option_cycle(screen, x, py, box.right - 2, bg, "keep newest flows:",
+          KEEP_CHOICES.map { |n| n.try { |v| Fmt.count(v.to_i64) } || "all" }, @keep_idx, sel)
       else
         screen.text(x, py, "[ Compress ]", Theme.accent, bg, Attribute::Bold)
         hint = "↵ run"

--- a/src/gori/tui/controllers/colormarker_controller.cr
+++ b/src/gori/tui/controllers/colormarker_controller.cr
@@ -88,7 +88,11 @@ module Gori::Tui
     end
 
     def body_hint(focus : Symbol) : String
-      "↑/↓ select · a add · ↵/e edit · x on/off · s scope · ⇧J/⇧K reorder · d delete"
+      # Rewriter's shape, which this list is otherwise a twin of. It used to advertise `s scope`
+      # and `⇧K/⇧J reorder` — its two least-used keys — while naming neither `space cmds` nor
+      # `esc`, both of which it binds. That is backwards: the space menu is the one affordance
+      # that reveals every other key, including the two this line was spending its width on.
+      "↑/↓ select · a add · ↵/e edit · x on/off · d delete · space cmds · esc tabs"
     end
 
     # --- keys ---

--- a/src/gori/tui/controllers/colormarker_controller.cr
+++ b/src/gori/tui/controllers/colormarker_controller.cr
@@ -77,7 +77,7 @@ module Gori::Tui
     end
 
     private def ensure_visible(inner : Rect, count : Int32) : Nil
-      lh = @view.row_capacity(inner)
+      lh = @view.row_capacity(inner, count)
       return if lh <= 0
       if @sel < @scroll
         @scroll = @sel
@@ -141,8 +141,10 @@ module Gori::Tui
       @host.focus_body
       inner = BodyChrome.frame_inner(rect)
       @last_body = inner
-      if idx = @view.row_at(inner, my, @scroll)
-        @sel = idx.clamp(0, {rule_list.size - 1, 0}.max) if idx < rule_list.size
+      # `row_at` already refuses the note row and anything past the last rule, so a hit is
+      # a real index — the clamp below is the belt to its braces, not the bounds check.
+      if idx = @view.row_at(inner, my, @scroll, rule_list.size)
+        @sel = idx.clamp(0, {rule_list.size - 1, 0}.max)
       end
       true
     end
@@ -155,9 +157,10 @@ module Gori::Tui
 
     def handle_wheel(step : Int32) : Bool
       return false if @last_body.empty?
-      lh = @view.row_capacity(@last_body)
+      count = rule_list.size
+      lh = @view.row_capacity(@last_body, count)
       return false if lh <= 0
-      @scroll = (@scroll + step).clamp(0, {rule_list.size - lh, 0}.max)
+      @scroll = (@scroll + step).clamp(0, {count - lh, 0}.max)
       true
     end
 
@@ -181,8 +184,8 @@ module Gori::Tui
       # A global rule is deleted out of EVERY project, and the prompt has to say so — the row
       # differs from a project rule's by one badge, and the confirm is the last place to notice.
       note = rule.global? ? " It is a GLOBAL rule — this removes it from every project." : ""
-      @host.confirm("Delete colour rule", "Delete “#{label}”?#{note} This can't be undone.",
-        confirm_label: "Delete", danger: true) do
+      @host.confirm("DELETE COLOUR RULE", "Delete “#{label}”?#{note} This can't be undone.",
+        confirm_label: "delete", danger: true) do
         # The store's answer, not an assumption. The failure text says what is actually still
         # true — the row keeps its colour — rather than borrowing the Rewriter's "still
         # rewriting live traffic", which would be alarmist AND false for a display rule.

--- a/src/gori/tui/controllers/colormarker_controller.cr
+++ b/src/gori/tui/controllers/colormarker_controller.cr
@@ -18,7 +18,6 @@ module Gori::Tui
       @view = ColormarkerView.new
       @sel = 0
       @scroll = 0
-      @last_body = Rect.new(0, 0, 0, 0) # last content rect — click/wheel geometry
     end
 
     def tab : Symbol
@@ -68,7 +67,6 @@ module Gori::Tui
       body_focused = focus == :body
       # multi_pane: false — one list, no second pane to hand focus to.
       BodyChrome.framed(screen, rect, BodyChrome.shell_focused(focus, multi_pane: false)) do |inner|
-        @last_body = inner
         list = rule_list
         @sel = @sel.clamp(0, {list.size - 1, 0}.max)
         ensure_visible(inner, list.size)
@@ -144,7 +142,11 @@ module Gori::Tui
     def handle_click(rect : Rect, mx : Int32, my : Int32) : Bool
       @host.focus_body
       inner = BodyChrome.frame_inner(rect)
-      @last_body = inner
+      # The scroll gauge on the card's right hairline, which `row_at` excludes by construction.
+      if row = @view.gauge_row_at(inner, mx, my, rule_list.size)
+        @sel = row
+        return true
+      end
       # `row_at` already refuses the note row and anything past the last rule, so a hit is
       # a real index — the clamp below is the belt to its braces, not the bounds check.
       if idx = @view.row_at(inner, my, @scroll, rule_list.size)
@@ -159,12 +161,12 @@ module Gori::Tui
       true
     end
 
+    # The SELECTION, like the Rewriter twin and every other selection-carrying list in the
+    # tree — not the viewport. Scrolling `@scroll` alone left the cursor off screen, and
+    # `e`/`x`/`d` then acted on a rule the operator could not see. `render`'s `ensure_visible`
+    # brings the viewport along, which is how ↑/↓ has always worked here.
     def handle_wheel(step : Int32) : Bool
-      return false if @last_body.empty?
-      count = rule_list.size
-      lh = @view.row_capacity(@last_body, count)
-      return false if lh <= 0
-      @scroll = (@scroll + step).clamp(0, {count - lh, 0}.max)
+      move_sel(step)
       true
     end
 

--- a/src/gori/tui/controllers/colormarker_controller.cr
+++ b/src/gori/tui/controllers/colormarker_controller.cr
@@ -88,7 +88,7 @@ module Gori::Tui
     end
 
     def body_hint(focus : Symbol) : String
-      "↑/↓ select · a add · e edit · x on/off · s scope · ⇧J/⇧K reorder · d delete"
+      "↑/↓ select · a add · ↵/e edit · x on/off · s scope · ⇧J/⇧K reorder · d delete"
     end
 
     # --- keys ---

--- a/src/gori/tui/controllers/colormarker_controller.cr
+++ b/src/gori/tui/controllers/colormarker_controller.cr
@@ -191,7 +191,7 @@ module Gori::Tui
         # rewriting live traffic", which would be alarmist AND false for a display rule.
         ok = engine.remove(rule.id, rule.scope)
         @sel = @sel.clamp(0, {rule_list.size - 1, 0}.max)
-        @host.status(ok ? "colour rule deleted" : "rule NOT deleted (project busy) — the row colour is unchanged")
+        @host.status(ok ? "colour rule deleted: #{label}" : "colour rule NOT deleted (project busy) — the row colour is unchanged")
       end
     end
 

--- a/src/gori/tui/controllers/colormarker_controller.cr
+++ b/src/gori/tui/controllers/colormarker_controller.cr
@@ -102,7 +102,13 @@ module Gori::Tui
       when key.up?, c == 'k'                   then move_up
       when key.down?, c == 'j'                 then move_sel(1)
       when key.escape?                         then @host.request_focus(:menu)
-      else                                          return handle_action_key(ev, c)
+      else
+        # Everything else — a/↵/e/d/x/⇧X/s/⇧J/⇧K — defers to the central keymap, so the rule
+        # actions are REBINDABLE and dispatch through the same `available?` gate the space
+        # menu uses. They were a hand-rolled `case` here while the four sibling rule lists
+        # (Scope, Env, Host overrides, Probe rules) all bound real chords and deferred; this
+        # list and the Rewriter's were the two that could not be rebound.
+        return false
       end
       true
     end
@@ -114,22 +120,6 @@ module Gori::Tui
       else
         move_sel(-1)
       end
-    end
-
-    private def handle_action_key(ev : Termisu::Event::Key, c : Char?) : Bool
-      key = ev.key
-      case
-      when key.enter?, c == 'e' then colormarker_edit
-      when c == 'a'             then colormarker_add
-      when c == 'd'             then colormarker_delete
-      when c == 'x'             then colormarker_toggle
-      when c == 'X'             then colormarker_toggle_default
-      when c == 's'             then colormarker_scope_toggle
-      when c == 'J'             then colormarker_move(1)
-      when c == 'K'             then colormarker_move(-1)
-      else                           return false
-      end
-      true
     end
 
     private def move_sel(d : Int32) : Nil

--- a/src/gori/tui/controllers/decoder_controller.cr
+++ b/src/gori/tui/controllers/decoder_controller.cr
@@ -266,16 +266,18 @@ module Gori::Tui
         decoder_new
       elsif ev.ctrl? && key.lower_w?
         decoder_close
-      elsif ev.ctrl? && key.lower_l?
-        clear_all
       elsif ev.ctrl? && key.lower_y?
+        # ^Y stays inline: it copies the OUTPUT specifically, and `decoder.copy` is the
+        # focused-pane copy on bare `y`. No verb to defer to.
         copy_output
-      elsif ev.ctrl? && key.lower_x?
-        cycle_output_mode
-      elsif ev.ctrl? && key.lower_s?
-        @host.open_chain_save
-      elsif ev.ctrl? && key.lower_o?
-        @host.open_chain_load
+      elsif ev.ctrl_z? || editing_motion?(ev)
+        # Undo and ⌥/⌃ word motion belong to the focused editor, not the keymap.
+        return route_pane_keys(ev, c)
+      elsif ev.ctrl? || ev.alt?
+        # Every OTHER modified chord defers to the central keymap, so it is rebindable — the
+        # rule the Repeater and Fuzzer already follow. Without it the pane handlers below can
+        # swallow it, which is why ^L/^X/^S/^O had to be hardcoded above.
+        return false
       elsif key.escape?
         @popup.close
         s = cur
@@ -287,13 +289,18 @@ module Gori::Tui
           @host.request_focus(:subtabs)
         end
       else
-        return case cur.pane
-        when :input  then edit_input(ev, c)
-        when :output then handle_output(ev)
-        else              edit_chain(ev, c); true
-        end
+        return route_pane_keys(ev, c)
       end
       true
+    end
+
+    # The focused pane's own key handling — shared by the fall-through above and the ^Z arm.
+    private def route_pane_keys(ev : Termisu::Event::Key, c : Char?) : Bool
+      case cur.pane
+      when :input  then edit_input(ev, c)
+      when :output then handle_output(ev)
+      else              edit_chain(ev, c); true
+      end
     end
 
     # The autocomplete popup owns Tab/Enter/↑/↓/Esc while it is open. The shell's

--- a/src/gori/tui/controllers/decoder_controller.cr
+++ b/src/gori/tui/controllers/decoder_controller.cr
@@ -912,7 +912,7 @@ module Gori::Tui
         return
       end
       if name.matches?(/[>|,¦§]/)
-        @host.status("chain name cannot contain > | , ¦ or §")
+        @host.status("chain name can't contain > | , ¦ or §")
         return
       end
       if (c = registry[name]?) && !c.category.saved?

--- a/src/gori/tui/controllers/decoder_controller.cr
+++ b/src/gori/tui/controllers/decoder_controller.cr
@@ -447,16 +447,16 @@ module Gori::Tui
       case s.pane
       when :chain
         if @popup.open?
-          return @popup_engaged ? "↑/↓ pick · ↹/↵ complete · esc close · type to filter" : "↓ browse · type to filter · ⇥ output · esc tabs"
+          return @popup_engaged ? "↑/↓ pick · ↹/↵ complete · esc close · type to filter" : "↓ browse · type to filter · ⇥ output · esc sub-tabs"
         end
-        "chain (> | ,) · ↑ input · ↓ output · ^Y copy · ^X mode · ^S save · ^O load · esc tabs"
+        "chain (> | ,) · ↑ input · ↓ output · ^Y copy · ^X mode · ^S save · ^O load · esc sub-tabs"
       when :output
-        "↑/↓ move · ⇧arrows select · #{y} copy · ↑-top chain · space cmds · ^X mode · ^Y copy all · esc tabs"
+        "↑/↓ move · ⇧arrows select · #{y} copy · ↑-top chain · space cmds · ^X mode · ^Y copy all · esc sub-tabs"
       when :input
         if s.input_mode == InputMode::Insert
           "type to edit · esc read · ↓ chain · ^L clear · ^X mode · ^N new · ^W close · ↑ sub-tabs"
         else
-          "i/↵ edit · ⇧arrows select · #{y} copy · space cmds · ↓/↹ chain · ^X mode · ^N new · esc tabs"
+          "i/↵ edit · ⇧arrows select · #{y} copy · space cmds · ↓/↹ chain · ^X mode · ^N new · esc sub-tabs"
         end
       else
         ""

--- a/src/gori/tui/controllers/discover_controller.cr
+++ b/src/gori/tui/controllers/discover_controller.cr
@@ -55,7 +55,7 @@ module Gori::Tui
       if @view.focus == :runs
         "↑/↓ runs · ↵/tab findings · ^R run · ^X stop · p pause · d dismiss · space cmds · esc sub-tabs"
       else
-        "↑/↓ nav · ↵/o request+response · tab runs · [ / ] runs · ^R run · ^X stop · p pause · esc sub-tabs"
+        "↑/↓ nav · ↵/o request+response · tab runs · ^R run · ^X stop · p pause · space cmds · esc sub-tabs"
       end
     end
 

--- a/src/gori/tui/controllers/discover_controller.cr
+++ b/src/gori/tui/controllers/discover_controller.cr
@@ -53,9 +53,9 @@ module Gori::Tui
     def body_hint(focus : Symbol) : String
       return "start from Sitemap/History (space → \"Discover here\")" if @view.empty?
       if @view.focus == :runs
-        "↑/↓ runs · ↵/tab findings · ^R run · ^X stop · p pause · d dismiss · space cmds · esc tabs"
+        "↑/↓ runs · ↵/tab findings · ^R run · ^X stop · p pause · d dismiss · space cmds · esc sub-tabs"
       else
-        "↑/↓ nav · ↵/o request+response · tab runs · [ / ] runs · ^R run · ^X stop · p pause · esc tabs"
+        "↑/↓ nav · ↵/o request+response · tab runs · [ / ] runs · ^R run · ^X stop · p pause · esc sub-tabs"
       end
     end
 

--- a/src/gori/tui/controllers/discover_controller.cr
+++ b/src/gori/tui/controllers/discover_controller.cr
@@ -70,6 +70,13 @@ module Gori::Tui
 
     def handle_click_content(content : Rect, mx : Int32, my : Int32) : Bool
       @host.focus_body
+      # The RUNS card's run control, before the pane it rides. The badge tracks the SELECTED
+      # run, so the click acts on the one it is describing — same as ^R/^X.
+      if @view.run_chrome_hit(content, mx, my)
+        @view.focus_pane(:runs)
+        @view.current.try(&.running?) ? discover_stop : discover_run
+        return true
+      end
       @view.click(content, mx, my)
       true
     end

--- a/src/gori/tui/controllers/discover_controller.cr
+++ b/src/gori/tui/controllers/discover_controller.cr
@@ -288,7 +288,7 @@ module Gori::Tui
     private def start_run(run : DiscoverRun) : Nil
       engine, err = build_engine(run)
       unless engine
-        @host.status(err || "cannot start discovery")
+        @host.status(err || "can't start discovery")
         return
       end
       run.engine = engine

--- a/src/gori/tui/controllers/fuzzer_controller.cr
+++ b/src/gori/tui/controllers/fuzzer_controller.cr
@@ -1030,7 +1030,7 @@ module Gori::Tui
       engine, err = v.build_engine(!@host.session.config.insecure_upstream?,
         @host.session.scope, @host.session.host_overrides)
       unless engine
-        @host.status(err || "cannot run")
+        @host.status(err || "can't run")
         return
       end
       total = begin
@@ -1219,7 +1219,7 @@ module Gori::Tui
 
     def request_close : Nil
       return unless tab = current_tab_obj
-      @host.confirm("CLOSE FUZZER", "Close fuzz session \"#{tab.view.summary}\"?\nIts template/config and results are discarded.",
+      @host.confirm("CLOSE FUZZER", "Close fuzz session “#{tab.view.summary}”?\nIts template/config and results are discarded.",
         confirm_label: "close", danger: true) { close_tab }
     end
 

--- a/src/gori/tui/controllers/fuzzer_controller.cr
+++ b/src/gori/tui/controllers/fuzzer_controller.cr
@@ -118,7 +118,12 @@ module Gori::Tui
       y = Hotkeys.binding_label(reg, "fuzzer.copy", "y")
       run = Hotkeys.binding_label(reg, "fuzz.run", "^R")
       stop = Hotkeys.binding_label(reg, "fuzz.stop", "^X")
-      mark = Hotkeys.binding_label(reg, "fuzz.automark", "^A")
+      # One phrasing for the marker trio, shared with the Repeater's request footer. This
+      # used to name `^A` in both modes and `^K` in INSERT only, and `^T` nowhere.
+      params = Hotkeys.binding_label(reg, "fuzz.automark", "^A")
+      word = Hotkeys.binding_label(reg, "fuzz.mark-word", "^K")
+      point = Hotkeys.binding_label(reg, "fuzz.insert-marker", "^T")
+      marks = "#{params} params · #{word} word · #{point} point"
       read_common = "⇧arrows select · #{y} copy · space cmds"
       sni = Hotkeys.binding_label(reg, "fuzz.toggle-sni", "^S")
       case v.focus
@@ -135,9 +140,9 @@ module Gori::Tui
           # `↹ text` and not `↹ pane`: Tab types a TAB here (a header value may hold one), the
           # same thing it does in the Repeater's request editor. The old wording promised a
           # focus move Tab has never made from an editor in INSERT.
-          "type · ⇧arrows select · ^Z undo · #{mark} params · ^K word · ^O config · #{run} run · esc read · ↹ text"
+          "type · ⇧arrows select · ^Z undo · #{marks} · ^O config · #{run} run · esc read · ↹ text"
         else
-          "i/↵ edit · #{read_common} · #{mark} params · ^O config · #{run} run · ↹ pane · esc tabs"
+          "i/↵ edit · #{read_common} · #{marks} · ^O config · #{run} run · ↹ pane · esc tabs"
         end
       when :config  then config_hint(v, run)
       when :results then "↑/↓ select · ↵ detail · o sort · m matched · v dist · #{run} run · #{stop} stop · space cmds · ↹ pane"
@@ -257,10 +262,8 @@ module Gori::Tui
     # Run the action a chord mapped to; false when it was not a chord (fall through).
     private def dispatch_chord(action : Symbol?, v : FuzzerView, c : Char?) : Bool
       case action
-      when :palette   then save_current; @host.open_palette
-      when :close     then request_close
-      when :markword  then @host.status(v.mark_word)
-      when :markpoint then @host.status(v.insert_marker)
+      when :palette then save_current; @host.open_palette
+      when :close   then request_close
       when :undo
         # Only the TEMPLATE pane has a text buffer; anywhere else ^Z is not ours, so it falls
         # through to the keymap rather than being silently swallowed.
@@ -273,16 +276,17 @@ module Gori::Tui
       true
     end
 
-    # The ctrl-chord (or digit sub-tab switch) this key maps to, else nil. run/stop/
-    # automark are NOT here — they're keymap-driven verbs (rebindable) and fall through.
+    # The ctrl-chord (or digit sub-tab switch) this key maps to, else nil. run/stop/automark
+    # are NOT here — they're keymap-driven verbs (rebindable) and fall through. Neither are
+    # ^K/^T any more: claiming them here meant the two most-used marker actions never reached
+    # the registry, so they were absent from the space menu and could not be rebound, while
+    # their four siblings were `fuzz.*` verbs. See `fuzz.mark-word` / `fuzz.insert-marker`.
     private def chord_action(ev : Termisu::Event::Key, c : Char?) : Symbol?
       return nil unless ev.ctrl?
       key = ev.key
       case
       when key.lower_p?         then :palette
       when key.lower_w?         then :close
-      when key.lower_k?         then :markword
-      when key.lower_t?         then :markpoint
       when key.lower_o?         then :config
       when key.lower_z?         then :undo
       when c && '1' <= c <= '9' then :switch

--- a/src/gori/tui/controllers/fuzzer_controller.cr
+++ b/src/gori/tui/controllers/fuzzer_controller.cr
@@ -666,6 +666,15 @@ module Gori::Tui
     def handle_click(rect : Rect, mx : Int32, my : Int32) : Bool
       body = body_rect_below_filter(rect)
       return true unless v = current_view
+      # The RESULTS gauge on the card hairline — `results_row_at` requires the pane rect,
+      # which excludes that column.
+      if row = v.results_gauge_row(body, mx, my)
+        save_current
+        @host.focus_body
+        v.focus_pane(:results)
+        v.select_result_row(row)
+        return true
+      end
       # RESULTS border badges (DIST / MATCH / sort) before row select.
       if chip = v.results_chrome_hit(body, mx, my)
         save_current

--- a/src/gori/tui/controllers/fuzzer_controller.cr
+++ b/src/gori/tui/controllers/fuzzer_controller.cr
@@ -538,11 +538,6 @@ module Gori::Tui
     end
 
     # Every modified key the TEMPLATE editor owns rather than the keymap — see `handle_body_key`.
-    private def editing_motion?(ev : Termisu::Event::Key) : Bool
-      return false unless ev.ctrl? || ev.alt?
-      key = ev.key
-      key.left? || key.right? || key.home? || key.end? || word_delete?(ev)
-    end
 
     # A backspace/forward-delete of a marker delimiter (§/¦) would unbalance the marker and
     # expose its concealed ¦chain. Confirm first; on accept, strip the WHOLE marker down to

--- a/src/gori/tui/controllers/fuzzer_controller.cr
+++ b/src/gori/tui/controllers/fuzzer_controller.cr
@@ -952,7 +952,7 @@ module Gori::Tui
         # feed (the AI firehose logs freely; only the human center suppresses it).
         @host.jobs.finish(v.job_id, :error, ev.message)
         log_event(v, :error, "Fuzzer: #{ev.message} on #{v.summary}")
-        @host.status("fuzz error: #{ev.message}")
+        @host.status("fuzzer error: #{ev.message}")
       end
     end
 

--- a/src/gori/tui/controllers/history_controller.cr
+++ b/src/gori/tui/controllers/history_controller.cr
@@ -551,13 +551,17 @@ module Gori::Tui
       # Marks can outlive the visible window (a filter change, a trim), so a batch confirm
       # spells out the split: this dialog — not the list chip — is the last thing read
       # before data is destroyed.
-      label =
+      # TWO labels, because the two surfaces read differently: the confirm body is a sentence
+      # and quotes the name (curly, like every other confirm), the toast is a one-line report
+      # where the `:` already marks what follows as the name.
+      name =
         if ids.size == 1
-          "\"#{@history.flow_summary(ids.first)}\""
+          @history.flow_summary(ids.first)
         else
           hidden = @history.marked_hidden_count
           "#{ids.size} flows#{hidden > 0 ? " (#{hidden} not visible)" : ""}"
         end
+      label = ids.size == 1 ? "“#{name}”" : name
       # return_to: :detail when launched from the open flow detail, so CANCEL restores the
       # detail (instead of dropping to the list) and the guard below still fires on accept
       # (the flow is gone, so :detail → :none).
@@ -567,11 +571,11 @@ module Gori::Tui
         # place — say so instead of reporting a delete that didn't happen, so the set is still
         # there to retry.
         unless @history.delete_ids(@host.session.store, ids)
-          @host.status("delete failed — project busy, marks kept; try again")
+          @host.status("flow NOT deleted (project busy) — the marks are kept, try again")
           next
         end
         @host.request_overlay(:none) if @host.overlay == :detail
-        @host.status("deleted #{label}")
+        @host.status("flow deleted: #{name}")
       end
     end
 

--- a/src/gori/tui/controllers/history_controller.cr
+++ b/src/gori/tui/controllers/history_controller.cr
@@ -153,6 +153,15 @@ module Gori::Tui
         flush_query_reload
         @history.stop_query
       end
+      # The scroll gauge on the frame's right hairline: a click there jumps the cursor to the
+      # row it points at. Before the pane test — the gauge column is inside the preview split's
+      # rect too, and the gauge is what the pointer was aiming at.
+      if row = @history.gauge_row_at(inner, mx, my)
+        @history.set_preview_focus(:list)
+        end_range_gesture
+        @history.select_row(row)
+        return true
+      end
       # Preview pane click focuses that side (settings:layout).
       if pane = @history.preview_pane_at(inner, mx, my)
         @history.set_preview_focus(pane)

--- a/src/gori/tui/controllers/intercept_controller.cr
+++ b/src/gori/tui/controllers/intercept_controller.cr
@@ -319,6 +319,15 @@ module Gori::Tui
         end
         return true
       end
+      # The queue's scroll gauge, before the pane test — it rides the card's right hairline,
+      # which `list_row_at` excludes.
+      if row = @intercept.gauge_row_at(inner, mx, my)
+        @host.focus_body
+        @intercept.focus_list
+        end_range_gesture unless row == @intercept.selected_index
+        @intercept.select_index(row)
+        return true
+      end
       return true unless pane = @intercept.pane_at(inner, mx, my)
       @host.focus_body
       if pane == :list

--- a/src/gori/tui/controllers/issues_controller.cr
+++ b/src/gori/tui/controllers/issues_controller.cr
@@ -398,23 +398,26 @@ module Gori::Tui
       # Marks can outlive the visible list (a filter change, a peer delete), so a batch
       # confirm spells out the split: this dialog — not the list chip — is the last thing
       # read before data is destroyed.
-      label =
+      # Two labels — see HistoryController#delete_selected, which this mirrors: the confirm
+      # body quotes the name, the toast reports it after a colon.
+      name =
         if ids.size == 1
-          "\"#{@issues.issue_summary(ids.first)}\""
+          @issues.issue_summary(ids.first)
         else
           hidden = @issues.hidden_count(ids)
           "#{ids.size} issues#{hidden > 0 ? " (#{hidden} not visible)" : ""}"
         end
+      label = ids.size == 1 ? "“#{name}”" : name
       @host.confirm(ids.size == 1 ? "DELETE ISSUE" : "DELETE ISSUES",
         "Delete #{label}?\nThis can't be undone.", confirm_label: "delete", danger: true) do
         # A rolled-back write (cross-process SQLite busy/lock) leaves the issues AND the marks
         # in place — say so instead of reporting a delete that didn't happen, so the set is
         # still there to retry.
         unless @issues.delete_ids(@host.session.store, ids)
-          @host.status("delete failed — project busy, marks kept; try again")
+          @host.status("issue NOT deleted (project busy) — the marks are kept, try again")
           next
         end
-        @host.status("deleted #{label}")
+        @host.status("issue deleted: #{name}")
       end
     end
 

--- a/src/gori/tui/controllers/issues_controller.cr
+++ b/src/gori/tui/controllers/issues_controller.cr
@@ -122,6 +122,13 @@ module Gori::Tui
         return true
       end
       list_rect, _ = @issues.list_split(inner)
+      # The list's scroll gauge on the frame's right hairline: jump the cursor to the row it
+      # points at. Before the filter-bar arm, which has no `mx` bound of its own.
+      if row = @issues.gauge_row_at(inner, mx, my)
+        @issues.set_preview_focus(:list)
+        @issues.select_index(row)
+        return true
+      end
       if my == list_rect.y && !@issues.querying?
         @issues.start_query
         return true

--- a/src/gori/tui/controllers/jwt_controller.cr
+++ b/src/gori/tui/controllers/jwt_controller.cr
@@ -71,7 +71,7 @@ module Gori::Tui
   # Body consumes every printable key (like Decoder/Notes), so command_scope is the JWT
   # scope and handle_body_key always returns true; the JWT verbs' mnemonics never collide
   # with literal text — they're reached from the space menu + palette. A runner-owned
-  # sub-tab strip appears from the first session (^N new · ^W close · ^E lens · ^A alg).
+  # sub-tab strip appears from the first session (^N new · ^W close · ^T lens · ^A alg).
   class JwtController < TabController
     DECODE_PANES = [:input, :decoded, :attacks]
     ENCODE_PANES = [:header, :payload, :secret, :output]
@@ -265,13 +265,6 @@ module Gori::Tui
         jwt_new
       elsif ev.ctrl? && key.lower_w?
         jwt_close
-      elsif ev.ctrl? && key.lower_e?
-        # ^E stays INLINE, alone among this tab's chords. It is in `Hotkeys::CLAIMED_CTRL_LETTERS`
-        # (the Runner's external-editor guard), so registering it on `jwt.toggle-mode` makes
-        # `keymap_spec`'s reserved-chord check fail — correctly. The shell's ^E branch has no
-        # `:jwt` arm and falls through, so the key works; it is simply not bindable, and this
-        # is the tab claiming a globally reserved letter rather than a defer that was missed.
-        toggle_mode
       elsif ev.ctrl? && key.lower_y?
         jwt_copy # copy-all; `jwt.copy` is the focused-pane copy on bare `y`
       elsif ev.ctrl_z? || editing_motion?(ev)
@@ -280,7 +273,7 @@ module Gori::Tui
       elsif ev.ctrl? || ev.alt?
         # Every OTHER modified chord defers to the central keymap, so it is rebindable — the
         # rule the Repeater and Fuzzer already follow. Without it the pane handlers below
-        # swallow it (`edit_json(...); true`), which is exactly why ^L/^A/^E had to be
+        # swallow it (`edit_json(...); true`), which is exactly why ^L/^A/^T had to be
         # hardcoded above: a verb chord would have been silently eaten before the keymap.
         return false
       elsif key.escape?
@@ -775,24 +768,33 @@ module Gori::Tui
 
     def body_hint(focus : Symbol) : String
       s = cur
-      y = Hotkeys.binding_label(@host.session.registry, "jwt.copy", "y")
+      reg = @host.session.registry
+      y = Hotkeys.binding_label(reg, "jwt.copy", "y")
+      # The lens switch was `^E` — a letter `Hotkeys::CLAIMED_CTRL_LETTERS` reserves for the
+      # shell's open-in-$EDITOR. It worked (the shell's ^E branch has no `:jwt` arm and falls
+      # through) but could never be a registered chord, so it was unbindable AND it spent the
+      # key that would one day give this tab's INPUT pane an external editor. `^T` is the
+      # Repeater's letter for the same gesture (`repeater.toggle-decoded`: switch which
+      # representation the pane is showing), and free here. Read from the keymap, so a rebind
+      # shows up in the footer instead of the footer lying about it.
+      lens = Hotkeys.binding_label(reg, "jwt.toggle-mode", "^T")
       case s.pane
       when :input
         if s.input_mode == InputMode::Insert
-          "type a JWT · esc read · ↓ decoded · ^E encode · ^L clear · ^N new · ↑ sub-tabs"
+          "type a JWT · esc read · ↓ decoded · #{lens} encode · ^L clear · ^N new · ↑ sub-tabs"
         else
-          "i/↵ edit · ⇧arrows select · #{y} copy · space cmds · ↓ decoded · ^E encode · ^N new · esc sub-tabs"
+          "i/↵ edit · ⇧arrows select · #{y} copy · space cmds · ↓ decoded · #{lens} encode · ^N new · esc sub-tabs"
         end
       when :decoded
-        "↑/↓ scroll · #{y} copy · space cmds · ↑-top input · ↓ attacks · ^E encode · esc sub-tabs"
+        "↑/↓ scroll · #{y} copy · space cmds · ↑-top input · ↓ attacks · #{lens} encode · esc sub-tabs"
       when :attacks
-        "↑/↓ pick · ↵/#{y} copy token · space cmds · ↑-top decoded · ^E encode · esc sub-tabs"
+        "↑/↓ pick · ↵/#{y} copy token · space cmds · ↑-top decoded · #{lens} encode · esc sub-tabs"
       when :header, :payload
-        "type JSON · ↑/↓ move+cross · ^A alg · ^E decode · space cmds · esc sub-tabs"
+        "type JSON · ↑/↓ move+cross · ^A alg · #{lens} decode · space cmds · esc sub-tabs"
       when :secret
-        "type secret · ^A alg (#{s.alg}) · ↑/↓ cross · ^E decode · space cmds · esc sub-tabs"
+        "type secret · ^A alg (#{s.alg}) · ↑/↓ cross · #{lens} decode · space cmds · esc sub-tabs"
       when :output
-        "↑/↓ scroll · #{y} copy token · space cmds · ^A alg · ^E decode · esc sub-tabs"
+        "↑/↓ scroll · #{y} copy token · space cmds · ^A alg · #{lens} decode · esc sub-tabs"
       else
         ""
       end

--- a/src/gori/tui/controllers/jwt_controller.cr
+++ b/src/gori/tui/controllers/jwt_controller.cr
@@ -760,18 +760,18 @@ module Gori::Tui
         if s.input_mode == InputMode::Insert
           "type a JWT · esc read · ↓ decoded · ^E encode · ^L clear · ^N new · ↑ sub-tabs"
         else
-          "i/↵ edit · ⇧arrows select · #{y} copy · space cmds · ↓ decoded · ^E encode · ^N new · esc tabs"
+          "i/↵ edit · ⇧arrows select · #{y} copy · space cmds · ↓ decoded · ^E encode · ^N new · esc sub-tabs"
         end
       when :decoded
-        "↑/↓ scroll · #{y} copy · space cmds · ↑-top input · ↓ attacks · ^E encode · esc tabs"
+        "↑/↓ scroll · #{y} copy · space cmds · ↑-top input · ↓ attacks · ^E encode · esc sub-tabs"
       when :attacks
-        "↑/↓ pick · ↵/#{y} copy token · space cmds · ↑-top decoded · ^E encode · esc tabs"
+        "↑/↓ pick · ↵/#{y} copy token · space cmds · ↑-top decoded · ^E encode · esc sub-tabs"
       when :header, :payload
-        "type JSON · ↑/↓ move+cross · ^A alg · ^E decode · space cmds · esc tabs"
+        "type JSON · ↑/↓ move+cross · ^A alg · ^E decode · space cmds · esc sub-tabs"
       when :secret
-        "type secret · ^A alg (#{s.alg}) · ↑/↓ cross · ^E decode · space cmds · esc tabs"
+        "type secret · ^A alg (#{s.alg}) · ↑/↓ cross · ^E decode · space cmds · esc sub-tabs"
       when :output
-        "↑/↓ scroll · #{y} copy token · space cmds · ^A alg · ^E decode · esc tabs"
+        "↑/↓ scroll · #{y} copy token · space cmds · ^A alg · ^E decode · esc sub-tabs"
       else
         ""
       end

--- a/src/gori/tui/controllers/jwt_controller.cr
+++ b/src/gori/tui/controllers/jwt_controller.cr
@@ -265,14 +265,24 @@ module Gori::Tui
         jwt_new
       elsif ev.ctrl? && key.lower_w?
         jwt_close
-      elsif ev.ctrl? && key.lower_l?
-        clear_all
       elsif ev.ctrl? && key.lower_e?
+        # ^E stays INLINE, alone among this tab's chords. It is in `Hotkeys::CLAIMED_CTRL_LETTERS`
+        # (the Runner's external-editor guard), so registering it on `jwt.toggle-mode` makes
+        # `keymap_spec`'s reserved-chord check fail — correctly. The shell's ^E branch has no
+        # `:jwt` arm and falls through, so the key works; it is simply not bindable, and this
+        # is the tab claiming a globally reserved letter rather than a defer that was missed.
         toggle_mode
-      elsif ev.ctrl? && key.lower_a?
-        cycle_alg
       elsif ev.ctrl? && key.lower_y?
-        jwt_copy
+        jwt_copy # copy-all; `jwt.copy` is the focused-pane copy on bare `y`
+      elsif ev.ctrl_z? || editing_motion?(ev)
+        # Undo and ⌥/⌃ word motion belong to the focused editor, not the keymap.
+        return route_pane(ev, c)
+      elsif ev.ctrl? || ev.alt?
+        # Every OTHER modified chord defers to the central keymap, so it is rebindable — the
+        # rule the Repeater and Fuzzer already follow. Without it the pane handlers below
+        # swallow it (`edit_json(...); true`), which is exactly why ^L/^A/^E had to be
+        # hardcoded above: a verb chord would have been silently eaten before the keymap.
+        return false
       elsif key.escape?
         handle_escape
       else

--- a/src/gori/tui/controllers/jwt_controller.cr
+++ b/src/gori/tui/controllers/jwt_controller.cr
@@ -567,7 +567,15 @@ module Gori::Tui
         elsif dec_c.contains?(mx, my)
           enter_pane(s, :decoded)
         elsif atk_c.contains?(mx, my)
+          # Select-only, not select-then-open: ↵ on this list COPIES the payload to the
+          # clipboard, and a second click quietly filling the clipboard is not what a click
+          # means anywhere else here.
           enter_pane(s, :attacks)
+          if row = s.view.attacks_gauge_row(atk_c, mx, my, s.attacks.size)
+            s.view.select_attack_row(row, s.attacks.size)
+          elsif row = s.view.attacks_row_at(atk_c, my, s.attacks.size)
+            s.view.select_attack_row(row, s.attacks.size)
+          end
         end
       else
         hdr_c, pay_c, sec_c, out_c = s.view.encode_layout(body)
@@ -579,6 +587,9 @@ module Gori::Tui
           s.payload.click_to_cursor(pay_c.inset(1, 1), mx, my)
         elsif sec_c.contains?(mx, my)
           enter_pane(s, :secret)
+          # The ` ^A:<alg> ` badge on the card's own border — the Decoder's identical
+          # ` ^X:<mode> ` chip has always been clickable, and this one was drawn and inert.
+          cycle_alg if s.view.secret_alg_hit(sec_c, mx, my, s.alg)
         elsif out_c.contains?(mx, my)
           enter_pane(s, :output)
         end

--- a/src/gori/tui/controllers/miner_controller.cr
+++ b/src/gori/tui/controllers/miner_controller.cr
@@ -485,7 +485,7 @@ module Gori::Tui
       engine, err = view.build_engine(!@host.session.config.insecure_upstream?,
         @host.session.scope, @host.session.host_overrides)
       unless engine
-        @host.status(err || "cannot mine")
+        @host.status(err || "can't mine")
         return
       end
       view.begin_run
@@ -614,7 +614,7 @@ module Gori::Tui
     # --- close / persist ---
     def request_close : Nil
       return unless tab = current_tab_obj
-      @host.confirm("CLOSE MINER", "Close mining session \"#{tab.view.summary}\"?\nIts config and results are discarded.",
+      @host.confirm("CLOSE MINER", "Close mining session “#{tab.view.summary}”?\nIts config and results are discarded.",
         confirm_label: "close", danger: true) { close_tab }
     end
 

--- a/src/gori/tui/controllers/miner_controller.cr
+++ b/src/gori/tui/controllers/miner_controller.cr
@@ -215,14 +215,50 @@ module Gori::Tui
     def handle_click(rect : Rect, mx : Int32, my : Int32) : Bool
       body = body_rect_below_filter(rect)
       return true unless v = current_view
-      if pane = v.pane_at(body, mx, my)
-        v.focus_pane(pane) unless pane == :detail
+      # The MINER card's run control, before the pane it rides.
+      if v.summary_chrome_hit(body, mx, my)
         @host.focus_body
-        # The FINDING pane takes a row cursor from the pointer; the other two are lists the click
-        # already selected in.
-        v.detail_click(body, mx, my) if pane == :detail
+        v.focus_pane(:summary)
+        v.running? ? mine_stop : mine_run
+        return true
+      end
+      # The FINDINGS gauge on the card hairline, which `pane_at`'s rects exclude.
+      if row = v.results_gauge_row(body, mx, my)
+        @host.focus_body
+        v.focus_pane(:results)
+        v.select_result_row(row)
+        return true
+      end
+      if pane = v.pane_at(body, mx, my)
+        @host.focus_body
+        # FINDINGS defers its own `focus_pane` into `click_results` — the select-then-open
+        # test reads `v.focus`, so focusing first would make "already focused" always true
+        # and a first click on row 0 of an unfocused pane would open the detail outright.
+        # (The Fuzzer orders it this way for the same reason.)
+        if pane == :detail
+          v.detail_click(body, mx, my) # the FINDING pane takes a row cursor from the pointer
+        elsif pane == :results
+          click_results(v, body, mx, my)
+        else
+          v.focus_pane(pane)
+        end
       end
       true
+    end
+
+    # Select the row under the cursor (grabbing focus from another pane on the first click),
+    # or — a second click on the already-selected row while FINDINGS already holds focus —
+    # open its detail, so the mouse matches ↵. History, Issues, Probe, OAST and the Fuzzer
+    # all read this way; this list had no row hit-test at all.
+    private def click_results(v : MinerView, body : Rect, mx : Int32, my : Int32) : Nil
+      already = v.focus == :results
+      row = v.results_row_at(body, mx, my)
+      if row && already && row == v.results_selected_index
+        v.open_detail
+      else
+        v.focus_pane(:results)
+        v.select_result_row(row) if row
+      end
     end
 
     # --- mouse drag + double-click (see TabController#supports_drag?) ---

--- a/src/gori/tui/controllers/notes_controller.cr
+++ b/src/gori/tui/controllers/notes_controller.cr
@@ -111,9 +111,9 @@ module Gori::Tui
         else
           @notes.read_move(-1, 0, selecting: selecting)
         end
-      when key.down?  then @notes.read_move(1, 0, selecting: selecting)
-      when key.left?  then @notes.read_move(0, -1, selecting: selecting)
-      when key.right? then @notes.read_move(0, 1, selecting: selecting)
+      when key.down?                  then @notes.read_move(1, 0, selecting: selecting)
+      when key.left?                  then @notes.read_move(0, -1, selecting: selecting)
+      when key.right?                 then @notes.read_move(0, 1, selecting: selecting)
       when @notes.read_motion_key(ev) then nil # Page keys + ⇧Home/⇧End — the shared editor set
       when c && !ev.ctrl? && !ev.alt? && !c.control?
         return false
@@ -126,8 +126,8 @@ module Gori::Tui
       case
       when key.enter? then @notes.newline
       when ev.ctrl_z? then @notes.undo
-      # Tested BEFORE plain ⌫, which would otherwise swallow the modified form as a
-      # one-character delete on a terminal that reports ⌥⌫ as Backspace+Alt.
+        # Tested BEFORE plain ⌫, which would otherwise swallow the modified form as a
+        # one-character delete on a terminal that reports ⌥⌫ as Backspace+Alt.
       when @notes.word_delete_key?(ev) then @notes.motion_key(ev)
       when key.backspace?              then @notes.backspace
       when key.up?
@@ -140,8 +140,8 @@ module Gori::Tui
           @notes.motion_key(ev)
         end
       when key.delete? then @notes.delete
-      # ⇧arrows select, Page keys, ⌥←/→ by word — the same set every other editor has
-      # (TextArea#handle_motion_key).
+        # ⇧arrows select, Page keys, ⌥←/→ by word — the same set every other editor has
+        # (TextArea#handle_motion_key).
       when @notes.motion_key(ev) then nil
       else
         if c && !ev.ctrl? && !ev.alt?
@@ -272,7 +272,7 @@ module Gori::Tui
         "type to edit · esc read · ^N new · ^W close · ^G goto · ^F find · ^1-9 · ↑ sub-tabs"
       else
         y = Hotkeys.binding_label(@host.session.registry, "notes.copy", "y")
-        "i/↵ edit · ⇧arrows select · #{y} copy · space cmds · ^N new · ^W close · ^G goto · ^F find · esc tabs"
+        "i/↵ edit · ⇧arrows select · #{y} copy · space cmds · ^N new · ^W close · ^G goto · ^F find · esc sub-tabs"
       end
     end
 
@@ -319,7 +319,7 @@ module Gori::Tui
       @notes.new_note
       @notes.enter_insert!
       @host.focus_body
-      @host.status("new note (#{@notes.count}) — ^1-9 switch · ^W close · esc tabs")
+      @host.status("new note (#{@notes.count}) — ^1-9 switch · ^W close · esc sub-tabs")
     end
 
     # Create a blank note without focusing the Notes tab (link-picker "create +

--- a/src/gori/tui/controllers/notes_controller.cr
+++ b/src/gori/tui/controllers/notes_controller.cr
@@ -347,7 +347,7 @@ module Gori::Tui
         do_notes_close
         return
       end
-      @host.confirm("CLOSE NOTE", "Close \"#{@notes.current_label}\"?\nIts text will be discarded.",
+      @host.confirm("CLOSE NOTE", "Close “#{@notes.current_label}”?\nIts text will be discarded.",
         confirm_label: "close", danger: true) { do_notes_close }
     end
 

--- a/src/gori/tui/controllers/oast_controller.cr
+++ b/src/gori/tui/controllers/oast_controller.cr
@@ -628,7 +628,7 @@ module Gori::Tui
 
     def delete_provider : Nil
       return unless p = selected_provider
-      @host.confirm("DELETE PROVIDER", "Delete OAST provider \"#{p.name}\"?\nIts callback history is kept.",
+      @host.confirm("DELETE PROVIDER", "Delete OAST provider “#{p.name}”?\nIts callback history is kept.",
         confirm_label: "delete", danger: true) do
         if l = @listeners.find { |ls| ls.provider_key == p.key }
           stop_listener(l)

--- a/src/gori/tui/controllers/oast_controller.cr
+++ b/src/gori/tui/controllers/oast_controller.cr
@@ -208,7 +208,9 @@ module Gori::Tui
         return "type to filter · ↵ keep · esc clear" if @filter_editing
         "↑/↓ select · ‹/› provider · g payload · y copy · / filter · ^R listen · ^X stop · ↵ detail · space cmds"
       else
-        "↑/↓ select · a add · e edit · t toggle · d delete · space cmds · esc sub-tabs"
+        # `x on/off` and `↵/e edit` — the vocabulary the three sibling rule lists use. Toggle was
+        # `t` here alone, and ↵ has always opened the editor without the hint saying so.
+        "↑/↓ select · a add · ↵/e edit · x on/off · d delete · space cmds · esc sub-tabs"
       end
     end
 
@@ -1077,7 +1079,7 @@ module Gori::Tui
       when key.down?, key.lower_j? then @prov_sel = {@prov_sel + 1, {@providers.size - 1, 0}.max}.min
       when key.enter?, c == 'e'    then open_edit_provider
       when c == 'a'                then open_add_provider
-      when c == 't'                then toggle_provider
+      when c == 'x'                then toggle_provider
       when c == 'd'                then delete_provider
       else                              return false
       end

--- a/src/gori/tui/controllers/oast_controller.cr
+++ b/src/gori/tui/controllers/oast_controller.cr
@@ -872,7 +872,8 @@ module Gori::Tui
     end
 
     private def render_providers(screen : Screen, rect : Rect, focused : Bool) : Nil
-      Frame.card(screen, rect, "PROVIDERS (#{@providers.size})", border: focused ? Theme.focus_gold : Theme.border, bg: Theme.bg)
+      Frame.card(screen, rect, "PROVIDERS", border: Frame.pane_border(focused), bg: Theme.bg)
+      Frame.border_meta(screen, rect, "PROVIDERS", @providers.size.to_s)
       inner = rect.inset(1, 1)
       if @providers.empty?
         screen.text(inner.x + 1, inner.y, "no providers — press a to add one (interactsh is prefilled)", Theme.muted, Theme.bg, width: inner.w - 2)

--- a/src/gori/tui/controllers/oast_controller.cr
+++ b/src/gori/tui/controllers/oast_controller.cr
@@ -208,7 +208,7 @@ module Gori::Tui
         return "type to filter · ↵ keep · esc clear" if @filter_editing
         "↑/↓ select · ‹/› provider · g payload · y copy · / filter · ^R listen · ^X stop · ↵ detail · space cmds"
       else
-        "↑/↓ select · a add · e edit · t toggle · d delete · space cmds · esc tabs"
+        "↑/↓ select · a add · e edit · t toggle · d delete · space cmds · esc sub-tabs"
       end
     end
 
@@ -1041,10 +1041,10 @@ module Gori::Tui
         end
       when c == 'g' then generate_payload
       when c == 'y' then copy_payload
-      # `r` (resume) and `a` (add issue) are NOT claimed here: both open an overlay, which a
-      # controller cannot do, so they stay verbs with plain chords and reach the keymap through
-      # the `return false` below — the same fall-through every unhandled key takes.
-      else               return false
+        # `r` (resume) and `a` (add issue) are NOT claimed here: both open an overlay, which a
+        # controller cannot do, so they stay verbs with plain chords and reach the keymap through
+        # the `return false` below — the same fall-through every unhandled key takes.
+      else return false
       end
       sync_scroll
       true

--- a/src/gori/tui/controllers/probe_controller.cr
+++ b/src/gori/tui/controllers/probe_controller.cr
@@ -91,7 +91,7 @@ module Gori::Tui
       mode = Hotkeys.binding_label(reg, "probe.mode", "m")
       filt = Hotkeys.binding_label(reg, "probe.filter", "/")
       if rules_tab?
-        return "↑/↓ move · ↵/x toggle · a add · e edit · d delete · space cmds · ↑ sub-tabs · esc tabs"
+        return "↑/↓ select · ↵/x on/off · a add · e edit · d delete · space cmds · ↑ sub-tabs · esc tabs"
       elsif @probe.detail_open?
         "↑/↓ URL · ⇧arrows select · y copy · o flow · r repeater · p promote · space cmds · ←/esc back"
       elsif @probe.querying?

--- a/src/gori/tui/controllers/probe_controller.cr
+++ b/src/gori/tui/controllers/probe_controller.cr
@@ -111,7 +111,7 @@ module Gori::Tui
       elsif @probe.preview_enabled?
         "↑/↓ move · ↵ open · ↹ preview · #{mode} mode · #{filt} filter · space cmds"
       else
-        "o flow · r repeater · p promote · c dismiss · d delete · #{mode} mode · #{filt} filter · space cmds"
+        "↑/↓ move · ↵ open · o flow · r repeater · p promote · c dismiss · d delete · #{mode} mode · #{filt} filter · space cmds"
       end
     end
 

--- a/src/gori/tui/controllers/probe_controller.cr
+++ b/src/gori/tui/controllers/probe_controller.cr
@@ -133,7 +133,9 @@ module Gori::Tui
       content = BodyChrome.content_rect(rect, strip: true) # inside the frame, below the sub-tab strip
       if rules_tab?
         @host.focus_body
-        if idx = @rules.row_at(content, mx, my)
+        if row = @rules.gauge_row_at(content, mx, my)
+          @rules.select_index(row)
+        elsif idx = @rules.row_at(content, mx, my)
           # Select first; a click on the already-selected row toggles it (whole row is the switch).
           @rules.selected_index == idx ? rules_toggle_selected : @rules.select_index(idx)
         end
@@ -151,6 +153,20 @@ module Gori::Tui
         return true
       end
       list_rect, _ = @probe.list_split(content)
+      # The list's scroll gauge on the frame's right hairline — `list_row_at` excludes that
+      # column, so it was the one part of the list a click could not reach.
+      if row = @probe.gauge_row_at(content, mx, my)
+        @probe.set_preview_focus(:list)
+        @probe.select_index(row)
+        return true
+      end
+      # Row 0 — the MODE band. Its chip and its `a:CLOSED` badge are drawn in the dresses this
+      # codebase uses for clickable chrome and were the only two that answered nothing.
+      if chip = @probe.mode_band_hit(list_rect, mx, my)
+        # `probe.set-mode` lives on the Runner (it raises a picker), unlike the lens toggle.
+        chip == :mode ? @host.probe_set_mode : probe_toggle_closed
+        return true
+      end
       if my == list_rect.y + 1 && !@probe.querying? # the filter-bar row (below the MODE band)
         @probe.start_query
         return true

--- a/src/gori/tui/controllers/probe_controller.cr
+++ b/src/gori/tui/controllers/probe_controller.cr
@@ -136,8 +136,13 @@ module Gori::Tui
         if row = @rules.gauge_row_at(content, mx, my)
           @rules.select_index(row)
         elsif idx = @rules.row_at(content, mx, my)
-          # Select first; a click on the already-selected row toggles it (whole row is the switch).
-          @rules.selected_index == idx ? rules_toggle_selected : @rules.select_index(idx)
+          # SELECT ONLY, like the Rewriter's and Colormarker's rule lists. A second click used
+          # to toggle — the exact reflex `probe-rules.toggle` gave up its `↵` for, and for the
+          # same reason: no other rule list flips a scanning rule off from a repeat gesture,
+          # and here the row that answered a double-click was often a BUILT-IN, where `↵`
+          # (now edit, gated to custom rules) does nothing at all. One row, two gestures, two
+          # answers. `x` toggles.
+          @rules.select_index(idx)
         end
         return true
       end

--- a/src/gori/tui/controllers/probe_controller.cr
+++ b/src/gori/tui/controllers/probe_controller.cr
@@ -91,7 +91,15 @@ module Gori::Tui
       mode = Hotkeys.binding_label(reg, "probe.mode", "m")
       filt = Hotkeys.binding_label(reg, "probe.filter", "/")
       if rules_tab?
-        return "↑/↓ select · ↵/x on/off · a add · e edit · d delete · space cmds · ↑ sub-tabs · esc tabs"
+        # `↵/e edit`, matching every other rule list — ↵ no longer toggles here (see
+        # verbs/probe.cr). Edit and delete are named ONLY when they can fire: both are gated
+        # to a selected CUSTOM rule, and built-ins are most of this list, so advertising them
+        # on a built-in row promised two keys that did nothing on most of the rows.
+        #
+        # `esc sub-tabs`, not `esc tabs`: escape goes to the strip (handle_body_key), and the
+        # strip is always shown here, so `focus_pane` never downgrades it to the tab bar.
+        edits = rules_custom_selected? ? " · ↵/e edit · d delete" : ""
+        return "↑/↓ select · x on/off · a add#{edits} · space cmds · ↑ sub-tabs · esc sub-tabs"
       elsif @probe.detail_open?
         "↑/↓ URL · ⇧arrows select · y copy · o flow · r repeater · p promote · space cmds · ←/esc back"
       elsif @probe.querying?

--- a/src/gori/tui/controllers/probe_controller.cr
+++ b/src/gori/tui/controllers/probe_controller.cr
@@ -478,8 +478,11 @@ module Gori::Tui
 
     def rules_delete : Nil
       c = @rules.selected_row.try(&.custom) || return
-      @host.confirm("DELETE RULE",
-        "Delete custom rule \"#{c.title}\"?\nExisting findings from it are kept until cleared.",
+      # Sentence-case title, `Delete` button — the same dress every other policy-rule delete
+      # wears. This one shouted "DELETE RULE" over a lowercase `delete` button, so the one
+      # dialog an operator sees least often was also the one that looked unlike the rest.
+      @host.confirm("DELETE PROBE RULE",
+        "Delete custom rule “#{c.title}”? Existing findings from it are kept until cleared.",
         confirm_label: "delete", danger: true) do
         c.global? ? Settings.delete_scan_rule(c.id) : @host.session.store.delete_probe_custom_rule(c.id.to_i64)
         reload_rules

--- a/src/gori/tui/controllers/probe_controller.cr
+++ b/src/gori/tui/controllers/probe_controller.cr
@@ -329,7 +329,7 @@ module Gori::Tui
       # probe_generation reload can shift the selection in between — so both the suppress and
       # the delete must target THIS issue by id, not whatever happens to be selected at confirm.
       id, code, host, title = i.id, i.code, i.host, i.title
-      @host.confirm("DELETE ISSUE", "Delete \"#{title}\" on #{host}?", confirm_label: "delete", danger: true) do
+      @host.confirm("DELETE ISSUE", "Delete “#{title}” on #{host}?", confirm_label: "delete", danger: true) do
         # Suppress FIRST: delete's exec_task yields to the store writer, and an
         # in-flight Active/passive fiber can re-upsert the same (code, host) in
         # that window if suppress runs after delete.
@@ -378,7 +378,7 @@ module Gori::Tui
     def probe_dismiss_code : Nil
       return unless i = @probe.target_issue
       code = i.code
-      @host.confirm("DISMISS GROUP", "Dismiss all open \"#{code}\" issues?", confirm_label: "dismiss", danger: false) do
+      @host.confirm("DISMISS GROUP", "Dismiss all open “#{code}” issues?", confirm_label: "dismiss", danger: false) do
         n = ProbeController.dismiss_open_by_code(@host.session.store, @host.session.scope, code)
         @probe.reload(@host.session.store)
         @host.status("dismissed #{n} \"#{code}\" issue#{n == 1 ? "" : "s"}")
@@ -509,7 +509,7 @@ module Gori::Tui
         confirm_label: "delete", danger: true) do
         c.global? ? Settings.delete_scan_rule(c.id) : @host.session.store.delete_probe_custom_rule(c.id.to_i64)
         reload_rules
-        @host.status("deleted rule \"#{c.title}\"")
+        @host.status("probe rule deleted: #{c.title}")
       end
     end
 

--- a/src/gori/tui/controllers/probe_controller.cr
+++ b/src/gori/tui/controllers/probe_controller.cr
@@ -277,7 +277,7 @@ module Gori::Tui
           # into the notification center (#127). Still logged to the #124 event feed
           # (the AI firehose logs freely; only the human center suppresses it).
           @host.session.store.insert_event("probe", "error", "error", "Probe: #{ev.message}", goto_tab: "probe")
-          @host.status(ev.message)
+          @host.status("probe error: #{ev.message}")
         when Probe::CompleteEvent
           # A manual "Run active scan" in Always mode came back clean — the analyzer only emits
           # this when the operator asked to be told either way, so it always posts to the tray.
@@ -479,13 +479,28 @@ module Gori::Tui
       @host.open_custom_rule_editor(nil)
     end
 
+    # Both of these are reachable only from a selected CUSTOM rule, and both used to return
+    # in silence on anything else — so `e` and `d` on a built-in were dead keys with no word
+    # about why. The hint no longer promises them there (see `body_hint`), but a key can still
+    # be pressed on the strength of muscle memory, and a rule list that answers nothing is the
+    # same "did gori see that?" moment every sibling list avoids.
     def rules_edit : Nil
-      c = @rules.selected_row.try(&.custom) || return
+      c = selected_custom_rule || return
       @host.open_custom_rule_editor(c)
     end
 
+    # The selected CUSTOM rule, or nil with the reason on the strip. Built-ins live in code —
+    # there is nothing to open and nothing to remove — so the message names that rather than
+    # saying "nothing selected", which would be false: a row IS selected.
+    private def selected_custom_rule : Probe::CustomRule?
+      row = @rules.selected_row
+      return row.custom if row && row.custom
+      @host.status(row ? "built-in rules can't be edited or deleted — x turns one off" : "no rule selected")
+      nil
+    end
+
     def rules_delete : Nil
-      c = @rules.selected_row.try(&.custom) || return
+      c = selected_custom_rule || return
       # Sentence-case title, `Delete` button — the same dress every other policy-rule delete
       # wears. This one shouted "DELETE RULE" over a lowercase `delete` button, so the one
       # dialog an operator sees least often was also the one that looked unlike the rest.

--- a/src/gori/tui/controllers/project_controller.cr
+++ b/src/gori/tui/controllers/project_controller.cr
@@ -50,16 +50,16 @@ module Gori::Tui
     def body_hint(focus : Symbol) : String
       case @project_view.pane
       when :scope
-        "↑/↓ move · a add · ↵/e edit · d del · space cmds · esc sub-tabs"
+        "↑/↓ select · a add · ↵/e edit · d delete · space cmds · esc sub-tabs"
       when :overrides
-        @project_view.ov_adding? ? "type \"IP host\" · ↵ save · esc cancel" : "↑/↓ move · a add · ↵/e edit · d del · space cmds · esc sub-tabs"
+        @project_view.ov_adding? ? "type \"IP host\" · ↵ save · esc cancel" : "↑/↓ select · a add · ↵/e edit · d delete · space cmds · esc sub-tabs"
       when :env
         if @project_view.env_prefix_editing?
           "type prefix · ↵ save · esc cancel"
         elsif @project_view.env_adding?
           "type \"KEY VALUE\" · ↵ save · esc cancel"
         else
-          "↑/↓ move · a add · ↵/e edit · d del · space cmds · esc sub-tabs"
+          "↑/↓ select · a add · ↵/e edit · d delete · space cmds · esc sub-tabs"
         end
       when :settings
         if @project_view.settings_text_row?

--- a/src/gori/tui/controllers/project_controller.cr
+++ b/src/gori/tui/controllers/project_controller.cr
@@ -757,9 +757,12 @@ module Gori::Tui
 
     private def commit_project_env : Nil
       case @project_view.env_commit
-      when :empty   then @host.status("env var: empty")
-      when :invalid then @host.status(%(env var: need "KEY VALUE" or "KEY=value"))
-      when :dup     then @host.status("env var: KEY already defined")
+      when :empty then @host.status("env var: empty")
+      when :invalid then @host.status( # The KEY rule spelled out, as the global editor's copy of this message already did — a
+      # rejected entry is usually a key with a dash or a leading digit, so naming the shape is
+      # the difference between one retry and three.
+%(env var: need "KEY VALUE" or "KEY=value" — KEY is [A-Za-z_][A-Za-z0-9_]*))
+      when :dup then @host.status("env var: KEY already defined")
       when :ok
         Env.save_project(@host.session.store, @project_view.env_vars)
         n = @project_view.env_vars.size

--- a/src/gori/tui/controllers/project_controller.cr
+++ b/src/gori/tui/controllers/project_controller.cr
@@ -472,9 +472,12 @@ module Gori::Tui
       @host.open_scope_rule_editor(nil, "include", "host", "")
     end
 
+    # Says what is missing, like `scope_delete_rule` below and like every rule list in gori.
+    # `e` on an empty list used to be a dead key: the guard was here, it just never spoke, so
+    # the pane answered a keypress with nothing at all while `d` two methods down explained
+    # itself. Three panes on this tab had the same split.
     def scope_edit_rule : Nil
-      rule = @project_view.selected_rule
-      return unless rule
+      rule = @project_view.selected_rule || return @host.status("no scope rule selected")
       @project_view.focus_pane(:scope)
       @host.open_scope_rule_editor(rule.id, rule.kind, rule.match_type, rule.pattern)
     end
@@ -643,6 +646,7 @@ module Gori::Tui
     end
 
     def hostov_edit_entry : Nil
+      return @host.status("no host override selected") unless @project_view.selected_override_host
       @host.focus_body
       @project_view.ov_edit_start
     end
@@ -703,6 +707,7 @@ module Gori::Tui
     end
 
     def env_edit_var : Nil
+      return @host.status("no env var selected") unless @project_view.selected_env_key
       @host.focus_body
       @project_view.env_edit_start
     end

--- a/src/gori/tui/controllers/project_controller.cr
+++ b/src/gori/tui/controllers/project_controller.cr
@@ -495,7 +495,7 @@ module Gori::Tui
         # traffic, and reporting "removed" over one that still gates is the failure this
         # branch exists to prevent. Selection cannot have moved — the confirm is modal.
         if pat = @project_view.scope_delete
-          @host.status("removed scope rule: #{pat}#{scope_blackhole_note}")
+          @host.status("scope rule deleted: #{pat}#{scope_blackhole_note}")
         else
           @host.status("scope rule NOT removed (project busy) — it still gates traffic")
         end
@@ -656,7 +656,7 @@ module Gori::Tui
       @host.confirm("DELETE HOST OVERRIDE", "Delete the override for “#{host}”? This can't be undone.",
         confirm_label: "delete", danger: true) do
         if removed = @project_view.ov_delete
-          @host.status("removed host override: #{removed}")
+          @host.status("host override deleted: #{removed}")
         end
       end
     end
@@ -719,7 +719,7 @@ module Gori::Tui
         confirm_label: "delete", danger: true) do
         if removed = @project_view.env_delete
           Env.save_project(@host.session.store, @project_view.env_vars)
-          @host.status("removed env: #{removed}")
+          @host.status("env var deleted: #{removed}")
         end
       end
     end

--- a/src/gori/tui/controllers/project_controller.cr
+++ b/src/gori/tui/controllers/project_controller.cr
@@ -171,17 +171,26 @@ module Gori::Tui
       case pane
       when :scope
         @project_view.focus_pane(:scope)
-        if idx = @project_view.scope_row_at(rect, mx, my)
+        # The card's scroll gauge rides its right hairline, which `scope_row_at` excludes.
+        if row = @project_view.scope_gauge_row(rect, mx, my)
+          @project_view.select_scope(row)
+        elsif idx = @project_view.scope_row_at(rect, mx, my)
           @project_view.select_scope(idx)
         end
       when :overrides
         @project_view.focus_pane(:overrides)
-        if idx = @project_view.ov_row_at(rect, mx, my)
+        # The card's scroll gauge rides its right hairline, which `ov_row_at` excludes.
+        if row = @project_view.ov_gauge_row(rect, mx, my)
+          @project_view.select_override(row)
+        elsif idx = @project_view.ov_row_at(rect, mx, my)
           @project_view.select_override(idx)
         end
       when :env
         @project_view.focus_pane(:env)
-        if idx = @project_view.env_row_at(rect, mx, my)
+        # The card's scroll gauge rides its right hairline, which `env_row_at` excludes.
+        if row = @project_view.env_gauge_row(rect, mx, my)
+          @project_view.select_env(row)
+        elsif idx = @project_view.env_row_at(rect, mx, my)
           @project_view.select_env(idx)
         end
       when :desc

--- a/src/gori/tui/controllers/project_controller.cr
+++ b/src/gori/tui/controllers/project_controller.cr
@@ -479,15 +479,23 @@ module Gori::Tui
       @host.open_scope_rule_editor(rule.id, rule.kind, rule.match_type, rule.pattern)
     end
 
+    # Deleting a scope rule CONFIRMS, the way deleting a rewrite, colour or probe rule already
+    # did. These three project lists were the only policy rules `d` removed outright — and of
+    # the four, a scope rule is the one whose loss changes what the proxy lets through, so an
+    # accidental keypress here is the most expensive of the set.
     def scope_delete_rule : Nil
-      # Read the selection BEFORE the delete so a refused write can be told apart from an
-      # empty list: `scope_delete` returns nil for both, and staying silent about the first
-      # leaves the rule on screen with no hint that the keypress did nothing.
-      selected = @project_view.selected_rule
-      if pat = @project_view.scope_delete
-        @host.status("removed scope rule: #{pat}#{scope_blackhole_note}")
-      elsif selected
-        @host.status("scope rule NOT removed (project busy) — it still gates traffic")
+      rule = @project_view.selected_rule || return @host.status("no scope rule selected")
+      label = "#{rule.include? ? "incl" : "excl"} #{rule.match_type} #{rule.pattern}"
+      @host.confirm("DELETE SCOPE RULE", "Delete “#{label}”? This can't be undone.",
+        confirm_label: "delete", danger: true) do
+        # The store's answer, not an assumption: a rolled-back batch leaves the rule gating
+        # traffic, and reporting "removed" over one that still gates is the failure this
+        # branch exists to prevent. Selection cannot have moved — the confirm is modal.
+        if pat = @project_view.scope_delete
+          @host.status("removed scope rule: #{pat}#{scope_blackhole_note}")
+        else
+          @host.status("scope rule NOT removed (project busy) — it still gates traffic")
+        end
       end
     end
 
@@ -640,8 +648,12 @@ module Gori::Tui
     end
 
     def hostov_delete_entry : Nil
-      if host = @project_view.ov_delete
-        @host.status("removed host override: #{host}")
+      host = @project_view.selected_override_host || return @host.status("no host override selected")
+      @host.confirm("DELETE HOST OVERRIDE", "Delete the override for “#{host}”? This can't be undone.",
+        confirm_label: "delete", danger: true) do
+        if removed = @project_view.ov_delete
+          @host.status("removed host override: #{removed}")
+        end
       end
     end
 
@@ -696,9 +708,14 @@ module Gori::Tui
     end
 
     def env_delete_var : Nil
-      if key_name = @project_view.env_delete
-        Env.save_project(@host.session.store, @project_view.env_vars)
-        @host.status("removed env: #{key_name}")
+      key = @project_view.selected_env_key || return @host.status("no env var selected")
+      # The KEY, never the value — a confirm is a modal an operator may be sharing a screen on.
+      @host.confirm("DELETE ENV VAR", "Delete “#{key}”? This can't be undone.",
+        confirm_label: "delete", danger: true) do
+        if removed = @project_view.env_delete
+          Env.save_project(@host.session.store, @project_view.env_vars)
+          @host.status("removed env: #{removed}")
+        end
       end
     end
 

--- a/src/gori/tui/controllers/repeater_controller.cr
+++ b/src/gori/tui/controllers/repeater_controller.cr
@@ -658,6 +658,14 @@ module Gori::Tui
         # invalidates. Moving focus here would yank the caret out of whatever pane was being
         # edited — the key (`^V`) doesn't, and the click should not differ.
         repeater_toggle_http2 # cycles WS→h1→h2 on a handshake tab, flips h1⇄h2 elsewhere
+      when :mark
+        # The chord the badge names, doing what the chord does. It used to read `^K` — a
+        # legacy key bound to nothing anywhere in the app, echoed by two hint strings — while
+        # the marker an operator actually places comes from `^T` (repeater.toggle-decoded,
+        # which on an ordinary request inserts a § at the cursor). A badge advertising a dead
+        # key is worse than a badge with no key on it.
+        view.focus_pane(:request)
+        repeater_toggle_decoded
       when :send
         view.focus_pane(:request)
         repeater_send

--- a/src/gori/tui/controllers/repeater_controller.cr
+++ b/src/gori/tui/controllers/repeater_controller.cr
@@ -2024,11 +2024,6 @@ module Gori::Tui
     # Every modified key the EDITOR owns rather than the keymap — see the `handle_body_key`
     # branch. Shared with the Fuzzer's controller in spirit, not in code: the two dispatchers
     # have different shapes, and one predicate each is cheaper than a mixin nobody else wants.
-    private def editing_motion?(ev : Termisu::Event::Key) : Bool
-      return false unless ev.ctrl? || ev.alt?
-      key = ev.key
-      key.left? || key.right? || key.home? || key.end? || word_delete?(ev)
-    end
 
     # A modified Home/End — the BUFFER's start/end rather than the line's.
     private def buffer_jump?(ev : Termisu::Event::Key) : Bool

--- a/src/gori/tui/controllers/repeater_controller.cr
+++ b/src/gori/tui/controllers/repeater_controller.cr
@@ -232,6 +232,16 @@ module Gori::Tui
       sni = Hotkeys.binding_label(reg, "repeater.toggle-sni", "^S")
       diff = Hotkeys.binding_label(reg, "repeater.toggle-diff", "d")
       pretty = Hotkeys.binding_label(reg, "repeater.toggle-pretty", "p")
+      # The §-marker trio, named in both request footers. `^T` in particular was reachable
+      # only by already knowing it: the border badge advertises MARK, not the key that makes
+      # one, and the footer listed goto/find/hex while saying nothing about marking at all —
+      # on the pane whose whole reason to carry markers is that you are about to fuzz it.
+      # `toggle-decoded` IS the ^T verb; on a plain HTTP request it inserts a § at the cursor
+      # (a decode/WS tab has its own hint method, so the label can't mislead there).
+      params = Hotkeys.binding_label(reg, "repeater.auto-mark", "^A")
+      word = Hotkeys.binding_label(reg, "repeater.mark-word", "^K")
+      point = Hotkeys.binding_label(reg, "repeater.toggle-decoded", "^T")
+      marks = "#{params} params · #{word} word · #{point} point"
       # ^R send lives on the REQUEST border chip (` ^R:SEND `) — not re-listed in the
       # request-focus footer (discoverability is the border badge; keys still work).
       return "HEX: 0-9a-f overtype · Ins/Del/⌫ bytes · ←/→/↑/↓ move · #{hex}/esc exit" if v.request_hex?
@@ -262,12 +272,12 @@ module Gori::Tui
           # → `request_tab_insert`) — a header value is allowed to hold one, and this is the
           # only editor that can type it. The pane ring is Tab's job only in READ mode, and
           # the footer said otherwise for both.
-          "type to edit · ⇧arrows select · ^Z undo · ^G goto · ^F find · #{hex} hex · esc read · ↹ text"
+          "type to edit · ⇧arrows select · ^Z undo · #{marks} · ^G goto · ^F find · #{hex} hex · esc read · ↹ text"
         else
           # The way back on an overridden handshake tab: the MESSAGES pane is hidden there, so
           # `^T` — the key that would otherwise reveal it — is not drawn to point at it.
           back = v.ws_http_only? ? " · ^V websocket" : ""
-          "i/↵ edit · #{read_common} · ^G goto · ^F find · #{hex} hex#{back} · ↹ pane · esc tabs"
+          "i/↵ edit · #{read_common} · #{marks} · ^G goto · ^F find · #{hex} hex#{back} · ↹ pane · esc tabs"
         end
       else
         ""

--- a/src/gori/tui/controllers/repeater_controller.cr
+++ b/src/gori/tui/controllers/repeater_controller.cr
@@ -1394,7 +1394,7 @@ module Gori::Tui
     # are discarded. No-op when no repeater is open.
     def request_close : Nil
       return unless tab = current_repeater_tab
-      @host.confirm("CLOSE REPEATER", "Close repeater \"#{tab.view.summary}\"?\nThe edited request and response are discarded.",
+      @host.confirm("CLOSE REPEATER", "Close repeater “#{tab.view.summary}”?\nThe edited request and response are discarded.",
         confirm_label: "close", danger: true) { close_repeater_tab }
     end
 

--- a/src/gori/tui/controllers/rewriter_controller.cr
+++ b/src/gori/tui/controllers/rewriter_controller.cr
@@ -756,7 +756,7 @@ module Gori::Tui
       when :preview_out
         "↑/↓ move · ⇧arrows select · y copy · x line · space cmds · ← input · esc input"
       else
-        "[/] sub-tab · ↑/↓ select · a add · ↵/e edit · x on/off · s global/project · d delete · ⇧J/⇧K reorder · esc tabs"
+        "[/] sub-tab · ↑/↓ select · a add · ↵/e edit · x on/off · s global/project · d delete · ⇧K/⇧J reorder · esc tabs"
       end
     end
   end

--- a/src/gori/tui/controllers/rewriter_controller.cr
+++ b/src/gori/tui/controllers/rewriter_controller.cr
@@ -568,8 +568,8 @@ module Gori::Tui
       # looks the same as a project rule's apart from one badge, and the confirm is the last
       # place to notice which of the two is about to go.
       note = rule.global? ? " It is a GLOBAL rule — this removes it from every project." : ""
-      @host.confirm("Delete rule", "Delete “#{label}”?#{note} This can't be undone.",
-        confirm_label: "Delete", danger: true) do
+      @host.confirm("DELETE RULE", "Delete “#{label}”?#{note} This can't be undone.",
+        confirm_label: "delete", danger: true) do
         # The store's answer, not an assumption: a rolled-back write left the rule rewriting
         # live traffic while this toasted "rule deleted". Both headless surfaces already
         # refuse to say that (`mcp/tools/rules.cr`, `cli/run/rewriter.cr`).
@@ -701,8 +701,8 @@ module Gori::Tui
 
     def extract_delete : Nil
       rule = selected_extract_rule || return @host.status("no extract rule selected")
-      @host.confirm("Delete extract rule", "Delete “$#{rule.name}”? Its binding is forgotten too.",
-        confirm_label: "Delete", danger: true) do
+      @host.confirm("DELETE EXTRACT RULE", "Delete “$#{rule.name}”? Its binding is forgotten too.",
+        confirm_label: "delete", danger: true) do
         ok = bindings.remove(rule.id)
         @sub_sel = @sub_sel.clamp(0, {extract_list.size - 1, 0}.max)
         @host.status(ok ? "extract rule deleted" : "extract rule NOT deleted (project busy) — it is still observing responses")

--- a/src/gori/tui/controllers/rewriter_controller.cr
+++ b/src/gori/tui/controllers/rewriter_controller.cr
@@ -428,9 +428,17 @@ module Gori::Tui
         return true
       end
       unless @sub == :rules
-        if idx = @view.sub_row_at(inner, mx, my, @sub_scroll, sub_count)
+        if row = @view.gauge_row_at(inner, mx, my, sub_count)
+          @sub_sel = row
+        elsif idx = @view.sub_row_at(inner, mx, my, @sub_scroll, sub_count)
           @sub_sel = idx
         end
+        return true
+      end
+      # The RULES list's scroll gauge rides the card's right hairline, which `row_at` excludes.
+      if row = @view.rules_gauge_row_at(inner, mx, my, rule_list.size, rules_engine.active?)
+        @focus = :list
+        @sel = row
         return true
       end
       case @view.pane_at(inner, mx, my)

--- a/src/gori/tui/controllers/rewriter_controller.cr
+++ b/src/gori/tui/controllers/rewriter_controller.cr
@@ -117,6 +117,16 @@ module Gori::Tui
       @sub == :rules
     end
 
+    # …and the FOCUS half of the same question. `rules_sub?` says the list is on screen;
+    # this says it is the thing the keyboard is pointed at. Both are needed now that the
+    # rule verbs carry real chords: the preview panes sit in the same body, and `d` there
+    # would otherwise delete the rule behind them. The menu was already safe by a different
+    # route (`command_section` answers :preview, and the verbs are `section: :rules`) — a
+    # chord has no section to hide behind.
+    def rule_list_focused? : Bool
+      @sub == :rules && @focus == :list
+    end
+
     # --- render ---
     def render_body(screen : Screen, rect : Rect, focus : Symbol) : Nil
       body_focused = focus == :body
@@ -281,7 +291,21 @@ module Gori::Tui
       when key.up?, c == 'k'                   then move_up
       when key.down?, c == 'j'                 then list_down
       when key.escape?                         then @host.request_focus(:menu)
-      else                                          return handle_action_key(ev, c)
+      when c == 'x'
+        # The one action still dispatched here, and not an oversight: `rewriter.select-line`
+        # binds bare `x` in this same SCOPE for the preview pane, and `Keymap#lookup` is keyed
+        # by scope alone — a chord on `rewriter.toggle` would shadow one of the two. The
+        # keymap has no focus dimension; this method only runs when the LIST has focus, so it
+        # is the disambiguator. (Trade-off: `x` alone is not rebindable here.)
+        rewriter_toggle
+      else
+        # a/↵/e/d/⇧X/s/⇧J/⇧K defer to the central keymap, so the rule actions are
+        # REBINDABLE and dispatch through the same `available?` gate the space menu uses —
+        # which is now focus-aware (`rewriter_rule_list_focused?`), because a chord has no
+        # `section:` to keep it away from the preview panes the way the menu entries do.
+        # This list and the Colormarker's were the last two rule lists still hand-rolling
+        # their keys while the other four bound real chords.
+        return false
       end
       true
     end
@@ -304,22 +328,6 @@ module Gori::Tui
       else
         move_sel(-1)
       end
-    end
-
-    private def handle_action_key(ev : Termisu::Event::Key, c : Char?) : Bool
-      key = ev.key
-      case
-      when key.enter?, c == 'e' then rewriter_edit
-      when c == 'a'             then rewriter_add
-      when c == 'd'             then rewriter_delete
-      when c == 'x'             then rewriter_toggle
-      when c == 'X'             then rewriter_toggle_default
-      when c == 's'             then rewriter_scope_toggle
-      when c == 'J'             then rewriter_move(1)
-      when c == 'K'             then rewriter_move(-1)
-      else                           return false
-      end
-      true
     end
 
     # Everything below the three pane-crossing arms is `TextArea#handle_motion_key` — the ONE

--- a/src/gori/tui/controllers/rewriter_controller.cr
+++ b/src/gori/tui/controllers/rewriter_controller.cr
@@ -557,12 +557,12 @@ module Gori::Tui
       if rule = selected_rule
         @host.open_rewriter_rule_editor(rule)
       else
-        @host.status("no rule selected")
+        @host.status("no rewrite rule selected")
       end
     end
 
     def rewriter_delete : Nil
-      rule = selected_rule || return @host.status("no rule selected")
+      rule = selected_rule || return @host.status("no rewrite rule selected")
       label = rule.name.empty? ? rule.pattern : rule.name
       # A global rule is deleted out of EVERY project, and the prompt has to say so — the row
       # looks the same as a project rule's apart from one badge, and the confirm is the last
@@ -575,7 +575,7 @@ module Gori::Tui
         # refuse to say that (`mcp/tools/rules.cr`, `cli/run/rewriter.cr`).
         ok = rules_engine.remove(rule.id, rule.scope)
         @sel = @sel.clamp(0, {rule_list.size - 1, 0}.max)
-        @host.status(ok ? "rule deleted" : "rule NOT deleted (project busy) — it is still rewriting traffic")
+        @host.status(ok ? "rule deleted: #{label}" : "rule NOT deleted (project busy) — it is still rewriting traffic")
       end
     end
 
@@ -584,7 +584,7 @@ module Gori::Tui
     # the change lands — the same keypress means "off in this engagement", not "off everywhere"
     # (that is ⇧X / `rewriter_toggle_default`).
     def rewriter_toggle : Nil
-      rule = selected_rule || return @host.status("no rule selected")
+      rule = selected_rule || return @host.status("no rewrite rule selected")
       unless rules_engine.toggle(rule.id, rule.scope)
         return @host.status("enable/disable NOT applied (project busy) — the rule is unchanged")
       end
@@ -594,7 +594,7 @@ module Gori::Tui
 
     # ⇧X: the global DEFAULT — what every project that has not overridden this rule follows.
     def rewriter_toggle_default : Nil
-      rule = selected_rule || return @host.status("no rule selected")
+      rule = selected_rule || return @host.status("no rewrite rule selected")
       return @host.status("only a global rule has a default — this one is project-scoped") unless rule.global?
       unless rules_engine.toggle_default(rule.id)
         return @host.status("default NOT changed (settings not writable) — the rule is unchanged")
@@ -605,7 +605,7 @@ module Gori::Tui
     end
 
     def rewriter_move(dir : Int32) : Nil
-      rule = selected_rule || return @host.status("no rule selected")
+      rule = selected_rule || return @host.status("no rewrite rule selected")
       # Only follow the rule when it actually moved: ⇧J on the last GLOBAL rule cannot push it
       # into the project block (that is a scope change, `s`), and walking the cursor there
       # anyway would read as a swap that never happened.
@@ -613,7 +613,7 @@ module Gori::Tui
     end
 
     def rewriter_duplicate : Nil
-      rule = selected_rule || return @host.status("no rule selected")
+      rule = selected_rule || return @host.status("no rewrite rule selected")
       name = rule.name.empty? ? "" : "#{rule.name} copy"
       rules_engine.add(rule.target, rule.part, rule.pattern, rule.replacement,
         rule.op, rule.match_kind, name, rule.host, rule.body_file, scope: rule.scope)
@@ -623,7 +623,7 @@ module Gori::Tui
     # `s`: move the selected rule between the global library and this project. The rule keeps
     # its fields and the state it has HERE; what changes is who else sees it.
     def rewriter_scope_toggle : Nil
-      rule = selected_rule || return @host.status("no rule selected")
+      rule = selected_rule || return @host.status("no rewrite rule selected")
       to = rule.global? ? Store::RuleScope::Project : Store::RuleScope::Global
       unless rules_engine.set_scope(rule, to)
         return @host.status("scope NOT changed (project busy or settings not writable) — the rule is unchanged")

--- a/src/gori/tui/controllers/sequencer_controller.cr
+++ b/src/gori/tui/controllers/sequencer_controller.cr
@@ -242,15 +242,50 @@ module Gori::Tui
     def handle_click(rect : Rect, mx : Int32, my : Int32) : Bool
       body = body_rect_below_filter(rect)
       return true unless v = current_view
-      if pane = v.pane_at(body, mx, my)
-        v.focus_pane(pane) unless pane == :detail
+      # The SEQUENCER card's run control, before the pane it rides.
+      if v.config_chrome_hit(body, mx, my)
         @host.focus_body
-        # The ANALYSIS report takes a row cursor from the pointer; the other panes are lists and
-        # fields the click already selected.
-        v.analysis_click(v.analysis_body(body), mx, my) if pane == :analysis
-        v.detail_click(body, mx, my) if pane == :detail
+        v.focus_pane(:config)
+        v.running? ? sequence_stop : sequence_run
+        return true
+      end
+      # The SAMPLES gauge on the card hairline, which `pane_at`'s rects exclude.
+      if row = v.samples_gauge_row(body, mx, my)
+        @host.focus_body
+        v.focus_pane(:samples)
+        v.select_sample_row(row)
+        return true
+      end
+      if pane = v.pane_at(body, mx, my)
+        @host.focus_body
+        # SAMPLES defers its own `focus_pane` into `click_samples`: that test reads `v.focus`,
+        # so focusing first would make "already focused" always true and a first click on the
+        # selected row of an unfocused pane would open the detail outright.
+        if pane == :samples
+          click_samples(v, body, mx, my)
+        else
+          v.focus_pane(pane) unless pane == :detail
+          # The ANALYSIS report takes a row cursor from the pointer; CONFIG is a field list
+          # the click already selected in.
+          v.analysis_click(v.analysis_body(body), mx, my) if pane == :analysis
+          v.detail_click(body, mx, my) if pane == :detail
+        end
       end
       true
+    end
+
+    # Select the row under the cursor, or — a second click on the already-selected row while
+    # SAMPLES already holds focus — open its detail, so the mouse matches ↵. The same
+    # select-then-open every other list in the tree uses; this one took no row click at all.
+    private def click_samples(v : SequencerView, body : Rect, mx : Int32, my : Int32) : Nil
+      already = v.focus == :samples
+      row = v.samples_row_at(body, mx, my)
+      if row && already && row == v.samples_selected_index
+        v.open_detail
+      else
+        v.focus_pane(:samples)
+        v.select_sample_row(row) if row
+      end
     end
 
     # --- mouse drag + double-click (see TabController#supports_drag?) ---

--- a/src/gori/tui/controllers/sequencer_controller.cr
+++ b/src/gori/tui/controllers/sequencer_controller.cr
@@ -603,7 +603,7 @@ module Gori::Tui
       engine, err = view.build_engine(!@host.session.config.insecure_upstream?, @host.session.scope,
         @host.session.host_overrides)
       unless engine
-        @host.status(err || "cannot collect")
+        @host.status(err || "can't collect")
         return
       end
       view.begin_run
@@ -732,7 +732,7 @@ module Gori::Tui
     # --- close / persist ---
     def request_close : Nil
       return unless tab = current_tab_obj
-      @host.confirm("CLOSE SEQUENCER", "Close sequencing session \"#{tab.view.summary}\"?\nIts config and collected tokens are discarded.",
+      @host.confirm("CLOSE SEQUENCER", "Close sequencing session “#{tab.view.summary}”?\nIts config and collected tokens are discarded.",
         confirm_label: "close", danger: true) { close_tab }
     end
 

--- a/src/gori/tui/controllers/sitemap_controller.cr
+++ b/src/gori/tui/controllers/sitemap_controller.cr
@@ -94,7 +94,7 @@ module Gori::Tui
       return "type query · ↹ complete · ↵ apply · esc clear" if @sitemap.querying?
       # Marks survive a filter change, so the `/` affordance stays up while they're set.
       return "↑/↓ move · / filter · t mark · ⇧T tag · space cmds · esc clears marks" if @sitemap.mark_count > 0
-      "↑/↓ move · / filter · t mark · ⇧T tag · g fold · ↵/→ expand · ← collapse · esc tabs"
+      "↑/↓ move · / filter · t mark · ⇧T tag · g fold · ↵/→ expand · ← collapse · esc sub-tabs"
     end
 
     # Live IME composition flows to whichever text field is open (the QL filter bar or

--- a/src/gori/tui/controllers/sitemap_controller.cr
+++ b/src/gori/tui/controllers/sitemap_controller.cr
@@ -72,6 +72,13 @@ module Gori::Tui
     # below its sub-tab strip; the standalone path insets the frame itself).
     def handle_click_content(content : Rect, mx : Int32, my : Int32) : Bool
       @host.focus_body
+      # The scroll gauge on the frame's right hairline — one column outside the tree rect, so
+      # `row_at` never sees it. A click there moves the cursor to the row it points at.
+      if row = @sitemap.gauge_row_at(content, mx, my)
+        end_range_gesture unless row == @sitemap.selected_index
+        @sitemap.select_index(row)
+        return true
+      end
       return true unless ri = @sitemap.row_at(content, mx, my)
       # A click that MOVES the cursor collapses the range, same as a plain arrow. A click on
       # the row already under the cursor doesn't: that reads as "expand this node" (the marker

--- a/src/gori/tui/controllers/sitemap_controller.cr
+++ b/src/gori/tui/controllers/sitemap_controller.cr
@@ -100,7 +100,9 @@ module Gori::Tui
       return "type a tag · ↵ save · esc cancel" if @sitemap.tagging?
       return "type query · ↹ complete · ↵ apply · esc clear" if @sitemap.querying?
       # Marks survive a filter change, so the `/` affordance stays up while they're set.
-      return "↑/↓ move · / filter · t mark · ⇧T tag · space cmds · esc clears marks" if @sitemap.mark_count > 0
+      # `space tag`, not `⇧T`: tagging is menu-only now — ⇧T meant "mark all" in every other
+      # marked list, so a hand that learnt `t`/⇧T there opened a text prompt here.
+      return "↑/↓ move · / filter · t mark · space tag · space cmds · esc clears marks" if @sitemap.mark_count > 0
       # `space cmds` on BOTH branches. The mark-set branch above named it and this one did not,
       # so the same tab advertised the space menu only while marks happened to be set.
       "↑/↓ move · / filter · t mark · g fold · ↵/→ expand · space cmds · esc sub-tabs"
@@ -184,7 +186,7 @@ module Gori::Tui
     end
 
     # --- tag editor (a text sub-mode; the shell routes its keys via handle_tag_key) ---
-    # ⇧T — open the tag editor over the target set (the marks if any, else the selected
+    # `space` → T — open the tag editor over the target set (the marks if any, else the selected
     # node). A synthetic group fold node has no real path, so it can't be tagged — toast
     # instead of opening an empty editor.
     def sitemap_tag : Nil

--- a/src/gori/tui/controllers/sitemap_controller.cr
+++ b/src/gori/tui/controllers/sitemap_controller.cr
@@ -94,7 +94,9 @@ module Gori::Tui
       return "type query · ↹ complete · ↵ apply · esc clear" if @sitemap.querying?
       # Marks survive a filter change, so the `/` affordance stays up while they're set.
       return "↑/↓ move · / filter · t mark · ⇧T tag · space cmds · esc clears marks" if @sitemap.mark_count > 0
-      "↑/↓ move · / filter · t mark · ⇧T tag · g fold · ↵/→ expand · ← collapse · esc sub-tabs"
+      # `space cmds` on BOTH branches. The mark-set branch above named it and this one did not,
+      # so the same tab advertised the space menu only while marks happened to be set.
+      "↑/↓ move · / filter · t mark · g fold · ↵/→ expand · space cmds · esc sub-tabs"
     end
 
     # Live IME composition flows to whichever text field is open (the QL filter bar or

--- a/src/gori/tui/custom_rule_overlay.cr
+++ b/src/gori/tui/custom_rule_overlay.cr
@@ -269,28 +269,16 @@ module Gori::Tui
       when ROW_TITLE   then draw_field(screen, box, py, bg, fg, sel, "title:", @fields[:title])
       when ROW_DESC    then draw_field(screen, box, py, bg, fg, sel, "desc:", @fields[:desc])
       when ROW_PATTERN then draw_field(screen, box, py, bg, fg, sel, "pattern:", @fields[:pattern])
-      when ROW_SCOPE   then draw_cycle(screen, x, py, bg, fg, "scope:", SCOPES, @scope_i, sel)
-      when ROW_SIDE    then draw_cycle(screen, x, py, bg, fg, "side:", SIDES, @side_i, sel)
-      when ROW_REGION  then draw_cycle(screen, x, py, bg, fg, "region:", REGIONS, @region_i, sel)
-      when ROW_KIND    then draw_cycle(screen, x, py, bg, fg, "match:", KINDS, @kind_i, sel)
-      when ROW_SEV     then draw_cycle(screen, x, py, bg, fg, "severity:", SEVS, @sev_i, sel)
+      when ROW_SCOPE   then Frame.option_cycle(screen, x, py, box.right - 2, bg, "scope:", SCOPES, @scope_i, sel)
+      when ROW_SIDE    then Frame.option_cycle(screen, x, py, box.right - 2, bg, "side:", SIDES, @side_i, sel)
+      when ROW_REGION  then Frame.option_cycle(screen, x, py, box.right - 2, bg, "region:", REGIONS, @region_i, sel)
+      when ROW_KIND    then Frame.option_cycle(screen, x, py, box.right - 2, bg, "match:", KINDS, @kind_i, sel)
+      when ROW_SEV     then Frame.option_cycle(screen, x, py, box.right - 2, bg, "severity:", SEVS, @sev_i, sel)
       else
         ok = valid?
         label = ok ? "[ Save rule ]" : "[ complete title, description & pattern ]"
         screen.text(x, py, label, ok ? Theme.accent : Theme.muted, bg, Attribute::Bold)
       end
-    end
-
-    private def draw_cycle(screen : Screen, x : Int32, py : Int32, bg : Color, fg : Color,
-                           label : String, opts : Array(String), sel_i : Int32, row_sel : Bool) : Nil
-      screen.text(x, py, label, Theme.muted, bg)
-      tx = x + label.size + 1
-      opts.each_with_index do |opt, oi|
-        lit = oi == sel_i
-        col = lit ? (row_sel ? Theme.text_bright : Theme.accent) : Theme.muted
-        tx = screen.text(tx, py, " #{opt} ", col, bg, lit ? Attribute::Bold : Attribute::None)
-      end
-      screen.text(tx, py, " ‹/›", Theme.muted, bg) if row_sel
     end
 
     private def draw_field(screen : Screen, box : Rect, py : Int32, bg : Color, fg : Color,

--- a/src/gori/tui/custom_rule_overlay.cr
+++ b/src/gori/tui/custom_rule_overlay.cr
@@ -234,10 +234,7 @@ module Gori::Tui
     end
 
     def overlay_box(area : Rect) : Rect?
-      w = {area.w - 4, 62}.min
-      h = {area.h - 2, ROW_COUNT + 4}.min # title + rows + footer + padding
-      return nil if w < 34 || h < 11
-      Rect.new(area.x + (area.w - w) // 2, area.y + (area.h - h) // 2, w, h)
+      Overlay.rule_form_box(area, ROW_COUNT)
     end
 
     def render(screen : Screen, area : Rect) : Nil

--- a/src/gori/tui/custom_rule_overlay.cr
+++ b/src/gori/tui/custom_rule_overlay.cr
@@ -254,9 +254,8 @@ module Gori::Tui
         break if py >= box.bottom - 1
         draw_row(screen, box, i, py)
       end
-      hint_y = box.bottom - 1
-      screen.text(box.x + 2, hint_y, "↑/↓ field · ←/→ options · ↵ save · esc cancel",
-        Theme.muted, Theme.panel, width: box.w - 4) if hint_y > first
+      # No key hint on the bottom border — the shell draws `hint` in the status strip for the
+      # open modal (Runner#key_hints). See RewriterRuleOverlay#render for the whole argument.
     end
 
     private def draw_row(screen : Screen, box : Rect, i : Int32, py : Int32) : Nil

--- a/src/gori/tui/decoder_view.cr
+++ b/src/gori/tui/decoder_view.cr
@@ -110,9 +110,13 @@ module Gori::Tui
     private def render_input(screen : Screen, card : Rect, input : TextArea, active : Bool,
                              mode : InputMode, read : TextReadState?, reading : Bool) : Nil
       Frame.card(screen, card, "INPUT", bg: Theme.bg, border: Frame.pane_border(active || reading))
-      if active || reading
-        Frame.mode_badge(screen, card.right - 1, card.y, card.x + 6, mode == InputMode::Insert)
-      end
+      # The REAL mode, drawn unconditionally — `Frame.mode_badge`'s contract, and the same
+      # bug Notes and the Fuzzer TEMPLATE already fixed. `DecoderController#handle_click`
+      # hit-tests `s.input_mode` alone, so gating the DRAW on focus left a live 5-cell target
+      # on a border with nothing painted on it: with focus on CHAIN or OUTPUT, a click on the
+      # INPUT card's blank top-right corner flipped the editor into insert. Nothing exits
+      # insert on a pane change, so that state is ordinary. Focus is carried by the border.
+      Frame.mode_badge(screen, card.right - 1, card.y, card.x + 6, mode == InputMode::Insert)
       body = card.inset(1, 1)
       input.render(screen, body, cursor: active, gauge: true, gauge_focused: active)
       paint_input_read_chrome(screen, body, input, read, reading) if reading && read

--- a/src/gori/tui/discover_config_overlay.cr
+++ b/src/gori/tui/discover_config_overlay.cr
@@ -232,15 +232,21 @@ module Gori::Tui
       screen.cell(box.x + 1, py, sel ? '▎' : ' ', Theme.accent, bg)
       x = box.x + 3
       case i
-      when ROW_TARGET  then cyc(screen, x, py, bg, sel, "start at:", selected_path, @seed.choices.size > 1)
+      when ROW_TARGET
+        # The one row whose options come from the seed rather than a constant — and the one
+        # that may not be cyclable at all (a single candidate). `focused: false` then drops
+        # the ‹/› cue, which is honest: the keys do nothing here.
+        Frame.option_cycle(screen, x, py, box.right - 2, bg, "start at:",
+          @seed.choices.map(&.to_s), @seed.choices.index(selected_path) || 0,
+          sel && @seed.choices.size > 1)
       when ROW_SPIDER  then check(screen, x, py, bg, sel, @spider, "spider (follow links)")
       when ROW_BRUTE   then check(screen, x, py, bg, sel, @bruteforce, "bruteforce (probe paths)")
       when ROW_EXT     then check(screen, x, py, bg, sel, @ext, "probe common extensions")
       when ROW_KEEP    then check(screen, x, py, bg, sel, @keep_alive, "reuse connections (keep-alive)")
-      when ROW_DEPTH   then cyc(screen, x, py, bg, sel, "max depth:", DEPTHS[@depth_idx].to_s)
-      when ROW_CONTAIN then cyc(screen, x, py, bg, sel, "scope:", CONTAINMENTS[@contain_idx].label)
-      when ROW_CONC    then cyc(screen, x, py, bg, sel, "concurrency:", CONCS[@conc_idx].to_s)
-      when ROW_MAXREQ  then cyc(screen, x, py, bg, sel, "max requests:", MAX_REQ_CHOICES[@maxreq_idx].try(&.to_s) || "uncapped")
+      when ROW_DEPTH   then Frame.option_cycle(screen, x, py, box.right - 2, bg, "max depth:", DEPTHS.map(&.to_s), @depth_idx, sel)
+      when ROW_CONTAIN then Frame.option_cycle(screen, x, py, box.right - 2, bg, "scope:", CONTAINMENTS.map(&.label), @contain_idx, sel)
+      when ROW_CONC    then Frame.option_cycle(screen, x, py, box.right - 2, bg, "concurrency:", CONCS.map(&.to_s), @conc_idx, sel)
+      when ROW_MAXREQ  then Frame.option_cycle(screen, x, py, box.right - 2, bg, "max requests:", MAX_REQ_CHOICES.map { |c| c.try(&.to_s) || "uncapped" }, @maxreq_idx, sel)
       when ROW_HEADERS then headers_row(screen, x, py, bg, sel)
       else                  start_row(screen, x, py, bg)
       end
@@ -263,12 +269,6 @@ module Gori::Tui
       vx = x + label.size + 1
       screen.text(vx, py, val, sel ? Theme.text_bright : Theme.text, bg)
       screen.text(vx + val.size + 2, py, "↵ edit", Theme.muted, bg)
-    end
-
-    private def cyc(screen : Screen, x : Int32, py : Int32, bg : Color, sel : Bool, label : String, val : String, cyclable : Bool = true) : Nil
-      screen.text(x, py, label, Theme.muted, bg)
-      shown = cyclable ? "#{val}  ‹/›" : val
-      screen.text(x + label.size + 1, py, shown, sel ? Theme.text_bright : Theme.text, bg)
     end
 
     def row_at(box : Rect, mx : Int32, my : Int32) : Int32?

--- a/src/gori/tui/discover_headers_overlay.cr
+++ b/src/gori/tui/discover_headers_overlay.cr
@@ -28,7 +28,7 @@ module Gori::Tui
   #
   # The refusal holds ONLY while the card that explains it is on screen. It used to hold
   # unconditionally, and that was a trap with no keyboard exit: `overlay_box` bails below
-  # w 34 / h 8 while `Layout.usable?` admits 40x8, so the whole 8–17-row band is
+  # a 34x8 card while `Layout.usable?` admits 40x8, so a band of short bodies is
   # live-but-unrenderable — the refusal was drawn on a branch that never ran, esc and
   # click-away both answered :stay, and the one line that DID draw advertised a dead key.
   # Only ^C/^D (quitting gori) or a resize got out. A refusal nobody can read is a lock,
@@ -172,8 +172,8 @@ module Gori::Tui
     end
 
     def overlay_box(area : Rect) : Rect?
-      w = {area.w - 6, 64}.min
-      h = {area.h - 4, 16}.min
+      w = {area.w - 4, 64}.min
+      h = {area.h - 2, 16}.min
       return nil if w < 34 || h < 8
       Rect.new(area.x + (area.w - w) // 2, area.y + (area.h - h) // 2, w, h)
     end

--- a/src/gori/tui/discover_headers_overlay.cr
+++ b/src/gori/tui/discover_headers_overlay.cr
@@ -82,7 +82,10 @@ module Gori::Tui
     end
 
     def hint : String
-      "one header per line · Host/Connection ignored · esc saves & closes"
+      # Keys only. The two format rules this editor enforces are stated on the card's own
+      # band, where the operator is already looking to type them — repeating them down here
+      # was the same sentence in two places, which is how the two spellings drifted.
+      "type headers · esc saves & closes"
     end
 
     # There is nothing to cancel INTO — the user is still inside the Discover popup — so a
@@ -205,7 +208,10 @@ module Gori::Tui
       if refused = @refused
         screen.text(box.x + 2, hintline, refused, Theme.red, Theme.bg, width: box.w - 4)
       else
-        screen.text(box.x + 2, hintline, "one per line · Host/Connection ignored · esc saves & closes", Theme.muted, Theme.bg, width: box.w - 4)
+        # The two rules this editor enforces, which nothing else states. The `esc saves &
+        # closes` tail came off — the shell draws `hint` in the status strip for the open
+        # modal, so spelling the key here was the same advice twice.
+        screen.text(box.x + 2, hintline, "one per line · Host/Connection ignored", Theme.muted, Theme.bg, width: box.w - 4)
       end
     end
 

--- a/src/gori/tui/discover_view.cr
+++ b/src/gori/tui/discover_view.cr
@@ -459,7 +459,8 @@ module Gori::Tui
     private def render_findings(screen : Screen, rect : Rect, focused : Bool) : Nil
       r = current
       n = r ? r.findings.size : 0
-      Frame.card(screen, rect, "FINDINGS (#{n})", border: focused ? Theme.focus_gold : Theme.border, bg: Theme.bg)
+      Frame.card(screen, rect, "FINDINGS", border: Frame.pane_border(focused), bg: Theme.bg)
+      Frame.border_meta(screen, rect, "FINDINGS", n.to_s)
       inner = rect.inset(1, 1)
       # A card under 3 rows has no interior — `inset` floors the height at 0 but keeps
       # `inner.y` one row down, so an unguarded placeholder lands OUTSIDE the pane.

--- a/src/gori/tui/discover_view.cr
+++ b/src/gori/tui/discover_view.cr
@@ -490,6 +490,11 @@ module Gori::Tui
         break if idx >= r.findings.size
         draw_row(screen, inner, r.findings[idx], idx, inner.y + 1 + i, focused)
       end
+      # The RUNS card six rows above has had a gauge all along; this one had none. A
+      # difference like that INSIDE one view reads as breakage rather than as a gap. Rows
+      # start at `inner.y + 1` — `inner.y` is the header — so the gauge measures from there.
+      Frame.scroll_gauge(screen, Rect.new(inner.x, inner.y + 1, inner.w, cap),
+        r.findings.size, @scroll, focused)
     end
 
     private def header_row(screen : Screen, inner : Rect) : Nil

--- a/src/gori/tui/discover_view.cr
+++ b/src/gori/tui/discover_view.cr
@@ -132,6 +132,11 @@ module Gori::Tui
   class DiscoverView
     PANE_ORDER = [:runs, :findings]
 
+    # The RUNS card's title, as a constant because THREE places measure it: the card, the
+    # run badge's `min_x`, and that badge's hit-test. It used to read `RUNS (#{@runs.size})`,
+    # so the badge's left stop moved every time the count gained a digit.
+    RUNS_TITLE = "RUNS"
+
     # Run-row column widths. The blocks are laid out from the right edge and DROP when the
     # body is narrow (counts first, then techniques) so a run's target and its status —
     # the two things an action needs — survive at any width.
@@ -326,8 +331,7 @@ module Gori::Tui
     end
 
     private def render_runs(screen : Screen, rect : Rect, focused : Bool) : Nil
-      title = "RUNS (#{@runs.size})"
-      Frame.card(screen, rect, title, border: Frame.pane_border(focused), bg: Theme.bg)
+      Frame.card(screen, rect, RUNS_TITLE, border: Frame.pane_border(focused), bg: Theme.bg)
       inner = rect.inset(1, 1)
       return if inner.h <= 0 || inner.w <= 0
       r = current
@@ -339,7 +343,12 @@ module Gori::Tui
       # The badge tracks the SELECTED row, which is what ^R/^X act on — so a stopped run
       # selected while another still crawls offers RUN, not STOP.
       chord, name = r.running? ? {"^X", "STOP"} : {"^R", "RUN"}
-      Frame.toggle_badge(screen, rect.right - 1, rect.y, rect.x + title.size + 4, chord, name, r.running?)
+      badge_x = Frame.toggle_badge(screen, rect.right - 1, rect.y, rect.x + RUNS_TITLE.size + 4, chord, name, r.running?)
+      # The count rides `border_meta`, not the title, like the FINDINGS card below it: a title
+      # that grows a digit moves every `min_x` derived from its width — the run badge's is.
+      # AFTER the badge and stopped at its left edge, because this border already carries one
+      # and the meta was otherwise drawn first and painted straight over.
+      Frame.border_meta(screen, rect, RUNS_TITLE, @runs.size.to_s, right_edge: badge_x - 1)
 
       rows_y, rows_cap, detail_y = run_bands(rect)
       runs_header_row(screen, inner) if rows_y > inner.y
@@ -543,19 +552,77 @@ module Gori::Tui
       res_rect.contains?(mx, my) ? :findings : nil
     end
 
-    # Focus the clicked pane, and on a RUNS row select that run — clicking a row is the
-    # discoverable way to reach an earlier crawl before pressing ^X on it.
+    # Focus the clicked pane, and select the row under the cursor in EITHER list — clicking a
+    # row is the discoverable way to reach an earlier crawl before pressing ^X on it, and
+    # FINDINGS used to fall out of this method one line in, so a click there focused the pane
+    # and left the cursor where it was. Its own sibling four lines up already selected.
     def click(rect : Rect, mx : Int32, my : Int32) : Nil
+      # Either card's scroll gauge first: it rides the frame hairline, which `pane_at` and
+      # both row hit-tests exclude.
+      if hit = gauge_hit(rect, mx, my)
+        pane, row = hit
+        focus_pane(pane)
+        pane == :runs ? select_run(row) : (@fsel = row)
+        return
+      end
       return unless pane = pane_at(rect, mx, my)
       focus_pane(pane)
-      return unless pane == :runs
-      card, _ = pane_rects(rect) # the same rect render framed, so a row click can't miss it
-      rows_y, rows_cap, _ = run_bands(card)
-      row = my - rows_y
-      return unless 0 <= row < rows_cap
-      idx = @rscroll + row
-      return unless 0 <= idx < @runs.size
-      select_run(idx)
+      runs_card, res_card = pane_rects(rect) # the tiling render drew into, not a re-derivation
+      if pane == :runs
+        rows_y, rows_cap, _ = run_bands(runs_card)
+        row = my - rows_y
+        return unless 0 <= row < rows_cap
+        idx = @rscroll + row
+        return unless 0 <= idx < @runs.size
+        select_run(idx)
+      else
+        return unless idx = findings_row_at(res_card, my)
+        @fsel = idx
+      end
+    end
+
+    # Mouse: the findings index under `my` within the FINDINGS card, or nil (no run, empty
+    # list, the header row, or past the last populated row). Mirrors render_findings'
+    # inset → header → @scroll+i. Y-only, like every other list hit-test here.
+    private def findings_row_at(card : Rect, my : Int32) : Int32?
+      r = current
+      return nil if r.nil? || r.findings.empty?
+      inner = card.inset(1, 1)
+      return nil if inner.h <= 0 || inner.w <= 0
+      i = my - (inner.y + 1) # rows start one line below the header
+      return nil if i < 0 || i >= {inner.h - 1, 0}.max
+      idx = @scroll + i
+      idx < r.findings.size ? idx : nil
+    end
+
+    # The RUNS / FINDINGS row a click on either card's scroll gauge asks for. Both scrolls
+    # are derived from their selection, so both answer with a selection.
+    def gauge_hit(rect : Rect, mx : Int32, my : Int32) : {Symbol, Int32}?
+      runs_card, res_card = pane_rects(rect)
+      rows_y, rows_cap, _ = run_bands(runs_card)
+      if row = Frame.scroll_gauge_row(Rect.new(runs_card.inset(1, 1).x, rows_y, runs_card.inset(1, 1).w, rows_cap),
+           @runs.size, mx, my)
+        return {:runs, row}
+      end
+      r = current || return nil
+      inner = res_card.inset(1, 1)
+      return nil if inner.h <= 1
+      if row = Frame.scroll_gauge_row(Rect.new(inner.x, inner.y + 1, inner.w, inner.h - 1),
+           r.findings.size, mx, my)
+        return {:findings, row}
+      end
+      nil
+    end
+
+    # Hit-test the RUNS card's run control (^R:RUN / ^X:STOP). It tracks the SELECTED row,
+    # exactly as render_runs draws it, so the click acts on the run the badge is describing.
+    def run_chrome_hit(rect : Rect, mx : Int32, my : Int32) : Symbol?
+      r = current || return nil
+      card, _ = pane_rects(rect)
+      return nil if card.empty?
+      chord, name = r.running? ? {"^X", "STOP"} : {"^R", "RUN"}
+      Frame.right_badge_hit(mx, my, card.y, card.right - 1, card.x + RUNS_TITLE.size + 4,
+        [{:run, chord, name}] of {Symbol, String, String})
     end
 
     private def select_run(idx : Int32) : Nil

--- a/src/gori/tui/env_overlay.cr
+++ b/src/gori/tui/env_overlay.cr
@@ -2,6 +2,7 @@ require "./screen"
 require "./theme"
 require "./frame"
 require "./highlight"
+require "./text_field"
 require "./overlay"
 require "../settings"
 require "../env"
@@ -25,9 +26,12 @@ module Gori::Tui
       @adding = false
       @prefix_editing = false
       @edit_index = nil.as(Int32?)
-      @input = ""
-      @icx = 0
-      @preedit = ""
+      # One `TextField` shared by the two inline editors this overlay opens (the add/edit row
+      # and the prefix row) — they are never open at once, and both used to stand on the same
+      # hand-rolled `@input`/`@icx`/`@preedit` triple. A TextField remembers the geometry it
+      # was drawn at, which is what gives the row a caret on a press, drag-select and
+      # double-click-word; the triple gave it none of them.
+      @field = TextField.new
       reset
     end
 
@@ -105,15 +109,12 @@ module Gori::Tui
         cancel_prefix_edit
       elsif key.enter?
         commit_prefix_and_persist
-      elsif key.left?
-        move_cursor(-1)
-      elsif key.right?
-        move_cursor(1)
       elsif key.backspace?
+        # The empty check comes BEFORE the field sees the key: `TextField#backspace` on an
+        # empty value is a silent no-op, and ⌫ on an empty row means "I am done here".
         cancel_prefix_edit unless backspace
-      elsif c && !ev.ctrl? && !ev.alt?
-        input(c)
-        set_preedit("")
+      else
+        @field.handle_edit_key(ev)
       end
       :stay
     end
@@ -125,18 +126,17 @@ module Gori::Tui
         cancel_add
       elsif key.enter?
         commit_and_persist
-      elsif key.left?
-        move_cursor(-1)
-      elsif key.right?
-        move_cursor(1)
       elsif key.backspace?
         cancel_add unless backspace
       elsif key.tab?
-        input(' ') # Tab types the KEY/VALUE separator, not a focus jump
-        set_preedit("")
-      elsif c && !ev.ctrl? && !ev.alt?
-        input(c)
-        set_preedit("")
+        # ↹ types the KEY/VALUE separator rather than jumping focus. There is nowhere to jump
+        # to — this row is one field holding a pair, which `commit_entry` parses. Deliberate,
+        # and the same in the hostname editor next door.
+        @field.insert(' ')
+      else
+        # Caret motion, word jumps, ⌥⌫ and selection now come from the shared editor; this
+        # row used to answer arrows with `move_cursor(±1)` and nothing else.
+        @field.handle_edit_key(ev)
       end
       :stay
     end
@@ -197,6 +197,8 @@ module Gori::Tui
         end
         return :stay
       end
+      # A press inside an open inline editor is a CARET, not a row pick — the row is text.
+      return :stay if (@adding || @prefix_editing) && click_text_field(mx, my)
       if idx = row_at(box, mx, my)
         set_selected(idx)
       end
@@ -219,25 +221,19 @@ module Gori::Tui
     def prefix_edit_start : Nil
       cancel_add
       @prefix_editing = true
-      @input = @prefix
-      @icx = @input.size
-      @preedit = ""
+      @field.set(@prefix)
     end
 
     def cancel_prefix_edit : Nil
       @prefix_editing = false
-      @input = ""
-      @icx = 0
-      @preedit = ""
+      @field.set("")
     end
 
     def add_start : Nil
       cancel_prefix_edit
       @adding = true
       @edit_index = nil
-      @input = ""
-      @icx = 0
-      @preedit = ""
+      @field.set("")
     end
 
     def edit_start : Nil
@@ -246,42 +242,40 @@ module Gori::Tui
       cancel_prefix_edit
       @adding = true
       @edit_index = @selected
-      @input = "#{key} #{val}"
-      @icx = @input.size
-      @preedit = ""
+      @field.set("#{key} #{val}")
     end
 
     def cancel_add : Nil
       @adding = false
       @edit_index = nil
-      @input = ""
-      @icx = 0
-      @preedit = ""
+      @field.set("")
     end
 
     def input(ch : Char) : Nil
-      @input = "#{@input[0, @icx]}#{ch}#{@input[@icx..]}"
-      @icx += 1
-      @preedit = ""
+      @field.insert(ch)
     end
 
+    # Whether there was anything to delete — the callers read this to tell a ⌫ that edited
+    # the text from one on an empty row, which cancels the row.
     def backspace : Bool
-      return false if @icx == 0
-      @input = "#{@input[0, @icx - 1]}#{@input[@icx..]}"
-      @icx -= 1
+      return false if @field.value.empty?
+      @field.backspace
       true
     end
 
-    def move_cursor(d : Int32) : Nil
-      @icx = (@icx + d).clamp(0, @input.size)
+    def set_preedit(text : String) : Nil
+      @field.set_preedit(text)
     end
 
-    def set_preedit(text : String) : Nil
-      @preedit = text
+    # The pointer contract (see `Overlay#text_fields`) — listed only while one of the two
+    # inline editors is open, so a click on the list cannot place a caret in a field that is
+    # not on screen.
+    def text_fields : Array(TextField)
+      (@adding || @prefix_editing) ? [@field] : [] of TextField
     end
 
     def commit_prefix : Symbol
-      text = @input.strip
+      text = @field.value.strip
       return :empty if text.empty?
       @prefix = text
       cancel_prefix_edit
@@ -295,7 +289,7 @@ module Gori::Tui
     # landmine the moment one is added: the shell would run this field parser instead of the
     # closure and read its truthy Symbol as "close me". (`commit_prefix` does not collide.)
     def commit_entry : Symbol
-      text = @input.strip
+      text = @field.value.strip
       return :empty if text.empty?
       parsed = Env.parse_line(text)
       return :invalid unless parsed
@@ -380,7 +374,7 @@ module Gori::Tui
       if @prefix_editing
         x = screen.text(x, py, "prefix ", Theme.accent, bg)
         w = {box.right - 1 - x, 3}.max
-        screen.input_line(x, py, @input, @icx, @preedit, Theme.text_bright, bg, width: w)
+        @field.render(screen, x, py, w, true, Theme.text_bright, bg)
       else
         screen.text(x, py, "prefix ", Theme.muted, bg)
         screen.text(x + 7, py, @prefix, Theme.text_bright, bg, width: {box.right - x - 8, 1}.max)
@@ -412,10 +406,13 @@ module Gori::Tui
     private def draw_add_row(screen : Screen, box : Rect, py : Int32) : Nil
       bg = Theme.accent_bg
       screen.fill(Rect.new(box.x + 1, py, box.w - 2, 1), bg)
+      # The marker column every other row writes — the add-row used to skip it, so the one
+      # row that HAS the focus was the only one without the bar that says so.
+      screen.cell(box.x + 1, py, '▎', Theme.accent, bg)
       x = box.x + 3
       x = screen.text(x, py, @edit_index ? "edit " : "add ", Theme.accent, bg)
       w = {box.right - 1 - x, 3}.max
-      screen.input_line(x, py, @input, @icx, @preedit, Theme.text_bright, bg, width: w)
+      @field.render(screen, x, py, w, true, Theme.text_bright, bg)
     end
 
     def row_at(box : Rect, mx : Int32, my : Int32) : Int32?

--- a/src/gori/tui/env_overlay.cr
+++ b/src/gori/tui/env_overlay.cr
@@ -346,7 +346,7 @@ module Gori::Tui
       end
       Frame.card(screen, box, "ENVIRONMENT", border: Theme.border_focus)
       meta = "#{@items.size} var#{@items.size == 1 ? "" : "s"}"
-      screen.text({box.right - meta.size - 2, box.x + 16}.max, box.y, meta, Theme.muted, Theme.panel)
+      Frame.border_meta(screen, box, "ENVIRONMENT", meta, bg: Theme.panel)
       draw_prefix_row(screen, box, box.y + 1)
       screen.text(box.x + 3, box.y + 2, "KEY VALUE · e.g. HOST api.example.com", Theme.muted, Theme.panel, width: {box.w - 5, 1}.max)
 
@@ -369,6 +369,8 @@ module Gori::Tui
         break if i >= @items.size
         draw_row(screen, box, i, y + row)
       end
+      Frame.scroll_gauge(screen, Rect.new(box.x + 1, y, box.w - 2, rows),
+        @items.size, start, true, Theme.panel)
     end
 
     private def draw_prefix_row(screen : Screen, box : Rect, py : Int32) : Nil

--- a/src/gori/tui/env_overlay.cr
+++ b/src/gori/tui/env_overlay.cr
@@ -201,6 +201,11 @@ module Gori::Tui
       end
       # A press inside an open inline editor is a CARET, not a row pick — the row is text.
       return :stay if (@adding || @prefix_editing) && click_text_field(mx, my)
+      # The gauge on the card's right hairline, before `row_at` — which has no `mx` bound.
+      if row = gauge_row_at(box, mx, my)
+        set_selected(row)
+        return :stay
+      end
       if idx = row_at(box, mx, my)
         set_selected(idx)
       end
@@ -415,6 +420,17 @@ module Gori::Tui
       x = screen.text(x, py, @edit_index ? "edit " : "add ", Theme.accent, bg)
       w = {box.right - 1 - x, 3}.max
       @field.render(screen, x, py, w, true, Theme.text_bright, bg)
+    end
+
+    # The row a click on the list's scroll gauge asks for. The gauge rides the card's right
+    # hairline; the window is derived from the selection, so this answers with a selection.
+    # `y`/`rows` mirror render exactly: the add-row, when open, takes the first interior line.
+    def gauge_row_at(box : Rect, mx : Int32, my : Int32) : Int32?
+      cap = list_capacity(box)
+      y = box.y + 3 + (@adding ? 1 : 0)
+      rows = cap - (@adding ? 1 : 0)
+      return nil if rows <= 0
+      Frame.scroll_gauge_row(Rect.new(box.x + 1, y, box.w - 2, rows), @items.size, mx, my)
     end
 
     def row_at(box : Rect, mx : Int32, my : Int32) : Int32?

--- a/src/gori/tui/env_overlay.cr
+++ b/src/gori/tui/env_overlay.cr
@@ -354,7 +354,7 @@ module Gori::Tui
       end
       return if rows <= 0
       if @items.empty?
-        screen.text(box.x + 3, y, "(no vars — a to add)", Theme.muted) unless @adding
+        screen.text(box.x + 3, y, "no env vars — press a to add", Theme.muted, Theme.panel) unless @adding
         return
       end
       start = list_window(rows)

--- a/src/gori/tui/env_overlay.cr
+++ b/src/gori/tui/env_overlay.cr
@@ -150,12 +150,14 @@ module Gori::Tui
     end
 
     private def commit_and_persist : Nil
+      verb = @edit_index ? "updated" : "added"
       case commit_entry
       when :empty   then toast("env var: empty")
       when :invalid then toast(%(env var: need "KEY VALUE" or "KEY=value" — KEY is [A-Za-z_][A-Za-z0-9_]*))
-      when :dup     then toast("env var: KEY already defined")
+      when :dup     then toast("env var: KEY already defined — edit it (e)")
       when :ok
-        toast(persist ? "env var saved — #{@items.size} total" : "env var applied — could not save to #{Settings.path}")
+        # `added` / `updated` — see HostsOverlay#commit_and_persist, which this mirrors.
+        toast(persist ? "env var #{verb} — #{@items.size} total" : "env var applied — could not save to #{Settings.path}")
       end
     end
 

--- a/src/gori/tui/env_overlay.cr
+++ b/src/gori/tui/env_overlay.cr
@@ -161,7 +161,7 @@ module Gori::Tui
 
     private def delete_and_persist : Nil
       return unless key_name = delete_selected
-      toast(persist ? "removed env: #{key_name}" : "removed #{key_name} — could not save to #{Settings.path}")
+      toast(persist ? "env var deleted: #{key_name}" : "env var deleted: #{key_name} — could not save to #{Settings.path}")
     end
 
     private def persist : Bool

--- a/src/gori/tui/export_overlay.cr
+++ b/src/gori/tui/export_overlay.cr
@@ -212,8 +212,8 @@ module Gori::Tui
     # Tall enough (14) that PathComplete's 8-row cap fits under the field instead of being
     # clipped; `area` still wins on a short terminal.
     def overlay_box(area : Rect) : Rect?
-      w = {area.w - 6, 76}.min
-      h = {area.h - 4, 14}.min
+      w = {area.w - 4, 76}.min
+      h = {area.h - 2, 14}.min
       return nil if w < 40 || h < 8
       Rect.new(area.x + (area.w - w) // 2, area.y + (area.h - h) // 2, w, h)
     end

--- a/src/gori/tui/extract_rule_overlay.cr
+++ b/src/gori/tui/extract_rule_overlay.cr
@@ -196,7 +196,7 @@ module Gori::Tui
     end
 
     def hint : String
-      "↑/↓ field · ←/→ kind · type when/selector · ↵ save · esc cancel"
+      "↑/↓ field · ←/→ options · type when/selector · ↵ save · esc cancel"
     end
 
     def handle_key(ev : Termisu::Event::Key) : Symbol
@@ -269,8 +269,8 @@ module Gori::Tui
         break if py >= box.bottom - 1
         draw_row(screen, box, i, py)
       end
-      hint_y = box.bottom - 1
-      screen.text(box.x + 2, hint_y, hint, Theme.muted, Theme.panel, width: box.w - 4) if hint_y > first
+      # No key hint on the bottom border — the shell draws `hint` in the status strip for the
+      # open modal (Runner#key_hints). See RewriterRuleOverlay#render for the whole argument.
     end
 
     private def draw_row(screen : Screen, box : Rect, i : Int32, py : Int32) : Nil

--- a/src/gori/tui/extract_rule_overlay.cr
+++ b/src/gori/tui/extract_rule_overlay.cr
@@ -250,10 +250,7 @@ module Gori::Tui
     end
 
     def overlay_box(area : Rect) : Rect?
-      w = {area.w - 4, 72}.min
-      h = {area.h - 2, ROW_COUNT + 4}.min # title + rows + hint + padding
-      return nil if w < 40 || h < 10
-      Rect.new(area.x + (area.w - w) // 2, area.y + (area.h - h) // 2, w, h)
+      Overlay.rule_form_box(area, ROW_COUNT)
     end
 
     def render(screen : Screen, area : Rect) : Nil

--- a/src/gori/tui/extract_rule_overlay.cr
+++ b/src/gori/tui/extract_rule_overlay.cr
@@ -284,7 +284,7 @@ module Gori::Tui
       when ROW_NAME then draw_field(screen, box, py, bg, fg, sel, "name: $", @fields[:name])
       when ROW_WHEN then draw_field(screen, box, py, bg, fg, sel, "when:", @fields[:filter])
       when ROW_HOST then draw_field(screen, box, py, bg, fg, sel, "host:", @fields[:host])
-      when ROW_KIND then draw_cycle(screen, x, py, bg, fg, "from:", KINDS.map(&.label), @kind_i, sel)
+      when ROW_KIND then Frame.option_cycle(screen, x, py, box.right - 2, bg, "from:", KINDS.map(&.label), @kind_i, sel)
       when ROW_SELECTOR
         draw_field(screen, box, py, bg, fg, sel, selector_label, @fields[:selector]) unless position?
       when ROW_RANGE
@@ -304,18 +304,6 @@ module Gori::Tui
       in Gori::ExtractKind::JsonPath then "path:"
       in Gori::ExtractKind::Position then "range:"
       end
-    end
-
-    private def draw_cycle(screen : Screen, x : Int32, py : Int32, bg : Color, fg : Color,
-                           label : String, opts : Array(String), sel_i : Int32, row_sel : Bool) : Nil
-      screen.text(x, py, label, Theme.muted, bg)
-      tx = x + label.size + 1
-      opts.each_with_index do |opt, oi|
-        lit = oi == sel_i
-        col = lit ? (row_sel ? Theme.text_bright : Theme.accent) : Theme.muted
-        tx = screen.text(tx, py, " #{opt} ", col, bg, lit ? Attribute::Bold : Attribute::None)
-      end
-      screen.text(tx, py, " ‹/›", Theme.muted, bg) if row_sel
     end
 
     private def draw_field(screen : Screen, box : Rect, py : Int32, bg : Color, fg : Color,

--- a/src/gori/tui/fmt.cr
+++ b/src/gori/tui/fmt.cr
@@ -70,5 +70,36 @@ module Gori::Tui
       return unit(m, "m") if m.round < 60
       unit(us / 3_600_000_000.0, "h")
     end
+
+    # Compact relative age — "3s" / "5m" / "2h" / "1d" — for a row that reports how long ago
+    # something happened. Three overlays each carried a private copy of these eight lines
+    # (the OAST session picker, the notifications centre, the TLS passthrough inventory),
+    # identical apart from one guard, which is the reason this lives here now.
+    #
+    # That guard: elapsed is CLAMPED AT ZERO. Two of the three read a wall-clock `Time`, which
+    # can move backwards under an NTP correction or when the record was written by another
+    # machine — the passthrough list lacked the clamp and would render `-5s` for a bypass it
+    # believed happened in the future. The notifications centre is safe by construction
+    # (`Time::Instant` is monotonic) and passes through the same door anyway.
+    def self.ago(seconds : Int64) : String
+      secs = {seconds, 0_i64}.max
+      return "#{secs}s" if secs < 60
+      mins = secs // 60
+      return "#{mins}m" if mins < 60
+      hours = mins // 60
+      return "#{hours}h" if hours < 24
+      "#{hours // 24}d"
+    end
+
+    # Wall-clock overload. `Time.local - t` is a Span; the clamp above is what makes a
+    # backwards clock render "0s" rather than a negative age.
+    def self.ago(t : Time) : String
+      ago((Time.local - t).total_seconds.to_i64)
+    end
+
+    # Monotonic overload — process-relative instants, which cannot run backwards.
+    def self.ago(t : Time::Instant) : String
+      ago((Time.instant - t).total_seconds.to_i64)
+    end
   end
 end

--- a/src/gori/tui/frame.cr
+++ b/src/gori/tui/frame.cr
@@ -205,6 +205,38 @@ module Gori::Tui
       focused ? screen.text(tx, y, cue, Theme.muted, bg) : tx
     end
 
+    # A right-anchored run of BARE text chips — no fill, one column of gap, each dropped
+    # whole when it would cross `min_x`. `chips` is right-to-left: the first entry is the
+    # rightmost, matching `right_badge_hit`'s convention. Returns the leftmost x actually
+    # drawn, or `right_edge + 1` when nothing fit, so the caller can size what sits left of it.
+    #
+    # This is the filter-bar cluster four views had each written out: History's
+    # `count · ⇧S scope · f:follow`, Sitemap's `count · ⇧S scope · g:fold`, and the bare
+    # `count · ⇧S scope` in Issues and Probe. Same shape, four copies, and they had already
+    # drifted on the gap — a TWO-column step after the count, a ONE-column step between the
+    # chips, in the same method. `toggle_badge` is not this: it fills a `" chord:NAME "` pill,
+    # where these are plain fg-coloured words on the bar.
+    def self.right_text_chain(screen : Screen, right_edge : Int32, y : Int32, min_x : Int32,
+                              chips : Array({String, Color}), bg : Color = Theme.bg) : Int32
+      x = right_edge + 1
+      chips.each do |(text, color)|
+        w = Screen.draw_width(text)
+        left = x - 1 - w
+        next if left < min_x # drop this one, keep trying the shorter ones further left
+        screen.text(left, y, text, color, bg)
+        x = left
+      end
+      x
+    end
+
+    # A filled severity/status pill: the label inked in the canvas colour ON `color`, bold.
+    # `Frame.chip`'s lit/muted pair cannot express this — the fill IS the datum here (a
+    # severity's own hue), not an on/off state — which is why Issues and Probe each grew a
+    # private `chip` for it. They were byte-identical.
+    def self.tag_chip(screen : Screen, x : Int32, y : Int32, label : String, color : Color) : Int32
+      screen.text(x, y, label, Theme.bg, color, Attribute::Bold)
+    end
+
     # A left-aligned mode/toggle chip at (x,y), returning the x past it. `lit` (active)
     # paints bright text on an accent fill; off is a muted, background-less label. Used
     # for keyed toggle chips on a pane's top border (e.g. Repeater's `d:diff`/`x:hex`).

--- a/src/gori/tui/frame.cr
+++ b/src/gori/tui/frame.cr
@@ -62,6 +62,29 @@ module Gori::Tui
       screen.text(inner.x + 1, y, " ‹ list ", Theme.accent, bg, Attribute::Bold)
     end
 
+    # A short right-aligned annotation riding a card's TOP border, right of the title —
+    # "2/2 enabled", "lens:off · 3", "4 entries". Rides the hairline the way `list_back_hint`
+    # does, so it costs no interior row.
+    #
+    # Every card that wanted one used to hand-roll this, and the copies had drifted into
+    # different magic numbers for the same layout: the Rewriter list guarded on
+    # `rect.w > meta.size + 20` and floored at `rect.x + 18`, its Colormarker twin at `+ 18`
+    # and `+ 16`, so the two lists dropped their count at different widths. Neither number
+    # was derived from anything — the title they were protecting is right there. `Frame.card`
+    # draws its title as ` TITLE ` from `rect.x + 2`, which is the only fact this needs, and
+    # it is now stated once.
+    #
+    # Draws nothing when the card is too narrow to hold the meta clear of the title, which is
+    # what makes it safe to call unconditionally.
+    def self.border_meta(screen : Screen, rect : Rect, title : String, meta : String,
+                         bg : Color = Theme.bg, fg : Color = Theme.muted) : Nil
+      return if meta.empty? || rect.w < 4
+      title_end = rect.x + 2 + (title.empty? ? 0 : Screen.draw_width(title) + 2)
+      x = rect.right - Screen.draw_width(meta) - 2
+      return if x <= title_end
+      screen.text(x, rect.y, meta, fg, bg)
+    end
+
     # A slim vertical scroll gauge riding the right border of a framed content area.
     # The thumb's height is proportional to how much of the content is on screen, so a
     # glance reads as "roughly how big is this", and its position tracks the scroll
@@ -88,11 +111,15 @@ module Gori::Tui
 
     # A `├───┤` divider across a card's interior at absolute row `y` — the seam
     # between an input/header band and the list below it.
-    def self.tee_divider(screen : Screen, rect : Rect, y : Int32, bg : Color = Theme.panel) : Nil
+    # `border` matches the enclosing card's outline, so a seam under a FOCUSED strip can light
+    # with it instead of staying a stray grey hairline — the same reason `inner_divider` takes
+    # one. Defaults to the resting hairline, so every existing caller is unchanged.
+    def self.tee_divider(screen : Screen, rect : Rect, y : Int32, bg : Color = Theme.panel,
+                         border : Color = Theme.border) : Nil
       return if rect.w < 2 || y <= rect.y || y >= rect.bottom - 1
-      screen.cell(rect.x, y, TEE_L, Theme.border, bg)
-      screen.hline(rect.x + 1, y, rect.w - 2, fg: Theme.border, bg: bg)
-      screen.cell(rect.right - 1, y, TEE_R, Theme.border, bg)
+      screen.cell(rect.x, y, TEE_L, border, bg)
+      screen.hline(rect.x + 1, y, rect.w - 2, fg: border, bg: bg)
+      screen.cell(rect.right - 1, y, TEE_R, border, bg)
     end
 
     # A tee-connected section divider for content rendered INSIDE a frame, where

--- a/src/gori/tui/frame.cr
+++ b/src/gori/tui/frame.cr
@@ -76,13 +76,23 @@ module Gori::Tui
     #
     # Draws nothing when the card is too narrow to hold the meta clear of the title, which is
     # what makes it safe to call unconditionally.
+    # `min_x` overrides the left stop for a card whose border carries more than a title —
+    # the Repeater's RESPONSE header runs a left-anchored `chip` cluster there, so the meta
+    # has to clear the chips rather than the (shorter) title. Callers pass the x their own
+    # chrome ended at; everyone else lets the title decide.
+    #
+    # Returns the x it drew at, or nil when it drew nothing — so a caller can CHAIN something
+    # further left (the Repeater hangs an `⚠ incomplete` marker off the meta it just placed)
+    # without re-deriving a position this method already computed.
     def self.border_meta(screen : Screen, rect : Rect, title : String, meta : String,
-                         bg : Color = Theme.bg, fg : Color = Theme.muted) : Nil
-      return if meta.empty? || rect.w < 4
-      title_end = rect.x + 2 + (title.empty? ? 0 : Screen.draw_width(title) + 2)
+                         bg : Color = Theme.bg, fg : Color = Theme.muted,
+                         min_x : Int32? = nil) : Int32?
+      return nil if meta.empty? || rect.w < 4
+      stop = min_x || (rect.x + 2 + (title.empty? ? 0 : Screen.draw_width(title) + 2))
       x = rect.right - Screen.draw_width(meta) - 2
-      return if x <= title_end
+      return nil if x <= stop
       screen.text(x, rect.y, meta, fg, bg)
+      x
     end
 
     # A slim vertical scroll gauge riding the right border of a framed content area.

--- a/src/gori/tui/frame.cr
+++ b/src/gori/tui/frame.cr
@@ -86,10 +86,13 @@ module Gori::Tui
     # without re-deriving a position this method already computed.
     def self.border_meta(screen : Screen, rect : Rect, title : String, meta : String,
                          bg : Color = Theme.bg, fg : Color = Theme.muted,
-                         min_x : Int32? = nil) : Int32?
+                         min_x : Int32? = nil, right_edge : Int32? = nil) : Int32?
       return nil if meta.empty? || rect.w < 4
       stop = min_x || (rect.x + 2 + (title.empty? ? 0 : Screen.draw_width(title) + 2))
-      x = rect.right - Screen.draw_width(meta) - 2
+      # `right_edge` (exclusive) for a border that ALREADY carries a badge: the meta right-aligns
+      # to the left of it instead of to the card's corner. Discover's RUNS card is the case —
+      # `border_meta` ran before the run badge and was simply overpainted by it.
+      x = (right_edge || (rect.right - 2)) - Screen.draw_width(meta)
       return nil if x <= stop
       screen.text(x, rect.y, meta, fg, bg)
       x
@@ -117,6 +120,41 @@ module Gori::Tui
         on = i >= off && i < off + thumb
         screen.cell(x, content.y + i, on ? '┃' : '│', on ? thumb_fg : track_fg, bg)
       end
+    end
+
+    # Inverse of `scroll_gauge`: the `top` a click on the gauge column asks for, or nil when
+    # the pointer is not on it — including when no gauge was drawn, since this refuses on the
+    # same `track < 2 || total <= track` test the draw does. A body that fits has no target.
+    #
+    # The clicked cell becomes the MIDDLE of the thumb, which is what a click on a scrollbar
+    # track means everywhere else: the row you point at is the row you want to be looking at,
+    # not the row that ends up at the top of the viewport.
+    def self.scroll_gauge_top(content : Rect, total : Int32, mx : Int32, my : Int32) : Int32?
+      track = content.h
+      return nil if track < 2 || total <= track
+      return nil if mx != content.right # the frame's right border column — where the draw puts it
+      i = my - content.y
+      return nil if i < 0 || i >= track
+      thumb = (track.to_i64 * track // total).to_i.clamp(1, track - 1)
+      span = track - thumb
+      return 0 if span <= 0
+      max_top = total - track
+      off = (i - thumb // 2).clamp(0, span)
+      (off.to_i64 * max_top // span).to_i.clamp(0, max_top)
+    end
+
+    # The ROW a click on the gauge points at, for a list whose scroll is DERIVED from its
+    # selection: those views run an `ensure_visible` on every render, so setting `top`
+    # directly would simply be undone on the next frame. Proportional — the top of the track
+    # is row 0, the bottom is the last row — which is also what an operator dragging a
+    # scrollbar to the end expects to land on.
+    def self.scroll_gauge_row(content : Rect, total : Int32, mx : Int32, my : Int32) : Int32?
+      track = content.h
+      return nil if track < 2 || total <= track
+      return nil if mx != content.right
+      i = my - content.y
+      return nil if i < 0 || i >= track
+      (i.to_i64 * (total - 1) // (track - 1)).to_i.clamp(0, total - 1)
     end
 
     # A `├───┤` divider across a card's interior at absolute row `y` — the seam
@@ -325,6 +363,14 @@ module Gori::Tui
       mx >= x && mx < x + text.size
     end
 
+    # Left edge after a `mode_badge` — the right_edge for whatever chains further left of it.
+    # Mirrors `mode_badge`'s own return, unchanged edge and all, so a hit-test can follow the
+    # chain past the mode chip the way the Repeater's ` ^K:MARK ` is drawn past it.
+    def self.mode_badge_edge(right_edge : Int32, min_x : Int32, insert : Bool) : Int32
+      x = right_edge - mode_badge_label(insert).size
+      x < min_x ? right_edge : x
+    end
+
     # Left edge after a right-chained `toggle_badge`/`action_badge` run — the right_edge
     # to pass the next (leftward) badge, including `mode_badge`. Same skip-past-min_x rule
     # as draw/hit. Pure geometry for chrome hit-tests that need to chain mode after others.
@@ -334,7 +380,7 @@ module Gori::Tui
       badges.each do |(_, chord, name)|
         text = " #{chord}:#{name} "
         x = edge - text.size
-        break if x < min_x
+        next if x < min_x # `next`, not `break` — see right_badge_hit
         edge = x
       end
       edge
@@ -364,11 +410,19 @@ module Gori::Tui
     # Hit-test for a left-to-right run of `Frame.chip` labels. `chips` is
     # `{id, label}` in draw order; each chip is followed by a 1-col gap (matching
     # the `+ 1` callers use after `Frame.chip`). Miss → nil. Pure geometry — no Screen.
+    #
+    # `limit` (exclusive) mirrors a caller that STOPS drawing at the first chip which would
+    # cross it. `Frame.chip` does not clip itself, so most runs have no limit and none is
+    # passed; the Repeater's RESPONSE cluster does, because that pane is half-width and the
+    # run used to spill through the card's own '╮'. Without this the hit walked all three
+    # chips regardless, so below ~88 columns ` ^X:hex ` and ` p:pretty ` kept 9 and 10 live
+    # cells on and past a border with nothing painted on them.
     def self.left_chip_hit(mx : Int32, my : Int32, y : Int32, start_x : Int32,
-                           chips : Array({Symbol, String})) : Symbol?
+                           chips : Array({Symbol, String}), limit : Int32? = nil) : Symbol?
       return nil if my != y
       x = start_x
       chips.each do |(id, label)|
+        break if limit && x + Screen.draw_width(label) > limit
         return id if mx >= x && mx < x + label.size
         x += label.size + 1
       end
@@ -380,6 +434,13 @@ module Gori::Tui
     # matching successive `toggle_badge` calls that pass the previous return as
     # the next right_edge). Labels are `" #{chord}:#{name} "`. A badge that
     # would sit left of `min_x` is skipped (same as draw). Miss → nil.
+    #
+    # `next`, not `break`, and that is the whole point: `toggle_badge` returns its
+    # `right_edge` UNCHANGED when it does not fit, so the chain keeps going and a shorter
+    # badge further along still draws at that same edge. This loop used to `break` while
+    # claiming "(same as draw)" in the line above — so on the Repeater's request border, at a
+    # width where ` ^R:SEND ` (9) does not fit but ` ^L:CL ` (7) does, CL was drawn and
+    # un-clickable, and every badge left of it hit-tested against an edge that never moved.
     def self.right_badge_hit(mx : Int32, my : Int32, y : Int32, right_edge : Int32, min_x : Int32,
                              badges : Array({Symbol, String, String})) : Symbol?
       return nil if my != y
@@ -387,7 +448,7 @@ module Gori::Tui
       badges.each do |(id, chord, name)|
         text = " #{chord}:#{name} "
         x = edge - text.size
-        break if x < min_x
+        next if x < min_x
         return id if mx >= x && mx < x + text.size
         edge = x
       end

--- a/src/gori/tui/frame.cr
+++ b/src/gori/tui/frame.cr
@@ -146,6 +146,55 @@ module Gori::Tui
       focused ? Theme.focus_gold : Theme.border
     end
 
+    # One `label: opt opt opt ‹/›` option row — the control every rule form and config popup
+    # uses for a choice the ←/→ keys walk. Returns the x past what it drew.
+    #
+    # Three dialects had grown for this. Four rule forms carried a byte-identical private copy
+    # (the strip below); the OAST provider form and the Scope form's `kind:` row drew ONLY the
+    # lit value, so an operator could not see that other choices existed; and the Miner and
+    # Sequencer configs drew the value with `‹/›` in the value's own colour, unconditionally.
+    #
+    # The rule this settles on is neither "always a strip" nor "always the value". A strip is
+    # how a choice advertises itself, so it wins WHEN IT FITS — but `MAX_REQ_CHOICES` is eight
+    # numbers plus `uncapped`, and forcing that into a 72-column card would push the row off
+    # its own edge. So: measure, draw the strip if there is room, otherwise fall back to the
+    # lit value alone. One renderer, one look wherever the width allows it, and the fallback is
+    # a width response rather than a per-file opinion.
+    #
+    # `right` is the exclusive right edge the row may use (a card's `box.right - 2`).
+    # The `‹/›` cue is drawn ONLY when the row has focus — it names keys that do nothing
+    # anywhere else, and several of these forms used to show it on every row at once.
+    # `value_x` pins the options to a fixed column instead of letting them follow the label.
+    # Only the Sequencer's config passes one: its rows share a value column with a text field,
+    # and dropping the alignment to gain the shared renderer would have been a trade in the
+    # wrong direction. Where a form has no such column — everywhere else — the options sit one
+    # cell past the label, as they always have.
+    def self.option_cycle(screen : Screen, x : Int32, y : Int32, right : Int32, bg : Color,
+                          label : String, options : Array(String), selected : Int32,
+                          focused : Bool, value_x : Int32? = nil,
+                          lit : Color? = nil) : Int32
+      after_label = screen.text(x, y, label, Theme.muted, bg) + 1
+      tx = value_x || after_label
+      cue = focused ? " ‹/›" : ""
+      cue_w = Screen.draw_width(cue)
+      strip_w = options.sum { |o| Screen.draw_width(o) + 2 }
+      # `lit` overrides the colour of the CHOSEN option. One caller needs it: the Probe active
+      # scan's `unsafe methods:` row, where the chosen state can put DELETE on the wire and has
+      # to shout in red. Passing the colour beats repainting the option afterwards, which would
+      # mean re-deriving the x this method already knows.
+      lit_col = lit || (focused ? Theme.text_bright : Theme.accent)
+      if tx + strip_w + cue_w <= right
+        options.each_with_index do |opt, i|
+          on = i == selected
+          tx = screen.text(tx, y, " #{opt} ", on ? lit_col : Theme.muted, bg,
+            on ? Attribute::Bold : Attribute::None)
+        end
+      elsif value = options[selected]?
+        tx = screen.text(tx, y, value, lit_col, bg, Attribute::Bold)
+      end
+      focused ? screen.text(tx, y, cue, Theme.muted, bg) : tx
+    end
+
     # A left-aligned mode/toggle chip at (x,y), returning the x past it. `lit` (active)
     # paints bright text on an accent fill; off is a muted, background-less label. Used
     # for keyed toggle chips on a pane's top border (e.g. Repeater's `d:diff`/`x:hex`).

--- a/src/gori/tui/fuzz_advanced_overlay.cr
+++ b/src/gori/tui/fuzz_advanced_overlay.cr
@@ -208,7 +208,10 @@ module Gori::Tui
         break if ri >= ROWS.size
         render_row(screen, box, ri, top + i, vx)
       end
-      screen.text(box.x + 2, box.bottom - 2, "⇥/↑↓ field · ←/→ edit · space toggle · esc applies", Theme.muted, Theme.bg, width: box.w - 4)
+      # No key hint on the card — the shell draws `hint` in the status strip for the open
+      # modal (Runner#key_hints). This copy had drifted furthest of the nine: it spelled the
+      # same three keys differently (`⇥/↑↓` for `↑/↓/⇥`, `space` for `␣`) and omitted `↵ next`
+      # entirely, so the two lines on screen disagreed about what the form could do.
     end
 
     private def render_row(screen : Screen, box : Rect, ri : Int32, y : Int32, vx : Int32) : Nil

--- a/src/gori/tui/fuzz_advanced_overlay.cr
+++ b/src/gori/tui/fuzz_advanced_overlay.cr
@@ -175,8 +175,8 @@ module Gori::Tui
 
     # --- rendering ----------------------------------------------------------
     def overlay_box(area : Rect) : Rect?
-      w = {area.w - 6, 60}.min
-      h = {area.h - 4, ROWS.size + 4}.min
+      w = {area.w - 4, 60}.min
+      h = {area.h - 2, ROWS.size + 4}.min
       return nil if w < 30 || h < 8
       Rect.new(area.x + (area.w - w) // 2, area.y + (area.h - h) // 2, w, h)
     end

--- a/src/gori/tui/fuzz_set_overlay.cr
+++ b/src/gori/tui/fuzz_set_overlay.cr
@@ -400,7 +400,7 @@ module Gori::Tui
       # bg: Theme.bg (not the card default panel) so the embedded List TextArea, which
       # always paints on Theme.bg, doesn't two-tone against the card interior.
       Frame.card(screen, box, card_title, bg: Theme.bg, border: Theme.border_focus)
-      render_meta(screen, box)
+      render_meta(screen, box, card_title)
       render_type_row(screen, box)
       Frame.tee_divider(screen, box, box.y + 2, Theme.bg)
       case @ptype
@@ -412,11 +412,12 @@ module Gori::Tui
       render_path_dropdown(screen, box) if @ptype == :wordlist
     end
 
-    private def render_meta(screen : Screen, box : Rect) : Nil
+    # `title` is threaded in rather than re-derived: it is dynamic here (` · edit` / ` · new`),
+    # and `Frame.border_meta` keeps the count clear of whichever one was drawn.
+    private def render_meta(screen : Screen, box : Rect, title : String) : Nil
       return unless @ptype == :list
       n = list_values.size
-      meta = "#{n} value#{n == 1 ? "" : "s"}"
-      screen.text({box.right - meta.size - 2, box.x + 22}.max, box.y, meta, Theme.muted, Theme.bg)
+      Frame.border_meta(screen, box, title, "#{n} value#{n == 1 ? "" : "s"}")
     end
 
     private def render_type_row(screen : Screen, box : Rect) : Nil

--- a/src/gori/tui/fuzz_set_overlay.cr
+++ b/src/gori/tui/fuzz_set_overlay.cr
@@ -382,8 +382,8 @@ module Gori::Tui
     LABEL_W = 9 # value column offset (widest field label "Charset" + padding)
 
     def overlay_box(area : Rect) : Rect?
-      w = {area.w - 6, 66}.min
-      h = {area.h - 4, 20}.min
+      w = {area.w - 4, 66}.min
+      h = {area.h - 2, 20}.min
       return nil if w < 34 || h < 8
       Rect.new(area.x + (area.w - w) // 2, area.y + (area.h - h) // 2, w, h)
     end

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -2067,11 +2067,6 @@ module Gori::Tui
       @show_dist ? "distribution shown" : "distribution hidden"
     end
 
-    private def pane_border(focused : Bool, insert : Bool = false) : Color
-      return Frame.pane_border(false) unless focused
-      insert ? Theme.accent : Theme.focus_gold
-    end
-
     # The TARGET card grows to a second content row (4 high vs 3) whenever an SNI override is
     # set OR is being edited, so the override is always visible and the input row only
     # appears once you reach for it (^S). Same rule and same numbers as RepeaterView.
@@ -2096,7 +2091,7 @@ module Gori::Tui
     private def render_target(screen : Screen, rect : Rect, focused : Bool) : Nil
       return if rect.h < 2
       ins = focused && target_insert?
-      Frame.card(screen, rect, "TARGET", bg: Theme.bg, border: pane_border(focused, insert: ins))
+      Frame.card(screen, rect, "TARGET", bg: Theme.bg, border: Frame.pane_border(focused))
       # The REAL mode, not `ins` — `target_chrome_hit` measures the bare `target_insert?`, and the
       # two labels are different widths. See `Frame.mode_badge`.
       Frame.mode_badge(screen, rect.right - 1, rect.y, rect.x + 8, target_insert?)
@@ -2153,7 +2148,7 @@ module Gori::Tui
       pc = spans.size
       label = @http2 ? "TEMPLATE (h2)" : "TEMPLATE"
       ins = focused && (template_insert? || @chain_focused)
-      Frame.card(screen, rect, label, bg: Theme.bg, border: pane_border(focused, insert: ins))
+      Frame.card(screen, rect, label, bg: Theme.bg, border: Frame.pane_border(focused))
       badge = " §#{pc} "
       min_x = rect.x + label.size + 4
       # ^R:RUN rides the TEMPLATE border as the primary action — rightmost, mirroring the
@@ -2696,7 +2691,7 @@ module Gori::Tui
         @focus = :results
         return
       end
-      Frame.card(screen, rect, "RESULT ##{r.index}", bg: Theme.bg, border: pane_border(focused))
+      Frame.card(screen, rect, "RESULT ##{r.index}", bg: Theme.bg, border: Frame.pane_border(focused))
       panes = detail_panes
       @detail_pane = :request unless panes.includes?(@detail_pane) # decode may have dropped a pane
       render_detail_chips(screen, rect, panes)

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -3048,11 +3048,30 @@ module Gori::Tui
       ri < sorted_results.size ? ri : nil
     end
 
+    # The row a click on the scroll gauge asks for. The gauge rides the frame's right hairline,
+    # one column outside the list rect, so the row hit-test cannot answer it — and `@scroll`
+    # here is DERIVED from the selection, so the answer is a selection.
+    def results_gauge_row(rect : Rect, mx : Int32, my : Int32) : Int32?
+      return nil unless pane = results_rect(rect)
+      inner = pane.inset(1, 1)
+      return nil if inner.h <= 1
+      # Rows region, below the header — the band the draw hands the gauge.
+      Frame.scroll_gauge_row(Rect.new(inner.x, inner.y + 1, inner.w, inner.h - 1),
+        sorted_results.size, mx, my)
+    end
+
     # The RESULTS pane rect within body `rect`, re-deriving render → render_bottom →
     # render_results' split (target band → 45%-tall top row → bottom minus the DIST
     # sidebar). nil when the layout leaves no room. Backs results_row_at hit-testing.
     private def results_rect(rect : Rect) : Rect?
       return nil unless @loaded
+      # render_bottom hands the whole band to RESULT DETAIL when `@focus == :detail`, so
+      # RESULTS is not on screen at all — and this rect backs `results_chrome_hit`, which
+      # `FuzzerController#handle_click` consults FIRST. Ungated, a click on the detail card's
+      # own top border in the badge zone toggled DIST/MATCH/sort *and* kicked the operator
+      # out of the detail via `focus_pane(:results)`. With `@show_dist` on, the two rects do
+      # not even share a right edge — this one is `dist_width` narrower than the card drawn.
+      return nil if @focus == :detail
       target_h = {rect.h, target_card_h}.min
       rest = Rect.new(rect.x, rect.y + target_h, rect.w, {rect.h - target_h, 0}.max)
       return nil if rest.h <= 0

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -2087,6 +2087,7 @@ module Gori::Tui
     # so render_target and the click→caret mapping agree on the value base.
     TARGET_PREFIX = "›"
     SNI_PREFIX    = "SNI ›"
+    SNI_BADGE     = " SNI "
 
     private def field_base(rect : Rect, prefix : String) : Int32
       rect.x + 2 + prefix.size + 1
@@ -2099,10 +2100,14 @@ module Gori::Tui
       # The REAL mode, not `ins` — `target_chrome_hit` measures the bare `target_insert?`, and the
       # two labels are different widths. See `Frame.mode_badge`.
       Frame.mode_badge(screen, rect.right - 1, rect.y, rect.x + 8, target_insert?)
-      unless @sni.strip.empty?
-        badge = " SNI "
-        bx = {rect.right - badge.size - 1, rect.x + 9}.max
-        screen.text(bx, rect.y, badge, Theme.text_bright, Theme.accent_bg)
+      # An at-a-glance SNI marker on the top border, CHAINED left of the mode chip rather
+      # than placed at `rect.right - size - 1` — which is inside the mode chip's own cells.
+      # Setting an override used to paint over the right of ` ↵:READ `, leaving `↵: SNI ` on
+      # the border, and `target_chrome_hit` still measured the full mode rect underneath, so
+      # clicking the visible SNI letters toggled insert. Repeater hit this first and fixed it
+      # the same way (`repeater_view.cr#target_chrome_chain`); this is that fix, ported.
+      if sni_x = target_sni_x(rect)
+        screen.text(sni_x, rect.y, SNI_BADGE, Theme.text_bright, Theme.accent_bg)
       end
       draw_target_row(screen, rect, rect.y + 1, TARGET_PREFIX, @target, @tcx,
         focused && @target_field == :url, ins)
@@ -2282,7 +2287,7 @@ module Gori::Tui
         @cfg_scroll = 0
         y = y0
         @sets.each_with_index do |s, i|
-          render_set_row(screen, inner, y, s, i, set_selected?(focused, i), pp)
+          render_set_row(screen, inner, y, s, i, set_selected?(i), focused, pp)
           y += 1
         end
         draw_add_row(screen, inner, y, focused, limit)
@@ -2299,7 +2304,7 @@ module Gori::Tui
         stop = {@cfg_scroll + visible, @sets.size}.min
         y = y0
         (@cfg_scroll...stop).each do |i|
-          render_set_row(screen, inner, y, @sets[i], i, set_selected?(focused, i), pp)
+          render_set_row(screen, inner, y, @sets[i], i, set_selected?(i), focused, pp)
           y += 1
         end
         above, below = @cfg_scroll, @sets.size - stop
@@ -2309,8 +2314,12 @@ module Gori::Tui
       end
     end
 
-    private def set_selected?(focused : Bool, i : Int32) : Bool
-      focused && config_row == :set && current_set_index == i
+    # Focus is NOT part of "is this row selected" — it decides how loudly the selection is
+    # drawn, which is `render_set_row`'s business. Folded in here it erased the CONFIG cursor
+    # outright whenever focus moved to a sibling pane, so coming back meant finding the row
+    # again by eye.
+    private def set_selected?(i : Int32) : Bool
+      config_row == :set && current_set_index == i
     end
 
     # `limit` is the tail's first row: the Add row PADS its width, so an unbounded one
@@ -2373,8 +2382,9 @@ module Gori::Tui
     # One Sets row. In per-position modes (pp) it carries a marker-coloured swatch + →N
     # chip tying it to template marker i (same tint marker i shows in the editor); the
     # chip draws AFTER the selection fill so it survives on the selected (accent_bg) row.
-    private def render_set_row(screen, inner : Rect, y : Int32, s : SetSpec, i : Int32, sel : Bool, pp : Bool) : Nil
-      bg = sel ? Theme.accent_bg : Theme.bg
+    private def render_set_row(screen, inner : Rect, y : Int32, s : SetSpec, i : Int32, sel : Bool,
+                               focused : Bool, pp : Bool) : Nil
+      bg = sel ? (focused ? Theme.accent_bg : Theme.selection_dim) : Theme.bg
       screen.fill(Rect.new(inner.x, y, inner.w, 1), bg) if sel
       fg = sel ? Theme.text_bright : Theme.text
       label = "#{i + 1} #{s.kind} #{s.value}"
@@ -3097,12 +3107,31 @@ module Gori::Tui
       Frame.mode_badge_hit(mx, my, left.y, mode_edge, min_x, template_insert? || @chain_focused) ? :mode : nil
     end
 
-    # Hit-test the TARGET border NOR/INS chip. Geometry matches render_target.
+    # `SNI` is a MARKER, not a control — nothing happens when it is clicked. It is hit-tested
+    # anyway so it can answer `nil` for itself: without this the mode chip's rect still covered
+    # those cells and a press on them flipped insert mode.
+    #
+    # Hit-test the TARGET border NOR/INS chip. Geometry matches render_target through the
+    # shared `target_sni_x`.
     def target_chrome_hit(rect : Rect, mx : Int32, my : Int32) : Symbol?
       return nil unless @loaded
       target_h = {rect.h, target_card_h}.min
       return nil if target_h < 2 || my != rect.y
+      if sni_x = target_sni_x(rect)
+        return nil if mx >= sni_x && mx < sni_x + SNI_BADGE.size
+      end
       Frame.mode_badge_hit(mx, my, rect.y, rect.right - 1, rect.x + 8, target_insert?) ? :mode : nil
+    end
+
+    # Where the SNI marker sits, or nil when there is no override or no room for one. The ONE
+    # place that geometry lives, so render and the hit-test cannot disagree about it.
+    private def target_sni_x(rect : Rect) : Int32?
+      return nil if @sni.strip.empty?
+      edge = rect.right - 1
+      mode = Frame.mode_badge_label(target_insert?)
+      edge -= mode.size if edge - mode.size >= rect.x + 8 # the mode chip's own stop
+      x = edge - SNI_BADGE.size
+      x >= rect.x + 9 ? x : nil # one column clear of the card title
     end
 
     def pane_at(rect : Rect, mx : Int32, my : Int32) : Symbol?

--- a/src/gori/tui/help_view.cr
+++ b/src/gori/tui/help_view.cr
@@ -136,7 +136,7 @@ module Gori::Tui
         Item.new("^N / ^W", "new / close a sub-tab"),
       ]},
       {"JWT", [
-        Item.new("^E", "switch decode ⟷ encode", "jwt.toggle-mode"),
+        Item.new("^T", "switch decode ⟷ encode", "jwt.toggle-mode"),
         Item.new("^A", "cycle the signing alg (alg=none included)", "jwt.cycle-alg"),
         Item.new("^L · ^Y", "clear the session · copy everything", "jwt.clear"),
         Item.new("↹", "cycle INPUT → DECODED → ATTACKS (decode) / HEADER → PAYLOAD → SECRET → OUTPUT (encode)"),

--- a/src/gori/tui/help_view.cr
+++ b/src/gori/tui/help_view.cr
@@ -101,7 +101,11 @@ module Gori::Tui
         Item.new("space", "command menu (READ mode on target/template/results/detail)"),
         Item.new("y · O", "copy selection/line · copy all pane (READ)"),
         Item.new("⇧arrows", "select text (line or char)"),
-        Item.new("^A · ^K · ^T · ^U", "auto-mark params · mark word · mark point (manual §) · clear §"),
+        Item.new("^A · ^K · ^T", "auto-mark params · mark word · mark point (manual §)"),
+        # NOT `^U clear §` — that was wrong twice over: ^U is fuzz.pretty-template (the tab's
+        # own ` ^U:PRETTY ` badge says so), and clear-marks has no chord at all. The advertised
+        # key silently reflowed the template you had just finished marking by hand.
+        Item.new("^U", "pretty-print the template body (space → c clears §)"),
         Item.new("^V", "toggle transport HTTP/1.1 ↔ HTTP/2"),
         Item.new("^S", "SNI override (on the target)", "fuzz.toggle-sni"),
         Item.new("^O", "focus the config pane (payload sets · Mode · Advanced · Run)"),
@@ -138,7 +142,7 @@ module Gori::Tui
         Item.new("^B", "reveal whitespace"),
       ]},
       {"OTHER TABS", [
-        Item.new("Sitemap", "↑/↓ · / filter · ↵/→ expand · t mark · ⇧T tag · g fold · ⇧S scope"),
+        Item.new("Sitemap", "↑/↓ · / filter · ↵/→ expand · t mark · g fold · ⇧S scope · space → T tag"),
         Item.new("Issues", "list: t mark · ⇧T all · ⇧arrows range · notes: i/↵ edit · x line · y copy · space cmds"),
         Item.new("Probe", "↑/↓ ↵ open · m mode · c dismiss · a all · / filter · ⇧S scope · space cmds"),
         Item.new("Notes", "i/↵ edit · x line · ⇧arrows select · y copy · space cmds (Copy selected when highlighted)"),

--- a/src/gori/tui/help_view.cr
+++ b/src/gori/tui/help_view.cr
@@ -104,7 +104,10 @@ module Gori::Tui
         Item.new("^N / ^W", "new / close a sub-tab"),
         Item.new("i / ↵", "enter INS (edit) on target/template · esc back to READ"),
         Item.new("space", "command menu (READ mode on target/template/results/detail)"),
-        Item.new("y · O", "copy selection/line · copy all pane (READ)"),
+        # NOT `y · O`. The `*.copy-all` verbs are gone — `Runner#read_copy` folds it into one
+        # key: `y` copies the selection if there is one, else the whole pane. The row was
+        # advertising an `O` that stopped existing when they merged.
+        Item.new("y", "copy the selection — or the whole pane when nothing is selected (READ)"),
         Item.new("⇧arrows", "select text (line or char)"),
         Item.new("^A · ^K · ^T", "auto-mark params · mark word · mark point (manual §)"),
         # NOT `^U clear §` — that was wrong twice over: ^U is fuzz.pretty-template (the tab's

--- a/src/gori/tui/help_view.cr
+++ b/src/gori/tui/help_view.cr
@@ -42,6 +42,12 @@ module Gori::Tui
         Item.new("↹ / ⇧↹", "focus ring: tab bar ↔ panes"),
         Item.new("↵ / ↓", "enter the tab body"),
         Item.new("1-9", "jump to the Nth visible tab"),
+        # Seventeen surfaces bind j/k and no hint anywhere named them, so a whole navigation
+        # layer was reachable only by guessing. It belongs HERE rather than in each tab's
+        # hint: it is a global convention like ^P or ^D, the hints are already at the width
+        # the status strip gives them, and spending six cells per tab to repeat one rule
+        # would push a tab-specific key off the end.
+        Item.new("j / k", "move down / up — anywhere ↑/↓ moves (h/l where ←/→ do)"),
         Item.new("Settings: Tabs", "show/hide + reorder tabs"),
         Item.new("esc", "pop back to the tab bar"),
       ]},

--- a/src/gori/tui/help_view.cr
+++ b/src/gori/tui/help_view.cr
@@ -83,6 +83,11 @@ module Gori::Tui
         Item.new("space", "command menu (READ mode on request/target/response)"),
         Item.new("y", "copy selection/line (READ)", "repeater.copy"),
         Item.new("x · ⇧arrows", "select the current line · extend selection"),
+        # The §…§ marker trio, same keys and same order as the FUZZER section below — the
+        # Repeater grew `^K`/`^T` to match and Help documented neither.
+        Item.new("^A · ^K · ^T", "auto-mark params · mark word · mark point (manual §)", "repeater.auto-mark"),
+        Item.new("space → c", "clear every § marker", "repeater.clear-marks"),
+        Item.new("^Y", "edit the decoder chain on the marker at the cursor", "repeater.attach-chain"),
         Item.new("^X", "hex-edit the request", "repeater.toggle-hex"),
         Item.new("^S", "SNI override (on the target)", "repeater.toggle-sni"),
         Item.new("^L", "toggle auto Content-Length", "repeater.toggle-auto-content-length"),
@@ -117,6 +122,34 @@ module Gori::Tui
         Item.new("o · m", "sort · matched-only"),
         Item.new("r", "rename the sub-tab (on the strip)"),
         Item.new("⇧←/→", "detail: scroll a long line sideways"),
+      ]},
+      # Miner, OAST and JWT had NO section at all, while Sequencer — also a default-hidden
+      # tab — has a full one, so "it's hidden" was never the rule being applied. Three tabs
+      # whose entire keyboard surface was undiscoverable from the one screen that exists to
+      # answer "what can I press here".
+      {"MINER", [
+        Item.new("Mine parameters", "from History/Repeater (space menu) — finds params the app accepts but never shows"),
+        Item.new("^R · ^X", "mine · stop", "mine.run"),
+        Item.new("↹", "summary ⟷ findings"),
+        Item.new("↑/↓ · ↵", "findings: select · open detail"),
+        Item.new("space → R", "send the selected finding to Repeater (param injected)", "mine.repeater"),
+        Item.new("^N / ^W", "new / close a sub-tab"),
+      ]},
+      {"JWT", [
+        Item.new("^E", "switch decode ⟷ encode", "jwt.toggle-mode"),
+        Item.new("^A", "cycle the signing alg (alg=none included)", "jwt.cycle-alg"),
+        Item.new("^L · ^Y", "clear the session · copy everything", "jwt.clear"),
+        Item.new("↹", "cycle INPUT → DECODED → ATTACKS (decode) / HEADER → PAYLOAD → SECRET → OUTPUT (encode)"),
+        Item.new("i / ↵", "enter INS on an editable pane · esc back to READ"),
+        Item.new("↑/↓ · ↵", "attacks: select · copy the selected payload"),
+        Item.new("^N / ^W", "new / close a sub-tab"),
+      ]},
+      {"OAST", [
+        Item.new("^R · ^X", "start listening · stop", "oast.listen"),
+        Item.new("↑/↓ · ↵", "callbacks: select · open detail"),
+        Item.new("space → p", "promote a callback to an Issue", "oast.promote"),
+        Item.new("space → a", "add a provider · e edit · x enable/disable"),
+        Item.new("payload", "insert an OAST payload into the focused editor (space → O)", "oast.insert-payload"),
       ]},
       {"SEQUENCER", [
         Item.new("Send to Sequencer", "from History/Repeater/Sitemap (space menu) — replay + analyze a token"),

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -507,6 +507,18 @@ module Gori::Tui
       ri < @rows.size ? ri : nil
     end
 
+    # The row a click on the list's scroll gauge asks for. The gauge rides the frame's right
+    # hairline — one column OUTSIDE the list rect, which is why `list_row_at` cannot answer it
+    # — and this list's `@scroll` is DERIVED from the selection by render's `ensure_visible`,
+    # so the answer is a selection, not an offset. See `Frame.scroll_gauge_row`.
+    def gauge_row_at(rect : Rect, mx : Int32, my : Int32) : Int32?
+      list_rect, _ = list_split(rect)
+      return nil if list_rect.empty?
+      lt = list_top(list_rect)
+      Frame.scroll_gauge_row(Rect.new(list_rect.x, lt, list_rect.w, {list_rect.bottom - lt, 0}.max),
+        @rows.size, mx, my)
+    end
+
     # Which preview sub-pane (if any) contains (mx,my). :req | :res | nil.
     def preview_pane_at(rect : Rect, mx : Int32, my : Int32) : Symbol?
       _, prev = list_split(rect)

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -1895,8 +1895,11 @@ module Gori::Tui
       return if rect.empty?
       bg = active ? Theme.selection_dim : Theme.bg
       screen.fill(rect, bg) if active
-      label = active ? " #{title} ▎" : " #{title} "
-      screen.text(rect.x + 1, rect.y, label, active ? Theme.accent : Theme.muted, bg, attr: Attribute::Bold)
+      # `▎` in the marker column, not trailing the title — this was the one place in gori
+      # where the bar followed its label instead of leading the row. Written on both states so
+      # the title sits at the same column either way.
+      screen.cell(rect.x, rect.y, active ? '▎' : ' ', Theme.accent, bg)
+      screen.text(rect.x + 1, rect.y, " #{title} ", active ? Theme.accent : Theme.muted, bg, attr: Attribute::Bold)
       lines ||= ["(empty)"]
       content_y = rect.y + 1
       content_h = {rect.bottom - content_y, 0}.max
@@ -2247,27 +2250,20 @@ module Gori::Tui
       # Right cluster: a scope-lens chip (always shown so the ⇧S toggle is discoverable)
       # and, when filtering, the row count. The scope lens is a filter too, so it lives
       # on the filter bar next to the QL query.
-      scope_on = @scope.try(&.active?) == true
-      chip, chip_color = scope_on ? {"⇧S scope:#{@scope.try(&.size) || 0}", Theme.accent} : {"⇧S scope:off", Theme.muted}
-      rx = rect.right - 1
+      # One right-anchored chain, drawn by `Frame.right_text_chain` — rightmost first. The
+      # `f:follow` toggle shares the scope chip's accent/muted dress so the two read as one
+      # cluster, and the mark chip joins them rather than being placed by hand afterwards.
+      chips = [] of {String, Color}
       if filtering?
         # @rows is capped at PAGE by the search LIMIT; show "N+" at the cap so the count
         # isn't silently misread as the exact match total when more actually match.
-        count = @rows.size >= PAGE ? "#{PAGE}+" : @rows.size.to_s
-        screen.text({rx - count.size, rect.x}.max, rect.y, count, Theme.muted)
-        rx -= count.size + 2
+        chips << {@rows.size >= PAGE ? "#{PAGE}+" : @rows.size.to_s, Theme.muted}
       end
-      scope_x = {rx - chip.size, rect.x}.max
-      screen.text(scope_x, rect.y, chip, chip_color)
-      # The live-tail (follow) toggle, left of the scope chip — same fg accent/muted
-      # style so the two mode toggles read as one cluster, surfacing the `f` chord
-      # (today follow is only implicit in the selection sitting on the newest row).
-      fchip = "f:follow"
-      fx = scope_x - fchip.size - 1
-      follow_shown = fx > rect.x + 1
-      screen.text(fx, rect.y, fchip, @follow ? Theme.accent : Theme.muted) if follow_shown
-
-      lx = render_mark_chip(screen, rect, follow_shown ? fx : scope_x)
+      scope_on = @scope.try(&.active?) == true
+      chips << (scope_on ? {"⇧S scope:#{@scope.try(&.size) || 0}", Theme.accent} : {"⇧S scope:off", Theme.muted})
+      chips << {"f:follow", @follow ? Theme.accent : Theme.muted}
+      chips << {mark_chip_text.not_nil!, Theme.accent} if mark_chip_text
+      lx = Frame.right_text_chain(screen, rect.right - 1, rect.y, rect.x + 2, chips)
 
       left_w = {lx - (rect.x + 1) - 1, 0}.max
       if !@query.blank?
@@ -2290,14 +2286,14 @@ module Gori::Tui
     # survive a tab switch, so this chip is what keeps the set from being invisible when you
     # come back. The hidden split covers marks the current filter/window doesn't show, so the
     # count never silently exceeds what's on screen.
-    private def render_mark_chip(screen : Screen, rect : Rect, right_x : Int32) : Int32
-      return right_x if @marks.empty?
+    # The mark chip's TEXT, or nil when there is nothing marked. It used to place itself,
+    # which is why it needed a `right_x` and its own too-narrow guard; as a string it joins
+    # the same chain as its neighbours and `Frame.right_text_chain` drops it on a narrow bar
+    # for the same reason it drops any of them.
+    private def mark_chip_text : String?
+      return nil if @marks.empty?
       hidden = marked_hidden_count
-      chip = hidden > 0 ? "#{@marks.size} marked ·#{hidden} hidden" : "#{@marks.size} marked"
-      x = right_x - chip.size - 1
-      return right_x unless x > rect.x + 1 # too narrow — the row count/scope chips win
-      screen.text(x, rect.y, chip, Theme.accent)
-      x
+      hidden > 0 ? "#{@marks.size} marked ·#{hidden} hidden" : "#{@marks.size} marked"
     end
 
     private def render_suggestions(screen : Screen, rect : Rect, y : Int32) : Nil

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -36,7 +36,7 @@ module Gori::Tui
     MAX_ROWS = 5000
     # Width the Colormarker `strip` column costs the fixed left block when armed: one colour
     # cell plus a one-column gap. See render_list_body.
-    STRIP_W    = 2
+    STRIP_W    =   2
     TRIM_SLACK = 512
     # Cap on h2 frames / WS messages loaded into a detail view. A long-lived WS
     # (100k+ messages) or a heavily-multiplexed h2 connection would otherwise
@@ -1839,6 +1839,11 @@ module Gori::Tui
         screen.text(size_x, y, fmt_size(row.response_size), Theme.muted, bg, width: 6) if show_size
         screen.text(dur_x, y, fmt_dur(row.duration_us), Theme.muted, bg, width: 6) if show_dur
       end
+      # The busiest list in gori, and it had no position feedback at all: a 12-row window over
+      # 400 flows looked exactly like a 12-row window over 12. `rect` is the framed interior,
+      # so `rect.right` is the frame's own hairline — where `scroll_gauge` draws.
+      Frame.scroll_gauge(screen, Rect.new(rect.x, list_top, rect.w, list_h),
+        @rows.size, @scroll, focused)
     end
 
     # Bottom preview pane: REQUEST | RESPONSE for the selected flow (settings:layout).
@@ -1903,6 +1908,12 @@ module Gori::Tui
         break if li >= lines.size
         screen.text(rect.x + 1, content_y + i, lines[li], Theme.text, bg, width: w)
       end
+      # Both preview halves scroll independently and neither said so. `rect.right` is the
+      # frame's hairline for the stacked layout and the RIGHT half of the split one; for the
+      # LEFT half it is the vertical `│` this pane draws between them, which the gauge
+      # replaces in place — a vertical rule either way, now one that also says where you are.
+      Frame.scroll_gauge(screen, Rect.new(rect.x, content_y, rect.w, content_h),
+        lines.size, sc, active, bg)
     end
 
     private def preview_text_lines(head : Bytes?, body : Bytes?) : Array(String)
@@ -2124,6 +2135,12 @@ module Gori::Tui
           Wrap.mark_search(screen, body.x + gw, y, text, vr.a, vr.b, @search_hl, body.x + gw + cw)
         end
       end
+      # The detail body scrolls (`@detail_scroll`) and had no gauge, while the Repeater's
+      # structurally identical response pane has had one all along. `total` is LINES, and
+      # `detail_rows` windows by wrapped ROWS, so the two disagree on a wrapped line — the
+      # gauge is a proportion, and lines are the number the operator's ↑/↓ and the gutter
+      # both count in, which makes it the honest one to show.
+      Frame.scroll_gauge(screen, body, total, @detail_scroll, focused)
     end
 
     # Windowed render of revealed (whitespace-visible) lines — mirrors the normal

--- a/src/gori/tui/hosts_overlay.cr
+++ b/src/gori/tui/hosts_overlay.cr
@@ -131,7 +131,7 @@ module Gori::Tui
 
     private def delete_and_persist : Nil
       return unless host = delete_selected
-      toast(persist ? "removed host override: #{host}" : "removed #{host} — could not save to #{Settings.path}")
+      toast(persist ? "host override deleted: #{host}" : "host override deleted: #{host} — could not save to #{Settings.path}")
     end
 
     private def commit_and_persist : Nil

--- a/src/gori/tui/hosts_overlay.cr
+++ b/src/gori/tui/hosts_overlay.cr
@@ -178,6 +178,11 @@ module Gori::Tui
       end
       # A press inside the open add/edit row is a CARET, not a row pick — the row is text.
       return :stay if @adding && click_text_field(mx, my)
+      # The gauge on the card's right hairline, before `row_at` — which has no `mx` bound.
+      if row = gauge_row_at(box, mx, my)
+        set_selected(row)
+        return :stay
+      end
       if idx = row_at(box, mx, my)
         set_selected(idx)
       end
@@ -365,6 +370,17 @@ module Gori::Tui
       # `TextField#render` is what records the geometry `hit?` inverts, so drawing through it
       # is what makes the pointer work — not merely tidier than `screen.input_line`.
       @field.render(screen, x, py, w, true, Theme.text_bright, bg)
+    end
+
+    # The row a click on the list's scroll gauge asks for. The gauge rides the card's right
+    # hairline; the window is derived from the selection, so this answers with a selection.
+    # `y`/`rows` mirror render exactly: the add-row, when open, takes the first interior line.
+    def gauge_row_at(box : Rect, mx : Int32, my : Int32) : Int32?
+      cap = list_capacity(box)
+      y = box.y + 2 + (@adding ? 1 : 0)
+      rows = cap - (@adding ? 1 : 0)
+      return nil if rows <= 0
+      Frame.scroll_gauge_row(Rect.new(box.x + 1, y, box.w - 2, rows), @items.size, mx, my)
     end
 
     # Row index under (mx,my) — inverts render's windowed layout (add-row offset +

--- a/src/gori/tui/hosts_overlay.cr
+++ b/src/gori/tui/hosts_overlay.cr
@@ -1,6 +1,7 @@
 require "./screen"
 require "./theme"
 require "./frame"
+require "./text_field"
 require "./overlay"
 require "../settings"
 require "../host_overrides"
@@ -31,9 +32,12 @@ module Gori::Tui
       @selected = 0
       @adding = false
       @edit_index = nil.as(Int32?) # non-nil ⇒ editing that row
-      @input = ""                  # add-row text ("IP host")
-      @icx = 0
-      @preedit = ""
+      # The add/edit row is a real `TextField`, like every form row in gori. Hand-rolled
+      # `@input`/`@icx`/`@preedit` triple used to stand in for it, which meant the row was
+      # text the pointer could not reach: no caret on a press, no drag to select, no
+      # double-click for a word — all of which a TextField already answers, because it
+      # remembers the geometry it was last drawn at (`hit?`).
+      @field = TextField.new
       reset
     end
 
@@ -107,18 +111,20 @@ module Gori::Tui
         cancel_add
       elsif key.enter?
         commit_and_persist
-      elsif key.left?
-        move_cursor(-1)
-      elsif key.right?
-        move_cursor(1)
       elsif key.backspace?
+        # ⌫ on an already-empty row means "I am done here", so the empty check comes BEFORE
+        # the field sees the key — `TextField#backspace` on an empty value is a silent no-op
+        # and the row would sit there with no way out but esc.
         cancel_add unless backspace
       elsif key.tab?
-        input(' ') # Tab types the IP/host separator, not a focus jump
-        set_preedit("")
-      elsif c && !ev.ctrl? && !ev.alt?
-        input(c)
-        set_preedit("")
+        # ↹ types the IP/host separator rather than jumping focus. There is nowhere to jump
+        # to: this row is one field holding two values, and the pair is what `commit_entry`
+        # parses. Deliberate, and the same in the ENV editor next door.
+        @field.insert(' ')
+      else
+        # Everything else goes through the shared editor: caret motion, word jumps, ⌥⌫ and
+        # selection — the keys this row used to answer with `move_cursor(±1)` alone.
+        @field.handle_edit_key(ev)
       end
       :stay
     end
@@ -165,6 +171,8 @@ module Gori::Tui
         cancel_add
         return :stay
       end
+      # A press inside the open add/edit row is a CARET, not a row pick — the row is text.
+      return :stay if @adding && click_text_field(mx, my)
       if idx = row_at(box, mx, my)
         set_selected(idx)
       end
@@ -186,9 +194,7 @@ module Gori::Tui
     def add_start : Nil
       @adding = true
       @edit_index = nil
-      @input = ""
-      @icx = 0
-      @preedit = ""
+      @field.set("")
     end
 
     def edit_start : Nil
@@ -196,38 +202,36 @@ module Gori::Tui
       host, ip = @items[@selected]
       @adding = true
       @edit_index = @selected
-      @input = "#{ip} #{host}"
-      @icx = @input.size
-      @preedit = ""
+      @field.set("#{ip} #{host}")
     end
 
     def cancel_add : Nil
       @adding = false
       @edit_index = nil
-      @input = ""
-      @icx = 0
-      @preedit = ""
+      @field.set("")
     end
 
     def input(ch : Char) : Nil
-      @input = "#{@input[0, @icx]}#{ch}#{@input[@icx..]}"
-      @icx += 1
-      @preedit = ""
+      @field.insert(ch)
     end
 
+    # Whether there was anything to delete — `handle_add_key` reads this to tell a ⌫ that
+    # edited the text from one on an empty row, which cancels.
     def backspace : Bool
-      return false if @icx == 0
-      @input = "#{@input[0, @icx - 1]}#{@input[@icx..]}"
-      @icx -= 1
+      return false if @field.value.empty?
+      @field.backspace
       true
     end
 
-    def move_cursor(d : Int32) : Nil
-      @icx = (@icx + d).clamp(0, @input.size)
+    def set_preedit(text : String) : Nil
+      @field.set_preedit(text)
     end
 
-    def set_preedit(text : String) : Nil
-      @preedit = text
+    # The pointer contract (see `Overlay#text_fields`): listing the field is the whole opt-in
+    # for caret-on-press, drag-select and double-click-word. Only while the row is OPEN —
+    # otherwise a click on the list would place a caret in a field nobody is looking at.
+    def text_fields : Array(TextField)
+      @adding ? [@field] : [] of TextField
     end
 
     # Commit the add/edit row ("IP host", /etc/hosts order). Returns :ok|:empty|:invalid|
@@ -241,7 +245,7 @@ module Gori::Tui
     # landmine the moment one is added: the shell would run this field parser instead of the
     # closure and read its truthy Symbol as "close me".
     def commit_entry : Symbol
-      text = @input.strip
+      text = @field.value.strip
       return :empty if text.empty?
       parsed = HostOverrides.parse_line(text)
       return :invalid unless parsed
@@ -347,10 +351,15 @@ module Gori::Tui
     private def draw_add_row(screen : Screen, box : Rect, py : Int32) : Nil
       bg = Theme.accent_bg
       screen.fill(Rect.new(box.x + 1, py, box.w - 2, 1), bg)
+      # The marker column every other row in this list writes — the add-row used to skip it,
+      # so the one row that HAS the focus was the only one without the bar that says so.
+      screen.cell(box.x + 1, py, '▎', Theme.accent, bg)
       x = box.x + 3
       x = screen.text(x, py, @edit_index ? "edit " : "add ", Theme.accent, bg)
       w = {box.right - 1 - x, 3}.max
-      screen.input_line(x, py, @input, @icx, @preedit, Theme.text_bright, bg, width: w)
+      # `TextField#render` is what records the geometry `hit?` inverts, so drawing through it
+      # is what makes the pointer work — not merely tidier than `screen.input_line`.
+      @field.render(screen, x, py, w, true, Theme.text_bright, bg)
     end
 
     # Row index under (mx,my) — inverts render's windowed layout (add-row offset +

--- a/src/gori/tui/hosts_overlay.cr
+++ b/src/gori/tui/hosts_overlay.cr
@@ -319,7 +319,7 @@ module Gori::Tui
       end
       return if rows <= 0
       if @items.empty?
-        screen.text(box.x + 3, y, "(no overrides — a to add)", Theme.muted) unless @adding
+        screen.text(box.x + 3, y, "no overrides — press a to add", Theme.muted, Theme.panel) unless @adding
         return
       end
       start = list_window(rows)

--- a/src/gori/tui/hosts_overlay.cr
+++ b/src/gori/tui/hosts_overlay.cr
@@ -301,7 +301,7 @@ module Gori::Tui
       end
       Frame.card(screen, box, "HOSTNAME OVERRIDES", border: Theme.border_focus)
       meta = "#{@items.size} entr#{@items.size == 1 ? "y" : "ies"}"
-      screen.text({box.right - meta.size - 2, box.x + 20}.max, box.y, meta, Theme.muted, Theme.panel)
+      Frame.border_meta(screen, box, "HOSTNAME OVERRIDES", meta, bg: Theme.panel)
       # A brief format example so the "IP HOSTNAME" entry shape is clear at a glance.
       screen.text(box.x + 3, box.y + 1, "IP HOSTNAME · e.g. 10.0.0.1 example.com", Theme.muted, Theme.panel, width: {box.w - 5, 1}.max)
 
@@ -324,6 +324,10 @@ module Gori::Tui
         break if i >= @items.size
         draw_row(screen, box, i, y + row)
       end
+      # `y`/`rows` are already past the add-row when one is open, so the gauge measures the
+      # entries actually windowed rather than the card interior.
+      Frame.scroll_gauge(screen, Rect.new(box.x + 1, y, box.w - 2, rows),
+        @items.size, start, true, Theme.panel)
     end
 
     private def draw_row(screen : Screen, box : Rect, i : Int32, py : Int32) : Nil

--- a/src/gori/tui/hosts_overlay.cr
+++ b/src/gori/tui/hosts_overlay.cr
@@ -135,12 +135,17 @@ module Gori::Tui
     end
 
     private def commit_and_persist : Nil
+      verb = @edit_index ? "updated" : "added"
       case commit_entry
       when :empty   then toast("host override: empty")
       when :invalid then toast(%(host override: need "IP host" — a valid IP + a hostname))
-      when :dup     then toast("host override: host already mapped")
+      when :dup     then toast("host override: host already mapped — edit it (e)")
       when :ok
-        toast(persist ? "host override saved — #{@items.size} total" : "host override applied — could not save to #{Settings.path}")
+        # `added` / `updated`, like the Project pane that edits the same list. `@edit_index`
+        # is non-nil exactly when this commit came from `e`, so the distinction was already
+        # in hand — the message simply never asked for it. Read before `commit_entry`
+        # clears it, which is why the verb is captured at the top of this method.
+        toast(persist ? "host override #{verb} — #{@items.size} total" : "host override applied — could not save to #{Settings.path}")
       end
     end
 

--- a/src/gori/tui/hotkeys_overlay.cr
+++ b/src/gori/tui/hotkeys_overlay.cr
@@ -401,12 +401,18 @@ module Gori::Tui
     private def render_footer(screen : Screen, box : Rect) : Nil
       ry = box.bottom - 2
       if fb = @feedback
-        color = case @feedback_kind
-                when :error then Theme.yellow
-                when :ok    then Theme.green
-                else             Theme.muted
-                end
-        screen.text(box.x + 2, ry, "• #{fb}", color, Theme.panel, width: {box.w - 4, 1}.max)
+        # `✓` / `✗`, the vocabulary the notification centre already owns — and the glyph is the
+        # point, not the hue. Both outcomes used to print the same `•` and differ only by
+        # green-vs-yellow, which is the CLOSEST pair in several shipped palettes (GRUVBOX
+        # #b8bb26/#fabd2f, DRACULA #50fa7b/#f1fa8c, MATRIX #00ff41/#eaff4d): whether a rebind
+        # was accepted or rejected came down to a hue discrimination the theme may not offer.
+        # `:error` was yellow here and red everywhere else for the same symbol name, too.
+        mark, color = case @feedback_kind
+                      when :error then {'✗', Theme.red}
+                      when :ok    then {'✓', Theme.green}
+                      else             {'·', Theme.muted}
+                      end
+        screen.text(box.x + 2, ry, "#{mark} #{fb}", color, Theme.panel, width: {box.w - 4, 1}.max)
       elsif (r = @rows[@selected]?) && r.kind == :binding && (v = @registry[r.verb_id]?)
         # Retagged: a description may name a claimed chord (settings.editor's "opened by ^E"),
         # and this is the one surface that renders verb descriptions.

--- a/src/gori/tui/hotkeys_overlay.cr
+++ b/src/gori/tui/hotkeys_overlay.cr
@@ -104,7 +104,7 @@ module Gori::Tui
 
     def hint : String
       return "press a key to bind · esc cancel" if capturing?
-      "↑/↓ select · e/␣ rebind · x unbind · r reset · ⇧R reset all · ←/→ profile · ↵ save · esc"
+      "↑/↓ select · e/␣ rebind · x/⌫ unbind · r reset · ⇧R reset all · ←/→ profile · ↵ save · esc cancel"
     end
 
     # In :capture the shell must route EVERY key here before its own pre-filter, so a

--- a/src/gori/tui/import_overlay.cr
+++ b/src/gori/tui/import_overlay.cr
@@ -142,8 +142,8 @@ module Gori::Tui
     # Tall enough (14) that PathComplete's 8-row cap fits under the field instead of
     # being clipped; `area` still wins on a short terminal.
     def overlay_box(area : Rect) : Rect?
-      w = {area.w - 6, 76}.min
-      h = {area.h - 4, 14}.min
+      w = {area.w - 4, 76}.min
+      h = {area.h - 2, 14}.min
       return nil if w < 40 || h < 8
       Rect.new(area.x + (area.w - w) // 2, area.y + (area.h - h) // 2, w, h)
     end

--- a/src/gori/tui/intercept_view.cr
+++ b/src/gori/tui/intercept_view.cr
@@ -908,10 +908,6 @@ module Gori::Tui
       {label, @enabled ? Theme.accent : Theme.muted}
     end
 
-    private def pane_border(focused : Bool) : Color
-      Frame.pane_border(focused)
-    end
-
     # --- what a queue row IS ---------------------------------------------------
     # Every branch on `Interceptor::Kind` in this file (and `InterceptController`'s toast
     # label) is an exhaustive `case ... in`, deliberately. They were all `kind.request?`
@@ -979,7 +975,7 @@ module Gori::Tui
 
     private def render_list(screen : Screen, rect : Rect, focused : Bool) : Nil
       return if rect.w < 2 || rect.h < 2
-      Frame.card(screen, rect, "QUEUE (#{@items.size})", bg: Theme.bg, border: pane_border(focused))
+      Frame.card(screen, rect, "QUEUE (#{@items.size})", bg: Theme.bg, border: Frame.pane_border(focused))
       inner = rect.inset(1, 1)
       ensure_visible(inner.h)
       (0...inner.h).each do |i|
@@ -1019,7 +1015,7 @@ module Gori::Tui
       return if rect.w < 2 || rect.h < 2
       it = selected_item
       title = it.nil? ? "DETAIL" : detail_title(it)
-      Frame.card(screen, rect, title, bg: Theme.bg, border: pane_border(focused))
+      Frame.card(screen, rect, title, bg: Theme.bg, border: Frame.pane_border(focused))
       # `e` (or ↵) toggles editing the held bytes vs previewing them — lit while editing,
       # a muted hint while previewing, so the edit affordance rides the border. A binary WS
       # message says READ-ONLY there instead: the affordance must not advertise an edit the

--- a/src/gori/tui/intercept_view.cr
+++ b/src/gori/tui/intercept_view.cr
@@ -783,6 +783,15 @@ module Gori::Tui
       idx < @items.size ? idx : nil
     end
 
+    # The row a click on the list's scroll gauge asks for. The gauge rides the frame's right
+    # hairline — one column OUTSIDE the list rect, which is why `list_row_at` cannot answer it
+    # — and this list's `@scroll` is DERIVED from the selection by render's `ensure_visible`,
+    # so the answer is a selection, not an offset. See `Frame.scroll_gauge_row`.
+    def gauge_row_at(rect : Rect, mx : Int32, my : Int32) : Int32?
+      left, _ = split_panes(body_rect(rect))
+      Frame.scroll_gauge_row(left.inset(1, 1), @items.size, mx, my)
+    end
+
     # Set the selection, clamped to the populated rows (mirrors `move`).
     def select_index(idx : Int32) : Nil
       return if @items.empty?

--- a/src/gori/tui/intercept_view.cr
+++ b/src/gori/tui/intercept_view.cr
@@ -847,13 +847,11 @@ module Gori::Tui
       label, color = direction_chip
       x = screen.text(x, rect.y, label, color, Theme.bg, Attribute::Bold) + 2
 
-      rx = rect.right - 1
-      if !@items.empty?
-        count = @items.size.to_s
-        screen.text({rx - count.size, rect.x}.max, rect.y, count, Theme.muted)
-        rx -= count.size + 2
-      end
-      rx = render_mark_chip(screen, rect, rx)
+      # One right-anchored chain — see HistoryView#render_ql_bar, which this mirrors.
+      chips = [] of {String, Color}
+      chips << {@items.size.to_s, Theme.muted} unless @items.empty?
+      chips << {mark_chip_text.not_nil!, Theme.accent} if mark_chip_text
+      rx = Frame.right_text_chain(screen, rect.right - 1, rect.y, rect.x + 2, chips)
 
       left_w = {rx - x, 0}.max
       if @query.blank?
@@ -871,13 +869,11 @@ module Gori::Tui
     # of the chip cluster. No "hidden" split (History's chip carries one): the queue renders
     # every pending item, and reload prunes marks whose item is gone, so the count can never
     # exceed what is on screen.
-    private def render_mark_chip(screen : Screen, rect : Rect, right_x : Int32) : Int32
-      return right_x if @marks.empty?
-      chip = "#{@marks.size} marked"
-      x = right_x - chip.size - 1
-      return right_x unless x > rect.x + 1 # too narrow — the held count wins
-      screen.text(x, rect.y, chip, Theme.accent)
-      x
+    # The mark chip's TEXT, or nil when nothing is marked — see HistoryView#mark_chip_text.
+    # No hidden-count half here: the held queue has no filter that can hide a marked row, so
+    # there is never a "· N hidden" to report.
+    private def mark_chip_text : String?
+      @marks.empty? ? nil : "#{@marks.size} marked"
     end
 
     # The Tab-completion row under the condition input: the leading candidate is what ↹
@@ -975,7 +971,8 @@ module Gori::Tui
 
     private def render_list(screen : Screen, rect : Rect, focused : Bool) : Nil
       return if rect.w < 2 || rect.h < 2
-      Frame.card(screen, rect, "QUEUE (#{@items.size})", bg: Theme.bg, border: Frame.pane_border(focused))
+      Frame.card(screen, rect, "QUEUE", bg: Theme.bg, border: Frame.pane_border(focused))
+      Frame.border_meta(screen, rect, "QUEUE", @items.size.to_s)
       inner = rect.inset(1, 1)
       ensure_visible(inner.h)
       (0...inner.h).each do |i|

--- a/src/gori/tui/intercept_view.cr
+++ b/src/gori/tui/intercept_view.cr
@@ -1054,7 +1054,7 @@ module Gori::Tui
       x = Frame.toggle_badge(screen, rect.right - 1, rect.y, min_x, "e", "EDIT", @editing)
       return unless @editing
       return if @loaded_ws # a WS payload has no head — the sync never runs on it
-      Frame.toggle_badge(screen, x, rect.y, min_x, "^l", "CL", @sync_content_length)
+      Frame.toggle_badge(screen, x, rect.y, min_x, "^L", "CL", @sync_content_length)
     end
 
     # Where `e`:EDIT would ride, for a message the editor must not open. Right-aligned with

--- a/src/gori/tui/issues_view.cr
+++ b/src/gori/tui/issues_view.cr
@@ -133,6 +133,17 @@ module Gori::Tui
       idx < @issues.size ? idx : nil
     end
 
+    # The row a click on the list's scroll gauge asks for. The gauge rides the frame's right
+    # hairline — one column OUTSIDE the list rect, which is why `list_row_at` cannot answer it
+    # — and this list's `@scroll` is DERIVED from the selection by render's `ensure_visible`,
+    # so the answer is a selection, not an offset. See `Frame.scroll_gauge_row`.
+    def gauge_row_at(rect : Rect, mx : Int32, my : Int32) : Int32?
+      list_rect, _ = list_split(rect)
+      top = list_rect.y + 3 # same band list_row_at and the gauge draw measure
+      Frame.scroll_gauge_row(Rect.new(list_rect.x, top, list_rect.w, {list_rect.bottom - top, 0}.max),
+        @issues.size, mx, my)
+    end
+
     def preview_at?(rect : Rect, mx : Int32, my : Int32) : Bool
       _, prev = list_split(rect)
       !!prev.try(&.contains?(mx, my))

--- a/src/gori/tui/issues_view.cr
+++ b/src/gori/tui/issues_view.cr
@@ -1020,11 +1020,15 @@ module Gori::Tui
     end
 
     private def status_color(s : Store::Status) : Color
+      # SEVERITY owns the colour ladder on these rows; triage status does not compete for it.
+      # The two were drawn five columns apart out of the SAME hues — `CRIT conf` was two reds
+      # meaning two different axes, `LOW open` two accents — on a list whose whole job is
+      # "scan for red". The four words (conf / fp / done / open) already tell the statuses
+      # apart, so what is left for colour here is the one distinction the WORDS do not make
+      # at a glance: still live, or already handled.
       case s
-      when .confirmed?      then Theme.red
-      when .false_positive? then Theme.muted
-      when .resolved?       then Theme.green
-      else                       Theme.accent # open
+      when .false_positive?, .resolved? then Theme.muted
+      else                                   Theme.text # open
       end
     end
 

--- a/src/gori/tui/issues_view.cr
+++ b/src/gori/tui/issues_view.cr
@@ -840,13 +840,11 @@ module Gori::Tui
           colors: Highlight.filter_query(@query, Theme.text_bright, FilterAst::SEPS_FIELD))
         return
       end
-      rx = rect.right - 1
-      if filtering?
-        count = @issues.size.to_s
-        screen.text({rx - count.size, rect.x}.max, rect.y, count, Theme.muted)
-        rx -= count.size + 2
-      end
-      rx = render_mark_chip(screen, rect, rx)
+      # One right-anchored chain — see HistoryView#render_ql_bar.
+      chips = [] of {String, Color}
+      chips << {@issues.size.to_s, Theme.muted} if filtering?
+      chips << {mark_chip_text.not_nil!, Theme.accent} if mark_chip_text
+      rx = Frame.right_text_chain(screen, rect.right - 1, rect.y, rect.x + 2, chips)
       left_w = {rx - (rect.x + 1), 0}.max
       if filtering?
         # The committed query stays highlighted — this readout is what you scan to
@@ -864,14 +862,11 @@ module Gori::Tui
     # switch, so this chip is what keeps the set from being invisible when you come back. The
     # hidden split covers marks the current filter doesn't show, so the count never silently
     # exceeds what's on screen.
-    private def render_mark_chip(screen : Screen, rect : Rect, right_x : Int32) : Int32
-      return right_x if @marks.empty?
+    # The mark chip's TEXT, or nil when nothing is marked — see HistoryView#mark_chip_text.
+    private def mark_chip_text : String?
+      return nil if @marks.empty?
       hidden = marked_hidden_count
-      chip = hidden > 0 ? "#{@marks.size} marked ·#{hidden} hidden" : "#{@marks.size} marked"
-      x = right_x - chip.size
-      return right_x unless x > rect.x + 1 # too narrow — the match count wins
-      screen.text(x, rect.y, chip, Theme.accent)
-      x - 2
+      hidden > 0 ? "#{@marks.size} marked ·#{hidden} hidden" : "#{@marks.size} marked"
     end
 
     private def render_detail(screen : Screen, rect : Rect, focused : Bool) : Nil
@@ -889,8 +884,8 @@ module Gori::Tui
 
       # y1 — chips: a filled severity chip + a status chip.
       cx = rect.x + 1
-      cx = chip(screen, cx, rect.y + 1, " #{severity_badge(issue.severity)} ", severity_color(issue.severity))
-      chip(screen, cx + 1, rect.y + 1, " #{issue.status.label} ", status_color(issue.status))
+      cx = Frame.tag_chip(screen, cx, rect.y + 1, " #{severity_badge(issue.severity)} ", severity_color(issue.severity))
+      Frame.tag_chip(screen, cx + 1, rect.y + 1, " #{issue.status.label} ", status_color(issue.status))
 
       # y2 — timestamps.
       meta = "created #{fmt_ts(issue.created_at)}"
@@ -986,10 +981,6 @@ module Gori::Tui
 
     # A filled "chip": ` LABEL ` painted with `color` as the background. Returns the
     # x just past it so chips lay out left-to-right.
-    private def chip(screen : Screen, x : Int32, y : Int32, label : String, color : Color) : Int32
-      screen.text(x, y, label, Theme.bg, color, Attribute::Bold)
-    end
-
     private def refresh_detail(store : Store) : Nil
       if issue = @detail
         @detail = store.get_issue(issue.id)

--- a/src/gori/tui/issues_view.cr
+++ b/src/gori/tui/issues_view.cr
@@ -950,14 +950,14 @@ module Gori::Tui
       notes_active = focused && notes_focused?
       ins = focused && notes_insert_mode?
       Frame.card(screen, card, "NOTES", bg: Theme.bg, border: Frame.pane_border(notes_active || ins))
-      if notes_active || ins
-        Frame.mode_badge(screen, card.right - 1, card.y, card.x + 7, ins)
-      elsif !notes_insert_mode?
-        # Unfocused NOTES still hints how to enter insert (same ↵ cue as the mode badge).
-        edit_hint = " ↵ "
-        bx = card.right - edit_hint.size - 1
-        screen.text(bx, card.y, edit_hint, Theme.muted, Theme.bg) if bx >= card.x + 7
-      end
+      # The REAL mode, always drawn — `Frame.mode_badge`'s contract, and this call broke it
+      # in the worst of the three possible ways. In insert-but-unfocused neither branch below
+      # ran, so NOTHING was painted on the border while `issues_controller` went on hit-testing
+      # the bare `notes_insert_mode?`: five blank cells that toggled insert when clicked. The
+      # `elsif` was a third geometry on top of that — a 3-cell ` ↵ ` the hit-test never knew
+      # about. `mode_badge` already draws its READ label muted on the canvas, which is the
+      # same quiet ↵ cue that branch existed to provide.
+      Frame.mode_badge(screen, card.right - 1, card.y, card.x + 7, notes_insert_mode?)
       body = card.inset(1, 1)
       return if body.empty?
       @notes.render(screen, body, cursor: ins, gauge: true, gauge_focused: notes_active)

--- a/src/gori/tui/issues_view.cr
+++ b/src/gori/tui/issues_view.cr
@@ -924,12 +924,16 @@ module Gori::Tui
           res = @detail_resolved[idx]
           active = idx == @selected_link
           fg = res.stale? ? Theme.muted : (active ? Theme.text_bright : Theme.text)
-          row_x = rect.x + 1
-          if active
-            screen.cell(row_x, list_y + i, '▎', Theme.accent, Theme.bg)
-            row_x += 1
-          end
-          screen.text(row_x, list_y + i, res.line, fg, width: w - (row_x - rect.x - 1))
+          # The marker column is written on EVERY row and the band is filled behind the
+          # selected one — the shape every other list in gori uses. This list drew the bar
+          # ONLY when active and then pushed the row's text one column right to make room,
+          # so the selected link was both hard to see (no band at all) and visibly out of
+          # line with its neighbours.
+          y = list_y + i
+          bg = active ? Theme.accent_bg : Theme.bg
+          screen.fill(Rect.new(rect.x + 1, y, w, 1), bg) if active
+          screen.cell(rect.x + 1, y, active ? '▎' : ' ', Theme.accent, bg)
+          screen.text(rect.x + 2, y, res.line, fg, bg, width: {w - 1, 1}.max)
         end
       end
       # NOTES — a real Frame.card (like Decoder INPUT) so INS/READ borders are rounded

--- a/src/gori/tui/issues_view.cr
+++ b/src/gori/tui/issues_view.cr
@@ -755,6 +755,10 @@ module Gori::Tui
         tw = {right - title_x, 0}.max
         screen.text(title_x, y, ellipsize(f.title, tw), title_fg, bg, width: tw)
       end
+      # `ensure_visible`'s own comment already named what was missing here: without a gauge,
+      # 44 results silently read as the 3 that happen to be under the window.
+      Frame.scroll_gauge(screen, Rect.new(rect.x, top, rect.w, list_h),
+        @issues.size, @scroll, focused)
     end
 
     # The cursor row keeps the accent band; a marked row gets the dim one; a row that is both
@@ -800,6 +804,7 @@ module Gori::Tui
         fg, text = lines[li]
         screen.text(body.x + 1, body.y + i, text, fg, bg, width: w)
       end
+      Frame.scroll_gauge(screen, body, lines.size, sc, false, bg)
     end
 
     private def issues_preview_lines(f : Store::Issue) : Array({Color, String})
@@ -935,6 +940,8 @@ module Gori::Tui
           screen.cell(rect.x + 1, y, active ? '▎' : ' ', Theme.accent, bg)
           screen.text(rect.x + 2, y, res.line, fg, bg, width: {w - 1, 1}.max)
         end
+        Frame.scroll_gauge(screen, Rect.new(rect.x, list_y, rect.w, list_h),
+          @detail_resolved.size, @links_scroll, focused)
       end
       # NOTES — a real Frame.card (like Decoder INPUT) so INS/READ borders are rounded
       # and the editor body is inset, never colliding with the outline.

--- a/src/gori/tui/jwt_view.cr
+++ b/src/gori/tui/jwt_view.cr
@@ -107,9 +107,12 @@ module Gori::Tui
       reading = active && mode == InputMode::Read
       insert = active && mode == InputMode::Insert
       Frame.card(screen, card, "INPUT", bg: Theme.bg, border: Frame.pane_border(active))
-      if active
-        Frame.mode_badge(screen, card.right - 1, card.y, card.x + 8, insert)
-      end
+      # `mode`, not `insert` — the badge states the pane's own mode, and `JwtController`
+      # hit-tests exactly that. Gating the draw on `active` (and passing the focus-folded
+      # `insert`) left a live 8-cell target on an unpainted border: with focus on DECODED,
+      # ATTACKS or SECRET, clicking the INPUT card's top-right corner toggled insert.
+      # See the same fix in notes_view / fuzzer_view; focus stays in the border colour.
+      Frame.mode_badge(screen, card.right - 1, card.y, card.x + 8, mode == InputMode::Insert)
       body = card.inset(1, 1)
       input.render(screen, body, cursor: insert, gauge: true, gauge_focused: active)
       paint_read_chrome(screen, body, input, read) if reading
@@ -251,6 +254,37 @@ module Gori::Tui
 
     def attacks_selected : Int32
       @atk_sel
+    end
+
+    # Mouse: the attack index under a click in the ATTACKS card, or nil (past the last row).
+    # Mirrors render_attacks' inset → @atk_scroll + i; the list has no header row. The pane
+    # drew a cursor and moved it with ↑/↓ and the wheel, and the pointer could not place it.
+    def attacks_row_at(card : Rect, my : Int32, count : Int32) : Int32?
+      return nil if count <= 0
+      body = card.inset(1, 1)
+      return nil if body.h <= 0
+      i = my - body.y
+      return nil if i < 0 || i >= body.h
+      idx = @atk_scroll + i
+      idx < count ? idx : nil
+    end
+
+    # The attack a click on the ATTACKS gauge asks for. `@atk_scroll` is derived from
+    # `@atk_sel` by render, so this answers with a selection. See `Frame.scroll_gauge_row`.
+    def attacks_gauge_row(card : Rect, mx : Int32, my : Int32, count : Int32) : Int32?
+      Frame.scroll_gauge_row(card.inset(1, 1), count, mx, my)
+    end
+
+    def select_attack_row(idx : Int32, count : Int32) : Nil
+      @atk_sel = idx.clamp(0, {count - 1, 0}.max)
+    end
+
+    # Hit-test the SECRET card's ` ^A:<alg> ` badge. Geometry mirrors render_secret. The
+    # Decoder's structurally identical ` ^X:<mode> ` on its OUTPUT card has always answered a
+    # click; this one, on the sibling tool tab, did not.
+    def secret_alg_hit(card : Rect, mx : Int32, my : Int32, alg : String) : Bool
+      !Frame.right_badge_hit(mx, my, card.y, card.right - 1, card.x + 9,
+        [{:alg, "^A", alg}] of {Symbol, String, String}).nil?
     end
 
     def decoded_at_top? : Bool

--- a/src/gori/tui/jwt_view.cr
+++ b/src/gori/tui/jwt_view.cr
@@ -92,7 +92,10 @@ module Gori::Tui
       unless out_c.empty?
         out_lines = output_ok ? output.split('\n') : ["✗ #{output}"]
         @out_lines = out_lines.size
-        title = "OUTPUT#{output_ok ? "" : "  ✗ invalid JSON"}"
+        # Just "OUTPUT". The failure is already the body's first line (`✗ <reason>`, in red,
+        # two lines below) — the title said a shorter version of the same thing, and a card
+        # title is what the card IS, not what state it is in.
+        title = "OUTPUT"
         @out_h, @out_scroll = draw_text_card(screen, out_c, title, out_lines, @out_scroll,
           focused && pane == :output, fg: output_ok ? Theme.text : Theme.red)
       end
@@ -140,7 +143,8 @@ module Gori::Tui
 
     # ---- ATTACKS list (one selectable row per generated payload) ----
     private def render_attacks(screen : Screen, card : Rect, attacks : Array(Jwt::Attack), focused : Bool) : Nil
-      Frame.card(screen, card, "ATTACKS · #{attacks.size}", bg: Theme.bg, border: Frame.pane_border(focused))
+      Frame.card(screen, card, "ATTACKS", bg: Theme.bg, border: Frame.pane_border(focused))
+      Frame.border_meta(screen, card, "ATTACKS", attacks.size.to_s)
       body = card.inset(1, 1)
       return if body.h <= 0
       if attacks.empty?

--- a/src/gori/tui/jwt_view.cr
+++ b/src/gori/tui/jwt_view.cr
@@ -156,9 +156,11 @@ module Gori::Tui
         idx = @atk_scroll + i
         a = attacks[idx]?
         break unless a
-        sel = focused && idx == @atk_sel
+        # Dimmed rather than erased when focus leaves this pane — the selection is still the
+        # attack ↵ applies, and with the marker gone there was nothing on screen saying which.
+        sel = idx == @atk_sel
         y = body.y + i
-        bg = sel ? Theme.accent_bg : Theme.bg
+        bg = sel ? (focused ? Theme.accent_bg : Theme.selection_dim) : Theme.bg
         screen.fill(Rect.new(body.x, y, body.w, 1), bg) if sel
         x = screen.text(body.x, y, sel ? "▎" : " ", Theme.accent, bg)
         x = screen.text(x, y, a.name, sel ? Theme.text_bright : Theme.text, bg, width: {body.w // 3, 8}.max)

--- a/src/gori/tui/listeners_overlay.cr
+++ b/src/gori/tui/listeners_overlay.cr
@@ -90,7 +90,11 @@ module Gori::Tui
     def handle_click(area : Rect, mx : Int32, my : Int32) : Symbol
       box = overlay_box(area)
       return :cancel if box.nil? || !box.contains?(mx, my)
-      if idx = row_at(box, mx, my)
+      # The gauge on the card's right hairline, before `row_at` — which has no `mx` bound and
+      # would otherwise read a click there as a plain pick of whatever row shares its `my`.
+      if row = gauge_row_at(box, mx, my)
+        set_selected(row)
+      elsif idx = row_at(box, mx, my)
         set_selected(idx)
       end
       :stay
@@ -237,6 +241,13 @@ module Gori::Tui
 
     # Row index under (mx,my) — inverts render's windowed layout so a click maps to the same
     # row that was drawn.
+    # The row a click on the list's scroll gauge asks for. The gauge rides the card's right
+    # hairline; the window is derived from the selection, so this answers with a selection.
+    def gauge_row_at(box : Rect, mx : Int32, my : Int32) : Int32?
+      Frame.scroll_gauge_row(Rect.new(box.x + 1, box.y + 2, box.w - 2, list_capacity(box)),
+        @rows.size, mx, my)
+    end
+
     def row_at(box : Rect, mx : Int32, my : Int32) : Int32?
       return nil unless box.contains?(mx, my)
       cap = list_capacity(box)

--- a/src/gori/tui/listeners_overlay.cr
+++ b/src/gori/tui/listeners_overlay.cr
@@ -170,7 +170,13 @@ module Gori::Tui
       sel = i == @selected
       bg = sel ? Theme.accent_bg : Theme.panel
       screen.fill(Rect.new(box.x + 1, py, box.w - 2, 1), bg)
-      screen.cell(box.x + 1, py, sel ? '▎' : ' ', status_color(row), bg)
+      # `Theme.accent`, not this row's status colour. The glyph is only drawn when the row is
+      # SELECTED (unselected rows get a space, where a foreground colour renders nothing), so
+      # tinting it never coloured the list — it recoloured the one bar whose job is to say
+      # "you are here", making the selection indicator mean two things at once. The status is
+      # already stated in words on this row: the up/down tail below, or the error reason in
+      # the detail column.
+      screen.cell(box.x + 1, py, sel ? '▎' : ' ', Theme.accent, bg)
 
       # A broken listener's status is the reason, shown in the detail column, so the right-hand
       # column is left empty rather than saying "down" as well — one fact, one place.

--- a/src/gori/tui/listeners_overlay.cr
+++ b/src/gori/tui/listeners_overlay.cr
@@ -124,20 +124,24 @@ module Gori::Tui
       end
       Frame.card(screen, box, "LISTENERS", border: Theme.border_focus)
       meta = "#{@rows.size} listener#{@rows.size == 1 ? "" : "s"}"
-      screen.text({box.right - meta.size - 2, box.x + 14}.max, box.y, meta, Theme.muted, Theme.panel)
+      Frame.border_meta(screen, box, "LISTENERS", meta, bg: Theme.panel)
 
       cap = list_capacity(box)
       return if cap <= 0
+      start = list_window(cap)
       if @rows.empty?
         screen.text(box.x + 3, box.y + 2, "(no additional listeners configured)", Theme.muted, Theme.panel)
       else
-        start = list_window(cap)
         cap.times do |row|
           i = start + row
           break if i >= @rows.size
           draw_row(screen, box, i, box.y + 2 + row)
         end
       end
+      # A windowed list with no gauge gave an operator scrolling past row `cap` nothing that
+      # said there was more. `true` for focused: an open modal IS the focus.
+      Frame.scroll_gauge(screen, Rect.new(box.x + 1, box.y + 2, box.w - 2, cap),
+        @rows.size, start, true, Theme.panel)
       draw_footer(screen, box)
     end
 

--- a/src/gori/tui/mine_config_overlay.cr
+++ b/src/gori/tui/mine_config_overlay.cr
@@ -254,7 +254,7 @@ module Gori::Tui
         label = any_checked? ? "[ Start mining ]" : "[ select a location ]"
         screen.text(x, py, label, any_checked? ? Theme.accent : Theme.muted, bg, Attribute::Bold)
       else
-        draw_cycler(screen, x, py, bg, sel, i)
+        draw_cycler(screen, x, py, box.right - 2, bg, sel, i)
       end
     end
 
@@ -266,19 +266,25 @@ module Gori::Tui
       screen.text(x + 4, py, label, sel ? Theme.text_bright : Theme.text, bg)
     end
 
-    # The three ←/›-cycled rows, split out of draw_row so adding a knob does not keep
+    # The three ←/→-cycled rows, split out of draw_row so adding a knob does not keep
     # growing one branch chain.
-    private def draw_cycler(screen : Screen, x : Int32, py : Int32, bg : Color, sel : Bool, i : Int32) : Nil
-      label, value =
+    #
+    # Through `Frame.option_cycle` like every other cycler in gori: the choices are drawn as a
+    # strip when the card is wide enough to hold one, and fall back to the lit value when it is
+    # not. That fallback is why this row used to be hand-rolled — `MAX_REQ_CHOICES` is eight
+    # numbers plus `uncapped` and does not always fit — but the helper decides that by
+    # measuring rather than by which file it lives in.
+    private def draw_cycler(screen : Screen, x : Int32, py : Int32, right : Int32, bg : Color,
+                            sel : Bool, i : Int32) : Nil
+      label, options, idx =
         if i == maxreq_row
-          {"max requests:", MAX_REQ_CHOICES[@maxreq_idx].try(&.to_s) || "uncapped"}
+          {"max requests:", MAX_REQ_CHOICES.map { |c| c.try(&.to_s) || "uncapped" }, @maxreq_idx}
         elsif i == conc_row
-          {"concurrency:", CONC_CHOICES[@conc_idx].to_s}
+          {"concurrency:", CONC_CHOICES.map(&.to_s), @conc_idx}
         else
-          {"notification:", NOTIFY_CHOICES[@notify_idx].label}
+          {"notification:", NOTIFY_CHOICES.map(&.label), @notify_idx}
         end
-      screen.text(x, py, label, Theme.muted, bg)
-      screen.text(x + label.size + 1, py, "#{value}  ‹/›", sel ? Theme.text_bright : Theme.text, bg)
+      Frame.option_cycle(screen, x, py, right, bg, label, options, idx, sel)
     end
 
     def row_at(box : Rect, mx : Int32, my : Int32) : Int32?

--- a/src/gori/tui/mine_config_overlay.cr
+++ b/src/gori/tui/mine_config_overlay.cr
@@ -118,7 +118,7 @@ module Gori::Tui
     end
 
     def hint : String
-      "↑/↓ field · ←/→ adjust · ␣ toggle · ↵ start · esc cancel"
+      "↑/↓ field · ←/→ options · ␣ toggle · ↵ start · esc cancel"
     end
 
     # Own key handling (formerly Runner#handle_mine_config_key): ↑/↓ move, ←/→ adjust

--- a/src/gori/tui/miner_view.cr
+++ b/src/gori/tui/miner_view.cr
@@ -536,7 +536,8 @@ module Gori::Tui
     end
 
     private def render_results(screen : Screen, rect : Rect, focused : Bool) : Nil
-      Frame.card(screen, rect, "FINDINGS (#{@results.size})", border: focused ? Theme.focus_gold : Theme.border, bg: Theme.bg)
+      Frame.card(screen, rect, "FINDINGS", border: Frame.pane_border(focused), bg: Theme.bg)
+      Frame.border_meta(screen, rect, "FINDINGS", @results.size.to_s)
       inner = rect.inset(1, 1)
       # A card under 3 rows has no interior — `inset` floors the height at 0 but keeps
       # `inner.y` one row down, so an unguarded placeholder lands OUTSIDE the pane.

--- a/src/gori/tui/miner_view.cr
+++ b/src/gori/tui/miner_view.cr
@@ -675,5 +675,55 @@ module Gori::Tui
       return :results if res_rect.contains?(mx, my)
       sum_rect.contains?(mx, my) ? :summary : nil
     end
+
+    # Mouse: the findings index under a click, or nil (outside the pane, on the header row,
+    # or past the last populated row). Mirrors render_results' inset → header → @scroll+i.
+    # The pane drew a cursor and moved it with ↑/↓ and the wheel from the start; only the
+    # pointer had no way to place it, so a click landed on a row and selected nothing.
+    def results_row_at(rect : Rect, mx : Int32, my : Int32) : Int32?
+      return nil if @focus == :detail || @results.empty?
+      _, res = pane_rects(rect)
+      return nil if res.empty? || !res.contains?(mx, my)
+      inner = res.inset(1, 1)
+      return nil if inner.h <= 0 || inner.w <= 0
+      i = my - (inner.y + 1) # rows start one line below the header
+      return nil if i < 0 || i >= {inner.h - 1, 0}.max
+      idx = @scroll + i
+      idx < @results.size ? idx : nil
+    end
+
+    # The row a click on the scroll gauge asks for. The gauge rides the frame's right hairline,
+    # one column outside the list rect, so `row_at` cannot answer it — and `@scroll` here is
+    # DERIVED from the selection, so the answer is a selection. See `Frame.scroll_gauge_row`.
+    def results_gauge_row(rect : Rect, mx : Int32, my : Int32) : Int32?
+      return nil if @focus == :detail
+      _, res = pane_rects(rect)
+      return nil if res.empty?
+      inner = res.inset(1, 1)
+      return nil if inner.h <= 0 || inner.w <= 0
+      # Rows start one line below the header — the band the draw hands the gauge.
+      Frame.scroll_gauge_row(Rect.new(inner.x, inner.y + 1, inner.w, inner.h - 1),
+        @results.size, mx, my)
+    end
+
+    def select_result_row(idx : Int32) : Nil
+      @sel = idx.clamp(0, {@results.size - 1, 0}.max)
+    end
+
+    def results_selected_index : Int32
+      @sel
+    end
+
+    # Hit-test the MINER card's run control. It is drawn in the same dress as the Repeater's
+    # ` ^R:SEND ` and the Fuzzer's ` ^R:RUN `, both of which answer a click; this one and its
+    # Sequencer/Discover twins did not. Geometry mirrors render_summary exactly.
+    def summary_chrome_hit(rect : Rect, mx : Int32, my : Int32) : Symbol?
+      return nil if @focus == :detail
+      sum, _ = pane_rects(rect)
+      return nil if sum.empty?
+      chord, name = @running ? {"^X", "STOP"} : {"^R", "MINE"}
+      Frame.right_badge_hit(mx, my, sum.y, sum.right - 1, sum.x + "MINER".size + 4,
+        [{:run, chord, name}] of {Symbol, String, String})
+    end
   end
 end

--- a/src/gori/tui/name_prompt_overlay.cr
+++ b/src/gori/tui/name_prompt_overlay.cr
@@ -63,8 +63,8 @@ module Gori::Tui
     LABEL_W = 7 # value column offset ("Name" + padding)
 
     def overlay_box(area : Rect) : Rect?
-      w = {area.w - 6, 72}.min
-      h = {area.h - 4, 9}.min
+      w = {area.w - 4, 72}.min
+      h = {area.h - 2, 9}.min
       return nil if w < 34 || h < 7
       Rect.new(area.x + (area.w - w) // 2, area.y + (area.h - h) // 2, w, h)
     end

--- a/src/gori/tui/notes_view.cr
+++ b/src/gori/tui/notes_view.cr
@@ -432,7 +432,11 @@ module Gori::Tui
         Frame.mode_badge(screen, rect.right - 1, rect.y, rect.x + 1, ins)
       end
       ed = current.area
-      ed.render(screen, area, cursor: ins,
+      # `gauge: true` like every other editor in the workbench — Decoder INPUT, JWT INPUT and
+      # DECODED, Issues NOTES, Repeater REQUEST, Fuzzer TEMPLATE, Intercept. `TextArea#render`
+      # defaults it OFF, and Notes was the one editor that never turned it on, so a long note
+      # scrolled with nothing on screen saying where in it you were.
+      ed.render(screen, area, cursor: ins, gauge: true, gauge_focused: focused,
         highlight: Settings.editor_markdown ? :markdown : nil)
       paint_read_chrome(screen, area, ed, focused && !insert_mode?) if !insert_mode?
     end

--- a/src/gori/tui/notes_view.cr
+++ b/src/gori/tui/notes_view.cr
@@ -428,9 +428,13 @@ module Gori::Tui
       area = Rect.new(rect.x + 1, rect.y, {rect.w - 2, 0}.max, rect.h)
       TrafficEmptyState.render(screen, area, variant: :notes) if current_blank?
       ins = focused && insert_mode?
-      if focused
-        Frame.mode_badge(screen, rect.right - 1, rect.y, rect.x + 1, ins)
-      end
+      # The REAL mode, and drawn unconditionally — `Frame.mode_badge`'s own contract, which
+      # this call broke twice over. `notes_controller` hit-tests the bare `insert_mode?` in
+      # both its click and double-click paths, so gating the DRAW on focus left a live 5-cell
+      # target on a border with nothing painted on it: clicking the blank cells of an
+      # unfocused Notes tab toggled insert. Nothing exits insert on a focus change, so that
+      # state is ordinary rather than exotic. Focus belongs in the BORDER, below.
+      Frame.mode_badge(screen, rect.right - 1, rect.y, rect.x + 1, insert_mode?)
       ed = current.area
       # `gauge: true` like every other editor in the workbench — Decoder INPUT, JWT INPUT and
       # DECODED, Issues NOTES, Repeater REQUEST, Fuzzer TEMPLATE, Intercept. `TextArea#render`

--- a/src/gori/tui/notifications_overlay.cr
+++ b/src/gori/tui/notifications_overlay.cr
@@ -120,6 +120,12 @@ module Gori::Tui
     def handle_click(area : Rect, mx : Int32, my : Int32) : Symbol
       box = overlay_box(area)
       return :cancel if box.nil? || !box.contains?(mx, my)
+      # The gauge on the card's right hairline, before `row_at` — which has no `mx` bound.
+      # Selects without committing: a scrollbar drag is navigation, not "open this one".
+      if row = gauge_row_at(box, mx, my)
+        set_selected(row)
+        return :stay
+      end
       if idx = row_at(box, mx, my)
         set_selected(idx)
         return :commit
@@ -209,8 +215,16 @@ module Gori::Tui
       screen.text(box.right - 1 - stamp.size, py, stamp, Theme.muted, bg)
     end
 
+    # The row a click on the list's scroll gauge asks for. The gauge rides the card's right
+    # hairline; the window is derived from the selection, so this answers with a selection.
+    def gauge_row_at(box : Rect, mx : Int32, my : Int32) : Int32?
+      Frame.scroll_gauge_row(Rect.new(box.x + 1, box.y + 2, box.w - 2, list_capacity(box)),
+        notes.size, mx, my)
+    end
+
     # Row index under (mx,my) — inverts render's windowed layout so a click maps to the
     # same row that was drawn.
+
     def row_at(box : Rect, mx : Int32, my : Int32) : Int32?
       return nil unless box.contains?(mx, my)
       cap = list_capacity(box)

--- a/src/gori/tui/notifications_overlay.cr
+++ b/src/gori/tui/notifications_overlay.cr
@@ -167,7 +167,7 @@ module Gori::Tui
       list = notes
       Frame.card(screen, box, "NOTIFICATIONS", border: Theme.border_focus)
       meta = "#{list.size} item#{list.size == 1 ? "" : "s"}"
-      screen.text({box.right - meta.size - 2, box.x + 16}.max, box.y, meta, Theme.muted, Theme.panel)
+      Frame.border_meta(screen, box, "NOTIFICATIONS", meta, bg: Theme.panel)
 
       cap = list_capacity(box)
       if list.empty?
@@ -181,6 +181,8 @@ module Gori::Tui
         break if i >= list.size
         draw_row(screen, box, list[i], i == sel, box.y + 2 + row)
       end
+      Frame.scroll_gauge(screen, Rect.new(box.x + 1, box.y + 2, box.w - 2, cap),
+        list.size, start, true, Theme.panel)
     end
 
     private def draw_row(screen : Screen, box : Rect, note : Notifications::Note, sel : Bool, py : Int32) : Nil

--- a/src/gori/tui/notifications_overlay.cr
+++ b/src/gori/tui/notifications_overlay.cr
@@ -1,5 +1,6 @@
 require "./screen"
 require "./theme"
+require "./fmt"
 require "./frame"
 require "./overlay"
 require "./notifications"
@@ -193,7 +194,7 @@ module Gori::Tui
       screen.cell(box.x + 3, py, g, gc, bg)
       bold = note.read ? Attribute::None : Attribute::Bold
       fg = sel ? Theme.text_bright : Theme.text
-      stamp = ago(note.created_at)
+      stamp = Fmt.ago(note.created_at)
       # Agent-originated notes (an MCP co-pilot acting in the loop) get a distinct "ai"
       # tag so the human can see at a glance which entries the AI produced. Other sources
       # already name themselves in the message ("Miner: …", "Probe: …"), so no tag.
@@ -242,14 +243,5 @@ module Gori::Tui
     end
 
     # Compact relative age: "3s" / "5m" / "2h" / "1d".
-    private def ago(t : Time::Instant) : String
-      secs = (Time.instant - t).total_seconds.to_i
-      return "#{secs}s" if secs < 60
-      mins = secs // 60
-      return "#{mins}m" if mins < 60
-      hours = mins // 60
-      return "#{hours}h" if hours < 24
-      "#{hours // 24}d"
-    end
   end
 end

--- a/src/gori/tui/oast_provider_overlay.cr
+++ b/src/gori/tui/oast_provider_overlay.cr
@@ -217,10 +217,7 @@ module Gori::Tui
     end
 
     def overlay_box(area : Rect) : Rect?
-      w = {area.w - 4, 56}.min
-      h = {area.h - 2, ROW_COUNT + 6}.min # title + rows + padding
-      return nil if w < 30 || h < 10
-      Rect.new(area.x + (area.w - w) // 2, area.y + (area.h - h) // 2, w, h)
+      Overlay.rule_form_box(area, ROW_COUNT)
     end
 
     def render(screen : Screen, area : Rect) : Nil

--- a/src/gori/tui/oast_provider_overlay.cr
+++ b/src/gori/tui/oast_provider_overlay.cr
@@ -120,7 +120,7 @@ module Gori::Tui
     end
 
     def hint : String
-      "↑/↓ field · ←/→ scope/type · type name/host/token · ↵ save · esc cancel"
+      "↑/↓ field · ←/→ options · type name/host/token · ↵ save · esc cancel"
     end
 
     # Click a field row to select it; a click on Save commits; a click outside the card
@@ -237,11 +237,10 @@ module Gori::Tui
         break if py >= box.bottom - 1
         draw_row(screen, box, i, py)
       end
-      hint_y = box.bottom - 1
-      if hint_y > first
-        screen.text(box.x + 2, hint_y, "↑/↓ field · ←/› options · ↵ save · esc cancel",
-          Theme.muted, Theme.panel, width: box.w - 4)
-      end
+      # No key hint on the bottom border — the shell draws `hint` in the status strip for the
+      # open modal (Runner#key_hints). See RewriterRuleOverlay#render for the whole argument.
+      # This copy is also where a `←/›` typo had been sitting, unreachable from the method
+      # every other surface reads.
     end
 
     private def draw_row(screen : Screen, box : Rect, i : Int32, py : Int32) : Nil

--- a/src/gori/tui/oast_provider_overlay.cr
+++ b/src/gori/tui/oast_provider_overlay.cr
@@ -253,23 +253,15 @@ module Gori::Tui
       case i
       when ROW_NAME then draw_field(screen, box, py, "name:", @name, sel, bg, fg)
       when ROW_SCOPE
-        draw_cycle(screen, x, py, bg, sel, "scope:", SCOPES, @scope_i)
+        Frame.option_cycle(screen, x, py, box.right - 2, bg, "scope:", SCOPES, @scope_i, sel)
       when ROW_TYPE
-        draw_cycle(screen, x, py, bg, sel, "type:", KINDS.map(&.label), @kind_idx)
+        Frame.option_cycle(screen, x, py, box.right - 2, bg, "type:", KINDS.map(&.label), @kind_idx, sel)
       when ROW_HOST  then draw_field(screen, box, py, "host:", @host, sel, bg, fg)
       when ROW_TOKEN then draw_field(screen, box, py, "token:", @token, sel, bg, fg)
       else
         label = valid? ? "[ Save provider ]" : "[ name + host required ]"
         screen.text(x, py, label, valid? ? Theme.accent : Theme.muted, bg, Attribute::Bold)
       end
-    end
-
-    private def draw_cycle(screen : Screen, x : Int32, py : Int32, bg : Color, row_sel : Bool,
-                           label : String, opts : Array(String), sel_i : Int32) : Nil
-      screen.text(x, py, label, Theme.muted, bg)
-      col = row_sel ? Theme.text_bright : Theme.accent
-      tx = screen.text(x + label.size + 1, py, opts[sel_i], col, bg, Attribute::Bold)
-      screen.text(tx, py, "  ‹/›", Theme.muted, bg)
     end
 
     private def draw_field(screen : Screen, box : Rect, py : Int32, label : String,

--- a/src/gori/tui/oast_session_picker.cr
+++ b/src/gori/tui/oast_session_picker.cr
@@ -1,5 +1,6 @@
 require "./screen"
 require "./theme"
+require "./fmt"
 require "./frame"
 require "./picker_overlay"
 
@@ -173,7 +174,7 @@ module Gori::Tui
     end
 
     private def meta_text(row : Row) : String
-      base = "#{row.hits} hit#{row.hits == 1 ? "" : "s"} · #{ago(row.started_at)}"
+      base = "#{row.hits} hit#{row.hits == 1 ? "" : "s"} · #{Fmt.ago(row.started_at)}"
       row.live ? "#{base} · ● live" : base
     end
 
@@ -190,14 +191,5 @@ module Gori::Tui
     # the session's start is a wall-clock stamp read back out of the project DB, so it is a
     # `Time`, not a monotonic tick. Clamped at 0 so a clock that moved backwards between the
     # write and this read shows "0s" rather than a negative age.
-    private def ago(t : Time) : String
-      secs = {(Time.local - t).total_seconds.to_i, 0}.max
-      return "#{secs}s" if secs < 60
-      mins = secs // 60
-      return "#{mins}m" if mins < 60
-      hours = mins // 60
-      return "#{hours}h" if hours < 24
-      "#{hours // 24}d"
-    end
   end
 end

--- a/src/gori/tui/overlay.cr
+++ b/src/gori/tui/overlay.cr
@@ -116,6 +116,41 @@ module Gori::Tui
   #   :commit → run `commit`; the shell closes the overlay iff `commit` returns true
   #   :cancel → close without committing
   abstract class Overlay
+    # The card geometry every ADD/EDIT-one-policy-rule form shares: Rewriter, Colormarker,
+    # Probe custom, extract, Scope, OAST provider. They are the same kind of thing reached from
+    # adjacent tabs, so opening two in a row must not resize the card under the operator — and
+    # it did: the six had settled on 72, 72, 62, 72, 52 and 56, with floors ranging from 28×8
+    # to 40×13, none of it derived from anything.
+    #
+    # 72 is the widest of them and the one three already used; it is what the Rewriter form
+    # needed once a fifth op pushed its option row past the old 66. The narrower cards were not
+    # narrower for a reason — a `pattern:` row holding a host glob or a regex wants the width
+    # as much as any of them.
+    #
+    # HEIGHT is not a constant, because it depends on how many rows a form has: each computes
+    # `rows + 4`, or `rows + 5` when it carries a preview band under the rows. That formula is
+    # the thing to keep, not a number — two forms had drifted off it (one hard-coded 11 for
+    # four rows, one asked for `+ 6`) and simply drew dead space above their own bottom edge.
+    RULE_FORM_W     = 72
+    RULE_FORM_MIN_W = 40
+    RULE_FORM_MIN_H = 10
+
+    # The card rect for one of those forms, centered in `area`. `rows` is the form's row count;
+    # `preview` adds the band some of them draw under the rows.
+    #
+    # The floor is `min(RULE_FORM_MIN_H, natural)`, not the constant — a card is never refused
+    # for being SHORTER than the form needs. Writing the constant straight into the guard is a
+    # mistake worth naming, because it fails silently in exactly one direction: the Scope form
+    # is four rows, so its natural height is 8, and a flat floor of 10 meant `overlay_box`
+    # returned nil at every terminal size and the form could not be opened at all.
+    def self.rule_form_box(area : Rect, rows : Int32, preview : Bool = false) : Rect?
+      natural = rows + (preview ? 5 : 4)
+      w = {area.w - 4, RULE_FORM_W}.min
+      h = {area.h - 2, natural}.min
+      return nil if w < RULE_FORM_MIN_W || h < {RULE_FORM_MIN_H, natural}.min
+      Rect.new(area.x + (area.w - w) // 2, area.y + (area.h - h) // 2, w, h)
+    end
+
     # Runs on a :commit outcome; returns true when the overlay should close (false keeps
     # it open — e.g. a validation error keeps the form up). Supplied at the open-site.
     property on_commit : Proc(Bool)?

--- a/src/gori/tui/palette.cr
+++ b/src/gori/tui/palette.cr
@@ -69,7 +69,7 @@ module Gori::Tui
     # Returns an empty Rect (w/h 0) when too small to draw (render's early-return).
     def overlay_box(area : Rect) : Rect
       w = {area.w - 4, 60}.min
-      h = {area.h - 4, 16}.min
+      h = {area.h - 2, 16}.min
       return Rect.new(0, 0, 0, 0) if w < 10 || h < 4
       x = area.x + (area.w - w) // 2
       y = area.y + (area.h - h) // 2

--- a/src/gori/tui/passthrough_overlay.cr
+++ b/src/gori/tui/passthrough_overlay.cr
@@ -112,20 +112,22 @@ module Gori::Tui
       end
       Frame.card(screen, box, "TLS PASSTHROUGH", border: Theme.border_focus)
       meta = "#{@hosts.size} host#{@hosts.size == 1 ? "" : "s"}"
-      screen.text({box.right - meta.size - 2, box.x + 18}.max, box.y, meta, Theme.muted, Theme.panel)
+      Frame.border_meta(screen, box, "TLS PASSTHROUGH", meta, bg: Theme.panel)
 
       cap = list_capacity(box)
       return if cap <= 0
+      start = list_window(cap)
       if @hosts.empty?
         screen.text(box.x + 3, box.y + 2, empty_message, Theme.muted, Theme.panel)
       else
-        start = list_window(cap)
         cap.times do |row|
           i = start + row
           break if i >= @hosts.size
           draw_row(screen, box, i, box.y + 2 + row)
         end
       end
+      Frame.scroll_gauge(screen, Rect.new(box.x + 1, box.y + 2, box.w - 2, cap),
+        @hosts.size, start, true, Theme.panel)
       draw_footer(screen, box)
     end
 

--- a/src/gori/tui/passthrough_overlay.cr
+++ b/src/gori/tui/passthrough_overlay.cr
@@ -164,7 +164,9 @@ module Gori::Tui
       sel = i == @selected
       bg = sel ? Theme.accent_bg : Theme.panel
       screen.fill(Rect.new(box.x + 1, py, box.w - 2, 1), bg)
-      screen.cell(box.x + 1, py, sel ? '▎' : ' ', Theme.yellow, bg)
+      # `Theme.accent` — the selection bar reads the same in every list. The yellow it used to
+      # carry said nothing this row does not: the pattern column below is already yellow.
+      screen.cell(box.x + 1, py, sel ? '▎' : ' ', Theme.accent, bg)
 
       conns = "#{entry.connections} conn#{entry.connections == 1 ? "" : "s"}"
       stamp = ago(entry.first_seen)

--- a/src/gori/tui/passthrough_overlay.cr
+++ b/src/gori/tui/passthrough_overlay.cr
@@ -79,7 +79,11 @@ module Gori::Tui
     def handle_click(area : Rect, mx : Int32, my : Int32) : Symbol
       box = overlay_box(area)
       return :cancel if box.nil? || !box.contains?(mx, my)
-      if idx = row_at(box, mx, my)
+      # The gauge on the card's right hairline, before `row_at` — which has no `mx` bound and
+      # would otherwise read a click there as a plain pick of whatever row shares its `my`.
+      if row = gauge_row_at(box, mx, my)
+        set_selected(row)
+      elsif idx = row_at(box, mx, my)
         set_selected(idx)
       end
       :stay
@@ -190,6 +194,13 @@ module Gori::Tui
 
     # Row index under (mx,my) — inverts render's windowed layout so a click maps to the same
     # row that was drawn.
+    # The row a click on the list's scroll gauge asks for. The gauge rides the card's right
+    # hairline; the window is derived from the selection, so this answers with a selection.
+    def gauge_row_at(box : Rect, mx : Int32, my : Int32) : Int32?
+      Frame.scroll_gauge_row(Rect.new(box.x + 1, box.y + 2, box.w - 2, list_capacity(box)),
+        @hosts.size, mx, my)
+    end
+
     def row_at(box : Rect, mx : Int32, my : Int32) : Int32?
       return nil unless box.contains?(mx, my)
       cap = list_capacity(box)

--- a/src/gori/tui/passthrough_overlay.cr
+++ b/src/gori/tui/passthrough_overlay.cr
@@ -1,5 +1,6 @@
 require "./screen"
 require "./theme"
+require "./fmt"
 require "./frame"
 require "./overlay"
 require "../settings"
@@ -171,7 +172,7 @@ module Gori::Tui
       screen.cell(box.x + 1, py, sel ? '▎' : ' ', Theme.accent, bg)
 
       conns = "#{entry.connections} conn#{entry.connections == 1 ? "" : "s"}"
-      stamp = ago(entry.first_seen)
+      stamp = Fmt.ago(entry.first_seen)
       tail = "#{stamp}  #{conns}"
       tail_x = box.right - 1 - Screen.display_width(tail)
 
@@ -212,14 +213,5 @@ module Gori::Tui
     # Compact relative age: "3s" / "5m" / "2h" / "1d". Mirrors NotificationsOverlay#ago, but
     # over a wall-clock Time (the inventory is written by a proxy fiber and read much later,
     # so it records when the bypass happened, not a monotonic tick).
-    private def ago(t : Time) : String
-      secs = (Time.local - t).total_seconds.to_i
-      return "#{secs}s" if secs < 60
-      mins = secs // 60
-      return "#{mins}m" if mins < 60
-      hours = mins // 60
-      return "#{hours}h" if hours < 24
-      "#{hours // 24}d"
-    end
   end
 end

--- a/src/gori/tui/preferences_view.cr
+++ b/src/gori/tui/preferences_view.cr
@@ -297,7 +297,11 @@ module Gori::Tui
       Frame.card(screen, box, "PREFERENCES", border: Theme.border_focus)
       strip = Rect.new(box.x + 2, box.y + 2, box.w - 4, 1)
       @strip_start = Chrome.render_tab_strip(screen, strip, GROUP_LABELS, @group, @on_strip, @strip_start)
-      screen.hline(box.x + 1, box.y + 3, box.w - 2, fg: @on_strip ? Theme.focus_gold : Theme.border, bg: Theme.panel)
+      # `tee_divider`, not a bare hline: the seam now lands ├ and ┤ ON the card's side borders
+      # instead of butting `─` straight into `│`, which is the whole reason frame.cr grew the
+      # helper. Same focus tint as before.
+      Frame.tee_divider(screen, box, box.y + 3, Theme.panel,
+        @on_strip ? Theme.focus_gold : Theme.border)
       render_group(screen, content_rect(box), !@on_strip)
       render_footer(screen, box)
     end
@@ -353,6 +357,12 @@ module Gori::Tui
         end
         y += 1 # spacer between sections
       end
+      # This form scrolls (`ensure_scroll` exists for it) and had no indicator at all, so a
+      # group taller than the card gave no sign there was more below. `content` is inset TWO
+      # columns from the card, so widen by one to land the gauge on the frame's own hairline
+      # the way every other list does — `scroll_gauge` draws at `content.right`.
+      Frame.scroll_gauge(screen, Rect.new(content.x, content.y, content.w + 1, content.h),
+        group_height, @scroll, body_focused, Theme.panel)
     end
 
     # `dirty` appends a ● so an edited-but-unsaved section is visible while you are still in

--- a/src/gori/tui/preferences_view.cr
+++ b/src/gori/tui/preferences_view.cr
@@ -423,7 +423,7 @@ module Gori::Tui
       # successful one just because it came through the modal.
       note_fg = @status ? (@status_warn ? Theme.yellow : Theme.green) : Theme.muted
       screen.text(box.x + 2, note_y, note, note_fg, Theme.panel, width: iw)
-      hint = @on_strip ? "←/→ group · ↓/↵ enter · esc close" : "↑/↓ field · ←/→ edit · ↵ save · ^R reset · esc close"
+      hint = @on_strip ? "←/→ group · ↓/↵ enter · esc close" : "↑/↓ field · ←/→ edit · ↵ save/open · ^R reset · esc close"
       hx = {box.right - hint.size - 2, box.x + 2}.max
       screen.text(hx, hint_y, hint, Theme.muted, Theme.panel, width: {box.right - hx - 1, 0}.max)
     end

--- a/src/gori/tui/preferences_view.cr
+++ b/src/gori/tui/preferences_view.cr
@@ -370,7 +370,11 @@ module Gori::Tui
     private def draw_subheader(screen : Screen, content : Rect, title : String, y : Int32, dirty : Bool) : Nil
       return unless content.y <= y < content.bottom
       screen.fill(Rect.new(content.x, y, content.w, 1), Theme.panel)
-      screen.text(content.x, y, title.upcase, Theme.focus_gold, Theme.panel, Attribute::Bold, width: content.w)
+      # `Theme.accent`, not `focus_gold`. Gold is gori's FOCUS colour — a focused pane's
+      # outline, the strip above this one when it has the keys — so spending it on a static
+      # section heading makes two different things look like the same thing. The Probe rules
+      # list already headed its sections in accent; this is the other half of that pair.
+      screen.text(content.x, y, title.upcase, Theme.accent, Theme.panel, Attribute::Bold, width: content.w)
       screen.text(content.x + title.size + 1, y, "● unsaved", Theme.yellow, Theme.panel, width: {content.right - content.x - title.size - 1, 1}.max) if dirty
     end
 

--- a/src/gori/tui/probe_active_overlay.cr
+++ b/src/gori/tui/probe_active_overlay.cr
@@ -18,6 +18,10 @@ module Gori::Tui
   # (see overlay.cr).
   class ProbeActiveOverlay < Overlay
     NOTIFY_CHOICES = Miner::NotifyMode.values
+    # The unsafe opt-in reads as a choice between two named states rather than a checkbox: it
+    # is not "one of many things to include" but "which of these two modes", which is what a
+    # cycler says.
+    UNSAFE_LABELS = ["off", "ON"]
 
     # Every flow this run covers (#442 — History's multi-select). `detail` is the FIRST, kept
     # as its own getter because the single-flow callers and the header text speak of one
@@ -283,13 +287,16 @@ module Gori::Tui
       screen.cell(box.x + 1, py, sel ? '▎' : ' ', Theme.accent, bg)
       x = box.x + 3
       if i == notify_row
-        screen.text(x, py, "notification:", Theme.muted, bg)
-        screen.text(x + 14, py, "#{notify_mode.label}  ‹/›", sel ? Theme.text_bright : Theme.text, bg)
+        Frame.option_cycle(screen, x, py, box.right - 2, bg,
+          "notification:", NOTIFY_CHOICES.map(&.label), @notify_idx, sel)
       elsif @show_unsafe_row && i == unsafe_row
-        screen.text(x, py, "unsafe methods:", Theme.muted, bg)
-        state = @allow_unsafe ? "ON" : "off"
-        col = @allow_unsafe ? Theme.red : (sel ? Theme.text_bright : Theme.text)
-        screen.text(x + 16, py, "#{state}  ‹/›", col, bg)
+        # The two-option cycler it always was, except the strip now shows `off` as the
+        # alternative instead of only naming the current state. `lit:` paints the chosen
+        # option red when it is ON — this is the one choice on the card that can put a DELETE
+        # on the wire, so it keeps the shout it had.
+        Frame.option_cycle(screen, x, py, box.right - 2, bg,
+          "unsafe methods:", UNSAFE_LABELS, @allow_unsafe ? 1 : 0, sel,
+          lit: @allow_unsafe ? Theme.red : nil)
       else
         screen.text(x, py, "[ Run active scan ]", Theme.accent, bg, Attribute::Bold)
       end

--- a/src/gori/tui/probe_rules_view.cr
+++ b/src/gori/tui/probe_rules_view.cr
@@ -1,5 +1,6 @@
 require "./screen"
 require "./theme"
+require "./frame"
 require "../probe"
 require "../store"
 
@@ -177,6 +178,11 @@ module Gori::Tui
         screen.fill(Rect.new(rect.x, y, rect.w, 1), Theme.bg)
         screen.text(rect.x + 1, y, footer, Theme.muted, Theme.bg, width: rect.w - 2)
       end
+      # This list runs to ~40 rows across three sections and had no scroll affordance at all,
+      # so an operator scrolled past the ACTIVE section with nothing on screen saying there
+      # was more. Tracks `list_h`, the rows actually windowed — not the footer under them.
+      Frame.scroll_gauge(screen, Rect.new(rect.x, rect.y, rect.w, list_h),
+        @rows.size, @scroll, focused)
     end
 
     # The selected selectable row's description, or nil (a header selected / no description).

--- a/src/gori/tui/probe_rules_view.cr
+++ b/src/gori/tui/probe_rules_view.cr
@@ -167,8 +167,27 @@ module Gori::Tui
 
     # The row a click on the list's scroll gauge asks for. The gauge rides the card's right
     # hairline; the window is derived from the selection, so this answers with a selection.
+    #
+    # SNAPPED to the nearest selectable row: `@rows` interleaves three `:header` rows and an
+    # `:empty` placeholder with the real ones, and `select_index` refuses those — so a raw
+    # proportional hit made ~4 of ~40 track positions silent no-ops, a thumb that moved
+    # nowhere. Every other gauge in this sweep resolves to a row the click can land on.
     def gauge_row_at(rect : Rect, mx : Int32, my : Int32) : Int32?
-      Frame.scroll_gauge_row(Rect.new(rect.x, rect.y, rect.w, list_h(rect)), @rows.size, mx, my)
+      idx = Frame.scroll_gauge_row(Rect.new(rect.x, rect.y, rect.w, list_h(rect)), @rows.size, mx, my)
+      return nil unless idx
+      nearest_selectable(idx)
+    end
+
+    # The selectable row closest to `idx`, searching outward. nil only when the list holds no
+    # selectable row at all (a filter that matched nothing).
+    private def nearest_selectable(idx : Int32) : Int32?
+      return idx if @rows[idx]?.try(&.selectable?)
+      (1...@rows.size).each do |d|
+        [idx - d, idx + d].each do |i|
+          return i if 0 <= i < @rows.size && @rows[i].selectable?
+        end
+      end
+      nil
     end
 
     private def selectable_indices : Array(Int32)

--- a/src/gori/tui/probe_rules_view.cr
+++ b/src/gori/tui/probe_rules_view.cr
@@ -208,9 +208,13 @@ module Gori::Tui
       bg = sel ? (focused ? Theme.accent_bg : Theme.selection_dim) : Theme.bg
       screen.fill(Rect.new(rect.x, y, rect.w, 1), bg)
       screen.cell(rect.x, y, sel ? '▎' : ' ', Theme.accent, bg)
-      box = row.enabled? ? "[x]" : "[ ]"
-      screen.text(rect.x + 2, y, box, row.enabled? ? Theme.green : Theme.muted, bg)
-      namex = rect.x + 6
+      # `✓`/`·` in accent — the same mark the Rewriter and Colormarker lists use for the same
+      # question. This list used to answer it with a green `[x]`/`[ ]`, so three rule lists an
+      # operator moves between spelled one state three ways. The checkbox also cost two extra
+      # columns, which is why the name starts at +4 now rather than +6: same offsets as the
+      # siblings, so the three lists line up when you switch tabs.
+      screen.cell(rect.x + 2, y, row.enabled? ? '✓' : '·', row.enabled? ? Theme.accent : Theme.muted, bg)
+      namex = rect.x + 4
       name_fg = sel ? Theme.text_bright : (row.enabled? ? Theme.text : Theme.muted)
       # The right side (meta column + optional note badge) is laid out first, so the name gets
       # whatever width remains to its left.

--- a/src/gori/tui/probe_rules_view.cr
+++ b/src/gori/tui/probe_rules_view.cr
@@ -17,7 +17,7 @@ module Gori::Tui
     # badge ("opt-in", "needs OAST") and `desc` the one-line description shown in the footer
     # when this row is selected.
     struct Row
-      getter kind : Symbol # :header | :builtin | :custom
+      getter kind : Symbol # :header | :empty | :builtin | :custom
       getter title : String
       getter meta : String
       getter? enabled : Bool
@@ -30,8 +30,11 @@ module Gori::Tui
                      @note = "", @desc = "")
       end
 
+      # An `:empty` placeholder is no more selectable than a header — it names an absence.
+      # It used to be built AS a header, which drew it accent+bold like a section title;
+      # it is its own kind now so it can read as the quiet prose it is.
       def selectable? : Bool
-        kind != :header
+        kind != :header && kind != :empty
       end
     end
 
@@ -61,7 +64,7 @@ module Gori::Tui
       rows << Row.new(:header, "CUSTOM RULES")
       custom = Probe.custom_rules(store)
       if custom.empty?
-        rows << Row.new(:header, "  (none — press a to add a custom rule)")
+        rows << Row.new(:empty, "  no custom rules — press a to add")
       else
         custom.each { |c| rows << custom_row(c) }
       end
@@ -210,6 +213,10 @@ module Gori::Tui
 
     private def draw_row(screen : Screen, rect : Rect, row : Row, idx : Int32, y : Int32, focused : Bool) : Nil
       return draw_header(screen, rect, row, y) if row.kind == :header
+      if row.kind == :empty
+        screen.text(rect.x + 1, y, row.title.strip, Theme.muted, Theme.bg, width: {rect.w - 2, 1}.max)
+        return
+      end
       sel = idx == @sel
       bg = sel ? (focused ? Theme.accent_bg : Theme.selection_dim) : Theme.bg
       screen.fill(Rect.new(rect.x, y, rect.w, 1), bg)

--- a/src/gori/tui/probe_rules_view.cr
+++ b/src/gori/tui/probe_rules_view.cr
@@ -148,10 +148,27 @@ module Gori::Tui
       @sel = idx if 0 <= idx < @rows.size && @rows[idx].selectable?
     end
 
+    # Rows the list actually windows, once the description footer has taken its share.
+    # `render`, `row_at` and `gauge_row_at` must all ask this the same way or they drift —
+    # `row_at` used to take the whole rect, so a click on the FOOTER (prose about the selected
+    # rule) resolved to the row one past the last visible one. Same shape as the Colormarker
+    # note row and the Sitemap tag prompt.
+    private def list_h(rect : Rect) : Int32
+      (footer_text && rect.h >= 3) ? rect.h - 1 : rect.h
+    end
+
     def row_at(rect : Rect, mx : Int32, my : Int32) : Int32?
       return nil unless rect.contains?(mx, my)
-      idx = @scroll + (my - rect.y)
+      i = my - rect.y
+      return nil if i < 0 || i >= list_h(rect)
+      idx = @scroll + i
       (0 <= idx < @rows.size) ? idx : nil
+    end
+
+    # The row a click on the list's scroll gauge asks for. The gauge rides the card's right
+    # hairline; the window is derived from the selection, so this answers with a selection.
+    def gauge_row_at(rect : Rect, mx : Int32, my : Int32) : Int32?
+      Frame.scroll_gauge_row(Rect.new(rect.x, rect.y, rect.w, list_h(rect)), @rows.size, mx, my)
     end
 
     private def selectable_indices : Array(Int32)
@@ -169,7 +186,7 @@ module Gori::Tui
       # place the Rules tab explains what a rule DOES, so an operator toggling it isn't guessing
       # from the name. Falls away on a very short pane (the list keeps every line it can).
       footer = footer_text
-      list_h = (footer && rect.h >= 3) ? rect.h - 1 : rect.h
+      list_h = list_h(rect)
       ensure_visible(list_h)
       list_h.times do |i|
         idx = @scroll + i

--- a/src/gori/tui/probe_view.cr
+++ b/src/gori/tui/probe_view.cr
@@ -463,6 +463,8 @@ module Gori::Tui
         break if idx >= @issues.size
         draw_row(screen, rect, @issues[idx], top + i, idx == @selected, focused)
       end
+      Frame.scroll_gauge(screen, Rect.new(rect.x, top, rect.w, list_h),
+        @issues.size, @scroll, focused)
     end
 
     # Bottom summary of the selected issue (settings:layout probe_preview).
@@ -493,6 +495,7 @@ module Gori::Tui
         fg, text = lines[li]
         screen.text(body.x + 1, body.y + i, text, fg, bg, width: w)
       end
+      Frame.scroll_gauge(screen, body, lines.size, sc, false, bg)
     end
 
     private def preview_lines(issue : Store::ProbeIssue) : Array({Color, String})

--- a/src/gori/tui/probe_view.cr
+++ b/src/gori/tui/probe_view.cr
@@ -761,11 +761,15 @@ module Gori::Tui
     end
 
     private def status_color(s : Store::Status) : Color
+      # SEVERITY owns the colour ladder on these rows; triage status does not compete for it.
+      # The two were drawn five columns apart out of the SAME hues — `CRIT conf` was two reds
+      # meaning two different axes, `LOW open` two accents — on a list whose whole job is
+      # "scan for red". The four words (conf / fp / done / open) already tell the statuses
+      # apart, so what is left for colour here is the one distinction the WORDS do not make
+      # at a glance: still live, or already handled.
       case s
-      when .confirmed?      then Theme.red
-      when .false_positive? then Theme.muted
-      when .resolved?       then Theme.green
-      else                       Theme.accent
+      when .false_positive?, .resolved? then Theme.muted
+      else                                   Theme.text
       end
     end
 

--- a/src/gori/tui/probe_view.cr
+++ b/src/gori/tui/probe_view.cr
@@ -231,6 +231,17 @@ module Gori::Tui
       idx < @issues.size ? idx : nil
     end
 
+    # The row a click on the scroll gauge asks for. The gauge rides the frame's right hairline
+    # — one column outside the list rect, which is why `row_at` cannot answer it — and `@scroll`
+    # here is DERIVED from the selection by `ensure_visible`, so the answer is a selection, not
+    # an offset. See `Frame.scroll_gauge_row`.
+    def gauge_row_at(rect : Rect, mx : Int32, my : Int32) : Int32?
+      list_rect, _ = list_split(rect)
+      top = list_rect.y + 4 # the band list_row_at and the gauge draw both measure
+      Frame.scroll_gauge_row(Rect.new(list_rect.x, top, list_rect.w, {list_rect.bottom - top, 0}.max),
+        @issues.size, mx, my)
+    end
+
     # True when (mx,my) lands in the bottom preview pane.
     def preview_at?(rect : Rect, mx : Int32, my : Int32) : Bool
       _, prev = list_split(rect)
@@ -581,7 +592,7 @@ module Gori::Tui
     # Row 0: a filled MODE chip (with its `m` cycle chord) + detected-tech summary + the
     # `a:CLOSED` lens toggle + right-aligned severity tallies.
     private def render_mode_band(screen : Screen, rect : Rect) : Nil
-      x = Frame.tag_chip(screen, rect.x + 1, rect.y, " m:#{@mode.title} ", mode_color(@mode)) + 1
+      x = Frame.tag_chip(screen, rect.x + 1, rect.y, mode_chip_label, mode_color(@mode)) + 1
       tallies_x = render_tallies(screen, rect, x + 1) # right-aligned, but never left of the mode chip
       # The CLOSED lens toggle chains left of the tallies; lit when showing closed/dismissed
       # issues, muted (its default open-only) otherwise — so the `a` chord stays in view.
@@ -591,21 +602,35 @@ module Gori::Tui
       end
     end
 
-    # Draws the right-aligned severity tallies; returns the leftmost x they occupy (or
-    # rect.right-1 when there are none) so the CLOSED lens badge can chain to their left.
-    private def render_tallies(screen : Screen, rect : Rect, floor : Int32) : Int32
+    # The severity tallies, as `{label, colour}` in draw order. Shared by the draw and by the
+    # geometry the CLOSED badge's hit-test chains off, so the two cannot drift.
+    private def tally_parts : Array({String, Color})
       labels = {4 => "C", 3 => "H", 2 => "M", 1 => "L", 0 => "I"}
       parts = [] of {String, Color}
       labels.each do |val, lab|
         n = @counts[val]
         parts << {"#{lab}:#{n}", severity_color(Store::Severity.new(val))} if n > 0
       end
+      parts
+    end
+
+    # Leftmost x the tallies occupy (or rect.right-1 when there are none) — the right_edge the
+    # CLOSED lens badge chains from. Right-aligned, but never left of `floor` (the mode chip):
+    # on a band too narrow to hold everything the tallies truncate at the right edge instead of
+    # overpainting the mode indicator. On a normal-width band nothing truncates.
+    private def tallies_left(rect : Rect, floor : Int32) : Int32
+      parts = tally_parts
       return rect.right - 1 if parts.empty?
       total = parts.sum { |(s, _)| s.size + 1 } - 1
-      # Right-align, but never start left of `floor` (the mode chip): on a band too narrow to
-      # hold everything the tallies truncate at the right edge instead of overpainting the mode
-      # indicator. On a normal-width band `left` is unchanged and nothing truncates.
-      left = rx = {rect.right - 1 - total, floor}.max
+      {rect.right - 1 - total, floor}.max
+    end
+
+    # Draws the right-aligned severity tallies; returns `tallies_left`.
+    private def render_tallies(screen : Screen, rect : Rect, floor : Int32) : Int32
+      parts = tally_parts
+      left = tallies_left(rect, floor)
+      return left if parts.empty?
+      rx = left
       parts.each do |(s, color)|
         break if rx >= rect.right
         rx = screen.text(rx, rect.y, s, color, width: {rect.right - rx, 0}.max)
@@ -613,6 +638,29 @@ module Gori::Tui
         rx = screen.text(rx, rect.y, " ", Theme.muted, width: 1)
       end
       left
+    end
+
+    # Hit-test the MODE band's two controls. Both are drawn in the dresses this codebase uses
+    # FOR clickable chrome — a filled `Frame.tag_chip` and a keyed `Frame.toggle_badge` — and
+    # both name a real chord (`m` cycles the mode, `a` toggles the closed lens). Neither
+    # answered a click: `handle_click` claimed the filter row one line below and the rows four
+    # below that, and left row 0 unowned.
+    def mode_band_hit(rect : Rect, mx : Int32, my : Int32) : Symbol?
+      return nil if my != rect.y
+      cx = rect.x + 1
+      chip_w = Screen.draw_width(mode_chip_label)
+      return :mode if mx >= cx && mx < cx + chip_w
+      # `x + 1` in render_mode_band, where `x` is one past the chip — the same floor it hands
+      # `render_tallies` and the same `min_x` it hands the badge.
+      floor = cx + chip_w + 2
+      Frame.right_badge_hit(mx, my, rect.y, tallies_left(rect, floor), floor,
+        [{:closed, "a", "CLOSED"}] of {Symbol, String, String})
+    end
+
+    # The MODE chip's text, in one place: the draw positions everything after it from this
+    # width, and so does `mode_band_hit`.
+    private def mode_chip_label : String
+      " m:#{@mode.title} "
     end
 
     private def render_filter_bar(screen : Screen, rect : Rect, y : Int32) : Nil

--- a/src/gori/tui/probe_view.cr
+++ b/src/gori/tui/probe_view.cr
@@ -581,7 +581,7 @@ module Gori::Tui
     # Row 0: a filled MODE chip (with its `m` cycle chord) + detected-tech summary + the
     # `a:CLOSED` lens toggle + right-aligned severity tallies.
     private def render_mode_band(screen : Screen, rect : Rect) : Nil
-      x = chip(screen, rect.x + 1, rect.y, " m:#{@mode.title} ", mode_color(@mode)) + 1
+      x = Frame.tag_chip(screen, rect.x + 1, rect.y, " m:#{@mode.title} ", mode_color(@mode)) + 1
       tallies_x = render_tallies(screen, rect, x + 1) # right-aligned, but never left of the mode chip
       # The CLOSED lens toggle chains left of the tallies; lit when showing closed/dismissed
       # issues, muted (its default open-only) otherwise — so the `a` chord stays in view.
@@ -626,16 +626,12 @@ module Gori::Tui
       end
       # Right cluster: a scope-lens chip (always shown so the ⇧S toggle is discoverable,
       # mirroring HistoryView/SitemapView) and, when filtering, the row count.
+      # One right-anchored chain — see HistoryView#render_ql_bar.
+      chips = [] of {String, Color}
+      chips << {@issues.size.to_s, Theme.muted} if filtering?
       scope_on = scope_active?
-      chip, chip_color = scope_on ? {"⇧S scope:#{@scope.try(&.size) || 0}", Theme.accent} : {"⇧S scope:off", Theme.muted}
-      rx = rect.right - 1
-      if filtering?
-        count = @issues.size.to_s
-        screen.text({rx - count.size, rect.x}.max, y, count, Theme.muted)
-        rx -= count.size + 2
-      end
-      scope_x = {rx - chip.size, rect.x}.max
-      screen.text(scope_x, y, chip, chip_color)
+      chips << (scope_on ? {"⇧S scope:#{@scope.try(&.size) || 0}", Theme.accent} : {"⇧S scope:off", Theme.muted})
+      scope_x = Frame.right_text_chain(screen, rect.right - 1, y, rect.x + 2, chips)
       left_w = {scope_x - (rect.x + 1) - 1, 0}.max
       if filtering?
         label = @query.blank? ? "(in-scope only)" : ": #{@query}"
@@ -657,15 +653,15 @@ module Gori::Tui
       screen.text(rect.x + 3, rect.y, issue.title, Theme.text_bright, width: title_w, attr: Attribute::Bold)
 
       cx = rect.x + 1
-      cx = chip(screen, cx, rect.y + 1, " #{severity_badge(issue.severity)} ", severity_color(issue.severity))
-      cx = chip(screen, cx + 1, rect.y + 1, " #{issue.status.label} ", status_color(issue.status))
-      cx = chip(screen, cx + 1, rect.y + 1, " #{issue.category} ", Theme.muted)
+      cx = Frame.tag_chip(screen, cx, rect.y + 1, " #{severity_badge(issue.severity)} ", severity_color(issue.severity))
+      cx = Frame.tag_chip(screen, cx + 1, rect.y + 1, " #{issue.status.label} ", status_color(issue.status))
+      cx = Frame.tag_chip(screen, cx + 1, rect.y + 1, " #{issue.category} ", Theme.muted)
       # CWE last, and only when the whole chip fits: `chip` draws through screen.text with no
       # width cap, so an unguarded one on a narrow pane would run past the pane's right edge and
       # paint over the neighbouring column. Dropping it is the right degradation — the id is also
       # on the preview meta line and in every export.
       if (id = Probe.cwe_id(issue.code)) && cx + 1 + id.size + 2 <= rect.right
-        chip(screen, cx + 1, rect.y + 1, " #{id} ", Theme.muted)
+        Frame.tag_chip(screen, cx + 1, rect.y + 1, " #{id} ", Theme.muted)
       end
 
       hint = detail_hint(issue.code)
@@ -708,10 +704,6 @@ module Gori::Tui
       issue = @detail || return
       sync_affected(issue)
       yield
-    end
-
-    private def chip(screen : Screen, x : Int32, y : Int32, label : String, color : Color) : Int32
-      screen.text(x, y, label, Theme.bg, color, Attribute::Bold)
     end
 
     # Detail-pane one-liner: built-in remediation, or the custom rule's own description for a

--- a/src/gori/tui/project_view.cr
+++ b/src/gori/tui/project_view.cr
@@ -281,7 +281,7 @@ module Gori::Tui
     PANES = [:desc, :scope, :overrides, :env, :settings]
     # Chip labels, in PANES order. Kept parallel rather than derived from the symbols so a
     # label can read well ("HOST OVERRIDES") without renaming the pane it addresses.
-    PANE_LABELS = ["DESCRIPTION", "SCOPE", "HOST OVERRIDES", "ENV", "PROJECT SETTINGS"]
+    PANE_LABELS = ["Description", "Scope", "Host overrides", "Env", "Project settings"]
     # One row for the sub-tab chips.
     STRIP_H = 1
 

--- a/src/gori/tui/project_view.cr
+++ b/src/gori/tui/project_view.cr
@@ -1351,9 +1351,10 @@ module Gori::Tui
       ins = focused && desc_insert_mode?
       border = desc_pane_border(focused, ins)
       Frame.card(screen, rect, "DESCRIPTION", bg: Theme.bg, border: border)
-      if focused
-        Frame.mode_badge(screen, rect.right - 1, rect.y, rect.x + 14, ins)
-      end
+      # The REAL mode, always drawn — `Frame.mode_badge`'s contract. `project_controller`
+      # hit-tests the bare `desc_insert_mode?`, so gating the draw on focus left a live
+      # target on a border with nothing on it. Focus is carried by the border colour above.
+      Frame.mode_badge(screen, rect.right - 1, rect.y, rect.x + 14, desc_insert_mode?)
       inner = rect.inset(1, 1)
       @desc_area.render(screen, inner, cursor: ins,
         highlight: Settings.editor_markdown ? :markdown : nil, gauge: true, gauge_focused: focused)

--- a/src/gori/tui/project_view.cr
+++ b/src/gori/tui/project_view.cr
@@ -419,6 +419,32 @@ module Gori::Tui
 
     # Shared row hit-test for the SCOPE/HOST-OVERRIDES list interiors: account for the
     # optional add-row offset and scroll_for's windowing. Mirrors render_*_list.
+    # The row a click on a card's scroll gauge asks for. All three lists window from a
+    # selection-derived `scroll_for`, so the answer is a selection. Same `y`/`rows` the draw
+    # and `row_at` use, which is why it takes `adding` too.
+    def scope_gauge_row(rect : Rect, mx : Int32, my : Int32) : Int32?
+      return nil unless card = card_rect(rect, :scope)
+      gauge_row(card.inset(1, 1), mx, my, false, @scope.rules.size)
+    end
+
+    def ov_gauge_row(rect : Rect, mx : Int32, my : Int32) : Int32?
+      return nil unless card = card_rect(rect, :overrides)
+      gauge_row(ov_list_inner(card.inset(1, 1)), mx, my, @ov_adding, @host_overrides.entries.size)
+    end
+
+    def env_gauge_row(rect : Rect, mx : Int32, my : Int32) : Int32?
+      return nil unless card = card_rect(rect, :env)
+      gauge_row(env_list_inner(card.inset(1, 1)), mx, my, @env_adding, @env_items.size)
+    end
+
+    private def gauge_row(inner : Rect, mx : Int32, my : Int32, adding : Bool, n : Int32) : Int32?
+      return nil if inner.h <= 0
+      y = adding ? inner.y + 1 : inner.y
+      rows = adding ? inner.h - 1 : inner.h
+      return nil if rows <= 0
+      Frame.scroll_gauge_row(Rect.new(inner.x, y, inner.w, rows), n, mx, my)
+    end
+
     private def row_at(inner : Rect, mx : Int32, my : Int32, adding : Bool, sel : Int32, n : Int32) : Int32?
       return nil if inner.h <= 0 || !inner.contains?(mx, my)
       y = adding ? inner.y + 1 : inner.y

--- a/src/gori/tui/project_view.cr
+++ b/src/gori/tui/project_view.cr
@@ -721,6 +721,13 @@ module Gori::Tui
       end
     end
 
+    # The selected override's host, for the delete CONFIRM to name what it is about to remove.
+    # Read-only and separate from `ov_delete` because the confirm has to say the name BEFORE
+    # the row is gone, and `ov_delete` can only report it after.
+    def selected_override_host : String?
+      current_override.try(&.host)
+    end
+
     # Removes the selected override, returning its host (for the toast) or nil.
     def ov_delete : String?
       entry = current_override
@@ -855,6 +862,13 @@ module Gori::Tui
       cancel_env_add
       clamp_env_sel
       :ok
+    end
+
+    # The selected variable's KEY, for the delete confirm to name it before it is gone. Never
+    # the value: a confirm that echoed a secret would print it into a modal the operator may
+    # be screen-sharing, and the key alone identifies the row.
+    def selected_env_key : String?
+      @env_items[@env_sel]?.try { |(key, _)| key }
     end
 
     def env_delete : String?
@@ -1146,12 +1160,18 @@ module Gori::Tui
         idx = scroll + i
         rule = rules[idx]
         ry = y + i
-        selected = focused && idx == @sel
-        bg = selected ? Theme.accent_bg : Theme.bg
-        if selected
-          screen.fill(Rect.new(inner.x, ry, inner.w, 1), bg)
-          screen.cell(inner.x, ry, '▎', Theme.accent, bg)
-        end
+        # The selection SURVIVES a focus change, dimmed — every other list in gori does this
+        # (`Theme.selection_dim`, see RewriterView/ProbeRulesView/DiscoverView…). These three
+        # project cards were the only ones that gated the whole marker on `focused`, so moving
+        # focus to a sibling card erased any sign of where you were in this one, and coming
+        # back meant finding your row again by eye.
+        selected = idx == @sel
+        bg = selected ? (focused ? Theme.accent_bg : Theme.selection_dim) : Theme.bg
+        screen.fill(Rect.new(inner.x, ry, inner.w, 1), bg) if selected
+        # The marker column is written on EVERY row (a space when unselected), the way every
+        # other list writes it — so the column is owned here rather than left to whatever was
+        # on the canvas underneath.
+        screen.cell(inner.x, ry, selected ? '▎' : ' ', Theme.accent, bg)
         render_rule_row(screen, inner, ry, rule, selected, bg)
       end
     end
@@ -1210,12 +1230,12 @@ module Gori::Tui
         idx = scroll + i
         entry = entries[idx]
         ry = y + i
-        selected = focused && idx == @ov_sel && !@ov_adding
-        bg = selected ? Theme.accent_bg : Theme.bg
-        if selected
-          screen.fill(Rect.new(list.x, ry, list.w, 1), bg)
-          screen.cell(list.x, ry, '▎', Theme.accent, bg)
-        end
+        # Dimmed rather than erased when focus leaves — see the SCOPE list above. `@ov_adding`
+        # still clears it outright: while the add-row is open there is no selected ENTRY.
+        selected = idx == @ov_sel && !@ov_adding
+        bg = selected ? (focused ? Theme.accent_bg : Theme.selection_dim) : Theme.bg
+        screen.fill(Rect.new(list.x, ry, list.w, 1), bg) if selected
+        screen.cell(list.x, ry, selected ? '▎' : ' ', Theme.accent, bg)
         render_ov_row(screen, list, ry, entry, selected, bg)
       end
     end
@@ -1283,12 +1303,11 @@ module Gori::Tui
         idx = scroll + i
         key, val = @env_items[idx]
         ry = y + i
-        selected = focused && idx == @env_sel && !@env_adding
-        bg = selected ? Theme.accent_bg : Theme.bg
-        if selected
-          screen.fill(Rect.new(list.x, ry, list.w, 1), bg)
-          screen.cell(list.x, ry, '▎', Theme.accent, bg)
-        end
+        # Dimmed rather than erased when focus leaves — see the SCOPE list above.
+        selected = idx == @env_sel && !@env_adding
+        bg = selected ? (focused ? Theme.accent_bg : Theme.selection_dim) : Theme.bg
+        screen.fill(Rect.new(list.x, ry, list.w, 1), bg) if selected
+        screen.cell(list.x, ry, selected ? '▎' : ' ', Theme.accent, bg)
         render_env_row(screen, list, ry, key, val, selected, bg)
       end
     end

--- a/src/gori/tui/project_view.cr
+++ b/src/gori/tui/project_view.cr
@@ -1135,9 +1135,10 @@ module Gori::Tui
       return if rect.w < 2 || rect.h < 2
       Frame.card(screen, rect, "SCOPE", bg: Theme.bg, border: Frame.pane_border(focused))
       n = @scope.rules.size
-      meta = " lens:#{@scope.enabled? ? "on" : "off"} · #{n} "
-      mx = {rect.right - meta.size - 1, rect.x + 8}.max
-      screen.text(mx, rect.y, meta, @scope.active? ? Theme.text_bright : Theme.muted, Theme.bg) if rect.w > meta.size + 10
+      # An ACTIVE lens is the one card meta that shouts — it changes what every other tab
+      # shows — so this one passes its own fg rather than taking `border_meta`'s muted default.
+      Frame.border_meta(screen, rect, "SCOPE", "lens:#{@scope.enabled? ? "on" : "off"} · #{n}",
+        fg: @scope.active? ? Theme.text_bright : Theme.muted)
       render_scope_list(screen, rect.inset(1, 1), focused)
     end
 
@@ -1174,6 +1175,7 @@ module Gori::Tui
         screen.cell(inner.x, ry, selected ? '▎' : ' ', Theme.accent, bg)
         render_rule_row(screen, inner, ry, rule, selected, bg)
       end
+      Frame.scroll_gauge(screen, Rect.new(inner.x, y, inner.w, rows), rules.size, scroll, focused)
     end
 
     private def render_rule_row(screen : Screen, inner : Rect, y : Int32, rule : Scope::Rule, selected : Bool, bg : Color) : Nil
@@ -1192,9 +1194,8 @@ module Gori::Tui
       return if rect.w < 2 || rect.h < 2
       Frame.card(screen, rect, "HOST OVERRIDES", bg: Theme.bg, border: Frame.pane_border(focused))
       n = @host_overrides.size
-      meta = " #{n} "
-      mx = {rect.right - meta.size - 1, rect.x + 14}.max
-      screen.text(mx, rect.y, meta, n > 0 ? Theme.text_bright : Theme.muted, Theme.bg) if rect.w > meta.size + 16
+      Frame.border_meta(screen, rect, "HOST OVERRIDES", n.to_s,
+        fg: n > 0 ? Theme.text_bright : Theme.muted)
       render_overrides_list(screen, rect.inset(1, 1), focused)
     end
 
@@ -1238,6 +1239,9 @@ module Gori::Tui
         screen.cell(list.x, ry, selected ? '▎' : ' ', Theme.accent, bg)
         render_ov_row(screen, list, ry, entry, selected, bg)
       end
+      # `y`/`rows` are already past the add-row when one is open, so the gauge measures the
+      # entries actually windowed rather than the card interior.
+      Frame.scroll_gauge(screen, Rect.new(list.x, y, list.w, rows), entries.size, scroll, focused)
     end
 
     # The HOST OVERRIDES list area: the card interior minus the top example-hint row. ONE
@@ -1270,9 +1274,7 @@ module Gori::Tui
       return if rect.w < 2 || rect.h < 2
       Frame.card(screen, rect, "ENVIRONMENT", bg: Theme.bg, border: Frame.pane_border(focused))
       n = @env_items.size
-      meta = "prefix #{Settings.env_prefix} · #{n}"
-      mx = {rect.right - meta.size - 1, rect.x + 14}.max
-      screen.text(mx, rect.y, meta, Theme.muted, Theme.bg, width: {rect.right - mx - 1, 1}.max) if rect.w > meta.size + 16
+      Frame.border_meta(screen, rect, "ENVIRONMENT", "prefix #{Settings.env_prefix} · #{n}")
       render_env_list(screen, rect.inset(1, 1), focused)
     end
 
@@ -1310,6 +1312,7 @@ module Gori::Tui
         screen.cell(list.x, ry, selected ? '▎' : ' ', Theme.accent, bg)
         render_env_row(screen, list, ry, key, val, selected, bg)
       end
+      Frame.scroll_gauge(screen, Rect.new(list.x, y, list.w, rows), @env_items.size, scroll, focused)
     end
 
     private def env_list_inner(inner : Rect) : Rect

--- a/src/gori/tui/project_view.cr
+++ b/src/gori/tui/project_view.cr
@@ -1151,7 +1151,7 @@ module Gori::Tui
       return if rows <= 0
 
       if rules.empty?
-        screen.text(inner.x, y, "(no rules — a to add)", Theme.muted)
+        screen.text(inner.x, y, "no scope rules — press a to add", Theme.muted, Theme.bg)
         return
       end
 
@@ -1221,7 +1221,7 @@ module Gori::Tui
       return if rows <= 0
 
       if entries.empty?
-        screen.text(list.x, y, "(no overrides — a to add)", Theme.muted) unless @ov_adding
+        screen.text(list.x, y, "no overrides — press a to add", Theme.muted, Theme.bg) unless @ov_adding
         return
       end
 
@@ -1296,7 +1296,7 @@ module Gori::Tui
       end
       return if rows <= 0
       if @env_items.empty?
-        screen.text(list.x, y, "(no vars — a to add)", Theme.muted) unless @env_adding || @env_prefix_editing
+        screen.text(list.x, y, "no env vars — press a to add", Theme.muted, Theme.bg) unless @env_adding || @env_prefix_editing
         return
       end
       scroll = scroll_for(@env_sel, @env_items.size, rows)

--- a/src/gori/tui/project_view.cr
+++ b/src/gori/tui/project_view.cr
@@ -1349,7 +1349,7 @@ module Gori::Tui
     private def render_desc_card(screen : Screen, rect : Rect, focused : Bool) : Nil
       return if rect.w < 2 || rect.h < 2
       ins = focused && desc_insert_mode?
-      border = desc_pane_border(focused, ins)
+      border = Frame.pane_border(focused)
       Frame.card(screen, rect, "DESCRIPTION", bg: Theme.bg, border: border)
       # The REAL mode, always drawn — `Frame.mode_badge`'s contract. `project_controller`
       # hit-tests the bare `desc_insert_mode?`, so gating the draw on focus left a live
@@ -1359,11 +1359,6 @@ module Gori::Tui
       @desc_area.render(screen, inner, cursor: ins,
         highlight: Settings.editor_markdown ? :markdown : nil, gauge: true, gauge_focused: focused)
       paint_desc_read_chrome(screen, inner, focused && !ins)
-    end
-
-    private def desc_pane_border(focused : Bool, insert : Bool) : Color
-      return Frame.pane_border(false) unless focused
-      insert ? Theme.accent : Frame.pane_border(true)
     end
 
     # The shared over-paint — see `TextReadState#paint_chrome`, which carries the reasoning

--- a/src/gori/tui/read_pane.cr
+++ b/src/gori/tui/read_pane.cr
@@ -278,6 +278,15 @@ module Gori::Tui
     # `selecting` is the drag half: the anchor stays where the press left it.
     def click(rect : Rect, mx : Int32, my : Int32, selecting : Bool = false) : Nil
       return if empty? || rect.empty?
+      # The scroll gauge rides `rect.right` (see render) — a click on that column scrolls
+      # instead of placing the read caret, for every ReadPane at once: History detail, Probe
+      # AFFECTED, the Miner FINDING, the Comparer, the Fuzzer result. Through `scroll_view`,
+      # which pulls the caret into the new window so `ensure_visible` cannot snap it back.
+      # Not on a DRAG — a selection extending past the right edge must keep growing.
+      if !selecting && (top = Frame.scroll_gauge_top(rect, @size, mx, my))
+        scroll_view(top - @scroll)
+        return
+      end
       # A drag that has left the pane through the TOP scrolls the view up under it, one row per
       # motion report, so a selection can be grown past the first visible row. Downward already
       # worked — the hit test puts the caret past the window's last row and `ensure_visible`

--- a/src/gori/tui/repeater_view.cr
+++ b/src/gori/tui/repeater_view.cr
@@ -4789,7 +4789,11 @@ module Gori::Tui
           rows << {"→ sent #{reqn} request message#{reqn == 1 ? "" : "s"} (#{grpc_send_body.size}b)", Theme.muted}
           rows << {"⚠ #{Proxy::H2::Grpc.framing_error(@grpc_req_residual)}", Theme.yellow} if @grpc_req_residual > 0
           st = result.response.try(&.status) || 0
-          rows << {"HTTP #{st}", st >= 400 ? Theme.red : Theme.text}
+          # `status_color`, not a local `>= 400 ? red`. This line painted a 404 RED while
+          # line ~4812 of this same file painted it yellow, and every other status cell in
+          # gori (flow_status, the Fuzzer results, Discover) reads the shared ladder. Red is
+          # 5xx; a 4xx that shows as red says "the server broke" about a 404.
+          rows << {"HTTP #{st}", Theme.status_color(st)}
           grpc_response_rows(result).each { |r| rows << r }
           rows << grpc_status_row(result)
         end
@@ -4809,7 +4813,9 @@ module Gori::Tui
         results = @group_results || [] of {String, Repeater::Result}
         results.each_with_index do |(label, res), i|
           st = res.response.try(&.status)
-          head_color = res.error ? Theme.red : ((st && st >= 400) ? Theme.yellow : Theme.green)
+          # Same ladder. The hand-rolled version also collapsed 3xx into green, where
+          # `status_color` gives it accent — a redirect is not a 2xx.
+          head_color = res.error ? Theme.red : Theme.status_color(st)
           rows << {"══ req #{i + 1} · #{label}", Theme.text_bright}
           summary = if res.error && !res.head.empty?
                       "HTTP #{st} · #{res.error}" # a partial response + a read error (e.g. a CL+TE desync)

--- a/src/gori/tui/repeater_view.cr
+++ b/src/gori/tui/repeater_view.cr
@@ -4315,12 +4315,17 @@ module Gori::Tui
       # already drops its NOR/INS chip when a fifth badge is chained onto it.
       #
       # Two dresses, no third: a filled chip at rest (the NAME is the state, so muted grey
-      # would read as "disabled"), and the ^R:SEND gold when the operator has overridden
+      # would read as "disabled"), and a BOLD ACCENT pill when the operator has overridden
       # auto-detection — a handshake tab that will NOT speak WebSocket is the one thing on this
       # band worth interrupting a glance for.
+      #
+      # Accent, not the ^R:SEND gold it used to borrow. This chip rides the TARGET card's top
+      # border, and that border IS `focus_gold` when the card has focus — so an overridden
+      # transport on a focused card put two golds on one edge and "gold means focus is here"
+      # stopped being readable. Gold is focus and the brand mark; nothing else.
       if transport_switchable?
         fg, bg, attr = if transport_badge_lit?
-                         {Theme.ink_on(Theme.focus_gold), Theme.focus_gold, Attribute::Bold}
+                         {Theme.ink_on(Theme.accent), Theme.accent, Attribute::Bold}
                        else
                          {Theme.text_bright, Theme.accent_bg, Attribute::None}
                        end

--- a/src/gori/tui/repeater_view.cr
+++ b/src/gori/tui/repeater_view.cr
@@ -4262,7 +4262,7 @@ module Gori::Tui
               else
                 "DECODED · GraphQL"
               end
-      Frame.card(screen, rect, label, bg: Theme.bg, border: pane_border(focused))
+      Frame.card(screen, rect, label, bg: Theme.bg, border: Frame.pane_border(focused))
       if ws_mode?
         # The seeded frames this pane cannot render as a line. Without this the operator sees
         # an empty (or short) MESSAGES pane and has no way to know a PING, a CLOSE 1002 or an
@@ -4294,15 +4294,10 @@ module Gori::Tui
       paint_request_read_chrome(screen, inner, @decoded, focused && !ins)
     end
 
-    private def pane_border(focused : Bool, insert : Bool = false) : Color
-      return Frame.pane_border(false) unless focused
-      insert ? Theme.accent : Theme.focus_gold
-    end
-
     private def render_target(screen : Screen, rect : Rect, focused : Bool) : Nil
       return if rect.h < 2
       ins = focused && target_insert?
-      Frame.card(screen, rect, "TARGET", bg: Theme.bg, border: pane_border(focused, insert: ins))
+      Frame.card(screen, rect, "TARGET", bg: Theme.bg, border: Frame.pane_border(focused))
       Frame.mode_badge(screen, rect.right - 1, rect.y, rect.x + 8, target_insert?) # the REAL mode, not focused&&mode — see Frame.mode_badge
       sni_x, tr_edge = target_chrome_chain(rect)
       # An at-a-glance SNI marker on the top border (right of the title) whenever an
@@ -4431,7 +4426,7 @@ module Gori::Tui
       return if rect.w < 2 || rect.h < 2
       label = render_request_label
       ins = focused && request_insert?
-      Frame.card(screen, rect, label, bg: Theme.bg, border: pane_border(focused, insert: ins))
+      Frame.card(screen, rect, label, bg: Theme.bg, border: Frame.pane_border(focused))
       min_x = rect.x + label.size + 4 # keep clear of the pane title on the top border
       right_edge = rect.right - 1     # leave the right border cell untouched
       # Primary action rides the REQUEST border (discoverable without the footer chord):
@@ -4590,7 +4585,7 @@ module Gori::Tui
     #     cursor coordinates address a different document.
     private def render_ws_handshake(screen : Screen, rect : Rect, focused : Bool, active : Bool) : Nil
       return if rect.w < 2 || rect.h < 2
-      Frame.card(screen, rect, "HANDSHAKE RESPONSE", bg: Theme.bg, border: pane_border(focused && active))
+      Frame.card(screen, rect, "HANDSHAKE RESPONSE", bg: Theme.bg, border: Frame.pane_border(focused && active))
       if result = @result
         meta = result.ok? ? "#{Fmt.dur(result.duration_us)} · #{Fmt.size((result.head.size + (result.body.try(&.size) || 0)).to_i64)}" : Fmt.dur(result.duration_us)
         # `rect.x + 22` used to stand in for "HANDSHAKE RESPONSE" — the title's width, copied
@@ -4653,7 +4648,7 @@ module Gori::Tui
         render_transcript(screen, rect, focused, "GROUP · #{g.size} req", group_transcript_lines, total)
         return
       end
-      Frame.card(screen, rect, "RESPONSE", bg: Theme.bg, border: pane_border(focused))
+      Frame.card(screen, rect, "RESPONSE", bg: Theme.bg, border: Frame.pane_border(focused))
       render_response_chrome(screen, rect)
       body = rect.inset(1, 1)
       if @resp_hex
@@ -4681,7 +4676,7 @@ module Gori::Tui
                                   title : String, lines : Array({String, Color}), dur_us : Int64?,
                                   active : Bool = true) : Nil
       lit = focused && active
-      Frame.card(screen, rect, title, bg: Theme.bg, border: pane_border(lit))
+      Frame.card(screen, rect, title, bg: Theme.bg, border: Frame.pane_border(lit))
       if d = dur_us
         meta = Fmt.dur(d)
         Frame.border_meta(screen, rect, title, meta)

--- a/src/gori/tui/repeater_view.cr
+++ b/src/gori/tui/repeater_view.cr
@@ -2815,7 +2815,8 @@ module Gori::Tui
           # ` ^T:MARK ` chains LEFT of the mode chip, under exactly the condition
           # render_request draws it: only when a `§` is in the buffer. It was the one badge on
           # this border missing from the hit list while its four neighbours all answered.
-          if !@grpc_mode && !ws_mode? && (literal_markers? || (@evidence && markers_active?))
+          if !@grpc_mode && !ws_mode? && !decode_mode? &&
+             (literal_markers? || (@evidence && markers_active?))
             mark_edge = Frame.mode_badge_edge(mode_edge, min_x, request_insert?)
             if Frame.right_badge_hit(mx, my, req_card.y, mark_edge, min_x,
                  [{:mark, "^T", "MARK"}] of {Symbol, String, String})
@@ -4492,7 +4493,12 @@ module Gori::Tui
       # Only when a `§` is actually in the buffer, so a request without one draws exactly the
       # border it drew before. Unlit = the capture's § are literal bytes (^T declares them);
       # lit = this buffer is a template and ^R renders them. See `markers_live?`.
-      if literal_markers? || (@evidence && markers_active?)
+      #
+      # …and NOT on a decode split. `repeater.toggle-decoded` is context-sensitive: on a
+      # SAML/GraphQL tab `^T` switches ENVELOPE ⇄ DECODED instead of inserting a §, so a badge
+      # reading `^T:MARK` there names a key that does something else entirely. Marking is still
+      # reachable from the space menu (`w` word / `i` point) and from ^K.
+      if !decode_mode? && (literal_markers? || (@evidence && markers_active?))
         Frame.toggle_badge(screen, mark_x, rect.y, min_x, "^T", "MARK", markers_live?)
       end
       update_request_marker_tint

--- a/src/gori/tui/repeater_view.cr
+++ b/src/gori/tui/repeater_view.cr
@@ -4389,11 +4389,13 @@ module Gori::Tui
       end
       if result = @result
         meta = result.ok? ? "#{Fmt.dur(result.duration_us)} · #{Fmt.size((result.head.size + (result.body.try(&.size) || 0)).to_i64)}" : Fmt.dur(result.duration_us)
-        meta_x = rect.right - meta.size - 1
-        screen.text(meta_x, rect.y, meta, Theme.muted, Theme.bg) if meta_x > chips_end + 1
+        # `min_x:` because this border's left stop is the CHIP cluster, not the title.
+        meta_x = Frame.border_meta(screen, rect, "", meta, min_x: chips_end + 1)
         # A persistent amber marker when the response was cut short (the body the
-        # origin sent is incomplete) — the transient send toast scrolls away.
-        if result.incomplete?
+        # origin sent is incomplete) — the transient send toast scrolls away. Chained off
+        # where the meta actually landed; when the meta did not fit there is nothing to
+        # hang it on, and the row is already too tight to carry it.
+        if result.incomplete? && meta_x
           warn = "⚠ incomplete"
           warn_x = meta_x - warn.size - 2
           screen.text(warn_x, rect.y, warn, Theme.yellow, Theme.bg) if warn_x > chips_end + 1
@@ -4586,8 +4588,9 @@ module Gori::Tui
       Frame.card(screen, rect, "HANDSHAKE RESPONSE", bg: Theme.bg, border: pane_border(focused && active))
       if result = @result
         meta = result.ok? ? "#{Fmt.dur(result.duration_us)} · #{Fmt.size((result.head.size + (result.body.try(&.size) || 0)).to_i64)}" : Fmt.dur(result.duration_us)
-        meta_x = rect.right - meta.size - 1
-        screen.text(meta_x, rect.y, meta, Theme.muted, Theme.bg) if meta_x > rect.x + 22
+        # `rect.x + 22` used to stand in for "HANDSHAKE RESPONSE" — the title's width, copied
+        # by hand into a guard that would not follow it if the title ever changed.
+        Frame.border_meta(screen, rect, "HANDSHAKE RESPONSE", meta)
       end
       body = rect.inset(1, 1)
       rv = resp_view
@@ -4676,8 +4679,7 @@ module Gori::Tui
       Frame.card(screen, rect, title, bg: Theme.bg, border: pane_border(lit))
       if d = dur_us
         meta = Fmt.dur(d)
-        mx = rect.right - meta.size - 1
-        screen.text(mx, rect.y, meta, Theme.muted, Theme.bg) if mx > rect.x + title.size + 4
+        Frame.border_meta(screen, rect, title, meta)
       end
       body = rect.inset(1, 1)
       return if body.h <= 0

--- a/src/gori/tui/repeater_view.cr
+++ b/src/gori/tui/repeater_view.cr
@@ -1679,7 +1679,7 @@ module Gori::Tui
       # …and provenance is all that arrives: the row holds the request TEXT and the flow id,
       # nothing that says which `§` in it the operator typed. Undeclared is the answer gori
       # can defend — see `markers_live?`. (A marked-up capture reopens with its markers inert
-      # and the border chip saying so; ^K re-declares.)
+      # and the border chip saying so; ^T re-declares.)
       @markers_declared = false
       apply_request_fields(target, request, http2, auto_cl, sni, ws_messages, ws_keep_key, ws_http_only)
 
@@ -2318,7 +2318,7 @@ module Gori::Tui
       # capture that carries one there is nothing to gain by declaring — and everything to
       # lose: the capture's own `§` would become live positions in exchange for zero new ones.
       # Name that instead of doing it silently.
-      return "the capture's own § would become markers and auto-mark adds none — ^K marks the token at the cursor" if literal_markers?
+      return "the capture's own § would become markers and auto-mark adds none — ^T marks at the cursor" if literal_markers?
       declare_markers
       @editor.set_text(Fuzz::Template.auto_mark(@editor.text))
       @dirty = true
@@ -2375,7 +2375,7 @@ module Gori::Tui
     # those bytes exactly; the TUI was the one surface that did not.
     #
     # So on an EVIDENCE tab markers start INERT and the operator declares them — by marking
-    # (^A / ^K / insert §), the same explicit act the Fuzzer's ⇧I → ^A workflow already is.
+    # (^A / ^T / insert §), the same explicit act the Fuzzer's ⇧I → ^A workflow already is.
     # Declaring is per-buffer and monotone: from then on every `§` in the buffer is a marker
     # (the status line says so when the capture carried one), which is the honest reading of
     # "this buffer is now a template".
@@ -2428,7 +2428,7 @@ module Gori::Tui
     end
 
     private def literal_marker_hint : String
-      "§ here is captured data, not a marker — ^K marks a token (the capture's § become markers too)"
+      "§ here is captured data, not a marker — ^T marks at the cursor (the capture's § become markers too)"
     end
 
     # Insert an OAST payload URL at the request-editor caret (cross-tab "Insert OAST
@@ -2763,11 +2763,15 @@ module Gori::Tui
       # RESPONSE: d:diff / x:hex / p:pretty (not drawn in WS/gRPC/group transcript modes)
       unless ws_mode? || @grpc_mode || group_mode?
         if right.w >= 2 && my == right.y
+          # `limit:` is render_response's own `rect.right - 1` stop. The draw breaks at the
+          # first chip that would cross the card's '╮'; without the same stop here the hit
+          # walked all three anyway, so on a half-width RESPONSE below ~88 columns hex and
+          # pretty answered clicks on the border and past it.
           if hit = Frame.left_chip_hit(mx, my, right.y, right.x + 12, [
                {:diff, " d:diff "},
                {:hex, " ^X:hex "},
                {:pretty, " p:pretty "},
-             ] of {Symbol, String})
+             ] of {Symbol, String}, limit: right.right - 1)
             return hit
           end
         end
@@ -2807,6 +2811,16 @@ module Gori::Tui
           mode_edge = Frame.right_badge_edge(right_edge, min_x, badges)
           if Frame.mode_badge_hit(mx, my, req_card.y, mode_edge, min_x, request_insert?)
             return :mode
+          end
+          # ` ^T:MARK ` chains LEFT of the mode chip, under exactly the condition
+          # render_request draws it: only when a `§` is in the buffer. It was the one badge on
+          # this border missing from the hit list while its four neighbours all answered.
+          if !@grpc_mode && !ws_mode? && (literal_markers? || (@evidence && markers_active?))
+            mark_edge = Frame.mode_badge_edge(mode_edge, min_x, request_insert?)
+            if Frame.right_badge_hit(mx, my, req_card.y, mark_edge, min_x,
+                 [{:mark, "^T", "MARK"}] of {Symbol, String, String})
+              return :mark
+            end
           end
         end
       end
@@ -4476,10 +4490,10 @@ module Gori::Tui
       mode_x = Frame.toggle_badge(screen, cl_x, rect.y, min_x, "^U", "PRETTY", false)
       mark_x = Frame.mode_badge(screen, mode_x, rect.y, min_x, request_insert?) # the REAL mode — see Frame.mode_badge
       # Only when a `§` is actually in the buffer, so a request without one draws exactly the
-      # border it drew before. Unlit = the capture's § are literal bytes (^K declares them);
+      # border it drew before. Unlit = the capture's § are literal bytes (^T declares them);
       # lit = this buffer is a template and ^R renders them. See `markers_live?`.
       if literal_markers? || (@evidence && markers_active?)
-        Frame.toggle_badge(screen, mark_x, rect.y, min_x, "^K", "MARK", markers_live?)
+        Frame.toggle_badge(screen, mark_x, rect.y, min_x, "^T", "MARK", markers_live?)
       end
       update_request_marker_tint
       render_plain_request_editor(screen, rect.inset(1, 1), focused, ins)

--- a/src/gori/tui/rewriter_rule_overlay.cr
+++ b/src/gori/tui/rewriter_rule_overlay.cr
@@ -421,11 +421,11 @@ module Gori::Tui
       sc = short_circuit_op?
       case i
       when ROW_NAME   then draw_field(screen, box, py, bg, fg, sel, "name:", @fields[:name])
-      when ROW_SCOPE  then draw_cycle(screen, x, py, bg, fg, "scope:", SCOPE_LABELS, @scope_i, sel)
-      when ROW_TARGET then sc ? draw_na(screen, x, py, bg, "target:", "request (a stub answers a request)") : draw_cycle(screen, x, py, bg, fg, "target:", TARGETS, @target_i, sel)
-      when ROW_OP     then draw_cycle(screen, x, py, bg, fg, "op:", OP_LABELS, @op_i, sel)
-      when ROW_MATCH  then hop ? draw_na(screen, x, py, bg, "match:") : draw_cycle(screen, x, py, bg, fg, "match:", MATCHES, @match_i, sel)
-      when ROW_PART   then (hop || sc) ? draw_na(screen, x, py, bg, "part:", sc ? "head (matches the request head)" : nil) : draw_cycle(screen, x, py, bg, fg, "part:", PARTS, @part_i, sel)
+      when ROW_SCOPE  then Frame.option_cycle(screen, x, py, box.right - 2, bg, "scope:", SCOPE_LABELS, @scope_i, sel)
+      when ROW_TARGET then sc ? draw_na(screen, x, py, bg, "target:", "request (a stub answers a request)") : Frame.option_cycle(screen, x, py, box.right - 2, bg, "target:", TARGETS, @target_i, sel)
+      when ROW_OP     then Frame.option_cycle(screen, x, py, box.right - 2, bg, "op:", OP_LABELS, @op_i, sel)
+      when ROW_MATCH  then hop ? draw_na(screen, x, py, bg, "match:") : Frame.option_cycle(screen, x, py, box.right - 2, bg, "match:", MATCHES, @match_i, sel)
+      when ROW_PART   then (hop || sc) ? draw_na(screen, x, py, bg, "part:", sc ? "head (matches the request head)" : nil) : Frame.option_cycle(screen, x, py, box.right - 2, bg, "part:", PARTS, @part_i, sel)
       when ROW_HOST   then draw_field(screen, box, py, bg, fg, sel, "host:", @fields[:host])
       when ROW_FIND   then draw_field(screen, box, py, bg, fg, sel, hop ? "header:" : "find:", @fields[:pattern])
       when ROW_VALUE
@@ -461,18 +461,6 @@ module Gori::Tui
     private def draw_na(screen : Screen, x : Int32, py : Int32, bg : Color, label : String, note : String? = nil) : Nil
       screen.text(x, py, label, Theme.muted, bg)
       screen.text(x + label.size + 1, py, note || "n/a (header op)", Theme.muted, bg)
-    end
-
-    private def draw_cycle(screen : Screen, x : Int32, py : Int32, bg : Color, fg : Color,
-                           label : String, opts : Array(String), sel_i : Int32, row_sel : Bool) : Nil
-      screen.text(x, py, label, Theme.muted, bg)
-      tx = x + label.size + 1
-      opts.each_with_index do |opt, oi|
-        lit = oi == sel_i
-        col = lit ? (row_sel ? Theme.text_bright : Theme.accent) : Theme.muted
-        tx = screen.text(tx, py, " #{opt} ", col, bg, lit ? Attribute::Bold : Attribute::None)
-      end
-      screen.text(tx, py, " ‹/›", Theme.muted, bg) if row_sel
     end
 
     private def draw_field(screen : Screen, box : Rect, py : Int32, bg : Color, fg : Color,

--- a/src/gori/tui/rewriter_rule_overlay.cr
+++ b/src/gori/tui/rewriter_rule_overlay.cr
@@ -42,9 +42,9 @@ module Gori::Tui
     SCOPES       = %w[project global]
     SCOPE_LABELS = ["this project", "global (every project)"]
     TARGETS      = %w[request response]
-    OPS       = %w[replace add_header set_header remove_header short_circuit]
-    OP_LABELS = ["replace", "add header", "set header", "remove header", "stub"]
-    MATCHES   = %w[literal regex]
+    OPS          = %w[replace add_header set_header remove_header short_circuit]
+    OP_LABELS    = ["replace", "add header", "set header", "remove header", "stub"]
+    MATCHES      = %w[literal regex]
     # `ws` rewrites a WebSocket MESSAGE on an upgraded (101) flow, with `target:` picking
     # the direction (request = client→server, response = server→client). It is its own part
     # rather than a flavour of `body` so that no existing body rule starts touching frames.
@@ -403,9 +403,11 @@ module Gori::Tui
         screen.fill(Rect.new(box.x + 1, pv_y, box.w - 2, 1), Theme.panel)
         screen.text(box.x + 2, pv_y, "▶ #{@preview}", Theme.muted, Theme.panel, width: box.w - 4)
       end
-      hint_y = box.bottom - 1
-      screen.text(box.x + 2, hint_y, "↑/↓ field · ←/→ options · ↵ save · esc cancel",
-        Theme.muted, Theme.panel, width: box.w - 4) if hint_y > first
+      # No key hint on the bottom border: the shell already draws `hint` in the status strip
+      # for whichever modal is open (Runner#key_hints), so a second copy here was the same
+      # advice twice — and the two had already drifted apart, this one having dropped the
+      # `type find/value` clause the method still carries. Per-row affordances stay where the
+      # key applies (the `‹/›` a cycler draws when it has focus).
     end
 
     private def draw_row(screen : Screen, box : Rect, i : Int32, py : Int32) : Nil

--- a/src/gori/tui/rewriter_rule_overlay.cr
+++ b/src/gori/tui/rewriter_rule_overlay.cr
@@ -377,11 +377,7 @@ module Gori::Tui
     end
 
     def overlay_box(area : Rect) : Rect?
-      # 72, not 66: a fifth op pushed the option row past the card edge at the old width.
-      w = {area.w - 4, 72}.min
-      h = {area.h - 2, ROW_COUNT + 5}.min # title + rows + preview + hint + padding
-      return nil if w < 40 || h < 13
-      Rect.new(area.x + (area.w - w) // 2, area.y + (area.h - h) // 2, w, h)
+      Overlay.rule_form_box(area, ROW_COUNT, preview: true)
     end
 
     def render(screen : Screen, area : Rect) : Nil

--- a/src/gori/tui/rewriter_stub_overlay.cr
+++ b/src/gori/tui/rewriter_stub_overlay.cr
@@ -107,8 +107,8 @@ module Gori::Tui
     end
 
     def overlay_box(area : Rect) : Rect?
-      w = {area.w - 6, 72}.min
-      h = {area.h - 4, 20}.min
+      w = {area.w - 4, 72}.min
+      h = {area.h - 2, 20}.min
       return nil if w < 40 || h < 10
       Rect.new(area.x + (area.w - w) // 2, area.y + (area.h - h) // 2, w, h)
     end

--- a/src/gori/tui/rewriter_stub_overlay.cr
+++ b/src/gori/tui/rewriter_stub_overlay.cr
@@ -125,7 +125,11 @@ module Gori::Tui
     def render(screen : Screen, area : Rect) : Nil
       box = overlay_box(area)
       unless box
-        screen.text(area.x + 1, area.y, "stub editor needs a larger window · esc to close", Theme.muted, Theme.bg) unless area.empty?
+        # `esc saves & closes`, not the `esc to close` every CANCELLING modal's degraded line
+        # says: esc here returns :commit (see handle_key), and this line is the only thing on
+        # screen when the card cannot be drawn. Telling an operator "close" about a key that
+        # keeps their unsaved response is the one place the wording has to be exact.
+        screen.text(area.x + 1, area.y, "stub editor needs a larger window · esc saves & closes", Theme.muted, Theme.bg) unless area.empty?
         return
       end
       # bg: Theme.bg (not the card default panel) so the embedded editor, which paints on
@@ -144,7 +148,10 @@ module Gori::Tui
         @editor.render(screen, editor, cursor: true)
       end
       screen.text(box.x + 2, statusy, "▶ #{status_line}", Theme.muted, Theme.bg, width: box.w - 4) if statusy > top
-      screen.text(box.x + 2, hintline, "no origin is dialed — gori answers this itself · esc saves & closes",
+      # What a stub MEANS, which the operator cannot infer from an empty editor. The `esc saves
+      # & closes` tail that used to ride along came off: the shell already draws `hint` in the
+      # status strip for the open modal, and esc is the one key this editor's hint leads with.
+      screen.text(box.x + 2, hintline, "no origin is dialed — gori answers this itself",
         Theme.muted, Theme.bg, width: box.w - 4)
     end
   end

--- a/src/gori/tui/rewriter_view.cr
+++ b/src/gori/tui/rewriter_view.cr
@@ -222,6 +222,25 @@ module Gori::Tui
       idx < count ? idx : nil
     end
 
+    # The row a click on a list's scroll gauge asks for. Three lists here — the RULES list
+    # (its own `layout` card, note-aware) and the two flat sub-tab lists — all with a scroll
+    # DERIVED from their selection, so all three answer with a selection.
+    def gauge_row_at(rect : Rect, mx : Int32, my : Int32, count : Int32) : Int32?
+      _, body = sub_layout(rect)
+      Frame.scroll_gauge_row(body.inset(1, 1), count, mx, my)
+    end
+
+    # The RULES list's own gauge: the card is `layout`'s first rect, and `live` steals its
+    # bottom row for the engine note exactly as `row_at` accounts for.
+    def rules_gauge_row_at(rect : Rect, mx : Int32, my : Int32, count : Int32, live : Bool) : Int32?
+      list_r, _, _ = layout(rect)
+      inner = list_r.inset(1, 1)
+      return nil if inner.empty?
+      list_h = inner.h
+      list_h -= 1 if live && list_h > 1
+      Frame.scroll_gauge_row(Rect.new(inner.x, inner.y, inner.w, list_h), count, mx, my)
+    end
+
     # The sub-tab whose strip label contains (mx,my), or nil.
     def sub_at(rect : Rect, mx : Int32, my : Int32) : Symbol?
       strip, _ = sub_layout(rect)

--- a/src/gori/tui/rewriter_view.cr
+++ b/src/gori/tui/rewriter_view.cr
@@ -23,7 +23,7 @@ module Gori::Tui
     # that says whether the first one worked. Splitting them across the tab bar would have
     # hidden that they are one workflow.
     SUBS       = [:rules, :extract, :bindings]
-    SUB_LABELS = ["rules", "extract", "bindings"]
+    SUB_LABELS = ["Rules", "Extract", "Bindings"]
     SUB_H      = 1
 
     # The strip row and what is left for the sub-tab's own body.

--- a/src/gori/tui/rewriter_view.cr
+++ b/src/gori/tui/rewriter_view.cr
@@ -101,6 +101,7 @@ module Gori::Tui
         render_extract_row(screen, inner, rules[idx], bound.includes?(rules[idx].name),
           inner.y + i, idx == sel, body_focused)
       end
+      Frame.scroll_gauge(screen, inner, rules.size, scroll, body_focused)
     end
 
     # The `bindings` sub-tab: the debugging readout. Name, bound?, descriptor, host scope,
@@ -124,6 +125,7 @@ module Gori::Tui
         break if idx >= rows.size
         render_binding_row(screen, inner, rows[idx], inner.y + i, idx == sel, body_focused, now)
       end
+      Frame.scroll_gauge(screen, inner, rows.size, scroll, body_focused)
     end
 
     private def render_sub_strip(screen : Screen, rect : Rect, active : Symbol, focused : Bool) : Nil
@@ -245,9 +247,7 @@ module Gori::Tui
       globals = rules.count(&.global?)
       meta = "#{globals} global · #{meta}" if globals > 0
       # Count rides the top border (right of the title), not a list row.
-      if rect.w > meta.size + 20
-        screen.text({rect.right - meta.size - 2, rect.x + 18}.max, rect.y, meta, Theme.muted, Theme.bg)
-      end
+      Frame.border_meta(screen, rect, "MATCH & REPLACE", meta)
       inner = rect.inset(1, 1)
       return if inner.empty?
 
@@ -271,6 +271,10 @@ module Gori::Tui
         break if idx >= rules.size
         render_row(screen, inner, rules[idx], list_top + i, idx == sel, focused)
       end
+      # The gauge tracks the LIST viewport, not the whole interior — the live note below it
+      # is not a row you can scroll to. No-ops when everything fits.
+      Frame.scroll_gauge(screen, Rect.new(inner.x, list_top, inner.w, list_h),
+        rules.size, scroll, focused)
     end
 
     private def render_row(screen : Screen, rect : Rect, rule : Store::MatchRule, py : Int32,

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -4865,8 +4865,11 @@ module Gori::Tui
       ov = active_overlay.as?(DiscoverConfigOverlay)
       names = hdrs.first(3).map { |n, _| n }.join(", ")
       names += ", …" if hdrs.size > 3
-      confirm("Use this flow's headers?",
-        "#{hdrs.size} header(s) from flow ##{id}: #{names}",
+      # The heading is the card's TITLE, so it takes the same shape as every other confirm
+      # (and every other card in gori): an uppercase noun for what this is about. The question
+      # itself belongs in the body, one line down, where the rest of them ask it.
+      confirm("USE FLOW HEADERS",
+        "Use this flow's headers? #{hdrs.size} header(s) from flow ##{id}: #{names}",
         confirm_label: "use", cancel_label: "start clean",
         danger: false, return_to: :discover_config) { ov.try(&.set_headers(hdrs)) }
     end

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -1613,9 +1613,16 @@ module Gori::Tui
     # own precedence: `:detail` is a History body drill-in rather than a capturing modal, so a
     # press inside it reaches the tab — and so must the drag and the double-click that follow,
     # or the request/response text is the one place selection works by keyboard and not by mouse.
+    # The contexts that swallow a press without owning any geometry a pointer gesture could
+    # continue into — the space menu, the copy-as / send-to pickers, and the four bottom
+    # prompts. Shared by the drag and double-click tiers so the two can't drift apart.
+    private def pointer_capture_elsewhere? : Bool
+      @space_menu_open || copy_as_shown? || send_to_shown? ||
+        @goto_open || @search_open || @rename_open || @tag_edit_open
+    end
+
     private def drag_press_target?(layout : Layout, mx : Int32, my : Int32) : Bool
-      return false if @space_menu_open || copy_as_shown? || send_to_shown?
-      return false if @goto_open || @search_open || @rename_open || @tag_edit_open
+      return false if pointer_capture_elsewhere?
       # An overlay hit-tests its own card, so the shell asks only whether it opts in — it owns
       # no geometry inside the modal to test against.
       if ov = active_overlay
@@ -1638,8 +1645,25 @@ module Gori::Tui
       @tabs[@active_tab]?.try(&.handle_drag(layout.body, mx, my))
     end
 
+    # Whether a double-click can reach the thing under the pointer at all: the same context
+    # rejections as `drag_press_target?`, and NOT its two `supports_drag?` questions.
+    #
+    # Those are different questions, and gating on the drag one made a whole gesture silently
+    # dead: `ColormarkerController#handle_double_click` opens the rule editor, and Colormarker
+    # — a list, with no text to extend a selection over — answers `supports_drag?` false, so
+    # the shell never asked. A double-click there read as two selects. The default
+    # `handle_double_click` returns false and `press_left` then falls through to the ordinary
+    # click, so a tab that implements nothing is unaffected by being offered the pair.
+    private def double_click_target?(layout : Layout, mx : Int32, my : Int32) : Bool
+      return false if pointer_capture_elsewhere?
+      return true if active_overlay # hit-tests its own card; the shell owns no geometry inside
+      return false if modal_overlay?
+      return false unless @focus == :body
+      layout.body.contains?(mx, my)
+    end
+
     private def dispatch_double_click(layout : Layout, mx : Int32, my : Int32) : Bool
-      return false unless drag_press_target?(layout, mx, my)
+      return false unless double_click_target?(layout, mx, my)
       # The first press of the pair already placed the caret and focused the pane, so the
       # word selection lands where the operator is looking.
       if ov = active_overlay

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -3120,15 +3120,15 @@ module Gori::Tui
       # read as "your query is not in there".
       if n < 0
         return status("replace: this buffer holds bytes that are not valid UTF-8 — " \
-                      "search and replace cannot run over it (^F highlighting still works)")
+                      "search and replace can't run over it (^F highlighting still works)")
       end
       return if n == 0
       q, r = @search_buffer, @search_replace_buffer
       plural = n == 1 ? "" : "s"
       msg = if r.empty?
-              "Delete #{n} occurrence#{plural} of \"#{q}\"?"
+              "Delete #{n} occurrence#{plural} of “#{q}”?"
             else
-              "Replace #{n} occurrence#{plural} of \"#{q}\" with \"#{r}\"?"
+              "Replace #{n} occurrence#{plural} of “#{q}” with “#{r}”?"
             end
       confirm("REPLACE ALL", "#{msg}\nOne undo step — ^Z puts it back.",
         confirm_label: r.empty? ? "delete" : "replace", danger: true) do
@@ -3232,18 +3232,26 @@ module Gori::Tui
       end
     end
 
+    # Glyph prefixes for the status strip, matched against the message TEXT. That coupling is
+    # the thing to know about this method: it is the one place where changing a toast's wording
+    # silently changes its appearance. `fuzz error:` was renamed `fuzzer error:` (one noun per
+    # engine, across both its channels) and the ✗ quietly stopped appearing — nothing failed,
+    # the mark was simply gone. `ERROR_PREFIXES` now carries every engine so the next one
+    # inherits the mark instead of needing a line here.
+    ERROR_PREFIXES = [
+      "repeater error:", "ws repeater error:", "fuzz:",
+      "fuzzer error:", "discover error:", "miner error:", "sequencer error:", "probe error:",
+    ]
+    BUSY_PREFIXES = ["sending →", "ws sending →", "fuzzing ", "fuzz running", "stopping"]
+    DONE_PREFIXES = ["sent →", "ws sent:", "Fuzzer:"]
+
     private def format_status_message(message : String?) : String?
       return nil unless message
-      if message.starts_with?("sending →") || message.starts_with?("ws sending →") ||
-         message.starts_with?("fuzzing ") || message.starts_with?("fuzz running") ||
-         message.starts_with?("stopping")
+      if BUSY_PREFIXES.any? { |p| message.starts_with?(p) }
         "#{SPINNER[@spinner_frame % SPINNER.size]} #{message}"
-      elsif message.starts_with?("sent →") || message.starts_with?("ws sent:") ||
-            message.starts_with?("Fuzzer:")
+      elsif DONE_PREFIXES.any? { |p| message.starts_with?(p) }
         "✓ #{message}"
-      elsif message.starts_with?("repeater error:") || message.starts_with?("ws repeater error:") ||
-            message.starts_with?("fuzz error:") || message.starts_with?("fuzz:") ||
-            message.starts_with?("cannot run")
+      elsif ERROR_PREFIXES.any? { |p| message.starts_with?(p) }
         "✗ #{message}"
       else
         message
@@ -4922,7 +4930,7 @@ module Gori::Tui
 
     private def open_mine_config(seed : MineSeed?, extra : Array(MineSeed) = [] of MineSeed) : Nil
       unless seed
-        @toast = "cannot mine this request"
+        @toast = "can't mine this request"
         return
       end
       if seed.applicable.empty?
@@ -4973,7 +4981,7 @@ module Gori::Tui
 
     private def open_sequence_config(seed : SequenceSeed?) : Nil
       unless seed
-        @toast = "cannot sequence this request"
+        @toast = "can't sequence this request"
         return
       end
       ov = SequenceConfigOverlay.new(seed)
@@ -4996,7 +5004,7 @@ module Gori::Tui
     # --- Discover config popup (Sitemap/History → "Discover here") ---
     private def open_discover_config(seed : DiscoverSeed?) : Nil
       unless seed
-        @toast = "cannot discover from here"
+        @toast = "can't discover from here"
         return
       end
       ov = DiscoverConfigOverlay.new(seed)

--- a/src/gori/tui/runner/fuzzer.cr
+++ b/src/gori/tui/runner/fuzzer.cr
@@ -50,6 +50,16 @@ class Gori::Tui::Runner < Gori::Verb::ExecContext
     (v = fuzzer_controller.current_view) && (@toast = v.auto_mark)
   end
 
+  # ^K / ^T. Delegators rather than `chord_action` arms, so both reach the keymap like every
+  # other marker action and show up in the space menu beside auto-mark and clear.
+  def fuzz_mark_word : Nil
+    (v = fuzzer_controller.current_view) && (@toast = v.mark_word)
+  end
+
+  def fuzz_insert_marker : Nil
+    (v = fuzzer_controller.current_view) && (@toast = v.insert_marker)
+  end
+
   # ^Y: jump focus DOWN into the visible CHAIN pane (the marker under the template
   # cursor). The controller gates on cursor-in-marker and toasts otherwise.
   def fuzz_attach_chain : Nil

--- a/src/gori/tui/runner/miner.cr
+++ b/src/gori/tui/runner/miner.cr
@@ -43,6 +43,17 @@ class Gori::Tui::Runner < Gori::Verb::ExecContext
     miner_controller.miner_duplicate
   end
 
+  # The strip's raw `r` rename / ^W close, promoted to verbs. `Runner#renameable_subtabs?`
+  # and `#subtab_close` have listed :miner all along; only the VERBS were missing, so the
+  # `:subtab` space-menu group here held Duplicate alone and neither key was rebindable.
+  def miner_rename_subtab : Nil
+    open_rename(current_subtab_index)
+  end
+
+  def miner_close_subtab : Nil
+    miner_controller.request_close
+  end
+
   def miner_finding_selected? : Bool
     miner_controller.finding_selected?
   end

--- a/src/gori/tui/runner/rewriter.cr
+++ b/src/gori/tui/runner/rewriter.cr
@@ -46,6 +46,12 @@ class Gori::Tui::Runner < Gori::Verb::ExecContext
     rewriter_controller.rules_sub?
   end
 
+  # The list is on screen AND has focus — what a rule CHORD has to mean. See the comment on
+  # `rewriter_rule_selected?` above for the `@sub` half of this; this is the `@focus` half.
+  def rewriter_rule_list_focused? : Bool
+    rewriter_controller.rule_list_focused?
+  end
+
   # The selected rule is a GLOBAL one — the gate for the two verbs that only mean something
   # for the library half (flip the default everywhere; the scope verb's label).
   def rewriter_global_rule_selected? : Bool
@@ -64,5 +70,4 @@ class Gori::Tui::Runner < Gori::Verb::ExecContext
   def rewriter_preview_out? : Bool
     rewriter_controller.rewriter_preview_out_focused?
   end
-
 end

--- a/src/gori/tui/runner/sequencer.cr
+++ b/src/gori/tui/runner/sequencer.cr
@@ -30,6 +30,17 @@ class Gori::Tui::Runner < Gori::Verb::ExecContext
     sequencer_controller.sequence_run
   end
 
+  # The strip's raw `r` rename / ^W close, promoted to verbs — `Runner#renameable_subtabs?`
+  # and `#subtab_close` have listed :sequencer all along, but there were no verbs, so this
+  # tab had NO `:subtab` menu group at all and neither key could be rebound.
+  def sequencer_rename_subtab : Nil
+    open_rename(current_subtab_index)
+  end
+
+  def sequencer_close_subtab : Nil
+    sequencer_controller.request_close
+  end
+
   def sequence_stop : Nil
     sequencer_controller.sequence_stop
   end

--- a/src/gori/tui/scope_rule_overlay.cr
+++ b/src/gori/tui/scope_rule_overlay.cr
@@ -167,10 +167,7 @@ module Gori::Tui
     end
 
     def overlay_box(area : Rect) : Rect?
-      w = {area.w - 4, 52}.min
-      h = {area.h - 2, 11}.min # title + 4 rows + padding
-      return nil if w < 28 || h < 8
-      Rect.new(area.x + (area.w - w) // 2, area.y + (area.h - h) // 2, w, h)
+      Overlay.rule_form_box(area, row_count)
     end
 
     def render(screen : Screen, area : Rect) : Nil

--- a/src/gori/tui/scope_rule_overlay.cr
+++ b/src/gori/tui/scope_rule_overlay.cr
@@ -68,7 +68,7 @@ module Gori::Tui
     end
 
     def hint : String
-      "↑/↓ field · ←/→ kind·type · type pattern · ↵ save · esc cancel"
+      "↑/↓ field · ←/→ options · type pattern · ↵ save · esc cancel"
     end
 
     # Click a field row to select it; a click on Save commits; a click outside the card
@@ -187,12 +187,8 @@ module Gori::Tui
         break if py >= box.bottom - 1
         draw_row(screen, box, i, py)
       end
-      # Footer hint
-      hint_y = box.bottom - 1
-      if hint_y > first
-        screen.text(box.x + 2, hint_y, "↑/↓ field · ←/→ kind·type · ↵ save · esc cancel",
-          Theme.muted, Theme.panel, width: box.w - 4)
-      end
+      # No key hint on the bottom border — the shell draws `hint` in the status strip for the
+      # open modal (Runner#key_hints). See RewriterRuleOverlay#render for the whole argument.
     end
 
     private def draw_row(screen : Screen, box : Rect, i : Int32, py : Int32) : Nil

--- a/src/gori/tui/scope_rule_overlay.cr
+++ b/src/gori/tui/scope_rule_overlay.cr
@@ -200,18 +200,12 @@ module Gori::Tui
       fg = sel ? Theme.text_bright : Theme.text
       case i
       when 0
-        screen.text(x, py, "kind:", Theme.muted, bg)
-        screen.text(x + 6, py, "#{kind}  ‹/›", fg, bg)
+        # `kind:` used to print the current value ALONE — so a form whose whole first question
+        # is "include or exclude?" never showed that the other answer existed. Both rows are
+        # strips now, through the same renderer as every other cycler in gori.
+        Frame.option_cycle(screen, x, py, box.right - 2, bg, "kind:", Scope::KINDS, @kind_idx, sel)
       when 1
-        screen.text(x, py, "type:", Theme.muted, bg)
-        # Show all types; the current one is bold (and bright when the row is selected)
-        tx = x + 6
-        Scope::TYPES.each_with_index do |t, ti|
-          lit = ti == @type_idx
-          col = lit ? (sel ? Theme.text_bright : Theme.accent) : Theme.muted
-          tx = screen.text(tx, py, " #{t} ", col, bg, lit ? Attribute::Bold : Attribute::None)
-        end
-        screen.text(tx, py, " ‹/›", Theme.muted, bg)
+        Frame.option_cycle(screen, x, py, box.right - 2, bg, "type:", Scope::TYPES, @type_idx, sel)
       when 2
         screen.text(x, py, "pattern:", Theme.muted, bg)
         vx = x + 9

--- a/src/gori/tui/sequence_config_overlay.cr
+++ b/src/gori/tui/sequence_config_overlay.cr
@@ -258,8 +258,8 @@ module Gori::Tui
       vw = {box.right - 2 - vx, 4}.max
       case i
       when KIND_ROW
-        screen.text(x, py, "token type:", Theme.muted, bg)
-        screen.text(vx, py, "#{kind.label}  ‹/›", sel ? Theme.text_bright : Theme.text, bg)
+        Frame.option_cycle(screen, x, py, box.right - 2, bg,
+          "token type:", KINDS.map(&.label), @kind_idx, sel, value_x: vx)
       when SELECTOR_ROW
         screen.text(x, py, selector_label, Theme.muted, bg)
         @selector.render(screen, vx, py, vw, sel, sel ? Theme.text_bright : Theme.text, bg)
@@ -267,23 +267,24 @@ module Gori::Tui
         label = valid? ? "[ Start collecting ]" : "[ set a token location ]"
         screen.text(x, py, label, valid? ? Theme.accent : Theme.muted, bg, Attribute::Bold)
       else
-        draw_cycler(screen, x, vx, py, bg, sel, i)
+        draw_cycler(screen, x, vx, py, box.right - 2, bg, sel, i)
       end
     end
 
-    # The four ←/›-cycled rows, split out of draw_row so adding a knob does not keep
-    # growing one branch chain.
-    private def draw_cycler(screen : Screen, x : Int32, vx : Int32, py : Int32,
+    # The four ←/→-cycled rows, split out of draw_row so adding a knob does not keep
+    # growing one branch chain. `value_x` keeps them on this form's shared value column, which
+    # the selector row above them also uses; the strip-or-lit-value decision belongs to
+    # `Frame.option_cycle` and is made by measuring the room left to `right`.
+    private def draw_cycler(screen : Screen, x : Int32, vx : Int32, py : Int32, right : Int32,
                             bg : Color, sel : Bool, i : Int32) : Nil
-      label, value =
+      label, options, idx =
         case i
-        when GOAL_ROW   then {"samples:", GOAL_CHOICES[@goal_idx].to_s}
-        when MAXREQ_ROW then {"max requests:", MAX_REQ_CHOICES[@maxreq_idx].try(&.to_s) || "uncapped"}
-        when CONC_ROW   then {"concurrency:", CONC_CHOICES[@conc_idx].to_s}
-        else                 {"notify:", NOTIFY_CHOICES[@notify_idx].label}
+        when GOAL_ROW   then {"samples:", GOAL_CHOICES.map(&.to_s), @goal_idx}
+        when MAXREQ_ROW then {"max requests:", MAX_REQ_CHOICES.map { |c| c.try(&.to_s) || "uncapped" }, @maxreq_idx}
+        when CONC_ROW   then {"concurrency:", CONC_CHOICES.map(&.to_s), @conc_idx}
+        else                 {"notify:", NOTIFY_CHOICES.map(&.label), @notify_idx}
         end
-      screen.text(x, py, label, Theme.muted, bg)
-      screen.text(vx, py, "#{value}  ‹/›", sel ? Theme.text_bright : Theme.text, bg)
+      Frame.option_cycle(screen, x, py, right, bg, label, options, idx, sel, value_x: vx)
     end
 
     def row_at(box : Rect, mx : Int32, my : Int32) : Int32?

--- a/src/gori/tui/sequence_config_overlay.cr
+++ b/src/gori/tui/sequence_config_overlay.cr
@@ -111,7 +111,7 @@ module Gori::Tui
     end
 
     def hint : String
-      "↑/↓ field · type to edit selector · ←/→ cycle · ↵ start · esc cancel"
+      "↑/↓ field · type to edit selector · ←/→ options · ↵ start · esc cancel"
     end
 
     # Own key handling (formerly Runner#handle_sequence_config_key). ↑/↓ move fields; the

--- a/src/gori/tui/sequencer_view.cr
+++ b/src/gori/tui/sequencer_view.cr
@@ -696,7 +696,8 @@ module Gori::Tui
     end
 
     private def render_samples(screen : Screen, rect : Rect, focused : Bool) : Nil
-      Frame.card(screen, rect, "SAMPLES (#{@samples.size})", border: focused ? Theme.focus_gold : Theme.border, bg: Theme.bg)
+      Frame.card(screen, rect, "SAMPLES", border: Frame.pane_border(focused), bg: Theme.bg)
+      Frame.border_meta(screen, rect, "SAMPLES", @samples.size.to_s)
       inner = rect.inset(1, 1)
       # A card under 3 rows has no interior — `inset` floors the height at 0 but keeps
       # `inner.y` one row down, so an unguarded placeholder lands OUTSIDE the pane.

--- a/src/gori/tui/sequencer_view.cr
+++ b/src/gori/tui/sequencer_view.cr
@@ -913,5 +913,52 @@ module Gori::Tui
       return :analysis if a_rect.contains?(mx, my)
       cfg_rect.contains?(mx, my) ? :config : nil
     end
+
+    # Mouse: the sample index under a click, or nil (outside SAMPLES, on the header row, or
+    # past the last populated row). Mirrors render_samples' inset → header → @scroll+i. The
+    # cursor moved with ↑/↓ and the wheel and could not be placed with the pointer.
+    def samples_row_at(rect : Rect, mx : Int32, my : Int32) : Int32?
+      return nil if @focus == :detail || @samples.empty?
+      _, s_rect, _ = pane_rects(rect)
+      return nil if s_rect.empty? || !s_rect.contains?(mx, my)
+      inner = s_rect.inset(1, 1)
+      return nil if inner.h <= 0 || inner.w <= 0
+      i = my - (inner.y + 1) # rows start one line below the header
+      return nil if i < 0 || i >= {inner.h - 1, 0}.max
+      idx = @scroll + i
+      idx < @samples.size ? idx : nil
+    end
+
+    # The row a click on the scroll gauge asks for. The gauge rides the frame's right hairline,
+    # one column outside the list rect, so `row_at` cannot answer it — and `@scroll` here is
+    # DERIVED from the selection, so the answer is a selection. See `Frame.scroll_gauge_row`.
+    def samples_gauge_row(rect : Rect, mx : Int32, my : Int32) : Int32?
+      return nil if @focus == :detail
+      _, s_rect, _ = pane_rects(rect)
+      return nil if s_rect.empty?
+      inner = s_rect.inset(1, 1)
+      return nil if inner.h <= 0 || inner.w <= 0
+      Frame.scroll_gauge_row(Rect.new(inner.x, inner.y + 1, inner.w, inner.h - 1),
+        @samples.size, mx, my)
+    end
+
+    def select_sample_row(idx : Int32) : Nil
+      @sel = idx.clamp(0, {@samples.size - 1, 0}.max)
+    end
+
+    def samples_selected_index : Int32
+      @sel
+    end
+
+    # Hit-test the SEQUENCER card's run control — same dress as the Repeater's ` ^R:SEND `
+    # and the Fuzzer's ` ^R:RUN `, which both answer a click. Mirrors render_config.
+    def config_chrome_hit(rect : Rect, mx : Int32, my : Int32) : Symbol?
+      return nil if @focus == :detail
+      cfg, _, _ = pane_rects(rect)
+      return nil if cfg.empty?
+      chord, name = @running ? {"^X", "STOP"} : {"^R", "RUN"}
+      Frame.right_badge_hit(mx, my, cfg.y, cfg.right - 1, cfg.x + "SEQUENCER".size + 4,
+        [{:run, chord, name}] of {Symbol, String, String})
+    end
   end
 end

--- a/src/gori/tui/settings_view.cr
+++ b/src/gori/tui/settings_view.cr
@@ -714,7 +714,12 @@ module Gori::Tui
       @saved = ok
       @baseline = @values.dup if ok # the working copy IS the persisted state now → no longer dirty
       @status = ok ? "saved" : "save failed"
-      ok ? "settings saved" : "settings: save failed (could not write #{Settings.path})"
+      # `<thing> applied — could not save to <path>`, the shape the rest of the app uses and
+      # `Runner#toggle_pet` documents: every setter above ran BEFORE `Settings.save`, so on a
+      # failed write the change IS live in this session and only persistence is missing. The
+      # old `settings: save failed (…)` said the second half and left the operator to guess
+      # the first — on the highest-traffic save in the app.
+      ok ? "settings saved" : "settings applied — could not save to #{Settings.path}"
     end
 
     # The centred settings box for `area` — the exact Rect render draws into (so

--- a/src/gori/tui/settings_view.cr
+++ b/src/gori/tui/settings_view.cr
@@ -864,34 +864,28 @@ module Gori::Tui
       vp.times do |row|
         i = @theme_scroll + row
         break if i >= names.size
-        draw_theme_row(screen, box, names[i], i == sel, list_top + row,
-          up: row == 0 && @theme_scroll > 0,
-          down: row == vp - 1 && i < names.size - 1)
+        draw_theme_row(screen, box, names[i], i == sel, list_top + row)
       end
+      # The shared gauge on the card's own hairline, replacing the ▲/▼/↕ glyphs this list used
+      # to paint into its last interior column — an affordance that existed nowhere else in
+      # gori, said only "there is more" rather than how much, and cost a column the swatch
+      # now gets back.
+      Frame.scroll_gauge(screen, Rect.new(box.x + 1, list_top, box.w - 2, vp),
+        names.size, @theme_scroll, true, Theme.panel)
     end
 
-    private def draw_theme_row(screen : Screen, box : Rect, name : String, selected : Bool, ry : Int32, *, up : Bool, down : Bool) : Nil
+    private def draw_theme_row(screen : Screen, box : Rect, name : String, selected : Bool, ry : Int32) : Nil
       bg = selected ? Theme.accent_bg : Theme.panel
       screen.fill(Rect.new(box.x + 1, ry, box.w - 2, 1), bg)
       screen.cell(box.x + 1, ry, selected ? '▎' : ' ', Theme.accent, bg)
       screen.cell(box.x + 3, ry, selected ? '◉' : '◯', selected ? Theme.accent : Theme.muted, bg)
-      # Right edge, inside the card border (box.right-1): a scroll marker on the last
-      # interior column (box.right-2), then the swatch left of it with a 1-col gap.
-      mark_x = box.right - 2
+      # The swatch now runs to the last interior column (box.right-2) — the scroll marker that
+      # used to sit there moved onto the card's hairline as a gauge.
       swatch_w = 7
-      sx = mark_x - 1 - swatch_w
+      sx = box.right - 1 - swatch_w
       name_w = {sx - (box.x + 5) - 1, 1}.max
       screen.text(box.x + 5, ry, name, selected ? Theme.text_bright : Theme.text, bg, width: name_w)
       draw_swatch(screen, sx, ry, name)
-      # Scroll marker (one glyph): ↕ when this lone row can scroll both ways (a 1-row
-      # viewport on a tiny terminal), else ▲ for more-above / ▼ for more-below.
-      if up && down
-        screen.cell(mark_x, ry, '↕', Theme.muted, bg)
-      elsif up
-        screen.cell(mark_x, ry, '▲', Theme.muted, bg)
-      elsif down
-        screen.cell(mark_x, ry, '▼', Theme.muted, bg)
-      end
     end
 
     # A tiny preview strip in the theme's OWN palette (not the active one): its canvas

--- a/src/gori/tui/setup_wizard.cr
+++ b/src/gori/tui/setup_wizard.cr
@@ -744,10 +744,12 @@ module Gori::Tui
       vp.times do |row|
         i = @theme_scroll + row
         break if i >= names.size
-        draw_theme_row(screen, box, list_w, names[i], i == sel, list_top + row,
-          up: row == 0 && @theme_scroll > 0,
-          down: row == vp - 1 && i < names.size - 1)
+        draw_theme_row(screen, box, list_w, names[i], i == sel, list_top + row)
       end
+      # The shared gauge on the list area's last column — where the per-row ▲/▼/↕ markers used
+      # to sit. Same replacement as the Settings theme list, which is a copy of this one.
+      Frame.scroll_gauge(screen, Rect.new(box.x + 1, list_top, list_w - 1, vp),
+        names.size, @theme_scroll, true, Theme.panel)
 
       if two_col
         px = box.x + 1 + list_w + PREVIEW_GAP
@@ -756,24 +758,19 @@ module Gori::Tui
     end
 
     private def draw_theme_row(screen : Screen, box : Rect, list_w : Int32, name : String,
-                               selected : Bool, ry : Int32, *, up : Bool, down : Bool) : Nil
+                               selected : Bool, ry : Int32) : Nil
       bg = selected ? Theme.accent_bg : Theme.panel
       screen.fill(Rect.new(box.x + 1, ry, list_w, 1), bg)
       screen.cell(box.x + 1, ry, selected ? '▎' : ' ', Theme.accent, bg)
       screen.cell(box.x + 3, ry, selected ? '◉' : '◯', selected ? Theme.accent : Theme.muted, bg)
-      mark_x = box.x + list_w # last column of the list area
+      # The list area's last column now carries the scroll gauge, so the swatch ends one cell
+      # short of it rather than leaving a gap for a per-row marker.
+      mark_x = box.x + list_w
       swatch_w = 7
-      sx = mark_x - 1 - swatch_w
+      sx = mark_x - swatch_w
       name_w = {sx - (box.x + 5) - 1, 1}.max
       screen.text(box.x + 5, ry, name, selected ? Theme.text_bright : Theme.text, bg, width: name_w)
       draw_swatch(screen, sx, ry, name)
-      if up && down
-        screen.cell(mark_x, ry, '↕', Theme.muted, bg)
-      elsif up
-        screen.cell(mark_x, ry, '▲', Theme.muted, bg)
-      elsif down
-        screen.cell(mark_x, ry, '▼', Theme.muted, bg)
-      end
     end
 
     # A 7-cell strip in the theme's OWN palette (Theme.palette, not the active one).

--- a/src/gori/tui/sitemap_view.cr
+++ b/src/gori/tui/sitemap_view.cr
@@ -1113,9 +1113,25 @@ module Gori::Tui
       return nil if mx < rect.x || mx >= rect.right # reject the frame border columns (mirror the other list helpers)
       top = list_top(rect)
       i = my - top
-      return nil if i < 0 || i >= {rect.bottom - top, 0}.max
+      # `@tagging` takes the bottom row for the prompt, exactly as render and the gauge on
+      # the same pass already account for. Without it a click on the `tag › …` prompt row
+      # selected the tree row one past the last VISIBLE one — and on the marker column it
+      # folded a node the operator could not see. Same shape as the Colormarker note row.
+      bottom = @tagging ? rect.bottom - 1 : rect.bottom
+      return nil if i < 0 || i >= {bottom - top, 0}.max
       idx = @scroll + i
       idx < visible_rows.size ? idx : nil
+    end
+
+    # The row a click on the scroll gauge asks for. The gauge rides the frame's right hairline
+    # — one column outside the list rect, which is why `row_at` cannot answer it — and `@scroll`
+    # here is DERIVED from the selection by `ensure_visible`, so the answer is a selection, not
+    # an offset. See `Frame.scroll_gauge_row`.
+    def gauge_row_at(rect : Rect, mx : Int32, my : Int32) : Int32?
+      rows = visible_rows
+      # `list_h`, matching the draw: while the tag prompt is open the tree gets one row less.
+      list_h = @tagging ? {rect.h - 1, 0}.max : rect.h
+      Frame.scroll_gauge_row(Rect.new(rect.x, rect.y, rect.w, list_h), rows.size, mx, my)
     end
 
     # Inverts render's marker column `rect.x + 1 + depth*2` for visible_rows[ri].

--- a/src/gori/tui/sitemap_view.cr
+++ b/src/gori/tui/sitemap_view.cr
@@ -1042,25 +1042,17 @@ module Gori::Tui
       # Right cluster: the scope-lens chip (always shown so the ⇧S toggle is
       # discoverable — the Scope lens filters the tree too) and, when filtering, the
       # matching host count.
+      # One right-anchored chain — see HistoryView#render_ql_bar, which this mirrors. The
+      # `g:fold` toggle keeps the scope chip's accent/muted dress so the two lenses read as
+      # one cluster, and its `g` chord stays in view (folding on vs off renders identically
+      # when a tree has no ids to fold).
+      chips = [] of {String, Color}
+      chips << {"#{@hosts.size}h", Theme.muted} if filtering?
       scope_on = @scope.try(&.active?) == true
-      chip, chip_color = scope_on ? {"⇧S scope:#{@scope.try(&.size) || 0}", Theme.accent} : {"⇧S scope:off", Theme.muted}
-      rx = rect.right - 1
-      if filtering?
-        count = "#{@hosts.size}h"
-        screen.text({rx - count.size, rect.x}.max, rect.y, count, Theme.muted)
-        rx -= count.size + 2
-      end
-      scope_x = {rx - chip.size, rect.x}.max
-      screen.text(scope_x, rect.y, chip, chip_color)
-      # The id-folding toggle, left of the scope chip — same fg
-      # accent/muted style so the two lens toggles read as one cluster, and its `g`
-      # chord stays in view (folding-on vs -off renders identically without ids).
-      gchip = "g:fold"
-      gx = scope_x - gchip.size - 1
-      group_shown = gx > rect.x + 1
-      screen.text(gx, rect.y, gchip, @grouping ? Theme.accent : Theme.muted) if group_shown
-
-      lx = render_mark_chip(screen, rect, group_shown ? gx : scope_x)
+      chips << (scope_on ? {"⇧S scope:#{@scope.try(&.size) || 0}", Theme.accent} : {"⇧S scope:off", Theme.muted})
+      chips << {"g:fold", @grouping ? Theme.accent : Theme.muted}
+      chips << {mark_chip_text.not_nil!, Theme.accent} if mark_chip_text
+      lx = Frame.right_text_chain(screen, rect.right - 1, rect.y, rect.x + 2, chips)
 
       left_w = {lx - (rect.x + 1) - 1, 0}.max
       if !@query.blank?
@@ -1083,14 +1075,11 @@ module Gori::Tui
     # sub-tab switch and a reload, so this chip is what keeps the set from being invisible when
     # you come back. The hidden split covers marks the current filter/expand state doesn't
     # show, so the count never silently exceeds what's on screen.
-    private def render_mark_chip(screen : Screen, rect : Rect, right_x : Int32) : Int32
-      return right_x if @marks.empty?
+    # The mark chip's TEXT, or nil when nothing is marked — see HistoryView#mark_chip_text.
+    private def mark_chip_text : String?
+      return nil if @marks.empty?
       hidden = marked_hidden_count
-      chip = hidden > 0 ? "#{@marks.size} marked ·#{hidden} hidden" : "#{@marks.size} marked"
-      x = right_x - chip.size - 1
-      return right_x unless x > rect.x + 1 # too narrow — the host count/scope chips win
-      screen.text(x, rect.y, chip, Theme.accent)
-      x
+      hidden > 0 ? "#{@marks.size} marked ·#{hidden} hidden" : "#{@marks.size} marked"
     end
 
     private def render_column_headers(screen : Screen, rect : Rect, hdr_y : Int32) : Nil

--- a/src/gori/tui/sitemap_view.cr
+++ b/src/gori/tui/sitemap_view.cr
@@ -806,6 +806,11 @@ module Gori::Tui
         break if ri >= rows.size
         draw_row(screen, rect, rows[ri], rect.y + i, ri == @selected, focused)
       end
+      # `list_h`, not `rect.h`: while the tag prompt is open it owns the bottom row, and a
+      # gauge measured against the full height would report a viewport one row taller than
+      # the tree actually gets.
+      Frame.scroll_gauge(screen, Rect.new(rect.x, rect.y, rect.w, list_h),
+        rows.size, @scroll, focused)
       render_tag_prompt(screen, rect) if @tagging
     end
 

--- a/src/gori/tui/tab_controller.cr
+++ b/src/gori/tui/tab_controller.cr
@@ -215,6 +215,24 @@ module Gori::Tui
       false
     end
 
+    # ⌥/⌃ + ←/→/Home/End/⌫ are EDITOR MOTION — word step, buffer jump, word delete — not
+    # command chords. A controller that defers modified chords to the central keymap (so they
+    # stay rebindable) has to let these through FIRST, or the editor loses word motion.
+    #
+    # Safe against the keymap by construction: `Verb::Chord` parses only letters, digits and
+    # punctuation, so none of these can ever BE a binding. Repeater and Fuzzer each carried a
+    # byte-identical private copy of this and its `word_delete?` half; the Decoder and JWT
+    # needed it too, and a fourth copy is how the first three drifted apart in every other
+    # part of this sweep.
+    def editing_motion?(ev : Termisu::Event::Key) : Bool
+      return false unless ev.ctrl? || ev.alt?
+      key = ev.key
+      return true if key.left? || key.right? || key.home? || key.end?
+      return true if key.backspace?
+      c = ev.char
+      !!c && (c == '\u{7F}' || c == '\b')
+    end
+
     # Whether a press in this tab's body can start a DRAG — pointer motion with the button
     # held, which extends a selection from where the press landed. False by default: a tab
     # opts in only for a pane that has a text selection to extend.

--- a/src/gori/tui/tabs_overlay.cr
+++ b/src/gori/tui/tabs_overlay.cr
@@ -176,7 +176,7 @@ module Gori::Tui
       end
       Frame.card(screen, box, "TAB BAR", border: Theme.border_focus)
       meta = "#{visible_count}/#{@items.size} shown"
-      screen.text({box.right - meta.size - 2, box.x + 12}.max, box.y, meta, Theme.muted, Theme.panel)
+      Frame.border_meta(screen, box, "TAB BAR", meta, bg: Theme.panel)
 
       list_top = box.y + 2
       cap = list_capacity(box)

--- a/src/gori/tui/tabs_overlay.cr
+++ b/src/gori/tui/tabs_overlay.cr
@@ -38,7 +38,7 @@ module Gori::Tui
     end
 
     def hint : String
-      "↑/↓ select · space show/hide · K/J reorder · r reset · ↵ save · esc cancel"
+      "↑/↓ select · space show/hide · ⇧K/⇧J reorder · r reset · ↵ save · esc cancel"
     end
 
     # ↑/↓ move the selection and ⇧↑/⇧↓ reorder the selected tab; ↵ saves+applies, esc

--- a/src/gori/tui/text_area.cr
+++ b/src/gori/tui/text_area.cr
@@ -891,6 +891,19 @@ module Gori::Tui
     # from the mouse instead of the keyboard.
     def click_to_cursor(rect : Rect, mx : Int32, my : Int32, selecting : Bool = false) : Nil
       return if rect.empty? || @lines.empty?
+      # The scroll gauge rides `rect.right` — render draws it there — so a click on that one
+      # column is a scroll request, not a caret placement. Answering it HERE covers every
+      # editor in the app at once, because every caller hands `click_to_cursor` the same rect
+      # it handed `render`. Routed through `scroll_view` rather than assigning `@scroll`, so
+      # the caret is dragged along (else render's `ensure_visible` snaps the view straight
+      # back) and wrap's `@scroll_sub` stays consistent. Under wrap the gauge is a proportion
+      # indicator rather than a coordinate — see the note on the draw — so this lands close
+      # rather than exactly, which is what the thumb was already saying.
+      # Not on a DRAG: a selection that has run past the right edge must keep extending.
+      if !selecting && (top = Frame.scroll_gauge_top(rect, @lines.size, mx, my))
+        scroll_view(top - @scroll)
+        return
+      end
       row = my - rect.y
       # A drag ABOVE the pane still means something — the pointer left the top edge while the
       # button was held — so it pins to the first visible row instead of being dropped. A

--- a/src/gori/verb/context/fuzzer.cr
+++ b/src/gori/verb/context/fuzzer.cr
@@ -5,13 +5,18 @@ abstract class Gori::Verb::ExecContext
   abstract def fuzz_toggle_http2 : Nil # flip the fuzz transport h1↔h2 (override seed protocol)
   abstract def fuzz_toggle_sni : Nil   # edit the TLS SNI the sweep presents (TARGET pane; dialed host unchanged)
 
-  # fuzzer workbench (run/stop/marking handled inline; these power the palette + cross-tab)
+  # fuzzer workbench (run/stop handled inline; these power the palette + cross-tab).
+  # Marking is NOT inline any more: ^K/^T used to be `chord_action` arms, which kept the two
+  # most-used marker actions out of the space menu and out of the keymap. They are verbs now,
+  # the same four the Repeater has had all along.
   abstract def fuzz_selected : Nil            # send History's selection to the Fuzzer tab
   abstract def fuzz_from_repeater : Nil       # turn the current Repeater request into a fuzz template
   abstract def fuzz_run : Nil                 # start the fuzz run
   abstract def fuzz_stop : Nil                # stop the running fuzz
   abstract def fuzz_new : Nil                 # open a blank fuzz session
   abstract def fuzz_automark : Nil            # auto-mark every request parameter
+  abstract def fuzz_mark_word : Nil           # toggle a marker around the token at the cursor
+  abstract def fuzz_insert_marker : Nil       # drop a single § at the cursor (bracket by hand)
   abstract def fuzz_attach_chain : Nil        # open the chain-edit prompt for the marker at the template cursor
   abstract def fuzz_list_paste : Nil          # open the payload-set editor pre-seeded to a List (multi-line, one value per line)
   abstract def fuzz_clear_marks : Nil         # strip all §…§ markers (and their chains) from the template

--- a/src/gori/verb/context/miner.cr
+++ b/src/gori/verb/context/miner.cr
@@ -7,6 +7,8 @@ abstract class Gori::Verb::ExecContext
   abstract def mine_run : Nil                 # re-run mining for the focused Miner session
   abstract def mine_stop : Nil                # stop the running mine
   abstract def miner_duplicate_subtab : Nil   # clone the active miner sub-tab's content into a new sibling
+  abstract def miner_rename_subtab : Nil      # open the rename prompt for the active sub-tab
+  abstract def miner_close_subtab : Nil       # close the active sub-tab (confirm-gated)
   abstract def miner_finding_selected? : Bool # a finding is selected in the focused miner session
   abstract def mine_repeater_selected : Nil   # send the selected miner finding to Repeater
   # The FINDING pane holds focus — the gate for its row select / copy verbs. A mined parameter's

--- a/src/gori/verb/context/rewriter.cr
+++ b/src/gori/verb/context/rewriter.cr
@@ -3,21 +3,22 @@
 abstract class Gori::Verb::ExecContext
   # rewriter: the Match & Replace rule list (the Rewriter tab). The body is a
   # navigable list, so these back both the space menu/palette AND the list's keys.
-  abstract def rewriter_add : Nil               # open the editor to add a rule
-  abstract def rewriter_edit : Nil              # edit the selected rule
-  abstract def rewriter_toggle : Nil            # enable/disable the selected rule
-  abstract def rewriter_delete : Nil            # delete the selected rule (confirms)
-  abstract def rewriter_move(dir : Int32) : Nil # reorder the selected rule ±1 in apply order
-  abstract def rewriter_duplicate : Nil         # copy the selected rule
-  abstract def rewriter_reload : Nil            # re-read rules from the DB (external edits)
-  abstract def rewriter_rule_selected? : Bool   # a rule is selected (gates edit/delete/… verbs)
-  abstract def rewriter_rules_sub? : Bool       # the RULES sub-tab is on screen
+  abstract def rewriter_add : Nil                 # open the editor to add a rule
+  abstract def rewriter_edit : Nil                # edit the selected rule
+  abstract def rewriter_toggle : Nil              # enable/disable the selected rule
+  abstract def rewriter_delete : Nil              # delete the selected rule (confirms)
+  abstract def rewriter_move(dir : Int32) : Nil   # reorder the selected rule ±1 in apply order
+  abstract def rewriter_duplicate : Nil           # copy the selected rule
+  abstract def rewriter_reload : Nil              # re-read rules from the DB (external edits)
+  abstract def rewriter_rule_selected? : Bool     # a rule is selected (gates edit/delete/… verbs)
+  abstract def rewriter_rules_sub? : Bool         # the RULES sub-tab is on screen
+  abstract def rewriter_rule_list_focused? : Bool # …and the list, not a preview pane, has focus
   # The scope half (`Store::RuleScope`): a rule lives either in this project or in the global
   # library every project reads, and these two are how an operator moves it and how they
   # change what the library says by default.
-  abstract def rewriter_scope_toggle : Nil            # move the selected rule global ⇄ project
-  abstract def rewriter_toggle_default : Nil          # flip a global rule's default everywhere
-  abstract def rewriter_global_rule_selected? : Bool  # the selection is a global rule
+  abstract def rewriter_scope_toggle : Nil           # move the selected rule global ⇄ project
+  abstract def rewriter_toggle_default : Nil         # flip a global rule's default everywhere
+  abstract def rewriter_global_rule_selected? : Bool # the selection is a global rule
   # The PREVIEW OUTPUT pane holds focus — the read-pane gate, matching the per-tab
   # `*_read_mode?` predicates the other read panes carry. It is the transformed sample, the one
   # place the post-rewrite bytes exist, so it is the only Rewriter pane with a caret to select

--- a/src/gori/verb/context/sequencer.cr
+++ b/src/gori/verb/context/sequencer.cr
@@ -2,12 +2,14 @@
 # the full facade and the class-reopening convention this mirrors store/compact.cr).
 abstract class Gori::Verb::ExecContext
   # sequencer (token randomness — cross-tab seeds open a config popup, collection runs in background)
-  abstract def sequence_selected : Nil      # send History's selected flow to the Sequencer (config popup)
-  abstract def sequence_from_repeater : Nil # sequence the current Repeater request
-  abstract def sequence_from_sitemap : Nil  # sequence the selected Sitemap endpoint's captured flow
-  abstract def sequence_run : Nil           # re-run collection for the focused Sequencer session
-  abstract def sequence_stop : Nil          # stop the running collection
-  abstract def sequence_configure : Nil     # reconfigure the focused session's token descriptor
+  abstract def sequence_selected : Nil       # send History's selected flow to the Sequencer (config popup)
+  abstract def sequence_from_repeater : Nil  # sequence the current Repeater request
+  abstract def sequence_from_sitemap : Nil   # sequence the selected Sitemap endpoint's captured flow
+  abstract def sequence_run : Nil            # re-run collection for the focused Sequencer session
+  abstract def sequence_stop : Nil           # stop the running collection
+  abstract def sequencer_rename_subtab : Nil # open the rename prompt for the active sub-tab
+  abstract def sequencer_close_subtab : Nil  # close the active sub-tab (confirm-gated)
+  abstract def sequence_configure : Nil      # reconfigure the focused session's token descriptor
   # Write the focused session's randomness report to a file (:markdown | :json — the
   # destination comes from the export popup), or file its verdict in the Issues report.
   abstract def sequence_export(format : Symbol) : Nil

--- a/src/gori/verbs/colormarker.cr
+++ b/src/gori/verbs/colormarker.cr
@@ -20,26 +20,26 @@ module Gori
 
       r.register Verb::Definition.new(
         "colormarker.add", "Add rule", "Open the editor to add a History row-colour rule",
-        Verb::Scope::Colormarker, available: in_cm, mnemonic: 'a') { |ctx| ctx.colormarker_add; nil }
+        Verb::Scope::Colormarker, [Verb::Chord.new("a")], available: in_cm, mnemonic: 'a') { |ctx| ctx.colormarker_add; nil }
       r.register Verb::Definition.new(
         "colormarker.edit", "Edit rule", "Edit the selected rule in the popup editor",
-        Verb::Scope::Colormarker, available: has_rule, mnemonic: 'e') { |ctx| ctx.colormarker_edit; nil }
+        Verb::Scope::Colormarker, [Verb::Chord.new("enter"), Verb::Chord.new("e")], available: has_rule, mnemonic: 'e') { |ctx| ctx.colormarker_edit; nil }
       r.register Verb::Definition.new(
         "colormarker.toggle", "Enable/disable", "Toggle the selected rule on or off in THIS project",
-        Verb::Scope::Colormarker, available: has_rule, mnemonic: 'x') { |ctx| ctx.colormarker_toggle; nil }
+        Verb::Scope::Colormarker, [Verb::Chord.new("x")], available: has_rule, mnemonic: 'x') { |ctx| ctx.colormarker_toggle; nil }
       r.register Verb::Definition.new(
         "colormarker.delete", "Delete rule", "Delete the selected rule (confirms first)",
-        Verb::Scope::Colormarker, available: has_rule, mnemonic: 'd') { |ctx| ctx.colormarker_delete; nil }
+        Verb::Scope::Colormarker, [Verb::Chord.new("d")], available: has_rule, mnemonic: 'd') { |ctx| ctx.colormarker_delete; nil }
       # "Move up/down" reads like cosmetics on the Rewriter, where rules compose and order is a
       # tiebreak. Here the FIRST enabled match paints the row and the rest are never consulted,
       # so a move changes which rule wins — the descriptions say so rather than leaving an
       # operator to discover it.
       r.register Verb::Definition.new(
         "colormarker.move-up", "Move up", "Give the selected rule higher precedence (first match wins)",
-        Verb::Scope::Colormarker, available: has_rule, mnemonic: 'u') { |ctx| ctx.colormarker_move(-1); nil }
+        Verb::Scope::Colormarker, [Verb::Chord.new("k", shift: true)], available: has_rule, mnemonic: 'u') { |ctx| ctx.colormarker_move(-1); nil }
       r.register Verb::Definition.new(
         "colormarker.move-down", "Move down", "Give the selected rule lower precedence (first match wins)",
-        Verb::Scope::Colormarker, available: has_rule, mnemonic: 'n') { |ctx| ctx.colormarker_move(1); nil }
+        Verb::Scope::Colormarker, [Verb::Chord.new("j", shift: true)], available: has_rule, mnemonic: 'n') { |ctx| ctx.colormarker_move(1); nil }
       r.register Verb::Definition.new(
         "colormarker.duplicate", "Duplicate rule", "Copy the selected rule into a new one",
         Verb::Scope::Colormarker, available: has_rule, mnemonic: 'c') { |ctx| ctx.colormarker_duplicate; nil }
@@ -53,11 +53,12 @@ module Gori
       global_rule = ->(ctx : Verb::ExecContext) { ctx.current_tab == :colormarker && ctx.colormarker_global_rule_selected? }
       r.register Verb::Definition.new(
         "colormarker.scope", "Global/project", "Move the selected rule between this project and the global library",
-        Verb::Scope::Colormarker, available: has_rule, mnemonic: 's') { |ctx| ctx.colormarker_scope_toggle; nil }
+        Verb::Scope::Colormarker, [Verb::Chord.new("s")], available: has_rule, mnemonic: 's') { |ctx| ctx.colormarker_scope_toggle; nil }
       r.register Verb::Definition.new(
         "colormarker.toggle-default", "Enable/disable everywhere",
         "Flip a GLOBAL rule's default — the state every project without an override follows",
-        Verb::Scope::Colormarker, available: global_rule, mnemonic: 'g') { |ctx| ctx.colormarker_toggle_default; nil }
+        Verb::Scope::Colormarker, [Verb::Chord.new("x", shift: true)],
+        available: global_rule, mnemonic: 'X') { |ctx| ctx.colormarker_toggle_default; nil }
     end
   end
 end

--- a/src/gori/verbs/comparer.cr
+++ b/src/gori/verbs/comparer.cr
@@ -60,10 +60,16 @@ module Gori
         Verb::Scope::Comparer, available: in_comparer, mnemonic: 'e',
         section: :subtab) { |ctx| ctx.comparer_rename_subtab; nil }
 
+      # `:common`, not `:subtab` — the space menu renders COMMON ∪ the FOCUSED PANE's section,
+      # so a `:subtab` close is invisible from the body and reachable only after moving focus
+      # to the strip. Decoder and JWT fixed that for themselves; this is the same fix.
+      #
+      # Repeater and Fuzzer deliberately do NOT follow: `repeater.mark-word` / `fuzz.mark-word`
+      # own 'w' in their `:request` / `:template` sections, so a COMMON 'w' would collide there
+      # and `Registry#validate_menu_keys!` would raise at boot. Their close stays in :subtab.
       r.register Verb::Definition.new(
         "comparer.close-subtab", "Close comparison", "Close the active comparison sub-tab (keeps ≥1)",
-        Verb::Scope::Comparer, available: in_comparer, mnemonic: 'w',
-        section: :subtab) { |ctx| ctx.comparer_close_subtab; nil }
+        Verb::Scope::Comparer, available: in_comparer, mnemonic: 'w') { |ctx| ctx.comparer_close_subtab; nil }
 
       r.register Verb::Definition.new(
         "comparer.duplicate-subtab", "Duplicate comparison", "Clone the active A/B pair into a new sub-tab",

--- a/src/gori/verbs/decoder.cr
+++ b/src/gori/verbs/decoder.cr
@@ -37,7 +37,7 @@ module Gori
       # Clears the INPUT text (and its chain spec) — the INPUT pane's own action.
       r.register Verb::Definition.new(
         "decoder.clear", "Clear input + chain", "Clear the current input and chain spec",
-        Verb::Scope::Decoder, available: in_decoder, mnemonic: 'l', section: :input) { |ctx| ctx.decoder_clear; nil }
+        Verb::Scope::Decoder, [Verb::Chord.new("l", ctrl: true)], available: in_decoder, mnemonic: 'l', section: :input) { |ctx| ctx.decoder_clear; nil }
 
       in_decoder_read = ->(ctx : Verb::ExecContext) { ctx.current_tab == :decoder && ctx.decoder_read_mode? }
       # The single smart Copy (see repeater.copy in verbs/history.cr) — copy-all is gone.
@@ -49,7 +49,7 @@ module Gori
       # Cycles the OUTPUT pane's display mode — tagged :output.
       r.register Verb::Definition.new(
         "decoder.mode", "Cycle output mode", "Cycle the output display: text / hex / base64",
-        Verb::Scope::Decoder, available: in_decoder, mnemonic: 'm', section: :output) { |ctx| ctx.decoder_cycle_mode; nil }
+        Verb::Scope::Decoder, [Verb::Chord.new("x", ctrl: true)], available: in_decoder, mnemonic: 'm', section: :output) { |ctx| ctx.decoder_cycle_mode; nil }
 
       # Save/load a chain spec by name — COMMON, like New/Close above and for the same
       # reason. These were tagged :tab, which put them ONLY in the tab-bar space menu:
@@ -60,11 +60,11 @@ module Gori
       # library is now reachable wherever the conversion is.
       r.register Verb::Definition.new(
         "decoder.save", "Save chain by name", "Save the current chain spec under a name",
-        Verb::Scope::Decoder, available: in_decoder, mnemonic: 's') { |ctx| ctx.decoder_save; nil }
+        Verb::Scope::Decoder, [Verb::Chord.new("s", ctrl: true)], available: in_decoder, mnemonic: 's') { |ctx| ctx.decoder_save; nil }
 
       r.register Verb::Definition.new(
         "decoder.load", "Load a saved chain", "Pick from the saved chain specs (^X deletes one)",
-        Verb::Scope::Decoder, available: in_decoder, mnemonic: 'o') { |ctx| ctx.decoder_load; nil }
+        Verb::Scope::Decoder, [Verb::Chord.new("o", ctrl: true)], available: in_decoder, mnemonic: 'o') { |ctx| ctx.decoder_load; nil }
 
       # Search-and-jump across conversion sub-tabs (section :tab — like repeater.find-subtab)
       # so jumping never needs Ctrl+digit. 'f' (find) since 's'/'o' are taken by Save/Load,

--- a/src/gori/verbs/discover.cr
+++ b/src/gori/verbs/discover.cr
@@ -11,7 +11,7 @@ module Gori
 
       r.register Verb::Definition.new(
         "discover.stop", "Stop", "Stop the selected discovery run (in-flight requests finish)",
-        Verb::Scope::Discover, [Verb::Chord.new("x", ctrl: true)], mnemonic: 'x') { |ctx| ctx.discover_stop; nil }
+        Verb::Scope::Discover, [Verb::Chord.new("x", ctrl: true)], mnemonic: 's') { |ctx| ctx.discover_stop; nil }
 
       # Plain `p` toggles pause in the body (handled by the controller); the space menu
       # exposes it too. No ctrl-p — that's reserved for the command palette.

--- a/src/gori/verbs/history.cr
+++ b/src/gori/verbs/history.cr
@@ -136,13 +136,20 @@ module Gori
       # across Body COMMON (lowercase 'x' is select-line). Mirrors probe.delete-selected.
       r.register Verb::Definition.new(
         "history.delete", "Delete flow", "Delete the selected flow from History (asks first)",
-        Verb::Scope::Body, available: history_targets, mnemonic: 'X', group: :danger) { |ctx| ctx.history_delete; nil }
+        Verb::Scope::Body, available: history_targets, mnemonic: 'D', group: :danger) { |ctx| ctx.history_delete; nil }
 
       # Wipe the project's entire History (confirm-gated). Menu-only; 'C' is free across
       # Body COMMON (lowercase 'c' is compare). Available whenever History has any rows.
+      # `X` wipes THIS TAB, `D` deletes the selected row — the pairing `probe.clear` (X) and
+      # `probe.delete-selected` (d) already had, and the one History inverted: it read `X` as
+      # delete-one and `C` as clear-all, so `X` meant "one flow" here and "every issue" one
+      # tab over, both in the danger group. `C` also collided with `Send to Comparer`, which
+      # is `C` in the Repeater and the Fuzzer — the Repeater→History move being the most
+      # travelled in the app, that letter went from "make a diff" to "wipe the capture".
+      # `d` cannot take delete here: it is `history.discover`, which fires outbound traffic.
       r.register Verb::Definition.new(
         "history.clear", "Clear history", "Delete ALL History flows for this project (asks first)",
-        Verb::Scope::Body, available: in_history, mnemonic: 'C', group: :danger) { |ctx| ctx.history_clear; nil }
+        Verb::Scope::Body, available: in_history, mnemonic: 'X', group: :danger) { |ctx| ctx.history_clear; nil }
 
       # --- repeater workbench (request editing is inline; these power the palette
       # and show their key hints — actual keys are handled directly by the TUI) ---
@@ -427,12 +434,13 @@ module Gori
         "detail.probe-active", "Run active scan", "Run the Probe active checks against this flow (shows the request count first)",
         Verb::Scope::HistoryDetail, mnemonic: 'A', group: :send) { |ctx| ctx.close_detail; ctx.probe_active_selected; nil }
 
-      # Delete the open flow (mirrors history.delete). Menu-only 'X' — free in HistoryDetail
-      # (lowercase 'x' is select-line). Confirm runs after the menu closes; the controller
-      # captures the id so a live reload can't retarget the delete.
+      # Delete the open flow (mirrors history.delete, and its letter): menu-only 'D', so the
+      # drill-in does not read `X` as "this one" while the list one keystroke away reads it as
+      # "all of them". Confirm runs after the menu closes; the controller captures the id so a
+      # live reload can't retarget the delete.
       r.register Verb::Definition.new(
         "detail.delete", "Delete flow", "Delete this flow from History (asks first)",
-        Verb::Scope::HistoryDetail, mnemonic: 'X', group: :danger) { |ctx| ctx.history_delete; nil }
+        Verb::Scope::HistoryDetail, mnemonic: 'D', group: :danger) { |ctx| ctx.history_delete; nil }
     end
 
     # Fuzzer/Intruder verbs: the cross-tab "send to Fuzzer" (⇧I from History, palette

--- a/src/gori/verbs/history.cr
+++ b/src/gori/verbs/history.cr
@@ -629,6 +629,17 @@ module Gori
       r.register Verb::Definition.new(
         "mine.duplicate-subtab", "Duplicate subtab", "Open a new miner session with the same request and config",
         Verb::Scope::Miner, available: in_miner, mnemonic: 'd', section: :subtab) { |ctx| ctx.miner_duplicate_subtab; nil }
+      # The strip's `r` rename / ^W close, which `Runner#renameable_subtabs?` and
+      # `#subtab_close` have supported for :miner all along with no verbs to show for it —
+      # so this `:subtab` group held Duplicate alone while six other multi-session tabs
+      # (Repeater, Fuzzer, Comparer, Decoder, JWT, Notes) list all three. 'e'/'w' are free
+      # in COMMON ∪ :subtab here (COMMON: r/s/k/y/v/x/S/R; :subtab: d).
+      r.register Verb::Definition.new(
+        "mine.rename-subtab", "Rename subtab", "Rename the active miner session's sub-tab chip",
+        Verb::Scope::Miner, available: in_miner, mnemonic: 'e', section: :subtab) { |ctx| ctx.miner_rename_subtab; nil }
+      r.register Verb::Definition.new(
+        "mine.close-subtab", "Close subtab", "Close the active miner session",
+        Verb::Scope::Miner, available: in_miner, mnemonic: 'w', section: :subtab) { |ctx| ctx.miner_close_subtab; nil }
 
       # Sub-tab search + inline filter (issue #121), section :tab — brings Miner to full
       # sub-tab parity (it had neither). Both gate on ≥2 sessions. 'f'/'/' are free here.

--- a/src/gori/verbs/history.cr
+++ b/src/gori/verbs/history.cr
@@ -642,9 +642,16 @@ module Gori
       r.register Verb::Definition.new(
         "mine.rename-subtab", "Rename subtab", "Rename the active miner session's sub-tab chip",
         Verb::Scope::Miner, available: in_miner, mnemonic: 'e', section: :subtab) { |ctx| ctx.miner_rename_subtab; nil }
+      # `:common`, not `:subtab` — the space menu renders COMMON ∪ the FOCUSED PANE's section,
+      # so a `:subtab` close is invisible from the body and reachable only after moving focus
+      # to the strip. Decoder and JWT fixed that for themselves; this is the same fix.
+      #
+      # Repeater and Fuzzer deliberately do NOT follow: `repeater.mark-word` / `fuzz.mark-word`
+      # own 'w' in their `:request` / `:template` sections, so a COMMON 'w' would collide there
+      # and `Registry#validate_menu_keys!` would raise at boot. Their close stays in :subtab.
       r.register Verb::Definition.new(
         "mine.close-subtab", "Close subtab", "Close the active miner session",
-        Verb::Scope::Miner, available: in_miner, mnemonic: 'w', section: :subtab) { |ctx| ctx.miner_close_subtab; nil }
+        Verb::Scope::Miner, available: in_miner, mnemonic: 'w') { |ctx| ctx.miner_close_subtab; nil }
 
       # Sub-tab search + inline filter (issue #121), section :tab — brings Miner to full
       # sub-tab parity (it had neither). Both gate on ≥2 sessions. 'f'/'/' are free here.

--- a/src/gori/verbs/history.cr
+++ b/src/gori/verbs/history.cr
@@ -289,7 +289,7 @@ module Gori
       r.register Verb::Definition.new(
         "repeater.toggle-auto-content-length", "Toggle auto Content-Length", "Recompute Content-Length from the body on send",
         Verb::Scope::Repeater, [Verb::Chord.new("l", ctrl: true)],
-        available: in_repeater) { |ctx| ctx.repeater_toggle_auto_content_length; nil }
+        available: in_repeater, mnemonic: 'L', section: :request) { |ctx| ctx.repeater_toggle_auto_content_length; nil }
       r.register Verb::Definition.new(
         "repeater.toggle-http2", "Toggle HTTP/2 (h2)", "Send this request over HTTP/2 or HTTP/1.1, overriding the captured protocol",
         Verb::Scope::Repeater, [Verb::Chord.new("v", ctrl: true)],
@@ -609,13 +609,15 @@ module Gori
         "mine.stop", "Stop mining", "Stop the running mine", Verb::Scope::Miner,
         [Verb::Chord.new("x", ctrl: true)], available: in_miner, mnemonic: 's') { |ctx| ctx.mine_stop; nil }
       # Send the selected finding (injected into the session request) to Repeater. COMMON so
-      # it's reachable from summary/results/detail; gated on a selected finding. 'p' is free
-      # in COMMON ∪ :subtab (COMMON: r/s/k/u; :subtab: d).
+      # it's reachable from summary/results/detail; gated on a selected finding. 'R', not 'p':
+      # `fuzz.repeater` had to move off `r` too and its comment names 'R' as "the letter the
+      # other tabs use for Repeater" — the two tabs with the same problem picked different
+      # answers. 'R' is free in COMMON ∪ :subtab here (COMMON: r/s/k/u; :subtab: d).
       r.register Verb::Definition.new(
         "mine.repeater", "Send to Repeater", "Open the selected finding as a request in Repeater (param injected)",
         Verb::Scope::Miner,
         available: ->(ctx : Verb::ExecContext) { ctx.current_tab == :miner && ctx.miner_finding_selected? },
-        mnemonic: 'p') { |ctx| ctx.mine_repeater_selected; nil }
+        mnemonic: 'R') { |ctx| ctx.mine_repeater_selected; nil }
       # Content-only clone of the active miner session (request + config; no findings).
       # 'd' is free in COMMON ∪ :subtab (COMMON: r/s/k/u/p).
       r.register Verb::Definition.new(

--- a/src/gori/verbs/history.cr
+++ b/src/gori/verbs/history.cr
@@ -417,9 +417,14 @@ module Gori
         "detail.copy-as", "Copy as…", "Pick a copy format for this pane (url/headers/body/cookies/curl/raw)",
         Verb::Scope::HistoryDetail, mnemonic: 'Y', group: :copy) { |ctx| ctx.copy_as_open; nil }
 
+      # 'F' for flow, not 'O': `O` is the OAST-payload letter in three scopes
+      # (`history.oast-copy` in this very list, `repeater.oast-insert`, `fuzzer.oast-insert`),
+      # and HistoryDetail carries no OAST verb — so one `↵` into the drill-in the same letter
+      # silently stopped meaning "OAST payload" and started meaning "copy the whole flow".
+      # `y` cannot take it here: in the detail that is `detail.copy`, the SELECTION copy.
       r.register Verb::Definition.new(
         "detail.copy-flow", "Copy flow", "Copy this flow's raw request to the clipboard",
-        Verb::Scope::HistoryDetail, mnemonic: 'O', group: :copy) { |ctx| ctx.copy_selection; nil }
+        Verb::Scope::HistoryDetail, mnemonic: 'F', group: :copy) { |ctx| ctx.copy_selection; nil }
 
       # Send the open flow to the Fuzzer (mirrors history.fuzz ⇧I/'z' from the list) —
       # close the detail first so it doesn't float over the Fuzzer tab.

--- a/src/gori/verbs/history.cr
+++ b/src/gori/verbs/history.cr
@@ -267,10 +267,16 @@ module Gori
       # request bytes, switch its envelope/decoded split, pretty-print its body —
       # mnemonics added so they front the :request space-menu group (previously
       # ctrl-only, so menu_key was nil and they were invisible there).
+      # 'x', matching its own ^X. It was 'b', and `b` is the app's WHITESPACE letter: the
+      # global reveal is ^B (`view.reveal-ws`) and the History detail binds bare `b` to
+      # `detail.toggle-ws`. So the Repeater's menu read `b` as hex while the drill-in one
+      # keystroke away read it as whitespace. `x` was free in `common ∪ :request` — the
+      # response pane's is not (`repeater.select-line` owns `x` there), which is why
+      # `repeater.toggle-resp-hex` keeps 'h' and `detail.toggle-hex` keeps 'e'.
       r.register Verb::Definition.new(
         "repeater.toggle-hex", "Toggle hex edit", "Edit the request as raw bytes — sends exactly what you type",
         Verb::Scope::Repeater, [Verb::Chord.new("x", ctrl: true)],
-        available: in_repeater, mnemonic: 'b', section: :request) { |ctx| ctx.repeater_toggle_hex; nil }
+        available: in_repeater, mnemonic: 'x', section: :request) { |ctx| ctx.repeater_toggle_hex; nil }
       r.register Verb::Definition.new(
         "repeater.toggle-decoded", "Switch envelope/decoded", "SAML/GraphQL/WS flow: switch envelope/decoded · otherwise: insert a § marker at the cursor",
         Verb::Scope::Repeater, [Verb::Chord.new("t", ctrl: true)],

--- a/src/gori/verbs/history.cr
+++ b/src/gori/verbs/history.cr
@@ -236,9 +236,13 @@ module Gori
       r.register Verb::Definition.new(
         "repeater.insert-marker", "Insert marker", "Drop a single § at the cursor to bracket a region by hand",
         Verb::Scope::Repeater, available: in_repeater, mnemonic: 'i', section: :request) { |ctx| ctx.repeater_insert_marker; nil }
+      # ^K, matching the Fuzzer's. The two panes are the same editor over the same template
+      # grammar, and this was the one marker action reachable in one and not the other —
+      # the Repeater had it on the space menu alone while the Fuzzer had it on a chord.
       r.register Verb::Definition.new(
         "repeater.mark-word", "Mark word", "Toggle a §…§ marker around the token at the cursor",
-        Verb::Scope::Repeater, available: in_repeater, mnemonic: 'w', section: :request) { |ctx| ctx.repeater_mark_word; nil }
+        Verb::Scope::Repeater, [Verb::Chord.new("k", ctrl: true)],
+        available: in_repeater, mnemonic: 'w', section: :request) { |ctx| ctx.repeater_mark_word; nil }
       r.register Verb::Definition.new(
         "repeater.auto-mark", "Auto-mark params", "Wrap every request parameter value in a §…§ marker",
         Verb::Scope::Repeater, [Verb::Chord.new("a", ctrl: true)],
@@ -512,6 +516,18 @@ module Gori
       r.register Verb::Definition.new(
         "fuzz.automark", "Auto-mark params", "Mark every request parameter value", Verb::Scope::Fuzzer,
         [Verb::Chord.new("a", ctrl: true)], available: in_fuzzer, mnemonic: 'm', section: :template) { |ctx| ctx.fuzz_automark; nil }
+      # ^K / ^T, the Repeater's twins by name and by mnemonic. They used to live in
+      # `FuzzerController#chord_action`, dispatched before the keymap ever saw them — which is
+      # why the two marker actions an operator reaches for MOST were the two missing from the
+      # Fuzzer's space menu, and the only ones in the family that could not be rebound.
+      r.register Verb::Definition.new(
+        "fuzz.mark-word", "Mark word", "Toggle a §…§ marker around the token at the cursor",
+        Verb::Scope::Fuzzer, [Verb::Chord.new("k", ctrl: true)],
+        available: in_fuzzer, mnemonic: 'w', section: :template) { |ctx| ctx.fuzz_mark_word; nil }
+      r.register Verb::Definition.new(
+        "fuzz.insert-marker", "Insert marker", "Drop a single § at the cursor to bracket a region by hand",
+        Verb::Scope::Fuzzer, [Verb::Chord.new("t", ctrl: true)],
+        available: in_fuzzer, mnemonic: 'i', section: :template) { |ctx| ctx.fuzz_insert_marker; nil }
       r.register Verb::Definition.new(
         "fuzz.attach-chain", "Edit decoder chain", "Focus the CHAIN pane to edit the encode/decode chain of the marker at the cursor (applied to each payload on send)",
         Verb::Scope::Fuzzer, [Verb::Chord.new("y", ctrl: true)],

--- a/src/gori/verbs/history.cr
+++ b/src/gori/verbs/history.cr
@@ -513,9 +513,13 @@ module Gori
       r.register Verb::Definition.new(
         "fuzz.duplicate-subtab", "Duplicate subtab", "Open a new fuzz session with the same template and config",
         Verb::Scope::Fuzzer, available: in_fuzzer, mnemonic: 'd', section: :subtab) { |ctx| ctx.fuzzer_duplicate_subtab; nil }
+      # Space-menu letters follow the REPEATER's, which is where the muscle memory lives: this
+      # section and `repeater.*`'s `:request` are the same five marker actions, and three of
+      # them disagreed — auto-mark was 'a' there and 'm' here, and attach-chain / clear-marks
+      # were 'c'/'e' there and 'e'/'c' here, i.e. SWAPPED, which is worse than merely different.
       r.register Verb::Definition.new(
         "fuzz.automark", "Auto-mark params", "Mark every request parameter value", Verb::Scope::Fuzzer,
-        [Verb::Chord.new("a", ctrl: true)], available: in_fuzzer, mnemonic: 'm', section: :template) { |ctx| ctx.fuzz_automark; nil }
+        [Verb::Chord.new("a", ctrl: true)], available: in_fuzzer, mnemonic: 'a', section: :template) { |ctx| ctx.fuzz_automark; nil }
       # ^K / ^T, the Repeater's twins by name and by mnemonic. They used to live in
       # `FuzzerController#chord_action`, dispatched before the keymap ever saw them — which is
       # why the two marker actions an operator reaches for MOST were the two missing from the
@@ -531,7 +535,7 @@ module Gori
       r.register Verb::Definition.new(
         "fuzz.attach-chain", "Edit decoder chain", "Focus the CHAIN pane to edit the encode/decode chain of the marker at the cursor (applied to each payload on send)",
         Verb::Scope::Fuzzer, [Verb::Chord.new("y", ctrl: true)],
-        available: in_fuzzer, mnemonic: 'c', section: :template) { |ctx| ctx.fuzz_attach_chain; nil }
+        available: in_fuzzer, mnemonic: 'e', section: :template) { |ctx| ctx.fuzz_attach_chain; nil }
       r.register Verb::Definition.new(
         "fuzz.list-paste", "Add List payload set", "Open the payload-set editor pre-seeded to a List — a multi-line editor, one value per line (paste splits automatically)",
         Verb::Scope::Fuzzer, [Verb::Chord.new("l", ctrl: true)],
@@ -546,7 +550,7 @@ module Gori
         available: in_fuzzer, mnemonic: 'h', section: :template) { |ctx| ctx.fuzz_toggle_http2; nil }
       r.register Verb::Definition.new(
         "fuzz.clear-marks", "Clear markers", "Strip every §…§ marker (and its attached chain) from the template",
-        Verb::Scope::Fuzzer, available: in_fuzzer, mnemonic: 'e', section: :template) { |ctx| ctx.fuzz_clear_marks; nil }
+        Verb::Scope::Fuzzer, available: in_fuzzer, mnemonic: 'c', section: :template) { |ctx| ctx.fuzz_clear_marks; nil }
       # Target-pane toggle (SNI override), the twin of repeater.toggle-sni: same ^S, same
       # two-line editor, same focus rule. `FuzzerView` already carried @sni, persisted it
       # with the session and handed it to build_engine — a session seeded from History had

--- a/src/gori/verbs/jwt.cr
+++ b/src/gori/verbs/jwt.cr
@@ -18,7 +18,8 @@ module Gori
         Verb::Scope::Jwt, available: in_jwt, mnemonic: 'w') { |ctx| ctx.jwt_close; nil }
       r.register Verb::Definition.new(
         "jwt.toggle-mode", "Toggle decode/encode", "Flip between the DECODE and ENCODE lenses",
-        Verb::Scope::Jwt, available: in_jwt, mnemonic: 'e') { |ctx| ctx.jwt_toggle_mode; nil }
+        Verb::Scope::Jwt, [Verb::Chord.new("t", ctrl: true)],
+        available: in_jwt, mnemonic: 'e') { |ctx| ctx.jwt_toggle_mode; nil }
       r.register Verb::Definition.new(
         "jwt.cycle-alg", "Cycle signing alg", "Cycle the signing algorithm: HS256 / HS384 / HS512 / none",
         Verb::Scope::Jwt, [Verb::Chord.new("a", ctrl: true)], available: in_jwt, mnemonic: 'a') { |ctx| ctx.jwt_cycle_alg; nil }

--- a/src/gori/verbs/jwt.cr
+++ b/src/gori/verbs/jwt.cr
@@ -21,13 +21,13 @@ module Gori
         Verb::Scope::Jwt, available: in_jwt, mnemonic: 'e') { |ctx| ctx.jwt_toggle_mode; nil }
       r.register Verb::Definition.new(
         "jwt.cycle-alg", "Cycle signing alg", "Cycle the signing algorithm: HS256 / HS384 / HS512 / none",
-        Verb::Scope::Jwt, available: in_jwt, mnemonic: 'a') { |ctx| ctx.jwt_cycle_alg; nil }
+        Verb::Scope::Jwt, [Verb::Chord.new("a", ctrl: true)], available: in_jwt, mnemonic: 'a') { |ctx| ctx.jwt_cycle_alg; nil }
       r.register Verb::Definition.new(
         "jwt.load-decoded", "Load decoded claims", "Seed the ENCODE editors from the INPUT token's header + payload",
         Verb::Scope::Jwt, available: in_jwt, mnemonic: 'l') { |ctx| ctx.jwt_load_decoded; nil }
       r.register Verb::Definition.new(
         "jwt.clear", "Clear session", "Clear the token, editors, and secret of the active session",
-        Verb::Scope::Jwt, available: in_jwt, mnemonic: 'k') { |ctx| ctx.jwt_clear; nil }
+        Verb::Scope::Jwt, [Verb::Chord.new("l", ctrl: true)], available: in_jwt, mnemonic: 'k') { |ctx| ctx.jwt_clear; nil }
 
       # The single smart Copy (selection if any, else the focused pane) — chord 'y'.
       in_jwt_read = ->(ctx : Verb::ExecContext) { ctx.current_tab == :jwt && ctx.jwt_read_mode? }

--- a/src/gori/verbs/notes.cr
+++ b/src/gori/verbs/notes.cr
@@ -54,8 +54,10 @@ module Gori
       # Export the note as Markdown. Mnemonic 'E', not 'e' or 'x': 'e' is Edit-in-$EDITOR
       # and 'x' is read_edit.cr's Select line, both already in this scope. A capital follows
       # the precedent 'S' (Send selection to) sets right next to it. No chord either — the
-      # Notes body swallows every printable key, so the space menu and the palette are the
-      # only surfaces this can be reached from.
+      # NO chord, unlike `issues.export-key` / `sequence.export` which both bind ⇧E — and that
+      # is not drift. Those two surfaces are LISTS; this one is a full-text editor, so ⇧E is
+      # the printable character `E` and would be typed into the note rather than exporting it.
+      # The space menu and the palette are the only ways in, by construction.
       r.register Verb::Definition.new(
         "notes.export", "Export note…", "Write the current note's text to a Markdown file",
         Verb::Scope::Notes, available: in_notes, mnemonic: 'E') { |ctx| ctx.notes_export; nil }

--- a/src/gori/verbs/oast.cr
+++ b/src/gori/verbs/oast.cr
@@ -52,9 +52,11 @@ module Gori
         available: ->(ctx : Verb::ExecContext) { ctx.oast_callback_selected? },
         mnemonic: 'a', group: :triage) { |ctx| ctx.oast_issue_create; nil }
 
-      r.register Verb::Definition.new(
-        "oast.callbacks-to-menu", "Back to menu", "Move focus up to the tab menu",
-        Verb::Scope::OastCallbacks, [Verb::Chord.new("escape")], hidden: true) { |ctx| ctx.focus_pane(:menu); nil }
+      # No `escape` verb for either sub-tab. `OastController#handle_callbacks_key` /
+      # `#handle_providers_key` claim escape first and return true, so a registration here
+      # could never fire — and the two that used to sit here said `focus_pane(:menu)` while
+      # the live handler goes to `:subtabs`, which is where the tab's `esc tabs` hint came
+      # from. Escape is the controller's, and the hint now says `esc sub-tabs`.
 
       # --- Providers sub-tab (a/e/t/d handled in the controller body; menu-only here) ---
       r.register Verb::Definition.new(
@@ -72,10 +74,6 @@ module Gori
       r.register Verb::Definition.new(
         "oast.delete-provider", "Delete provider", "Delete the selected provider (keeps its callback history)",
         Verb::Scope::OastProviders, [] of Verb::Chord, mnemonic: 'd') { |ctx| ctx.oast_delete_provider; nil }
-
-      r.register Verb::Definition.new(
-        "oast.providers-to-menu", "Back to menu", "Move focus up to the tab menu",
-        Verb::Scope::OastProviders, [Verb::Chord.new("escape")], hidden: true) { |ctx| ctx.focus_pane(:menu); nil }
 
       # --- cross-tab: insert / copy a fresh OAST payload (gated on an active listener) ---
       insert_avail = ->(tab : Symbol) {

--- a/src/gori/verbs/oast.cr
+++ b/src/gori/verbs/oast.cr
@@ -69,7 +69,7 @@ module Gori
 
       r.register Verb::Definition.new(
         "oast.toggle-provider", "Enable / disable", "Toggle the selected provider on or off",
-        Verb::Scope::OastProviders, [] of Verb::Chord, mnemonic: 't') { |ctx| ctx.oast_toggle_provider; nil }
+        Verb::Scope::OastProviders, [] of Verb::Chord, mnemonic: 'x') { |ctx| ctx.oast_toggle_provider; nil }
 
       r.register Verb::Definition.new(
         "oast.delete-provider", "Delete provider", "Delete the selected provider (keeps its callback history)",

--- a/src/gori/verbs/probe.cr
+++ b/src/gori/verbs/probe.cr
@@ -84,9 +84,15 @@ module Gori
         "probe.delete-selected", "Delete issue", "Delete the selected issue",
         Verb::Scope::Probe, [Verb::Chord.new("d")], group: :danger) { |ctx| ctx.probe_delete; nil }
 
+      # NO bare chord. This wipes every Probe issue in the project, and it used to answer a
+      # single `x` — one chip to the right, on the Rules sub-tab, `x` is a harmless enable
+      # toggle. Two meanings that far apart do not belong on the same unmodified letter, and
+      # no Probe hint ever named this one, so the destructive reading was the unadvertised
+      # one. It keeps its space-menu entry under `X` (the menu is the deliberate path for a
+      # :danger verb) and stays reachable from the palette; the confirm still gates it.
       r.register Verb::Definition.new(
         "probe.clear", "Clear issues", "Delete all Probe issues for this project", Verb::Scope::Probe,
-        [Verb::Chord.new("x")], group: :danger) { |ctx| ctx.probe_clear; nil }
+        mnemonic: 'X', group: :danger) { |ctx| ctx.probe_clear; nil }
 
       r.register Verb::Definition.new(
         "probe.leave", "Back to menu", "Return focus to the tab menu", Verb::Scope::Probe,
@@ -121,15 +127,22 @@ module Gori
       # Nav (↑/↓, j/k) + Esc→strip are controller-claimed; these are the actions. edit/delete are
       # gated to a selected CUSTOM rule (built-ins can't be edited/removed, only toggled).
       probe_custom = ->(ctx : Verb::ExecContext) { ctx.probe_custom_rule_selected? }
+      # `x` alone, and the space-menu key is `x` too — the same letter the Rewriter and
+      # Colormarker rule lists use for the same action, where it used to be `t` here.
+      #
+      # ↵ is deliberately NOT bound: it toggles in no other rule list. Eight of them (rewrite,
+      # colour, extract, scope, host, env, and the two global editors) open the editor on ↵,
+      # so a reflex carried from any of them silently disabled a scanning rule here.
       r.register Verb::Definition.new(
         "probe-rules.toggle", "Toggle rule", "Enable or disable the selected rule",
-        Verb::Scope::ProbeRules, [Verb::Chord.new("enter"), Verb::Chord.new("x")], mnemonic: 't') { |ctx| ctx.probe_rule_toggle; nil }
+        Verb::Scope::ProbeRules, [Verb::Chord.new("x")], mnemonic: 'x') { |ctx| ctx.probe_rule_toggle; nil }
       r.register Verb::Definition.new(
         "probe-rules.add", "Add custom rule", "Open the popup to add a custom match rule",
         Verb::Scope::ProbeRules, [Verb::Chord.new("a")]) { |ctx| ctx.probe_rule_add; nil }
       r.register Verb::Definition.new(
         "probe-rules.edit", "Edit custom rule", "Edit the selected custom rule",
-        Verb::Scope::ProbeRules, [Verb::Chord.new("e")], available: probe_custom) { |ctx| ctx.probe_rule_edit; nil }
+        Verb::Scope::ProbeRules, [Verb::Chord.new("enter"), Verb::Chord.new("e")],
+        mnemonic: 'e', available: probe_custom) { |ctx| ctx.probe_rule_edit; nil }
       r.register Verb::Definition.new(
         "probe-rules.delete", "Delete custom rule", "Delete the selected custom rule",
         Verb::Scope::ProbeRules, [Verb::Chord.new("d")], available: probe_custom) { |ctx| ctx.probe_rule_delete; nil }

--- a/src/gori/verbs/rewriter.cr
+++ b/src/gori/verbs/rewriter.cr
@@ -15,27 +15,41 @@ module Gori
     # leak `Runner#rewriter_rule_selected?` documents, one axis over: it remembered `@sub` and
     # forgot `@focus`.
     def self.register_rewriter(r : Verb::Registry) : Nil
-      in_rw = ->(ctx : Verb::ExecContext) { ctx.current_tab == :rewriter }
-      has_rule = ->(ctx : Verb::ExecContext) { ctx.current_tab == :rewriter && ctx.rewriter_rule_selected? }
+      # Both gates now ask about FOCUS, not just the sub-tab. They have to: these verbs carry
+      # real chords, and the preview panes share this body — `d` with the preview focused
+      # would delete the rule sitting behind it. The space menu was already safe by another
+      # route (`command_section` answers :preview there, and every verb here is
+      # `section: :rules`), but a chord has no section to hide behind.
+      in_rw = ->(ctx : Verb::ExecContext) { ctx.current_tab == :rewriter && ctx.rewriter_rule_list_focused? }
+      has_rule = ->(ctx : Verb::ExecContext) do
+        ctx.current_tab == :rewriter && ctx.rewriter_rule_list_focused? && ctx.rewriter_rule_selected?
+      end
 
       r.register Verb::Definition.new(
         "rewriter.add", "Add rule", "Open the editor to add a Match & Replace rule",
-        Verb::Scope::Rewriter, available: in_rw, mnemonic: 'a', section: :rules) { |ctx| ctx.rewriter_add; nil }
+        Verb::Scope::Rewriter, [Verb::Chord.new("a")], available: in_rw, mnemonic: 'a', section: :rules) { |ctx| ctx.rewriter_add; nil }
       r.register Verb::Definition.new(
         "rewriter.edit", "Edit rule", "Edit the selected rule in the popup editor",
-        Verb::Scope::Rewriter, available: has_rule, mnemonic: 'e', section: :rules) { |ctx| ctx.rewriter_edit; nil }
+        Verb::Scope::Rewriter, [Verb::Chord.new("enter"), Verb::Chord.new("e")], available: has_rule, mnemonic: 'e', section: :rules) { |ctx| ctx.rewriter_edit; nil }
+      # The ONE rule verb with no chord, and the reason the whole list used to be hand-rolled:
+      # `rewriter.select-line` (read_edit.cr) already binds bare `x` in this SCOPE for the
+      # preview pane. Two `section:`s never render together, so the space menu is fine with
+      # `x` meaning two things — but `Keymap#lookup` is keyed by scope alone and returns ONE
+      # id, so a second `x` here would simply shadow one of them (keymap_spec catches it).
+      # The keymap has no focus dimension; `RewriterController` does, so `x` stays there.
+      # Colormarker could take `x` because it has no read pane at all.
       r.register Verb::Definition.new(
         "rewriter.toggle", "Enable/disable", "Toggle the selected rule on or off in THIS project",
         Verb::Scope::Rewriter, available: has_rule, mnemonic: 'x', section: :rules) { |ctx| ctx.rewriter_toggle; nil }
       r.register Verb::Definition.new(
         "rewriter.delete", "Delete rule", "Delete the selected rule (confirms first)",
-        Verb::Scope::Rewriter, available: has_rule, mnemonic: 'd', section: :rules) { |ctx| ctx.rewriter_delete; nil }
+        Verb::Scope::Rewriter, [Verb::Chord.new("d")], available: has_rule, mnemonic: 'd', section: :rules) { |ctx| ctx.rewriter_delete; nil }
       r.register Verb::Definition.new(
         "rewriter.move-up", "Move up", "Move the selected rule earlier in apply order",
-        Verb::Scope::Rewriter, available: has_rule, mnemonic: 'u', section: :rules) { |ctx| ctx.rewriter_move(-1); nil }
+        Verb::Scope::Rewriter, [Verb::Chord.new("k", shift: true)], available: has_rule, mnemonic: 'u', section: :rules) { |ctx| ctx.rewriter_move(-1); nil }
       r.register Verb::Definition.new(
         "rewriter.move-down", "Move down", "Move the selected rule later in apply order",
-        Verb::Scope::Rewriter, available: has_rule, mnemonic: 'n', section: :rules) { |ctx| ctx.rewriter_move(1); nil }
+        Verb::Scope::Rewriter, [Verb::Chord.new("j", shift: true)], available: has_rule, mnemonic: 'n', section: :rules) { |ctx| ctx.rewriter_move(1); nil }
       r.register Verb::Definition.new(
         "rewriter.duplicate", "Duplicate rule", "Copy the selected rule into a new one",
         Verb::Scope::Rewriter, available: has_rule, mnemonic: 'c', section: :rules) { |ctx| ctx.rewriter_duplicate; nil }
@@ -52,14 +66,17 @@ module Gori
       # default to flip: `x` IS its state. Both gate on a selected rule for the reason
       # `rewriter_rule_selected?` documents — the menu must not act on a row the operator
       # cannot see from the `extract` / `bindings` sub-tabs.
-      global_rule = ->(ctx : Verb::ExecContext) { ctx.current_tab == :rewriter && ctx.rewriter_global_rule_selected? }
+      global_rule = ->(ctx : Verb::ExecContext) do
+        ctx.current_tab == :rewriter && ctx.rewriter_rule_list_focused? && ctx.rewriter_global_rule_selected?
+      end
       r.register Verb::Definition.new(
         "rewriter.scope", "Global/project", "Move the selected rule between this project and the global library",
-        Verb::Scope::Rewriter, available: has_rule, mnemonic: 's', section: :rules) { |ctx| ctx.rewriter_scope_toggle; nil }
+        Verb::Scope::Rewriter, [Verb::Chord.new("s")], available: has_rule, mnemonic: 's', section: :rules) { |ctx| ctx.rewriter_scope_toggle; nil }
       r.register Verb::Definition.new(
         "rewriter.toggle-default", "Enable/disable everywhere",
         "Flip a global rule's default — what every project that hasn't overridden it follows",
-        Verb::Scope::Rewriter, available: global_rule, mnemonic: 'g', section: :rules) { |ctx| ctx.rewriter_toggle_default; nil }
+        Verb::Scope::Rewriter, [Verb::Chord.new("x", shift: true)],
+        available: global_rule, mnemonic: 'X', section: :rules) { |ctx| ctx.rewriter_toggle_default; nil }
     end
   end
 end

--- a/src/gori/verbs/sequencer.cr
+++ b/src/gori/verbs/sequencer.cr
@@ -73,9 +73,16 @@ module Gori
       r.register Verb::Definition.new(
         "sequence.rename-subtab", "Rename subtab", "Rename the active sequencing session's sub-tab chip",
         Verb::Scope::Sequencer, available: in_seq, mnemonic: 'e', section: :subtab) { |ctx| ctx.sequencer_rename_subtab; nil }
+      # `:common`, not `:subtab` — the space menu renders COMMON ∪ the FOCUSED PANE's section,
+      # so a `:subtab` close is invisible from the body and reachable only after moving focus
+      # to the strip. Decoder and JWT fixed that for themselves; this is the same fix.
+      #
+      # Repeater and Fuzzer deliberately do NOT follow: `repeater.mark-word` / `fuzz.mark-word`
+      # own 'w' in their `:request` / `:template` sections, so a COMMON 'w' would collide there
+      # and `Registry#validate_menu_keys!` would raise at boot. Their close stays in :subtab.
       r.register Verb::Definition.new(
         "sequence.close-subtab", "Close subtab", "Close the active sequencing session",
-        Verb::Scope::Sequencer, available: in_seq, mnemonic: 'w', section: :subtab) { |ctx| ctx.sequencer_close_subtab; nil }
+        Verb::Scope::Sequencer, available: in_seq, mnemonic: 'w') { |ctx| ctx.sequencer_close_subtab; nil }
       r.register Verb::Definition.new(
         "sequence.find-subtab", "Search sub-tabs", "Filter the open sequencing sessions and jump to one",
         Verb::Scope::Sequencer,

--- a/src/gori/verbs/sequencer.cr
+++ b/src/gori/verbs/sequencer.cr
@@ -65,6 +65,17 @@ module Gori
         Verb::Scope::Sequencer, [] of Verb::Chord, available: has_report,
         mnemonic: 'i') { |ctx| ctx.sequence_promote; nil }
 
+      # The strip's `r` rename / ^W close. `Runner#renameable_subtabs?` and `#subtab_close`
+      # have listed :sequencer all along, but with no verbs this tab had NO `:subtab` menu
+      # group at all — the only multi-session tab without one. 'e'/'w' are free in
+      # COMMON ∪ :subtab (COMMON: r/s/c/i/x/y/v/S/E/J).
+      in_seq = ->(ctx : Verb::ExecContext) { ctx.current_tab == :sequencer }
+      r.register Verb::Definition.new(
+        "sequence.rename-subtab", "Rename subtab", "Rename the active sequencing session's sub-tab chip",
+        Verb::Scope::Sequencer, available: in_seq, mnemonic: 'e', section: :subtab) { |ctx| ctx.sequencer_rename_subtab; nil }
+      r.register Verb::Definition.new(
+        "sequence.close-subtab", "Close subtab", "Close the active sequencing session",
+        Verb::Scope::Sequencer, available: in_seq, mnemonic: 'w', section: :subtab) { |ctx| ctx.sequencer_close_subtab; nil }
       r.register Verb::Definition.new(
         "sequence.find-subtab", "Search sub-tabs", "Filter the open sequencing sessions and jump to one",
         Verb::Scope::Sequencer,

--- a/src/gori/verbs/sequencer.cr
+++ b/src/gori/verbs/sequencer.cr
@@ -51,9 +51,15 @@ module Gori
         "sequence.export", "Export report…", "Write this session's randomness report to a Markdown file (asks for the path)",
         Verb::Scope::Sequencer, [Verb::Chord.new("e", shift: true)], available: has_report,
         mnemonic: 'E') { |ctx| ctx.sequence_export(:markdown); nil }
+      # 'J', because without a mnemonic AND without a chord this verb was reachable from
+      # NOTHING: `menu_key` returns nil, `SpaceMenu#open` filters on `menu_key`, and the
+      # palette only queries Global scope — so a shipped export had no keyboard path at all.
+      # Its Markdown twin four lines up carries ⇧E + 'E'; Issues solves the same two-format
+      # problem by registering the palette entries in `Scope::Global` instead.
       r.register Verb::Definition.new(
         "sequence.export-json", "Export report (JSON)…", "Write this session's randomness report to a JSON file (asks for the path)",
-        Verb::Scope::Sequencer, [] of Verb::Chord, available: has_report) { |ctx| ctx.sequence_export(:json); nil }
+        Verb::Scope::Sequencer, [] of Verb::Chord, available: has_report,
+        mnemonic: 'J') { |ctx| ctx.sequence_export(:json); nil }
       r.register Verb::Definition.new(
         "sequence.promote", "File as issue", "Record this randomness verdict in the Issues report (no token values)",
         Verb::Scope::Sequencer, [] of Verb::Chord, available: has_report,

--- a/src/gori/verbs/sitemap.cr
+++ b/src/gori/verbs/sitemap.cr
@@ -66,13 +66,19 @@ module Gori
         available: ->(ctx : Verb::ExecContext) { ctx.sitemap_marked_count > 0 },
         mnemonic: 'N') { |ctx| ctx.sitemap_mark_clear; nil }
 
-      # ⇧T — tag the selected path (or every marked path) with a free-text memo; a group fold
-      # node toasts. The chord is Chord.new("t", shift: true), NOT Chord.new("T") —
-      # Keybind.from_event normalises a typed capital to shift+lowercase, so a "T" chord would
-      # never fire; menu_key skips shift chords, hence the explicit mnemonic.
+      # Tag the selected path (or every marked path) with a free-text memo; a group fold node
+      # toasts. MENU-ONLY, on 'T'.
+      #
+      # It used to hold the ⇧T chord, and that was the one letter whose MEANING changed
+      # between sibling list tabs: History, Issues and Intercept all read `t`/⇧T as
+      # "mark / mark all", so a hand that learnt the pair there opened a text prompt here.
+      # ⇧T is deliberately left UNBOUND in this scope rather than reassigned — see
+      # `sitemap.mark-toggle` above for why a tree has no useful "mark every row" today, and
+      # keep the letter free for the day one is worth having. Tagging loses nothing by being
+      # a space-menu entry: `sitemap.mark-clear` is menu-only for the same reason.
       r.register Verb::Definition.new(
         "sitemap.tag", "Tag path", "Pin a free-text memo to the selected — or every marked — path (filter with tag:)",
-        Verb::Scope::Sitemap, [Verb::Chord.new("t", shift: true)],
+        Verb::Scope::Sitemap,
         mnemonic: 'T', group: :triage) { |ctx| ctx.sitemap_tag; nil }
 
       # `g` — fold/unfold path-param ids (/users/<uuid> → {uuid}, /users/1,2,3… → [1, 2, 3 … +N]).


### PR DESCRIPTION
A consistency sweep across the whole TUI, in five passes. Each pass started as "these two
screens look different", and each one turned up defects underneath the cosmetics — the
inconsistency was usually a symptom, not the disease.

## Where it started

The Rewriter and Colormarker pages looked nothing like the Repeater. The real axis was not
per-file drift but **two design languages**: `Frame`'s shared chrome helpers were used by every
workbench tab and by **none** of the policy/settings pages, which hand-rolled their own card
meta, scroll indicators and cyclers.

Fixing that surfaced a geometry bug: `ColormarkerView#render` steals the bottom row for a note,
and `row_capacity`/`row_at` did not — so the last rule hid under the note and a click on the
note resolved to a phantom index. Its twin `RewriterView` had subtracted the row correctly all
along. Copy-paste, then only one side fixed.

## What each pass found

**Chrome.** Scroll gauges were missing from ten lists including the four an operator lives in.
Card-border meta was copy-pasted at eight sites with five different guard constants. Thirteen
forms had three dialects of `‹/›` cycler. Six cards baked a count into their TITLE, which made
the title's *width* a moving target — and two views derive a badge's `min_x` from exactly that
width, so chrome shifted as a number gained a digit.

**Wording and keys.** `esc tabs` was a lie on six tabs. The Fuzzer's SNI badge overpainted its
mode chip, so clicking the visible `SNI` letters toggled insert — the Repeater had fixed the
identical bug and the fix was never ported.

**Colour.** `theme.cr` states "only HTTP status keeps functional colour"; there were 69 yellows,
68 reds and 50 greens. The Repeater painted 4xx **red in one pane and yellow in another, twenty
lines apart in one file**. Severity and triage status drew from one ladder five columns apart,
so `CRIT conf` was two reds meaning two different things. Capture on/off differed by hue alone —
invisible on HIGH_CONTRAST, where accent, text and text_bright are all `#ffffff`.

**The pointer.** Draw-vs-hit desync had already shipped three times, so this pass swept it: the
Fuzzer's RESULTS badges stayed live over the RESULT DETAIL card that replaced them; the Decoder
and JWT drew their mode badge only when focused and hit-tested it always; the Repeater's
RESPONSE chips clipped on draw and not on hit. `Frame.right_badge_hit` `break`ed where the draw
`next`s — the root of a whole class, fixed in the helper. Colormarker's double-click was dead
code: the shell gated it on `supports_drag?`, and a list with no text answers that false.

Scroll gauges were drawn at 46 sites with no hit-test anywhere. They are clickable now, and the
answer differs by what owns the scroll: `TextArea` and `ReadPane` take an offset — two methods
covering every editor and read pane in the app — while a list whose scroll is *derived* from its
selection takes a row, because setting its offset would be undone on the next render.

**The keys.** `X` deleted one flow in History and wiped **every issue** in Probe. `space C` was
Send to Comparer in the Repeater and Clear-All-History one tab over. Help told the Fuzzer
operator `^U` clears markers — `^U` is pretty-print, and clear-marks has no chord at all, so the
advertised key silently reflowed the template you had just finished marking. `sequence.export-json`
was reachable from **nothing**. Miner, JWT and OAST had no Help section while Sequencer — also
default-hidden — had a full one. Decoder, JWT, Rewriter and Colormarker hardcoded their keys
before the keymap, so they could not be rebound; converting them needed a defer guard first,
which is precisely *why* they were hardcoded.

## Two things worth knowing

**Source-grep specs must be control-run.** Four times a passing spec caught nothing. Twice the
regex matched **my own comment explaining the rule it enforces** — including one control run that
passed with the fix deleted. Those specs read code with comments stripped now.

**Twice, "the majority" was the un-fixed side.** The Sitemap's missing mark-all and the sub-tab
close section both looked like drift and both had a written rationale — found only when I went to
change them, once by a spec failing. Look for the comment that made the difference before
levelling it.

## Verification

`crystal spec` green (7878 examples; the 8 `capture_status`/`project_registry` failures are the
standing local-environment ones — a gori holding `:8070`). `crystal tool format` on touched files
only. Ameba unchanged against baseline. Every new rule control-run — reverted, confirmed failing.
Behaviour verified in a live TUI where a spec cannot see it: the Decoder badge surviving a focus
change, `a` reaching the keymap in Colormarker and the Rewriter, and `a` typing a character when
the Rewriter's preview has focus instead of opening the add dialog.

Reviewed with `/code-review`: three findings fixed in 10a7f753, two left standing with the
reasoning recorded in the commit.

https://claude.ai/code/session_012aoiM5pA9yPJQXDH1gGXoh