### PR TITLE
Harden OAST against silent evidence loss and OOM

### DIFF
--- a/spec/oast/engine_spec.cr
+++ b/spec/oast/engine_spec.cr
@@ -76,6 +76,21 @@ private class RecordingHttp < FakeHttp
   end
 end
 
+# A shift-sequenced Http: each call pops the next scripted {status, body}. postbin polls by
+# destructively shifting the bin one request at a time, so this models a bin that returns good
+# requests and then a malformed body (a proxy or rate-limit page served with a 200).
+private class SeqHttp < O::Http
+  def initialize(@responses : Array(Tuple(Int32, String)))
+  end
+
+  def request(method : String, url : String,
+              headers : Hash(String, String) = {} of String => String,
+              body : String? = nil) : O::Http::Response
+    status, body_str = @responses.shift? || {404, ""}
+    O::Http::Response.new(status, body_str)
+  end
+end
+
 describe Gori::Oast do
   describe O::RsaKeyPair do
     it "generates a 2048 key and exports a valid SPKI PEM that round-trips" do
@@ -286,6 +301,21 @@ describe Gori::Oast do
       results.first.method.should eq("GET")
       results.first.source_ip.should eq("10.0.0.1")
       results.first.unique_id.empty?.should be_false
+    end
+  end
+
+  describe O::Postbin do
+    # Regression: a malformed body on a LATER shift must not discard the interactions already
+    # shifted off the bin this cycle. The shifts are destructive server-side, so a raise out of
+    # poll would lose them for good.
+    it "keeps the interactions already shifted when a later shift returns a malformed body" do
+      provider = O::Postbin.new("https://postb.in")
+      session = O::Session.new(1_i64, O::ProviderKind::Postbin, "https://postb.in", "binid", "", token: "binid")
+      good = ->(id : String) { {200, {"reqId" => id, "method" => "GET", "path" => "/#{id}"}.to_json} }
+      http = SeqHttp.new([good.call("a"), good.call("b"), {200, "<html>rate limited</html>"}])
+      results = provider.poll(http, session) # must NOT raise
+      results.size.should eq(2)
+      results.map(&.unique_id).should eq(["a", "b"])
     end
   end
 

--- a/spec/probe/oast_bridge_spec.cr
+++ b/spec/probe/oast_bridge_spec.cr
@@ -167,6 +167,20 @@ describe Gori::Probe::OutOfBand do
     end
   end
 
+  it "mints against the most-recently-polled session, not merely the newest row" do
+    oob_store do |store|
+      old_id = store.insert_oast_session(nil, "interactsh", "https://oast.pro", "corrold", "s", nil, nil)
+      new_id = store.insert_oast_session(nil, "interactsh", "https://oast.pro", "corrnew", "s", nil, nil)
+      # With neither session polled yet, the newest row wins (the old default).
+      Gori::Probe::OutOfBand::StoreMinter.build(store).not_nil!.session_id.should eq(new_id)
+      # But once the OLDER session is the one being polled (a live listener's heartbeat), the
+      # minter follows it — so its payloads land where a callback will actually be read, instead
+      # of against the newer row that was started and stopped.
+      store.touch_oast_session(old_id)
+      Gori::Probe::OutOfBand::StoreMinter.build(store).not_nil!.session_id.should eq(old_id)
+    end
+  end
+
   it "leaves an unanswered probe outstanding (no callback ⇒ no finding)" do
     oob_store do |store|
       store.insert_probe_oast_probe("tok-lonely", "tok-lonely.oast.example", 7_i64, "ssrf_oast",

--- a/src/gori/oast/http.cr
+++ b/src/gori/oast/http.cr
@@ -20,6 +20,14 @@ module Gori::Oast
   class HttpClient < Http
     TIMEOUT = 20.seconds
 
+    # Hard ceiling on a single response body we will buffer. OAST talks to third-party interaction
+    # servers whose content the rest of the engine already treats as adversarial (an interactsh-
+    # class domain collects unsolicited scanner traffic); a hostile or broken one answering a poll
+    # with a multi-gigabyte body would exhaust memory before any per-row cap applies, since TIMEOUT
+    # bounds only time, not bytes. A poll response is base64 callback records — real ones are
+    # kilobytes — so 16 MiB is orders past legitimate and still safe to hold.
+    MAX_BODY = 16 * 1024 * 1024
+
     def initialize(@verify_tls : Bool = true)
     end
 
@@ -42,11 +50,37 @@ module Gori::Oast
       hdrs = HTTP::Headers.new
       headers.each { |k, v| hdrs[k] = v }
       begin
-        resp = client.exec(method.upcase, request_target(uri), headers: hdrs, body: body)
-        Response.new(resp.status_code, resp.body)
+        # Stream the body so an over-cap response is refused as it arrives — the non-streaming
+        # `resp.body` would buffer the whole thing into memory first, which is the exhaustion this
+        # guards against.
+        status = 0
+        payload = ""
+        client.exec(method.upcase, request_target(uri), headers: hdrs, body: body) do |resp|
+          status = resp.status_code
+          payload = read_capped(resp.body_io, host)
+        end
+        Response.new(status, payload)
       ensure
         client.close
       end
+    end
+
+    # Read `io` fully into a String, raising once it would exceed MAX_BODY. A clean engine error
+    # (the poller / CLI / MCP already surface it as a poll error) beats an out-of-memory kill.
+    private def read_capped(io : IO, host : String) : String
+      mem = IO::Memory.new
+      buf = Bytes.new(64 * 1024)
+      total = 0_i64
+      loop do
+        n = io.read(buf)
+        break if n == 0
+        total += n
+        if total > MAX_BODY
+          raise Gori::Error.new("OAST: response body from #{host} exceeded #{MAX_BODY // (1024 * 1024)} MiB — refusing to buffer it")
+        end
+        mem.write(buf[0, n])
+      end
+      mem.to_s
     end
 
     private def request_target(uri : URI) : String

--- a/src/gori/oast/providers/interactsh.cr
+++ b/src/gori/oast/providers/interactsh.cr
@@ -70,9 +70,16 @@ module Gori::Oast
       data.each do |item|
         b64 = item.as_s?
         next unless b64
-        plaintext = decrypt_interaction(session, aes_key, Base64.decode(b64))
-        next unless plaintext
-        out << to_interaction(parse_json(plaintext))
+        # One malformed item must not sink the batch: interactsh delivers a whole poll at once and
+        # marks it consumed server-side, so a raise out of Base64.decode / parse_json here would
+        # drop the siblings that decoded fine. Skip the bad item; keep the good ones.
+        begin
+          plaintext = decrypt_interaction(session, aes_key, Base64.decode(b64))
+          next unless plaintext
+          out << to_interaction(parse_json(plaintext))
+        rescue
+          next
+        end
       end
       out
     end

--- a/src/gori/oast/providers/postbin.cr
+++ b/src/gori/oast/providers/postbin.cr
@@ -29,7 +29,17 @@ module Gori::Oast
         resp = http.request("GET", "#{base_url}/api/bin/#{session.correlation_id}/req/shift")
         break if resp.status == 404 # bin drained
         break unless resp.status == 200
-        it = to_interaction(parse_json(resp.body))
+        # Each shift has ALREADY removed this request from the bin server-side, so a raise on a
+        # malformed body (a proxy error page or a rate-limit HTML served with a 200) would discard
+        # every interaction shifted so far THIS cycle — unrecoverably, since the bin no longer
+        # holds them. Keep what parsed and stop; the poller drains the remainder next cycle.
+        # (parse_time already guards the timestamp field for the same reason; this guards the body
+        # parse sitting above it.)
+        it = begin
+          to_interaction(parse_json(resp.body))
+        rescue
+          break
+        end
         out << it if it
       end
       out

--- a/src/gori/probe/out_of_band.cr
+++ b/src/gori/probe/out_of_band.cr
@@ -69,11 +69,12 @@ module Gori
         getter session_id : Int64
 
         # nil when this project has no OAST session to mint from — the ordinary state, and the
-        # reason every OAST rule plans nothing rather than erroring. The NEWEST session wins:
-        # sessions accumulate across a project's life and only the most recent one is plausibly
-        # still being polled, so an older row would mint payloads whose callbacks nobody reads.
+        # reason every OAST rule plans nothing rather than erroring. The most-recently-POLLED
+        # session wins (see pick_session): sessions accumulate across a project's life, and the one
+        # a listener is actively polling is where a callback will be read — not necessarily the
+        # newest row, which may have been registered and then stopped.
         def self.build(store : Store) : StoreMinter?
-          rec = store.oast_sessions.last?
+          rec = pick_session(store.oast_sessions)
           return nil unless rec
           kind = Oast::ProviderKind.parse?(rec.kind)
           return nil unless kind
@@ -83,6 +84,17 @@ module Gori
           new(provider, session)
         rescue DB::Error | SQLite3::Exception
           nil
+        end
+
+        # The session a fresh payload should mint against: the one something is actually polling.
+        # A live TUI listener heartbeats `last_poll_at` every cycle, so the most-recently-polled
+        # session is the live one — not necessarily the newest row, which may have been registered
+        # and then stopped (its correlation id dead, a payload minted against it never calling
+        # home). A session never polled (no listener yet, or a row from before heartbeating) carries
+        # a null last_poll_at and loses to any polled session; among equals the newest id wins.
+        private def self.pick_session(sessions : Array(Store::OastSessionRecord)) : Store::OastSessionRecord?
+          return nil if sessions.empty?
+          sessions.max_by { |s| {s.last_poll_at || Int64::MIN, s.id} }
         end
 
         def initialize(@provider : Oast::Provider, @session : Oast::Session)

--- a/src/gori/store/oast_sessions.cr
+++ b/src/gori/store/oast_sessions.cr
@@ -74,9 +74,14 @@ module Gori
       }
     end
 
-    def touch_oast_session(id : Int64, last_poll_at : Int64) : Nil
+    # Stamp a session's last_poll_at = now. The TUI OAST controller calls this while a listener is
+    # live (at register/resume and on a periodic heartbeat), making last_poll_at a cross-process
+    # liveness signal: `OutOfBand::StoreMinter.build` mints OOB probe payloads against the
+    # most-recently-polled session rather than merely the newest row, which may have been started
+    # and then stopped (its correlation id dead, its payloads unable to call home).
+    def touch_oast_session(id : Int64) : Nil
       exec_task ->(c : DB::Connection) {
-        c.exec("UPDATE oast_sessions SET last_poll_at=? WHERE id=?", last_poll_at, id)
+        c.exec("UPDATE oast_sessions SET last_poll_at=? WHERE id=?", now_us, id)
         nil
       }
     end

--- a/src/gori/tui/controllers/oast_controller.cr
+++ b/src/gori/tui/controllers/oast_controller.cr
@@ -26,6 +26,13 @@ module Gori::Tui
     DRAIN_CAP     = 512
     POLL_INTERVAL = 5.seconds
 
+    # How often a live listener re-stamps its session's `last_poll_at` — the cross-process liveness
+    # signal the probe OOB minter reads (Oast::StoreMinter). Coarser than POLL_INTERVAL on purpose:
+    # it only needs to keep a live session ranked above a stopped one, not to be precise, and a
+    # live-but-idle listener draws no callbacks, so this heartbeat is the ONLY thing keeping its row
+    # ahead of a newer, stopped session.
+    SESSION_HEARTBEAT = 30.seconds
+
     # Ring cap on the in-memory callback window. A per-project result buffer fed by a NETWORK
     # PEER must have a cap or an eviction policy: unlike every other result list in this layer,
     # growth here is paced by the PROVIDER, not the operator. An interact.sh-class domain
@@ -134,6 +141,7 @@ module Gori::Tui
       @ordered_cache_key = nil.as({Int32, String, Int32}?)
       @filtered_cache = nil.as(Array(CbRow)?)
       @filtered_cache_key = nil.as({Int32, String, Int32}?)
+      @last_session_heartbeat = Time.instant # gate for the last_poll_at heartbeat (see SESSION_HEARTBEAT)
       reload
     end
 
@@ -1231,7 +1239,23 @@ module Gori::Tui
         inserted = true
       end
       reanchor_callback_selection(sel_key) if inserted && sel_key
+      heartbeat_active_sessions
       applied
+    end
+
+    # Keep each live session's `last_poll_at` fresh so the probe OOB minter (Oast::StoreMinter)
+    # can tell a session that is being polled from one that was started and stopped. Runs off-tab
+    # too — drain_events is called every tick regardless of focus — which is the point: you start
+    # a listener here, switch tabs, and a probe scan still mints against it. Throttled to
+    # SESSION_HEARTBEAT and skipped entirely when nothing is listening, so an idle project writes
+    # nothing. Does not mark the tick `applied`: it changes no on-screen state.
+    private def heartbeat_active_sessions : Nil
+      return if @listeners.empty?
+      now = Time.instant
+      return if now - @last_session_heartbeat < SESSION_HEARTBEAT
+      @last_session_heartbeat = now
+      store = @host.session.store
+      @listeners.each { |l| store.touch_oast_session(l.session.id) if l.active? }
     end
 
     # Move @cb_sel back onto the callback identified by `key` after live inserts shifted the
@@ -1305,6 +1329,9 @@ module Gori::Tui
         @listeners << listener
         @seen[id] ||= Set(String).new
         @session_label[id] = reg.provider_label
+        # Mark the session live NOW so a probe scan in the ≤SESSION_HEARTBEAT window before the
+        # first heartbeat still mints against it rather than an older polled session.
+        @host.session.store.touch_oast_session(id)
         if reg.want_payload
           deliver_payload(reg.provider.generate_payload(reg.session))
         elsif reg.resumed


### PR DESCRIPTION
Stability review of the OAST (out-of-band) feature surfaced three paths where a callback — the ground-truth evidence an OAST finding rests on — could be lost, or an OOB probe could silently never fire. All three are fixed here.

## 1. Preserve partial batches on a poll parse failure
`Postbin#poll` drains the bin with **destructive shifts**, so a raise out of `parse_json` mid-loop discarded every interaction already shifted off the bin — unrecoverably. The engine's own `parse_time` comment already flagged this loss class but only guarded the timestamp field. Now each item is guarded and what parsed is kept (the poller drains the rest next cycle).

`Interactsh#poll` gets the same per-item guard: interactsh marks a whole poll consumed server-side, so one malformed item must not sink its decoded siblings.

## 2. Bind the probe OOB minter to a live session
`StoreMinter.build` minted payloads against the **newest** `oast_sessions` row regardless of whether it was still being polled, so a session that was registered then stopped produced probes whose callbacks nobody reads. `last_poll_at` was a dead column (`touch_oast_session` had zero callers); it's now written from the TUI controller at register/resume and on a 30s heartbeat (runs off-tab too), and `StoreMinter` picks the **most-recently-polled** session, falling back to newest.

## 3. Cap the OAST HTTP response body at 16 MiB
`HttpClient` buffered a poll response in full with no size ceiling (`TIMEOUT` bounds only time), so a hostile or broken interaction server — including the public presets the operator doesn't control — could OOM the process before any per-row cap applied. The body is now streamed and an over-cap response is refused with a clean error the poller/CLI/MCP already surface.

## Tests
- `spec/oast/engine_spec.cr` — postbin keeps already-shifted interactions when a later shift returns a malformed body.
- `spec/probe/oast_bridge_spec.cr` — minter follows the most-recently-polled session, not merely the newest row.

Full project compiles (`crystal build --no-codegen`); all OAST-touching specs pass (108 examples, 0 failures, 0 warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)