### PR TITLE
Quiet the Repeater's ^T:MARK chip, and let a reopened tab keep its markers

### DIFF
--- a/spec/tui/fuzzer_view_spec.cr
+++ b/spec/tui/fuzzer_view_spec.cr
@@ -186,6 +186,21 @@ describe Gori::Tui::FuzzerView do
     grid2.should_not contain("§x¦rot13§")
   end
 
+  it "points a chain-less position at BOTH halves of its setup (^Y and the CONFIG pane)" do
+    # A marked position is only half a Fuzzer run: with no payload set in CONFIG the sweep
+    # produces nothing, and the two halves live in different panes. The tooltip used to open
+    # only for a marker that already HAD a `¦chain` — i.e. never on a freshly auto-marked
+    # template, which is every position an operator meets first.
+    view = FuzzerView.new
+    view.load_request("https://h", "§x§ HTTP/1.1\r\nHost: h\r\n\r\n", false, "")
+    view.focus_pane(:template) # cursor at offset 0 → inside §x§, which carries no chain
+    b = MemoryBackend.new(120, 30)
+    view.render(Screen.new(b), Rect.new(0, 0, 120, 30))
+    grid = (0...30).map { |y| b.row(y) }.join("\n")
+    grid.should contain("no chain yet")
+    grid.should contain("^Y edit · ^O sets")
+  end
+
   # `template_scroll_view` used to bail on `template_insert?`, so the wheel died the moment `i`
   # was pressed — the same `unless insert?` the Repeater request pane shed, in the one other
   # pane that had it. `chain_pane_active?` still bails: the ^Y sub-pane owns the wheel then.

--- a/spec/tui/mouse_geometry_spec.cr
+++ b/spec/tui/mouse_geometry_spec.cr
@@ -289,7 +289,7 @@ describe "code-review fixes" do
     # `render_request`, so the badge was drawn — and clickable — reading `^T:MARK` while the
     # key it names did something unrelated. Draw and hit are gated together.
     src = File.read(File.join(__DIR__, "..", "..", "src", "gori", "tui", "repeater_view.cr"))
-    draw = src[/# …and NOT on a decode split.*?end/m].not_nil!
+    draw = src[/# NOT on a decode split either\..*?end/m].not_nil!
     draw.should contain("!decode_mode?")
     hit = src[/` \^T:MARK ` chains LEFT.*?return :mark/m].not_nil!
     hit.should contain("!decode_mode?")

--- a/spec/tui/repeater_view_spec.cr
+++ b/spec/tui/repeater_view_spec.cr
@@ -1269,6 +1269,135 @@ describe Gori::Tui::RepeaterView do
     grid.should_not contain("PREVIEW") # the ^Y modal is NOT auto-shown
   end
 
+  it "draws ^T:MARK only while the capture's § are INERT, never once they are live" do
+    # The badge is a WARNING with an escape hatch — "these § are the origin's bytes and go out
+    # verbatim; ^T declares them markers" — which nothing else on screen says. Once they ARE
+    # markers the editor tints them and `§N` rides the border, so the lit half of the badge
+    # reported no state and only re-named a key the status strip already carries.
+    grid = ->(v : RepeaterView) do
+      b = MemoryBackend.new(120, 24)
+      v.render(Screen.new(b), Rect.new(0, 0, 120, 24))
+      (0...24).map { |y| b.row(y) }.join("\n")
+    end
+
+    ev = RepeaterView.new
+    ev.restore("https://a.test", "GET /?q=§v§ HTTP/1.1\nHost: a.test\n\n", false, false, evidence: true)
+    ev.focus_pane(:request)
+    ev.literal_markers?.should be_true
+    grid.call(ev).should contain("^T:MARK") # inert → the warning stands
+
+    ev.insert_marker # declares the buffer a template
+    ev.literal_markers?.should be_false
+    grid.call(ev).should_not contain("^T:MARK")
+
+    draft = RepeaterView.new # a draft's § were always live — it never carried the badge
+    draft.restore("https://a.test", "GET /?q=§v§ HTTP/1.1\nHost: a.test\n\n", false, false)
+    draft.focus_pane(:request)
+    grid.call(draft).should_not contain("^T:MARK")
+  end
+
+  describe "#adopt_capture_markers (provenance across a reopen)" do
+    # A reopened evidence tab lands undeclared: the repeater ROW carries the request text and a
+    # flow_id, nothing saying which `§` the operator typed. But the CAPTURE is still in the
+    # store and answers it — a `§` the origin never sent can only have been typed here. Without
+    # this, a tab the operator marked by hand came back with its markers inert, `^T:MARK` on the
+    # border, and a `^R` that would put `§…§` on the wire as literal bytes.
+    marked = "GET /?q=§hello§ HTTP/1.1\nHost: a.test\n\n"
+
+    it "declares the operator's markers when the capture carried none" do
+      view = RepeaterView.new
+      view.restore("http://a.test", marked, false, false, evidence: true)
+      view.literal_markers?.should be_true # restore's conservative landing
+
+      view.adopt_capture_markers("GET /?q=hello HTTP/1.1\r\nHost: a.test\r\n\r\n".to_slice, nil)
+      view.literal_markers?.should be_false # …corrected from the capture
+      view.markers_active?.should be_true   # and the markers render again on send
+    end
+
+    it "stays inert when the capture carried a § of its own — gori cannot tell them apart" do
+      view = RepeaterView.new
+      view.restore("http://a.test", marked, false, false, evidence: true)
+      view.adopt_capture_markers("GET /?q=§ HTTP/1.1\r\nHost: a.test\r\n\r\n".to_slice, nil)
+      view.literal_markers?.should be_true
+    end
+
+    it "reads the capture's BODY too, not just its head" do
+      view = RepeaterView.new
+      view.restore("http://a.test", "POST / HTTP/1.1\nHost: a.test\n\n§v§", false, false, evidence: true)
+      view.adopt_capture_markers("POST / HTTP/1.1\r\nHost: a.test\r\n\r\n".to_slice, "a§b".to_slice)
+      view.literal_markers?.should be_true
+    end
+
+    it "stays inert with no capture to read, and leaves a draft alone" do
+      view = RepeaterView.new
+      view.restore("http://a.test", marked, false, false, evidence: true)
+      view.adopt_capture_markers(nil, nil) # flow deleted / seed lost → the honest answer is inert
+      view.literal_markers?.should be_true
+
+      draft = RepeaterView.new # never evidence → nothing to re-derive, and nothing to break
+      draft.restore("http://a.test", marked, false, false)
+      draft.adopt_capture_markers("GET / HTTP/1.1\r\n\r\n".to_slice, nil)
+      draft.literal_markers?.should be_false
+    end
+  end
+
+  it "offers ^Y over a marker that has NO chain — the state with nothing else on screen" do
+    # The tooltip used to open only for a marker that ALREADY had a `¦chain`, i.e. it explained
+    # the case the operator had already solved and stayed silent on the one they hadn't. ^Y is
+    # the sole way into the chain editor and appears on no border, so an unchained marker had
+    # no path out of itself.
+    view = RepeaterView.new
+    view.restore("https://a.test", "§v§ HTTP/1.1\nHost: a.test\n\n", false, false)
+    view.focus_pane(:request) # caret at offset 0 → inside §v§, which carries no chain
+    b = MemoryBackend.new(120, 24)
+    view.render(Screen.new(b), Rect.new(0, 0, 120, 24))
+    grid = (0...24).map { |y| b.row(y) }.join("\n")
+    grid.should contain("no chain yet")
+    grid.should contain("^Y edit")
+    grid.should_not contain("^O sets") # the Fuzzer's extra half — a Repeater marker is complete alone
+  end
+
+  it "keeps the tooltip off the caret when it sits outside every marker" do
+    view = RepeaterView.new
+    view.restore("https://a.test", "GET /x HTTP/1.1\nHost: a.test\n\n", false, false)
+    view.focus_pane(:request)
+    b = MemoryBackend.new(120, 24)
+    view.render(Screen.new(b), Rect.new(0, 0, 120, 24))
+    grid = (0...24).map { |y| b.row(y) }.join("\n")
+    grid.should_not contain("no chain yet")
+    grid.should_not contain("^Y edit")
+  end
+
+  it "yields the hint-only tooltip to the $KEY peek, but never a real chain" do
+    # `§$HOST§` is an ordinary marker whose value is an env var. The empty-chain tooltip is a
+    # standing reminder; the resolved value is a datum nothing else shows — so the reminder
+    # steps aside. A marker that HAS a chain still wins: only this tooltip can reveal bytes
+    # that are concealed in the buffer.
+    saved = Gori::Settings.env_vars
+    Gori::Settings.env_vars = [{"PEEKHOST", "peekval"}]
+    begin
+      view = RepeaterView.new
+      view.restore("https://a.test", "§$PEEKHOST§ HTTP/1.1\nHost: a.test\n\n", false, false)
+      view.focus_pane(:request)
+      view.edit_move(0, 5) # into the $PEEKHOST run — both overlays now want this caret
+      b = MemoryBackend.new(120, 24)
+      view.render(Screen.new(b), Rect.new(0, 0, 120, 24))
+      grid = (0...24).map { |y| b.row(y) }.join("\n")
+      grid.should_not contain("no chain yet")
+      grid.should contain("peekval") # …and the peek it stepped aside for is the thing on screen
+
+      chained = RepeaterView.new
+      chained.restore("https://a.test", "§$PEEKHOST¦md5§ HTTP/1.1\nHost: a.test\n\n", false, false)
+      chained.focus_pane(:request)
+      chained.edit_move(0, 5) # the SAME caret — a real chain outranks the peek
+      b2 = MemoryBackend.new(120, 24)
+      chained.render(Screen.new(b2), Rect.new(0, 0, 120, 24))
+      (0...24).map { |y| b2.row(y) }.join("\n").should contain("^Y edit")
+    ensure
+      Gori::Settings.env_vars = saved
+    end
+  end
+
   it "opens the CHAIN modal (with a transform preview) only after ^Y" do
     view = RepeaterView.new
     view.restore("https://a.test", "§v¦md5§ HTTP/1.1\nHost: a.test\n\n", false, false)

--- a/src/gori/tui/chain_peek.cr
+++ b/src/gori/tui/chain_peek.cr
@@ -12,13 +12,18 @@ module Gori::Tui
   class ChainPeek
     getter? open : Bool = false
     @chain = ""
+    @hint = DEFAULT_HINT
 
-    HINT = "^Y edit"
+    # What `^Y` opens is the same everywhere, so this is the floor — but the marker under the
+    # caret means different things per surface, and the Fuzzer chains `^O` onto it (a position
+    # with no payload set produces nothing, which the chain alone never says). Owner-fed.
+    DEFAULT_HINT = "^Y edit"
 
     # Show the chain of the marker under the caret (opens the peek). An empty chain still
     # opens — the marker is concealment-eligible, the hint invites attaching a chain.
-    def set(chain : String) : Nil
+    def set(chain : String, hint : String = DEFAULT_HINT) : Nil
       @chain = chain
+      @hint = hint
       @open = true
     end
 
@@ -47,7 +52,7 @@ module Gori::Tui
 
     # Box width = ▸ + chain + the right-aligned hint, floored so short chains still read.
     private def box_width(bounds : Rect) : Int32
-      ({Screen.display_width(shown) + HINT.size + 6, 16}.max).clamp(1, bounds.w)
+      ({Screen.display_width(shown) + Screen.display_width(@hint) + 6, 16}.max).clamp(1, bounds.w)
     end
 
     # One tooltip row: a fill band, the accent ▸ chain glyph, the chain spec, then the
@@ -57,10 +62,10 @@ module Gori::Tui
       bg = Theme.elevated
       screen.fill(Rect.new(x, y, w, 1), bg)
       cx = screen.text(x + 1, y, "▸ ", Theme.marker_accent, bg, width: {w - 1, 1}.max)
-      hint_x = x + w - HINT.size - 1
+      hint_x = x + w - Screen.display_width(@hint) - 1
       chain_room = {hint_x - 1 - cx, 0}.max
       cx = screen.text(cx, y, shown, @chain.empty? ? Theme.muted : Theme.text_bright, bg, width: chain_room)
-      screen.text(hint_x, y, HINT, Theme.muted, bg) if hint_x > cx
+      screen.text(hint_x, y, @hint, Theme.muted, bg) if hint_x > cx
     end
   end
 end

--- a/src/gori/tui/controllers/repeater_controller.cr
+++ b/src/gori/tui/controllers/repeater_controller.cr
@@ -1923,6 +1923,12 @@ module Gori::Tui
       return unless flow_id
       return unless detail = @host.session.store.get_flow(flow_id)
       view.seed_original(detail.response_head, detail.response_body)
+      # The REQUEST half of the same row, which nothing read before: it is what lets a
+      # reopened evidence tab tell its own `§` from the origin's instead of assuming the
+      # worst about both. Every path that lands a tab undeclared — first open, a peer's
+      # reconcile, a row appearing mid-session — comes through here right after, so this is
+      # the one call site. See `RepeaterView#adopt_capture_markers`.
+      view.adopt_capture_markers(detail.request_head, detail.request_body)
     end
 
     private def edit_repeater_request(ev : Termisu::Event::Key, view : RepeaterView) : Bool

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -98,7 +98,12 @@ module Gori::Tui
       @editor.wrap = true
       @editor.env_complete = true # `$KEY` autocomplete against the registered env vars (expanded on send)
       @editor.chain_peek = true   # tooltip revealing the concealed ¦chain of the §…§ marker under the caret
-      @last_synced_config = ""    # last store config blob applied (reconcile equality)
+      # …and here it carries `^O` as well. A marked position in the Fuzzer is only half a
+      # setup: with no payload set in the CONFIG pane the run produces nothing, and the two
+      # halves sit in different panes, so the tooltip over the position names the pane that
+      # completes it. (In the Repeater a marker IS complete on its own — hence the default.)
+      @editor.chain_peek_hint = "^Y edit · ^O sets"
+      @last_synced_config = "" # last store config blob applied (reconcile equality)
       @config = Fuzz::Config.new(keep_bodies: :matched)
       @sets = [] of SetSpec
       @matcher = Fuzz::Matcher.new(keep_bodies: :matched)
@@ -2183,8 +2188,11 @@ module Gori::Tui
       end
       @editor.bg_regions = bg
       @editor.conceal_spans = conceal
-      chain = chain_under_cursor
-      @editor.chain_peek_text = (chain && !chain.empty?) ? chain : nil # tooltip only for a concealed (non-empty) chain
+      # A marker WITHOUT a chain gets the tooltip too (`""` → "no chain yet · ^Y edit · ^O
+      # sets"). That is the state a freshly auto-marked template is in for every one of its
+      # positions, i.e. the one an operator meets first and the one that used to say nothing.
+      # nil (caret outside every marker) still draws nothing.
+      @editor.chain_peek_text = chain_under_cursor
       inner = rect.inset(1, 1)
       read_active = focused && !ins
       @editor.render(screen, inner, cursor: ins, highlight: :request, peek: focused, gauge: true, gauge_focused: focused)

--- a/src/gori/tui/repeater_view.cr
+++ b/src/gori/tui/repeater_view.cr
@@ -2413,6 +2413,38 @@ module Gori::Tui
       invalidate_marker_caches
     end
 
+    # Re-derive provenance for a REOPENED evidence tab from the flow it was seeded off.
+    #
+    # `restore`/`apply_peer_request` land undeclared because the repeater row says nothing
+    # about which `§` in its text the operator typed. That is true of the ROW — and it made a
+    # tab the operator had marked by hand come back with its own markers inert, `^T:MARK` on
+    # the border, and a `^R` that would put `§…§` on the wire as literal bytes. The operator
+    # marked it; gori just forgot between two runs.
+    #
+    # But the row is not the only evidence. The CAPTURE is still in the store, and it answers
+    # the question directly: a `§` that is in this buffer and was NOT in the origin's bytes can
+    # only have been typed here. So:
+    #
+    #   * capture had NO `§` → every `§` in the buffer is the operator's → declare.
+    #   * capture HAD a `§` → gori genuinely cannot tell one from the other, so the markers
+    #     stay inert and the border chip says so. That is the case `markers_live?` exists for,
+    #     and it keeps its guard.
+    #   * no capture to read (flow deleted, seed lost) → inert, for the same reason.
+    #
+    # Idempotent, and never UNdeclares: the operator's own act outranks a re-derivation.
+    #
+    # Head AND body, because a `§` in either is one gori cannot attribute — and the seed read
+    # the same stored bytes this reads, truncation included, so the two sides are comparable
+    # even for a capture whose body was cut at the cap.
+    def adopt_capture_markers(capture_head : Bytes?, capture_body : Bytes?) : Nil
+      return if !@evidence || @markers_declared
+      return unless capture_head
+      return if Fuzz::Template.marker_bytes_in?(capture_head)
+      return if (b = capture_body) && Fuzz::Template.marker_bytes_in?(b)
+      return unless Fuzz::Template.marker_bytes_in?(@editor.text.to_slice)
+      declare_markers
+    end
+
     # The caches key on `@editor.edits`, which a pure state flip does not bump.
     private def invalidate_marker_caches : Nil
       @marker_regions_rev = -1
@@ -2813,10 +2845,10 @@ module Gori::Tui
             return :mode
           end
           # ` ^T:MARK ` chains LEFT of the mode chip, under exactly the condition
-          # render_request draws it: only when a `§` is in the buffer. It was the one badge on
-          # this border missing from the hit list while its four neighbours all answered.
-          if !@grpc_mode && !ws_mode? && !decode_mode? &&
-             (literal_markers? || (@evidence && markers_active?))
+          # render_request draws it: only while the buffer's `§` are still INERT capture bytes.
+          # It was the one badge on this border missing from the hit list while its four
+          # neighbours all answered.
+          if !@grpc_mode && !ws_mode? && !decode_mode? && literal_markers?
             mark_edge = Frame.mode_badge_edge(mode_edge, min_x, request_insert?)
             if Frame.right_badge_hit(mx, my, req_card.y, mark_edge, min_x,
                  [{:mark, "^T", "MARK"}] of {Symbol, String, String})
@@ -4490,16 +4522,21 @@ module Gori::Tui
       cl_x = Frame.toggle_badge(screen, send_edge, rect.y, min_x, "^L", "CL", @auto_content_length)
       mode_x = Frame.toggle_badge(screen, cl_x, rect.y, min_x, "^U", "PRETTY", false)
       mark_x = Frame.mode_badge(screen, mode_x, rect.y, min_x, request_insert?) # the REAL mode — see Frame.mode_badge
-      # Only when a `§` is actually in the buffer, so a request without one draws exactly the
-      # border it drew before. Unlit = the capture's § are literal bytes (^T declares them);
-      # lit = this buffer is a template and ^R renders them. See `markers_live?`.
+      # The INERT half only. `literal_markers?` is a state nothing else on screen shows: the
+      # `§` in this buffer are the capture's own bytes, they will go out verbatim, and `^T`
+      # is what declares them markers instead — a warning with its own escape hatch, which is
+      # what a border chip is for.
       #
-      # …and NOT on a decode split. `repeater.toggle-decoded` is context-sensitive: on a
+      # The LIT half is gone. Once the markers ARE live they are tinted in the editor, `§N`
+      # rides the border, and the chip added nothing but a second name for a key the status
+      # strip already advertises — so `^T` on an unmarked request grew a badge that reported
+      # no state, which is how it read.
+      #
+      # NOT on a decode split either. `repeater.toggle-decoded` is context-sensitive: on a
       # SAML/GraphQL tab `^T` switches ENVELOPE ⇄ DECODED instead of inserting a §, so a badge
-      # reading `^T:MARK` there names a key that does something else entirely. Marking is still
-      # reachable from the space menu (`w` word / `i` point) and from ^K.
-      if !decode_mode? && (literal_markers? || (@evidence && markers_active?))
-        Frame.toggle_badge(screen, mark_x, rect.y, min_x, "^T", "MARK", markers_live?)
+      # reading `^T:MARK` there names a key that does something else entirely.
+      if !decode_mode? && literal_markers?
+        Frame.toggle_badge(screen, mark_x, rect.y, min_x, "^T", "MARK", false)
       end
       update_request_marker_tint
       render_plain_request_editor(screen, rect.inset(1, 1), focused, ins)
@@ -4568,8 +4605,12 @@ module Gori::Tui
       end
       @editor.bg_regions = bg
       @editor.conceal_spans = conceal
-      chain = chain_under_cursor
-      @editor.chain_peek_text = (chain && !chain.empty?) ? chain : nil # tooltip only for a concealed (non-empty) chain
+      # A marker WITHOUT a chain gets the tooltip too (`""` → "no chain yet · ^Y edit"). The
+      # chain pane is reachable by exactly one key that appears nowhere on this pane, so the
+      # state with no chain — the one where the operator has nothing on screen to work from —
+      # was the state that said nothing at all, while a marker that already had one explained
+      # itself. nil (caret outside every marker) still draws nothing.
+      @editor.chain_peek_text = chain_under_cursor
     end
 
     # {open, sep, close} marker regions cached on the editor revision — update_request_marker_tint

--- a/src/gori/tui/text_area.cr
+++ b/src/gori/tui/text_area.cr
@@ -132,9 +132,10 @@ module Gori::Tui
       @env_peek = nil.as(EnvPeek?)
       # Opt-in chain tooltip (nil = disabled). Paired with @conceal_spans on the request
       # editors: reveals the hidden ¦chain of the §…§ marker under the caret. @chain_peek_text
-      # is fed by the owner each frame (nil = caret not in a chained marker → no tooltip).
+      # is fed by the owner each frame (nil = caret not in a marker → no tooltip).
       @chain_peek = nil.as(ChainPeek?)
       @chain_peek_text = nil.as(String?)
+      @chain_peek_hint = ChainPeek::DEFAULT_HINT
       set_text(text)
     end
 
@@ -1602,7 +1603,8 @@ module Gori::Tui
       if cursor && (cc = caret_cell) && ec
         ec.render(screen, cc[0], cc[1], rect)
       end
-      # Chain tooltip takes precedence over the env peek (a §…§ marker is never also a $KEY).
+      # Chain tooltip takes precedence over the env peek — but only when it has a chain to
+      # reveal; `render_chain_peek` owns that tie-break (a `§$KEY§` marker is a real shape).
       return if render_chain_peek(screen, caret_cell, rect, cursor, peek, ec)
       ep = @env_peek
       return unless ep
@@ -1618,7 +1620,7 @@ module Gori::Tui
       end
     end
 
-    # The chain tooltip pass: when the caret sits in a chained §…§ marker (owner-fed via
+    # The chain tooltip pass: when the caret sits in a §…§ marker (owner-fed via
     # @chain_peek_text) and the editor is focused, reveal the concealed chain at the caret
     # and suppress the env peek. Returns true when it took over (the caller then skips the
     # env peek). No-op (false) when the tooltip is disabled or the caret isn't in a marker.
@@ -1627,8 +1629,14 @@ module Gori::Tui
       cp = @chain_peek
       return false unless cp
       chain = @chain_peek_text
-      if chain && (cursor || peek) && (cc = caret_cell) && !(cursor && ec && ec.open?)
-        cp.set(chain)
+      # An EMPTY chain draws the affordance only ("no chain yet · ^Y edit"), so it YIELDS to a
+      # `$KEY` peek under the same caret: `§$HOST§` is an ordinary marker, and the resolved
+      # value is a datum nothing else on screen shows, where the hint is a standing reminder
+      # that will be there on the next keystroke too. A non-empty chain still wins — it reveals
+      # bytes concealed in the buffer, which is the one thing only this tooltip can do.
+      if chain && (cursor || peek) && (cc = caret_cell) && !(cursor && ec && ec.open?) &&
+         !(chain.empty? && @env_peek && env_token_at_cursor)
+        cp.set(chain, @chain_peek_hint)
         cp.render(screen, cc[0], cc[1], rect)
         @env_peek.try(&.close)
         return true
@@ -2139,9 +2147,18 @@ module Gori::Tui
     end
 
     # Per-frame feed: the chain of the §…§ marker under the caret, or nil when the caret
-    # isn't in a chained marker. The owner resolves it (it knows the §-marker layout).
+    # isn't in a marker at all. `""` is a marker WITHOUT a chain and still opens the tooltip
+    # (as "no chain yet" + the hint) — that is the case where the operator has the least to
+    # go on, so it is the one that most needs the affordance. The owner resolves it (it
+    # knows the §-marker layout).
     def chain_peek_text=(chain : String?) : Nil
       @chain_peek_text = chain
+    end
+
+    # The right-aligned affordance on the chain tooltip's row. Per-surface: see
+    # `ChainPeek::DEFAULT_HINT`.
+    def chain_peek_hint=(hint : String) : Nil
+      @chain_peek_hint = hint
     end
 
     def env_completing? : Bool


### PR DESCRIPTION
Reported from dogfooding: `^T` in the Repeater grew a ` ^T:MARK ` chip on the REQUEST border that reported nothing — and chasing it surfaced a real defect underneath.

## The chip

It had two halves and only one of them was a state.

**LIT** (`§` are live) is gone. Once the markers are declared the editor tints them and `§N` rides the border, so the chip was a second name for a key the status strip already advertises.

**UNLIT** stays. On an evidence tab whose `§` are still the origin's bytes, nothing else on screen says they will go out verbatim, and `^T` is what changes that. Draw and hit-test are gated together, as before.

## The defect underneath

`restore` lands undeclared: the repeater row carries the request text and a `flow_id` and nothing saying which `§` the operator typed. So a tab someone had marked by hand came back with **its own markers inert** — chip on the border, and a `^R` that would put `§…§` on the wire as literal bytes.

Reproduced end to end: History → `^R` to Repeater → `^T` mark → restart → markers dead.

But the row is not the only evidence. The **capture** is still in the store, and a `§` that is in the buffer and was not in the origin's bytes can only have been typed here:

| capture | verdict |
|---|---|
| no `§` of its own | every `§` in the buffer is the operator's → **declare** |
| carries a `§` | genuinely ambiguous → **inert**, chip earns its place |
| unreadable (flow deleted) | **inert** |

`adopt_capture_markers` reads the request half of the flow `seed_repeater_original` already fetches — no new query, no migration. One call site covers all three paths that land a tab undeclared (first open, peer reconcile, a row appearing mid-session).

## Chain tooltip

The `§…§` tooltip now opens for a marker with **no** chain (`▸ no chain yet   ^Y edit`). It used to open only for a marker that already had one — explaining the case the operator had solved and staying silent on the one they hadn't, while `^Y` is the sole way into the chain editor and appears on no border.

An empty-chain tooltip yields to a `$KEY` peek under the same caret (`§$HOST§` is a real shape); a real chain still wins, since only it can reveal concealed bytes.

The Fuzzer carries `^Y edit · ^O sets` instead — a marked position there is half a setup, and the payload sets that complete it live in another pane.

## Verification

Full suite green (7983 examples, 0 failures) on the rebased result, since CI does not build the merge result. `crystal tool format` clean on touched files; no new ameba findings.

Live-verified in tmux against a real build, not just specs:
- chip gone after `^T` on a draft, and gone after reopening the marked evidence tab
- markers genuinely **live** after reopen — the tooltip only opens when `markers_live?`, so it is evidence of the state, not just a hidden badge
- both tooltips rendered in place (Repeater and Fuzzer)

9 new specs: chip INERT/LIVE transition, provenance re-derivation in both directions (+ body, + no-capture, + draft), chain-less tooltip, caret outside every marker, env-peek yield, Fuzzer hint.