### PR TITLE
Shrink the picker's brand mark, and shade the far ring so it reads as two

### DIFF
--- a/spec/tui/brand_art_spec.cr
+++ b/spec/tui/brand_art_spec.cr
@@ -11,9 +11,34 @@ describe "Brand::ART" do
   it "is drawn entirely in single-cell glyphs" do
     Brand::ART.each_with_index do |line, row|
       line.each_char_with_index do |ch, col|
-        Screen.draw_width(ch.to_s).should eq(1), "row #{row} col #{col}: #{ch.inspect} is not one cell"
+        glyph, _ = Brand.ink(ch, Theme.focus_gold)
+        Screen.draw_width(glyph.to_s).should eq(1), "row #{row} col #{col}: #{glyph.inspect} is not one cell"
       end
     end
+  end
+
+  # ART carries ring membership, not glyphs — `ink` is what turns a cell into
+  # something paintable. A glyph it doesn't know gets painted verbatim, so a new
+  # marker added to the figure without a matching branch would silently ship as
+  # whatever character the author happened to type.
+  it "paints every ART glyph through a known ink" do
+    known = {' ', '█', Brand::FAR_RING}
+    Brand::ART.each_with_index do |line, row|
+      line.each_char_with_index do |ch, col|
+        known.includes?(ch).should be_true, "row #{row} col #{col}: #{ch.inspect} has no ink"
+      end
+    end
+  end
+
+  # The two rings only read as two because the far one is dimmer. Assert the
+  # separation itself — a mix ratio edited to 0 would leave a flat blob and no
+  # other spec would notice.
+  it "sinks the far ring toward the canvas, still as a solid block" do
+    glyph, far = Brand.ink(Brand::FAR_RING, Theme.focus_gold)
+    glyph.should eq('█')
+    near = Brand.ink('█', Theme.focus_gold)[1]
+    far.should_not eq(near)
+    (Theme.luma(near) - Theme.luma(far)).abs.should be > 0.1 # luma is 0..1
   end
 
   it "scrambles the entrance through single-cell glyphs too" do

--- a/spec/tui/help_view_spec.cr
+++ b/spec/tui/help_view_spec.cr
@@ -57,6 +57,10 @@ describe Gori::Tui::HelpView do
     # Same ink as the project-picker brand mark. Asserted against Brand::ART itself
     # so restyling the mark can't quietly stop it being drawn: the bottom arc is one
     # unbroken run of glyphs, so it lands in the grid as a single contiguous string.
-    backend.contains?(Brand::ART.last.lstrip).should be_true
+    # Through `ink`, because ART stores ring membership rather than glyphs — the
+    # far ring's marker is painted as a solid block in a dimmer gold, and the
+    # backend records glyphs.
+    bottom = Brand::ART.last.lstrip.chars.map { |ch| Brand.ink(ch, Theme.focus_gold)[0] }.join
+    backend.contains?(bottom).should be_true
   end
 end

--- a/src/gori/tui/brand.cr
+++ b/src/gori/tui/brand.cr
@@ -7,12 +7,16 @@ module Gori::Tui
   # optical centering so the visible shape — not its leading spaces — is centred.
   module Brand
     # The interlocked rings of the gori logo (docs/static/images/gori.svg), hand
-    # drawn at 32 cells over 16 rows. A terminal cell is about half as wide as it
+    # drawn at 20 cells over 9 rows. A terminal cell is about half as wide as it
     # is tall, so that reads as a roughly square figure — the mark's own artwork is
     # 1365×1193 (1.14:1), close enough that it reads as the logo rather than a
-    # stretched copy. It is deliberately big: at the ~20×9 the mark was drawn at
-    # before, the two rings collapsed into a blob and stopped reading as rings.
-    # The size is what costs the height gate — see ProjectPicker.art_shown?.
+    # stretched copy.
+    #
+    # This is the small cut. A 32×16 version was drawn first and resolved more of
+    # the rings' overlap, but it dominated the picker and pushed the height gate to
+    # 34 rows, so anything shorter fell back to the bare wordmark. At this size the
+    # rings read as a simplified silhouette rather than a traced outline, and the
+    # gate drops to 27 rows / 26 cols — see ProjectPicker.art_shown?.
     #
     # Solid blocks, not scattered glyphs. The strokes are one or two cells thick,
     # so any mix of glyph weights reads as broken lines rather than arcs, and `█`
@@ -24,22 +28,15 @@ module Gori::Tui
     # draw places glyph N of a line at column N, so a two-cell grapheme would
     # shear its row and pull the rings apart.
     ART = [
-      "                    █████",
-      "               ██████ ██████",
-      "            ███          █████",
-      "         ███████          ████",
-      "      ████       █████    █████",
-      "     ███               █ ██████",
-      "    ████           ██   ██████",
-      "    █████              ██████",
-      "  █ ██████            ██████  █",
-      " ██  ██████         ███████   ███",
-      " ██   ████████    ████████  █  ██",
-      " ██     ████████████████       ██",
-      " ████     ████████████      █████",
-      "  █████████████████  ███████████",
-      "   █████████████  █████████████",
-      "                       ████",
+      "          ██████",
+      "       █       ███",
+      "   ███    ███  ███",
+      "  ███    ██    ███",
+      "  ███         ███",
+      " █ ████     ████  █",
+      "██  █████ █████   ██",
+      " ██   ████████  ███",
+      "  █████████████████",
     ]
 
     ART_H     = ART.size

--- a/src/gori/tui/brand.cr
+++ b/src/gori/tui/brand.cr
@@ -16,9 +16,12 @@ module Gori::Tui
     # ring is that its outer contour closes: a 20×9 cut fit in more terminals but
     # left the upper-left arc a lone floating cell with gaps either side, and a
     # broken arc reads as debris, not as a loop. 24 columns is the narrowest the
-    # arc stays connected at. Going the other way costs more than it buys — a
-    # 30×15 version resolves the logo's inner highlights, but they land as 1-cell
-    # specks at terminal scale, and `art_shown?` is a cliff rather than a slope:
+    # arc stays connected at. The interior is left empty for the same reason the
+    # contour matters: the logo's inner highlights are thinner than a cell here,
+    # so drawing them puts loose specks inside the ring and weakens the loop.
+    #
+    # Going wider costs more than it buys — a 30×15 version does resolve those
+    # highlights, but only barely, and `art_shown?` is a cliff rather than a slope:
     # its floor would rise to 33 rows, above a default 80×24 or any split pane, so
     # those terminals lose the mark entirely instead of getting a smaller one.
     # Here the gate is 29 rows / 30 cols — see ProjectPicker.art_shown?.
@@ -36,8 +39,8 @@ module Gori::Tui
       "            ███████",
       "         ██       ███",
       "     ████████     ████",
-      "   ███         ██ ████",
-      "   ███        █  ████",
+      "   ███            ████",
+      "   ███           ████",
       "   ███          ████ ▒",
       " ▒ █████      █████  ▒▒",
       "▒▒  ██████  ██████    ▒▒",

--- a/src/gori/tui/brand.cr
+++ b/src/gori/tui/brand.cr
@@ -7,16 +7,21 @@ module Gori::Tui
   # optical centering so the visible shape — not its leading spaces — is centred.
   module Brand
     # The interlocked rings of the gori logo (docs/static/images/gori.svg), hand
-    # drawn at 20 cells over 9 rows. A terminal cell is about half as wide as it
+    # drawn at 24 cells over 11 rows. A terminal cell is about half as wide as it
     # is tall, so that reads as a roughly square figure — the mark's own artwork is
     # 1365×1193 (1.14:1), close enough that it reads as the logo rather than a
     # stretched copy.
     #
-    # This is the small cut. A 32×16 version was drawn first and resolved more of
-    # the rings' overlap, but it dominated the picker and pushed the height gate to
-    # 34 rows, so anything shorter fell back to the bare wordmark. At this size the
-    # rings read as a simplified silhouette rather than a traced outline, and the
-    # gate drops to 27 rows / 26 cols — see ProjectPicker.art_shown?.
+    # Size is set by the top arc, not by overall detail. What makes this read as a
+    # ring is that its outer contour closes: a 20×9 cut fit in more terminals but
+    # left the upper-left arc a lone floating cell with gaps either side, and a
+    # broken arc reads as debris, not as a loop. 24 columns is the narrowest the
+    # arc stays connected at. Going the other way costs more than it buys — a
+    # 30×15 version resolves the logo's inner highlights, but they land as 1-cell
+    # specks at terminal scale, and `art_shown?` is a cliff rather than a slope:
+    # its floor would rise to 33 rows, above a default 80×24 or any split pane, so
+    # those terminals lose the mark entirely instead of getting a smaller one.
+    # Here the gate is 29 rows / 30 cols — see ProjectPicker.art_shown?.
     #
     # The figure is two rings — a big tilted ellipse and a flat one lying across
     # the bottom, its tips curling up either side — and at this size they only
@@ -28,15 +33,17 @@ module Gori::Tui
     # draw places glyph N of a line at column N, so a two-cell grapheme would
     # shear its row and pull the rings apart.
     ART = [
-      "          ██████",
-      "       █       ███",
-      "   ███    ███  ███",
-      "  ███    ██    ███",
-      "  ███         ███",
-      " ▒ ████     ████  ▒",
-      "▒▒  █████ █████   ▒▒",
-      " ▒▒   ████████  ▒▒▒",
-      "  ██████████▒▒▒▒▒▒▒",
+      "            ███████",
+      "         ██       ███",
+      "     ████████     ████",
+      "   ███         ██ ████",
+      "   ███        █  ████",
+      "   ███          ████ ▒",
+      " ▒ █████      █████  ▒▒",
+      "▒▒  ██████  ██████    ▒▒",
+      " ▒▒▒  ██████████    ▒▒▒",
+      " █████████████ ▒▒▒▒▒▒▒▒",
+      "   ███████   ▒▒▒▒▒▒▒▒",
     ]
 
     # The far ring's marker, and how far its colour sits toward the canvas.

--- a/src/gori/tui/brand.cr
+++ b/src/gori/tui/brand.cr
@@ -18,11 +18,11 @@ module Gori::Tui
     # rings read as a simplified silhouette rather than a traced outline, and the
     # gate drops to 27 rows / 26 cols — see ProjectPicker.art_shown?.
     #
-    # Solid blocks, not scattered glyphs. The strokes are one or two cells thick,
-    # so any mix of glyph weights reads as broken lines rather than arcs, and `█`
-    # is the one glyph whose ink and advance are identical in every font — which
-    # also keeps this the same mark as the SVG/favicon everywhere else. The noise
-    # belongs in the picker's entrance instead (see ART_NOISE there).
+    # The figure is two rings — a big tilted ellipse and a flat one lying across
+    # the bottom, its tips curling up either side — and at this size they only
+    # read as two if they differ. So the ART glyph carries ring membership: `█`
+    # is the near ring, `▒` the far one. `ink` turns that into what actually gets
+    # painted; nothing draws ART's characters directly.
     #
     # Every glyph must measure one cell (see spec/tui/brand_art_spec.cr): the
     # draw places glyph N of a line at column N, so a two-cell grapheme would
@@ -33,11 +33,15 @@ module Gori::Tui
       "   ███    ███  ███",
       "  ███    ██    ███",
       "  ███         ███",
-      " █ ████     ████  █",
-      "██  █████ █████   ██",
-      " ██   ████████  ███",
-      "  █████████████████",
+      " ▒ ████     ████  ▒",
+      "▒▒  █████ █████   ▒▒",
+      " ▒▒   ████████  ▒▒▒",
+      "  ██████████▒▒▒▒▒▒▒",
     ]
+
+    # The far ring's marker, and how far its colour sits toward the canvas.
+    FAR_RING     = '▒'
+    FAR_RING_MIX = 0.58
 
     ART_H     = ART.size
     ART_LEFT  = ART.min_of { |line| line.size - line.lstrip.size }
@@ -52,6 +56,24 @@ module Gori::Tui
     BYLINE  = "made by #{AUTHOR}"
     TAGLINE = "Hack from the terminal."
 
+    # What an ART cell paints: both rings are solid blocks, the far one dimmed
+    # toward the canvas so the interlock reads as depth rather than as one blob.
+    #
+    # The dim is COLOUR, not a lighter glyph. Painting `▒` literally renders it
+    # as a dither pattern (a checkerboard in Menlo), and on a stroke one or two
+    # cells thick that reads as texture rather than distance — the same reason
+    # the mark is solid `█` and the scatter lives in the picker's entrance
+    # instead (see ART_NOISE there). The pattern is font-dependent too, where a
+    # blend of the palette's own colours is not.
+    #
+    # Every draw resolves its cells here, so the picker hero and Help → About
+    # cannot disagree about the figure — which is exactly how the picker once
+    # ended up painting ART as a plain silhouette while About drew the mark.
+    def self.ink(ch : Char, fg : Color) : {Char, Color}
+      return {'█', Theme.blend(fg, Theme.bg, FAR_RING_MIX)} if ch == FAR_RING
+      {ch, fg}
+    end
+
     # Static gilded art (no entrance animation). Defaults to the theme's gold
     # (focus_gold: logo-sampled champagne gold on dark, deepened logo gold on
     # light), so the mark reads as the real brand gold in every palette.
@@ -62,7 +84,8 @@ module Gori::Tui
       ART.each_with_index do |line, i|
         line.each_char_with_index do |ch, col|
           next if ch == ' '
-          screen.cell(origin_x + col, y + i, ch, fg, Theme.bg, attr: Attribute::Bold)
+          glyph, colour = ink(ch, fg)
+          screen.cell(origin_x + col, y + i, glyph, colour, Theme.bg, attr: Attribute::Bold)
         end
       end
     end

--- a/src/gori/tui/project_picker.cr
+++ b/src/gori/tui/project_picker.cr
@@ -1049,8 +1049,8 @@ module Gori::Tui
     TAGLINE = Brand::TAGLINE
 
     # The art is a nicety, not load-bearing — only show it when the terminal is
-    # tall enough to keep a usable project list beneath this taller logo and wide
-    # enough to fit the block without clipping; otherwise fall back to the wordmark.
+    # tall enough to keep a usable project list beneath the logo and wide enough
+    # to fit the block without clipping; otherwise fall back to the wordmark.
     #
     # Both bounds derive from the figure, because it gets redrawn and a literal
     # stops matching it. Height: `card_metrics` spends `ART_H + 4` rows on the

--- a/src/gori/tui/project_picker.cr
+++ b/src/gori/tui/project_picker.cr
@@ -1585,11 +1585,17 @@ module Gori::Tui
 
     # Glyph + colour for a cell `prog` frames after the wave front reached it: a
     # scrambled ART_NOISE glyph from the band matching the stage, colour ramping
-    # from a dim gold up toward full strength, then the art's own glyph `ch`.
+    # up toward full strength, then the cell's settled ink.
+    #
+    # `Brand.ink` resolves that settled pair — which for a far-ring cell is a
+    # dimmed gold — and the ramp aims at it rather than at focus_gold, so the far
+    # ring arrives at its own shade instead of reaching full gold and dropping
+    # back a frame later.
     private def art_cell(prog : Int32, ch : Char, col : Int32, row : Int32, frame : Int32) : {Char, Color}
-      return {ch, Theme.focus_gold} if prog > ART_NOISE.size
+      glyph, settled_fg = Brand.ink(ch, Theme.focus_gold)
+      return {glyph, settled_fg} if prog > ART_NOISE.size
       t = 0.35 + 0.65 * prog / (ART_NOISE.size + 1)
-      {noise_glyph(col, row, frame, prog - 1), Theme.blend(Theme.focus_gold, Theme.bg, t)}
+      {noise_glyph(col, row, frame, prog - 1), Theme.blend(settled_fg, Theme.bg, t)}
     end
 
     # A cell's scramble glyph. A pure hash of (col, row, frame, band) the way


### PR DESCRIPTION
## What

Two changes to `Brand::ART`, the ASCII mark on the project-picker hero (and in
Help → About).

**1. Smaller.** It was drawn at 32x16 — it resolved more of the rings' overlap,
but it dominated the hero and pushed `art_shown?` to a 34-row floor, so anything
shorter got the bare wordmark. Redrawn at 20x9; the gate drops to **27 rows /
26 cols**, so the mark now shows on most windows instead of only tall ones.

**2. Two rings, two shades.** At the smaller size both rings were one weight of
`█`, so the flat ring lying across the bottom merged into the big tilted one and
the figure read as a blob on a solid base. Ring membership now rides in the ART
glyph — `█` near, `▒` far — and `Brand.ink` resolves a cell into the (glyph,
colour) pair that actually gets painted: both rings stay solid blocks, the far
one blended toward the canvas with `Theme.blend`, so it recedes in every palette
rather than against a hardcoded hex.

The dim is **colour, not a lighter glyph**. Painting `▒` literally renders as a
dither pattern — a visible checkerboard in Menlo — and on a stroke one or two
cells thick that reads as texture rather than distance; the pattern is
font-dependent besides. Both were rendered against the real font before choosing.

## How

`ART` and `ink` are the only things that change shape. Ink extent, the picker's
entrance timeline (`ART_MAX_D`/`REVEAL_DONE`/glint), `card_metrics` and Help →
About all derive from the figure, so they re-lay-out with no constant to chase.

- The art is dedented flush left so `ART_LEFT` is 0 and `ART_MIN_W` measures the
  ink alone — leftover indentation would inflate the width gate via `INK_W + 2*LEFT`.
- Both draws resolve through `ink`, so the picker hero and About can't disagree
  about the figure — the failure mode that once had the picker painting `ART` as
  a plain silhouette while About drew the mark.
- The entrance ramps toward the cell's *own* settled colour, so the far ring
  arrives at its shade instead of reaching full gold and dropping back a frame later.

## Verification

- `crystal spec spec/tui/` — 2613 examples, 0 failures. Specs now follow the
  **painted** glyph rather than ART's characters (ART stores membership), reject
  any ART glyph `ink` doesn't know, and assert the separation itself — a mix
  ratio edited to 0 would leave a flat blob no other spec would catch. The
  existing size sweep re-runs against the new figure.
- tmux on a real pty: picker at 100x40 and at 40x27 (the new minimum height) —
  card fits; 26 rows falls back to the wordmark; About paints the new mark.
- Read the colours back out of the pane rather than trusting the code: the art
  renders as exactly two fg colours, `rgb(217,194,139)` (69 cells, near ring) and
  `rgb(130,117,85)` (18 cells, far ring), every cell a `█` — no dither glyph ships.