### PR TITLE
Weave the landing hero into the logo's three-ring knot

### DIFF
--- a/docs/i18n/en.toml
+++ b/docs/i18n/en.toml
@@ -61,7 +61,7 @@ install_aria = "Install gori"
 install_pick_aria = "Choose an install method"
 install_copy = "Copy install command"
 
-hero_art_alt = "Gori wallpaper"
+hero_art_alt = "The gori mark: three rings woven through one another around a disc of the gori artwork"
 showcase_alt = "gori History tab in the terminal, listing captured HTTP flows with time, method, protocol, host, path, status, type, size and duration"
 showcase_note = "Every request your client makes lands in <strong>History</strong> as a flow, one keystroke from Repeater, the Fuzzer, or an issue."
 

--- a/docs/i18n/ko.toml
+++ b/docs/i18n/ko.toml
@@ -61,7 +61,7 @@ install_aria = "gori 설치"
 install_pick_aria = "설치 방법 선택"
 install_copy = "설치 명령 복사"
 
-hero_art_alt = "gori 배경 이미지"
+hero_art_alt = "gori 마크: gori 아트워크 원반을 감싸고 서로 엮인 세 개의 고리"
 showcase_alt = "터미널에서 실행 중인 gori의 History 탭. 캡처된 HTTP 플로우가 시간, 메서드, 프로토콜, 호스트, 경로, 상태, 유형, 크기, 소요 시간과 함께 나열되어 있습니다."
 showcase_note = "클라이언트가 보내는 모든 요청은 <strong>History</strong>에 플로우로 쌓이며, 한 번의 키 입력으로 Repeater, Fuzzer, 이슈로 넘어갑니다."
 

--- a/docs/static/css/style.css
+++ b/docs/static/css/style.css
@@ -27,6 +27,12 @@
      (highlight #f1e1b1 → body #d9c28b) so the nav matches downloadable brand assets. */
   --grad-logo: linear-gradient(135deg, #f1e1b1 0%, #eedca5 40%, #d9c28b 100%);
   --selection: rgb(var(--accent-rgb) / 0.26);
+  /* Band each hero ribbon lays down to cut the ones it crosses. It runs over
+     the disc art as well as the page, so it is a translucent dark rather
+     than the page colour. */
+  --knot-cut: rgb(4 6 12 / 0.72);
+  /* The colour a hero ribbon reaches at the back of its turn. */
+  --knot-far: color-mix(in srgb, var(--accent) 26%, var(--bg));
   --shadow: 0 24px 80px rgb(2 3 9 / 0.62);
   --shadow-soft: 0 14px 44px rgb(2 3 9 / 0.5);
   --header-bg: rgb(9 11 18 / 0.82);
@@ -76,6 +82,14 @@
   --grad-gold-leaf: linear-gradient(135deg, #8a5d0a 0%, #c39a3c 26%, #a8791f 52%, #6f4e12 76%, #cba43e 100%);
   --grad-logo: linear-gradient(135deg, #c5a45a 0%, #b08d3f 55%, #8a6a28 100%);
   --selection: rgb(var(--accent-rgb) / 0.2);
+  /* On paper the band is a warm shadow, not a cut: at a dark-theme alpha it
+     would print as a black outline, and it would grey out the pale far arcs
+     it sits under. The tone difference between near and far carries the
+     crossings instead. */
+  --knot-cut: rgb(72 54 22 / 0.24);
+  /* Deeper than the dark theme's: mixing toward cream washes out fast, and
+     past this the far arcs stop reading as gold at all. */
+  --knot-far: color-mix(in srgb, var(--accent) 54%, var(--bg));
   --shadow: 0 22px 70px rgb(60 50 30 / 0.16);
   --shadow-soft: 0 12px 34px rgb(60 50 30 / 0.12);
   --header-bg: rgb(250 249 247 / 0.82);
@@ -833,93 +847,116 @@ kbd {
   display: block;
 }
 
-/* The disc lives in its own element so it can clip the drifting image, while
-   .hero-art stays unclipped and carries the two orbits around it. The width
-   stays under 100% of the column so those orbits never reach the page edge. */
+/* The hero mark: the same three-ring weave the logo carries, drawn around a
+   disc of the official art. Geometry and the over/under order are generated
+   (see partials/hero-knot.html); everything below is only paint and motion.
+   The rings reach the edge of the box, so the box stays under 100% of the
+   column, which .home-main would otherwise clip. */
 .hero-art {
-  position: relative;
   justify-self: center;
-  /* Under 100% of the column so the orbits below never reach the page edge,
-     which .home-main would clip. */
-  width: min(84%, 36rem);
+  width: min(94%, 44rem);
   aspect-ratio: 1;
+  margin: 0;
 }
 
-/* Two concentric orbits: the border draws the inner one, the outline the
-   outer. An outline follows border-radius and ignores the element's own
-   overflow, which is why it can sit outside without a third element. */
-.hero-art::before {
-  content: "";
-  position: absolute;
-  inset: -1.7rem;
-  border: 1px solid rgb(var(--accent-rgb) / 0.24);
-  border-radius: 50%;
-  outline: 1px solid rgb(var(--accent-rgb) / 0.1);
-  outline-offset: 1.6rem;
-  pointer-events: none;
-}
-
-/* Two request nodes riding the orbits, one per circle, opposite directions:
-   traffic circling the loop. The spin lives in the motion block below; with
-   motion off they park at the base rotations here, two nodes at rest. */
-.hero-orbit {
-  position: absolute;
-  inset: -1.7rem;
-  border-radius: 50%;
-  pointer-events: none;
-  transform: rotate(230deg);
-}
-
-.hero-orbit-out {
-  inset: -3.3rem;
-  transform: rotate(115deg);
-}
-
-.hero-orbit::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: 50%;
-  width: 8px;
-  height: 8px;
-  margin: -4px;
-  border-radius: 50%;
-  background: var(--accent-strong);
-  box-shadow: 0 0 10px rgb(var(--accent-rgb) / 0.9), 0 0 0 3px rgb(var(--accent-rgb) / 0.16);
-}
-
-.hero-orbit-out::before {
-  width: 6px;
-  height: 6px;
-  margin: -3px;
-}
-
-.hero-disc {
-  position: absolute;
-  inset: 0;
-  overflow: hidden;
-  border-radius: 50%;
-  background: #0a0a0b;
-  box-shadow: var(--shadow);
-}
-
-.hero-disc::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  border: 1px solid rgb(var(--accent-rgb) / 0.26);
-  border-radius: 50%;
-  background: linear-gradient(115deg, rgb(var(--scrim-rgb) / 0.2), transparent 40%, rgb(var(--accent-rgb) / 0.1));
-}
-
-/* Warm the monochrome wave capture into gold leaf on indigo, so the disc reads
-   like the official art rather than a cold render. */
-.hero-disc img {
+.hero-knot {
   display: block;
   width: 100%;
   height: 100%;
-  object-fit: cover;
+  /* Inherited by the ribbons, so they still land in gold if the depth mix
+     below ever fails to compute. */
+  stroke: var(--accent);
+}
+
+/* The whole weave turns as one rigid piece. Rotating in the picture plane is
+   the only motion that leaves the painted depth order still correct, so the
+   knot can move without the crossings ever going wrong. */
+.knot-spin {
+  transform-box: view-box;
+  transform-origin: 50% 50%;
+}
+
+/* Each ribbon carries a dark band under it that cuts whatever it crosses —
+   the strokes are opaque gold, so without this a crossing would just merge.
+   Translucent rather than the page colour, because these bands also run over
+   the disc art, where they have to read as the ribbon's own shadow.
+   Butt, not round: a round cap would overshoot the piece and lay a dark tick
+   across the neighbouring piece of its own ring at every seam. */
+.knot-cut {
+  fill: none;
+  stroke: var(--knot-cut);
+  stroke-linecap: butt;
+}
+
+/* --d is the piece's depth, generated with the arcs as a percentage: 0% at
+   the far side of a ring, 100% at the near. It drives colour rather than
+   stroke-opacity because the pieces meet with round caps, and translucent
+   caps would composite over one another and bead at every seam. Mixing
+   toward the page instead reads as the same distance and stays flat. */
+.knot-arc {
+  fill: none;
+  stroke: color-mix(in srgb, var(--accent-strong) var(--d), var(--knot-far));
+  stroke-linecap: round;
+}
+
+.knot-s0 {
+  stop-color: rgb(var(--scrim-rgb));
+  stop-opacity: 0.28;
+}
+
+.knot-s1 {
+  stop-color: rgb(var(--scrim-rgb));
+  stop-opacity: 0;
+}
+
+.knot-s2 {
+  stop-color: rgb(var(--accent-rgb));
+  stop-opacity: 0.12;
+}
+
+/* Filter lengths are user units here, not CSS pixels: the viewBox is 240
+   wide, so 13 is roughly the 40px lift the rest of the page uses. */
+.knot-core {
+  filter: drop-shadow(0 5px 13px rgb(2 3 9 / 0.6));
+}
+
+.knot-core-rim {
+  fill: none;
+  stroke: rgb(var(--accent-rgb) / 0.28);
+  stroke-width: 0.8;
+}
+
+/* Three request nodes riding the rings, one each: traffic circling the loop.
+   They are placed by offset-path alone, so they only exist where that is
+   supported — otherwise they would pile up at the origin. */
+.knot-node {
+  display: none;
+  fill: var(--accent-strong);
+  filter: drop-shadow(0 0 2.6px rgb(var(--accent-rgb) / 0.95));
+}
+
+@supports (offset-path: path("M0 0L1 1")) {
+  .knot-node {
+    display: block;
+    /* fill-box, so the anchor riding the path is the dot's own centre and
+       not the middle of the viewBox. */
+    transform-box: fill-box;
+    transform-origin: 50% 50%;
+    offset-rotate: 0deg;
+  }
+
+  /* Generated with the arcs: the full ellipse of each ring. */
+  .knot-node-0 {
+    offset-path: path("M233 120A113 64.81 0 0 1 7 120A113 64.81 0 0 1 233 120");
+  }
+
+  .knot-node-1 {
+    offset-path: path("M176.5 217.86A113 64.81 60 0 1 63.5 22.14A113 64.81 60 0 1 176.5 217.86");
+  }
+
+  .knot-node-2 {
+    offset-path: path("M63.5 217.86A113 64.81 120 0 1 176.5 22.14A113 64.81 120 0 1 63.5 217.86");
+  }
 }
 
 /* --- Showcase: a real terminal capture floating under the hero --------- */
@@ -2768,21 +2805,34 @@ html.search-lock body {
     animation: hero-rise 760ms cubic-bezier(0.16, 1, 0.3, 1) 160ms backwards;
   }
 
-  .hero-disc img {
+  .knot-core-art {
     animation: quiet-drift 16s cubic-bezier(0.16, 1, 0.3, 1) infinite alternate;
+    transform-box: fill-box;
     transform-origin: 74% 45%;
   }
 
-  /* The negative delay puts the outer node mid-lap from the first frame, so
-     the two never read as starting from the same spot. */
-  .hero-orbit {
-    animation: orbit-spin 34s linear infinite;
+  /* One slow turn of the whole weave. Three-fold symmetry means it reads as
+     repeating every third of a lap, so the lap itself can be long. */
+  .knot-spin {
+    animation: knot-turn 66s linear infinite;
   }
 
-  .hero-orbit-out {
-    animation-duration: 56s;
+  /* Each node rides its own ring and dims on the far side, so the traffic
+     passes behind the disc instead of skating over it. The negative delays
+     keep the three from ever setting off together. */
+  .knot-node {
+    animation: knot-ride 21s linear infinite, knot-depth 21s ease-in-out infinite;
+  }
+
+  .knot-node-1 {
+    animation-duration: 29s;
+    animation-delay: -11s;
+  }
+
+  .knot-node-2 {
+    animation-duration: 37s;
+    animation-delay: -25s;
     animation-direction: reverse;
-    animation-delay: -21s;
   }
 
   .path-ring:hover::before,
@@ -3014,21 +3064,52 @@ html.search-lock body {
   }
 }
 
+/* Lengths here are SVG user units, not CSS pixels: the viewBox is 240 across.
+   The art box already overhangs its clip circle (see the generator), and the
+   scale opens up more slack still, so the drift can never pull an edge of the
+   image into the disc. */
 @keyframes quiet-drift {
   from {
     transform: scale(1);
   }
   to {
-    transform: scale(1.035) translateX(-0.8rem);
+    transform: scale(1.075) translate(-3.4px, 1.2px);
   }
 }
 
-@keyframes orbit-spin {
+@keyframes knot-turn {
   from {
     transform: rotate(0deg);
   }
   to {
     transform: rotate(360deg);
+  }
+}
+
+@keyframes knot-ride {
+  from {
+    offset-distance: 0%;
+  }
+  to {
+    offset-distance: 100%;
+  }
+}
+
+/* The ride starts at a ring's near horizon, so the first half of the lap is
+   the half in front of the disc and the second half is the one behind it. */
+@keyframes knot-depth {
+  0%,
+  100% {
+    opacity: 0.55;
+  }
+  25% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+  75% {
+    opacity: 0.1;
   }
 }
 
@@ -3075,7 +3156,7 @@ html.search-lock body {
   }
 
   .hero-art {
-    width: min(88%, 30rem);
+    width: min(88%, 36rem);
   }
 
   .home-structure {
@@ -3131,21 +3212,7 @@ html.search-lock body {
   }
 
   .hero-art {
-    width: min(84%, 24rem);
-  }
-
-  .hero-art::before {
-    inset: -1.1rem;
-    outline-offset: 1rem;
-  }
-
-  /* The orbit nodes track the tightened circles above. */
-  .hero-orbit {
-    inset: -1.1rem;
-  }
-
-  .hero-orbit-out {
-    inset: -2.1rem;
+    width: min(92%, 29rem);
   }
 
   .structure-art {

--- a/docs/templates/page.html
+++ b/docs/templates/page.html
@@ -34,13 +34,7 @@
         </div>
       </div>
     </div>
-    <figure class="hero-art">
-      <i class="hero-orbit" aria-hidden="true"></i>
-      <i class="hero-orbit hero-orbit-out" aria-hidden="true"></i>
-      <span class="hero-disc">
-        <img src="{{ base_url }}/images/wallpaper.webp" alt="{{ "home.hero_art_alt" | t }}">
-      </span>
-    </figure>
+    {% include "partials/hero-knot.html" %}
   </section>
 
   <section class="home-showcase rv" aria-label="gori running in the terminal">

--- a/docs/templates/partials/hero-knot.html
+++ b/docs/templates/partials/hero-knot.html
@@ -1,0 +1,191 @@
+{# The hero mark: three rings woven around a disc of the official art, the
+   same weave the logo carries. Generated geometry -- three circles of radius
+   113 tilted 55 deg out of the screen plane and spun 0/60/120 deg about the
+   view axis, each cut at its own horizon and at every crossing, then painted
+   back to front. So the over/under pattern is the one the solid would show,
+   not a hand-authored guess, and a rigid spin of the whole group keeps it
+   true. Re-generate rather than edit these arcs by hand. #}
+<figure class="hero-art">
+  <svg class="hero-knot" viewBox="0 0 240 240" role="img" aria-label="{{ "home.hero_art_alt" | t }}">
+    <defs>
+      <linearGradient id="knotSheen" gradientUnits="userSpaceOnUse"
+                      x1="41" y1="41" x2="199" y2="199">
+        <stop class="knot-s0" offset="0"/>
+        <stop class="knot-s1" offset="0.42"/>
+        <stop class="knot-s2" offset="1"/>
+      </linearGradient>
+      <clipPath id="knotDisc">
+        <circle cx="120" cy="120" r="79"/>
+      </clipPath>
+    </defs>
+
+    {# Everything behind the disc. #}
+    <g class="knot-spin">
+      <path class="knot-cut" stroke-width="3.92" d="M84.48 58.47A113 64.81 0 0 1 120 55.19"/>
+      <path class="knot-arc" stroke-width="1.72" style="--d:0.0%" d="M84.48 58.47A113 64.81 0 0 1 120 55.19"/>
+      <path class="knot-cut" stroke-width="3.92" d="M120 55.19A113 64.81 0 0 1 155.52 58.47"/>
+      <path class="knot-arc" stroke-width="1.72" style="--d:0.0%" d="M120 55.19A113 64.81 0 0 1 155.52 58.47"/>
+      <path class="knot-cut" stroke-width="3.92" d="M155.52 58.47A113 64.81 60 0 1 176.13 87.59"/>
+      <path class="knot-arc" stroke-width="1.72" style="--d:0.0%" d="M155.52 58.47A113 64.81 60 0 1 176.13 87.59"/>
+      <path class="knot-cut" stroke-width="3.92" d="M176.13 87.59A113 64.81 60 0 1 191.05 120"/>
+      <path class="knot-arc" stroke-width="1.72" style="--d:0.0%" d="M176.13 87.59A113 64.81 60 0 1 191.05 120"/>
+      <path class="knot-cut" stroke-width="3.92" d="M191.05 120A113 64.81 120 0 1 176.13 152.41"/>
+      <path class="knot-arc" stroke-width="1.72" style="--d:0.0%" d="M191.05 120A113 64.81 120 0 1 176.13 152.41"/>
+      <path class="knot-cut" stroke-width="3.92" d="M176.13 152.41A113 64.81 120 0 1 155.52 181.53"/>
+      <path class="knot-arc" stroke-width="1.72" style="--d:0.0%" d="M176.13 152.41A113 64.81 120 0 1 155.52 181.53"/>
+      <path class="knot-cut" stroke-width="4.05" d="M60.84 64.78A113 64.81 0 0 1 84.48 58.47"/>
+      <path class="knot-arc" stroke-width="1.85" style="--d:0.5%" d="M60.84 64.78A113 64.81 0 0 1 84.48 58.47"/>
+      <path class="knot-cut" stroke-width="4.05" d="M155.52 58.47A113 64.81 0 0 1 179.16 64.78"/>
+      <path class="knot-arc" stroke-width="1.85" style="--d:0.5%" d="M155.52 58.47A113 64.81 0 0 1 179.16 64.78"/>
+      <path class="knot-cut" stroke-width="4.05" d="M138.25 41.16A113 64.81 60 0 1 155.52 58.47"/>
+      <path class="knot-arc" stroke-width="1.85" style="--d:0.5%" d="M138.25 41.16A113 64.81 60 0 1 155.52 58.47"/>
+      <path class="knot-cut" stroke-width="4.05" d="M191.05 120A113 64.81 60 0 1 197.4 143.62"/>
+      <path class="knot-arc" stroke-width="1.85" style="--d:0.5%" d="M191.05 120A113 64.81 60 0 1 197.4 143.62"/>
+      <path class="knot-cut" stroke-width="4.05" d="M197.4 96.38A113 64.81 120 0 1 191.05 120"/>
+      <path class="knot-arc" stroke-width="1.85" style="--d:0.5%" d="M197.4 96.38A113 64.81 120 0 1 191.05 120"/>
+      <path class="knot-cut" stroke-width="4.05" d="M155.52 181.53A113 64.81 120 0 1 138.25 198.84"/>
+      <path class="knot-arc" stroke-width="1.85" style="--d:0.5%" d="M155.52 181.53A113 64.81 120 0 1 138.25 198.84"/>
+      <path class="knot-cut" stroke-width="4.25" d="M179.16 64.78A113 64.81 0 0 1 199.64 74.02"/>
+      <path class="knot-arc" stroke-width="2.05" style="--d:2.2%" d="M179.16 64.78A113 64.81 0 0 1 199.64 74.02"/>
+      <path class="knot-cut" stroke-width="4.25" d="M197.4 143.62A113 64.81 60 0 1 199.64 165.98"/>
+      <path class="knot-arc" stroke-width="2.05" style="--d:2.2%" d="M197.4 143.62A113 64.81 60 0 1 199.64 165.98"/>
+      <path class="knot-cut" stroke-width="4.25" d="M138.25 198.84A113 64.81 120 0 1 120 211.96"/>
+      <path class="knot-arc" stroke-width="2.05" style="--d:2.2%" d="M138.25 198.84A113 64.81 120 0 1 120 211.96"/>
+      <path class="knot-cut" stroke-width="4.25" d="M40.36 74.02A113 64.81 0 0 1 60.84 64.78"/>
+      <path class="knot-arc" stroke-width="2.05" style="--d:2.2%" d="M40.36 74.02A113 64.81 0 0 1 60.84 64.78"/>
+      <path class="knot-cut" stroke-width="4.25" d="M120 28.04A113 64.81 60 0 1 138.25 41.16"/>
+      <path class="knot-arc" stroke-width="2.05" style="--d:2.2%" d="M120 28.04A113 64.81 60 0 1 138.25 41.16"/>
+      <path class="knot-cut" stroke-width="4.25" d="M199.64 74.02A113 64.81 120 0 1 197.4 96.38"/>
+      <path class="knot-arc" stroke-width="2.05" style="--d:2.2%" d="M199.64 74.02A113 64.81 120 0 1 197.4 96.38"/>
+      <path class="knot-cut" stroke-width="4.54" d="M22.26 87.47A113 64.81 0 0 1 40.36 74.02"/>
+      <path class="knot-arc" stroke-width="2.34" style="--d:6.2%" d="M22.26 87.47A113 64.81 0 0 1 40.36 74.02"/>
+      <path class="knot-cut" stroke-width="4.54" d="M199.64 74.02A113 64.81 0 0 1 217.74 87.47"/>
+      <path class="knot-arc" stroke-width="2.34" style="--d:6.2%" d="M199.64 74.02A113 64.81 0 0 1 217.74 87.47"/>
+      <path class="knot-cut" stroke-width="4.54" d="M99.3 19.09A113 64.81 60 0 1 120 28.04"/>
+      <path class="knot-arc" stroke-width="2.34" style="--d:6.2%" d="M99.3 19.09A113 64.81 60 0 1 120 28.04"/>
+      <path class="knot-cut" stroke-width="4.54" d="M199.64 165.98A113 64.81 60 0 1 197.04 188.38"/>
+      <path class="knot-arc" stroke-width="2.34" style="--d:6.2%" d="M199.64 165.98A113 64.81 60 0 1 197.04 188.38"/>
+      <path class="knot-cut" stroke-width="4.54" d="M197.04 51.62A113 64.81 120 0 1 199.64 74.02"/>
+      <path class="knot-arc" stroke-width="2.34" style="--d:6.2%" d="M197.04 51.62A113 64.81 120 0 1 199.64 74.02"/>
+      <path class="knot-cut" stroke-width="4.54" d="M120 211.96A113 64.81 120 0 1 99.3 220.91"/>
+      <path class="knot-arc" stroke-width="2.34" style="--d:6.2%" d="M120 211.96A113 64.81 120 0 1 99.3 220.91"/>
+      <path class="knot-cut" stroke-width="4.92" d="M10.88 103.16A113 64.81 0 0 1 22.26 87.47"/>
+      <path class="knot-arc" stroke-width="2.72" style="--d:13.5%" d="M10.88 103.16A113 64.81 0 0 1 22.26 87.47"/>
+      <path class="knot-cut" stroke-width="4.92" d="M217.74 87.47A113 64.81 0 0 1 229.12 103.16"/>
+      <path class="knot-arc" stroke-width="2.72" style="--d:13.5%" d="M217.74 87.47A113 64.81 0 0 1 229.12 103.16"/>
+      <path class="knot-cut" stroke-width="4.92" d="M80.03 17.08A113 64.81 60 0 1 99.3 19.09"/>
+      <path class="knot-arc" stroke-width="2.72" style="--d:13.5%" d="M80.03 17.08A113 64.81 60 0 1 99.3 19.09"/>
+      <path class="knot-cut" stroke-width="4.92" d="M197.04 188.38A113 64.81 60 0 1 189.15 206.08"/>
+      <path class="knot-arc" stroke-width="2.72" style="--d:13.5%" d="M197.04 188.38A113 64.81 60 0 1 189.15 206.08"/>
+      <path class="knot-cut" stroke-width="4.92" d="M189.15 33.92A113 64.81 120 0 1 197.04 51.62"/>
+      <path class="knot-arc" stroke-width="2.72" style="--d:13.5%" d="M189.15 33.92A113 64.81 120 0 1 197.04 51.62"/>
+      <path class="knot-cut" stroke-width="4.92" d="M99.3 220.91A113 64.81 120 0 1 80.03 222.92"/>
+      <path class="knot-arc" stroke-width="2.72" style="--d:13.5%" d="M99.3 220.91A113 64.81 120 0 1 80.03 222.92"/>
+      <path class="knot-cut" stroke-width="5.33" d="M7 120A113 64.81 0 0 1 10.88 103.16"/>
+      <path class="knot-arc" stroke-width="3.13" style="--d:24.2%" d="M7 120A113 64.81 0 0 1 10.88 103.16"/>
+      <path class="knot-cut" stroke-width="5.33" d="M63.5 22.14A113 64.81 60 0 1 80.03 17.08"/>
+      <path class="knot-arc" stroke-width="3.13" style="--d:24.2%" d="M63.5 22.14A113 64.81 60 0 1 80.03 17.08"/>
+      <path class="knot-cut" stroke-width="5.33" d="M176.5 22.14A113 64.81 120 0 1 189.15 33.92"/>
+      <path class="knot-arc" stroke-width="3.13" style="--d:24.2%" d="M176.5 22.14A113 64.81 120 0 1 189.15 33.92"/>
+      <path class="knot-cut" stroke-width="5.33" d="M229.12 103.16A113 64.81 0 0 1 233 120"/>
+      <path class="knot-arc" stroke-width="3.13" style="--d:24.2%" d="M229.12 103.16A113 64.81 0 0 1 233 120"/>
+      <path class="knot-cut" stroke-width="5.33" d="M189.15 206.08A113 64.81 60 0 1 176.5 217.86"/>
+      <path class="knot-arc" stroke-width="3.13" style="--d:24.2%" d="M189.15 206.08A113 64.81 60 0 1 176.5 217.86"/>
+      <path class="knot-cut" stroke-width="5.33" d="M80.03 222.92A113 64.81 120 0 1 63.5 217.86"/>
+      <path class="knot-arc" stroke-width="3.13" style="--d:24.2%" d="M80.03 222.92A113 64.81 120 0 1 63.5 217.86"/>
+    </g>
+
+    {# The core. Not in a spinning group: the art holds still while the
+       rings turn around it. #}
+    <g class="knot-core">
+      <circle cx="120" cy="120" r="79" fill="#0a0a0b"/>
+      <g clip-path="url(#knotDisc)">
+        <image class="knot-core-art" href="{{ base_url }}/images/wallpaper.webp"
+               x="26.78" y="26.78" width="186.44" height="186.44"
+               preserveAspectRatio="xMidYMid slice"/>
+      </g>
+      <circle cx="120" cy="120" r="79" fill="url(#knotSheen)"/>
+      <circle class="knot-core-rim" cx="120" cy="120" r="78.6"/>
+    </g>
+
+    {# Everything in front of it, and the three request nodes riding the
+       rings -- traffic circling the loop. #}
+    <g class="knot-spin">
+      <path class="knot-cut" stroke-width="5.77" d="M10.88 136.84A113 64.81 0 0 1 7 120"/>
+      <path class="knot-arc" stroke-width="3.57" style="--d:37.9%" d="M10.88 136.84A113 64.81 0 0 1 7 120"/>
+      <path class="knot-cut" stroke-width="5.77" d="M50.85 33.92A113 64.81 60 0 1 63.5 22.14"/>
+      <path class="knot-arc" stroke-width="3.57" style="--d:37.9%" d="M50.85 33.92A113 64.81 60 0 1 63.5 22.14"/>
+      <path class="knot-cut" stroke-width="5.77" d="M159.97 17.08A113 64.81 120 0 1 176.5 22.14"/>
+      <path class="knot-arc" stroke-width="3.57" style="--d:37.9%" d="M159.97 17.08A113 64.81 120 0 1 176.5 22.14"/>
+      <path class="knot-cut" stroke-width="5.77" d="M176.5 217.86A113 64.81 60 0 1 159.97 222.92"/>
+      <path class="knot-arc" stroke-width="3.57" style="--d:37.9%" d="M176.5 217.86A113 64.81 60 0 1 159.97 222.92"/>
+      <path class="knot-cut" stroke-width="5.77" d="M63.5 217.86A113 64.81 120 0 1 50.85 206.08"/>
+      <path class="knot-arc" stroke-width="3.57" style="--d:37.9%" d="M63.5 217.86A113 64.81 120 0 1 50.85 206.08"/>
+      <path class="knot-cut" stroke-width="5.77" d="M233 120A113 64.81 0 0 1 229.12 136.84"/>
+      <path class="knot-arc" stroke-width="3.57" style="--d:37.9%" d="M233 120A113 64.81 0 0 1 229.12 136.84"/>
+      <path class="knot-cut" stroke-width="6.18" d="M22.26 152.53A113 64.81 0 0 1 10.88 136.84"/>
+      <path class="knot-arc" stroke-width="3.98" style="--d:53.5%" d="M22.26 152.53A113 64.81 0 0 1 10.88 136.84"/>
+      <path class="knot-cut" stroke-width="6.18" d="M42.96 51.62A113 64.81 60 0 1 50.85 33.92"/>
+      <path class="knot-arc" stroke-width="3.98" style="--d:53.5%" d="M42.96 51.62A113 64.81 60 0 1 50.85 33.92"/>
+      <path class="knot-cut" stroke-width="6.18" d="M140.7 19.09A113 64.81 120 0 1 159.97 17.08"/>
+      <path class="knot-arc" stroke-width="3.98" style="--d:53.5%" d="M140.7 19.09A113 64.81 120 0 1 159.97 17.08"/>
+      <path class="knot-cut" stroke-width="6.18" d="M159.97 222.92A113 64.81 60 0 1 140.7 220.91"/>
+      <path class="knot-arc" stroke-width="3.98" style="--d:53.5%" d="M159.97 222.92A113 64.81 60 0 1 140.7 220.91"/>
+      <path class="knot-cut" stroke-width="6.18" d="M50.85 206.08A113 64.81 120 0 1 42.96 188.38"/>
+      <path class="knot-arc" stroke-width="3.98" style="--d:53.5%" d="M50.85 206.08A113 64.81 120 0 1 42.96 188.38"/>
+      <path class="knot-cut" stroke-width="6.18" d="M229.12 136.84A113 64.81 0 0 1 217.74 152.53"/>
+      <path class="knot-arc" stroke-width="3.98" style="--d:53.5%" d="M229.12 136.84A113 64.81 0 0 1 217.74 152.53"/>
+      <path class="knot-cut" stroke-width="6.56" d="M40.36 165.98A113 64.81 0 0 1 22.26 152.53"/>
+      <path class="knot-arc" stroke-width="4.36" style="--d:69.2%" d="M40.36 165.98A113 64.81 0 0 1 22.26 152.53"/>
+      <path class="knot-cut" stroke-width="6.56" d="M40.36 74.02A113 64.81 60 0 1 42.96 51.62"/>
+      <path class="knot-arc" stroke-width="4.36" style="--d:69.2%" d="M40.36 74.02A113 64.81 60 0 1 42.96 51.62"/>
+      <path class="knot-cut" stroke-width="6.56" d="M120 28.04A113 64.81 120 0 1 140.7 19.09"/>
+      <path class="knot-arc" stroke-width="4.36" style="--d:69.2%" d="M120 28.04A113 64.81 120 0 1 140.7 19.09"/>
+      <path class="knot-cut" stroke-width="6.56" d="M140.7 220.91A113 64.81 60 0 1 120 211.96"/>
+      <path class="knot-arc" stroke-width="4.36" style="--d:69.2%" d="M140.7 220.91A113 64.81 60 0 1 120 211.96"/>
+      <path class="knot-cut" stroke-width="6.56" d="M42.96 188.38A113 64.81 120 0 1 40.36 165.98"/>
+      <path class="knot-arc" stroke-width="4.36" style="--d:69.2%" d="M42.96 188.38A113 64.81 120 0 1 40.36 165.98"/>
+      <path class="knot-cut" stroke-width="6.56" d="M217.74 152.53A113 64.81 0 0 1 199.64 165.98"/>
+      <path class="knot-arc" stroke-width="4.36" style="--d:69.2%" d="M217.74 152.53A113 64.81 0 0 1 199.64 165.98"/>
+      <path class="knot-cut" stroke-width="6.85" d="M60.84 175.22A113 64.81 0 0 1 40.36 165.98"/>
+      <path class="knot-arc" stroke-width="4.65" style="--d:82.5%" d="M60.84 175.22A113 64.81 0 0 1 40.36 165.98"/>
+      <path class="knot-cut" stroke-width="6.85" d="M42.6 96.38A113 64.81 60 0 1 40.36 74.02"/>
+      <path class="knot-arc" stroke-width="4.65" style="--d:82.5%" d="M42.6 96.38A113 64.81 60 0 1 40.36 74.02"/>
+      <path class="knot-cut" stroke-width="6.85" d="M101.75 41.16A113 64.81 120 0 1 120 28.04"/>
+      <path class="knot-arc" stroke-width="4.65" style="--d:82.5%" d="M101.75 41.16A113 64.81 120 0 1 120 28.04"/>
+      <path class="knot-cut" stroke-width="6.85" d="M120 211.96A113 64.81 60 0 1 101.75 198.84"/>
+      <path class="knot-arc" stroke-width="4.65" style="--d:82.5%" d="M120 211.96A113 64.81 60 0 1 101.75 198.84"/>
+      <path class="knot-cut" stroke-width="6.85" d="M40.36 165.98A113 64.81 120 0 1 42.6 143.62"/>
+      <path class="knot-arc" stroke-width="4.65" style="--d:82.5%" d="M40.36 165.98A113 64.81 120 0 1 42.6 143.62"/>
+      <path class="knot-cut" stroke-width="6.85" d="M199.64 165.98A113 64.81 0 0 1 179.16 175.22"/>
+      <path class="knot-arc" stroke-width="4.65" style="--d:82.5%" d="M199.64 165.98A113 64.81 0 0 1 179.16 175.22"/>
+      <path class="knot-cut" stroke-width="7.05" d="M84.48 181.53A113 64.81 0 0 1 60.84 175.22"/>
+      <path class="knot-arc" stroke-width="4.85" style="--d:92.2%" d="M84.48 181.53A113 64.81 0 0 1 60.84 175.22"/>
+      <path class="knot-cut" stroke-width="7.05" d="M48.95 120A113 64.81 60 0 1 42.6 96.38"/>
+      <path class="knot-arc" stroke-width="4.85" style="--d:92.2%" d="M48.95 120A113 64.81 60 0 1 42.6 96.38"/>
+      <path class="knot-cut" stroke-width="7.05" d="M84.48 58.47A113 64.81 120 0 1 101.75 41.16"/>
+      <path class="knot-arc" stroke-width="4.85" style="--d:92.2%" d="M84.48 58.47A113 64.81 120 0 1 101.75 41.16"/>
+      <path class="knot-cut" stroke-width="7.05" d="M101.75 198.84A113 64.81 60 0 1 84.48 181.53"/>
+      <path class="knot-arc" stroke-width="4.85" style="--d:92.2%" d="M101.75 198.84A113 64.81 60 0 1 84.48 181.53"/>
+      <path class="knot-cut" stroke-width="7.05" d="M42.6 143.62A113 64.81 120 0 1 48.95 120"/>
+      <path class="knot-arc" stroke-width="4.85" style="--d:92.2%" d="M42.6 143.62A113 64.81 120 0 1 48.95 120"/>
+      <path class="knot-cut" stroke-width="7.05" d="M179.16 175.22A113 64.81 0 0 1 155.52 181.53"/>
+      <path class="knot-arc" stroke-width="4.85" style="--d:92.2%" d="M179.16 175.22A113 64.81 0 0 1 155.52 181.53"/>
+      <path class="knot-cut" stroke-width="7.18" d="M120 184.81A113 64.81 0 0 1 84.48 181.53"/>
+      <path class="knot-arc" stroke-width="4.98" style="--d:98.9%" d="M120 184.81A113 64.81 0 0 1 84.48 181.53"/>
+      <path class="knot-cut" stroke-width="7.18" d="M63.87 152.41A113 64.81 60 0 1 48.95 120"/>
+      <path class="knot-arc" stroke-width="4.98" style="--d:98.9%" d="M63.87 152.41A113 64.81 60 0 1 48.95 120"/>
+      <path class="knot-cut" stroke-width="7.18" d="M63.87 87.59A113 64.81 120 0 1 84.48 58.47"/>
+      <path class="knot-arc" stroke-width="4.98" style="--d:98.9%" d="M63.87 87.59A113 64.81 120 0 1 84.48 58.47"/>
+      <path class="knot-cut" stroke-width="7.18" d="M155.52 181.53A113 64.81 0 0 1 120 184.81"/>
+      <path class="knot-arc" stroke-width="4.98" style="--d:98.9%" d="M155.52 181.53A113 64.81 0 0 1 120 184.81"/>
+      <path class="knot-cut" stroke-width="7.18" d="M84.48 181.53A113 64.81 60 0 1 63.87 152.41"/>
+      <path class="knot-arc" stroke-width="4.98" style="--d:98.9%" d="M84.48 181.53A113 64.81 60 0 1 63.87 152.41"/>
+      <path class="knot-cut" stroke-width="7.18" d="M48.95 120A113 64.81 120 0 1 63.87 87.59"/>
+      <path class="knot-arc" stroke-width="4.98" style="--d:98.9%" d="M48.95 120A113 64.81 120 0 1 63.87 87.59"/>
+      <circle class="knot-node knot-node-0" r="3.1"/>
+      <circle class="knot-node knot-node-1" r="2.7"/>
+      <circle class="knot-node knot-node-2" r="2.4"/>
+    </g>
+  </svg>
+</figure>

--- a/docs/tools/hero-knot/README.md
+++ b/docs/tools/hero-knot/README.md
@@ -1,0 +1,32 @@
+# hero-knot
+
+Generates `templates/partials/hero-knot.html`, the woven three-ring mark in the
+landing-page hero.
+
+```
+python3 tools/hero-knot/build.py
+```
+
+The three rings are real circles tilted out of the screen plane, so the script
+can compute where each one passes in front of or behind the others and cut them
+at exactly those points. The arcs are then written out back to front: the
+over/under pattern is derived from the geometry rather than drawn by hand, which
+is why the arcs in the partial should never be edited directly — change a
+constant at the top of the script and re-run it.
+
+## What lives where
+
+- **Geometry and depth order** — this script, into the partial.
+- **Colour, thickness ramp and motion** — `static/css/style.css`, under
+  "The hero mark". The partial only tags each arc with its depth (`--d`) and
+  stroke width.
+- **The nodes' motion paths** — printed by the script, pasted into the
+  `offset-path` block in `style.css`. They are the full ellipses the arcs are
+  cut from, so they have to be updated whenever the partial is regenerated.
+
+## Why the whole mark can spin
+
+The painted depth order is only correct for the viewpoint it was computed from.
+Turning the group in the picture plane is a rigid motion — it moves every arc
+the same way and never changes which one is nearer — so the weave stays true.
+Anything that would rotate the rings *through* the screen plane would not.

--- a/docs/tools/hero-knot/build.py
+++ b/docs/tools/hero-knot/build.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Generate templates/partials/hero-knot.html -- the woven three-ring hero mark.
+
+Three identical circles of radius R, each tilted TAU out of the screen plane
+and then spun by PHI_i about the view axis.  Orthographic projection turns
+each into an ellipse (semi-axes R and R*cos TAU) whose depth is
+z = R*sin(TAU)*sin(theta) -- a function of the ring parameter alone.
+
+Every ring is cut at its own z=0 points and at every crossing with another
+ring, then all pieces are painted back to front.  That is a painter's
+algorithm over a real 3D embedding, so the over/under pattern is the one the
+solid would actually show: the weave is derived, not hand-authored.
+"""
+import math
+import pathlib
+
+C = 120.0          # centre of the 240x240 viewBox
+R = 113.0          # ring radius
+TAU = math.radians(55.0)
+PHI = [0.0, 60.0, 120.0]
+DISC = 79.0        # radius of the core disc
+STEPS = 4000       # sampling resolution for crossing detection
+
+RY = R * math.cos(TAU)
+ZAMP = R * math.sin(TAU)
+
+OUT = pathlib.Path(__file__).resolve().parents[2] / "templates/partials/hero-knot.html"
+
+
+def pt(i, th):
+    p = math.radians(PHI[i])
+    cx, sx = math.cos(p), math.sin(p)
+    a, b = R * math.cos(th), RY * math.sin(th)
+    return (C + a * cx - b * sx, C + a * sx + b * cx)
+
+
+def z(th):
+    return ZAMP * math.sin(th)
+
+
+def implicit(i, x, y):
+    """<0 inside ring i's ellipse, >0 outside."""
+    p = math.radians(PHI[i])
+    dx, dy = x - C, y - C
+    u = dx * math.cos(p) + dy * math.sin(p)
+    v = -dx * math.sin(p) + dy * math.cos(p)
+    return (u / R) ** 2 + (v / RY) ** 2 - 1.0
+
+
+def crossings(i, j):
+    """theta values on ring i where it crosses ring j."""
+    out = []
+    prev_th = 0.0
+    prev = implicit(j, *pt(i, prev_th))
+    for k in range(1, STEPS + 1):
+        th = 2 * math.pi * k / STEPS
+        cur = implicit(j, *pt(i, th))
+        if prev * cur < 0:
+            lo, hi = prev_th, th
+            for _ in range(60):
+                mid = (lo + hi) / 2
+                if implicit(j, *pt(i, mid)) * prev < 0:
+                    hi = mid
+                else:
+                    lo = mid
+            out.append((lo + hi) / 2)
+        prev_th, prev = th, cur
+    return out
+
+
+def dedupe(vals, eps=1e-4):
+    vals = sorted(v % (2 * math.pi) for v in vals)
+    out = []
+    for v in vals:
+        if not out or abs(v - out[-1]) > eps:
+            out.append(v)
+    if len(out) > 1 and abs(out[0] + 2 * math.pi - out[-1]) < eps:
+        out.pop()
+    return out
+
+
+def fmt(v):
+    s = f"{v:.2f}".rstrip("0").rstrip(".")
+    return s if s not in ("-0", "") else "0"
+
+
+# A piece gets one width and one opacity, taken at its middle, so a long
+# piece would step visibly against its neighbours. Splitting every run down
+# to at most STEP keeps consecutive pieces close enough in depth that the
+# taper reads continuous.
+STEP = math.radians(22.0)
+
+pieces = []
+for i in range(3):
+    cuts = [0.0, math.pi]
+    for j in range(3):
+        if j != i:
+            cuts += crossings(i, j)
+    cuts = dedupe(cuts)
+    for k, a in enumerate(cuts):
+        b = cuts[(k + 1) % len(cuts)]
+        if b <= a:
+            b += 2 * math.pi
+        n = max(1, math.ceil((b - a) / STEP))
+        for s in range(n):
+            t0 = a + (b - a) * s / n
+            t1 = a + (b - a) * (s + 1) / n
+            x1, y1 = pt(i, t0)
+            x2, y2 = pt(i, t1)
+            large = 1 if (t1 - t0) > math.pi else 0
+            pieces.append({
+                "z": z((t0 + t1) / 2),
+                "d": (f"M{fmt(x1)} {fmt(y1)}"
+                      f"A{fmt(R)} {fmt(RY)} {fmt(PHI[i])} {large} 1 {fmt(x2)} {fmt(y2)}"),
+            })
+
+pieces.sort(key=lambda p: p["z"])
+
+
+def shade(zv):
+    """Near side thicker and brighter: what gives a flat stroke the weight of
+    a turning ribbon."""
+    t = (zv / ZAMP + 1) / 2            # 0 far, 1 near
+    return 1.7 + 3.3 * t, t ** 1.7
+
+
+def emit(group, indent):
+    lines = []
+    for p in group:
+        w, o = shade(p["z"])
+        lines.append(f'{indent}<path class="knot-cut" stroke-width="{fmt(w + 2.2)}"'
+                     f' d="{p["d"]}"/>')
+        lines.append(f'{indent}<path class="knot-arc" stroke-width="{fmt(w)}"'
+                     f' style="--d:{o * 100:.1f}%" d="{p["d"]}"/>')
+    return "\n".join(lines)
+
+
+back = emit([p for p in pieces if p["z"] < 0], "      ")
+front = emit([p for p in pieces if p["z"] >= 0], "      ")
+
+# Full-ring paths, handed to CSS as the motion path each traffic node rides.
+rings = []
+for i in range(3):
+    x0, y0 = pt(i, 0.0)
+    xh, yh = pt(i, math.pi)
+    rings.append(f"M{fmt(x0)} {fmt(y0)}"
+                 f"A{fmt(R)} {fmt(RY)} {fmt(PHI[i])} 0 1 {fmt(xh)} {fmt(yh)}"
+                 f"A{fmt(R)} {fmt(RY)} {fmt(PHI[i])} 0 1 {fmt(x0)} {fmt(y0)}")
+
+# The art box overhangs the clip circle: the drift below scales and slides it,
+# and without the overhang a corner would swing into view at the far end of
+# the travel.
+ART = DISC * 1.18
+box = fmt(C - ART)
+side = fmt(2 * ART)
+
+doc = f"""{{# The hero mark: three rings woven around a disc of the official art, the
+   same weave the logo carries. Generated geometry -- three circles of radius
+   {fmt(R)} tilted {fmt(math.degrees(TAU))} deg out of the screen plane and spun 0/60/120 deg about the
+   view axis, each cut at its own horizon and at every crossing, then painted
+   back to front. So the over/under pattern is the one the solid would show,
+   not a hand-authored guess, and a rigid spin of the whole group keeps it
+   true. Re-generate rather than edit these arcs by hand. #}}
+<figure class="hero-art">
+  <svg class="hero-knot" viewBox="0 0 240 240" role="img" aria-label="{{{{ "home.hero_art_alt" | t }}}}">
+    <defs>
+      <linearGradient id="knotSheen" gradientUnits="userSpaceOnUse"
+                      x1="{fmt(C - DISC)}" y1="{fmt(C - DISC)}" x2="{fmt(C + DISC)}" y2="{fmt(C + DISC)}">
+        <stop class="knot-s0" offset="0"/>
+        <stop class="knot-s1" offset="0.42"/>
+        <stop class="knot-s2" offset="1"/>
+      </linearGradient>
+      <clipPath id="knotDisc">
+        <circle cx="{fmt(C)}" cy="{fmt(C)}" r="{fmt(DISC)}"/>
+      </clipPath>
+    </defs>
+
+    {{# Everything behind the disc. #}}
+    <g class="knot-spin">
+{back}
+    </g>
+
+    {{# The core. Not in a spinning group: the art holds still while the
+       rings turn around it. #}}
+    <g class="knot-core">
+      <circle cx="{fmt(C)}" cy="{fmt(C)}" r="{fmt(DISC)}" fill="#0a0a0b"/>
+      <g clip-path="url(#knotDisc)">
+        <image class="knot-core-art" href="{{{{ base_url }}}}/images/wallpaper.webp"
+               x="{box}" y="{box}" width="{side}" height="{side}"
+               preserveAspectRatio="xMidYMid slice"/>
+      </g>
+      <circle cx="{fmt(C)}" cy="{fmt(C)}" r="{fmt(DISC)}" fill="url(#knotSheen)"/>
+      <circle class="knot-core-rim" cx="{fmt(C)}" cy="{fmt(C)}" r="{fmt(DISC - 0.4)}"/>
+    </g>
+
+    {{# Everything in front of it, and the three request nodes riding the
+       rings -- traffic circling the loop. #}}
+    <g class="knot-spin">
+{front}
+      <circle class="knot-node knot-node-0" r="3.1"/>
+      <circle class="knot-node knot-node-1" r="2.7"/>
+      <circle class="knot-node knot-node-2" r="2.4"/>
+    </g>
+  </svg>
+</figure>
+"""
+
+OUT.write_text(doc)
+print(f"wrote {OUT} ({len(pieces)} pieces)")
+print()
+print("Paste these into static/css/style.css, inside the offset-path @supports")
+print("block -- the nodes ride the same ellipses the arcs are cut from, so they")
+print("have to be regenerated together with the partial:")
+print()
+for i, r in enumerate(rings):
+    print(f'  .knot-node-{i} {{')
+    print(f'    offset-path: path("{r}");')
+    print("  }")


### PR DESCRIPTION
## What

The landing hero's art was a wave disc with two flat orbit circles — a different visual language from the logo, which is three rings woven through one another. This replaces it with the same weave around the disc.

## How

The weave is **generated, not drawn** (`docs/tools/hero-knot/build.py`): three equal circles tilted 55° out of the screen plane and spun 0/60/120° about the view axis, orthographically projected. Each ring is cut at its own horizon and at every crossing with another ring, then all pieces are painted back to front — a painter's algorithm over a real 3D embedding, so the over/under pattern is the one the solid would actually show.

That also makes the spin safe: a rigid rotation in the picture plane never changes which arc is nearer, so the knot turns without a crossing ever going wrong.

- Colour/thickness/motion live in `style.css`; the partial only tags each arc with its depth (`--d`) and stroke width
- Three request nodes ride the full ring ellipses via `offset-path`, dimming through the back half of each lap
- `prefers-reduced-motion` renders the knot parked and complete; no `offset-path` support hides the nodes

## Verified

Dark/light themes, en/ko, 1440/1000/600px widths, reduced-motion, and a 33s-late frame (weave still correct mid-spin). `hwaro build` passes (44 pages).