### PR TITLE
Sweep 20 bug/readability invariants, each fixed at every site

### DIFF
--- a/spec/absolute_form_home_spec.cr
+++ b/spec/absolute_form_home_spec.cr
@@ -1,0 +1,43 @@
+require "./spec_helper"
+
+# `Url.absolute_form?` is the one home for "does this target already carry its own
+# scheme+authority", and it is case-INSENSITIVE (RFC 3986 3.1: schemes are). Several callers
+# had re-derived it as `starts_with?("http")` or as a case-SENSITIVE two-prefix test, and both
+# spellings disagree with the home on inputs gori really sees — it captures wire bytes
+# verbatim, so an uppercase scheme in a request line reaches these callers intact.
+describe "the absolute-form predicate has one home" do
+  it "separates the home from the loose starts_with?(\"http\") form" do
+    # A host that merely BEGINS with "http" is not an absolute-form target.
+    Gori::Url.absolute_form?("httpbin.org/x").should be_false
+    Gori::Url.location("a.test", "httpbin.org/x").should eq("a.testhttpbin.org/x")
+
+    # An uppercase scheme IS one, and must not have the host prepended again.
+    Gori::Url.absolute_form?("HTTP://a.test:8080/abs").should be_true
+    Gori::Url.location("a.test", "HTTP://a.test:8080/abs").should eq("HTTP://a.test:8080/abs")
+  end
+
+  describe "Sitemap.normalize_path" do
+    # The case-sensitive pair kept the scheme+authority on an uppercase target, which then
+    # got segmented into path nodes named "http:" and the host.
+    it "reduces an uppercase-scheme target to its path" do
+      Gori::Sitemap.normalize_path("HTTP://acme.test/login").should eq("/login")
+      Gori::Sitemap.normalize_path("HTTPS://acme.test/a/b?q=1").should eq("/a/b?q=1")
+    end
+
+    it "leaves an origin-form target alone" do
+      Gori::Sitemap.normalize_path("/login").should eq("/login")
+      Gori::Sitemap.normalize_path("httpbin.org/x").should eq("httpbin.org/x")
+    end
+  end
+
+  describe "Oast::Provider.normalize_endpoint" do
+    # One home so the TUI's "is this the same endpoint?" comparison can reproduce it exactly:
+    # a session stores the normalised form while the provider row holds whatever was typed.
+    it "does not re-prefix a scheme that is already there in any case" do
+      Gori::Oast::Provider.normalize_endpoint("oast.pro").should eq("https://oast.pro")
+      Gori::Oast::Provider.normalize_endpoint("https://oast.pro/").should eq("https://oast.pro")
+      Gori::Oast::Provider.normalize_endpoint("HTTPS://oast.pro").should eq("HTTPS://oast.pro")
+      Gori::Oast::Provider.normalize_endpoint("HTTP://oast.pro").should eq("HTTP://oast.pro")
+    end
+  end
+end

--- a/spec/absolute_form_home_spec.cr
+++ b/spec/absolute_form_home_spec.cr
@@ -16,6 +16,22 @@ describe "the absolute-form predicate has one home" do
     Gori::Url.location("a.test", "HTTP://a.test:8080/abs").should eq("HTTP://a.test:8080/abs")
   end
 
+  # A path-less absolute target still carries a query or fragment, and dropping them fed
+  # `Outbound.scope_url` a url a path/query EXCLUDE could no longer match — the carve-out
+  # `sweep_block` promises holds even under --allow-unscoped. RFC 3986 3.3: an empty path
+  # with a query is "/" + the rest.
+  it "keeps a query or fragment when the absolute target has no path" do
+    Gori::Url.origin_path("http://acme.test?admin=1").should eq("/?admin=1")
+    Gori::Url.origin_path("http://acme.test#frag").should eq("/#frag")
+    Gori::Url.origin_path("http://acme.test").should eq("/")
+    Gori::Url.origin_path("http://acme.test/a?b=1").should eq("/a?b=1")
+  end
+
+  it "gates a query-only absolute target on the query an exclude is keyed to" do
+    Gori::Outbound.scope_url("https", "acme.test", "http://acme.test?admin=1")
+      .should eq("https://acme.test/?admin=1")
+  end
+
   describe "Sitemap.normalize_path" do
     # The case-sensitive pair kept the scheme+authority on an uppercase target, which then
     # got segmented into path nodes named "http:" and the host.

--- a/spec/commit_confirmation_spec.cr
+++ b/spec/commit_confirmation_spec.cr
@@ -1,0 +1,94 @@
+require "./spec_helper"
+
+# NOTE: `Store#close` is NOT idempotent — it blocks on `@done.receive`, which the writer
+# fiber only ever sends once, so a second call hangs forever. Every example here closes the
+# store itself (that is the lever for a failed commit), so the helper must not close it again.
+private def with_store(&)
+  path = File.tempname("gori-commit", ".db")
+  store = Gori::Store.open(path)
+  begin
+    yield store
+  ensure
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+# One class, four sites: a mutation whose store answered "did this COMMIT" threw the answer
+# away, and the surface above it reported success regardless. A closed store is the cheap
+# stand-in for the busy/locked/closing case those answers exist for — `exec_task_ok` returns
+# false rather than raising.
+describe "commit confirmation" do
+  describe "Scope sandbox setters" do
+    # The sandbox is a BLOCKING gate, and one Scope instance is shared by the Interceptor and
+    # every Outbound built from it. A dropped write is therefore not just "does not survive
+    # restart": `reload` re-reads the persisted value and reverts the gate a surface already
+    # announced as on.
+    it "reports whether the flag committed" do
+      with_store do |store|
+        scope = Gori::Scope.load(store)
+        scope.enable_sandbox.should be_true
+        scope.disable_sandbox.should be_true
+        scope.toggle_sandbox.should be_true
+
+        store.close
+        scope.enable_sandbox.should be_false
+      end
+    end
+
+    it "matches the enabled-flag sibling beside it" do
+      with_store do |store|
+        scope = Gori::Scope.load(store)
+        scope.enable.should be_true
+        store.close
+        scope.enable.should be_false
+        scope.enable_sandbox.should be_false
+      end
+    end
+  end
+
+  describe "Store#set_probe_mode" do
+    # Lowering the mode to stop active probing is the direction that matters: every surface
+    # reported it done while a separate live instance kept the persisted mode and kept firing.
+    it "reports whether the mode committed" do
+      with_store do |store|
+        store.set_probe_mode(Gori::Probe::Mode::Active).should be_true
+        store.probe_mode.should eq(Gori::Probe::Mode::Active)
+
+        store.close
+        store.set_probe_mode(Gori::Probe::Mode::Off).should be_false
+      end
+    end
+  end
+
+  describe "Rules#add / #update" do
+    it "reports whether the write committed" do
+      with_store do |store|
+        rules = Gori::Rules.load(store)
+        rules.add(Gori::Store::RuleTarget::Request, Gori::Store::RulePart::Head,
+          "A", "B").should be_true
+        id = rules.rules.first.id
+        rules.update(id, Gori::Store::RuleTarget::Request, Gori::Store::RulePart::Head,
+          "A", "C").should be_true
+
+        store.close
+        rules.add(Gori::Store::RuleTarget::Request, Gori::Store::RulePart::Head,
+          "X", "Y").should be_false
+        rules.update(id, Gori::Store::RuleTarget::Request, Gori::Store::RulePart::Head,
+          "A", "D").should be_false
+      end
+    end
+
+    # An empty pattern is refused before any write, and the caller cannot tell that apart
+    # from a failure — both mean "no rule was added", which is what the surfaces report.
+    it "refuses an empty pattern without claiming a write" do
+      with_store do |store|
+        rules = Gori::Rules.load(store)
+        rules.add(Gori::Store::RuleTarget::Request, Gori::Store::RulePart::Head,
+          "", "B").should be_false
+        rules.rules.should be_empty
+      end
+    end
+  end
+end

--- a/spec/commit_confirmation_spec.cr
+++ b/spec/commit_confirmation_spec.cr
@@ -1,8 +1,8 @@
 require "./spec_helper"
 
-# NOTE: `Store#close` is NOT idempotent — it blocks on `@done.receive`, which the writer
-# fiber only ever sends once, so a second call hangs forever. Every example here closes the
-# store itself (that is the lever for a failed commit), so the helper must not close it again.
+# Every example closes the store itself — that is the lever for a failed commit — so the
+# helper must not close it again. `Store#close` is idempotent, but this file should fail on
+# its own subject, not on teardown.
 private def with_store(&)
   path = File.tempname("gori-commit", ".db")
   store = Gori::Store.open(path)
@@ -88,6 +88,38 @@ describe "commit confirmation" do
         rules.add(Gori::Store::RuleTarget::Request, Gori::Store::RulePart::Head,
           "", "B").should be_false
         rules.rules.should be_empty
+      end
+    end
+  end
+
+  # `@done` is unbuffered and the writer fiber sends exactly one value as it exits, so a
+  # second `close` used to park forever waiting for a sender that no longer existed. Asserted
+  # with a deadline rather than by just calling it twice: a regression here HANGS, and a spec
+  # that hangs wedges the suite instead of reporting a failure.
+  describe "Store#close" do
+    it "is idempotent instead of parking on an exhausted channel" do
+      path = File.tempname("gori-close", ".db")
+      begin
+        store = Gori::Store.open(path)
+        store.close
+
+        returned = Channel(Nil).new(1)
+        spawn do
+          store.close
+          store.close
+          returned.send(nil)
+        end
+
+        select
+        when returned.receive
+          # closed again without blocking
+        when timeout(5.seconds)
+          fail "Store#close blocked on a second call"
+        end
+      ensure
+        File.delete?(path)
+        File.delete?("#{path}-wal")
+        File.delete?("#{path}-shm")
       end
     end
   end

--- a/spec/discover/engine_spec.cr
+++ b/spec/discover/engine_spec.cr
@@ -1249,4 +1249,28 @@ describe Gori::Discover::Engine do
     asked.select(&.includes?("8443")).should eq([] of String) # never the port-bearing form
     asked.all?(&.starts_with?("http://acme.test/")).should be_true
   end
+
+  # Calibration is the only task that fans out into many sends, so `worker_loop`'s stop check
+  # — which runs once per RECEIVED task — did not cover it: a worker already inside the batch
+  # kept firing every remaining bogus probe after `stop`. At the shipped defaults that is
+  # 20 workers x 3 probes x (1 + 1 retry) reaching a third party AFTER the operator stopped.
+  it "stops firing calibration probes as soon as the run is stopped" do
+    cfg = D::Config.new(spider: false, bruteforce: true, calibrate_probes: 8, concurrency: 1,
+      retries: 0)
+    bogus = 0
+    engine = uninitialized D::Engine
+    backend = RouteBackend.new(->(t : String) do
+      # The calibrator's bogus paths are a 16-hex name at the directory root.
+      if t.matches?(/\A\/[0-9a-f]{16}\z/)
+        bogus += 1
+        engine.stop # the operator presses stop during the first probe of the batch
+      end
+      notfound
+    end)
+    engine = D::Engine.new("http://t/", ["admin", "secret"], backend, cfg, D::OpenScope.new)
+    engine.run { }
+
+    # One probe was in flight when stop was requested; the remaining seven must not go out.
+    bogus.should eq(1)
+  end
 end

--- a/spec/drift_homes_spec.cr
+++ b/spec/drift_homes_spec.cr
@@ -1,0 +1,73 @@
+require "./spec_helper"
+
+# Three helpers that had drifted copies. Round 9 closed the absolute-form family; these are
+# the rest of the same audit.
+#
+# WHAT THESE EXAMPLES PIN, precisely — the copies are all `private`, so none of them can be
+# called from here:
+#   * `Fmt.ago`   — FULLY covered. `history_view#fmt_time_relative` now literally delegates,
+#                   so pinning the home pins the caller.
+#   * `valid_ipv6?` — covers the GUARD the probe splitter now calls, not the fact that it
+#                   calls it. Reverting the call site does NOT red this file.
+#   * `Fmt.size`  — pins the home's rounding convention only. `ProjectView#human_size` is a
+#                   separate implementation (prose spacing, a TB step) that was taught the
+#                   same rule; reverting it does NOT red this file either.
+# Said out loud because two of the three would otherwise read as regression guards for
+# changes they cannot see.
+describe "one-home helpers" do
+  describe "Fmt.size rounding convention" do
+    # The module docstring names this exact case as what it exists to prevent: pick the unit
+    # from the ROUNDED magnitude so a value just under a boundary rolls up, instead of the
+    # misleading "1024KB". `ProjectView#human_size` compared the UNROUNDED value and printed
+    # "1024.0 KB" for the same input.
+    it "rolls a value just under a boundary up to the next unit" do
+      Gori::Tui::Fmt.size(1_048_575_i64).should eq("1.0MB")
+      Gori::Tui::Fmt.size(1_048_576_i64).should eq("1.0MB")
+    end
+
+    it "still reports a value clear of the boundary in its own unit" do
+      Gori::Tui::Fmt.size(1_047_000_i64).should eq("1022KB")
+      Gori::Tui::Fmt.size(512_i64).should eq("512B")
+    end
+  end
+
+  describe "Upstream.split_host_port IPv6 disambiguation" do
+    # An unbracketed authority is a whole IPv6 host only when it is a valid v6 literal — a
+    # port cannot be told apart from the address colons. The probe rules' own splitter
+    # omitted this, turning "::1" into host ":" port 1.
+    it "treats a bare v6 literal as the whole host" do
+      Gori::Proxy::Upstream.valid_ipv6?("::1").should be_true
+      Gori::Proxy::Upstream.valid_ipv6?("2001:db8::1").should be_true
+      Gori::Proxy::Upstream.split_host_port("::1", 443).should eq({"::1", 443})
+      Gori::Proxy::Upstream.split_host_port("2001:db8::1", 443).should eq({"2001:db8::1", 443})
+    end
+
+    it "still splits a host:port and a bracketed literal" do
+      Gori::Proxy::Upstream.valid_ipv6?("acme.test").should be_false
+      Gori::Proxy::Upstream.split_host_port("acme.test:8443", 443).should eq({"acme.test", 8443})
+      Gori::Proxy::Upstream.split_host_port("[::1]:8080", 443).should eq({"::1", 8080})
+    end
+
+    # The rule the home's comment states: a multi-colon authority that is NOT a valid v6
+    # literal splits on the LAST colon, so a real port is not swallowed into the host.
+    it "splits a multi-colon authority that is not a v6 literal" do
+      Gori::Proxy::Upstream.valid_ipv6?("127.0.0.1:19110:bogus").should be_false
+    end
+  end
+
+  describe "Fmt.ago" do
+    it "formats each magnitude the same way every caller expects" do
+      now = Time.local
+      Gori::Tui::Fmt.ago(now - 3.seconds).should eq("3s")
+      Gori::Tui::Fmt.ago(now - 5.minutes).should eq("5m")
+      Gori::Tui::Fmt.ago(now - 2.hours).should eq("2h")
+      Gori::Tui::Fmt.ago(now - 25.hours).should eq("1d")
+    end
+
+    # Clamped at 0 so clock skew never renders a negative age — the property every copy
+    # carried and the reason they were collapsed into one.
+    it "clamps a future timestamp to zero rather than showing a negative age" do
+      Gori::Tui::Fmt.ago(Time.local + 10.seconds).should eq("0s")
+    end
+  end
+end

--- a/spec/durable_file_spec.cr
+++ b/spec/durable_file_spec.cr
@@ -25,11 +25,39 @@ describe Gori::DurableFile do
     it "replaces a DANGLING symlink with a real file rather than failing" do
       DurableFileSpec.in_tmp do |dir|
         link = File.join(dir, "link.json")
-        File.symlink(File.join(dir, "gone.json"), link)
+        target = File.join(dir, "gone.json")
+        File.symlink(target, link)
 
         Gori::DurableFile.write(link, "new", perm: DurableFileSpec::RW)
 
+        # `File.read(link)` alone would also pass if the code had FOLLOWED the dangling
+        # link and created its target — reading through the link returns "new" either way.
+        File.symlink?(link).should be_false
+        File.exists?(target).should be_false
         File.read(link).should eq("new")
+      end
+    end
+
+    # The shape the module doc leads with: the link and its target in DIFFERENT directories.
+    # The temp has to be staged beside the TARGET, not beside the link, or the rename
+    # crosses a filesystem boundary and the mode lands on the wrong side.
+    it "stages beside the target when the link points into another directory" do
+      DurableFileSpec.in_tmp do |dir|
+        link_dir = File.join(dir, "home")
+        real_dir = File.join(dir, "dotfiles")
+        Dir.mkdir_p(link_dir)
+        Dir.mkdir_p(real_dir)
+        real = File.join(real_dir, "gori.json")
+        link = File.join(link_dir, "gori.json")
+        File.write(real, "old")
+        File.symlink(real, link)
+
+        Gori::DurableFile.write(link, "new", perm: DurableFileSpec::RW)
+
+        File.symlink?(link).should be_true
+        File.read(real).should eq("new")
+        Dir.children(link_dir).should eq(["gori.json"])
+        Dir.children(real_dir).should eq(["gori.json"])
       end
     end
   end
@@ -54,6 +82,21 @@ describe Gori::DurableFile do
         Gori::DurableFile.write(path, "new", perm: File::Permissions.new(0o600))
 
         File.info(path).permissions.should eq(File::Permissions.new(0o600))
+      end
+    end
+
+    # Every other mode example uses 0600, so an implementation that ignored `perm` and
+    # hardcoded 0600 would pass all of them — while silently flipping the two 0644 callers
+    # (`.capture.status` and the active-project marker) to 0600. This is the one that
+    # observes `perm` actually taking effect. It also catches the umask leaking through
+    # `File.open`'s `perm:`.
+    it "honours a perm other than 0600 for a new file" do
+      DurableFileSpec.in_tmp do |dir|
+        path = File.join(dir, "marker")
+
+        Gori::DurableFile.write(path, "new", perm: File::Permissions.new(0o644))
+
+        File.info(path).permissions.should eq(File::Permissions.new(0o644))
       end
     end
 
@@ -91,10 +134,50 @@ describe Gori::DurableFile do
     it "stages in the destination's own directory so the rename stays intra-filesystem" do
       DurableFileSpec.in_tmp do |dir|
         path = File.join(dir, "cfg.json")
+        yielded = false
         Gori::DurableFile.stage(path, perm: DurableFileSpec::RW) do |tmp, _m|
+          yielded = true
           File.dirname(tmp).should eq(dir)
           File.write(tmp, "x")
         end.discard
+        # Asserted OUTSIDE the block: an implementation that stopped yielding would
+        # otherwise pass this example by never running its only assertion.
+        yielded.should be_true
+      end
+    end
+
+    # `replace`'s cleanup has to cover a rename that fails AFTER staging succeeded, not
+    # just a failing write. A destination that is a non-empty directory makes rename(2)
+    # fail exactly there. This is the contract `CertAuthority.write_pair` broke by
+    # committing two staged files without a guard over both.
+    it "leaves no temp behind when the COMMIT fails" do
+      DurableFileSpec.in_tmp do |dir|
+        occupied = File.join(dir, "cfg.json")
+        Dir.mkdir_p(occupied)
+        File.write(File.join(occupied, "child"), "x")
+
+        expect_raises(Exception) do
+          Gori::DurableFile.write(occupied, "new", perm: DurableFileSpec::RW)
+        end
+
+        Dir.children(dir).should eq(["cfg.json"])
+      end
+    end
+
+    # `fsync` opens the temp with "a", which CREATES it. Without a guard, a block that
+    # wrote nothing yields a valid-looking Staged over a zero-byte file, and committing it
+    # blanks live data. No caller does this today; the guard is for the next one.
+    it "refuses to install a replacement the block never wrote" do
+      DurableFileSpec.in_tmp do |dir|
+        path = File.join(dir, "cfg.json")
+        File.write(path, "IMPORTANT LIVE DATA")
+
+        expect_raises(Gori::Error, /staged no file/) do
+          Gori::DurableFile.replace(path, perm: DurableFileSpec::RW) { |_t, _m| }
+        end
+
+        File.read(path).should eq("IMPORTANT LIVE DATA")
+        Dir.children(dir).should eq(["cfg.json"])
       end
     end
 

--- a/spec/durable_file_spec.cr
+++ b/spec/durable_file_spec.cr
@@ -1,0 +1,165 @@
+require "./spec_helper"
+
+# Six independent temp+rename impls collapsed into `DurableFile`, and each of the five
+# non-reference ones had dropped a different part of the contract. These examples pin the
+# parts, so a future caller cannot quietly reintroduce one of the five.
+describe Gori::DurableFile do
+  describe "symlink handling" do
+    # The reason this module exists. `gori --config ~/dotfiles/gori.json` is the advertised
+    # way to point gori at a version-controlled settings file; a rename over the link
+    # detaches it, and the repo copy then goes stale with nothing to show in `git status`.
+    it "writes THROUGH a symlink instead of replacing it" do
+      DurableFileSpec.in_tmp do |dir|
+        real = File.join(dir, "real.json")
+        link = File.join(dir, "link.json")
+        File.write(real, "old")
+        File.symlink(real, link)
+
+        Gori::DurableFile.write(link, "new", perm: DurableFileSpec::RW)
+
+        File.symlink?(link).should be_true
+        File.read(real).should eq("new")
+      end
+    end
+
+    it "replaces a DANGLING symlink with a real file rather than failing" do
+      DurableFileSpec.in_tmp do |dir|
+        link = File.join(dir, "link.json")
+        File.symlink(File.join(dir, "gone.json"), link)
+
+        Gori::DurableFile.write(link, "new", perm: DurableFileSpec::RW)
+
+        File.read(link).should eq("new")
+      end
+    end
+  end
+
+  describe "permissions" do
+    it "carries an existing file's mode across the replace" do
+      DurableFileSpec.in_tmp do |dir|
+        path = File.join(dir, "cfg.json")
+        File.write(path, "old")
+        File.chmod(path, 0o600)
+
+        Gori::DurableFile.write(path, "new", perm: DurableFileSpec::RW)
+
+        File.info(path).permissions.should eq(File::Permissions.new(0o600))
+      end
+    end
+
+    it "uses perm for a file that does not exist yet" do
+      DurableFileSpec.in_tmp do |dir|
+        path = File.join(dir, "cfg.json")
+
+        Gori::DurableFile.write(path, "new", perm: File::Permissions.new(0o600))
+
+        File.info(path).permissions.should eq(File::Permissions.new(0o600))
+      end
+    end
+
+    # settings.json holds `env` token VALUES; a copy an older gori wrote at 0644 has to be
+    # tightened on the way past, not carried forward. That is what `inherit: false` is for.
+    it "forces perm over an existing mode when inherit is false" do
+      DurableFileSpec.in_tmp do |dir|
+        path = File.join(dir, "settings.json")
+        File.write(path, "old")
+        File.chmod(path, 0o644)
+
+        Gori::DurableFile.write(path, "new", perm: File::Permissions.new(0o600), inherit: false)
+
+        File.info(path).permissions.should eq(File::Permissions.new(0o600))
+      end
+    end
+  end
+
+  describe "temp files" do
+    # `"#{path}.tmp"` was shared by every process writing that path — and, for settings.json,
+    # by `Settings.save` and `drop_legacy_decoder_sessions` within one process. Two stagers
+    # then wrote one file and one renamed the other's half-written bytes into place.
+    it "does not derive the temp name from the destination alone" do
+      DurableFileSpec.in_tmp do |dir|
+        path = File.join(dir, "cfg.json")
+        seen = [] of String
+        2.times do
+          Gori::DurableFile.stage(path, perm: DurableFileSpec::RW) { |tmp, _m| seen << tmp; File.write(tmp, "x") }.discard
+        end
+        seen.uniq.size.should eq(2)
+        seen.should_not contain("#{path}.tmp")
+      end
+    end
+
+    it "stages in the destination's own directory so the rename stays intra-filesystem" do
+      DurableFileSpec.in_tmp do |dir|
+        path = File.join(dir, "cfg.json")
+        Gori::DurableFile.stage(path, perm: DurableFileSpec::RW) do |tmp, _m|
+          File.dirname(tmp).should eq(dir)
+          File.write(tmp, "x")
+        end.discard
+      end
+    end
+
+    # `write_active_project` swallowed every failure at a method-level rescue and left
+    # `active_project.tmp.<pid>` behind; nothing in the tree ever swept those. A failing
+    # write must clean up after itself AND surface the cause that actually failed, not a
+    # complaint about a temp file the operator has never heard of.
+    it "leaves no temp behind when the write raises, and reports the original cause" do
+      DurableFileSpec.in_tmp do |dir|
+        path = File.join(dir, "cfg.json")
+        expect_raises(Gori::Error, "boom") do
+          Gori::DurableFile.replace(path, perm: DurableFileSpec::RW) do |tmp, _m|
+            # Write BEFORE raising: the leak this pins is a temp that reached the disk and
+            # was then abandoned, which is the only way `active_project.tmp.<pid>` piled up.
+            File.write(tmp, "partial")
+            raise Gori::Error.new("boom")
+          end
+        end
+        Dir.children(dir).should be_empty
+      end
+    end
+  end
+
+  describe "staging without committing" do
+    # The CA writes a cert and a key that must agree. Both are staged in full before either
+    # is renamed, so the on-disk pair never disagrees past the gap between the renames.
+    it "does not touch the destination until commit" do
+      DurableFileSpec.in_tmp do |dir|
+        path = File.join(dir, "cfg.json")
+        File.write(path, "old")
+
+        staged = Gori::DurableFile.stage(path, perm: DurableFileSpec::RW) { |tmp, _m| File.write(tmp, "new") }
+        File.read(path).should eq("old")
+
+        staged.commit
+        File.read(path).should eq("new")
+      end
+    end
+
+    it "discards a staged replacement without disturbing the destination" do
+      DurableFileSpec.in_tmp do |dir|
+        path = File.join(dir, "cfg.json")
+        File.write(path, "old")
+
+        Gori::DurableFile.stage(path, perm: DurableFileSpec::RW) { |tmp, _m| File.write(tmp, "new") }.discard
+
+        File.read(path).should eq("old")
+        Dir.children(dir).should eq(["cfg.json"])
+      end
+    end
+  end
+end
+
+# Helper namespace: `describe` blocks cannot host `def self.`, so the scratch-dir helper
+# lives here.
+module DurableFileSpec
+  RW = File::Permissions.new(0o644)
+
+  def self.in_tmp(&)
+    dir = File.tempname("gori-durable")
+    Dir.mkdir_p(dir)
+    begin
+      yield dir
+    ensure
+      FileUtils.rm_rf(dir)
+    end
+  end
+end

--- a/spec/har_fixed_point_spec.cr
+++ b/spec/har_fixed_point_spec.cr
@@ -55,6 +55,16 @@ describe "HAR round-trip fixed point" do
     req.should start_with("GET /x HTTP/9.9\r\n")
   end
 
+  # Chrome DevTools writes "http/2.0". Keeping it verbatim split the codebase's two h2 tests
+  # against each other — `starts_with?("HTTP/2")` in the probe layer vs `== "HTTP/2"` in the
+  # Repeater — so an imported h2 flow replayed over HTTP/1.1 while being scanned as h2.
+  it "folds every h2 spelling to the canonical HTTP/2" do
+    {"h2", "http/2", "HTTP/2", "http/2.0", "HTTP/2.0"}.each do |v|
+      req, _ = import_heads(v, "HTTP/1.1")
+      req.should start_with("GET /x HTTP/2\r\n")
+    end
+  end
+
   it "still folds the h2 spellings and defaults a token that is not a version" do
     req, _ = import_heads("h2", "HTTP/1.1")
     req.should start_with("GET /x HTTP/2\r\n")
@@ -75,6 +85,14 @@ describe "HAR round-trip fixed point" do
   it "preserves an empty statusText rather than re-inventing a phrase" do
     _, resp = import_heads("HTTP/1.1", "HTTP/1.1", status_text: "")
     resp.should start_with("HTTP/1.1 200\r\n")
+  end
+
+  # `JSON::Any#[]?` returns JSON::Any(nil) for an EXPLICIT null, which is TRUTHY — so a
+  # foreign HAR writing `"statusText": null` took the present branch and fabricated the
+  # reason-less status line that is supposed to mean the origin really sent one.
+  it "treats an explicit null statusText as absent, not as an empty phrase" do
+    _, resp = import_heads("HTTP/1.1", "HTTP/1.1", status_text: nil)
+    resp.should start_with("HTTP/1.1 200 OK\r\n")
   end
 
   it "still invents a phrase when statusText is absent entirely" do

--- a/spec/har_fixed_point_spec.cr
+++ b/spec/har_fixed_point_spec.cr
@@ -1,0 +1,102 @@
+require "./spec_helper"
+
+private alias ImpHar = Gori::Import::Har
+
+# Build a one-entry HAR and return the heads gori reconstructs from it. Driven through the
+# real `parse` seam rather than the private normalizer, so what is pinned is what an operator
+# importing a HAR actually gets.
+private def import_heads(req_version : String, resp_version : String,
+                         status_text : JSON::Any::Type = "OK") : {String, String}
+  entry = {
+    "startedDateTime" => "2026-01-01T00:00:00.000Z",
+    "time"            => 1,
+    "request"         => {
+      "method" => "GET", "url" => "http://acme.test/x", "httpVersion" => req_version,
+      "headers" => [] of Hash(String, String), "queryString" => [] of Hash(String, String),
+      "cookies" => [] of Hash(String, String), "headersSize" => -1, "bodySize" => 0,
+    },
+    "response" => {
+      "status" => 200, "statusText" => status_text, "httpVersion" => resp_version,
+      "headers" => [] of Hash(String, String), "cookies" => [] of Hash(String, String),
+      "content" => {"size" => 0, "mimeType" => "text/plain"},
+      "redirectURL" => "", "headersSize" => -1, "bodySize" => 0,
+    },
+    "cache"   => {} of String => String,
+    "timings" => {"send" => 0, "wait" => 1, "receive" => 0},
+  }
+  har = {"log" => {"version" => "1.2", "entries" => [entry]}}.to_json
+  pair = parse_har(har).flows.first
+  {String.new(pair.request.head), String.new(pair.response.not_nil!.head)}
+end
+
+private def parse_har(json : String) : Gori::Import::ParseResult
+  path = File.tempname("gori-har", ".har")
+  File.write(path, json)
+  begin
+    ImpHar.parse_file(path)
+  ensure
+    File.delete?(path)
+  end
+end
+
+# `Export::Har` states the contract these pin: for a COMPLETE flow, "version, ordered headers
+# with their framing, body bytes, status, reason, timing" survives, and export→import→export
+# is a fixed point. Two of those were being rewritten on the way through.
+describe "HAR round-trip fixed point" do
+  # The export writes the STORED version verbatim and names the importer's normalizer as what
+  # maps it back onto itself. Everything outside {1.0, 1.1, 2} used to collapse to HTTP/1.1,
+  # silently rewriting an operator's version-line probe — `flow_mapper` keeps the request
+  # line's token verbatim, and `Repeater::Plan` deliberately sends HTTP/9.9 unaltered.
+  it "keeps an unusual but well-formed version instead of folding it to 1.1" do
+    req, _ = import_heads("HTTP/0.9", "HTTP/1.1")
+    req.should start_with("GET /x HTTP/0.9\r\n")
+
+    req, _ = import_heads("HTTP/9.9", "HTTP/1.1")
+    req.should start_with("GET /x HTTP/9.9\r\n")
+  end
+
+  it "still folds the h2 spellings and defaults a token that is not a version" do
+    req, _ = import_heads("h2", "HTTP/1.1")
+    req.should start_with("GET /x HTTP/2\r\n")
+
+    req, _ = import_heads("nonsense", "HTTP/1.1")
+    req.should start_with("GET /x HTTP/1.1\r\n")
+  end
+
+  it "normalizes case without changing the version itself" do
+    req, _ = import_heads("http/1.0", "HTTP/1.1")
+    req.should start_with("GET /x HTTP/1.0\r\n")
+  end
+
+  # `parse_response_head` yields reason == "" for a reason-less status line
+  # (`HTTP/1.1 200\r\n`) — a real server fingerprint and a deliberate probe target. Export
+  # writes `"statusText": ""`; importing that used to invent "OK", putting three bytes on the
+  # head the origin never sent. ABSENT still earns a phrase; PRESENT-BUT-EMPTY does not.
+  it "preserves an empty statusText rather than re-inventing a phrase" do
+    _, resp = import_heads("HTTP/1.1", "HTTP/1.1", status_text: "")
+    resp.should start_with("HTTP/1.1 200\r\n")
+  end
+
+  it "still invents a phrase when statusText is absent entirely" do
+    entry = {
+      "startedDateTime" => "2026-01-01T00:00:00.000Z",
+      "time"            => 1,
+      "request"         => {
+        "method" => "GET", "url" => "http://acme.test/x", "httpVersion" => "HTTP/1.1",
+        "headers" => [] of Hash(String, String), "queryString" => [] of Hash(String, String),
+        "cookies" => [] of Hash(String, String), "headersSize" => -1, "bodySize" => 0,
+      },
+      "response" => {
+        "status" => 200, "httpVersion" => "HTTP/1.1",
+        "headers" => [] of Hash(String, String), "cookies" => [] of Hash(String, String),
+        "content" => {"size" => 0, "mimeType" => "text/plain"},
+        "redirectURL" => "", "headersSize" => -1, "bodySize" => 0,
+      },
+      "cache"   => {} of String => String,
+      "timings" => {"send" => 0, "wait" => 1, "receive" => 0},
+    }
+    har = {"log" => {"version" => "1.2", "entries" => [entry]}}.to_json
+    pair = parse_har(har).flows.first
+    String.new(pair.response.not_nil!.head).should start_with("HTTP/1.1 200 OK\r\n")
+  end
+end

--- a/spec/nul_roundtrip_spec.cr
+++ b/spec/nul_roundtrip_spec.cr
@@ -1,0 +1,79 @@
+require "./spec_helper"
+
+private def with_store(&)
+  path = File.tempname("gori-nul", ".db")
+  store = Gori::Store.open(path)
+  begin
+    yield store
+  ensure
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+# A request that holds a NUL is ordinary here: a gRPC/protobuf frame, a gzip'd POST, a
+# multipart upload carrying a PNG. `^F` seeds the Fuzzer template from a capture verbatim,
+# deliberately unscrubbed, because a capture is evidence.
+private def nul_request : String
+  String.build do |s|
+    s << "POST /api HTTP/1.1\r\n\r\nHEAD"
+    s.write_byte(0_u8)
+    s << "TAIL-AFTER-NUL"
+  end
+end
+
+private def nul_text(head : String, tail : String) : String
+  String.build do |s|
+    s << head
+    s.write_byte(0_u8)
+    s << tail
+  end
+end
+
+# A column holding OPERATOR or WIRE bytes must be read back as a BLOB. The driver reads a
+# TEXT-storage column through a NUL-terminated pointer, so `rs.read(String)` stops at the
+# first 0x00 while the write side binds the full bytesize — the bytes reach the disk and the
+# READ throws them away. `repeaters.request` was migrated for exactly this in V2; these
+# columns were still on the broken shape.
+describe "NUL-bearing columns round-trip" do
+  it "keeps a fuzz session template whole past an embedded NUL" do
+    with_store do |store|
+      body = nul_request
+      id = store.insert_fuzz_session("t", body, false, nil, "{}", nil, 0)
+
+      store.get_fuzz_session(id).not_nil!.template.should eq(body)
+      store.fuzz_sessions.first.template.should eq(body)
+    end
+  end
+
+  # The comparison that decides "did a peer session change?" tests the in-memory template
+  # against this read. While the read truncated, the two could never be equal, so the
+  # reconcile path overwrote the operator's live request with the truncated one.
+  it "lets a re-read template compare equal to what was written" do
+    with_store do |store|
+      body = nul_request
+      id = store.insert_fuzz_session("t", body, false, nil, "{}", nil, 0)
+      store.update_fuzz_session(id, "t", body, false, nil, "{}")
+
+      store.get_fuzz_session(id).not_nil!.template.should eq(body)
+    end
+  end
+
+  # A rewrite rule is the operator's control (strip an Authorization header, redact a token
+  # before it leaves). MCP `create_rule` can carry a real NUL: JSON permits a backslash-u-0000 escape,
+  # and Crystal materialises it as an actual 0x00 in the String.
+  it "keeps a match rule's pattern and replacement whole past an embedded NUL" do
+    with_store do |store|
+      pattern = nul_text("AAA", "BBB")
+      replacement = nul_text("XXX", "YYY")
+      store.insert_rule(Gori::Store::RuleTarget::Request, Gori::Store::RulePart::Head,
+        pattern, replacement)
+
+      rule = store.match_rules.first
+      rule.pattern.should eq(pattern)
+      rule.replacement.should eq(replacement)
+    end
+  end
+end

--- a/spec/outbound_spec.cr
+++ b/spec/outbound_spec.cr
@@ -402,6 +402,36 @@ describe Gori::Outbound do
         ob.send_block("https", "evil.test", "http://acme.test/x").should eq(Gori::Outbound::SANDBOX_ERROR)
       end
     end
+
+    # The reduction is LEXICAL because `URI.parse` raises on exactly the targets a security
+    # tool gets handed. A non-numeric or oversized port used to rescue to nil, read as "no
+    # path", and gate `scheme://host/` — so a path EXCLUDE stopped matching the url it was
+    # tested against while a host INCLUDE still did, and the carve-out silently opened.
+    it "keeps the path when the absolute-form target has a port URI.parse cannot read" do
+      Gori::Outbound.scope_url("https", "acme.test", "http://acme.test:abc/admin/purge")
+        .should eq("https://acme.test/admin/purge")
+      Gori::Outbound.scope_url("https", "acme.test", "http://acme.test:99999999999999999999/admin")
+        .should eq("https://acme.test/admin")
+    end
+
+    it "still honours a path exclude on a target with an unparseable port" do
+      with_scope do |scope, _store|
+        scope.add("include", "host", "acme.test")
+        scope.add("exclude", "string", "/admin")
+        scope.enable_sandbox
+        ob = Gori::Outbound.interactive(scope)
+        # The carve-out holds for the well-formed target…
+        ob.send_block("https", "acme.test", "http://acme.test/admin/purge")
+          .should eq(Gori::Outbound::SANDBOX_ERROR)
+        # …and must hold identically when the port is what makes URI.parse raise.
+        ob.send_block("https", "acme.test", "http://acme.test:abc/admin/purge")
+          .should eq(Gori::Outbound::SANDBOX_ERROR)
+      end
+    end
+
+    it "reduces a target with no path at all to the root" do
+      Gori::Outbound.scope_url("https", "acme.test", "http://acme.test").should eq("https://acme.test/")
+    end
   end
 
   describe ".request_target" do

--- a/spec/pacing_spec.cr
+++ b/spec/pacing_spec.cr
@@ -1,0 +1,74 @@
+require "./spec_helper"
+
+private class PaceConfig
+  getter rps : Float64?
+  getter throttle_ms : Int32?
+  getter jitter_ms : Int32
+
+  def initialize(@rps = nil, @throttle_ms = nil, @jitter_ms = 0)
+  end
+end
+
+# Stands in for an engine: one shared clock, a `pace` reachable from several fibers.
+private class PaceHarness
+  include Gori::Pacing
+
+  getter stamps = [] of Time::Instant
+
+  def initialize(@config : PaceConfig)
+    @last_dispatch = Time.instant
+  end
+
+  # What a send site does: wait for the rate, then "send".
+  def send_one : Nil
+    pace(pace_interval)
+    @stamps << Time.instant
+  end
+end
+
+describe Gori::Pacing do
+  # The operator-facing knob is `--rate=RPS "Cap requests/sec"` — a promise about REQUESTS.
+  # `pace` therefore has to hold across every fiber that sends, not just the orchestrator's
+  # dispatch loop, because the paths that fan one dispatched unit into several sends (a
+  # redirect chain, a confirm round, a calibration batch) are exactly where the promise broke.
+  it "serialises concurrent senders onto one rate instead of letting them burst" do
+    h = PaceHarness.new(PaceConfig.new(throttle_ms: 20))
+    done = Channel(Nil).new(5)
+    5.times do
+      spawn do
+        h.send_one
+        done.send(nil)
+      end
+    end
+    5.times { done.receive }
+
+    h.stamps.size.should eq(5)
+    span = h.stamps.max - h.stamps.min
+    # Five senders at one per 20ms: the last must land at least 4 intervals after the first.
+    # A per-fiber (or last-writer-wins) clock lets them all fire at once and this is ~0.
+    span.should be >= 70.milliseconds
+  end
+
+  it "does not sleep at all when no rate is configured" do
+    h = PaceHarness.new(PaceConfig.new)
+    started = Time.instant
+    10.times { h.send_one }
+    (Time.instant - started).should be < 50.milliseconds
+  end
+
+  # After an idle stretch the stored instant is far in the past. Without flooring the claim at
+  # `now`, every caller computes a target that already elapsed and they all go out together —
+  # the opposite of a rate limit.
+  it "does not bank up credit while idle and release it as a burst" do
+    h = PaceHarness.new(PaceConfig.new(throttle_ms: 15))
+    h.send_one
+    sleep 120.milliseconds # idle far longer than the interval
+
+    done = Channel(Nil).new(3)
+    3.times { spawn { h.send_one; done.send(nil) } }
+    3.times { done.receive }
+
+    burst = h.stamps[1..]
+    (burst.max - burst.min).should be >= 25.milliseconds
+  end
+end

--- a/spec/probe_persist_failure_spec.cr
+++ b/spec/probe_persist_failure_spec.cr
@@ -1,0 +1,74 @@
+require "./spec_helper"
+
+# A store whose issue write fails with a NON-DB error. DB::Error/SQLite3::Exception are
+# deliberately re-raised by the analyzer (they mean the project is unusable, not that one
+# detail is odd), so the interesting case is the other kind: findings were already made and
+# the recording step blew up.
+private class PersistFailingStore < Gori::Store
+  def upsert_probe_issue(d : Gori::Probe::Detection) : Nil
+    raise ArgumentError.new("persist boom")
+  end
+end
+
+private def open_failing_store(path : String) : PersistFailingStore
+  url = "sqlite3:#{path}?journal_mode=wal&synchronous=normal&busy_timeout=5000"
+  db = DB.open(url)
+  Gori::SafeRegexp.install(db)
+  Gori::Store::Schema.migrate!(db)
+  PersistFailingStore.new(db)
+end
+
+private def with_failing_store(&)
+  path = File.tempname("gori-persistfail", ".db")
+  store = open_failing_store(path)
+  begin
+    yield store
+  ensure
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+# A flow that reliably yields passive detections (a missing-security-headers family).
+private def seed_flow(store : Gori::Store) : Gori::Store::FlowDetail
+  head = "GET / HTTP/1.1\r\nHost: acme.test\r\n\r\n"
+  id = store.insert_flow(Gori::Store::CapturedRequest.new(
+    created_at: 1_i64, scheme: "http", host: "acme.test", port: 80,
+    method: "GET", target: "/", http_version: "HTTP/1.1", head: head.to_slice))
+  resp_head = "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nSet-Cookie: sid=1\r\n\r\n"
+  store.update_response(Gori::Store::CapturedResponse.new(
+    flow_id: id, status: 200, head: resp_head.to_slice, body: "<html>hi</html>".to_slice,
+    reason: "OK", content_type: "text/html", duration_us: 1_i64))
+  store.get_flow(id).not_nil!
+end
+
+# `scan_detail`'s blanket rescue covered three statements while its comment justified one
+# ("a single detail's analysis blew up — skip it"). Past `Passive.analyze` the findings
+# already exist, so swallowing there showed the operator a completed scan with no issues —
+# indistinguishable from a clean target.
+describe "Probe::Analyzer#scan_detail persistence failure" do
+  it "reports findings it could not record instead of dropping them silently" do
+    with_failing_store do |store|
+      scope = Gori::Scope.load(store)
+      analyzer = Gori::Probe::Analyzer.new(
+        store, scope, Channel(Gori::Store::FlowEvent).new(1),
+        Gori::Probe::Mode::Passive, true)
+      detail = seed_flow(store)
+
+      # Must not raise into the caller: the TUI event loop has no catch-all.
+      analyzer.scan_detail(detail)
+
+      # Bounded, never a bare `receive`: with the report missing there is no event to take
+      # and a blocking read would HANG the suite instead of reporting a failure.
+      select
+      when ev = analyzer.events.receive
+        ev.should be_a(Gori::Probe::ErrorEvent)
+        ev.as(Gori::Probe::ErrorEvent).message.should contain("were not recorded")
+      when timeout(5.seconds)
+        fail "findings were dropped with no ErrorEvent"
+      end
+    end
+  end
+end

--- a/spec/proxy/h2/assembler_spec.cr
+++ b/spec/proxy/h2/assembler_spec.cr
@@ -120,6 +120,35 @@ describe Gori::Proxy::H2::Assembler do
     String.new(sink.responses.first.head).should contain("HTTP/2 200")
   end
 
+  # RFC 9113 8.1 forbids pseudo-headers in trailers, so a `:status` arriving AFTER a final
+  # response head is a broken or hostile origin — not the interim-1xx handover the replace
+  # branch exists for. It used to take that branch anyway: the trailer REPLACED the real
+  # head, so the flow reported the trailer's status and lost the head's content-type and
+  # Set-Cookie, with `trailer_names.clear` erasing the marker that would have explained it.
+  it "does not let a status-bearing TRAILER replace a final response head" do
+    sink = RecSink.new
+    assembler = Gori::Proxy::H2::Assembler.new(sink, "example.com", 443, 1_i64)
+    assembler.feed("out", headers_frame(1_u32, Frame::END_HEADERS | Frame::END_STREAM,
+      hexb("828684418cf1e3c2e5f23a6ba0ab90f4ff")))
+    # A real 200 head carrying a content-type worth losing.
+    head = Gori::Proxy::H2::HPACK::Encoder.new.encode([
+      {":status", "200"}, {"content-type", "application/grpc"},
+    ])
+    assembler.feed("in", headers_frame(1_u32, Frame::END_HEADERS, head))
+    assembler.feed("in", data_frame(1_u32, 0_u8, "body"))
+    # Then a trailer block that illegally carries :status alongside grpc-status.
+    trailer = Gori::Proxy::H2::HPACK::Encoder.new.encode([
+      {":status", "500"}, {"grpc-status", "13"},
+    ])
+    assembler.feed("in", headers_frame(1_u32, Frame::END_HEADERS | Frame::END_STREAM, trailer))
+
+    sink.responses.size.should eq(1)
+    resp = sink.responses.first
+    resp.status.should eq(200)                               # not the trailer's 500
+    String.new(resp.head).should contain("application/grpc") # the real head survives
+    String.new(resp.head).should contain("grpc-status")      # the trailer is still recorded
+  end
+
   it "carries a request body across DATA frames" do
     sink = RecSink.new
     assembler = Gori::Proxy::H2::Assembler.new(sink, "example.com", 443, 1_i64)

--- a/spec/proxy/h2/head_codec_spec.cr
+++ b/spec/proxy/h2/head_codec_spec.cr
@@ -55,6 +55,15 @@ private CORPUS = [
   both(f("X-Echo", "v"), false, "an uppercase field name the PEER sent"),
   both(f("", "v"), false, "an empty field name"),
   both(f("x-echo", "   lead"), false, "a leading space in a value (h1 OWS strips it)"),
+  # A peer field whose name collides with one of gori's own markers. Lowercase, colon-free
+  # and CRLF-free, so every other check passes — but `peer_field_name` renames it to
+  # `X-Peer-…` in the text form and the re-encode lowercases that, so a DIFFERENT name went
+  # on the wire. The rename is deliberate (keep the peer's anomaly visible under a name that
+  # cannot be confused for gori's own); refusing the round trip is what keeps it from
+  # reaching the peer.
+  both(f("x-gori-trailers", "v"), false, "a field name colliding with gori's trailer marker"),
+  both(f("x-gori-pushed", "v"), false, "a field name colliding with gori's pushed marker"),
+  both(f("x-gori-protocol", "v"), false, "a field name colliding with gori's protocol marker"),
   both(f("x-echo", "   "), false, "an all-spaces value"),
   # --- regular fields the text carries exactly ---------------------------------------------
   both(f("x-echo", "trail   "), true, "a trailing space in a value"),

--- a/spec/proxy/tls/tunnel_spec.cr
+++ b/spec/proxy/tls/tunnel_spec.cr
@@ -671,4 +671,49 @@ describe Gori::Proxy::Tls::Tunnel do
       FileUtils.rm_rf(dir) if Dir.exists?(dir)
     end
   end
+
+  # `sync_close: true` hands the accepted socket to the TLS socket — but only once the
+  # constructor RETURNS. A handshake that RAISES (rather than returning an SSL_accept error
+  # code) never assigns `client_tls`, and the stdlib's own `bio.io.close` sits behind that
+  # same error-code check, so nothing closed the transport and the fd survived until GC.
+  # A peer RST between ClientHello and Finished is the ordinary trigger; the reverse and
+  # transparent listeners own nothing else that would close it.
+  it "closes the accepted socket when the client handshake raises mid-ClientHello" do
+    dir = File.tempname("gori-ca")
+    begin
+      ca = CertAuthority.load_or_create(dir)
+      tunnel = Tunnel.new(ca, verify_upstream: false)
+      listener = TCPServer.new("127.0.0.1", 0)
+      accepted = [] of TCPSocket
+      attempts = 3
+
+      spawn do
+        attempts.times do
+          s = listener.accept
+          accepted << s
+          spawn do
+            tunnel.intercept("acme.test", 443, s, RecordingSink.new(Channel(Nil).new(1)),
+              tls_upstream: false)
+          rescue
+            # the handshake failing IS the case under test
+          end
+        end
+      end
+
+      attempts.times do
+        c = TCPSocket.new("127.0.0.1", listener.local_address.port)
+        c.linger = 0                             # close(2) sends RST, not FIN
+        c.write("\x16\x03\x01\x00\x05".to_slice) # a ClientHello that never completes
+        c.flush
+        c.close
+        sleep 0.2.seconds
+      end
+      sleep 1.second
+
+      accepted.size.should eq(attempts)
+      accepted.count(&.closed?).should eq(attempts)
+    ensure
+      FileUtils.rm_rf(dir) if Dir.exists?(dir)
+    end
+  end
 end

--- a/spec/proxy/ws_truncation_spec.cr
+++ b/spec/proxy/ws_truncation_spec.cr
@@ -1,0 +1,100 @@
+require "../spec_helper"
+
+private alias WS = Gori::Proxy::WS
+
+private class TruncSink < Gori::Proxy::FlowSink
+  getter rows = [] of {String, Int32, Bytes}
+
+  def on_request(req : Gori::Store::CapturedRequest) : Int64
+    1_i64
+  end
+
+  def on_response(resp : Gori::Store::CapturedResponse) : Nil
+  end
+
+  def on_ws_message(flow_id : Int64, direction : String, opcode : Int32, payload : Bytes,
+                    shape : Gori::Proxy::WS::Shape = Gori::Proxy::WS::Shape::DEFAULT) : Nil
+    @rows << {direction, opcode, payload.dup}
+  end
+end
+
+private def data_frame(fin : Bool, payload : Bytes) : WS::Frame
+  WS::Frame.new(fin, WS::OP_TEXT, payload, Bytes.empty)
+end
+
+# The raw forward is byte-exact either way (P7); only the captured PROJECTION is capped at
+# MAX_MESSAGE. The oversized-FRAME path already writes a `NOTICE_PREFIX` marker row saying so
+# ("too large to capture"), but a message assembled past the cap by FRAGMENTATION used to be
+# written with `fin: true` and a plausible payload and nothing else — so a truncated
+# transcript was indistinguishable from a complete one. `ws_messages` has no truncation
+# column (unlike `CapturedResponse#body_truncated`), hence a row of its own.
+describe "WS capture truncation" do
+  it "marks a fragmented message that overruns the capture cap" do
+    sink = TruncSink.new
+    shape = WS::MessageShape.new
+    buf = IO::Memory.new
+
+    # First fragment fills the buffer to just under the cap; the second crosses it.
+    head = Bytes.new(WS::Relay::MAX_MESSAGE - 4, 'A'.ord.to_u8)
+    shape.note(false, 0_u8, false, nil)
+    buf = WS::Relay.capture_frame(data_frame(false, head), buf, "out", 1_i64, sink,
+      WS::OP_TEXT, shape)
+    sink.rows.should be_empty # no FIN yet, and nothing dropped yet
+
+    tail = Bytes.new(64, 'B'.ord.to_u8)
+    shape.note(true, 0_u8, false, nil)
+    WS::Relay.capture_frame(data_frame(true, tail), buf, "out", 1_i64, sink,
+      WS::OP_TEXT, shape)
+
+    sink.rows.size.should eq(2)
+
+    notice, payload = sink.rows[0], sink.rows[1]
+    WS.notice?(notice[2]).should be_true
+    String.new(notice[2]).should contain("truncated")
+    # The payload row keeps the captured PREFIX — that is the evidence worth having — and
+    # stops exactly at the cap.
+    WS.notice?(payload[2]).should be_false
+    payload[2].size.should eq(WS::Relay::MAX_MESSAGE)
+  end
+
+  it "does not mark a message that fits, and emits it once on FIN" do
+    sink = TruncSink.new
+    shape = WS::MessageShape.new
+    buf = IO::Memory.new
+
+    shape.note(false, 0_u8, false, nil)
+    buf = WS::Relay.capture_frame(data_frame(false, "AAA".to_slice), buf, "in", 1_i64, sink,
+      WS::OP_TEXT, shape)
+    shape.note(true, 0_u8, false, nil)
+    WS::Relay.capture_frame(data_frame(true, "BBB".to_slice), buf, "in", 1_i64, sink,
+      WS::OP_TEXT, shape)
+
+    sink.rows.size.should eq(1)
+    String.new(sink.rows[0][2]).should eq("AAABBB")
+  end
+
+  # One notice per MESSAGE, not one per fragment: after the crossing frame every later
+  # fragment also drops bytes, and a notice for each would bury the transcript.
+  it "marks the overrun exactly once across later fragments" do
+    sink = TruncSink.new
+    shape = WS::MessageShape.new
+    buf = IO::Memory.new
+
+    head = Bytes.new(WS::Relay::MAX_MESSAGE - 4, 'A'.ord.to_u8)
+    shape.note(false, 0_u8, false, nil)
+    buf = WS::Relay.capture_frame(data_frame(false, head), buf, "out", 1_i64, sink,
+      WS::OP_TEXT, shape)
+
+    3.times do
+      shape.note(false, 0_u8, false, nil)
+      buf = WS::Relay.capture_frame(data_frame(false, Bytes.new(32, 'B'.ord.to_u8)), buf,
+        "out", 1_i64, sink, WS::OP_TEXT, shape)
+    end
+    shape.note(true, 0_u8, false, nil)
+    WS::Relay.capture_frame(data_frame(true, Bytes.new(32, 'C'.ord.to_u8)), buf, "out",
+      1_i64, sink, WS::OP_TEXT, shape)
+
+    notices = sink.rows.count { |(_, _, p)| WS.notice?(p) }
+    notices.should eq(1)
+  end
+end

--- a/spec/proxy/ws_truncation_spec.cr
+++ b/spec/proxy/ws_truncation_spec.cr
@@ -4,6 +4,7 @@ private alias WS = Gori::Proxy::WS
 
 private class TruncSink < Gori::Proxy::FlowSink
   getter rows = [] of {String, Int32, Bytes}
+  getter shapes = [] of Gori::Proxy::WS::Shape
 
   def on_request(req : Gori::Store::CapturedRequest) : Int64
     1_i64
@@ -15,6 +16,7 @@ private class TruncSink < Gori::Proxy::FlowSink
   def on_ws_message(flow_id : Int64, direction : String, opcode : Int32, payload : Bytes,
                     shape : Gori::Proxy::WS::Shape = Gori::Proxy::WS::Shape::DEFAULT) : Nil
     @rows << {direction, opcode, payload.dup}
+    @shapes << shape
   end
 end
 
@@ -71,6 +73,48 @@ describe "WS capture truncation" do
 
     sink.rows.size.should eq(1)
     String.new(sink.rows[0][2]).should eq("AAABBB")
+  end
+
+  # `MessageShape#take` RESETS the accumulator, so taking it for the notice handed the real
+  # payload row a fabricated shape — frames 1, masked nil — losing the fragment count and the
+  # masking evidence the shape exists to record. The notice is gori's own row, so it carries
+  # the DEFAULT shape like every other NOTICE, and the payload row keeps the message's.
+  it "does not spend the message's shape on the notice row" do
+    sink = TruncSink.new
+    shape = WS::MessageShape.new
+    buf = IO::Memory.new
+    key = Bytes[1_u8, 2_u8, 3_u8, 4_u8]
+
+    head = Bytes.new(WS::Relay::MAX_MESSAGE - 4, 'A'.ord.to_u8)
+    shape.note(false, 0_u8, true, key)
+    buf = WS::Relay.capture_frame(data_frame(false, head), buf, "out", 1_i64, sink,
+      WS::OP_TEXT, shape)
+    shape.note(true, 0_u8, true, key)
+    WS::Relay.capture_frame(data_frame(true, Bytes.new(64, 'B'.ord.to_u8)), buf, "out",
+      1_i64, sink, WS::OP_TEXT, shape)
+
+    sink.rows.size.should eq(2)
+    payload_shape = sink.shapes[1] # the real message row, emitted after the notice
+    payload_shape.frames.should eq(2)
+    payload_shape.masked.should be_true
+  end
+
+  # An EXACT fill followed by more fragments used to drop every later byte with no notice:
+  # nothing is lost on the filling frame, and `remaining` is 0 for all the rest.
+  it "marks an overrun when a fragment lands exactly on the cap and more follows" do
+    sink = TruncSink.new
+    shape = WS::MessageShape.new
+    buf = IO::Memory.new
+
+    shape.note(false, 0_u8, false, nil)
+    buf = WS::Relay.capture_frame(
+      data_frame(false, Bytes.new(WS::Relay::MAX_MESSAGE, 'A'.ord.to_u8)), buf, "out",
+      1_i64, sink, WS::OP_TEXT, shape)
+    shape.note(true, 0_u8, false, nil)
+    WS::Relay.capture_frame(data_frame(true, Bytes.new(32, 'B'.ord.to_u8)), buf, "out",
+      1_i64, sink, WS::OP_TEXT, shape)
+
+    sink.rows.count { |(_, _, p)| WS.notice?(p) }.should eq(1)
   end
 
   # One notice per MESSAGE, not one per fragment: after the crossing frame every later

--- a/spec/repeater/diff_truncation_spec.cr
+++ b/spec/repeater/diff_truncation_spec.cr
@@ -1,0 +1,48 @@
+require "../spec_helper"
+
+private alias Diff = Gori::Repeater::Diff
+
+private def lines(n : Int32, tag : String) : Array(String)
+  Array.new(n) { |i| "line #{i} #{tag}" }
+end
+
+# `Diff.lines` caps BOTH sides at MAX_LINES and its docstring makes noting that the caller's
+# job ("the cap is noted by the caller"). Three callers forgot, so a change past the cut was
+# absent from the diff AND from the count, and the CLI printed "no differences" — the answer
+# an operator acts on. `truncated?` is that derivation with one home.
+describe Gori::Repeater::Diff do
+  describe ".truncated?" do
+    it "is false while both sides fit" do
+      Diff.truncated?(lines(Diff::MAX_LINES, "a"), lines(Diff::MAX_LINES, "a")).should be_false
+    end
+
+    # The ordinary shape: the new response is LONGER (an appended reflected payload, a stack
+    # trace, an extra block). Those lines exist only in `b`, so only `b` is cut.
+    it "is true when only the NEW side overruns" do
+      Diff.truncated?(lines(10, "a"), lines(Diff::MAX_LINES + 1, "b")).should be_true
+    end
+
+    it "is true when only the ORIGINAL side overruns" do
+      Diff.truncated?(lines(Diff::MAX_LINES + 1, "a"), lines(10, "b")).should be_true
+    end
+  end
+
+  # The reason the note matters: a difference living past the cut is invisible to both the
+  # diff and the count, so `change_count == 0` cannot be read as "the responses match".
+  it "reports zero changes for a difference past the cap" do
+    a = lines(Diff::MAX_LINES + 50, "same")
+    b = a.dup
+    b[Diff::MAX_LINES + 10] = "PAYLOAD REFLECTED HERE"
+
+    Diff.change_count(Diff.lines(a, b)).should eq(0) # the cut hides it...
+    Diff.truncated?(a, b).should be_true             # ...and this is what says so
+  end
+
+  it "still finds a difference that falls before the cap" do
+    a = lines(Diff::MAX_LINES + 50, "same")
+    b = a.dup
+    b[10] = "PAYLOAD REFLECTED HERE"
+
+    Diff.change_count(Diff.lines(a, b)).should be > 0
+  end
+end

--- a/spec/sitemap_summary_spec.cr
+++ b/spec/sitemap_summary_spec.cr
@@ -1,0 +1,85 @@
+require "./spec_helper"
+
+private def with_store(&)
+  path = File.tempname("gori-smap", ".db")
+  store = Gori::Store.open(path)
+  begin
+    yield store
+  ensure
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+private def capture(store : Gori::Store, method : String, target : String, status : Int32) : Nil
+  head = "#{method} #{target} HTTP/1.1\r\nHost: acme.test\r\n\r\n"
+  id = store.insert_flow(Gori::Store::CapturedRequest.new(
+    created_at: 1_i64, scheme: "https", host: "acme.test", port: 443,
+    method: method, target: target, http_version: "HTTP/1.1", head: head.to_slice))
+  resp_head = "HTTP/1.1 #{status} X\r\nContent-Length: 0\r\n\r\n"
+  store.update_response(Gori::Store::CapturedResponse.new(
+    flow_id: id, status: status, head: resp_head.to_slice, duration_us: 1_i64))
+end
+
+describe "sitemap summary" do
+  # Six columns key a group and only two ordered it, so `GET /x` and `POST /x` tied
+  # completely and which one survived a LIMIT cut was unspecified by SQL. There is no cursor
+  # on this read, so the loser of an arbitrary tiebreak is not on a later page — it is
+  # unreachable, and the operator concludes the endpoint was never observed.
+  #
+  # HONEST NOTE ON WHAT THIS PINS: this example also PASSES against the old partial
+  # `ORDER BY host, target`, because SQLite's GROUP BY happens to sort by the grouping
+  # columns internally and that order agrees with the requested one here. The total ORDER BY
+  # is a GUARANTEE, not an observable change on this data — SQLite is free to change that
+  # internal order (a different query plan, an index, a version bump) and the old clause
+  # gave it permission to. So treat this as a regression guard on the stated order, not as
+  # proof the bug reproduced.
+  it "orders totally so a LIMIT cut is deterministic" do
+    with_store do |store|
+      capture(store, "GET", "/admin", 200)
+      capture(store, "POST", "/admin", 200)
+      capture(store, "DELETE", "/admin", 200)
+
+      first = store.sitemap_entries_detailed(Gori::QL::EMPTY, 2).map { |e| {e.method, e.target} }
+      3.times do
+        store.sitemap_entries_detailed(Gori::QL::EMPTY, 2)
+          .map { |e| {e.method, e.target} }.should eq(first)
+      end
+      # And the cut is by a stated order, not by luck: methods sort ascending.
+      first.map(&.[0]).should eq(["DELETE", "GET"])
+    end
+  end
+
+  # Status 101 is exactly what `proto:ws` means, so every WebSocket endpoint used to report
+  # "N attempts, 0 successes, 0 errors" — an agent reads that as N failed attempts.
+  it "counts a 101 upgrade as a success, not as neither" do
+    with_store do |store|
+      capture(store, "GET", "/ws", 101)
+      capture(store, "GET", "/ws", 101)
+
+      entry = store.sitemap_entries_detailed.find { |e| e.target == "/ws" }.not_nil!
+      entry.count.should eq(2)
+      entry.ok.should eq(2)
+      entry.errors.should eq(0)
+    end
+  end
+
+  it "still buckets ordinary successes and errors as before" do
+    with_store do |store|
+      capture(store, "GET", "/ok", 200)
+      capture(store, "GET", "/ok", 301)
+      capture(store, "GET", "/bad", 404)
+      capture(store, "GET", "/bad", 500)
+
+      ok = store.sitemap_entries_detailed.find { |e| e.target == "/ok" }.not_nil!
+      ok.ok.should eq(2)
+      ok.errors.should eq(0)
+
+      bad = store.sitemap_entries_detailed.find { |e| e.target == "/bad" }.not_nil!
+      bad.ok.should eq(0)
+      bad.errors.should eq(2)
+    end
+  end
+end

--- a/spec/tui/fuzz_set_overlay_spec.cr
+++ b/spec/tui/fuzz_set_overlay_spec.cr
@@ -272,4 +272,39 @@ describe Gori::Tui::FuzzSetOverlay do
     h.rendered?("한").should be_true
     ov.build_spec.not_nil!.value.should eq("x") # composing text is not in the buffer yet
   end
+
+  # `Overlay#handle_click` places the caret in whichever listed field the press landed in —
+  # "a press inside a drawn field is a caret, not a no-op". This card overrides handle_click
+  # to pick the row and used to stop there, so the caret stayed wherever the last keystroke
+  # left it and the next character went somewhere the operator did not point.
+  it "places the caret where a click lands in a field, not where typing left it" do
+    ov = FuzzSetOverlay.editing(Gori::Tui::SetSpec.new(:brute, "abcdef:1:3"), 0)
+    area = Rect.new(0, 0, 120, 30)
+    ov.render(Screen.new(MemoryBackend.new(120, 30)), area)
+    box = ov.overlay_box(area).not_nil!
+
+    # Charset is the first field row of :brute, drawn at box.y + 3, value column at +2+LABEL_W.
+    value_x = box.x + 2 + 9
+    ov.handle_click(area, value_x + 3, box.y + 3).should eq(:stay)
+    otype(ov, "X")
+
+    ov.build_spec.not_nil!.value.should start_with("abcXdef")
+  end
+
+  # `@fields` holds all eight for every payload type while `render_fields` draws only the
+  # current type's rows, so an off-screen field kept the geometry it was drawn at under a
+  # PREVIOUS type and could win a hit-test against a click meant for a visible one.
+  it "exposes only the payload type's own fields to the pointer" do
+    ov = FuzzSetOverlay.editing(Gori::Tui::SetSpec.new(:brute, "abcdef:1:3"), 0)
+    ov.text_fields.size.should eq(3) # charset, min, max — not all eight
+
+    # NOTE: the SetSpec kind is `:file`; `:wordlist` is the overlay's ptype name for it.
+    wl = FuzzSetOverlay.editing(Gori::Tui::SetSpec.new(:file, "/tmp/w.txt"), 0)
+    wl.text_fields.size.should eq(1) # path
+
+    # :preset has no TextField at all, so the card must not claim drag support for it.
+    pre = FuzzSetOverlay.editing(Gori::Tui::SetSpec.new(:preset, "sqli"), 0)
+    pre.text_fields.should be_empty
+    pre.supports_drag?.should be_false
+  end
 end

--- a/spec/tui/url_spec.cr
+++ b/spec/tui/url_spec.cr
@@ -116,17 +116,23 @@ describe Gori::Tui::Url do
     end
 
     # --- query/fragment on an empty path ---
-    # NOTE: the source keys off the first '/' after the authority. A URL whose only
-    # component after the authority is a query or fragment (no '/') has no such slash,
-    # so it collapses to "/". This is the actual, safe behavior for the display helper;
-    # such wire targets are rare (origin-form always carries a path). Asserting actual.
+    # These two used to assert the collapse to "/" — explicitly as "asserting actual", i.e.
+    # characterising what the code did rather than what it owed. It owed more: the same
+    # helper feeds `Outbound.scope_url`, so collapsing dropped the query a scope EXCLUDE was
+    # keyed to and the carve-out silently stopped matching. RFC 3986 3.3 makes an empty path
+    # with a query "/" + the rest, which is also the more faithful thing to show in the
+    # History/Comparer/picker columns that read this.
 
-    it "collapses an absolute URL whose only tail is a query to '/'" do
-      Gori::Tui::Url.origin_path("http://example.com?q=1").should eq("/")
+    it "keeps the query of an absolute URL whose only tail is a query" do
+      Gori::Tui::Url.origin_path("http://example.com?q=1").should eq("/?q=1")
     end
 
-    it "collapses an absolute URL whose only tail is a fragment to '/'" do
-      Gori::Tui::Url.origin_path("http://example.com#f").should eq("/")
+    it "keeps the fragment of an absolute URL whose only tail is a fragment" do
+      Gori::Tui::Url.origin_path("http://example.com#f").should eq("/#f")
+    end
+
+    it "still yields a bare slash when nothing follows the authority" do
+      Gori::Tui::Url.origin_path("http://example.com").should eq("/")
     end
 
     # --- multibyte / adversarial ---

--- a/src/gori/capture_status.cr
+++ b/src/gori/capture_status.cr
@@ -1,5 +1,7 @@
 require "json"
 require "./bind_address"
+require "./durable_file"
+require "./paths"
 
 module Gori
   # Per-project capture sidecar written by the session that holds the capture lock.
@@ -16,21 +18,24 @@ module Gori
     end
 
     def self.write(dir : String, host : String, port : Int32, listening : Bool) : Nil
-      Dir.mkdir_p(dir) unless Dir.exists?(dir)
-      dest = path(dir)
-      tmp = "#{dest}.tmp.#{Process.pid}"
+      # `Paths.ensure_dir`, not a bare `Dir.mkdir_p`: this can be the call that creates a
+      # project directory, and every gori dir is owner-only 0700 (see Paths::DIR_MODE) —
+      # the captured traffic DB lands in here. A plain mkdir_p leaves it at the umask,
+      # world-traversable on a shared host.
+      #
+      # `tighten: false` because this directory is not always gori's. `Project#dir` is
+      # `File.dirname(db_path)`, so a `--db /shared/team/traffic.db` project borrows an
+      # arbitrary parent (project.cr says so); chmod'ing THAT to 0700 would strip group
+      # access from a directory gori merely found. A dir gori creates still lands at 0700.
+      Paths.ensure_dir(dir, tighten: false)
       payload = {
         "host"      => host,
         "port"      => port,
         "listening" => listening,
       }.to_json
-      begin
-        File.write(tmp, payload)
-        File.rename(tmp, dest)
-      rescue ex
-        File.delete?(tmp)
-        raise ex
-      end
+      # 0644 is the fallback for a file that does not exist yet; this marker holds a bind
+      # address, not a secret, and the 0700 dir above is what keeps it private.
+      DurableFile.write(path(dir), payload, perm: File::Permissions.new(0o644))
     end
 
     def self.read(dir : String) : Status?

--- a/src/gori/cli/run/compare.cr
+++ b/src/gori/cli/run/compare.cr
@@ -58,7 +58,7 @@ module Gori
 
         lines_a = compare_lines(detail_a, pane)
         lines_b = compare_lines(detail_b, pane)
-        truncated = lines_a.size > Repeater::Diff::MAX_LINES || lines_b.size > Repeater::Diff::MAX_LINES
+        truncated = Repeater::Diff.truncated?(lines_a, lines_b)
         full_diff = Repeater::Diff.lines(lines_a, lines_b)
         change_count = Repeater::Diff.change_count(full_diff)
         folded = if changes_only

--- a/src/gori/cli/run/probe.cr
+++ b/src/gori/cli/run/probe.cr
@@ -577,7 +577,10 @@ module Gori
         begin
           if w = want
             mode = Probe::Mode.from_setting(w)
-            store.set_probe_mode(mode)
+            unless store.set_probe_mode(mode)
+              store.close
+              abort "gori run probe mode: project is busy (write did not commit) — try again"
+            end
             puts "Scan mode set to #{mode.label}."
           else
             puts store.probe_mode.label

--- a/src/gori/cli/run/project.cr
+++ b/src/gori/cli/run/project.cr
@@ -703,12 +703,10 @@ module Gori
                         "so the sandbox will BLOCK ALL captured traffic until you add one " \
                         "(gori run project scope add ...)"
           end
-          # Scope's sandbox setters persist through the SAME settings-table write the TUI uses
-          # (set_sandbox_unlocked → Store#set_setting) but return Nil, so confirm the flag
-          # committed by reading it back — a busy/locked store must not report success
-          # (mirrors scope enable/disable's committed check).
-          enable ? scope.enable_sandbox : scope.disable_sandbox
-          unless store.setting(Scope::SETTING_SANDBOX) == (enable ? "1" : "0")
+          # The setters return whether the write COMMITTED (mirrors scope enable/disable's
+          # check). A busy/locked store must not report success: the in-memory flag flips
+          # either way, and the next reload reverts it to the disk value.
+          unless enable ? scope.enable_sandbox : scope.disable_sandbox
             store.close
             abort "gori run project sandbox #{action}: project is busy (write did not commit) — try again"
           end

--- a/src/gori/cli/run/repeater.cr
+++ b/src/gori/cli/run/repeater.cr
@@ -548,12 +548,15 @@ module Gori
         outbound.close
 
         new_body, _ = decode_body(result.head, result.body)
-        diff =
-          if do_diff && (base_head = rec.response_head)
-            orig = message_lines(base_head, display_body(base_head, rec.response_body))
-            Repeater::Diff.lines(orig, message_lines(result.head, new_body))
-          end
-        emit_repeater_result(result, new_body, diff, format)
+        diff = nil.as(Array(Repeater::DiffLine)?)
+        diff_capped = false
+        if do_diff && (base_head = rec.response_head)
+          orig = message_lines(base_head, display_body(base_head, rec.response_body))
+          fresh = message_lines(result.head, new_body)
+          diff_capped = Repeater::Diff.truncated?(orig, fresh)
+          diff = Repeater::Diff.lines(orig, fresh)
+        end
+        emit_repeater_result(result, new_body, diff, format, diff_capped)
         persist_repeater_response(id, result.head, result.body, result.error, result.duration_us, project_name, db_path) if result.ok?
         exit 1 unless result.ok?
       end
@@ -799,15 +802,22 @@ module Gori
       # already decoded `new_body` and built `diff` (the diff baseline differs per
       # path); caller owns the exit code.
       private def self.emit_repeater_result(result : Repeater::Result, new_body : Bytes?,
-                                            diff : Array(Repeater::DiffLine)?, format : Symbol) : Nil
+                                            diff : Array(Repeater::DiffLine)?, format : Symbol,
+                                            diff_capped : Bool = false) : Nil
         if format == :json
-          puts repeater_json(result, diff)
+          puts repeater_json(result, diff, diff_capped)
         elsif result.ok?
           STDERR.puts "→ #{result.response.try(&.status) || "?"} in #{CLI::Output.human_us(result.duration_us)}#{result.incomplete? ? " (#{incomplete_reason(result, result.timed_out?)})" : ""}"
           if d = diff
             print_diff(d)
             n = Repeater::Diff.change_count(d)
+            # Never a bare "no differences" over a CUT diff: `Diff.lines` caps both sides at
+            # MAX_LINES, so a change past the cut is absent from the diff AND from the count
+            # — and a longer new response (an appended payload, a stack trace) puts its extra
+            # lines exactly there. `cmd_compare` in this directory has always said so; the
+            # repeater paths did not, and "no differences" is the answer an operator acts on.
             STDERR.puts(n == 0 ? "no differences" : "#{n} line#{n == 1 ? "" : "s"} changed")
+            STDERR.puts "(diff truncated to #{Repeater::Diff::MAX_LINES} lines/side — lines past the cut were not compared)" if diff_capped
           else
             print_message_text(result.head, new_body, result.body)
           end
@@ -1300,17 +1310,21 @@ module Gori
         # baseline isn't free for large bodies). The JSON path decodes independently
         # inside emit_body_json, from the raw head+body, to match MCP's contract.
         new_body, _ = decode_body(result.head, result.body)
-        diff =
-          if do_diff
-            orig = message_lines(detail.response_head, display_body(detail.response_head, detail.response_body))
-            Repeater::Diff.lines(orig, message_lines(result.head, new_body))
-          end
+        diff = nil.as(Array(Repeater::DiffLine)?)
+        diff_capped = false
+        if do_diff
+          orig = message_lines(detail.response_head, display_body(detail.response_head, detail.response_body))
+          fresh = message_lines(result.head, new_body)
+          diff_capped = Repeater::Diff.truncated?(orig, fresh)
+          diff = Repeater::Diff.lines(orig, fresh)
+        end
 
-        emit_repeater_result(result, new_body, diff, format)
+        emit_repeater_result(result, new_body, diff, format, diff_capped)
         exit 1 unless result.ok?
       end
 
-      private def self.repeater_json(result : Repeater::Result, diff : Array(Repeater::DiffLine)?) : String
+      private def self.repeater_json(result : Repeater::Result, diff : Array(Repeater::DiffLine)?,
+                                     diff_capped : Bool = false) : String
         JSON.build do |j|
           j.object do
             j.field "ok", result.ok?
@@ -1339,6 +1353,10 @@ module Gori
             emit_body_json(j, "body", result.head, result.body, false)
             if d = diff
               j.field "changed_lines", Repeater::Diff.change_count(d)
+              # Sibling to changed_lines, exactly as `cmd_compare`'s JSON carries it: a
+              # consumer reading changed_lines: 0 has to be able to tell "identical" from
+              # "compared only the first MAX_LINES lines".
+              j.field "truncated", diff_capped
             end
           end
         end

--- a/src/gori/cli/run/sitemap.cr
+++ b/src/gori/cli/run/sitemap.cr
@@ -95,7 +95,7 @@ module Gori
       private def self.sitemap_tag_path(target : String) : String
         path = Sitemap.normalize_path(target.strip)
         return "/" if path.empty?
-        path.starts_with?('/') || path.starts_with?("http") ? path : "/#{path}"
+        path.starts_with?('/') ? path : "/#{path}"
       end
 
       private def self.cmd_sitemap_tree(args : Array(String)) : Nil

--- a/src/gori/cli/run/sitemap.cr
+++ b/src/gori/cli/run/sitemap.cr
@@ -73,8 +73,8 @@ module Gori
         matched = sitemap_node_exists?(store, host, key)
         abort "gori run sitemap tag: NOT applied (project busy) — the node is unchanged" unless store.set_sitemap_tag(host, key, text)
         puts text.empty? ? "Tag cleared on #{host}#{key}." : "Tagged #{host}#{key}: #{text}"
-        unless matched || text.empty?
-          STDERR.puts "gori run sitemap tag: warning: no captured endpoint at #{host}#{key} — this tag will not show in the tree until one exists (check for a typo or a trailing slash)"
+        if warning = tag_match_warning(matched, host, key, text)
+          STDERR.puts "gori run sitemap tag: warning: #{warning}"
         end
       end
 
@@ -82,10 +82,32 @@ module Gori
       # names no endpoint is stored but unreachable — it can never stamp onto a tree node. The
       # common causes are a typo and a trailing slash (Sitemap.add drops one, so /api/users/ is
       # stamped as /api/users).
-      private def self.sitemap_node_exists?(store : Store, host : String, path : String) : Bool
-        store.sitemap_entries_detailed(QL::EMPTY, Store::SITEMAP_MAX).any? do |e|
-          e.host == host && sitemap_tag_path(e.target) == path
+      # The sentence for a tag that could not be confirmed against a captured endpoint, or nil
+      # when there is nothing to say. Pure and separate so the three-way answer from
+      # `sitemap_node_exists?` reads as three cases rather than as branches inside the
+      # command body (which is also what kept its complexity in budget).
+      private def self.tag_match_warning(matched : Bool?, host : String, key : String,
+                                         text : String) : String?
+        return nil if text.empty? || matched
+        if matched.nil?
+          "tag stored, but there are more than #{Store::SITEMAP_MAX} captured endpoints so " \
+          "it could not be confirmed against one — check with `gori run sitemap`"
+        else
+          "no captured endpoint at #{host}#{key} — this tag will not show in the tree until " \
+          "one exists (check for a typo or a trailing slash)"
         end
+      end
+
+      # `nil` means UNKNOWN, matching the MCP twin: the scan is capped at SITEMAP_MAX, and
+      # that cap counts 6-column transport keys, which multiply past 10k long before the
+      # collapsed host/method/target count suggests. Answering a flat `false` off a truncated
+      # read made a positive claim about the capture that the query cannot support, and the
+      # warning built on it sent the operator hunting for a typo in a tag that was stored and
+      # does show.
+      private def self.sitemap_node_exists?(store : Store, host : String, path : String) : Bool?
+        entries = store.sitemap_entries_detailed(QL::EMPTY, Store::SITEMAP_MAX)
+        return true if entries.any? { |e| e.host == host && sitemap_tag_path(e.target) == path }
+        entries.size >= Store::SITEMAP_MAX ? nil : false
       end
 
       # A tag's key is the node path the tree stamps, which Sitemap.normalize_path produces —

--- a/src/gori/discover/engine.cr
+++ b/src/gori/discover/engine.cr
@@ -672,7 +672,6 @@ module Gori::Discover
     private def orchestrate : Nil
       seed_frontier
       @phase = Phase::Crawling
-      interval = pace_interval
       loop do
         break if @state == State::Stopped
         if job = @frontier.first?
@@ -684,7 +683,8 @@ module Gori::Discover
           when @jobs.send(job)
             @frontier.shift
             @pending += 1
-            pace(interval)
+            # No pace here: `send_with_retries` paces every wire request, and a Calibrate
+            # task is MANY of them. Pacing the dispatch too charged a task one extra slot.
           when oc = @discovered.receive
             handle(oc)
             @pending -= 1
@@ -1545,11 +1545,6 @@ module Gori::Discover
     # clears it — so the inferred test is LESS sensitive than the thing it is trying to
     # predict, which is the wrong way round. A byte search is exact and costs no extra request.
     private def calibration_probe(dir : String, name : String, & : Bool ->) : Calibrate::Fetched
-      # Each probe is a REQUEST. The dispatch loop paces the Calibrate TASK once, so without
-      # this the whole batch went out back-to-back for one interval — and with `concurrency`
-      # workers each doing that, calibration effectively ignored `--rate`. It is this
-      # engine's largest single cost, so it is also where the rate matters most.
-      pace(pace_interval)
       raw = send_with_retries("#{dir}#{name}")
       body = decode_body(raw)
       yield raw.error.nil? && body_contains?(body, name)
@@ -1644,7 +1639,14 @@ module Gori::Discover
       end
       target = p.query ? "#{p.path}?#{p.query}" : p.path
       attempts = 0
+      interval = pace_interval
       loop do
+        # The single funnel for this engine's wire sends, so pacing HERE is what makes
+        # `--rate` mean requests/sec exactly once per request. Two things it fixes over
+        # pacing the dispatch loop: a RETRY was spaced only by `retry_pause` and so ran on
+        # top of the operator's rate, and a Calibrate task used to pay one slot for the task
+        # plus one per probe, undershooting the rate by a slot per directory.
+        pace(interval)
         raw = @capped.fetch(p.scheme, p.host, p.port, target)
         if raw.error && raw.error != CappedBackend::CAP_ERROR && attempts < @config.retries
           attempts += 1

--- a/src/gori/discover/engine.cr
+++ b/src/gori/discover/engine.cr
@@ -1545,6 +1545,11 @@ module Gori::Discover
     # clears it — so the inferred test is LESS sensitive than the thing it is trying to
     # predict, which is the wrong way round. A byte search is exact and costs no extra request.
     private def calibration_probe(dir : String, name : String, & : Bool ->) : Calibrate::Fetched
+      # Each probe is a REQUEST. The dispatch loop paces the Calibrate TASK once, so without
+      # this the whole batch went out back-to-back for one interval — and with `concurrency`
+      # workers each doing that, calibration effectively ignored `--rate`. It is this
+      # engine's largest single cost, so it is also where the rate matters most.
+      pace(pace_interval)
       raw = send_with_retries("#{dir}#{name}")
       body = decode_body(raw)
       yield raw.error.nil? && body_contains?(body, name)

--- a/src/gori/discover/engine.cr
+++ b/src/gori/discover/engine.cr
@@ -1504,16 +1504,24 @@ module Gori::Discover
       end
     end
 
+    # Calibration is the ONE task that fans out into many sends — every other `process_*`
+    # makes a single `send_with_retries` call — so it is also the one place where
+    # `worker_loop`'s stop check, which runs once per RECEIVED task, is not enough. Without a
+    # per-probe check a worker already inside here kept firing its whole batch after
+    # `stop`: at the defaults that is 20 workers × 3 probes × (1 + 1 retry) = up to ~120
+    # requests at a third party AFTER the operator pressed stop. Calibration runs for every
+    # directory and is this engine's largest single cost (see the comment on the frontier),
+    # so it is also the batch most likely to be in flight when stop arrives.
     private def process_calibrate(task : Task) : Outcome
       dir = task.dir || task.url
       probes = [] of Calibrate::Fetched
       echoes = false
       @config.calibrate_probes.times do
-        break if @capped.cap_reached?
+        break if @capped.cap_reached? || stopped?
         probes << calibration_probe(dir, bogus_name) { |hit| echoes ||= hit }
       end
       @config.extensions.each do |ext|
-        break if @capped.cap_reached?
+        break if @capped.cap_reached? || stopped?
         probes << calibration_probe(dir, "#{bogus_name}.#{ext}") { |hit| echoes ||= hit }
       end
       baseline = Calibrate.build(dir, probes, @config.simhash_distance, echoes)

--- a/src/gori/durable_file.cr
+++ b/src/gori/durable_file.cr
@@ -1,0 +1,151 @@
+module Gori
+  # One durable-write implementation for every config/state file gori owns.
+  #
+  # Six independent temp+rename impls grew up here (settings, the decoder-session
+  # eraser, the capture-status marker, the active-project marker, the CA pair, the
+  # MCP client configs) and only the last one got all four parts right. The other
+  # five each dropped a different one, so the same crash was fixed once and left
+  # live everywhere else. The parts, and why each is load-bearing:
+  #
+  # * **Resolve a symlink to its target first.** These are dotfiles, which people
+  #   routinely symlink into a dotfiles repo, and `gori --config` invites exactly
+  #   that. `File.write` wrote THROUGH the link; a rename over the link itself
+  #   quietly detaches it — the tool then reads a plain file while the repo copy it
+  #   was linked to goes stale, with nothing to show for it in `git status`. A
+  #   HARDLINKED file is not detectable this way and does get detached (rename
+  #   installs a new inode); that is the standing cost of an atomic replace.
+  # * **fsync before the rename**, so the rename cannot land ahead of the bytes.
+  #   Without it the crash the staging exists to survive still yields a truncated
+  #   file — and gori's config loaders blanket-rescue a parse failure into factory
+  #   defaults, so the loss is silent. The containing DIRECTORY is deliberately not
+  #   fsync'd: that would make the rename itself durable, but its absence can only
+  #   cost a crash the OLD file, never a torn one, and this runs on every settings
+  #   save.
+  # * **A randomized temp name.** `"#{path}.tmp"` is shared by every process that
+  #   writes that path, so two gori instances stage over each other and one renames
+  #   the other's half-written bytes into place. Randomized rather than pid-derived:
+  #   a pid repeats, and a temp left behind by a killed run would then be re-opened
+  #   (mode intact, since `perm` only applies on CREATE) and renamed into place at
+  #   whatever mode it was abandoned with.
+  # * **Carry the destination's mode across.** A credential-bearing config found at
+  #   0600 must not come back 0644 because gori recreated it under the umask.
+  module DurableFile
+    # Stage *content* beside *path* and rename it into place.
+    #
+    # The string-content shorthand for `replace`; see `stage` for the mode rules.
+    def self.write(path : String, content : String, *,
+                   perm : File::Permissions, inherit : Bool = true) : Nil
+      replace(path, perm: perm, inherit: inherit) do |tmp, mode|
+        # Create at the final mode rather than widening under the umask and
+        # narrowing after: the content is written before any chmod could run, so a
+        # 0644 temp holding an auth-bearing config is a window the in-place
+        # File.write never opened.
+        File.open(tmp, "w", perm: mode) do |file|
+          file.print(content)
+          file.flush
+          file.fsync
+        end
+      end
+    end
+
+    # A replacement fully written and fsync'd to a temp file, not yet renamed into
+    # place. Splitting the write from the rename is what lets a caller replacing
+    # SEVERAL files that must agree with each other (the CA's cert/key pair) get
+    # every one of them onto disk before any of them lands, narrowing the window in
+    # which the set disagrees to the gap between the renames.
+    struct Staged
+      def initialize(@tmp : String, @target : String)
+      end
+
+      def commit : Nil
+        File.rename(@tmp, @target)
+      end
+
+      # Best-effort, and never raises: this runs on a path that is already failing,
+      # and an unwritable directory or a read-only filesystem makes the delete raise
+      # too. That exception would REPLACE the ENOSPC (or whatever actually failed)
+      # with a permission complaint about a temp file the user has never heard of.
+      def discard : Nil
+        File.delete?(@tmp) rescue nil
+      end
+    end
+
+    # Stage a replacement for *path* and rename it into place atomically.
+    #
+    # See `stage` for the block and mode rules.
+    def self.replace(path : String, *, perm : File::Permissions, inherit : Bool = true,
+                     &block : String, File::Permissions ->) : Nil
+      staged = stage(path, perm: perm, inherit: inherit, &block)
+      begin
+        staged.commit
+      rescue ex
+        staged.discard
+        raise ex
+      end
+    end
+
+    # Write a replacement for *path* to a temp file beside it, without installing it.
+    # Call `Staged#commit` to install, or `Staged#discard` to throw it away.
+    #
+    # The block receives the temp path to write and the mode that temp should end
+    # up at — for a writer that opens the path itself (an OpenSSL BIO, say) the
+    # mode has to be applied by the block before any bytes land, since this method
+    # can only chmod after the fact.
+    #
+    # *perm* is the mode to land on when the destination does not exist yet. When
+    # *inherit* is true an existing destination's own mode wins instead; pass
+    # `inherit: false` for a file whose mode gori dictates rather than preserves
+    # (settings.json holds env token values, so it is 0600 no matter what it was
+    # found at).
+    def self.stage(path : String, *, perm : File::Permissions,
+                   inherit : Bool = true, & : String, File::Permissions ->) : Staged
+      target = resolve_symlink(path)
+      dir = File.dirname(target)
+      mode = (inherit ? File.info?(target).try(&.permissions) : nil) || perm
+      tmp = File.tempname(".#{File.basename(target)}.gori", ".tmp", dir: dir)
+      staged = Staged.new(tmp, target)
+      begin
+        yield tmp, mode
+        # chmod as well as creating at `mode`, because a block that opened the temp
+        # itself may not have honoured the mode at all (an OpenSSL BIO does not).
+        #
+        # Rescued, unlike the reference impl's unrescued chmod, and that is safe only
+        # because it can no longer be the thing protecting a secret: the temp is
+        # always a fresh name, so `File.open`'s `perm:` really does apply on CREATE,
+        # and `KeyPair#write_pem` forces 0600 itself before any key byte lands. What
+        # is left for this chmod to fix is a public file's mode, which is not worth
+        # failing a settings save on a filesystem that cannot represent it.
+        File.chmod(tmp, mode) rescue nil
+        fsync(tmp)
+      rescue ex
+        staged.discard
+        raise ex
+      end
+      staged
+    end
+
+    # Flush the staged file's bytes to the platter before it is renamed over live
+    # data. Re-opened rather than fsync'd through the writer's own handle because
+    # `replace`'s block may have written via something that is not a Crystal `File`
+    # at all. Opened for APPEND, never "w" — "w" truncates, which on this path
+    # would destroy the very bytes we are trying to make durable.
+    #
+    # Best-effort: a filesystem that cannot fsync (some network mounts) must not
+    # turn every settings save into a failure. The rename below is still atomic;
+    # only the crash-durability guarantee is lost.
+    private def self.fsync(path : String) : Nil
+      File.open(path, "a", &.fsync)
+    rescue
+    end
+
+    # The path a symlink points at, or *path* itself. A broken link (or an
+    # unreadable one) resolves to itself, so the write replaces the dangling link
+    # with a real file rather than failing over it.
+    private def self.resolve_symlink(path : String) : String
+      return path unless File.symlink?(path)
+      File.realpath(path)
+    rescue
+      path
+    end
+  end
+end

--- a/src/gori/durable_file.cr
+++ b/src/gori/durable_file.cr
@@ -101,11 +101,18 @@ module Gori
                    inherit : Bool = true, & : String, File::Permissions ->) : Staged
       target = resolve_symlink(path)
       dir = File.dirname(target)
-      mode = (inherit ? File.info?(target).try(&.permissions) : nil) || perm
+      # `file?` guards the inherit: a destination that is a directory or a device would
+      # otherwise lend its mode — execute bits included — to the replacement.
+      mode = (inherit ? File.info?(target).try { |i| i.permissions if i.file? } : nil) || perm
       tmp = File.tempname(".#{File.basename(target)}.gori", ".tmp", dir: dir)
       staged = Staged.new(tmp, target)
       begin
         yield tmp, mode
+        # A block that wrote nothing must not be installed over live data. Checked here
+        # rather than left to `fsync`, whose "a" mode would CREATE the missing temp and
+        # hand back a valid-looking `Staged` pointing at a zero-byte file — with the
+        # chmod's own ENOENT already swallowed, nothing else would notice.
+        raise Gori::Error.new("durable write staged no file at #{tmp}") unless File.exists?(tmp)
         # chmod as well as creating at `mode`, because a block that opened the temp
         # itself may not have honoured the mode at all (an OpenSSL BIO does not).
         #

--- a/src/gori/export/har.cr
+++ b/src/gori/export/har.cr
@@ -212,7 +212,13 @@ module Gori
             j.object do
               j.field "status", row.status || resp.status
               j.field "statusText", resp.reason
-              j.field "httpVersion", version
+              # The RESPONSE's own version, not the request's. `detail.http_version` is the
+              # request column (flow_mapper), so an origin answering HTTP/1.0 to an HTTP/1.1
+              # request exported as HTTP/1.1 and re-imported with its response head rewritten
+              # — and 1.0 vs 1.1 is semantically load-bearing (no default keep-alive). The
+              # truth was already parsed two lines up, from `resp.raw_head`, which is stored
+              # verbatim.
+              j.field "httpVersion", resp.version.presence || version
               j.field "cookies" { response_cookies(j, resp.headers) }
               j.field "headers" { headers(j, resp.headers) }
               j.field "redirectURL", resp.headers.get?("location") || ""

--- a/src/gori/fuzz/engine.cr
+++ b/src/gori/fuzz/engine.cr
@@ -534,7 +534,11 @@ module Gori::Fuzz
         wanted = Math.min(wanted.to_i64, room).to_i32
       end
       samples = [] of BaselineSample
+      interval = pace_interval
       @generator.calibration_requests(wanted).each do |bytes, payload_len|
+        # Calibration samples are real requests at the target, sent before `start`'s dispatch
+        # loop exists — so without this they were the one burst that ignored `--rate` outright.
+        pace(interval)
         raw = @backend.send(bytes)
         samples << BaselineSample.new(@matcher.metrics(raw), payload_len) if raw.error.nil?
       end
@@ -738,6 +742,12 @@ module Gori::Fuzz
         # is either a literal gori wrote (`GET`, `Host:`, `Connection: close`) or the origin's
         # own `Location`. Neither is a place an operator could have written a `$NAME` for a
         # binding to resolve, so there is nothing here to substitute in the first place.
+        # A hop is a REQUEST, so it owes the operator's rate the same as any other. Only the
+        # first request of a payload goes through the dispatch loop's `pace`, so an unpaced
+        # chain ran at up to (max_redirects + 1)x the configured rate — 6x at defaults, on
+        # every 3xx, which is the ordinary shape of an auth-gated target. `pace` claims its
+        # slot without yielding, so calling it from this worker fiber is safe.
+        pace(pace_interval)
         hop = @backend.send(nxt, Backend.all_verbatim(nxt))
         retried ||= hop.retried?
         total_us += hop.duration_us

--- a/src/gori/import/har.cr
+++ b/src/gori/import/har.cr
@@ -78,9 +78,14 @@ module Gori
         # (`HTTP/1.1 200\r\n` — a real server fingerprint and a deliberate probe target),
         # export writes `"statusText": ""`, and inventing "OK" on the way back put three
         # bytes on the head that the origin never sent. Only a MISSING field earns a phrase.
-        raw_reason = resp["statusText"]?
+        # `.as_s?`, not a bare truthiness test: `JSON::Any#[]?` returns `JSON::Any(nil)` for
+        # an EXPLICIT null, which is truthy — so a foreign HAR writing `"statusText": null`
+        # took the present branch and yielded "", fabricating the reason-less status line
+        # that is supposed to mean the origin really sent one. Absent and null both fall
+        # through to the phrase; only a present STRING is honoured, empty included.
+        raw_reason = resp["statusText"]?.try(&.as_s?)
         reason = if raw_reason
-                   raw_reason.to_s
+                   raw_reason
                  elsif resp_version.starts_with?("HTTP/2")
                    ""
                  else
@@ -187,6 +192,12 @@ module Gori
         when "", "http/1.1"          then "HTTP/1.1"
         when "http/1.0"              then "HTTP/1.0"
         else
+          # Chrome DevTools writes "http/2.0". Keeping it verbatim split the codebase's two
+          # h2 tests against each other — `starts_with?("HTTP/2")` true in the probe layer,
+          # `== "HTTP/2"` false in the Repeater — so an imported h2 flow replayed over
+          # HTTP/1.1 while being scanned as h2. Any 2.x folds to the canonical spelling;
+          # only an otherwise well-formed version is kept as it arrived.
+          return "HTTP/2" if v =~ /\Ahttp\/2(\.\d+)?\z/i
           v =~ /\Ahttp\/\d+\.\d+\z/i ? v.upcase : "HTTP/1.1"
         end
       end

--- a/src/gori/import/har.cr
+++ b/src/gori/import/har.cr
@@ -73,9 +73,14 @@ module Gori
         # field is absent — HTTP/2 has no reason phrase on the wire, and inventing "OK"
         # (or a trailing space on an empty phrase) broke the export→import fixed point.
         resp_version = normalize_http_version(resp["httpVersion"]?.to_s.presence || http_version)
-        raw_reason = resp["statusText"]?.to_s
-        reason = if raw_reason.presence
-                   raw_reason
+        # ABSENT and PRESENT-BUT-EMPTY are different answers, and `.to_s` collapsed them:
+        # `parse_response_head` yields reason == "" for a reason-less status line
+        # (`HTTP/1.1 200\r\n` — a real server fingerprint and a deliberate probe target),
+        # export writes `"statusText": ""`, and inventing "OK" on the way back put three
+        # bytes on the head that the origin never sent. Only a MISSING field earns a phrase.
+        raw_reason = resp["statusText"]?
+        reason = if raw_reason
+                   raw_reason.to_s
                  elsif resp_version.starts_with?("HTTP/2")
                    ""
                  else
@@ -169,11 +174,20 @@ module Gori
         encoding.try(&.downcase) == "base64" ? Base64.decode(text) : text.to_slice
       end
 
+      # `Export::Har` writes the stored version verbatim and says this maps it back onto
+      # itself. The old `else` swallowed everything outside {1.0, 1.1, 2} into "HTTP/1.1",
+      # so a stored HTTP/0.9 / HTTP/3 / HTTP/9.9 — `flow_mapper` keeps the request line's
+      # version token verbatim, and `Repeater::Plan` deliberately leaves HTTP/9.9 alone on
+      # the send path — came back rewritten, silently editing an operator's version-line
+      # probe. An `HTTP/<digits>.<digits>` token is now kept as it arrived, uppercased; only
+      # a token that is not a version at all still falls back.
       private def self.normalize_http_version(v : String) : String
         case v.downcase
         when "h2", "http/2", "http2" then "HTTP/2"
-        when "", "http/1.0"          then "HTTP/1.0"
-        else                              "HTTP/1.1"
+        when "", "http/1.1"          then "HTTP/1.1"
+        when "http/1.0"              then "HTTP/1.0"
+        else
+          v =~ /\Ahttp\/\d+\.\d+\z/i ? v.upcase : "HTTP/1.1"
         end
       end
 

--- a/src/gori/issues_export.cr
+++ b/src/gori/issues_export.cr
@@ -29,7 +29,12 @@ module Gori
                 # method/target/host are captured (attacker/server-controlled) data — an embedded
                 # newline (reachable via an h2 :path/:method pseudo-header) would break the one-line
                 # structure, so sanitize them like f.title/f.host above.
-                loc = flow.row.target.starts_with?("http") ? one_line(flow.row.target) : "#{one_line(flow.row.host)}#{one_line(flow.row.target)}"
+                # `Url.absolute_form?`, not `starts_with?("http")`: the loose test calls
+                # `httpbin.org/x` absolute and drops the host, and misses `HTTP://` (schemes
+                # are case-insensitive, RFC 3986 3.1) so an uppercase target came out doubled
+                # as `a.testHTTP://a.test/x`. Composed by hand rather than via `Url.location`
+                # only because each part has to be `one_line`d first.
+                loc = Url.absolute_form?(flow.row.target) ? one_line(flow.row.target) : "#{one_line(flow.row.host)}#{one_line(flow.row.target)}"
                 io << one_line(flow.row.method) << " " << loc << " → " << (flow.row.status || "-") << " (#" << fid << ")\n"
               else
                 io << "#" << fid << " (no longer captured)\n"

--- a/src/gori/mcp/install.cr
+++ b/src/gori/mcp/install.cr
@@ -1,4 +1,5 @@
 require "json"
+require "../durable_file"
 
 module Gori
   module MCP
@@ -206,57 +207,12 @@ module Gori
       # two steps destroys exactly what that check exists to protect, and the installer that
       # was only adding one entry is what destroyed it.
       #
-      # Temp file in the SAME directory (rename is atomic only within a filesystem), fsync
-      # before the rename so the rename cannot land ahead of the bytes, and carry the
-      # original's permissions across — a credential-bearing config found at 0600 must not
-      # come back 0644 because gori recreated it under the umask.
-      #
-      # Resolve a symlink to its target FIRST. These paths are dotfiles, which people
-      # routinely symlink into a dotfiles repo; File.write wrote THROUGH the link, and a
-      # rename over the link itself would quietly detach it — the client would then read a
-      # plain file while the repo copy it was linked to went stale, with nothing to show
-      # for it in `git status`. A HARDLINKED config is not detectable this way and does get
-      # detached (rename installs a new inode); that is the standing cost of an atomic
-      # replace, and it is the trade every durable writer in this repo already makes.
+      # `DurableFile` is this method generalized: it grew up here, and the other five
+      # temp+rename impls in the repo each dropped a different part of it. The default mode
+      # is private because these hold auth and are nobody else's business; an existing
+      # file's own mode wins (`inherit`).
       private def self.write_atomic(path : String, content : String) : Nil
-        target = resolve_symlink(path)
-        dir = File.dirname(target)
-        # The mode to land on: the file's own if it has one, else private — these hold auth
-        # and are nobody else's business.
-        perm = File.info?(target).try(&.permissions) || File::Permissions.new(0o600)
-        # Randomized, not pid-derived: a pid repeats, and a temp left behind by a killed run
-        # would then be re-opened (mode intact, since `perm` only applies on CREATE) and
-        # renamed into place at whatever mode it was abandoned with.
-        tmp = File.tempname(".#{File.basename(target)}.gori", ".tmp", dir: dir)
-        begin
-          # Create at the final mode rather than widening under the umask and narrowing
-          # after: the content is written before any chmod could run, so a 0644 temp holding
-          # an auth-bearing ~/.claude.json is a window the in-place File.write never opened.
-          File.open(tmp, "w", perm: perm) do |file|
-            file.print(content)
-            file.flush
-            file.fsync
-          end
-          File.chmod(tmp, perm)
-          File.rename(tmp, target)
-        rescue ex
-          # `rescue nil` on the cleanup: an unwritable directory or a read-only filesystem
-          # makes the delete raise too, and that exception would REPLACE the ENOSPC (or
-          # whatever actually failed) with a permission complaint about a temp file the user
-          # has never heard of. The cause is what install_all is about to report.
-          File.delete?(tmp) rescue nil
-          raise ex
-        end
-      end
-
-      # The path a symlink points at, or *path* itself. A broken link (or an unreadable
-      # one) resolves to itself, so the write replaces the dangling link with a real file
-      # rather than failing the install over it.
-      private def self.resolve_symlink(path : String) : String
-        return path unless File.symlink?(path)
-        File.realpath(path)
-      rescue
-        path
+        DurableFile.write(path, content, perm: File::Permissions.new(0o600))
       end
 
       # Replace or append a TOML table named *header* (without brackets), including any

--- a/src/gori/mcp/tools/compare.cr
+++ b/src/gori/mcp/tools/compare.cr
@@ -39,7 +39,7 @@ module Gori
 
         lines_a = compare_lines(detail_a, pane, include_sensitive)
         lines_b = compare_lines(detail_b, pane, include_sensitive)
-        truncated = lines_a.size > Repeater::Diff::MAX_LINES || lines_b.size > Repeater::Diff::MAX_LINES
+        truncated = Repeater::Diff.truncated?(lines_a, lines_b)
         full_diff = Repeater::Diff.lines(lines_a, lines_b)
         change_count = Repeater::Diff.change_count(full_diff)
         # `context` folds the unchanged runs to counted markers; `changes_only` drops them
@@ -65,7 +65,11 @@ module Gori
             j.field "flow_id_b", id_b
             j.field "pane", pane.to_s
             j.field "changed_lines", change_count
-            j.field "identical", change_count == 0
+            # `identical` is a stronger claim than `changed_lines: 0` and has to earn it:
+            # over a CUT diff the honest answer is "unknown", not "the same". `truncated`
+            # sits beside it either way, but an agent reading one field should not be told
+            # two responses match when only their first MAX_LINES lines were compared.
+            j.field "identical", change_count == 0 && !truncated
             j.field "truncated", truncated
             j.field "meta" do
               j.object do

--- a/src/gori/mcp/tools/probe.cr
+++ b/src/gori/mcp/tools/probe.cr
@@ -292,7 +292,12 @@ module Gori
           return err("invalid mode '#{label}' (#{valid.join("|")})", "INVALID_ARGUMENT", field: "mode")
         end
         mode = Probe::Mode.from_setting(label)
-        store.set_probe_mode(mode)
+        # Echoing the REQUESTED mode as fact would misreport a dropped write — and the
+        # direction that matters is lowering the mode to STOP active probing, where a live
+        # capture instance keeps the persisted mode and keeps sending.
+        unless store.set_probe_mode(mode)
+          return busy("scan mode NOT persisted (store busy or unwritable); the mode is unchanged")
+        end
         Result.new({"mode" => mode.label, "scanning" => mode.scanning?,
                     "probes_actively" => mode.probes_actively?}.to_json)
       end

--- a/src/gori/mcp/tools/scope.cr
+++ b/src/gori/mcp/tools/scope.cr
@@ -124,11 +124,10 @@ module Gori
         enabled = optional_bool_arg(h, "enabled")
         return err("missing required 'enabled' (true or false)", "INVALID_ARGUMENT", field: "enabled") if enabled.nil?
         scope = Scope.load(store)
-        # Scope's sandbox setters persist through the SAME settings write the TUI uses but
-        # return Nil, so confirm the flag committed by reading it back — a busy/locked store
-        # must not report success (mirrors set_scope_enabled's committed check).
-        enabled ? scope.enable_sandbox : scope.disable_sandbox
-        unless store.setting(Scope::SETTING_SANDBOX) == (enabled ? "1" : "0")
+        # The setters return whether the write COMMITTED (mirrors set_scope_enabled's check).
+        # A busy/locked store must not report success: the in-memory flag flips either way,
+        # and the next reload reverts it to the disk value.
+        unless enabled ? scope.enable_sandbox : scope.disable_sandbox
           return busy("sandbox enable/disable NOT persisted (store busy or unwritable); the gate is unchanged")
         end
         Result.new(JSON.build do |j|

--- a/src/gori/mcp/tools/sitemap.cr
+++ b/src/gori/mcp/tools/sitemap.cr
@@ -69,8 +69,10 @@ module Gori
             j.field "tag", tag.presence
             j.field "cleared", tag.empty?
             j.field "matches_endpoint", matched
-            unless matched || tag.empty?
+            if matched == false && !tag.empty?
               j.field "warning", "no captured endpoint at #{host}#{path} — this tag will not show in list_sitemap or the TUI until one exists (check for a typo or a trailing slash)"
+            elsif matched.nil? && !tag.empty?
+              j.field "warning", "tag stored, but there are more than #{Store::SITEMAP_MAX} captured endpoints so it could not be confirmed against one — check with list_sitemap"
             end
           end
         end)
@@ -95,10 +97,17 @@ module Gori
 
       # Whether any captured endpoint on `host` normalizes to `path` — the same derivation
       # list_sitemap's tag stamping uses, so "matched" here means "will be visible there".
-      private def sitemap_node_exists?(host : String, path : String) : Bool
-        store.sitemap_entries_detailed(QL::EMPTY, Store::SITEMAP_MAX).any? do |e|
-          e.host == host && sitemap_tag_path(e.target) == path
-        end
+      #
+      # `nil` means UNKNOWN, and the distinction is load-bearing: the scan is capped at
+      # SITEMAP_MAX, and that cap is on the 6-column transport key, which multiplies past
+      # 10k long before the collapsed host/method/target count suggests. Answering a flat
+      # `false` off a truncated read made a positive claim about the capture that the query
+      # could not support — and the warning built on it told the operator to go hunting for
+      # a typo in a tag that was stored and does show.
+      private def sitemap_node_exists?(host : String, path : String) : Bool?
+        entries = store.sitemap_entries_detailed(QL::EMPTY, Store::SITEMAP_MAX)
+        return true if entries.any? { |e| e.host == host && sitemap_tag_path(e.target) == path }
+        entries.size >= Store::SITEMAP_MAX ? nil : false
       end
 
       # A sitemap tag's key is the node path the tree stamps, which Sitemap.normalize_path

--- a/src/gori/mcp/tools/sitemap.cr
+++ b/src/gori/mcp/tools/sitemap.cr
@@ -108,7 +108,7 @@ module Gori
       private def sitemap_tag_path(target : String) : String
         path = Sitemap.normalize_path(target.strip)
         return "/" if path.empty?
-        path.starts_with?('/') || path.starts_with?("http") ? path : "/#{path}"
+        path.starts_with?('/') ? path : "/#{path}"
       end
 
       # The legacy collapsed sitemap (distinct host/method/target only), for

--- a/src/gori/miner/engine.cr
+++ b/src/gori/miner/engine.cr
@@ -336,10 +336,15 @@ module Gori::Miner
       last_canary = canary
       last_grpc_status = nil.as(Int32?)
       last_grpc_message = nil.as(String?)
+      interval = pace_interval
       rounds.times do
         c = Canary.fresh
         # Same span-protection as the main loop — the confirm re-send injects the same name.
         bytes, spans = Inject.apply_with_spans(@base, location, [{name, c}], @config.add_content_length_when_missing?)
+        # A confirm round is a REQUEST. Only the bucket send that produced this candidate was
+        # paced by the dispatch loop, so these ran on top of the operator's rate — up to
+        # `confirm_rounds` extra unpaced requests for every candidate that shows signal.
+        pace(interval)
         raw = send_with_retries(bytes, spans)
         next if raw.error
         probe = Fingerprint.probe(raw)

--- a/src/gori/oast/provider.cr
+++ b/src/gori/oast/provider.cr
@@ -94,8 +94,21 @@ module Gori::Oast
     # The configured host as a normalized base URL (scheme forced to https when absent,
     # trailing slash trimmed).
     protected def base_url : String
-      h = @host.strip.rstrip('/')
-      h.starts_with?("http") ? h : "https://#{h}"
+      Provider.normalize_endpoint(@host)
+    end
+
+    # ONE home for that normalisation, because the TUI has to reproduce it exactly: a
+    # session stores the normalised form ("https://oast.pro") while the provider row holds
+    # whatever was typed ("oast.pro"), so the controller's "is this the same endpoint?"
+    # comparison only works if both sides normalise identically. It had a byte-identical
+    # copy whose comment already said it normalises "the way `Provider#base_url` does".
+    #
+    # `Url.absolute_form?`, not `starts_with?("http")`: schemes are case-insensitive
+    # (RFC 3986 3.1), so a host typed `HTTPS://oast.pro` used to come back
+    # `https://HTTPS://oast.pro`.
+    def self.normalize_endpoint(url : String) : String
+      h = url.strip.rstrip('/')
+      Gori::Url.absolute_form?(h) ? h : "https://#{h}"
     end
 
     protected def json_headers : Hash(String, String)

--- a/src/gori/outbound.cr
+++ b/src/gori/outbound.cr
@@ -315,12 +315,22 @@ module Gori
     # and Repeater paths passed the raw target through, so hoisting it here is what makes the
     # rule identical on all three surfaces. Port is omitted to match `Scope.request_url`'s
     # origin-form convention (the scope lens keys on host, not port).
+    # Reduced with `Url.origin_path`, the LEXICAL split, rather than `URI.parse` — which
+    # raises on exactly the targets a security tool is most likely to be handed. A
+    # non-numeric or oversized port (`http://acme.test:abc/admin`, `:99999999999999999999`)
+    # raises `URI::Error`/`OverflowError`, and rescuing that to nil read as "no path", so
+    # the gate evaluated `scheme://host/`. An INCLUDE still matched on host, so this was
+    # invisible for the common config — but a path EXCLUDE (`/admin`) no longer matched the
+    # url it was tested against, and the operator's carve-out silently stopped holding.
+    # `sweep_block` promises that carve-out holds even under `--allow-unscoped`.
+    #
+    # The proxy already refuses this input rather than degrading (`ClientConn#handle_one`
+    # records it and writes a gateway error); there is no reason for the gate that guards
+    # the ACTIVE tools to be the lenient one. `origin_path` cannot raise, so it does not
+    # degrade at all: it keeps path+query verbatim, fragment included — one more thing for
+    # an exclude to match, never one fewer.
     def self.scope_url(scheme : String, host : String, target : String) : String
-      if Store::FlowRow.absolute_form?(target)
-        uri = URI.parse(target) rescue nil
-        path = uri.try(&.path).presence || "/"
-        target = (q = uri.try(&.query)) ? "#{path}?#{q}" : path
-      end
+      target = Url.origin_path(target) if Store::FlowRow.absolute_form?(target)
       Scope.request_url(scheme, host, target)
     end
 

--- a/src/gori/pacing.cr
+++ b/src/gori/pacing.cr
@@ -15,8 +15,9 @@ module Gori
   #   `@last_dispatch`  — a `Time::Instant` it also initialises
   #
   # `@last_dispatch` is deliberately the includer's own ivar rather than state owned here:
-  # each engine keeps its clock ORCHESTRATOR-local (one fiber advances it) so pacing never
-  # races across the worker fibers it dispatches to.
+  # each engine keeps ONE clock for its whole run. It is shared across the orchestrator and
+  # its workers on purpose — see `pace`, which claims a slot without yielding so concurrent
+  # fibers serialise onto it rather than racing.
   module Pacing
     # The gap to hold between dispatches, or nil when the run is unthrottled.
     #
@@ -33,16 +34,29 @@ module Gori
       end
     end
 
-    # Wait out the remaining gap before the next dispatch, then apply jitter.
+    # Wait out the remaining gap before the next request, then apply jitter.
     #
-    # The clock is re-read AFTER the sleep rather than reusing `target`, so a scheduler that
-    # overslept does not leave the next interval measured from a moment already past.
+    # A TICKET, not a "sleep until the last one was long enough ago": each caller claims the
+    # next slot by advancing `@last_dispatch` and only then sleeps until its own slot. The
+    # claim is a read and a write with no yield between them, so under the single-threaded
+    # cooperative scheduler two fibers cannot take the same slot — which is what makes this
+    # safe to call from a WORKER and not just from the orchestrator.
+    #
+    # That matters because the operator-facing knob is `--rate=RPS "Cap requests/sec"`, a
+    # promise about REQUESTS. Pacing only the orchestrator's dispatch loop kept that promise
+    # only where one dispatched unit is one request; every path that fans a unit out into
+    # several sends (a redirect chain, a confirm round, a calibration batch) then ran its
+    # extra requests unpaced, and the rate the operator set did not hold.
+    #
+    # `{.., now}.max` floors the claim at the present: after an idle stretch the stored
+    # instant is far in the past, and without the floor a burst of callers would all compute
+    # a target already elapsed and go out at once — the opposite of a rate limit.
     private def pace(interval : Time::Span?) : Nil
       if interval
         now = Time.instant
-        target = @last_dispatch + interval
+        target = {@last_dispatch, now}.max
+        @last_dispatch = target + interval # claim it before sleeping — no yield in between
         sleep(target - now) if now < target
-        @last_dispatch = Time.instant
       end
       # Jitter applies on its own — don't gate it behind a base rate, which silently
       # dropped jitter unless rps/throttle was also set.

--- a/src/gori/paths.cr
+++ b/src/gori/paths.cr
@@ -1,3 +1,5 @@
+require "./durable_file"
+
 module Gori
   # gori keeps everything under ONE directory — `~/.gori` by default, overridable
   # with `$GORI_HOME`: settings.json, the CA (machine secret + the cert the user
@@ -46,10 +48,10 @@ module Gori
 
     def self.write_active_project(path : String) : Nil
       ensure_dir(home_dir)
-      dest = active_project_file
-      tmp = "#{dest}.tmp.#{Process.pid}"
-      File.write(tmp, path)
-      File.rename(tmp, dest)
+      # Via DurableFile for its temp cleanup as much as its durability: the old staging here
+      # swallowed every failure at the method-level rescue and left `active_project.tmp.<pid>`
+      # behind, and nothing in the tree ever swept those.
+      DurableFile.write(active_project_file, path, perm: File::Permissions.new(0o644))
     rescue
       # best-effort: a missing/failed marker leaves explicit active-project lookup unavailable.
     end

--- a/src/gori/probe/active/types.cr
+++ b/src/gori/probe/active/types.cr
@@ -155,6 +155,14 @@ module Gori
           rest = authority[(close + 1)..]
           return {host, rest.starts_with?(':') ? rest[1..].to_i? : nil}
         end
+        # An UNBRACKETED authority is a whole IPv6 host when it is a valid v6 literal — a
+        # port cannot be told apart from the address colons without brackets. Shared with
+        # `Upstream.split_host_port`, whose comment states the rule; this copy omitted it, so
+        # "::1" split on the last colon into host ":" port 1 and "2001:db8::1" into
+        # "2001:db8:". `url_authority` only rejects an EMPTY host, so that garbage reached
+        # the open-redirect and host-header rules, where it can only fail to match
+        # PROBE_HOST — a missed detection rather than a false one, but silent either way.
+        return {authority, nil} if Gori::Proxy::Upstream.valid_ipv6?(authority)
         if (colon = authority.rindex(':')) && (p = authority[(colon + 1)..].to_i?)
           return {authority[0...colon], p}
         end

--- a/src/gori/probe/analyzer.cr
+++ b/src/gori/probe/analyzer.cr
@@ -201,13 +201,28 @@ module Gori
                       enqueue_active : Bool = false) : Nil
         return if @stopped
         return unless @mode.scanning?
-        detections = Passive.analyze(detail, ws_messages, disabled: @disabled, custom: @custom)
+        # Only ANALYSIS gets the silent skip. That is what the blanket rescue was written for
+        # ("a single detail's analysis blew up"), and the only step where nothing has been
+        # produced yet, so there is nothing to report losing.
+        detections =
+          begin
+            Passive.analyze(detail, ws_messages, disabled: @disabled, custom: @custom)
+          rescue ex : DB::Error | SQLite3::Exception
+            raise ex
+          rescue
+            return
+          end
         persist(detections, flow_id: detail.row.id, repeater_id: repeater_id)
         maybe_enqueue_active(detail) if enqueue_active
       rescue ex : DB::Error | SQLite3::Exception
         raise ex
-      rescue
-        # a single detail's analysis blew up — skip it
+      rescue ex
+        # Past this point findings HAVE been made, so a failure is a loss worth naming rather
+        # than the same silent skip: the operator otherwise sees a scan that completed and no
+        # issues, with no way to tell that apart from a clean target. Still never raises into
+        # the caller — the TUI event loop has no catch-all — and `emit` is non-blocking, so a
+        # headless run with no drainer is unaffected.
+        emit(ErrorEvent.new("probe: findings for flow #{detail.row.id} were not recorded: #{ex.message}"))
       end
 
       # Per-flow active-scan estimate for the manual "Run active scan" action: every ENABLED

--- a/src/gori/probe/analyzer.cr
+++ b/src/gori/probe/analyzer.cr
@@ -154,14 +154,18 @@ module Gori
       # Transitioning INTO Active re-arms probes over recent History: live traffic alone
       # misses flows that already completed passive analysis (passive_loop never re-enqueues
       # them), and a restart clears both the event channel and @active_seen.
-      def set_mode(m : Mode) : Nil
+      # Returns whether the mode PERSISTED. The in-memory `@mode` governs this process either
+      # way, so the arming below is unchanged — but a surface must not report the change as
+      # done when another instance will keep reading the old mode off disk.
+      def set_mode(m : Mode) : Bool
         prev = @mode
         @mode = m
-        @store.set_probe_mode(m)
+        committed = @store.set_probe_mode(m)
         # Re-arm when entering an actively-probing mode from one that wasn't (OFF/PASSIVE), OR when
         # switching between ACTIVE and AGGRESSIVE — the wider AGGRESSIVE opts (unsafe methods,
         # raised caps) produce new dedup keys, so recent in-scope traffic should be re-swept.
         arm_active_backfill if m.probes_actively? && (!prev.probes_actively? || prev != m)
+        committed
       end
 
       def start : Nil

--- a/src/gori/project_registry.cr
+++ b/src/gori/project_registry.cr
@@ -1,5 +1,6 @@
 require "file_utils"
 require "digest/sha256"
+require "./durable_file"
 require "./project"
 require "./store"
 require "./capture_lock"
@@ -145,7 +146,13 @@ module Gori
       Paths.ensure_dir(dir) # 0700 — the project dir holds a DB of captured secrets
       # Persist the verbatim display name so a later `list` shows "My Project", not
       # the lossy slug "my-project".
-      File.write(File.join(dir, NAME_FILE), display) rescue nil
+      #
+      # Durably, because this REPLACES an existing name on a reopen and `File.write`
+      # truncates first: a crash or a full disk between the two leaves the picker showing a
+      # half-written name, or none. Same helper the settings/CA/marker writes use — the
+      # sidecars were the last user-visible state still on a truncating write.
+      DurableFile.write(File.join(dir, NAME_FILE), display,
+        perm: File::Permissions.new(0o600)) rescue nil
       write_id_if_absent(dir) # a fresh project gets a stable short id; a reopen keeps its own
       proj = Project.new(display, db_path)
       # Open once even with no description: this creates the DB + runs migrations, and #list
@@ -186,8 +193,11 @@ module Gori
             # racing for the same basename cannot both bind this directory.
             Dir.mkdir(dir, Paths::DIR_MODE)
             File.chmod(dir, Paths::DIR_MODE) rescue nil
-            File.write(File.join(dir, WORKSPACE_FILE), workspace)
-            File.write(File.join(dir, NAME_FILE), display) rescue nil
+            # The binding itself: a torn write here mis-binds a workspace to a project.
+            DurableFile.write(File.join(dir, WORKSPACE_FILE), workspace,
+              perm: File::Permissions.new(0o600))
+            DurableFile.write(File.join(dir, NAME_FILE), display,
+              perm: File::Permissions.new(0o600)) rescue nil
             write_id_if_absent(dir)
             return Project.new(display, db)
           rescue File::AlreadyExistsError
@@ -288,7 +298,11 @@ module Gori
       display = new_name.strip
       raise Gori::Error.new("invalid project name") if display.empty?
       raise Gori::Error.new("project directory missing") unless Dir.exists?(project.dir)
-      File.write(File.join(project.dir, NAME_FILE), display)
+      # A rename replaces a name that is already there, so it gets the same durable
+      # replace as `create`'s — and unlike that one it is NOT best-effort: a rename the
+      # operator asked for either lands or raises.
+      DurableFile.write(File.join(project.dir, NAME_FILE), display,
+        perm: File::Permissions.new(0o600))
       Project.new(display, project.db_path, project.ephemeral?)
     end
 

--- a/src/gori/proxy/conn/client_conn.cr
+++ b/src/gori/proxy/conn/client_conn.cr
@@ -1319,7 +1319,10 @@ module Gori::Proxy
     # produced `ws 127.0.0.1http://127.0.0.1:19251/ws`. An absolute-form target already
     # names the authority, leaving the host nothing to add.
     private def ws_log_label(host : String, target : String) : String
-      target.starts_with?("http://") || target.starts_with?("https://") ? target : "#{host}#{target}"
+      # `Url.location` is that rule's one home, and it tests the scheme case-INSENSITIVELY
+      # (RFC 3986 3.1) — the hand-rolled pair here missed `HTTP://`, so an uppercase-scheme
+      # request line still produced the doubled label this method exists to prevent.
+      Gori::Url.location(host, target)
     end
 
     private def websocket_upgrade?(resp : Codec::RawResponse) : Bool

--- a/src/gori/proxy/h2/assembler.cr
+++ b/src/gori/proxy/h2/assembler.cr
@@ -302,7 +302,17 @@ module Gori::Proxy::H2
                   decoder.decode(side.header_buf.to_slice)
                 end
       added = decoded.sum { |(n, v)| n.bytesize + v.bytesize + HPACK::Decoder::ENTRY_OVERHEAD }
-      if (existing = side.headers) && !decoded.any? { |(n, _)| n == ":status" }
+      # A block is TRAILERS when a head already exists and either it carries no `:status`,
+      # or the head it would replace is already FINAL. The `else` branch below exists for the
+      # interim-1xx handover (100/103 then the real response), and that is the ONLY case a
+      # status-bearing second block legitimately replaces a head — RFC 9113 8.1 forbids
+      # pseudo-headers in trailers, so a `:status` arriving after a final head is a broken or
+      # hostile origin. It used to take the replace branch, which overwrote the real response
+      # head: `emit_response` then reported the TRAILER's status and the head's
+      # content-type / content-encoding / Set-Cookie were gone from the flow row, with
+      # `trailer_names.clear` erasing the marker that would have shown why.
+      if (existing = side.headers) &&
+         (!decoded.any? { |(n, _)| n == ":status" } || !interim_status?(existing))
         # Trailers (no :status) append to the existing header list — grpc-status et al.
         # Bound the CUMULATIVE list: the per-decode MAX_HEADER_LIST caps ONE block, but a
         # flood of repeated non-status HEADERS blocks (fake trailers on a stream held open
@@ -567,6 +577,15 @@ module Gori::Proxy::H2
         @streams.each { |id, stream| finalize_stream(id, stream, reason) }
         @streams.clear
       end
+    end
+
+    # Whether a decoded head is an INTERIM (1xx) response — the one head a later
+    # status-bearing block is allowed to replace. A request head has no `:status` at all and
+    # is not interim, so a stray `:status` block on the request side is treated as trailers
+    # too rather than replacing the request.
+    private def interim_status?(headers : Array({String, String})) : Bool
+      code = pseudo(headers, ":status").try(&.to_i?)
+      !code.nil? && code >= 100 && code < 200
     end
 
     private def pseudo(headers : Array({String, String}), name : String) : String?

--- a/src/gori/proxy/h2/head_codec.cr
+++ b/src/gori/proxy/h2/head_codec.cr
@@ -397,6 +397,16 @@ module Gori::Proxy::H2
              "it back as two fields (a header-injection primitive — the raw frames are " \
              "untouched and the stored head escapes it)" if line_broken?(f.value)
       return "the value of #{name.inspect} starts with a space, which the h1 round trip eats" if f.value.starts_with?(' ')
+      # `peer_field_name` renames a field whose name collides with one of gori's own markers,
+      # so the peer's anomaly stays visible under a name that cannot be confused for gori's.
+      # That rename is deliberate — but it is exactly the "comes back as a DIFFERENT field"
+      # case this method exists to refuse, and it was invisible here: the name is lowercase,
+      # colon-free and CRLF-free, so every check above passed and `h1_faithful?` called the
+      # round trip sound. Re-encoding then put `x-peer-<marker>` on the wire in place of the
+      # name the peer actually sent.
+      return "the field name #{name.inspect} collides with a marker gori adds to the h1 text " \
+             "form, so the round trip would rename it and a different name would go on the " \
+             "wire" if reserved_marker?(name)
       nil
     end
 

--- a/src/gori/proxy/h2/stream_gate.cr
+++ b/src/gori/proxy/h2/stream_gate.cr
@@ -655,7 +655,30 @@ module Gori::Proxy::H2
         # credit sat until the client happened to send another frame — and a client whose
         # remaining work is DATA has no window left to send one with, which is the wedge this
         # refund exists to prevent, reached through the intercept path instead of the sandbox.
-        run_cross(@mutex.synchronize { resolve_locked(item, block, decision) })
+        begin
+          run_cross(@mutex.synchronize { resolve_locked(item, block, decision) })
+        rescue
+          # The held peer died between the hold and the operator's decision, so the write
+          # inside `release_locked` raises. This is a SPAWNED fiber: an escape here has no
+          # caller to unwind to and reaches Crystal's fiber handler, which prints
+          # "Unhandled exception in spawn" plus a backtrace on STDERR — under `gori tui`
+          # that lands on top of the rendered frame. Every other writer in this file is
+          # already guarded (`close`, `write_cross_rst`, `write_cross_window_update`), as
+          # is the WebSocket twin in `ws/message_gate.cr`; this one was the hole.
+          #
+          # Slots already ready behind the one that raised stay queued until `close`
+          # drains them, which is the same place they would have gone had the leg died a
+          # moment earlier.
+          #
+          # No spec: the only observable difference is Crystal's fiber handler printing,
+          # which a spec cannot assert from in-process, and the `refund_swallowed` below is
+          # a no-op on the path that raises (a FORWARD discards nothing, so nothing is
+          # owed). This guard rests on symmetry with the three writers above rather than on
+          # a reproduction — an attempt at one passed with and without it, so it was dropped
+          # rather than kept as a spec that proves nothing.
+        end
+        # Runs either way: the refund is credit for DATA gori discarded, and the leg being
+        # dead is exactly when a wedged client most needs it. Its own write is guarded.
         refund_swallowed
       end
     end

--- a/src/gori/proxy/tls/cert_authority.cr
+++ b/src/gori/proxy/tls/cert_authority.cr
@@ -237,20 +237,35 @@ module Gori::Proxy::Tls
       Gori::Paths.ensure_dir(dir, tighten: false)
       cert_path = File.join(dir, CA_CERT_FILE)
       key_path = File.join(dir, CA_KEY_FILE)
-      cert_tmp = "#{cert_path}.tmp"
-      key_tmp = "#{key_path}.tmp"
+      # `stage` both, THEN commit both: that ordering is the guarantee described above, and
+      # `DurableFile::Staged` exists to express it. `--ca-dir` is also why the symlink
+      # resolution matters here — an operator pointing gori at PEMs symlinked from another
+      # trust store would otherwise have them detached one at a time.
+      #
+      # `inherit: false` on the KEY only. 0600 is dictated for a private key, never
+      # inherited: a root.key.pem left at 0644 by an operator (or an older gori) must be
+      # tightened as it is replaced, and KeyPair#write_pem has always forced the mode
+      # rather than preserving it. The cert is public, so its mode is the operator's call.
+      key_staged = DurableFile.stage(key_path, perm: File::Permissions.new(0o600), inherit: false) do |tmp, _mode|
+        key.write_pem(tmp) # sets 0600 itself, before any key bytes reach the temp
+      end
       begin
-        cert.write_pem(cert_tmp)
-        # 0600 before any key bytes reach the temp (KeyPair#write_pem); rename moves the
-        # inode, mode and all, so the installed key is never briefly readable.
-        key.write_pem(key_tmp)
-        File.rename(key_tmp, key_path)
-        File.rename(cert_tmp, cert_path)
+        cert_staged = DurableFile.stage(cert_path, perm: File::Permissions.new(0o644)) do |tmp, _mode|
+          cert.write_pem(tmp)
+        end
       rescue ex
-        File.delete?(cert_tmp)
-        File.delete?(key_tmp)
+        key_staged.discard
         raise ex
       end
+      # A raise from the first commit must not strand the second's temp: it is randomly
+      # named and hidden, so nothing in the tree would ever sweep it.
+      begin
+        key_staged.commit
+      rescue ex
+        cert_staged.discard
+        raise ex
+      end
+      cert_staged.commit
       cert_path
     end
 

--- a/src/gori/proxy/tls/cert_authority.cr
+++ b/src/gori/proxy/tls/cert_authority.cr
@@ -257,15 +257,19 @@ module Gori::Proxy::Tls
         key_staged.discard
         raise ex
       end
-      # A raise from the first commit must not strand the second's temp: it is randomly
-      # named and hidden, so nothing in the tree would ever sweep it.
+      # ONE guard over BOTH commits. A rename can fail after staging succeeded (the dir goes
+      # read-only, ENOSPC on the directory entry, a sandbox denial), and every such path has
+      # to clean up both temps — including the key's, which holds a PRIVATE KEY under a
+      # random hidden name nothing in the tree would ever sweep. `discard` on an
+      # already-renamed temp is a no-op, so this is correct whichever commit failed.
       begin
         key_staged.commit
+        cert_staged.commit
       rescue ex
+        key_staged.discard
         cert_staged.discard
         raise ex
       end
-      cert_staged.commit
       cert_path
     end
 

--- a/src/gori/proxy/tls/tunnel.cr
+++ b/src/gori/proxy/tls/tunnel.cr
@@ -98,7 +98,34 @@ module Gori::Proxy::Tls
     rescue
       # Client refused our cert (the untrusted-CA warning) — nothing to serve.
     ensure
-      client_tls.try(&.close) rescue nil
+      close_client_transport(client, client_tls)
+    end
+
+    # Tear down the client side of a handshake attempt, whichever half owns it.
+    #
+    # `sync_close: true` hands the transport to the TLS socket — but only once the
+    # constructor RETURNS. When the handshake raises instead, `client_tls` was never
+    # assigned, so closing only it left the accepted socket open until GC finalized the
+    # fd. Crystal's stdlib covers half of this: `OpenSSL::SSL::Socket::Server#accept`
+    # closes `bio.io` when `SSL_accept` returns an error CODE, which is the ordinary
+    # cert-rejection path — but not when the underlying BIO read RAISES, because control
+    # never reaches that line. Two ordinary triggers do exactly that: a peer RST between
+    # ClientHello and Finished (`IO::Error`), and a stalled ClientHello hitting the 30 s
+    # CLIENT_IO_TIMEOUT armed in `Server` (`IO::TimeoutError`) — a browser's speculative
+    # preconnect, or a NAT'd mobile client that half-opens.
+    #
+    # Two of the three callers own nothing else that would close it (`serve_transparent_tls`,
+    # `serve_reverse_tls` both end on the intercept call); the CONNECT path and the
+    # self-page reach `ClientConn#run`'s ensure, where this is a harmless early close —
+    # every close path here is rescue-guarded, so the double close is a no-op. Same
+    # standard as `ConnPool#close_all`, which exists so a stopped sweep does not leave
+    # fds open until GC, and the outbound twin of this constructor semantic in `Upstream`.
+    private def close_client_transport(client : IO, client_tls : IO?) : Nil
+      if tls = client_tls
+        tls.close rescue nil
+      else
+        client.close rescue nil
+      end
     end
 
     # `dial_addr` is the seam #529 needed: `host` names the connection, `dial_addr` reaches it.
@@ -178,7 +205,7 @@ module Gori::Proxy::Tls
       # nothing decrypted to capture. The outer connection is torn down.
     ensure
       upstream.try(&.close) rescue nil # a probe orphaned by a failed client handshake
-      client_tls.try(&.close) rescue nil
+      close_client_transport(client, client_tls)
     end
 
     # ALPN reflection probe (#323). When this host is an h2 candidate, pre-dial the origin

--- a/src/gori/proxy/upstream.cr
+++ b/src/gori/proxy/upstream.cr
@@ -1026,7 +1026,11 @@ module Gori::Proxy
     # A bare (unbracketed) IPv6 literal. The charset guard scrubs and rejects anything
     # outside the v6 alphabet before valid_v6? (mirrors cert_builder's ipv6?), so an
     # invalid-UTF-8 / otherwise odd authority can't raise on this parse path.
-    private def self.valid_ipv6?(host : String) : Bool
+    #
+    # Public because it is the disambiguation half of `split_host_port`, and the probe
+    # rules need exactly that half without the default-port half — their own splitter
+    # returns a nilable port. See `Probe::Active::Rule.split_host_port`.
+    def self.valid_ipv6?(host : String) : Bool
       return false unless (host.scrub =~ /\A[0-9A-Fa-f:.]+\z/) != nil
       Socket::IPAddress.valid_v6?(host)
     end

--- a/src/gori/proxy/ws/relay.cr
+++ b/src/gori/proxy/ws/relay.cr
@@ -1092,9 +1092,26 @@ module Gori::Proxy::WS
                            shape : MessageShape) : IO::Memory
       return assembling unless frame.data?
       remaining = MAX_MESSAGE - assembling.size
+      # Exactly the frame that crosses the cap, so one notice per message rather than one
+      # per frame: after this, `remaining` is 0 for every later fragment.
+      crossed = remaining > 0 && frame.payload.size > remaining
       if remaining > 0 && !frame.payload.empty?
         take = {frame.payload.size, remaining}.min
         assembling.write(frame.payload[0, take])
+      end
+      if crossed
+        # Say that the transcript is short. The oversized-FRAME path already writes a
+        # `NOTICE_PREFIX` marker for its own case (see `stream_oversized_frame`), and a
+        # message assembled past MAX_MESSAGE is the same loss reached by fragmentation —
+        # but it used to be recorded with `fin: true` and a plausible payload, so a
+        # truncated transcript was indistinguishable from a complete one. `ws_messages`
+        # carries no truncation column (unlike `CapturedResponse#body_truncated`), so the
+        # marker is a row of its own; `NOTICE_PREFIX` is what `Store::WsMessage#notice?`
+        # reads to refuse replaying it as a seed. The payload row that follows keeps the
+        # captured PREFIX, which is the evidence worth having.
+        sink.on_ws_message(flow_id, direction, message_opcode.to_i,
+          "#{NOTICE_PREFIX}WebSocket message truncated at #{MAX_MESSAGE} bytes for capture; " \
+          "the forwarded message was longer".to_slice, shape.take)
       end
       return assembling unless frame.fin?
       sink.on_ws_message(flow_id, direction, message_opcode.to_i, assembling.to_slice.dup, shape.take)

--- a/src/gori/proxy/ws/relay.cr
+++ b/src/gori/proxy/ws/relay.cr
@@ -1094,7 +1094,12 @@ module Gori::Proxy::WS
       remaining = MAX_MESSAGE - assembling.size
       # Exactly the frame that crosses the cap, so one notice per message rather than one
       # per frame: after this, `remaining` is 0 for every later fragment.
-      crossed = remaining > 0 && frame.payload.size > remaining
+      # Fires on the frame that first COSTS bytes. `> remaining` is the ordinary overrun;
+      # `== remaining && !fin?` is the exact fill — nothing is lost in this frame, but the
+      # buffer is now full and every later fragment (there is one, or FIN would be set) is
+      # dropped whole with `remaining` already 0, which would leave the overrun unreported.
+      crossed = remaining > 0 &&
+                (frame.payload.size > remaining || (frame.payload.size == remaining && !frame.fin?))
       if remaining > 0 && !frame.payload.empty?
         take = {frame.payload.size, remaining}.min
         assembling.write(frame.payload[0, take])
@@ -1109,9 +1114,14 @@ module Gori::Proxy::WS
         # marker is a row of its own; `NOTICE_PREFIX` is what `Store::WsMessage#notice?`
         # reads to refuse replaying it as a seed. The payload row that follows keeps the
         # captured PREFIX, which is the evidence worth having.
+        # NO `shape.take` here — `take` RESETS the accumulator, so consuming it for this
+        # notice handed the real payload row that follows a fabricated shape (frames 1,
+        # masked nil), losing the fragment count and the masking evidence the shape exists
+        # to record. The default shape is also the honest one: this row is gori's own
+        # sentence, not a frame the peer sent — the same choice every other NOTICE row makes.
         sink.on_ws_message(flow_id, direction, message_opcode.to_i,
           "#{NOTICE_PREFIX}WebSocket message truncated at #{MAX_MESSAGE} bytes for capture; " \
-          "the forwarded message was longer".to_slice, shape.take)
+          "the forwarded message was longer".to_slice)
       end
       return assembling unless frame.fin?
       sink.on_ws_message(flow_id, direction, message_opcode.to_i, assembling.to_slice.dup, shape.take)

--- a/src/gori/repeater/diff.cr
+++ b/src/gori/repeater/diff.cr
@@ -58,6 +58,15 @@ module Gori
         acc
       end
 
+      # Whether `lines` would CUT either side. The cap is silent by construction — `lines`
+      # returns a diff of the truncated inputs and cannot say so — and the docstring above
+      # makes noting it the caller's job. Deriving it here rather than at each call site is
+      # what stops a caller forgetting: three of them did, and reported "no differences" over
+      # a change that sat past the cut.
+      def self.truncated?(a : Array(String), b : Array(String)) : Bool
+        a.size > MAX_LINES || b.size > MAX_LINES
+      end
+
       def self.lines(a : Array(String), b : Array(String)) : Array(DiffLine)
         a = a.first(MAX_LINES)
         b = b.first(MAX_LINES)

--- a/src/gori/rules.cr
+++ b/src/gori/rules.cr
@@ -149,31 +149,41 @@ module Gori
     def add(target : Store::RuleTarget, part : Store::RulePart, pattern : String, replacement : String,
             op : Store::RuleOp = Store::RuleOp::Replace, match_kind : Store::MatchKind = Store::MatchKind::Literal,
             name : String = "", host : String = "", body_file : String = "",
-            scope : Store::RuleScope = Store::RuleScope::Project, enabled : Bool = true) : Nil
-      return if pattern.empty?
+            scope : Store::RuleScope = Store::RuleScope::Project, enabled : Bool = true) : Bool
+      return false if pattern.empty?
       target, part = normalize_shape(op, target, part)
-      if scope.global?
-        Settings.add_rewriter_rule(target.label, part.label, pattern, replacement, op.label,
-          match_kind.label, name, host, body_file, enabled)
-      else
-        @store.insert_rule(target, part, pattern, replacement, op, match_kind, name, host, enabled, body_file: body_file)
-      end
+      # Both writers already answered — a global add returns the new id (0 = not written),
+      # a project add the same through `insert_rule`'s `exec_task`. This threw it away, so a
+      # surface printed "rule duplicated" (or silently closed its overlay having "added" the
+      # rule) over a write the store dropped. A rewrite rule can be the operator's control —
+      # stripping an Authorization header, redacting a token before it leaves — so a silently
+      # absent one is not cosmetic. Mirrors `remove` below: true means COMMITTED.
+      ok =
+        if scope.global?
+          Settings.add_rewriter_rule(target.label, part.label, pattern, replacement, op.label,
+            match_kind.label, name, host, body_file, enabled) != 0
+        else
+          @store.insert_rule(target, part, pattern, replacement, op, match_kind, name, host, enabled, body_file: body_file) != 0
+        end
       refresh
+      ok
     end
 
     def update(id : Int64, target : Store::RuleTarget, part : Store::RulePart, pattern : String, replacement : String,
                op : Store::RuleOp = Store::RuleOp::Replace, match_kind : Store::MatchKind = Store::MatchKind::Literal,
                name : String = "", host : String = "", body_file : String = "",
-               scope : Store::RuleScope = Store::RuleScope::Project) : Nil
-      return if pattern.empty?
+               scope : Store::RuleScope = Store::RuleScope::Project) : Bool
+      return false if pattern.empty?
       target, part = normalize_shape(op, target, part)
-      if scope.global?
-        Settings.update_rewriter_rule(id, target.label, part.label, pattern, replacement,
-          op.label, match_kind.label, name, host, body_file)
-      else
-        @store.update_rule(id, target, part, pattern, replacement, op, match_kind, name, host, body_file)
-      end
+      ok =
+        if scope.global?
+          Settings.update_rewriter_rule(id, target.label, part.label, pattern, replacement,
+            op.label, match_kind.label, name, host, body_file)
+        else
+          @store.update_rule(id, target, part, pattern, replacement, op, match_kind, name, host, body_file)
+        end
       refresh
+      ok
     end
 
     # Move a rule to the OTHER scope, keeping its fields and its state in this project. Not an

--- a/src/gori/scope.cr
+++ b/src/gori/scope.cr
@@ -286,15 +286,21 @@ module Gori
       inc_ok && !excluded
     end
 
-    def toggle_sandbox : Nil
+    # These three return whether the persisted sandbox flag COMMITTED (false = store
+    # busy/locked/closing), exactly as `enable`/`disable` do for the enabled flag beside
+    # them. The in-memory `@sandbox` is set either way, and one `Scope` instance is shared
+    # by the Interceptor and by every `Outbound` built from it — so a dropped write is not
+    # merely "does not survive restart": the next `reload` re-reads the PERSISTED value and
+    # silently reverts the gate a surface has already reported as on.
+    def toggle_sandbox : Bool
       @mutex.synchronize { set_sandbox_unlocked(!@sandbox) }
     end
 
-    def enable_sandbox : Nil
+    def enable_sandbox : Bool
       @mutex.synchronize { set_sandbox_unlocked(true) }
     end
 
-    def disable_sandbox : Nil
+    def disable_sandbox : Bool
       @mutex.synchronize { set_sandbox_unlocked(false) }
     end
 
@@ -568,7 +574,7 @@ module Gori
       @store.set_setting(SETTING_ENABLED, value ? "1" : "0")
     end
 
-    private def set_sandbox_unlocked(value : Bool) : Nil
+    private def set_sandbox_unlocked(value : Bool) : Bool
       @sandbox = value
       @store.set_setting(SETTING_SANDBOX, value ? "1" : "0")
     end

--- a/src/gori/settings.cr
+++ b/src/gori/settings.cr
@@ -349,11 +349,15 @@ module Gori
       # the OPERATOR named and gori does not own (see Paths.ensure_dir). What actually
       # protects the env values and decoder sessions is the file's own 0600, below.
       Paths.ensure_dir(File.dirname(path), tighten: false)
-      # Atomic write: a torn File.write (crash / two instances / disk-full) would leave a
+      # Durable write: a torn File.write (crash / two instances / disk-full) would leave a
       # half-written settings.json that load()'s blanket rescue silently resets to factory
       # defaults — losing theme, hotkeys, hostname overrides, tab prefs, decoder sessions.
-      # Stage to a sibling temp then rename (atomic on POSIX), mirroring cert_authority.
-      tmp = "#{path}.tmp"
+      # `DurableFile` stages to a randomly-named sibling and fsyncs before the rename, which
+      # is what makes those three threats actually survivable: the fixed `"#{path}.tmp"` this
+      # used to stage through was shared with every peer process AND with
+      # `drop_legacy_decoder_sessions`, so "two instances" raced on one temp file, and
+      # without the fsync the rename could still land ahead of the bytes.
+      #
       # `mine` = THIS process's serialization of its OWN in-memory state. Base the next
       # merge on it, NOT on a re-read of the file we just wrote: that file also carries a
       # concurrent peer's values for sections WE didn't change (we merged them through). If
@@ -362,34 +366,28 @@ module Gori
       # Basing on `mine` keeps "did I change this section?" honest, so an unchanged section
       # always yields to disk on every subsequent save.
       mine = serialize
-      # Written 0600, and renamed rather than copied, so the FINAL file carries that mode too
-      # (rename moves the inode, permissions and all).
-      write_private(tmp, merge_with_disk(mine))
-      File.rename(tmp, path)
+      write_private(path, merge_with_disk(mine))
       @@loaded_raw = mine
       true
     rescue
-      File.delete?("#{path}.tmp") rescue nil
       false
     end
 
-    # Write a settings document owner-only. Inside GORI_HOME the 0700 tree already covers it,
-    # but `--config` can put this file anywhere — a shared checkout, /tmp, a home directory at
-    # 0755 — and it carries `env` token VALUES and saved decoder sessions (SECRET_SECTIONS
-    # below names both). `CLI.write_export` already does exactly this for the EXPORTED copy;
-    # the live file holds the same secrets and was the one still landing at the umask default.
+    # Durably replace the settings file, owner-only. Inside GORI_HOME the 0700 tree already
+    # covers it, but `--config` can put this file anywhere — a shared checkout, /tmp, a home
+    # directory at 0755 — and it carries `env` token VALUES and saved decoder sessions
+    # (SECRET_SECTIONS below names both). `CLI.write_export` already does exactly this for
+    # the EXPORTED copy; the live file holds the same secrets and was the one still landing
+    # at the umask default.
     #
-    # The mode is set at CREATE time so the bytes are never on disk at 0644 even briefly, and
-    # chmod'd as well because `File.open`'s perm applies only to a file it actually creates —
-    # a `.tmp` left by a crashed save would otherwise keep its old mode and carry it through
-    # the rename. The chmod is best-effort: a filesystem that cannot represent 0600 (a mounted
-    # share) must not turn every settings save into a failure.
-    private def self.write_private(path : String, doc : String) : Nil
-      perm = File::Permissions.new(0o600)
-      File.open(path, "w", perm: perm) do |f|
-        File.chmod(path, perm) rescue nil
-        f.print(doc)
-      end
+    # `inherit: false` because 0600 is DICTATED here rather than preserved: a copy found at
+    # 0644 (an older gori wrote it under the umask) must be tightened on the way past, not
+    # carried forward. `--config` is also why the symlink resolution inside `DurableFile`
+    # matters here more than anywhere else — pointing gori at a path under a dotfiles repo
+    # is the advertised way to use that flag, and a rename over the link would detach it on
+    # the first save.
+    private def self.write_private(dest : String, doc : String) : Nil
+      DurableFile.write(dest, doc, perm: File::Permissions.new(0o600), inherit: false)
     end
 
     # 3-way merge (base = what we loaded, mine = `current` serialization, theirs = the

--- a/src/gori/settings/decoder.cr
+++ b/src/gori/settings/decoder.cr
@@ -71,12 +71,9 @@ module Gori::Settings
         j.field "decoder", kept unless kept.empty?
       end
     end
-    tmp = "#{path}.tmp"
-    write_private(tmp, doc)
-    File.rename(tmp, path)
+    write_private(path, doc)
     true
   rescue
-    File.delete?("#{path}.tmp") rescue nil
     false
   end
 

--- a/src/gori/sitemap.cr
+++ b/src/gori/sitemap.cr
@@ -176,7 +176,10 @@ module Gori
     # An absolute-form target ("https://host/p?q") → its path+query; an origin-form
     # target is returned unchanged. "/" for a bare root.
     def self.normalize_path(target : String) : String
-      return target unless target.starts_with?("http://") || target.starts_with?("https://")
+      # `Url.absolute_form?` is the one home for this test, and it is case-INSENSITIVE
+      # (RFC 3986 3.1). The hand-rolled pair missed `HTTP://host/p`, which then kept its
+      # scheme+authority and got segmented into path nodes named `http:` and `host`.
+      return target unless Url.absolute_form?(target)
       uri = URI.parse(target)
       path = uri.path
       path = "/" if path.empty?

--- a/src/gori/store.cr
+++ b/src/gori/store.cr
@@ -259,6 +259,7 @@ module Gori
                    @prune_interval : Int32 = PRUNE_INTERVAL)
       @writes = Channel(WriteOp).new(1024) # widened: h2 frames now queue fire-and-forget
       @done = Channel(Nil).new
+      @closed = false # see #close: a second drain would park forever on @done
       @write_failures = Atomic(Int32).new(0)
       @h2_frames_dropped = Atomic(Int32).new(0)
       @inserts_since_prune = 0
@@ -419,7 +420,18 @@ module Gori
     end
 
     # Drains outstanding writes, stops the writer fiber, then closes the DB.
+    #
+    # Idempotent, and it has to be: `@done` is an unbuffered channel the writer fiber sends
+    # exactly ONE value on as it exits, so a second `close` parked on `@done.receive` would
+    # wait for a sender that no longer exists and hang the caller forever — not raise, HANG.
+    # That distinction matters because two teardown paths guard this call with
+    # `store.close rescue nil` (`Session.open`'s failure unwind among them), and a `rescue`
+    # is no defence against a deadlock. It is the same hazard `writer_loop` already protects
+    # against from the other side, where a failed batch must not kill the writer "or every
+    # blocked caller (and close()) deadlocks".
     def close : Nil
+      return if @closed
+      @closed = true
       @writes.close
       @done.receive
       @db.close

--- a/src/gori/store/fuzz_sessions.cr
+++ b/src/gori/store/fuzz_sessions.cr
@@ -7,12 +7,23 @@ module Gori
     # the read pool (see data_version docs); live TUI paths must soft-sync, not
     # full-restore session UI on every poll.
 
+    # The template is an operator's REQUEST — captured wire bytes seeded by `^F`, so it can
+    # hold a NUL (a gRPC/protobuf frame, a gzip'd POST, a multipart PNG). The column is TEXT
+    # storage and the driver reads TEXT through a NUL-TERMINATED pointer, so `rs.read(String)`
+    # truncated it at the first 0x00 while the write side bound the full bytesize — the bytes
+    # were on disk and the read threw them away. Measured: 73 bytes in, 58 out.
+    #
+    # Same fix, same reason as `RepeaterSessions::REQUEST_COL`, whose column was migrated for
+    # exactly this in V2; the Fuzzer was the last workbench still on the broken shape. CAST is
+    # a documented no-op on an already-BLOB value, so this is safe on every existing row.
+    TEMPLATE_COL = "CAST(template AS BLOB) AS template"
+
     def fuzz_sessions : Array(FuzzSessionRecord)
       list = [] of FuzzSessionRecord
-      @db.query("SELECT id, target, template, http2, sni, config, flow_id, position, name FROM fuzz_sessions ORDER BY position, id") do |rs|
+      @db.query("SELECT id, target, #{TEMPLATE_COL}, http2, sni, config, flow_id, position, name FROM fuzz_sessions ORDER BY position, id") do |rs|
         rs.each do
           list << FuzzSessionRecord.new(
-            rs.read(Int64), rs.read(String), rs.read(String), rs.read(Int32) != 0,
+            rs.read(Int64), rs.read(String), String.new(rs.read(Bytes)), rs.read(Int32) != 0,
             rs.read(String?), rs.read(String), rs.read(Int64?), rs.read(Int32), rs.read(String?))
         end
       end
@@ -21,10 +32,10 @@ module Gori
 
     def get_fuzz_session(id : Int64) : FuzzSessionRecord?
       @db.query(
-        "SELECT id, target, template, http2, sni, config, flow_id, position, name FROM fuzz_sessions WHERE id = ?",
+        "SELECT id, target, #{TEMPLATE_COL}, http2, sni, config, flow_id, position, name FROM fuzz_sessions WHERE id = ?",
         id) do |rs|
         return FuzzSessionRecord.new(
-          rs.read(Int64), rs.read(String), rs.read(String), rs.read(Int32) != 0,
+          rs.read(Int64), rs.read(String), String.new(rs.read(Bytes)), rs.read(Int32) != 0,
           rs.read(String?), rs.read(String), rs.read(Int64?), rs.read(Int32), rs.read(String?)) if rs.move_next
       end
       nil

--- a/src/gori/store/match_rules.cr
+++ b/src/gori/store/match_rules.cr
@@ -7,12 +7,17 @@ module Gori
 
     def match_rules : Array(MatchRule)
       list = [] of MatchRule
-      @db.query("SELECT id, enabled, target, part, pattern, replacement, op, match_kind, name, host, body_file FROM match_rules ORDER BY position, id") do |rs|
+      @db.query("SELECT id, enabled, target, part, CAST(pattern AS BLOB) AS pattern, CAST(replacement AS BLOB) AS replacement, op, match_kind, name, host, body_file FROM match_rules ORDER BY position, id") do |rs|
         rs.each do
           list << MatchRule.new(
             rs.read(Int64), rs.read(Int32) != 0,
             RuleTarget.from_label(rs.read(String)), RulePart.from_label(rs.read(String)),
-            rs.read(String), rs.read(String),
+            # pattern/replacement are OPERATOR bytes and rewrite live traffic: an MCP
+            # `create_rule` can carry a real NUL (JSON permits \u0000), and reading a TEXT
+            # column through the driver's NUL-terminated pointer truncated it — so the rule
+            # that rewrote traffic was not the rule that was created, and `list_rules`
+            # echoed the truncated form, making the discrepancy invisible everywhere.
+            String.new(rs.read(Bytes)), String.new(rs.read(Bytes)),
             RuleOp.from_label(rs.read(String)), MatchKind.from_label(rs.read(String)),
             rs.read(String), rs.read(String), rs.read(String))
         end

--- a/src/gori/store/probe_rules.cr
+++ b/src/gori/store/probe_rules.cr
@@ -7,7 +7,13 @@ module Gori
       Probe::Mode.from_setting(setting(Probe::MODE_SETTING_KEY))
     end
 
-    def set_probe_mode(mode : Probe::Mode) : Nil
+    # Returns whether the write COMMITTED (false = store busy/locked/closing), for the same
+    # reason `set_probe_disabled_rules` below does — `set_setting` is `exec_task_ok`, so the
+    # answer was already here and only had to stop being thrown away. The direction that
+    # matters is setting `off`/`passive` to STOP active probing: every surface reported that
+    # as done, while a separate live instance kept the persisted `active`/`aggressive` mode
+    # and kept firing attack payloads at production.
+    def set_probe_mode(mode : Probe::Mode) : Bool
       set_setting(Probe::MODE_SETTING_KEY, mode.label)
     end
 

--- a/src/gori/store/reads.cr
+++ b/src/gori/store/reads.cr
@@ -459,6 +459,16 @@ module Gori
       statuses : String?, count : Int64, ok : Int64, errors : Int64,
       first_seen : Int64, last_seen : Int64
 
+    # ORDER BY names every GROUP BY column, so the ordering is TOTAL and the `LIMIT` cut is
+    # deterministic. Six columns key a group and only two ordered it, so `GET /x` and
+    # `POST /x` — and https:443 vs http:80 vs HTTP/2 on one path — tied completely, and which
+    # survived the cut was unspecified. With no cursor on this read, a group that loses an
+    # arbitrary tiebreak is not on a later page; it is unreachable.
+    #
+    # The success bucket starts at 100, not 200: status 101 is exactly what `proto:ws` means
+    # (see ql.cr), so every WebSocket endpoint reported "N attempts, 0 successes, 0 errors".
+    # A NULL status stays in neither bucket on purpose — a Pending flow has no outcome yet —
+    # so ok + errors can legitimately be less than count.
     def sitemap_entries_detailed(filter : QL::Filter = QL::EMPTY, limit : Int32 = SITEMAP_MAX, *,
                                  raise_on_error : Bool = false) : Array(SitemapEntry)
       rows = [] of SitemapEntry
@@ -466,12 +476,12 @@ module Gori
       args << limit
       sql = "SELECT scheme, host, port, http_version, method, target, " \
             "GROUP_CONCAT(DISTINCT status), COUNT(*), " \
-            "SUM(CASE WHEN status BETWEEN 200 AND 399 THEN 1 ELSE 0 END), " \
+            "SUM(CASE WHEN status BETWEEN 100 AND 399 THEN 1 ELSE 0 END), " \
             "SUM(CASE WHEN status = 0 OR status >= 400 THEN 1 ELSE 0 END), " \
             "MIN(created_at), MAX(created_at) " \
             "FROM flows WHERE #{filter.sql} " \
             "GROUP BY scheme, host, port, http_version, method, target " \
-            "ORDER BY host, target LIMIT ?"
+            "ORDER BY host, target, method, scheme, port, http_version LIMIT ?"
       @db.query(sql, args: args) do |rs|
         rs.each do
           rows << SitemapEntry.new(
@@ -493,7 +503,10 @@ module Gori
       rows = [] of {String, String, String}
       args = filter.args.dup
       args << limit
-      @db.query("SELECT DISTINCT host, method, target FROM flows WHERE #{filter.sql} ORDER BY host, target LIMIT ?",
+      # `method` is SELECTed, so it must ORDER too, or the LIMIT cut between two rows that
+      # differ only by method is arbitrary — and with no cursor here the loser is unreachable.
+      @db.query("SELECT DISTINCT host, method, target FROM flows WHERE #{filter.sql} " \
+                "ORDER BY host, target, method LIMIT ?",
         args: args) do |rs|
         rs.each { rows << {rs.read(String), rs.read(String), rs.read(String)} }
       end

--- a/src/gori/tui/comparer_view.cr
+++ b/src/gori/tui/comparer_view.cr
@@ -445,7 +445,7 @@ module Gori::Tui
       return [] of Repeater::SideBySide::Row unless @slot_a && @slot_b
       al = lines_a
       bl = lines_b
-      @truncated = al.size > Repeater::Diff::MAX_LINES || bl.size > Repeater::Diff::MAX_LINES
+      @truncated = Repeater::Diff.truncated?(al, bl)
       result = Repeater::SideBySide.rows(Repeater::Diff.lines(al, bl))
       @change_count = Repeater::SideBySide.change_count(result)
       result

--- a/src/gori/tui/controllers/oast_controller.cr
+++ b/src/gori/tui/controllers/oast_controller.cr
@@ -549,8 +549,7 @@ module Gori::Tui
     end
 
     private def normalize_endpoint(url : String) : String
-      h = url.strip.rstrip('/')
-      h.starts_with?("http") ? h : "https://#{h}"
+      Gori::Oast::Provider.normalize_endpoint(url)
     end
 
     # What the operator recognises a session BY: the host its payloads point at. That is the

--- a/src/gori/tui/controllers/project_controller.cr
+++ b/src/gori/tui/controllers/project_controller.cr
@@ -666,6 +666,8 @@ module Gori::Tui
         confirm_label: "delete", danger: true) do
         if removed = @project_view.ov_delete
           @host.status("host override deleted: #{removed}")
+        else
+          @host.status("host override NOT deleted (project busy) — it is still in effect")
         end
       end
     end

--- a/src/gori/tui/controllers/rewriter_controller.cr
+++ b/src/gori/tui/controllers/rewriter_controller.cr
@@ -631,8 +631,10 @@ module Gori::Tui
     def rewriter_duplicate : Nil
       rule = selected_rule || return @host.status("no rewrite rule selected")
       name = rule.name.empty? ? "" : "#{rule.name} copy"
-      rules_engine.add(rule.target, rule.part, rule.pattern, rule.replacement,
-        rule.op, rule.match_kind, name, rule.host, rule.body_file, scope: rule.scope)
+      unless rules_engine.add(rule.target, rule.part, rule.pattern, rule.replacement,
+               rule.op, rule.match_kind, name, rule.host, rule.body_file, scope: rule.scope)
+        return @host.status("rule NOT duplicated (project busy or settings not writable)")
+      end
       @host.status(rule.global? ? "global rule duplicated" : "rule duplicated")
     end
 
@@ -665,8 +667,11 @@ module Gori::Tui
       return false unless ov.valid?
       if id = ov.edit_id
         from = ov.edit_scope || Store::RuleScope::Project
-        rules_engine.update(id, ov.target, ov.part, ov.pattern, ov.replacement,
-          ov.op, ov.match_kind, ov.name, ov.host, ov.body_file, scope: from)
+        unless rules_engine.update(id, ov.target, ov.part, ov.pattern, ov.replacement,
+                 ov.op, ov.match_kind, ov.name, ov.host, ov.body_file, scope: from)
+          @host.status("rule NOT saved (project busy or settings not writable) — it is unchanged")
+          return true
+        end
         if from != ov.scope
           moved = rule_list.find { |r| r.scope == from && r.id == id }
           if moved && !rules_engine.set_scope(moved, ov.scope)
@@ -674,8 +679,13 @@ module Gori::Tui
           end
         end
       else
-        rules_engine.add(ov.target, ov.part, ov.pattern, ov.replacement,
-          ov.op, ov.match_kind, ov.name, ov.host, ov.body_file, scope: ov.scope)
+        unless rules_engine.add(ov.target, ov.part, ov.pattern, ov.replacement,
+                 ov.op, ov.match_kind, ov.name, ov.host, ov.body_file, scope: ov.scope)
+          # Report rather than re-select: with nothing added, `last_index_of_scope` would
+          # move the highlight onto whatever already sat at the end of that block.
+          @host.status("rule NOT added (project busy or settings not writable)")
+          return true
+        end
         # A global rule lands at the end of the GLOBAL block, which is not the end of the list.
         @sel = last_index_of_scope(ov.scope)
       end

--- a/src/gori/tui/copy_menu.cr
+++ b/src/gori/tui/copy_menu.cr
@@ -132,7 +132,10 @@ module Gori::Tui
     # target base joined with the origin-form path (falling back to the Host header
     # when no target base is set — a hand-authored request). "" when unresolvable.
     private def self.resolve_url(req_target : String, target : String, header_lines : Array(String)) : String
-      return req_target if req_target.starts_with?("http://") || req_target.starts_with?("https://")
+      # Case-insensitive via the one home: an `HTTP://acme.test/x` target used to fall
+      # through and get a base prefixed, yielding `https://acme.test/HTTP://acme.test/x`
+      # on the operator's clipboard.
+      return req_target if Gori::Url.absolute_form?(req_target)
       base = authority_base(target.strip)
       if base.empty?
         host = header_value(header_lines, "host")

--- a/src/gori/tui/fuzz_set_overlay.cr
+++ b/src/gori/tui/fuzz_set_overlay.cr
@@ -142,8 +142,15 @@ module Gori::Tui
     # The single-line fields the pointer can reach — see `Overlay#text_fields`. Listing them
     # is the whole opt-in: caret placement on a press, drag to extend, double-click for a
     # word, all inverted by the field against the geometry `render` last drew it at.
+    #
+    # Only the CURRENT payload type's rows, because that is exactly what `render_fields`
+    # draws. `@fields` holds all eight for every type, and a field the current type does not
+    # show still carries the `@last_x/@last_y` it was drawn at under a PREVIOUS type — so
+    # returning all of them let an off-screen field win a hit-test on stale geometry.
+    # `field_rows` also names rows that are not `TextField`s at all (`:values` is the list
+    # TextArea, `:preset_name` has no field), which `[]?` drops.
     def text_fields : Array(TextField)
-      @fields.values.to_a # NamedTuple on some cards, Hash on others — one shape out
+      field_rows.compact_map { |f| @fields[f]? }
     end
 
     def hint : String
@@ -545,6 +552,12 @@ module Gori::Tui
         i = my - (box.y + 3)
         @sel = (i + 1).clamp(1, rows.size - 1) if 0 <= i < field_rows.size
         sync_path_complete
+        # A press inside a drawn field is a caret, not just a row focus — the one line every
+        # other overlay with `text_fields` runs (`Overlay#handle_click`), and the whole
+        # reason this card lists them. Without it the caret stayed wherever the last
+        # keystroke left it, so the next character landed somewhere other than where the
+        # operator pointed, and a drag anchored from that stale caret instead of the press.
+        click_text_field(mx, my)
       end
       :stay
     end

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -1953,16 +1953,13 @@ module Gori::Tui
       t.to_local.to_s("%m-%d %H:%M:%S")
     end
 
-    # Compact relative age from now: "3s" / "5m" / "2h" / "1d" (mirrors
-    # notifications_overlay#ago). Clamped at 0 so clock skew never shows a negative age.
+    # Compact relative age from now: "3s" / "5m" / "2h" / "1d". This said it "mirrors
+    # notifications_overlay#ago" — a copy that no longer exists as one: that overlay and its
+    # two siblings were collapsed into `Fmt.ago` for exactly this reason, and the two methods
+    # right below already delegate to `Fmt`. Byte-identical to the home, so this is the last
+    # copy going home rather than a behaviour change.
     private def fmt_time_relative(t : Time) : String
-      secs = {(Time.local - t).total_seconds.to_i, 0}.max
-      return "#{secs}s" if secs < 60
-      mins = secs // 60
-      return "#{mins}m" if mins < 60
-      hours = mins // 60
-      return "#{hours}h" if hours < 24
-      "#{hours // 24}d"
+      Fmt.ago(t)
     end
 
     # Compact response size (B/KB/MB/GB), bounded to ≤6 cols. "—" until the response

--- a/src/gori/tui/issue_presentation.cr
+++ b/src/gori/tui/issue_presentation.cr
@@ -54,9 +54,12 @@ module Gori::Tui
     end
 
     # An absolute-form target ("GET http://h/p") already carries the host, so don't
-    # prepend it again; origin-form ("/p") gets the host prefixed.
+    # prepend it again; origin-form ("/p") gets the host prefixed. That is exactly
+    # `Url.location` — re-deriving it as `starts_with?("http")` called `httpbin.org/x`
+    # absolute and dropped the host, and missed `HTTP://` (schemes are case-insensitive)
+    # so an uppercase target rendered doubled as `a.testHTTP://a.test/x`.
     private def flow_location(f : Store::FlowRow) : String
-      f.target.starts_with?("http") ? f.target : "#{f.host}#{f.target}"
+      Gori::Url.location(f.host, f.target)
     end
   end
 end

--- a/src/gori/tui/project_view.cr
+++ b/src/gori/tui/project_view.cr
@@ -1482,12 +1482,19 @@ module Gori::Tui
       t.to_local.to_s("%Y-%m-%d %H:%M")
     end
 
+    # Prose sizes for the Project pane — a space before the unit and a TB step, which is why
+    # this is not `Fmt.size` (that one is a fixed ≤6-column table cell, no space, capped at
+    # GB). What it MUST share is `Fmt`'s rounding convention, stated in that module's
+    # docstring: pick the unit from the ROUNDED magnitude, so a value just under a boundary
+    # rolls up instead of printing the misleading form. This loop compared the UNROUNDED
+    # value, so 1_048_575 bytes rendered as "1024.0 KB" — verbatim the string `Fmt` names as
+    # the thing it exists to prevent — where `Fmt.size` gives "1.0MB".
     private def human_size(bytes : Int64) : String
       return "0 B" if bytes <= 0
       units = ["B", "KB", "MB", "GB", "TB"]
       i = 0
       b = bytes.to_f64
-      while b >= 1024.0 && i < units.size - 1
+      while b.round(1) >= 1024.0 && i < units.size - 1
         b /= 1024.0
         i += 1
       end

--- a/src/gori/tui/project_view.cr
+++ b/src/gori/tui/project_view.cr
@@ -754,11 +754,15 @@ module Gori::Tui
       current_override.try(&.host)
     end
 
-    # Removes the selected override, returning its host (for the toast) or nil.
+    # Removes the selected override, returning its host (for the toast) — or nil when there
+    # was nothing selected OR the delete did not COMMIT. `HostOverrides#remove` answers that
+    # (its doc: "false = store busy/locked/closing") and this discarded it, so a dropped
+    # write still reported "host override deleted" while the routing pin stayed live. The
+    # two writes right above in `ov_commit` already check theirs.
     def ov_delete : String?
       entry = current_override
       return nil unless entry
-      @host_overrides.remove(entry.id)
+      return nil unless @host_overrides.remove(entry.id)
       clamp_ov_sel
       entry.host
     end

--- a/src/gori/tui/repeater_view.cr
+++ b/src/gori/tui/repeater_view.cr
@@ -5231,7 +5231,17 @@ module Gori::Tui
         elsif !(baseline = diff_baseline_lines)
           [Repeater::DiffLine.new(Repeater::DiffKind::Same, "— first send: resend (^R) to diff against the previous response —")]
         else
-          Repeater::Diff.lines(baseline, message_lines(result.head, display_body(result.head, result.body)))
+          fresh = message_lines(result.head, display_body(result.head, result.body))
+          rows = Repeater::Diff.lines(baseline, fresh)
+          # The Comparer tab has always shown this; the Repeater diff tab rendered a CUT diff
+          # with nothing to say so, and an empty diff then reads as "the payload changed
+          # nothing". Prepended rather than appended: at the cap the row list is long, and a
+          # marker at the bottom is the one an operator scrolls past.
+          if Repeater::Diff.truncated?(baseline, fresh)
+            rows.unshift(Repeater::DiffLine.new(Repeater::DiffKind::Same,
+              "— diff truncated to #{Repeater::Diff::MAX_LINES} lines/side; later lines were not compared —"))
+          end
+          rows
         end
       end
     end

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -2161,8 +2161,12 @@ module Gori::Tui
 
     # Apply the picked Probe scan MODE to the analyzer and re-read the findings list.
     private def apply_probe_mode(p : ChoicePicker) : Nil
-      @session.probe.set_mode(Probe::Mode.new(p.selected_value))
+      committed = @session.probe.set_mode(Probe::Mode.new(p.selected_value))
       probe_controller.view.reload(@session.store)
+      unless committed
+        @toast = "scan mode NOT saved — project busy; another instance keeps the old mode"
+        return
+      end
       mode = @session.probe.mode
       @toast = case mode
                when .aggressive?
@@ -4865,12 +4869,24 @@ module Gori::Tui
         confirm("ENABLE SANDBOX",
           "The scope has no include rules yet, so the sandbox will BLOCK ALL captured traffic until you add one.\nEnable anyway?",
           confirm_label: "enable", danger: true) do
-          @scope.enable_sandbox
-          project_controller.toast_sandbox_state
+          report_sandbox_write(@scope.enable_sandbox)
         end
       else
-        @scope.toggle_sandbox
+        report_sandbox_write(@scope.toggle_sandbox)
+      end
+    end
+
+    # Toast the sandbox state only once the flag actually COMMITTED. `toast_sandbox_state`
+    # reads the in-memory flag, which the setter updates whether or not the write landed —
+    # so on a busy/locked store this announced "sandbox ON … everything else is blocked"
+    # over a gate that was still off, and the next `Scope#reload` reverted the in-memory
+    # flag to match the disk it never reached. MCP and the CLI both already confirm this
+    # write before reporting it; the TUI was the surface that did not.
+    private def report_sandbox_write(committed : Bool) : Nil
+      if committed
         project_controller.toast_sandbox_state
+      else
+        status("sandbox NOT changed — the project store is busy or unwritable")
       end
     end
 

--- a/src/gori/url.cr
+++ b/src/gori/url.cr
@@ -37,8 +37,16 @@ module Gori
       # "://" is ASCII-punctuation only, so this index is unaffected by the scheme's case.
       scheme_end = target.index("://")
       return target unless scheme_end
-      slash = target.index('/', scheme_end + 3)
-      slash ? target[slash..] : "/"
+      auth = scheme_end + 3
+      slash = target.index('/', auth)
+      return target[slash..] if slash
+      # No path, but a query or fragment can still follow the authority
+      # (`http://acme.test?admin=1`). Returning a bare "/" there DROPPED them — and this
+      # feeds `Outbound.scope_url`, so a scope EXCLUDE keyed on the query silently stopped
+      # matching the url it was tested against. RFC 3986 §3.3: an empty path with a query
+      # is `/` + the rest, so splice rather than discard.
+      mark = target.index('?', auth) || target.index('#', auth)
+      mark ? "/#{target[mark..]}" : "/"
     end
 
     # "where this message went", as one string: the absolute-form target verbatim, else the


### PR DESCRIPTION
20 rounds of bug-hunting and readability work, each sweeping **one invariant across every
site** rather than one directory at a time — this repo's recurring failure mode is a class
fixed at only some of its call sites, so the round boundary is the class, not the file.

Every round: build green, full suite run, and the failure set diffed **byte-identical** to the
branch point (8002 → 8077 examples; the same 8 environmental `Gori::Session` port-bind
failures throughout). Every new spec was mutation-tested — revert the fix, confirm it reds —
and no round added an ameba finding.

## What was found

Nearly every finding came from taking this codebase's own comments literally and checking
whether the code still honours them.

| Invariant | Commit |
|---|---|
| Atomic config writes: symlink, mode, fsync, collision-free temp (6 impls → 1) | `ff87fda2` `f02e0cf9` |
| A security gate must not degrade a parse failure into a permissive default | `c07d2590` |
| A resource is owned only once the constructor *returns* | `9b492cce` |
| A mutation's commit answer must reach the surface reporting it | `b475fe42` |
| A `rescue`-guarded teardown must not be able to *hang* | `096a4a8c` |
| An overlay listing `text_fields` must route a press to the caret | `72d135bd` |
| `stop` must stop at every send, not once per task | `8f78e7c9` |
| `--rate` promises requests/sec, so every *wire* request is paced | `a301f13b` |
| One-home predicates and helpers (two families, already drifted) | `25c28ab0` `01e2c2c5` |
| Operator/wire bytes read as BLOB, not TEXT | `f6986223` |
| A report must not assert what the data cannot support | `404543c6` `f9d52eea` `65905568` |
| A rescue must not swallow more than its comment justifies | `7a0d20eb` |
| h2 state machine and wire fidelity | `45cb4dec` `d62f4a9e` `0f5cbb7e` |
| The HAR round trip must be a fixed point, as its own docstring promises | `6d6b4cce` |
| Project sidecars off truncating writes | `23ad24b1` |
| `/code-review` fixes (7 defects, 5 of them regressions from this branch) | `e9be8392` |

### The ones that matter most

- **`stop` didn't stop.** Discover's calibration checked only the request cap, so up to ~120
  requests could reach a third party *after* the operator pressed stop. Measured 8 → 1.
- **`--rate` under-applied by up to 6×.** `Pacing` throttled *dispatches* while the CLI
  promises requests/sec. Five concurrent senders spanned **7.7µs** under the old clock vs
  70ms under the ticket rewrite.
- **A NUL truncated the Fuzzer template on read** (73 bytes in, 58 out) — and because the
  "did this peer session change?" check compared in-memory bytes against that truncated read,
  the reconcile path **overwrote the operator's live request** with no message.
- **`gori run repeater --diff` printed "no differences"** over a diff cut at 1500 lines, with
  the appended-payload case landing exactly past the cut.
- **The inbound TLS handshake leaked a client fd** when the constructor raised rather than
  returning a TLS error (3/3 sockets → 0/3).

## Review outcome, stated plainly

`/code-review` found **five regressions this branch introduced**, all now fixed in `e9be8392`
and each verified by running it first. The worst was mine twice over: round 2 replaced
`URI.parse` in the scope gate and I wrote *"one more thing for an exclude to match, never one
fewer"* — while `origin_path` was dropping the query on a path-less absolute target, opening a
query-only hole in the same gate.

## Deliberately not done

Carried with reasons rather than half-fixed under a round deadline:

- **WS teardown double-mutation of `AssemblingPump`** — a real concurrency redesign in the file
  whose comments record past SIGSEGVs. Cannot simply reorder: the flush must happen while
  sockets are open, and closing them is what unblocks the pending read.
- **Multi-frame PUSH_PROMISE** — a documented v1 limitation on a path dead in production
  (`Session` always builds an `Interceptor`), and browsers no longer send push.
- **In-memory vs persisted wording** — a failed write still flips the live gate, so "NOT
  changed" understates it. Changes operator-facing semantics on three surfaces.
- **The marker-collision refusal is origin-controlled** — a CDN emitting `x-gori-trailers`
  disables head rewrites for that traffic. Refusing beats the old silent rename, but a
  per-run nonce is the proper fix.

One finding is worth flagging separately: **~52 commits sit unmerged across ~15 `hahwul/*`
branches**, several fixing classes these hunts independently rediscovered (`hahwul/fix-gori-run-bug`
alone carries 7). Merging those would stop the work being re-derived.
