### PR TITLE
perf(miner): n-ary bucket split to shorten the bisection critical path

### DIFF
--- a/bench/miner_conc_diag.cr
+++ b/bench/miner_conc_diag.cr
@@ -1,0 +1,210 @@
+# Where does a mine's wall clock go, and what does the bisection branch factor cost?
+#
+# `miner_perf_bench` measures the TRANSPORT A/B (dial-per-send vs the keep-alive pool) but
+# says its other half — the run's SCHEDULE — "is not an A/B here". This is that half. A mine
+# is latency-bound and its critical path is the bisection tree's DEPTH, so the question that
+# ranks every further optimization is: at a realistic RTT, is the worker pool SATURATED
+# (cut requests) or STARVED waiting on the tree's tail (cut depth)?
+#
+# Part 1 wraps the send seam to timestamp every request and reports average in-flight
+# concurrency = Σ(send durations) / wall. Against a fixed-delay origin that number is the
+# answer: ≈ the configured concurrency means saturated; far below means depth-bound, and the
+# n-ary split (Engine#split / BISECT_MAX_WAYS) is what lowers that floor.
+#
+# Part 2 answers the budget question the split raises: a wider split must never send MORE
+# probes than binary, or a run under `--max-requests` finds fewer. It counts sends for a
+# single 128-bucket across positive densities, binary (conc 2) vs 4-ary (conc 4).
+#
+# Build: crystal build bench/miner_conc_diag.cr -o bin/miner_conc_diag --release
+# Run:   bin/miner_conc_diag
+require "socket"
+require "http/server"
+
+module Gori
+  class Error < Exception; end
+end
+
+require "../src/gori/bindings"
+require "../src/gori/fuzz"
+require "../src/gori/miner"
+require "../src/gori/outbound"
+
+alias M = Gori::Miner
+alias F = Gori::Fuzz
+
+SECRETS = {"debug", "admin", "callback", "redirect_url", "template"}
+BODY    = "x" * 2048
+
+# Timestamps every send that reaches the wire, as microsecond offsets from its own start.
+class Recorder < F::Backend
+  getter spans = [] of {Int64, Int64}
+  getter baseline_mark = 0
+
+  def initialize(@inner : F::Backend)
+    @t0 = Time.instant
+  end
+
+  def origin : F::Origin
+    @inner.origin
+  end
+
+  def send(bytes : Bytes) : Gori::Repeater::Result
+    send(bytes, nil)
+  end
+
+  def send(bytes : Bytes, verbatim : Array({Int32, Int32})?) : Gori::Repeater::Result
+    a = (Time.instant - @t0).total_microseconds.to_i64
+    r = @inner.send(bytes, verbatim)
+    @spans << {a, (Time.instant - @t0).total_microseconds.to_i64}
+    r
+  end
+
+  def mark_baseline_done : Nil
+    @baseline_mark = @spans.size
+  end
+
+  def evidence? : Bool
+    @inner.evidence?
+  end
+
+  def blocked : Int64
+    @inner.blocked
+  end
+
+  def blocked_reason : String?
+    @inner.blocked_reason
+  end
+
+  def extra_requests : Int64
+    @inner.extra_requests
+  end
+
+  def close : Nil
+    @inner.close
+  end
+end
+
+# Counts sends only — for the density/budget half. No socket.
+class CountingBackend < F::Backend
+  getter origin : F::Origin
+  getter sent : Int32 = 0
+
+  def initialize(@origin : F::Origin, @grow : Set(String))
+  end
+
+  def send(bytes : Bytes) : Gori::Repeater::Result
+    @sent += 1
+    params = query_params(bytes)
+    body = "BASELINE BODY CONTENT"
+    body += " XXXXXXXXXXXXXXXXXXXXXXXXXXXXXX" if @grow.any? { |g| params.has_key?(g) }
+    head = "HTTP/1.1 200 OK\r\nContent-Length: #{body.bytesize}\r\n\r\n".to_slice
+    resp = Gori::Proxy::Codec::Http1.parse_response_head(head)
+    Gori::Repeater::Result.new(head, body.to_slice, resp, 1000_i64)
+  end
+
+  private def query_params(bytes : Bytes) : Hash(String, String)
+    pairs = Hash(String, String).new
+    line = String.new(bytes).lines.first? || ""
+    target = line.split(' ')[1]? || ""
+    qi = target.index('?')
+    return pairs unless qi
+    target[(qi + 1)..].split('&').each do |pair|
+      k, _, v = pair.partition('=')
+      pairs[k] = v unless k.empty?
+    end
+    pairs
+  end
+end
+
+private def start_origin(delay : Time::Span) : Int32
+  server = HTTP::Server.new do |ctx|
+    sleep delay if delay > Time::Span.zero
+    hits = 0
+    q = ctx.request.query_params
+    SECRETS.each { |s| hits += 1 if q.has_key?(s) }
+    ctx.request.headers.each { |name, _| hits += 1 if SECRETS.includes?(name.downcase) }
+    if cookie = ctx.request.headers["Cookie"]?
+      SECRETS.each { |s| hits += 1 if cookie.includes?("#{s}=") }
+    end
+    ctx.response.content_type = "text/html"
+    ctx.response.print BODY
+    hits.times { ctx.response.print "\nsecret parameter accepted\n" }
+  end
+  port = server.bind_tcp("127.0.0.1", 0).port
+  spawn { server.listen }
+  port
+end
+
+private def run_mine(port : Int32, concurrency : Int32, locations : Array(M::Location)) : {Float64, Recorder, Int32}
+  request = "GET /?q=1 HTTP/1.1\r\nHost: 127.0.0.1:#{port}\r\nAccept: */*\r\nCookie: sid=1\r\n\r\n"
+  config = M::Config.new(locations: locations, concurrency: concurrency, keep_alive: true)
+  options = M::PlanOptions.new(request,
+    target: "http://127.0.0.1:#{port}/", locations: locations, config: config, verify: false)
+  plan = M::Plan.build(options, Gori::Outbound.waived(nil, Gori::Outbound::Reason::NoProject))
+  rec = Recorder.new(plan.sender)
+  engine = M::Engine.new(plan.request, false, plan.names, rec, config)
+  found = 0
+  t0 = Time.instant
+  engine.run do |ev|
+    case ev
+    when M::BaselineEvent then rec.mark_baseline_done
+    when M::DoneEvent     then found = ev.progress.found
+    end
+  end
+  wall = (Time.instant - t0).total_milliseconds
+  plan.sender.close
+  {wall, rec, found}
+end
+
+private def report(label : String, wall : Float64, rec : Recorder, found : Int32, conc : Int32) : Nil
+  spans = rec.spans
+  busy = spans.sum { |(a, b)| (b - a) } / 1000.0
+  avg = busy / wall
+  puts "  #{label.ljust(24)} wall #{wall.round(1).to_s.rjust(7)}ms · #{spans.size.to_s.rjust(4)} reqs " \
+       "(#{rec.baseline_mark} baseline) · #{found} found · avg in-flight #{avg.round(2).to_s.rjust(6)}/#{conc} " \
+       "· util #{(100.0 * avg / conc).round(1)}%"
+end
+
+# ── Part 1: schedule / utilization vs concurrency ──────────────────────────────────────────
+ALL = [M::Location::Query, M::Location::Headers, M::Location::Cookies]
+puts "Part 1 — schedule: is the pool saturated (cut requests) or depth-bound (cut depth)?"
+{20.milliseconds, 50.milliseconds}.each do |delay|
+  port = start_origin(delay)
+  sleep 200.milliseconds
+  run_mine(port, 20, ALL) # warm-up
+  puts "\n== origin delay #{delay.total_milliseconds}ms · query/headers/cookies =="
+  {10, 20, 40}.each do |c|
+    wall, rec, found = run_mine(port, c, ALL)
+    report("concurrency #{c}", wall, rec, found, c)
+  end
+end
+
+# ── Part 2: what the branch factor costs — sends by positive density ───────────────────────
+def count_run(names : Array(String), grow : Set(String), conc : Int32) : {Int32, Int32}
+  c = M::Config.new
+  c.locations = [M::Location::Query]
+  c.bucket_size = M::Config::DEFAULT_BUCKETS.dup
+  c.bucket_size[M::Location::Query] = 128
+  c.concurrency = conc
+  c.stability_rounds = 2
+  c.retries = 0
+  base = "GET /api HTTP/1.1\r\nHost: h\r\n\r\n".to_slice
+  backend = CountingBackend.new(F::Origin.new("http", "h", 80), grow)
+  engine = M::Engine.new(base, http2: false, names: names, backend: backend, config: c)
+  found = 0
+  engine.run { |ev| found += 1 if ev.is_a?(M::FindingEvent) }
+  {backend.sent, found}
+end
+
+NAMES = (1..128).map { |i| "p#{i}" }
+puts "\nPart 2 — budget: a wider split must never send MORE than binary (128-bucket)"
+puts "  density   binary conc2   4-ary conc4   overage"
+[1, 8, 32, 64, 128].each do |d|
+  grow = NAMES.first(d).to_set
+  bsent, bfound = count_run(NAMES, grow, 2)
+  wsent, wfound = count_run(NAMES, grow, 4)
+  over = wsent - bsent
+  pct = bsent.zero? ? 0.0 : (100.0 * over / bsent)
+  puts "  #{d.to_s.rjust(3)}/128    #{bsent.to_s.rjust(4)} (#{bfound.to_s.rjust(3)})     " \
+       "#{wsent.to_s.rjust(4)} (#{wfound.to_s.rjust(3)})     #{over >= 0 ? "+" : ""}#{over} (#{pct.round(0)}%)"
+end

--- a/spec/miner/engine_spec.cr
+++ b/spec/miner/engine_spec.cr
@@ -131,6 +131,49 @@ private class MultiLocationBackend < F::Backend
   end
 end
 
+# Records, per send, how many of the run's CANDIDATE names the query carried — the size of
+# the bucket that request tested. Baseline's raw probe carries none and its control probe
+# carries only bogus `zz…` names, so neither pollutes the count. Grows the body for `magic`,
+# so exactly one name is positive and the bisection follows a single, deterministic path
+# whose bucket sizes reveal the branch factor. Used to pin `Engine#split`.
+private class RecordingBucketBackend < F::Backend
+  getter origin : F::Origin
+  getter counts = [] of Int32
+
+  def initialize(@origin : F::Origin, @candidates : Set(String), @magic : String)
+  end
+
+  def send(bytes : Bytes) : Gori::Repeater::Result
+    params = query_params(bytes)
+    @counts << params.keys.count { |k| @candidates.includes?(k) }
+    body = "BASELINE BODY CONTENT"
+    body += " XXXXXXXXXXXXXXXXXXXXXXXXXXXXXX" if params.has_key?(@magic)
+    head = "HTTP/1.1 200 OK\r\nContent-Length: #{body.bytesize}\r\n\r\n".to_slice
+    resp = Gori::Proxy::Codec::Http1.parse_response_head(head)
+    Gori::Repeater::Result.new(head, body.to_slice, resp, 1000_i64)
+  end
+
+  private def query_params(bytes : Bytes) : Hash(String, String)
+    pairs = Hash(String, String).new
+    line = String.new(bytes).lines.first? || ""
+    target = line.split(' ')[1]? || ""
+    qi = target.index('?')
+    return pairs unless qi
+    target[(qi + 1)..].split('&').each do |pair|
+      k, _, v = pair.partition('=')
+      pairs[k] = v unless k.empty?
+    end
+    pairs
+  end
+
+  # The largest bucket tested AFTER the initial full bucket — i.e. the widest second-generation
+  # sub-bucket the split produced. Smaller means a wider (shallower) split.
+  def widest_split : Int32
+    initial = @counts.max
+    @counts.reject { |c| c == initial || c.zero? }.max? || 0
+  end
+end
+
 private def mine(backend : F::Backend, names : Array(String), config : M::Config) : Array(M::Finding)
   base = "GET /api HTTP/1.1\r\nHost: h\r\n\r\n".to_slice
   engine = M::Engine.new(base, http2: false, names: names, backend: backend, config: config)
@@ -176,6 +219,52 @@ describe Gori::Miner::Engine do
     raise "expected a finding for 'debug'" unless debug
     debug.evidence.should eq(M::Evidence::Length)
     findings.size.should eq(1)
+  end
+
+  it "isolates EVERY hidden parameter when a whole bucket is positive, for no more requests" do
+    # Two guarantees for the densest case (every name positive → the bucket fully expands to
+    # singletons):
+    #   1. correctness — an off-by-one in the slice arithmetic would drop or double a name and
+    #      silently miss it, so assert not one of the ten is lost.
+    #   2. budget — a wider split must never send MORE probes than binary would, or a run under
+    #      `--max-requests` would exhaust its cap sooner and find fewer (a false negative). The
+    #      pruning tree has ~K·b/(b−1) nodes, so 4-ary sends FEWER here, never more.
+    names = (1..10).map { |i| "grow#{i}" }
+    build = ->(conc : Int32) do
+      c = cfg
+      c.bucket_size[M::Location::Query] = 16 # one initial bucket holds all 10
+      c.concurrency = conc
+      backend = HiddenParamBackend.new(F::Origin.new("http", "h", 80), grow: names)
+      findings = mine(backend, names, c)
+      {findings.map(&.name).sort, backend.sent}
+    end
+    binary_names, binary_sent = build.call(2)
+    wide_names, wide_sent = build.call(4) # split ≠ binary
+    wide_names.should eq(names.sort)      # every one still isolated…
+    binary_names.should eq(names.sort)
+    wide_sent.should be <= binary_sent # …and the wider split never costs more requests
+  end
+
+  it "splits a positive bucket wider as concurrency rises (shallower bisection tree)" do
+    # The mine's critical path is the bisection DEPTH, so a positive bucket is split into
+    # `min(concurrency, BISECT_MAX_WAYS)` sub-buckets, not always two — filling idle workers to
+    # trade the run's spare throughput for a shorter path. A serial/paced run keeps the binary
+    # tree it had. Observe it through the widest second-generation bucket: wider split → smaller.
+    names = ["a", "b", "c", "d", "e", "f", "g", "h"]
+    cands = names.to_set
+    build = ->(conc : Int32) do
+      c = cfg
+      c.bucket_size[M::Location::Query] = 8 # all eight in one initial bucket
+      c.concurrency = conc
+      backend = RecordingBucketBackend.new(F::Origin.new("http", "h", 80), cands, "d")
+      mine(backend, names, c)
+      backend.widest_split
+    end
+    # concurrency 2 bisects [8]→[4,4]; concurrency 4 splits [8]→[2,2,2,2].
+    binary = build.call(2)
+    wide = build.call(4)
+    binary.should eq(4)
+    wide.should be < binary
   end
 
   it "finds nothing when no parameter influences the response" do

--- a/src/gori/miner/engine.cr
+++ b/src/gori/miner/engine.cr
@@ -12,11 +12,12 @@ module Gori::Miner
   # count against `--max-requests`) lives with the send seam it wraps: Fuzz::CappedBackend.
 
   # Drives a parameter-mining run: calibrate a baseline, then for each location stuff
-  # candidate names into buckets, diff vs baseline, and BINARY-SEARCH each interesting
-  # bucket to isolate the responsible name. Concurrency = ONE work queue for the whole run,
-  # drained by a bounded worker pool: every location's buckets go in together and a
-  # bisection's halves are pushed straight back, so nothing waits on a round barrier or on
-  # another location finishing. See `drain`.
+  # candidate names into buckets, diff vs baseline, and BISECT each interesting bucket
+  # (into up to `BISECT_MAX_WAYS` sub-buckets, not just two — see `split`) to isolate the
+  # responsible name. Concurrency = ONE work queue for the whole run, drained by a bounded
+  # worker pool: every location's buckets go in together and a bisection's children are
+  # pushed straight back, so nothing waits on a round barrier or on another location
+  # finishing. See `drain`.
   #
   # Single-threaded fiber scheduler (no -Dpreview_mt): plain ivar increments and array
   # appends never yield mid-op, so the counters and per-round outcome array need no locks.
@@ -25,6 +26,15 @@ module Gori::Miner
     include Gori::Pacing
 
     MAX_CONCURRENCY = 100
+
+    # Upper bound on the bisection branch factor — how many sub-buckets a positive bucket is
+    # split into to isolate the responsible name (see `split`). 4 halves the tree DEPTH vs a
+    # binary bisection and never costs more probes (measured: equal when a bucket holds ≤1
+    # positive, −6%…−11% as it fills, because the pruning tree over K names has K·b/(b−1)
+    # nodes — fewer as b grows). Higher than 4 keeps shrinking the count but the depth returns
+    # flatten, so 4 is the knee. The effective factor is `min(this, concurrency)`, so a run
+    # with fewer workers than this never splits wider than it can fill.
+    BISECT_MAX_WAYS = 4
 
     # Per-request growth ceiling for the Json location. A JSON candidate is injected into EVERY
     # object node, so a deeply-nested body could otherwise balloon one request to megabytes; this
@@ -307,11 +317,48 @@ module Gori::Miner
         record_finding(confirmed) if confirmed
         mark_done(1)
       else
-        mid = remaining.size // 2
-        children << Task.new(task.location, remaining[0...mid])
-        children << Task.new(task.location, remaining[mid..])
+        split(remaining).each { |slice| children << Task.new(task.location, slice) }
       end
       children
+    end
+
+    # Partition a positive bucket into `bisect_ways` roughly-equal contiguous sub-buckets to
+    # search next, instead of the two halves a strict binary bisection would.
+    #
+    # A mine is LATENCY-bound and its critical path is this tree's DEPTH: isolating one name
+    # in a K-bucket takes ~log_b(K) sequential round trips at branch factor b, and — since the
+    # tail of a bisection is only 1-2 tasks wide — that chain is a floor no amount of
+    # concurrency can lower (see `drain`: at concurrency 40 the pool sat ~half idle waiting on
+    # it). Widening the split lowers the floor: log₄ is half of log₂.
+    #
+    # It buys the depth WITHOUT costing requests. To isolate a lone positive, a b-way split
+    # sends `b` probes at each of `log_b(K)` levels = `b·log_b(K)` = `2·log₂(K)` for b∈{2,4} —
+    # the same count a binary search sends, in wider, shallower waves. When a bucket holds
+    # SEVERAL positives it recurses into several children, but the total still falls, not
+    # rises: the pruning tree over K names has ~K·b/(b−1) nodes (2K binary, ~1.33K at b=4), so
+    # a dense bucket costs FEWER probes under 4-ary (measured −6%…−11% at ≥8 positives per
+    # 128). Under `--max-requests` that means 4-ary reaches full coverage inside the same
+    # budget a binary run would — it never finds fewer. That is why `BISECT_MAX_WAYS` caps b
+    # for DEPTH returns, not to bound a request cost that only shrinks.
+    #
+    # Tied to `@concurrency` on purpose, floored at 2: widening past the worker count cannot
+    # help — the extra pieces just queue — so a serial/paced run (concurrency 1-2) keeps the
+    # exact binary tree it had, request-for-request, and only a run with idle workers to fill
+    # splits wider. That also keeps the split neutral for a SATURATED pool, whose wall clock is
+    # its request count over its worker count regardless of how the tree branches.
+    private def split(names : Array(String)) : Array(Array(String))
+      ways = @concurrency.clamp(2, BISECT_MAX_WAYS)
+      k = {names.size, ways}.min
+      base = names.size // k
+      extra = names.size % k
+      slices = Array(Array(String)).new(k)
+      start = 0
+      k.times do |i|
+        len = base + (i < extra ? 1 : 0)
+        slices << names[start, len]
+        start += len
+      end
+      slices
     end
 
     # Re-test an isolated name alone with fresh canaries; Confirmed only if it


### PR DESCRIPTION
## What was slow

The miner was already heavily optimized (keep-alive pooling, one work queue across locations, early-exit confirms, single-pass canary scan). Measuring with a utilization diagnostic instead of guessing: a mine is **latency-bound and depth-bound**. At the default concurrency the worker pool is ~88% saturated, but as you raise workers it collapses (48% at concurrency 40) — the wall hits a floor set by the bisection tree's **depth**. Isolating one name in a 128-bucket takes ~log₂(128)=7 sequential round-trips no matter how many workers idle behind it.

## The change

`Miner::Engine` bisected every positive bucket into **two** halves. Now it splits into **`min(concurrency, BISECT_MAX_WAYS=4)`** sub-buckets (`Engine#split`). Wider, shallower search cuts the critical path ~2×. Tied to concurrency and floored at 2, so a serial/paced run keeps the exact binary tree it had.

## Measured (50 ms-RTT origin, query/headers/cookies)

| concurrency | before | after |
|---|---|---|
| 10 (default) | 1307 ms | 1235 ms (−5.5%) |
| 20 | 769 ms | 696 ms (−9.5%) |
| 40 | 605 ms | **485 ms (−20%)** |
| query-only, 20 | 600 ms | **433 ms (−28%)** |

Findings identical. **Request count equal-or-lower at every positive density** (−11% on a fully-dense bucket): the pruning tree over K names has ~`K·b/(b−1)` nodes, so a wider split never sends *more* probes — which keeps it safe under `--max-requests` (it never finds fewer).

## Tests

- `spec/miner/engine_spec.cr` — 2 new specs: one pins partition correctness + budget-safety (dense bucket never costs more than binary), one pins that the split widens with concurrency. **Revert-and-rerun verified** the widening spec fails on a binary revert.
- Full miner suite green (185 examples), CLI/MCP/TUI mine surfaces green, `bin/gori` builds clean.

## Files

- `src/gori/miner/engine.cr` — `Engine#split` + `BISECT_MAX_WAYS`
- `spec/miner/engine_spec.cr` — pinning specs
- `bench/miner_conc_diag.cr` — utilization + budget-by-density reproducer, filling the schedule half `miner_perf_bench` left un-benched

## Out of scope

h2 request multiplexing — the largest remaining latency win, but excluded from connection pooling on purpose (stream-state correctness risk). Left for its own change.