### PR TITLE
Stop discover paying 64 branches per token to fingerprint a response

### DIFF
--- a/bench/discover_fingerprint_bench.cr
+++ b/bench/discover_fingerprint_bench.cr
@@ -1,0 +1,245 @@
+# Discover's per-RESPONSE fingerprint cost — the one piece of CPU every send pays.
+#
+# `discover_extract_bench` measures the link pass, but that runs only on CRAWL bodies and is
+# bounded by `max_pages`. `Fingerprint.simhash` is different: `Engine#distill` calls it on
+# EVERY response, and a brute-force pass is ~315 sends per directory against a soft-404 page
+# that is usually a full framework error page, not a stub. So this is the cost that scales
+# with the request count, and on the single-threaded scheduler (no -Dpreview_mt) every
+# microsecond of it is taken from the same thread the orchestrator dispatches on.
+#
+# `hamming` is measured separately because its caller multiplies it: `ClusterMap#observe`
+# linear-scans up to MAX_CLUSTERS = 4096 representatives per crawl page, and
+# `Calibrate.hit?`'s `fp_novel` runs it over the baseline set for every probe.
+#
+# The legacy implementations below are the ones this bench exists to have replaced; they are
+# kept so the comparison is measured rather than remembered, and so EQUIVALENCE is pinned —
+# a faster fingerprint that returns a different UInt64 would silently re-cluster every
+# baseline in the engine.
+#
+# Build: crystal build bench/discover_fingerprint_bench.cr -o bin/discover_fingerprint_bench --release
+# Run:   bin/discover_fingerprint_bench
+require "benchmark"
+
+module Gori
+  class Error < Exception; end
+end
+
+require "../src/gori/discover/fingerprint"
+
+include Gori::Discover
+
+# ── the implementations this replaced ───────────────────────────────────────────────────────
+#
+# One ±1 vote per BIT per token: 64 iterations of shift/mask/compare/branch into a
+# StaticArray, on a hash whose bits are ~50/50, which is a branch predictor's worst case.
+module Legacy
+  FNV_OFFSET = 0xcbf29ce484222325_u64
+  FNV_PRIME  = 0x00000100000001b3_u64
+
+  def self.simhash(body : Bytes) : UInt64
+    votes = StaticArray(Int32, 64).new(0)
+    tokens = 0
+    i = 0
+    n = body.size
+    while i < n && tokens < Fingerprint::MAX_TOKENS
+      while i < n && !alnum?(body.unsafe_fetch(i))
+        i += 1
+      end
+      start = i
+      while i < n && alnum?(body.unsafe_fetch(i))
+        i += 1
+      end
+      len = i - start
+      next if len == 0
+      next if dynamic?(body, start, len)
+      tokens += 1
+      h = fnv1a(body, start, len)
+      bit = 0
+      while bit < 64
+        if (h >> bit) & 1_u64 == 1_u64
+          votes.to_unsafe[bit] += 1
+        else
+          votes.to_unsafe[bit] -= 1
+        end
+        bit += 1
+      end
+    end
+    out = 0_u64
+    bit = 0
+    while bit < 64
+      out |= (1_u64 << bit) if votes.to_unsafe[bit] > 0
+      bit += 1
+    end
+    out
+  end
+
+  # Kernighan's clear-the-lowest-set-bit loop: one iteration per differing bit.
+  def self.hamming(a : UInt64, b : UInt64) : Int32
+    x = a ^ b
+    c = 0
+    while x != 0
+      x &= x - 1
+      c += 1
+    end
+    c
+  end
+
+  def self.alnum?(b : UInt8) : Bool
+    (b >= 0x30_u8 && b <= 0x39_u8) ||
+      (b >= 0x41_u8 && b <= 0x5a_u8) ||
+      (b >= 0x61_u8 && b <= 0x7a_u8)
+  end
+
+  def self.dynamic?(body : Bytes, start : Int32, len : Int32) : Bool
+    all_digits = true
+    all_hex = true
+    k = 0
+    while k < len
+      b = body.unsafe_fetch(start + k)
+      digit = b >= 0x30_u8 && b <= 0x39_u8
+      hex = digit || (b >= 0x61_u8 && b <= 0x66_u8) || (b >= 0x41_u8 && b <= 0x46_u8)
+      all_digits = false unless digit
+      all_hex = false unless hex
+      break unless all_digits || all_hex
+      k += 1
+    end
+    all_digits || (all_hex && len >= 12)
+  end
+
+  def self.fnv1a(body : Bytes, start : Int32, len : Int32) : UInt64
+    h = FNV_OFFSET
+    k = 0
+    while k < len
+      b = body.unsafe_fetch(start + k)
+      b |= 0x20_u8 if b >= 0x41_u8 && b <= 0x5a_u8
+      h = (h ^ b.to_u64) &* FNV_PRIME
+      k += 1
+    end
+    h
+  end
+end
+
+# ── the corpus ──────────────────────────────────────────────────────────────────────────────
+#
+# Built at RUNTIME and held in an Array the loops index, so LLVM cannot constant-fold the
+# calls away — a folded benchmark reports a win that does not exist.
+
+# The response shape a brute-force run sees ~315 times per directory: a framework's 404 page,
+# which on anything modern is the full site chrome around a short message, not a stub.
+def soft_404 : Bytes
+  nav = (1..25).map { |i| %(<li><a href="/section/#{i}">Section #{i}</a></li>) }.join
+  ("<!doctype html><html><head><title>404 - Page not found</title>" \
+   "<link rel=stylesheet href=/assets/app.css></head><body><header><nav><ul>" +
+     nav + "</ul></nav></header><main><h1>Page not found</h1>" \
+           "<p>Sorry, the page you requested does not exist. Try the search box above.</p>" \
+           "</main><footer>Copyright 2026 Acme Corporation. All rights reserved.</footer></body></html>").to_slice
+end
+
+def catalog_page : Bytes
+  nav = (1..40).map { |i| %(<a href="/catalog/section-#{i}">S#{i}</a>) }.join
+  rows = (1..120).map { |i| %(<a href="/product/#{i}?ref=grid"><img src="/img/p#{i}.jpg">Product #{i}</a>) }.join
+  ("<html><head></head><body>" + nav + rows + nav + "</body></html>").to_slice
+end
+
+def big_listing : Bytes
+  String.build do |io|
+    2000.times { |i| io << %(<div class="row-#{i}"><span>item name #{i}</span><a href="/x/#{i}">go</a></div>) }
+  end.to_slice
+end
+
+def json_doc : Bytes
+  String.build do |io|
+    io << %({"items":[)
+    400.times do |i|
+      io << "," if i > 0
+      io << %({"id":#{i},"name":"resource name #{i}","href":"/api/v2/resource/#{i}","kind":"widget"})
+    end
+    io << "]}"
+  end.to_slice
+end
+
+CORPUS = [
+  {"soft-404 page", soft_404},
+  {"catalog page ", catalog_page},
+  {"json document", json_doc},
+  {"big listing  ", big_listing},
+]
+
+# ── equivalence, pinned over the corpus AND over adversarial bytes ───────────────────────────
+#
+# The algebra says the two agree (`votes = 2*ones - tokens`, so `votes > 0` iff `2*ones >
+# tokens`), but the algebra is not the pin — a corpus is. Random bytes cover the token
+# shapes the pages do not: empty runs, all-digit and long-hex tokens the `dynamic?` filter
+# drops, and bodies with no alnum byte at all.
+CORPUS.each do |name, body|
+  got = Fingerprint.simhash(body)
+  want = Legacy.simhash(body)
+  raise "simhash disagrees on #{name}: #{got} != #{want}" unless got == want
+end
+
+rng = Random.new(20260811)
+2000.times do |i|
+  size = i < 64 ? i : rng.rand(1..8192)
+  body = Bytes.new(size) { rng.rand(256).to_u8 }
+  raise "simhash disagrees on random body ##{i} (#{size}B)" unless Fingerprint.simhash(body) == Legacy.simhash(body)
+end
+# Bodies made ONLY of the token classes the filter reacts to.
+["", "0123456789", "deadbeefcafebabe", "a", ("z" * 400), ("1234 " * 500), ("////" * 500),
+ ("DEADBEEFCAFE" * 100), ("x" * 199_999 + " y")].each do |s|
+  b = s.to_slice
+  raise "simhash disagrees on #{s.bytesize}B edge body" unless Fingerprint.simhash(b) == Legacy.simhash(b)
+end
+puts "simhash == legacy on #{CORPUS.size} corpus bodies + 2000 random + 9 edge bodies"
+
+HAMMING_PAIRS = Array.new(4096) { |i| {Random.new(i).rand(UInt64), Random.new(i + 99_991).rand(UInt64)} }
+HAMMING_PAIRS.each do |a, b|
+  raise "hamming disagrees on #{a}/#{b}" unless Fingerprint.hamming(a, b) == Legacy.hamming(a, b)
+end
+puts "hamming == legacy on #{HAMMING_PAIRS.size} random pairs"
+puts ""
+
+CORPUS.each { |name, body| puts "  #{name}: #{body.size}B" }
+puts ""
+
+# ── simhash ─────────────────────────────────────────────────────────────────────────────────
+CORPUS.each do |name, body|
+  Benchmark.ips do |x|
+    x.report("legacy simhash #{name}") { Legacy.simhash(body) }
+    x.report("       simhash #{name}") { Fingerprint.simhash(body) }
+  end
+end
+
+# ── hamming, and the scan that multiplies it ────────────────────────────────────────────────
+#
+# The pairs come out of a runtime Array and every result is accumulated into a value the
+# report returns, so neither the call nor the loop can be eliminated.
+puts ""
+Benchmark.ips do |x|
+  x.report("legacy hamming x4096") do
+    c = 0
+    HAMMING_PAIRS.each { |a, b| c += Legacy.hamming(a, b) }
+    c
+  end
+  x.report("       hamming x4096") do
+    c = 0
+    HAMMING_PAIRS.each { |a, b| c += Fingerprint.hamming(a, b) }
+    c
+  end
+end
+
+# `ClusterMap#observe` at its bound: MAX_CLUSTERS representatives, none of them within
+# `distance`, so every observe walks the whole list — what a page of distinct content costs
+# once the map has filled.
+FULL_MAP = ClusterMap.new
+ClusterMap::MAX_CLUSTERS.times { |i| FULL_MAP.observe(Random.new(i).rand(UInt64) | (1_u64 << (i % 64)), 0) }
+MISSES = Array.new(256) { |i| Random.new(i + 7_777_777).rand(UInt64) }
+
+puts ""
+puts "ClusterMap: #{ClusterMap::MAX_CLUSTERS} representatives, distance 0 (every observe walks the full list)"
+Benchmark.ips do |x|
+  x.report("observe (full scan) ") do
+    c = 0
+    MISSES.each { |fp| c += FULL_MAP.observe(fp, 0) }
+    c
+  end
+end

--- a/bench/discover_fingerprint_bench.cr
+++ b/bench/discover_fingerprint_bench.cr
@@ -183,13 +183,17 @@ rng = Random.new(20260811)
   body = Bytes.new(size) { rng.rand(256).to_u8 }
   raise "simhash disagrees on random body ##{i} (#{size}B)" unless Fingerprint.simhash(body) == Legacy.simhash(body)
 end
-# Bodies made ONLY of the token classes the filter reacts to.
+# Bodies made ONLY of the token classes the filter reacts to — plus the one that crosses
+# MAX_TOKENS. The corpus above tops out around 20k tokens (`"x" * 199_999` is ONE token, and
+# the all-digit / long-hex strings yield none), so nothing else reaches the truncation, and it
+# is the one input where the `tokens` denominator meets an early exit.
 ["", "0123456789", "deadbeefcafebabe", "a", ("z" * 400), ("1234 " * 500), ("////" * 500),
- ("DEADBEEFCAFE" * 100), ("x" * 199_999 + " y")].each do |s|
+ ("DEADBEEFCAFE" * 100), ("x" * 199_999 + " y"), ("ab " * (Fingerprint::MAX_TOKENS + 1)),
+ ("ab cd 42 " * (Fingerprint::MAX_TOKENS // 2))].each do |s|
   b = s.to_slice
   raise "simhash disagrees on #{s.bytesize}B edge body" unless Fingerprint.simhash(b) == Legacy.simhash(b)
 end
-puts "simhash == legacy on #{CORPUS.size} corpus bodies + 2000 random + 9 edge bodies"
+puts "simhash == legacy on #{CORPUS.size} corpus bodies + 2000 random + 11 edge bodies (incl. past MAX_TOKENS)"
 
 HAMMING_PAIRS = Array.new(4096) { |i| {Random.new(i).rand(UInt64), Random.new(i + 99_991).rand(UInt64)} }
 HAMMING_PAIRS.each do |a, b|

--- a/bench/discover_keepalive_bench.cr
+++ b/bench/discover_keepalive_bench.cr
@@ -30,6 +30,11 @@ end
 
 require "../src/gori/discover/engine"
 require "../src/gori/discover/wordlist"
+# `Env.expand_bindings` (reached from `Sender#binding_headers`) calls `Bindings.boundary_forging?`,
+# and `env.cr` cannot require `bindings.cr` back without a cycle — so a partial build that stops at
+# the engine leaves the constant undefined. The full binary always has it; name it here so the
+# bench does too.
+require "../src/gori/bindings"
 
 alias D = Gori::Discover
 

--- a/spec/discover/extract_spec.cr
+++ b/spec/discover/extract_spec.cr
@@ -122,6 +122,49 @@ describe Gori::Discover::Extract do
     E.sitemap_body?(io.to_slice).should be_true
   end
 
+  # `sitemap_body?` runs a byte prefilter before it will build a String, so that the common
+  # answer — "no", on every image, font and archive a spider follows — costs no allocation and
+  # no PCRE2. The prefilter carries the LITERALS only; the `\b` stays with the regex, which
+  # reads it with Unicode semantics (`<locé` is not a match, `<loc ` is). This pins the
+  # two against each other: the shipped predicate must agree, body for body, with running
+  # SITEMAP_ROOT over the sniff window directly.
+  it "answers exactly what the sitemap regex answers, prefilter or not" do
+    oracle = ->(body : Bytes) do
+      slice = body.size > E::SNIFF_MAX ? body[0, E::SNIFF_MAX] : body
+      String.new(slice).scrub.matches?(E::SITEMAP_ROOT)
+    end
+
+    bodies = [
+      # the real shapes
+      %(<?xml version="1.0"?><urlset><url><loc>http://h/p</loc></url></urlset>),
+      %(<sitemapindex><sitemap><loc>http://h/s.xml</loc></sitemap></sitemapindex>),
+      %(<URLSET><URL><LOC>http://h/p</LOC></URL></URLSET>), # the `i` flag
+      %(<UrlSet >), %(<Loc\t>), %(<sitemapINDEX\n>),
+      # literal present, boundary absent — the prefilter says maybe, the regex says no
+      %(<location>a</location>), %(<locale lang="en">), %(<urlsets>), %(<sitemapindexes>),
+      %(<locé>), %(<loc_id>), %(<loc0>),
+      # literal absent — the prefilter alone decides
+      %(<html><body><a href="/loc">not a sitemap</a></body></html>),
+      %(<html><urlsetx</html>), %(no angle brackets at all: urlset loc sitemapindex),
+      "User-agent: *\nDisallow: /admin\n", "", "<", "<l", "<lo", "<loc", "<urlse",
+      # the literal split across the end of the sniff window
+      ("y" * (E::SNIFF_MAX - 2)) + "<loc>", ("y" * (E::SNIFF_MAX - 5)) + "<loc>",
+    ].map(&.to_slice)
+
+    # …plus bodies that are not valid UTF-8, where the regex only ever sees the scrubbed form.
+    binaries = [
+      Bytes[0xff, 0xfe, 0x3c, 0x6c, 0x6f, 0x63, 0x3e],      # <loc> behind invalid lead bytes
+      Bytes[0x3c, 0x6c, 0x6f, 0x63, 0xff, 0x3e],            # <loc followed by an invalid byte
+      Bytes[0x3c, 0x4c, 0x4f, 0x43, 0xc0, 0x80],            # <LOC + an overlong sequence
+      Bytes.new(2048) { |i| ((i * 7) % 251).to_u8 },        # an "image"
+      Bytes.new(E::SNIFF_MAX + 64) { |i| (i % 256).to_u8 }, # larger than the sniff window
+    ]
+
+    (bodies + binaries).each do |body|
+      E.sitemap_body?(body).should eq(oracle.call(body))
+    end
+  end
+
   # The scrub is only reached for a body that is ACTUALLY invalid: `String#scrub` walks the
   # whole string through a Char::Reader whether or not it finds anything (130µs on a valid
   # 40 KB page against 9µs for `valid_encoding?`), and EVERY crawled page and probe response

--- a/spec/discover/fingerprint_spec.cr
+++ b/spec/discover/fingerprint_spec.cr
@@ -14,6 +14,78 @@ describe Gori::Discover::Fingerprint do
     b = FP.simhash("completely unrelated administrative control panel interface settings".to_slice)
     FP.hamming(a, b).should be > 5
   end
+
+  # The two above are DISTANCE assertions, and a miscount big enough to matter can still leave
+  # near content near and far content far. These pin the majority rule itself, at the token
+  # counts where the bit-sliced accumulator drains (every 255 tokens) — the one place the
+  # implementation can lose a count without changing the shape of the answer.
+  #
+  # The oracle needs no second implementation. With exactly TWO distinct tokens, bit j of the
+  # result is: set when both hashes set it, clear when neither does, and the MORE FREQUENT
+  # token's bit where they disagree. So for n_a > n_b the whole hash collapses to the hash of
+  # `a` alone — a majority of one token decides every contested bit, which is precisely what a
+  # dropped carry would flip.
+  describe "majority across the accumulator drain" do
+    # 255 is the drain point, so these straddle it, land on it, and cross it twice.
+    {
+      {128, 127}, # 255 tokens — drains exactly once, with nothing left over
+      {129, 128}, # 257 — one drain plus a remainder
+      {200, 199}, # 399
+      {300, 299}, # 599 — two drains plus a remainder
+      {1, 0},     # the degenerate single-token case
+    }.each do |(more, less)|
+      it "resolves a #{more}:#{less} split to the majority token" do
+        body = (("alpha " * more) + ("bravo " * less)).to_slice
+        FP.simhash(body).should eq(FP.simhash("alpha".to_slice))
+
+        # …and the same split the other way round resolves the other way, so the test cannot
+        # pass by the two tokens happening to share a hash.
+        flipped = (("alpha " * less) + ("bravo " * more)).to_slice
+        FP.simhash(flipped).should eq(FP.simhash("bravo".to_slice))
+      end
+    end
+
+    it "is unchanged by interleaving, so a drain cannot depend on token order" do
+      grouped = (("alpha " * 300) + ("bravo " * 299)).to_slice
+      interleaved = String.build do |io|
+        299.times { io << "alpha bravo " }
+        io << "alpha "
+      end.to_slice
+      FP.simhash(interleaved).should eq(FP.simhash(grouped))
+    end
+
+    it "gives an exact tie no bits, on either side of the drain" do
+      # Neither token is a majority, so every contested bit stays clear and only the bits BOTH
+      # hashes set survive — the `>` in `2 * ones > tokens`, which an off-by-one would turn
+      # into `>=` and hand the tie to whichever token was counted last.
+      {127, 255}.each do |n|
+        tie = (("alpha " * n) + ("bravo " * n)).to_slice
+        both = FP.simhash("alpha".to_slice) & FP.simhash("bravo".to_slice)
+        FP.simhash(tie).should eq(both)
+      end
+    end
+
+    it "counts a body with no scannable token as empty" do
+      FP.simhash(Bytes.new(0)).should eq(0_u64)
+      FP.simhash("   ---   ".to_slice).should eq(0_u64)
+      # Every token here is `dynamic?` (all-digit / long-hex) and therefore skipped, so the
+      # body scans to zero tokens even though it is full of alnum runs.
+      FP.simhash("12345 6789 deadbeefcafebabe 0123456789ab".to_slice).should eq(0_u64)
+    end
+  end
+end
+
+describe "Gori::Discover::Fingerprint.hamming" do
+  it "counts differing bits" do
+    FP.hamming(0_u64, 0_u64).should eq(0)
+    FP.hamming(0_u64, UInt64::MAX).should eq(64)
+    FP.hamming(UInt64::MAX, UInt64::MAX).should eq(0)
+    FP.hamming(0b1011_u64, 0b0001_u64).should eq(2)
+    FP.hamming(1_u64 << 63, 0_u64).should eq(1)
+    # Symmetric, and never negative — it feeds `<=` comparisons against `simhash_distance`.
+    FP.hamming(0x0123456789abcdef_u64, 0xfedcba9876543210_u64).should eq(64)
+    FP.hamming(0xfedcba9876543210_u64, 0x0123456789abcdef_u64).should eq(64)
+  end
 end
 
 describe Gori::Discover::ClusterMap do

--- a/spec/discover/fingerprint_spec.cr
+++ b/spec/discover/fingerprint_spec.cr
@@ -65,6 +65,21 @@ describe Gori::Discover::Fingerprint do
       end
     end
 
+    # `tokens` changed ROLE with the bit-sliced accumulator. It used to bound the loop and
+    # nothing else, so miscounting it was invisible; it is now the DENOMINATOR every output bit
+    # is decided against (`2 * ones > tokens`). A token that is counted but never folded in —
+    # the shape a `tokens += 1` that drifted above the `dynamic?` guard would produce — inflates
+    # the denominator without contributing any ones, and silently clears every contested bit.
+    #
+    # Nothing else here catches that: the all-dynamic body below answers 0 either way, and the
+    # majority cases hold no dynamic tokens at all.
+    it "counts only the tokens it folds in, so a skipped one cannot move the majority" do
+      # 200 `alpha` against 199 `bravo`, with an all-digit token after each — `dynamic?` drops
+      # those, so the denominator is 399 and not 798.
+      body = (("alpha 12345 " * 200) + ("bravo 67890 " * 199)).to_slice
+      FP.simhash(body).should eq(FP.simhash("alpha".to_slice))
+    end
+
     it "counts a body with no scannable token as empty" do
       FP.simhash(Bytes.new(0)).should eq(0_u64)
       FP.simhash("   ---   ".to_slice).should eq(0_u64)

--- a/src/gori/discover/extract.cr
+++ b/src/gori/discover/extract.cr
@@ -164,13 +164,65 @@ module Gori::Discover
     SNIFF_MAX    = 8192 # a sitemap's root element sits at the top; no need to read further
     SITEMAP_ROOT = /<(?:urlset|sitemapindex|loc)\b/i
 
+    # The three root-element names SITEMAP_ROOT can open with, lowercased. A match REQUIRES one
+    # of these right after a `<`, so their absence is proof the regex cannot match — which is
+    # what makes the byte prefilter below exact rather than approximate.
+    SITEMAP_TAGS = {"urlset".to_slice, "sitemapindex".to_slice, "loc".to_slice}
+
     # Does this body look like an XML sitemap? Lets the engine pick the sitemap parser from
     # the RESPONSE rather than from how the URL was found — so a sitemap served off the
     # well-known /sitemap.xml path (a robots.txt `Sitemap:` URL, or a <sitemapindex> child)
     # still gets its <loc> URLs extracted instead of being wrongly parsed as HTML/robots.
+    #
+    # `Engine#extract_links` asks this of EVERY response body before it looks at the content
+    # type, deliberately — a sitemap served under a wrong type still has to parse. That made it
+    # the one extractor a crawl pays for on bodies it then does nothing with, and the bill was
+    # not small: `text` builds a String of the whole sniff window, and on a body that is not
+    # valid UTF-8 — an image, a font, an archive, which the `text_like?` comment notes are the
+    # COMMON case for a spider — `scrub` then rebuilds it again with a 3-byte replacement per
+    # bad byte. Measured on a 120 KB binary: 52µs and 32 KB of garbage, per response, to answer
+    # "no".
+    #
+    # So the String is now built only for a body that could actually match. `sitemap_prefix?`
+    # is a STRICT SUPERSET of the regex — same literals, minus the `\b` — so a negative from it
+    # is a negative from `SITEMAP_ROOT`, and a positive falls through to the regex for the real
+    # answer. That keeps the Unicode-aware `\b` (PCRE2 reads `<locé` as no match) exactly where
+    # it was instead of being restated per byte, which is the half of this predicate a byte
+    # scan has no business deciding.
     def self.sitemap_body?(body : Bytes) : Bool
       slice = body.size > SNIFF_MAX ? body[0, SNIFF_MAX] : body
+      return false unless sitemap_prefix?(slice)
       text(slice).matches?(SITEMAP_ROOT)
+    end
+
+    # `<` followed, case-insensitively, by one of SITEMAP_TAGS — the literal part of
+    # SITEMAP_ROOT, on the raw bytes. Every name is ASCII, so a byte-wise ASCII fold answers
+    # the same question the `i` flag does for them.
+    private def self.sitemap_prefix?(body : Bytes) : Bool
+      i = 0
+      n = body.size
+      while i < n
+        if body.unsafe_fetch(i) == 0x3c_u8 # '<'
+          SITEMAP_TAGS.each do |tag|
+            return true if tag_at?(body, i + 1, tag)
+          end
+        end
+        i += 1
+      end
+      false
+    end
+
+    # Does `tag` (already lowercase ASCII) sit at `body[at...]`, ignoring ASCII case?
+    private def self.tag_at?(body : Bytes, at : Int32, tag : Bytes) : Bool
+      return false if at + tag.size > body.size
+      k = 0
+      while k < tag.size
+        b = body.unsafe_fetch(at + k)
+        b |= 0x20_u8 if b >= 0x41_u8 && b <= 0x5a_u8 # fold A-Z
+        return false unless b == tag.unsafe_fetch(k)
+        k += 1
+      end
+      true
     end
 
     private def self.scan_text(body : Bytes) : String

--- a/src/gori/discover/fingerprint.cr
+++ b/src/gori/discover/fingerprint.cr
@@ -14,8 +14,42 @@ module Gori::Discover
     FNV_OFFSET = 0xcbf29ce484222325_u64
     FNV_PRIME  = 0x00000100000001b3_u64
 
+    # How many tokens the bit-sliced accumulator below may fold in before it must be drained
+    # into `votes`. Eight planes count to 2**8 - 1, and the 256th token would carry out of the
+    # top plane and be lost — so the drain happens ON 255, not after it.
+    PLANE_FULL = 255
+
+    # 64-bit SimHash. Counts, per bit position, how many token hashes set it; the output bit is
+    # set when that is a strict majority.
+    #
+    # The count is kept BIT-SLICED — eight UInt64 "planes", where bit j of plane i is bit i of
+    # the counter for column j — so folding a token in is eight register-only half-adds of the
+    # whole 64-column counter at once, instead of 64 separate loop iterations. That inner loop
+    # was ~90% of this function: it read, compared and wrote one `Int32` per BIT per token, and
+    # branched on an FNV output bit, which is ~50/50 and therefore the branch predictor's worst
+    # case. On a 155 KB body it ran 20k tokens x 64 = 1.3M times.
+    #
+    # `distill` calls this on EVERY response — a brute-force pass is ~315 sends per directory —
+    # and the scheduler is single-threaded (no -Dpreview_mt), so this CPU is taken from the same
+    # thread the orchestrator dispatches on.
+    #
+    # Counting ONES rather than the old ±1 votes is what makes the planes work, and it is exact
+    # rather than approximate: the old `votes = ones - (tokens - ones) = 2*ones - tokens`, so
+    # `votes > 0` iff `2*ones > tokens`, ties falling the same way in both. `discover_fingerprint_bench`
+    # pins the equality over a corpus, 2000 random bodies and the token-class edge cases.
     def self.simhash(body : Bytes) : UInt64
       votes = StaticArray(Int32, 64).new(0)
+      # The vertical counter. Locals rather than an array so they stay in registers — a
+      # StaticArray is a value type and passing one to a helper would copy it per token.
+      p0 = 0_u64
+      p1 = 0_u64
+      p2 = 0_u64
+      p3 = 0_u64
+      p4 = 0_u64
+      p5 = 0_u64
+      p6 = 0_u64
+      p7 = 0_u64
+      pending = 0
       tokens = 0
       i = 0
       n = body.size
@@ -32,34 +66,63 @@ module Gori::Discover
         next if len == 0
         next if dynamic?(body, start, len)
         tokens += 1
-        h = fnv1a(body, start, len)
-        bit = 0
-        while bit < 64
-          if (h >> bit) & 1_u64 == 1_u64
-            votes.to_unsafe[bit] += 1
-          else
-            votes.to_unsafe[bit] -= 1
-          end
-          bit += 1
+        # Add 1 to every column whose bit is set, in parallel: `c` is the carry mask, and each
+        # plane is a half-add (sum = plane ^ carry, carry out = plane & carry). The top plane
+        # drops its carry, which is why `pending` never reaches 256.
+        c = fnv1a(body, start, len)
+        t = p0 & c; p0 ^= c; c = t
+        t = p1 & c; p1 ^= c; c = t
+        t = p2 & c; p2 ^= c; c = t
+        t = p3 & c; p3 ^= c; c = t
+        t = p4 & c; p4 ^= c; c = t
+        t = p5 & c; p5 ^= c; c = t
+        t = p6 & c; p6 ^= c; c = t
+        p7 ^= c
+        pending += 1
+        if pending == PLANE_FULL
+          drain(votes.to_unsafe, p0, p1, p2, p3, p4, p5, p6, p7)
+          p0 = p1 = p2 = p3 = p4 = p5 = p6 = p7 = 0_u64
+          pending = 0
         end
       end
+      drain(votes.to_unsafe, p0, p1, p2, p3, p4, p5, p6, p7) if pending > 0
       out = 0_u64
       bit = 0
       while bit < 64
-        out |= (1_u64 << bit) if votes.to_unsafe[bit] > 0
+        # `2 * ones > tokens` — the old `votes > 0`, restated for a ones-only count.
+        out |= (1_u64 << bit) if votes.to_unsafe[bit] &* 2 > tokens
         bit += 1
       end
       out
     end
 
-    def self.hamming(a : UInt64, b : UInt64) : Int32
-      x = a ^ b
-      c = 0
-      while x != 0
-        x &= x - 1
-        c += 1
+    # Add the bit-sliced counters back into the per-column totals and leave the planes to be
+    # zeroed by the caller. Runs once per PLANE_FULL tokens, so its 64 iterations amortize to
+    # well under one per token.
+    private def self.drain(votes : Int32*, p0 : UInt64, p1 : UInt64, p2 : UInt64, p3 : UInt64,
+                           p4 : UInt64, p5 : UInt64, p6 : UInt64, p7 : UInt64) : Nil
+      bit = 0
+      while bit < 64
+        v = (p0 >> bit) & 1_u64
+        v |= ((p1 >> bit) & 1_u64) << 1
+        v |= ((p2 >> bit) & 1_u64) << 2
+        v |= ((p3 >> bit) & 1_u64) << 3
+        v |= ((p4 >> bit) & 1_u64) << 4
+        v |= ((p5 >> bit) & 1_u64) << 5
+        v |= ((p6 >> bit) & 1_u64) << 6
+        v |= ((p7 >> bit) & 1_u64) << 7
+        votes[bit] += v.to_i32
+        bit += 1
       end
-      c
+    end
+
+    # `popcount` is one instruction on every target gori builds for; the loop it replaces ran
+    # once per DIFFERING bit, which for two unrelated fingerprints is ~32 iterations with an
+    # unpredictable trip count. That matters because of who calls it: `ClusterMap#observe`
+    # linear-scans up to MAX_CLUSTERS representatives per crawl page, and `Calibrate.hit?`
+    # runs it over the baseline set for every probe.
+    def self.hamming(a : UInt64, b : UInt64) : Int32
+      (a ^ b).popcount.to_i32
     end
 
     private def self.alnum?(b : UInt8) : Bool


### PR DESCRIPTION
## What

Three hot paths in `Discover`, all CPU the engine pays on the single-threaded scheduler (no `-Dpreview_mt`), where every microsecond is taken from the same thread the orchestrator dispatches on.

**`Fingerprint.simhash`** — `Engine#distill` calls it on *every* response, and a brute-force pass is ~315 sends per directory, so this is the CPU that scales with the request count. ~90% of it was one loop: a ±1 vote per BIT per token, 64 iterations of read/compare/branch/write into a `StaticArray`, branching on an FNV output bit (~50/50 — the branch predictor's worst case). On a 155 KB body that ran 1.3M times.

The count is now **bit-sliced**: eight `UInt64` planes, where bit *j* of plane *i* is bit *i* of the counter for column *j*. Folding a token in is eight register-only half-adds of all 64 counters at once, drained into the totals every 255 tokens. Counting **ones** instead of ±1 votes is what makes the planes work, and it is exact rather than approximate — the old `votes = 2*ones - tokens`, so `votes > 0` iff `2*ones > tokens`, ties falling the same way in both.

**`Fingerprint.hamming`** → `popcount`. The Kernighan loop ran once per *differing* bit — ~32 unpredictable iterations for two unrelated fingerprints — and its callers multiply it: `ClusterMap#observe` linear-scans up to `MAX_CLUSTERS` representatives per crawl page, and `Calibrate.hit?` runs it over the baseline set for every probe.

**`Extract.sitemap_body?`** — `extract_links` asks it of every response body *before* it looks at the content type (deliberately: a sitemap served under a wrong type still has to parse), so a crawl paid it on every image, font and archive it followed. It built a `String` of the sniff window, and on a body that is not valid UTF-8 `scrub` rebuilt it again with a 3-byte replacement per bad byte. It now runs a byte prefilter carrying the regex's **literals only** — a negative there is a negative from the regex, a positive falls through to PCRE2 — so the Unicode-aware `\b` (`<locé` is not a match, `<loc ` is) stays exactly where it was instead of being restated per byte.

## Measured

`bench/discover_fingerprint_bench.cr` (new), release, arm64:

| | before | after | |
|---|---|---|---|
| `simhash` 1.5 KB soft-404 | 7.4µs | 1.6µs | **4.6x** |
| `simhash` 11 KB page | 68.9µs | 12.8µs | **5.4x** |
| `simhash` 33 KB json | 126.0µs | 32.0µs | **3.9x** |
| `simhash` 155 KB listing | 883.0µs | 176.6µs | **5.0x** |
| `hamming` x4096 | 140.9µs | 1.2µs | **119x** |
| `ClusterMap#observe` at its bound | 131µs | 0.9µs | **146x** |
| `sitemap_body?` 10 KB html | 12.8µs / 8 KB | 2.7µs / **0 alloc** | 4.7x |
| `sitemap_body?` 120 KB binary | 51.9µs / 32 KB | 2.1µs / **0 alloc** | 24x |

End to end — a 318-request brute-force run over loopback with keep-alive, against an origin serving a realistic framework 404:

| soft-404 body | before | after | |
|---|---|---|---|
| 1.6 KB | 0.047s | 0.048s | network-bound; no change, as expected |
| 11 KB | 0.120s | 0.068s | **1.8x** |
| 65 KB | 0.603s | 0.212s | **2.9x**, and 3.0x less user CPU |

The 1.6 KB row is left in deliberately: with a small body the run is network-bound and the win is unobservable in wall clock. It shows up as body size grows, which is where real framework error pages live. **On a remote target the wall-clock win is correspondingly smaller** — what this buys there is headroom on the one thread everything shares, which is what bites at the concurrency the TUI offers.

## Equivalence

Both rewrites are byte-for-byte equivalent, and that is **pinned rather than argued**.

- `discover_fingerprint_bench` keeps the old implementations and asserts equality over the corpus, 2000 random bodies, and the token-class edge cases — including two that cross `MAX_TOKENS` — before it reports a single number.
- New specs pin the majority rule at the drain boundary (255 tokens) via a two-token oracle that needs no second implementation, plus `sitemap_body?` against running `SITEMAP_ROOT` over the sniff window directly.
- Every new spec was checked against a **deliberately broken** implementation — a moved drain point, a dropped plane, `>=` for `>`, a dropped tag literal, a case-sensitive compare, an off-by-one at the window edge — and each one fails. Restored, all green.

The second commit closes a hole the first one left. `tokens` **changed role**: it used to bound the loop and nothing else, so miscounting it was invisible; it is now the denominator every output bit is decided against. A `tokens += 1` that drifted above the `dynamic?` guard counts a token it never folds in, clears every contested bit — and shipped green, because the all-dynamic body answers 0 either way and the majority cases hold no dynamic tokens. The added case is a 200:199 majority with an all-digit token after each; the narrow drift fails it and nothing else.

## Also

`bench/discover_keepalive_bench.cr` gets a require it was always missing: `env.cr` cannot require `bindings.cr` back without a cycle, so a partial build that stopped at the engine left `Bindings` undefined and the bench did not compile at all.

## Not in this PR

The remaining discover levers are **throughput policy, not CPU**, and each has a security-tool tradeoff worth deciding deliberately rather than folding into a perf PR: `MAX_POOLS = 4` (a `host+subdomains` or multi-host scope-aware run falls back to dial-per-send past four origins), `retry_pause = 500ms` parking a worker slot per retry, and the default `concurrency = 20`.

## Testing

- `crystal spec spec/discover/` — 265 examples, 0 failures (was 254; +11 new).
- `crystal spec` — 8087 examples, 8 failures, all the known environmental `Gori::Session` port-bind set in `project_registry_spec` / `capture_status_spec`, identical on `main`.
- `crystal tool format --check` clean on the touched files.
- `ameba`: two new findings, both `Metrics/CyclomaticComplexity` on the verbatim `Legacy.simhash` / `Legacy.dynamic?` copies in the new bench — unavoidable, since being verbatim is the point. The two on `fingerprint.cr` itself are byte-identical to `main`'s. Repo baseline is 956 findings and ameba is not in the CI check list.
- No `DESIGN.md` change needed — its `Fingerprint.dynamic?` / `simhash_distance` passages describe behaviour this keeps bit-identical.