### PR TITLE
Make a drop say whether it dropped anything (intercept settle/ack sweep)

### DIFF
--- a/spec/intercept_filter_spec.cr
+++ b/spec/intercept_filter_spec.cr
@@ -112,6 +112,16 @@ describe Gori::InterceptFilter do
       Gori::InterceptFilter.suggestions("body:tra", 8).should be_empty
     end
 
+    it "offers only the proto values a hold gate can ever answer (no grpc/sse)" do
+      # A gate knows its leg — Ws for a held WebSocket message, Http for everything else — and
+      # `grpc`/`sse` are read off a CAPTURED response's Content-Type, which does not exist yet
+      # when the message is being held. Completing them handed the operator a condition that
+      # silently holds nothing, which reads as intercept being broken.
+      Gori::InterceptFilter.suggestions("proto:", 6).should eq(["proto:ws", "proto:http"])
+      Gori::InterceptFilter.suggestions("proto:g", 7).should be_empty
+      Gori::InterceptFilter.suggestions("proto:s", 7).should be_empty
+    end
+
     it "takes host values from the injected pool and preserves a leading -" do
       hosts = ["api.acme.test", "app.acme.test"]
       Gori::InterceptFilter.suggestions("host:ap", 7, hosts).should eq(["host:api.acme.test", "host:app.acme.test"])

--- a/spec/interceptor_spec.cr
+++ b/spec/interceptor_spec.cr
@@ -77,8 +77,43 @@ describe Gori::Interceptor do
       result = Channel(Gori::Interceptor::Decision).new
       spawn { result.send(req(ic, "GET / HTTP/1.1\r\n\r\n")) }
       Fiber.yield
-      ic.drop(ic.pending.first.id)
+      ic.drop(ic.pending.first.id).should be_true
       receive_within(result).action.should eq(Gori::Interceptor::Action::Drop)
+    end
+  end
+
+  # The claim `forward` already makes, now made by `drop` too. The involuntary releases run on
+  # PROXY fibers (`H2::StreamGate#fail_open` past the buffer ceiling, `#close`, `#abandon_locked`,
+  # `WS::MessageGate#fail_open_locked`) concurrently with the surface a human or agent drops
+  # from, so "dropped" for a message the gate already put on the wire is the worst version of an
+  # ack that does not describe the act: it says gori BLOCKED those bytes.
+  it "drop reports whether IT settled the item (false when somebody else got there first)" do
+    with_store do |store|
+      ic = Gori::Interceptor.new(Gori::Scope.load(store))
+      ic.toggle
+      result = Channel(Gori::Interceptor::Decision).new
+      spawn { result.send(req(ic, "GET / HTTP/1.1\r\n\r\n")) }
+      Fiber.yield
+      id = ic.pending.first.id
+
+      ic.forward(id).should be_true # a gate fails the hold open first
+      ic.drop(id).should be_false   # …so this drop decided nothing
+      receive_within(result).action.should eq(Gori::Interceptor::Action::Forward)
+      ic.drop(999_i64).should be_false # never-held id, same answer
+    end
+  end
+
+  it "forward_all returns how many it actually released" do
+    with_store do |store|
+      ic = Gori::Interceptor.new(Gori::Scope.load(store))
+      ic.toggle
+      done = Channel(Nil).new
+      2.times { spawn { req(ic, "GET / HTTP/1.1\r\n\r\n"); done.send(nil) } }
+      Fiber.yield
+      ic.pending_count.should eq(2)
+      ic.forward_all.should eq(2)
+      2.times { receive_within(done) }
+      ic.forward_all.should eq(0) # nothing held → nothing claimed
     end
   end
 

--- a/src/gori/intercept_filter.cr
+++ b/src/gori/intercept_filter.cr
@@ -99,7 +99,13 @@ module Gori
     METHOD_VAL = %w(GET POST PUT PATCH DELETE HEAD OPTIONS QUERY)
     SCHEME_VAL = %w(http https)
     STATUS_VAL = %w(2xx 3xx 4xx 5xx >=400 >=500 200 301 302 401 403 404 500 502 503)
-    PROTO_VAL  = %w(ws http grpc sse)
+    # `ws`/`http` ONLY — a strict subset of History's `proto:` pool, for the same reason this
+    # whole field list is one. A hold gate knows the protocol from the leg it is standing on
+    # (`Subject#proto` is `Ws` for a WebSocket message and `Http` for everything else); `grpc`
+    # and `sse` are decided from a captured response's Content-Type, which does not exist yet at
+    # a gate. Offering them completed a term that can never match — i.e. a `proto:grpc`
+    # condition silently holds NOTHING, which reads as intercept being broken.
+    PROTO_VAL = %w(ws http)
 
     # Tab-complete candidates for the token under `cx`: field names until a `:` is
     # typed, then that field's values. The grammar's punctuation is carried through by

--- a/src/gori/interceptor.cr
+++ b/src/gori/interceptor.cr
@@ -505,23 +505,37 @@ module Gori
       true
     end
 
-    def drop(id : Int64) : Nil
+    # True when THIS call is the one that settled the item — the same claim `forward` makes,
+    # and for the same reason. A drop is not a private decision: it tells the operator (and an
+    # agent's ack) that the message never reached its destination. The involuntary releases run
+    # on PROXY fibers (`H2::StreamGate#fail_open` past the buffer ceiling, `#close`,
+    # `#abandon_locked`, `WS::MessageGate#fail_open_locked`) concurrently with the TUI fiber, so
+    # a `forward` landing first leaves this a no-op — and reporting "dropped" for it claims gori
+    # blocked bytes the gate had already put on the wire.
+    def drop(id : Int64) : Bool
       item = @mutex.synchronize { @items.delete(id) }
-      return unless item
+      return false unless item
       @revision.add(1)
       item.reply.send(Decision.new(Action::Drop, Bytes.empty))
+      true
     end
 
     # `overrides` lets the caller supply edited bytes for specific held items (keyed by
     # id) — e.g. an in-progress editor edit that would otherwise be lost when the whole
     # queue is released at once. Items without an override forward their original bytes.
-    def forward_all(overrides : Hash(Int64, Bytes)? = nil) : Nil
+    #
+    # Returns how many were actually released. The caller cannot get that from a preceding
+    # `pending_count`: proxy fibers enqueue holds concurrently, so a message held between the
+    # count and this call goes out under a toast reporting the older number — the same
+    # "the ack must describe the act" rule `forward`'s return value exists for.
+    def forward_all(overrides : Hash(Int64, Bytes)? = nil) : Int32
       items = @mutex.synchronize { vals = @items.values; @items.clear; vals }
       @revision.add(1) unless items.empty?
       items.each do |it|
         bytes = overrides.try(&.[it.id]?) || it.raw
         it.reply.send(Decision.new(Action::Forward, bytes))
       end
+      items.size
     end
 
     # Shutdown: latch so nothing re-enqueues, then auto-forward every held item

--- a/src/gori/store/intercept_bridge.cr
+++ b/src/gori/store/intercept_bridge.cr
@@ -39,6 +39,22 @@ module Gori
       rows
     end
 
+    # {item_id => viewed_ms} for one session's held rows — the auto-forward reaper's whole
+    # question, without the `raw` BLOB.
+    #
+    # The reaper runs on the cross-process cadence (every 750ms) for as long as anything is
+    # held and the human is not on the intercept tab, and it used to ask `intercept_held`, which
+    # SELECTs every column. A held multi-MiB response therefore came off disk, through SQLite
+    # and into a fresh `Bytes` copy per Item, better than once a second — to read one Int64 per
+    # row that the query below reads directly.
+    def intercept_viewed_ms(token : String) : Hash(Int64, Int64)
+      viewed = {} of Int64 => Int64
+      @db.query("SELECT item_id, viewed_ms FROM intercept_held WHERE session_token = ?", token) do |rs|
+        rs.each { viewed[rs.read(Int64)] = rs.read(Int64) }
+      end
+      viewed
+    end
+
     # Stamp `viewed_ms` on held items an MCP intercept_list/get just returned — the agent's
     # liveness signal for the auto-forward reaper. Best-effort (no-op if a row was released).
     def touch_intercept_held(token : String, item_ids : Array(Int64), now_ms : Int64) : Nil

--- a/src/gori/tui/controllers/intercept_controller.cr
+++ b/src/gori/tui/controllers/intercept_controller.cr
@@ -424,7 +424,7 @@ module Gori::Tui
     def intercept_forward : Nil
       ids = @intercept.target_ids
       return if ids.empty?
-      return if refuse_unappliable_edit?
+      return if refuse_unappliable_edit?(ids)
       ic = @host.session.interceptor
       edit = @intercept.pending_edit
       label = batch_label(ids) # built BEFORE the decisions go out — the items are gone after
@@ -448,10 +448,19 @@ module Gori::Tui
       ids = @intercept.target_ids
       return if ids.empty?
       ic = @host.session.interceptor
-      label = batch_label(ids)
-      ids.each { |id| ic.drop(id) }
+      label = batch_label(ids) # built BEFORE the decisions go out — the items are gone after
+      # Count what actually got dropped, exactly as the forward above does. `Interceptor#drop`
+      # is a no-op on an item somebody else already settled — the h2/WS gates fail a hold OPEN
+      # from a proxy fiber when a stream resets or the buffer ceiling is hit — and "dropped GET
+      # /admin" for a request that went to the origin is the worst version of this lie: it says
+      # gori BLOCKED bytes that are already on the wire.
+      dropped = ids.count { |id| ic.drop(id) }
       @intercept.reload(ic)
-      @host.status("dropped #{label}")
+      if dropped == ids.size
+        @host.status("dropped #{label}")
+      else
+        @host.status("dropped #{dropped} of #{ids.size} — the rest were already decided elsewhere")
+      end
     end
 
     # How a forward/drop toast names its targets: the one held message when the verb ran on
@@ -476,22 +485,32 @@ module Gori::Tui
     # the operator can forward it as it is, drop it, or write a different edit. And the WHOLE
     # batch is refused rather than the edited item alone — reporting "forwarded 4 held
     # messages" for a set that went out as 3 is the lie being removed.
-    private def refuse_unappliable_edit? : Bool
+    #
+    # `ids` scopes that to the batch actually going out. The editor holds ONE item's edit and
+    # `pending_edit` is keyed on the item the EDITOR loaded, not on the queue cursor — so an
+    # unappliable edit left behind on a message the operator has since arrowed away from refused
+    # every later forward of every OTHER hold, under a toast naming a message that was not in
+    # the batch. A refusal has to be about something the operator is actually about to send.
+    private def refuse_unappliable_edit?(ids : Array(Int64)) : Bool
       refusal = @intercept.refused_edit
       return false unless refusal
       item, reason = refusal
+      return false unless ids.includes?(item.id)
       @host.status("edit NOT applied to #{item.label} — #{reason}")
       true
     end
 
     def intercept_forward_all : Nil
-      n = @host.session.interceptor.pending_count
-      return if refuse_unappliable_edit?
+      ic = @host.session.interceptor
+      return if refuse_unappliable_edit?(ic.pending.map(&.id))
       # Carry the currently-loaded item's in-progress edit into the bulk forward, so
       # "forward all" doesn't send its stale original bytes (single-forward already does).
       overrides = @intercept.pending_edit.try { |e| {e[0] => e[1]} }
-      @host.session.interceptor.forward_all(overrides)
-      @intercept.reload(@host.session.interceptor)
+      # The count comes BACK from the release rather than from a `pending_count` read before it:
+      # a proxy fiber holding a message in that window has it forwarded too, and this toast is
+      # the operator's only record of how many irreversible decisions just went out.
+      n = ic.forward_all(overrides)
+      @intercept.reload(ic)
       @host.status("forwarded all (#{n})")
     end
 

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -682,7 +682,14 @@ module Gori::Tui
           store.ack_intercept_command(cmd.id, "forwarded", desc)
           push_agent_note(:success, "forwarded #{desc}", item)
         when "drop"
-          ic.drop(item_id)
+          # Same claim `forward` above makes, for the same reason: `drop` is a no-op on an item
+          # somebody else settled first, and the h2/WS gates fail a hold OPEN from a PROXY fiber
+          # (buffer ceiling, RST_STREAM, teardown) concurrently with this one. Acking "dropped"
+          # there tells the agent gori blocked a message that is already on the wire.
+          unless ic.drop(item_id)
+            store.ack_intercept_command(cmd.id, "error", "already decided by another surface: #{desc}")
+            return false
+          end
           store.ack_intercept_command(cmd.id, "dropped", desc)
           push_agent_note(:warn, "dropped #{desc}", item)
         when "forward_edit"
@@ -768,8 +775,11 @@ module Gori::Tui
       ic = @session.interceptor
       pending = ic.pending
       return false if pending.empty?
-      viewed = {} of Int64 => Int64
-      @session.store.intercept_held(@session.intercept_token).each { |r| viewed[r.item_id] = r.viewed_ms }
+      # `intercept_viewed_ms`, NOT `intercept_held`: this runs on the 750ms cross-process cadence
+      # for as long as anything is held, and the full row carries the held `raw` BLOB — a held
+      # multi-MiB response was being read out of SQLite and copied more than once a second to
+      # answer a question that is one Int64 per row.
+      viewed = @session.store.intercept_viewed_ms(@session.intercept_token)
       @intercept_agent_seen = true if viewed.each_value.any? { |v| v > 0 } # an agent polled the queue
       return false unless @intercept_agent_seen                            # no agent ever attached → P4: hold indefinitely
       now_ms = Time.utc.to_unix_ms


### PR DESCRIPTION
`Interceptor#forward` reports whether IT was the call that settled an item, because the
involuntary releases run on PROXY fibers concurrently with the surface a human or an agent
decides from. Its sibling `drop` did not, so the same race resolves the other way in silence.
Four more defects came out of walking the rest of the feature.

### A drop that dropped nothing still said "dropped"

`H2::StreamGate#fail_open` past the buffer ceiling writes the held head **out** — that is what
failing open means — and `#abandon_locked`, `#close` and `WS::MessageGate#fail_open_locked`
settle held items from a pump fiber too. Win that race and `drop` finds nothing to delete and
returns, while both surfaces report success anyway:

- the status bar says `dropped GET /admin`
- the MCP/CLI ack says `"dropped"`

…for a request that is already on the wire. A drop's whole content is "these bytes did NOT
reach their destination", so this is the worst version of an ack that doesn't describe the act.

`drop` returns `Bool` now. The agent drain acks `already decided by another surface` (the
wording `forward` already uses) and the TUI counts what actually went:
`dropped 2 of 3 — the rest were already decided elsewhere`.

### An edit refusal about a message that isn't in the batch

`pending_edit` is keyed on the item the **editor** loaded, not on the queue cursor — deliberate,
it's what lets `forward all` pick up an in-progress edit. `refuse_unappliable_edit?` read it
with no reference to what was being sent, so an unappliable edit left behind on message A (an
h2 head with no HTTP/1.1 text form — the state a CRLF-injection probe *induces*) refused every
later forward of every **other** hold, under a toast naming a message the operator had arrowed
away from. It takes the target ids now.

### `forward all (N)` counted the wrong N

It read `pending_count` first and reported that; a proxy fiber holding a message between the two
calls has it forwarded as well. `forward_all` returns what it released.

### The reaper re-read every held body, twice a second

`reap_stale_holds` wants one Int64 per row (`viewed_ms`) and asked `intercept_held`, which
SELECTs every column including the held `raw` BLOB. It runs on the 750ms cross-process cadence
for as long as anything is held and the human is not on the intercept tab, so a held multi-MiB
response came off disk, through SQLite and into a fresh `Bytes` per Item better than once a
second. `Store#intercept_viewed_ms` reads the two columns the question is about.

### `proto:` completed terms that cannot match

A hold gate knows its protocol from the leg it stands on — `Ws` for a held WebSocket message,
`Http` for everything else — while `grpc`/`sse` are decided from a captured response's
Content-Type, which does not exist yet at a gate. Completing them handed the operator a
condition that silently holds **nothing**, which reads as intercept being broken. `PROTO_VAL`
is `ws http`.

### Verification

- `crystal build --no-codegen src/main.cr` clean
- full suite `8103 examples, 8 failures` — the 8 are the pre-existing `capture_status` /
  `project_registry` ones (a gori already listening on :8070), unchanged by this branch
- ameba on the touched files: 39 before, 39 after — no new findings
- new specs pin the drop settle-claim, `forward_all`'s count, and the `proto:` pool
