### PR TITLE
Multi-select in the project picker, so one delete can take N projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Probe: passive-rule improvements, the OAST SSRF rule classed CWE-918, and a navigable AFFECTED URLS list in a finding
 - Miner: latency-bound scheduling — one work queue for all locations, parallel calibration (~2.4x)
 - JWT: the lens switch (`^T`) now shows on the pane it acts on; new `dancheong` (dark) and `hanji` (light) themes
+- Project picker: multi-select over the project list — `Tab` / `⇧Tab` mark and step, `⇧↑` / `⇧↓` extend a range, `ctrl-a` marks everything the search shows, `esc` clears. The space menu's **Delete** then acts on the marks if any are set, else the cursor row; it names what it is about to wipe, says how much of the set the current search is hiding, and keeps (rather than silently skips) a project another gori still has open
 - `gori ca`: reject a flag written before the verb, repair a CA directory missing one of the key/cert pair, and reject an Ed25519/Ed448 or mismatched-key root with an operator-legible message instead of failing at the first CONNECT
 - Fixes: bracketed-paste freeze and poison in the Repeater; the `--` separator dropping subcommand args across ~60 `gori run` sites; colormarker custom-colour persistence and reorder writes; clipboard OSC 52 over tty; project-settings and host-override reload/rollback audit; OAST partial-poll evidence loss; and many dogfood-surfaced bugs
 

--- a/spec/tui/project_marks_spec.cr
+++ b/spec/tui/project_marks_spec.cr
@@ -1,0 +1,320 @@
+require "../spec_helper"
+
+include Gori::Tui
+
+# Multi-select on the project picker. The picker itself holds a live Termisu and can't be
+# built here, which is exactly why the rule that decides WHICH project directories a
+# confirmed delete wipes lives in ProjectMarks and in ProjectPicker's class methods — the
+# sentence the operator reads before an `rm_rf`, and the set it is about, are pinned here.
+describe Gori::Tui::ProjectMarks do
+  # Three saved projects, as the picker keys them: on the directory slug, which is unique
+  # and survives a rename.
+  dirs = ["/p/alpha", "/p/beta", "/p/gamma"]
+
+  it "toggles a mark on and back off" do
+    m = ProjectMarks.new
+    m.empty?.should be_true
+    m.toggle(dirs[1])
+    m.marked?(dirs[1]).should be_true
+    m.size.should eq(1)
+    m.toggle(dirs[1])
+    m.marked?(dirs[1]).should be_false
+    m.empty?.should be_true
+  end
+
+  it "marks every filtered project, unioning with what is already marked" do
+    m = ProjectMarks.new
+    m.toggle(dirs[2])
+    m.mark_all(["/p/alpha", "/p/beta"]) # a narrowed search
+    m.size.should eq(3)
+    dirs.each { |d| m.marked?(d).should be_true }
+  end
+
+  it "clears everything on esc" do
+    m = ProjectMarks.new
+    m.mark_all(dirs)
+    m.clear
+    m.empty?.should be_true
+  end
+
+  describe "#extend" do
+    it "marks the contiguous range from the anchor and returns the new cursor" do
+      m = ProjectMarks.new
+      m.extend(dirs, 0, 1).should eq(1) # ⇧↓ from the first row
+      m.marked?(dirs[0]).should be_true # the anchor row is in the range
+      m.marked?(dirs[1]).should be_true
+      m.marked?(dirs[2]).should be_false
+    end
+
+    it "hands back what the gesture no longer covers, so ⇧↓⇧↓⇧↑ leaves two rows" do
+      m = ProjectMarks.new
+      cur = m.extend(dirs, 0, 1)
+      cur = m.extend(dirs, cur, 1)
+      m.size.should eq(3)
+      cur = m.extend(dirs, cur, -1)
+      cur.should eq(1)
+      m.size.should eq(2)
+      m.marked?(dirs[2]).should be_false
+    end
+
+    it "leaves a Tab mark alone when a range sweeps over it and back off" do
+      m = ProjectMarks.new
+      m.toggle(dirs[2]) # deliberate mark on the last row
+      # …then walk away from it, or the range below would anchor ON gamma (toggle re-anchors)
+      # and could never retreat past it — the assertion would hold no matter what @extent did.
+      m.end_gesture
+      cur = m.extend(dirs, 0, 1)
+      cur = m.extend(dirs, cur, 1) # range now covers the Tab mark too
+      m.extend(dirs, cur, -1)      # …and retreats off it
+      m.marked?(dirs[2]).should be_true
+      m.size.should eq(3) # gamma (deliberate) + alpha, beta (the range that stayed)
+    end
+
+    it "clamps at both ends instead of wrapping" do
+      m = ProjectMarks.new
+      m.extend(dirs, 0, -1).should eq(0)
+      m.extend(dirs, 2, 1).should eq(2)
+    end
+
+    it "re-anchors at the cursor when the anchor fell out of the filter" do
+      m = ProjectMarks.new
+      m.toggle(dirs[0]) # anchors on alpha
+      visible = ["/p/beta", "/p/gamma"]
+      m.extend(visible, 0, 1) # alpha is gone from the list — anchor at beta
+      m.marked?("/p/beta").should be_true
+      m.marked?("/p/gamma").should be_true
+    end
+  end
+
+  describe "#end_gesture" do
+    it "gives back a range when a plain arrow ends it, and reports how many" do
+      m = ProjectMarks.new
+      m.extend(dirs, 0, 1)
+      m.end_gesture.should eq(2)
+      m.empty?.should be_true
+    end
+
+    it "keeps deliberate Tab marks — only the gesture's own rows go" do
+      m = ProjectMarks.new
+      m.toggle(dirs[0]) # Tab
+      m.extend(dirs, 1, 1)
+      m.size.should eq(3)
+      m.end_gesture.should eq(2)
+      m.marked?(dirs[0]).should be_true
+      m.size.should eq(1)
+    end
+
+    it "re-anchors, so the next ⇧arrow starts from the cursor rather than a stale row" do
+      m = ProjectMarks.new
+      m.extend(dirs, 0, 1) # anchor at alpha
+      m.end_gesture
+      m.extend(dirs, 2, -1) # ⇧↑ from gamma: anchors there, not back at alpha
+      m.marked?(dirs[0]).should be_false
+      m.marked?(dirs[1]).should be_true
+      m.marked?(dirs[2]).should be_true
+    end
+  end
+
+  it "unmarks only what a partial delete actually removed" do
+    m = ProjectMarks.new
+    m.mark_all(dirs)
+    m.unmark(["/p/alpha"]) # beta refused (in use), gamma refused
+    m.marked?("/p/alpha").should be_false
+    m.size.should eq(2)
+  end
+
+  # An UNMARKED row that is still on the list is a perfectly good place for the next ⇧arrow
+  # to measure from — only the anchor's own removal invalidates it. (Tab twice to land the
+  # anchor on a row that carries no mark; a rule keyed on "is the anchor still marked?"
+  # instead of "did the anchor go?" drops it here for no reason.)
+  it "keeps the range anchor when the delete took some other project" do
+    m = ProjectMarks.new
+    m.toggle(dirs[0]) # mark alpha, anchor alpha
+    m.toggle(dirs[0]) # unmark it — the anchor stays on alpha
+    m.unmark(["/p/gamma"])
+    m.extend(dirs, 2, -1) # ⇧↑ from gamma still measures from the alpha anchor: 0..1
+    m.marked?("/p/beta").should be_true
+    # A dropped anchor would have re-seeded at the cursor (gamma) and swept 1..2 instead.
+    m.marked?("/p/gamma").should be_false
+  end
+
+  it "drops marks whose project a peer deleted out from under us" do
+    m = ProjectMarks.new
+    m.mark_all(dirs)
+    m.retain(["/p/alpha", "/p/beta"])
+    m.size.should eq(2)
+    m.marked?("/p/gamma").should be_false
+  end
+
+  describe "marks the filter is hiding" do
+    it "counts them" do
+      m = ProjectMarks.new
+      m.mark_all(dirs)
+      m.hidden_count(["/p/beta"]).should eq(2)
+      m.hidden_count(dirs).should eq(0)
+      ProjectMarks.new.hidden_count(dirs).should eq(0)
+    end
+
+    it "still hands them to a batch verb, visible ones first in display order" do
+      m = ProjectMarks.new
+      m.mark_all(dirs)
+      m.ordered(["/p/gamma", "/p/beta"]).should eq(["/p/gamma", "/p/beta", "/p/alpha"])
+    end
+  end
+end
+
+describe Gori::Tui::ProjectPicker do
+  describe ".space_entries" do
+    it "is byte-identical to the old menu when nothing is marked" do
+      ProjectPicker.space_entries(0).map(&.label).should eq(["Open", "Rename", "Compress", "Delete"])
+    end
+
+    # The AC of a batch menu: a delete opened over 3 marks must say it is about 3, and the
+    # single-target verbs must say they are not.
+    it "says what Delete will take, and marks the others cursor-only" do
+      labels = ProjectPicker.space_entries(3).map(&.label)
+      labels.should eq(["Open (cursor)", "Rename (cursor)", "Compress (cursor)", "Delete 3 projects", "Clear marks"])
+    end
+
+    it "keeps the mnemonics stable, and adds only 'n' for the mark-only entry" do
+      ProjectPicker.space_entries(2).map(&.key).should eq(['o', 'r', 'c', 'd', 'n'])
+      ProjectPicker.space_entries(2).map(&.action).should eq([:open, :rename, :compress, :delete, :mark_clear])
+    end
+
+    it "does not pluralise a single mark" do
+      ProjectPicker.space_entries(1).map(&.label).should contain("Delete 1 project")
+    end
+  end
+
+  describe ".space_menu_box" do
+    # Frame.card ellipsizes a title past `w - 4`. The real menu's labels happen to be wide
+    # enough today, so this drives the rule itself with short ones: the box is sized off the
+    # title too, or a menu that grew a shorter verb would silently truncate the "· 3 MARKED"
+    # count that is the whole reason it looks different.
+    it "is sized to fit the banner even when every label is shorter than it" do
+      short = [ProjectPicker::SpaceEntry.new('d', "Delete", :delete)]
+      title = "SPACE · 12 MARKED"
+      box = ProjectPicker.space_menu_box(120, 40, short, title)
+      (box.w - 4).should be >= Screen.display_width(title)
+    end
+
+    it "fits the marked menu it actually draws" do
+      entries = ProjectPicker.space_entries(3)
+      title = "SPACE · 3 MARKED"
+      box = ProjectPicker.space_menu_box(120, 40, entries, title)
+      (box.w - 4).should be >= Screen.display_width(title)
+      (box.w - 6).should be >= entries.max_of { |e| Screen.display_width(e.label) }
+      box.h.should eq(entries.size + 2)
+    end
+
+    # A narrow terminal must clamp rather than draw a card off the right edge.
+    it "never exceeds the terminal it is drawn on" do
+      entries = ProjectPicker.space_entries(3)
+      ProjectPicker.space_menu_box(30, 20, entries, "SPACE · 3 MARKED").w.should be <= 30
+      ProjectPicker.space_menu_box(20, 12, entries, "SPACE · 3 MARKED").w.should be <= 20
+    end
+  end
+
+  describe ".delete_confirm_body" do
+    it "quotes the one project by name" do
+      body = ProjectPicker.delete_confirm_body(["shop"], 0, 0)
+      body.should eq(%(Delete "shop"?\nThis permanently removes all of its captured data.))
+    end
+
+    it "names a small batch, so 'delete' is never a count with no referent" do
+      body = ProjectPicker.delete_confirm_body(["shop", "api"], 0, 0)
+      body.lines.first.should eq(%(Delete "shop", "api"?))
+      body.should contain("all of their captured data")
+    end
+
+    it "falls back to the count once there are more names than it lists" do
+      ProjectPicker.delete_confirm_body(["a", "b", "c", "d"], 0, 0).lines.first.should eq("Delete 4 projects?")
+    end
+
+    # THE reason the fallback is by width and not by count alone: ConfirmDialog caps its card
+    # at 60 columns and draws each line at `box.w - 6`, so a longer head is ELLIPSIZED — and
+    # a truncated head on THIS dialog means confirming an irreversible wipe having read
+    # `Delete "acme-staging-01", "acme-stagi…`, with a project and the "?" cut off.
+    it "falls back to the count when three names would be ellipsized" do
+      names = ["acme-staging-01", "acme-staging-02", "acme-staging-03"]
+      ProjectPicker.delete_confirm_body(names, 0, 0).lines.first.should eq("Delete 3 projects?")
+      # …and every line it does emit fits the dialog's text column.
+      ProjectPicker.delete_confirm_body(names, 2, 1).each_line do |line|
+        Screen.display_width(line).should be <= ProjectPicker::NAMED_DELETE_WIDTH
+      end
+    end
+
+    # The head names one project whatever it costs — "Delete 1 project?" names nothing, and a
+    # long single name is ellipsized the same way its list row is.
+    it "always names a single project" do
+      ProjectPicker.delete_confirm_body(["a-very-long-project-name-that-will-not-fit-in-the-card"], 0, 0)
+        .lines.first.should start_with(%(Delete "a-very-long))
+    end
+
+    it "keeps the hidden line singular when there is one project" do
+      body = ProjectPicker.delete_confirm_body(["shop"], 1, 0)
+      body.should contain("It is hidden by the current search.")
+      body.should_not contain("them")
+    end
+
+    # The one thing the list itself cannot show: marks survive the fuzzy filter, so a set
+    # assembled across two searches reaches projects that are not on screen.
+    it "spells out the marks the current search is hiding" do
+      body = ProjectPicker.delete_confirm_body(["a", "b", "c", "d"], 2, 0)
+      body.should contain("2 of them are hidden by the current search.")
+      ProjectPicker.delete_confirm_body(["a", "b", "c", "d"], 1, 0).should contain("1 of them is hidden")
+    end
+
+    it "says what it is keeping because it is in use" do
+      ProjectPicker.delete_confirm_body(["a"], 0, 1).should contain("1 more is in use and will be kept.")
+      ProjectPicker.delete_confirm_body(["a"], 0, 2).should contain("2 more are in use and will be kept.")
+    end
+  end
+
+  describe ".delete_result_flash" do
+    # A clean single delete is its own report — the row is gone. The notice row it would
+    # otherwise take belongs to the open error, the only trace that a project failed to open.
+    it "stays silent when one project deleted cleanly" do
+      ProjectPicker.delete_result_flash(1, [] of String, nil).should be_nil
+    end
+
+    it "reports a clean batch" do
+      ProjectPicker.delete_result_flash(3, [] of String, nil).should eq("deleted 3 projects")
+    end
+
+    it "reports a partial delete rather than letting the refusals pass as success" do
+      ProjectPicker.delete_result_flash(2, ["api"], nil).should eq(%(deleted 2 projects — kept "api"))
+      ProjectPicker.delete_result_flash(1, ["api", "shop"], nil).should eq("deleted 1 project — kept 2")
+    end
+
+    it "passes the registry's own refusal through when a single delete is refused" do
+      msg = "project is open in another gori instance — close it there first"
+      ProjectPicker.delete_result_flash(0, ["api"], msg).should eq(msg)
+      ProjectPicker.delete_result_flash(0, ["api"], nil).not_nil!.should contain(%("api"))
+    end
+
+    # A batch's refusals can be a mix of in-use and filesystem failures, so the line names no
+    # cause: "kept 2 in use" sent an operator hunting for a second gori that was never there
+    # when the real reason was an unwritable directory.
+    it "claims no cause it cannot know on a batch line" do
+      ProjectPicker.delete_result_flash(0, ["api", "shop"], "…").should eq("deleted nothing — kept 2")
+      ProjectPicker.delete_result_flash(2, ["api", "shop"], "…").not_nil!.should_not contain("in use")
+    end
+  end
+
+  it "names a blocked delete that never reached the confirm" do
+    ProjectPicker.delete_blocked_flash(["api"]).should contain(%(can't delete "api"))
+    ProjectPicker.delete_blocked_flash(["api", "shop"]).should contain("can't delete 2 projects")
+  end
+
+  describe ".mark_chip" do
+    it "draws nothing at all with an empty mark set" do
+      ProjectPicker.mark_chip(0, 0).should eq("")
+    end
+
+    it "carries the count, and how much of it the search is hiding" do
+      ProjectPicker.mark_chip(3, 0).should eq(" · 3 marked")
+      ProjectPicker.mark_chip(3, 1).should eq(" · 3 marked (1 hidden)")
+    end
+  end
+end

--- a/src/gori/tui/project_marks.cr
+++ b/src/gori/tui/project_marks.cr
@@ -1,0 +1,150 @@
+module Gori::Tui
+  # Multi-select for the ProjectPicker's list — the same mark model History, the Intercept
+  # queue, the Sitemap tree and the Issues list carry (#442), lifted into a state object of
+  # its own because the picker holds a live `Termisu` and so cannot be built in a spec: the
+  # rule that decides which projects a `rm_rf` reaches has to be pinnable without one.
+  #
+  # Keyed on the project DIRECTORY, not the display name. The directory slug is unique and
+  # survives a rename (ProjectRegistry#rename rewrites only the `.name` sidecar), so a mark
+  # placed before a rename still names the same project afterwards.
+  #
+  # A mark is NOT confined to what the fuzzy filter currently shows: narrowing the query
+  # after marking leaves the set intact (that is how you assemble a batch out of two
+  # searches), which is why `hidden_count` exists and why the delete confirm spells the
+  # split out — see ProjectPicker.delete_confirm_body.
+  class ProjectMarks
+    def initialize
+      @marks = Set(String).new
+      # Where a ⇧arrow range is measured from, and the ids that gesture itself added —
+      # kept apart from deliberate Tab marks so ⇧↑ hands back only what ⇧↓ just took.
+      @anchor = nil.as(String?)
+      @extent = Set(String).new
+    end
+
+    def marked?(dir : String) : Bool
+      @marks.includes?(dir)
+    end
+
+    def size : Int32
+      @marks.size
+    end
+
+    # The one emptiness predicate — callers spell the positive as `!marks.empty?`. An `any?`
+    # alias would read better at the call site but reads to a linter as `Enumerable#any?`
+    # (Performance/AnyInsteadOfPresent), and a false positive per call site is a poor trade
+    # for a negation.
+    def empty? : Bool
+      @marks.empty?
+    end
+
+    # Tab / ⇧Tab — flip one project's mark. The caller steps the cursor afterwards (the
+    # picker owns its own row indices); the anchor lands on the row just toggled, so a Tab
+    # followed by ⇧↓ extends from it.
+    def toggle(dir : String) : Nil
+      @marks.includes?(dir) ? @marks.delete(dir) : @marks.add(dir)
+      @anchor = dir
+      @extent.clear
+    end
+
+    # Ctrl-A — mark everything the CURRENT filter shows, unioned with what is already
+    # marked, so narrowing the query twice accumulates rather than replaces.
+    def mark_all(dirs : Enumerable(String), cursor : String? = nil) : Nil
+      dirs.each { |d| @marks.add(d) }
+      @anchor = cursor
+      @extent.clear
+    end
+
+    def clear : Nil
+      @marks.clear
+      reset_anchor
+    end
+
+    # End a ⇧arrow range gesture AND hand back everything it marked — what letting go of ⇧
+    # and pressing a plain arrow does in a GUI list, where the highlight collapses instead
+    # of being left behind. Only the gesture's own dirs go: Tab marks are deliberate tags,
+    # and dropping those too would put a discontiguous set out of reach ("this one, skip
+    # three, that one"). Returns how many marks it gave back.
+    def end_gesture : Int32
+      before = @marks.size
+      @extent.each { |d| @marks.delete(d) }
+      reset_anchor
+      before - @marks.size
+    end
+
+    # ⇧↑/⇧↓ — extend a contiguous range from the anchor, the keyboard form of a GUI
+    # shift+click. `cursor` is an index into `dirs`; the new cursor index is returned. The
+    # anchor is seeded from the cursor when it is unset or has fallen out of the filter, so
+    # the first ⇧arrow always starts from where you are.
+    def extend(dirs : Array(String), cursor : Int32, delta : Int32) : Int32
+      return cursor if dirs.empty?
+      anchor_idx = @anchor.try { |a| dirs.index(a) }
+      unless anchor_idx
+        @anchor = dirs[cursor]?
+        anchor_idx = cursor
+        @extent.clear
+      end
+      moved = (cursor + delta).clamp(0, dirs.size - 1)
+      lo, hi = {anchor_idx, moved}.minmax
+      wanted = Set(String).new
+      (lo..hi).each { |i| dirs[i]?.try { |d| wanted.add(d) } }
+      # Give back what THIS gesture added but the new range no longer covers, so ⇧↑ after
+      # ⇧↓⇧↓ leaves two rows marked rather than three. @extent holds only the gesture's own
+      # dirs, so a Tab mark survives a range sweeping over it and back off.
+      (@extent - wanted).each { |d| @marks.delete(d) }
+      added = wanted - @marks
+      @marks.concat(added)
+      @extent = (@extent & wanted) | added
+      moved
+    end
+
+    # Drop specific marks — the post-delete prune, so a deleted project's dir can't linger
+    # in the set and inflate the next count. Only what actually went: a project the delete
+    # REFUSED stays marked, so the operator can close the other gori and press again.
+    def unmark(dirs : Enumerable(String)) : Nil
+      # Reset the anchor only when the anchor ITSELF went — an unmarked row that is still on
+      # the list is a perfectly good place for the next ⇧arrow to measure from, which is why
+      # HistoryView#unmark_ids keeps its anchor too (it asks `index_of(a).nil?`).
+      anchor_gone = false
+      dirs.each do |d|
+        @marks.delete(d)
+        @extent.delete(d)
+        anchor_gone = true if d == @anchor
+      end
+      reset_anchor if anchor_gone
+    end
+
+    # Keep only marks that still name a live project, called wherever the picker re-lists
+    # the registry. A project a peer deleted out from under us is not a target, and a count
+    # that outlives the directory it points at is the one number here that must not lie.
+    def retain(dirs : Enumerable(String)) : Nil
+      live = dirs.to_set
+      @marks.select! { |d| live.includes?(d) }
+      @extent.select! { |d| live.includes?(d) }
+      reset_anchor if (a = @anchor) && !live.includes?(a)
+    end
+
+    # Marks in DISPLAY order: the ones the filter is showing first, in list order, then the
+    # off-window rest sorted by dir so the order is stable rather than Set-insertion order.
+    def ordered(visible : Array(String)) : Array(String)
+      shown = visible.select { |d| @marks.includes?(d) }
+      hidden = (@marks - shown.to_set).to_a.sort!
+      shown + hidden
+    end
+
+    # Marks whose project the current filter does NOT show. Surfaced next to the count and
+    # again in the delete confirm, so a set larger than the visible list is never a surprise.
+    def hidden_count(visible : Array(String)) : Int32
+      return 0 if @marks.empty?
+      shown = 0
+      visible.each { |d| shown += 1 if @marks.includes?(d) }
+      @marks.size - shown
+    end
+
+    # Forget where a range gesture started (and what it had added), so the next ⇧arrow
+    # anchors at the cursor instead of sweeping back to a stale point.
+    private def reset_anchor : Nil
+      @anchor = nil
+      @extent.clear
+    end
+  end
+end

--- a/src/gori/tui/project_picker.cr
+++ b/src/gori/tui/project_picker.cr
@@ -11,6 +11,7 @@ require "./screen"
 require "./theme"
 require "./frame"
 require "./confirm_dialog"
+require "./project_marks"
 require "./notifications"
 require "./companion"
 require "./settings_view"
@@ -27,6 +28,14 @@ module Gori::Tui
   # same discovery surface as the in-session space menu, scoped to the picker.
   # Use arrows + ↵ , Space, ctrl-n/ctrl-t/ctrl-d etc. Returns chosen Project or nil
   # to quit. Monochrome, keyboard-first (Grok Build feel).
+  #
+  # The list also MARKS (ProjectMarks): Tab / ⇧Tab flip a project's mark and step, ⇧↑/⇧↓
+  # extend a range, ctrl-a marks the whole filter, esc clears. The space menu's Delete then
+  # acts on the marks if any are set, else the cursor row — the one target rule History and
+  # the Issues list use. The chords deviate from the app-wide `t` / ⇧T ON PURPOSE and cannot
+  # be "fixed" back: on this screen every printable key types into the search box (see
+  # handle_list), so `t` would filter rather than mark. Tab is fzf's toggle in exactly this
+  # shape of list, and ctrl-a is the same select-all everything else spells ⇧T.
   class ProjectPicker
     # Throttle flock + status-file probes so the 50 ms poll loop doesn't hammer
     # the filesystem on every visible project row every frame.
@@ -52,6 +61,40 @@ module Gori::Tui
       SpaceEntry.new('d', "Delete", :delete),
     ]
 
+    # The menu while marks are set. Delete is the batch verb and says so; the other three
+    # are named SINGLE-target explicitly, the way the Runner tags its HISTORY_CURSOR_ONLY
+    # verbs, so a menu opened over 3 marks can't read as an offer to do all three:
+    #   • Open returns ONE project (that is the picker's whole return value).
+    #   • Rename edits one display name.
+    #   • Compress measures and VACUUMs synchronously on this event loop, with a per-project
+    #     byte estimate in its popup — N of those is N multi-second freezes and an estimate
+    #     that would be a fiction for every individual project.
+    # Clear marks mirrors the in-app `*.mark-clear` entry, mnemonic and all.
+    #
+    # Class-level and pure so the labels a destructive menu shows can be pinned in a spec:
+    # the picker holds a live Termisu and cannot be built in one.
+    def self.space_entries(marked : Int32) : Array(SpaceEntry)
+      return SPACE_ENTRIES if marked <= 0
+      [
+        SpaceEntry.new('o', "Open (cursor)", :open),
+        SpaceEntry.new('r', "Rename (cursor)", :rename),
+        SpaceEntry.new('c', "Compress (cursor)", :compress),
+        SpaceEntry.new('d', "Delete #{plural_projects(marked)}", :delete),
+        SpaceEntry.new('n', "Clear marks", :mark_clear),
+      ]
+    end
+
+    def self.plural_projects(n : Int32) : String
+      "#{n} project#{n == 1 ? "" : "s"}"
+    end
+
+    # The mark count appended to the list divider, or "" with nothing marked (so an unmarked
+    # picker's divider stays byte-identical to what it always drew).
+    def self.mark_chip(marked : Int32, hidden : Int32) : String
+      return "" if marked <= 0
+      hidden > 0 ? " · #{marked} marked (#{hidden} hidden)" : " · #{marked} marked"
+    end
+
     # `notice` is why the caller is showing the picker rather than a project — a session
     # that failed to open (a bad `--db`, an unreadable store). It rides the same h-3 row as
     # the update notice but in red, because without it a failed open is indistinguishable
@@ -65,7 +108,7 @@ module Gori::Tui
       @query = "" # current search filter; only editable when Search row selected
       @selected = 0
       @results_scroll = 0
-      @mode = :list # :list | :new | :confirm | :space | :rename | :settings | :theme | :compress | :measuring | :compressing
+      @mode = :list # :list | :new | :confirm | :space | :rename | :settings | :theme | :compress | + BUSY_LABELS
       @name = ""
       @desc = ""
       @new_field = :name # :name | :desc (only in :new mode)
@@ -73,7 +116,12 @@ module Gori::Tui
       @preedit = ""      # live IME composing text for the active field (search/name/desc)
       # Delete confirmation (project deletion is irreversible — wipes its dir).
       @confirm = nil.as(ConfirmDialog?)
-      @pending_delete = nil.as(Project?)
+      # The projects a confirmed delete will wipe — a LIST because the space menu's Delete
+      # acts on the mark set (see target_projects). Captured when the confirm opens, so a
+      # cursor move or a peer's write between the question and the answer can't retarget it.
+      @pending_deletes = [] of Project
+      # Multi-select over the project rows; every batch verb reads it through target_projects.
+      @marks = ProjectMarks.new
       # Space menu over a project row (open/rename/compress/delete).
       @space_selected = 0
       @space_project = nil.as(Project?)
@@ -320,7 +368,14 @@ module Gori::Tui
     # --- input ---------------------------------------------------------------
 
     private def entry_count : Int32
-      3 + filtered_projects.size # New, Temp, Search, then (filtered) projects
+      entry_count_for(filtered_projects) # New, Temp, Search, then (filtered) projects
+    end
+
+    # `entry_count` off a list already in hand. `filtered_projects` re-runs the whole fuzzy
+    # scoring on every call, so the mark gestures — which need both the list and its bound —
+    # would otherwise score the registry twice per keystroke.
+    private def entry_count_for(fp : Array(Project)) : Int32
+      3 + fp.size
     end
 
     # Saved projects filtered by @query using Gori::Fuzzy.
@@ -347,13 +402,19 @@ module Gori::Tui
       # Space on a project row opens the action menu (open/rename/delete); on the
       # Search row it types a literal space into the query.
       if key.up?
-        @selected = (@selected - 1).clamp(0, entry_count - 1)
+        ev.shift? ? mark_extend(-1) : move_selection(-1)
       elsif key.down?
-        @selected = (@selected + 1).clamp(0, entry_count - 1)
+        ev.shift? ? mark_extend(1) : move_selection(1)
+      elsif (key.tab? || key.back_tab?) && !ev.ctrl? && !ev.alt?
+        # BEFORE the printable arm below: Tab reaches it as '\t' (Event::Key#char falls back
+        # to key.to_char), which would type a tab into the search query instead of marking.
+        # Modifier-guarded like every other arm here: ^I is byte-identical to Tab (0x09, so
+        # termisu hands back Key::Tab), and ^I is not a request to mark anything.
+        mark_toggle(key.tab? ? 1 : -1)
       elsif key.enter?
         return activate
       elsif key.space? && !ev.ctrl? && !ev.alt?
-        if @selected >= 3
+        if space_opens_menu?
           open_space_menu
         elsif @selected == 2
           @query += " "
@@ -366,7 +427,12 @@ module Gori::Tui
           @results_scroll = 0
         end
       elsif key.escape?
-        if @query.empty?
+        # Marks first — esc is the reflex for dropping a selection everywhere else in gori,
+        # and a set that outlived the esc meant to clear it would go on aiming the next
+        # delete. Only then does esc mean "clear the query", and only then "quit".
+        if !@marks.empty?
+          @marks.clear
+        elsif @query.empty?
           return :quit
         else
           @query = ""
@@ -391,6 +457,8 @@ module Gori::Tui
         return open_temp
       elsif ev.ctrl? && key.lower_d?
         request_delete
+      elsif ev.ctrl? && key.lower_a?
+        mark_all
       elsif ev.ctrl? && key.comma?
         @preferences.open_default
         @mode = :settings
@@ -499,17 +567,18 @@ module Gori::Tui
     # Project-row space menu: ↑/↓ move, mnemonic key or ↵ run, esc dismiss.
     private def handle_space(ev : Termisu::Event::Key) : Project | Symbol | Nil
       key = ev.key
+      entries = space_entries
       @preedit = ""
       if key.escape? || ev.ctrl_c?
         close_space_menu
       elsif key.up?
-        @space_selected = (@space_selected - 1).clamp(0, SPACE_ENTRIES.size - 1)
+        @space_selected = (@space_selected - 1).clamp(0, entries.size - 1)
       elsif key.down?
-        @space_selected = (@space_selected + 1).clamp(0, SPACE_ENTRIES.size - 1)
+        @space_selected = (@space_selected + 1).clamp(0, entries.size - 1)
       elsif key.enter?
-        return activate_space_entry(SPACE_ENTRIES[@space_selected])
+        return activate_space_entry(entries[@space_selected])
       elsif (c = ev.char || key.to_char) && !ev.ctrl? && !ev.alt?
-        if entry = SPACE_ENTRIES.find { |e| e.key == c.downcase }
+        if entry = entries.find { |e| e.key == c.downcase }
           return activate_space_entry(entry)
         end
       end
@@ -576,65 +645,229 @@ module Gori::Tui
       nil
     end
 
-    # Open the delete-confirmation modal for the selected project (project
-    # deletion wipes its directory — irreversible, so it's always confirmed).
-    # When `project` is passed (space menu), use that; otherwise the list selection.
-    private def request_delete(project : Project? = nil) : Nil
-      target = project
-      if target.nil?
-        return if @selected < 3
-        target = filtered_projects[@selected - 3]?
+    # Open the delete-confirmation modal for the target set — the marks if any are set, else
+    # the cursor project (project deletion wipes the directory, so it's always confirmed).
+    # The ONE entry point: ctrl-d, the footer button and the space menu all land here, so
+    # there is no path on which "delete" means something other than target_projects.
+    private def request_delete : Nil
+      targets = target_projects
+      return if targets.empty?
+      # Split off what can't be deleted BEFORE asking, so the dialog only ever offers a
+      # delete that can actually happen. Two ways to be in use: another live instance
+      # capturing into it, and a peer (an MCP server takes no capture lock) merely holding
+      # the database open. `registry.delete` refuses both as the TOCTOU backstop.
+      blocked = [] of Project
+      deletable = targets.reject do |p|
+        in_use = probe_running(p)[0] || OpenLock.in_use?(p.db_path)
+        blocked << p if in_use
+        in_use
       end
-      return unless target
-      # Don't offer to delete a project another live instance is capturing into —
-      # the green "● on" dot already flags it; deleting would silently orphan its
-      # capture. (registry.delete also refuses, as a TOCTOU backstop below.)
-      return if probe_running(target)[0]
-      # And a project some other gori merely has OPEN — an MCP server takes no capture lock, so
-      # the dot above says nothing about it. Without this the confirm dialog offered a delete
-      # `registry.delete` was always going to refuse, which reads as the delete being broken.
-      if OpenLock.in_use?(target.db_path)
-        set_flash(%(can't delete "#{target.name}" — it's open in another gori instance), ok: false)
+      if deletable.empty?
+        # Said out loud even for the capture-lock case the green "● on" dot already flags:
+        # a ctrl-d that does nothing at all reads as delete being broken rather than refused
+        # — the same reasoning the post-confirm refusal below is written for.
+        set_flash(ProjectPicker.delete_blocked_flash(blocked.map(&.name)), ok: false)
         return
       end
-      @confirm = ConfirmDialog.new("DELETE PROJECT",
-        %(Delete "#{target.name}"?\nThis permanently removes all of its captured data.),
+      # Hoisted: `filtered_projects` re-runs the fuzzy scoring on every call.
+      shown = filtered_projects.map(&.dir).to_set
+      hidden = deletable.count { |p| !shown.includes?(p.dir) }
+      dialog = ConfirmDialog.new(deletable.size == 1 ? "DELETE PROJECT" : "DELETE PROJECTS",
+        ProjectPicker.delete_confirm_body(deletable.map(&.name), hidden, blocked.size),
         confirm_label: "delete", cancel_label: "cancel", danger: true)
-      @pending_delete = target
+      # ConfirmDialog DECLINES to draw on a terminal too small for its card (render and
+      # overlay_box share the guard, the latter answering with a 0×0 rect). Its mouse path
+      # already takes that as "not showing"; the key path never did, so on a short window
+      # ctrl-d used to arm an invisible dialog that `y` then committed — an unattended,
+      # unreadable rm_rf. Refuse to arm it at all instead: a delete you cannot read is a
+      # delete you cannot have confirmed.
+      w, h = @backend.size
+      if dialog.overlay_box(Rect.new(0, 0, w, h)).w == 0
+        set_flash("window too small to confirm a delete — make it taller", ok: false)
+        return
+      end
+      @confirm = dialog
+      @pending_deletes = deletable
       @confirm_kind = :delete
       @mode = :confirm
     end
 
+    # How many projects the confirm names outright before falling back to the count.
+    NAMED_DELETE_MAX = 3
+
+    # …and how wide those names may run. ConfirmDialog caps its card at 60 columns and draws
+    # each line with `width: box.w - 6`, so anything past this is ELLIPSIZED — which on this
+    # dialog means the operator confirms an irreversible wipe having read `Delete "acme-01",
+    # "acme-02", "acme-…`, with a project name and the question mark cut off. A count is a
+    # worse sentence than three names but an honest one, so the width decides, not the count
+    # alone. (Kept in step with ConfirmDialog#overlay_box / #render by the spec below.)
+    NAMED_DELETE_WIDTH = 54
+
+    # The last sentence read before N project directories are wiped, so it has to name the
+    # whole set — including the marks the current filter is hiding, which is the one thing
+    # the list itself cannot show.
+    # Pure + class-level so a spec can pin it without a Termisu.
+    def self.delete_confirm_body(names : Array(String), hidden : Int32, blocked : Int32) : String
+      one = names.size == 1
+      head = "Delete #{plural_projects(names.size)}?"
+      if names.size <= NAMED_DELETE_MAX
+        named = %(Delete #{names.map { |n| %("#{n}") }.join(", ")}?)
+        # A single project is named whatever it costs: "Delete 1 project?" names nothing at
+        # all, and ConfirmDialog ellipsizes a long name the same way the list row does.
+        head = named if one || Screen.display_width(named) <= NAMED_DELETE_WIDTH
+      end
+      String.build do |io|
+        io << head
+        io << '\n' << "This permanently removes all of " << (one ? "its" : "their") << " captured data."
+        if hidden > 0
+          io << '\n'
+          # "them" needs a plural to refer to; with one target the sentence is about it.
+          one ? (io << "It is hidden by the current search.") : (io << hidden << " of them " << (hidden == 1 ? "is" : "are") << " hidden by the current search.")
+        end
+        io << '\n' << blocked << " more " << (blocked == 1 ? "is" : "are") << " in use and will be kept." if blocked > 0
+      end
+    end
+
+    # Why a delete never got as far as the confirm: every target is in use.
+    def self.delete_blocked_flash(names : Array(String)) : String
+      return "nothing to delete" if names.empty?
+      return %(can't delete "#{names.first}" — it's open in another gori instance) if names.size == 1
+      "can't delete #{plural_projects(names.size)} — they're open in another gori instance"
+    end
+
     private def commit_delete : Nil
-      if project = @pending_delete
-        begin
-          @registry.delete(project) # refuses if a live instance took the lock since request_delete
-          @projects = @registry.list
-          invalidate_running_cache
-          @selected = 2
+      targets = @pending_deletes
+      unless targets.empty?
+        deleted = [] of String # dirs — only these are unmarked (a refusal stays marked to retry)
+        refused = [] of String
+        first_error = nil.as(String?)
+        # N synchronous rm_rf calls, each potentially over a multi-GB project directory, on
+        # the same event loop that draws. Paint the busy card first for the same reason the
+        # compress path does (see commit_compress) — otherwise the picker freezes on the
+        # stale confirm frame and reads as hung rather than as working.
+        @mode = :deleting
+        render
+        targets.each do |project|
+          @registry.delete(project) # refuses if it went live since request_delete
+          deleted << project.dir
         rescue ex : Gori::Error
           # Became live (capturing, or opened by a peer) between the confirm and here. The
           # message names WHICH, and it has to reach the screen: swallowed, the dialog just
           # closed with the project still listed and nothing said, so the operator saw delete
           # as broken rather than as refused.
-          set_flash(ex.message || %(can't delete "#{project.name}" — it is in use), ok: false)
-        rescue IO::Error
+          refused << project.name
+          first_error ||= ex.message
+        rescue ex : IO::Error
           # rm_rf hit a real filesystem failure (permission, locked file) — keep the TUI
-          # alive; refresh the list since the directory may be partially removed.
-          @projects = @registry.list
-          invalidate_running_cache
+          # alive; the directory may be partially removed, so the reload below re-reads it.
+          # Its message is captured too: reported as the generic refusal it is NOT, this
+          # reads as "close the other gori" and sends the operator after an instance that
+          # was never there.
+          refused << project.name
+          first_error ||= %(can't delete "#{project.name}" — #{ex.message})
+        end
+        @marks.unmark(deleted)
+        reload_projects
+        @selected = 2 unless deleted.empty?
+        if msg = ProjectPicker.delete_result_flash(deleted.size, refused, first_error)
+          set_flash(msg, ok: refused.empty?)
         end
       end
       cancel_confirm
+    end
+
+    # What a committed delete says afterwards. A clean single delete stays silent (the row
+    # is gone from the list — that IS the report, and the notice row belongs to the open
+    # error); anything partial or refused has to say so.
+    def self.delete_result_flash(deleted : Int32, refused : Array(String), first_error : String?) : String?
+      return nil if refused.empty? && deleted <= 1
+      if refused.empty?
+        return "deleted #{plural_projects(deleted)}"
+      end
+      if deleted == 0 && refused.size == 1
+        return first_error || %(can't delete "#{refused.first}")
+      end
+      # No cause named on the batch line: the refusals can be a mix of in-use and filesystem
+      # failures, and one sentence cannot claim both. The single-target line above says which,
+      # because there it can (it carries the raising error's own message).
+      kept = refused.size == 1 ? %("#{refused.first}") : refused.size.to_s
+      deleted == 0 ? "deleted nothing — kept #{kept}" : "deleted #{plural_projects(deleted)} — kept #{kept}"
     end
 
     private def cancel_confirm : Nil
       @mode = :list
       @confirm = nil
       @confirm_kind = :delete
-      @pending_delete = nil
+      @pending_deletes = [] of Project
       @pending_compact = nil
       @compact_project = nil
+    end
+
+    # --- marks (multi-select) -------------------------------------------------
+
+    # A plain arrow ends a ⇧arrow range gesture and hands its marks back, the way a GUI list
+    # collapses its highlight when you let go of ⇧. Nothing is said about it: the picker's
+    # one message row belongs to the open error (the only trace that a project failed to
+    # open) and to the compaction flash, and the divider chip already carries a live count.
+    private def move_selection(delta : Int32) : Nil
+      @marks.end_gesture
+      @selected = (@selected + delta).clamp(0, entry_count - 1)
+    end
+
+    # Tab / ⇧Tab — flip the cursor project's mark, then step, so a run of Tab marks
+    # consecutive rows. From an action row it acts on the TOP VISIBLE match instead of doing
+    # nothing: "type a filter, Tab Tab Tab" is the gesture this list is shaped for, and
+    # after a keystroke of typing the cursor is parked on the Search row by definition.
+    #
+    # @results_scroll, not 0: it is the top drawn row by construction (see render_list), so
+    # the mark lands on the row the operator is looking at. The two agree today — a render
+    # runs between every keystroke, and `ensure_results_visible` zeroes the scroll while the
+    # cursor sits on an action row — but that is an ordering argument, not an invariant this
+    # method establishes, and it is one refactor away from marking an off-screen project.
+    private def mark_toggle(step : Int32) : Nil
+      fp = filtered_projects
+      return if fp.empty?
+      idx = @selected < 3 ? @results_scroll : @selected - 3
+      return unless proj = fp[idx]?
+      @marks.toggle(proj.dir)
+      @selected = (idx + step + 3).clamp(3, entry_count_for(fp) - 1)
+    end
+
+    # ⇧↑/⇧↓ — extend a contiguous range from the anchor. Until the cursor is on a project
+    # row there is nothing to anchor on, so it just moves, exactly like the plain arrow.
+    private def mark_extend(delta : Int32) : Nil
+      fp = filtered_projects
+      if @selected < 3 || fp.empty?
+        @selected = (@selected + delta).clamp(0, entry_count_for(fp) - 1)
+        return
+      end
+      @selected = @marks.extend(fp.map(&.dir), @selected - 3, delta) + 3
+    end
+
+    # ctrl-a — mark everything the current filter shows (the list's ⇧T, respelled: see the
+    # class comment for why the app-wide letter chords can't reach this screen).
+    private def mark_all : Nil
+      fp = filtered_projects
+      return if fp.empty?
+      @marks.mark_all(fp.map(&.dir), selected_project.try(&.dir))
+    end
+
+    # The set every batch verb acts on: the marks if any are set, else the cursor row. One
+    # rule, so no verb here needs a notion of "batch mode" — the same shape as
+    # HistoryView#target_ids. Marks outlive the fuzzy filter, so this deliberately reaches
+    # projects the list is not currently showing; what that means for a delete is spelled
+    # out in the confirm (see delete_confirm_body).
+    private def target_projects : Array(Project)
+      return [selected_project].compact if @marks.empty?
+      by_dir = @projects.to_h { |p| {p.dir, p} }
+      @marks.ordered(filtered_projects.map(&.dir)).compact_map { |dir| by_dir[dir]? }
+    end
+
+    # Re-read the registry after a mutation, dropping marks whose project is gone with it.
+    private def reload_projects : Nil
+      @projects = @registry.list
+      @marks.retain(@projects.map(&.dir))
+      invalidate_running_cache
     end
 
     # --- space menu (project row actions) ------------------------------------
@@ -642,6 +875,24 @@ module Gori::Tui
     private def selected_project : Project?
       return nil if @selected < 3
       filtered_projects[@selected - 3]?
+    end
+
+    private def space_entries : Array(SpaceEntry)
+      ProjectPicker.space_entries(@marks.size)
+    end
+
+    # Where `space` opens the action menu: a project row, marks or no marks. It was briefly
+    # allowed from New/Temp while marks were set, and that was wrong twice over — three of the
+    # five entries (Open/Rename/Compress) are cursor-only, so they closed the menu in silence
+    # with no cursor project to act on, and the footer had to grow "space actions" on the row
+    # that already carries ctrl-n/ctrl-t, pushing `ctrl-c quit` off an 80-column terminal.
+    # Marks still reach a delete from anywhere via ctrl-d, which needs no cursor row.
+    #
+    # THE single source of the rule: the key ladder and the footer hint (whose "space actions"
+    # token is clickable) both read it, so the row can never offer a button the chord doesn't
+    # honour. The Search row is excluded by the same rule — it is a text field, so space types.
+    private def space_opens_menu? : Bool
+      @selected >= 3
     end
 
     private def open_space_menu : Nil
@@ -657,9 +908,21 @@ module Gori::Tui
       @space_selected = 0
     end
 
+    # Delete reads target_projects (marks, else the cursor) rather than the row the menu was
+    # opened on, so it is the SAME resolver ctrl-d and the footer button go through. The
+    # other three are single-target by design and stay on the cursor project — the menu says
+    # so while marks are set (see ProjectPicker.space_entries).
     private def activate_space_entry(entry : SpaceEntry) : Project | Symbol | Nil
       project = @space_project || selected_project
       close_space_menu
+      case entry.action
+      when :delete
+        request_delete
+        return nil
+      when :mark_clear
+        @marks.clear
+        return nil
+      end
       return nil unless project
       case entry.action
       when :open
@@ -669,9 +932,6 @@ module Gori::Tui
         nil
       when :compress
         start_compress(project)
-        nil
-      when :delete
-        request_delete(project)
         nil
       end
     end
@@ -689,8 +949,7 @@ module Gori::Tui
       if project && !name.empty?
         begin
           renamed = @registry.rename(project, name)
-          @projects = @registry.list
-          invalidate_running_cache
+          reload_projects # the dir slug is untouched by a rename, so any mark on it survives
           # Keep the cursor on the renamed project when it still matches the filter;
           # otherwise clamp so we don't land past the end of a shrunken list.
           if idx = filtered_projects.index { |p| p.dir == renamed.dir }
@@ -810,8 +1069,7 @@ module Gori::Tui
         rescue ex : Gori::Error | IO::Error | DB::Error | SQLite3::Exception
           set_flash("compress failed: #{ex.message}", ok: false)
         end
-        @projects = @registry.list
-        invalidate_running_cache
+        reload_projects
       end
       cancel_confirm # resets mode → :list and clears the confirm/compress state
     end
@@ -897,9 +1155,11 @@ module Gori::Tui
       when :theme        then handle_theme_mouse(w, h, mx, my)
       when :space        then handle_space_mouse(w, h, mx, my)
       when :compress     then handle_compress_mouse(w, h, mx, my)
-      when :compressing  then nil # blocking VACUUM in progress — ignore clicks
       when :new, :rename then nil # text form — keyboard only (cursor placement is Phase 2)
-      else                    handle_list_mouse(mx, my)
+      else
+        # A blocking step (VACUUM, measure, the batch rm_rf) owns the loop — ignore clicks
+        # rather than let one land on the list drawn under the busy card.
+        BUSY_LABELS.has_key?(@mode) ? nil : handle_list_mouse(mx, my)
       end
     end
 
@@ -933,6 +1193,10 @@ module Gori::Tui
       if idx == @selected
         activate
       else
+        # Like a plain arrow, moving the cursor by click ends a ⇧arrow range and hands its
+        # marks back; deliberate Tab marks stay. (So does the wheel — on this screen it moves
+        # the selection rather than scrolling under it. See picker_wheel.)
+        @marks.end_gesture
         @selected = idx
         @results_scroll = 0 if idx < 3 # focusing an action row shows the list from the top
         nil
@@ -941,12 +1205,18 @@ module Gori::Tui
 
     private def picker_wheel(delta : Int32) : Nil
       case @mode
-      when :settings                             then @preferences.wheel(delta)
-      when :theme                                then (@theme_card.move_field(delta); preview_theme)
-      when :space                                then @space_selected = (@space_selected + delta.sign).clamp(0, SPACE_ENTRIES.size - 1)
-      when :compress                             then @compact.try(&.move(delta.sign))
-      when :new, :confirm, :rename, :compressing then nil # nothing to scroll
-      else                                            @selected = (@selected + delta).clamp(0, entry_count - 1)
+      when :settings               then @preferences.wheel(delta)
+      when :theme                  then (@theme_card.move_field(delta); preview_theme)
+      when :space                  then @space_selected = (@space_selected + delta.sign).clamp(0, space_entries.size - 1)
+      when :compress               then @compact.try(&.move(delta.sign))
+      when :new, :confirm, :rename then nil # nothing to scroll
+      when .in?(BUSY_LABELS.keys)  then nil # a blocking step owns the loop
+      else
+        # The picker's wheel moves the SELECTION (it has no independent scroll of its own),
+        # so it is an arrow by another name and ends a ⇧arrow range exactly as one does.
+        # Without this the anchor outlived a scroll: wheel down five rows, press ⇧↓ once,
+        # and the range snapped back to the stale anchor — marking six projects on one key.
+        move_selection(delta)
       end
     end
 
@@ -981,11 +1251,12 @@ module Gori::Tui
     end
 
     private def handle_space_mouse(w : Int32, h : Int32, mx : Int32, my : Int32) : Project | Symbol | Nil
+      entries = space_entries
       box = space_menu_box(w, h)
       return close_space_menu unless box.contains?(mx, my) # click away → dismiss
       if idx = space_row_at(box, mx, my)
         if idx == @space_selected
-          return activate_space_entry(SPACE_ENTRIES[idx])
+          return activate_space_entry(entries[idx])
         else
           @space_selected = idx
         end
@@ -1153,7 +1424,7 @@ module Gori::Tui
         @theme_card.render(screen, Rect.new(0, 0, w, h)) if @mode == :theme
         render_space_menu(screen, w, h) if @mode == :space
         @compact.try(&.render(screen, Rect.new(0, 0, w, h))) if @mode == :compress
-        render_compressing(screen, w, h) if @mode == :compressing || @mode == :measuring
+        render_busy(screen, w, h) if BUSY_LABELS.has_key?(@mode)
       end
       # Sync the terminal hardware cursor to the focused caret so the terminal's
       # own IME composition UI (jamo/candidate popup) anchors at the right cell —
@@ -1233,7 +1504,14 @@ module Gori::Tui
       div_y = box.y + 1 + actions
       Frame.tee_divider(screen, box, div_y, bg: Theme.panel)
       count = @query.empty? ? "Projects (#{fp.size})" : "Matches (#{fp.size})"
-      screen.text(box.x + 2, div_y, " #{count} ", Theme.muted, Theme.panel)
+      # The live mark count rides the divider the way the in-app mark chip rides the filter
+      # row — including how much of the set the current search is hiding, since a mark
+      # outlives the query that scrolled it off screen and still aims the next delete.
+      # Guarded rather than relying on hidden_count's own empty fast path: the argument is
+      # built BEFORE the call, so an unmarked picker — the overwhelmingly common state —
+      # would allocate a full dir array 20 times a second for a chip that renders as "".
+      count += ProjectPicker.mark_chip(@marks.size, @marks.hidden_count(fp.map(&.dir))) unless @marks.empty?
+      screen.text(box.x + 2, div_y, " #{count} ", Theme.muted, Theme.panel, width: {cw - 4, 1}.max)
       list_top = div_y + 1
 
       ensure_results_visible(res_rows)
@@ -1247,13 +1525,18 @@ module Gori::Tui
           proj = fp[ri]
           py = list_top + vi
           is_selected = (ri + 3 == @selected)
-          bg = is_selected ? Theme.accent_bg : Theme.panel
-          screen.fill(Rect.new(box.x + 1, py, cw - 2, 1), bg) if is_selected
-          screen.cell(box.x + 1, py, is_selected ? '▎' : ' ', Theme.accent, bg)
+          # A marked row reads as a dim band with a FULLER gutter bar, so it stays legible
+          # as marked next to the cursor row (accent band + ▎) and on the cursor row that is
+          # ALSO marked (accent band + ▌) — the same two glyphs every marking list in gori
+          # uses. Both are single-width, so the row never shifts.
+          marked = @marks.marked?(proj.dir)
+          bg = is_selected ? Theme.accent_bg : (marked ? Theme.selection_dim : Theme.panel)
+          screen.fill(Rect.new(box.x + 1, py, cw - 2, 1), bg) if is_selected || marked
+          screen.cell(box.x + 1, py, marked ? '▌' : (is_selected ? '▎' : ' '), Theme.accent, bg)
           meta, meta_fg = project_meta(proj)
           mdw = Screen.display_width(meta)
           name_w = cw - 3 - (mdw + 2)
-          screen.text(box.x + 3, py, proj.name, is_selected ? Theme.text_bright : Theme.text, bg, width: [name_w, 1].max)
+          screen.text(box.x + 3, py, proj.name, is_selected || marked ? Theme.text_bright : Theme.text, bg, width: [name_w, 1].max)
           meta_x = box.right - mdw - 2
           screen.text(meta_x, py, meta, meta_fg, bg) unless meta.empty?
         end
@@ -1268,10 +1551,15 @@ module Gori::Tui
         hint = case
                when @mode == :compress
                  "↑/↓ select   ‹/› keep   space toggle   ↵ compress   esc close"
-               when @mode == :compressing
-                 "compressing …"
-               else # :space
-                 "↑/↓ select   ↵ run   o open   r rename   c compress   d delete   esc close"
+               when label = BUSY_LABELS[@mode]?
+                 # Every blocking mode, off the one table — :measuring used to fall through
+                 # to the :space arm below and label its busy card with the action menu's
+                 # mnemonics, and :deleting would have joined it.
+                 label.strip.downcase
+               else # :space — mnemonics read off the live menu, so a mark-only entry
+                 # (Clear marks) can't be missing from the row that lists them.
+                 keys = space_entries.map { |e| "#{e.key} #{e.label.split(' ').first.downcase}" }.join("   ")
+                 "↑/↓ select   ↵ run   #{keys}   esc close"
                end
         centered(screen, h - 2, hint, Theme.muted, w)
       end
@@ -1353,8 +1641,20 @@ module Gori::Tui
       # A project row is selected → `space` opens its action menu; on the New/Temp/Search
       # rows that chord does something else entirely, so the token (and its button) is
       # offered only where it applies, exactly as the flat hint used to switch.
-      tokens << HintToken.new("space actions", :space) if @selected >= 3
-      tokens << HintToken.new("type to search")
+      tokens << HintToken.new("space actions", :space) if space_opens_menu?
+      # On a project row the mark gesture TAKES the search hint's place rather than joining
+      # it (and takes esc's new first meaning with it once marks are live). This row is the
+      # widest thing the picker draws and it trims from the right, so a token added without
+      # one given back pushes `ctrl-c quit` off the end — and on the action rows, where the
+      # row is at its longest (ctrl-n/ctrl-t ride there), the search hint is the one that
+      # applies and marking is not offered at all. Both are inert, like every token that
+      # describes a gesture rather than a button.
+      if @selected >= 3
+        tokens << HintToken.new("tab mark")
+        tokens << HintToken.new("esc clear") unless @marks.empty?
+      else
+        tokens << HintToken.new("type to search")
+      end
       if @selected < 3
         tokens << HintToken.new("ctrl-n new", :new)
         tokens << HintToken.new("ctrl-t temp", :temp)
@@ -1428,9 +1728,22 @@ module Gori::Tui
     # Bottom-right space menu over the project list — open / rename / delete.
     # Mirrors the in-session SpaceMenu chrome (card + mnemonic + ▎ selection).
     private def space_menu_box(w : Int32, h : Int32) : Rect
-      label_w = SPACE_ENTRIES.max_of(&.label.size)
-      mw = {label_w + 6, 16}.max # border + ▎ + key + gap + label + border
-      mh = SPACE_ENTRIES.size + 2
+      ProjectPicker.space_menu_box(w, h, space_entries, space_menu_title)
+    end
+
+    # "SPACE · 3 MARKED" while a mark set is live — the picker's form of the Runner's space
+    # menu banner, so opening the menu over marks announces up front that Delete below is
+    # plural. Sized for BOTH the widest label and this title: Frame.card ellipsizes a title
+    # past `w - 4`, and a menu that silently truncates its own count is worse than no count.
+    private def space_menu_title : String
+      @marks.empty? ? "SPACE" : "SPACE · #{@marks.size} MARKED"
+    end
+
+    def self.space_menu_box(w : Int32, h : Int32, entries : Array(SpaceEntry), title : String) : Rect
+      label_w = entries.max_of { |e| Screen.display_width(e.label) }
+      mw = {label_w + 6, Screen.display_width(title) + 5, 16}.max # border + ▎ + key + gap + label + border
+      mw = {mw, w - 2}.min
+      mh = entries.size + 2
       x = {w - mw - 2, 0}.max
       y = {h - mh - 3, 1}.max # above the hint row
       Rect.new(x, y, mw, mh)
@@ -1438,15 +1751,15 @@ module Gori::Tui
 
     private def space_row_at(box : Rect, mx : Int32, my : Int32) : Int32?
       i = my - (box.y + 1)
-      return nil if i < 0 || i >= SPACE_ENTRIES.size
+      return nil if i < 0 || i >= space_entries.size
       return nil if mx <= box.x || mx >= box.right - 1
       i
     end
 
     private def render_space_menu(screen : Screen, w : Int32, h : Int32) : Nil
       box = space_menu_box(w, h)
-      Frame.card(screen, box, "SPACE", border: Theme.border_focus)
-      SPACE_ENTRIES.each_with_index do |entry, i|
+      Frame.card(screen, box, space_menu_title, border: Theme.border_focus)
+      space_entries.each_with_index do |entry, i|
         ry = box.y + 1 + i
         active = i == @space_selected
         bg = active ? Theme.accent_bg : Theme.panel
@@ -1461,8 +1774,17 @@ module Gori::Tui
     # A small centered busy card painted while a synchronous blocking step runs (the picker
     # has no background jobs / spinner), so the freeze reads as work — the measure scan on a
     # multi-GB project, then the VACUUM.
-    private def render_compressing(screen : Screen, w : Int32, h : Int32) : Nil
-      msg = @mode == :measuring ? " Measuring … " : " Compressing … "
+    # The blocking steps the picker runs on its own event loop, and what the busy card calls
+    # each. Keyed by @mode so `render` needs no growing `||` chain, and so a mode added
+    # without a label can't silently paint a blank card.
+    BUSY_LABELS = {
+      :measuring   => " Measuring … ",
+      :compressing => " Compressing … ",
+      :deleting    => " Deleting … ",
+    }
+
+    private def render_busy(screen : Screen, w : Int32, h : Int32) : Nil
+      msg = BUSY_LABELS[@mode]? || " Working … "
       bw = {msg.size + 4, 22}.max
       bh = 3
       box = Rect.new({(w - bw) // 2, 0}.max, {(h - bh) // 2, 0}.max, bw, bh)


### PR DESCRIPTION
The startup picker was the one list in gori without marked multi-select — deleting five projects meant five trips through `space` → `d` → confirm. This brings it the same model History, the Intercept queue, the Sitemap tree and the Issues list already carry (#442, #459, #460, #461).

## Gestures

| | |
|---|---|
| mark + step | `Tab` / `⇧Tab` |
| extend a range | `⇧↑` / `⇧↓` (a plain arrow, click or wheel hands the range back) |
| mark everything the search shows | `ctrl-a` |
| clear | `esc` (order: marks → query → quit) |

**Not the app-wide `t` / `⇧T`, deliberately.** On this screen every printable key types into the fuzzy search box, so `t` would filter rather than mark. `Tab` is fzf's toggle in exactly this shape of list. The `key.tab?` arm sits above the printable arm because Tab arrives carrying `'\t'`.

## Delete

All three entry points — `ctrl-d`, the footer button, the space menu — resolve through one `target_projects` (marks if any, else the cursor row), so no path can mean something different by "delete". Open / Rename / Compress stay single-target and the menu labels them `(cursor)` while marks are live: Open returns one project, and Compress measures + VACUUMs synchronously with a per-database byte estimate that would be fiction summed across N.

Because this is `rm_rf` on a project tree, the confirm has to carry its weight:

- **Names what it will wipe**, falling back to a count as soon as the names would be ellipsized by ConfirmDialog's 60-column card — a truncated head here means confirming a wipe having read `Delete "acme-staging-01", "acme-stagi…`.
- **Spells out what the search is hiding.** Marks outlive the query, so a set assembled across two searches reaches projects that are not on screen.
- **Splits off projects another gori has open** before the dialog opens and says so; a refused delete keeps its mark so it can be retried.
- **Refuses outright on a window too short to draw the dialog.** ConfirmDialog declines to render below a height its mouse path already treats as "not showing", but the key path did not — `ctrl-d` armed an invisible dialog that `y` then committed. Predates marks; fixed here.
- **Paints a busy card** before N synchronous `rm_rf` calls, like the compress path.

## Notes for review

- `ProjectMarks` is a separate pure state object because the picker holds a live `Termisu` and cannot be constructed in a spec — the rule deciding which directories get wiped has to be pinnable without one. Same reason `space_entries` / `delete_confirm_body` / `delete_result_flash` / `mark_chip` are class methods.
- **Deliberately out of scope:** `ProjectMarks` is the reusable extraction the four existing mark implementations wanted, but migrating History / Intercept / Sitemap / Issues onto it is a refactor of its own and is not attempted here.
- An unmarked picker draws byte-identically to before (menu, divider, footer, single-delete dialog), verified side by side.

## Verification

- 39 new examples in `spec/tui/project_marks_spec.cr`; full `spec/tui/` green (2670). The 8 `Gori::Session` port-bind failures in the whole-suite run are environmental (a live gori holds the port) and fail identically on `main`.
- Every spec was mutation-checked — three were vacuous when first written (the menu-box width rule, the "a Tab mark survives a range sweeping over it", and the anchor-retention rule) and were rewritten until they bite.
- Driven manually in tmux: marking, range extend/give-back, `ctrl-a`, the hidden-mark confirm, a partial batch delete against a second live gori instance (3 deleted, the in-use one kept and still marked), the wheel/stale-anchor case, the long-name fallback, and the short-window refusal.