### PR TITLE
Clear the safely-fixable ameba backlog and gate formatting in CI

### DIFF
--- a/.ameba.yml
+++ b/.ameba.yml
@@ -25,6 +25,22 @@ Lint/NotNilAfterNoBang:
 Style/RedundantNilInControlExpression:
   Enabled: false
 
+# 106 sites, every one of them in the TUI. 43 of the flagged `set_*` methods are not
+# field writes at all: `TextArea#set_text` resets ten sibling ivars and clears the
+# undo stack, `SpaceMenu#set_selected` clamps what it stores, others break the typing
+# run or drop stale conceal spans. `x.text = s` reads as a cheap idempotent assignment
+# and would hide exactly that. The rule is all-or-nothing per rule, not per site, so
+# renaming only the 63 genuine one-liners is not expressible here — and splitting the
+# set two ways by name would leave the distinction invisible at the call site anyway.
+#
+# NB the return value is NOT the hazard people expect coming from Ruby: Crystal's
+# `foo=` yields its BODY's value, not the assigned one (`(t.v = 99)` is 5 when the
+# body clamps to 5), so the rename would be value-preserving. It is the 106 call-site
+# renames through the least-tested part of the tree, for no behavioural gain, that
+# make this not worth it.
+Naming/AccessorMethodName:
+  Enabled: false
+
 # Duplicate signal — `just check` already runs `crystal tool format --check`, and
 # this rule reports the same files a second time.
 Lint/Formatting:

--- a/.ameba.yml
+++ b/.ameba.yml
@@ -41,6 +41,16 @@ Style/RedundantNilInControlExpression:
 Naming/AccessorMethodName:
   Enabled: false
 
+# All 42 sites are the same nil-guard: `return X unless val && !val.empty?`. The rule
+# exists for the double negative `unless !x`, but here the `!` sits on the INNER term,
+# and `!x.empty?` is simply how Crystal spells "is non-empty" — there is no `non_empty?`
+# predicate to use instead. The condition as written reads positively ("unless we have a
+# non-empty val"); De Morgan turns it into `if !val || val.empty?`, which reads worse and
+# is what the rule would have us write. Re-check this if a site ever appears that is a
+# genuine `unless !x`.
+Style/NegatedConditionsInUnless:
+  Enabled: false
+
 # Duplicate signal — `just check` already runs `crystal tool format --check`, and
 # this rule reports the same files a second time.
 Lint/Formatting:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
       # a dependency bump for a formatting change nobody here made.
       - name: Check formatting
         run: crystal tool format --check src spec bench scripts
-  # Still no ameba job. The backlog is down from ~965 findings to ~646, but 248 of the
+  # Still no ameba job. The backlog is down from 965 findings to 641, but 248 of the
   # remainder are Metrics/CyclomaticComplexity in the TUI — splitting those methods is a
   # real refactor, not lint cleanup, and `.ameba.yml` already records the decision to
   # raise the bar to 12 rather than carve them up. `just check` still runs it locally.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,11 +59,30 @@ jobs:
         # scheduler. Enabling MT here would build a binary those files do not
         # describe.
         run: shards build
-  # No lint job, and no `crystal tool format --check` job: the tree does not
-  # currently pass either (ameba reports ~700 pre-existing findings, and the
-  # formatter rewrites 100+ files). Both are run locally via `just check`. Add
-  # them back as gates once the backlog is cleared, not before — a check that is
-  # always red is a check nobody reads.
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: crystal-lang/install-crystal@v1
+        with:
+          # Deliberately NOT the build matrix. `crystal tool format` is the formatter
+          # shipped WITH the compiler, so its output is a property of the version that
+          # runs it, not of this repo — gating on two versions would ask the tree to be
+          # a fixed point of two different formatters at once. Pin the one development
+          # happens on; bump this line when that moves.
+          crystal: 1.21.0
+      # No `shards install`, and the paths are explicit rather than a bare `--check`:
+      # the bare form walks the whole working directory, which after an install means
+      # gating on `lib/` — third-party code this repo cannot fix, breaking the build on
+      # a dependency bump for a formatting change nobody here made.
+      - name: Check formatting
+        run: crystal tool format --check src spec bench scripts
+  # Still no ameba job. The backlog is down from ~965 findings to ~646, but 248 of the
+  # remainder are Metrics/CyclomaticComplexity in the TUI — splitting those methods is a
+  # real refactor, not lint cleanup, and `.ameba.yml` already records the decision to
+  # raise the bar to 12 rather than carve them up. `just check` still runs it locally.
+  # Add the gate when that category is dealt with, not by excluding it — a check that is
+  # always red is a check nobody reads, but one that is green by exclusion is worse.
   tests:
     runs-on: ubuntu-latest
     strategy:

--- a/justfile
+++ b/justfile
@@ -82,15 +82,18 @@ test-import:
     crystal spec spec/import
 
 # Check code format and lint without changing files.
+# Paths are explicit and must stay in step with ci.yml's `format` job: bare
+# `crystal tool format` walks the whole working directory, so once `shards install`
+# has run it reformats `lib/` too — third-party code that is not ours to change.
 [group('development')]
 check:
-    crystal tool format --check
+    crystal tool format --check src spec bench scripts
     lib/ameba/bin/ameba.cr
 
 # Auto-format code and fix lint issues.
 [group('development')]
 fix:
-    crystal tool format
+    crystal tool format src spec bench scripts
     lib/ameba/bin/ameba.cr --fix
 
 # Check that every version-bearing file agrees: shard.yml, src/gori.cr,

--- a/src/gori/cli/run.cr
+++ b/src/gori/cli/run.cr
@@ -583,7 +583,7 @@ module Gori
         prefix = Settings.env_prefix
         detail.split(", ").each do |token|
           name = token.starts_with?(prefix) ? token[prefix.size..] : token
-          if (id = ids[name]?)
+          if id = ids[name]?
             hits << {name, id}
           else
             rest << name

--- a/src/gori/cli/run/compare.cr
+++ b/src/gori/cli/run/compare.cr
@@ -63,7 +63,7 @@ module Gori
         change_count = Repeater::Diff.change_count(full_diff)
         folded = if changes_only
                    full_diff.reject { |dl| dl.kind == Repeater::DiffKind::Same }.map { |dl| Repeater::Diff::Folded.new(dl, 0) }
-                 elsif (n = context)
+                 elsif n = context
                    Repeater::Diff.fold(full_diff, n)
                  else
                    full_diff.map { |dl| Repeater::Diff::Folded.new(dl, 0) }

--- a/src/gori/cli/run/cookie.cr
+++ b/src/gori/cli/run/cookie.cr
@@ -82,7 +82,7 @@ module Gori
       # The cookie subject: positional argument or STDIN (mirrors jwt_token_input).
       private def self.cookie_input(positional : Array(String)) : String
         s =
-          if (v = positional.first?)
+          if v = positional.first?
             abort "gori run cookie: too many arguments (one cookie)" if positional.size > 1
             v.strip
           elsif !STDIN.tty?

--- a/src/gori/cli/run/cookie.cr
+++ b/src/gori/cli/run/cookie.cr
@@ -39,11 +39,9 @@ module Gori
           p.on("--salt=SALT", "Flask/Django signing salt") { |v| salt = v }
           p.on("--algorithm=ALG", "Django HMAC algorithm: sha256 (default) | sha1") { |v| algorithm = v.downcase }
           p.on("--timestamp=UNIX", "Unix second to stamp (--forge; default: now)") do |v|
-            begin
-              timestamp = parse_forge_timestamp(v)
-            rescue ex : ArgumentError
-              abort "gori run cookie: #{ex.message}"
-            end
+            timestamp = parse_forge_timestamp(v)
+          rescue ex : ArgumentError
+            abort "gori run cookie: #{ex.message}"
           end
           p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }

--- a/src/gori/cli/run/intercept.cr
+++ b/src/gori/cli/run/intercept.cr
@@ -45,35 +45,35 @@ module Gori
 
       private def self.print_intercept_help : Nil
         puts <<-HELP
-        gori run intercept — inspect/drive the live intercept queue of a capturing TUI instance
+          gori run intercept — inspect/drive the live intercept queue of a capturing TUI instance
 
-        Usage: gori run intercept [<subcommand>] [options]
+          Usage: gori run intercept [<subcommand>] [options]
 
-        Requires an open TUI on this project with intercept catch on — Interceptor is
-        TUI-only (a headless `gori run capture` never holds requests). Write subcommands
-        round-trip through the project database and bounded-poll for the TUI's ack.
+          Requires an open TUI on this project with intercept catch on — Interceptor is
+          TUI-only (a headless `gori run capture` never holds requests). Write subcommands
+          round-trip through the project database and bounded-poll for the TUI's ack.
 
-        Subcommands:
-          list                                 List held items + intercept state (default)
-          get <item-id>                        Full detail for one held item
-          forward <item-id>                    Forward a held item byte-exact
-          drop <item-id>                       Drop a held item (client gets a canned 502)
-          edit <item-id> (--raw=… | --raw-file=PATH)   Forward with edited bytes
-          enable                               Turn on live intercept catch
-          disable                              Turn off live intercept catch
-          filter <query>                       Set the conditional-intercept filter ("" clears)
-          direction <both|request|response>    Set which leg(s) intercept holds
+          Subcommands:
+            list                                 List held items + intercept state (default)
+            get <item-id>                        Full detail for one held item
+            forward <item-id>                    Forward a held item byte-exact
+            drop <item-id>                       Drop a held item (client gets a canned 502)
+            edit <item-id> (--raw=… | --raw-file=PATH)   Forward with edited bytes
+            enable                               Turn on live intercept catch
+            disable                              Turn off live intercept catch
+            filter <query>                       Set the conditional-intercept filter ("" clears)
+            direction <both|request|response>    Set which leg(s) intercept holds
 
-        Examples:
-          gori run intercept
-          gori run intercept get 3 --format json
-          gori run intercept forward 3
-          gori run intercept edit 3 --raw-file edited.txt
-          gori run intercept edit 3 --raw-file desync.txt --no-update-content-length
-          gori run intercept direction request
+          Examples:
+            gori run intercept
+            gori run intercept get 3 --format json
+            gori run intercept forward 3
+            gori run intercept edit 3 --raw-file edited.txt
+            gori run intercept edit 3 --raw-file desync.txt --no-update-content-length
+            gori run intercept direction request
 
-        See 'gori run intercept <subcommand> --help' for more.
-        HELP
+          See 'gori run intercept <subcommand> --help' for more.
+          HELP
       end
 
       # --- bridge state (read side) -------------------------------------------

--- a/src/gori/cli/run/jwt.cr
+++ b/src/gori/cli/run/jwt.cr
@@ -39,7 +39,7 @@ module Gori
       end
 
       private def self.jwt_token_input(positional : Array(String)) : String
-        if (s = positional.first?)
+        if s = positional.first?
           abort "gori run jwt: too many arguments (one token)" if positional.size > 1
           s.strip
         elsif !STDIN.tty?

--- a/src/gori/cli/run/oast.cr
+++ b/src/gori/cli/run/oast.cr
@@ -50,13 +50,13 @@ module Gori
 
       private def self.oast_help : Nil
         puts <<-HELP
-        Usage: gori run oast <subcommand>
-          listen      Register an OAST payload and stream incoming callbacks
-          presets     List the built-in public providers
-          providers   Manage SAVED providers (list, add, update, enable/disable, delete)
+          Usage: gori run oast <subcommand>
+            listen      Register an OAST payload and stream incoming callbacks
+            presets     List the built-in public providers
+            providers   Manage SAVED providers (list, add, update, enable/disable, delete)
 
-        Run `gori run oast listen -h` for listen options.
-        HELP
+          Run `gori run oast listen -h` for listen options.
+          HELP
       end
 
       # --- saved providers (the TUI OAST tab's Providers sub-tab) ---------------------------

--- a/src/gori/cli/run/project.cr
+++ b/src/gori/cli/run/project.cr
@@ -38,30 +38,30 @@ module Gori
 
       private def self.print_project_help : Nil
         puts <<-HELP
-        gori run project — list/create/delete projects, or manage project-scoped config
+          gori run project — list/create/delete projects, or manage project-scoped config
 
-        Usage: gori run project [<subcommand>] [options]
+          Usage: gori run project [<subcommand>] [options]
 
-        Subcommands:
-          list               List known projects (default when no subcommand)
-          create <name>      Create (or reopen) a project by name
-          delete|rm <name>   Delete a project and everything captured in it
-          scope              Manage scope rules (list, add, update, delete, enable/disable)
-          sandbox            Get/set the hard-containment sandbox gate (status, on, off)
-          env                Manage project env vars ($KEY substitution)
-          host-override      Manage host overrides (list, add, update, delete)
+          Subcommands:
+            list               List known projects (default when no subcommand)
+            create <name>      Create (or reopen) a project by name
+            delete|rm <name>   Delete a project and everything captured in it
+            scope              Manage scope rules (list, add, update, delete, enable/disable)
+            sandbox            Get/set the hard-containment sandbox gate (status, on, off)
+            env                Manage project env vars ($KEY substitution)
+            host-override      Manage host overrides (list, add, update, delete)
 
-        Examples:
-          gori run project --format json
-          gori run project create "API test" --description="staging sweep"
-          gori run project delete api-test --yes
-          gori run project scope add --kind=include --type=host --pattern=api.example.com
-          gori run project sandbox on
-          gori run project env set TOKEN=secret
-          gori run project host-override add --host=api.example.com --ip=10.0.0.1
+          Examples:
+            gori run project --format json
+            gori run project create "API test" --description="staging sweep"
+            gori run project delete api-test --yes
+            gori run project scope add --kind=include --type=host --pattern=api.example.com
+            gori run project sandbox on
+            gori run project env set TOKEN=secret
+            gori run project host-override add --host=api.example.com --ip=10.0.0.1
 
-        See 'gori run project <subcommand> --help' for more.
-        HELP
+          See 'gori run project <subcommand> --help' for more.
+          HELP
       end
 
       private def self.cmd_project_list(args : Array(String)) : Nil

--- a/src/gori/cookie.cr
+++ b/src/gori/cookie.cr
@@ -34,7 +34,7 @@ module Gori
     end
 
     # Supported formats, in detection + display order.
-    FORMATS = %w(flask django rack)
+    FORMATS = %w[flask django rack]
 
     # Which framework minted this cookie, from its punctuation alone (no secret needed):
     #   Rack   — "<base64>--<40-hex sha1>"      (the `--` separator + hex tail)

--- a/src/gori/cookie/django.cr
+++ b/src/gori/cookie/django.cr
@@ -22,7 +22,7 @@ module Gori
       DEFAULT_SALT    = "django.core.signing"
       SESSION_SALT    = "django.contrib.sessions.backends.signed_cookies"
       DEFAULT_ALGO    = "sha256"
-      SUPPORTED_ALGOS = %w(sha1 sha256)
+      SUPPORTED_ALGOS = %w[sha1 sha256]
 
       record Parsed,
         payload_seg : String, # base64url, possibly leading-"." for zlib

--- a/src/gori/fuzz/matcher.cr
+++ b/src/gori/fuzz/matcher.cr
@@ -139,22 +139,22 @@ module Gori::Fuzz
     # the old `spec.nil? || spec.blank?` guard — so a match dimension stays "unconstrained"
     # rather than flipping to "reject everything".
     macro num_spec(name)
-      getter {{name.id}} : String?
-      @{{name.id}}_c : Array(NumTerm)?
+      getter {{ name.id }} : String?
+      @{{ name.id }}_c : Array(NumTerm)?
 
-      def {{name.id}}=(v : String?)
-        @{{name.id}} = v
-        @{{name.id}}_c = (v && !v.blank?) ? Predicate.compile_num(v) : nil
+      def {{ name.id }}=(v : String?)
+        @{{ name.id }} = v
+        @{{ name.id }}_c = (v && !v.blank?) ? Predicate.compile_num(v) : nil
       end
     end
 
     macro status_spec(name)
-      getter {{name.id}} : String?
-      @{{name.id}}_c : Array(StatusTerm)?
+      getter {{ name.id }} : String?
+      @{{ name.id }}_c : Array(StatusTerm)?
 
-      def {{name.id}}=(v : String?)
-        @{{name.id}} = v
-        @{{name.id}}_c = (v && !v.blank?) ? Predicate.compile_status(v) : nil
+      def {{ name.id }}=(v : String?)
+        @{{ name.id }} = v
+        @{{ name.id }}_c = (v && !v.blank?) ? Predicate.compile_status(v) : nil
       end
     end
 

--- a/src/gori/hotkeys.cr
+++ b/src/gori/hotkeys.cr
@@ -10,7 +10,7 @@ module Gori
   module Hotkeys
     # Selectable OS default profiles (the Settings.keymap_os domain). "auto" tracks the
     # build's native platform.
-    PROFILES = %w(auto darwin linux windows)
+    PROFILES = %w[auto darwin linux windows]
 
     # Verb ids the editor must NOT expose, because their chord is consumed by a hardcoded
     # handler BEFORE the keymap — so a rebind/unbind on them can't take effect:
@@ -35,9 +35,9 @@ module Gori
     #     JWT, Rewriter, Project — nine controllers consume it before the keymap is read).
     #     Listed late: the guards predate the list, so the hotkey editor was offering ^Z as
     #     bindable and the binding was shadowed wherever an editor had focus.
-    CLAIMED_CTRL_LETTERS = %w(g f b e p n w z)
+    CLAIMED_CTRL_LETTERS = %w[g f b e p n w z]
     CLAIMED_CTRL_DIGITS  = ('1'..'9').map(&.to_s)
-    CLAIMED_CTRL_PUNCT   = %w(,)
+    CLAIMED_CTRL_PUNCT   = %w[,]
 
     # Every claimed key, modifier-free. The ctrl and alt chord sets below are both built
     # from this, and Keybind.dealias uses it to decide which events to rewrite.
@@ -48,7 +48,7 @@ module Gori
 
     # Selectable command modifiers (the Settings.command_modifier domain). "ctrl" is the
     # built-in family's native modifier; "alt" ADDS an ⌥ alias for it (see #alias_active?).
-    COMMAND_MODIFIERS = %w(ctrl alt)
+    COMMAND_MODIFIERS = %w[ctrl alt]
 
     # Clamped on READ as well as on parse (Settings.normalize_command_modifier), the same
     # defence #chord_overrides applies to hand-edited bindings: nothing downstream should

--- a/src/gori/hotkeys.cr
+++ b/src/gori/hotkeys.cr
@@ -37,7 +37,9 @@ module Gori
     #     bindable and the binding was shadowed wherever an editor had focus.
     CLAIMED_CTRL_LETTERS = %w[g f b e p n w z]
     CLAIMED_CTRL_DIGITS  = ('1'..'9').map(&.to_s)
-    CLAIMED_CTRL_PUNCT   = %w[,]
+    # Spelled as a plain array, not `%w[,]`: in a word list a comma reads as a separator,
+    # so the one-element form looks like a typo for an empty list. This is the ^, prefs chord.
+    CLAIMED_CTRL_PUNCT = [","]
 
     # Every claimed key, modifier-free. The ctrl and alt chord sets below are both built
     # from this, and Keybind.dealias uses it to decide which events to rewrite.

--- a/src/gori/hotkeys.cr
+++ b/src/gori/hotkeys.cr
@@ -212,7 +212,7 @@ module Gori
         next unless registry[id]?
         next unless labels.any? { |l| (c = Verb::Chord.parse(l)) && CLAIMED_ALT_CHORDS.includes?(c) }
         id
-      end.sort
+      end.sort!
     end
 
     # Effective binding as a status/Help token, or `fallback` when unbound / unknown.

--- a/src/gori/import/burp.cr
+++ b/src/gori/import/burp.cr
@@ -50,7 +50,7 @@ module Gori
         skipped = 0
         found = 0
         pos = 0
-        while (block = next_element(raw, "item", pos))
+        while block = next_element(raw, "item", pos)
           inner, pos = block
           found += 1
           # One unparseable item (no URL, undecodable base64, a host that isn't a host) skips
@@ -123,7 +123,7 @@ module Gori
       private def self.next_element(src : String, name : String, from : Int32) : {String, Int32}?
         needle = "<#{name}"
         pos = from
-        while (open_at = src.index(needle, pos))
+        while open_at = src.index(needle, pos)
           after = open_at + needle.size
           ch = src[after]?
           # `<response` must not match `<responselength`: the next char has to end the name.
@@ -145,7 +145,7 @@ module Gori
       private def self.element(src : String, name : String) : {String, String}?
         needle = "<#{name}"
         pos = 0
-        while (open_at = src.index(needle, pos))
+        while open_at = src.index(needle, pos)
           after = open_at + needle.size
           ch = src[after]?
           unless ch && (ch.whitespace? || ch == '>' || ch == '/')

--- a/src/gori/import/oas.cr
+++ b/src/gori/import/oas.cr
@@ -6,7 +6,7 @@ require "./builder"
 module Gori
   module Import
     module Oas
-      HTTP_METHODS = %w(get post put patch delete head options trace)
+      HTTP_METHODS = %w[get post put patch delete head options trace]
 
       def self.parse_file(path : String) : ParseResult
         raw = File.read(path)

--- a/src/gori/intercept_filter.cr
+++ b/src/gori/intercept_filter.cr
@@ -90,22 +90,22 @@ module Gori
     # its payload to the gate. It must stay in lockstep with field_symbol below: completing a
     # field this parser doesn't know would silently degrade the whole token to free text (see
     # parse_term).
-    FIELDS = %w(host path method scheme status proto body)
+    FIELDS = %w[host path method scheme status proto body]
 
     # Static value pools for the low-cardinality fields (mirrors History's). `host:`
     # has no static pool — its candidates are injected by the caller (the TUI passes
     # the store's DISTINCT hosts); `path:`/`body:` have none at all, since their values
     # are unbounded.
-    METHOD_VAL = %w(GET POST PUT PATCH DELETE HEAD OPTIONS QUERY)
-    SCHEME_VAL = %w(http https)
-    STATUS_VAL = %w(2xx 3xx 4xx 5xx >=400 >=500 200 301 302 401 403 404 500 502 503)
+    METHOD_VAL = %w[GET POST PUT PATCH DELETE HEAD OPTIONS QUERY]
+    SCHEME_VAL = %w[http https]
+    STATUS_VAL = %w[2xx 3xx 4xx 5xx >=400 >=500 200 301 302 401 403 404 500 502 503]
     # `ws`/`http` ONLY — a strict subset of History's `proto:` pool, for the same reason this
     # whole field list is one. A hold gate knows the protocol from the leg it is standing on
     # (`Subject#proto` is `Ws` for a WebSocket message and `Http` for everything else); `grpc`
     # and `sse` are decided from a captured response's Content-Type, which does not exist yet at
     # a gate. Offering them completed a term that can never match — i.e. a `proto:grpc`
     # condition silently holds NOTHING, which reads as intercept being broken.
-    PROTO_VAL = %w(ws http)
+    PROTO_VAL = %w[ws http]
 
     # Tab-complete candidates for the token under `cx`: field names until a `:` is
     # typed, then that field's values. The grammar's punctuation is carried through by

--- a/src/gori/jwt/attacks.cr
+++ b/src/gori/jwt/attacks.cr
@@ -44,7 +44,7 @@ module Gori
     # Servers that honour `alg` from the token itself accept an unsigned token; the case
     # variants dodge naive `alg == "none"` denylists. Also the two signature-removal shapes.
     private def none_family(list, header, header_seg : String, payload_seg : String) : Nil
-      %w(none None NONE nOnE).each do |a|
+      %w[none None NONE nOnE].each do |a|
         h = header.dup
         h["alg"] = JSON::Any.new(a)
         list << Attack.new("alg=#{a}", "none",

--- a/src/gori/jwt/forge.cr
+++ b/src/gori/jwt/forge.cr
@@ -18,7 +18,7 @@ module Gori
 
     # The algorithms Encode offers, in cycle order. `none` produces an unsigned token
     # (empty third segment) — the classic auth-bypass shape, offered deliberately.
-    ALGS = %w(HS256 HS384 HS512 none)
+    ALGS = %w[HS256 HS384 HS512 none]
 
     # HS name → the OpenSSL digest it signs with. `none` is absent (handled by sign).
     HMAC_DIGEST = {

--- a/src/gori/mcp/install.cr
+++ b/src/gori/mcp/install.cr
@@ -140,11 +140,9 @@ module Gori
         args = build_args(db_path, project, read_only, insecure_upstream, use_active_project,
           no_project, settings_path)
         targets.uniq.map do |target|
-          begin
-            Outcome.new(target, install_argv(target, exe_path, args), nil, args)
-          rescue ex
-            Outcome.new(target, nil, ex.message.presence || ex.class.to_s, args)
-          end
+          Outcome.new(target, install_argv(target, exe_path, args), nil, args)
+        rescue ex
+          Outcome.new(target, nil, ex.message.presence || ex.class.to_s, args)
         end
       end
 

--- a/src/gori/mcp/tools/context.cr
+++ b/src/gori/mcp/tools/context.cr
@@ -72,15 +72,13 @@ module Gori
       private def get_current_context : Result
         raw = store.setting(Store::UI_STATE_KEY)
         parsed = raw.try do |r|
-          begin
-            obj = JSON.parse(r)
-            # Must decode to a JSON OBJECT: valid-but-wrong-shape JSON (an array,
-            # scalar, or null) would make `parsed["active_tab"]?` below raise a raw
-            # "Expected Hash for #[]?" cast error — treat it as unreadable instead.
-            obj if obj.as_h?
-          rescue
-            nil
-          end
+          obj = JSON.parse(r)
+          # Must decode to a JSON OBJECT: valid-but-wrong-shape JSON (an array,
+          # scalar, or null) would make `parsed["active_tab"]?` below raise a raw
+          # "Expected Hash for #[]?" cast error — treat it as unreadable instead.
+          obj if obj.as_h?
+        rescue
+          nil
         end
         Result.new(JSON.build do |j|
           j.object do
@@ -369,12 +367,10 @@ module Gori
 
       private def parse_ui_state : JSON::Any?
         store.setting(Store::UI_STATE_KEY).try do |r|
-          begin
-            obj = JSON.parse(r)
-            obj if obj.as_h?
-          rescue
-            nil
-          end
+          obj = JSON.parse(r)
+          obj if obj.as_h?
+        rescue
+          nil
         end
       end
 

--- a/src/gori/mcp/tools/decode.cr
+++ b/src/gori/mcp/tools/decode.cr
@@ -33,7 +33,7 @@ module Gori
         reg = Decoder.shared_registry
         result = Decoder.run(reg, input, spec)
 
-        if (idx = result.failed_at)
+        if idx = result.failed_at
           step = result.steps[idx]
           msg = "decoder failed at step #{idx + 1} '#{step.token}': #{step.error || "failed"}"
           msg += " — available converters: #{reg.names.join(", ")}" if step.state.unknown?

--- a/src/gori/miner/baseline.cr
+++ b/src/gori/miner/baseline.cr
@@ -121,17 +121,15 @@ module Gori::Miner
       failure = nil.as(Exception?)
       workers.times do
         spawn(name: "miner-baseline") do
-          begin
-            while i = jobs.receive?
-              begin
-                block.call(i)
-              rescue ex
-                failure ||= ex
-              end
+          while i = jobs.receive?
+            begin
+              block.call(i)
+            rescue ex
+              failure ||= ex
             end
-          ensure
-            done.send(nil)
           end
+        ensure
+          done.send(nil)
         end
       end
       count.times { |i| jobs.send(i) }

--- a/src/gori/miner/engine.cr
+++ b/src/gori/miner/engine.cr
@@ -221,22 +221,20 @@ module Gori::Miner
 
       workers.times do |i|
         spawn(name: "miner-worker-#{i}") do
-          begin
-            while task = jobs.receive?
-              # Children are queued BEFORE the task is counted out, so the "queue empty and
-              # nothing in flight" test below is a true end-of-work and never races a child in.
-              process_bucket(task).each { |child| work << child } unless @state.stopped?
-              @inflight -= 1
-              # Non-blocking: a worker must never park reporting completion (the dispatcher
-              # only listens while it is idle). Dropping a poke is safe — see `wait_for_worker`.
-              select
-              when @idle.send(nil)
-              else
-              end
+          while task = jobs.receive?
+            # Children are queued BEFORE the task is counted out, so the "queue empty and
+            # nothing in flight" test below is a true end-of-work and never races a child in.
+            process_bucket(task).each { |child| work << child } unless @state.stopped?
+            @inflight -= 1
+            # Non-blocking: a worker must never park reporting completion (the dispatcher
+            # only listens while it is idle). Dropping a poke is safe — see `wait_for_worker`.
+            select
+            when @idle.send(nil)
+            else
             end
-          ensure
-            finished.send(nil)
           end
+        ensure
+          finished.send(nil)
         end
       end
 

--- a/src/gori/oast/presets.cr
+++ b/src/gori/oast/presets.cr
@@ -7,13 +7,13 @@ module Gori::Oast
   module Presets
     record Preset, kind : ProviderKind, name : String, host : String, token : String? = nil
 
-    INTERACTSH_SERVERS = %w(
+    INTERACTSH_SERVERS = %w[
       https://oast.pro
       https://oast.live
       https://oast.site
       https://oast.fun
       https://oast.me
-    )
+    ]
 
     def self.all : Array(Preset)
       list = [] of Preset

--- a/src/gori/oast/providers/interactsh.cr
+++ b/src/gori/oast/providers/interactsh.cr
@@ -115,15 +115,13 @@ module Gori::Oast
     private def decrypt_interaction(session : Session, aes_key : Bytes, data : Bytes) : String?
       modes = session.aes_mode_cfb? ? {"aes-256-cfb", "aes-256-ctr"} : {"aes-256-ctr", "aes-256-cfb"}
       modes.each do |mode|
-        begin
-          text = String.new(Crypto.aes256_decrypt(data, aes_key, mode))
-          if looks_like_interaction?(text)
-            session.aes_mode_cfb = (mode == "aes-256-cfb")
-            return text
-          end
-        rescue
-          # try the other mode
+        text = String.new(Crypto.aes256_decrypt(data, aes_key, mode))
+        if looks_like_interaction?(text)
+          session.aes_mode_cfb = (mode == "aes-256-cfb")
+          return text
         end
+      rescue
+        # try the other mode
       end
       nil
     end

--- a/src/gori/open_lock.cr
+++ b/src/gori/open_lock.cr
@@ -63,12 +63,10 @@ module Gori
       file = File.open(lock_path, "a") # never "w": truncating races a peer's own open
       begin
         RETRY_ATTEMPTS.times do |attempt|
-          begin
-            file.flock_shared(blocking: false)
-            return new(file)
-          rescue IO::Error
-            sleep RETRY_DELAY if attempt < RETRY_ATTEMPTS - 1
-          end
+          file.flock_shared(blocking: false)
+          return new(file)
+        rescue IO::Error
+          sleep RETRY_DELAY if attempt < RETRY_ATTEMPTS - 1
         end
         # Gave up. Say so: from here the database is open with nothing announcing it, which is
         # the one state a peer's delete cannot see. gori.log, not STDERR (#411).

--- a/src/gori/pacing.cr
+++ b/src/gori/pacing.cr
@@ -29,8 +29,6 @@ module Gori
         (1.0 / rps).seconds
       elsif (t = @config.throttle_ms) && t > 0
         t.milliseconds
-      else
-        nil
       end
     end
 

--- a/src/gori/probe/passive/cookies.cr
+++ b/src/gori/probe/passive/cookies.cr
@@ -35,7 +35,7 @@ module Gori
             flags = segs[1..].map(&.strip.downcase)
             # Keep the ORIGINAL-case Expires value for date parsing (flags are lowercased above,
             # which would break HTTP_DATE's month/day names).
-            expires_val = segs[1..].map(&.strip).find { |f| f.downcase.starts_with?("expires=") }.try { |f| f.partition('=')[2].strip }
+            expires_val = segs[1..].map(&.strip).find(&.downcase.starts_with?("expires=")).try(&.partition('=').[2].strip)
             # A cookie being deleted holds no secret — skip its hygiene (avoids logout/reset FPs).
             next if deletion?(value, flags, expires_val)
 

--- a/src/gori/probe_query.cr
+++ b/src/gori/probe_query.cr
@@ -13,7 +13,7 @@ module Gori
     #   category:tech sev:>=high   → tech issues at High or Critical
     #   -status:resolved host:api  → not-resolved AND host contains "api"
     class Filter
-      FIELDS = %w(severity: status: category: host: code:)
+      FIELDS = %w[severity: status: category: host: code:]
 
       private record Term, kind : Symbol, op : Symbol, text : String, negate : Bool
 

--- a/src/gori/proxy/conn/self_page.cr
+++ b/src/gori/proxy/conn/self_page.cr
@@ -159,15 +159,15 @@ module Gori::Proxy
 
     private def self.simple_html(title : String, body : String) : String
       <<-HTML
-      <!doctype html><html lang="en"><head><meta charset="utf-8">
-      <meta name="viewport" content="width=device-width,initial-scale=1">
-      <title>gori - #{HTML.escape(title)}</title>#{STYLE}</head>
-      <body><main class="page"><section class="hero">
-        <p class="mark">#{WORDMARK}</p>
-        <h1>#{HTML.escape(title)}</h1>
-        <p class="lead">#{body}</p>
-      </section></main></body></html>
-      HTML
+        <!doctype html><html lang="en"><head><meta charset="utf-8">
+        <meta name="viewport" content="width=device-width,initial-scale=1">
+        <title>gori - #{HTML.escape(title)}</title>#{STYLE}</head>
+        <body><main class="page"><section class="hero">
+          <p class="mark">#{WORDMARK}</p>
+          <h1>#{HTML.escape(title)}</h1>
+          <p class="lead">#{body}</p>
+        </section></main></body></html>
+        HTML
     end
 
     private def self.index_html(*, ca_available : Bool, spki : String?, ca_path : String?,
@@ -185,13 +185,13 @@ module Gori::Proxy
       cta =
         if ca_available
           <<-HTML
-          <div class="cta">
-            <a class="btn primary" href="/ca.der" download>Download CA (DER)</a>
-            <a class="btn ghost" href="/ca.pem" download>Download PEM</a>
-          </div>
-          <p class="hint">DER (<code>.der</code>/<code>.crt</code>) installs by double-click on macOS and Windows.
-          PEM (<code>.pem</code>) suits Firefox and most Linux tooling.</p>
-          HTML
+            <div class="cta">
+              <a class="btn primary" href="/ca.der" download>Download CA (DER)</a>
+              <a class="btn ghost" href="/ca.pem" download>Download PEM</a>
+            </div>
+            <p class="hint">DER (<code>.der</code>/<code>.crt</code>) installs by double-click on macOS and Windows.
+            PEM (<code>.pem</code>) suits Firefox and most Linux tooling.</p>
+            HTML
         else
           %(<p class="hint">HTTPS interception is off right now, so there's no CA certificate to download.</p>)
         end
@@ -199,108 +199,108 @@ module Gori::Proxy
       fingerprint = fp ? %(<div><span class="k">Fingerprint</span><code>#{fp}</code></div>) : ""
 
       <<-HTML
-      <!doctype html><html lang="en"><head><meta charset="utf-8">
-      <meta name="viewport" content="width=device-width,initial-scale=1">
-      <title>gori proxy</title>#{STYLE}</head>
-      <body><main class="page">
-        <section class="hero">
-          <p class="mark">#{WORDMARK}</p>
-          <h1>You've reached the proxy</h1>
-          <p class="lead">gori captures and inspects HTTP traffic between your browser and the web.
-          Install its CA certificate to read HTTPS.</p>
-          #{cta}
-        </section>
+        <!doctype html><html lang="en"><head><meta charset="utf-8">
+        <meta name="viewport" content="width=device-width,initial-scale=1">
+        <title>gori proxy</title>#{STYLE}</head>
+        <body><main class="page">
+          <section class="hero">
+            <p class="mark">#{WORDMARK}</p>
+            <h1>You've reached the proxy</h1>
+            <p class="lead">gori captures and inspects HTTP traffic between your browser and the web.
+            Install its CA certificate to read HTTPS.</p>
+            #{cta}
+          </section>
 
-        <section class="details">
-          <h2>Trust the certificate</h2>
-          <dl class="steps">
-            <div><dt>Firefox</dt><dd>Settings → Certificates → Authorities → Import the <code>.pem</code>, then trust it for websites.</dd></div>
-            <div><dt>macOS</dt><dd>Open the <code>.der</code> in Keychain Access, then set it to Always Trust.</dd></div>
-            <div><dt>Windows</dt><dd>Open the <code>.der</code>, then install to Trusted Root Certification Authorities.</dd></div>
-          </dl>
+          <section class="details">
+            <h2>Trust the certificate</h2>
+            <dl class="steps">
+              <div><dt>Firefox</dt><dd>Settings → Certificates → Authorities → Import the <code>.pem</code>, then trust it for websites.</dd></div>
+              <div><dt>macOS</dt><dd>Open the <code>.der</code> in Keychain Access, then set it to Always Trust.</dd></div>
+              <div><dt>Windows</dt><dd>Open the <code>.der</code>, then install to Trusted Root Certification Authorities.</dd></div>
+            </dl>
 
-          <div class="meta">
-            <div><span class="k">Listening on</span><code>#{listen_s}</code></div>
-            <div><span class="k">Also at</span><code>#{MAGIC_URL}</code></div>
-            <div><span class="k">CA file</span><code>#{path}</code></div>
-            #{fingerprint}
-            <div><span class="k">Version</span><code>v#{ver}</code></div>
-          </div>
+            <div class="meta">
+              <div><span class="k">Listening on</span><code>#{listen_s}</code></div>
+              <div><span class="k">Also at</span><code>#{MAGIC_URL}</code></div>
+              <div><span class="k">CA file</span><code>#{path}</code></div>
+              #{fingerprint}
+              <div><span class="k">Version</span><code>v#{ver}</code></div>
+            </div>
 
-          <p class="warn">Only install this CA on a machine you control, for testing. A trusted root CA can decrypt your HTTPS traffic.</p>
-        </section>
-      </main></body></html>
-      HTML
+            <p class="warn">Only install this CA on a machine you control, for testing. A trusted root CA can decrypt your HTTPS traffic.</p>
+          </section>
+        </main></body></html>
+        HTML
     end
 
     # gori's palette + type, self-contained. Dark-first (the indigo night) with a
     # warm-paper light variant under prefers-color-scheme: light. Tokens are lifted
     # from docs/static/css/style.css.
     STYLE = <<-CSS
-    <style>
-    :root{
-      color-scheme:dark;
-      --bg:#0b0e16;--text:#c6c8d4;--heading:#f6f5f1;--muted:#8d90a2;--quiet:#6a6d7e;
-      --accent:#c8a860;--accent-strong:#e6cf92;
-      /* Logo body gold (docs --grad-logo / gori.svg), not the yellower accent leaf. */
-      --logo:#d9c28b;
-      --accent-rgb:200 168 96;--cloud-rgb:108 126 178;--hair:rgb(250 250 250 /.12);
-    }
-    @media (prefers-color-scheme:light){
+      <style>
       :root{
-        color-scheme:light;
-        --bg:#faf9f7;--text:#33322f;--heading:#141210;--muted:#6b6454;--quiet:#8a8272;
-        --accent:#a8791f;--accent-strong:#8a5d0a;
-        --logo:#8a6a28;
-        --accent-rgb:168 121 31;--cloud-rgb:150 132 96;--hair:rgb(26 22 14 /.14);
+        color-scheme:dark;
+        --bg:#0b0e16;--text:#c6c8d4;--heading:#f6f5f1;--muted:#8d90a2;--quiet:#6a6d7e;
+        --accent:#c8a860;--accent-strong:#e6cf92;
+        /* Logo body gold (docs --grad-logo / gori.svg), not the yellower accent leaf. */
+        --logo:#d9c28b;
+        --accent-rgb:200 168 96;--cloud-rgb:108 126 178;--hair:rgb(250 250 250 /.12);
       }
-    }
-    *{box-sizing:border-box;margin:0;padding:0}
-    body{min-height:100dvh;background:var(--bg);color:var(--text);
-      font:16px/1.62 ui-sans-serif,-apple-system,BlinkMacSystemFont,"Segoe UI","Noto Sans KR","Apple SD Gothic Neo",Arial,sans-serif;
-      -webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}
-    .sr{position:absolute;width:1px;height:1px;margin:-1px;padding:0;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
-    .page{max-width:44rem;margin:0 auto;padding:2rem 1.5rem 3.5rem}
-    .hero{position:relative;min-height:min(80dvh,660px);display:flex;flex-direction:column;justify-content:center;padding:1.5rem 0}
-    .hero::before{content:"";position:absolute;z-index:0;top:-2rem;left:-14%;width:66%;height:66%;pointer-events:none;
-      background:radial-gradient(60% 60% at 32% 30%,rgb(var(--accent-rgb)/.12),transparent 70%),
-        radial-gradient(52% 60% at 62% 52%,rgb(var(--cloud-rgb)/.11),transparent 72%)}
-    .hero>*{position:relative;z-index:1}
-    .mark{font-family:"STIX Two Math","Cambria Math","Noto Sans Math",Georgia,"Times New Roman",serif;
-      font-size:clamp(3.4rem,13vw,6rem);line-height:1;color:var(--logo);letter-spacing:.02em;margin-bottom:1.05rem}
-    h1{color:var(--heading);font-size:clamp(1.55rem,4.5vw,2.15rem);line-height:1.16;font-weight:760;letter-spacing:-.015em;
-      max-width:18ch;text-wrap:balance;margin-bottom:.7rem}
-    .lead{color:var(--muted);font-size:1.06rem;max-width:44ch;margin-bottom:1.5rem}
-    .cta{display:flex;flex-wrap:wrap;gap:.7rem}
-    .btn{display:inline-flex;align-items:center;min-height:2.9rem;padding:.72rem 1.25rem;border-radius:10px;
-      font-weight:650;font-size:.95rem;text-decoration:none;
-      transition:transform .15s,filter .15s,border-color .15s,background .15s,color .15s}
-    .btn:active{transform:translateY(1px)}
-    .btn:focus-visible{outline:2px solid var(--accent);outline-offset:3px}
-    .btn.primary{background:var(--accent);color:#17130a}
-    .btn.primary:hover{filter:brightness(1.06)}
-    .btn.ghost{border:1px solid var(--hair);color:var(--heading)}
-    .btn.ghost:hover{border-color:var(--accent)}
-    .hint{margin-top:1.05rem;color:var(--muted);font-size:.86rem;max-width:48ch}
-    .details{border-top:1px solid var(--hair);padding-top:2rem}
-    h2{color:var(--heading);font-size:1.05rem;font-weight:720;margin-bottom:1rem}
-    .steps{display:grid;gap:.9rem;margin-bottom:1.9rem}
-    .steps dt{color:var(--heading);font-weight:650;font-size:.92rem;margin-bottom:.15rem}
-    .steps dd{color:var(--muted);font-size:.9rem}
-    a{color:var(--accent-strong);text-decoration:underline;text-underline-offset:.2em;text-decoration-color:rgb(var(--accent-rgb)/.45)}
-    a:hover{color:var(--heading);text-decoration-color:currentColor}
-    code{font-family:ui-monospace,"SF Mono",Menlo,Consolas,monospace;font-size:.85em;color:var(--accent-strong);word-break:break-all}
-    .meta{border-top:1px solid var(--hair);padding-top:1.2rem;display:grid;gap:.42rem;font-size:.85rem}
-    .meta .k{color:var(--quiet);display:inline-block;min-width:8.5rem}
-    .meta code{color:var(--text)}
-    .warn{margin-top:1.35rem;color:var(--quiet);font-size:.82rem;max-width:54ch}
-    @media (prefers-reduced-motion:no-preference){
-      .hero>.mark,.hero>h1,.hero>.lead,.hero>.cta,.hero>.hint{animation:rise .7s cubic-bezier(.16,1,.3,1) both}
-      .hero>h1{animation-delay:.08s}.hero>.lead{animation-delay:.16s}
-      .hero>.cta{animation-delay:.24s}.hero>.hint{animation-delay:.32s}
-    }
-    @keyframes rise{from{opacity:0;transform:translateY(14px)}to{opacity:1;transform:none}}
-    </style>
-    CSS
+      @media (prefers-color-scheme:light){
+        :root{
+          color-scheme:light;
+          --bg:#faf9f7;--text:#33322f;--heading:#141210;--muted:#6b6454;--quiet:#8a8272;
+          --accent:#a8791f;--accent-strong:#8a5d0a;
+          --logo:#8a6a28;
+          --accent-rgb:168 121 31;--cloud-rgb:150 132 96;--hair:rgb(26 22 14 /.14);
+        }
+      }
+      *{box-sizing:border-box;margin:0;padding:0}
+      body{min-height:100dvh;background:var(--bg);color:var(--text);
+        font:16px/1.62 ui-sans-serif,-apple-system,BlinkMacSystemFont,"Segoe UI","Noto Sans KR","Apple SD Gothic Neo",Arial,sans-serif;
+        -webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}
+      .sr{position:absolute;width:1px;height:1px;margin:-1px;padding:0;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
+      .page{max-width:44rem;margin:0 auto;padding:2rem 1.5rem 3.5rem}
+      .hero{position:relative;min-height:min(80dvh,660px);display:flex;flex-direction:column;justify-content:center;padding:1.5rem 0}
+      .hero::before{content:"";position:absolute;z-index:0;top:-2rem;left:-14%;width:66%;height:66%;pointer-events:none;
+        background:radial-gradient(60% 60% at 32% 30%,rgb(var(--accent-rgb)/.12),transparent 70%),
+          radial-gradient(52% 60% at 62% 52%,rgb(var(--cloud-rgb)/.11),transparent 72%)}
+      .hero>*{position:relative;z-index:1}
+      .mark{font-family:"STIX Two Math","Cambria Math","Noto Sans Math",Georgia,"Times New Roman",serif;
+        font-size:clamp(3.4rem,13vw,6rem);line-height:1;color:var(--logo);letter-spacing:.02em;margin-bottom:1.05rem}
+      h1{color:var(--heading);font-size:clamp(1.55rem,4.5vw,2.15rem);line-height:1.16;font-weight:760;letter-spacing:-.015em;
+        max-width:18ch;text-wrap:balance;margin-bottom:.7rem}
+      .lead{color:var(--muted);font-size:1.06rem;max-width:44ch;margin-bottom:1.5rem}
+      .cta{display:flex;flex-wrap:wrap;gap:.7rem}
+      .btn{display:inline-flex;align-items:center;min-height:2.9rem;padding:.72rem 1.25rem;border-radius:10px;
+        font-weight:650;font-size:.95rem;text-decoration:none;
+        transition:transform .15s,filter .15s,border-color .15s,background .15s,color .15s}
+      .btn:active{transform:translateY(1px)}
+      .btn:focus-visible{outline:2px solid var(--accent);outline-offset:3px}
+      .btn.primary{background:var(--accent);color:#17130a}
+      .btn.primary:hover{filter:brightness(1.06)}
+      .btn.ghost{border:1px solid var(--hair);color:var(--heading)}
+      .btn.ghost:hover{border-color:var(--accent)}
+      .hint{margin-top:1.05rem;color:var(--muted);font-size:.86rem;max-width:48ch}
+      .details{border-top:1px solid var(--hair);padding-top:2rem}
+      h2{color:var(--heading);font-size:1.05rem;font-weight:720;margin-bottom:1rem}
+      .steps{display:grid;gap:.9rem;margin-bottom:1.9rem}
+      .steps dt{color:var(--heading);font-weight:650;font-size:.92rem;margin-bottom:.15rem}
+      .steps dd{color:var(--muted);font-size:.9rem}
+      a{color:var(--accent-strong);text-decoration:underline;text-underline-offset:.2em;text-decoration-color:rgb(var(--accent-rgb)/.45)}
+      a:hover{color:var(--heading);text-decoration-color:currentColor}
+      code{font-family:ui-monospace,"SF Mono",Menlo,Consolas,monospace;font-size:.85em;color:var(--accent-strong);word-break:break-all}
+      .meta{border-top:1px solid var(--hair);padding-top:1.2rem;display:grid;gap:.42rem;font-size:.85rem}
+      .meta .k{color:var(--quiet);display:inline-block;min-width:8.5rem}
+      .meta code{color:var(--text)}
+      .warn{margin-top:1.35rem;color:var(--quiet);font-size:.82rem;max-width:54ch}
+      @media (prefers-reduced-motion:no-preference){
+        .hero>.mark,.hero>h1,.hero>.lead,.hero>.cta,.hero>.hint{animation:rise .7s cubic-bezier(.16,1,.3,1) both}
+        .hero>h1{animation-delay:.08s}.hero>.lead{animation-delay:.16s}
+        .hero>.cta{animation-delay:.24s}.hero>.hint{animation-delay:.32s}
+      }
+      @keyframes rise{from{opacity:0;transform:translateY(14px)}to{opacity:1;transform:none}}
+      </style>
+      CSS
   end
 end

--- a/src/gori/ql.cr
+++ b/src/gori/ql.cr
@@ -191,7 +191,7 @@ module Gori
       TermAnalysis.new(applied, ignored, invalid_regex_terms(query))
     end
 
-    REGEX_FIELDS = %w(host path url header body)
+    REGEX_FIELDS = %w[host path url header body]
 
     # The field/operator split, shared by compilation and diagnosis so the two can't
     # disagree about what counts as a term. The first ':' (field op) or '~' (regex op)

--- a/src/gori/repeater/minimize.cr
+++ b/src/gori/repeater/minimize.cr
@@ -26,14 +26,14 @@ module Gori::Repeater
     # so we never strip an identity header just because THIS response happened to ignore it.
     # (Cookie is minimized crumb-by-crumb instead — see cookie_crumbs.) Matched
     # case-insensitively.
-    REMOVABLE_HEADERS = %w(
+    REMOVABLE_HEADERS = %w[
       accept accept-encoding accept-language accept-charset
       user-agent referer origin dnt sec-gpc
       upgrade-insecure-requests cache-control pragma
       if-modified-since if-none-match priority purpose x-requested-with
-    )
+    ]
     # `sec-fetch-*` and `sec-ch-ua*` are whole families of client-hint headers.
-    REMOVABLE_PREFIXES = %w(sec-fetch- sec-ch-ua)
+    REMOVABLE_PREFIXES = %w[sec-fetch- sec-ch-ua]
     # Headers that are NEVER candidates for removal: the framing / hop-by-hop set (stripping
     # them breaks the request or its wire framing) PLUS `host` — required for virtual-host
     # routing, so removing it can silently change which site answers. `host` is already in the
@@ -531,8 +531,8 @@ module Gori::Repeater
     # body — a param that only moves these (a redirect target, a Set-Cookie, CORS/auth) must
     # not be silently stripped. Set-Cookie is handled separately (by cookie NAME, since its
     # value rotates); the rest compare by value. Only ones stable across calibration are used.
-    BEHAVIOR_HEADERS = %w(location content-type content-disposition
-      access-control-allow-origin access-control-allow-credentials www-authenticate)
+    BEHAVIOR_HEADERS = %w[location content-type content-disposition
+      access-control-allow-origin access-control-allow-credentials www-authenticate]
 
     # Normalized signature of a response's behavior-relevant headers (empty when the head
     # can't be parsed). Set-Cookie reduces to its sorted cookie NAMES so a rotating session/

--- a/src/gori/repeater/subtab_filter.cr
+++ b/src/gori/repeater/subtab_filter.cr
@@ -45,10 +45,10 @@ module Gori
     class SubtabFilter
       # Completable field names (canonical forms shown in the filter guidance row).
       # Aliases host/target and method/verb share value pools below.
-      FIELDS = %w(tag name host target method verb)
+      FIELDS = %w[tag name host target method verb]
 
       # Common HTTP methods suggested even when no open session uses them yet.
-      METHODS = %w(GET POST PUT PATCH DELETE HEAD OPTIONS CONNECT TRACE)
+      METHODS = %w[GET POST PUT PATCH DELETE HEAD OPTIONS CONNECT TRACE]
 
       # The searchable projection of one Repeater session. Kept free of TUI types so the
       # matcher is pure + unit-testable; the controller builds these from its views.

--- a/src/gori/sequencer/engine.cr
+++ b/src/gori/sequencer/engine.cr
@@ -165,47 +165,43 @@ module Gori::Sequencer
       finished = Channel(Nil).new(@concurrency)
 
       spawn(name: "sequencer-dispatch") do
-        begin
-          loop do
-            break if @state.stopped?
-            park_if_paused
-            break if @state.stopped?
-            # Stop handing out jobs once enough are already IN FLIGHT to reach the
-            # goal, not only once they've fully round-tripped. `@dispatched - @sent`
-            # is the outstanding (dispatched-but-not-yet-completed) count — @sent
-            # increments in process_one right after the send returns, success or
-            # not — so this sum is an optimistic projection of the final collected
-            # count if every outstanding job extracts a token. It only grows via a
-            # dispatch here (+1) and only shrinks via an extraction MISS in
-            # process_one (-1), so it steps by exactly ±1 and lands on @config.goal
-            # exactly (no overshoot) whenever the goal is reachable, while still
-            # letting the loop keep dispatching past a run of misses (bounded by
-            # max_sends below) — unlike the old `@collected >= @config.goal` check,
-            # which only reacted after a full round-trip and let the channel's
-            # buffer slot plus one already-in-flight worker job race the goal by up
-            # to 2 extra live requests.
-            break if @collected + (@dispatched - @sent) >= @config.goal
-            break if @dispatched >= @config.max_sends
-            break if backend.cap_reached?
-            pace(interval)
-            jobs.send(@dispatched)
-            @dispatched += 1
-          end
-        ensure
-          jobs.close
+        loop do
+          break if @state.stopped?
+          park_if_paused
+          break if @state.stopped?
+          # Stop handing out jobs once enough are already IN FLIGHT to reach the
+          # goal, not only once they've fully round-tripped. `@dispatched - @sent`
+          # is the outstanding (dispatched-but-not-yet-completed) count — @sent
+          # increments in process_one right after the send returns, success or
+          # not — so this sum is an optimistic projection of the final collected
+          # count if every outstanding job extracts a token. It only grows via a
+          # dispatch here (+1) and only shrinks via an extraction MISS in
+          # process_one (-1), so it steps by exactly ±1 and lands on @config.goal
+          # exactly (no overshoot) whenever the goal is reachable, while still
+          # letting the loop keep dispatching past a run of misses (bounded by
+          # max_sends below) — unlike the old `@collected >= @config.goal` check,
+          # which only reacted after a full round-trip and let the channel's
+          # buffer slot plus one already-in-flight worker job race the goal by up
+          # to 2 extra live requests.
+          break if @collected + (@dispatched - @sent) >= @config.goal
+          break if @dispatched >= @config.max_sends
+          break if backend.cap_reached?
+          pace(interval)
+          jobs.send(@dispatched)
+          @dispatched += 1
         end
+      ensure
+        jobs.close
       end
 
       @concurrency.times do |i|
         spawn(name: "sequencer-worker-#{i}") do
-          begin
-            while jobs.receive?
-              next if @state.stopped?
-              process_one(backend)
-            end
-          ensure
-            finished.send(nil)
+          while jobs.receive?
+            next if @state.stopped?
+            process_one(backend)
           end
+        ensure
+          finished.send(nil)
         end
       end
 

--- a/src/gori/settings.cr
+++ b/src/gori/settings.cr
@@ -329,7 +329,7 @@ module Gori
 
     private def self.normalize_os(raw : String?) : String
       down = raw.try(&.downcase)
-      %w(darwin linux windows).includes?(down) ? down.not_nil! : "auto"
+      %w[darwin linux windows].includes?(down) ? down.not_nil! : "auto"
     end
 
     # Read a boolean field, keeping `current` when it's absent or non-bool. A plain
@@ -471,12 +471,12 @@ module Gori
     # produces it without a fully-populated settings object. Add a section → add its key here.
     # The `document_keys - SECTION_KEYS` guard in spec/settings_profile_spec.cr catches a
     # rename, and catches an addition as soon as any example populates the new section.
-    SECTION_KEYS = %w(
+    SECTION_KEYS = %w[
       theme mouse pretty_bodies layout statusline display companion notifications general update
       network upstream_rules outbound_tls retention listeners editor tabs hostname_overrides
       env scan_rules oast_providers hotkeys mine fuzzer probe discover decoder rewriter
       colormarker
-    )
+    ]
 
     # Every top-level key the current settings would write — i.e. which sections this install
     # actually has a value for. NOT the list of valid names (see SECTION_KEYS): a section

--- a/src/gori/settings/scan_rules.cr
+++ b/src/gori/settings/scan_rules.cr
@@ -44,7 +44,7 @@ module Gori::Settings
       kind = clamp_field(o["kind"]?.try(&.as_s?), SCAN_RULE_KINDS, "string")
       severity = clamp_field(o["severity"]?.try(&.as_s?), SCAN_RULE_SEVERITIES, "info")
       desc = o["description"]?.try(&.as_s?) || ""
-      enabled = o["enabled"]?.try { |v| v.as_bool? }
+      enabled = o["enabled"]?.try(&.as_bool?)
       out << ScanRule.new(id, title, desc, side, region, kind, pattern, severity, enabled.nil? ? true : enabled)
     end
     out

--- a/src/gori/store.cr
+++ b/src/gori/store.cr
@@ -1019,17 +1019,17 @@ module Gori
       response_size = (resp.head.empty? && resp.body.nil?) ? nil : resp.head.size.to_i64 + body_size
       conn.exec(
         <<-SQL,
-        UPDATE flows SET
-          response_head = ?, response_body = ?, status = ?, reason = ?,
-          content_type = ?, response_size = ?, state = ?,
-          ttfb_us = ?, duration_us = ?, error = ?, response_body_truncated = ?,
-          -- nil means "the response side has nothing to add", NOT "clear it": the request
-          -- side may already have written an advisory on this row and a bare `advisory = ?`
-          -- would erase it. COALESCE keeps whatever is stored when the DTO carries nothing.
-          advisory = COALESCE(?, advisory),
-          fts_dirty = 1
-        WHERE id = ?
-        SQL
+          UPDATE flows SET
+            response_head = ?, response_body = ?, status = ?, reason = ?,
+            content_type = ?, response_size = ?, state = ?,
+            ttfb_us = ?, duration_us = ?, error = ?, response_body_truncated = ?,
+            -- nil means "the response side has nothing to add", NOT "clear it": the request
+            -- side may already have written an advisory on this row and a bare `advisory = ?`
+            -- would erase it. COALESCE keeps whatever is stored when the DTO carries nothing.
+            advisory = COALESCE(?, advisory),
+            fts_dirty = 1
+          WHERE id = ?
+          SQL
         resp.head, resp.body, resp.status, resp.reason, resp.content_type,
         response_size,
         resp.state.value, resp.ttfb_us, resp.duration_us, resp.error,

--- a/src/gori/store.cr
+++ b/src/gori/store.cr
@@ -378,11 +378,10 @@ module Gori
         # loop borrowed, and that teardown is exactly where the escape came from (see the
         # rescue inside `writer_loop`). Making the send unconditional means a writer that dies
         # for any future reason degrades to "writes stop" instead of "gori never exits".
-        begin
-          writer_loop
-        ensure
-          @done.send(nil)
-        end
+
+        writer_loop
+      ensure
+        @done.send(nil)
       end
     end
 
@@ -577,30 +576,29 @@ module Gori
       # shutdown (measured: the process never exits), which in the TUI means gori does not quit
       # and leaves the terminal on the alternate screen. Logged, not raised: the loop is over by
       # then — every op has been answered — and there is nothing left to abort.
-      begin
-        writer_connection_loop
-      rescue ex
-        # gori.log, not STDERR (#411): in TUI mode STDERR is the alternate screen.
-        #
-        # WHICH failure this was decides what is safe to do next, and conflating them was wrong
-        # in both directions. `@writer_loop_exited` is set inside the connection block after the
-        # loop returns, so:
-        #
-        # * set ⇒ the LOOP finished and the RELEASE raised (the constraint-poisoned statement).
-        #   Every op has been answered; the connection is half-closed, so `#close` must not
-        #   re-close the pool (that is a use-after-free — see #close).
-        # * clear ⇒ the loop itself died with `@writes` still OPEN and no reader. A caller that
-        #   sends after this would park forever on its reply channel: the hang this rescue was
-        #   added to prevent, moved from `close` to the next write. Close the channel so every
-        #   caller takes its existing `rescue Channel::ClosedError` path (0 / false / dropped)
-        #   instead, and leave the pool closable.
-        if @writer_loop_exited
-          ::Log.warn { "store writer connection teardown failed: #{ex.message}" }
-          @writer_teardown_failed = true
-        else
-          ::Log.error { "store writer fiber died mid-loop: #{ex.message} — further writes will be refused" }
-          @writes.close rescue nil
-        end
+
+      writer_connection_loop
+    rescue ex
+      # gori.log, not STDERR (#411): in TUI mode STDERR is the alternate screen.
+      #
+      # WHICH failure this was decides what is safe to do next, and conflating them was wrong
+      # in both directions. `@writer_loop_exited` is set inside the connection block after the
+      # loop returns, so:
+      #
+      # * set ⇒ the LOOP finished and the RELEASE raised (the constraint-poisoned statement).
+      #   Every op has been answered; the connection is half-closed, so `#close` must not
+      #   re-close the pool (that is a use-after-free — see #close).
+      # * clear ⇒ the loop itself died with `@writes` still OPEN and no reader. A caller that
+      #   sends after this would park forever on its reply channel: the hang this rescue was
+      #   added to prevent, moved from `close` to the next write. Close the channel so every
+      #   caller takes its existing `rescue Channel::ClosedError` path (0 / false / dropped)
+      #   instead, and leave the pool closable.
+      if @writer_loop_exited
+        ::Log.warn { "store writer connection teardown failed: #{ex.message}" }
+        @writer_teardown_failed = true
+      else
+        ::Log.error { "store writer fiber died mid-loop: #{ex.message} — further writes will be refused" }
+        @writes.close rescue nil
       end
     end
 

--- a/src/gori/store/schema.cr
+++ b/src/gori/store/schema.cr
@@ -16,37 +16,37 @@ module Gori
         # OOM the proxy or bloat one row, and the *_body_truncated flags mark the cut.
         # h2_conn_id/h2_stream_id link a decoded h2 projection back to its raw frame log.
         <<-SQL,
-        CREATE TABLE flows (
-          id                      INTEGER PRIMARY KEY,
-          created_at              INTEGER NOT NULL,
-          scheme                  TEXT    NOT NULL,
-          host                    TEXT    NOT NULL,
-          port                    INTEGER NOT NULL,
-          method                  TEXT    NOT NULL,
-          target                  TEXT    NOT NULL,
-          http_version            TEXT    NOT NULL,
-          sni                     TEXT,
-          alpn                    TEXT,
-          tls_version             TEXT,
-          request_head            BLOB    NOT NULL,
-          request_body            BLOB,
-          response_head           BLOB,
-          response_body           BLOB,
-          status                  INTEGER,
-          reason                  TEXT,
-          content_type            TEXT,
-          request_size            INTEGER NOT NULL DEFAULT 0,
-          response_size           INTEGER,
-          state                   INTEGER NOT NULL,
-          ttfb_us                 INTEGER,
-          duration_us             INTEGER,
-          error                   TEXT,
-          h2_conn_id              INTEGER,
-          h2_stream_id            INTEGER,
-          request_body_truncated  INTEGER NOT NULL DEFAULT 0,
-          response_body_truncated INTEGER NOT NULL DEFAULT 0
-        )
-        SQL
+          CREATE TABLE flows (
+            id                      INTEGER PRIMARY KEY,
+            created_at              INTEGER NOT NULL,
+            scheme                  TEXT    NOT NULL,
+            host                    TEXT    NOT NULL,
+            port                    INTEGER NOT NULL,
+            method                  TEXT    NOT NULL,
+            target                  TEXT    NOT NULL,
+            http_version            TEXT    NOT NULL,
+            sni                     TEXT,
+            alpn                    TEXT,
+            tls_version             TEXT,
+            request_head            BLOB    NOT NULL,
+            request_body            BLOB,
+            response_head           BLOB,
+            response_body           BLOB,
+            status                  INTEGER,
+            reason                  TEXT,
+            content_type            TEXT,
+            request_size            INTEGER NOT NULL DEFAULT 0,
+            response_size           INTEGER,
+            state                   INTEGER NOT NULL,
+            ttfb_us                 INTEGER,
+            duration_us             INTEGER,
+            error                   TEXT,
+            h2_conn_id              INTEGER,
+            h2_stream_id            INTEGER,
+            request_body_truncated  INTEGER NOT NULL DEFAULT 0,
+            response_body_truncated INTEGER NOT NULL DEFAULT 0
+          )
+          SQL
         "CREATE INDEX idx_flows_created_at ON flows (created_at)",
         # The one projection filter with useful cardinality + range queries.
         "CREATE INDEX idx_flows_status ON flows (status)",
@@ -83,16 +83,16 @@ module Gori
 
         # WebSocket message log. `repeater_id` is set for messages sent from a WS Repeater tab.
         <<-SQL,
-        CREATE TABLE ws_messages (
-          id          INTEGER PRIMARY KEY,
-          flow_id     INTEGER NOT NULL,
-          created_at  INTEGER NOT NULL,
-          direction   TEXT    NOT NULL,
-          opcode      INTEGER NOT NULL,
-          payload     BLOB    NOT NULL,
-          repeater_id INTEGER
-        )
-        SQL
+          CREATE TABLE ws_messages (
+            id          INTEGER PRIMARY KEY,
+            flow_id     INTEGER NOT NULL,
+            created_at  INTEGER NOT NULL,
+            direction   TEXT    NOT NULL,
+            opcode      INTEGER NOT NULL,
+            payload     BLOB    NOT NULL,
+            repeater_id INTEGER
+          )
+          SQL
         "CREATE INDEX idx_ws_messages_flow ON ws_messages (flow_id)",
         "CREATE INDEX idx_ws_messages_repeater ON ws_messages (repeater_id)",
 
@@ -101,27 +101,27 @@ module Gori
         # the frame-log detail view only ever renders the `length` column (see
         # Store#insert_h2_frame_one).
         <<-SQL,
-        CREATE TABLE h2_connections (
-          id         INTEGER PRIMARY KEY,
-          created_at INTEGER NOT NULL,
-          host       TEXT    NOT NULL,
-          port       INTEGER NOT NULL,
-          alpn       TEXT    NOT NULL
-        )
-        SQL
+          CREATE TABLE h2_connections (
+            id         INTEGER PRIMARY KEY,
+            created_at INTEGER NOT NULL,
+            host       TEXT    NOT NULL,
+            port       INTEGER NOT NULL,
+            alpn       TEXT    NOT NULL
+          )
+          SQL
         <<-SQL,
-        CREATE TABLE h2_frames (
-          id         INTEGER PRIMARY KEY,
-          conn_id    INTEGER NOT NULL,
-          created_at INTEGER NOT NULL,
-          direction  TEXT    NOT NULL,
-          stream_id  INTEGER NOT NULL,
-          type       INTEGER NOT NULL,
-          flags      INTEGER NOT NULL,
-          length     INTEGER NOT NULL,
-          payload    BLOB    NOT NULL
-        )
-        SQL
+          CREATE TABLE h2_frames (
+            id         INTEGER PRIMARY KEY,
+            conn_id    INTEGER NOT NULL,
+            created_at INTEGER NOT NULL,
+            direction  TEXT    NOT NULL,
+            stream_id  INTEGER NOT NULL,
+            type       INTEGER NOT NULL,
+            flags      INTEGER NOT NULL,
+            length     INTEGER NOT NULL,
+            payload    BLOB    NOT NULL
+          )
+          SQL
         "CREATE INDEX idx_h2_frames_conn ON h2_frames (conn_id)",
         # So the retention prune's orphan-connection reap (`SELECT conn_id FROM h2_frames
         # WHERE created_at >= ?`) is answered index-only instead of full-scanning the frame
@@ -136,46 +136,46 @@ module Gori
         # UNIQUE sits on the (kind, match_type, pattern) triple, so the same pattern can be
         # both an include and an exclude, or a host rule and a string rule.
         <<-SQL,
-        CREATE TABLE scope_rules (
-          id         INTEGER PRIMARY KEY,
-          kind       TEXT NOT NULL DEFAULT 'include',
-          match_type TEXT NOT NULL DEFAULT 'host',
-          pattern    TEXT NOT NULL,
-          UNIQUE(kind, match_type, pattern)
-        )
-        SQL
+          CREATE TABLE scope_rules (
+            id         INTEGER PRIMARY KEY,
+            kind       TEXT NOT NULL DEFAULT 'include',
+            match_type TEXT NOT NULL DEFAULT 'host',
+            pattern    TEXT NOT NULL,
+            UNIQUE(kind, match_type, pattern)
+          )
+          SQL
 
         # Issues: human-confirmed vuln records, with a triage STATUS axis (open / confirmed /
         # false-positive / resolved) separate from severity, so a false positive is a
         # reversible state instead of a delete. NOTE: distinct from probe_issues below
         # (machine-found scan results).
         <<-SQL,
-        CREATE TABLE issues (
-          id         INTEGER PRIMARY KEY,
-          created_at INTEGER NOT NULL,
-          updated_at INTEGER NOT NULL,
-          title      TEXT    NOT NULL,
-          severity   INTEGER NOT NULL,
-          host       TEXT,
-          flow_id    INTEGER,
-          notes      TEXT    NOT NULL DEFAULT '',
-          status     INTEGER NOT NULL DEFAULT 0
-        )
-        SQL
+          CREATE TABLE issues (
+            id         INTEGER PRIMARY KEY,
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL,
+            title      TEXT    NOT NULL,
+            severity   INTEGER NOT NULL,
+            host       TEXT,
+            flow_id    INTEGER,
+            notes      TEXT    NOT NULL DEFAULT '',
+            status     INTEGER NOT NULL DEFAULT 0
+          )
+          SQL
         "CREATE INDEX idx_issues_severity ON issues (severity)",
 
         # Cross-entity links: attach History/Repeater/Fuzzer/Miner refs to an Issue or Note.
         <<-SQL,
-        CREATE TABLE entity_links (
-          id         INTEGER PRIMARY KEY,
-          owner_kind TEXT    NOT NULL,
-          owner_id   INTEGER NOT NULL,
-          ref_kind   TEXT    NOT NULL,
-          ref_id     INTEGER NOT NULL,
-          created_at INTEGER NOT NULL,
-          UNIQUE(owner_kind, owner_id, ref_kind, ref_id)
-        )
-        SQL
+          CREATE TABLE entity_links (
+            id         INTEGER PRIMARY KEY,
+            owner_kind TEXT    NOT NULL,
+            owner_id   INTEGER NOT NULL,
+            ref_kind   TEXT    NOT NULL,
+            ref_id     INTEGER NOT NULL,
+            created_at INTEGER NOT NULL,
+            UNIQUE(owner_kind, owner_id, ref_kind, ref_id)
+          )
+          SQL
         "CREATE INDEX idx_entity_links_owner ON entity_links (owner_kind, owner_id)",
 
         # Sitemap path tags: a free-text memo pinned to a (host, path) node in the Sitemap
@@ -183,14 +183,14 @@ module Gori
         # sharing the DB (reconciled on the data_version poll like issues). UNIQUE(host, path)
         # makes the write an upsert; an empty tag deletes the row.
         <<-SQL,
-        CREATE TABLE sitemap_tags (
-          id   INTEGER PRIMARY KEY,
-          host TEXT NOT NULL,
-          path TEXT NOT NULL,
-          tag  TEXT NOT NULL,
-          UNIQUE(host, path)
-        )
-        SQL
+          CREATE TABLE sitemap_tags (
+            id   INTEGER PRIMARY KEY,
+            host TEXT NOT NULL,
+            path TEXT NOT NULL,
+            tag  TEXT NOT NULL,
+            UNIQUE(host, path)
+          )
+          SQL
 
         # Project-level hostname overrides (a per-project /etc/hosts): map a host to the IP the
         # proxy should DIAL for it, while SNI/cert/Host header keep the original host. `host` is
@@ -198,12 +198,12 @@ module Gori
         # edit the row to change its IP). Read on the proxy hot path (Upstream.dial) via the
         # Mutex-guarded HostOverrides model.
         <<-SQL,
-        CREATE TABLE host_overrides (
-          id   INTEGER PRIMARY KEY,
-          host TEXT NOT NULL UNIQUE,
-          ip   TEXT NOT NULL
-        )
-        SQL
+          CREATE TABLE host_overrides (
+            id   INTEGER PRIMARY KEY,
+            host TEXT NOT NULL UNIQUE,
+            ip   TEXT NOT NULL
+          )
+          SQL
 
         # ── Rewriter (Match & Replace) ───────────────────────────────────────────
         # A rule rewrites either the message HEAD (request/status line + headers) or its BODY
@@ -211,20 +211,20 @@ module Gori
         # set-header / remove-header), a MATCH KIND (literal / regex, for replace), an optional
         # NAME, and an optional HOST glob ('' = all hosts) that scopes the rule.
         <<-SQL,
-        CREATE TABLE match_rules (
-          id          INTEGER PRIMARY KEY,
-          enabled     INTEGER NOT NULL DEFAULT 1,
-          target      TEXT    NOT NULL,
-          pattern     TEXT    NOT NULL,
-          replacement TEXT    NOT NULL DEFAULT '',
-          position    INTEGER NOT NULL DEFAULT 0,
-          part        TEXT    NOT NULL DEFAULT 'head',
-          op          TEXT    NOT NULL DEFAULT 'replace',
-          match_kind  TEXT    NOT NULL DEFAULT 'literal',
-          name        TEXT    NOT NULL DEFAULT '',
-          host        TEXT    NOT NULL DEFAULT ''
-        )
-        SQL
+          CREATE TABLE match_rules (
+            id          INTEGER PRIMARY KEY,
+            enabled     INTEGER NOT NULL DEFAULT 1,
+            target      TEXT    NOT NULL,
+            pattern     TEXT    NOT NULL,
+            replacement TEXT    NOT NULL DEFAULT '',
+            position    INTEGER NOT NULL DEFAULT 0,
+            part        TEXT    NOT NULL DEFAULT 'head',
+            op          TEXT    NOT NULL DEFAULT 'replace',
+            match_kind  TEXT    NOT NULL DEFAULT 'literal',
+            name        TEXT    NOT NULL DEFAULT '',
+            host        TEXT    NOT NULL DEFAULT ''
+          )
+          SQL
 
         # ── Workbenches ──────────────────────────────────────────────────────────
         # Repeater tabs, persisted so they survive a reopen AND sync across sessions sharing
@@ -238,25 +238,25 @@ module Gori
         # restore() can rebuild the Replay::Result faithfully — including an errored send.
         # All NULL until the first send. Scroll/focus/diff-baseline stay transient.
         <<-SQL,
-        CREATE TABLE repeaters (
-          id                   INTEGER PRIMARY KEY,
-          created_at           INTEGER NOT NULL,
-          updated_at           INTEGER NOT NULL,
-          target               TEXT    NOT NULL,
-          request              TEXT    NOT NULL,
-          http2                INTEGER NOT NULL DEFAULT 0,
-          auto_content_length  INTEGER NOT NULL DEFAULT 1,
-          flow_id              INTEGER,
-          position             INTEGER NOT NULL DEFAULT 0,
-          response_head        BLOB,
-          response_body        BLOB,
-          response_error       TEXT,
-          response_duration_us INTEGER,
-          name                 TEXT,
-          sni                  TEXT,
-          tags                 TEXT
-        )
-        SQL
+          CREATE TABLE repeaters (
+            id                   INTEGER PRIMARY KEY,
+            created_at           INTEGER NOT NULL,
+            updated_at           INTEGER NOT NULL,
+            target               TEXT    NOT NULL,
+            request              TEXT    NOT NULL,
+            http2                INTEGER NOT NULL DEFAULT 0,
+            auto_content_length  INTEGER NOT NULL DEFAULT 1,
+            flow_id              INTEGER,
+            position             INTEGER NOT NULL DEFAULT 0,
+            response_head        BLOB,
+            response_body        BLOB,
+            response_error       TEXT,
+            response_duration_us INTEGER,
+            name                 TEXT,
+            sni                  TEXT,
+            tags                 TEXT
+          )
+          SQL
         "CREATE INDEX idx_repeaters_position ON repeaters (position, id)",
 
         # Fuzzer / Intruder persistence:
@@ -268,56 +268,56 @@ module Gori
         #    frontends persist selectively per keep_bodies (a billion-row cluster bomb is
         #    never stored whole).
         <<-SQL,
-        CREATE TABLE fuzz_sessions (
-          id         INTEGER PRIMARY KEY,
-          created_at INTEGER NOT NULL,
-          updated_at INTEGER NOT NULL,
-          target     TEXT    NOT NULL,
-          template   TEXT    NOT NULL,
-          http2      INTEGER NOT NULL DEFAULT 0,
-          sni        TEXT,
-          config     TEXT    NOT NULL DEFAULT '',
-          flow_id    INTEGER,
-          position   INTEGER NOT NULL DEFAULT 0,
-          name       TEXT
-        )
-        SQL
+          CREATE TABLE fuzz_sessions (
+            id         INTEGER PRIMARY KEY,
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL,
+            target     TEXT    NOT NULL,
+            template   TEXT    NOT NULL,
+            http2      INTEGER NOT NULL DEFAULT 0,
+            sni        TEXT,
+            config     TEXT    NOT NULL DEFAULT '',
+            flow_id    INTEGER,
+            position   INTEGER NOT NULL DEFAULT 0,
+            name       TEXT
+          )
+          SQL
         "CREATE INDEX idx_fuzz_sessions_position ON fuzz_sessions (position, id)",
         <<-SQL,
-        CREATE TABLE fuzz_runs (
-          id          INTEGER PRIMARY KEY,
-          session_id  INTEGER,
-          created_at  INTEGER NOT NULL,
-          finished_at INTEGER,
-          target      TEXT    NOT NULL,
-          mode        TEXT    NOT NULL,
-          total       INTEGER,
-          sent        INTEGER NOT NULL DEFAULT 0,
-          matched     INTEGER NOT NULL DEFAULT 0,
-          errors      INTEGER NOT NULL DEFAULT 0,
-          status      TEXT    NOT NULL DEFAULT 'running'
-        )
-        SQL
+          CREATE TABLE fuzz_runs (
+            id          INTEGER PRIMARY KEY,
+            session_id  INTEGER,
+            created_at  INTEGER NOT NULL,
+            finished_at INTEGER,
+            target      TEXT    NOT NULL,
+            mode        TEXT    NOT NULL,
+            total       INTEGER,
+            sent        INTEGER NOT NULL DEFAULT 0,
+            matched     INTEGER NOT NULL DEFAULT 0,
+            errors      INTEGER NOT NULL DEFAULT 0,
+            status      TEXT    NOT NULL DEFAULT 'running'
+          )
+          SQL
         "CREATE INDEX idx_fuzz_runs_session ON fuzz_runs (session_id, id)",
         <<-SQL,
-        CREATE TABLE fuzz_results (
-          id            INTEGER PRIMARY KEY,
-          run_id        INTEGER NOT NULL,
-          idx           INTEGER NOT NULL,
-          payloads      TEXT    NOT NULL,
-          status        INTEGER,
-          length        INTEGER NOT NULL DEFAULT 0,
-          words         INTEGER NOT NULL DEFAULT 0,
-          lines         INTEGER NOT NULL DEFAULT 0,
-          duration_us   INTEGER NOT NULL DEFAULT 0,
-          error         TEXT,
-          matched       INTEGER NOT NULL DEFAULT 0,
-          extracted     TEXT,
-          request       BLOB,
-          response_head BLOB,
-          response_body BLOB
-        )
-        SQL
+          CREATE TABLE fuzz_results (
+            id            INTEGER PRIMARY KEY,
+            run_id        INTEGER NOT NULL,
+            idx           INTEGER NOT NULL,
+            payloads      TEXT    NOT NULL,
+            status        INTEGER,
+            length        INTEGER NOT NULL DEFAULT 0,
+            words         INTEGER NOT NULL DEFAULT 0,
+            lines         INTEGER NOT NULL DEFAULT 0,
+            duration_us   INTEGER NOT NULL DEFAULT 0,
+            error         TEXT,
+            matched       INTEGER NOT NULL DEFAULT 0,
+            extracted     TEXT,
+            request       BLOB,
+            response_head BLOB,
+            response_body BLOB
+          )
+          SQL
         "CREATE INDEX idx_fuzz_results_run ON fuzz_results (run_id, idx)",
 
         # Param-miner sessions. Mirrors fuzz_sessions, but stores the byte-exact `request`
@@ -325,40 +325,40 @@ module Gori
         # table — mining results stay in-memory per session. `config` is opaque JSON managed
         # by the frontend (locations, bucket sizes, concurrency, …).
         <<-SQL,
-        CREATE TABLE miner_sessions (
-          id         INTEGER PRIMARY KEY,
-          created_at INTEGER NOT NULL,
-          updated_at INTEGER NOT NULL,
-          target     TEXT    NOT NULL,
-          request    BLOB    NOT NULL,
-          http2      INTEGER NOT NULL DEFAULT 0,
-          sni        TEXT,
-          config     TEXT    NOT NULL DEFAULT '',
-          flow_id    INTEGER,
-          position   INTEGER NOT NULL DEFAULT 0,
-          name       TEXT
-        )
-        SQL
+          CREATE TABLE miner_sessions (
+            id         INTEGER PRIMARY KEY,
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL,
+            target     TEXT    NOT NULL,
+            request    BLOB    NOT NULL,
+            http2      INTEGER NOT NULL DEFAULT 0,
+            sni        TEXT,
+            config     TEXT    NOT NULL DEFAULT '',
+            flow_id    INTEGER,
+            position   INTEGER NOT NULL DEFAULT 0,
+            name       TEXT
+          )
+          SQL
         "CREATE INDEX idx_miner_sessions_position ON miner_sessions (position, id)",
 
         # Sequencer sessions: token-randomness collection. Structurally identical to
         # miner_sessions. Collected tokens are live secrets, so like the miner there is NO
         # results table: samples and the computed report stay in-memory and never hit disk.
         <<-SQL,
-        CREATE TABLE sequencer_sessions (
-          id         INTEGER PRIMARY KEY,
-          created_at INTEGER NOT NULL,
-          updated_at INTEGER NOT NULL,
-          target     TEXT    NOT NULL,
-          request    BLOB    NOT NULL,
-          http2      INTEGER NOT NULL DEFAULT 0,
-          sni        TEXT,
-          config     TEXT    NOT NULL DEFAULT '',
-          flow_id    INTEGER,
-          position   INTEGER NOT NULL DEFAULT 0,
-          name       TEXT
-        )
-        SQL
+          CREATE TABLE sequencer_sessions (
+            id         INTEGER PRIMARY KEY,
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL,
+            target     TEXT    NOT NULL,
+            request    BLOB    NOT NULL,
+            http2      INTEGER NOT NULL DEFAULT 0,
+            sni        TEXT,
+            config     TEXT    NOT NULL DEFAULT '',
+            flow_id    INTEGER,
+            position   INTEGER NOT NULL DEFAULT 0,
+            name       TEXT
+          )
+          SQL
         "CREATE INDEX idx_sequencer_sessions_position ON sequencer_sessions (position, id)",
 
         # ── Probe (passive/active scanner) ───────────────────────────────────────
@@ -369,24 +369,24 @@ module Gori
         # first-seen Repeater evidence link when there is no parent flow (or as a secondary).
         # The Probe MODE itself lives in the generic `settings` table (key "probe_mode").
         <<-SQL,
-        CREATE TABLE probe_issues (
-          id                 INTEGER PRIMARY KEY,
-          code               TEXT    NOT NULL,
-          category           TEXT    NOT NULL,
-          host               TEXT    NOT NULL,
-          title              TEXT    NOT NULL,
-          severity           INTEGER NOT NULL,
-          status             INTEGER NOT NULL DEFAULT 0,
-          hit_count          INTEGER NOT NULL DEFAULT 1,
-          affected           TEXT    NOT NULL DEFAULT '[]',
-          sample_flow_id     INTEGER,
-          sample_repeater_id INTEGER,
-          evidence           TEXT,
-          first_seen         INTEGER NOT NULL,
-          last_seen          INTEGER NOT NULL,
-          UNIQUE(code, host)
-        )
-        SQL
+          CREATE TABLE probe_issues (
+            id                 INTEGER PRIMARY KEY,
+            code               TEXT    NOT NULL,
+            category           TEXT    NOT NULL,
+            host               TEXT    NOT NULL,
+            title              TEXT    NOT NULL,
+            severity           INTEGER NOT NULL,
+            status             INTEGER NOT NULL DEFAULT 0,
+            hit_count          INTEGER NOT NULL DEFAULT 1,
+            affected           TEXT    NOT NULL DEFAULT '[]',
+            sample_flow_id     INTEGER,
+            sample_repeater_id INTEGER,
+            evidence           TEXT,
+            first_seen         INTEGER NOT NULL,
+            last_seen          INTEGER NOT NULL,
+            UNIQUE(code, host)
+          )
+          SQL
         "CREATE INDEX idx_probe_issues_cat ON probe_issues (category, host)",
 
         # Hard-deleted Probe issues must stay gone across Project leave/re-open: without a
@@ -395,30 +395,30 @@ module Gori
         # analyzer on start. Clear-all removes both issues and suppressions so a full rescan
         # is still possible.
         <<-SQL,
-        CREATE TABLE probe_suppressions (
-          code       TEXT    NOT NULL,
-          host       TEXT    NOT NULL,
-          created_at INTEGER NOT NULL,
-          PRIMARY KEY (code, host)
-        )
-        SQL
+          CREATE TABLE probe_suppressions (
+            code       TEXT    NOT NULL,
+            host       TEXT    NOT NULL,
+            created_at INTEGER NOT NULL,
+            PRIMARY KEY (code, host)
+          )
+          SQL
 
         # Per-project user-defined Probe match rules (the Rules sub-tab's project-scope custom
         # rules). Global-scope rules live in settings.json instead. `severity` is the lowercase
         # Store::Severity label; side/region/kind are validated in the store layer before insert.
         <<-SQL,
-        CREATE TABLE probe_custom_rules (
-          id          INTEGER PRIMARY KEY,
-          title       TEXT    NOT NULL,
-          description TEXT    NOT NULL DEFAULT '',
-          side        TEXT    NOT NULL,
-          region      TEXT    NOT NULL,
-          kind        TEXT    NOT NULL,
-          pattern     TEXT    NOT NULL,
-          severity    TEXT    NOT NULL,
-          enabled     INTEGER NOT NULL DEFAULT 1
-        )
-        SQL
+          CREATE TABLE probe_custom_rules (
+            id          INTEGER PRIMARY KEY,
+            title       TEXT    NOT NULL,
+            description TEXT    NOT NULL DEFAULT '',
+            side        TEXT    NOT NULL,
+            region      TEXT    NOT NULL,
+            kind        TEXT    NOT NULL,
+            pattern     TEXT    NOT NULL,
+            severity    TEXT    NOT NULL,
+            enabled     INTEGER NOT NULL DEFAULT 1
+          )
+          SQL
 
         # ── AI seam (MCP) ────────────────────────────────────────────────────────
         # The AI-facing event feed: an append-only log of job lifecycle (miner/fuzzer/probe)
@@ -429,19 +429,19 @@ module Gori
         # consumer can't silently skip a row even if a future retention sweep deletes rows.
         # created_at is unix micros for display only — the cursor key is always `id`.
         <<-SQL,
-        CREATE TABLE events (
-          id              INTEGER PRIMARY KEY AUTOINCREMENT,
-          created_at      INTEGER NOT NULL,
-          source          TEXT    NOT NULL,
-          kind            TEXT    NOT NULL,
-          level           TEXT    NOT NULL,
-          message         TEXT    NOT NULL,
-          goto_tab        TEXT,
-          goto_session_id INTEGER,
-          flow_id         INTEGER,
-          payload         TEXT
-        )
-        SQL
+          CREATE TABLE events (
+            id              INTEGER PRIMARY KEY AUTOINCREMENT,
+            created_at      INTEGER NOT NULL,
+            source          TEXT    NOT NULL,
+            kind            TEXT    NOT NULL,
+            level           TEXT    NOT NULL,
+            message         TEXT    NOT NULL,
+            goto_tab        TEXT,
+            goto_session_id INTEGER,
+            flow_id         INTEGER,
+            payload         TEXT
+          )
+          SQL
 
         # The cross-process live-intercept bridge. The MCP process (Store only, no live
         # Interceptor) drives hold/forward/drop/edit through the DB: the capturing TUI
@@ -453,38 +453,38 @@ module Gori
         # the TUI's drain watermark silently skip a row). session_token defeats cross-session
         # reuse of the interceptor's per-session item ids.
         <<-SQL,
-        CREATE TABLE intercept_held (
-          session_token TEXT    NOT NULL,
-          item_id       INTEGER NOT NULL,
-          kind          TEXT    NOT NULL,
-          method        TEXT    NOT NULL,
-          host          TEXT    NOT NULL,
-          port          INTEGER NOT NULL,
-          scheme        TEXT    NOT NULL,
-          target        TEXT    NOT NULL,
-          flow_id       INTEGER,
-          raw           BLOB    NOT NULL,
-          held_at_ms    INTEGER NOT NULL,
-          edited        INTEGER NOT NULL DEFAULT 0,
-          viewed_ms     INTEGER NOT NULL DEFAULT 0,
-          PRIMARY KEY (session_token, item_id)
-        )
-        SQL
+          CREATE TABLE intercept_held (
+            session_token TEXT    NOT NULL,
+            item_id       INTEGER NOT NULL,
+            kind          TEXT    NOT NULL,
+            method        TEXT    NOT NULL,
+            host          TEXT    NOT NULL,
+            port          INTEGER NOT NULL,
+            scheme        TEXT    NOT NULL,
+            target        TEXT    NOT NULL,
+            flow_id       INTEGER,
+            raw           BLOB    NOT NULL,
+            held_at_ms    INTEGER NOT NULL,
+            edited        INTEGER NOT NULL DEFAULT 0,
+            viewed_ms     INTEGER NOT NULL DEFAULT 0,
+            PRIMARY KEY (session_token, item_id)
+          )
+          SQL
         <<-SQL,
-        CREATE TABLE intercept_commands (
-          id            INTEGER PRIMARY KEY AUTOINCREMENT,
-          created_at    INTEGER NOT NULL,
-          session_token TEXT,
-          verb          TEXT    NOT NULL,
-          item_id       INTEGER,
-          bytes         BLOB,
-          arg           TEXT,
-          status        TEXT    NOT NULL DEFAULT 'pending',
-          applied_at    INTEGER,
-          result        TEXT,
-          origin        TEXT
-        )
-        SQL
+          CREATE TABLE intercept_commands (
+            id            INTEGER PRIMARY KEY AUTOINCREMENT,
+            created_at    INTEGER NOT NULL,
+            session_token TEXT,
+            verb          TEXT    NOT NULL,
+            item_id       INTEGER,
+            bytes         BLOB,
+            arg           TEXT,
+            status        TEXT    NOT NULL DEFAULT 'pending',
+            applied_at    INTEGER,
+            result        TEXT,
+            origin        TEXT
+          )
+          SQL
 
         # ── OAST (out-of-band) ───────────────────────────────────────────────────
         # Configured providers, listening sessions, and the durable callback history.
@@ -493,47 +493,47 @@ module Gori
         # 0600 and holds captured credentials; never logged). Callbacks are
         # append-only/immutable; UNIQUE(session_id, provider_uid) + INSERT OR IGNORE dedups.
         <<-SQL,
-        CREATE TABLE oast_providers (
-          id         INTEGER PRIMARY KEY,
-          created_at INTEGER NOT NULL,
-          updated_at INTEGER NOT NULL,
-          name       TEXT    NOT NULL,
-          kind       TEXT    NOT NULL,
-          host       TEXT    NOT NULL,
-          token      TEXT,
-          enabled    INTEGER NOT NULL DEFAULT 1,
-          position   INTEGER NOT NULL DEFAULT 0
-        )
-        SQL
+          CREATE TABLE oast_providers (
+            id         INTEGER PRIMARY KEY,
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL,
+            name       TEXT    NOT NULL,
+            kind       TEXT    NOT NULL,
+            host       TEXT    NOT NULL,
+            token      TEXT,
+            enabled    INTEGER NOT NULL DEFAULT 1,
+            position   INTEGER NOT NULL DEFAULT 0
+          )
+          SQL
         <<-SQL,
-        CREATE TABLE oast_sessions (
-          id              INTEGER PRIMARY KEY,
-          created_at      INTEGER NOT NULL,
-          provider_id     INTEGER,
-          kind            TEXT    NOT NULL,
-          server_url      TEXT    NOT NULL,
-          correlation_id  TEXT    NOT NULL,
-          secret          TEXT    NOT NULL DEFAULT '',
-          private_key_pem TEXT,
-          token           TEXT,
-          last_poll_at    INTEGER
-        )
-        SQL
+          CREATE TABLE oast_sessions (
+            id              INTEGER PRIMARY KEY,
+            created_at      INTEGER NOT NULL,
+            provider_id     INTEGER,
+            kind            TEXT    NOT NULL,
+            server_url      TEXT    NOT NULL,
+            correlation_id  TEXT    NOT NULL,
+            secret          TEXT    NOT NULL DEFAULT '',
+            private_key_pem TEXT,
+            token           TEXT,
+            last_poll_at    INTEGER
+          )
+          SQL
         <<-SQL,
-        CREATE TABLE oast_callbacks (
-          id           INTEGER PRIMARY KEY,
-          session_id   INTEGER NOT NULL,
-          created_at   INTEGER NOT NULL,
-          provider_uid TEXT    NOT NULL,
-          protocol     TEXT    NOT NULL,
-          method       TEXT,
-          source_ip    TEXT,
-          full_id      TEXT    NOT NULL,
-          raw_request  BLOB    NOT NULL,
-          raw_response BLOB,
-          UNIQUE(session_id, provider_uid)
-        )
-        SQL
+          CREATE TABLE oast_callbacks (
+            id           INTEGER PRIMARY KEY,
+            session_id   INTEGER NOT NULL,
+            created_at   INTEGER NOT NULL,
+            provider_uid TEXT    NOT NULL,
+            protocol     TEXT    NOT NULL,
+            method       TEXT,
+            source_ip    TEXT,
+            full_id      TEXT    NOT NULL,
+            raw_request  BLOB    NOT NULL,
+            raw_response BLOB,
+            UNIQUE(session_id, provider_uid)
+          )
+          SQL
         "CREATE INDEX idx_oast_callbacks_session ON oast_callbacks (session_id, id)",
       ]
 
@@ -626,18 +626,18 @@ module Gori
       # and have no meaningful order. No column for the VALUE either — see `ExtractRule`.
       V6 = [
         <<-SQL,
-        CREATE TABLE extract_rules (
-          id           INTEGER PRIMARY KEY,
-          enabled      INTEGER NOT NULL DEFAULT 1,
-          name         TEXT    NOT NULL UNIQUE,
-          match_filter TEXT    NOT NULL DEFAULT '',
-          kind         TEXT    NOT NULL,
-          selector     TEXT    NOT NULL DEFAULT '',
-          pos_start    INTEGER NOT NULL DEFAULT 0,
-          pos_end      INTEGER NOT NULL DEFAULT 0,
-          host         TEXT    NOT NULL DEFAULT ''
-        )
-        SQL
+          CREATE TABLE extract_rules (
+            id           INTEGER PRIMARY KEY,
+            enabled      INTEGER NOT NULL DEFAULT 1,
+            name         TEXT    NOT NULL UNIQUE,
+            match_filter TEXT    NOT NULL DEFAULT '',
+            kind         TEXT    NOT NULL,
+            selector     TEXT    NOT NULL DEFAULT '',
+            pos_start    INTEGER NOT NULL DEFAULT 0,
+            pos_end      INTEGER NOT NULL DEFAULT 0,
+            host         TEXT    NOT NULL DEFAULT ''
+          )
+          SQL
       ]
 
       # WebSocket frame SHAPE, on both halves of `ws_messages` — the capture rows and the
@@ -770,72 +770,72 @@ module Gori
       # links are already safely `(gone)`.
       V10 = [
         <<-SQL,
-        CREATE TABLE fuzz_sessions_v10 (
-          id         INTEGER PRIMARY KEY AUTOINCREMENT,
-          created_at INTEGER NOT NULL,
-          updated_at INTEGER NOT NULL,
-          target     TEXT    NOT NULL,
-          template   TEXT    NOT NULL,
-          http2      INTEGER NOT NULL DEFAULT 0,
-          sni        TEXT,
-          config     TEXT    NOT NULL DEFAULT '',
-          flow_id    INTEGER,
-          position   INTEGER NOT NULL DEFAULT 0,
-          name       TEXT
-        )
-        SQL
+          CREATE TABLE fuzz_sessions_v10 (
+            id         INTEGER PRIMARY KEY AUTOINCREMENT,
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL,
+            target     TEXT    NOT NULL,
+            template   TEXT    NOT NULL,
+            http2      INTEGER NOT NULL DEFAULT 0,
+            sni        TEXT,
+            config     TEXT    NOT NULL DEFAULT '',
+            flow_id    INTEGER,
+            position   INTEGER NOT NULL DEFAULT 0,
+            name       TEXT
+          )
+          SQL
         <<-SQL,
-        INSERT INTO fuzz_sessions_v10
-          (id, created_at, updated_at, target, template, http2, sni, config, flow_id, position, name)
-          SELECT id, created_at, updated_at, target, template, http2, sni, config, flow_id, position, name
-          FROM fuzz_sessions
-        SQL
+          INSERT INTO fuzz_sessions_v10
+            (id, created_at, updated_at, target, template, http2, sni, config, flow_id, position, name)
+            SELECT id, created_at, updated_at, target, template, http2, sni, config, flow_id, position, name
+            FROM fuzz_sessions
+          SQL
         "DROP TABLE fuzz_sessions",
         "ALTER TABLE fuzz_sessions_v10 RENAME TO fuzz_sessions",
         "CREATE INDEX idx_fuzz_sessions_position ON fuzz_sessions (position, id)",
         "DELETE FROM sqlite_sequence WHERE name = 'fuzz_sessions'",
         <<-SQL,
-        INSERT INTO sqlite_sequence (name, seq)
-          SELECT 'fuzz_sessions', COALESCE(MAX(v), 0) FROM (
-            SELECT MAX(id) AS v FROM fuzz_sessions
-            UNION ALL
-            SELECT MAX(ref_id) FROM entity_links WHERE ref_kind = 'fuzz'
-          )
-        SQL
+          INSERT INTO sqlite_sequence (name, seq)
+            SELECT 'fuzz_sessions', COALESCE(MAX(v), 0) FROM (
+              SELECT MAX(id) AS v FROM fuzz_sessions
+              UNION ALL
+              SELECT MAX(ref_id) FROM entity_links WHERE ref_kind = 'fuzz'
+            )
+          SQL
 
         <<-SQL,
-        CREATE TABLE miner_sessions_v10 (
-          id         INTEGER PRIMARY KEY AUTOINCREMENT,
-          created_at INTEGER NOT NULL,
-          updated_at INTEGER NOT NULL,
-          target     TEXT    NOT NULL,
-          request    BLOB    NOT NULL,
-          http2      INTEGER NOT NULL DEFAULT 0,
-          sni        TEXT,
-          config     TEXT    NOT NULL DEFAULT '',
-          flow_id    INTEGER,
-          position   INTEGER NOT NULL DEFAULT 0,
-          name       TEXT
-        )
-        SQL
+          CREATE TABLE miner_sessions_v10 (
+            id         INTEGER PRIMARY KEY AUTOINCREMENT,
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL,
+            target     TEXT    NOT NULL,
+            request    BLOB    NOT NULL,
+            http2      INTEGER NOT NULL DEFAULT 0,
+            sni        TEXT,
+            config     TEXT    NOT NULL DEFAULT '',
+            flow_id    INTEGER,
+            position   INTEGER NOT NULL DEFAULT 0,
+            name       TEXT
+          )
+          SQL
         <<-SQL,
-        INSERT INTO miner_sessions_v10
-          (id, created_at, updated_at, target, request, http2, sni, config, flow_id, position, name)
-          SELECT id, created_at, updated_at, target, request, http2, sni, config, flow_id, position, name
-          FROM miner_sessions
-        SQL
+          INSERT INTO miner_sessions_v10
+            (id, created_at, updated_at, target, request, http2, sni, config, flow_id, position, name)
+            SELECT id, created_at, updated_at, target, request, http2, sni, config, flow_id, position, name
+            FROM miner_sessions
+          SQL
         "DROP TABLE miner_sessions",
         "ALTER TABLE miner_sessions_v10 RENAME TO miner_sessions",
         "CREATE INDEX idx_miner_sessions_position ON miner_sessions (position, id)",
         "DELETE FROM sqlite_sequence WHERE name = 'miner_sessions'",
         <<-SQL,
-        INSERT INTO sqlite_sequence (name, seq)
-          SELECT 'miner_sessions', COALESCE(MAX(v), 0) FROM (
-            SELECT MAX(id) AS v FROM miner_sessions
-            UNION ALL
-            SELECT MAX(ref_id) FROM entity_links WHERE ref_kind = 'miner'
-          )
-        SQL
+          INSERT INTO sqlite_sequence (name, seq)
+            SELECT 'miner_sessions', COALESCE(MAX(v), 0) FROM (
+              SELECT MAX(id) AS v FROM miner_sessions
+              UNION ALL
+              SELECT MAX(ref_id) FROM entity_links WHERE ref_kind = 'miner'
+            )
+          SQL
       ]
 
       # `repeaters.ws_http_only` is the operator's override of gori's WebSocket AUTO-DETECTION.
@@ -884,25 +884,25 @@ module Gori
       # unable to say which probe drew it.
       V12 = [
         <<-SQL,
-        CREATE TABLE probe_oast_probes (
-          id         INTEGER PRIMARY KEY,
-          created_at INTEGER NOT NULL,
-          token      TEXT    NOT NULL,
-          payload    TEXT    NOT NULL,
-          session_id INTEGER NOT NULL,
-          rule_id    TEXT    NOT NULL,
-          code       TEXT    NOT NULL,
-          category   TEXT    NOT NULL,
-          title      TEXT    NOT NULL,
-          severity   INTEGER NOT NULL,
-          host       TEXT    NOT NULL,
-          url        TEXT    NOT NULL,
-          evidence   TEXT,
-          flow_id    INTEGER,
-          matched_at INTEGER,
-          UNIQUE(token)
-        )
-        SQL
+          CREATE TABLE probe_oast_probes (
+            id         INTEGER PRIMARY KEY,
+            created_at INTEGER NOT NULL,
+            token      TEXT    NOT NULL,
+            payload    TEXT    NOT NULL,
+            session_id INTEGER NOT NULL,
+            rule_id    TEXT    NOT NULL,
+            code       TEXT    NOT NULL,
+            category   TEXT    NOT NULL,
+            title      TEXT    NOT NULL,
+            severity   INTEGER NOT NULL,
+            host       TEXT    NOT NULL,
+            url        TEXT    NOT NULL,
+            evidence   TEXT,
+            flow_id    INTEGER,
+            matched_at INTEGER,
+            UNIQUE(token)
+          )
+          SQL
         "CREATE INDEX idx_probe_oast_pending ON probe_oast_probes (id) WHERE matched_at IS NULL",
       ]
 
@@ -931,16 +931,16 @@ module Gori
       # refuse the workflow the feature exists for.
       V13 = [
         <<-SQL,
-        CREATE TABLE color_rules (
-          id           INTEGER PRIMARY KEY,
-          enabled      INTEGER NOT NULL DEFAULT 1,
-          name         TEXT    NOT NULL DEFAULT '',
-          match_filter TEXT    NOT NULL DEFAULT '',
-          color        TEXT    NOT NULL DEFAULT 'yellow',
-          style        TEXT    NOT NULL DEFAULT 'full',
-          position     INTEGER NOT NULL DEFAULT 0
-        )
-        SQL
+          CREATE TABLE color_rules (
+            id           INTEGER PRIMARY KEY,
+            enabled      INTEGER NOT NULL DEFAULT 1,
+            name         TEXT    NOT NULL DEFAULT '',
+            match_filter TEXT    NOT NULL DEFAULT '',
+            color        TEXT    NOT NULL DEFAULT 'yellow',
+            style        TEXT    NOT NULL DEFAULT 'full',
+            position     INTEGER NOT NULL DEFAULT 0
+          )
+          SQL
       ]
 
       MIGRATIONS = [V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13]

--- a/src/gori/tui/controllers/comparer_controller.cr
+++ b/src/gori/tui/controllers/comparer_controller.cr
@@ -100,7 +100,7 @@ module Gori::Tui
     end
 
     def apply_rename(v : ComparerView, name : String) : Nil
-      return unless @sessions.any? { |s| s.same?(v) }
+      return unless @sessions.any?(&.same?(v))
       clean = name.strip
       v.name = clean.empty? ? nil : clean
     end

--- a/src/gori/tui/controllers/comparer_controller.cr
+++ b/src/gori/tui/controllers/comparer_controller.cr
@@ -47,7 +47,7 @@ module Gori::Tui
     end
 
     def filter_fields : Array(String)
-      %w(name host method) # each session's A/B slots carry a target + method
+      %w[name host method] # each session's A/B slots carry a target + method
     end
 
     def filter_subjects : Array(Repeater::SubtabFilter::Subject)

--- a/src/gori/tui/controllers/decoder_controller.cr
+++ b/src/gori/tui/controllers/decoder_controller.cr
@@ -127,7 +127,7 @@ module Gori::Tui
     end
 
     def filter_fields : Array(String)
-      %w(name) # a conversion has no HTTP context; free-text covers the chain + input
+      %w[name] # a conversion has no HTTP context; free-text covers the chain + input
     end
 
     def filter_subjects : Array(Repeater::SubtabFilter::Subject)

--- a/src/gori/tui/controllers/decoder_controller.cr
+++ b/src/gori/tui/controllers/decoder_controller.cr
@@ -859,7 +859,7 @@ module Gori::Tui
       # passive discovery menu (engaged? = false → Tab keeps navigating the focus ring,
       # ↓ dives in). A typed token filters AND engages it (Tab/↵ accept). set() opens the
       # popup iff the match list is non-empty.
-      matches = registry.match(tok).map(&.name).uniq
+      matches = registry.match(tok).map(&.name).uniq!
       @popup.set(matches.first(64), ts, te)
       @popup_engaged = !tok.empty?
     end

--- a/src/gori/tui/controllers/fuzzer_controller.cr
+++ b/src/gori/tui/controllers/fuzzer_controller.cr
@@ -91,7 +91,7 @@ module Gori::Tui
     end
 
     def filter_fields : Array(String)
-      %w(name host method) # fuzz sessions carry an HTTP template (target + method)
+      %w[name host method] # fuzz sessions carry an HTTP template (target + method)
     end
 
     def filter_subjects : Array(Repeater::SubtabFilter::Subject)

--- a/src/gori/tui/controllers/fuzzer_controller.cr
+++ b/src/gori/tui/controllers/fuzzer_controller.cr
@@ -899,7 +899,7 @@ module Gori::Tui
     # Re-find by VIEW identity so a closed/reordered tab is a no-op, never a neighbour. Blank
     # clears the custom label (the chip reverts to the template-derived summary).
     def apply_rename(view : FuzzerView, name : String) : Nil
-      return unless tab = @fuzzers.find { |t| t.view.same?(view) }
+      return unless tab = @fuzzers.find(&.view.same?(view))
       clean = name.strip
       view.name = clean.empty? ? nil : clean
       if id = tab.db_id
@@ -1314,7 +1314,7 @@ module Gori::Tui
       @current_idx =
         if cur_db && (idx = @fuzzers.index { |t| t.db_id == cur_db })
           idx
-        elsif (cv = cur_view) && (idx = @fuzzers.index { |t| t.view.same?(cv) })
+        elsif (cv = cur_view) && (idx = @fuzzers.index(&.view.same?(cv)))
           idx
         elsif @fuzzers.empty?
           -1

--- a/src/gori/tui/controllers/jwt_controller.cr
+++ b/src/gori/tui/controllers/jwt_controller.cr
@@ -140,7 +140,7 @@ module Gori::Tui
     end
 
     def filter_fields : Array(String)
-      %w(name)
+      %w[name]
     end
 
     def filter_subjects : Array(Repeater::SubtabFilter::Subject)

--- a/src/gori/tui/controllers/miner_controller.cr
+++ b/src/gori/tui/controllers/miner_controller.cr
@@ -728,7 +728,7 @@ module Gori::Tui
       @current_idx =
         if cur_db && (idx = @miners.index { |t| t.db_id == cur_db })
           idx
-        elsif (cv = cur_view) && (idx = @miners.index { |t| t.view.same?(cv) })
+        elsif (cv = cur_view) && (idx = @miners.index(&.view.same?(cv)))
           idx
         elsif @miners.empty?
           -1

--- a/src/gori/tui/controllers/miner_controller.cr
+++ b/src/gori/tui/controllers/miner_controller.cr
@@ -345,7 +345,7 @@ module Gori::Tui
     end
 
     def filter_fields : Array(String)
-      %w(name host method) # mining sessions carry an HTTP request (target + method)
+      %w[name host method] # mining sessions carry an HTTP request (target + method)
     end
 
     def filter_subjects : Array(Repeater::SubtabFilter::Subject)

--- a/src/gori/tui/controllers/notes_controller.cr
+++ b/src/gori/tui/controllers/notes_controller.cr
@@ -254,7 +254,7 @@ module Gori::Tui
     end
 
     def filter_fields : Array(String)
-      %w(name) # notes have no HTTP context; free-text covers each note's body text
+      %w[name] # notes have no HTTP context; free-text covers each note's body text
     end
 
     def filter_subjects : Array(Repeater::SubtabFilter::Subject)

--- a/src/gori/tui/controllers/oast_controller.cr
+++ b/src/gori/tui/controllers/oast_controller.cr
@@ -420,12 +420,10 @@ module Gori::Tui
       db_id = prov.project_id
       @registering << key
       spawn(name: "gori-oast-register") do
-        begin
-          session = provider.register(http)
-          reg.send(RegOk.new(session, provider, key, db_id, label, want_payload))
-        rescue ex
-          reg.send(RegErr.new(ex.message || "register failed", label, key))
-        end
+        session = provider.register(http)
+        reg.send(RegOk.new(session, provider, key, db_id, label, want_payload))
+      rescue ex
+        reg.send(RegErr.new(ex.message || "register failed", label, key))
       end
       @host.status("registering with #{label}…")
     end
@@ -489,12 +487,10 @@ module Gori::Tui
       db_id = config.project_id
       @registering << key
       spawn(name: "gori-oast-resume") do
-        begin
-          provider.resume(http, session)
-          reg.send(RegOk.new(session, provider, key, db_id, label, false, resumed: true))
-        rescue ex
-          reg.send(RegErr.new(ex.message || "resume failed", label, key))
-        end
+        provider.resume(http, session)
+        reg.send(RegOk.new(session, provider, key, db_id, label, false, resumed: true))
+      rescue ex
+        reg.send(RegErr.new(ex.message || "resume failed", label, key))
       end
       @host.status("resuming #{label} session ##{session_id}…")
     end

--- a/src/gori/tui/controllers/repeater_controller.cr
+++ b/src/gori/tui/controllers/repeater_controller.cr
@@ -997,7 +997,7 @@ module Gori::Tui
     # Apply the typed name to the captured tab + persist. Re-find by VIEW identity (the
     # reconcile may have reordered/removed it) — gone → no-op, never hits a neighbour.
     def apply_rename(view : RepeaterView, name : String) : Nil
-      return unless tab = @repeaters.find { |t| t.view.same?(view) }
+      return unless tab = @repeaters.find(&.view.same?(view))
       clean = name.strip
       view.name = clean.empty? ? nil : clean
       if id = tab.db_id
@@ -1009,7 +1009,7 @@ module Gori::Tui
     # reconcile may have reordered/removed it) — gone → no-op. Mirrors apply_rename;
     # blank clears every tag. The raw string is normalized (ws/comma split, dedupe).
     def apply_tags(view : RepeaterView, raw : String) : Nil
-      return unless tab = @repeaters.find { |t| t.view.same?(view) }
+      return unless tab = @repeaters.find(&.view.same?(view))
       view.tags = Repeater::Tags.parse(raw)
       if id = tab.db_id
         @host.session.store.set_repeater_tags(id, Repeater::Tags.serialize(view.tags))
@@ -1029,7 +1029,7 @@ module Gori::Tui
         view, result = pair
         # Drop a result whose sub-tab was closed (^W) mid-flight — applying it would
         # mutate an orphaned view and flash a toast for a gone session.
-        next unless tab = @repeaters.find { |t| t.view.same?(view) }
+        next unless tab = @repeaters.find(&.view.same?(view))
         view.apply(result)
         # Persist a SUCCESSFUL send as the tab's last response (V11) so it survives a
         # reopen. Only on success: a later failed resend must not wipe a good response.
@@ -1042,7 +1042,7 @@ module Gori::Tui
       end
       while pair = nonblocking_ws_result
         view, result = pair
-        next unless tab = @repeaters.find { |t| t.view.same?(view) } # sub-tab closed mid-flight
+        next unless tab = @repeaters.find(&.view.same?(view)) # sub-tab closed mid-flight
         view.apply_ws(result)
         if result.ok?
           recv = result.messages.count(&.direction.==("in"))
@@ -1059,7 +1059,7 @@ module Gori::Tui
       end
       while pair = nonblocking_group_result
         view, labeled = pair
-        next unless @repeaters.find { |t| t.view.same?(view) } # sub-tab closed mid-flight
+        next unless @repeaters.find(&.view.same?(view)) # sub-tab closed mid-flight
         view.apply_group(labeled)
         ok = labeled.count { |(_, r)| r.error.nil? }
         @host.status("send group: #{ok}/#{labeled.size} ok on one connection")
@@ -1067,7 +1067,7 @@ module Gori::Tui
       end
       while pair = nonblocking_minimize_event
         view, msg = pair
-        next unless tab = @repeaters.find { |t| t.view.same?(view) } # sub-tab closed mid-run → drop
+        next unless tab = @repeaters.find(&.view.same?(view)) # sub-tab closed mid-run → drop
         case msg
         in Repeater::Minimize::Progress
           if (mj = @minimize_job) && mj[0].same?(view)
@@ -1282,7 +1282,7 @@ module Gori::Tui
       @current_repeater_idx =
         if cur_db && (idx = @repeaters.index { |t| t.db_id == cur_db })
           idx
-        elsif (cv = cur_view) && (idx = @repeaters.index { |t| t.view.same?(cv) })
+        elsif (cv = cur_view) && (idx = @repeaters.index(&.view.same?(cv)))
           idx # a db_id-less (WS) active tab: re-find by identity so the resort can't swap it
         elsif @repeaters.empty?
           -1

--- a/src/gori/tui/controllers/repeater_controller.cr
+++ b/src/gori/tui/controllers/repeater_controller.cr
@@ -154,7 +154,7 @@ module Gori::Tui
     end
 
     def filter_fields : Array(String)
-      %w(tag name host method)
+      %w[tag name host method]
     end
 
     # The filter bar occupies a body row whenever the strip is up (from the first session),

--- a/src/gori/tui/controllers/sequencer_controller.cr
+++ b/src/gori/tui/controllers/sequencer_controller.cr
@@ -840,7 +840,7 @@ module Gori::Tui
       @current_idx =
         if cur_db && (idx = @sessions.index { |t| t.db_id == cur_db })
           idx
-        elsif (cv = cur_view) && (idx = @sessions.index { |t| t.view.same?(cv) })
+        elsif (cv = cur_view) && (idx = @sessions.index(&.view.same?(cv)))
           idx
         elsif @sessions.empty?
           -1

--- a/src/gori/tui/controllers/sequencer_controller.cr
+++ b/src/gori/tui/controllers/sequencer_controller.cr
@@ -461,7 +461,7 @@ module Gori::Tui
     end
 
     def filter_fields : Array(String)
-      %w(name host method)
+      %w[name host method]
     end
 
     def filter_subjects : Array(Repeater::SubtabFilter::Subject)

--- a/src/gori/tui/controllers/statusline_controller.cr
+++ b/src/gori/tui/controllers/statusline_controller.cr
@@ -40,11 +40,9 @@ module Gori::Tui
       done = Channel(String).new(1)
       output = process.output
       spawn(name: "gori-statusline-read") do
-        begin
-          done.send(read_first_line(output))
-        rescue
-          done.send("")
-        end
+        done.send(read_first_line(output))
+      rescue
+        done.send("")
       end
 
       result =

--- a/src/gori/tui/discover_config_overlay.cr
+++ b/src/gori/tui/discover_config_overlay.cr
@@ -22,7 +22,7 @@ module Gori::Tui
     DEPTHS       = [1, 2, 3, 4, 5, 6, 8]
     CONCS        = [10, 20, 40, 80]
     CONTAINMENTS = [Discover::Containment::ScopeAware, Discover::Containment::SameOrigin, Discover::Containment::HostAndSubdomains]
-    COMMON_EXT   = %w(php asp aspx jsp html json txt bak zip)
+    COMMON_EXT   = %w[php asp aspx jsp html json txt bak zip]
 
     # Hard ceiling on REQUESTS the run may put on the target (retries and redirect hops
     # each charge it — `Fuzz::CappedBackend`, the same counter `--max-requests` and MCP's

--- a/src/gori/tui/highlight.cr
+++ b/src/gori/tui/highlight.cr
@@ -365,13 +365,13 @@ module Gori::Tui
         at = Attribute::None
         case c
         when '`'
-          if (j = text.index('`', i + 1))
+          if j = text.index('`', i + 1)
             e = j + 1
             col = Theme.syn_string
           end
         when '*'
           if i + 1 < n && text[i + 1] == '*'
-            if (k = text.index("**", i + 2))
+            if k = text.index("**", i + 2)
               e = k + 2
               at = Attribute::Bold
             end

--- a/src/gori/tui/highlight.cr
+++ b/src/gori/tui/highlight.cr
@@ -784,7 +784,7 @@ module Gori::Tui
 
     # Well-known Set-Cookie attribute names (lowercased) — coloured as keywords so the
     # cookie's own name/value pairs stand out from the flags that follow.
-    COOKIE_ATTRS = %w(path domain expires max-age samesite secure httponly partitioned priority)
+    COOKIE_ATTRS = %w[path domain expires max-age samesite secure httponly partitioned priority]
 
     # Colour a header value by header name: cookies and auth get dedicated tokenisers,
     # everything else a light param lexer. `v` keeps the leading space after the colon
@@ -975,7 +975,7 @@ module Gori::Tui
             i += 1
           end
           word = raw.byte_slice(start, i - start)
-          spans << Span.new(word, %w(true false null).includes?(word) ? Theme.syn_literal : Theme.text)
+          spans << Span.new(word, %w[true false null].includes?(word) ? Theme.syn_literal : Theme.text)
         elsif json_struct?(c)
           spans << Span.new(raw.byte_slice(i, 1), Theme.muted)
           i += 1
@@ -1019,7 +1019,7 @@ module Gori::Tui
     end
 
     # GraphQL operation keywords (styled distinctly from `true`/`false`/`null` literals).
-    GRAPHQL_KEYWORDS = %w(query mutation subscription fragment on)
+    GRAPHQL_KEYWORDS = %w[query mutation subscription fragment on]
 
     # GraphQL query language (the Pretty/decoded display form): `#` comments, operation
     # keywords, `$variables`, `@directives`, strings, numbers, and field/type names (an

--- a/src/gori/tui/highlight.cr
+++ b/src/gori/tui/highlight.cr
@@ -419,7 +419,7 @@ module Gori::Tui
       # Special case for width=1: always show the first glyph (even if it is
       # wide, e.g. Hangul), never ellipsis. Matches Screen#fit policy.
       if limit == 1
-        if line.any? && !line[0].text.empty?
+        if line.present? && !line[0].text.empty?
           first = line[0].text.each_grapheme.first.to_s
           # Char path so a leading C0 control becomes the space cell (not rejected).
           if first.size == 1

--- a/src/gori/tui/highlight.cr
+++ b/src/gori/tui/highlight.cr
@@ -648,7 +648,7 @@ module Gori::Tui
       # unwrapped line, and it must not allocate a copy per row per frame. O(spans), and
       # deliberately NOT "materialise the plain text and compare lengths": that would
       # rebuild a multi-MB body line on the hot render path.
-      total = line.sum { |span| span.text.size }
+      total = line.sum(&.text.size)
       return line if a <= 0 && b >= total
       sliced = Line.new
       return sliced if a >= b

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -735,7 +735,7 @@ module Gori::Tui
       if (d = @detail) && d.row.id == id
         return "#{d.row.method} #{Url.origin_path(d.row.target)}"
       end
-      if (row = @rows.find { |r| r.id == id })
+      if row = @rows.find { |r| r.id == id }
         return "#{row.method} #{Url.origin_path(row.target)}"
       end
       "flow ##{id}"
@@ -835,7 +835,7 @@ module Gori::Tui
     def query_suggestions : Array(String)
       cur = FilterAst.token_at(@query, @qcx)
       return [] of String if cur.core.empty?
-      if (colon = cur.core.index(':'))
+      if colon = cur.core.index(':')
         field = cur.core[0...colon].downcase
         prefix = FilterAst.unquote_prefix(cur.core[(colon + 1)..])
         suggest_values(field, prefix).map { |s| "#{cur.prefix}#{s}" }
@@ -1809,11 +1809,11 @@ module Gori::Tui
       # (Each span includes its trailing 1-col gap.) HOST+PATH split the rest.
       cluster_w = 4                                # STA (3-digit code + gap)
       spare = rect.right - host_x - 18 - cluster_w # reserve 18 for HOST+PATH first
-      if (show_type = spare >= 7)
+      if show_type = spare >= 7
         cluster_w += 7
         spare -= 7
       end
-      if (show_size = spare >= 7)
+      if show_size = spare >= 7
         cluster_w += 7
         spare -= 7
       end

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -53,8 +53,8 @@ module Gori::Tui
     # nothing, and the empty list reads as "no flows match". `url` is the reverse case —
     # a real, working field that was never suggested. spec/tui/history_view_spec.cr pins
     # this list against ql.cr so the two cannot drift apart again.
-    QL_FIELDS  = %w(host url method status path scheme proto body header size reqsize respsize dur stub)
-    METHOD_VAL = %w(GET POST PUT DELETE PATCH HEAD OPTIONS QUERY)
+    QL_FIELDS  = %w[host url method status path scheme proto body header size reqsize respsize dur stub]
+    METHOD_VAL = %w[GET POST PUT DELETE PATCH HEAD OPTIONS QUERY]
     # Discoverability hints for the QL filter, kept loosely in sync with QL_FIELDS.
     # FILTER_HINT sits on the idle bar (press `/` to start filtering); QUERY_HINT sits
     # on the suggestion row at a cold start (already editing, nothing to Tab-complete

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -2227,8 +2227,6 @@ module Gori::Tui
       sel_spans = if focused && detail_navigable? && @detail_read.selection?
                     size, line_at = detail_line_source
                     @detail_read.highlight_spans(size, line_at)
-                  else
-                    nil
                   end
       # The wrap is computed on the PLAIN text (`line_text`) and the styled overlay is then
       # sliced to the same char range — Highlight is a 1:1 colour overlay, so one layout

--- a/src/gori/tui/issues_view.cr
+++ b/src/gori/tui/issues_view.cr
@@ -24,7 +24,7 @@ module Gori::Tui
     include PreviewPane
     include IssuePresentation
 
-    QUERY_FIELDS = %w(severity: status: host: title:)
+    QUERY_FIELDS = %w[severity: status: host: title:]
 
     def initialize
       @all = [] of Store::Issue    # the raw store list (severity-desc)

--- a/src/gori/tui/line_field_read.cr
+++ b/src/gori/tui/line_field_read.cr
@@ -64,7 +64,7 @@ module Gori::Tui
     end
 
     def selection_span(cx : Int32) : {Int32, Int32}?
-      return nil unless (ax = @anchor)
+      return nil unless ax = @anchor
       x0, x1 = {ax, cx}.min, {ax, cx}.max
       return nil if x0 >= x1
       {x0, x1}

--- a/src/gori/tui/path_complete.cr
+++ b/src/gori/tui/path_complete.cr
@@ -142,8 +142,6 @@ module Gori::Tui
           {name, 1_000_000}
         elsif s = Gori::Fuzzy.score(pl, dn)
           {name, s}
-        else
-          nil
         end
       end
       scored.sort_by! { |(name, rank)| {-rank, name} }

--- a/src/gori/tui/project_picker.cr
+++ b/src/gori/tui/project_picker.cr
@@ -613,7 +613,7 @@ module Gori::Tui
       when 2
         # Enter while on Search row: immediately pick the top match if any.
         # (Arrow down into the box if you want to choose a different result.)
-        if filtered_projects.any?
+        if filtered_projects.present?
           return filtered_projects[0]
         end
         nil

--- a/src/gori/tui/project_picker.cr
+++ b/src/gori/tui/project_picker.cr
@@ -391,7 +391,7 @@ module Gori::Tui
       scored.sort_by! { |(_, score)| -score }.map { |(p, _)| p }
     end
 
-    private def handle_list(ev : Termisu::Event::Key) : Project | Symbol | Nil
+    private def handle_list(ev : Termisu::Event::Key) : Project | Symbol?
       key = ev.key
       @preedit = "" # any committed key ends an in-progress IME composition
       @flash = nil  # a fresh keystroke dismisses the last compaction result line
@@ -470,7 +470,7 @@ module Gori::Tui
     # we act on its Outcome — :close pops back to the list, :open (only :theme is allowed
     # here) opens the theme card, a save just persists (no live proxy to re-apply
     # pre-project). ^C still quits the picker.
-    private def handle_preferences(ev : Termisu::Event::Key) : Project | Symbol | Nil
+    private def handle_preferences(ev : Termisu::Event::Key) : Project | Symbol?
       return :quit if ev.ctrl_c?
       @preedit = "" # a committed key ends any in-progress IME composition (the modal owns its own)
       outcome = @preferences.handle_key(ev)
@@ -501,7 +501,7 @@ module Gori::Tui
 
     # The theme card opened from the modal's Theme row: ↑/↓ preview, ↵ apply + persist,
     # esc reverts. Mirrors the in-app theme editor, minus the proxy/toast.
-    private def handle_theme(ev : Termisu::Event::Key) : Project | Symbol | Nil
+    private def handle_theme(ev : Termisu::Event::Key) : Project | Symbol?
       key = ev.key
       return :quit if ev.ctrl_c?
       if key.escape?
@@ -541,7 +541,7 @@ module Gori::Tui
     # be shared: the two ladders drifted once already, and the arm that missed the ctrl/alt
     # guard was this one — where "yes" means `rm_rf` on the project directory or a VACUUM,
     # neither of which can be taken back.
-    private def handle_confirm(ev : Termisu::Event::Key) : Project | Symbol | Nil
+    private def handle_confirm(ev : Termisu::Event::Key) : Project | Symbol?
       @preedit = ""
       dlg = @confirm
       key = ev.key
@@ -550,7 +550,7 @@ module Gori::Tui
       when ConfirmDialog.affirmative?(ev)                 then commit_confirmed
       when key.left?, key.right?, key.tab?, key.back_tab? then dlg.try(&.move)
       when key.enter?
-        (dlg.try(&.confirm_selected?)) ? commit_confirmed : cancel_confirm
+        dlg.try(&.confirm_selected?) ? commit_confirmed : cancel_confirm
       end
       nil
     end
@@ -565,7 +565,7 @@ module Gori::Tui
     end
 
     # Project-row space menu: ↑/↓ move, mnemonic key or ↵ run, esc dismiss.
-    private def handle_space(ev : Termisu::Event::Key) : Project | Symbol | Nil
+    private def handle_space(ev : Termisu::Event::Key) : Project | Symbol?
       key = ev.key
       entries = space_entries
       @preedit = ""
@@ -586,7 +586,7 @@ module Gori::Tui
     end
 
     # Rename prompt: type a new display name, ↵ commit, esc cancel.
-    private def handle_rename(ev : Termisu::Event::Key) : Project | Symbol | Nil
+    private def handle_rename(ev : Termisu::Event::Key) : Project | Symbol?
       key = ev.key
       @preedit = ""
       if key.escape?
@@ -912,7 +912,7 @@ module Gori::Tui
     # opened on, so it is the SAME resolver ctrl-d and the footer button go through. The
     # other three are single-target by design and stay on the cursor project — the menu says
     # so while marks are set (see ProjectPicker.space_entries).
-    private def activate_space_entry(entry : SpaceEntry) : Project | Symbol | Nil
+    private def activate_space_entry(entry : SpaceEntry) : Project | Symbol?
       project = @space_project || selected_project
       close_space_menu
       case entry.action
@@ -1002,7 +1002,7 @@ module Gori::Tui
 
     # Compress popup: ↑/↓ move, ‹/› cycle keep-flows, space toggle, ↵/space on the
     # Compress row opens the confirm (else toggles the focused row), esc dismiss.
-    private def handle_compress(ev : Termisu::Event::Key) : Project | Symbol | Nil
+    private def handle_compress(ev : Termisu::Event::Key) : Project | Symbol?
       ov = @compact
       return nil unless ov
       key = ev.key
@@ -1085,7 +1085,7 @@ module Gori::Tui
       @flash_ok = ok
     end
 
-    private def handle_new(ev : Termisu::Event::Key) : Project | Symbol | Nil
+    private def handle_new(ev : Termisu::Event::Key) : Project | Symbol?
       key = ev.key
       @preedit = "" # any committed key ends an in-progress IME composition
       if key.escape?
@@ -1141,7 +1141,7 @@ module Gori::Tui
       ri < filtered_projects.size ? ri + 3 : nil
     end
 
-    private def handle_picker_mouse(ev : Termisu::Event::Mouse) : Project | Symbol | Nil
+    private def handle_picker_mouse(ev : Termisu::Event::Mouse) : Project | Symbol?
       return nil unless ev.press? || ev.wheel?
       w, h = @backend.size
       mx, my = ev.x - 1, ev.y - 1
@@ -1165,7 +1165,7 @@ module Gori::Tui
 
     # Click a compress-popup row to focus + toggle it (or open the confirm on the
     # Compress row); a click outside the card dismisses, like the other overlays.
-    private def handle_compress_mouse(w : Int32, h : Int32, mx : Int32, my : Int32) : Project | Symbol | Nil
+    private def handle_compress_mouse(w : Int32, h : Int32, mx : Int32, my : Int32) : Project | Symbol?
       ov = @compact
       return nil if ov.nil?
       box = ov.overlay_box(Rect.new(0, 0, w, h))
@@ -1184,7 +1184,7 @@ module Gori::Tui
     # the already-selected entry activates it (same model as the History/Issues list).
     # The footer hint's buttons are checked first and fire on a SINGLE click: they're
     # commands, not a selection, so select-first would just make them feel broken.
-    private def handle_list_mouse(mx : Int32, my : Int32) : Project | Symbol | Nil
+    private def handle_list_mouse(mx : Int32, my : Int32) : Project | Symbol?
       w, h = @backend.size
       if action = hint_action_at(mx, my, w, h)
         return run_hint_action(action)
@@ -1250,7 +1250,7 @@ module Gori::Tui
       end
     end
 
-    private def handle_space_mouse(w : Int32, h : Int32, mx : Int32, my : Int32) : Project | Symbol | Nil
+    private def handle_space_mouse(w : Int32, h : Int32, mx : Int32, my : Int32) : Project | Symbol?
       entries = space_entries
       box = space_menu_box(w, h)
       return close_space_menu unless box.contains?(mx, my) # click away → dismiss
@@ -1704,7 +1704,7 @@ module Gori::Tui
     # Run a footer button. Each arm mirrors its chord in `handle_list_key` exactly — notably
     # `:new`, which (like ctrl-n) direct-creates when the search box already holds a name
     # rather than opening the form with it retyped.
-    private def run_hint_action(action : Symbol) : Project | Symbol | Nil
+    private def run_hint_action(action : Symbol) : Project | Symbol?
       case action
       # `return`, not a bare call: `activate`'s Project IS how the picker says "open
       # this" (see `run`). Without it the footer button did nothing, and on the Temp row

--- a/src/gori/tui/repeater_view.cr
+++ b/src/gori/tui/repeater_view.cr
@@ -2628,7 +2628,7 @@ module Gori::Tui
       env_sep = @editor.text.index("\n\n")
       return unless env_sep
       head_lines = @editor.text[0, env_sep].split('\n')
-      host_idx = head_lines.index { |l| l.lstrip.downcase.starts_with?("host:") }
+      host_idx = head_lines.index(&.lstrip.downcase.starts_with?("host:"))
       return unless host_idx
       new_line = "Host: #{authority}"
       return if head_lines[host_idx] == new_line

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -174,7 +174,7 @@ module Gori::Tui
       # The target is held by VIEW identity (not a positional index): the cross-session
       # reconcile can reorder/remove repeater tabs while the prompt is open, so the
       # controller's apply_rename re-finds the tab by its view — never a shifted neighbour.
-      @rename_view = nil.as(RepeaterView | FuzzerView | DecoderView | JwtView | MinerView | SequencerView | ComparerView | Nil)
+      @rename_view = nil.as(RepeaterView | FuzzerView | DecoderView | JwtView | MinerView | SequencerView | ComparerView?)
       # The Repeater sub-tab TAG editor (issue #121) — a bottom prompt mirroring rename,
       # space-separated tags. Held by VIEW identity for the same reconcile-race reason.
       @tag_edit_open = false
@@ -872,7 +872,7 @@ module Gori::Tui
       chars = 0
       nav = 0
       keys = 0
-      while (more = @term.poll_event(0))
+      while more = @term.poll_event(0)
         handle(more)
         keys += 1 if more.is_a?(Termisu::Event::Key)
         if coalesceable_char?(more)

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -5342,9 +5342,9 @@ module Gori::Tui
     # detail_copy_selection), so its title stays the static "Copy selection" —
     # flipping it here would be a no-op at best and misleading at worst (no
     # selection ⇒ it still only copies the current line, not "the whole pane").
-    READ_COPY_VERBS = %w(
+    READ_COPY_VERBS = %w[
       notes.copy repeater.copy decoder.copy issue.copy project.copy fuzzer.copy
-    )
+    ]
 
     def space_menu_title(verb_id : String) : String?
       return "Copy selection" if READ_COPY_VERBS.includes?(verb_id) && read_selection_active?

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -2039,14 +2039,12 @@ module Gori::Tui
         "certificate in your clients (gori ca / path copied).\n" \
         "New connections use it immediately.",
         confirm_label: "import", danger: true) do
-        begin
-          warning = @session.ca.import!(cert, key)
-          Clipboard.copy(path)
-          note = warning ? " (warning: #{warning})" : ""
-          @toast = "root CA imported#{note} — re-trust it (path copied): #{path}"
-        rescue ex
-          @toast = "CA import failed: #{ex.message}"
-        end
+        warning = @session.ca.import!(cert, key)
+        Clipboard.copy(path)
+        note = warning ? " (warning: #{warning})" : ""
+        @toast = "root CA imported#{note} — re-trust it (path copied): #{path}"
+      rescue ex
+        @toast = "CA import failed: #{ex.message}"
       end
       false
     end
@@ -5304,13 +5302,11 @@ module Gori::Tui
         "certificate in your clients (gori ca / path copied).\n" \
         "New connections use it immediately.",
         confirm_label: "regenerate", danger: true) do
-        begin
-          @session.ca.regenerate!
-          Clipboard.copy(path)
-          @toast = "root CA regenerated — re-trust it (path copied): #{path}"
-        rescue ex
-          @toast = "CA regeneration failed: #{ex.message}"
-        end
+        @session.ca.regenerate!
+        Clipboard.copy(path)
+        @toast = "root CA regenerated — re-trust it (path copied): #{path}"
+      rescue ex
+        @toast = "CA regeneration failed: #{ex.message}"
       end
     end
 

--- a/src/gori/tui/sitemap_view.cr
+++ b/src/gori/tui/sitemap_view.cr
@@ -30,7 +30,7 @@ module Gori::Tui
     # The QL fields meaningful for the endpoint tree. Mirrors History's set so the same
     # `/` query language applies, plus `tag:` — a Sitemap-local field (handled here, not
     # in the shared QL) that filters the tree by a node's path memo.
-    QL_FIELDS = %w(host path method status scheme proto body header size dur tag)
+    QL_FIELDS = %w[host path method status scheme proto body header size dur tag]
     # Discoverability hints for the filter, kept loosely in sync with QL_FIELDS.
     # FILTER_HINT sits on the idle bar (press `/` to start); QUERY_HINT sits on the
     # suggestion row at a cold start (already editing, nothing to Tab-complete yet) and

--- a/src/gori/tui/sitemap_view.cr
+++ b/src/gori/tui/sitemap_view.cr
@@ -489,7 +489,7 @@ module Gori::Tui
     def apply_tag(text : String) : Nil
       value = text.blank? ? nil : text
       index = node_index
-      @tag_targets.each { |key| index[key]?.try { |node| node.tag = value } }
+      @tag_targets.each { |key| index[key]?.try(&.tag=(value)) }
       cancel_tag
     end
 

--- a/src/gori/tui/tab_controller.cr
+++ b/src/gori/tui/tab_controller.cr
@@ -389,7 +389,7 @@ module Gori::Tui
     # The field names this tab advertises in the filter bar guidance/hint rows (and the
     # only fields Tab-completes). HTTP tabs override to name/host/method; Repeater adds tag.
     def filter_fields : Array(String)
-      %w(name)
+      %w[name]
     end
 
     # The filter bar occupies a body row whenever there are ≥2 sub-tabs to filter (below

--- a/src/gori/tui/theme.cr
+++ b/src/gori/tui/theme.cr
@@ -1110,12 +1110,11 @@ module Gori::Tui
     def self.set_custom_marks(map : Hash(String, String)) : Nil
       marks = {} of String => Color
       map.each do |name, hex|
-        begin
-          marks[name.downcase] = Color.from_hex(hex)
-        rescue
-          # A hex the parser rejects is simply absent, resolving to the fallback below — the
-          # registry's own `normalize_hex` should have caught it, this is belt and braces.
-        end
+        marks[name.downcase] = Color.from_hex(hex)
+      rescue
+        # A hex the parser rejects is simply absent, resolving to the fallback below — the
+        # registry's own `normalize_hex` should have caught it, this is belt and braces.
+
       end
       @@custom_marks = marks
     end

--- a/src/gori/tui/theme.cr
+++ b/src/gori/tui/theme.cr
@@ -1032,7 +1032,7 @@ module Gori::Tui
     private def self.merge_palette(base : Palette, root : JSON::Any) : Palette
       {% begin %}
         Palette.new(
-          {% for f in %w(bg panel elevated border border_focus focus_gold accent accent_bg selection_dim text text_bright muted green yellow red orange syn_header syn_string syn_number syn_literal syn_comment syn_keyword) %}
+          {% for f in %w[bg panel elevated border border_focus focus_gold accent accent_bg selection_dim text text_bright muted green yellow red orange syn_header syn_string syn_number syn_literal syn_comment syn_keyword] %}
             {{ f.id }}: color_field(root, {{ f }}, base.{{ f.id }}),
           {% end %}
         )
@@ -1053,7 +1053,7 @@ module Gori::Tui
 
     # Colour accessors generated from the Palette fields. Each reads the active
     # palette, so call sites (`Theme.bg`, `Theme.accent`, …) re-theme automatically.
-    {% for name in %w(bg panel elevated border border_focus focus_gold accent accent_bg selection_dim text text_bright muted green yellow red orange syn_header syn_string syn_number syn_literal syn_comment syn_keyword) %}
+    {% for name in %w[bg panel elevated border border_focus focus_gold accent accent_bg selection_dim text text_bright muted green yellow red orange syn_header syn_string syn_number syn_literal syn_comment syn_keyword] %}
       def self.{{ name.id }} : Color
         @@active.{{ name.id }}
       end

--- a/src/gori/tui/tutorial.cr
+++ b/src/gori/tui/tutorial.cr
@@ -687,7 +687,7 @@ module Gori::Tui
     private def run_overlay_selection : Nil
       if @overlay == :palette
         rows = filtered_palette
-        if (row = rows[@pal_sel]?)
+        if row = rows[@pal_sel]?
           # Mirror a couple of real "Go to …" actions so the palette feels alive.
           case row[1]
           when "Go to Repeater" then @p_tab = 4; mark_switch

--- a/src/gori/tui/wrap.cr
+++ b/src/gori/tui/wrap.cr
@@ -345,7 +345,7 @@ module Gori::Tui
         lo, hi = 0, dl.size
       end
       pos = 0
-      while (i = dl.index(q, pos))
+      while i = dl.index(q, pos)
         pos = i + q.size
         ma = {i, lo}.max
         mb = {pos, hi}.min

--- a/src/gori/verb.cr
+++ b/src/gori/verb.cr
@@ -63,7 +63,7 @@ module Gori
     record Chord, key : String, ctrl : Bool = false, alt : Bool = false, shift : Bool = false do
       # The named (non-character) keys a chord may carry, matching the names
       # Tui::Keybind.from_event emits. Anything else must be a single ASCII char.
-      NAMED_KEYS = %w(enter escape tab up down left right backspace space)
+      NAMED_KEYS = %w[enter escape tab up down left right backspace space]
 
       # Human-readable label for palette hints, e.g. "ctrl-p", "g", "enter".
       def label : String

--- a/src/gori/verb/registry.cr
+++ b/src/gori/verb/registry.cr
@@ -55,7 +55,7 @@ module Gori
         by_scope.each do |scope, verbs|
           common = verbs.select { |v| v.section == :common }
           check_menu_keys!(scope, :common, common)
-          sections = verbs.map(&.section).uniq.reject { |s| s == :common }
+          sections = verbs.map(&.section).uniq!.reject { |s| s == :common }
           sections.each do |section|
             view = common + verbs.select { |v| v.section == section }
             check_menu_keys!(scope, section, view)


### PR DESCRIPTION
Works the backlog the `ci.yml` comment named. That comment turned out to be **half stale**: it said the formatter rewrites 100+ files, but the tree already passed `crystal tool format --check`.

## CI gates

- **`crystal tool format --check` is now a gate.** Pinned to Crystal **1.21.0** rather than the `[1.20.2, 1.21.0]` build matrix — the formatter ships *with* the compiler, so gating on both would ask the tree to be a fixed point of two different formatters at once.
- Paths are **explicit** (`src spec bench scripts`). A bare `--check` walks the whole working directory, so after `shards install` it would gate on `lib/` — third-party code this repo can't fix, breaking the build on a dependency bump.
- `just check` / `just fix` were running the bare form, so local and CI were checking different file sets. Now aligned.
- **ameba stays ungated**, and the comment now says why with current numbers.

## ameba: 965 → 641 findings (src 675 → 351)

One category per commit, each independently revertable:

| commit | rule | notes |
|---|---|---|
| `d5535669` | `Style/VerboseBlock` | 1 nested `try` the rule can't rewrite is left |
| `97fa3f4e` | `Lint/ElseNil` | `if`-form only; see below |
| `07605613` | `Style/RedundantBegin` | scope preserved — `open_lock`'s rescue stays per-iteration, miner-baseline's `ensure` still covers the whole spawn body |
| `9db520ef` | nil unions, condition parens, macro spacing | |
| `34a7ee10` | `Style/PercentLiteralDelimiters` | no content in the tree contains a bracket |
| `b2743dca` | `Lint/PercentArrays` | `%w[,]` → `[","]`, cleared honestly rather than by exclusion |
| `8bb5a34b` | `Style/HeredocIndent` | verified content-preserving, see below |
| `bb57192f` | `ChainedCallWithNoBang`, `AnyInsteadOfPresent` | every bang receiver is a fresh `map`/`compact_map` result |

## Rules disabled, with reasons in `.ameba.yml`

- **`Naming/AccessorMethodName`** (106) — 43 of the flagged `set_*` do more than assign (`TextArea#set_text` resets ten sibling ivars and clears the undo stack; `SpaceMenu#set_selected` clamps). `x.text = s` reads as a cheap idempotent write and would hide that.
  Note the config records that the *return value* is **not** the hazard: Crystal's `foo=` yields its **body's** value, not the assigned one — unlike Ruby — so the rename would have been value-preserving. The reason is churn through the least-tested code, not semantics.
- **`Style/NegatedConditionsInUnless`** (42) — every site is `unless val && !val.empty?`. The rule targets the double negative `unless !x`; here the `!` is on the inner term, and `!x.empty?` is just how Crystal spells "non-empty". De Morgan reads worse.

## Left alone deliberately

- **248 `Metrics/CyclomaticComplexity`**, the bulk of the residual — TUI code, and `.ameba.yml` already records the decision to raise the bar to 12 rather than split those methods. That's a refactor, not lint cleanup.
- **16 `case … else nil`** in return position — same rationale already used to disable `Style/RedundantNilInControlExpression` (the explicit nil documents a `T?` return).
- **All 5 src `Lint/UselessAssign` are false positives.** Ameba misses reads across a `rescue` boundary (`project_registry.cr`'s `claimed`, read only in `rescue`) and across a `while` back-edge (`import/burp.cr`'s `pos`, read by the loop condition — "fixing" it would infinite-loop). This is why `--fix` was never run tree-wide.

## Verification

- **Spec suite identical to a pre-change baseline** — the same 8 `Gori::Session` port-bind failures, which are environmental (a live gori holds the port), zero new.
- **Heredocs proved content-preserving by applying `<<-` semantics**, not by eyeballing the diff. The tempting check ("only leading whitespace, uniform delta per changed block") is blind in exactly the failure case: if a body shifts but its terminator doesn't, the terminator is an *unchanged* line, falls outside the block, and the stripped content silently gains indent. Instead, each of the **42** heredocs was re-stripped against its own terminator and diffed old-vs-new — 0 differences. `schema.cr`'s SQL is executed, never hashed or compared as text.
- **`[] of Int32` gives `present? == false == any?`**, so the two `any?` → `present?` swaps sitting in front of `[0]` indexing are safe rather than IndexErrors. (`responds_to?` alone would not have shown this.)

## ⚠️ Merge sequencing

`8bb5a34b` is 610 lines of pure whitespace, **864 of them in `store/schema.cr`** — the worst possible conflict shape. Four unmerged branches touch 5 of those 6 files:

- `e2836790` — `store/schema.cr`
- `23c6c144` — `cli/run/{intercept,oast,project}.cr`
- `6b77351e` — `cli/run/intercept.cr`
- `1c22b8df` — `cli/run/oast.cr`

Worth landing those first, or dropping `8bb5a34b` and redoing it after.
