### PR TITLE
Gate bench/ in CI, page the probe list in SQL, and close the sitemap-reload question

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,38 @@ jobs:
       # a dependency bump for a formatting change nobody here made.
       - name: Check formatting
         run: crystal tool format --check src spec bench scripts
+  benchmarks:
+    # Type-checks every harness in `bench/`. Nothing ran them before: `format` above only
+    # FORMATS bench/, and the other jobs build `src` and run `spec` — so a harness could rot
+    # for months and the first sign would be someone reaching for it mid-investigation.
+    # Seventeen of them had. AGENTS.md points at these for "measure, don't guess", and a
+    # measurement tool that does not compile is worse than none: it turns a decision that
+    # should be made on numbers into one made on a plausible story.
+    #
+    # `--no-codegen`, so this checks that they still describe the API they measure without
+    # paying for optimised binaries — 26s for the whole directory on a cold cache. They are
+    # NOT executed: several want a loopback origin or a seeded multi-GB database, and their
+    # run times are measured in minutes.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: crystal-lang/install-crystal@v1
+        with:
+          # One version, not the build matrix, for the same reason `format` pins one: the
+          # harnesses compile against the same `src` the matrix already builds twice, so a
+          # second version here would re-test the compiler rather than this repo.
+          crystal: 1.21.0
+      - name: Install native link dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            pkg-config libbrotli-dev libzstd-dev libsqlite3-dev
+      - name: Install dependencies
+        run: shards install
+      - name: Type-check bench harnesses
+        # The same script `just benchmark-check` runs, so local and CI cannot drift apart
+        # (and this job needs no `just` on the runner).
+        run: scripts/bench_check.sh
   # Still no ameba job. The backlog is down from 965 findings to 641, but 248 of the
   # remainder are Metrics/CyclomaticComplexity in the TUI — splitting those methods is a
   # real refactor, not lint cleanup, and `.ameba.yml` already records the decision to

--- a/justfile
+++ b/justfile
@@ -111,19 +111,13 @@ version-update:
 # Type-check every harness in bench/ without generating code.
 #
 # AGENTS.md says "measure, don't guess" and points at these harnesses, but nothing built
-# them: `just check` only FORMATS bench/, and CI runs build + spec + docker. 17 of the 43
-# had rotted silently — most of them by requiring a subtree (`src/gori/tui`) that stopped
-# being self-contained, two by drifting off an interface that grew a parameter. Run this
-# after touching anything a harness reaches into.
+# them: `just check` only FORMATS bench/, and CI ran build + spec + format. Seventeen had
+# rotted silently — most by requiring a subtree (`src/gori/tui`) that stopped being
+# self-contained, two by drifting off an interface that grew a parameter. The CI
+# `benchmarks` job runs the SAME script, so the two cannot check different things.
 [group('benchmark')]
 benchmark-check:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    fail=0
-    for f in bench/*.cr; do
-      crystal build "$f" -o /dev/null --no-codegen 2>/dev/null || { echo "BROKEN: $f"; fail=1; }
-    done
-    [ $fail -eq 0 ] && echo "all bench harnesses build"
+    scripts/bench_check.sh
 
 # Build (release) and run the end-to-end proxy benchmark harness.
 [group('benchmark')]

--- a/scripts/bench_check.sh
+++ b/scripts/bench_check.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Type-checks every harness in bench/ and reports the ones that no longer compile.
+#
+# Usage: scripts/bench_check.sh   (just benchmark-check, and the CI `benchmarks` job)
+#
+# ONE implementation with two callers on purpose. The justfile recipe is the local entry
+# point and CI runs the same script, so the two cannot drift into checking different things —
+# which matters here more than usual, because the failure this guards against is silent by
+# construction: nothing else in CI compiles bench/, so a rotted harness stays green until
+# someone reaches for it mid-investigation. Seventeen had rotted that way before this
+# existed.
+#
+# `--no-codegen`: this asks whether each harness still describes the API it measures, not
+# whether it produces a fast binary. Harnesses are never RUN here — several want a loopback
+# origin or a seeded multi-GB database, and their run times are minutes.
+set -uo pipefail
+
+cd "$(dirname "$0")/.."
+
+fail=0
+broken=()
+for f in bench/*.cr; do
+  if ! crystal build "$f" -o /dev/null --no-codegen 2>/dev/null; then
+    broken+=("$f")
+    fail=1
+  fi
+done
+
+if [ "$fail" -ne 0 ]; then
+  echo "bench harnesses that no longer compile:" >&2
+  for f in "${broken[@]}"; do
+    echo "  $f" >&2
+  done
+  echo "" >&2
+  echo "Re-run one for the compiler's reason:  crystal build ${broken[0]} -o /dev/null --no-codegen" >&2
+  exit 1
+fi
+
+echo "all bench harnesses build ($(ls bench/*.cr | wc -l | tr -d ' ') harnesses)"

--- a/spec/store/probe_issues_page_spec.cr
+++ b/spec/store/probe_issues_page_spec.cr
@@ -1,0 +1,86 @@
+require "../spec_helper"
+
+# `probe_issues` grows as (code x host), so a wide crawl reaches hundreds of thousands of
+# rows and every row read parses its `affected` JSON. The MCP list tool wanted a hundred of
+# them and was materialising all of them to slice in Crystal — 148 ms at 250k rows against
+# 5.9 ms for the SQL page. Since the query changed, the gate is that the page is the SAME
+# page: these compare it against the read-everything-and-slice it replaced.
+private def page_store(&)
+  path = File.tempname("gori-probe-page", ".db")
+  store = Gori::Store.open(path)
+  begin
+    yield store
+  ensure
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+# `last_seen` is unique per row so the (severity DESC, last_seen DESC) sort is total — with
+# ties, two queries may order equal rows differently and the comparison would be about
+# SQLite's tie-breaking rather than about this change. `code` is unique per row too, because
+# the table is UNIQUE(code, host); host and category still repeat so the filters group.
+private def seed(store, n : Int32)
+  n.times do |i|
+    store.@db.exec(
+      "INSERT INTO probe_issues (code, category, host, title, severity, status, hit_count, " \
+      "affected, first_seen, last_seen) VALUES (?, ?, ?, ?, ?, ?, 1, '[]', ?, ?)",
+      "code#{i}", "cat#{i % 3}", "h#{i % 11}.test", "t#{i}",
+      (i % 5), (i % 4), i.to_i64, (n - i).to_i64)
+  end
+end
+
+describe "Store#probe_issues_page" do
+  it "returns the same page the load-everything-and-slice path did" do
+    page_store do |store|
+      seed(store, 200)
+      {% for args in [{nil, nil}, {"cat1", nil}, {nil, "h3.test"}] %}
+        cat, host = {{ args[0] }}, {{ args[1] }}
+        [{0, 10}, {0, 100}, {25, 10}, {195, 10}, {500, 10}].each do |(off, lim)|
+          [false, true].each do |open_only|
+            all = store.probe_issues(cat, host)
+            all = all.select(&.status.open?) if open_only
+            want = all[off, lim]? || [] of Gori::Store::ProbeIssue
+
+            got, total = store.probe_issues_page(cat, host, open_only: open_only,
+              limit: lim, offset: off)
+            got.map(&.id).should eq(want.map(&.id)),
+              "page differs at cat=#{cat} host=#{host} off=#{off} lim=#{lim} open=#{open_only}"
+            total.should eq(all.size),
+              "total differs at cat=#{cat} host=#{host} open=#{open_only}"
+          end
+        end
+      {% end %}
+    end
+  end
+
+  it "filters by min_severity the same way the unbounded read does" do
+    page_store do |store|
+      seed(store, 60)
+      sev = Gori::Store::Severity.new(3)
+      want = store.probe_issues(nil, nil, sev)
+      got, total = store.probe_issues_page(nil, nil, sev, limit: 1000)
+      got.map(&.id).should eq(want.map(&.id))
+      total.should eq(want.size)
+    end
+  end
+
+  it "reports a total that outruns the page, which is what lets a caller say N of M" do
+    page_store do |store|
+      seed(store, 500)
+      got, total = store.probe_issues_page(limit: 25)
+      got.size.should eq(25)
+      total.should eq(500) # the whole matching set, not the page
+    end
+  end
+
+  it "answers an empty table without raising" do
+    page_store do |store|
+      got, total = store.probe_issues_page(limit: 50)
+      got.should be_empty
+      total.should eq(0)
+    end
+  end
+end

--- a/src/gori/mcp/tools/probe.cr
+++ b/src/gori/mcp/tools/probe.cr
@@ -76,15 +76,20 @@ module Gori
         return category if category.is_a?(Result)
 
         include_closed = bool_arg(h, "include_closed", false)
-        all = store.probe_issues(category.as(String?), str(h, "host").try(&.strip).presence,
-          severity_from(str(h, "severity")))
-        all = all.select(&.status.open?) unless include_closed
-
         req_off = int(h, "offset")
         req_lim = int(h, "limit")
         offset = clamp_nonneg(req_off)
         limit = clamp(req_lim, 100, 500)
-        page = all[offset, limit]? || [] of Store::ProbeIssue
+        # Page and total in SQL. This used to read EVERY matching row, filter `status.open?`
+        # in Crystal (parsing each row's `affected` JSON on the way), and then slice a hundred
+        # out of it — so answering a default `probe_issues` call on a wide crawl materialised
+        # hundreds of thousands of rows to return 100. The emitted fields are unchanged: the
+        # `total`/`has_more` contract this tool already published is exactly what makes the
+        # bounded read safe here.
+        page, total = store.probe_issues_page(
+          category.as(String?), str(h, "host").try(&.strip).presence,
+          severity_from(str(h, "severity")),
+          open_only: !include_closed, limit: limit, offset: offset)
         Result.new(JSON.build do |j|
           j.object do
             j.field("issues") { j.array { page.each { |i| Probe.issue_json(j, i) } } }
@@ -92,8 +97,8 @@ module Gori
             j.field "offset", offset
             j.field "limit", limit
             emit_clamp(j, req_off, offset, req_lim, limit)
-            j.field "total", all.size
-            j.field "has_more", offset + page.size < all.size
+            j.field "total", total
+            j.field "has_more", offset + page.size < total
             j.field "include_closed", include_closed
           end
         end)

--- a/src/gori/store/probe_issues.cr
+++ b/src/gori/store/probe_issues.cr
@@ -100,8 +100,10 @@ module Gori
       (parts << incoming).join(", ")
     end
 
-    def probe_issues(category : String? = nil, host : String? = nil,
-                     min_severity : Severity? = nil) : Array(ProbeIssue)
+    # The WHERE fragment the three list/count entry points share, so a filter added to one
+    # cannot quietly not apply to the others.
+    private def probe_issue_where(category : String?, host : String?, min_severity : Severity?,
+                                  open_only : Bool) : {String, Array(DB::Any)}
       conds = [] of String
       args = [] of DB::Any
       if c = category
@@ -113,7 +115,17 @@ module Gori
       if ms = min_severity
         conds << "severity >= ?"; args << ms.value
       end
-      where = conds.empty? ? "" : " WHERE #{conds.join(" AND ")}"
+      conds << "status = #{Status::Open.value}" if open_only
+      {conds.empty? ? "" : " WHERE #{conds.join(" AND ")}", args}
+    end
+
+    # EVERY matching finding. Callers that MUTATE or EXPORT need this — a bulk dismiss that
+    # saw a capped list would report the number it closed as though it were the number that
+    # matched, and a report that dropped rows would be a security report with findings missing.
+    # Callers that merely DISPLAY should use `probe_issues_page` instead.
+    def probe_issues(category : String? = nil, host : String? = nil,
+                     min_severity : Severity? = nil) : Array(ProbeIssue)
+      where, args = probe_issue_where(category, host, min_severity, false)
       list = [] of ProbeIssue
       @db.query("SELECT #{PROBE_COLS} FROM probe_issues#{where} ORDER BY severity DESC, last_seen DESC",
         args: args) do |rs|
@@ -122,6 +134,31 @@ module Gori
       list
     rescue
       [] of ProbeIssue # never crash the run loop over a read
+    end
+
+    # One PAGE plus the true total, both decided in SQL.
+    #
+    # `probe_issues` grows as (code x host), so a wide crawl reaches hundreds of thousands of
+    # rows — and every row read parses its `affected` JSON. A caller that wanted a hundred of
+    # them was materialising all of them first, then slicing in Crystal. The page and the count
+    # are now two indexed queries (idx_probe_issues_triage backs the sort), and `total` stays
+    # exact, which is what lets a caller say "showing N of M" honestly rather than just
+    # stopping at N.
+    def probe_issues_page(category : String? = nil, host : String? = nil,
+                          min_severity : Severity? = nil, *,
+                          open_only : Bool = false, limit : Int32, offset : Int32 = 0) : {Array(ProbeIssue), Int32}
+      where, args = probe_issue_where(category, host, min_severity, open_only)
+      total = @db.scalar("SELECT COUNT(*) FROM probe_issues#{where}", args: args).as(Int64).to_i
+      list = [] of ProbeIssue
+      page_args = args.dup
+      page_args << limit.to_i64 << offset.to_i64
+      @db.query("SELECT #{PROBE_COLS} FROM probe_issues#{where} " \
+                "ORDER BY severity DESC, last_seen DESC LIMIT ? OFFSET ?", args: page_args) do |rs|
+        rs.each { list << read_probe_issue(rs) }
+      end
+      {list, total}
+    rescue
+      {[] of ProbeIssue, 0}
     end
 
     def get_probe_issue(id : Int64) : ProbeIssue?

--- a/src/gori/tui/probe_view.cr
+++ b/src/gori/tui/probe_view.cr
@@ -78,6 +78,21 @@ module Gori::Tui
       @issues.size
     end
 
+    # Reads the WHOLE table, deliberately, and this is the one place it still hurts: at 250k
+    # findings (a wide crawl — the rows are (code x host)) a refresh is ~107 ms, and the
+    # Runner re-runs it on every `probe_generation` bump, which during an active scan is
+    # close to every tick.
+    #
+    # `Store#probe_issues_page` exists and MCP uses it, but a bounded read is not a drop-in
+    # here, because everything below `apply_filter` runs in Crystal over `@all`: the triage
+    # and scope lenses, `Probe::Filter`, and `recount`. Capping the read would make the
+    # severity tallies count the WINDOW rather than the set — the same "faster and wrong"
+    # shape that made a LIMIT the wrong answer for the dismiss counts — and a filter matching
+    # only rows outside the window would show nothing while the total said otherwise.
+    #
+    # Doing it properly means pushing the lenses, the filter and the tallies into SQL, which
+    # is a change to a query surface rather than to this view. Left whole until then: honest
+    # and slow beats fast and misleading on a triage list.
     def reload(store : Store) : Nil
       @all = store.probe_issues
       @mode = store.probe_mode

--- a/src/gori/tui/sitemap_view.cr
+++ b/src/gori/tui/sitemap_view.cr
@@ -99,6 +99,19 @@ module Gori::Tui
     # Rebuild the tree from the store. Selection, scroll, and manual expand/collapse
     # are re-anchored by durable (host, path) keys so a data_version poll under live
     # capture does not jump the cursor to the top host every ~750ms.
+    #
+    # A FULL rebuild, deliberately, and measured before leaving it that way: the whole path —
+    # `sitemap_entries` (DISTINCT, capped at `Store::SITEMAP_MAX`), `Sitemap.build`, the two
+    # fold passes, tag stamping, expand-depth, the endpoint counts and the flatten — runs in
+    # ~6.4 ms at 100k flows with the tree at its 10k-endpoint cap. Against the 750 ms
+    # data_version cadence, and only while this tab is ACTIVE (`@tabs[@active_tab]` in
+    # Runner#apply_external_change), that is under 1% of a core. An incremental rebuild would
+    # trade that for cache-invalidation state across build, folding, tagging and expansion —
+    # the four things whose interaction the anchoring above already has to get right.
+    #
+    # Roughly two thirds of the 6.4 ms is the DISTINCT query, which scales with the FLOW table
+    # rather than the capped tree, so the number to watch is retention: at the 100k default it
+    # is what is quoted here. Re-measure before assuming it still holds if that default moves.
     def reload(store : Store) : Nil
       prev_sel = selection_anchor
       prev_scroll = @scroll


### PR DESCRIPTION
Three items from the #665 follow-up list. Two were closed by measuring rather
than by building.

## bench/ is gated now

Seventeen harnesses did not compile when #665 started, and nothing was watching:
`just check` only *formats* `bench/`, and CI ran build, spec and format. A
rotted harness stays green until someone reaches for it mid-investigation —
which is exactly when the measurement is needed, and exactly when a plausible
story gets used instead of a number. #665 turned **eight** proposals down on
numbers these harnesses produced, including the one its plan called the biggest
win.

`scripts/bench_check.sh` type-checks the directory (`--no-codegen`, 26s cold),
names what broke, and prints the command to see why. One implementation, two
callers — `just benchmark-check` and the CI `benchmarks` job — so local and CI
cannot drift. Verified both directions: green here, exit 1 naming the file with
a harness broken on purpose.

## Probe findings list pages in SQL

The plan for this was "cap the triage lists with LIMIT". Reading every consumer
first turned it into something narrower, twice.

`store.issues` needs no cap: those are **operator-created**, so the table is
bounded by human effort, not by a crawl.

`store.probe_issues` does grow — rows are (code × host) — but only some callers
may be capped. `dismiss_open_by_code` MUTATES what it selects, so a capped list
would dismiss the first N and report that as the number that matched.
`issues_export_to` and `gori run issues --export` build a **report**; a capped
read drops findings from a security report. Same shape as the dismiss counts in
#665: faster and wrong.

So the cap is a separate read. `probe_issues_page` decides page and total in
SQL; `probe_issues` keeps its whole-table contract for mutation and export, with
a comment marking which is which.

MCP's list tool already published `total`/`has_more`/`returned` — and satisfied
it by reading every matching row, filtering in Crystal, then slicing 100 out:

| 250k findings | |
| --- | --- |
| load-all + slice 100 | 148.4 ms |
| SQL page + COUNT | **5.94 ms** |

Emitted JSON unchanged. Since the query changed, the spec compares the page
against the read-and-slice it replaces across category/host/severity filters,
open-only, and offsets past the end.

**The TUI Probe tab still reads the whole table**, and why is now written where
someone will look: everything under `apply_filter` runs in Crystal over `@all` —
the triage and scope lenses, `Probe::Filter`, `recount` — so a bounded read
would make the severity tallies count the *window* rather than the set, and a
filter matching only rows outside the window would show nothing while the total
said otherwise. That needs the lenses, filter and tallies pushed into SQL, which
is a change to a query surface rather than to this view.

## T5 is closed, not deferred

Incremental sitemap reload was on the list on **structure alone** — a full
rebuild on every 750 ms `data_version` poll — and had never been measured.

| | |
| --- | --- |
| Full `SitemapView#reload`, 100k flows, tree at its 10k-endpoint cap | **6.4 ms** |
| Poll cadence | 750 ms |
| Runs while | only the Sitemap tab is **active** |

Under 1% of a core. An incremental rebuild would trade that for
cache-invalidation state across build, folding, tagging and expansion — the four
things whose interaction the existing selection/scroll anchoring already has to
get right.

The measurement sits on `SitemapView#reload` with the one number that would
change the answer: roughly two thirds is the DISTINCT query, which scales with
the FLOW table rather than the capped tree — so `retention_flows` governs this,
not `SITEMAP_MAX`.

## Verification

`crystal spec` 8322 examples, 0 failures. Format clean, no new ameba findings.
All 44 harnesses build. Rebased on main, merge result builds, CI green including
the new `benchmarks` job. Touches nothing in the QL/filter layer.
