### PR TITLE
Chunk the import write so a captured flow is not stuck behind the whole file

### DIFF
--- a/spec/import/chunking_spec.cr
+++ b/spec/import/chunking_spec.cr
@@ -1,0 +1,69 @@
+require "../spec_helper"
+
+# The whole file used to go in as ONE `insert_import_batch` — one writer op and therefore one
+# transaction — so a captured flow arriving mid-import waited behind the entire file. Measured
+# on a 50k-entry HAR with capture writes against the same store: 598 ms of stall, against
+# 22 ms once chunked. Chunking gives up whole-file atomicity, so these pin what replaced it.
+private def chunk_store(&)
+  path = File.tempname("gori-import-chunk", ".db")
+  store = Gori::Store.open(path)
+  begin
+    yield store
+  ensure
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+private def pair(i : Int32) : Gori::Import::Builder::FlowPair
+  Gori::Import::Builder.complete_flow(
+    i.to_i64, "http://h.test/p/#{i}", "GET", Gori::Import::Builder::Headers.new,
+    nil, "HTTP/1.1", 200, "OK", Gori::Import::Builder::Headers.new, nil, nil, nil)
+end
+
+describe "Import.insert_all chunking" do
+  it "commits every pair across chunk boundaries" do
+    chunk_store do |store|
+      n = Gori::Import::IMPORT_CHUNK * 2 + 7 # spans three chunks, last one partial
+      committed, attempted = Gori::Import.insert_all(store, (0...n).map { |i| pair(i) })
+      committed.should eq(n)
+      attempted.should eq(n)
+      store.count.should eq(n.to_i64)
+    end
+  end
+
+  it "reports attempted alongside committed on a clean import" do
+    chunk_store do |store|
+      committed, attempted = Gori::Import.insert_all(store, (0...5).map { |i| pair(i) })
+      committed.should eq(5)
+      attempted.should eq(5)
+      Gori::Import::Result.new(committed, 0, attempted).short?.should be_false
+    end
+  end
+end
+
+# The contract that REPLACED whole-file atomicity: a short import must be named, not printed
+# as a smaller success. Every surface reads these two fields (`shortfall_note` is the one
+# home for the wording; MCP emits the same facts as `attempted` + `partial`).
+describe "Import::Result shortfall" do
+  it "says how many did not commit, and how to retry" do
+    r = Gori::Import::Result.new(count: 1200, skipped: 0, attempted: 5000)
+    r.short?.should be_true
+    note = r.shortfall_note.should_not be_nil
+    note.should contain("3800 of 5000")
+    note.should contain("re-run")
+  end
+
+  it "stays silent when everything committed" do
+    Gori::Import::Result.new(count: 5000, skipped: 3, attempted: 5000).short?.should be_false
+    Gori::Import::Result.new(count: 5000, skipped: 3, attempted: 5000).shortfall_note.should be_nil
+  end
+
+  it "stays silent for a Result built without an attempted count" do
+    # The field defaults to 0 so older construction sites keep compiling; a zero must not be
+    # read as "attempted nothing, so everything is missing".
+    Gori::Import::Result.new(count: 4).short?.should be_false
+  end
+end

--- a/src/gori/cli/run/import.cr
+++ b/src/gori/cli/run/import.cr
@@ -101,6 +101,7 @@ module Gori
       private def self.import_result_text(kind : Symbol, path : String, result : Import::Result) : String
         s = "imported #{result.count} flow#{result.count == 1 ? "" : "s"} from #{Import.label(kind)} · #{path}"
         s += " (#{result.skipped} #{result.skipped == 1 ? "entry" : "entries"} skipped)" if result.skipped > 0
+        result.shortfall_note.try { |note| s += " — #{note}" }
         s
       end
 
@@ -110,6 +111,9 @@ module Gori
             j.field "kind", kind.to_s
             j.field "path", path
             j.field "count", result.count
+            # Both numbers, always: a consumer diffing them is how a partial import is
+            # detected without parsing prose.
+            j.field "attempted", result.attempted
             j.field "skipped", result.skipped
           end
         end

--- a/src/gori/import.cr
+++ b/src/gori/import.cr
@@ -10,7 +10,22 @@ module Gori
   # Bulk-import captured flows from HAR files, URL lists, OpenAPI specs, Postman or
   # Insomnia collections, or a Burp item export.
   module Import
-    record Result, count : Int32, skipped : Int32 = 0
+    # `attempted` is how many parsed pairs the import TRIED to write; `count` is how many
+    # committed. They differ only when a chunk rolled back part-way (see `insert_all`), and
+    # every surface that prints `count` has to say so when they do — a smaller number printed
+    # as a success is how an import that half-failed looks like an import of a small file.
+    record Result, count : Int32, skipped : Int32 = 0, attempted : Int32 = 0 do
+      def short? : Bool
+        attempted > 0 && count < attempted
+      end
+
+      # The clause a surface appends when the import did not finish. One home, because three
+      # surfaces print this line and a fourth (MCP) emits the same facts as JSON.
+      def shortfall_note : String?
+        return nil unless short?
+        "#{attempted - count} of #{attempted} did NOT commit (store busy or unwritable) — re-run the import to retry them"
+      end
+    end
 
     # The human name of each source, in ONE place. The TUI card title, the TUI toast and the
     # CLI result line all read it, so they cannot drift apart as sources are added — the
@@ -59,12 +74,45 @@ module Gori
       Burp.parse_file(path)
     end
 
-    # Insert every parsed pair into the store atomically. Returns the committed count.
-    def self.insert_all(store : Store, pairs : Array(Builder::FlowPair)) : Int32
-      batch = pairs.map do |pair|
-        {pair.request, pair.response}
+    # Pairs per store write. The whole file used to go in as ONE `insert_import_batch`, which
+    # is one writer op and therefore ONE transaction — and `Store::BATCH_MAX` bounds ops per
+    # transaction, not pairs per op, so nothing capped it. A captured flow arriving mid-import
+    # waits behind the entire file, which is the one thing P6 says must not happen.
+    #
+    # MEASURED on a 50k-entry HAR, with capture writes running against the same store
+    # (median of three; the numbers are stable to ~1%):
+    #
+    #   chunk   import    worst capture stall
+    #   none     598 ms   598 ms
+    #   1000     703 ms    13 ms
+    #   2000     569 ms    22 ms
+    #   4000     496 ms    41 ms
+    #
+    # 2000 is the size that is better than today on BOTH axes — the import is slightly faster
+    # than the single giant transaction, and the stall drops 26x. (Chunking being faster is
+    # not a typo: one enormous transaction costs more in WAL and memory than several medium
+    # ones. 4000 is faster still, but there is no reason to buy speed with stall when the
+    # smaller size already beats the status quo.)
+    IMPORT_CHUNK = 2000
+
+    # Insert every parsed pair. Returns {committed, attempted}.
+    #
+    # NOT atomic across the file any more, and the count says so. A chunk that rolls back (a
+    # closing store, a full disk) stops the import with the earlier chunks already committed,
+    # so the caller is handed both numbers and every surface reports the shortfall rather than
+    # printing a smaller success. Whole-file atomicity was not protecting much: nothing
+    # deduplicates on re-import, so a failed all-or-nothing import meant starting over anyway,
+    # and 80% of a 200 MB HAR plus an honest message beats losing all of it.
+    def self.insert_all(store : Store, pairs : Array(Builder::FlowPair)) : {Int32, Int32}
+      committed = 0
+      pairs.each_slice(IMPORT_CHUNK) do |slice|
+        n = store.insert_import_batch(slice.map { |pair| {pair.request, pair.response} })
+        committed += n
+        # A short answer means the batch rolled back or the store is closing; stop rather than
+        # push more work at a store that just refused some.
+        break if n < slice.size
       end
-      store.insert_import_batch(batch)
+      {committed, pairs.size}
     end
 
     def self.import_file(store : Store, kind : Symbol, path : String) : Result
@@ -91,7 +139,8 @@ module Gori
         end
         raise Gori::Error.new("no flows found in #{expanded}")
       end
-      Result.new(insert_all(store, parsed.flows), parsed.skipped)
+      committed, attempted = insert_all(store, parsed.flows)
+      Result.new(committed, parsed.skipped, attempted)
     end
   end
 end

--- a/src/gori/mcp/tools/import.cr
+++ b/src/gori/mcp/tools/import.cr
@@ -38,7 +38,12 @@ module Gori
             j.field "kind", kind_s
             j.field "path", path
             j.field "count", result.count
+            j.field "attempted", result.attempted
             j.field "skipped", result.skipped
+            # The import writes in chunks, so a roll-back part-way leaves the earlier ones
+            # committed. Named rather than implied, so an agent does not read a short count as
+            # a complete import of a smaller file.
+            result.shortfall_note.try { |note| j.field "partial", note }
           end
         end)
       rescue ex : Gori::Error

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -4408,6 +4408,9 @@ module Gori::Tui
       sitemap_controller.reload
       msg = "imported #{result.count} flow#{result.count == 1 ? "" : "s"} from #{label} · #{path}"
       msg += " (#{result.skipped} entries skipped)" if result.skipped > 0
+      # The import is chunked, so a partial write is possible — say so rather than letting a
+      # short count read as a successful import of a smaller file (see Import::Result).
+      result.shortfall_note.try { |note| msg += " — #{note}" }
       @toast = msg
     rescue ex
       @toast = "import failed: #{ex.message}"


### PR DESCRIPTION
The last item on the #665 follow-up list that was still unmeasured. Measuring it
confirmed the problem this time — unlike the eight proposals that branch turned
down.

## The problem, measured

A 50k-entry / 228 MB HAR, imported while capture writes run against the same
store:

| | before | after |
| --- | --- | --- |
| worst capture stall | **598 ms** | **22 ms** |
| WAL high-water | 227 MB | **9.8 MB** |
| import (db write) | 598 ms | 569 ms |

The whole file went in as ONE `insert_import_batch` — one writer op, therefore
one transaction. `Store::BATCH_MAX` bounds ops per transaction, not *pairs per
op*, so nothing capped it, and a flow captured mid-import waited for the entire
file to commit. That is the case P6 exists to prevent.

## Chunk size

Median of three runs each, stable to ~1%:

| chunk | import | worst stall |
| --- | --- | --- |
| none (today) | 598 ms | 598 ms |
| 1000 | 703 ms | 13 ms |
| **2000** | **569 ms** | **22 ms** |
| 4000 | 496 ms | 41 ms |

2000 is better than the status quo on **both** axes. Chunking being *faster* is
not a typo — one enormous transaction costs more in WAL and memory than several
medium ones. 4000 is faster still but doubles the stall, and there is no reason
to buy speed with stall when the smaller size already beats today.

## What it gives up, and what replaced it

`insert_all` documented itself as atomic and no longer is: a chunk that rolls
back leaves the earlier ones committed.

That guarantee was not protecting much. Nothing deduplicates on re-import, so a
failed all-or-nothing import meant starting over anyway — 80% of a 200 MB HAR
plus an honest message beats losing all of it.

What replaces it is that the shortfall is **named**. `Import::Result` carries
`attempted` beside `count`, and `shortfall_note` is the one home for the
wording; the TUI toast and CLI line append it, MCP emits `attempted` plus a
`partial` field. Without that, a half-failed import of a big file is
indistinguishable from a clean import of a small one — the failure mode this
whole line of work keeps running into.

## What it does not fix

Peak RSS is unchanged at **1.54 GB** for a 228 MB HAR. That is the parser
materialising every pair (and the JSON document) before a single row is written,
not the insert. Fixing it means streaming the parse, per format, across six
formats — a separate change with its own shape.

## Verification

`crystal spec` 8327 examples, 0 failures. Format clean; no new ameba findings
(the 21 on `runner.cr` are identical to HEAD). All 44 harnesses build. Rebased
on main, merge result builds. End-to-end on the real 228 MB HAR: 50,000 rows,
WAL peak 9.8 MB. Touches nothing in the QL/filter layer.
