### PR TITLE
Answer the TLS keep-alive checkout without spending a millisecond on it

### DIFF
--- a/spec/fuzz/conn_pool_checkout_spec.cr
+++ b/spec/fuzz/conn_pool_checkout_spec.cr
@@ -1,0 +1,154 @@
+require "../spec_helper"
+require "file_utils"
+require "socket"
+require "openssl"
+
+private alias P = Gori::Repeater::ConnPool
+
+# `ConnPool.checkout_state` is the question asked of every parked socket right before a
+# request is written onto it: is anything waiting, and is the peer still there. It answers on
+# two very different paths — an fd-level MSG_PEEK for a plaintext TCPSocket, and a timed read
+# probe for TLS, where OpenSSL hides the fd and residue can sit in its DECRYPTED buffer where
+# a raw peek cannot see it.
+#
+# Only the plaintext path had coverage. The TLS branch is the one that costs (measured: a
+# clean TLS checkout is ~1.6 ms against 0.38 µs for plaintext, because it pays the whole
+# DRAIN_PROBE deadline), so it is the one anybody optimising this will touch — with nothing
+# failing if they get it wrong. These pin all three answers on BOTH transports first.
+private def with_ca(&)
+  dir = File.tempname("gori-pool-tls-ca")
+  begin
+    yield Gori::Proxy::Tls::CertAuthority.load_or_create(dir)
+  ensure
+    FileUtils.rm_rf(dir) if Dir.exists?(dir)
+  end
+end
+
+# A TLS origin whose per-connection behaviour the caller scripts: what to write back (if
+# anything) and whether to hang up. Returns the CLIENT side of a live, handshaken socket.
+private def tls_socket(ca, *, greet : String? = nil, hangup : Bool = false, &)
+  server = TCPServer.new("127.0.0.1", 0)
+  port = server.local_address.port
+  ready = Channel(Nil).new(1)
+  spawn do
+    if conn = server.accept?
+      begin
+        ssl = OpenSSL::SSL::Socket::Server.new(conn, ca.context_for("127.0.0.1", advertise_h2: false),
+          sync_close: true)
+        if g = greet
+          ssl << g
+          ssl.flush
+        end
+        ready.send(nil)
+        if hangup
+          ssl.close
+        else
+          sleep 5.seconds # hold it open for the duration of the example
+        end
+      rescue
+        ready.send(nil) rescue nil
+      end
+    end
+  end
+
+  ctx = OpenSSL::SSL::Context::Client.new
+  ctx.verify_mode = OpenSSL::SSL::VerifyMode::NONE
+  tcp = TCPSocket.new("127.0.0.1", port)
+  client = OpenSSL::SSL::Socket::Client.new(tcp, ctx, sync_close: true, hostname: "127.0.0.1")
+  ready.receive
+  begin
+    yield client
+  ensure
+    client.close rescue nil
+    server.close rescue nil
+  end
+end
+
+# The plaintext twin of the above, so both transports answer the same three questions.
+private def tcp_socket(*, greet : String? = nil, hangup : Bool = false, &)
+  server = TCPServer.new("127.0.0.1", 0)
+  port = server.local_address.port
+  ready = Channel(Nil).new(1)
+  spawn do
+    if conn = server.accept?
+      if g = greet
+        conn << g
+        conn.flush
+      end
+      ready.send(nil)
+      hangup ? conn.close : sleep(5.seconds)
+    end
+  end
+  client = TCPSocket.new("127.0.0.1", port)
+  ready.receive
+  begin
+    yield client
+  ensure
+    client.close rescue nil
+    server.close rescue nil
+  end
+end
+
+# The probe races the origin's write, so poll to a deadline rather than sleeping a guess
+# (spec_helper's PR #555 note: a bare wait on socket-driven work is how CI hangs).
+private def settle(io, want : P::Checkout, timeout : Time::Span = 3.seconds) : P::Checkout
+  deadline = Time.instant + timeout
+  got = P.checkout_state(io)
+  while got != want && Time.instant < deadline
+    sleep 10.milliseconds
+    got = P.checkout_state(io)
+  end
+  got
+end
+
+describe "ConnPool.checkout_state" do
+  describe "plaintext (fd MSG_PEEK)" do
+    it "answers Clean on an idle socket with nothing waiting" do
+      tcp_socket { |io| P.checkout_state(io).should eq(P::Checkout::Clean) }
+    end
+
+    it "answers Residue when the origin left bytes on the socket" do
+      tcp_socket(greet: "leftover") { |io| settle(io, P::Checkout::Residue).should eq(P::Checkout::Residue) }
+    end
+
+    it "answers Closed when the peer hung up before the write" do
+      # Its own answer, not folded into Clean: since the idempotency gate landed, a
+      # POST/PUT/PATCH/DELETE cannot be re-sent on the stale path, so handing back a socket
+      # proved dead would DROP the request. A FIN seen before the write means the origin never
+      # saw it at all.
+      tcp_socket(hangup: true) { |io| settle(io, P::Checkout::Closed).should eq(P::Checkout::Closed) }
+    end
+  end
+
+  describe "TLS (the DRAIN_PROBE path)" do
+    it "answers Clean on an idle socket with nothing waiting" do
+      with_ca { |ca| tls_socket(ca) { |io| P.checkout_state(io).should eq(P::Checkout::Clean) } }
+    end
+
+    it "answers Residue for bytes sitting in OpenSSL's DECRYPTED buffer" do
+      # The case a raw fd peek cannot see, and the whole reason this branch exists: the record
+      # has already been read off the kernel socket and decrypted, so only OpenSSL knows.
+      with_ca do |ca|
+        tls_socket(ca, greet: "HTTP/1.1 200 OK\r\n\r\nleftover") do |io|
+          settle(io, P::Checkout::Residue).should eq(P::Checkout::Residue)
+        end
+      end
+    end
+
+    it "answers Closed when the peer hung up before the write" do
+      with_ca do |ca|
+        tls_socket(ca, hangup: true) { |io| settle(io, P::Checkout::Closed).should eq(P::Checkout::Closed) }
+      end
+    end
+  end
+
+  it "refuses the socket rather than trusting it when the probe itself fails" do
+    # A closed IO makes the probe raise. Residue, NOT Closed: a failed probe proves nothing
+    # about whether the peer closed, and Closed is the answer that licenses re-sending a POST.
+    io = TCPSocket.new("127.0.0.1", TCPServer.new("127.0.0.1", 0).local_address.port) rescue nil
+    if io
+      io.close
+      P.checkout_state(io).should eq(P::Checkout::Residue)
+    end
+  end
+end

--- a/src/gori/repeater/conn_pool.cr
+++ b/src/gori/repeater/conn_pool.cr
@@ -17,6 +17,36 @@ module IO::Buffered
   end
 end
 
+# `SSL_pending` — bytes OpenSSL has already decrypted and is holding for the next read. Not in
+# Crystal's LibSSL bindings, and it is the half of "is this TLS socket clean?" that an fd-level
+# peek structurally cannot answer: the record is already off the kernel socket. Present in every
+# OpenSSL and LibreSSL gori can link against (it predates SSL_has_pending, which is 1.1+ and
+# would also cover a buffered-but-undecrypted record — the fd peek below covers that instead,
+# so the older, universally available call is enough).
+lib LibSSL
+  fun ssl_pending = SSL_pending(handle : SSL) : Int
+end
+
+# The two things `OpenSSL::SSL::Socket` knows and does not expose, both needed to answer
+# "clean?" WITHOUT a timed read. Same shape as `gori_buffered_residue?` above: reaching into
+# stdlib internals deliberately, so a rename fails to compile rather than silently misbehaving.
+class OpenSSL::SSL::Socket
+  # Decrypted bytes waiting inside OpenSSL.
+  def gori_ssl_pending? : Bool
+    LibSSL.ssl_pending(@ssl) > 0
+  end
+
+  # The socket underneath the TLS layer, so the kernel buffer can be peeked for a record that
+  # has arrived but not been decrypted yet. `BIO` exposes its `io`; the SSL socket does not.
+  def gori_underlying_io : IO
+    {% if compare_versions(Crystal::VERSION, "1.12.0") >= 0 %}
+      @bio.to_reference.io
+    {% else %}
+      @bio.io
+    {% end %}
+  end
+end
+
 module Gori::Repeater
   # HTTP/1.1 keep-alive connection pool for a sweep's sends.
   #
@@ -174,7 +204,7 @@ module Gori::Repeater
         # check is an early retire, and THIS one, right before we write onto the socket, is the
         # reliable one: by now any straggler residue is on the wire. Without it a poisoned socket
         # would frame this request's response against the previous response's leftovers.
-        case checkout_state(io)
+        case ConnPool.checkout_state(io)
         when Checkout::Closed
           # The origin's FIN was on the socket BEFORE gori wrote a byte of this request. That
           # proves what `stale?` (below) explicitly cannot: the ORIGIN NEVER SAW THIS REQUEST.
@@ -340,10 +370,20 @@ module Gori::Repeater
     # 0x02 on every platform gori targets (Linux, macOS, the BSDs).
     MSG_PEEK = 0x02
 
-    # The short-probe deadline for a non-`TCPSocket` (TLS) socket, where the fd trick below
-    # cannot see decrypted application bytes. Only ever paid on a socket that turns out
-    # CLEAN, which is the common case — but a reused TLS socket has already saved a full
-    # handshake, so a millisecond to prove it is safe is a good trade.
+    # LAST-RESORT probe deadline, for a socket that answers to `read_timeout` but is neither a
+    # `TCPSocket` nor an `OpenSSL::SSL::Socket` gori can look inside. Every socket the pool
+    # actually parks now takes a non-blocking path (see `checkout_state`); this is what keeps a
+    # future transport correct-but-slow rather than silently unchecked.
+    #
+    # It used to be the whole TLS answer, and it cost the full deadline on every CLEAN
+    # checkout — which is the common case. MEASURED against a real TLS origin, 200 checkouts:
+    # median 1598µs (min 1105, max 5169), against 0.38µs for the plaintext fd peek. Sequential
+    # callers paid it per request: a default `gori run sequence` over https is 500 samples on
+    # one connection, so ~800ms of the run was this probe.
+    #
+    # With the two-step check in `checkout_state`, a socket parked after a real exchange now
+    # answers in 0.5µs median (max 3µs, fast path 250/250 over a live TLS origin) and this
+    # deadline is only reached when bytes are genuinely waiting.
     DRAIN_PROBE = 1.millisecond
 
     # What is waiting on a parked socket, asked once, right before this request is written.
@@ -364,30 +404,68 @@ module Gori::Repeater
     # so handing back a socket proved dead DROPPED the request. It is now its own answer — and
     # a better one for every method, because a FIN observed BEFORE the write means the origin
     # never saw the request at all.
-    private def checkout_state(io : IO) : Checkout
+    # `MSG_PEEK` on a socket fd: read-without-consume, non-blocking because Crystal's sockets
+    # are evented. EAGAIN/EWOULDBLOCK means nothing is waiting, a byte means residue, 0 means
+    # the peer sent FIN. ~0.38µs measured. Shared by the plaintext branch and the fd half of
+    # the TLS one, so the two cannot disagree about what a peek means.
+    private def self.peek_state(sock : TCPSocket) : Checkout
+      buf = uninitialized UInt8[1]
+      n = LibC.recv(sock.fd, buf.to_unsafe.as(Void*), LibC::SizeT.new(1), MSG_PEEK)
+      return Checkout::Closed if n == 0
+      return Checkout::Residue if n > 0
+      {Errno::EAGAIN, Errno::EWOULDBLOCK}.includes?(Errno.value) ? Checkout::Clean : Checkout::Residue
+    end
+
+    # Let the transport itself say what is waiting, bounded by DRAIN_PROBE. `nil` = EOF (the
+    # peer closed); a byte = residue, and it is CONSUMED — which is fine because this only
+    # runs on a socket that is about to be retired either way, and never on the clean fast
+    # path above.
+    private def self.drain_probe_state(io) : Checkout
+      prev = io.read_timeout
+      begin
+        io.read_timeout = DRAIN_PROBE
+        io.read_byte.nil? ? Checkout::Closed : Checkout::Residue
+      rescue IO::TimeoutError
+        Checkout::Clean
+      ensure
+        io.read_timeout = prev
+      end
+    end
+
+    # Pure and class-level, like the two reuse predicates below it, so a spec can drive it
+    # against a real socket rather than only through a whole pooled send. It reads nothing off
+    # the pool — only the socket it is handed.
+    def self.checkout_state(io : IO) : Checkout
       # 1. Residue already pulled into the buffered layer by `read_head`'s byte reads. This is
       #    where a body-past-Content-Length or a HEAD-with-body actually lands, and it is
       #    non-blocking, so it must be checked FIRST.
       return Checkout::Residue if io.is_a?(IO::Buffered) && io.gori_buffered_residue?
       # 2. Residue — or the peer's FIN — still on the kernel socket.
       if io.is_a?(TCPSocket)
-        buf = uninitialized UInt8[1]
-        n = LibC.recv(io.fd, buf.to_unsafe.as(Void*), LibC::SizeT.new(1), MSG_PEEK)
-        return Checkout::Closed if n == 0
-        return Checkout::Residue if n > 0
-        {Errno::EAGAIN, Errno::EWOULDBLOCK}.includes?(Errno.value) ? Checkout::Clean : Checkout::Residue
-      elsif io.responds_to?(:read_timeout=) && io.responds_to?(:read_timeout)
-        prev = io.read_timeout
-        begin
-          io.read_timeout = DRAIN_PROBE
-          # nil = EOF (the peer closed); a byte = residue. The byte is consumed, which is why
-          # this branch only ever runs on a socket that is about to be retired either way.
-          io.read_byte.nil? ? Checkout::Closed : Checkout::Residue
-        rescue IO::TimeoutError
+        peek_state(io)
+      elsif io.is_a?(OpenSSL::SSL::Socket)
+        # TLS answers in two steps, and the ORDER is the whole design.
+        #
+        # 1. Decrypted bytes already inside OpenSSL are residue outright (`SSL_pending`), free.
+        # 2. Otherwise ask the fd whether ANYTHING is waiting. If the kernel buffer is empty
+        #    too, the socket is provably idle and this returns Clean without a read — the
+        #    common case, and what removes the ~1.6ms this branch used to cost every checkout.
+        #
+        # Only when bytes ARE waiting does it fall through to the timed read below. That step
+        # cannot be skipped: a peek sees bytes but not what they MEAN. A TLS 1.3 record
+        # carrying a NewSessionTicket has outer content type 0x17, exactly like application
+        # data — the real type is encrypted — so nothing short of letting OpenSSL decrypt it
+        # can tell a post-handshake message from a leftover response. Reading the content-type
+        # byte was tried and is wrong for TLS 1.3 for that reason.
+        return Checkout::Residue if io.gori_ssl_pending?
+        under = io.gori_underlying_io
+        if under.is_a?(TCPSocket) && peek_state(under) == Checkout::Clean
           Checkout::Clean
-        ensure
-          io.read_timeout = prev
+        else
+          drain_probe_state(io)
         end
+      elsif io.responds_to?(:read_timeout=) && io.responds_to?(:read_timeout)
+        drain_probe_state(io)
       else
         Checkout::Clean # an IO with no timeout knob is not a pooled socket; nothing to prove
       end


### PR DESCRIPTION
Every pooled checkout asks one question of the parked socket: is anything
waiting, and is the peer still there. Plaintext answers with an fd-level
`MSG_PEEK` in 0.38 µs. TLS could not — OpenSSL hides the fd and residue may sit
in its **decrypted** buffer — so it fell back to `read_timeout = 1ms; read_byte`
and paid the whole deadline on every **clean** checkout, which is the common
case.

Measured against a real TLS origin, 200 checkouts:

| | |
| --- | --- |
| TLS clean checkout | median **1598 µs** (min 1105, max 5169) |
| plaintext fd peek | **0.38 µs** |

Sequential callers paid it per request, and #665 turned keep-alive on for three
of them. A default `gori run sequence` over https is 500 samples on one
connection — roughly **800 ms of that run was this probe**.

## After

Two steps, and the order is the design:

1. `SSL_pending` — decrypted bytes already inside OpenSSL are residue, free.
2. otherwise peek the fd underneath. If the kernel buffer is empty too, the
   socket is provably idle: **Clean, no read**.

Only when bytes *are* waiting does it fall through to the timed read.

On a socket parked after a real exchange: **0.5 µs median, max 3 µs, fast path
250/250**.

## The step that cannot be skipped

The first attempt did the peek and called any waiting byte residue. The spec
caught it: an idle TLS socket came back `Residue`, and a hung-up one came back
`Residue` instead of `Closed`.

A peek sees bytes but not what they **mean** — a session ticket and a
`close_notify` are bytes too. Reading the record's content-type byte does not
rescue it either: TLS 1.3 encrypts the real type and sets the outer one to
`0x17` for everything, so a `NewSessionTicket` is indistinguishable from
application data without decrypting it. Only OpenSSL can answer that, which is
what the timed read is for — so it stays, for the case where something is
actually there.

## Order of work

The harness came first, deliberately. This branch is the one that costs, so it
is the one anybody optimising the pool will touch, and it had **no coverage** —
`conn_pool_spec` uses plaintext origins only.

`conn_pool_checkout_spec` pins all three answers (Clean / Residue / Closed) on
**both** transports against a real TLS origin built from gori's own CA, plus the
probe-failed case. It is what turned a wrong design into a right one instead of
into a response desync.

`checkout_state` becomes a class method to make that possible — it reads nothing
off the pool, only the socket it is handed, like the two reuse predicates beside
it. `SSL_pending` and the two accessors are stdlib reach-ins in the same style as
`gori_buffered_residue?` directly above them: deliberate, and they fail to
compile rather than misbehave if the internals move.

## Verification

`crystal spec` 8351 examples, 0 failures. Format clean, no new ameba findings.
All 44 harnesses build. Rebased onto #668 and the merge result builds and passes.
Touches nothing in the QL/filter layer.
