### PR TITLE
Stop two probe rule gates from failing silently

### DIFF
--- a/spec/probe_spec.cr
+++ b/spec/probe_spec.cr
@@ -1969,6 +1969,31 @@ describe "Gori::Probe::Active::NextjsActionNoAuth" do
     end
   end
 
+  # `Http1.parse_headers` builds a header VALUE with a bare `String.new`, so a non-UTF-8 byte in a
+  # probe response's Location made `LOGIN_PATH.matches?` raise. That raise was caught by
+  # `detections`' method-level rescue, which returns NO detections — so the whole rule went silent
+  # on that host rather than crashing. Both directions are pinned: the suppression still works, and
+  # a genuine bypass is still reported.
+  it "still judges a redirect target carrying a non-UTF-8 byte" do
+    with_store do |store|
+      flow = action_flow.call(store, action_headers, 200, priv)
+      plan = probe.plan(flow, unsafe).not_nil!
+
+      # An auth route with a stray byte → control still held, still suppressed.
+      bad_login = Gori::Repeater::Result.new(
+        "HTTP/1.1 200 OK\r\nLocation: /auth/\xFFx\r\n\r\n".to_slice, priv.to_slice, nil, 1_i64)
+      probe.detections(plan, bad_login, flow).should be_empty
+
+      # A non-auth Location with a stray byte → nothing suppresses, the bypass is reported.
+      # This is the case that produced no detection at all before the scrub.
+      bad_other = Gori::Repeater::Result.new(
+        "HTTP/1.1 200 OK\r\nLocation: /assets/\xFF.bin\r\n\r\n".to_slice, priv.to_slice, nil, 1_i64)
+      dets = probe.detections(plan, bad_other, flow)
+      dets.size.should eq(1)
+      dets.first.code.should eq("nextjs_action_no_auth")
+    end
+  end
+
   it "does not flag when the authenticated baseline had no body to compare against" do
     with_store do |store|
       # An empty-bodied 200 (or a 204) authenticated action: there is no privileged payload to
@@ -4055,6 +4080,29 @@ describe "Gori::Probe::Scan rules config parity" do
       after = Gori::Probe::Scan.scan_flows(store, ids, active: false)
       after.count { |d| d.code == "secret_in_url" }.should eq(0)
     end
+  end
+
+  # `probe_disabled_rules` stores the operator's DEVIATION FROM DEFAULT, so membership FLIPS
+  # meaning for `DEFAULT_DISABLED_RULES` ids — which is why `Probe.rule_disabled?` exists and why
+  # issue.cr claims the flip lives in exactly ONE place. `Passive.analyze` and `analyze_ws` had
+  # drifted to a bare `disabled.includes?`. It was inert only because every default-OFF id today is
+  # an ACTIVE rule, so no passive rule ever reached the branch where the two disagree; the first
+  # default-OFF passive rule would have shipped silently dead for the operator who enabled it.
+  #
+  # No behavioural spec can pin this while `DEFAULT_DISABLED_RULES` has no passive member, so the
+  # pin is structural — the same shape as spec/tui/color_semantics_spec.cr, which re-derives a rule
+  # by grepping source rather than by exercising a case that does not exist yet.
+  it "gates every probe rule through Probe.rule_disabled?, never a bare set lookup" do
+    root = File.join(__DIR__, "..", "src", "gori", "probe")
+    offenders = [] of String
+    Dir.glob(File.join(root, "**", "*.cr")).sort.each do |path|
+      File.read(path).lines.each_with_index do |line, i|
+        next if line.lstrip.starts_with?('#') # a comment may name the old shape; code may not
+        next unless line.matches?(/\bdisabled\.includes\?\(/)
+        offenders << "#{File.basename(path)}:#{i + 1} — #{line.strip}"
+      end
+    end
+    offenders.should be_empty
   end
 
   it "runs the operator's custom match rules in a headless passive scan" do

--- a/src/gori/probe/active/nextjs_action_no_auth.cr
+++ b/src/gori/probe/active/nextjs_action_no_auth.cr
@@ -170,9 +170,16 @@ module Gori
         # calls redirect() (X-Action-Redirect, delivered on a 2xx), and a plain Location, against a
         # login/auth path pattern. Only the redirect TARGET is inspected (a header, not the body),
         # so a privileged payload that merely links to /login can't over-suppress a real finding.
+        #
+        # scrub: `Http1.parse_headers` builds a header VALUE with a bare `String.new` (no scrub),
+        # so a non-UTF-8 byte in a probe response's Location makes the PCRE raise — and here that
+        # raise is swallowed by `detections`' method-level rescue, which returns no detections at
+        # all. The failure is therefore not a crash but this whole rule going SILENT on that host.
+        # The sibling test below (AUTH_FAIL) already scrubs; LOGIN_PATH is ASCII, so this is
+        # lossless. (cf. cors.cr)
         private def control_redirected?(resp : Proxy::Codec::RawResponse) : Bool
           {resp.headers.get?("X-Action-Redirect"), resp.headers.get?("Location")}.any? do |v|
-            v && LOGIN_PATH.matches?(v)
+            v && LOGIN_PATH.matches?(v.scrub)
           end
         end
 

--- a/src/gori/probe/passive.cr
+++ b/src/gori/probe/passive.cr
@@ -64,8 +64,13 @@ module Gori
       NO_DISABLED = Set(String).new
       NO_CUSTOM   = [] of CustomRule
 
-      # `disabled` holds RuleInfo#id values the operator switched off in the Rules sub-tab (skipped
-      # here); `custom` are the merged global+project user match rules, run after the built-ins.
+      # `disabled` records the operator's DEVIATION FROM DEFAULT, not a plain "off" list, so it is
+      # read through `Probe.rule_disabled?` — the same helper the active path, the analyzer and the
+      # headless scan use. A bare `disabled.includes?` was correct only by accident: membership
+      # FLIPS meaning for `DEFAULT_DISABLED_RULES` ids, and today every one of those is an ACTIVE
+      # rule, so no passive rule reached the branch where the two disagree. The first default-OFF
+      # passive rule would have shipped silently dead for the operator who enabled it.
+      # `custom` are the merged global+project user match rules, run after the built-ins.
       # A SHORT-CIRCUITED flow is refused outright (#511): gori wrote that response itself from
       # a Match&Replace stub, so every passive rule here would be reading the operator's own
       # bytes and reporting them as a property of the target. That is the `probe-rule-fp-review`
@@ -79,7 +84,7 @@ module Gori
         return [] of Detection if detail.row.short_circuited?
         ctx = Context.new(detail, ws_messages)
         acc = [] of Detection
-        RULES.each { |r| r.check(ctx, acc) unless disabled.includes?(r.info.id) }
+        RULES.each { |r| r.check(ctx, acc) unless Probe.rule_disabled?(r.info.id, disabled) }
         custom.each(&.check(ctx, acc))
         acc
       end
@@ -92,7 +97,7 @@ module Gori
         return [] of Detection if ws_messages.empty? || detail.row.short_circuited?
         ctx = Context.new(detail, ws_messages)
         acc = [] of Detection
-        WS_RULES.each { |r| r.check(ctx, acc) unless disabled.includes?(r.info.id) }
+        WS_RULES.each { |r| r.check(ctx, acc) unless Probe.rule_disabled?(r.info.id, disabled) }
         acc
       end
     end


### PR DESCRIPTION
Two gating bugs in Probe, both silent by construction. Neither surfaces as an error — each just makes a rule stop reporting.

### `nextjs_action_no_auth` went quiet on a non-UTF-8 redirect target

`control_redirected?` ran `LOGIN_PATH` against a **raw** header value. `Http1.parse_headers` builds header values with a bare `String.new` (no scrub), so one non-UTF-8 byte in a probe response's `Location` made PCRE raise. That raise was caught by `detections`' method-level rescue, which returns `[] of Detection` — so the failure was not a crash but **the whole rule going silent on that host**.

Its sibling test against the same response (`AUTH_FAIL`, two lines up) already scrubs, which is what makes this an oversight rather than a decision. It is also the only unscrubbed PCRE-on-a-raw-header-value left in the probe tree.

The spec pins both directions, and the control run is real: with the scrub reverted, the bypass case reports **0** findings instead of 1.

### `Passive.analyze` had drifted off `Probe.rule_disabled?`

`analyze` and `analyze_ws` gated rules with a bare `disabled.includes?`, while every other gating site (`active.cr`, `analyzer.cr` ×3) goes through `Probe.rule_disabled?`.

That set records the operator's **deviation from default**, not a plain "off" list, so membership *flips* meaning for `DEFAULT_DISABLED_RULES` ids — which is exactly why `issue.cr` states the flip lives in one place and no surface can drift.

It was inert **only by accident**: every default-OFF id today is an *active* rule, so no passive rule ever reached the branch where the two expressions disagree. The first default-OFF passive rule would have shipped dead for the operator who enabled it.

No behavioural spec can pin this while `DEFAULT_DISABLED_RULES` has no passive member, so the pin is structural — a source grep in the shape of `spec/tui/color_semantics_spec.cr`. Control-run too: reverting `passive.cr` makes it fail and names both lines.

### Verification

- `crystal spec spec/probe_spec.cr spec/probe/` → 467 examples, 0 failures
- Both new specs control-run: each fails with its fix reverted
- `crystal tool format --check` clean; `crystal build --no-codegen src/main.cr` clean
- ameba on both changed source files: 0 findings

https://claude.ai/code/session_01UiZppfkBza2AytWMHBh9ab