### PR TITLE
Stop DOM-XSS pairing on two shapes that carry no taint

### DIFF
--- a/spec/probe/passive/dom_xss_spec.cr
+++ b/spec/probe/passive/dom_xss_spec.cr
@@ -157,6 +157,23 @@ describe Gori::Probe::Passive::DomXss do
         dom(store, body: html_script("if (el.innerHTML == location.hash) { warn() }")).should be_empty
       end
     end
+
+    it "does not flag an argument-less .html() (a getter, not a sink)" do
+      with_store do |store|
+        # `$(el).html()` READS markup. The sink needs something written INTO it, which is what
+        # the (?!\)) guard asks for — the same read-vs-write distinction as innerHTML's (?!=).
+        dom(store, body: html_script("var cur = location.hash + $('#out').html()")).should be_empty
+      end
+    end
+
+    it "does not flag a URLSearchParams built from untainted input" do
+      with_store do |store|
+        # `URLSearchParams` was a source in its own right, so this benign, extremely common line
+        # paired it with the `location assignment` sink. The identifier says nothing about where
+        # the data came from; a genuinely tainted construction names its own source instead.
+        dom(store, body: html_script("location.href = \"/x?\" + new URLSearchParams(form)")).should be_empty
+      end
+    end
   end
 
   # (5) source/sink only inside a string or comment does NOT flag (client_code is stripped).

--- a/src/gori/probe/passive/js_scan.cr
+++ b/src/gori/probe/passive/js_scan.cr
@@ -49,7 +49,16 @@ module Gori
           {/\bhistory\.state\b/, "history.state"},
           {/\b(?:e|ev|evt|event|msg|message)\.data\b/, "postMessage data"},
           {/\b(?:localStorage|sessionStorage)\.getItem\b/, "web storage"},
-          {/\bURLSearchParams\b/, "URLSearchParams"},
+          # No `URLSearchParams` entry, deliberately. It was here and it is DOMINATED: the
+          # source↔sink window is bounded by BOUNDS (';' '{' '}' '\n'), so a constructor in an
+          # earlier statement was never reachable, and every in-statement TAINTED construction
+          # already carries its own listed source — `new URLSearchParams(location.search)`,
+          # `(window.location.search)`, `(location.hash.slice(1))` all match location.search /
+          # location.hash right beside it. There is no one-liner where the bare identifier is the
+          # only source token AND the flow is tainted, so it contributed zero unique findings.
+          # What it did contribute is a false pair on ordinary SPA code:
+          # `location.href = "/x?" + new URLSearchParams(form)` — untainted input, benign
+          # navigation — reported as DOM-XSS against the `location assignment` sink below.
         ] of {Regex, String}
 
         # HTML/JS execution sinks. Each keys on a distinctive identifier so PCRE's first-byte
@@ -65,7 +74,10 @@ module Gori
           {/\bnew\s+Function\s*\(/, "Function"},
           {/\bset(?:Timeout|Interval)\s*\(/, "setTimeout/setInterval"},
           {/\bdangerouslySetInnerHTML\b/, "dangerouslySetInnerHTML"},
-          {/\.html\s*\(/, "jQuery.html()"},
+          # `(?!\))` keeps the ARGUMENT-LESS form out: `$(el).html()` READS the markup, it does not
+          # write it — the same distinction the `(?!=)` guards above draw between `=` and `==`.
+          # `\s*` before it so a newline-wrapped argument still counts as a sink.
+          {/\.html\s*\(\s*(?!\))/, "jQuery.html()"},
           # Navigation sinks. A tainted navigation target is how `javascript:`-URL XSS and
           # client-side open redirect both land, and neither is reachable through the HTML/eval
           # sinks above. The bare-`location` form deliberately also matches `document.location =`


### PR DESCRIPTION
Two residual false pairs in the DOM-XSS correlator. Both fire on ordinary SPA code, and neither costs a true positive.

### Drop the `URLSearchParams` source

It is **dominated**, which is the strongest form of this argument:

- the source↔sink window is bounded by `BOUNDS` (`;` `{` `}` `\n`), so a constructor in an earlier statement was never reachable;
- every in-statement *tainted* construction already carries its own listed source — `new URLSearchParams(location.search)`, `(window.location.search)`, `(location.hash.slice(1))` all match `location.search` / `location.hash` sitting right beside them.

I could not construct a one-liner where the bare identifier is the **only** source token and the flow is genuinely tainted. Against that zero unique-TP value stands a confirmed FP:

```js
location.href = "/x?" + new URLSearchParams(form)   // untainted input, benign navigation
```

paired with the `location assignment` sink. The identifier says nothing about where the data came from.

Zero spec coverage (`grep` finds no other reference in `src/` or `spec/`) and absent from the source-label table in `dom_xss_spec.cr`, so nothing else moves. Side benefit, not the justification: it also narrows the whole-script source prefilter.

### Require a non-empty argument on the jQuery sink

`/\.html\s*\(/` matched the **getter** `$(el).html()`, which reads markup rather than writing it — the same read-vs-write distinction the `(?!=)` guards already draw between `=` and `==`. Now `/\.html\s*\(\s*(?!\))/`; the `\s*` keeps a newline-wrapped argument counting as a sink, so no FN.

### Verification

- `crystal spec spec/probe_spec.cr spec/probe/` → 467 examples, 0 failures
- Both new negatives **control-run**: each fails with only its own fix reverted
- The existing positive `$('#out').html(location.hash)` stays green — that is what proves the sink guard did not overshoot
- `crystal tool format --check` clean; `crystal build --no-codegen src/main.cr` clean; ameba 0 findings on both files

Stacks alongside #671 (independent — both branch off main).

https://claude.ai/code/session_01UiZppfkBza2AytWMHBh9ab