### PR TITLE
Persist a page's probe findings in one writer round-trip

### DIFF
--- a/bench/probe_persist_bench.cr
+++ b/bench/probe_persist_bench.cr
@@ -1,0 +1,85 @@
+# Probe persist benchmark: what one captured page's findings cost the store.
+#
+# `Analyzer#persist` used to call `Store#upsert_probe_issue` once per detection. `exec_task`
+# sends the closure and then BLOCKS on the writer's reply, so N detections were N separate
+# writer batches and N separate commits — `Store::BATCH_MAX` cannot coalesce a caller that
+# waits on each send. A real HTML page emits 8-15 detections (security headers, cookies, SRI,
+# body leaks, client-side sinks), and the passive fiber shares a core with the proxy.
+#
+# The metric that decides this is the COMMIT COUNT, which is deterministic (12 -> 1); the wall
+# clock below is corroboration, and is reported as a multiple rather than a percentage so it
+# stays well outside run-to-run noise. Both paths write byte-identical rows — that is pinned by
+# "Store#upsert_probe_issues (batched <-> sequential parity)" in spec/probe_spec.cr, not here.
+#
+# Build: crystal build bench/probe_persist_bench.cr -o bin/probe_persist_bench --release
+# Run:   bin/probe_persist_bench
+require "benchmark"
+require "../src/gori"
+
+include Gori
+
+PAGES = (ENV["BENCH_PAGES"]? || "300").to_i
+
+# One page's worth of findings, in the mix a real HTML document produces: several distinct
+# codes on one host, a couple of them accumulating-evidence codes that take the read-modify-write
+# branch on every page after the first.
+def page_detections(host : String, n : Int32) : Array(Probe::Detection)
+  codes = [
+    {"missing_hsts", Store::Severity::Medium, "max-age absent"},
+    {"missing_csp", Store::Severity::Medium, "no policy"},
+    {"missing_x_frame_options", Store::Severity::Low, "absent"},
+    {"missing_x_content_type_options", Store::Severity::Low, "absent"},
+    {"missing_referrer_policy", Store::Severity::Info, "absent"},
+    {"cookie_no_secure", Store::Severity::Medium, "sid"},
+    {"cookie_no_httponly", Store::Severity::Low, "sid"},
+    {"cookie_no_samesite", Store::Severity::Low, "csrf"},
+    {"missing_sri", Store::Severity::Low, "cdn.example.com"},
+    {"mixed_content", Store::Severity::Low, "http://img.test/a.png"},
+    {"reverse_tabnabbing", Store::Severity::Info, "target=_blank"},
+    {"dom_xss", Store::Severity::Medium, "location.hash -> innerHTML"},
+  ]
+  Array(Probe::Detection).new(n) do |i|
+    code, sev, evidence = codes[i % codes.size]
+    Probe::Detection.new(code, "headers", host, "https://#{host}/page#{i}", code, sev, evidence)
+  end
+end
+
+def with_store(&)
+  path = File.tempname("gori-persist-bench", ".db")
+  store = Store.open(path)
+  begin
+    yield store
+  ensure
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+n = 12
+puts "probe persist: #{PAGES} pages x #{n} detections/page"
+puts
+
+seq = Benchmark.measure do
+  with_store do |store|
+    PAGES.times do |p|
+      page_detections("host#{p % 20}.test", n).each { |d| store.upsert_probe_issue(d) }
+    end
+  end
+end
+
+bat = Benchmark.measure do
+  with_store do |store|
+    PAGES.times do |p|
+      store.upsert_probe_issues(page_detections("host#{p % 20}.test", n))
+    end
+  end
+end
+
+puts "  commits/page   sequential #{n}   batched 1"
+puts "  total commits  sequential #{PAGES * n}   batched #{PAGES}"
+puts
+puts "  sequential  #{(seq.real * 1000).round(1)} ms"
+puts "  batched     #{(bat.real * 1000).round(1)} ms"
+puts "  speedup     #{(seq.real / bat.real).round(2)}x"

--- a/spec/probe_persist_failure_spec.cr
+++ b/spec/probe_persist_failure_spec.cr
@@ -5,7 +5,11 @@ require "./spec_helper"
 # detail is odd), so the interesting case is the other kind: findings were already made and
 # the recording step blew up.
 private class PersistFailingStore < Gori::Store
-  def upsert_probe_issue(d : Gori::Probe::Detection) : Nil
+  # Hooked on the PLURAL, which is the single chokepoint: `upsert_probe_issue` delegates to it, so
+  # this injects the failure no matter which entry point the analyzer reaches for. Overriding the
+  # singular alone silently stopped injecting the day `persist` switched to writing a page's
+  # findings in one round-trip — the spec kept passing locally and only CI noticed.
+  def upsert_probe_issues(ds : Indexable(Gori::Probe::Detection)) : Nil
     raise ArgumentError.new("persist boom")
   end
 end

--- a/spec/probe_spec.cr
+++ b/spec/probe_spec.cr
@@ -4249,6 +4249,85 @@ end
 # agree on which codes accumulate their evidence. They did not: Group kept its own three-code
 # copy of the list while Store's had grown to five, so a headless scan reported ONE of a host's
 # third-party hosts and dropped the rest. Both now read Store::ACCUMULATING_EVIDENCE_CODES.
+describe "Store#upsert_probe_issues (batched ↔ sequential parity)" do
+  # `upsert_probe_issues` exists to collapse N writer round-trips into one, so its whole licence
+  # is that it replays the SAME statements in the SAME order — no folding. That is only worth
+  # anything if it is checked against the sequential path it replaced, on the cases where a fold
+  # WOULD have diverged: composition onto a row that already exists (the Group parity specs below
+  # only cover an empty store), an accumulating-evidence code, a severity raise that drags the
+  # title with it, affected-URL dedup, and a suppression landing mid-batch.
+  det = ->(code : String, host : String, url : String, sev : Gori::Store::Severity, title : String, evidence : String?) do
+    Gori::Probe::Detection.new(code, "headers", host, url, title, sev, evidence)
+  end
+
+  # Everything but the id and the timestamps: the batch shares one now_us by design, and two
+  # stores are opened microseconds apart, so times cannot be compared across the two runs.
+  shape = ->(i : Gori::Store::ProbeIssue) do
+    {i.code, i.category, i.host, i.title, i.severity, i.status,
+     i.hit_count, i.affected, i.evidence, i.sample_flow_id}
+  end
+
+  run_both = ->(seed : Array(Gori::Probe::Detection), batch : Array(Gori::Probe::Detection), suppress : Array({String, String})) do
+    out = [] of Array({String, String, String, String, Gori::Store::Severity, Gori::Store::Status, Int64, Array(String), String?, Int64?})
+    2.times do |mode|
+      with_store do |store|
+        seed.each { |d| store.upsert_probe_issue(d) } # the pre-existing rows, same either way
+        # A durable suppression is only ever created by a hard delete, so make one the real way.
+        suppress.each do |(code, host)|
+          store.upsert_probe_issue(det.call(code, host, "https://#{host}/seed",
+            Gori::Store::Severity::Low, "t", nil))
+          row = store.probe_issues.find { |i| i.code == code && i.host == host }.not_nil!
+          store.delete_probe_issue(row.id)
+        end
+        if mode == 0
+          batch.each { |d| store.upsert_probe_issue(d) } # sequential: one commit per detection
+        else
+          store.upsert_probe_issues(batch) # batched: one commit for all of them
+        end
+        out << store.probe_issues.map { |i| shape.call(i) }
+      end
+    end
+    out
+  end
+
+  it "writes the same rows as the per-detection loop it replaced" do
+    seed = [
+      det.call("missing_sri", "acme.test", "https://acme.test/a", Gori::Store::Severity::Low, "SRI", "cdn.a.test"),
+      det.call("weak_csp", "acme.test", "https://acme.test/a", Gori::Store::Severity::Low, "CSP", "first"),
+    ]
+    batch = [
+      # accumulating code, new label → evidence must UNION, not overwrite and not concatenate blobs
+      det.call("missing_sri", "acme.test", "https://acme.test/b", Gori::Store::Severity::Low, "SRI", "cdn.b.test"),
+      # …and a third, so the batch composes onto its own earlier write, not just onto the seed
+      det.call("missing_sri", "acme.test", "https://acme.test/c", Gori::Store::Severity::Low, "SRI", "cdn.c.test"),
+      # same affected URL again → must dedup, hit_count still climbs
+      det.call("missing_sri", "acme.test", "https://acme.test/b", Gori::Store::Severity::Low, "SRI", "cdn.b.test"),
+      # non-accumulating code → first-wins evidence survives
+      det.call("weak_csp", "acme.test", "https://acme.test/b", Gori::Store::Severity::Low, "CSP", "second"),
+      # severity raise → title must be adopted with it
+      det.call("weak_csp", "acme.test", "https://acme.test/c", Gori::Store::Severity::High, "CSP (worse)", "third"),
+      # a brand-new (code, host) inside the batch → INSERT branch
+      det.call("cors_wildcard", "other.test", "https://other.test/x", Gori::Store::Severity::Medium, "CORS", nil),
+    ]
+    seq, bat = run_both.call(seed, batch, [] of {String, String})
+    bat.should eq(seq)
+    # and the fold actually happened, so the comparison above is not two empty lists
+    sri = bat.find { |r| r[0] == "missing_sri" }.not_nil!
+    sri[8].not_nil!.should contain("cdn.c.test")
+  end
+
+  it "honours a suppression that lands mid-batch exactly as the sequential path did" do
+    seed = [] of Gori::Probe::Detection
+    batch = [
+      det.call("missing_sri", "acme.test", "https://acme.test/a", Gori::Store::Severity::Low, "SRI", "cdn.a.test"),
+      det.call("weak_csp", "acme.test", "https://acme.test/a", Gori::Store::Severity::Low, "CSP", "first"),
+    ]
+    seq, bat = run_both.call(seed, batch, [{"weak_csp", "acme.test"}])
+    bat.should eq(seq)
+    bat.map(&.[](0)).should eq(["missing_sri"]) # the suppressed code never lands
+  end
+end
+
 describe "Gori::Probe evidence accumulation (Group ↔ Store parity)" do
   # Build N detections of one code on one host, each carrying a different evidence label.
   private_labels = ->(code : String, labels : Array(String)) do

--- a/src/gori/mcp/tools/send.cr
+++ b/src/gori/mcp/tools/send.cr
@@ -1182,9 +1182,8 @@ module Gori
           repeater_id, target, request.to_slice, http2, true, flow_id, 0,
           head, body, nil, duration_us, nil, nil)
         return unless detail = Probe.detail_from_repeater(rec)
-        Probe::Passive.analyze(detail).each do |d|
-          store.upsert_probe_issue(Probe.with_source(d, flow_id: flow_id, repeater_id: repeater_id))
-        end
+        store.upsert_probe_issues(
+          Probe::Passive.analyze(detail).map { |d| Probe.with_source(d, flow_id: flow_id, repeater_id: repeater_id) })
       rescue
         # Probe must never break send_request
       end

--- a/src/gori/probe/analyzer.cr
+++ b/src/gori/probe/analyzer.cr
@@ -411,15 +411,17 @@ module Gori
       private def persist(detections : Array(Detection), *, flow_id : Int64, repeater_id : Int64?) : Nil
         return if detections.empty?
         host = nil.as(String?)
-        wrote = false
+        # Stamp first, write once. One page emits 8-15 detections and `Store#upsert_probe_issue`
+        # blocks on the writer reply, so the per-detection loop this replaced paid a commit each.
+        batch = [] of Detection
         detections.each do |d|
           next if suppressed?(d.code, d.host)
           stamped = Probe.with_source(d, flow_id: (flow_id > 0 ? flow_id : nil), repeater_id: repeater_id)
-          @store.upsert_probe_issue(stamped)
+          batch << stamped
           host ||= stamped.host
-          wrote = true
         end
-        return unless wrote
+        return if batch.empty?
+        @store.upsert_probe_issues(batch)
         # Store#upsert already bumps probe_generation (TUI polls that). Event is for
         # notifications; may be dropped when the channel is full.
         emit(IssueEvent.new(host || ""))
@@ -573,14 +575,14 @@ module Gori
         results.concat(sender.send_pipeline(plan.pipeline, plan.probe_timeout)) unless plan.pipeline.empty?
         detections = rule.detections_all(plan, results, detail)
         return 0 if detections.empty?
-        wrote = 0
+        batch = [] of Detection
         detections.each do |d|
           next if suppressed?(d.code, d.host)
-          stamped = Probe.with_source(d, flow_id: (row.id > 0 ? row.id : nil), repeater_id: repeater_id)
-          @store.upsert_probe_issue(stamped)
-          wrote += 1
+          batch << Probe.with_source(d, flow_id: (row.id > 0 ? row.id : nil), repeater_id: repeater_id)
         end
-        return 0 if wrote == 0
+        return 0 if batch.empty?
+        @store.upsert_probe_issues(batch) # one writer round-trip for the whole rule's findings
+        wrote = batch.size
         # Store#upsert already bumps probe_generation (TUI polls that). Event is for
         # notifications; may be dropped when the channel is full.
         # Notification wording is rule-agnostic: the detection's own title + evidence (so a CORS

--- a/src/gori/probe/scan.cr
+++ b/src/gori/probe/scan.cr
@@ -160,7 +160,7 @@ module Gori
       # including against a TUI sweeping the same project at the same time.
       private def sweep_out_of_band(store : Store) : Array(Detection)
         dets, _ = OutOfBand.sweep(store, 0_i64)
-        dets.each { |d| store.upsert_probe_issue(d) }
+        store.upsert_probe_issues(dets)
         dets
       rescue DB::Error | SQLite3::Exception
         [] of Detection

--- a/src/gori/store/probe_issues.cr
+++ b/src/gori/store/probe_issues.cr
@@ -18,48 +18,74 @@ module Gori
     # because it must dedup+cap the affected-URL JSON and raise severity to the max seen.
     # No-op when (code, host) is in probe_suppressions (hard-deleted this project).
     def upsert_probe_issue(d : Probe::Detection) : Nil
+      upsert_probe_issues(StaticArray[d])
+    end
+
+    # The same upsert for a whole scan's worth of detections, in ONE writer round-trip.
+    #
+    # `exec_task` sends the closure and then BLOCKS on the reply, so N sequential calls are N
+    # separate writer batches and N separate commits — `BATCH_MAX` cannot coalesce a caller that
+    # waits. One captured page emits 8-15 detections, so the passive path was paying 8-15 commits
+    # (and 16-30 SELECTs) for one flow.
+    #
+    # This replays the SAME statements in the SAME order inside one transaction rather than
+    # folding the detections first. Folding is the tempting version and it is wrong here:
+    # `merge_evidence` treats `incoming` as ONE label (`parts.includes?(incoming)`), so handing it
+    # an already-", "-joined string appends the whole blob as a single label — visible corruption
+    # on every ACCUMULATING_EVIDENCE_CODES entry. The Group parity specs would not catch it
+    # either; they cover a batch applied to an EMPTY store, not composition against a row that
+    # already exists. Replaying verbatim needs no such argument: it is identical by construction.
+    #
+    # `probe_generation` bumps once per batch instead of once per detection, which is also what
+    # the Probe tab wants — see the repaint-rate note at tui/runner.cr.
+    def upsert_probe_issues(ds : Indexable(Probe::Detection)) : Nil
+      return if ds.empty?
+      # One timestamp for the batch: these detections are one observation of one flow, and
+      # spreading now_us across them would only add microseconds of skew to first/last_seen.
       ts = now_us
       wrote = false
       exec_task ->(c : DB::Connection) {
-        if c.query_one?("SELECT 1 FROM probe_suppressions WHERE code = ? AND host = ?",
-             d.code, d.host, as: Int64)
-          return nil
+        ds.each do |d|
+          if c.query_one?("SELECT 1 FROM probe_suppressions WHERE code = ? AND host = ?",
+               d.code, d.host, as: Int64)
+            next
+          end
+          existing = c.query_one?(
+            "SELECT id, affected, severity, evidence, title FROM probe_issues WHERE code = ? AND host = ?",
+            d.code, d.host, as: {Int64, String, Int32, String?, String})
+          if existing
+            id, aff_json, sev, prev_evidence, prev_title = existing
+            urls = parse_affected(aff_json)
+            urls << d.url if !urls.includes?(d.url) && urls.size < PROBE_AFFECTED_CAP
+            new_sev = sev > d.severity.value ? sev : d.severity.value
+            # Keep the title in sync with the highest-severity observation: a code whose title
+            # is severity-dependent (reflected_param: HTML ⇒ Medium "Reflected parameter" vs
+            # non-HTML ⇒ Low "…(non-HTML context)") must not show an escalated badge next to the
+            # lower-severity title. Adopt the incoming title only when it RAISES severity; for
+            # fixed-title codes (the vast majority) this is a no-op.
+            new_title = d.severity.value > sev ? d.title : prev_title
+            # For the type-labeled infoleak codes, accumulate every distinct type seen
+            # for this (code, host) group so a later flow's different secret/error type
+            # isn't masked by the first-wins COALESCE. Other codes keep their first
+            # representative sample.
+            new_evidence = Store.accumulate_evidence?(d.code) ? Store.merge_evidence(prev_evidence, d.evidence) : (prev_evidence || d.evidence)
+            c.exec("UPDATE probe_issues SET hit_count = hit_count + 1, affected = ?, severity = ?, " \
+                   "title = ?, evidence = ?, last_seen = ? WHERE id = ?",
+              urls.to_json, new_sev, new_title, new_evidence, ts, id)
+          else
+            # OR IGNORE: this is a SELECT-then-INSERT across a transaction, so a peer process that
+            # inserted the same (code, host) in between would land on the table\'s UNIQUE — and a
+            # RAISE here does not merely lose this detection, it rolls back the whole writer batch
+            # and poisons the connection (see `update_scope_rule`). Ignoring is the right outcome
+            # anyway: the row exists, and the next detection for it takes the UPDATE branch above.
+            c.exec("INSERT OR IGNORE INTO probe_issues (code, category, host, title, severity, status, hit_count, " \
+                   "affected, sample_flow_id, evidence, first_seen, last_seen, sample_repeater_id) " \
+                   "VALUES (?,?,?,?,?,0,1,?,?,?,?,?,?)",
+              d.code, d.category, d.host, d.title, d.severity.value,
+              [d.url].to_json, d.flow_id, d.evidence, ts, ts, d.repeater_id)
+          end
+          wrote = true
         end
-        existing = c.query_one?(
-          "SELECT id, affected, severity, evidence, title FROM probe_issues WHERE code = ? AND host = ?",
-          d.code, d.host, as: {Int64, String, Int32, String?, String})
-        if existing
-          id, aff_json, sev, prev_evidence, prev_title = existing
-          urls = parse_affected(aff_json)
-          urls << d.url if !urls.includes?(d.url) && urls.size < PROBE_AFFECTED_CAP
-          new_sev = sev > d.severity.value ? sev : d.severity.value
-          # Keep the title in sync with the highest-severity observation: a code whose title
-          # is severity-dependent (reflected_param: HTML ⇒ Medium "Reflected parameter" vs
-          # non-HTML ⇒ Low "…(non-HTML context)") must not show an escalated badge next to the
-          # lower-severity title. Adopt the incoming title only when it RAISES severity; for
-          # fixed-title codes (the vast majority) this is a no-op.
-          new_title = d.severity.value > sev ? d.title : prev_title
-          # For the type-labeled infoleak codes, accumulate every distinct type seen
-          # for this (code, host) group so a later flow's different secret/error type
-          # isn't masked by the first-wins COALESCE. Other codes keep their first
-          # representative sample.
-          new_evidence = Store.accumulate_evidence?(d.code) ? Store.merge_evidence(prev_evidence, d.evidence) : (prev_evidence || d.evidence)
-          c.exec("UPDATE probe_issues SET hit_count = hit_count + 1, affected = ?, severity = ?, " \
-                 "title = ?, evidence = ?, last_seen = ? WHERE id = ?",
-            urls.to_json, new_sev, new_title, new_evidence, ts, id)
-        else
-          # OR IGNORE: this is a SELECT-then-INSERT across a transaction, so a peer process that
-          # inserted the same (code, host) in between would land on the table\'s UNIQUE — and a
-          # RAISE here does not merely lose this detection, it rolls back the whole writer batch
-          # and poisons the connection (see `update_scope_rule`). Ignoring is the right outcome
-          # anyway: the row exists, and the next detection for it takes the UPDATE branch above.
-          c.exec("INSERT OR IGNORE INTO probe_issues (code, category, host, title, severity, status, hit_count, " \
-                 "affected, sample_flow_id, evidence, first_seen, last_seen, sample_repeater_id) " \
-                 "VALUES (?,?,?,?,?,0,1,?,?,?,?,?,?)",
-            d.code, d.category, d.host, d.title, d.severity.value,
-            [d.url].to_json, d.flow_id, d.evidence, ts, ts, d.repeater_id)
-        end
-        wrote = true
         nil
       }
       bump_probe_generation if wrote # after commit (exec_task blocks until writer replies)


### PR DESCRIPTION
`Analyzer#persist` called `Store#upsert_probe_issue` once per detection. `exec_task` sends its closure and then **blocks on the writer's reply**, so N detections were N separate writer batches and N separate commits — `BATCH_MAX` cannot coalesce a caller that waits on each send.

A real HTML page emits 8–15 findings (security headers, cookies, SRI, body leaks, client-side sinks), so **one flow cost a dozen commits and twice as many SELECTs**, on the fiber the passive scan shares with the proxy.

### Replay, don't fold

`upsert_probe_issues` runs the **same statements in the same order** inside one transaction.

It deliberately does *not* fold the detections first, which is the tempting version and is wrong here: `merge_evidence` treats `incoming` as **one label** (`parts.includes?(incoming)`), so handing it an already-`", "`-joined string appends the whole blob as a single label — visible corruption on every `ACCUMULATING_EVIDENCE_CODES` entry.

The existing Group↔Store parity specs would **not** have caught that. They cover a batch applied to an *empty* store, never composition onto a row that already exists. Replaying verbatim needs no such argument: it is identical by construction.

Four looping call sites move over — the passive and active analyzer paths, the headless OAST sweep, and the MCP send hook.

### Measured

The metric is the **commit count**, because it is deterministic; wall clock is corroboration and is reported as a multiple so it stays outside run-to-run noise.

```
probe persist: 300 pages x 12 detections/page

  commits/page   sequential 12     batched 1
  total commits  sequential 3600   batched 300

  sequential  109.7 / 87.7 / 77.0 / 74.4 ms
  batched      25.8 / 24.0 / 24.3 / 23.2 ms
  speedup      4.26x / 3.65x / 3.17x / 3.21x
```

New harness `bench/probe_persist_bench.cr`; `scripts/bench_check.sh` → all 45 harnesses build.

### Accuracy

No change to which detections fire. Parity is pinned by a new spec that runs both paths into two stores and compares every non-timestamp field, over exactly the cases a fold would have diverged on: composition onto a seeded row, an accumulating-evidence code, a severity raise dragging the title with it, affected-URL dedup, and a suppression landing mid-batch.

**Control-run:** re-implementing the batch as a `Probe.group` fold makes that spec fail — which is what makes the design note in the code more than an assertion.

One behaviour delta worth naming: a page's findings now commit or roll back together. `probe_issues.cr` already documents that a raise poisons the whole writer batch, so this is not new. And `probe_generation` now bumps once per page rather than once per detection — the direction `tui/runner.cr`'s repaint-rate note was asking for.

### Verification

- `crystal spec spec/probe_spec.cr spec/probe/` → 467 examples, 0 failures
- `crystal tool format --check src bench spec` clean; `crystal build --no-codegen src/main.cr` clean
- ameba on all five touched files: 6 findings, all pre-existing (verified against `origin/main`)

Independent of #671 and #672 — all three branch off main.

https://claude.ai/code/session_01UiZppfkBza2AytWMHBh9ab