### PR TITLE
Give header:/body: a side, and make the filter bar teach its own grammar

### DIFF
--- a/docs/content/reference/query-language.ko.md
+++ b/docs/content/reference/query-language.ko.md
@@ -31,6 +31,25 @@ method:POST
 status:404
 ```
 
+### 한쪽 방향만 보기: `req.` / `resp.`
+
+`header:`와 `body:`는 **요청과 응답을 모두** 뒤집니다. 한쪽만 보려면 `req.` 또는 `resp.`를 앞에 붙입니다.
+
+| 필드 | 뜻 |
+| --- | --- |
+| `req.body` / `resp.body` | 그 방향의 본문만 |
+| `req.header` / `resp.header` | 그 방향의 헤드만 |
+
+```text
+resp.body:secrettoken                 응답 본문에만 들어있는 토큰
+resp.header:set-cookie                쿠키를 내려주는 응답
+-resp.body:abcd                       응답 본문에 abcd가 없는 것
+req.body~(?i)password                 요청 본문 정규식(한쪽만)
+NOT (req.body:token OR resp.body:token)
+```
+
+`res.`는 `resp.`의 동의어이고, `req.size` / `resp.size`는 `reqsize` / `respsize`와 같습니다. 방향이 하나뿐인 필드(`host`, `method`, `status` 등)에는 접두사를 붙이지 않습니다.
+
 ## 상태 클래스 {#status-classes}
 
 `status:`는 클래스 약어를 받습니다:

--- a/docs/content/reference/query-language.md
+++ b/docs/content/reference/query-language.md
@@ -31,6 +31,27 @@ method:POST
 status:404
 ```
 
+### One side only: `req.` / `resp.`
+
+`header:` and `body:` search **both the request and the response**. Prefix either with `req.` or
+`resp.` to search one side.
+
+| Field | Meaning |
+| --- | --- |
+| `req.body` / `resp.body` | That side's body only |
+| `req.header` / `resp.header` | That side's head only |
+
+```text
+resp.body:secrettoken                 a token only the response carries
+resp.header:set-cookie                responses that set a cookie
+-resp.body:abcd                       responses whose body lacks abcd
+req.body~(?i)password                 regex over the request body only
+NOT (req.body:token OR resp.body:token)
+```
+
+`res.` is a synonym of `resp.`, and `req.size` / `resp.size` are synonyms of `reqsize` /
+`respsize`. Fields that only ever have one side (`host`, `method`, `status`, …) take no prefix.
+
 ## Status Classes
 
 `status:` accepts class shorthands:

--- a/spec/filter_ast_spec.cr
+++ b/spec/filter_ast_spec.cr
@@ -33,6 +33,44 @@ describe Gori::FilterAst do
     parse("((a OR b) c) OR d").should eq("(or (and (or a b) c) d)")
   end
 
+  # `seps` already stops a bar painting an OPERATOR it does not run; `known` is the same idea one
+  # level down for the field NAME. Without it `hsot:acme` renders in the same confident colour as
+  # `host:acme`, while the backend free-texts the whole token and matches nothing real — the one
+  # visible signal saying the opposite of the truth.
+  describe ".spans with a known-field predicate" do
+    private_known = ->(f : String) { f == "host" }
+
+    it "marks a field the backend does not implement, and its value with it" do
+      kinds = Gori::FilterAst.spans("hsot:acme", ":~", private_known).map { |s| {s.size, s.kind} }
+      kinds.should eq([{5, Gori::FilterAst::SpanKind::UnknownField},
+                       {4, Gori::FilterAst::SpanKind::Plain}])
+
+      # The VALUE goes plain too: the backend free-texts `hsot:acme` whole, so painting `acme`
+      # as a field's value would claim a match nobody performs.
+      real = Gori::FilterAst.spans("host:acme", ":~", private_known).map { |s| {s.size, s.kind} }
+      real.should eq([{5, Gori::FilterAst::SpanKind::Field},
+                      {4, Gori::FilterAst::SpanKind::Value}])
+    end
+
+    it "matches the name case-insensitively, the way the compilers do" do
+      # `split_field` downcases before dispatching, so `HOST:x` compiles and must not be a typo.
+      Gori::FilterAst.spans("HOST:x", ":~", private_known).first.kind
+        .should eq(Gori::FilterAst::SpanKind::Field)
+    end
+
+    it "keeps the negation and the grouping painted as operators regardless" do
+      kinds = Gori::FilterAst.spans("-hsot:x", ":~", private_known).map(&.kind)
+      kinds.first.should eq(Gori::FilterAst::SpanKind::Operator) # the `-`
+      kinds[1].should eq(Gori::FilterAst::SpanKind::UnknownField)
+    end
+
+    it "leaves every existing caller alone when no predicate is given" do
+      # Opt-in: a backend states its vocabulary, it is never assumed for it.
+      Gori::FilterAst.spans("hsot:acme").map(&.kind)
+        .should eq([Gori::FilterAst::SpanKind::Field, Gori::FilterAst::SpanKind::Value])
+    end
+  end
+
   it "treats NOT on a single term as identical to the - prefix" do
     parse("NOT host:cdn").should eq("-host:cdn")
     parse("-host:cdn").should eq("-host:cdn")

--- a/spec/ql_spec.cr
+++ b/spec/ql_spec.cr
@@ -477,6 +477,148 @@ describe "Gori::Store#search (QL)" do
     end
   end
 
+  # `header:`/`body:` search BOTH sides; `req.`/`resp.` picks one. The fast path is an FTS5
+  # COLUMN FILTER over `flows_fts(req, resp)` — a table that already stored the two sides apart —
+  # so these pin that the filter really scopes rather than being ignored by the MATCH parser,
+  # which would silently return the two-sided answer and look like it worked.
+  it "scopes header:/body: to one side with a req./resp. prefix" do
+    tmp_store do |store|
+      req_side = store.insert_flow(Gori::Store::CapturedRequest.new(
+        created_at: 1_i64, scheme: "http", host: "acme.test", port: 80,
+        method: "POST", target: "/login", http_version: "HTTP/1.1",
+        head: "POST /login HTTP/1.1\r\nHost: acme.test\r\nX-Only-Req: 1\r\n\r\n".to_slice,
+        body: "csrf=secrettoken".to_slice))
+
+      resp_side = store.insert_flow(Gori::Store::CapturedRequest.new(
+        created_at: 2_i64, scheme: "http", host: "acme.test", port: 80,
+        method: "GET", target: "/", http_version: "HTTP/1.1",
+        head: "GET / HTTP/1.1\r\nHost: acme.test\r\n\r\n".to_slice, body: nil))
+      store.update_response(Gori::Store::CapturedResponse.new(
+        flow_id: resp_side, status: 200,
+        head: "HTTP/1.1 200 OK\r\nSet-Cookie: sid=1\r\n\r\n".to_slice,
+        body: "<input value=secrettoken>".to_slice))
+
+      quiet = capture(store, "acme.test", "GET", "/about", 200) # no body either side
+      store.flush                                               # body: reads the off-commit trigram index
+
+      ids = ->(q : String) { store.search(Gori::QL.parse(q), 50).map(&.id).sort }
+
+      # the two-sided spelling still finds both — the prefix ADDS a way to ask, it does not
+      # change what the old one answers
+      ids.call("body:secrettoken").should eq([req_side, resp_side].sort)
+
+      ids.call("req.body:secrettoken").should eq([req_side])
+      ids.call("resp.body:secrettoken").should eq([resp_side])
+      ids.call("res.body:secrettoken").should eq([resp_side]) # `res.` is a synonym of `resp.`
+
+      # a short needle takes the byte-wise `instr` path instead of the index — same scoping
+      ids.call("req.body:se").should eq([req_side])
+      ids.call("resp.body:se").should eq([resp_side])
+
+      # regex (`~`) scopes too, and reaches bytes the index does not
+      ids.call("req.body~secret[a-z]+").should eq([req_side])
+      ids.call("resp.body~secret[a-z]+").should eq([resp_side])
+
+      # heads: `X-Only-Req` is on the request, `Set-Cookie` on the response
+      ids.call("req.header:x-only-req").should eq([req_side])
+      ids.call("resp.header:x-only-req").should be_empty
+      ids.call("resp.header:set-cookie").should eq([resp_side])
+      ids.call("req.header:set-cookie").should be_empty
+      ids.call("resp.header~(?i)set-cookie").should eq([resp_side])
+
+      # NEGATION keeps the other side AND the flow with nothing on either — the NULL-safety the
+      # two-sided spelling already had must survive the column filter (an unguarded scoped clause
+      # would answer NULL for a response-less flow and SQLite would exclude it).
+      neg = ids.call("-resp.body:secrettoken")
+      neg.should contain(req_side)
+      neg.should contain(quiet)
+      neg.should_not contain(resp_side)
+
+      neg_head = ids.call("-resp.header:set-cookie")
+      neg_head.should contain(req_side) # response-less: kept, not dropped
+      neg_head.should contain(quiet)
+      neg_head.should_not contain(resp_side)
+
+      # and it composes with the grammar exactly like any other term
+      ids.call("NOT (req.body:secrettoken OR resp.body:secrettoken)").should eq([quiet])
+    end
+  end
+
+  it "accepts req./resp. size synonyms and reports namespaced fields as known" do
+    Gori::QL.parse("req.size:>100").sql.should eq(Gori::QL.parse("reqsize:>100").sql)
+    Gori::QL.parse("resp.size:>100").sql.should eq(Gori::QL.parse("respsize:>100").sql)
+    Gori::QL.parse("res.size:>100").sql.should eq(Gori::QL.parse("respsize:>100").sql)
+
+    # `FIELDS` is the pool a surface OFFERS; `known_field?` is what it ACCEPTS. A validating
+    # surface (Colormarker's unknown-field refusal) must read the wider one or it rejects a
+    # spelling QL compiles.
+    Gori::QL.known_field?("resp.body").should be_true
+    Gori::QL.known_field?("res.body").should be_true
+    Gori::QL.known_field?("req.size").should be_true
+    Gori::QL.known_field?("resp.host").should be_false # single-sided field takes no prefix
+    Gori::QL::FIELDS.should contain("resp.body")
+    Gori::QL::FIELDS.should_not contain("res.body") # accepted, deliberately not offered
+
+    # an invalid regex under an ALIAS is still reported — diagnosis canonicalises the way
+    # compilation does, or `res.body~[bad` would compile to the never-match clause unflagged
+    Gori::QL.invalid_regex_terms("res.body~[bad").should eq(["res.body~[bad"])
+  end
+
+  # Advertising a namespace invites guesses at the rest of it. `resp.status:` is not a typo the
+  # way `hsot:` is — it is someone applying the rule the hint row and Help page just taught them.
+  it "REPORTS a side prefix on a field that has no side, instead of free-texting it to zero" do
+    %w[resp.status:200 resp.code:200 req.method:POST res.host:acme].each do |q|
+      a = Gori::QL.analyze(q)
+      a.ignored.should eq([q]), "#{q} should be reported as dropped"
+      a.applied.should be_empty
+      a.clean?.should be_false # so `strict:` refuses it and ql_explain names it
+      # ...and a query that was ONLY this must not fall through to match-all.
+      Gori::QL.reject_empty?(q, Gori::QL.parse(q)).should be_true
+    end
+
+    # The `~` spelling takes the same path — diagnosis and compilation cannot disagree.
+    Gori::QL.analyze("resp.status~2..").ignored.should eq(["resp.status~2.."])
+
+    # An ordinary unknown field is UNCHANGED: it still free-texts the whole token, which makes a
+    # typo self-evident (it matches nothing real) and is behaviour other surfaces rely on.
+    Gori::QL.analyze("hsot:acme").applied.should eq(["hsot:acme"])
+    Gori::QL.analyze("time:12:00").applied.should eq(["time:12:00"])
+    # A bare word that merely STARTS with a prefix is free text, not a field at all.
+    Gori::QL.analyze("respond").applied.should eq(["respond"])
+  end
+
+  # The pin that makes "a field is added when its explanation is added" true rather than a wish.
+  # Every hint string that used to be written by hand beside a widget is generated from these two
+  # now, so a field with no entry would render as a blank description column somewhere.
+  describe "FIELD_HELP / SYNTAX_HELP" do
+    it "explains every field the completion pool offers, and nothing it does not" do
+      Gori::QL::FIELDS.each do |f|
+        Gori::QL::FIELD_HELP[f]?.should_not be_nil, "FIELD_HELP is missing `#{f}:`"
+      end
+      (Gori::QL::FIELD_HELP.keys - Gori::QL::FIELDS).should be_empty
+    end
+
+    it "resolves help through an alias, so an accepted spelling is never undocumented" do
+      Gori::QL.field_help("res.body").should eq(Gori::QL::FIELD_HELP["resp.body"])
+      Gori::QL.field_help("req.size").should eq(Gori::QL::FIELD_HELP["reqsize"])
+      Gori::QL.field_help("nope").should be_nil
+    end
+
+    it "keeps every line inside the one terminal column it renders in" do
+      Gori::QL::FIELD_HELP.each { |name, help| help.size.should be <= 46, "#{name}: too long" }
+      Gori::QL::SYNTAX_HELP.each { |(ex, why)| (ex.size + why.size).should be <= 78 }
+    end
+
+    it "documents the operators a field-name pool can never show" do
+      why = Gori::QL::SYNTAX_HELP.map { |(ex, _)| ex }.join(" ")
+      why.should contain("-")   # negation
+      why.should contain("OR")  # boolean
+      why.should contain("NOT") # group negation
+      why.should contain("~")   # regex
+      why.should contain("resp.")
+    end
+  end
+
   it "matches bodies, hosts and headers by regex (~), case-sensitively" do
     tmp_store do |store|
       secret = store.insert_flow(Gori::Store::CapturedRequest.new(

--- a/spec/tui/colormarker_rule_overlay_spec.cr
+++ b/spec/tui/colormarker_rule_overlay_spec.cr
@@ -175,11 +175,15 @@ describe ColormarkerRuleOverlay do
     4.times { ov.handle_key(key(Termisu::Input::Key::Down)) }
     backend = MemoryBackend.new(100, 20)
     ov.render(Screen.new(backend), Rect.new(0, 0, 100, 20))
-    # No token to complete yet, so the band names what this backend actually knows — the
-    # QL fields History's search bar accepts are a superset, and reaching for one is the
-    # likely mistake.
+    # No token to complete yet, so the band teaches the language: a sample of the fields this
+    # backend knows, and — the part the old band could never show — the operators. It listed
+    # `USEFUL_FIELDS` and nothing else, so "paint everything EXCEPT" was invisible on the surface
+    # where a standing rule makes that mistake permanent. The full field list moved to Help's
+    # Query page; `QuerySuggest.cold_hint`'s own spec pins the wording, this one pins that the
+    # band renders it.
     backend.contains?("host:").should be_true
-    backend.contains?("proto:").should be_true
+    backend.contains?("path:").should be_true
+    backend.contains?("-term excludes").should be_true
   end
 
   it "cancels on esc" do

--- a/spec/tui/help_view_spec.cr
+++ b/spec/tui/help_view_spec.cr
@@ -17,6 +17,63 @@ describe Gori::Tui::HelpView do
     backend.contains?("DECODER").should be_true # the Decoder tab cheat-sheet
   end
 
+  describe "the Query page" do
+    it "renders the whole language, built from the parser's own tables" do
+      view = HelpView.new
+      backend = MemoryBackend.new(100, 120)
+      view.render_query(Screen.new(backend), Rect.new(0, 0, 100, 120))
+
+      backend.contains?("SYNTAX").should be_true
+      backend.contains?("FIELDS").should be_true
+      backend.contains?("WORTH KNOWING").should be_true
+
+      # Every field QL offers, with its meaning — not a hand-kept subset. This is the page the
+      # one-row hints delegate to, so it is the one place that must be complete.
+      Gori::QL::FIELDS.each do |name|
+        backend.contains?("#{name}:").should be_true, "Query page is missing `#{name}:`"
+      end
+      backend.contains?(Gori::QL::FIELD_HELP["resp.body"]).should be_true
+
+      # ...the operators, which no field list can show...
+      backend.contains?("-path:/static").should be_true
+      backend.contains?("NOT (host:cdn OR host:img)").should be_true
+      # ...the spellings QL accepts but does not offer...
+      backend.contains?("res.body:").should be_true
+      # ...and the ways a query can look clean without having looked.
+      backend.contains?("compressed bodies").should be_true
+    end
+
+    it "fits every syntax example in the left column without ellipsis" do
+      # The column is widened past the cheat-sheet's KEY_W precisely so an example query is not
+      # truncated — `NOT (host:cdn OR ho…` would teach the syntax wrong.
+      Gori::QL::SYNTAX_HELP.each do |(example, _)|
+        example.size.should be <= HelpView::QUERY_KEY_W, "example too wide: #{example}"
+      end
+      Gori::QL::CAVEATS.each { |(what, _)| what.size.should be <= HelpView::QUERY_KEY_W }
+    end
+
+    it "scrolls independently of the Shortcuts page" do
+      # One shared offset would carry the cheat-sheet's position onto this page, where `at_top?`
+      # then answers about the wrong page and ↑ pops focus to the strip mid-scroll.
+      view = HelpView.new
+      view.move(40)
+      view.query_at_top?.should be_true
+      view.at_top?.should be_false
+
+      view.query_move(3)
+      view.query_at_top?.should be_false
+    end
+
+    it "clamps to the last screenful rather than scrolling into blank space" do
+      view = HelpView.new
+      view.query_move(10_000)
+      backend = MemoryBackend.new(100, 12)
+      view.render_query(Screen.new(backend), Rect.new(0, 0, 100, 12))
+      backend.contains?("WORTH KNOWING").should be_true # the last section is still on screen
+      backend.contains?("SYNTAX").should be_false       # ...and the first has gone by
+    end
+  end
+
   it "gives every workbench tab a section" do
     # Miner, JWT and OAST had none, while Sequencer — also default-hidden — had a full one,
     # so "it's a hidden tab" was never the rule. Three tabs whose whole keyboard surface was

--- a/spec/tui/history_view_spec.cr
+++ b/spec/tui/history_view_spec.cr
@@ -1087,6 +1087,38 @@ describe Gori::Tui::HistoryView do
     end
   end
 
+  # ↵ with the dropdown open must be able to TERMINATE. Re-deriving candidates after a splice can
+  # hand back the token that was just completed — `method:GET` narrows the value pool to exactly
+  # `["method:GET"]` — so a popup that re-opens itself would make every ↵ re-splice the identical
+  # string and `stop_query` unreachable: the bar could not be left with Enter at all.
+  it "closes the dropdown when Enter completes, so the filter bar can still be exited" do
+    view = HistoryView.new
+    view.start_query
+    "met".each_char { |c| view.query_insert(c) }
+    view.popup_down # open it
+    view.popup_open?.should be_true
+
+    view.query_complete(close: true).should be_true
+    view.query.should eq("method:")
+    view.popup_open?.should be_false # ...so the NEXT ↵ reaches stop_query
+
+    # Tab is the chaining gesture and deliberately keeps it open: field → value in two presses.
+    view.popup_down
+    view.query_complete.should be_true
+    view.query.should eq("method:GET")
+    view.popup_open?.should be_true
+  end
+
+  it "Tab-completes an operator without eating the token's opening paren" do
+    # Candidates are spliced over the token's whole span, so a bare `OR` over `(O` would delete
+    # the paren and dissolve the group being typed.
+    view = HistoryView.new
+    view.start_query
+    "host:a (O".each_char { |c| view.query_insert(c) }
+    view.query_complete.should be_true
+    view.query.should eq("host:a (OR")
+  end
+
   it "Tab-completes method/scheme/status statically and host from the store" do
     tmp_store do |store|
       store.insert_flow(Gori::Store::CapturedRequest.new(

--- a/spec/tui/query_suggest_spec.cr
+++ b/spec/tui/query_suggest_spec.cr
@@ -1,0 +1,168 @@
+require "../spec_helper"
+
+include Gori::Tui
+
+# The completion row and the standing hints beside it are now GENERATED, from `QL::FIELDS` /
+# `QL::FIELD_HELP` and each backend's own sample. These pin the two properties that made them
+# worth generating: the operators survive a narrow terminal, and the description shown is the
+# BACKEND's rather than QL's by assumption.
+describe Gori::Tui::QuerySuggest do
+  describe ".cold_hint" do
+    it "names the operators a field pool can never reveal" do
+      hint = QuerySuggest.cold_hint
+      hint.should contain("-term excludes") # the one an operator reported not being able to find
+      hint.should contain("OR")
+      hint.should contain("NOT")
+      hint.should contain("~regex")
+      hint.should contain("host:") # ...and still names the vocabulary
+    end
+
+    it "keeps the operators inside 80 columns, ahead of the truncation point" do
+      # A bar is one row. If the field sample runs long the terminal eats the tail, and the tail
+      # is the half that cannot be discovered by pressing Tab — so `-term excludes` has to land
+      # before column 80 for every pool a caller might hand over, including an 18-name one.
+      [Gori::QL::HINT_FIELDS, Gori::QL::FIELDS, Gori::InterceptFilter::HINT_FIELDS].each do |pool|
+        idx = QuerySuggest.cold_hint(pool).index("-term excludes")
+        idx.should_not be_nil
+        idx.not_nil!.should be < 80
+      end
+    end
+
+    it "samples a long pool rather than spilling it" do
+      QuerySuggest.cold_hint(Gori::QL::FIELDS).should_not contain("stub:")
+    end
+
+    it "sheds field chips until the negation fits the caller's real width" do
+      # The colour-rule form's band is 68 columns. A fixed six-chip sample pushed `-term excludes`
+      # clean off it — on the surface where that mistake becomes a STANDING RULE rather than a
+      # query you notice and retype.
+      narrow = QuerySuggest.cold_hint(width: 68)
+      narrow.index("-term excludes").not_nil!.should be <= 68 - "-term excludes".size
+      narrow.should contain("host:") # ...without shedding so far that the vocabulary is gone
+
+      # It sheds from the TAIL, so the names that cannot be guessed outlive the ones that can.
+      QuerySuggest.cold_hint(width: 60).should contain("resp.body:")
+      QuerySuggest.cold_hint(width: 60).should_not contain("header:")
+
+      # And it degrades all the way to operators-only rather than looping or truncating them.
+      QuerySuggest.cold_hint(width: 10).should start_with("-term excludes")
+    end
+  end
+
+  describe ".idle_hint" do
+    it "carries the caller's own prefix and still names the negation" do
+      hint = QuerySuggest.idle_hint("/ filter")
+      hint.should start_with("/ filter")
+      hint.should contain("-term excludes")
+    end
+  end
+
+  describe ".line" do
+    it "explains the field Tab would take, and only while completing a NAME" do
+      # A field candidate: the description is the point — `resp.body:` is not self-describing.
+      line = QuerySuggest.line(["resp.body:", "resp.header:"])
+      line.should contain("resp.body:")
+      line.should contain(Gori::QL::FIELD_HELP["resp.body"])
+      line.should contain("resp.header:") # the also-rans stay listed
+
+      # A VALUE candidate: the values already are the explanation, and "exact method — GET POST
+      # PUT …" would push them off a narrow bar.
+      QuerySuggest.line(["method:POST", "method:PUT"]).should_not contain("exact method")
+    end
+
+    it "reads the help from the BACKEND, not from QL" do
+      # Same field name, genuinely different semantics: `body:` at a hold gate is the payload in
+      # hand, not the trigram index. Borrowing QL's wording here would be a confident lie.
+      gate = QuerySuggest.line(["body:"], ->(f : String) { Gori::InterceptFilter.field_help(f) })
+      gate.should contain("payload in hand")
+      gate.should_not contain("8 KiB")
+
+      QuerySuggest.line(["body:"]).should contain("8 KiB") # QL's own surfaces still say so
+    end
+
+    it "is empty with nothing to complete, so a caller can fall back to a hint" do
+      QuerySuggest.line([] of String).should eq("")
+    end
+  end
+
+  # match vs NON-match. The grammar has had `-`/`NOT`/`OR` all along; what it did not have was a
+  # completion row that ever mentioned them. These three pin the ways it now does.
+  describe "guidance for exclusion" do
+    # `with_operators` takes the whole Cursor, so build one the way a bar does.
+    cursor = ->(query : String) { Gori::FilterAst.token_at(query, query.size) }
+
+    it "offers the boolean operators a field pool cannot" do
+      # `NOT (` is the point: `-` negates a TERM and cannot negate a GROUP, so this was the one
+      # form with zero discovery — and the only way to exclude a disjunction.
+      QuerySuggest.with_operators([] of String, cursor.call("N")).should eq(["NOT ("])
+      QuerySuggest.with_operators([] of String, cursor.call("NOT")).should eq(["NOT ("])
+      QuerySuggest.with_operators([] of String, cursor.call("O")).should eq(["OR"])
+      QuerySuggest.with_operators([] of String, cursor.call("A")).should eq(["AND"])
+
+      # CASE-SENSITIVE, matching the grammar: `FilterAst` reads AND/OR/NOT as operators only in
+      # uppercase, precisely so searching for the words "not"/"or" still works. Offering `NOT (`
+      # for a typed `n` would advertise something that compiles as free text.
+      QuerySuggest.with_operators([] of String, cursor.call("n")).should be_empty
+      QuerySuggest.with_operators([] of String, cursor.call("not")).should be_empty
+
+      # It stops as soon as the token diverges, so free text starting with N is barely disturbed.
+      QuerySuggest.with_operators([] of String, cursor.call("Nginx")).should be_empty
+
+      # Fields keep their slot; operators are appended.
+      QuerySuggest.with_operators(["host:"], cursor.call("N")).should eq(["host:", "NOT ("])
+      QuerySuggest.with_operators(["host:"], cursor.call("")).should eq(["host:"])
+    end
+
+    it "carries the token's punctuation, and declines where it cannot" do
+      # A candidate is spliced over the token's WHOLE span. A bare "OR" over `(O` would delete the
+      # opening paren and dissolve the group the operator was being typed to build.
+      QuerySuggest.with_operators([] of String, cursor.call("host:a (O")).should eq(["(OR"])
+      QuerySuggest.with_operators([] of String, cursor.call("((N")).should eq(["((NOT ("])
+
+      # A `-` prefix disqualifies them instead: `-NOT (` lexes as ONE WORD, so completing it would
+      # produce free text wearing an operator's clothes.
+      QuerySuggest.with_operators([] of String, cursor.call("-N")).should be_empty
+      QuerySuggest.with_operators([] of String, cursor.call("(-O")).should be_empty
+    end
+
+    it "says a negated candidate EXCLUDES, where the description alone would not" do
+      # `-host:` used to render the same sentence as `host:` — the row explaining the field never
+      # mentioned the polarity the operator had just chosen.
+      QuerySuggest.line(["-host:"]).should contain("excludes")
+      QuerySuggest.line(["host:"]).should_not contain("excludes")
+      QuerySuggest.line(["(-host:acme"]).should contain("excludes") # inside a group too
+
+      # On a VALUE list there is no description at all, which is exactly where the lone dash is
+      # easiest to miss — the eye is on the values.
+      QuerySuggest.line(["-method:GET", "-method:POST"]).should contain("excludes")
+
+      # A bare `-` is not a negation (`FilterAst` needs something after it), so nothing claims it is.
+      QuerySuggest.negated?("-").should be_false
+      QuerySuggest.negated?("-host:").should be_true
+    end
+
+    it "explains the operator Tab would take" do
+      QuerySuggest.line(["NOT ("]).should contain("excludes a whole group")
+      QuerySuggest.line(["OR"]).should contain("either side matches")
+    end
+
+    it "keeps the standing hint on a lone dash, the keystroke that commits to an exclusion" do
+      # `FilterAst.token_at` peels a `-` into the token prefix only when something FOLLOWS it, so
+      # a bare dash arrives as `core` and looks like a free-text word — which every bar answered
+      # by blanking the row, removing all guidance at the exact moment it was wanted.
+      QuerySuggest.hint_slot?("").should be_true
+      QuerySuggest.hint_slot?("-").should be_true
+      QuerySuggest.hint_slot?("ho").should be_false # a real word still blanks the row
+    end
+  end
+
+  describe ".field_of" do
+    it "peels the grammar's punctuation so a negated or grouped candidate still finds its help" do
+      QuerySuggest.field_of("resp.body:").should eq("resp.body")
+      QuerySuggest.field_of("-resp.body:").should eq("resp.body")
+      QuerySuggest.field_of("(-host:acme").should eq("host")
+      QuerySuggest.field_of("body~re").should eq("body")
+      QuerySuggest.field_of("login").should eq("login")
+    end
+  end
+end

--- a/spec/tui/suggest_popup_spec.cr
+++ b/spec/tui/suggest_popup_spec.cr
@@ -1,0 +1,143 @@
+require "../spec_helper"
+require "../support/memory_backend"
+
+include Gori::Tui
+
+# The `↓` dropdown. It is OPT-IN because it is dearer than the inline row, not cheaper — it
+# occludes list rows where the row costs one — so most of what matters here is that it stays out
+# of the way until asked for, and hands back exactly what the inline row would have done when it
+# was never opened.
+describe Gori::Tui::SuggestPopup do
+  it "stays shut until asked, and refuses to open on nothing" do
+    p = SuggestPopup.new
+    p.open?.should be_false
+
+    p.set([] of String)
+    p.open!.should be_false
+    p.open?.should be_false
+
+    p.set(["host:", "header:"])
+    p.open!.should be_true
+    p.open?.should be_true
+  end
+
+  it "leaves Tab's outcome unchanged while it has never been opened" do
+    # The whole compatibility promise: a bar whose popup was never opened splices `sugg.first`,
+    # exactly as every filter bar did before this class existed.
+    p = SuggestPopup.new
+    p.choice(["host:", "header:"]).should eq("host:")
+    p.choice([] of String).should be_nil
+
+    # ...and once open, Tab takes what the arrows landed on instead.
+    p.set(["host:", "header:"])
+    p.open!
+    p.move(1)
+    p.choice(["host:", "header:"]).should eq("header:")
+  end
+
+  it "clamps at both ends rather than wrapping" do
+    p = SuggestPopup.new
+    p.set(["a:", "b:", "c:"])
+    p.open!
+    p.move(-1)
+    p.selected.should eq(0)
+    p.move(99)
+    p.selected.should eq(2)
+  end
+
+  it "does not raise when moved with nothing in it" do
+    # `clamp(0, -1)` raises on min > max instead of saturating, so the empty case has to return
+    # before it. Unreachable via the current callers, which is why it needs a test.
+    p = SuggestPopup.new
+    p.set([] of String)
+    p.move(1)
+    p.selected.should eq(0)
+  end
+
+  it "keeps the selection on the same candidate across an edit that narrows the list" do
+    # Typing another character must not silently move what Tab would take.
+    p = SuggestPopup.new
+    p.set(["req.header:", "resp.header:", "req.body:", "resp.body:"])
+    p.open!
+    p.move(3)
+    p.choice([] of String).should eq("resp.body:")
+
+    p.set(["resp.header:", "resp.body:"]) # the user typed `resp.`
+    p.choice([] of String).should eq("resp.body:")
+  end
+
+  it "shuts itself when an edit leaves nothing to show" do
+    # An empty dropdown is a hole punched in the list for no content.
+    p = SuggestPopup.new
+    p.set(["host:"])
+    p.open!
+    p.set([] of String)
+    p.open?.should be_false
+  end
+
+  it "renders a row per candidate, each with its meaning and its polarity" do
+    p = SuggestPopup.new
+    p.set(["-resp.body:", "-resp.header:"])
+    p.open!
+    backend = MemoryBackend.new(100, 12)
+    p.render(Screen.new(backend), 4, 1, Rect.new(1, 2, 98, 9))
+
+    backend.contains?("-resp.body:").should be_true
+    backend.contains?("-resp.header:").should be_true
+    # The reason a row each is worth the occlusion: EVERY candidate gets its description, where
+    # the one-line row can only describe the first.
+    backend.contains?(Gori::QL::FIELD_HELP["resp.body"]).should be_true
+    backend.contains?(Gori::QL::FIELD_HELP["resp.header"]).should be_true
+    backend.contains?("excludes").should be_true
+  end
+
+  it "shuts itself on a frame it cannot draw, rather than hijacking Esc and Enter invisibly" do
+    # `open?` gates Esc and ↵ in three controllers. An open-but-undrawable popup — a pane
+    # narrower than MIN_W, or one where the anchor has reached the bottom — makes Esc stop
+    # clearing the filter and ↵ stop applying it, with nothing on screen to explain why. Reachable
+    # by resizing the terminal while the list is open.
+    backend = MemoryBackend.new(100, 12)
+    screen = Screen.new(backend)
+
+    narrow = SuggestPopup.new
+    narrow.set(["host:", "header:"])
+    narrow.open!
+    narrow.render(screen, 1, 1, Rect.new(1, 2, 8, 9)) # w < MIN_W
+    narrow.open?.should be_false
+
+    squashed = SuggestPopup.new
+    squashed.set(["host:", "header:"])
+    squashed.open!
+    squashed.render(screen, 1, 9, Rect.new(1, 10, 98, 0)) # no rows to grow into
+    squashed.open?.should be_false
+  end
+
+  it "draws nothing while closed, however many candidates it holds" do
+    p = SuggestPopup.new
+    p.set(["host:", "header:"])
+    backend = MemoryBackend.new(100, 12)
+    p.render(Screen.new(backend), 4, 1, Rect.new(1, 2, 98, 9))
+    backend.contains?("host:").should be_false
+  end
+
+  it "flips above the anchor when there is no room below" do
+    p = SuggestPopup.new
+    p.set(["host:", "header:", "path:"])
+    p.open!
+    backend = MemoryBackend.new(100, 12)
+    # Anchor near the bottom of the allowed region: below has 1 row, above has 6.
+    p.render(Screen.new(backend), 4, 8, Rect.new(1, 2, 98, 7))
+    backend.contains?("host:").should be_true
+  end
+
+  it "reads the BACKEND's help, like the inline row" do
+    p = SuggestPopup.new
+    p.set(["body:"])
+    p.open!
+    backend = MemoryBackend.new(100, 12)
+    p.render(Screen.new(backend), 4, 1, Rect.new(1, 2, 98, 9),
+      ->(f : String) { Gori::InterceptFilter.field_help(f) })
+    backend.contains?("payload in hand").should be_true
+    backend.contains?("8 KiB").should be_false
+  end
+end

--- a/src/gori/colormarker.cr
+++ b/src/gori/colormarker.cr
@@ -456,6 +456,22 @@ module Gori
     # because the reason is.
     USEFUL_FIELDS = QL::FIELDS
 
+    # What each field means IN A COLOUR RULE. QL's own text is right for a QUERY and wrong here for
+    # the two content fields, because `compile` parses with `fts: false, body_max: BODY_SCAN_MAX`:
+    # a rule scans the stored bytes rather than the trigram index, and reads 64 KiB of each side
+    # rather than the index's 8 KiB. Telling a rule author "8 KiB/side, via an index that lags
+    # capture" would be wrong about both the mechanism and the bound — in the direction that makes
+    # them narrow a rule that did not need narrowing.
+    FIELD_HELP = QL::FIELD_HELP.merge({
+      "body"      => "body bytes as captured — 64 KiB/side scan",
+      "req.body"  => "request body as captured — 64 KiB scan",
+      "resp.body" => "response body as captured — 64 KiB scan",
+    })
+
+    # As a proc, built once — the rule overlay draws this every frame while the condition row has
+    # focus, and an inline closure there allocates per frame.
+    FIELD_HELP_FOR_RULE = ->(f : String) { FIELD_HELP[QL.canonical_field(f)]? }
+
     # The fields a `FlowRow` answers on its own — the ROW tier's vocabulary, and the whole of it.
     # `InterceptFilter::FIELDS` minus the CONTENT ones: a hold gate fills `Subject#head`/`#payload`
     # with the bytes it has, and a captured row has neither, so `header:` and `body:` belong to
@@ -521,7 +537,10 @@ module Gori
     # is reported as a field is exactly what would ACT as one, `~` terms included.
     def self.unknown_fields(match_filter : String) : Array(String)
       names = QL.fields_used(match_filter).map(&.name)
-      names.uniq!.reject! { |n| QL::FIELDS.includes?(n) }
+      # `QL.known_field?`, NOT `QL::FIELDS.includes?`: `FIELDS` is the pool a surface OFFERS, and
+      # QL accepts spellings it does not offer (`res.body`, `req.size` — see `QL::FIELD_ALIASES`).
+      # Testing membership of the narrower list would refuse a condition QL compiles perfectly.
+      names.uniq!.reject! { |n| QL.known_field?(n) }
     end
 
     # Non-fatal notes about a condition that IS usable but will not behave the way its author

--- a/src/gori/filter_ast.cr
+++ b/src/gori/filter_ast.cr
@@ -463,12 +463,13 @@ module Gori
     # --- syntax highlighting -------------------------------------------------
 
     enum SpanKind
-      Operator # AND / OR / NOT, and the `-` prefix (which means the same thing)
-      Paren    # a `(`/`)` that actually groups
-      Field    # the `host:` / `body~` prefix, separator included
-      Value    # what follows a field separator
-      Quote    # the `"` marks themselves
-      Plain    # a bare free-text word
+      Operator     # AND / OR / NOT, and the `-` prefix (which means the same thing)
+      Paren        # a `(`/`)` that actually groups
+      Field        # the `host:` / `body~` prefix, separator included
+      UnknownField # ...spelled like a field, but one the BACKEND does not implement
+      Value        # what follows a field separator
+      Quote        # the `"` marks themselves
+      Plain        # a bare free-text word
     end
 
     record Span, start : Int32, size : Int32, kind : SpanKind
@@ -489,7 +490,18 @@ module Gori
     SEPS_FIELD       = ":"
     SEPS_FIELD_REGEX = ":~"
 
-    def self.spans(query : String, seps : String = SEPS_FIELD_REGEX) : Array(Span)
+    # `known`, when given, is the backend's "do I implement this field name?" and it exists for
+    # exactly the reason `seps` does, one level down. `seps` already stops a bar painting an
+    # operator it does not run; this stops one painting a FIELD it does not have. `hsot:acme` is
+    # a typo whose whole token gets free-texted — it matches nothing real — and every bar
+    # rendered it in the same confident blue as `host:acme`, so the one visible signal said the
+    # query was fine. Naming a namespace made it worse: `resp.status:200` is a reasonable guess
+    # at a real prefix, and QL now DROPS it, while the bar still called it a field.
+    #
+    # Nil (the default) keeps the old behaviour for a caller that has no such predicate, so a
+    # backend opts in rather than being told what its vocabulary is.
+    def self.spans(query : String, seps : String = SEPS_FIELD_REGEX,
+                   known : Proc(String, Bool)? = nil) : Array(Span)
       acc = [] of Span
       lex(query).each do |lexeme|
         case lexeme.tok
@@ -498,7 +510,7 @@ module Gori
         when .and?, .or?, .not?
           acc << Span.new(lexeme.start, lexeme.size, SpanKind::Operator)
         else
-          word_spans(query, lexeme, acc, seps)
+          word_spans(query, lexeme, acc, seps, known)
         end
       end
       acc
@@ -520,7 +532,8 @@ module Gori
 
     # Sub-classify one word: an optional `-`, an optional `field:`/`field~` prefix, then
     # the remainder with any quote marks called out.
-    private def self.word_spans(query : String, lexeme : Lexeme, acc : Array(Span), seps : String) : Nil
+    private def self.word_spans(query : String, lexeme : Lexeme, acc : Array(Span), seps : String,
+                                known : Proc(String, Bool)? = nil) : Nil
       s = lexeme.start
       e = s + lexeme.size
       i = s
@@ -534,11 +547,17 @@ module Gori
 
       sep = field_sep(query, i, e, seps)
       if sep
-        acc << Span.new(i, sep - i + 1, SpanKind::Field)
+        # The name is matched case-INSENSITIVELY because `split_field` downcases before it
+        # dispatches: `HOST:x` compiles, so it must not be painted as a typo.
+        name = query[i...sep].downcase
+        real = known.nil? || known.call(name)
+        acc << Span.new(i, sep - i + 1, real ? SpanKind::Field : SpanKind::UnknownField)
         i = sep + 1
       end
 
-      kind = sep ? SpanKind::Value : SpanKind::Plain
+      # A value under an UNKNOWN field is not a value — the backend free-texts the whole token,
+      # so painting `acme` as a value in `hsot:acme` would claim a match nobody will perform.
+      kind = (sep && real) ? SpanKind::Value : SpanKind::Plain
       run = i
       while i < e
         if query[i] == '"'

--- a/src/gori/intercept_filter.cr
+++ b/src/gori/intercept_filter.cr
@@ -155,6 +155,43 @@ module Gori
     # condition silently holds NOTHING, which reads as intercept being broken.
     PROTO_VAL = %w[ws http]
 
+    # What each field means AT A HOLD GATE — deliberately NOT `QL::FIELD_HELP`, even though the
+    # names and the grammar are shared. Three of these mean something materially different here,
+    # and a completion row that borrowed QL's wording would state the difference backwards:
+    #
+    #   status:  scopes the condition to RESPONSES (a request has no status, so the term makes
+    #            every request fail rather than comparing anything).
+    #   header:  the head of the message IN HAND — request head at the request gate, response head
+    #            at the response gate. There is no `req.`/`resp.` here because a gate only ever
+    #            stands on one leg; the leg IS the direction.
+    #   body:    the payload in hand, which per the class header is a WS message or an Extract
+    #            rule's response body — never an HTTP hold, where the gate is what decides whether
+    #            to buffer a body at all.
+    # MERGED over QL's rather than copied from it: five of the nine entries were byte-identical,
+    # so editing QL's `path` line would have updated History, Sitemap and the colour-rule band and
+    # silently left this bar saying the old thing — the exact drift the generated hints were built
+    # to end. What is written out is precisely the DELTA, which is also the documentation.
+    FIELD_HELP = QL::FIELD_HELP.merge({
+      "status" => "code/class — and scopes to RESPONSES only",
+      "proto"  => "http, or ws to opt WebSocket messages IN",
+      "header" => "head of the message in hand (this leg only)",
+      "body"   => "payload in hand — WS messages, extract rules",
+    })
+
+    # As a proc, built once: the bar draws this every frame while the condition is being edited,
+    # and an inline closure at the call site allocates one per frame.
+    FIELD_HELP_PROC = ->(f : String) { FIELD_HELP[f]? }
+
+    def self.field_help(name : String) : String?
+      FIELD_HELP[name]?
+    end
+
+    # The subset a one-row hint samples (see `QL::HINT_FIELDS` for why a hint samples at all).
+    # NOT `FIELDS.first(6)`, which would spend the row on `url:`/`scheme:` and cut exactly the two
+    # this gate is interesting for: `header:` is the only way to condition on a header, and `body:`
+    # arrived with the WebSocket hold.
+    HINT_FIELDS = %w[host path method status header body]
+
     # Tab-complete candidates for the token under `cx`: field names until a `:` is
     # typed, then that field's values. The grammar's punctuation is carried through by
     # FilterAst::Cursor, so `-ho` → `-host:` and `(ho` → `(host:`. `hosts` is the

--- a/src/gori/ql.cr
+++ b/src/gori/ql.cr
@@ -80,6 +80,12 @@ module Gori
       Fields (use : for value match, ~ for regex):
         host path method scheme proto status size reqsize respsize dur header body url stub
 
+      Sides: header: and body: search the REQUEST AND THE RESPONSE. Prefix either with `req.` or
+      `resp.` to search one side — req.body:token resp.header:set-cookie resp.body~secret\\d+ —
+      and negate as usual (-resp.body:abcd). `res.` is accepted as a synonym of `resp.`, and
+      req.size/resp.size are synonyms of reqsize/respsize. Fields that only ever have one side
+      (host, method, status, …) take no prefix.
+
       Comparisons (status size reqsize respsize dur):
         status:>=500  size:>10000  dur:>=500  dur:<2s  (dur defaults to ms; suffix ms|s)
 
@@ -99,7 +105,14 @@ module Gori
       So `body:` can return NOTHING for content that is genuinely there — deep in a large
       body, or in a gzipped/binary one. `body~regex` scans the stored bytes instead, with no
       cap and no content-type rule, so it is the one to reach for when `body:` comes back
-      empty and you expected a hit. (`body:` is the fast path; `body~` is the complete one.)
+      empty and you expected a hit. (`body:` is the fast path; `body~` is the more complete one.)
+
+      NEITHER READS A COMPRESSED BODY. gori stores the WIRE form (DESIGN.md P7) and decompresses
+      only at display time, so `body:` skips a gzip/br/zstd body at index time and `body~` regexes
+      the compressed bytes. Most real response bodies are compressed, which matters most under
+      NEGATION: `-body:secret` and `-body~secret` both KEEP every compressed response, so a query
+      that comes back "clean" has not actually looked. Decode-aware matching lives on the Probe
+      custom rules (side/region + Content-Encoding decode), not here.
       A COLOUR RULE's `body:` is the complete one: a rule has to paint the row that just
       arrived, and the index lags capture, so create_color_rule scans the bytes instead. Same
       language, one deliberate difference — a colour rule can paint what this query misses.
@@ -193,7 +206,7 @@ module Gori
       bad = [] of String
       FilterAst.terms(FilterAst.parse(query)).each do |term|
         field, value, op = split_field(term.text) || next
-        next unless op == :regex && field.in?(REGEX_FIELDS)
+        next unless op == :regex && canonical(field).in?(REGEX_FIELDS)
         next if value.empty?
         bad << term.source unless valid_regex?(value)
       end
@@ -223,14 +236,145 @@ module Gori
     # History's and Colormarker's completion pools, Colormarker's unknown-field refusal and the
     # docs all read it, so a field added to `field_cond` becomes offerable everywhere at once
     # instead of in the four hand-kept copies that used to drift.
-    FIELDS = %w[host path url method scheme proto status size reqsize respsize dur header body stub]
+    FIELDS = %w[host path url method scheme proto status size reqsize respsize dur header body stub
+      req.header resp.header req.body resp.body]
 
-    REGEX_FIELDS = %w[host path url header body]
+    REGEX_FIELDS = %w[host path url header body req.header resp.header req.body resp.body]
 
-    # The fields that read a message's CONTENT rather than its addressing — the two a surface
-    # can only answer with the bytes in hand (or a query that reads them). Named because
-    # "can this backend answer the term?" is asked at three surfaces and each was spelling the
-    # pair out for itself.
+    # A `req.`/`resp.` prefix picks ONE SIDE of a field that has two. `header:`/`body:` search the
+    # request AND the response, which is right for "find this string anywhere" and useless for the
+    # question an operator actually asks more often — did the SERVER send it? There was no way to
+    # say that at all: `size` was the only field with a side split, and it got one by growing two
+    # hand-written twins (`reqsize`/`respsize`) rather than a rule.
+    #
+    # The prefix is that rule, and it is deliberately spelled INSIDE the existing `field:value`
+    # token instead of as new grammar: `split_field` cuts at the first `:`/`~`, so `resp.body`
+    # arrives as an ordinary field name and the lexer, the parser, the syntax highlighting and
+    # Tab-completion all keep working untouched — `-resp.body:x` negates and `NOT (req.body:a OR
+    # resp.body:b)` groups exactly as they did before. The alternative (a Caido-style
+    # `resp.body.cont:"x"` grammar) would have bought the same expressiveness for a new operator
+    # vocabulary, the loss of boolean NOT, and a migration of every rule string already stored in
+    # `colormarker_rules.match_filter`.
+    #
+    # `res.` is accepted alongside `resp.` because the coin-flip between them fails SILENTLY:
+    # an unknown field free-texts the WHOLE token (see `field_cond`'s else), so `res.body:secret`
+    # returns nothing and reads as "no flow has that" rather than "you spelled the prefix the
+    # other way". Completion offers `resp.` only, so there is still one spelling to learn.
+    SIDES = {"req." => :req, "resp." => :resp, "res." => :resp}
+
+    # Spellings QL ACCEPTS but does not OFFER. Two groups, one reason each:
+    #
+    #   `res.*`      the `resp.` coin-flip above.
+    #   `req.size`   the namespace has to be uniform or it is a trap: someone who learns
+    #   `resp.size`  `resp.body` will try `resp.size`, and the honest answer is that it already
+    #                exists under an older name. Aliasing costs one line; letting it free-text
+    #                costs a query that silently matches nothing.
+    #
+    # Kept OUT of `FIELDS` so the completion pool stays one name per concept, and read through
+    # `known_field?` so a surface that VALIDATES fields (Colormarker's unknown-field refusal)
+    # cannot start rejecting a spelling that `field_cond` happily compiles.
+    FIELD_ALIASES = {
+      "res.header" => "resp.header", "res.body" => "resp.body",
+      "req.size" => "reqsize", "resp.size" => "respsize", "res.size" => "respsize",
+    }
+
+    # Does QL implement this field name? THE membership test — `FIELDS` alone is the pool a
+    # surface OFFERS, which is a strict subset of what it accepts.
+    def self.known_field?(name : String) : Bool
+      FIELDS.includes?(name) || FIELD_ALIASES.has_key?(name)
+    end
+
+    # One line per field, for the surfaces that TEACH this language rather than parse it — the
+    # completion row's description column and Help's Query page. Both used to be prose written
+    # by hand next to the widget, which is why `FILTER_HINT` and `QUERY_HINT` disagreed with each
+    # other and with `FIELDS` about what exists; a field is only really added when the thing that
+    # EXPLAINS it is added too, so the explanation lives beside the parser.
+    #
+    # Kept short on purpose: it renders in one terminal column beside a field name, so anything
+    # past ~46 characters is truncated rather than wrapped. Where a field has a bound that will
+    # bite (the `body:` index, `path:` including the query string), the line spends its budget
+    # naming the bound rather than restating the field name.
+    FIELD_HELP = {
+      "host"        => "server host — substring; host~ for regex",
+      "path"        => "path AND query string — substring",
+      "url"         => "scheme://host + path — substring",
+      "method"      => "exact method — GET POST PUT …",
+      "scheme"      => "exact — http or https",
+      "proto"       => "ws grpc sse http (+s = over TLS)",
+      "status"      => "code; classes (5xx) and >= <= compare",
+      "size"        => "request + response bytes — >10k <1M",
+      "reqsize"     => "request bytes only",
+      "respsize"    => "response bytes only",
+      "dur"         => "latency; ms unless suffixed — dur:>1.5s",
+      "header"      => "head bytes, BOTH sides — see req./resp.",
+      "body"        => "body via index: 8 KiB/side, no compressed",
+      "stub"        => "true = gori answered it, origin never saw it",
+      "req.header"  => "request head bytes only",
+      "resp.header" => "response head bytes only",
+      "req.body"    => "request body only",
+      "resp.body"   => "response body only",
+    }
+
+    # The fields the one-line hints SAMPLE, in the order that reads best on a bar. A hint gets one
+    # terminal row and `FIELDS` has eighteen entries, so something has to choose; choosing once
+    # here — with a spec pinning every entry against `FIELDS` — beats each widget choosing for
+    # itself in prose, which is exactly how three hint strings came to disagree about what exists.
+    # `resp.body` earns its slot because a prefix nobody has seen cannot be guessed, where `host:`
+    # would be typed by someone who never read a hint at all.
+    # Six, not eight, and that ceiling is load-bearing: a hint is ONE row, and it has to fit the
+    # field sample AND the operator tail inside 80 columns or the tail — the half a completion
+    # pool can never teach — is what the terminal truncates away. Six chips leaves room for
+    # `-term excludes` to survive the cut; the full list lives in Help's Query page.
+    #
+    # Ordered so a narrow surface sheds the GUESSABLE names first (`QuerySuggest.cold_hint` shrinks
+    # the sample from the tail): `resp.body` sits third because a prefix nobody has seen cannot be
+    # guessed, where `host:` gets typed by someone who never read a hint at all.
+    HINT_FIELDS = %w[host path resp.body status method header]
+
+    # `FIELD_HELP` for a name as the user spelled it (aliases inherit their canonical entry).
+    def self.field_help(name : String) : String?
+      FIELD_HELP[canonical(name)]?
+    end
+
+    # The places this language does something an operator would not predict. Every one of these
+    # is a way a query can look CLEAN while not having looked — the direction that matters on a
+    # security proxy, and the direction a field list can never warn about. They live here, beside
+    # the code that causes them, and Help's Query page renders them verbatim.
+    CAVEATS = [
+      {"compressed bodies", "body: skips them, body~ reads the gzip — neither matches"},
+      {"-body: on a big body", "the index stops at 8 KiB/side, so it KEEPS a deep hit"},
+      {"path: vs the query string", "path: matches both, so -path:x drops ?q=x too"},
+      {"-status: -dur: -respsize:", "a pending flow has NULL there and falls out of both"},
+      {"a dropped term broadens", "status:>=foo is ignored, not refused — use ql_explain"},
+      {"a bad regex matches nothing", "body~[ is a HARD error, never silently dropped"},
+    ]
+
+    # The grammar itself — everything that is NOT a field name, as {what you type, what it does}.
+    # The one place an operator can learn that `-` negates, since a field-name completion pool can
+    # never show it. Read by Help's Query page, so it cannot drift from the parser the way the
+    # hand-written hint strings did.
+    SYNTAX_HELP = [
+      {"host:acme status:5xx", "space = AND (both must hold)"},
+      {"host:a OR host:b", "OR; NOT > AND > OR, ( ) to group"},
+      {"-path:/static", "leading - excludes — so does NOT path:/static"},
+      {"NOT (host:cdn OR host:img)", "NOT negates a whole group"},
+      {"body~secret\\d+", "~ is regex; : is plain substring"},
+      {"status:>=500 dur:>1.5s", ">= <= > < = on status size dur"},
+      {"resp.body:token", "req. / resp. picks one side of body: header:"},
+      {"host:\"my host\"", "quotes keep spaces inside one term"},
+      {"login", "a bare word searches method, host and path"},
+    ]
+
+    # The fields that read a message's CONTENT rather than its addressing — the ones a surface can
+    # only answer with the bytes in hand (or a query that reads them). Named because "can this
+    # backend answer the term?" is asked at three surfaces and each was spelling the list out for
+    # itself.
+    #
+    # The `req.`/`resp.` spellings are deliberately NOT here. The one consumer
+    # (`Colormarker::ROW_FIELDS`) derives itself by SUBTRACTING this from `InterceptFilter::FIELDS`,
+    # which has no namespaced names to subtract — so a `resp.body:` rule already falls out of the
+    # row tier and lands on the store tier, which is where it belongs. Adding them would be a
+    # no-op that reads like a fix.
     CONTENT_FIELDS = %w[header body]
 
     # One field named by a query, and whether it was written with the regex operator.
@@ -284,20 +428,37 @@ module Gori
     private def self.field_cond(field : String, value : String, term : String,
                                 fts : Bool = true, body_max : Int32? = nil) : {String, Array(DB::Any)}?
       return nil if value.empty?
+      # Resolve an accepted-but-not-offered spelling to its canonical name FIRST, so every arm
+      # below (and `size_cond`'s own three-way switch) sees one name per concept.
+      field = FIELD_ALIASES.fetch(field, field)
       case field
-      when "host"                        then {"lower(host) LIKE ? ESCAPE '\\'", [like(value)] of DB::Any}
-      when "url"                         then {"#{URL_EXPR} LIKE ? ESCAPE '\\'", [like(value)] of DB::Any}
-      when "path"                        then {"lower(target) LIKE ? ESCAPE '\\'", [like(value)] of DB::Any}
-      when "method"                      then {"upper(method) = ?", [value.upcase] of DB::Any}
-      when "scheme"                      then {"scheme = ?", [value.downcase] of DB::Any}
-      when "proto"                       then proto_cond(value)
-      when "status"                      then status_cond(value)
-      when "size", "reqsize", "respsize" then size_cond(field, value)
-      when "dur"                         then duration_cond(value)
-      when "header"                      then header_cond(value)
-      when "body"                        then body_cond(value, fts, body_max)
-      when "stub"                        then stub_cond(value)
+      when "host"                                then {"lower(host) LIKE ? ESCAPE '\\'", [like(value)] of DB::Any}
+      when "url"                                 then {"#{URL_EXPR} LIKE ? ESCAPE '\\'", [like(value)] of DB::Any}
+      when "path"                                then {"lower(target) LIKE ? ESCAPE '\\'", [like(value)] of DB::Any}
+      when "method"                              then {"upper(method) = ?", [value.upcase] of DB::Any}
+      when "scheme"                              then {"scheme = ?", [value.downcase] of DB::Any}
+      when "proto"                               then proto_cond(value)
+      when "status"                              then status_cond(value)
+      when "size", "reqsize", "respsize"         then size_cond(field, value)
+      when "dur"                                 then duration_cond(value)
+      when "header", "req.header", "resp.header" then header_cond(value, side_of(field))
+      when "body", "req.body", "resp.body"       then body_cond(value, fts, body_max, side_of(field))
+      when "stub"                                then stub_cond(value)
       else
+        # A side prefix we OWN, on a field that has no side. `resp.status:200` is not a typo the
+        # way `hosst:x` is — it is a correct guess at a namespace this module advertises, made by
+        # someone the completion row and Help's Query page just taught `resp.body:`. Free-texting
+        # it (the fallback below, right for any other unknown field) searches method/host/target
+        # for the literal `resp.status:200`, matches nothing, and reports the query CLEAN — which
+        # is the exact "is it unsupported, or is the UI just not telling me?" question this
+        # namespace was added to answer, asked again one field over.
+        #
+        # Dropping is louder in every direction that matters: `analyze` lists the term under
+        # `ignored`, `ql_explain` and `strict:` name it, `reject_empty?` refuses a query that was
+        # ONLY this, and `Colormarker.unusable_reason` refuses a rule carrying one. It does
+        # broaden a surviving AND-chain, which this file elsewhere calls the dangerous direction —
+        # the difference is that this broaden is REPORTED and the old narrow-to-zero was silent.
+        return nil if side_prefixed?(field)
         # Unknown field — a typo (`hosst:x`) or a literal colon in a value (`time:12:00`):
         # free-text the WHOLE token (prefix included), not just the part after the ':'. This
         # mirrors regex_cond's fallback, searches what the user actually typed, and makes a
@@ -381,8 +542,34 @@ module Gori
     # bodyless flow has an empty FTS row, so it never matches and `-body:x`
     # correctly KEEPS it. The trigram index needs >=3 characters, so shorter
     # values fall back to the NULL-safe BLOB LIKE scan.
+    # The body columns a `side` selects — both, or one. Named because `body_cond`,
+    # `body_literal_cond` and `body_regex_cond` each build their own clause and must not be able
+    # to disagree about what `resp.` means.
+    private def self.body_columns(side : Symbol?) : Array(String)
+      case side
+      when :req  then ["request_body"]
+      when :resp then ["response_body"]
+      else            ["request_body", "response_body"]
+      end
+    end
+
+    private def self.head_columns(side : Symbol?) : Array(String)
+      case side
+      when :req  then ["request_head"]
+      when :resp then ["response_head"]
+      else            ["request_head", "response_head"]
+      end
+    end
+
+    # The `flows_fts` column for one side. The index is `fts5(req, resp, …)` — the two sides were
+    # stored apart from the start (see `store/schema.cr`), so a side-scoped `body:` is a column
+    # filter on an index that already exists, not a new one.
+    private def self.fts_column(side : Symbol) : String
+      side == :req ? "req" : "resp"
+    end
+
     private def self.body_cond(value : String, fts : Bool = true,
-                               body_max : Int32? = nil) : {String, Array(DB::Any)}?
+                               body_max : Int32? = nil, side : Symbol? = nil) : {String, Array(DB::Any)}?
       value = value.chars.reject(&.control?).join # strip NUL/control chars (FTS/LIKE safety)
       # `field_cond`'s `return nil if value.empty?` runs BEFORE this strip, so a value made
       # only of control bytes survived that guard and arrived here as "". `like("")` is
@@ -411,15 +598,22 @@ module Gori
         # body, so the positive term still skips it and `NOT FALSE` keeps it under negation.
         conds = [] of String
         params = [] of DB::Any
+        cols = body_columns(side)
         case_permutations(value).each do |v|
-          conds << "COALESCE(instr(#{body_col("request_body", body_max)}, CAST(? AS BLOB)), 0) > 0"
-          conds << "COALESCE(instr(#{body_col("response_body", body_max)}, CAST(? AS BLOB)), 0) > 0"
-          params << v << v
+          cols.each do |col|
+            conds << "COALESCE(instr(#{body_col(col, body_max)}, CAST(? AS BLOB)), 0) > 0"
+            params << v
+          end
         end
         return {"(#{conds.join(" OR ")})", params}
       end
-      return body_literal_cond(value, body_max) unless fts
+      return body_literal_cond(value, body_max, side) unless fts
       phrase = %("#{value.gsub('"', "\"\"")}") # quoted phrase → contiguous substring match
+      # An FTS5 COLUMN FILTER (`resp : "phrase"`) narrows the match to one indexed column. The
+      # column name is this module's own constant, never user input — the value stays inside the
+      # quoted phrase whose embedded quotes were doubled just above — so the term is still not an
+      # injection surface, and it stays a single bound `?`.
+      phrase = "#{fts_column(side)} : #{phrase}" if side
       {"id IN (SELECT rowid FROM flows_fts WHERE flows_fts MATCH ?)", [phrase] of DB::Any}
     end
 
@@ -433,11 +627,12 @@ module Gori
     # a body mixing binary and text is scanned whole. LIKE would have made `body:token` silently
     # miss what `body~token` finds — in a tool whose targets deliberately put NULs in bodies, and
     # in exactly the direction `body_cond`'s short-needle branch above already refused to fail.
-    private def self.body_literal_cond(value : String, body_max : Int32? = nil) : {String, Array(DB::Any)}
+    private def self.body_literal_cond(value : String, body_max : Int32? = nil,
+                                       side : Symbol? = nil) : {String, Array(DB::Any)}
       # Control characters are stripped by `body_cond` before this runs, so the escaped literal
       # can never carry a NUL of its own. `(?i)` because `body:` promises case-insensitive
       # matching where `body~` is case-SENSITIVE by default.
-      body_regex_cond("(?i)#{Regex.escape(value)}", body_max)
+      body_regex_cond("(?i)#{Regex.escape(value)}", body_max, side)
     end
 
     # Every upper/lower spelling of a one- or two-character needle, so a byte-wise `instr`
@@ -559,22 +754,24 @@ module Gori
     # trap `body_cond` already routed around. `instr` is case-SENSITIVE, so OR every case
     # permutation of a short needle; longer needles go through a case-insensitive literal
     # REGEXP, which SafeRegexp already makes NUL-transparent.
-    private def self.header_cond(value : String) : {String, Array(DB::Any)}?
+    private def self.header_cond(value : String, side : Symbol? = nil) : {String, Array(DB::Any)}?
       value = value.chars.reject(&.control?).join
       return nil if value.empty?
       if value.size < 3
         conds = [] of String
         params = [] of DB::Any
+        cols = head_columns(side)
         case_permutations(value).each do |v|
-          conds << "COALESCE(instr(request_head, CAST(? AS BLOB)), 0) > 0"
-          conds << "COALESCE(instr(response_head, CAST(? AS BLOB)), 0) > 0"
-          params << v << v
+          cols.each do |col|
+            conds << "COALESCE(instr(#{col}, CAST(? AS BLOB)), 0) > 0"
+            params << v
+          end
         end
         return {"(#{conds.join(" OR ")})", params}
       end
       pat = "(?i)#{Regex.escape(value)}"
       return {"0", [] of DB::Any} unless valid_regex?(pat)
-      header_regex_cond(pat)
+      header_regex_cond(pat, side)
     end
 
     # The `~` operator: case-sensitive regex (SQLite REGEXP, the same shard-provided
@@ -589,32 +786,77 @@ module Gori
       # fall back to a literal free-text search of the WHOLE token. This must happen BEFORE
       # the validity guard — otherwise `foo~[` (an unterminated char class) would compile to
       # the never-match clause instead of free-texting "foo~[".
+      # Same alias resolution `field_cond` does, and for the same reason: `res.body~x` must
+      # compile like `resp.body~x`, and `invalid_regex_terms` below canonicalises identically so
+      # the diagnosis cannot disagree with the compilation about which terms are regex terms.
+      field = canonical(field)
+      return regex_field_cond(field, value, body_max) if field.in?(REGEX_FIELDS)
+      # A side prefix we own on a field that has none — dropped, not free-texted; see `field_cond`.
+      return nil if side_prefixed?(field)
+      free_text(term)
+    end
+
+    # The clause for a `~` term on a field that HAS one. Split out of `regex_cond` so that method
+    # stays the three-way ROUTING decision (regex field / owned prefix / free text) and this one
+    # stays a flat dispatch: merged, the namespaced arms pushed the pair past the cyclomatic gate
+    # CI runs, and the two halves were never one thought anyway.
+    private def self.regex_field_cond(field : String, value : String,
+                                      body_max : Int32?) : {String, Array(DB::Any)}?
+      return nil if value.empty?
+      # An invalid pattern would raise inside the SQLite REGEXP callback, so validate up
+      # front and emit a never-matches clause instead.
+      return {"0", [] of DB::Any} unless valid_regex?(value)
       case field
-      when "host", "path", "url", "header", "body" # = REGEX_FIELDS
-        return nil if value.empty?
-        # An invalid pattern would raise inside the SQLite REGEXP callback, so validate up
-        # front and emit a never-matches clause instead.
-        return {"0", [] of DB::Any} unless valid_regex?(value)
-        case field
-        when "host"   then {"host REGEXP ?", [value] of DB::Any}
-        when "path"   then {"target REGEXP ?", [value] of DB::Any}
-        when "url"    then {"#{URL_EXPR} REGEXP ?", [value] of DB::Any}
-        when "header" then header_regex_cond(value)
-        else               body_regex_cond(value, body_max)
-        end
-      else
-        free_text(term)
+      when "host"        then {"host REGEXP ?", [value] of DB::Any}
+      when "path"        then {"target REGEXP ?", [value] of DB::Any}
+      when "url"         then {"#{URL_EXPR} REGEXP ?", [value] of DB::Any}
+      when "header"      then header_regex_cond(value)
+      when "req.header"  then header_regex_cond(value, :req)
+      when "resp.header" then header_regex_cond(value, :resp)
+      when "req.body"    then body_regex_cond(value, body_max, :req)
+      when "resp.body"   then body_regex_cond(value, body_max, :resp)
+      else                    body_regex_cond(value, body_max)
       end
+    end
+
+    # Does this unknown field wear a side prefix THIS MODULE advertises? The one place the
+    # prefix set is tested, so `field_cond` and `regex_cond` cannot start disagreeing about
+    # whether `resp.status:` is a reported mistake or a free-text word.
+    private def self.side_prefixed?(field : String) : Bool
+      SIDES.each_key.any? { |p| field.starts_with?(p) }
+    end
+
+    # Which side a canonical field name selects, or nil for the two-sided spelling. Lets the
+    # three `header` arms (and the three `body` ones) collapse into one apiece — six near-identical
+    # `when`s is how `field_cond` earns a complexity warning for saying nothing new.
+    private def self.side_of(field : String) : Symbol?
+      SIDES.each { |prefix, side| return side if field.starts_with?(prefix) }
+      nil
+    end
+
+    # An accepted spelling resolved to the one name the compilers switch on. Shared by
+    # `field_cond`, `regex_cond` and `invalid_regex_terms` so an alias cannot be understood by
+    # one of them and not the others.
+    private def self.canonical(field : String) : String
+      FIELD_ALIASES.fetch(field, field)
+    end
+
+    # `canonical`, public, for a surface that keeps its OWN help table over these names
+    # (`Colormarker::FIELD_HELP`) and must resolve `res.body` the way the compilers do.
+    def self.canonical_field(field : String) : String
+      canonical(field)
     end
 
     # NULL-guarded REGEXP over both body columns (a bodyless flow contributes no match,
     # so `-body~x` keeps it — same null-safety as the body: LIKE fallback above).
-    private def self.body_regex_cond(value : String, body_max : Int32? = nil) : {String, Array(DB::Any)}
-      req = body_col("request_body", body_max)
-      res = body_col("response_body", body_max)
-      {"((request_body IS NOT NULL AND CAST(#{req} AS TEXT) REGEXP ?) OR " \
-       "(response_body IS NOT NULL AND CAST(#{res} AS TEXT) REGEXP ?))",
-       [value, value] of DB::Any}
+    private def self.body_regex_cond(value : String, body_max : Int32? = nil,
+                                     side : Symbol? = nil) : {String, Array(DB::Any)}
+      params = [] of DB::Any
+      conds = body_columns(side).map do |col|
+        params << value
+        "(#{col} IS NOT NULL AND CAST(#{body_col(col, body_max)} AS TEXT) REGEXP ?)"
+      end
+      {"(#{conds.join(" OR ")})", params}
     end
 
     # A body column as the caller wants it READ: whole, or its first `body_max` bytes. The
@@ -628,10 +870,20 @@ module Gori
       body_max ? "substr(#{column}, 1, #{body_max.to_i})" : column
     end
 
-    private def self.header_regex_cond(value : String) : {String, Array(DB::Any)}
-      {"(CAST(request_head AS TEXT) REGEXP ? OR " \
-       "(response_head IS NOT NULL AND CAST(response_head AS TEXT) REGEXP ?))",
-       [value, value] of DB::Any}
+    private def self.header_regex_cond(value : String, side : Symbol? = nil) : {String, Array(DB::Any)}
+      params = [] of DB::Any
+      conds = head_columns(side).map do |col|
+        params << value
+        # `request_head` is BLOB NOT NULL, so it needs no guard; `response_head` is nullable and
+        # an unguarded REGEXP over NULL yields NULL, which SQLite's three-valued logic EXCLUDES
+        # under negation — that is how `-header:x` would silently drop every response-less flow.
+        if col == "response_head"
+          "(#{col} IS NOT NULL AND CAST(#{col} AS TEXT) REGEXP ?)"
+        else
+          "CAST(#{col} AS TEXT) REGEXP ?"
+        end
+      end
+      {"(#{conds.join(" OR ")})", params}
     end
 
     # A pattern must compile or the SQLite REGEXP callback raises (mirrors Scope.valid?).

--- a/src/gori/tui/colormarker_rule_overlay.cr
+++ b/src/gori/tui/colormarker_rule_overlay.cr
@@ -2,6 +2,7 @@ require "./screen"
 require "./theme"
 require "./frame"
 require "./text_field"
+require "./query_suggest"
 require "./overlay"
 require "../store"
 require "../colormarker"
@@ -279,7 +280,9 @@ module Gori::Tui
       # The wider pool: a colour rule accepts every History QL field, not just the ones a hold
       # gate can answer. Completing only the gate's list would have hidden `body:`/`size:` from
       # the one surface that had just learned to answer them.
-      InterceptFilter.suggestions(field.value, field.caret, hosts, Colormarker::USEFUL_FIELDS)
+      QuerySuggest.with_operators(
+        InterceptFilter.suggestions(field.value, field.caret, hosts, Colormarker::USEFUL_FIELDS),
+        FilterAst.token_at(field.value, field.caret))
     end
 
     private def host_prefix(field : TextField) : String
@@ -324,7 +327,7 @@ module Gori::Tui
       # complete, everywhere else it reports what the rule would paint.
       pv_y = box.bottom - 2
       if pv_y > first
-        band = @sel == ROW_WHEN ? completion_band : (@preview.empty? ? "" : "▶ #{@preview}")
+        band = @sel == ROW_WHEN ? completion_band(box.w - 4) : (@preview.empty? ? "" : "▶ #{@preview}")
         unless band.empty?
           screen.fill(Rect.new(box.x + 1, pv_y, box.w - 2, 1), Theme.panel)
           screen.text(box.x + 2, pv_y, band, Theme.muted, Theme.panel, width: box.w - 4)
@@ -334,12 +337,17 @@ module Gori::Tui
       # open modal (Runner#key_hints). See RewriterRuleOverlay#render for the whole argument.
     end
 
-    private def completion_band : String
+    private def completion_band(width : Int32) : String
       sugg = suggestions
-      return "↹ #{sugg.first(6).join("  ")}" unless sugg.empty?
-      # No candidates: name the fields. They are History's, exactly — the search bar's list is no
-      # longer a superset — so an operator who knows one bar knows this one.
-      "fields: #{Colormarker::USEFUL_FIELDS.join(": ")}:"
+      return QuerySuggest.line(sugg, Colormarker::FIELD_HELP_FOR_RULE) unless sugg.empty?
+      # No candidates: name the grammar, not just the fields. The old band listed `USEFUL_FIELDS`
+      # and nothing else, so the one thing a rule author most often wants — "paint everything
+      # EXCEPT" — was the one thing the band never mentioned.
+      # The LIVE band width, not `RULE_FORM_W`: `Overlay.rule_form_box` sizes the card as
+      # `{area.w - 4, RULE_FORM_W}.min`, so on a narrow terminal the constant overstates the room
+      # and the shrink stops early — leaving `-term excludes` past the right edge on exactly the
+      # surface where the mistake it prevents becomes a standing rule.
+      QuerySuggest.cold_hint(width: width)
     end
 
     private def draw_row(screen : Screen, box : Rect, i : Int32, py : Int32) : Nil

--- a/src/gori/tui/controllers/help_controller.cr
+++ b/src/gori/tui/controllers/help_controller.cr
@@ -2,17 +2,54 @@ require "../tab_controller"
 require "../help_view"
 
 module Gori::Tui
-  # The Help tab: two read-only sub-tabs sharing one strip — Shortcuts (the
-  # scrollable cheat-sheet) and About (brand art, version, author, GitHub).
+  # The Help tab: three read-only sub-tabs sharing one strip — Shortcuts (the scrollable
+  # cheat-sheet), Query (the QL reference) and About (brand art, version, author, GitHub).
   # Unlike Repeater/Notes the set is FIXED: no create/close/rename. The strip, focus
   # routing, ←/→, ^1-9 and click hit-testing all come free from the runner's shared
   # sub-tab machinery once we expose subtab_labels; we add only the page renderers.
   class HelpController < TabController
     # The fixed sub-tab strip. Index 0 (Shortcuts) is the default landing page,
-    # preserving the tab's original behaviour.
-    PAGE_LABELS = ["Shortcuts", "About"]
+    # preserving the tab's original behaviour. Query sits BESIDE Shortcuts rather than after
+    # About: the two are the same kind of thing (a reference you scroll), where About is the
+    # colophon, and ^2 landing on a reference reads better than ^2 landing on brand art.
+    PAGE_LABELS = ["Shortcuts", "Query", "About"]
 
     @current : Int32 = 0
+
+    # Derived from the LABEL rather than the index, so reordering `PAGE_LABELS` can never leave a
+    # predicate pointing at a different page. Inserting Query already shifted About from 1 to 2 and
+    # four separate `@current == 0` / `== 1` literals had to move with it — the failure mode being
+    # a page that renders the wrong content or silently stops scrolling. The label is the thing
+    # that actually names the page, and nothing in the strip machinery depends on a fixed position.
+    # (Named predicates mirror `ProbeController#rules_tab?`; deriving them from the label goes one
+    # step further.)
+    private def page : String
+      PAGE_LABELS[@current]? || PAGE_LABELS.first
+    end
+
+    private def query_page? : Bool
+      page == "Query"
+    end
+
+    private def about_page? : Bool
+      page == "About"
+    end
+
+    # About is a centred static block with nothing below the fold; the other two scroll.
+    private def scrollable_page? : Bool
+      !about_page?
+    end
+
+    # Scroll whichever page is showing. Each keeps its OWN offset (see `HelpView`), so switching
+    # pages does not carry one page's position onto another.
+    private def page_move(delta : Int32) : Nil
+      return unless scrollable_page?
+      query_page? ? @help.query_move(delta) : @help.move(delta)
+    end
+
+    private def page_at_top? : Bool
+      query_page? ? @help.query_at_top? : @help.at_top?
+    end
 
     def initialize(host : Host)
       super(host)
@@ -36,7 +73,7 @@ module Gori::Tui
     # the bottom is clamped at render (clamp_scroll), so the large Home/End magnitude is
     # safe and lands on the last page.
     def body_scroll(delta : Int32) : Bool
-      @help.move(delta)
+      page_move(delta)
       true
     end
 
@@ -65,8 +102,10 @@ module Gori::Tui
       focused = focus == :body
       shell = BodyChrome.shell_focused(focus, multi_pane: false)
       @subtab_start = BodyChrome.framed_body(screen, rect, shell, focus == :subtabs, PAGE_LABELS, @current, @subtab_start) do |content|
-        if @current == 1
+        if about_page?
           @help.render_about(screen, content)
+        elsif query_page?
+          @help.render_query(screen, content)
         else
           @help.render(screen, content, focused: focused) # Shortcuts
         end
@@ -74,8 +113,8 @@ module Gori::Tui
     end
 
     # Read-only navigation. ←/→ switch pages (claimed so arrows never fall through
-    # to top-level tab switching — there's no caret to move here). ↑/↓ scroll only
-    # the Shortcuts page; ↑ at its top (or any non-scrolling page) steps up to the
+    # to top-level tab switching — there's no caret to move here). ↑/↓ scroll whichever
+    # page is showing; ↑ at its top (or on About, which does not scroll) steps up to the
     # strip. esc pops to the tab bar. EVERY other key falls through (return false)
     # so the space menu and the global keymap still see it.
     def handle_body_key(ev : Termisu::Event::Key) : Bool
@@ -85,9 +124,9 @@ module Gori::Tui
       when key.left?, key.lower_h?  then move_subtab(-1)
       when key.right?, key.lower_l? then move_subtab(1)
       when key.up?, key.lower_k?
-        (@current == 0 && !@help.at_top?) ? @help.move(-1) : @host.request_focus(:subtabs)
+        (scrollable_page? && !page_at_top?) ? page_move(-1) : @host.request_focus(:subtabs)
       when key.down?, key.lower_j?
-        @help.move(1) if @current == 0
+        page_move(1)
       else
         return false # ^P / space / q / global keys pass through
       end
@@ -95,7 +134,7 @@ module Gori::Tui
     end
 
     def handle_wheel(step : Int32) : Bool
-      @help.move(step) if @current == 0 # only the Shortcuts page scrolls
+      page_move(step) # About is static; the other two scroll
       true
     end
 

--- a/src/gori/tui/controllers/history_controller.cr
+++ b/src/gori/tui/controllers/history_controller.cr
@@ -366,13 +366,12 @@ module Gori::Tui
       key = ev.key
       c = ev.char || key.to_char
       store = @host.session.store
+      return true if query_nav(key)
       case
-      when key.enter?     then flush_query_reload; @history.stop_query
-      when key.escape?    then @query_reload_at = nil; @history.cancel_query; @history.reload(store)
+      when key.enter?     then query_enter
+      when key.escape?    then query_escape(store)
       when key.tab?       then (@history.query_complete; schedule_query_reload)
       when key.backspace? then @history.query_backspace; schedule_query_reload
-      when key.left?      then @history.query_move(-1)
-      when key.right?     then @history.query_move(1)
       else
         if c && !ev.ctrl? && !ev.alt?
           @history.query_insert(c)
@@ -381,6 +380,44 @@ module Gori::Tui
         end
       end
       true
+    end
+
+    # ↵ with the dropdown open takes the highlighted candidate and SHUTS it — the same thing ↹
+    # does, except for the shutting, which is what lets the next ↵ reach `stop_query`. Closed, it
+    # is unchanged: apply the filter and leave edit mode.
+    # ↓/↑ drive the dropdown, ←/→ the caret. Handled ahead of the `case` below rather than as
+    # four more arms in it: the dropdown's two keys pushed `handle_query_key` past the complexity
+    # gate CI runs, and "move something" is a different question from "what does this key do".
+    # `↓`/`↑` were dead in this bar before the dropdown — a one-line field has no second row to
+    # move a caret to — which is why they could be claimed without displacing anything.
+    private def query_nav(key) : Bool
+      case
+      when key.down?  then @history.popup_down
+      when key.up?    then @history.popup_up
+      when key.left?  then @history.query_move(-1)
+      when key.right? then @history.query_move(1)
+      else                 return false
+      end
+      true
+    end
+
+    private def query_enter : Nil
+      if @history.popup_open?
+        @history.query_complete(close: true)
+        schedule_query_reload
+      else
+        flush_query_reload
+        @history.stop_query
+      end
+    end
+
+    # esc closes the DROPDOWN first and clears the filter only on a second press. Otherwise
+    # opening the list to look at it would cost the query you were part-way through typing.
+    private def query_escape(store) : Nil
+      return @history.popup_close if @history.popup_open?
+      @query_reload_at = nil
+      @history.cancel_query
+      @history.reload(store)
     end
 
     # Called from the run loop each tick: run a debounced filter reload if the

--- a/src/gori/tui/controllers/intercept_controller.cr
+++ b/src/gori/tui/controllers/intercept_controller.cr
@@ -212,17 +212,51 @@ module Gori::Tui
       @intercept.querying?
     end
 
+    # Open dropdown ⇒ ↵ takes the highlighted candidate and shuts it (pushing the narrowed
+    # condition live, as every other edit here does); closed ⇒ leave edit mode. Mirrors History.
+    # ↓/↑ drive the dropdown, ←/→ the caret. Handled ahead of the `case` below rather than as
+    # four more arms in it: the dropdown's two keys pushed `handle_query_key` past the complexity
+    # gate CI runs, and "move something" is a different question from "what does this key do".
+    # `↓`/`↑` were dead in this bar before the dropdown — a one-line field has no second row to
+    # move a caret to — which is why they could be claimed without displacing anything.
+    private def query_nav(key) : Bool
+      case
+      when key.down?  then @intercept.popup_down
+      when key.up?    then @intercept.popup_up
+      when key.left?  then @intercept.query_move(-1)
+      when key.right? then @intercept.query_move(1)
+      else                 return false
+      end
+      true
+    end
+
+    private def query_enter(ic) : Nil
+      if @intercept.popup_open?
+        ic.set_filter(@intercept.query) if @intercept.query_complete(close: true)
+      else
+        @intercept.stop_query
+      end
+    end
+
+    # esc closes the dropdown first. Clearing the condition on a glance at the candidate list
+    # would UNHOLD everything the operator had narrowed to — the one bar where the second-press
+    # rule is not merely convenience.
+    private def query_escape(ic) : Nil
+      return @intercept.popup_close if @intercept.popup_open?
+      @intercept.cancel_query
+      ic.set_filter("")
+    end
+
     def handle_query_key(ev : Termisu::Event::Key) : Bool
       key = ev.key
       c = ev.char || key.to_char
       ic = @host.session.interceptor
+      return true if query_nav(key)
       case
-      when key.enter?     then @intercept.stop_query
-      when key.escape?    then @intercept.cancel_query; ic.set_filter("")
+      when key.enter?     then query_enter(ic)
+      when key.escape?    then query_escape(ic)
       when key.tab?       then ic.set_filter(@intercept.query) if @intercept.query_complete
       when key.backspace? then @intercept.query_backspace; ic.set_filter(@intercept.query)
-      when key.left?      then @intercept.query_move(-1)
-      when key.right?     then @intercept.query_move(1)
       else
         if c && !ev.ctrl? && !ev.alt?
           @intercept.query_insert(c)

--- a/src/gori/tui/controllers/sitemap_controller.cr
+++ b/src/gori/tui/controllers/sitemap_controller.cr
@@ -141,13 +141,12 @@ module Gori::Tui
       key = ev.key
       c = ev.char || key.to_char
       store = @host.session.store
+      return true if query_nav(key)
       case
-      when key.enter?     then flush_query_reload; @sitemap.stop_query
-      when key.escape?    then @query_reload_at = nil; @sitemap.cancel_query; @sitemap.reload(store)
+      when key.enter?     then query_enter
+      when key.escape?    then query_escape(store)
       when key.tab?       then (@sitemap.query_complete; schedule_query_reload)
       when key.backspace? then @sitemap.query_backspace; schedule_query_reload
-      when key.left?      then @sitemap.query_move(-1)
-      when key.right?     then @sitemap.query_move(1)
       else
         if c && !ev.ctrl? && !ev.alt?
           @sitemap.query_insert(c)
@@ -156,6 +155,42 @@ module Gori::Tui
         end
       end
       true
+    end
+
+    # Open dropdown ⇒ ↵ takes the highlighted candidate and shuts it; closed ⇒ apply and leave
+    # edit mode. Mirrors HistoryController exactly — one grammar, one set of gestures.
+    # ↓/↑ drive the dropdown, ←/→ the caret. Handled ahead of the `case` below rather than as
+    # four more arms in it: the dropdown's two keys pushed `handle_query_key` past the complexity
+    # gate CI runs, and "move something" is a different question from "what does this key do".
+    # `↓`/`↑` were dead in this bar before the dropdown — a one-line field has no second row to
+    # move a caret to — which is why they could be claimed without displacing anything.
+    private def query_nav(key) : Bool
+      case
+      when key.down?  then @sitemap.popup_down
+      when key.up?    then @sitemap.popup_up
+      when key.left?  then @sitemap.query_move(-1)
+      when key.right? then @sitemap.query_move(1)
+      else                 return false
+      end
+      true
+    end
+
+    private def query_enter : Nil
+      if @sitemap.popup_open?
+        @sitemap.query_complete(close: true)
+        schedule_query_reload
+      else
+        flush_query_reload
+        @sitemap.stop_query
+      end
+    end
+
+    # esc closes the dropdown first, so looking at the list never costs the typed query.
+    private def query_escape(store) : Nil
+      return @sitemap.popup_close if @sitemap.popup_open?
+      @query_reload_at = nil
+      @sitemap.cancel_query
+      @sitemap.reload(store)
     end
 
     # Called each run-loop tick: run the debounced filter reload if the deadline

--- a/src/gori/tui/help_view.cr
+++ b/src/gori/tui/help_view.cr
@@ -2,10 +2,11 @@ require "./screen"
 require "./theme"
 require "./brand"
 require "../hotkeys"
+require "../ql"
 
 module Gori::Tui
-  # The Help tab: a scrollable keyboard + mouse cheat-sheet. Read-only —
-  # ↑/↓ (or the wheel) scroll; there's nothing to select. When constructed with a
+  # The Help tab: a scrollable keyboard + mouse cheat-sheet, a QL reference, and an About page.
+  # Read-only — ↑/↓ (or the wheel) scroll; there's nothing to select. When constructed with a
   # registry, rebindable rows resolve their key column through Hotkeys (same path
   # as the command palette) so a rebind is reflected here.
   class HelpView
@@ -65,7 +66,7 @@ module Gori::Tui
         Item.new("⇧I", "send the flow to the Fuzzer", "history.fuzz"),
         Item.new("⇧F", "create an issue", "issue.create"),
         Item.new("f", "follow newest", "history.toggle-follow"),
-        Item.new("/", "filter (query language)", "history.query"),
+        Item.new("/", "filter (query language — see the Query page)", "history.query"),
         Item.new("y", "copy flow", "history.copy"),
         Item.new("space → Y", "copy as… — urls · hosts · cURL · raw · req+res pair"),
         Item.new("i", "toggle intercept hold-mode", "intercept.toggle"),
@@ -281,14 +282,19 @@ module Gori::Tui
       end
     end
 
-    private def draw_row(screen : Screen, rect : Rect, y : Int32, row : Row) : Nil
+    # `key_w` is a parameter rather than the constant because the Query page's left column holds
+    # QL EXPRESSIONS, not key chords: `NOT (host:cdn OR host:img)` is 26 columns where the widest
+    # chord label is 20, and truncating an example query to `NOT (host:cdn OR ho…` would teach the
+    # syntax wrong. Same two-column row, one page's worth of extra room.
+    private def draw_row(screen : Screen, rect : Rect, y : Int32, row : Row,
+                         key_w : Int32 = KEY_W) : Nil
       case row.kind
       when :head
         screen.text(rect.x + 1, y, row.a, Theme.accent, attr: Attribute::Bold, width: {rect.w - 2, 1}.max)
       when :item
-        kw = {KEY_W, {rect.w - 3 - KEY_GAP, 1}.max}.min
+        kw = {key_w, {rect.w - 3 - KEY_GAP, 1}.max}.min
         screen.text(rect.x + 2, y, row.a, Theme.text_bright, width: kw)
-        dx = rect.x + 2 + KEY_W + KEY_GAP
+        dx = rect.x + 2 + key_w + KEY_GAP
         screen.text(dx, y, row.b, Theme.muted, width: {rect.right - dx - 1, 1}.max) if dx < rect.right - 1
         # :gap → blank line
       end
@@ -297,6 +303,76 @@ module Gori::Tui
     private def clamp_scroll(h : Int32) : Nil
       max = {@rows.size - h, 0}.max
       @scroll = @scroll.clamp(0, max)
+    end
+
+    # --- the "Query" sub-tab page ---------------------------------------------
+    # The QL reference, in the tab an operator is already in. It exists because the language had
+    # nowhere to be READ: a filter bar teaches one row at a time, `ql_reference` is an MCP tool
+    # for models, and the docs site is not open while you are looking at traffic. Help's own entry
+    # for `/` said "filter (query language)" and stopped there.
+    #
+    # Every row is BUILT from the parser's tables — `QL::SYNTAX_HELP`, `QL::FIELDS` +
+    # `QL::FIELD_HELP`, `QL::CAVEATS` — and none is written here. That is the whole point: a
+    # hand-authored copy of the field list is what `FILTER_HINT` and `QUERY_HINT` were, and they
+    # disagreed with `FIELDS` and with each other for long enough that an operator could not find
+    # `-term` on the two surfaces most likely to be asked for it.
+    QUERY_KEY_W = 28
+
+    # Its own offset, not `@scroll`: the two pages have different lengths, and sharing one would
+    # carry the cheat-sheet's position onto this page — where `at_top?` then answers about the
+    # wrong page and ↑ pops focus to the strip in the middle of a scroll.
+    @query_scroll : Int32 = 0
+
+    def query_move(delta : Int32) : Nil
+      @query_scroll = {@query_scroll + delta, 0}.max
+    end
+
+    def query_at_top? : Bool
+      @query_scroll == 0
+    end
+
+    def render_query(screen : Screen, rect : Rect) : Nil
+      return if rect.empty?
+      rows = query_rows
+      @query_scroll = @query_scroll.clamp(0, {rows.size - rect.h, 0}.max)
+      (0...rect.h).each do |i|
+        li = @query_scroll + i
+        break if li >= rows.size
+        draw_row(screen, rect, rect.y + i, rows[li], QUERY_KEY_W)
+      end
+    end
+
+    # Memoised per instance: the tables are constants, so this is the same list every time, and
+    # `render_query` runs on the draw path.
+    private def query_rows : Array(Row)
+      @query_rows ||= build_query_rows
+    end
+
+    @query_rows : Array(Row)? = nil
+
+    private def build_query_rows : Array(Row)
+      rows = [] of Row
+      rows << Row.new(:head, "SYNTAX", "")
+      QL::SYNTAX_HELP.each { |(example, meaning)| rows << Row.new(:item, example, meaning) }
+
+      # Fields in `FIELDS` order — the order completion offers them, so the page and the Tab key
+      # agree about what comes first.
+      rows << Row.new(:gap, "", "")
+      rows << Row.new(:head, "FIELDS  (: matches, ~ is regex)", "")
+      QL::FIELDS.each do |name|
+        rows << Row.new(:item, "#{name}:", QL::FIELD_HELP[name]? || "")
+      end
+
+      rows << Row.new(:gap, "", "")
+      rows << Row.new(:head, "ALSO ACCEPTED", "")
+      QL::FIELD_ALIASES.each do |from, to|
+        rows << Row.new(:item, "#{from}:", "= #{to}:")
+      end
+
+      rows << Row.new(:gap, "", "")
+      rows << Row.new(:head, "WORTH KNOWING", "")
+      QL::CAVEATS.each { |(what, why)| rows << Row.new(:item, what, why) }
+      rows
     end
 
     # --- the "About" sub-tab page ---------------------------------------------

--- a/src/gori/tui/highlight.cr
+++ b/src/gori/tui/highlight.cr
@@ -223,17 +223,26 @@ module Gori::Tui
     # `seps` must match what the BACKEND behind this bar actually splits on — only QL
     # implements `~`, so the four bars that don't pass `SEPS_FIELD` and `title~admin`
     # stays plain there, because that is how it will be matched (as free text).
+    # `known` is the backend's field vocabulary — see `FilterAst.spans`. Without it an
+    # unrecognised `hsot:` renders in the same confident blue as a real field, which is the one
+    # visible signal an operator has while typing, and it says the opposite of the truth.
     def self.filter_query(query : String, base : Color = Theme.text,
-                          seps : String = FilterAst::SEPS_FIELD_REGEX) : Array(Color)
+                          seps : String = FilterAst::SEPS_FIELD_REGEX,
+                          known : Proc(String, Bool)? = nil) : Array(Color)
       colors = Array(Color).new(query.size, base)
-      FilterAst.spans(query, seps).each do |span|
+      FilterAst.spans(query, seps, known).each do |span|
         fg = case span.kind
              in .operator? then Theme.syn_keyword
              in .paren?    then Theme.syn_keyword
              in .field?    then Theme.syn_header
-             in .value?    then Theme.text_bright
-             in .quote?    then Theme.syn_string
-             in .plain?    then base
+               # Deliberately the FREE-TEXT colour, not an error red: the token is not broken, it
+               # is being read as a plain word — which is precisely what the backend will do with
+               # it. Painting it as an error would overstate a `time:12:00` that the operator meant
+               # literally, while this just declines to promise a field match.
+             in .unknown_field? then Theme.muted
+             in .value?         then Theme.text_bright
+             in .quote?         then Theme.syn_string
+             in .plain?         then base
              end
         (span.start...(span.start + span.size)).each { |i| colors[i] = fg if i < colors.size }
       end

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -1,6 +1,8 @@
 require "./screen"
 require "./theme"
 require "./frame"
+require "./query_suggest"
+require "./suggest_popup"
 require "./traffic_empty_state"
 require "../settings"
 require "./highlight"
@@ -54,13 +56,23 @@ module Gori::Tui
     # spec below was written to catch cannot happen at all.
     QL_FIELDS  = QL::FIELDS
     METHOD_VAL = %w[GET POST PUT DELETE PATCH HEAD OPTIONS QUERY]
-    # Discoverability hints for the QL filter, kept loosely in sync with QL_FIELDS.
-    # FILTER_HINT sits on the idle bar (press `/` to start filtering); QUERY_HINT sits
-    # on the suggestion row at a cold start (already editing, nothing to Tab-complete
-    # yet) and also spells out that bare words are a free-text search. Example values
-    # double as syntax cues.
-    FILTER_HINT = "/ filter  ·  host:  method:  status:>=500  proto:ws  path:  size:>10000  dur:>500  header:  body~regex"
-    QUERY_HINT  = "fields:  host:  method:  status:  proto:  path:  scheme:  size:  dur:  header:  body    ·    AND OR NOT ( ) combine  ·  or type words to search"
+    # Discoverability hints for the QL filter. Both are GENERATED from the field pool and the
+    # grammar's own operator list (`QuerySuggest`) rather than written out here: as prose they
+    # drifted from `QL_FIELDS` and from each other — this pair listed `AND OR NOT` and never `-`,
+    # while Intercept's listed both — so an operator looking for "everything EXCEPT" found nothing
+    # on the two surfaces most likely to be asked the question.
+    #
+    # FILTER_HINT sits on the idle bar (press `/` to start filtering); QUERY_HINT sits on the
+    # suggestion row at a cold start (already editing, nothing to Tab-complete yet).
+    FILTER_HINT = QuerySuggest.idle_hint("/ filter")
+    QUERY_HINT  = QuerySuggest.cold_hint
+    # The editing bar's label. A constant because `render_query_popup` has to line the dropdown
+    # up under the token, which means knowing exactly how far the query text is indented.
+    QUERY_PREFIX = "filter › "
+    # The highlighter's field vocabulary. `QL.known_field?`, not `QL_FIELDS.includes?`: the pool
+    # is what Tab OFFERS and is a strict subset of what QL accepts, so testing against it would
+    # paint `res.body:` — which compiles perfectly — as a typo.
+    QL_KNOWN = ->(f : String) { QL.known_field?(f) }
 
     getter rows : Array(Store::FlowRow)
     getter? follow : Bool
@@ -102,6 +114,8 @@ module Gori::Tui
       @suggest_store = nil.as(Store?)
       @host_suggest_prefix = nil.as(String?) # cache key (downcase prefix)
       @host_suggest_values = [] of String
+      # The `↓` completion dropdown. Closed until asked for — see `SuggestPopup`.
+      @popup = SuggestPopup.new
       @scope = nil.as(Scope?)
       # Colormarker (the row-colour lens). Nil until `set_colormarker` — every construction
       # site outside HistoryController leaves it nil, which is what makes the whole feature a
@@ -828,6 +842,7 @@ module Gori::Tui
 
     def stop_query : Nil # Enter: keep the filter, leave edit mode
       @querying = false
+      @popup.close
     end
 
     def cancel_query : Nil # Esc: clear the filter, leave edit mode
@@ -835,21 +850,57 @@ module Gori::Tui
       @query = ""
       @qcx = 0
       @preedit = ""
+      @popup.close
     end
 
     def query_insert(ch : Char) : Nil
       @query = "#{@query[0, @qcx]}#{ch}#{@query[@qcx..]}"
       @qcx += 1
+      sync_popup
     end
 
     def query_backspace : Nil
       return if @qcx == 0
       @query = "#{@query[0, @qcx - 1]}#{@query[@qcx..]}"
       @qcx -= 1
+      sync_popup
     end
 
     def query_move(d : Int32) : Nil
       @qcx = (@qcx + d).clamp(0, @query.size)
+      sync_popup
+    end
+
+    # --- the opt-in completion dropdown (`↓`) ---------------------------------
+    # The inline row stays the default; this is the roomier second view of the same candidates.
+    # See `SuggestPopup` for why it is opt-in rather than the primary shape.
+
+    def popup_open? : Bool
+      @popup.open?
+    end
+
+    # `↓`: open the dropdown, or move down inside it. Nil rather than Bool — the key is claimed
+    # either way, and an earlier Bool "so the key falls through" was a contract no controller
+    # honoured, which is worse than not offering one.
+    def popup_down : Nil
+      return @popup.move(1) if @popup.open?
+      @popup.set(query_suggestions)
+      @popup.open!
+    end
+
+    def popup_up : Nil
+      @popup.move(-1)
+    end
+
+    def popup_close : Nil
+      @popup.close
+    end
+
+    # Keep the candidate set in step with the query on every edit. The popup re-anchors its
+    # selection onto the same candidate when it survived, and shuts itself when the edit left
+    # nothing to show — an empty dropdown is a hole in the list for no content.
+    private def sync_popup : Nil
+      @popup.set(query_suggestions) if @popup.open?
     end
 
     # IME composing text, drawn (underlined) at the caret without touching the
@@ -858,13 +909,26 @@ module Gori::Tui
       @preedit = text
     end
 
-    # Tab-complete the current token to the first suggestion.
-    def query_complete : Bool
+    # Tab-complete the current token: to the SELECTED candidate when the dropdown is open,
+    # otherwise to the first — so a bar whose popup was never opened behaves exactly as before.
+    #
+    # `close` is what ↵ passes and ↹ does not, and it is load-bearing rather than cosmetic. With
+    # the dropdown open, re-deriving candidates after the splice can hand back a list containing
+    # the token that was just completed (`method:GET` narrows the value pool to exactly
+    # `["method:GET"]`), so the popup never shuts, ↵ re-splices the identical string forever, and
+    # `stop_query` becomes unreachable — the bar could not be left with Enter at all. ↹ keeps it
+    # open on purpose, because chaining field → value is the whole point of Tab.
+    def query_complete(close : Bool = false) : Bool
       sugg = query_suggestions
-      return false if sugg.empty?
+      pick = @popup.choice(sugg)
+      return false unless pick
       cur = FilterAst.token_at(@query, @qcx)
-      @query = "#{@query[0, cur.start]}#{sugg.first}#{@query[cur.stop..]}"
-      @qcx = cur.start + sugg.first.size
+      @query = "#{@query[0, cur.start]}#{pick}#{@query[cur.stop..]}"
+      @qcx = cur.start + pick.size
+      # Completing consumes the choice: the token is now whole, so the old candidate set is
+      # stale. Re-derive it (a field completion opens a value list) and let `set` close the
+      # popup if that leaves nothing.
+      close ? @popup.close : (@popup.set(query_suggestions) if @popup.open?)
       true
     end
 
@@ -874,13 +938,18 @@ module Gori::Tui
     def query_suggestions : Array(String)
       cur = FilterAst.token_at(@query, @qcx)
       return [] of String if cur.core.empty?
-      if colon = cur.core.index(':')
-        field = cur.core[0...colon].downcase
-        prefix = FilterAst.unquote_prefix(cur.core[(colon + 1)..])
-        suggest_values(field, prefix).map { |s| "#{cur.prefix}#{s}" }
-      else
-        QL_FIELDS.select(&.starts_with?(cur.core.downcase)).map { |f| "#{cur.prefix}#{f}:" }
-      end
+      fields =
+        if colon = cur.core.index(':')
+          field = cur.core[0...colon].downcase
+          prefix = FilterAst.unquote_prefix(cur.core[(colon + 1)..])
+          suggest_values(field, prefix).map { |s| "#{cur.prefix}#{s}" }
+        else
+          QL_FIELDS.select(&.starts_with?(cur.core.downcase)).map { |f| "#{cur.prefix}#{f}:" }
+        end
+      # ...then the boolean operators, which no field pool can offer. The whole CURSOR, so an
+      # operator candidate carries the token's `(` the way a field one does. See
+      # `QuerySuggest::OPERATORS`.
+      QuerySuggest.with_operators(fields, cur)
     end
 
     # --- detail view ---------------------------------------------------------
@@ -1829,9 +1898,37 @@ module Gori::Tui
       render_preview_pane(screen, preview_rect, focused) if preview_rect
     end
 
+    # The list, then the `↓` dropdown OVER it. Split so the popup is drawn last unconditionally:
+    # the body below returns early on several paths (no rows, the empty-state card), and a
+    # dropdown that vanished exactly when the filter matched nothing would be missing from the
+    # one moment an operator is most likely to be fixing a query.
     private def render_list_body(screen : Screen, rect : Rect, focused : Bool, *,
                                  listen : {String, Int32}? = nil, capturing : Bool = true) : Nil
       return if rect.empty?
+      render_list_rows(screen, rect, focused, listen: listen, capturing: capturing)
+      render_query_popup(screen, rect)
+    end
+
+    # Anchored under the suggestion row (so it never covers the inline hint it expands on) and
+    # bounded by the list, which is the only region it is allowed to occlude.
+    private def render_query_popup(screen : Screen, rect : Rect) : Nil
+      return unless @querying && @popup.open?
+      # `list_top`, not the row under the bar: the column header and its divider sit between the
+      # two, and a card straddling them reads as a rendering fault rather than a menu. The list
+      # is also the only region this is allowed to cover.
+      top = list_top(rect)
+      anchor_y = top - 1
+      bounds = Rect.new(rect.x + 1, top, {rect.w - 2, 0}.max, {rect.bottom - top, 0}.max)
+      # Anchored at the START of the query text, not at the token's offset within it.
+      # `Screen#input_line` scrolls its window horizontally once the query outgrows the bar, so
+      # `base + token.start` stops being the token's screen column on exactly the long queries
+      # where precision would matter — the card would drift right of what it completes and then
+      # clamp. A fixed anchor is always adjacent to the bar and never lies.
+      @popup.render(screen, rect.x + 1 + QUERY_PREFIX.size, anchor_y, bounds)
+    end
+
+    private def render_list_rows(screen : Screen, rect : Rect, focused : Bool, *,
+                                 listen : {String, Int32}? = nil, capturing : Bool = true) : Nil
       render_ql_bar(screen, rect)
       hdr_y = rect.y + 1
       if @querying
@@ -2428,11 +2525,11 @@ module Gori::Tui
 
     private def render_ql_bar(screen : Screen, rect : Rect) : Nil
       if @querying
-        prefix = "filter › "
-        screen.text(rect.x + 1, rect.y, prefix, Theme.accent)
-        base = rect.x + 1 + prefix.size
-        screen.input_line(base, rect.y, @query, @qcx, @preedit, Theme.text_bright, width: rect.w - prefix.size - 2,
-          colors: Highlight.filter_query(@query, Theme.text_bright))
+        screen.text(rect.x + 1, rect.y, QUERY_PREFIX, Theme.accent)
+        base = rect.x + 1 + QUERY_PREFIX.size
+        screen.input_line(base, rect.y, @query, @qcx, @preedit, Theme.text_bright,
+          width: rect.w - QUERY_PREFIX.size - 2,
+          colors: Highlight.filter_query(@query, Theme.text_bright, known: QL_KNOWN))
         return
       end
 
@@ -2459,7 +2556,7 @@ module Gori::Tui
         # The committed query stays highlighted — this readout is what you scan to
         # check how the active filter is actually being read.
         qx = screen.text(rect.x + 1, rect.y, ": ", Theme.muted, width: left_w)
-        screen.styled_text(qx, rect.y, @query, Highlight.filter_query(@query, Theme.text),
+        screen.styled_text(qx, rect.y, @query, Highlight.filter_query(@query, Theme.text, known: QL_KNOWN),
           Theme.text, width: {rect.x + 1 + left_w - qx, 0}.max)
       else
         # No QL query typed — whether or not a Scope lens is active. Surface the filter
@@ -2488,14 +2585,14 @@ module Gori::Tui
     private def render_suggestions(screen : Screen, rect : Rect, y : Int32) : Nil
       sugg = query_suggestions
       unless sugg.empty?
-        screen.text(rect.x + 1, y, "↹ #{sugg.first(8).join("  ")}", Theme.muted, width: rect.w - 2)
+        QuerySuggest.render(screen, rect.x + 1, y, rect.w - 2, sugg)
         return
       end
       # No live completions to Tab through. At a cold start (nothing typed yet, or the
       # cursor sits just after a space) show a standing hint so the query language is
       # discoverable from the moment `/` opens; on a non-empty token with no match stay
       # quiet — the user is deliberately free-texting a word.
-      return unless FilterAst.token_at(@query, @qcx).core.empty?
+      return unless QuerySuggest.hint_slot?(FilterAst.token_at(@query, @qcx).core)
       screen.text(rect.x + 1, y, QUERY_HINT, Theme.muted, width: rect.w - 2)
     end
 

--- a/src/gori/tui/intercept_view.cr
+++ b/src/gori/tui/intercept_view.cr
@@ -1,6 +1,8 @@
 require "./screen"
 require "./theme"
 require "./frame"
+require "./query_suggest"
+require "./suggest_popup"
 require "./traffic_empty_state"
 require "../settings"
 require "./highlight"
@@ -24,12 +26,27 @@ module Gori::Tui
     # queue|detail split — the Intercept tab's analogue of History's QL bar. While the
     # condition is being edited a second row carries Tab suggestions (see bar_h).
     FILTER_BAR_H = 1
-    # Standing hint on the suggestion row at a cold start (editing, but nothing typed
-    # yet to complete), so the condition language is discoverable the moment `/` opens.
-    # Example values double as syntax cues; keep in sync with InterceptFilter::FIELDS.
-    # `proto:ws` earns its own note: it is not a narrowing term but the WebSocket hold's
-    # OPT-IN, and without it no WS message is held however permissive the rest is (#500).
-    QUERY_HINT = "fields:  host:  path:  url:  method:  scheme:  status:  proto:  header:  body:    ·    ~regex    ·    proto:ws opts WS messages IN    ·    AND OR NOT ( ) combine  ·  -term negates"
+    # Standing hint on the suggestion row at a cold start (editing, but nothing typed yet to
+    # complete), so the condition language is discoverable the moment `/` opens. GENERATED from
+    # this backend's field sample plus the shared operator list, so it cannot drift from the
+    # parser or from History's and Sitemap's wording the way the hand-written version did.
+    # `proto:ws` is appended by hand and earns it: it is not a narrowing term but the WebSocket
+    # hold's OPT-IN, and without it no WS message is held however permissive the rest is (#500) —
+    # a fact no generator over a field list could know.
+    QUERY_HINT = QuerySuggest.cold_hint(InterceptFilter::HINT_FIELDS,
+      note: "proto:ws opts WS messages IN")
+    # The idle bar, before `/` opens the condition. Same generator as History's and Sitemap's, so
+    # the three stop disagreeing about which operators exist.
+    IDLE_HINT = QuerySuggest.idle_hint("/ condition", InterceptFilter::HINT_FIELDS)
+    # The highlighter's field vocabulary. This backend's `FIELDS` really is the whole of what it
+    # accepts (the comment there requires it to stay in lockstep with `field_symbol`), so unlike
+    # History there is no wider accepted set to reach for.
+    GATE_KNOWN = ->(f : String) { InterceptFilter::FIELDS.includes?(f) }
+    # The editing bar's label — a constant because `render_query_popup` lines the dropdown up
+    # under the token, which means knowing how far the condition text is indented.
+    QUERY_PREFIX = "catch › "
+    # This backend's help, as one shared proc — see `InterceptFilter::FIELD_HELP_PROC`.
+    GATE_HELP = InterceptFilter::FIELD_HELP_PROC
 
     # How much of a held WebSocket payload the queue row previews. A row is one line, and
     # the detail pane is where the message is actually read.
@@ -67,6 +84,8 @@ module Gori::Tui
       @suggest_store = nil.as(Store?)
       @host_suggest_prefix = nil.as(String?)
       @host_suggest_values = [] of String
+      # The `↓` completion dropdown. Closed until asked for — see `SuggestPopup`.
+      @popup = SuggestPopup.new
       @loaded_id = nil.as(Int64?) # which item the editor currently holds
       @editor_dirty = false       # whether the held bytes were actually edited (vs just viewed)
       # Whether the LOADED item is a WebSocket message. Captured when the editor takes the
@@ -301,6 +320,7 @@ module Gori::Tui
 
     def stop_query : Nil # Enter: keep the condition, leave edit mode
       @querying = false
+      @popup.close
     end
 
     def cancel_query : Nil # Esc: clear the condition, leave edit mode
@@ -308,36 +328,73 @@ module Gori::Tui
       @query = ""
       @qcx = 0
       @preedit = ""
+      @popup.close
     end
 
     def query_insert(ch : Char) : Nil
       @query = "#{@query[0, @qcx]}#{ch}#{@query[@qcx..]}"
       @qcx += 1
+      sync_popup
     end
 
     def query_backspace : Nil
       return if @qcx == 0
       @query = "#{@query[0, @qcx - 1]}#{@query[@qcx..]}"
       @qcx -= 1
+      sync_popup
     end
 
     def query_move(d : Int32) : Nil
       @qcx = (@qcx + d).clamp(0, @query.size)
+      sync_popup
     end
 
-    # Tab: splice the first suggestion over the token under the caret. False when there
-    # is nothing to complete, so the caller can leave the query untouched.
-    def query_complete : Bool
+    # --- the opt-in completion dropdown (`\u2193`) ---------------------------------
+    # Same component and contract as History's and Sitemap's; see `SuggestPopup`.
+
+    def popup_open? : Bool
+      @popup.open?
+    end
+
+    # `↓`: open the dropdown, or move down inside it. Nil rather than Bool — the key is claimed
+    # either way, and an earlier Bool "so the key falls through" was a contract no controller
+    # honoured, which is worse than not offering one.
+    def popup_down : Nil
+      return @popup.move(1) if @popup.open?
+      @popup.set(query_suggestions)
+      @popup.open!
+    end
+
+    def popup_up : Nil
+      @popup.move(-1)
+    end
+
+    def popup_close : Nil
+      @popup.close
+    end
+
+    private def sync_popup : Nil
+      @popup.set(query_suggestions) if @popup.open?
+    end
+
+    # Splice the SELECTED candidate (dropdown open) or the first (closed) over the token under
+    # the caret. False when there is nothing to complete, so the caller can leave the query
+    # untouched. `close` is ↵'s — see HistoryView#query_complete for why ↵ must shut the popup or
+    # the bar cannot be left with Enter.
+    def query_complete(close : Bool = false) : Bool
       sugg = query_suggestions
-      return false if sugg.empty?
+      pick = @popup.choice(sugg)
+      return false unless pick
       cur = FilterAst.token_at(@query, @qcx)
-      @query = "#{@query[0, cur.start]}#{sugg.first}#{@query[cur.stop..]}"
-      @qcx = cur.start + sugg.first.size
+      @query = "#{@query[0, cur.start]}#{pick}#{@query[cur.stop..]}"
+      @qcx = cur.start + pick.size
+      close ? @popup.close : (@popup.set(query_suggestions) if @popup.open?)
       true
     end
 
     def query_suggestions : Array(String)
-      InterceptFilter.suggestions(@query, @qcx, host_suggestions)
+      cur = FilterAst.token_at(@query, @qcx)
+      QuerySuggest.with_operators(InterceptFilter.suggestions(@query, @qcx, host_suggestions), cur)
     end
 
     # DISTINCT hosts for the `host:` pool, memoised on the typed prefix (single-entry,
@@ -815,9 +872,30 @@ module Gori::Tui
 
     # --- rendering -----------------------------------------------------------
 
+    # The queue/detail split, then the `↓` dropdown OVER it — drawn last unconditionally, since
+    # the body below returns early on the empty-queue path and that is exactly when an operator
+    # is most likely to be editing the condition. Mirrors HistoryView / SitemapView.
     def render(screen : Screen, rect : Rect, focused : Bool = true, *,
                listen : {String, Int32}? = nil, capturing : Bool = true) : Nil
       return if rect.empty?
+      render_panes(screen, rect, focused, listen: listen, capturing: capturing)
+      render_query_popup(screen, rect)
+    end
+
+    private def render_query_popup(screen : Screen, rect : Rect) : Nil
+      return unless @querying && @popup.open?
+      top = rect.y + bar_h
+      bounds = Rect.new(rect.x + 1, top, {rect.w - 2, 0}.max, {rect.bottom - top, 0}.max)
+      # Anchored at the START of the query text, not at the token's offset within it.
+      # `Screen#input_line` scrolls its window horizontally once the query outgrows the bar, so
+      # `base + token.start` stops being the token's screen column on exactly the long queries
+      # where precision would matter — the card would drift right of what it completes and then
+      # clamp. A fixed anchor is always adjacent to the bar and never lies.
+      @popup.render(screen, rect.x + 1 + QUERY_PREFIX.size, top - 1, bounds, GATE_HELP)
+    end
+
+    private def render_panes(screen : Screen, rect : Rect, focused : Bool = true, *,
+                             listen : {String, Int32}? = nil, capturing : Bool = true) : Nil
       render_filter_bar(screen, Rect.new(rect.x, rect.y, rect.w, FILTER_BAR_H), focused)
       render_suggestions(screen, rect, rect.y + FILTER_BAR_H) if @querying
       body = body_rect(rect)
@@ -840,12 +918,11 @@ module Gori::Tui
     private def render_filter_bar(screen : Screen, rect : Rect, focused : Bool) : Nil
       return if rect.empty?
       if @querying
-        prefix = "catch › "
-        screen.text(rect.x + 1, rect.y, prefix, Theme.accent)
-        base = rect.x + 1 + prefix.size
+        screen.text(rect.x + 1, rect.y, QUERY_PREFIX, Theme.accent)
+        base = rect.x + 1 + QUERY_PREFIX.size
         screen.input_line(base, rect.y, @query, @qcx, @preedit, Theme.text_bright,
-          width: {rect.w - prefix.size - 2, 0}.max,
-          colors: Highlight.filter_query(@query, Theme.text_bright, FilterAst::SEPS_FIELD))
+          width: {rect.w - QUERY_PREFIX.size - 2, 0}.max,
+          colors: Highlight.filter_query(@query, Theme.text_bright, FilterAst::SEPS_FIELD, GATE_KNOWN))
         return
       end
 
@@ -864,12 +941,12 @@ module Gori::Tui
 
       left_w = {rx - x, 0}.max
       if @query.blank?
-        screen.text(x, rect.y, "/ condition  ·  host:  method:  path:  status:>=500  scheme:", Theme.muted, width: left_w)
+        screen.text(x, rect.y, IDLE_HINT, Theme.muted, width: left_w)
       else
         # The committed condition stays highlighted — this readout is what you scan to
         # check WHY something is (or isn't) being held.
         x = screen.text(x, rect.y, ": ", Theme.muted, width: left_w)
-        screen.styled_text(x, rect.y, @query, Highlight.filter_query(@query, Theme.text, FilterAst::SEPS_FIELD),
+        screen.styled_text(x, rect.y, @query, Highlight.filter_query(@query, Theme.text, FilterAst::SEPS_FIELD, GATE_KNOWN),
           Theme.text, width: {rect.right - 1 - x, 0}.max)
       end
     end
@@ -894,10 +971,11 @@ module Gori::Tui
       return if y >= rect.bottom
       sugg = query_suggestions
       unless sugg.empty?
-        screen.text(rect.x + 1, y, "↹ #{sugg.first(8).join("  ")}", Theme.muted, width: {rect.w - 2, 0}.max)
+        # This backend's own help, not QL's — see `InterceptFilter::FIELD_HELP`.
+        QuerySuggest.render(screen, rect.x + 1, y, {rect.w - 2, 0}.max, sugg, GATE_HELP)
         return
       end
-      return unless FilterAst.token_at(@query, @qcx).core.empty?
+      return unless QuerySuggest.hint_slot?(FilterAst.token_at(@query, @qcx).core)
       screen.text(rect.x + 1, y, QUERY_HINT, Theme.muted, width: {rect.w - 2, 0}.max)
     end
 

--- a/src/gori/tui/query_suggest.cr
+++ b/src/gori/tui/query_suggest.cr
@@ -1,0 +1,230 @@
+require "./screen"
+require "./theme"
+require "../ql"
+
+module Gori::Tui
+  # The completion row under a filter bar: what Tab would take, what it MEANS, and what else is
+  # on offer — plus the standing hints that stand in when there is nothing to complete.
+  #
+  # It exists because the row used to be one muted string per surface (`"↹ #{sugg.first(8)…}"`,
+  # copied five times) and the hints beside it were hand-written prose (copied three times, and
+  # disagreeing: History's listed `AND OR NOT` and not `-`, Intercept's listed both, Sitemap's and
+  # Issues' listed neither). A filter bar is where this language is LEARNED — it is the only place
+  # most operators ever see the grammar — so the row that teaches it should not be the part of the
+  # codebase most likely to be stale.
+  #
+  # Two things the flat row could never say, and this one does:
+  #
+  #   * WHICH candidate Tab takes. Every surface splices `sugg.first` and every surface painted
+  #     all eight identically, so the row showed the outcome of pressing Tab nowhere in it.
+  #   * WHAT the candidate means. `resp.body:` is not self-describing, and a field pool can only
+  #     ever list names — the meanings live in `QL::FIELD_HELP`, beside the parser that implements
+  #     them, and are read from there rather than restated here.
+  module QuerySuggest
+    MAX_SHOWN = 8
+
+    # The default help source, hoisted out of the parameter lists below: a default argument that
+    # is a literal proc allocates a fresh closure on EVERY call, and these run on the draw path.
+    QL_HELP = ->(f : String) { QL.field_help(f) }
+
+    # The boolean operators, offered as completion candidates. A field pool can only ever list
+    # field names, so `NOT` and `OR` had no completion at all: typing `N` matched nothing and the
+    # row went blank under the "deliberately free-texting a word" policy. They lived only in the
+    # standing hint, which disappears the moment you type — so the grammar's two most useful
+    # spellings were reachable only by already knowing them.
+    #
+    # `NOT (` matters most and is the reason this exists: `-` negates a TERM and cannot negate a
+    # GROUP, so `NOT ( … )` is the only way to exclude a disjunction and it was the one form with
+    # zero discovery. The trailing `(` is part of the candidate because the shape is the lesson.
+    #
+    # Matched CASE-SENSITIVELY, which is not a detail: `FilterAst` recognises these uppercase and
+    # unquoted only, precisely so searching for the words "and"/"or"/"not" still works. Offering
+    # `NOT (` for a typed `n` would advertise an operator that would compile as free text. No QL
+    # field begins with n/o/a either, so an uppercase prefix collides with nothing.
+    OPERATORS = {
+      "NOT (" => "excludes a whole group — close with )",
+      "OR"    => "either side matches",
+      "AND"   => "both match — the same as a space",
+    }
+
+    # `candidates` plus any operator the typed token could still become. Appended AFTER the field
+    # candidates so a field never loses its slot; in practice the two sets never overlap.
+    #
+    # Takes the whole `Cursor`, not just `core`, because completion SPLICES OVER the token's full
+    # span — punctuation included. A bare `"OR"` spliced over `(O` deletes the opening paren and
+    # silently dissolves the group the operator was being typed to build, so an operator candidate
+    # has to carry `cur.prefix` exactly as a field candidate does.
+    #
+    # And a `-` in that prefix disqualifies operators outright rather than carrying: `-NOT (`
+    # lexes as one WORD (`word_tok` tests the whole chunk, which is not `NOT`), so offering it
+    # would complete a token the grammar reads as free text — the very thing the case-sensitive
+    # match above exists to prevent.
+    def self.with_operators(candidates : Array(String), cur : Gori::FilterAst::Cursor) : Array(String)
+      return candidates if cur.core.empty? || cur.prefix.includes?('-')
+      candidates + OPERATORS.keys.select(&.starts_with?(cur.core)).map { |op| "#{cur.prefix}#{op}" }
+    end
+
+    # Should a standing hint stand in for an empty candidate list? A blank row is the deliberate
+    # answer to a non-empty token nothing matches — the human is free-texting a word — but a lone
+    # `-` is not a word, it is an operator mid-typing, and blanking there removed all guidance at
+    # the exact keystroke where the operator committed to an exclusion. `FilterAst.token_at`
+    # cannot help: it peels a `-` into the token prefix only when something follows it, so a bare
+    # dash arrives as `core` and looks like free text.
+    def self.hint_slot?(core : String) : Bool
+      core.empty? || core == "-"
+    end
+
+    # Draw the row at (x, y) within `w` columns. `suggestions` is the surface's candidate list,
+    # already in Tab order — the first entry is what Tab splices, so it is the one painted bright
+    # and the one described. Returns nothing; a caller with no candidates should draw a hint
+    # instead (see `cold_hint`), or nothing at all when the token is a deliberate free-text word.
+    # `help` is the BACKEND's explanation of a field name, not QL's by assumption: the grammar is
+    # shared and the semantics are not. `body:` at a hold gate reads the bytes in hand, so QL's
+    # "via index: 8 KiB/side, no compressed" would be a confident lie on the Intercept bar — see
+    # `InterceptFilter::FIELD_HELP`. Defaulting to QL keeps the store-backed surfaces (History,
+    # Sitemap, colour rules) on one line of wiring.
+    def self.render(screen : Screen, x : Int32, y : Int32, w : Int32,
+                    suggestions : Array(String),
+                    help : Proc(String, String?) = QL_HELP) : Nil
+      return if suggestions.empty? || w <= 2
+      right = x + w
+      cx = screen.text(x, y, "↹ ", Theme.muted, width: w)
+      head = suggestions.first
+      cx = screen.text(cx, y, head, Theme.text_bright, width: {right - cx, 0}.max)
+
+      # POLARITY, in its own colour, before the meaning. A negated candidate used to render
+      # byte-identically to its positive twin apart from one leading `-`: `-host:` said
+      # "server host — substring", the same sentence `host:` said, so the row explaining the
+      # field never mentioned the half the operator had just chosen. On a VALUE list
+      # (`-method:GET  -method:POST …`) it matters more, not less — the eye is on the values and
+      # the dash is four characters behind them.
+      if negated?(head)
+        cx = screen.text(cx, y, "  excludes", Theme.focus_gold, width: {right - cx, 0}.max)
+      end
+
+      # The meaning, but only while completing a FIELD NAME. On a value list the candidates
+      # already are the explanation, and spending the row on "exact method — GET POST PUT …"
+      # would push the values themselves off a narrow bar.
+      if why = describe_for(head, help)
+        cx = screen.text(cx, y, "  #{why}", Theme.muted, width: {right - cx, 0}.max)
+      end
+
+      rest = suggestions[1, MAX_SHOWN - 1]? || [] of String
+      return if cx >= right
+      # The also-rans, then the affordance for the roomier view. `↓ list` is the only place the
+      # dropdown announces itself — it is opt-in, so nothing else would ever mention it — and it
+      # goes LAST because it is the least urgent thing on the row and the first that should be
+      # truncated away on a narrow bar.
+      tail = rest.empty? ? "" : "   #{rest.join("  ")}"
+      screen.text(cx, y, "#{tail}   ↓ list", Theme.muted, width: {right - cx, 0}.max)
+    end
+
+    # `render` as one flat string, for a caller that paints a single band rather than a bar row
+    # (the colour-rule overlay fills its own background first). Loses the bright/muted split — so
+    # "what Tab takes" is carried by position alone — but keeps the description, which is the part
+    # a modal with no room for a second row most needs.
+    def self.line(suggestions : Array(String),
+                  help : Proc(String, String?) = QL_HELP) : String
+      return "" if suggestions.empty?
+      head = suggestions.first
+      why = describe_for(head, help)
+      rest = suggestions[1, MAX_SHOWN - 1]? || [] of String
+      String.build do |io|
+        io << "↹ " << head
+        io << "  ·  excludes" if negated?(head)
+        io << "  ·  " << why if why
+        io << "   " << rest.join("  ") unless rest.empty?
+      end
+    end
+
+    # Is this candidate an EXCLUSION? Reads the grammar's own rule rather than "starts with a
+    # dash": `FilterAst` negates on a leading unquoted `-` that has something after it, and a
+    # candidate may carry an opening paren in front of it (`(-host:`).
+    def self.negated?(candidate : String) : Bool
+      core = candidate.lstrip('(')
+      core.starts_with?('-') && core.size > 1
+    end
+
+    # The one-line meaning of a candidate, or nil when it speaks for itself. A field NAME gets the
+    # BACKEND's explanation; an operator gets ours (a backend has no opinion about `OR` — it is
+    # `FilterAst`'s, shared by every surface); a VALUE gets none, because the candidate list beside
+    # it already is the explanation. Read by the inline row (for the one candidate Tab would take)
+    # and by the dropdown (for every row, which is the reason a row each is worth the occlusion).
+    def self.describe_for(candidate : String, help : Proc(String, String?)) : String?
+      return OPERATORS[candidate]? if OPERATORS.has_key?(candidate)
+      candidate.ends_with?(':') ? help.call(field_of(candidate)) : nil
+    end
+
+    # The field name inside a candidate, with the grammar's punctuation peeled off — `(-resp.body:`
+    # is the field `resp.body`. Mirrors what `FilterAst::Cursor#prefix` carries, so a candidate
+    # produced under a negation or inside a group still finds its help entry.
+    def self.field_of(candidate : String) : String
+      core = candidate.lstrip('(').lstrip('-')
+      sep = core.index(':') || core.index('~')
+      sep ? core[0...sep] : core
+    end
+
+    # The row shown while EDITING with nothing to complete yet — a cold start, or the caret just
+    # after a space. Fields lead (they are the vocabulary, and two specs assert a bar names them),
+    # but `-term excludes` sits immediately after them rather than at the end: the operators are
+    # the half a completion pool can NEVER reveal — you discover `host:` by typing `h` and pressing
+    # Tab, and you discover `-` only by being told — so they must survive an 80-column truncation.
+    # That is what caps `fields` at a handful; see `QL::HINT_FIELDS`.
+    #
+    # `width`, when given, is the caller's real column budget and the sample SHRINKS to fit it —
+    # dropping field chips one at a time until `-term excludes` lands inside the row. Without it
+    # the operators are simply first-after-the-fields and the terminal truncates whatever spills,
+    # which is right for a full-width bar and wrong for a 68-column modal band (the colour-rule
+    # form), where a fixed six-chip sample pushed the negation off the end entirely — on the one
+    # surface where the mistake it prevents becomes a standing rule rather than a re-typed query.
+    # `note` is a backend-specific clause no generator over a field list could produce (Intercept's
+    # `proto:ws` opt-in). It goes INSIDE `compose` rather than being appended by the caller: an
+    # appended note lands past the operator tail, which is already ~120 columns, so it was
+    # permanently truncated on every real terminal — and the shrink below can only protect what it
+    # composes itself.
+    def self.cold_hint(fields : Array(String) = QL::HINT_FIELDS, width : Int32? = nil,
+                       note : String? = nil) : String
+      n = {fields.size, HINT_MAX}.min
+      loop do
+        line = compose(fields.first(n), note)
+        return line if width.nil? || n == 0 || fits?(line, width)
+        n -= 1
+      end
+    end
+
+    # `>= <` earns its place beside the operators: the old hand-written hints carried example
+    # VALUES (`status:>=500`, `dur:>500`, `size:>10000`) as syntax cues, and generating from a
+    # field-name pool dropped every one of them. Completion cannot teach comparison either — Tab
+    # offers names until a `:` is typed — so without this nothing on the bar shows that `status:`
+    # takes an operator at all.
+    private def self.compose(fields : Array(String), note : String? = nil) : String
+      chips = fields.empty? ? "" : "fields: #{sample(fields)}  ·  "
+      tail = note ? "#{note}  ·  " : ""
+      "#{chips}-term excludes  ·  #{tail}OR NOT ( ) group  ·  ~regex  ·  >= < on status size dur"
+    end
+
+    # Does the operator that matters survive this width? Not "does the whole line fit" — the tail
+    # is meant to be truncated. `-term excludes` is the one piece a completion pool can never
+    # teach, so it is the one the shrink loop protects.
+    private def self.fits?(line : String, width : Int32) : Bool
+      idx = line.index("-term excludes")
+      !idx.nil? && idx + "-term excludes".size <= width
+    end
+
+    # The row shown on the IDLE bar, before the filter is even open. Shorter than `cold_hint` —
+    # it shares the line with the row count — and still names the negation, which is the one piece
+    # of the grammar an operator reported not being able to find.
+    def self.idle_hint(prefix : String, fields : Array(String) = QL::HINT_FIELDS) : String
+      "#{prefix}  ·  #{sample(fields)}  ·  -term excludes  ·  AND OR NOT ( )"
+    end
+
+    # `fields` as `name:` chips. Capped rather than trusted: a caller may hand over its whole pool
+    # (the colour-rule overlay's is eighteen names long), and an uncapped sample would push the
+    # operator tail past the right edge of every bar in the app.
+    HINT_MAX = 6
+
+    private def self.sample(fields : Array(String)) : String
+      fields.first(HINT_MAX).map { |f| "#{f}:" }.join("  ")
+    end
+  end
+end

--- a/src/gori/tui/sitemap_view.cr
+++ b/src/gori/tui/sitemap_view.cr
@@ -1,6 +1,8 @@
 require "./screen"
 require "./theme"
 require "./frame"
+require "./query_suggest"
+require "./suggest_popup"
 require "./traffic_empty_state"
 require "../settings"
 require "../store"
@@ -37,13 +39,27 @@ module Gori::Tui
     # every term here still COMPILES through QL, this list only decides what Tab offers.
     # Anything added to `QL::FIELDS` is therefore usable here the moment it exists; it just
     # is not suggested until someone decides it reads well against a tree.
-    QL_FIELDS = %w[host path method status scheme proto body header size dur tag]
-    # Discoverability hints for the filter, kept loosely in sync with QL_FIELDS.
-    # FILTER_HINT sits on the idle bar (press `/` to start); QUERY_HINT sits on the
-    # suggestion row at a cold start (already editing, nothing to Tab-complete yet) and
-    # spells out that bare words are a free-text search. Example values double as cues.
-    FILTER_HINT = "/ filter  ·  host:  method:  path:  status:>=500  proto:ws  size:>10000  dur:>500  header:  body~regex  tag:"
-    QUERY_HINT  = "fields:  host:  method:  path:  status:  proto:  scheme:  size:  dur:  header:  body:  tag:    ·    AND OR NOT ( ) combine  ·  or type words to search"
+    # `resp.body`/`resp.header` are offered and their request twins are not, which is the same
+    # curation rule the paragraph above states rather than an omission: a tree node groups the
+    # exchanges under one path, and "did the server ever send this here" is a question about that
+    # group, where the request side is a property of one call within it. Both still compile.
+    QL_FIELDS = %w[host path method status scheme proto body header resp.body resp.header size dur tag]
+    # Discoverability hints for the filter. GENERATED from the pool and the grammar's operator
+    # list (`QuerySuggest`) rather than written out — as prose these drifted from `QL_FIELDS` and
+    # never mentioned `-term` at all. `tag:` is appended because it is this surface's own field
+    # and the shared sample cannot know about it.
+    FILTER_HINT = QuerySuggest.idle_hint("/ filter", ["tag"] + QL::HINT_FIELDS)
+    QUERY_HINT  = QuerySuggest.cold_hint(["tag"] + QL::HINT_FIELDS)
+    # The highlighter's field vocabulary: everything QL ACCEPTS (a superset of `QL_FIELDS`, which
+    # is only what Tab offers here) plus this surface's own `tag:`, which QL knows nothing about
+    # because `partition` pulls it out before the query ever reaches the parser.
+    QL_KNOWN = ->(f : String) { f == "tag" || QL.known_field?(f) }
+    # The editing bar's label — a constant because `render_query_popup` lines the dropdown up
+    # under the token, which means knowing how far the query text is indented.
+    QUERY_PREFIX = "filter › "
+    # QL's help plus this surface's own field, which the shared table cannot know about because
+    # `tag:` never reaches the parser (`FilterAst.partition` pulls it out first).
+    QL_HELP = ->(f : String) { f == "tag" ? "path memo on this node — set with space → T" : QL.field_help(f) }
 
     # Right-aligned column widths: path memo sits left of the method/aside cluster.
     TAG_COL_W     = 16
@@ -71,6 +87,8 @@ module Gori::Tui
       @qcx = 0                      # caret position within @query
       @preedit = ""                 # IME composition, drawn at the caret
       @query_note = nil.as(String?) # why an active filter is empty when its QL residual is INVALID
+      # The `↓` completion dropdown. Closed until asked for — see `SuggestPopup`.
+      @popup = SuggestPopup.new
       # Numeric-sequence folding (Feature: path-param explosion). On by default; `g`
       # toggles it for the rare case of wanting every literal id.
       @grouping = true
@@ -434,6 +452,7 @@ module Gori::Tui
 
     def stop_query : Nil # Enter: keep the filter, leave edit mode
       @querying = false
+      @popup.close
     end
 
     def cancel_query : Nil # Esc: clear the filter, leave edit mode
@@ -441,34 +460,69 @@ module Gori::Tui
       @query = ""
       @qcx = 0
       @preedit = ""
+      @popup.close
     end
 
     def query_insert(ch : Char) : Nil
       @query = "#{@query[0, @qcx]}#{ch}#{@query[@qcx..]}"
       @qcx += 1
+      sync_popup
     end
 
     def query_backspace : Nil
       return if @qcx == 0
       @query = "#{@query[0, @qcx - 1]}#{@query[@qcx..]}"
       @qcx -= 1
+      sync_popup
     end
 
     def query_move(d : Int32) : Nil
       @qcx = (@qcx + d).clamp(0, @query.size)
+      sync_popup
+    end
+
+    # --- the opt-in completion dropdown (`\u2193`) ---------------------------------
+    # Same component and same contract as History's; see `SuggestPopup` for why it is opt-in.
+
+    def popup_open? : Bool
+      @popup.open?
+    end
+
+    # `↓`: open the dropdown, or move down inside it. Nil rather than Bool — the key is claimed
+    # either way, and an earlier Bool "so the key falls through" was a contract no controller
+    # honoured, which is worse than not offering one.
+    def popup_down : Nil
+      return @popup.move(1) if @popup.open?
+      @popup.set(query_suggestions)
+      @popup.open!
+    end
+
+    def popup_up : Nil
+      @popup.move(-1)
+    end
+
+    def popup_close : Nil
+      @popup.close
+    end
+
+    private def sync_popup : Nil
+      @popup.set(query_suggestions) if @popup.open?
     end
 
     def set_preedit(text : String) : Nil
       @preedit = text
     end
 
-    # Tab-complete the current token to the first field-name suggestion.
-    def query_complete : Bool
+    # Complete the current token to the SELECTED candidate (dropdown open) or the first (closed).
+    # `close` is ↵'s — see HistoryView#query_complete for why ↵ must shut the popup.
+    def query_complete(close : Bool = false) : Bool
       sugg = query_suggestions
-      return false if sugg.empty?
+      pick = @popup.choice(sugg)
+      return false unless pick
       s, e = current_token_bounds
-      @query = "#{@query[0, s]}#{sugg.first}#{@query[e..]}"
-      @qcx = s + sugg.first.size
+      @query = "#{@query[0, s]}#{pick}#{@query[e..]}"
+      @qcx = s + pick.size
+      close ? @popup.close : (@popup.set(query_suggestions) if @popup.open?)
       true
     end
 
@@ -476,8 +530,13 @@ module Gori::Tui
     # — the tree's useful axes are host/path/method, which are open-ended).
     def query_suggestions : Array(String)
       token = current_token
-      return [] of String if token.empty? || token.includes?(':')
-      QL_FIELDS.select(&.starts_with?(token.downcase)).map { |f| "#{f}:" }
+      return [] of String if token.empty?
+      fields = token.includes?(':') ? [] of String : QL_FIELDS.select(&.starts_with?(token.downcase)).map { |f| "#{f}:" }
+      # `token_at` rather than the raw token: an operator candidate splices over the whole span,
+      # so it has to carry any `(` the way the field candidates above would need to. (This bar's
+      # own tokenizer does not peel punctuation — see `current_token_bounds` — which is a separate
+      # gap; going through the shared cursor here at least keeps the operators honest.)
+      QuerySuggest.with_operators(fields, FilterAst.token_at(@query, @qcx))
     end
 
     private def current_token : String
@@ -816,9 +875,33 @@ module Gori::Tui
       end
     end
 
+    # The tree, then the `↓` dropdown OVER it. Split so the popup is drawn last unconditionally:
+    # the body below returns early on several paths (no endpoints, the empty-state card), and a
+    # dropdown that vanished exactly when the filter matched nothing would be missing from the
+    # one moment an operator is most likely to be fixing a query. Mirrors HistoryView.
     def render(screen : Screen, rect : Rect, focused : Bool = true, *,
                listen : {String, Int32}? = nil, capturing : Bool = true) : Nil
       return if rect.empty?
+      render_tree_body(screen, rect, focused, listen: listen, capturing: capturing)
+      render_query_popup(screen, rect)
+    end
+
+    # Anchored below the column header's divider — never over it — and bounded by the tree,
+    # which is the only region it may occlude.
+    private def render_query_popup(screen : Screen, rect : Rect) : Nil
+      return unless @querying && @popup.open?
+      top = list_top(rect)
+      bounds = Rect.new(rect.x + 1, top, {rect.w - 2, 0}.max, {rect.bottom - top, 0}.max)
+      # Anchored at the START of the query text, not at the token's offset within it.
+      # `Screen#input_line` scrolls its window horizontally once the query outgrows the bar, so
+      # `base + token.start` stops being the token's screen column on exactly the long queries
+      # where precision would matter — the card would drift right of what it completes and then
+      # clamp. A fixed anchor is always adjacent to the bar and never lies.
+      @popup.render(screen, rect.x + 1 + QUERY_PREFIX.size, top - 1, bounds, QL_HELP)
+    end
+
+    private def render_tree_body(screen : Screen, rect : Rect, focused : Bool = true, *,
+                                 listen : {String, Int32}? = nil, capturing : Bool = true) : Nil
       render_ql_bar(screen, rect)
       hdr_y = rect.y + 1
       if @querying
@@ -1092,11 +1175,11 @@ module Gori::Tui
 
     private def render_ql_bar(screen : Screen, rect : Rect) : Nil
       if @querying
-        prefix = "filter › "
-        screen.text(rect.x + 1, rect.y, prefix, Theme.accent)
-        base = rect.x + 1 + prefix.size
-        screen.input_line(base, rect.y, @query, @qcx, @preedit, Theme.text_bright, width: rect.w - prefix.size - 2,
-          colors: Highlight.filter_query(@query, Theme.text_bright))
+        screen.text(rect.x + 1, rect.y, QUERY_PREFIX, Theme.accent)
+        base = rect.x + 1 + QUERY_PREFIX.size
+        screen.input_line(base, rect.y, @query, @qcx, @preedit, Theme.text_bright,
+          width: rect.w - QUERY_PREFIX.size - 2,
+          colors: Highlight.filter_query(@query, Theme.text_bright, known: QL_KNOWN))
         return
       end
 
@@ -1120,7 +1203,7 @@ module Gori::Tui
         # The committed query stays highlighted — this readout is what you scan to
         # check how the active filter is actually being read.
         qx = screen.text(rect.x + 1, rect.y, ": ", Theme.muted, width: left_w)
-        screen.styled_text(qx, rect.y, @query, Highlight.filter_query(@query, Theme.text),
+        screen.styled_text(qx, rect.y, @query, Highlight.filter_query(@query, Theme.text, known: QL_KNOWN),
           Theme.text, width: {rect.x + 1 + left_w - qx, 0}.max)
       else
         # No QL query typed — whether or not a Scope lens is active. Surface the filter
@@ -1157,14 +1240,14 @@ module Gori::Tui
     private def render_suggestions(screen : Screen, rect : Rect, y : Int32) : Nil
       sugg = query_suggestions
       unless sugg.empty?
-        screen.text(rect.x + 1, y, "↹ #{sugg.first(8).join("  ")}", Theme.muted, width: rect.w - 2)
+        QuerySuggest.render(screen, rect.x + 1, y, rect.w - 2, sugg)
         return
       end
       # No live completions to Tab through. At a cold start (nothing typed yet, or the
       # cursor sits just after a space) show a standing hint so the query language is
       # discoverable from the moment `/` opens; on a non-empty token with no match stay
       # quiet — the user is deliberately free-texting a word.
-      return unless current_token.empty?
+      return unless QuerySuggest.hint_slot?(current_token)
       screen.text(rect.x + 1, y, QUERY_HINT, Theme.muted, width: rect.w - 2)
     end
 

--- a/src/gori/tui/suggest_popup.cr
+++ b/src/gori/tui/suggest_popup.cr
@@ -1,0 +1,159 @@
+require "./screen"
+require "./theme"
+require "./query_suggest"
+
+module Gori::Tui
+  # The filter bars' opt-in completion dropdown: the same candidates the inline row already
+  # shows, given a row each so every one of them can carry its meaning, and a selection so Tab
+  # takes the one you want instead of always the first.
+  #
+  # OPT-IN is the whole design. A dropdown is not cheaper than the inline row — it is dearer:
+  # the row costs exactly one line of the list (`list_top` adds it only while querying), where a
+  # dropdown covers up to `MAX_ROWS` of the rows you are trying to read. On an 80x12 terminal the
+  # History list body is one row, and neither shape has anywhere to go. So the inline row stays
+  # the default and this opens on `↓` — a key every filter bar's controller left dead. The
+  # occlusion is then something the operator asked for, and it arrives together with the
+  # selection that makes it worth asking for.
+  #
+  # Modelled on `EnvComplete`, deliberately not shared with it: that one anchors to a caret that
+  # can be anywhere in a two-dimensional editor and has no notion of a description column, where
+  # this one hangs off a known bar row and its second column is the point.
+  class SuggestPopup
+    MAX_ROWS =  8
+    MIN_W    = 20
+    # The polarity marker, as ONE constant read by both the drawer and the width calculator.
+    EXCLUDES = " excludes"
+
+    getter? open : Bool = false
+    getter selected : Int32 = 0
+
+    @items = [] of String
+    @scroll = 0
+
+    # Replace the candidate set. Keeps the popup's OPEN state (the operator opened it; a
+    # keystroke that narrows the list should not shut it) but closes when nothing is left,
+    # since an empty dropdown is a hole punched in the list for no content. The selection
+    # re-anchors to the same candidate when it survived the edit, so typing another character
+    # does not silently move what Tab would take.
+    def set(items : Array(String)) : Nil
+      keep = @items[@selected]?
+      @items = items
+      if items.empty?
+        @open = false
+        @selected = 0
+      else
+        @selected = (keep ? items.index(keep) : nil) || 0
+      end
+      @scroll = @scroll.clamp(0, {items.size - 1, 0}.max)
+    end
+
+    # `↓` on a closed bar. Opens only when there is something to show — otherwise the key falls
+    # through to whatever the surface does with it.
+    def open! : Bool
+      return false if @items.empty?
+      @open = true
+    end
+
+    def close : Nil
+      @open = false
+    end
+
+    # `&&`, not `||`: an empty list must return BEFORE the clamp, whose max would be -1 and which
+    # raises on min > max rather than saturating. Unreachable through the current callers (`set`
+    # closes on empty and `open!` refuses it), which is exactly why it would have been a crash
+    # nobody found until a fourth caller appeared.
+    def move(d : Int32) : Nil
+      return unless @open && !@items.empty?
+      @selected = (@selected + d).clamp(0, @items.size - 1)
+    end
+
+    # What Tab should splice: the SELECTED candidate while open, else the first — so a bar whose
+    # popup was never opened behaves exactly as it did before this existed.
+    def choice(fallback : Array(String)) : String?
+      return @items[@selected]? if @open
+      fallback.first?
+    end
+
+    # Draw anchored under (ax, ay), clamped inside `bounds` — the list area the popup is allowed
+    # to cover.
+    #
+    # CLOSES ITSELF rather than silently declining when there is no room. `open?` gates Esc and
+    # ↵ in three controllers, so an open-but-undrawable popup hijacks both: Esc stops clearing the
+    # filter and ↵ stops applying it, with nothing on screen to explain why. A pane narrower than
+    # `MIN_W`, or one where `list_top` has reached the bottom, is exactly that state — and it is
+    # reachable by resizing the terminal while the list is open. Shutting on the frame that cannot
+    # draw costs one wasted keypress at worst and self-heals.
+    def render(screen : Screen, ax : Int32, ay : Int32, bounds : Rect,
+               help : Proc(String, String?) = QuerySuggest::QL_HELP) : Nil
+      return unless @open
+      return @open = false if @items.empty? || bounds.w < MIN_W || bounds.h < 1
+      down, h = placement(ay, bounds)
+      return @open = false if h <= 0
+      # `desc_col` scans every candidate; computed ONCE here rather than per row, which is what
+      # `draw_row` calling it did — up to nine full scans of the list per frame.
+      col = desc_col
+      w = box_width(bounds, help, col)
+      sync_scroll(h)
+      x = ax.clamp(bounds.x, {bounds.right - w, bounds.x}.max)
+      y0 = down ? ay + 1 : ay - h
+      h.times { |i| draw_row(screen, x, y0 + i, w, @scroll + i, help, col) }
+    end
+
+    # Which way to grow, and how far. The flip-above branch does NOT fire for any current caller:
+    # all three filter bars sit at the TOP of their pane and pass `bounds.y == ay + 1`, so `above`
+    # is always -1 and the card always opens downward. It is kept because it is the only correct
+    # answer for a caller that anchors lower, and because getting `h` right is what makes a short
+    # pane close the popup (above) instead of painting outside its bounds.
+    private def placement(ay : Int32, bounds : Rect) : {Bool, Int32}
+      below = bounds.bottom - (ay + 1)
+      above = ay - bounds.y
+      down = below >= above
+      {down, {@items.size, MAX_ROWS, {down ? below : above, 0}.max}.min}
+    end
+
+    # Wide enough for the widest ROW, floored so a one-word list still reads as a card and
+    # clamped to what the pane can give. Measured by summing the same pieces `draw_row` paints,
+    # in the same order: a width calculator that forgets one of them silently truncates the
+    # piece that happens to be last — which is how the polarity marker cost every negated
+    # candidate the tail of its description.
+    private def box_width(bounds : Rect, help : Proc(String, String?), col : Int32) : Int32
+      desc_w = @items.max_of { |c| QuerySuggest.describe_for(c, help).try(&.size) || 0 }
+      ({1 + col + 1 + desc_w + 1, MIN_W}.max).clamp(1, bounds.w)
+    end
+
+    # Where the description column starts, relative to the candidate's own left edge. ONE column
+    # for every row rather than wherever each candidate happens to end: a ragged second column in
+    # a card this small reads as noise, and the whole reason the dropdown is worth its occlusion
+    # is that the meanings are scannable.
+    private def desc_col : Int32
+      @items.max_of { |c| c.size + (QuerySuggest.negated?(c) ? EXCLUDES.size : 0) }
+    end
+
+    private def sync_scroll(h : Int32) : Nil
+      @scroll = @selected if @selected < @scroll
+      @scroll = @selected - h + 1 if @selected >= @scroll + h
+      @scroll = @scroll.clamp(0, {@items.size - h, 0}.max)
+    end
+
+    # One row: selection bar, the candidate, then its meaning. A NEGATED candidate says so, in
+    # the same colour the inline row uses — the popup is a second view of one model, not a
+    # second opinion about it.
+    private def draw_row(screen : Screen, x : Int32, y : Int32, w : Int32, idx : Int32,
+                         help : Proc(String, String?), col : Int32) : Nil
+      cand = @items[idx]? || return
+      active = idx == @selected
+      bg = active ? Theme.accent_bg : Theme.elevated
+      screen.fill(Rect.new(x, y, w, 1), bg)
+      screen.cell(x, y, active ? '▎' : ' ', Theme.accent, bg)
+      cx = screen.text(x + 1, y, cand, active ? Theme.text_bright : Theme.text, bg,
+        width: {w - 1, 1}.max)
+      # No `cx =`: the description below is placed at the SHARED column, not after this marker,
+      # so the returned x is genuinely unused.
+      screen.text(cx, y, EXCLUDES, Theme.focus_gold, bg, width: {x + w - cx, 0}.max) if QuerySuggest.negated?(cand)
+      return unless why = QuerySuggest.describe_for(cand, help)
+      # Aligned to the shared column, never to where THIS candidate ended.
+      dx = x + 1 + col + 1
+      screen.text(dx, y, why, Theme.muted, bg, width: {x + w - dx, 0}.max) if dx < x + w
+    end
+  end
+end


### PR DESCRIPTION
## The gap

`header:` and `body:` searched the request **and** the response with no way to say which. `size` was the only field with a side split, and it got one by growing two hand-written twins (`reqsize`/`respsize`) rather than a rule.

## The rule

```
req.body:token   resp.header:set-cookie   -resp.body:abcd   resp.body~secret\d+
```

Spelled **inside** the existing `field:value` token, so `FilterAst` needs no change at all — `split_field` cuts at the first `:`/`~`, so `resp.body` arrives as an ordinary field name and the lexer, parser, highlighting and Tab-completion keep working. `-resp.body:x` negates and `NOT (req.body:a OR resp.body:b)` groups exactly as before.

The fast path is an FTS5 **column filter** over `flows_fts(req, resp)` — a table that already stored the two sides apart — so this costs no new index. `res.` and `req.size`/`resp.size` are accepted but not offered: the coin-flip between spellings fails silently.

Considered and rejected: a Caido-style `resp.body.cont:"x"` grammar. Same expressiveness, but it costs a new operator vocabulary, the loss of boolean `NOT` (HTTPQL has none — negation is baked into `ncont`/`ne`), and a migration of every rule string already in `colormarker_rules.match_filter`.

**Advertising a namespace invites guesses at the rest of it**, so a side prefix on a field that has no side (`resp.status:`) is now **dropped and reported** rather than free-texted to zero rows with `analyze` calling the query clean.

## The surface that teaches it

Every one-line hint was prose copied per widget, and the three copies disagreed about which operators exist — History's named `AND OR NOT` and never `-`, Sitemap's and Issues' named neither. They are generated now, from tables beside the parser (`QL::FIELD_HELP` / `SYNTAX_HELP` / `CAVEATS`).

The completion row shows which candidate Tab takes, what it means, and whether it **excludes**:

```
↹ -resp.body:  excludes  response body only   -resp.header:   ↓ list
```

- `NOT` and `OR` are completable for the first time. `-` cannot negate a group, so `NOT ( … )` was the only way to exclude a disjunction and had zero discovery.
- A bare `-` keeps the standing hint instead of blanking the row at the exact keystroke that commits to an exclusion.
- `↓` opens a dropdown with a row per candidate and a selection. **Opt-in**, because it is dearer than the inline row, not cheaper: the row costs one line of the list, a dropdown occludes eight, and at 80x12 the History body is already one row. Measured, not assumed.

## Help ▸ Query

A third sub-tab built from the same tables: syntax, every field with its meaning, the accepted-but-not-offered spellings, and the ways a query can look clean without having looked — compressed bodies are invisible to **both** `body:` and `body~`, since gori stores the wire form.

## Highlighting

The highlighter called any `word:` a field, so `hsot:acme` rendered in the same confident blue as `host:acme` while the backend free-texted it. `FilterAst.spans` takes a `known` predicate now, beside `seps` and for the same reason one level down.

History, Sitemap, Intercept and the colour-rule form all get this. The hold gate keeps its **own** help — `body:` there is the payload in hand, not the index — and the colour-rule form keeps its own too, since a rule scans 64 KiB of captured bytes rather than reading the 8 KiB index.

## Verification

- **8371 examples, 0 new failures.** The 8 remaining are the known `Gori::Session` port-bind failures; `spec/tui/clipboard_spec.cr`'s 2 errors are pre-existing and reproduce on a clean tree.
- New specs for the side scoping, the drop guard, exclusion guidance, the dropdown, and the `known` predicate — **each revert-checked** (reverting the fix makes them fail).
- `crystal tool format --check` clean; **ameba at exact parity** with the clean-tree baseline (30/30 on the changed files, 0 on the two new ones).
- Driven headlessly in tmux on all four surfaces: hints, completion, polarity, the dropdown's open/move/accept/esc, the three Help sub-tabs, and the unknown-field colours read off the raw SGR output.

Docs updated in `query-language.md` and `.ko.md`.