### PR TITLE
Build a custom rule's "whole" region once per flow, not once per rule

### DIFF
--- a/bench/probe_custom_rule_bench.cr
+++ b/bench/probe_custom_rule_bench.cr
@@ -1,0 +1,100 @@
+# Probe custom-rule benchmark: what an operator's rule LIBRARY costs per flow.
+#
+# The "whole" region (head + body) was concatenated inside `CustomRule#region_text`, so N
+# whole-region rules built N copies of the same head + up-to-64 KiB body for ONE page — on the
+# fiber the passive scan shares with the proxy. It is now one memoized getter on `Context`, like
+# every other region. This A/Bs the two shapes directly; the wall clock is secondary to the bytes,
+# which is the metric AGENTS.md says actually holds up.
+#
+# ALSO MEASURED AND REJECTED, recorded here so it is not re-proposed: precompiling a regex rule's
+# pattern at rule-LOAD time instead of calling `SafeRegexp.compile` per check. The premise is
+# real — that cache is shared with the SQL `REGEXP` callback and clears WHOLESALE at CACHE_MAX,
+# so QL filter-box keystrokes really do evict operator patterns — but with the cache being
+# actively evicted it measured 0.98-1.16x across 2 / 16 / 112 KiB bodies. Matching a body costs
+# an order of magnitude more than a PCRE2 compile, so there was nothing to win.
+#
+# Build: crystal build bench/probe_custom_rule_bench.cr -o bin/probe_custom_rule_bench --release
+# Run:   BENCH_BODY_KB=112 bin/probe_custom_rule_bench
+require "benchmark"
+require "../src/gori"
+
+include Gori
+
+RULES   = (ENV["BENCH_RULES"]? || "10").to_i
+ITERS   = (ENV["BENCH_ITERS"]? || "300").to_i
+BODY_KB = (ENV["BENCH_BODY_KB"]? || "112").to_i
+
+BODY = String.build do |io|
+  io << "<!doctype html><html><body>"
+  line = "<p>line of an ordinary page with some prose in it</p>"
+  ((BODY_KB * 1024) // line.bytesize).times { io << line }
+  io << "</body></html>"
+end
+
+RESP_HEAD = "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nServer: nginx\r\n\r\n"
+
+def with_store(&)
+  path = File.tempname("gori-customrule-bench", ".db")
+  store = Store.open(path)
+  begin
+    yield store
+  ensure
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+def detail(store) : Store::FlowDetail
+  req = Store::CapturedRequest.new(
+    created_at: 1_000_i64, scheme: "https", host: "acme.test", port: 443,
+    method: "GET", target: "/", http_version: "HTTP/1.1",
+    head: "GET / HTTP/1.1\r\nHost: acme.test\r\n\r\n".to_slice, body: nil)
+  id = store.insert_flow(req)
+  store.update_response(Store::CapturedResponse.new(
+    flow_id: id, status: 200, head: RESP_HEAD.to_slice, body: BODY.to_slice,
+    reason: "OK", content_type: "text/html", duration_us: 1_i64))
+  store.get_flow(id) || raise "bench setup: the flow just inserted did not read back"
+end
+
+# `memoized` reads Context's getter (built once per flow); the other arm rebuilds the
+# concatenation for every rule, which is what `CustomRule#join` did.
+def run_whole(store, n : Int32, memoized : Bool) : Float64
+  d = detail(store)
+  Benchmark.measure do
+    ITERS.times do
+      ctx = Probe::Passive::Context.new(d)
+      n.times do
+        text = if memoized
+                 ctx.response_whole_text
+               else
+                 h, b = ctx.response_head_text, ctx.body_text
+                 h.nil? ? b : (b.nil? ? h : "#{h}\r\n#{b}")
+               end
+        text.try(&.includes?("n0t_h3re"))
+      end
+    end
+  end.real
+end
+
+def alloc_whole(store, n : Int32, memoized : Bool) : Int64
+  before = GC.stats.total_bytes
+  run_whole(store, n, memoized)
+  (GC.stats.total_bytes - before).to_i64
+end
+
+def mb(bytes : Int64) : String
+  "#{(bytes / 1024.0 / 1024.0).round(1)} MB"
+end
+
+puts "custom rules: #{RULES} whole-region rules x #{ITERS} flows, #{BODY.bytesize // 1024} KiB body"
+puts
+
+with_store do |store|
+  per_rule = run_whole(store, RULES, false)
+  memoized = run_whole(store, RULES, true)
+  puts "  rebuilt per rule    #{(per_rule * 1000).round(1)} ms   #{mb(alloc_whole(store, RULES, false))} allocated"
+  puts "  memoized on Context #{(memoized * 1000).round(1)} ms   #{mb(alloc_whole(store, RULES, true))} allocated"
+  puts "  speedup             #{(per_rule / memoized).round(2)}x"
+end

--- a/spec/probe_custom_rule_spec.cr
+++ b/spec/probe_custom_rule_spec.cr
@@ -277,3 +277,28 @@ describe "Gori::Probe::CustomRule evidence" do
     end
   end
 end
+
+describe "Gori::Probe::Passive::Context whole-region memo" do
+  it "joins head and body with CRLF, byte-identically to the per-rule build it replaced" do
+    with_store do |store|
+      ctx = Gori::Probe::Passive::Context.new(
+        flow(store, resp_head: "HTTP/1.1 200 OK\r\nX-A: 1\r\n\r\n", body: "BODY"))
+      ctx.response_whole_text.should eq("#{ctx.response_head_text}\r\n#{ctx.body_text}")
+    end
+  end
+
+  it "hands every rule the SAME string rather than rebuilding it per rule" do
+    with_store do |store|
+      ctx = Gori::Probe::Passive::Context.new(flow(store, body: "BODY"))
+      ctx.response_whole_text.not_nil!.same?(ctx.response_whole_text.not_nil!).should be_true
+    end
+  end
+
+  it "falls back to whichever side exists when the other is absent" do
+    with_store do |store|
+      ctx = Gori::Probe::Passive::Context.new(flow(store, body: nil))
+      ctx.response_whole_text.should eq(ctx.response_head_text) # no body → head alone
+      ctx.request_whole_text.should eq(ctx.request_head_text)   # GET, no request body
+    end
+  end
+end

--- a/src/gori/probe/custom_rule.cr
+++ b/src/gori/probe/custom_rule.cr
@@ -73,21 +73,15 @@ module Gori
           case region
           when "header" then ctx.request_head_text
           when "body"   then ctx.request_body_text
-          else               join(ctx.request_head_text, ctx.request_body_text)
+          else               ctx.request_whole_text
           end
         else
           case region
           when "header" then ctx.response_head_text
           when "body"   then ctx.body_text
-          else               join(ctx.response_head_text, ctx.body_text)
+          else               ctx.response_whole_text
           end
         end
-      end
-
-      private def join(head : String?, body : String?) : String?
-        return body if head.nil?
-        return head if body.nil?
-        "#{head}\r\n#{body}"
       end
 
       # Byte-safe match returning {matched?, evidence}. Text is pre-scrubbed; a bad user regex
@@ -104,6 +98,12 @@ module Gori
       # `pattern`, which every surface already shows next to the rule, so the field would be
       # pure duplication.
       private def match_evidence(text : String) : {Bool, String?}
+        # `SafeRegexp.compile` is a cache lookup, and precompiling the pattern at rule-LOAD time
+        # was measured and REJECTED: 0.98-1.16x over 2/16/112 KiB bodies with the shared cache
+        # being actively evicted (bench/probe_custom_rule_bench.cr). The cache is shared with the
+        # SQL `REGEXP` callback and clears wholesale at CACHE_MAX, so filter-box keystrokes really
+        # do evict operator patterns — but a PCRE2 compile is an order of magnitude cheaper than
+        # matching a body, so removing it buys nothing worth a field on this record.
         if kind == "regex"
           m = SafeRegexp.compile(pattern).match(text)
           return {false, nil} unless m

--- a/src/gori/probe/passive/context.cr
+++ b/src/gori/probe/passive/context.cr
@@ -204,6 +204,10 @@ module Gori
         @req_body_text_done = false
         @resp_head_text : String?
         @resp_head_text_done = false
+        @req_whole_text : String?
+        @req_whole_text_done = false
+        @resp_whole_text : String?
+        @resp_whole_text_done = false
 
         # Raw request head (request line + headers) as scrubbed text.
         def request_head_text : String
@@ -230,6 +234,29 @@ module Gori
           return @resp_head_text if @resp_head_text_done
           @resp_head_text_done = true
           @resp_head_text = @detail.response_head.try { |h| String.new(h).scrub }
+        end
+
+        # The "whole" region — head and body joined — memoized like every other region getter.
+        # It was built inside CustomRule instead, which meant a fresh head+body concatenation PER
+        # RULE per flow: an operator with ten whole-region rules copied a 64 KiB body ten times
+        # for one page. Nothing here changes what a rule sees; the join is byte-identical.
+        # Memoized separately per side because most rules ask for only one of them.
+        def request_whole_text : String?
+          return @req_whole_text if @req_whole_text_done
+          @req_whole_text_done = true
+          @req_whole_text = join_region(request_head_text, request_body_text)
+        end
+
+        def response_whole_text : String?
+          return @resp_whole_text if @resp_whole_text_done
+          @resp_whole_text_done = true
+          @resp_whole_text = join_region(response_head_text, body_text)
+        end
+
+        private def join_region(head : String?, body : String?) : String?
+          return body if head.nil?
+          return head if body.nil?
+          "#{head}\r\n#{body}"
         end
       end
     end


### PR DESCRIPTION
`CustomRule#region_text` concatenated head + body **inside the rule**, so N whole-region rules built N copies of the same head and up-to-64 KiB body for one page — on the fiber the passive scan shares with the proxy. It is now a memoized getter on `Context`, like every other region, and the join is byte-identical.

### Measured

10 rules × 300 flows (`bench/probe_custom_rule_bench.cr`). The wall clock is the smaller half of the story:

| body | wall clock | allocated |
|---|---|---|
| 16 KiB | 103.5 → 72.7 ms (**1.42x**) | 52.1 → **9.7 MB** |
| 112 KiB | 331.7 → 286.6 ms (**1.16x**) | 206.8 → **37.9 MB** |

### Also measured, and rejected

Precompiling a regex rule's pattern at load time instead of calling `SafeRegexp.compile` per check.

The premise is real and I verified it: that cache **is** shared with the SQL `REGEXP` callback and evicts by clearing **wholesale** at `CACHE_MAX = 32`, so QL filter-box keystrokes genuinely do evict the operator's custom-rule patterns.

But with the cache being actively evicted it measured **0.98–1.16x** across 2 / 16 / 112 KiB bodies. Matching a body costs an order of magnitude more than a PCRE2 compile, so there was nothing to win — and it did not justify an extra field on the record. The measurement is recorded in `custom_rule.cr` next to the call it would have replaced, per the house convention (`body_leaks.cr:136`, `js_scan.cr:395`), so it is not re-proposed.

### Accuracy

No change to what any rule sees. Specs pin that the memoized join is byte-identical to the per-rule build it replaced, that every rule gets the *same* string (`same?`, which is what proves the memo), and that it still falls back to whichever side exists when the other is absent.

### Verification

- `crystal spec spec/probe_custom_rule_spec.cr spec/probe_spec.cr spec/probe/` → 486 examples, 0 failures
- `crystal tool format --check src bench spec` clean; `crystal build --no-codegen src/main.cr` clean
- `scripts/bench_check.sh` → all 45 harnesses build
- ameba on all four touched files: 0 findings

Independent of #671, #672, #673 — all branch off main.

https://claude.ai/code/session_01UiZppfkBza2AytWMHBh9ab