### PR TITLE
Scan binary WebSocket frames for credential shapes

### DIFF
--- a/spec/probe_spec.cr
+++ b/spec/probe_spec.cr
@@ -2530,9 +2530,56 @@ describe Gori::Probe, "WebSocket + Repeater sources" do
       hit = dets.find { |d| d.code == "secret_in_ws" }.not_nil!
       hit.evidence.should eq("AWS access key id")
       hit.evidence.not_nil!.should_not contain(secret)
-      # binary frames are ignored
-      bin = [Gori::Store::WsMessage.new(2_i64, detail.row.id, nil, 1_i64, "in", 2, secret.to_slice)]
-      Gori::Probe::Passive.analyze(detail, bin).map(&.code).should_not contain("secret_in_ws")
+    end
+  end
+
+  # Binary frames used to be skipped, and a spec asserted that without recording why. protobuf /
+  # msgpack / CBOR over WebSocket is the mainstream encoding for realtime APIs and a token rides
+  # in such a frame as an ordinary ASCII string field, so skipping them was a plain false negative
+  # on the transport this rule exists for. No deframing is involved: the patterns are ASCII vendor
+  # prefixes, and the projection maps every non-printable byte to a space.
+  it "flags a secret embedded in a BINARY WebSocket frame" do
+    with_store do |store|
+      head = "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n"
+      detail = capture_flow(store, head, target: "/ws", status: 101, content_type: nil,
+        req_headers: "Upgrade: websocket\r\nConnection: Upgrade\r\n")
+      secret = "AKIAIOSFODNN7EXAMPLE"
+      # A protobuf-ish frame: field tags and lengths around an ASCII string field.
+      payload = Bytes.new(secret.bytesize + 6)
+      payload[0] = 0x0a_u8; payload[1] = secret.bytesize.to_u8
+      secret.to_slice.copy_to(payload.to_unsafe + 2, secret.bytesize)
+      payload[secret.bytesize + 2] = 0x10_u8
+      payload[secret.bytesize + 3] = 0xff_u8 # invalid UTF-8, so the text path would have mangled it
+      payload[secret.bytesize + 4] = 0x00_u8
+      payload[secret.bytesize + 5] = 0x80_u8
+      bin = [Gori::Store::WsMessage.new(2_i64, detail.row.id, nil, 1_i64, "in", 2, payload)]
+      hit = Gori::Probe::Passive.analyze(detail, bin).find { |d| d.code == "secret_in_ws" }.not_nil!
+      hit.evidence.should eq("AWS access key id")
+      hit.evidence.not_nil!.should_not contain(secret)
+    end
+  end
+
+  it "does not scan control frames or gori's own advisory rows" do
+    with_store do |store|
+      head = "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n"
+      detail = capture_flow(store, head, target: "/ws", status: 101, content_type: nil,
+        req_headers: "Upgrade: websocket\r\nConnection: Upgrade\r\n")
+      secret = "AKIAIOSFODNN7EXAMPLE"
+      # opcode 8 = close: a control frame carries no application payload.
+      close = [Gori::Store::WsMessage.new(3_i64, detail.row.id, nil, 1_i64, "in", 8, secret.to_slice)]
+      Gori::Probe::Passive.analyze(detail, close).map(&.code).should_not contain("secret_in_ws")
+    end
+  end
+
+  it "finds nothing in a binary frame that carries no credential shape" do
+    with_store do |store|
+      head = "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n"
+      detail = capture_flow(store, head, target: "/ws", status: 101, content_type: nil,
+        req_headers: "Upgrade: websocket\r\nConnection: Upgrade\r\n")
+      noise = Bytes.new(4096) { |i| ((i * 37) % 256).to_u8 }
+      Gori::Probe::Passive.analyze(detail, [
+        Gori::Store::WsMessage.new(4_i64, detail.row.id, nil, 1_i64, "in", 2, noise),
+      ]).map(&.code).should_not contain("secret_in_ws")
     end
   end
 

--- a/src/gori/probe/passive/ws_payloads.cr
+++ b/src/gori/probe/passive/ws_payloads.cr
@@ -4,13 +4,21 @@ require "./secrets"
 module Gori
   module Probe
     module Passive
-      # WebSocket text-frame secrets (category "infoleak"). Scans captured post-101
-      # text messages (both directions) with the same high-confidence credential shapes
-      # as BodyLeaks — evidence is the TYPE label only, never the matched value.
+      # WebSocket payload secrets (category "infoleak"). Scans captured post-101 messages (both
+      # directions) with the same high-confidence credential shapes as BodyLeaks — evidence is the
+      # TYPE label only, never the matched value.
+      #
+      # BINARY frames are scanned too, which reverses an earlier decision (a spec asserted "binary
+      # frames are ignored" without recording why). protobuf / msgpack / CBOR over WebSocket is the
+      # mainstream encoding for realtime APIs, and a token rides in such a frame as an ordinary
+      # ASCII string field — so ignoring them was a straight false negative on the very transport
+      # this rule exists for. No deframing is needed and none is done: every shape in
+      # `Secrets::PATTERNS` is a literal ASCII vendor prefix plus a fixed-charset tail, which
+      # survives the projection below intact.
       class WsPayloads < Rule
         def info : RuleInfo
           RuleInfo.new("ws_payloads", "WebSocket payload secrets",
-            "Scans WebSocket text frames for exposed secrets.",
+            "Scans WebSocket text and binary frames for exposed secrets.",
             Category::INFOLEAK)
         end
 
@@ -21,8 +29,11 @@ module Gori
           seen = Set(String).new # distinct type labels per flow (avoid ×N from echo/repeater)
           jwt_seen = false
           ctx.ws_messages.each do |msg|
-            next unless msg.text?
-            text = payload_text(msg.payload)
+            # Control frames (ping/pong/close) carry no application payload, and a `notice?` row is
+            # gori's own "[gori] …" advisory — scanning either would be scanning ourselves. Every
+            # other opcode, text or binary, is application data.
+            next if msg.control? || msg.notice?
+            text = payload_text(msg.payload, msg.text?)
             next if text.nil? || text.empty?
             Secrets::PATTERNS.each do |(pat, label)|
               next if seen.includes?(label)
@@ -42,9 +53,30 @@ module Gori
           end
         end
 
-        private def payload_text(payload : Bytes) : String?
+        # Scannable text for one frame, capped at MSG_CAP.
+        #
+        # A TEXT frame is declared UTF-8, so `scrub` is the right repair and keeps the payload
+        # readable. A BINARY frame is not, and scrub is the wrong tool for it twice over: it
+        # EXPANDS each invalid byte to a 3-byte U+FFFD, so a 64 KiB frame would allocate ~192 KiB
+        # per message on the fiber the passive scan shares with the proxy, and it would do that
+        # for every frame of a chatty socket.
+        #
+        # The projection below is size-preserving, always valid UTF-8, and LOSSLESS for the shapes
+        # this rule matches: every pattern is pure ASCII, and mapping a non-ASCII byte to a space
+        # creates a `\b` boundary — which is correct, because no credential token spans one. Same
+        # shape as `CustomRule#safe_evidence`.
+        private def payload_text(payload : Bytes, text_frame : Bool) : String?
           return nil if payload.empty?
-          String.new(payload[0, {payload.size, MSG_CAP}.min]).scrub
+          bytes = payload[0, {payload.size, MSG_CAP}.min]
+          return String.new(bytes).scrub if text_frame
+          # Mapped over a byte slice rather than char-by-char into a String::Builder: the result is
+          # ASCII by construction, so `String.new` on it is valid UTF-8 without a second pass, and
+          # this skips one virtual IO dispatch per byte (a 64 KiB frame is 65_536 of them).
+          projected = Bytes.new(bytes.size) do |i|
+            b = bytes[i]
+            0x20_u8 <= b <= 0x7e_u8 ? b : 0x20_u8
+          end
+          String.new(projected)
         end
       end
     end


### PR DESCRIPTION
`WsPayloads` skipped every non-text frame, and a spec asserted *"binary frames are ignored"* without recording why. protobuf / msgpack / CBOR over WebSocket is the mainstream encoding for realtime APIs, and a token rides in such a frame as an ordinary ASCII string field — so the rule was blind on the transport it exists for.

Control frames and gori's own `[gori] …` advisory rows stay out; they carry no application payload. (The advisory exclusion is new too — the old text-only gate let those through.)

### No deframing, and none is needed

Every shape in `Secrets::PATTERNS` is a literal ASCII vendor prefix plus a fixed-charset tail (`AKIA`, `ghp_`, `sk_live_`, …), so it survives a printable-ASCII projection intact. The most permissive tail in the set still needs 34 specific bytes in a row.

Scope is held to `Secrets::PATTERNS` + `JWT` on purpose — `PRIVATE_IP` and `ERROR_SIGNATURES` are short and unanchored, and would false-positive on binary.

### Why not `scrub`

`scrub` **expands** each invalid byte to a 3-byte U+FFFD, so a 64 KiB binary frame would allocate ~192 KiB per message, on the fiber the passive scan shares with the proxy.

The projection maps `0x20..0x7e` through and everything else to a space. It is size-preserving, ASCII by construction, and **lossless for these patterns**: mapping a non-ASCII byte to a space creates a `\b` boundary, which is correct because no credential token spans one. Text frames keep `scrub`, which is the right repair for a declared-UTF-8 payload.

Mapping over a byte slice rather than char-by-char into a `String::Builder` skips one virtual IO dispatch per byte:

```
projection only, 200 frames:
   1 KiB   0.84 ms -> 0.26 ms
  16 KiB   7.51 ms -> 1.28 ms
  64 KiB  24.11 ms -> 1.55 ms
```

### Cost, stated plainly

End to end, 200 frames per flow: **1 KiB → 3.9 ms**, 16 KiB → 60 ms, 64 KiB → 215 ms. What dominates the ceiling is the 24 pattern matches, which is exactly the cost text frames already had — this change makes that ceiling *reachable* for binary sockets, it does not raise it. Reducing the 24-pattern cost is a separate, measurement-gated item.

### Verification

- `crystal spec spec/probe_spec.cr spec/probe/ spec/probe_custom_rule_spec.cr` → 486 examples, 0 failures
- **Control-run:** restoring `next unless msg.text?` makes the new binary-frame spec fail
- Negative specs: a control frame is not scanned, and 4 KiB of structured noise produces nothing
- `crystal tool format --check` clean; `crystal build --no-codegen src/main.cr` clean after rebase; ameba 0 findings

Independent of #671, #672, #673, #675.

https://claude.ai/code/session_01UiZppfkBza2AytWMHBh9ab