### PR TITLE
Give INS a copy, so `y` stops eating the selection it was meant to copy

### DIFF
--- a/docs/content/getting-started/quick-start.md
+++ b/docs/content/getting-started/quick-start.md
@@ -165,6 +165,8 @@ This is the loop you'll spend most of your time in: take a captured request, cha
    X-Gori-Test: 1
    ```
 4. Press `Esc` to leave edit mode, then `Ctrl-R` to **send**.
+
+   Copying while you edit: `Shift`+arrows select in both modes, but the copy key differs. In READ it is `y`; in INS `y` is a literal character — and typing it over a selection *replaces* the selection — so use **`Ctrl-Y`**. `Esc` also carries the selection out of INS, so `Esc` then `y` works too. If a keystroke does eat a selection, `Ctrl-Z` puts it back in one step.
 5. The response, its timing, and a diff against the previous reply appear on the right. `Tab` cycles target → request → response.
 
 <figure class="tui-shot">

--- a/docs/content/guide/decoder.md
+++ b/docs/content/guide/decoder.md
@@ -67,7 +67,7 @@ Saved chains can call each other. A recursive definition fails that step with a 
 
 A few entries only go one way, and the chain will not undo them. `shell-escape` and `powershell-escape` wrap a value in a quoted literal. `homoglyph` swaps ASCII letters for Unicode lookalikes, and is partial: a letter with no established confusable is left alone. `typo` is a generator rather than a transform, emitting one near-miss variant per line, built from omissions, adjacent-character swaps, and QWERTY neighbour keys.
 
-OUTPUT can cycle display modes (text → hex → base64) for binary results. Copy with `y` in READ mode, or use the space menu.
+OUTPUT can cycle display modes (text → hex → base64) for binary results. Copy with `y` in READ mode, `Ctrl-Y` while editing INPUT in INS, or use the space menu.
 
 ## When to Use It
 

--- a/docs/content/guide/hotkeys.md
+++ b/docs/content/guide/hotkeys.md
@@ -30,6 +30,8 @@ Rules of thumb:
 
 - Default for new pane actions is L3 (space menu only). Promote to a direct key only after the loop proves it.
 - **Ctrl** is for actions that must work while typing (INS) or that are destructive. It is not a general upgrade from bare.
+- **Copy is the worked example of that rule.** `y` copies in READ, and `Ctrl-Y` copies in **INS as well**, in every text box. In INS a bare `y` is a literal character — and typing it over a `Shift`+arrows selection *replaces* the selection — so the copy reflex needs a chord that survives typing. Both are the same verb (`*.copy`), so rebinding follows.
+- The space menu is **not** an INS fallback: text editors swallow keys upstream, so `Space` stays a literal character there. An action that has to be reachable while typing needs a Ctrl chord, not just a mnemonic. (This is why `Ctrl-Q` — not the space menu alone — carries the Repeater/Fuzzer decoder-chain editor after it gave `Ctrl-Y` up to Copy.)
 - **History → Repeater** and **Repeater send** stay on **`Ctrl-R`** (same muscle memory). Do not move History→Repeater to bare `r`.
 - Match & Replace and Notifications ship keyless (palette / badge); rebind them if you want a Global chord.
 

--- a/spec/support/fake_context.cr
+++ b/spec/support/fake_context.cr
@@ -1303,6 +1303,14 @@ class FakeExecContext < Gori::Verb::ExecContext
     @intercept_preview
   end
 
+  # Copy's wider gate — settable independently so a spec can hold the held-bytes editor open
+  # (preview NOT readable) and still assert `^Y` reaches Copy.
+  property intercept_copyable : Bool = false
+
+  def intercept_copyable? : Bool
+    intercept_copyable
+  end
+
   def oast_detail_readable? : Bool
     @oast_detail
   end
@@ -1405,6 +1413,15 @@ class FakeExecContext < Gori::Verb::ExecContext
 
   def read_copy : Nil
     rec(:read_copy)
+  end
+
+  # Settable so the INS half of the `*.copy` verbs' availability can be exercised: those verbs
+  # are available in READ mode OR while an editor is focused, which is what gives `^Y` a copy
+  # to reach when a bare `y` would be a literal character.
+  property editor_focused : Bool = false
+
+  def editor_focused? : Bool
+    editor_focused
   end
 
   def copy_as_open : Nil

--- a/spec/tui/fuzzer_view_spec.cr
+++ b/spec/tui/fuzzer_view_spec.cr
@@ -246,7 +246,7 @@ describe Gori::Tui::FuzzerView do
     view.render(Screen.new(b), Rect.new(0, 0, 120, 30))
     grid = (0...30).map { |y| b.row(y) }.join("\n")
     grid.should contain("no chain yet")
-    grid.should contain("^Y edit · ^O sets")
+    grid.should contain("^Q edit · ^O sets")
   end
 
   # `template_scroll_view` used to bail on `template_insert?`, so the wheel died the moment `i`

--- a/spec/tui/intercept_view_spec.cr
+++ b/spec/tui/intercept_view_spec.cr
@@ -285,9 +285,14 @@ describe Gori::Tui::InterceptView do
     end
 
     # The read caret and the editor's are different carets over the same bytes: while the editor
-    # is open the preview is not drawn, so its gestures must stand down rather than address a
+    # is open the preview is not drawn, so its GESTURES must stand down rather than address a
     # pane nobody is looking at.
-    it "stands down entirely while the editor is open" do
+    #
+    # COPY is the exception, and deliberately so. It used to stand down with them, which left the
+    # held-bytes editor as a pane where a ⇧arrow selection could be built, destroyed by the next
+    # printable (`TextArea#insert` cuts it), and never copied. Copy now routes to whichever
+    # selection model is live — the editor's while editing, the read pane's otherwise.
+    it "stands its read gestures down while the editor is open, but not copy" do
       tmp_interceptor do |ic|
         hold_req(ic, "acme.test", "/e", "GET /e HTTP/1.1\r\nHost: acme.test\r\n\r\n")
         view = InterceptView.new
@@ -298,9 +303,25 @@ describe Gori::Tui::InterceptView do
         view.editing?.should be_true
 
         view.preview_select_word(rect, 60, 8).should be_false
-        view.preview_selection?.should be_false
-        view.preview_copy_text.should eq("")
-        view.preview_copy_all.should eq("")
+        view.preview_selection?.should be_false # the EDITOR has no selection yet either
+        # No selection → the whole held message, the same fallback `y` has in every read pane.
+        view.preview_copy_all.should contain("GET /e HTTP/1.1")
+        view.preview_copy_text.should contain("GET /e HTTP/1.1")
+      end
+    end
+
+    it "copies the EDITOR's selection while the editor is open" do
+      tmp_interceptor do |ic|
+        hold_req(ic, "acme.test", "/e", "GET /e HTTP/1.1\r\nHost: acme.test\r\n\r\n")
+        view = InterceptView.new
+        view.reload(ic)
+        view.render(Screen.new(MemoryBackend.new(110, 16)), Rect.new(0, 0, 110, 16))
+        view.toggle_edit
+        view.edit_move(0, 0) # place the caret at the buffer start
+        3.times { view.edit_move(0, 1, selecting: true) }
+
+        view.preview_selection?.should be_true
+        view.preview_copy_text.should eq("GET")
       end
     end
   end

--- a/spec/tui/repeater_view_spec.cr
+++ b/spec/tui/repeater_view_spec.cr
@@ -1265,7 +1265,7 @@ describe Gori::Tui::RepeaterView do
     grid.should_not contain("§v¦md5§")
     # ...but the caret tooltip reveals the concealed chain + the ^Y edit affordance.
     grid.should contain("md5")         # chain shown in the tooltip
-    grid.should contain("^Y edit")     # edit affordance
+    grid.should contain("^Q edit")     # edit affordance
     grid.should_not contain("PREVIEW") # the ^Y modal is NOT auto-shown
   end
 
@@ -1353,7 +1353,7 @@ describe Gori::Tui::RepeaterView do
     view.render(Screen.new(b), Rect.new(0, 0, 120, 24))
     grid = (0...24).map { |y| b.row(y) }.join("\n")
     grid.should contain("no chain yet")
-    grid.should contain("^Y edit")
+    grid.should contain("^Q edit")
     grid.should_not contain("^O sets") # the Fuzzer's extra half — a Repeater marker is complete alone
   end
 
@@ -1365,7 +1365,7 @@ describe Gori::Tui::RepeaterView do
     view.render(Screen.new(b), Rect.new(0, 0, 120, 24))
     grid = (0...24).map { |y| b.row(y) }.join("\n")
     grid.should_not contain("no chain yet")
-    grid.should_not contain("^Y edit")
+    grid.should_not contain("^Q edit")
   end
 
   it "yields the hint-only tooltip to the $KEY peek, but never a real chain" do
@@ -1392,7 +1392,7 @@ describe Gori::Tui::RepeaterView do
       chained.edit_move(0, 5) # the SAME caret — a real chain outranks the peek
       b2 = MemoryBackend.new(120, 24)
       chained.render(Screen.new(b2), Rect.new(0, 0, 120, 24))
-      (0...24).map { |y| b2.row(y) }.join("\n").should contain("^Y edit")
+      (0...24).map { |y| b2.row(y) }.join("\n").should contain("^Q edit")
     ensure
       Gori::Settings.env_vars = saved
     end

--- a/spec/tui/text_area_ins_select_spec.cr
+++ b/spec/tui/text_area_ins_select_spec.cr
@@ -158,6 +158,90 @@ describe "Gori::Tui::TextArea INSERT-mode selection" do
       ed.insert_newline
       ed.text.should eq("hello\n")
     end
+
+    # What the owner reports as "replaced N chars — ^Z to undo". The count has to be measured
+    # BEFORE the cut, and it has to be reset by every insert: an owner reads it right after the
+    # call, so a stale count from an earlier keystroke would name the wrong number of lost
+    # characters. `> 1` is the owner's threshold (TabController#report_replaced), so the
+    # 1-char case is asserted here only to prove it is distinguishable.
+    it "reports how many characters a replace destroyed, and resets on the next insert" do
+      ed = TextArea.new("hello world")
+      ed.place_cursor(0, 0)
+      5.times { ed.move(0, 1, selecting: true) }
+      ed.insert('X')
+      ed.last_replaced.should eq(5)
+      ed.insert('Y') # no selection this time
+      ed.last_replaced.should eq(0)
+      ed.place_cursor(0, 0)
+      ed.move(0, 1, selecting: true)
+      ed.insert('Z')
+      ed.last_replaced.should eq(1) # ordinary typing over one char — owner stays quiet
+    end
+
+    it "counts a multi-line replace across the line break it swallows" do
+      ed = TextArea.new("ab\ncd")
+      ed.place_cursor(0, 1)
+      3.times { ed.move(0, 1, selecting: true) } # "b\nc"
+      ed.selection_text.should eq("b\nc")
+      ed.insert('X')
+      ed.last_replaced.should eq(3)
+      ed.text.should eq("aXd")
+    end
+  end
+
+  # Leaving INS used to DROP the selection: `TextReadState#apply` → `place_cursor` clears the
+  # anchor on purpose (it is also the read-cursor write-back for ordinary NOR navigation), so
+  # `esc` then `y` — the reflex — copied nothing. `adopt_editor_selection` is the one path that
+  # hands the span over instead. The round trip is the part most likely to regress.
+  describe "handing an INS selection to READ mode on esc" do
+    it "carries the span over, so the read side can copy exactly what was selected" do
+      ed = TextArea.new("hello world")
+      read = TextReadState.new
+      ed.place_cursor(0, 0)
+      5.times { ed.move(0, 1, selecting: true) }
+
+      read.adopt_editor_selection(ed).should be_true
+      read.selection?.should be_true
+      read.copy_text(ed).should eq("hello")
+      # The span now lives in exactly ONE place: the editor-side anchor is retired, so
+      # pressing `i` again cannot bring a stale INS band back.
+      ed.selection?.should be_false
+    end
+
+    it "carries a backwards selection over the same way" do
+      ed = TextArea.new("hello world")
+      read = TextReadState.new
+      ed.place_cursor(0, 5)
+      5.times { ed.move(0, -1, selecting: true) } # caret ends LEFT of the anchor
+      read.adopt_editor_selection(ed).should be_true
+      read.copy_text(ed).should eq("hello")
+    end
+
+    it "is authoritative when there was no INS selection: it CLEARS the read one" do
+      # The round trip. READ-select, `i`, type, `esc` must not resurrect the band from before
+      # the edit — the inverse of the invariant `place_cursor` protects. A plain `sync_from`
+      # leaves the read anchor alone and would do exactly that.
+      ed = TextArea.new("hello world")
+      read = TextReadState.new
+      read.select_line(ed)
+      read.selection?.should be_true
+
+      ed.insert('X') # the edit that made the old span meaningless
+      read.adopt_editor_selection(ed).should be_false
+      read.selection?.should be_false
+      ed.selection?.should be_false
+    end
+
+    it "leaves ordinary NOR navigation clearing the anchor, as before" do
+      # The other half of the bargain: only the INS→READ transition hands over. `place_cursor`
+      # is still the write-back every read-mode move goes through, and it still clears.
+      ed = TextArea.new("hello world")
+      ed.place_cursor(0, 0)
+      5.times { ed.move(0, 1, selecting: true) }
+      ed.selection?.should be_true
+      ed.place_cursor(0, 7)
+      ed.selection?.should be_false
+    end
   end
 
   describe "what collapses the selection" do

--- a/spec/verb/registry_spec.cr
+++ b/spec/verb/registry_spec.cr
@@ -1257,6 +1257,10 @@ private class FakeContext < ExecContext
     false
   end
 
+  def intercept_copyable? : Bool
+    false
+  end
+
   def oast_detail_readable? : Bool
     false
   end
@@ -1357,6 +1361,12 @@ private class FakeContext < ExecContext
 
   def read_copy : Nil
     @calls << :read_copy
+  end
+
+  property editor_focused : Bool = false
+
+  def editor_focused? : Bool
+    editor_focused
   end
 
   def copy_as_open : Nil

--- a/spec/verbs/core_spec.cr
+++ b/spec/verbs/core_spec.cr
@@ -126,22 +126,39 @@ describe "Gori::Verbs.register_core" do
   end
 
   describe "project description copy" do
-    # The chord stays dropped: ProjectController raw-dispatches 'y' in the description pane and
-    # handle_body_key returns true there, so the shared Keymap is never consulted — a chord could
-    # only ever be dead weight in the rebind editor. The mnemonic mirrors that real key.
-    it "carries the 'y' menu key with no chord, in its own scope, gated on tab AND pane" do
+    # BARE 'y' stays chordless: ProjectController raw-dispatches it in the description pane and
+    # handle_body_key returns true there, so the shared Keymap is never consulted — a bare chord
+    # could only ever be dead weight in the rebind editor. The mnemonic mirrors that real key.
+    #
+    # `^Y` IS registered, because that raw dispatch only covers READ. In INS a bare `y` is a
+    # literal character (and typing it over a ⇧arrow selection REPLACES it), so the ctrl form is
+    # the only way to copy without leaving the mode.
+    it "carries the 'y' menu key with only the ctrl chord, in its own scope, gated on tab AND pane" do
       verb = r["project.copy"]
-      verb.chords.should be_empty
+      verb.chords.should eq([Gori::Verb::Chord.new("y", ctrl: true)])
       verb.menu_key.should eq('y')
       verb.scope.should eq(Gori::Verb::Scope::ProjectDesc) # NOT Body — see the History list
       ctx = FakeExecContext.new
       ctx.current_tab = :project
-      verb.available?(ctx).should be_false # the description pane is not in read mode
+      verb.available?(ctx).should be_false # neither read mode nor a focused editor
       ctx.project_desc_read_mode = true
       verb.available?(ctx).should be_true
       ctx.current_tab = :history
       verb.available?(ctx).should be_false # pane flag alone must not leak it into History
       verb_intents(r, "project.copy").should eq([:read_copy])
+    end
+
+    # The INS half: with the pane in INSERT (read_mode false) the verb must still be available,
+    # or `^Y` would be a dead key in exactly the mode that needs it.
+    it "is available while the description editor is focused in INS, and still tab-gated" do
+      verb = r["project.copy"]
+      ctx = FakeExecContext.new
+      ctx.current_tab = :project
+      ctx.project_desc_read_mode = false
+      ctx.editor_focused = true
+      verb.available?(ctx).should be_true
+      ctx.current_tab = :history
+      verb.available?(ctx).should be_false
     end
   end
 

--- a/spec/verbs/decoder_spec.cr
+++ b/spec/verbs/decoder_spec.cr
@@ -61,11 +61,21 @@ describe "Gori::Verbs.register_decoder" do
     Gori::Verbs.registry.has_section?(Gori::Verb::Scope::Decoder, :tab).should be_true
   end
 
-  it "gates Copy on a read-mode pane and routes it through the shared read_copy" do
+  # `y` in READ, `^Y` in INS too — one verb, two chords. The INS half exists because the editor
+  # ladders claim printables upstream of the keymap, so a bare `y` types a `y` there (and over a
+  # ⇧arrow selection it REPLACES it). `^Y` was previously a hardcoded copy-OUTPUT chord in
+  # DecoderController; it is folded into this verb so INPUT's INS mode gets it and it rebinds.
+  it "gates Copy on a read-mode pane OR a focused editor, and routes it through read_copy" do
     r["decoder.copy"].available?(in_decoder).should be_false
     r["decoder.copy"].available?(in_decoder(read: true)).should be_true
-    r["decoder.copy"].chords.should eq([Gori::Verb::Chord.new("y")])
+    r["decoder.copy"].chords.should eq([
+      Gori::Verb::Chord.new("y"), Gori::Verb::Chord.new("y", ctrl: true),
+    ])
     verb_intents(r, "decoder.copy").should eq([:read_copy])
+
+    ins = in_decoder # read_mode false — the INPUT pane in INSERT
+    ins.editor_focused = true
+    r["decoder.copy"].available?(ins).should be_true
   end
 
   it "shows the sub-tab search/filter only with two or more conversions open" do

--- a/spec/verbs/jwt_spec.cr
+++ b/spec/verbs/jwt_spec.cr
@@ -28,11 +28,20 @@ describe "Gori::Verbs.register_jwt" do
     end
   end
 
-  it "gates the smart Copy on a read-mode pane, but not the pane-specific copies" do
+  # `y` in READ, `^Y` in INS too — see decoder.copy for the reasoning. `^Y` used to be a
+  # hardcoded copy-all chord in JwtController; folded in here so the INPUT/header/payload
+  # editors get it while typing, and so it is rebindable.
+  it "gates the smart Copy on a read-mode pane OR a focused editor, but not the pane-specific copies" do
     r["jwt.copy"].available?(in_jwt).should be_false
     r["jwt.copy"].available?(in_jwt(read: true)).should be_true
-    r["jwt.copy"].chords.should eq([Gori::Verb::Chord.new("y")])
+    r["jwt.copy"].chords.should eq([
+      Gori::Verb::Chord.new("y"), Gori::Verb::Chord.new("y", ctrl: true),
+    ])
     verb_intents(r, "jwt.copy").should eq([:jwt_copy])
+
+    ins = in_jwt # read_mode false — an editable pane in INSERT
+    ins.editor_focused = true
+    r["jwt.copy"].available?(ins).should be_true
 
     # copy-token / copy-attack copy a computed value, not a text selection, so they only
     # need the tab — and they live in the section of the pane that value comes from.

--- a/src/gori/tui/chain_peek.cr
+++ b/src/gori/tui/chain_peek.cr
@@ -17,7 +17,7 @@ module Gori::Tui
     # What `^Y` opens is the same everywhere, so this is the floor — but the marker under the
     # caret means different things per surface, and the Fuzzer chains `^O` onto it (a position
     # with no payload set produces nothing, which the chain alone never says). Owner-fed.
-    DEFAULT_HINT = "^Y edit"
+    DEFAULT_HINT = "^Q edit"
 
     # Show the chain of the marker under the caret (opens the peek). An empty chain still
     # opens — the marker is concealment-eligible, the hint invites attaching a chain.

--- a/src/gori/tui/confirm_dialog.cr
+++ b/src/gori/tui/confirm_dialog.cr
@@ -49,8 +49,12 @@ module Gori::Tui
     # `y` is guarded on ctrl/alt because `key.y?` is termisu's CASE-INSENSITIVE macro: it
     # compares the key enum alone and knows nothing about modifiers, so an unguarded branch
     # reads every `^Y` as the destructive answer to a card whose hint only ever advertises a
-    # bare `y`. `^Y` is a live chord (repeater.attach-chain), fired in the very pane the
-    # marker-removal confirm pops up in. Shift is deliberately NOT guarded — `key.y?` matches
+    # bare `y`. `^Y` is a live chord — it is now COPY in every text box, which makes this guard
+    # load-bearing on a hotter path than before: the marker-removal confirm pops up inside the
+    # request editor, exactly where an operator reaches for `^Y` to copy. (It was
+    # repeater.attach-chain when this guard was written; that verb has since moved to `^Q`, and
+    # the guard outlived the specific chord because the RULE is about modifiers, not about which
+    # verb owns them.) Shift is deliberately NOT guarded — `key.y?` matches
     # UpperY on purpose, and a shifted/caps-locked `Y` is the advertised mnemonic. `n`/esc
     # stay unguarded too: a modified key that CANCELS costs one keystroke, one that COMMITS
     # destroys data, so the strictness is spent only where the harm is.

--- a/src/gori/tui/controllers/decoder_controller.cr
+++ b/src/gori/tui/controllers/decoder_controller.cr
@@ -266,10 +266,6 @@ module Gori::Tui
         decoder_new
       elsif ev.ctrl? && key.lower_w?
         decoder_close
-      elsif ev.ctrl? && key.lower_y?
-        # ^Y stays inline: it copies the OUTPUT specifically, and `decoder.copy` is the
-        # focused-pane copy on bare `y`. No verb to defer to.
-        copy_output
       elsif ev.ctrl_z? || editing_motion?(ev)
         # Undo and ⌥/⌃ word motion belong to the focused editor, not the keymap.
         return route_pane_keys(ev, c)
@@ -283,7 +279,9 @@ module Gori::Tui
         s = cur
         if s.pane == :input && s.input_mode == InputMode::Insert
           s.input_mode = InputMode::Read
-          s.input_read.sync_from(s.input)
+          # Carry an INS ⇧arrow selection over to READ, so `esc` then `y` copies it —
+          # see TextReadState#adopt_editor_selection.
+          s.input_read.adopt_editor_selection(s.input)
         else
           commit
           @host.request_focus(:subtabs)
@@ -458,10 +456,12 @@ module Gori::Tui
         end
         "chain (> | ,) · ↑ input · ↓ output · ^Y copy · ^X mode · ^S save · ^O load · esc sub-tabs"
       when :output
-        "↑/↓ move · ⇧arrows select · #{y} copy · ↑-top chain · space cmds · ^X mode · ^Y copy all · esc sub-tabs"
+        # `^Y` is the same Copy verb as `y` now (it exists so the key survives INS on INPUT),
+        # so it is not re-listed here as a second, different action.
+        "↑/↓ move · ⇧arrows select · #{y} copy · ↑-top chain · space cmds · ^X mode · esc sub-tabs"
       when :input
         if s.input_mode == InputMode::Insert
-          "type to edit · esc read · ↓ chain · ^L clear · ^X mode · ^N new · ^W close · ↑ sub-tabs"
+          "type to edit · ⇧arrows select · ^Y copy · esc read · ↓ chain · ^L clear · ^X mode · ^N new · ^W close · ↑ sub-tabs"
         else
           "i/↵ edit · ⇧arrows select · #{y} copy · space cmds · ↓/↹ chain · ^X mode · ^N new · esc sub-tabs"
         end
@@ -553,8 +553,13 @@ module Gori::Tui
       s = cur
       text = case s.pane
              when :output then s.view.output_copy_text(s.result)
-             when :input  then s.input_read.copy_text(s.input)
-             else              ""
+             when :input  then input_copy_text(s)
+               # The CHAIN pane has no selection of its own, and `^Y` USED to be a hardcoded
+               # copy-OUTPUT chord reachable from here (the chain footer advertised it). Now
+               # that `^Y` is the unified Copy verb, routing :chain to the output keeps that
+               # working instead of answering "nothing to copy" on a pane that used to copy.
+             when :chain then s.view.output_copy_text(s.result)
+             else             ""
              end
       if text.empty?
         @host.status("nothing to copy")
@@ -589,7 +594,7 @@ module Gori::Tui
       s = cur
       case s.pane
       when :output then s.view.output_copy_text(s.result)
-      when :input  then s.input_read.copy_text(s.input)
+      when :input  then input_copy_text(s)
       else              ""
       end
     end
@@ -599,10 +604,22 @@ module Gori::Tui
       s.pane == :output || (s.pane == :input && s.input_mode == InputMode::Read)
     end
 
+    # The INPUT pane's two selection models, one per mode — see RepeaterView#pane_selection?.
+    # `decoder_selection_active?` and `input_copy_text` change together: claiming a selection
+    # while copy still read `input_read` would offer "Copy selection" and copy the caret line.
+    private def input_copy_text(s) : String
+      if s.input_mode == InputMode::Insert
+        s.input.selection_text || s.input_read.copy_text(s.input)
+      else
+        s.input_read.copy_text(s.input)
+      end
+    end
+
     def decoder_selection_active? : Bool
       s = cur
       case s.pane
-      when :input  then s.input_mode == InputMode::Read && s.input_read.selection?
+      when :input
+        s.input_mode == InputMode::Insert ? s.input.selection? : s.input_read.selection?
       when :output then s.view.output_selection?
       else              false
       end
@@ -697,7 +714,8 @@ module Gori::Tui
       else
         if c && !ev.ctrl? && !ev.alt?
           s.input.insert(c)
-          s.input.set_preedit("") # commit any preedit (termisu dup-guard)
+          report_replaced(s.input.last_replaced) # a printable over a selection REPLACES it
+          s.input.set_preedit("")                # commit any preedit (termisu dup-guard)
           touch
         end
       end

--- a/src/gori/tui/controllers/fuzzer_controller.cr
+++ b/src/gori/tui/controllers/fuzzer_controller.cr
@@ -491,7 +491,10 @@ module Gori::Tui
       when key.end?         then buffer_jump?(ev) ? v.template_buffer_end(ev.shift?) : v.template_end(ev.shift?)
       when key.delete?      then template_delete_key(v, backward: false)
       else
-        printable(ev).try { |ch| v.template_insert(ch) }
+        printable(ev).try do |ch|
+          v.template_insert(ch)
+          report_replaced(v.template_last_replaced) # a printable over a selection REPLACES it
+        end
       end
       true
     end

--- a/src/gori/tui/controllers/intercept_controller.cr
+++ b/src/gori/tui/controllers/intercept_controller.cr
@@ -85,6 +85,14 @@ module Gori::Tui
       elsif ev.key.space? && !ev.ctrl? && !ev.alt? && !@intercept.editing?
         @host.open_space_menu # space menu in the navigable queue (editing swallows space as a char)
         true
+      elsif @intercept.editing? && (ev.ctrl? || ev.alt?) &&
+            !ev.ctrl_z? && !(ev.ctrl? && key.lower_r?) && !(ev.ctrl? && key.lower_l?) &&
+            !@intercept.edit_word_delete_key?(ev) && !editing_motion?(ev)
+        # Any OTHER modified chord defers to the central keymap so it stays rebindable — `^Y`
+        # Copy above all, which is the only way to copy an INS selection here (bare `y` is a
+        # literal character, and typing it would REPLACE the selection). ^Z undo, ^R forward,
+        # ^L Content-Length sync and ⌥/⌃ motion are this editor's own and stay above.
+        false
       elsif @intercept.editing?
         handle_edit_key(ev)
         true
@@ -122,6 +130,7 @@ module Gori::Tui
         # ⇧arrows select, Page keys, ⇧Home/⇧End, ⌥←/→ by word — TextArea#handle_motion_key.
       elsif c && !ev.ctrl? && !ev.alt?
         @intercept.edit_insert(c)
+        report_replaced(@intercept.edit_last_replaced) # a printable over a selection REPLACES it
       end
     end
 
@@ -310,8 +319,16 @@ module Gori::Tui
     end
 
     # --- READ-pane delegators (the preview's read verbs + the Runner's read_* ladders) ---
+    # Gates `x`/`v`/`S` — the READ-pane verbs, which the editor has no use for.
     def intercept_preview_readable? : Bool
       !@intercept.empty? && !@intercept.editing?
+    end
+
+    # Copy's gate, which is DELIBERATELY wider: it also fires while the held-bytes editor is
+    # open, because an INS selection there could be built and destroyed but never copied. See
+    # `InterceptView#preview_selection?` for the two selection models it routes between.
+    def intercept_copyable? : Bool
+      !@intercept.empty?
     end
 
     def intercept_preview_selection_active? : Bool
@@ -333,7 +350,7 @@ module Gori::Tui
     # `y`: the selection, or the whole held message when nothing is selected. The bytes here are
     # the item's own — byte-exact, which is the point of holding it.
     def intercept_preview_copy : Nil
-      return unless intercept_preview_readable?
+      return unless intercept_copyable?
       sel = @intercept.preview_selection?
       text = sel ? @intercept.preview_copy_text : @intercept.preview_copy_all
       return if text.empty?

--- a/src/gori/tui/controllers/issues_controller.cr
+++ b/src/gori/tui/controllers/issues_controller.cr
@@ -51,7 +51,7 @@ module Gori::Tui
       y = Hotkeys.binding_label(reg, "issue.copy", "y")
       if @issues.detail_open?
         if @issues.notes_insert_mode?
-          "type to edit · esc save · ^W discard"
+          "type to edit · ⇧arrows select · ^Y copy · esc save · ^W discard"
         elsif @issues.notes_focused?
           "↑/↓ move · ⇧arrows select · #{y} copy · i/↵ edit · space cmds · esc links"
         else
@@ -222,8 +222,14 @@ module Gori::Tui
       case
       when ev.ctrl? && key.lower_w? then @issues.cancel_notes_edit
       when ev.ctrl_z?               then @issues.notes_undo
-      when key.escape?              then @issues.save_notes(@host.session.store)
-      when key.enter?               then @issues.notes_newline
+      when (ev.ctrl? || ev.alt?) && !@issues.notes_word_delete_key?(ev) && !editing_motion?(ev)
+        # Every other modified chord defers to the central keymap so it stays rebindable —
+        # `^Y` Copy above all, which is the only way to copy an INS selection here (bare `y`
+        # is a literal character, and typing it would REPLACE the selection). ⌥⌫ and ⌥/⌃
+        # motion are this editor's own and are excluded above.
+        return false
+      when key.escape? then @issues.save_notes(@host.session.store)
+      when key.enter?  then @issues.notes_newline
         # Before plain ⌫, which would swallow the modified form as a one-character delete.
       when @issues.notes_word_delete_key?(ev) then @issues.notes_motion_key(ev)
       when key.backspace?                     then @issues.notes_backspace
@@ -232,6 +238,7 @@ module Gori::Tui
       else
         if c && !ev.ctrl? && !ev.alt?
           @issues.notes_insert(c)
+          report_replaced(@issues.notes_last_replaced) # a printable over a selection REPLACES it
           @issues.set_preedit("")
         end
       end

--- a/src/gori/tui/controllers/jwt_controller.cr
+++ b/src/gori/tui/controllers/jwt_controller.cr
@@ -283,8 +283,6 @@ module Gori::Tui
         jwt_new
       elsif ev.ctrl? && key.lower_w?
         jwt_close
-      elsif ev.ctrl? && key.lower_y?
-        jwt_copy # copy-all; `jwt.copy` is the focused-pane copy on bare `y`
       elsif ev.ctrl_z? || editing_motion?(ev)
         # Undo and ⌥/⌃ word motion belong to the focused editor, not the keymap.
         return route_pane(ev, c)
@@ -306,7 +304,8 @@ module Gori::Tui
       s = cur
       if s.pane == :input && s.input_mode == InputMode::Insert
         s.input_mode = InputMode::Read
-        s.input_read.sync_from(s.input)
+        # Carry an INS ⇧arrow selection over to READ — see TextReadState#adopt_editor_selection.
+        s.input_read.adopt_editor_selection(s.input)
       else
         commit
         @host.request_focus(:subtabs)
@@ -347,6 +346,7 @@ module Gori::Tui
       else
         if c && !ev.ctrl? && !ev.alt?
           s.input.insert(c)
+          report_replaced(s.input.last_replaced) # a printable over a selection REPLACES it
           s.input.set_preedit("")
           recompute_decode(s)
         end
@@ -777,15 +777,23 @@ module Gori::Tui
         (s.pane == :input && s.input_mode == InputMode::Read)
     end
 
+    # The INPUT pane's two selection models, one per mode — see RepeaterView#pane_selection?.
+    # This pair changes together with `jwt_selection_text`'s :input arm.
     def jwt_selection_active? : Bool
       s = cur
-      s.pane == :input && s.input_mode == InputMode::Read && s.input_read.selection?
+      return false unless s.pane == :input
+      s.input_mode == InputMode::Insert ? s.input.selection? : s.input_read.selection?
     end
 
     def jwt_selection_text : String
       s = cur
       case s.pane
-      when :input   then s.input_mode == InputMode::Read ? s.input_read.copy_text(s.input) : ""
+      when :input
+        if s.input_mode == InputMode::Insert
+          s.input.selection_text || s.input_read.copy_text(s.input)
+        else
+          s.input_read.copy_text(s.input)
+        end
       when :decoded then s.decoded
       when :output  then s.output_ok? ? s.output : ""
       when :attacks then (a = s.attacks[s.view.attacks_selected]?) ? a.token : ""

--- a/src/gori/tui/controllers/notes_controller.cr
+++ b/src/gori/tui/controllers/notes_controller.cr
@@ -88,6 +88,13 @@ module Gori::Tui
           save_notes
           @host.request_focus(:subtabs)
         end
+      elsif (ev.ctrl? || ev.alt?) && !ev.ctrl_z? && !editing_motion?(ev)
+        # Any OTHER modified chord defers to the central keymap so it stays rebindable —
+        # `^Y` Copy above all, which is the only way to copy an INS selection (bare `y` is
+        # a literal character here, and typing it would REPLACE the selection instead).
+        # ^Z and ⌥/⌃ motion belong to this editor and are handled below/above.
+        # Editors never insert ctrl/alt chars, so the defer is safe mid-edit.
+        return false
       elsif @notes.insert_mode?
         edit_insert(ev, c)
       else
@@ -146,6 +153,7 @@ module Gori::Tui
       else
         if c && !ev.ctrl? && !ev.alt?
           @notes.insert(c)
+          report_replaced(@notes.last_replaced) # a printable over a selection REPLACES it
           @notes.set_preedit("")
         end
       end
@@ -269,7 +277,7 @@ module Gori::Tui
 
     def body_hint(focus : Symbol) : String
       if @notes.insert_mode?
-        "type to edit · esc read · ^N new · ^W close · ^G goto · ^F find · ^1-9 · ↑ sub-tabs"
+        "type to edit · ⇧arrows select · ^Y copy · esc read · ^N new · ^W close · ^G goto · ^F find · ^1-9 · ↑ sub-tabs"
       else
         y = Hotkeys.binding_label(@host.session.registry, "notes.copy", "y")
         "i/↵ edit · ⇧arrows select · #{y} copy · space cmds · ^N new · ^W close · ^G goto · ^F find · esc sub-tabs"

--- a/src/gori/tui/controllers/project_controller.cr
+++ b/src/gori/tui/controllers/project_controller.cr
@@ -71,7 +71,7 @@ module Gori::Tui
         end
       else
         if @project_view.desc_insert_mode?
-          "type to edit · esc read · ↑/↓/↔ move · ^G goto · ^F find · ^E $EDITOR"
+          "type to edit · ⇧arrows select · ^Y copy · esc read · ↑/↓/↔ move · ^G goto · ^F find · ^E $EDITOR"
         else
           "i/↵ edit · ⇧arrows select · y copy · space cmds · ↑/↓ move · ^G goto · ^F find · esc sub-tabs"
         end
@@ -150,7 +150,6 @@ module Gori::Tui
         true
       else
         handle_project_desc_key(ev)
-        true
       end
     end
 
@@ -362,7 +361,8 @@ module Gori::Tui
     end
 
     # --- DESCRIPTION pane: READ/INS multi-line editing ---
-    private def handle_project_desc_key(ev : Termisu::Event::Key) : Nil
+    # Returns false when the key should fall through to the shell keymap — see the `^Y` arm.
+    private def handle_project_desc_key(ev : Termisu::Event::Key) : Bool
       key = ev.key
       c = ev.char || key.to_char
       if ev.ctrl? && key.lower_p?
@@ -375,11 +375,18 @@ module Gori::Tui
         else
           leave_to_strip
         end
+      elsif (ev.ctrl? || ev.alt?) && !ev.ctrl_z? && !editing_motion?(ev)
+        # Any OTHER modified chord defers to the central keymap so it stays rebindable —
+        # `^Y` Copy above all, which is the only way to copy an INS selection (bare `y` is a
+        # literal character here, and typing it would REPLACE the selection instead). ^Z and
+        # ⌥/⌃ motion belong to this editor and are handled below.
+        return false
       elsif @project_view.desc_insert_mode?
         edit_desc_insert(ev, key, c)
       else
         handle_desc_read(ev, key, c)
       end
+      true
     end
 
     # ⇧←/→ SELECT here, they no longer h-scroll. The description is a navigable pane with a
@@ -418,6 +425,7 @@ module Gori::Tui
       else
         if c && !ev.ctrl? && !ev.alt?
           @project_view.insert(c)
+          report_replaced(@project_view.last_replaced) # a printable over a selection REPLACES it
           @project_view.set_preedit("")
         end
       end

--- a/src/gori/tui/controllers/repeater_controller.cr
+++ b/src/gori/tui/controllers/repeater_controller.cr
@@ -272,7 +272,10 @@ module Gori::Tui
           # → `request_tab_insert`) — a header value is allowed to hold one, and this is the
           # only editor that can type it. The pane ring is Tab's job only in READ mode, and
           # the footer said otherwise for both.
-          "type to edit · ⇧arrows select · ^Z undo · #{marks} · ^G goto · ^F find · #{hex} hex · esc read · ↹ text"
+          # `^Y copy` is named here and not only in READ: a ⇧arrow selection can be built in
+          # INSERT, and the bare `y` that copies it in READ is a literal character here — one
+          # that REPLACES the selection. The footer has to say which key copies while typing.
+          "type to edit · ⇧arrows select · ^Y copy · ^Z undo · #{marks} · ^G goto · ^F find · #{hex} hex · esc read · ↹ text"
         else
           # The way back on an overridden handshake tab: the MESSAGES pane is hidden there, so
           # `^T` — the key that would otherwise reveal it — is not drawn to point at it.
@@ -392,13 +395,13 @@ module Gori::Tui
             else
               "GraphQL query/vars"
             end
-      mode = v.request_insert? ? "type to edit" : "i/↵ edit · ⇧arrows select · y copy · space cmds"
+      mode = v.request_insert? ? "type to edit · ⇧arrows select · ^Y copy" : "i/↵ edit · ⇧arrows select · y copy · space cmds"
       "#{mode} #{sub} · ^T switch · ^G goto · ^F find · esc read · ↹ pane"
     end
 
     private def ws_hint(v : RepeaterView) : String
       sub = v.req_pane == :envelope ? "handshake request" : "messages"
-      mode = v.request_insert? ? "type to edit" : "i/↵ edit · ⇧arrows select · y copy · space cmds"
+      mode = v.request_insert? ? "type to edit · ⇧arrows select · ^Y copy" : "i/↵ edit · ⇧arrows select · y copy · space cmds"
       # `^V http` is listed because this key used to REFUSE here ("transport is fixed"), so
       # nothing in the tab suggested a handshake could be sent as an ordinary request.
       "#{mode} #{sub} · ^T switch · ^V http · ^G goto · ^F find · esc read · ↹ pane"
@@ -2037,7 +2040,8 @@ module Gori::Tui
       else
         if c && !ev.ctrl? && !ev.alt?
           view.edit_insert(c)
-          view.set_preedit("") # commit preedit
+          report_replaced(view.edit_last_replaced) # a printable over a selection REPLACES it
+          view.set_preedit("")                     # commit preedit
         end
       end
       true

--- a/src/gori/tui/controllers/rewriter_controller.cr
+++ b/src/gori/tui/controllers/rewriter_controller.cr
@@ -370,6 +370,7 @@ module Gori::Tui
       else
         if (c = ev.char || key.to_char) && !ev.ctrl? && !ev.alt? && !c.control?
           ed.insert(c)
+          report_replaced(ed.last_replaced) # a printable over a selection REPLACES it
           ed.set_preedit("")
         elsif key.space? && !ev.ctrl? && !ev.alt?
           @host.open_space_menu
@@ -505,14 +506,28 @@ module Gori::Tui
     end
 
     # --- READ-pane delegators (the Rewriter verbs + the Runner's read_* ladders) ---
+    # Two panes, two selection models: `@out` is the read-only transform result, `@preview_input`
+    # is the editable sample. The INPUT half used to be absent everywhere here, so a ⇧arrow
+    # selection built in that editor could be destroyed by the next printable (TextArea#insert
+    # cuts it) but never copied. Same shape as RepeaterView#pane_selection?.
     def rewriter_selection_active? : Bool
-      @sub == :rules && @focus == :preview_out && @out.selection?
+      return false unless @sub == :rules
+      case @focus
+      when :preview_out then @out.selection?
+      when :preview_in  then @preview_input.selection?
+      else                   false
+      end
     end
 
     def rewriter_selection_text : String
-      return "" unless @sub == :rules && @focus == :preview_out
-      sync_preview_out
-      @out.copy_text
+      return "" unless @sub == :rules
+      case @focus
+      when :preview_in then @preview_input.selection_text || @preview_input.text
+      when :preview_out
+        sync_preview_out
+        @out.copy_text
+      else ""
+      end
     end
 
     def rewriter_select_line : Nil
@@ -530,10 +545,20 @@ module Gori::Tui
     # Same `Clipboard.copy` + status shape every other tab's copy verb uses, so the toast reads
     # the same and the OSC-52 truncation note is not re-derived here.
     def rewriter_copy : Nil
-      return unless @sub == :rules && @focus == :preview_out
-      sync_preview_out
-      sel = @out.selection?
-      text = sel ? @out.copy_text : @out.copy_all
+      return unless @sub == :rules
+      case @focus
+      when :preview_in
+        # The editable sample. `^Y` is the only way to copy a selection here: in INS a bare `y`
+        # is a literal character, and typing it REPLACES the selection.
+        sel = @preview_input.selection?
+        text = sel ? (@preview_input.selection_text || "") : @preview_input.text
+      when :preview_out
+        sync_preview_out
+        sel = @out.selection?
+        text = sel ? @out.copy_text : @out.copy_all
+      else
+        return
+      end
       return if text.empty?
       written = Clipboard.copy(text)
       note = Clipboard.note(written, text)

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -102,7 +102,7 @@ module Gori::Tui
       # setup: with no payload set in the CONFIG pane the run produces nothing, and the two
       # halves sit in different panes, so the tooltip over the position names the pane that
       # completes it. (In the Repeater a marker IS complete on its own — hence the default.)
-      @editor.chain_peek_hint = "^Y edit · ^O sets"
+      @editor.chain_peek_hint = "^Q edit · ^O sets"
       @last_synced_config = "" # last store config blob applied (reconcile equality)
       @config = Fuzz::Config.new(keep_bodies: :matched)
       @sets = [] of SetSpec
@@ -546,6 +546,8 @@ module Gori::Tui
     def exit_template_insert! : Nil
       @template_mode = InputMode::Read
       @editor.env_complete_close # no dangling $ENV dropdown once we leave insert mode
+      # Carry an INS ⇧arrow selection over to READ — see TextReadState#adopt_editor_selection.
+      @template_read.adopt_editor_selection(@editor)
     end
 
     # --- $ENV autocomplete in the template editor ---
@@ -1704,6 +1706,11 @@ module Gori::Tui
     end
 
     # --- template editing ----------------------------------------------------
+    # Characters the last `template_insert` replaced — see TextArea#last_replaced.
+    def template_last_replaced : Int32
+      @editor.last_replaced
+    end
+
     def template_insert(ch : Char) : Nil
       # Marker-in-marker guard: a §/¦ typed inside (or flush against) a closed marker is
       # auto-escaped to a §§/¦¦ literal so the structure survives (Template.insert_breaks_marker?).
@@ -1874,8 +1881,14 @@ module Gori::Tui
       @editor.scroll_view(step)
     end
 
+    # One selection model per mode — see RepeaterView#request_copy_text, which this mirrors.
+    # Changes together with `pane_selection?`'s :template arm.
     def template_copy_text : String
-      @template_read.copy_text(@editor)
+      if pane_insert?(:template)
+        @editor.selection_text || @template_read.copy_text(@editor)
+      else
+        @template_read.copy_text(@editor)
+      end
     end
 
     def template_copy_all_text : String
@@ -1902,7 +1915,9 @@ module Gori::Tui
 
     def pane_selection? : Bool
       case @focus
-      when :template then !pane_insert?(:template) && @template_read.selection?
+      # INS has its own selection model (the editor's `@sel_anchor`); reporting only the READ
+      # side made a visible ⇧arrow band uncopyable — see RepeaterView#pane_selection?.
+      when :template then pane_insert?(:template) ? @editor.selection? : @template_read.selection?
       when :target   then !pane_insert?(:target) && @target_read.selection?
       when :detail   then detail_navigable? && @detail_read.selection?
       else                false

--- a/src/gori/tui/help_view.cr
+++ b/src/gori/tui/help_view.cr
@@ -82,13 +82,18 @@ module Gori::Tui
         Item.new("t", "tag the active sub-tab (on the strip)", "repeater.tag-subtab"),
         Item.new("i / ↵", "enter INS (edit) on request/target · esc back to READ"),
         Item.new("space", "command menu (READ mode on request/target/response)"),
-        Item.new("y", "copy selection/line (READ)", "repeater.copy"),
+        # Copy is the one READ verb that also works while TYPING: in INS a bare `y` is a
+        # literal character (and typing it over a selection REPLACES it), so INS gets the
+        # ctrl form. The key column resolves `y` from the verb id; `^Y` is its second chord.
+        Item.new("y · ^Y", "copy selection/line — `y` in READ, ^Y in INS too", "repeater.copy"),
         Item.new("x · ⇧arrows", "select the current line · extend selection"),
         # The §…§ marker trio, same keys and same order as the FUZZER section below — the
         # Repeater grew `^K`/`^T` to match and Help documented neither.
         Item.new("^A · ^K · ^T", "auto-mark params · mark word · mark point (manual §)", "repeater.auto-mark"),
         Item.new("space → c", "clear every § marker", "repeater.clear-marks"),
-        Item.new("^Y", "edit the decoder chain on the marker at the cursor", "repeater.attach-chain"),
+        # ^Q, not ^Y — ^Y is Copy in every text box now (see the `y · ^Y` row above). The key
+        # column resolves from the verb id, so it follows a rebind either way.
+        Item.new("^Q", "edit the decoder chain on the marker at the cursor", "repeater.attach-chain"),
         Item.new("^X", "hex-edit the request", "repeater.toggle-hex"),
         Item.new("^S", "SNI override (on the target)", "repeater.toggle-sni"),
         Item.new("^L", "toggle auto Content-Length", "repeater.toggle-auto-content-length"),
@@ -142,7 +147,7 @@ module Gori::Tui
       {"JWT", [
         Item.new("^T", "switch decode ⟷ encode", "jwt.toggle-mode"),
         Item.new("^A", "cycle the signing alg (alg=none included)", "jwt.cycle-alg"),
-        Item.new("^L · ^Y", "clear the session · copy everything", "jwt.clear"),
+        Item.new("^L", "clear the session", "jwt.clear"),
         Item.new("↹", "cycle INPUT → DECODED → ATTACKS (decode) / HEADER → PAYLOAD → SECRET → OUTPUT (encode)"),
         Item.new("i / ↵", "enter INS on an editable pane · esc back to READ"),
         Item.new("↑/↓ · ↵", "attacks: select · copy the selected payload"),
@@ -189,10 +194,11 @@ module Gori::Tui
       {"DECODER", [
         Item.new("i / ↵", "enter INS on INPUT · esc back to READ"),
         Item.new("INPUT READ", "⇧arrows select · y copy · space cmds"),
+        Item.new("INPUT INS", "⇧arrows select · ^Y copy (bare y types a `y`)"),
         Item.new("chain", "always editable — base64 > url-encode > sha256 ( > | , )"),
         Item.new("↹ / ↵", "complete the suggested converter (popup)"),
         Item.new("OUTPUT", "↑/↓ move · ⇧arrows select · y copy"),
-        Item.new("^Y · ^X", "copy all output · cycle text/hex/base64"),
+        Item.new("^X", "cycle text/hex/base64"),
         Item.new("^S · ^O", "save the chain under a name · pick from the saved chains"),
         Item.new("chain library", "shared by every project · picker: type to filter · ^X deletes an entry"),
         Item.new("^N · ^W", "new · close conversion sub-tab"),

--- a/src/gori/tui/intercept_view.cr
+++ b/src/gori/tui/intercept_view.cr
@@ -625,6 +625,11 @@ module Gori::Tui
       mark_editor_edit
     end
 
+    # Characters the last `edit_insert` replaced — see TextArea#last_replaced.
+    def edit_last_replaced : Int32
+      @editor.last_replaced
+    end
+
     def edit_newline : Nil
       return unless @editing
       @editor.insert_newline
@@ -647,8 +652,10 @@ module Gori::Tui
       reflect_content_length_in_editor
     end
 
-    def edit_move(dr : Int32, dc : Int32) : Nil
-      @editor.move(dr, dc) if @editing
+    # `selecting` is the ⇧ half, forwarded to `TextArea#move` exactly as `edit_motion_key` does —
+    # exposed so a caller (and a spec) can extend the INS selection without synthesising a key.
+    def edit_move(dr : Int32, dc : Int32, selecting : Bool = false) : Nil
+      @editor.move(dr, dc, selecting: selecting) if @editing
     end
 
     # The shared editor keymap — ⇧arrows select, Page keys, ⇧Home/⇧End, ⌥←/→ by word, ⌥⌫
@@ -1196,19 +1203,25 @@ module Gori::Tui
       @preview.clear_selection
     end
 
+    # Two selection models, one per mode, and they can never both be live: `@preview` is the
+    # read-only pane's, `@editor` holds the held-bytes editor's INS one. These three used to
+    # bail outright while editing (`return "" if @editing`), which made an INS ⇧arrow selection
+    # impossible to copy on the one pane whose whole point is that you are rewriting bytes by
+    # hand — while the next printable would REPLACE it. Same split as
+    # RepeaterView#pane_selection? / #request_copy_text; all three change together.
     def preview_selection? : Bool
-      !@editing && @preview.selection?
+      @editing ? @editor.selection? : @preview.selection?
     end
 
     def preview_copy_text : String
-      return "" if @editing
+      return @editor.selection_text || @editor.text if @editing
       it = selected_item || return ""
       sync_preview(it)
       @preview.copy_text
     end
 
     def preview_copy_all : String
-      return "" if @editing
+      return @editor.text if @editing
       it = selected_item || return ""
       sync_preview(it)
       @preview.copy_all

--- a/src/gori/tui/issues_view.cr
+++ b/src/gori/tui/issues_view.cr
@@ -553,7 +553,8 @@ module Gori::Tui
 
     def exit_notes_insert! : Nil
       @notes_mode = InputMode::Read
-      @notes_read.sync_from(@notes)
+      # Carry an INS ⇧arrow selection over to READ — see TextReadState#adopt_editor_selection.
+      @notes_read.adopt_editor_selection(@notes)
     end
 
     def notes_read_move(dr : Int32, dc : Int32, selecting : Bool = false) : Nil
@@ -565,8 +566,15 @@ module Gori::Tui
       @notes.scroll_view(step)
     end
 
+    # One selection model per mode — see NotesView#selection? / RepeaterView#pane_selection?.
+    # This pair changes together: claiming a selection while copy still read `@notes_read`
+    # would offer "Copy selection" and then copy the caret line.
     def notes_copy_text : String
-      @notes_read.copy_text(@notes)
+      if notes_insert_mode?
+        @notes.selection_text || @notes_read.copy_text(@notes)
+      else
+        @notes_read.copy_text(@notes)
+      end
     end
 
     def notes_copy_all : String
@@ -574,7 +582,8 @@ module Gori::Tui
     end
 
     def notes_selection? : Bool
-      notes_focused? && !notes_insert_mode? && @notes_read.selection?
+      return false unless notes_focused?
+      notes_insert_mode? ? @notes.selection? : @notes_read.selection?
     end
 
     def notes_select_line : Nil
@@ -593,6 +602,11 @@ module Gori::Tui
 
     def notes_insert(ch : Char) : Nil
       @notes.insert(ch) if notes_insert_mode?
+    end
+
+    # Characters the last `notes_insert` replaced — see TextArea#last_replaced.
+    def notes_last_replaced : Int32
+      @notes.last_replaced
     end
 
     def notes_newline : Nil

--- a/src/gori/tui/notes_view.cr
+++ b/src/gori/tui/notes_view.cr
@@ -201,7 +201,9 @@ module Gori::Tui
 
     def exit_insert! : Nil
       @mode = InputMode::Read
-      @read.sync_from(current.area)
+      # Carry an INS ⇧arrow selection over to READ, so `esc` then `y` copies it instead of
+      # silently dropping it — see TextReadState#adopt_editor_selection.
+      @read.adopt_editor_selection(current.area)
     end
 
     def read_move(dr : Int32, dc : Int32, selecting : Bool = false) : Nil
@@ -209,12 +211,21 @@ module Gori::Tui
       @read.move(current.area, dr, dc, selecting: selecting)
     end
 
+    # Two selection models, one per mode, and they can never both be live: `@read` holds the
+    # READ band, the TextArea its own INS one. Reporting only the READ side made a visible
+    # ⇧arrow selection uncopyable in INS — see RepeaterView#pane_selection?, which this pair
+    # mirrors. Both members change together: claiming a selection here while copy still read
+    # `@read` would offer "Copy selection" and then copy the caret line.
     def copy_text : String
-      @read.copy_text(current.area)
+      if insert_mode?
+        current.area.selection_text || @read.copy_text(current.area)
+      else
+        @read.copy_text(current.area)
+      end
     end
 
     def selection? : Bool
-      !insert_mode? && @read.selection?
+      insert_mode? ? current.area.selection? : @read.selection?
     end
 
     def select_line : Nil
@@ -229,6 +240,11 @@ module Gori::Tui
     def insert(ch : Char) : Nil
       current.area.insert(ch)
       @dirty = true
+    end
+
+    # Characters the last `insert` replaced — see TextArea#last_replaced.
+    def last_replaced : Int32
+      current.area.last_replaced
     end
 
     def newline : Nil

--- a/src/gori/tui/project_view.cr
+++ b/src/gori/tui/project_view.cr
@@ -201,7 +201,8 @@ module Gori::Tui
 
     def exit_desc_insert! : Nil
       @desc_mode = InputMode::Read
-      @desc_read.sync_from(@desc_area)
+      # Carry an INS ⇧arrow selection over to READ — see TextReadState#adopt_editor_selection.
+      @desc_read.adopt_editor_selection(@desc_area)
     end
 
     def desc_read_move(dr : Int32, dc : Int32, selecting : Bool = false) : Nil
@@ -209,8 +210,13 @@ module Gori::Tui
       @desc_read.move(@desc_area, dr, dc, selecting: selecting)
     end
 
+    # One selection model per mode — see NotesView#selection? / RepeaterView#pane_selection?.
     def desc_copy_text : String
-      @desc_read.copy_text(@desc_area)
+      if desc_insert_mode?
+        @desc_area.selection_text || @desc_read.copy_text(@desc_area)
+      else
+        @desc_read.copy_text(@desc_area)
+      end
     end
 
     def desc_copy_all : String
@@ -218,7 +224,8 @@ module Gori::Tui
     end
 
     def desc_selection? : Bool
-      @pane == :desc && !desc_insert_mode? && @desc_read.selection?
+      return false unless @pane == :desc
+      desc_insert_mode? ? @desc_area.selection? : @desc_read.selection?
     end
 
     def desc_select_line : Nil
@@ -944,6 +951,11 @@ module Gori::Tui
     def insert(ch : Char) : Nil
       @desc_area.insert(ch)
       @desc_dirty = true
+    end
+
+    # Characters the last `insert` replaced — see TextArea#last_replaced.
+    def last_replaced : Int32
+      @desc_area.last_replaced
     end
 
     def newline : Nil

--- a/src/gori/tui/read_cursor.cr
+++ b/src/gori/tui/read_cursor.cr
@@ -50,6 +50,22 @@ module Gori::Tui
       @cx = cx
     end
 
+    # Adopt an explicit anchor+caret pair as this cursor's selection. The one range SETTER —
+    # `select_line` and `select_word_at_cursor` derive their span from the buffer, and `move`
+    # grows one a step at a time, so a caller handing over a span computed elsewhere had no
+    # way in. Used when leaving INSERT: the editor's own `@sel_anchor` selection is transferred
+    # here so `esc` then `y` copies what was selected in INS, instead of dropping it (see
+    # `TextReadState#adopt_editor_selection`).
+    #
+    # No clamping: the caller owns the buffer these coordinates came from, and both
+    # `highlight_spans` and `selection_text` clamp per line as they read. An anchor equal to
+    # the caret collapses the selection, which `selection?` already reports as none.
+    def select_range(anchor_cy : Int32, anchor_cx : Int32, cy : Int32, cx : Int32) : Nil
+      @anchor = {anchor_cy, anchor_cx}
+      @cy = cy
+      @cx = cx
+    end
+
     def line_selection? : Bool
       a = @anchor
       return false unless a

--- a/src/gori/tui/repeater_view.cr
+++ b/src/gori/tui/repeater_view.cr
@@ -412,11 +412,12 @@ module Gori::Tui
     def exit_request_insert! : Nil
       @request_mode = InputMode::Read
       req_editor.env_complete_close # no dangling $ENV dropdown once we leave insert mode
-      # Drop the INS selection with the mode that owns it. Its band is only painted while
-      # `cursor` is on (INS), so leaving the anchor set hides it without clearing it — and
-      # `esc` then `i` brought a band back that the operator had visually dismissed, over a
-      # caret they had since moved.
-      req_editor.clear_selection
+      # HAND the INS selection to READ rather than dropping it: `esc` then `y` is the reflex,
+      # and discarding it here meant an INS selection could be built and destroyed but never
+      # copied. This still answers what the old hard clear was for — an INS band is painted
+      # only while INS is on, so leaving the anchor set HID a live selection — because the
+      # read-mode band IS painted here, and the handover retires the editor-side anchor.
+      @req_read.adopt_editor_selection(req_editor)
     end
 
     # --- $ENV autocomplete in the request editor (delegates to the active req editor) ---
@@ -3245,6 +3246,11 @@ module Gori::Tui
       before = ed.edits
       ed.undo
       mark_req_edit(reflect: false) if ed.edits != before # see mark_req_edit
+    end
+
+    # Characters the last `edit_insert` replaced — see TextArea#last_replaced.
+    def edit_last_replaced : Int32
+      req_editor.last_replaced
     end
 
     def edit_insert(ch : Char) : Nil

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -3592,9 +3592,17 @@ module Gori::Tui
     # editor) rather than driving a navigable list/tree or a read-only pane. Splits
     # the BODY badge into EDITOR/BODY so the user can tell at a glance whether the
     # keys under their fingers land as text or as commands.
-    private def body_editor? : Bool
+    # Also the `*.copy` verbs' INS-side availability gate (Verb::ExecContext#editor_focused?),
+    # which is why it is no longer private: one definition of "the keys under your fingers
+    # land as text", read by both the status badge and the keymap.
+    def body_editor? : Bool
       return false unless @focus == :body
       @tabs[@active_tab]?.try(&.body_badge) == :editor
+    end
+
+    # :ditto:
+    def editor_focused? : Bool
+      body_editor?
     end
 
     # Contextual key hints for the bottom row — change with the focused region,

--- a/src/gori/tui/runner/intercept.cr
+++ b/src/gori/tui/runner/intercept.cr
@@ -50,6 +50,10 @@ class Gori::Tui::Runner < Gori::Verb::ExecContext
   end
 
   # The read-only held-message preview is on screen — the gate for its read verbs.
+  def intercept_copyable? : Bool
+    intercept_controller.intercept_copyable?
+  end
+
   def intercept_preview_readable? : Bool
     intercept_controller.intercept_preview_readable?
   end

--- a/src/gori/tui/tab_controller.cr
+++ b/src/gori/tui/tab_controller.cr
@@ -235,6 +235,20 @@ module Gori::Tui
       !!c && (c == '\u{7F}' || c == '\b')
     end
 
+    # Say so when a keystroke just destroyed a MULTI-character selection (replace-on-type:
+    # `TextArea#insert` cuts the selection before splicing). The loss is one undo step, but
+    # nothing told the operator that — and this is the exact keystroke people mean when they
+    # report "I pressed a key and my text vanished", because in INS the copy reflex `y` is a
+    # literal character. Every INS printable arm calls this right after `insert`, reading the
+    # count the editor exposes (`TextArea#last_replaced`).
+    #
+    # `> 1` on purpose: replacing a single selected character is ordinary typing and a toast
+    # for it would fire constantly.
+    def report_replaced(n : Int32) : Nil
+      return unless n > 1
+      @host.status("replaced #{n} chars — ^Z to undo")
+    end
+
     # Whether a press in this tab's body can start a DRAG — pointer motion with the button
     # held, which extends a selection from where the press landed. False by default: a tab
     # opts in only for a pane that has a text selection to extend.

--- a/src/gori/tui/text_area.cr
+++ b/src/gori/tui/text_area.cr
@@ -143,6 +143,11 @@ module Gori::Tui
       @chain_peek = nil.as(ChainPeek?)
       @chain_peek_text = nil.as(String?)
       @chain_peek_hint = ChainPeek::DEFAULT_HINT
+      # Characters the LAST `insert` replaced (0 when it replaced nothing). Read by the owner
+      # right after the call, exactly the way owners already check `edits` around `backspace`
+      # — this widget has no route to the shell and must not grow one, so it reports the fact
+      # and the controller decides whether to say anything about it.
+      @last_replaced = 0
       set_text(text)
     end
 
@@ -165,6 +170,9 @@ module Gori::Tui
     end
 
     getter edits : Int32
+    # Characters the last `insert` replaced — see the ivar's note. Owners report a MULTI-char
+    # replace ("^Z to undo"); a 1-char one is ordinary typing over a selection and stays quiet.
+    getter last_replaced : Int32
     getter cy : Int32
     getter cx : Int32
     getter scroll : Int32
@@ -366,6 +374,7 @@ module Gori::Tui
       # The ONE call that may join the step before it — see `push_undo`. A selection makes
       # this a replace, which is a step of its own however it was typed.
       push_undo(force: !@sel_anchor.nil?)
+      note_replaced
       # Replace-on-type: a printable typed over a selection REPLACES it. The cut runs after
       # push_undo and before the splice, so the pair is ONE undo step — ⌃Z brings back both
       # the deleted run and the character that displaced it, which is what "replace" means.
@@ -416,6 +425,7 @@ module Gori::Tui
     def insert_text(text : String) : Nil
       return if text.empty?
       push_undo
+      note_replaced
       cut_selection # replace-on-paste, one undo step — see `insert`
       line = @lines[@cy]
       cx = @cx.clamp(0, line.size)
@@ -446,8 +456,17 @@ module Gori::Tui
     # Insert `ch` TWICE as one undo unit — the `§§`/`¦¦` escaped-literal pair the marker
     # guard produces when a `§`/`¦` would otherwise nest inside (or flush against) a marker.
     # Caret ends past both, so the literal sits behind it like a normal keystroke.
+    # How much the splice about to run will DESTROY, for an owner that wants to say so (see
+    # `last_replaced`). Measured before the cut, and set on EVERY splice that cuts — including
+    # the ones that replace nothing — so an owner reading it right after a call can never see a
+    # stale count from an earlier keystroke.
+    private def note_replaced : Nil
+      @last_replaced = @sel_anchor.nil? ? 0 : (selection_text.try(&.size) || 0)
+    end
+
     def insert_pair(ch : Char) : Nil
       push_undo
+      note_replaced
       cut_selection # replace-on-type, one undo step — see `insert`
       line = @lines[@cy]
       cx = @cx.clamp(0, line.size)
@@ -828,6 +847,13 @@ module Gori::Tui
     # is empty). Both ends are clamped to the buffer as it stands now: the anchor was planted
     # against an earlier revision and an external `replace_line` / `resync Content-Length`
     # can have shortened its line since.
+    # The INSERT-mode selection as an ORDERED span, for an owner handing it to the read-mode
+    # cursor when leaving INS (`TextReadState#adopt_editor_selection`). Public because the
+    # handover crosses files; nil when nothing is selected, exactly like `selection?`.
+    def selection_span : {Int32, Int32, Int32, Int32}?
+      selection_range
+    end
+
     private def selection_range : {Int32, Int32, Int32, Int32}?
       anc = @sel_anchor
       return nil unless anc

--- a/src/gori/tui/text_read_state.cr
+++ b/src/gori/tui/text_read_state.cr
@@ -108,6 +108,47 @@ module Gori::Tui
       @cursor.sync(editor.cy, editor.cx)
     end
 
+    # Leaving INSERT: carry the editor's own ⇧arrow selection over to this mode, so `esc`
+    # then `y` copies what was selected while typing.
+    #
+    # Without this the selection was simply lost. INS grew ⇧arrow selection (the shared
+    # `TextArea#handle_motion_key`) and replace-on-type (`TextArea#insert` cuts the selection
+    # before splicing), but no way to COPY — the copy verbs were READ-only and `esc` routed
+    # through `apply` → `place_cursor`, which drops `@sel_anchor` on purpose. So the operator
+    # could build a selection, could destroy it with the next keystroke, and could not copy it
+    # by any means.
+    #
+    # This is NOT `place_cursor`'s job: that method is also the read-cursor write-back for
+    # ordinary NOR navigation, where clearing the stale INS anchor is correct (see the note
+    # there). Only the INS→READ transition hands over; every other path still clears.
+    #
+    # AUTHORITATIVE in both directions: after this call the READ selection is exactly the INS
+    # selection that existed at `esc` time, empty included. That is what keeps the round trip
+    # honest — READ-select, `i`, type, `esc` must not resurrect the band from before the edit,
+    # which a plain `sync_from` (it leaves the read anchor alone) would do. It is also why
+    # RepeaterView#exit_request_insert! can route here instead of hard-clearing: the reason it
+    # cleared was that an INS band is painted only while INS is on, so leaving the anchor set
+    # HID a live selection. Handing it to this mode — whose band is painted in READ — keeps it
+    # visible instead, so there is no longer a hidden state to dismiss.
+    #
+    # Returns true when a selection was actually adopted. `apply` runs last on purpose — it
+    # calls `place_cursor`, which retires the editor-side anchor, so the span lives in exactly
+    # one place afterwards and cannot come back the next time `i` is pressed.
+    def adopt_editor_selection(editor : TextArea) : Bool
+      span = editor.selection_span
+      lines = editor.lines_snapshot
+      if span.nil? || lines.empty?
+        editor.clear_selection # retire a collapsed anchor so `i` cannot revive it
+        @cursor.clear_selection
+        sync_from(editor)
+        return false
+      end
+      y0, x0, y1, x1 = span
+      @cursor.select_range(y0, x0, y1, x1)
+      apply(editor, lines)
+      true
+    end
+
     # Adopt the EDITOR's caret as this mode's, extending the read selection to it when
     # `selecting` (⇧Home/⇧End, which move the editor caret directly) and collapsing it
     # otherwise. `sync_from`'s counterpart for a key that went through the editor first.

--- a/src/gori/verb/context.cr
+++ b/src/gori/verb/context.cr
@@ -117,6 +117,16 @@ module Gori
       # whole focused pane. Routes to the active tab's existing copy delegators
       # (not new copy logic) — mirrors read_selection_active?'s per-tab dispatch.
       abstract def read_copy : Nil
+      # Whether the focused body region captures typed characters as text (INS / an
+      # editor sub-mode) rather than driving a navigable list or a read-only pane.
+      #
+      # This is what lets the `*.copy` verbs be available in INS, where their bare `y`
+      # cannot reach them: in INS the editor ladders claim printables upstream of the
+      # keymap, so `y` types a `y` and only the `^Y` chord arrives. Gating on this rather
+      # than on read_selection_active? is deliberate — a selection-only gate would make
+      # `^Y` a DEAD KEY in INS whenever nothing is selected, while READ's `y` copies the
+      # whole pane in that case (see Runner#read_copy). One key, one meaning, both modes.
+      abstract def editor_focused? : Bool
       # "Copy as X": open a centered picker of the focused HTTP message's copy formats
       # (url/headers/body/cookies/curl/raw). Focus-aware — the offered set follows the
       # active pane; degrades to read_copy when the context has no format variants.

--- a/src/gori/verb/context/intercept.cr
+++ b/src/gori/verb/context/intercept.cr
@@ -20,4 +20,7 @@ abstract class Gori::Verb::ExecContext
   # the gate for its select-line / copy verbs. Its caret comes from the POINTER: the tab has no
   # focus tier for this pane, so there is no keyboard caret to gate on.
   abstract def intercept_preview_readable? : Bool
+  # Copy's wider gate: also true while the held-bytes EDITOR is open, so an INS selection there
+  # can be copied (`^Y`) instead of only destroyed by the next printable.
+  abstract def intercept_copyable? : Bool
 end

--- a/src/gori/verbs/core.cr
+++ b/src/gori/verbs/core.cr
@@ -183,10 +183,16 @@ module Gori
       # only ever be dead weight in the rebind editor. Mnemonic 'y' matches the key that
       # actually works in the pane.
       in_project_desc_read = ->(ctx : Verb::ExecContext) { ctx.current_tab == :project && ctx.project_desc_read_mode? }
+      # Bare `y` stays chordless here (ProjectController raw-dispatches it — see above), but
+      # `^Y` IS registered: INS has no other way to reach Copy, and the raw dispatch only
+      # covers READ. See repeater.copy in verbs/history.cr.
+      in_project_desc_copy = ->(ctx : Verb::ExecContext) do
+        ctx.current_tab == :project && (ctx.project_desc_read_mode? || ctx.editor_focused?)
+      end
       r.register Verb::Definition.new(
         "project.copy", "Copy", "Copy the selected description text, or the whole description if nothing is selected, to the clipboard",
-        Verb::Scope::ProjectDesc,
-        available: in_project_desc_read, mnemonic: 'y') { |ctx| ctx.read_copy; nil }
+        Verb::Scope::ProjectDesc, [Verb::Chord.new("y", ctrl: true)],
+        available: in_project_desc_copy, mnemonic: 'y') { |ctx| ctx.read_copy; nil }
 
       # Match & Replace now lives in the Rewriter tab; this palette entry jumps there
       # (kept under the familiar "Match & Replace" name so a search still finds it).

--- a/src/gori/verbs/decoder.cr
+++ b/src/gori/verbs/decoder.cr
@@ -41,10 +41,15 @@ module Gori
 
       in_decoder_read = ->(ctx : Verb::ExecContext) { ctx.current_tab == :decoder && ctx.decoder_read_mode? }
       # The single smart Copy (see repeater.copy in verbs/history.cr) — copy-all is gone.
+      # `^Y` used to be a hardcoded copy-OUTPUT chord in DecoderController; it is folded in
+      # here so INPUT's INS mode gets the same key, and so the chord is rebindable.
+      in_decoder_copy = ->(ctx : Verb::ExecContext) do
+        ctx.current_tab == :decoder && (ctx.decoder_read_mode? || ctx.editor_focused?)
+      end
       r.register Verb::Definition.new(
         "decoder.copy", "Copy", "Copy the selected text, or the whole focused pane if nothing is selected, from INPUT/OUTPUT",
-        Verb::Scope::Decoder, [Verb::Chord.new("y")],
-        available: in_decoder_read, mnemonic: 'y') { |ctx| ctx.read_copy; nil }
+        Verb::Scope::Decoder, [Verb::Chord.new("y"), Verb::Chord.new("y", ctrl: true)],
+        available: in_decoder_copy, mnemonic: 'y') { |ctx| ctx.read_copy; nil }
 
       # Cycles the OUTPUT pane's display mode — tagged :output.
       r.register Verb::Definition.new(

--- a/src/gori/verbs/history.cr
+++ b/src/gori/verbs/history.cr
@@ -155,6 +155,13 @@ module Gori
       # and show their key hints — actual keys are handled directly by the TUI) ---
       in_repeater = ->(ctx : Verb::ExecContext) { ctx.current_tab == :repeater }
       in_repeater_read = ->(ctx : Verb::ExecContext) { ctx.current_tab == :repeater && ctx.repeater_read_mode? }
+      # Copy is the one READ verb that must also work while TYPING: INS can build a
+      # ⇧arrow selection but had no way to copy it, so the next printable replaced it
+      # (TextArea#insert cuts the selection). READ keeps bare `y`; INS reaches the same
+      # verb through the `^Y` chord, which the editor ladders defer to the keymap.
+      in_repeater_copy = ->(ctx : Verb::ExecContext) do
+        ctx.current_tab == :repeater && (ctx.repeater_read_mode? || ctx.editor_focused?)
+      end
 
       r.register Verb::Definition.new(
         "repeater.send", "Send repeater", "Resend the request byte-exact and diff the response",
@@ -168,8 +175,8 @@ module Gori
       # farther down so the physical registration order matches).
       r.register Verb::Definition.new(
         "repeater.copy", "Copy", "Copy the selected text, or the whole focused pane if nothing is selected, to the clipboard",
-        Verb::Scope::Repeater, [Verb::Chord.new("y")],
-        available: in_repeater_read, mnemonic: 'y') { |ctx| ctx.read_copy; nil }
+        Verb::Scope::Repeater, [Verb::Chord.new("y"), Verb::Chord.new("y", ctrl: true)],
+        available: in_repeater_copy, mnemonic: 'y') { |ctx| ctx.read_copy; nil }
 
       # "Copy as X": a picker of focus-aware copy formats (REQUEST → url/headers/body/
       # cookies/curl/wscat-for-WS/raw · RESPONSE → status+headers/body/raw). Sits beside Copy in
@@ -257,9 +264,15 @@ module Gori
       r.register Verb::Definition.new(
         "repeater.clear-marks", "Clear markers", "Strip every §…§ marker (and its attached chain)",
         Verb::Scope::Repeater, available: in_repeater, mnemonic: 'c', section: :request) { |ctx| ctx.repeater_clear_marks; nil }
+      # ^Q, not ^Y: `^Y` is now Copy in every text box (see `in_repeater_copy`), and Copy is
+      # the far more frequent action of the two, so it takes the chord whose letter means
+      # something. attach-chain keeps a CTRL chord rather than falling back to its space-menu
+      # mnemonic because the space menu is unreachable from INS (`Runner#handle_key`: "text
+      # editors swallow keys upstream, so space stays a literal char there") — and attaching a
+      # chain to a `§` marker you have just typed is an INS-mode action. Both are rebindable.
       r.register Verb::Definition.new(
         "repeater.attach-chain", "Edit decoder chain", "Focus the CHAIN pane to edit the encode/decode chain of the marker at the cursor (applied on send)",
-        Verb::Scope::Repeater, [Verb::Chord.new("y", ctrl: true)],
+        Verb::Scope::Repeater, [Verb::Chord.new("q", ctrl: true)],
         available: in_repeater, mnemonic: 'e', section: :request) { |ctx| ctx.repeater_attach_chain; nil }
 
       # Request-pane VIEW toggles — keymap-driven (Repeater scope) so they're rebindable.
@@ -553,7 +566,7 @@ module Gori
         available: in_fuzzer, mnemonic: 'i', section: :template) { |ctx| ctx.fuzz_insert_marker; nil }
       r.register Verb::Definition.new(
         "fuzz.attach-chain", "Edit decoder chain", "Focus the CHAIN pane to edit the encode/decode chain of the marker at the cursor (applied to each payload on send)",
-        Verb::Scope::Fuzzer, [Verb::Chord.new("y", ctrl: true)],
+        Verb::Scope::Fuzzer, [Verb::Chord.new("q", ctrl: true)], # ^Y → Copy; see repeater.attach-chain
         available: in_fuzzer, mnemonic: 'e', section: :template) { |ctx| ctx.fuzz_attach_chain; nil }
       r.register Verb::Definition.new(
         "fuzz.list-paste", "Add List payload set", "Open the payload-set editor pre-seeded to a List — a multi-line editor, one value per line (paste splits automatically)",
@@ -581,11 +594,15 @@ module Gori
         Verb::Scope::Fuzzer, [Verb::Chord.new("s", ctrl: true)],
         available: in_fuzzer, mnemonic: 'i', section: :target) { |ctx| ctx.fuzz_toggle_sni; nil }
       in_fuzzer_read = ->(ctx : Verb::ExecContext) { ctx.current_tab == :fuzzer && ctx.fuzzer_read_mode? }
-      # The single smart Copy (see repeater.copy above) — copy-all is gone.
+      in_fuzzer_copy = ->(ctx : Verb::ExecContext) do
+        ctx.current_tab == :fuzzer && (ctx.fuzzer_read_mode? || ctx.editor_focused?)
+      end
+      # The single smart Copy (see repeater.copy above) — copy-all is gone. `y` in READ,
+      # `^Y` in INS, same verb.
       r.register Verb::Definition.new(
         "fuzzer.copy", "Copy", "Copy the selected text, or the whole focused pane if nothing is selected, to the clipboard",
-        Verb::Scope::Fuzzer, [Verb::Chord.new("y")],
-        available: in_fuzzer_read, mnemonic: 'y') { |ctx| ctx.read_copy; nil }
+        Verb::Scope::Fuzzer, [Verb::Chord.new("y"), Verb::Chord.new("y", ctrl: true)],
+        available: in_fuzzer_copy, mnemonic: 'y') { |ctx| ctx.read_copy; nil }
     end
 
     # Param-miner verbs: the cross-tab "Mine parameters" entry (space menu in History,

--- a/src/gori/verbs/issues.cr
+++ b/src/gori/verbs/issues.cr
@@ -145,11 +145,15 @@ module Gori
       # bracket chords ([ ] { }) hidden (awkward as menu mnemonics; discoverable in Help).
       # The single smart Copy (see repeater.copy in verbs/history.cr) — copy-all is gone.
       in_issues_notes_read = ->(ctx : Verb::ExecContext) { ctx.issues_notes_read_mode? }
+      # `y` in READ, `^Y` in INS — see repeater.copy in verbs/history.cr.
+      in_issues_notes_copy = ->(ctx : Verb::ExecContext) do
+        ctx.issues_notes_read_mode? || (ctx.current_tab == :issues && ctx.editor_focused?)
+      end
 
       r.register Verb::Definition.new(
         "issue.copy", "Copy", "Copy the selected notes text, or the whole notes if nothing is selected, to the clipboard",
-        Verb::Scope::IssuesDetail, [Verb::Chord.new("y")],
-        available: in_issues_notes_read, mnemonic: 'y') { |ctx| ctx.read_copy; nil }
+        Verb::Scope::IssuesDetail, [Verb::Chord.new("y"), Verb::Chord.new("y", ctrl: true)],
+        available: in_issues_notes_copy, mnemonic: 'y') { |ctx| ctx.read_copy; nil }
 
       r.register Verb::Definition.new(
         "issue.edit-notes", "Edit notes", "Edit the issue notes inline (i/↵/e)", Verb::Scope::IssuesDetail,

--- a/src/gori/verbs/jwt.cr
+++ b/src/gori/verbs/jwt.cr
@@ -32,10 +32,15 @@ module Gori
 
       # The single smart Copy (selection if any, else the focused pane) — chord 'y'.
       in_jwt_read = ->(ctx : Verb::ExecContext) { ctx.current_tab == :jwt && ctx.jwt_read_mode? }
+      # `^Y` used to be a hardcoded copy-all chord in JwtController; folded in here so the
+      # INPUT/header/payload editors get the same key in INS, and so it is rebindable.
+      in_jwt_copy = ->(ctx : Verb::ExecContext) do
+        ctx.current_tab == :jwt && (ctx.jwt_read_mode? || ctx.editor_focused?)
+      end
       r.register Verb::Definition.new(
         "jwt.copy", "Copy", "Copy the selection, or the whole focused pane if nothing is selected",
-        Verb::Scope::Jwt, [Verb::Chord.new("y")],
-        available: in_jwt_read, mnemonic: 'y') { |ctx| ctx.jwt_copy; nil }
+        Verb::Scope::Jwt, [Verb::Chord.new("y"), Verb::Chord.new("y", ctrl: true)],
+        available: in_jwt_copy, mnemonic: 'y') { |ctx| ctx.jwt_copy; nil }
 
       # Copy the re-signed OUTPUT token — tagged :output (the ENCODE result pane).
       r.register Verb::Definition.new(

--- a/src/gori/verbs/notes.cr
+++ b/src/gori/verbs/notes.cr
@@ -42,10 +42,15 @@ module Gori
 
       # The single smart Copy (see repeater.copy in verbs/history.cr) — copy-all is gone.
       in_notes_read = ->(ctx : Verb::ExecContext) { ctx.current_tab == :notes && ctx.notes_read_mode? }
+      # `y` in READ, `^Y` in INS — one verb. See repeater.copy in verbs/history.cr for why
+      # Copy is available while typing at all (an INS selection had no way to be copied).
+      in_notes_copy = ->(ctx : Verb::ExecContext) do
+        ctx.current_tab == :notes && (ctx.notes_read_mode? || ctx.editor_focused?)
+      end
       r.register Verb::Definition.new(
         "notes.copy", "Copy", "Copy the selected text, or the whole current note if nothing is selected, to the clipboard",
-        Verb::Scope::Notes, [Verb::Chord.new("y")],
-        available: in_notes_read, mnemonic: 'y') { |ctx| ctx.read_copy; nil }
+        Verb::Scope::Notes, [Verb::Chord.new("y"), Verb::Chord.new("y", ctrl: true)],
+        available: in_notes_copy, mnemonic: 'y') { |ctx| ctx.read_copy; nil }
 
       r.register Verb::Definition.new(
         "notes.clear", "Clear note", "Clear the current note's text",

--- a/src/gori/verbs/read_edit.cr
+++ b/src/gori/verbs/read_edit.cr
@@ -137,6 +137,9 @@ module Gori
       # verb moved into a `:rules` section at the same time). Two sections never render together,
       # so `x` keeps meaning "select line" here and "toggle" there.
       in_rewriter_out = ->(ctx : Verb::ExecContext) { ctx.current_tab == :rewriter && ctx.rewriter_preview_out? }
+      in_rewriter_copy = ->(ctx : Verb::ExecContext) do
+        ctx.current_tab == :rewriter && (ctx.rewriter_preview_out? || ctx.editor_focused?)
+      end
       r.register Verb::Definition.new(
         "rewriter.select-line", "Select line", "Select the entire current preview line",
         Verb::Scope::Rewriter, [Verb::Chord.new("x")],
@@ -148,9 +151,11 @@ module Gori
         "rewriter.send-to", "Send selection to…", "Send the selected text to another tool (Decoder, …)",
         Verb::Scope::Rewriter, available: in_sel, mnemonic: 'S', section: :preview) { |ctx| ctx.send_to_open; nil }
       r.register Verb::Definition.new(
-        "rewriter.copy", "Copy", "Copy the selected preview text, or the whole transformed sample if nothing is selected",
-        Verb::Scope::Rewriter, [Verb::Chord.new("y")],
-        available: in_rewriter_out, mnemonic: 'y', section: :preview) { |ctx| ctx.read_copy; nil }
+        # `^Y` and the wider gate: the INPUT pane is an EDITOR, where a bare `y` is a literal
+        # character that replaces the selection, so Copy has to be reachable by chord there too.
+        "rewriter.copy", "Copy", "Copy the selected preview text, or the whole pane if nothing is selected",
+        Verb::Scope::Rewriter, [Verb::Chord.new("y"), Verb::Chord.new("y", ctrl: true)],
+        available: in_rewriter_copy, mnemonic: 'y', section: :preview) { |ctx| ctx.read_copy; nil }
 
       # The Comparer's diff. Whole ROWS, never a char span: a screen row is two columns of the
       # same diff, so `ReadPane(line_select_only: true)` is what the cursor is — see
@@ -178,6 +183,7 @@ module Gori
       # with a live queue action — the menu is the discoverable route, as it is for the Project
       # description.
       in_icept_preview = ->(ctx : Verb::ExecContext) { ctx.current_tab == :intercept && ctx.intercept_preview_readable? }
+      in_icept_copy = ->(ctx : Verb::ExecContext) { ctx.current_tab == :intercept && ctx.intercept_copyable? }
       r.register Verb::Definition.new(
         "intercept.select-line", "Select line", "Select the entire current preview line",
         Verb::Scope::Intercept, available: in_icept_preview, mnemonic: 'x') { |ctx| ctx.read_select_line; nil }
@@ -188,8 +194,13 @@ module Gori
         "intercept.send-to", "Send selection to…", "Send the selected text to another tool (Decoder, …)",
         Verb::Scope::Intercept, available: in_sel, mnemonic: 'S') { |ctx| ctx.send_to_open; nil }
       r.register Verb::Definition.new(
+        # Bare `y` stays chordless for the reason above (the queue spends the letters), but `^Y`
+        # IS registered and the gate is the WIDER `intercept_copyable?`: the held-bytes editor
+        # can build a ⇧arrow selection in INS, where a bare `y` is a literal character that
+        # REPLACES it. A ctrl chord collides with nothing in the queue.
         "intercept.copy", "Copy", "Copy the selected preview text, or the whole held message if nothing is selected",
-        Verb::Scope::Intercept, available: in_icept_preview, mnemonic: 'y') { |ctx| ctx.read_copy; nil }
+        Verb::Scope::Intercept, [Verb::Chord.new("y", ctrl: true)],
+        available: in_icept_copy, mnemonic: 'y') { |ctx| ctx.read_copy; nil }
 
       # An OAST callback's detail. `section: :detail` (OastController#command_section answers to
       # match): the callbacks LIST spends `y` on "copy the generated payload", and this pane's `y`


### PR DESCRIPTION
Reported as "I press `y` to copy in the editor and my text disappears". It is not
muscle memory — it is a functional hole. INS mode could BUILD a ⇧arrow selection and
DESTROY it, but had no way to copy it:

  * every `*.copy` verb was gated `available: *_read_mode?`, so Copy did not exist in INS;
  * `esc` then `y` did not work either — leaving INS routes through `TextReadState#apply`
    → `place_cursor`, which drops `@sel_anchor` on purpose;
  * `space` is a literal char in editors, `^C` is the quit arm, and the palette filtered
    Copy out by `available?`.

So the reflex `y` fell through to the printable arm, where `TextArea#insert` cuts the
selection before splicing (replace-on-type). Selection gone, one keystroke, no toast.

^Y IS COPY, in every text box, INS included. A second chord on the existing `*.copy`
verbs, gated on a new `ExecContext#editor_focused?` (which reuses `Runner#body_editor?`,
the same predicate the EDITOR status badge reads). Deliberately NOT gated on "selection
active": that would make `^Y` a DEAD KEY whenever nothing is selected, while READ's `y`
copies the whole pane in that case. One key, one meaning, both modes. Routing is the
existing `read_copy` and `Clipboard.copy` — no new copy logic. The two hardcoded `^Y`
chords in DecoderController/JwtController are folded into the verb, so they rebind now.

attach-chain: ^Y → ^Q. Copy is the far more frequent action, so it takes the letter that
means something. attach-chain keeps a CTRL chord rather than falling back to its
`space → e` mnemonic, because the space menu is UNREACHABLE from INS — the same fact that
causes this bug — and attaching a chain to a `§` you have just typed is an INS action.
`^Q` was the last free Ctrl letter; `hotkeys.md` records the rule that decided it ("Ctrl is
for actions that must work while typing"). Both are rebindable.

ESC HANDS THE SELECTION OVER. `TextReadState#adopt_editor_selection` carries an INS span
to the read cursor, so `esc` then `y` copies what was selected. Not by loosening
`place_cursor` — that is also the read-cursor write-back for ordinary NOR navigation,
where clearing is correct. Authoritative BOTH ways: no INS selection ⇒ it clears the read
one, or a READ-select → `i` → type → `esc` round trip resurrects the band from before the
edit. `ReadCursor#select_range` is the range setter this needed (`select_line` /
`select_word_at` derive their own span).

THE LOSS IS NOW ANNOUNCED. `replaced 42 chars — ^Z to undo`, gated to multi-char replaces
so ordinary typing over one character stays quiet. `TextArea#last_replaced` reports the
count from all three cutting paths (`insert`, `insert_pair`, `insert_text`) and the
CONTROLLER decides — the widget has no route to the shell and does not grow one, the same
bargain the `edits` checks around `backspace` already make.

THE CLASS, AT EVERY SITE. Four controllers swallowed unclaimed ctrl chords in INS (Notes,
Issues notes, Project description, Intercept) so `^Y` could never have reached the keymap
there. Seven panes reported only the READ half of their selection, which made a visible
INS band uncopyable — the shape `RepeaterView#pane_selection?` had already been fixed to
and nothing else had. Intercept and Rewriter were the sneaky ones: their copy verbs
targeted a DIFFERENT pane (`intercept_preview_copy` bailed on `!@editing`, `rewriter_copy`
early-returned unless `:preview_out`), so relaxing `available:` alone would have shipped
the new toast on two surfaces that still could not copy.

Two claims from the audit that did NOT survive checking, recorded so they are not
re-fixed: the Fuzzer template does have `^Z` (wired upstream via `chord_action` → `:undo`,
not in the `edit_template` ladder); and `ConfirmDialog.affirmative?` already guards
ctrl/alt, verified live — the CLOSE REPEATER card survives `^Y`. That guard is now
load-bearing on a hotter path, so its note says why it outlived the chord it named.

VERIFICATION. The new behaviour specs were re-run with the fix REVERTED and 5 of 6 fail
(the 6th is a deliberate no-regression guard on `place_cursor`, correctly passing both
ways). Full suite green except the eight `Gori::Session` port-bind examples, which fail on
a clean tree too — a live gori holds the port. Driven end-to-end in tmux: `^Y` copies in
Notes, the Repeater request, the Project description, the Rewriter input and the Intercept
held-bytes editor (previously impossible); `esc` then `y` copies the same bytes; `^Q` opens
AND saves the chain modal with its tooltip reading `^Q edit`; the toast fires at 7 chars
and `^Z` restores; a 1-char replace stays silent.

NOT DONE, on purpose: the Fuzzer template's INS ladder still re-spells the arrow motions
inline instead of routing through the shared `handle_motion_key`. That is duplication, not
missing behaviour, and deduping it would put its `template_up` pane-pop and `buffer_jump?`
semantics at risk for no gain here.
