### PR TITLE
Close 34 ways gori could crash, hang, or quietly rewrite what it captured

### DIFF
--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -110,6 +110,7 @@ Where a run streams, `json` and `jsonl` are not always the same shape:
 | `0` | Success |
 | `1` | Error — a failed send, an unreadable project, a mutation that could not be applied |
 | `3` | `run fuzz --fail-if-no-matches` completed but nothing matched |
+| `130` | Interrupted by SIGINT/SIGTERM — `fuzz`, `mine`, `discover` and `sequence` flush what they collected first, then exit `130` so a scripted `&& next-step` does not treat a truncated run as a finished one |
 
 Without `--fail-if-no-matches`, a fuzz run that matched nothing *and* errored on every send still exits `1`, so "no findings" stays distinguishable from "never reached the target". With the flag, `3` wins.
 

--- a/spec/cli/run/argv_non_utf8_spec.cr
+++ b/spec/cli/run/argv_non_utf8_spec.cr
@@ -1,0 +1,54 @@
+require "../../spec_helper"
+
+# argv is whatever bytes the OS handed us — Crystal builds those Strings without validating
+# UTF-8 — and `split_ql_negations` matched a PCRE2 regex straight against them. PCRE2 does not
+# fail to match on a bad subject, it RAISES `ArgumentError: Regex match error: UTF-8 error`,
+# and neither `Run.dispatch` (rescues IO::Error) nor `CLI.run` (rescues Gori::Error) catches
+# that, so `gori run history $'\xff'` printed a Crystal backtrace out of `main` before any
+# store was even opened. Reachable from a plain shell, and realistically from a wrapper script
+# interpolating a latin-1 term captured off the wire.
+#
+# The remedy is the one `read_token_list` in src/gori/cli/run/sequence.cr already uses: scrub
+# the SUBJECT of the match, never the value. What gets pushed into the returned arrays is the
+# original `a`, so the operator's query bytes reach QL exactly as typed (P7) — the assertions
+# below check both halves, because scrubbing the stored value would be the easy wrong fix.
+#
+# The two sibling sites, `parse_duration` (`--for`) and `parse_numbers` (`--numbers`), took the
+# same one-word change, but both end in `abort` on a value that does not match and so cannot be
+# exercised in-process; `split_ql_negations` returns, so it carries the behavioural pin.
+module Gori::CLI::Run
+  def self.split_ql_negations_for_spec(args : Array(String))
+    split_ql_negations(args)
+  end
+end
+
+private def raw(bytes : Bytes) : String
+  String.new(bytes)
+end
+
+describe "CLI::Run.split_ql_negations — non-UTF-8 argv" do
+  it "classifies an invalid-UTF-8 term instead of raising out of main" do
+    junk = raw(Bytes[0xff])
+    junk.valid_encoding?.should be_false
+    neg, rest = Gori::CLI::Run.split_ql_negations_for_spec([junk])
+    neg.should be_empty
+    rest.size.should eq(1)
+    rest[0].to_slice.should eq(junk.to_slice)
+  end
+
+  it "keeps the query term byte-exact — the scrub is the match subject, not the value" do
+    # "-host:" + 0xff: a negation term whose VALUE carries the junk byte.
+    junk = raw(Bytes[0x2d, 0x68, 0x6f, 0x73, 0x74, 0x3a, 0xff])
+    neg, rest = Gori::CLI::Run.split_ql_negations_for_spec([junk])
+    rest.should be_empty
+    neg.size.should eq(1)
+    neg[0].to_slice.should eq(junk.to_slice)
+    neg[0].valid_encoding?.should be_false # not silently repaired on its way through
+  end
+
+  it "still splits ordinary terms the same way" do
+    neg, rest = Gori::CLI::Run.split_ql_negations_for_spec(["host:x", "-path:/b", "-n50", "-k"])
+    neg.should eq(["-path:/b"])
+    rest.should eq(["host:x", "-n50", "-k"])
+  end
+end

--- a/spec/cli/run/interrupt_exit_status_spec.cr
+++ b/spec/cli/run/interrupt_exit_status_spec.cr
@@ -1,0 +1,27 @@
+require "../../spec_helper"
+
+# The two halves of an interrupted sweep, as a CLASS.
+#
+# `Run.install_interrupt_trap` stops the engine and flushes; `Run.report_interrupted` is the
+# other half — it says how much survived and `exit 130`s, so a scripted
+# `gori run … && ./triage.sh` does not treat a truncated run as a finished one.
+#
+# `gori run discover` had the trap and NOT the exit: it called a file-local reporter that only
+# wrote a line to STDERR and returned, so an interrupted-but-error-free crawl fell through to
+# exit 0 while its three siblings exited 130 for the same Ctrl-C. That local reporter predated
+# the shared helper and survived the extraction; nothing failed when it did, because both
+# halves end in `exit` and neither can be exercised in-process. So the pairing is asserted over
+# the SOURCE, the way spec/cli_spec.cr pins `unknown_args`.
+describe "gori run — interrupt trap and non-zero exit are one pair" do
+  it "is honoured by every subcommand that installs the trap" do
+    dir = File.join(__DIR__, "..", "..", "..", "src", "gori", "cli", "run")
+    offenders = [] of String
+    Dir.glob(File.join(dir, "**", "*.cr")).sort.each do |path|
+      next if File.basename(path) == "interrupt.cr" # where the pair is defined
+      src = File.read(path)
+      next unless src.includes?("install_interrupt_trap(")
+      offenders << File.basename(path) unless src.includes?("Run.report_interrupted(")
+    end
+    offenders.should be_empty
+  end
+end

--- a/spec/cli/run/option_parser_missing_option_spec.cr
+++ b/spec/cli/run/option_parser_missing_option_spec.cr
@@ -1,0 +1,61 @@
+require "../../spec_helper"
+
+# Every parser under `src/gori/cli/` that takes a `=VALUE` flag, as a CLASS.
+#
+# `OptionParser`'s default `missing_option` handler RAISES `OptionParser::MissingOption`. That
+# is neither `Gori::Error` (the only type `CLI.run` rescues, src/gori/cli.cr) nor `IO::Error`
+# (the only type `Run.dispatch` rescues, src/gori/cli/run.cr), so a value flag left bare at the
+# end of argv — `gori run rewriter rm 1 --project`, or an unset `--project "$P"` in a wrapper
+# script — reaches `main` and prints a Crystal backtrace instead of a one-line abort:
+#
+#   gori run rewriter rm 1 --project      → Unhandled exception: Missing option: --project
+#   gori run colormarker move 1 --db      → same
+#   gori run decoder list --format        → same
+#
+# `unknown_args` does not absorb it: the token matches a DECLARED option, so `handle_flag` runs
+# first. src/gori/cli/run/oast.cr fixed one parser for exactly this and read as the only one;
+# eleven more were carrying the same hole. Asserted over the SOURCE rather than per-command,
+# the way the `unknown_args` guard in spec/cli_spec.cr is, because the defect is one a new
+# subcommand reintroduces by copying the idiom from its neighbours — which is how these got it.
+#
+# A parser declaring no `=VALUE` flag cannot hit the handler, so it is exempt rather than
+# force-fitted.
+describe "gori run — missing_option on every value-taking parser" do
+  it "is bound wherever a =VALUE flag is declared" do
+    dir = File.join(__DIR__, "..", "..", "..", "src", "gori", "cli")
+    offenders = [] of String
+    Dir.glob(File.join(dir, "**", "*.cr")).sort.each do |path|
+      lines = File.read_lines(path)
+      i = 0
+      while i < lines.size
+        line = lines[i]
+        unless line.includes?("OptionParser.new do")
+          i += 1
+          next
+        end
+        # The block runs to the `end` sitting at the opener's own indentation.
+        indent = line.size - line.lstrip.size
+        j = i + 1
+        body = [] of String
+        while j < lines.size
+          l = lines[j]
+          break if l.strip == "end" && (l.size - l.lstrip.size) == indent
+          body << l
+          j += 1
+        end
+        # `p.on("--project=NAME", …)`, `p.on("-p PORT", …)` — and `[a-z][A-Z]` for the
+        # short-ATTACHED form `p.on("-fFIND", …)`, which the `[= ]` alternative does not see.
+        # Today every short-attached flag happens to carry a `--long=VALUE` twin, so the first
+        # alternative alone still passed — which is exactly the kind of accident that lets an
+        # unpaired `-nN` slip through later. Flag names in this tree are lowercase kebab-case,
+        # so `[a-z][A-Z]` cannot fire on a bare switch. `-h`/`--help` do not match either.
+        takes_value = body.any? do |l|
+          l.includes?("p.on(") && l.matches?(/"-{1,2}[^"]*(?:[= ][A-Z]|[a-z][A-Z])/)
+        end
+        offenders << "#{File.basename(path)}:#{i + 1}" if takes_value && !body.any?(&.includes?("p.missing_option"))
+        i = j
+      end
+    end
+    offenders.should be_empty
+  end
+end

--- a/spec/cookie_spec.cr
+++ b/spec/cookie_spec.cr
@@ -188,6 +188,35 @@ describe Gori::Cookie do
       value = RACK.split("--").first
       Gori::Cookie::Rack.forge(value, SECRET).should eq(RACK) # same value+secret → same cookie
     end
+
+    # A cookie is bytes lifted verbatim off the wire, so the tail after "--" need not be valid
+    # UTF-8. The hex-tail test used to be a Regex, and PCRE2 RAISES on an invalid byte instead
+    # of not matching — `gori run cookie` died with a Crystal backtrace, and `verify`'s "false
+    # on a structural parse failure too" contract went with it. Rack is tested FIRST by
+    # `detect`, so this reached every caller before the byte-safe Django/Flask predicates ran.
+    it "answers, rather than raising, on a signature tail that is not valid UTF-8" do
+      bad = "sess--" + "0" * 39 + String.new(Bytes[0xFF])
+      Gori::Cookie.detect(bad).should be_nil
+      Gori::Cookie.verify(bad, SECRET).should be_false
+      expect_raises(Gori::Cookie::CookieError, /unrecognized cookie format/) do
+        Gori::Cookie.decode(bad)
+      end
+      expect_raises(Gori::Cookie::CookieError, /unrecognized cookie format/) do
+        Gori::Cookie.crack(bad, ["a", SECRET])
+      end
+      # Pinned to rack, the parse failure is still a CookieError, not an ArgumentError.
+      expect_raises(Gori::Cookie::CookieError, /40-char hex/) do
+        Gori::Cookie.decode(bad, "rack")
+      end
+    end
+
+    # The byte-level hex test has to keep the Regex's exact charset and length.
+    it "keeps the 40-hex tail rule, either case and that length only" do
+      Gori::Cookie.detect("v--" + "AbCdEf0123" * 4).should eq("rack")
+      Gori::Cookie.detect("v--" + "0" * 39).should be_nil
+      Gori::Cookie.detect("v--" + "0" * 41).should be_nil
+      Gori::Cookie.detect("v--" + "g" * 40).should be_nil
+    end
   end
 
   describe ".crack" do

--- a/spec/discover/calibrate_spec.cr
+++ b/spec/discover/calibrate_spec.cr
@@ -87,6 +87,40 @@ describe Gori::Discover::Calibrate do
     end
   end
 
+  # The same storm as the `echoes` case above, arriving by the other door: `calibrate_probes`
+  # is 3, and two of them flaking (a timeout, a reset) used to leave ONE response deciding the
+  # kind — `cohesive?` and `uniform_redirect` are both unanimous with a single sample, so a
+  # lone 200 was promoted to WildcardOk and every wordlist entry against a dynamic miss page
+  # came back a finding at 0.55, over the default 0.5 floor. An errored probe shrinks the
+  # sample; it must not shorten the calibration.
+  describe "a directory where only ONE calibration probe came back" do
+    soft = Gori::Discover::Fingerprint.simhash("the soft 404 body that comes back for everything".to_slice)
+    real = Gori::Discover::Fingerprint.simhash("a completely different real page about accounts".to_slice)
+
+    it "is Uncalibratable rather than WildcardOk, and reports nothing on a 200-everything dir" do
+      base = C.build("http://h/",
+        [fetched(200, 1000, soft), fetched(nil, 0, err: "timeout"), fetched(nil, 0, err: "reset")], 3)
+      base.kind.should eq(C::BaselineKind::Uncalibratable)
+      # Content divergence is all a 200-everything origin can offer, and on one sample it is
+      # not evidence — `Uncalibratable` trusts status only, so this whole sweep stays quiet.
+      C.hit?(base, fetched(200, 1010, real))[0].should be_false
+    end
+
+    it "is Uncalibratable rather than WildcardRedirect, and claims no funnel target" do
+      base = C.build("http://h/",
+        [fetched(302, 0, loc: "/login"), fetched(nil, 0, err: "timeout"), fetched(nil, 0, err: "reset")], 3)
+      base.kind.should eq(C::BaselineKind::Uncalibratable)
+      base.redirect_target.should be_nil # one probe is unanimous with itself; that is not a funnel
+    end
+
+    it "still calibrates normally once two probes survive (the control)" do
+      base = C.build("http://h/",
+        [fetched(200, 1000, soft), fetched(200, 1000, soft), fetched(nil, 0, err: "reset")], 3)
+      base.kind.should eq(C::BaselineKind::WildcardOk)
+      C.hit?(base, fetched(200, 1010, real))[0].should be_true
+    end
+  end
+
   it "is uncalibratable when every bogus probe errored, and never fabricates a hit from no signal" do
     base = C.build("http://h/", [fetched(nil, 0, err: "connect failed")], 3)
     base.kind.should eq(C::BaselineKind::Uncalibratable)

--- a/spec/discover/engine_spec.cr
+++ b/spec/discover/engine_spec.cr
@@ -241,6 +241,22 @@ describe Gori::Discover::Engine do
     bf.should_not contain("http://t/other")
   end
 
+  # A redirect `Location` is the ONE link source that reaches `Url.resolve` unscrubbed — the
+  # other four all come out of `Extract`, which scrubs before anything meets PCRE2. `resolve`
+  # tested the scheme with a Regex, and PCRE2 raises ArgumentError on invalid UTF-8, so a
+  # Latin-1 relative Location unwound the ORCHESTRATOR fiber: the run ended on a terminal
+  # "Regex match error" with no Done, discarding every outcome still in flight.
+  it "finishes a run whose redirect Location is a relative, not-valid-UTF-8 path" do
+    cfg = D::Config.new(spider: true, bruteforce: false, max_depth: 2, concurrency: 1, retries: 0)
+    loc = String.new(Bytes[0x63, 0x61, 0x66, 0xe9, 0x2f, 0x78]) # "caf\xE9/x"
+    backend = RouteBackend.new(->(t : String) do
+      t == "/" ? make(302, "", location: loc) : html("an ordinary page")
+    end)
+    kinds, messages = terminal_of(D::Engine.new("http://t/", [] of String, backend, cfg))
+    messages.should be_empty
+    kinds.last.should eq(:done)
+  end
+
   it "stops a /user/{n} link farm via template folding" do
     cfg = D::Config.new(spider: true, bruteforce: false, max_depth: 5, max_pages: 1000,
       template_saturation: 20, concurrency: 2, retries: 0)

--- a/spec/discover/url_spec.cr
+++ b/spec/discover/url_spec.cr
@@ -156,6 +156,32 @@ describe Gori::Discover::Url do
       U.resolve(base, "   ").should be_nil
     end
 
+    # A 3xx `Location` is the one href that reaches `resolve` straight off the wire — every
+    # page-derived link came through `Extract`, which scrubs. The scheme test used to be a
+    # Regex, and PCRE2 raises ArgumentError on invalid UTF-8; `downcase` keeps a lone Latin-1
+    # octet intact, so this href raised instead of resolving. It runs on discover's
+    # orchestrator fiber, so the raise ended the whole run.
+    it "resolves a relative href that is not valid UTF-8 instead of raising out of PCRE2" do
+      base = U.parse("http://h/app/index.html").not_nil!
+      href = String.new(Bytes[0x63, 0x61, 0x66, 0xe9, 0x2f, 0x78]) # "caf\xE9/x"
+      href.valid_encoding?.should be_false
+      U.resolve(base, href).should eq("http://h/app/#{href}")
+      # The absolute-path form took a byte-safe branch and always worked — the control that
+      # says this is about the scheme test, not about the href being odd.
+      U.resolve(base, "/#{href}").should eq("http://h/#{href}")
+    end
+
+    it "still refuses a scheme-prefixed href with the byte scan the Regex used to do" do
+      base = U.parse("http://h/p").not_nil!
+      U.resolve(base, "ftp://h/x").should be_nil
+      U.resolve(base, "svn+ssh://h/x").should be_nil
+      U.resolve(base, "view-source:http://h/x").should be_nil
+      # Not a scheme: the class stops at the first byte outside [a-z0-9+.-], so the ':' in a
+      # query or a path segment must not make a relative href look absolute.
+      U.resolve(base, "c?x=a:b").should eq("http://h/c?x=a:b")
+      U.resolve(base, "2fa:x").should eq("http://h/2fa:x") # a scheme cannot start with a digit
+    end
+
     # SUSPECTED BUG: resolve() checks the absolute-URL prefix case-sensitively
     # (h.starts_with?("http://")), so an uppercase scheme falls through to the
     # "some other scheme" branch and returns nil. HTML/URL schemes are

--- a/spec/env_escape_spec.cr
+++ b/spec/env_escape_spec.cr
@@ -223,6 +223,31 @@ describe "Gori::Env — the $$ escape" do
     end
   end
 
+  # A Content-Length at the Int64 edge is a standard integer-overflow probe, so it arrives on
+  # this path as the payload — and Crystal's `+` is CHECKED, so shifting it raised OverflowError
+  # out of the send. `gori run repeater` has no rescue for that (`CLI.dispatch` catches only
+  # `Gori::Error`), so it died with a raw backtrace before any I/O. Saturating keeps the
+  # method's contract: it shifts what it can and never raises.
+  it "saturates rather than overflowing a Content-Length at the Int64 edge" do
+    with_env(declared: ["id"], bound: {"id" => "V"}) do
+      # The `$$` escape SHORTENS the body by one, and needs no bindings at all — which is why
+      # the negative twin is reachable from a request file alone.
+      wire = "POST /g HTTP/1.1\r\nHost: h\r\nContent-Length: -9223372036854775808\r\n\r\n$$id"
+      out = String.new(Gori::Env.expand_bindings(wire.to_slice))
+      out.should end_with("\r\n\r\n$id")
+      out.should contain("Content-Length: 0") # the lower bound this always had
+    end
+  end
+
+  it "saturates a Content-Length at Int64::MAX when a binding GROWS the body" do
+    with_env(declared: ["id"], bound: {"id" => "0123456789"}) do
+      wire = "POST /g HTTP/1.1\r\nHost: h\r\nContent-Length: 9223372036854775807\r\n\r\n$id"
+      out = String.new(Gori::Env.expand_bindings(wire.to_slice))
+      out.should end_with("\r\n\r\n0123456789")
+      out.should contain("Content-Length: 9223372036854775807")
+    end
+  end
+
   # An EVIDENCE path interprets nothing, so it unescapes nothing: a `$$` in captured bytes is
   # two bytes the origin sent, not an escape the operator typed.
   it "is left alone on an evidence path, which expands nothing at all" do

--- a/spec/export/har_spec.cr
+++ b/spec/export/har_spec.cr
@@ -421,6 +421,56 @@ describe Gori::Export::Har do
     end
   end
 
+  # A captured HEAD is not UTF-8: RFC 7230's field-value is VCHAR / obs-text (%x80-FF), and a
+  # Latin-1 filename in a `Content-Disposition` is the everyday source of one. Written straight
+  # through, those octets produced a document jq / Python / DevTools all reject — and one gori
+  # could not read back either: `Import::Builder`'s guard ran PCRE2 over the invalid value,
+  # raised, and `Import::Har`'s per-entry rescue dropped the WHOLE flow as "skipped". Unlike a
+  # body there is no base64 escape for a head, so the substitution is made and NAMED.
+  describe "a head carrying obs-text" do
+    obs_req = "GET /items?a=1&b HTTP/1.1\r\nHost: shop.test\r\nX-Note: caf\xe9\r\n\r\n"
+    obs_resp = "HTTP/1.1 200 caf\xe9\r\nContent-Type: text/html\r\n" \
+               "Content-Disposition: attachment; filename=\"caf\xe9.pdf\"\r\nContent-Length: 9\r\n\r\n"
+
+    it "writes a valid-UTF-8 document and says the head was scrubbed" do
+      with_store do |store|
+        har, report = export([capture_flow(store, req_head: obs_req, resp_head: obs_resp)])
+        har.valid_encoding?.should be_true
+        report.written.should eq(1)
+        report.scrubbed.should eq(1)
+        report.notes.any?(&.includes?("U+FFFD")).should be_true
+
+        entry = JSON.parse(har)["log"]["entries"][0]
+        entry["comment"].as_s.should contain(Gori::Export::Har::SCRUBBED_MARK)
+        entry["response"]["statusText"].as_s.should eq("caf\uFFFD")
+        cd = entry["response"]["headers"].as_a
+          .find { |h| h["name"].as_s == "Content-Disposition" }.not_nil!
+        cd["value"].as_s.should contain("caf\uFFFD.pdf")
+      end
+    end
+
+    it "still imports back as one flow instead of vanishing into the skipped count" do
+      with_store do |store|
+        har, _ = export([capture_flow(store, req_head: obs_req, resp_head: obs_resp)])
+        back = reimport(har)
+        back.row.status.should eq(200)
+        String.new(back.request_head).should contain("X-Note: caf\uFFFD\r\n")
+      end
+    end
+
+    it "leaves a clean head alone — no substitution, no count, no comment" do
+      with_store do |store|
+        # A VALID multi-byte value is not obs-text and must survive byte-exact; only the
+        # `valid_encoding?` check runs on it (scrub is ~130µs on a valid 40 KB string).
+        har, report = export([capture_flow(store,
+          req_head: "GET /items?a=1&b HTTP/1.1\r\nHost: shop.test\r\nX-Note: café\r\n\r\n")])
+        report.scrubbed.should eq(0)
+        har.should contain("café")
+        JSON.parse(har)["log"]["entries"][0].as_h.has_key?("comment").should be_false
+      end
+    end
+  end
+
   describe "flows with no HAR representation" do
     it "skips a WebSocket flow and says so, rather than emitting the handshake alone" do
       with_store do |store|

--- a/spec/fuzz_spec.cr
+++ b/spec/fuzz_spec.cr
@@ -346,6 +346,18 @@ describe F::PayloadSet do
     bf.each { |v| vals << v }
     vals.should eq(["1", "2", "11", "12", "21", "22"])
   end
+
+  it "counts a one-symbol charset in closed form instead of walking it" do
+    # `base == 1` makes the overflow guard (`pw > Int64::MAX // base`) unreachable, so the
+    # count walked `len` steps per length — ~max²/2 of yield-free integer arithmetic. At
+    # max 1e8 that is weeks, on the single-threaded scheduler, before any send: this example
+    # simply does not RETURN without the short-circuit (MCP `brute a:1-100000000`).
+    F::BruteForce.new("a", 1, 100_000_000).size.should eq(100_000_000_i64)
+    F::BruteForce.new("a", 3, 5).size.should eq(3) # "aaa", "aaaa", "aaaaa"
+    vals = [] of String
+    F::BruteForce.new("a", 1, 3).each { |v| vals << v }
+    vals.should eq(["a", "aa", "aaa"])
+  end
 end
 
 describe F::Generator do
@@ -676,6 +688,51 @@ describe F::Engine do
     results, _ = drain(engine)
     results.size.should eq(1)
     backend.sent.should eq(1)
+  end
+
+  # ^X during auto-calibration reaches the engine (`FuzzerView#request_stop`), and until now
+  # it stopped only the sweep: `calibrate_baseline` never read the flag, so the remaining
+  # CALIBRATION_SAMPLES went out one at a time — and since calibration honours `--rate`, at
+  # rps 0.2 that is ~25s of real requests trailing out under "stopping…". Measured against an
+  # UNSTOPPED run of the same setup, the shape `stop during a bucket's fan-out` uses, so the
+  # example says "stopping cuts calibration short" and cannot be satisfied by tuning.
+  it "stops sending calibration samples when the run is stopped mid-calibration" do
+    run = ->(stop_at : Int32?) do
+      set = F::PayloadSet.new(F::InlineList.new(["only"]))
+      cfg = F::Config.new(mode: F::Mode::Sniper, concurrency: 1, auto_calibrate: true)
+      gen = F::Generator.new(base, [set], cfg)
+      engine = nil.as(F::Engine?)
+      n = 0
+      backend = FakeBackend.new(F::Origin.new("http", "h", 80)) do |_b|
+        n += 1
+        engine.try(&.stop) if stop_at && n == stop_at
+        ok_result(200, "x")
+      end
+      # Bound to a non-nilable local as well: `engine` has to stay `F::Engine?` for the
+      # backend block that closes over it (it is called before the assignment happens).
+      eng = F::Engine.new(gen, F::Matcher.new(auto_calibrate: true), backend, cfg)
+      engine = eng
+      eng.calibrate_baseline
+      backend.sent
+    end
+
+    full = run.call(nil)
+    full.should eq(F::Engine::CALIBRATION_SAMPLES) # the phase really does send a burst
+
+    run.call(1).should eq(1) # the stop landed on the first sample; the other five stayed home
+  end
+
+  it "sends no calibration sample at all when the stop landed before the run started" do
+    # The TUI publishes `v.engine` before spawning the run fiber, so ^X can arrive between
+    # the two — calibration must not open with a burst nobody is waiting for any more.
+    set = F::PayloadSet.new(F::InlineList.new(["only"]))
+    cfg = F::Config.new(mode: F::Mode::Sniper, concurrency: 1, auto_calibrate: true)
+    gen = F::Generator.new(base, [set], cfg)
+    backend = FakeBackend.new(F::Origin.new("http", "h", 80)) { |_b| ok_result(200, "x") }
+    engine = F::Engine.new(gen, F::Matcher.new(auto_calibrate: true), backend, cfg)
+    engine.stop
+    engine.calibrate_baseline
+    backend.sent.should eq(0)
   end
 
   it "enforces max_requests as a hard cap on real sends (retries count)" do

--- a/spec/import/import_spec.cr
+++ b/spec/import/import_spec.cr
@@ -374,6 +374,28 @@ describe Gori::Import do
     end
   end
 
+  # `servers: ["https://api.example.com"]` is a common YAML shorthand and not the OpenAPI
+  # shape. `as_a?` proves the ELEMENT exists, not that it is an object, and
+  # `JSON::Any#[]?(String)` raises a raw `Exception` on a non-Hash — which `cmd_import`
+  # (`rescue ex : Gori::Error`) and the deliberately narrow top-level rescue both let through,
+  # so the operator got a Crystal backtrace. `server_base` runs before the per-operation
+  # rescue, so nothing else caught it either.
+  it "raises a clean Gori::Error when OpenAPI servers[0] is not an object" do
+    [%("https://api.example.com"), "42", "[]", "null"].each do |element|
+      oas = File.tempname("gori", ".json")
+      begin
+        File.write(oas, %({"servers":[#{element}],"paths":{"/users":{"get":{}}}}))
+        with_store do |store|
+          expect_raises(Gori::Error, /servers\[0\] is not an object/) do
+            Gori::Import.import_file(store, :oas, oas)
+          end
+        end
+      ensure
+        File.delete?(oas)
+      end
+    end
+  end
+
   it "reports the skipped count (not the opaque 'no flows found') when every OpenAPI operation is malformed" do
     oas = File.tempname("gori", ".json")
     begin
@@ -838,6 +860,32 @@ describe Gori::Import::Builder do
     head.should contain("X-Foo: a\tb")
   end
 
+  # The boundary guard used to be a PCRE match, and PCRE2 RAISES `ArgumentError: UTF-8 error`
+  # on an invalid-UTF-8 subject. A header value carrying obs-text (RFC 7230 field-value =
+  # VCHAR / obs-text %x80-FF — a Latin-1 `Content-Disposition` filename is the everyday one)
+  # therefore blew up inside the guard, and every import parser's bare per-entry rescue turned
+  # that into a SILENTLY dropped entry: a third-party HAR lost the whole flow to a legal header.
+  it "passes an obs-text header value through instead of raising inside the boundary guard" do
+    headers = Gori::Import::Builder::Headers.new
+    headers << {"Content-Disposition", "attachment; filename=\"caf\xe9.pdf\""}
+    head = Gori::Import::Builder.request_head("GET", "/", "HTTP/1.1",
+      scheme: "http", host: "h.test", port: 80, headers: headers, body: nil)
+    # Byte-exact, never sanitised (P7): the guard REJECTS a boundary byte, it never repairs one.
+    head.should eq("GET / HTTP/1.1\r\nHost: h.test\r\n" \
+                   "Content-Disposition: attachment; filename=\"caf\xe9.pdf\"\r\n\r\n".to_slice)
+  end
+
+  it "still rejects CR/LF/NUL when the same value also carries obs-text" do
+    headers = Gori::Import::Builder::Headers.new
+    headers << {"X-Foo", "caf\xe9\r\nX-Injected: evil"}
+    expect_raises(Gori::Error, /control character/) do
+      Gori::Import::Builder.request_head("GET", "/", "HTTP/1.1", scheme: "http", host: "h.test", port: 80, headers: headers, body: nil)
+    end
+    expect_raises(Gori::Error, /control character/) do
+      Gori::Import::Builder.response_head("HTTP/1.1", 200, "caf\xe9\x00", Gori::Import::Builder::Headers.new, nil)
+    end
+  end
+
   it "rejects a host containing a space (non-URL garbage), consistent with bad-scheme skips" do
     expect_raises(Gori::Error, /bad host/) do
       Gori::Import::Builder.endpoint("not a url at all")
@@ -1141,6 +1189,64 @@ describe Gori::Import::Builder do
         0_i64, "http://h.test/big", "GET", empty, nil, "HTTP/1.1", 200, "OK",
         headers, "5\r\nhello\r\n5\r\nwor".to_slice, "text/plain", nil, nil, nil)
       String.new(pair.response.not_nil!.head).should_not contain("Transfer-Encoding")
+    end
+  end
+
+  # A chunk-size line near 2^31 is the canonical chunk-size-overflow smuggling payload —
+  # exactly the byte pattern an operator imports a HAR to preserve. The walk bounds-checked
+  # with `pos + size + 2`, a CHECKED Int32 add, so gori's OWN arithmetic raised OverflowError
+  # and the per-entry rescue reported the entry as `skipped`: `7ffffff0` imported and the
+  # byte-identical `7fffffff` vanished. `Codec::Body.chunked_complete?` already subtracts.
+  describe "a chunk-size line near Int32::MAX" do
+    it "answers the walk instead of overflowing on it" do
+      headers = Gori::Import::Builder::Headers.new
+      headers << {"Transfer-Encoding", "chunked"}
+      # `ffffffff` is refuted as a trigger (to_i? returns nil); leading zeros still reach
+      # Int32::MAX, so the padded form has to be pinned too.
+      %w[7ffffffe 7fffffff 000000007fffffff].each do |hex|
+        body = "#{hex}\r\nabc".to_slice
+        head = String.new(Gori::Import::Builder.request_head("POST", "/a", "HTTP/1.1",
+          scheme: "https", host: "x.test", port: 443, headers: headers, body: body))
+        # The declared chunk is larger than the bytes present, so the body does not back the
+        # framing — the same answer `7ffffff0` already got, which is the point.
+        head.should_not contain("Transfer-Encoding")
+        head.should contain("Content-Length: #{body.size}\r\n")
+      end
+    end
+
+    it "keeps the framing when the source says the body was TRUNCATED, like any other size" do
+      headers = Gori::Import::Builder::Headers.new
+      headers << {"Transfer-Encoding", "chunked"}
+      empty = Gori::Import::Builder::Headers.new
+      pair = Gori::Import::Builder.complete_flow(
+        0_i64, "http://h.test/big", "GET", empty, nil, "HTTP/1.1", 200, "OK",
+        headers, "5\r\nhello\r\n7fffffff\r\nwor".to_slice, "text/plain", nil, nil, 5_000_i64)
+      head = String.new(pair.response.not_nil!.head)
+      head.should contain("Transfer-Encoding: chunked\r\n")
+      head.should_not contain("Content-Length")
+    end
+
+    it "imports the HAR entry rather than counting it as skipped" do
+      har = File.tempname("gori", ".har")
+      begin
+        File.write(har, <<-JSON)
+          {"log":{"entries":[
+            {"startedDateTime":"2026-06-01T12:00:00.000Z","time":1,
+             "request":{"method":"POST","url":"https://x.test/a","httpVersion":"HTTP/1.1",
+               "headers":[{"name":"Transfer-Encoding","value":"chunked"}],
+               "postData":{"mimeType":"text/plain","text":"7fffffff\\r\\nabc"}},
+             "response":{"status":200,"statusText":"OK","httpVersion":"HTTP/1.1","headers":[],
+               "content":{"size":0,"mimeType":"text/plain"}}}
+          ]}}
+          JSON
+        with_store do |store|
+          result = Gori::Import.import_file(store, :har, har)
+          result.count.should eq(1)
+          result.skipped.should eq(0)
+        end
+      ensure
+        File.delete?(har)
+      end
     end
   end
 

--- a/spec/interceptor_spec.cr
+++ b/spec/interceptor_spec.cr
@@ -625,6 +625,35 @@ describe "Interceptor scope gates over an ABSOLUTE-FORM target" do
       # No blank line at all: the whole thing is the head.
       Gori::Interceptor.split_edit("GET / HTTP/2".to_slice)[1].should be_false
     end
+
+    # The boundary indexes BYTES. Scanning a String counted CHARACTERS, so one non-ASCII
+    # character in the head put the split a byte short of the blank line: the head came back
+    # truncated mid-separator and a body-less edit reported a body — which is how `refuse_edit`
+    # below came to reject an h2 edit whose only sin was a UTF-8 header value.
+    it "counts BYTES, so a non-ASCII header value does not shift the boundary" do
+      ["\r\n", "\n"].each do |eol|
+        raw = "GET / HTTP/2#{eol}x-test: café#{eol}#{eol}".to_slice
+        head, body = Gori::Interceptor.split_edit(raw)
+        head.size.should eq(raw.size) # the WHOLE thing is the head
+        body.should be_false
+      end
+      # ...and the same head with a body still splits at the real separator.
+      head, body = Gori::Interceptor.split_edit("POST / HTTP/2\r\nx-test: café\r\n\r\nBODY".to_slice)
+      String.new(head).should eq("POST / HTTP/2\r\nx-test: café\r\n\r\n")
+      body.should be_true
+    end
+
+    # Held bytes are wire bytes and need not decode as UTF-8; the split must not care.
+    it "splits bytes that are not valid UTF-8 at all" do
+      io = IO::Memory.new
+      io.write "GET / HTTP/2\r\nx-b: ".to_slice
+      io.write Bytes[0xFF, 0xFE]
+      io.write "\r\n\r\nB".to_slice
+      raw = io.to_slice
+      head, body = Gori::Interceptor.split_edit(raw)
+      head.size.should eq(raw.size - 1)
+      body.should be_true
+    end
   end
   # R3-F1/F2, the surface half. `refuse_edit` is what every surface that offers an edit asks
   # BEFORE it decides, because the settle side can only discard — and discarding after an ack
@@ -658,6 +687,10 @@ describe "Interceptor scope gates over an ABSOLUTE-FORM target" do
         # RFC 9113 §8.1.1 probe, not a body.
         item.refuse_edit("POST /edited HTTP/2\r\nHost: h\r\ncontent-length: 3\r\n\r\n".to_slice)
           .should be_nil
+        # ...and so is a head carrying a non-ASCII header value, which the char-vs-byte split
+        # used to report as a body the operator could only clear by deleting the character.
+        item.refuse_edit("GET /edited HTTP/2\r\nHost: h\r\nx-test: café\r\n\r\n".to_slice).should be_nil
+        item.refuse_edit("GET /edited HTTP/2\nHost: h\nx-test: café\n\n".to_slice).should be_nil
       end
     end
 

--- a/spec/mcp_fuzz_spec.cr
+++ b/spec/mcp_fuzz_spec.cr
@@ -123,6 +123,50 @@ describe "MCP fuzz tools" do
     end
   end
 
+  # "try every string" is exactly what an agent emits, and both halves of it used to be
+  # unbounded: a one-symbol charset made counting the set O(max²) of yield-free arithmetic
+  # (the whole process froze — before the scope gate, before the budget guard, with the
+  # server's ping/cancel reader fiber starved), and a huge `min` made BruteIterator allocate
+  # an odometer of that many slots (8.6 GB at Int32::MAX). Lengths are clamped here, at the
+  # strict surface: FUZZ_MAX_REQUESTS caps how MANY payloads go out, never how long one is.
+  it "clamps brute-force lengths so a huge one can neither freeze nor OOM the server" do
+    port = start_origin
+    with_store do |store|
+      tools = Gori::MCP::Tools.new(store, allow_actions: true, verify_upstream: false)
+      base = {
+        "template"       => "GET /?q=§x§ HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n",
+        "url"            => "http://127.0.0.1:#{port}",
+        "allow_unscoped" => true,
+        "max_requests"   => 1, # the clamped set is still 4096 candidates — don't send them
+      }
+      # The string form, the shape an agent reaches for first. Without the clamp this call
+      # does not RETURN: counting "a" × 1e8 takes weeks.
+      s = call_json(tools, "fuzz_start", base.merge({"payloads" => [{"brute" => "a:1-100000000"}]}).to_json)
+      s["total"].as_i.should eq(4096)
+      # The object form's `min` is what BruteIterator allocates up front.
+      o = call_json(tools, "fuzz_start",
+        base.merge({"payloads" => [{"brute" => {"charset" => "ab", "min" => 2147483647}}]}).to_json)
+      o["job_id"].as_s.should_not be_empty
+
+      # Both jobs stop themselves at the 1-request cap; drain them so the store closes clean.
+      # ASSERTED, not best-effort: falling through on timeout would let `with_store` close the
+      # DB under a live job fiber, whose next write then hits a closed SQLite handle — an
+      # intermittent failure landing in some unrelated example. The ceiling is generous
+      # (12 s) because a loaded runner still has to walk the clamped 4096-candidate set.
+      [s["job_id"].as_s, o["job_id"].as_s].each do |id|
+        settled = false
+        600.times do
+          if call_json(tools, "fuzz_status", %({"job_id":#{id.to_json}}))["status"].as_s != "running"
+            settled = true
+            break
+          end
+          sleep 0.02.seconds
+        end
+        settled.should be_true
+      end
+    end
+  end
+
   # A built-in preset (issue #566) is selectable as a payload SOURCE, composes with a
   # second set, and merges an optional user file — the same model the CLI/TUI use.
   it "accepts a built-in preset as a payload set, and merges a user file" do

--- a/spec/mcp_int_args_spec.cr
+++ b/spec/mcp_int_args_spec.cr
@@ -1,0 +1,122 @@
+require "./spec_helper"
+
+# Every MCP integer argument that ends up in an Int32 has to be BOUNDED IN Int64 FIRST.
+# Crystal's `.to_i` / `.to_i32` are checked, so a large-but-legal integer — `{"limit":
+# 10000000000}`, the "no limit" number an LLM reaches for — raised OverflowError at the call
+# site, sailed past the INVALID_ARGUMENT arm in `Tools#call` and came back as INTERNAL
+# "tool error: Arithmetic overflow". An INTERNAL code tells an agent's error policy "the
+# server is broken, back off / escalate" over a mistake in its own arguments.
+#
+# `Tools#clamp` and `mine_bucket` were already written in the right order; preview_color_rule,
+# compare_flows and the extract-rule offsets inverted it.
+
+private def with_store(&)
+  path = File.tempname("gori-mcp-ints", ".db")
+  store = Gori::Store.open(path)
+  begin
+    yield store
+  ensure
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+private def int_tools(store) : Gori::MCP::Tools
+  Gori::MCP::Tools.new(store, allow_actions: true, verify_upstream: false)
+end
+
+# The failure this file exists for: an INTERNAL result carrying the OverflowError's message.
+private def refute_overflow(r : Gori::MCP::Tools::Result, what : String)
+  r.error_code.should_not eq("INTERNAL")
+  if r.text.includes?("Arithmetic overflow")
+    fail "#{what} came back as an arithmetic overflow: #{r.text[0, 200]}"
+  end
+end
+
+private def int_json(tools : Gori::MCP::Tools, name : String, args : String) : JSON::Any
+  r = tools.call(name, JSON.parse(args))
+  refute_overflow(r, "#{name}#{args}")
+  fail "tool #{name}#{args} errored: #{r.text}" if r.is_error
+  JSON.parse(r.text)
+end
+
+private def seed_int_flow(store, body : String) : Int64
+  id = store.insert_flow(Gori::Store::CapturedRequest.new(
+    created_at: 1_i64, scheme: "https", host: "acme.test", port: 443,
+    method: "GET", target: "/x", http_version: "HTTP/1.1",
+    head: "GET /x HTTP/1.1\r\nHost: acme.test\r\n\r\n".to_slice, body: nil))
+  store.update_response(Gori::Store::CapturedResponse.new(
+    flow_id: id, status: 200, head: "HTTP/1.1 200 OK\r\n\r\n".to_slice,
+    body: body.to_slice, content_type: "text/plain"))
+  id
+end
+
+describe "MCP integer arguments — bounded before they are narrowed" do
+  it "preview_color_rule bounds a huge 'limit' instead of overflowing into INTERNAL" do
+    with_store do |store|
+      tools = int_tools(store)
+      pv = int_json(tools, "preview_color_rule", %({"when":"body:secret","limit":10000000000}))
+      pv["scanned"].as_i.should eq(0)
+      pv["would_match"].as_i.should eq(0)
+    end
+  end
+
+  # The floor stays a CLAMP, not a refusal. `0` is the other spelling of "no limit" an agent
+  # reaches for — right beside the huge number above — and this argument has been forgiving at
+  # both ends since it existed (`list_history`'s row limit still is). Pinned so the overflow fix
+  # above cannot quietly turn one way of failing the call into another.
+  it "preview_color_rule clamps a 'limit' below the floor instead of failing the call" do
+    with_store do |store|
+      r = int_tools(store).call("preview_color_rule", JSON.parse(%({"when":"body:secret","limit":0})))
+      r.is_error.should be_false
+    end
+  end
+
+  it "compare_flows bounds a huge 'context' instead of overflowing into INTERNAL" do
+    with_store do |store|
+      a = seed_int_flow(store, "line1\nline2\nline3")
+      b = seed_int_flow(store, "line1\nCHANGED\nline3")
+      tools = int_tools(store)
+      huge = int_json(tools, "compare_flows",
+        %({"flow_id_a":#{a},"flow_id_b":#{b},"context":5000000000}))
+      # A context at or past the diff's length folds nothing, so the bound is exact: the
+      # huge value must diff identically to a context that already covers the whole message.
+      wide = int_json(tools, "compare_flows",
+        %({"flow_id_a":#{a},"flow_id_b":#{b},"context":1000}))
+      huge["changed_lines"].as_i.should be > 0
+      huge["diff"].should eq(wide["diff"])
+    end
+  end
+
+  it "create_extract_rule bounds a huge 'pos_start' instead of overflowing into INTERNAL" do
+    with_store do |store|
+      tools = int_tools(store)
+      int_json(tools, "create_extract_rule",
+        %({"name":"TOK","kind":"cookie","selector":"sid","pos_start":5000000000}))
+      row = store.extract_rules.find { |r| r.name == "TOK" }.not_nil!
+      row.pos_start.should eq(Int32::MAX)
+    end
+  end
+
+  it "update_extract_rule bounds a huge 'pos_end' and leaves the stored offsets alone when omitted" do
+    with_store do |store|
+      tools = int_tools(store)
+      int_json(tools, "create_extract_rule",
+        %({"name":"TOK","kind":"cookie","selector":"sid"}))
+      id = store.extract_rules.find { |r| r.name == "TOK" }.not_nil!.id
+      int_json(tools, "update_extract_rule", %({"id":#{id},"pos_end":5000000000}))
+      row = store.extract_rules.find { |r| r.id == id }.not_nil!
+      row.pos_end.should eq(Int32::MAX)
+      row.pos_start.should eq(0)
+
+      # The omitted-field contract still holds: a later update that names neither offset
+      # must pass the stored values through, not re-read them as caller input.
+      int_json(tools, "update_extract_rule", %({"id":#{id},"selector":"session"}))
+      kept = store.extract_rules.find { |r| r.id == id }.not_nil!
+      kept.pos_end.should eq(Int32::MAX)
+      kept.selector.should eq("session")
+    end
+  end
+end

--- a/spec/media_type_spec.cr
+++ b/spec/media_type_spec.cr
@@ -88,5 +88,18 @@ describe Gori::MediaType do
       MT.boundary(%(multipart/form-data; BOUNDARY="a;b")).should eq("a;b")
       MT.boundary("application/json").should be_nil
     end
+
+    # The two probe call sites reach `boundary` with a header value read straight off the wire
+    # (`Http1.parse_headers` builds values with a bare `String.new`), and PCRE RAISES on the
+    # first illegal byte instead of not matching — one such Content-Type silently voided a whole
+    # flow's passive scan and killed the TUI's active-scan estimate.
+    it "does not raise on a boundary carrying invalid UTF-8" do
+      ct = "multipart/form-data; boundary=graphql" + String.new(Bytes[0xFF_u8])
+      MT.multipart?(ct).should be_true
+      # Nil, not a raise: a boundary with an illegal byte cannot delimit the body anyway.
+      MT.boundary(ct).should be_nil
+      # A well-formed value is unchanged by the scrub.
+      MT.boundary("multipart/form-data; boundary=graphql-9").should eq("graphql-9")
+    end
   end
 end

--- a/spec/miner/engine_spec.cr
+++ b/spec/miner/engine_spec.cr
@@ -617,5 +617,50 @@ describe Gori::Miner::Engine do
       stopped = run.call(4)
       stopped.should be < full
     end
+
+    it "does not open with calibration when the stop landed before the run fiber started" do
+      # `start` spawns; the caller (the TUI publishes the engine before the fiber ticks) can
+      # stop it in between. Calibration is real requests at the target, so the mine must not
+      # open with the stability wave nobody is waiting for any more.
+      backend = StopAtBackend.new(F::Origin.new("http", "h", 80), %w(alpha))
+      engine = M::Engine.new("GET /api HTTP/1.1\r\nHost: h\r\n\r\n".to_slice, http2: false,
+        names: %w(alpha beta), backend: backend, config: cfg)
+      stopped = nil.as(Bool?)
+      engine.stop
+      engine.run { |ev| stopped = ev.stopped if ev.is_a?(M::DoneEvent) }
+      backend.sent.should eq(0)
+      stopped.should be_true
+    end
+  end
+
+  # `Inject.inject_query` bails UNMODIFIED on a request line that is not METHOD SP TARGET SP
+  # VERSION — rebuilding it from the split would collapse `GET  /a HTTP/1.1` into a single
+  # space, rewriting bytes the operator handed gori (P7), so the bail is right. What was wrong
+  # was downstream: the engine sent whatever came back — here, the BASELINE request — saw no
+  # residual signal, and took the `kind.none?` branch that calls the whole bucket clean. 100%
+  # progress, found 0, errors 0, exit 0: a false negative dressed as a clean bill of health.
+  describe "a location that can inject nothing" do
+    it "reports the bucket inconclusive instead of calling its names clean" do
+      names = %w(alpha beta gamma delta)
+      backend = HiddenParamBackend.new(F::Origin.new("http", "h", 80), reflect: ["alpha"])
+      # A raw space in the target: `Codec::Http1` flags the line malformed? and keeps the
+      # octets, so a captured flow — or a hand-written `--request` file — carries it verbatim.
+      base = "GET /search?q=hello world HTTP/1.1\r\nHost: h\r\n\r\n".to_slice
+      engine = M::Engine.new(base, http2: false, names: names, backend: backend, config: cfg)
+      progress = nil.as(M::Progress?)
+      findings = [] of M::Finding
+      engine.run do |ev|
+        findings << ev.finding if ev.is_a?(M::FindingEvent)
+        progress = ev.progress if ev.is_a?(M::DoneEvent)
+      end
+
+      findings.should be_empty
+      progress.not_nil!.errors.should be > 0
+      engine.first_error.to_s.should contain("nothing could be injected")
+      # The 2 stability rounds + 1 control probe of calibration, and not one bucket send:
+      # re-sending the baseline as if it were a probe is exactly what produced the false
+      # clean verdict.
+      backend.sent.should eq(3)
+    end
   end
 end

--- a/spec/oast/engine_spec.cr
+++ b/spec/oast/engine_spec.cr
@@ -304,6 +304,28 @@ describe Gori::Oast do
     end
   end
 
+  # Twin of `Session#host`: `payload_host` parses whatever endpoint the operator typed
+  # (`normalize_endpoint` only prepends a scheme), and `URI.parse` RAISES on an authority it
+  # cannot frame instead of returning nil. Minting a payload must degrade to the raw string,
+  # not blow up mid-generation.
+  describe "Boast#payload_host" do
+    it "falls back to the raw base_url when URI.parse raises on a bad authority" do
+      {"fd00::1:9000", "collector.local:8O80/events", "a:99999999999999999999"}.each do |host|
+        provider = O::Boast.new(host, "sec")
+        session = O::Session.new(1_i64, O::ProviderKind::Boast, host, "boastid", "sec", token: "sec")
+        payload = provider.generate_payload(session)
+        payload.should end_with("https://#{host}")
+      end
+    end
+
+    it "still uses the parsed host for a well-formed endpoint" do
+      provider = O::Boast.new("https://odiss.eu:2096/events", "sec")
+      session = O::Session.new(1_i64, O::ProviderKind::Boast, "https://odiss.eu:2096/events",
+        "boastid", "sec", token: "sec")
+      provider.generate_payload(session).should end_with(".odiss.eu")
+    end
+  end
+
   describe O::CustomHttp do
     it "parses a tolerant JSON list and hashes a dedup id when absent" do
       provider = O::CustomHttp.new("https://my.oast.example/log")

--- a/spec/oast/session_spec.cr
+++ b/spec/oast/session_spec.cr
@@ -109,5 +109,24 @@ describe O::Session do
     it "returns the raw value for a bare multibyte host with no scheme" do
       custom_session("안녕.example").host.should eq("안녕.example")
     end
+
+    # A custom-http provider registers with NO network round-trip, so whatever authority the
+    # operator typed is persisted verbatim and re-read every time the resume picker renders.
+    # `URI.parse` RAISES (it does not return nil) on an authority it cannot frame, and that
+    # raise reached the TUI tick loop — three opens inside 10s killed the process.
+    it "falls back to the raw server_url when URI.parse RAISES on a bad authority" do
+      # unbracketed IPv6 + port -> URI::Error "bad port"
+      custom_session("https://fd00::1:9000").host.should eq("https://fd00::1:9000")
+      # a typo'd port (letter O for zero) -> URI::Error "bad port"
+      custom_session("https://collector.local:8O80/log").host
+        .should eq("https://collector.local:8O80/log")
+      # a port that does not fit an Int32 -> OverflowError, not URI::Error
+      custom_session("https://a:99999999999999999999").host
+        .should eq("https://a:99999999999999999999")
+    end
+
+    it "still parses the BRACKETED IPv6 form (the rescue does not swallow a good parse)" do
+      custom_session("https://[fd00::1]:9000").host.should_not be_empty
+    end
   end
 end

--- a/spec/probe/graphql_content_type_utf8_spec.cr
+++ b/spec/probe/graphql_content_type_utf8_spec.cr
@@ -1,0 +1,132 @@
+require "../spec_helper"
+
+# A `Content-Type` is read straight off the wire (`Http1.parse_headers` builds header values
+# with a bare `String.new`, and obs-text 0x80-0xFF is legal there), so a multipart boundary can
+# carry a byte that is not valid UTF-8 — a Content-Type parser-differential payload, or just a
+# client that picked its boundary out of a non-UTF-8 charset. PCRE RAISES on the first illegal
+# byte instead of not matching, and the two probe call sites that reach `Graphql.from_body` are
+# the only ones that hand it an unscrubbed value. The raise landed in `MediaType.boundary` and
+# took out the whole flow's passive pass (Tech is RULES[0], and `scan_detail` swallows it), then
+# the same shape came back through the TUI's "Run active scan" estimate, which had no rescue at
+# all. Both are pinned here.
+
+# `boundary=graphql\xFF`: multipart essence (so `from_body` takes the multipart branch) plus the
+# `graphql` substring the Tech / GraphqlIntrospection byte gates open on.
+private def hostile_ct : String
+  "multipart/form-data; boundary=graphql" + String.new(Bytes[0xFF_u8])
+end
+
+private def with_store(&)
+  path = File.tempname("gori-probe-ct", ".db")
+  store = Gori::Store.open(path)
+  begin
+    yield store
+  ensure
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+# A captured POST whose request head carries `ct` verbatim, with a body (the GraphQL gates all
+# require one). `target` stays off `/graphql` so the active rule's cheap path check cannot
+# short-circuit the body branch that raised.
+private def capture_ct_flow(store, ct : String, *, target = "/api", host = "acme.test") : Gori::Store::FlowDetail
+  head = String.build do |io|
+    io << "POST " << target << " HTTP/1.1\r\nHost: " << host << "\r\nContent-Type: " << ct << "\r\n\r\n"
+  end
+  req = Gori::Store::CapturedRequest.new(
+    created_at: 1_000_i64, scheme: "https", host: host, port: 443,
+    method: "POST", target: target, http_version: "HTTP/1.1",
+    head: head.to_slice, body: %({"query":"{__schema{queryType{name}}}"}).to_slice)
+  id = store.insert_flow(req)
+  store.update_response(Gori::Store::CapturedResponse.new(
+    flow_id: id, status: 200, head: "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nServer: nginx/1.18.0\r\n\r\n".to_slice,
+    body: "<p>hi</p>".to_slice, reason: "OK", content_type: "text/html", duration_us: 1_i64))
+  store.get_flow(id).not_nil!
+end
+
+# A rule whose gate blows up on every flow — the stand-in for "the next rule that raises", which
+# is what the estimate loop had no answer for.
+#
+# Reopened inside `Active` rather than declared at the top of this file so each restriction can be
+# spelled exactly as `Rule`'s abstract def spells it: Crystal matches an abstract def against its
+# implementation by the restriction as WRITTEN, so the equivalent-but-fully-qualified
+# `Gori::Store::FlowDetail` / `Gori::Probe::Active::Options` reads as a different signature and the
+# subclass is rejected as not implementing it.
+module Gori::Probe::Active
+  # Not `private`: a private constant cannot be named through its full path from the describe
+  # block below, which lives outside this module body.
+  class SpecEstimateRaisingRule < Rule
+    def info : RuleInfo
+      RuleInfo.new("spec_raising_rule", "Spec raising rule",
+        "Raises from its gate; exists only to pin the estimate's per-rule isolation.",
+        Category::INFOLEAK)
+    end
+
+    def dedup_key(detail : Store::FlowDetail, opts : Options = Options::DEFAULT) : String?
+      raise ArgumentError.new("gate exploded")
+    end
+
+    def plan(detail : Store::FlowDetail, opts : Options = Options::DEFAULT) : Plan?
+      nil
+    end
+
+    def detections(plan : Plan, result : Repeater::Result, detail : Store::FlowDetail) : Array(Detection)
+      [] of Detection
+    end
+  end
+end
+
+describe "a Content-Type whose multipart boundary is not valid UTF-8" do
+  it "still runs the whole passive pass (Tech is RULES[0], so its raise ate every later rule)" do
+    with_store do |store|
+      detail = capture_ct_flow(store, hostile_ct)
+      codes = Gori::Probe::Passive.analyze(detail).map(&.code)
+      codes.should_not be_empty
+      # A rule that runs AFTER Tech: before the fix the flow was silently never scanned at all.
+      codes.should contain("missing_hsts")
+    end
+  end
+
+  it "lets the active GraphQL gate decide instead of raising" do
+    with_store do |store|
+      detail = capture_ct_flow(store, hostile_ct)
+      Gori::Probe::Active::GraphqlIntrospection.new.dedup_key(detail).should be_nil
+    end
+  end
+
+  it "keeps the Run-active-scan estimate alive" do
+    with_store do |store|
+      detail = capture_ct_flow(store, hostile_ct)
+      a = Gori::Probe::Analyzer.new(store, Gori::Scope.load(store),
+        Channel(Gori::Store::FlowEvent).new(1), Gori::Probe::Mode::Passive, true)
+      a.active_estimate(detail).map(&.info.id).should_not contain("graphql_introspection")
+    end
+  end
+end
+
+# The estimate is called bare from the TUI's synchronous key path, where the run loop's
+# catch-all ends the process on the third raise in ten seconds. An estimate is advisory, so a
+# rule that cannot decide is omitted — the same isolation `Active.analyze` and `run_active_now`
+# already have.
+describe "Gori::Probe::Analyzer#active_estimate rule isolation" do
+  it "omits a rule whose gate raises and keeps every other rule's estimate" do
+    with_store do |store|
+      detail = capture_ct_flow(store, "text/plain", target: "/search?q=hi")
+      a = Gori::Probe::Analyzer.new(store, Gori::Scope.load(store),
+        Channel(Gori::Store::FlowEvent).new(1), Gori::Probe::Mode::Passive, true)
+      opts = Gori::Probe::Active::Options.new(allow_unsafe: true)
+      baseline = a.active_estimate(detail, opts).map(&.info.id)
+      baseline.should_not be_empty
+
+      Gori::Probe::Active::RULES << Gori::Probe::Active::SpecEstimateRaisingRule.new
+      begin
+        a.active_estimate(detail, opts).map(&.info.id).should eq(baseline)
+      ensure
+        Gori::Probe::Active::RULES.pop
+      end
+    end
+  end
+end

--- a/spec/proxy/h2/assembler_spec.cr
+++ b/spec/proxy/h2/assembler_spec.cr
@@ -33,6 +33,22 @@ private def plain_connect_block : Bytes
   ])
 end
 
+# A trailing HEADERS block of `count` DISTINCT literal-without-indexing fields with empty
+# values — the cheapest legal way for an origin to hand the assembler a big trailer-name list
+# (9 wire bytes each here), and small enough per field that the whole block stays under
+# MAX_HEADER_BLOCK and its decoded size under the cumulative MAX_HEADER_LIST cap.
+private def distinct_trailer_block(count : Int32) : Bytes
+  io = IO::Memory.new
+  count.times do |i|
+    name = "t%05d" % i
+    io.write_byte(0x00_u8) # literal w/o indexing, new name
+    io.write_byte(name.bytesize.to_u8)
+    io << name
+    io.write_byte(0x00_u8) # empty value
+  end
+  io.to_slice
+end
+
 # Records emitted flows (decoded projection) without a DB.
 private class RecSink < Gori::Proxy::FlowSink
   getter requests = [] of Gori::Store::CapturedRequest
@@ -321,6 +337,56 @@ describe Gori::Proxy::H2::Assembler do
     assembler.feed("out", headers_frame(1_u32, Frame::END_HEADERS | Frame::END_STREAM,
       hexb("828684418cf1e3c2e5f23a6ba0ab90f4ff")))
     String.new(sink.requests.first.head).should_not contain("X-Gori-Trailers")
+  end
+
+  # Trailer names used to be deduped with `Array#includes?`, a linear scan per field, so a
+  # block of N distinct names cost N^2/2 String compares — one legal 1 MiB block (~174k
+  # names, still under both the per-block and the cumulative cap) measured 39s. That runs
+  # inside the Assembler mutex with no IO, so on Crystal's single-threaded scheduler the TUI,
+  # every other connection and the Store writer fiber got no turn for the whole of it (P6).
+  it "records a large trailer block without a quadratic dedupe scan" do
+    sink = RecSink.new
+    assembler = Gori::Proxy::H2::Assembler.new(sink, "grpc.test", 443, 1_i64)
+    assembler.feed("out", headers_frame(1_u32, Frame::END_HEADERS | Frame::END_STREAM,
+      hexb("828684418cf1e3c2e5f23a6ba0ab90f4ff")))
+    assembler.feed("in", headers_frame(1_u32, Frame::END_HEADERS, Bytes[0x88_u8]))
+
+    block = distinct_trailer_block(60_000)
+    block.size.should be < Gori::Proxy::H2::Assembler::MAX_HEADER_BLOCK # accepted whole
+    elapsed = Time.measure do
+      assembler.feed("in", headers_frame(1_u32, Frame::END_HEADERS, block))
+    end
+    elapsed.should be < 10.seconds # was: minutes, all of it inside the mutex
+
+    assembler.feed("in", data_frame(1_u32, Frame::END_STREAM, ""))
+    head = String.new(sink.responses.first.head)
+    head.should contain("X-Gori-Trailers: t00000, t00001") # the marker keeps arrival order…
+    head.should contain("t59999")                          # …and still names every one
+  end
+
+  # The membership index has to be cleared with the array it indexes. A final status block
+  # REPLACES an interim 1xx head, taking that head's trailer names with it; an index that
+  # remembered `grpc-status` from the discarded head would silently suppress it from the real
+  # trailer's marker line.
+  it "still names a trailer whose name was already recorded against a replaced interim head" do
+    sink = RecSink.new
+    assembler = Gori::Proxy::H2::Assembler.new(sink, "grpc.test", 443, 1_i64)
+    assembler.feed("out", headers_frame(1_u32, Frame::END_HEADERS | Frame::END_STREAM,
+      hexb("828684418cf1e3c2e5f23a6ba0ab90f4ff")))
+    # Interim 100, then a trailer recorded against it.
+    assembler.feed("in", headers_frame(1_u32, Frame::END_HEADERS,
+      Gori::Proxy::H2::HPACK::Encoder.new.encode([{":status", "100"}])))
+    assembler.feed("in", headers_frame(1_u32, Frame::END_HEADERS,
+      Gori::Proxy::H2::HPACK::Encoder.new.encode([{"grpc-status", "0"}])))
+    # The real response replaces the interim head, then carries its own grpc-status trailer.
+    assembler.feed("in", headers_frame(1_u32, Frame::END_HEADERS, Bytes[0x88_u8]))
+    assembler.feed("in", data_frame(1_u32, 0_u8, "msg"))
+    assembler.feed("in", headers_frame(1_u32, Frame::END_HEADERS | Frame::END_STREAM,
+      Gori::Proxy::H2::HPACK::Encoder.new.encode([{"grpc-status", "13"}])))
+
+    head = String.new(sink.responses.first.head)
+    head.should contain("grpc-status: 13")
+    head.should contain("X-Gori-Trailers: grpc-status")
   end
 
   it "captures a server push (PUSH_PROMISE → promised-stream flow + response)" do

--- a/spec/proxy/intercept_hold_size_spec.cr
+++ b/spec/proxy/intercept_hold_size_spec.cr
@@ -1,0 +1,173 @@
+require "../spec_helper"
+require "log/spec"
+require "socket"
+
+# An intercept HOLD buffers the whole entity so the human can see and edit it
+# (`Codec::Body.read_complete`, no `max_bytes`). With intercept on, a page POSTing a multi-GB
+# body — or a multi-GB download with the response direction held — grew the proxy heap by the
+# whole declared length before anyone was shown anything, and did it BEFORE `@sink.on_request`,
+# so the eventual raise lost the flow from History as well.
+#
+# Every sibling buffering path in `client_conn.cr` already has the ceiling (`MAX_REWRITE_BODY`
+# via `rewritable_body_size?`), and the h2 half of this very feature fails a hold open past
+# `MAX_DEFERRED_BYTES` (`H2::StreamGate#fail_open`). The h1 hold now does the same: over the
+# ceiling the message is NOT held and takes the byte-exact streaming path, with one warning so
+# the operator learns why nothing appeared in the queue.
+#
+# The tests key on "did the head reach the other side promptly?" rather than on shipping 16 MiB:
+# a hold reads the body BEFORE writing anything onward, so a held message shows the peer nothing.
+
+private class HoldSink < Gori::Proxy::FlowSink
+  def on_request(req : Gori::Store::CapturedRequest) : Int64
+    1_i64
+  end
+
+  def on_response(resp : Gori::Store::CapturedResponse) : Nil
+  end
+
+  def on_ws_message(flow_id : Int64, direction : String, opcode : Int32, payload : Bytes,
+                    shape : Gori::Proxy::WS::Shape = Gori::Proxy::WS::Shape::DEFAULT) : Nil
+  end
+end
+
+private def with_hold_store(&)
+  path = File.tempname("gori-hold", ".db")
+  store = Gori::Store.open(path)
+  begin
+    yield store
+  ensure
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+# An origin that reports the request head it received, then answers `resp`.
+private def start_head_reporting_origin(seen : Channel(String), resp : String) : {Int32, TCPServer}
+  origin = TCPServer.new("127.0.0.1", 0)
+  port = origin.local_address.port
+  spawn do
+    if conn = origin.accept?
+      conn.read_timeout = 10.seconds
+      head = Gori::Proxy::Codec::Http1.read_head(conn)
+      seen.send(head ? String.new(head) : "origin-eof")
+      conn << resp
+      conn.flush
+      sleep 3.seconds # keep the socket up so the client can read what arrived
+      conn.close rescue nil
+    end
+  rescue ex
+    seen.send("origin-err:#{ex.class}") rescue nil
+  end
+  {port, origin}
+end
+
+# The declared length used for the over-ceiling cases. Only the DECLARED size is gated, so no
+# test ever has to move 16 MiB.
+private def over_ceiling : Int32
+  64 * 1024 * 1024
+end
+
+describe "intercept hold body ceiling" do
+  it "does NOT hold a request whose declared body is over the ceiling — it streams, and says so" do
+    with_hold_store do |store|
+      ic = Gori::Interceptor.new(Gori::Scope.load(store))
+      ic.toggle # enable, both directions
+      seen = Channel(String).new(1)
+      origin_port, origin = start_head_reporting_origin(seen,
+        "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok")
+
+      proxy = Gori::Proxy::Server.new("127.0.0.1", 0, HoldSink.new, interceptor: ic)
+      proxy.start
+
+      Log.capture do |logs|
+        client = TCPSocket.new("127.0.0.1", proxy.port)
+        client << "POST /upload HTTP/1.1\r\nHost: 127.0.0.1:#{origin_port}\r\n" \
+                  "Content-Length: #{over_ceiling}\r\n\r\n"
+        client << "partial"
+        client.flush
+
+        # Held, the head would sit in gori's heap behind a body that never finishes arriving and
+        # the origin would see nothing at all.
+        receive_within(seen, what: "the forwarded request head").should contain("POST /upload")
+        ic.pending_count.should eq(0)
+        logs.check(:warn, /over the .* hold ceiling/).entry.message.should contain("request")
+
+        client.close
+      end
+
+      proxy.stop
+      origin.close rescue nil
+    end
+  end
+
+  it "still holds a small request (the ceiling is the only thing that changed)" do
+    with_hold_store do |store|
+      ic = Gori::Interceptor.new(Gori::Scope.load(store))
+      ic.toggle
+      seen = Channel(String).new(1)
+      origin_port, origin = start_head_reporting_origin(seen,
+        "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok")
+
+      proxy = Gori::Proxy::Server.new("127.0.0.1", 0, HoldSink.new, interceptor: ic)
+      proxy.start
+
+      client = TCPSocket.new("127.0.0.1", proxy.port)
+      client << "POST /upload HTTP/1.1\r\nHost: 127.0.0.1:#{origin_port}\r\n" \
+                "Content-Length: 4\r\n\r\nBODY"
+      client.flush
+
+      held = Channel(Gori::Interceptor::Item).new(1)
+      spawn do
+        20.times do
+          if item = ic.pending.first?
+            held.send(item)
+            break
+          end
+          sleep 100.milliseconds
+        end
+      end
+      item = receive_within(held, what: "the held request")
+      item.kind.should eq(Gori::Interceptor::Kind::Request)
+      String.new(item.raw).should contain("BODY")
+
+      ic.forward(item.id, item.raw)
+      receive_within(seen, what: "the forwarded request head").should contain("POST /upload")
+
+      client.close
+      proxy.stop
+      origin.close rescue nil
+    end
+  end
+
+  it "does NOT hold a response whose declared body is over the ceiling — it streams to the client" do
+    with_hold_store do |store|
+      ic = Gori::Interceptor.new(Gori::Scope.load(store))
+      ic.toggle
+      ic.set_direction(Gori::Interceptor::Direction::ResponseOnly) # the request must not be held
+      seen = Channel(String).new(1)
+      origin_port, origin = start_head_reporting_origin(seen,
+        "HTTP/1.1 200 OK\r\nX-Big: yes\r\nContent-Length: #{over_ceiling}\r\n\r\npartial")
+
+      proxy = Gori::Proxy::Server.new("127.0.0.1", 0, HoldSink.new, interceptor: ic)
+      proxy.start
+
+      client = TCPSocket.new("127.0.0.1", proxy.port)
+      client.read_timeout = 10.seconds
+      client << "GET /download HTTP/1.1\r\nHost: 127.0.0.1:#{origin_port}\r\n\r\n"
+      client.flush
+      receive_within(seen, what: "the forwarded request head").should contain("GET /download")
+
+      # Held, gori would buffer 64 MiB before writing a byte back and the client would see
+      # nothing; streaming, the head arrives at once.
+      head = Gori::Proxy::Codec::Http1.read_head(client).not_nil!
+      String.new(head).should contain("X-Big: yes")
+      ic.pending_count.should eq(0)
+
+      client.close
+      proxy.stop
+      origin.close rescue nil
+    end
+  end
+end

--- a/spec/proxy/response_head_deadline_spec.cr
+++ b/spec/proxy/response_head_deadline_spec.cr
@@ -1,0 +1,84 @@
+require "../spec_helper"
+require "socket"
+
+# The RESPONSE head is a slowloris surface too.
+#
+# `handle_request` has always bounded the CLIENT head with `deadline:`/`timeout_sock:` (the
+# drip-feed a per-read timeout can't catch), and `Repeater::Engine#read_response_head` carries
+# the same bound on the origin side citing this file. `ClientConn#safe_read_head` — the ONLY way
+# a response head is read, on all three of its call sites — passed neither, so an origin emitting
+# one header byte per <io_timeout never tripped a timer: the fiber, the client fd, the upstream fd
+# and one of `Server`'s connection permits were pinned for as long as it cared to trickle (P6).
+#
+# The bound itself (raise after the deadline, restore the caller's baseline timeout) is proven in
+# spec/proxy/socket_tuning_spec.cr against the same call shape; what these pin is that the proxy
+# ASKS for it everywhere, and that asking for it does not cut a slow-but-progressing origin short.
+
+private class HeadSink < Gori::Proxy::FlowSink
+  def on_request(req : Gori::Store::CapturedRequest) : Int64
+    1_i64
+  end
+
+  def on_response(resp : Gori::Store::CapturedResponse) : Nil
+  end
+
+  def on_ws_message(flow_id : Int64, direction : String, opcode : Int32, payload : Bytes,
+                    shape : Gori::Proxy::WS::Shape = Gori::Proxy::WS::Shape::DEFAULT) : Nil
+  end
+end
+
+describe "proxy head reads carry the slowloris deadline" do
+  # Checked against the CODE rather than a list of call sites: a new head read inherits the rule
+  # instead of a hand-maintained exemption list. `safe_read_head` was exactly the site that was
+  # added later and never got the kwargs.
+  it "passes deadline:/timeout_sock: at every Codec::Http1.read_head call under src/gori/proxy" do
+    root = File.join(__DIR__, "..", "..", "src", "gori", "proxy")
+    offenders = [] of String
+    Dir.glob(File.join(root, "**", "*.cr")).sort.each do |path|
+      src = File.read(path)
+      # One level of nesting is enough for the `SocketTuning.underlying_socket(io)` argument.
+      src.scan(/Codec::Http1\.read_head\((?:[^()]|\([^()]*\))*\)/m) do |m|
+        call = m[0]
+        next if call.includes?("deadline:") && call.includes?("timeout_sock:")
+        offenders << "#{File.basename(path)}: #{call.gsub(/\s+/, " ")}"
+      end
+    end
+    offenders.should be_empty
+  end
+
+  it "still proxies an origin that drips its response head slowly but finishes" do
+    # The bound is on TOTAL head-assembly time, not on the gap between bytes, so a legitimately
+    # slow origin (a CGI flushing headers as it computes them) must be unaffected.
+    origin = TCPServer.new("127.0.0.1", 0)
+    port = origin.local_address.port
+    spawn do
+      if conn = origin.accept?
+        Gori::Proxy::Codec::Http1.read_head(conn)
+        "HTTP/1.1 200 OK\r\nX-Slow: yes\r\nContent-Length: 2\r\n\r\n".each_byte do |b|
+          conn.write_byte(b)
+          conn.flush
+          sleep 2.milliseconds
+        end
+        conn << "hi"
+        conn.flush
+        conn.close rescue nil
+      end
+    rescue
+    end
+
+    proxy = Gori::Proxy::Server.new("127.0.0.1", 0, HeadSink.new)
+    proxy.start
+
+    client = TCPSocket.new("127.0.0.1", proxy.port)
+    client.read_timeout = 10.seconds
+    client << "GET /slow HTTP/1.1\r\nHost: 127.0.0.1:#{port}\r\nConnection: close\r\n\r\n"
+    client.flush
+
+    head = Gori::Proxy::Codec::Http1.read_head(client).not_nil!
+    String.new(head).should contain("X-Slow: yes")
+
+    client.close
+    proxy.stop
+    origin.close rescue nil
+  end
+end

--- a/spec/proxy/tls/client_hello_spec.cr
+++ b/spec/proxy/tls/client_hello_spec.cr
@@ -107,6 +107,21 @@ describe Gori::Proxy::Tls::ClientHello do
       consumed.size.should eq(hello.size)
     end
 
+    # An invalid-UTF-8 byte inside the SNI value used to escape peek_sni as an ArgumentError out
+    # of PCRE2, which the accept fiber's blanket rescue turned into a dropped connection — the
+    # one thing this function's contract says cannot happen, and it cost the transparent
+    # listener its kernel-original-destination fallback (#528).
+    it "is nil, not an exception, for an SNI value that is not valid UTF-8" do
+      hello = real_client_hello("zzqqzzqq.test")
+      needle = "zzqqzzqq.test".to_slice
+      at = (0..(hello.size - needle.size)).find { |i| hello[i, needle.size] == needle }
+      at.should_not be_nil
+      hello[at.not_nil! + 4] = 0xFF_u8 # one raw byte PCRE2 refuses to decode
+      sni, consumed = ClientHello.peek_sni(IO::Memory.new(hello))
+      sni.should be_nil
+      consumed.size.should eq(hello.size) # still replayable, so the caller can fall back
+    end
+
     # The genuine no-SNI case (an old client, or one that simply omits the extension). A
     # transparent listener has to cope with having no name at all, so this must be nil rather
     # than an error — hand-built, because a modern OpenSSL will not produce it.

--- a/spec/proxy/ws_spec.cr
+++ b/spec/proxy/ws_spec.cr
@@ -1167,6 +1167,57 @@ describe "WebSocket through the proxy (end-to-end)" do
     sink.ws.should contain({"in", "ping"})
   end
 
+  it "relays client frames when the 101 also carries Content-Type: text/event-stream" do
+    # `Content-Type` on a 101 is purely origin-chosen, and `relax_for_streaming_response` read it
+    # as "this is an SSE stream" — which spawns a client-abort watcher parked on `@io.read`. The
+    # 101 branch then hands `@io` to `WS::Relay` instead of closing it (closing is what ends that
+    # watcher everywhere else), so two fibers read the same client socket and the already-parked
+    # watcher swallowed every client->server byte into its scratch buffer for the tunnel's whole
+    # lifetime: the origin below never saw the frame.
+    origin = TCPServer.new("127.0.0.1", 0)
+    port = origin.local_address.port
+    got = Channel(String).new(1)
+    spawn do
+      conn = origin.accept
+      conn.read_timeout = 5.seconds
+      Gori::Proxy::Codec::Http1.read_head(conn) # the upgrade GET
+      conn << "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n" \
+              "Content-Type: text/event-stream\r\n\r\n"
+      conn.flush
+      frame = Gori::Proxy::WS.read_frame(conn).not_nil!
+      got.send(String.new(frame.payload))
+      conn.write(Bytes[0x81_u8, frame.payload.size.to_u8]) # unmasked echo
+      conn.write(frame.payload)
+      conn.flush
+    rescue ex
+      got.send("origin-err:#{ex.class}") rescue nil
+    end
+
+    ws_chan = Channel(Nil).new(4)
+    sink = IntegSink.new(ws_chan)
+    proxy = Gori::Proxy::Server.new("127.0.0.1", 0, sink)
+    proxy.start
+
+    client = TCPSocket.new("127.0.0.1", proxy.port)
+    client.read_timeout = 5.seconds
+    client << "GET /ws HTTP/1.1\r\nHost: 127.0.0.1:#{port}\r\n" \
+              "Upgrade: websocket\r\nConnection: Upgrade\r\n" \
+              "Sec-WebSocket-Key: dGhlIHNhbXBsZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n"
+    client.flush
+    String.new(Gori::Proxy::Codec::Http1.read_head(client).not_nil!).should contain("101")
+
+    client.write(masked_frame("ping"))
+    client.flush
+    # The origin — not just the client — must see it: a swallowed frame reports origin-err here.
+    receive_within(got).should eq("ping")
+    echoed = Gori::Proxy::WS.read_frame(client).not_nil!
+    String.new(echoed.payload).should eq("ping")
+
+    client.close
+    proxy.stop
+    origin.close rescue nil
+  end
+
   it "strips the client's permessage-deflate offer from the handshake it relays (#518)" do
     # Without the strip the origin accepts the extension, both peers compress, and every
     # frame WS::Relay captures is a deflate stream stored as if it were the message. The

--- a/spec/proxy/ws_teardown_spec.cr
+++ b/spec/proxy/ws_teardown_spec.cr
@@ -1,0 +1,226 @@
+require "../spec_helper"
+require "socket"
+
+# `Relay.run`'s teardown, which is the one moment at which the relay's two pump fibers and
+# `run`'s own fiber are all live at once: it writes what each pump is still withholding while
+# BOTH sockets are still open, and only then closes them. Everything here is about that window.
+# The byte-exact and rewrite-only paths are covered in ws_spec.cr and the gated ones in
+# ws_hold_spec.cr; these are the teardown's own hazards.
+
+private WS_CTX = Gori::Proxy::WS::Context.new(host: "echo.test", port: 80, scheme: "http",
+  method: "GET", target: "/ws")
+
+# A masked client frame of any opcode. Unlike ws_spec.cr's helper this also writes the 16-bit
+# extended length, because a control frame LARGER than §5.5's 125 bytes is the whole point of
+# the parking-ceiling example below (`forward_control` deliberately relays such a frame).
+private def masked_op_frame(opcode : UInt8, payload : Bytes, fin : Bool = true) : Bytes
+  mask = Bytes[0xAA, 0xBB, 0xCC, 0xDD]
+  io = IO::Memory.new
+  io.write_byte((fin ? 0x80_u8 : 0_u8) | opcode)
+  if payload.size < 126
+    io.write_byte((0x80 | payload.size).to_u8)
+  else
+    io.write_byte(0xFE_u8) # masked, 16-bit extended length
+    io.write_byte((payload.size >> 8).to_u8)
+    io.write_byte((payload.size & 0xFF).to_u8)
+  end
+  io.write(mask)
+  payload.each_with_index { |b, i| io.write_byte(b ^ mask[i & 3]) }
+  io.to_slice
+end
+
+# A Match & Replace lens whose `out` rule matches nothing: enough to put the socket on the
+# assembling pump (which is what parks control frames and withholds fragments) while leaving
+# every message byte-exact, so the wire says only what the teardown did.
+private class TeardownRewriter < Gori::Proxy::HeadRewriter
+  def rewrite_request(head : Bytes, host : String) : Bytes
+    head
+  end
+
+  def rewrite_response(head : Bytes, host : String) : Bytes
+    head
+  end
+
+  def rewrites_ws_out_for_host?(host : String) : Bool
+    true
+  end
+
+  def rewrites_ws_in_for_host?(host : String) : Bool
+    false
+  end
+
+  def rewrite_ws_out(payload : Bytes, host : String) : Bytes
+    payload
+  end
+
+  def rewrite_ws_in(payload : Bytes, host : String) : Bytes
+    payload
+  end
+end
+
+private class TeardownSink < Gori::Proxy::FlowSink
+  getter messages = [] of {String, Int32, String}
+
+  def on_request(req : Gori::Store::CapturedRequest) : Int64
+    1_i64
+  end
+
+  def on_response(resp : Gori::Store::CapturedResponse) : Nil
+  end
+
+  def on_ws_message(flow_id : Int64, direction : String, opcode : Int32, payload : Bytes,
+                    shape : Gori::Proxy::WS::Shape = Gori::Proxy::WS::Shape::DEFAULT) : Nil
+    @messages << {direction, opcode, String.new(payload)}
+  end
+end
+
+# A sink that YIELDS inside the teardown flush, which is what a real one does: every
+# `on_ws_message` is a store round-trip. On the first `out` row it also delivers one more
+# fragment onto the pump's own socket, so `Relay.run`'s fiber and the still-live pump fiber
+# are inside the same half-assembled message at the same time.
+private class RacingSink < Gori::Proxy::FlowSink
+  getter messages = [] of {String, Int32, String}
+  @fired = false
+
+  def initialize(@late_io : IO, @late : Bytes)
+  end
+
+  def on_request(req : Gori::Store::CapturedRequest) : Int64
+    1_i64
+  end
+
+  def on_response(resp : Gori::Store::CapturedResponse) : Nil
+  end
+
+  def on_ws_message(flow_id : Int64, direction : String, opcode : Int32, payload : Bytes,
+                    shape : Gori::Proxy::WS::Shape = Gori::Proxy::WS::Shape::DEFAULT) : Nil
+    @messages << {direction, opcode, String.new(payload)}
+    return if @fired || direction != "out"
+    @fired = true
+    @late_io.write(@late)
+    @late_io.flush
+    @late_io.close # ... and then the client is gone, so the pump ends either way
+    sleep 30.milliseconds
+  end
+end
+
+describe "WS::Relay teardown" do
+  # `Relay.run` reaches `flush_at_teardown` from its OWN fiber while the surviving pump fiber
+  # is still reading — the flush latches `@torn_down` (disabling that pump's own `ensure`
+  # flush and its loss notice), then yields on the sink write, then ends with `reset_buffer`.
+  # A fragment that arrived inside that window was appended by the pump and then either wiped
+  # by the reset with no wire write and no row, or — when it carried the FIN — re-emitted from
+  # `interleaved_raw`, which still held the leading frame the flush had ALREADY written. The
+  # peer then read `TEXT fin=0 "AAA"` twice, a §5.4 violation gori invented rather than
+  # relayed, and the transcript claimed a message the wire never carried.
+  #
+  # `AAA` is written EXACTLY once here. What arrives after the flush is not forwarded — the
+  # sockets are closing and there is nothing left that could put it out — but it is not
+  # allowed to corrupt what already went.
+  it "does not re-emit an already-flushed fragment when one arrives during the teardown flush" do
+    lead = masked_op_frame(Gori::Proxy::WS::OP_TEXT, "AAA".to_slice, fin: false)
+    tail = masked_op_frame(Gori::Proxy::WS::OP_CONT, "BBB".to_slice)
+
+    cs_r, cs_w = IO.pipe
+    ts_r, ts_w = IO.pipe
+    ss_r, ss_w = IO.pipe
+    tc_r, tc_w = IO.pipe
+    client = IO::Stapled.new(cs_r, tc_w)
+    upstream = IO::Stapled.new(ss_r, ts_w)
+
+    cs_w.write(lead)
+    cs_w.flush
+    ss_w.close # the ORIGIN ends first, with the client still mid-message
+
+    sink = RacingSink.new(cs_w, tail)
+    Gori::Proxy::WS::Relay.run(client, upstream, 7_i64, sink, TeardownRewriter.new, WS_CTX)
+
+    ts_w.close
+    ts_r.gets_to_end.to_slice.should eq(lead) # was: lead + lead + tail
+    # ... and capture says the same thing. The second row was built from a buffer the flush
+    # had already emptied, so it claimed a complete "AAABBB" the peer never received.
+    sink.messages.select { |(dir, _, _)| dir == "out" }.should eq([{"out", 1, "AAA"}])
+    _ = tc_r
+  end
+
+  # The parking ceiling used to be a COUNT only, and the constant's own comment justified that
+  # with §5.5's 125-byte control payload cap — a cap `forward_control` deliberately does not
+  # enforce (P7: a peer that advertises more gets its frame relayed, not its tunnel killed).
+  # So "8 frames" really meant "8 x MAX_FRAME" = ~128 MiB parked per direction, outside the
+  # MAX_MESSAGE budget that bounds the assembly buffer and the raw accumulator. Three 400-byte
+  # PINGs are five frames BELOW the count ceiling, so only the byte ceiling can fire here.
+  it "gives up the parked interleave on the byte ceiling, five frames below the count one" do
+    lead = masked_op_frame(Gori::Proxy::WS::OP_TEXT, "AAA".to_slice, fin: false)
+    tail = masked_op_frame(Gori::Proxy::WS::OP_CONT, "BBB".to_slice)
+    pings = (0...3).map do |i|
+      masked_op_frame(Gori::Proxy::WS::OP_PING, Bytes.new(400, (0x30 + i).to_u8))
+    end
+
+    cs_r, cs_w = IO.pipe
+    ts_r, ts_w = IO.pipe
+    ss_r, ss_w = IO.pipe
+    tc_r, tc_w = IO.pipe
+    client = IO::Stapled.new(cs_r, tc_w)
+    upstream = IO::Stapled.new(ss_r, ts_w)
+
+    cs_w.write(lead)
+    pings.each { |p| cs_w.write(p) }
+    cs_w.write(tail)
+    cs_w.close
+    ss_w.close
+
+    sink = TeardownSink.new
+    Gori::Proxy::WS::Relay.run(client, upstream, 7_i64, sink, TeardownRewriter.new, WS_CTX)
+
+    ts_w.close
+    # The documented hoist, identical to the count ceiling's: the third PING trips it,
+    # everything parked goes out ahead of the fragments, and the message follows byte-exact.
+    ts_r.gets_to_end.to_slice.should eq(pings.reduce(Bytes.empty) { |a, p| a + p } + lead + tail)
+
+    notices = sink.messages.select { |(_, _, text)| text.starts_with?("[gori] ") }
+    notices.size.should eq(1)        # once per direction per socket
+    notices.first[0].should eq("in") # a diagnostic is not traffic — never the seed direction
+    # The sentence names WHICH ceiling gave way; a count of three could not have tripped the
+    # other one, and an operator reading "8 control frames" here would be told a falsehood.
+    # Read off the constant rather than spelled out: the ceiling is derived from the WIRE size
+    # of a compliant control frame (payload cap + header + mask key), so a literal here would
+    # pin the arithmetic to whichever of those someone last remembered.
+    notices.first[2].should contain(
+      "more than #{Gori::Proxy::WS::Relay::MAX_PARKED_BYTES} bytes of control frames arrived between the fragments")
+    notices.first[2].should contain("client→server")
+    sink.messages.last.should eq({"out", 1, "AAABBB"})
+    _ = tc_r
+  end
+
+  # Every teardown write happens BEFORE the two `close` calls, and ClientConn relaxes both
+  # legs on the way into the tunnel — so a peer that stopped reading blocked the settle/flush
+  # writes with no deadline, and `close`, the only thing that could have unblocked them, was
+  # sequenced after. That pinned `Relay.run`'s fiber, both pump fibers, both fds and one of
+  # the server's connection slots permanently: the fd-exhaustion shape `Pump.blind_tunnel`
+  # cross-closes to avoid. Re-arming a bounded timeout makes the stalled write RAISE into the
+  # "could not be delivered" disposition both write sites already have.
+  #
+  # Asserted on the socket rather than by stalling a peer, because the arming is the fix and a
+  # filled send buffer is a timing test. `UNIXSocket` is used for the same reason `SocketTuning`
+  # resolves through wrappers: the timeout lives on the fd, not on the relay.
+  it "re-arms a bounded write timeout on both legs before the teardown writes" do
+    client, client_peer = UNIXSocket.pair
+    upstream, upstream_peer = UNIXSocket.pair
+    Gori::Proxy::SocketTuning.relax(client)
+    Gori::Proxy::SocketTuning.relax(upstream)
+    client.write_timeout.should be_nil # the state Relay.run inherits from ClientConn
+    upstream.write_timeout.should be_nil
+
+    client_peer.close
+    upstream_peer.close
+
+    Gori::Proxy::WS::Relay.run(client, upstream, 7_i64, TeardownSink.new)
+
+    client.write_timeout.should eq(Gori::Proxy::WS::Relay::CLOSE_TIMEOUT)
+    upstream.write_timeout.should eq(Gori::Proxy::WS::Relay::CLOSE_TIMEOUT)
+    # The read timeout comes with it, and that is why the arming is placed AFTER the CLOSE
+    # decision window: armed before it, a surviving pump would trip at exactly CLOSE_TIMEOUT
+    # and land in `observed` as a peer reset that never happened.
+    client.read_timeout.should eq(Gori::Proxy::WS::Relay::CLOSE_TIMEOUT)
+  end
+end

--- a/spec/repeater/minimize_spec.cr
+++ b/spec/repeater/minimize_spec.cr
@@ -107,8 +107,40 @@ private class DeadOrigin < F::Backend
   end
 end
 
+# Answers 200 only when the raw request bytes still carry the FF FE pair — a byte-wise
+# scan, never `String#includes?`, so the check itself can't launder the invalid bytes.
+private class ByteSensitiveOrigin < F::Backend
+  getter origin : F::Origin = F::Origin.new("http", "h", 80)
+  getter sent = 0
+
+  def send(bytes : Bytes) : Gori::Repeater::Result
+    @sent += 1
+    ok = contains_ff_fe?(bytes)
+    body = ok ? "the full user record body goes here" : "no"
+    head = "HTTP/1.1 #{ok ? 200 : 403} X\r\nContent-Length: #{body.bytesize}\r\n\r\n".to_slice
+    r = Gori::Proxy::Codec::Http1.parse_response_head(head)
+    Gori::Repeater::Result.new(head, body.to_slice, r, 1000_i64)
+  end
+
+  private def contains_ff_fe?(b : Bytes) : Bool
+    return false if b.size < 2
+    (0..b.size - 2).any? { |i| b[i] == 0xFF_u8 && b[i + 1] == 0xFE_u8 }
+  end
+end
+
+private def contains_bytes?(text : String, needle : Bytes) : Bool
+  hay = text.to_slice
+  return false if needle.size > hay.size
+  (0..hay.size - needle.size).any? { |i| hay[i, needle.size] == needle }
+end
+
 # LF→CRLF wire form; the fake origins don't validate Content-Length, so no resync needed.
 private RESOLVE = ->(t : String) { t.gsub("\n", "\r\n").to_slice }
+
+# Identity resolve for the invalid-UTF-8 fixture. `RESOLVE` above uses `gsub` with a ONE-byte
+# needle, which Crystal routes through the char-walking path and which therefore rewrites
+# invalid bytes to U+FFFD — it would destroy the very bytes that test is about.
+private IDENTITY_RESOLVE = ->(t : String) { t.to_slice }
 
 private def minimize(backend : F::Backend, text : String, auto_cl : Bool = false) : Min::Report
   Min.run(text, auto_cl: auto_cl, resolve: RESOLVE, backend: backend) { |_| }
@@ -203,6 +235,34 @@ describe Gori::Repeater::Minimize do
     report.minimized_text.should contain("sid=abc123")
     report.minimized_text.should_not contain("junk")
     report.minimized_text.should_not contain("trash")
+  end
+
+  # A Cookie value can legitimately carry bytes that are not valid UTF-8 — a latin-1 token, a
+  # binary session id, an operator's own byte-level payload — and MCP's `request_base64` exists
+  # precisely to seed one. The crumb splitter used a Regexp, so PCRE2 raised
+  # `ArgumentError: UTF-8 error` during candidate ENUMERATION, before a single request went
+  # out, and `gori run repeater minimize` has no rescue above it.
+  it "enumerates and removes cookie crumbs when the Cookie value is not valid UTF-8" do
+    io = IO::Memory.new
+    io << "GET /p HTTP/1.1\nHost: h\nCookie: sid="
+    io.write(Bytes[0xFF, 0xFE])
+    io << "; junk=1"
+    text = String.new(io.to_slice)
+    text.valid_encoding?.should be_false
+
+    origin = ByteSensitiveOrigin.new
+    report = Min.run(text, auto_cl: false, resolve: IDENTITY_RESOLVE, backend: origin) { |_| }
+
+    report.aborted.should be_false
+    origin.sent.should be > 0
+    # the cosmetic crumb was reachable at all (it wasn't, before: the enumeration raised)
+    report.removed.map(&.label).should contain("junk")
+    contains_bytes?(report.minimized_text, "junk=1".to_slice).should be_false
+    # and the load-bearing crumb comes back BYTE-EXACT: `--apply` persists minimized_text (P7)
+    contains_bytes?(report.minimized_text, Bytes[0xFF, 0xFE]).should be_true
+    contains_bytes?(report.minimized_text, "sid=".to_slice).should be_true
+    # U+FFFD never appears: nothing on this path may launder the operator's bytes
+    contains_bytes?(report.minimized_text, Bytes[0xEF, 0xBF, 0xBD]).should be_false
   end
 
   it "removes an unused body param and re-lengths, keeping a load-bearing one (auto-CL on)" do

--- a/spec/repeater/ws_engine_spec.cr
+++ b/spec/repeater/ws_engine_spec.cr
@@ -210,6 +210,22 @@ describe Gori::Repeater::WsEngine do
     received.includes?(0xFE_u8).should be_true
   end
 
+  # `head_lines` pops trailing blank lines, so an empty (or all-blank) editor yields `[]` and
+  # the header walk's `lines[1..]` raised IndexError. That raise landed AFTER the dial, so the
+  # operator got "Index out of bounds" for a connection gori had already opened. The request
+  # line right above it already synthesizes `GET / HTTP/1.1` for exactly this case; the send
+  # must now fail (or succeed) on the ORIGIN's answer, not on an internal index error.
+  it "synthesizes a handshake for an empty or blank request instead of raising IndexError" do
+    [Bytes.new(0), "\r\n".to_slice, "\n".to_slice].each do |head|
+      port = start_ws_origin(echo: false)
+      result = WsEngine.send(head, [] of WsEngine::OutMsg,
+        scheme: "http", host: "127.0.0.1", port: port, verify_upstream: false)
+      (result.error || "").should_not contain("Index out of bounds")
+      result.upgraded?.should be_true
+      result.close_code.should eq(1000)
+    end
+  end
+
   describe ".upgrade_request?" do
     it "matches the Upgrade: websocket header case-insensitively with flexible spacing" do
       WsEngine.upgrade_request?("GET /ws HTTP/1.1\r\nUpgrade: websocket\r\n\r\n").should be_true

--- a/spec/settings_spec.cr
+++ b/spec/settings_spec.cr
@@ -724,6 +724,53 @@ describe Gori::Settings do
     end
   end
 
+  # A section that RAISES is a different degradation from an unparseable file: `load_raw` and
+  # `load_root` both succeeded, so the file-shaped `load_degraded?` test answered false while
+  # every section below the raise sat at its factory default — and the next save (a tab
+  # toggle, the update-check stamp, `gori settings import`) wrote that half-document over the
+  # operator's real file, which is the #594 loss. The base is no defence: a section that never
+  # loaded is either absent from `serialize` or holds a default, so the 3-way merge drops it
+  # either way. The only safe answer is to refuse the write until a load gets through.
+  #
+  # A top-level ARRAY reproduces it at the very first section — `JSON::Any#[]?` raises on a
+  # non-object, the same coercion `object_section` was written for.
+  it "refuses to write back a settings file it could only half read" do
+    dir = File.tempname("gori-settings-partial")
+    Dir.mkdir_p(dir)
+    prev = ENV["GORI_HOME"]?
+    prev_theme = Gori::Settings.theme
+    sink = IO::Memory.new
+    begin
+      ENV["GORI_HOME"] = dir
+      Gori::Settings.warning_io = sink
+      Gori::Settings.reset_load_warning_guard
+      original = %([{"theme":"dracula"}])
+      File.write(Gori::Settings.path, original)
+
+      Gori::Settings.load
+      Gori::Settings.load_degraded?.should be_true
+      Gori::Settings.load_warning.not_nil!.should contain(Gori::Settings.path)
+      sink.to_s.should contain("will not overwrite") # and it SAYS so, like the corrupt path
+
+      Gori::Settings.save.should be_false
+      File.read(Gori::Settings.path).should eq(original) # byte-unchanged
+
+      # Cleared by the next load that gets all the way through, so the refusal never outlives
+      # the file that caused it.
+      File.write(Gori::Settings.path, %({"theme":"goridark"}))
+      Gori::Settings.load
+      Gori::Settings.load_degraded?.should be_false
+      Gori::Settings.load_warning.should be_nil
+      Gori::Settings.save.should be_true
+    ensure
+      Gori::Settings.warning_io = nil # spec_helper's default: never on the suite's STDERR
+      prev ? (ENV["GORI_HOME"] = prev) : ENV.delete("GORI_HOME")
+      FileUtils.rm_rf(dir)
+      Gori::Settings.theme = prev_theme
+      Gori::Settings.bind_port = 8070
+    end
+  end
+
   # Preserving the file was only half of it: the fallback to defaults was SILENT, so a
   # hand-edited comma reset the bind address, the upstream connection rules and the TLS
   # pass-through list with the only trace a `.corrupt` sibling nobody was told to look for.
@@ -1255,6 +1302,58 @@ describe Gori::Settings do
       FileUtils.rm_rf(dir)
       Gori::Settings.colormarker_rules = [] of Gori::Settings::ColormarkerRule
       Gori::Settings.colormarker_next_rule_id = 1_i64
+    end
+  end
+
+  # `max(id) + 1` on a hand-edited `"id": 9223372036854775807` is CHECKED arithmetic, so it
+  # raised OverflowError inside apply_sections — the third door into the #594 room `int_field`
+  # and `object_section` each closed one of: everything below the raising section kept its
+  # factory default, load's blanket rescue said nothing, and the next save wrote the result
+  # over the operator's file. Both parsers and both mint sites saturate now.
+  it "keeps reading a settings file past a rule id at the Int64 ceiling" do
+    dir = File.tempname("gori-settings-idceiling")
+    Dir.mkdir_p(dir)
+    prev = ENV["GORI_HOME"]?
+    begin
+      ENV["GORI_HOME"] = dir
+      Gori::Settings.rewriter_rules = [] of Gori::Settings::RewriterRule
+      Gori::Settings.colormarker_rules = [] of Gori::Settings::ColormarkerRule
+      Gori::Settings.confirm_quit = false
+
+      File.write(Gori::Settings.path, %({"rewriter":{"rules":[\
+{"id":9223372036854775807,"enabled":true,"name":"top","pattern":"x"}]},\
+"colormarker":{"rules":[{"id":9223372036854775807,"when":"status:500","color":"red"}]},\
+"general":{"confirm_quit":true}}))
+      Gori::Settings.load
+
+      # `general` is parsed AFTER both of those, so it is the canary for "apply_sections ran
+      # to the end". Before the fix it sat at its default here.
+      Gori::Settings.confirm_quit?.should be_true
+      Gori::Settings.load_degraded?.should be_false
+
+      # The rules themselves survive — only the unusable id is renumbered, the same answer a
+      # duplicate id gets, because a counter cannot be advanced past Int64::MAX.
+      Gori::Settings.rewriter_rules.map(&.name).should eq(["top"])
+      Gori::Settings.rewriter_rules.first.id.should_not eq(Int64::MAX)
+      Gori::Settings.colormarker_rules.size.should eq(1)
+      Gori::Settings.colormarker_rules.first.id.should_not eq(Int64::MAX)
+
+      # And a counter read straight off the file at the ceiling must not raise at the MINT
+      # site either (`next_rule_id` parses fine on its own, so nothing else bounds it).
+      Gori::Settings.rewriter_next_rule_id = Int64::MAX
+      Gori::Settings.add_rewriter_rule("request", "head", "X-Trace", "on",
+        "set_header", "literal", "", "", "").should eq(Int64::MAX)
+      Gori::Settings.rewriter_next_rule_id.should eq(Int64::MAX)
+      Gori::Settings.colormarker_next_rule_id = Int64::MAX
+      Gori::Settings.add_colormarker_rule("status:404", "red", "full").should eq(Int64::MAX)
+    ensure
+      prev ? (ENV["GORI_HOME"] = prev) : ENV.delete("GORI_HOME")
+      FileUtils.rm_rf(dir)
+      Gori::Settings.rewriter_rules = [] of Gori::Settings::RewriterRule
+      Gori::Settings.rewriter_next_rule_id = 1_i64
+      Gori::Settings.colormarker_rules = [] of Gori::Settings::ColormarkerRule
+      Gori::Settings.colormarker_next_rule_id = 1_i64
+      Gori::Settings.confirm_quit = Gori::Settings::DEFAULT_CONFIRM_QUIT
     end
   end
 

--- a/spec/tui/probe_drain_coalesce_spec.cr
+++ b/spec/tui/probe_drain_coalesce_spec.cr
@@ -1,0 +1,265 @@
+require "../spec_helper"
+require "file_utils"
+
+include Gori::Tui
+
+# `ProbeController#drain_events` runs on the render fiber, once per run-loop tick, from EVERY
+# tab. It used to do two unbounded things there: loop the analyzer channel with no per-tick
+# ceiling (every sibling drain has one — `DRAIN_CAP` in the fuzzer/miner/sequencer/discover/
+# oast controllers), and call `refresh_from_store` once PER IssueEvent — a full-table
+# `probe_issues` SELECT plus filter and detail re-derive, the exact cost the Runner's own
+# probe_generation poll already refuses to pay off-tab ("repainting the whole screen up to 20
+# times a second" during an active scan).
+#
+# probe/event.cr has always promised the opposite — "the controller coalesces them into a
+# single list reload per frame" — so these examples pin the promise: one reload per drain, no
+# reload at all while Probe is not the active tab, and a bounded number of events per tick.
+
+# The narrow shell facade a controller is given; everything here is inert except `session`,
+# `notifications`, `status` and `active_tab` — the only members this drain touches. File-local
+# for the same reason oast_callback_cap_spec's identical double is: `Host` is ~30 abstract
+# methods, and a shared support double would be another file to keep in sync with the module.
+private class FakeHost
+  include Gori::Tui::Host
+
+  getter statuses = [] of String
+  property active_tab : Symbol = :probe
+
+  def initialize(@session : Gori::Session)
+    @jobs = Gori::Tui::Jobs.new
+    @notifications = Gori::Tui::Notifications.new
+  end
+
+  def session : Gori::Session
+    @session
+  end
+
+  def jobs : Gori::Tui::Jobs
+    @jobs
+  end
+
+  def notifications : Gori::Tui::Notifications
+    @notifications
+  end
+
+  def status(message : String) : Nil
+    @statuses << message
+  end
+
+  def request_overlay(kind : Symbol) : Nil
+  end
+
+  def request_focus(pane : Symbol) : Nil
+  end
+
+  def focus_body : Nil
+  end
+
+  def switch_tab(tab : Symbol) : Nil
+  end
+
+  def goto_tab(tab : Symbol) : Nil
+  end
+
+  def open_palette : Nil
+  end
+
+  def open_space_menu : Nil
+  end
+
+  def open_fuzz_set_editor(edit_index : Int32?) : Nil
+  end
+
+  def open_fuzz_advanced_editor : Nil
+  end
+
+  def reconfigure_sequence : Nil
+  end
+
+  def open_scope_rule_editor(edit_id : Int64?, kind : String, match_type : String, pattern : String) : Nil
+  end
+
+  def open_custom_rule_editor(rule : Gori::Probe::CustomRule?) : Nil
+  end
+
+  def open_rewriter_rule_editor(rule : Gori::Store::MatchRule?) : Nil
+  end
+
+  def open_colormarker_rule_editor(rule : Gori::Store::ColorRule?) : Nil
+  end
+
+  def open_colormarker_color_editor(color : Gori::Settings::ColormarkerColor?) : Nil
+  end
+
+  def open_extract_rule_editor(rule : Gori::Store::ExtractRule?) : Nil
+  end
+
+  def open_chain_save : Nil
+  end
+
+  def open_chain_load : Nil
+  end
+
+  def open_oast_provider_editor(provider : Gori::Oast::ProviderConfig?) : Nil
+  end
+
+  def confirm(title : String, message : String, *, confirm_label : String, danger : Bool,
+              return_to : Symbol = :none, &action : -> Nil) : Nil
+    action.call
+  end
+
+  def overlay : Symbol
+    :none
+  end
+
+  def focus : Symbol
+    :body
+  end
+
+  def reveal? : Bool
+    false
+  end
+
+  def toggle_reveal : Nil
+  end
+
+  def pretty? : Bool
+    false
+  end
+
+  def toggle_pretty : Nil
+  end
+
+  def toggle_scope_lens : Nil
+  end
+
+  def toggle_sandbox : Nil
+  end
+
+  def apply_project_network(bind_host : String, bind_port : Int32, upstream : String,
+                            connect_secs : Int32, io_secs : Int32, capture_mib : Int32) : String
+    ""
+  end
+end
+
+# Counts the full-table reloads the drain triggers. Crystal has no `override`, so this
+# deliberately shadows the base method and chains with `super` — the point is to observe how
+# MANY times the real one runs, not to replace it.
+private class SpyProbeController < Gori::Tui::ProbeController
+  getter reloads : Int32 = 0
+
+  def initialize(host : Gori::Tui::Host)
+    super
+    @reloads = 0
+  end
+
+  def refresh_from_store : Bool
+    @reloads += 1
+    super
+  end
+end
+
+# The CA is the one slow part of standing a Session up (a root keypair) and no example asserts
+# anything about it, so it is built once.
+private PROBE_DRAIN_CA_ROOT = File.tempname("gori-probe-drain-ca")
+Spec.after_suite { FileUtils.rm_rf(PROBE_DRAIN_CA_ROOT) }
+
+private def with_probe_controller(&)
+  root = File.tempname("gori-probe-drain")
+  Dir.mkdir_p(root)
+  project = Gori::ProjectRegistry.new(root).temp("probedrain")
+  session = Gori::Session.open(Gori::Config.new(listen: "127.0.0.1", port: 0),
+    Gori::Proxy::Tls::CertAuthority.load_or_create(PROBE_DRAIN_CA_ROOT), Gori::Verbs.registry, project)
+  begin
+    host = FakeHost.new(session)
+    yield SpyProbeController.new(host), host, session
+  ensure
+    session.close
+    FileUtils.rm_rf(root) if Dir.exists?(root)
+  end
+end
+
+private def issue_event(n : Int32, summary : String? = nil) : Gori::Probe::IssueEvent
+  Gori::Probe::IssueEvent.new("h#{n}.test", summary)
+end
+
+private def seed_issue(store : Gori::Store, n : Int32) : Nil
+  store.upsert_probe_issue(Gori::Probe::Detection.new(
+    "reflected_param", Gori::Probe::Category::ACTIVE, "h#{n}.test",
+    "https://h#{n}.test/?q=1", "Reflected parameter",
+    Gori::Store::Severity::Medium, "query (q)", n.to_i64))
+end
+
+describe "Gori::Tui::ProbeController#drain_events" do
+  it "reloads the issue list ONCE per drain, not once per IssueEvent" do
+    with_probe_controller do |controller, host, session|
+      host.active_tab = :probe
+      seed_issue(session.store, 1)
+      before = controller.reloads
+
+      8.times { |n| session.probe.events.send(issue_event(n)) }
+      controller.drain_events.should be_true
+
+      # The defect: eight events meant eight full-table SELECT + filter passes on the render
+      # fiber. One drain is one reload now, exactly as probe/event.cr's contract says.
+      (controller.reloads - before).should eq(1)
+      # …and the reload really happened, so a delivered IssueEvent never leaves the view behind.
+      controller.view.row_count.should eq(1)
+    end
+  end
+
+  it "skips the reload entirely while Probe is not the active tab, and catches up on entry" do
+    with_probe_controller do |controller, host, session|
+      host.active_tab = :history
+      seed_issue(session.store, 1)
+      before = controller.reloads
+
+      4.times { |n| session.probe.events.send(issue_event(n)) }
+      # Still drained (the toast/badge work is unconditional — it is visible from any tab)…
+      controller.drain_events.should be_true
+      # …but the full-table read is the poll path's rule: not for a list nobody is looking at.
+      (controller.reloads - before).should eq(0)
+      controller.view.row_count.should eq(0)
+
+      # The only way into the Probe tab is `focus_tab`, which runs on_enter — so the off-tab
+      # skip is caught up before the list is ever painted.
+      controller.on_enter
+      controller.view.row_count.should eq(1)
+    end
+  end
+
+  it "stops at DRAIN_CAP events per tick and finishes the rest on the next one" do
+    prev_toast = Gori::Settings.notify_toast?
+    begin
+      Gori::Settings.notify_toast = true # the per-event status line is the drain's own counter
+      with_probe_controller do |controller, host, session|
+        host.active_tab = :probe
+        total = Gori::Tui::ProbeController::DRAIN_CAP + 40
+        ch = session.probe.events
+
+        # The analyzer's channel holds 256, so the flood has to come from a producer fiber:
+        # the per-event `insert_event` is a writer round-trip and therefore a yield point,
+        # which is precisely how the uncapped loop could run far past one channel-full.
+        spawn do
+          total.times { |n| ch.send(issue_event(n, "reflected param on h#{n}.test")) }
+        end
+        Fiber.yield # let the producer fill the channel before the first tick
+
+        controller.drain_events.should be_true
+        first = host.statuses.size
+        first.should be <= Gori::Tui::ProbeController::DRAIN_CAP
+        first.should be < total # the defect: one tick swallowed the whole flood
+
+        # Nothing is dropped — the remainder is drained on subsequent ticks, 50 ms apart.
+        20.times do
+          break if host.statuses.size >= total
+          controller.drain_events
+          Fiber.yield # stands in for the run loop's tick sleep, so the producer can refill
+        end
+        host.statuses.size.should eq(total)
+      end
+    ensure
+      Gori::Settings.notify_toast = prev_toast
+    end
+  end
+end

--- a/spec/tui/repeater_view_spec.cr
+++ b/spec/tui/repeater_view_spec.cr
@@ -2334,6 +2334,67 @@ describe Gori::Tui::RepeaterView do
     end
   end
 
+  # The complement of the paste repairs above: a request that arrived WITH its CRLFs must keep
+  # them. Every §/¦ helper is handed `@editor.text` — the CR-free projection its offsets index —
+  # and used to push that projection straight back through `set_text`, so the marking chord the
+  # status line advertises flattened the capture's body before the tab had sent anything.
+  # `edit_buffer_text` documents the same loss for ^E; `FuzzerView#restore_wire_eols` has guarded
+  # the identical five helpers all along. Non-multipart on purpose: `request_bytes` restores CRLF
+  # delimiters only for multipart, so a smuggling payload has nothing else standing behind it.
+  describe "marking keeps a captured request's wire terminators" do
+    smuggle = "POST /x HTTP/1.1\r\nHost: h.test\r\nContent-Length: 45\r\n\r\n" \
+              "0\r\n\r\nGET /smuggled HTTP/1.1\r\nHost: h.test\r\n\r\n"
+
+    seed = -> {
+      view = RepeaterView.new
+      view.restore("http://h.test", smuggle, false, false) # auto-CL off: the desync is the test
+      view.focus_pane(:request)
+      view
+    }
+
+    it "^A auto-mark leaves the bytes alone (it writes back even on its no-op)" do
+      view = seed.call
+      view.auto_mark
+      view.request_text.count('\r').should eq(smuggle.count('\r'))
+      String.new(view.request_bytes).should eq(smuggle) # markers render to their own defaults
+    end
+
+    it "^K mark_word marks the token and nothing else" do
+      view = seed.call
+      view.goto_request_line(1)
+      view.mark_word.should contain("marked position")
+      view.request_text.should eq(smuggle.sub("POST /x", "§POST§ /x"))
+      String.new(view.request_bytes).should eq(smuggle)
+    end
+
+    it "clear-marks puts the buffer back byte for byte" do
+      view = seed.call
+      view.goto_request_line(1)
+      view.mark_word
+      view.clear_marks.should contain("cleared")
+      view.request_text.should eq(smuggle)
+      String.new(view.request_bytes).should eq(smuggle)
+    end
+
+    it "the marker-strip confirm keeps the terminators" do
+      view = seed.call
+      view.goto_request_line(1)
+      view.mark_word
+      view.strip_marker_span({0, 6}) # §POST§, char span like the sibling spec above
+      view.request_text.should eq(smuggle)
+    end
+
+    it "the ^Y chain commit keeps the terminators" do
+      view = seed.call
+      view.goto_request_line(1)
+      view.mark_word
+      view.focus_chain_pane.should be_nil # caret is inside the marker it just made
+      "md5".each_char { |c| view.handle_chain_pane_key(Termisu::Event::Key.new(Termisu::Input::Key::LowerA, char: c)) }
+      view.commit_chain_pane
+      view.request_text.should eq(smuggle.sub("POST /x", "§POST¦md5§ /x"))
+    end
+  end
+
   describe "pretty_print_request" do
     it "pretty-prints JSON request body in-place and preserves markers" do
       view = RepeaterView.new

--- a/spec/tui/settings_view_spec.cr
+++ b/spec/tui/settings_view_spec.cr
@@ -339,6 +339,16 @@ describe SettingsView do
       Gori::Settings.upstream_rules = [Gori::Settings::UpstreamRule.new("*", "http", "p.test:1")]
       v.reload(:network)
       SettingsView::NETWORK_FIELDS[row].readonly.should be_true
+
+      # Forward-delete is the third edit verb, and the one that used to be missing the guard.
+      # ← on a non-bool/non-choice row falls through to move_cursor, which pulls the caret off
+      # end-of-line and so defeats delete's only other brake (`cursor >= size`) — Del then ate a
+      # character out of the live "1 rule" summary and flipped `dirty?`, which paints a spurious
+      # "● unsaved" on the Network subheader and blocks the first esc for an edit nobody made.
+      row.times { v.move_field(1) }
+      v.toggle_or_move(-1)
+      v.delete
+      v.dirty?.should be_false
     ensure
       prev_home ? (ENV["GORI_HOME"] = prev_home) : ENV.delete("GORI_HOME")
       Gori::Settings.upstream_rules = prev

--- a/spec/tui/text_area_spec.cr
+++ b/spec/tui/text_area_spec.cr
@@ -441,6 +441,67 @@ describe Gori::Tui::TextArea do
       ta.match_count("").should eq(0) # an empty query never matches
       ta.text.should eq("bar baz")
     end
+
+    # ^F replace-all reaches the Repeater's and the Intercept's request editors, and both send
+    # `wire_text`. The gsub has to run over `#text` (the offsets index it), so the terminators
+    # have to go back on afterwards — otherwise a captured multipart body came out bare-LF and
+    # auto-Content-Length resynced DOWN behind it.
+    it "keeps the buffer's wire terminators across a replace" do
+      wire = "POST /u HTTP/1.1\r\nHost: h\r\nContent-Type: multipart/form-data; boundary=B\r\n\r\n" \
+             "--B\r\nContent-Disposition: form-data; name=\"q\"\r\n\r\nadmin\r\n--B--\r\n"
+      ta = TextArea.new(wire)
+      ta.replace_matches("admin", "guest").should eq(1)
+      ta.wire_text.should eq(wire.sub("admin\r\n--B--", "guest\r\n--B--"))
+      ta.wire_text.count('\r').should eq(wire.count('\r'))
+    end
+
+    it "keeps a mixed-ending buffer's bare LFs bare" do
+      ta = TextArea.new("POST /x HTTP/1.1\r\nHost: h\r\n\r\n0\r\n\r\nGET /a HTTP/1.1\nHost: h\n")
+      ta.replace_matches("/a", "/b").should eq(1)
+      ta.wire_text.should eq("POST /x HTTP/1.1\r\nHost: h\r\n\r\n0\r\n\r\nGET /b HTTP/1.1\nHost: h\n")
+    end
+
+    it "is still one undo step, back to the wire bytes" do
+      wire = "a\r\nadmin\r\nb\n"
+      ta = TextArea.new(wire)
+      ta.replace_matches("admin", "root")
+      ta.wire_text.should eq("a\r\nroot\r\nb\n")
+      ta.undo
+      ta.wire_text.should eq(wire)
+    end
+  end
+
+  # Lifted from `FuzzerView#restore_wire_eols`: a transform computed over the LF projection
+  # (every offset it works from indexes that string) must not write the projection back.
+  describe "#set_text_keeping_eols / #replace_all_keeping_eols" do
+    it "reattaches the original terminators line for line" do
+      ta = TextArea.new("h1\r\nh2\r\n\r\nbo\r\ndy")
+      ta.set_text_keeping_eols("h1\nh2X\n\nbo\ndy")
+      ta.wire_text.should eq("h1\r\nh2X\r\n\r\nbo\r\ndy")
+    end
+
+    it "keeps the caret and one undo step through the replace_all form" do
+      ta = TextArea.new("a\r\nbb\r\nc\r\n")
+      ta.replace_all_keeping_eols("a\nbXb\nc\n", 4)
+      ta.wire_text.should eq("a\r\nbXb\r\nc\r\n")
+      ta.cursor_offset.should eq(4)
+      ta.undo
+      ta.wire_text.should eq("a\r\nbb\r\nc\r\n")
+    end
+
+    # Only a line-count change could reattach terminators to the WRONG lines; better a buffer
+    # that lost its CRLFs than one whose body boundaries moved.
+    it "falls back to the LF text unchanged when the line count moved" do
+      ta = TextArea.new("a\r\nb\r\n")
+      ta.set_text_keeping_eols("a\nb\nc\n")
+      ta.wire_text.should eq("a\nb\nc\n")
+    end
+
+    it "is a no-op on a buffer that had no CRs to restore" do
+      ta = TextArea.new("a\nb\n")
+      ta.set_text_keeping_eols("a\nbX\n")
+      ta.wire_text.should eq("a\nbX\n")
+    end
   end
 
   describe "#home / #end_of_line" do

--- a/src/gori/cli/run.cr
+++ b/src/gori/cli/run.cr
@@ -663,7 +663,13 @@ module Gori
       private def self.split_ql_negations(args : Array(String)) : {Array(String), Array(String)}
         neg = [] of String
         rest = [] of String
-        args.each { |a| a.matches?(/\A-[A-Za-z]+[:~]/) ? (neg << a) : (rest << a) }
+        # Classify on a scrubbed copy: argv comes from the OS unvalidated, and PCRE2 raises
+        # "Regex match error: UTF-8 error" on a non-UTF-8 subject — `gori run history $'\xff'`
+        # backtraced out of `main`, since neither `Run.dispatch` nor `CLI.run` rescues
+        # ArgumentError. Same remedy as `read_token_list` in ./run/sequence.cr. `scrub` returns
+        # self for valid UTF-8, and it is `a` (not `a.scrub`) that is kept, so the operator's
+        # query bytes reach QL exactly as typed.
+        args.each { |a| a.scrub.matches?(/\A-[A-Za-z]+[:~]/) ? (neg << a) : (rest << a) }
         {neg, rest}
       end
 
@@ -759,7 +765,11 @@ module Gori
 
       # "30s" / "5m" / "1h" / bare seconds → a Time::Span.
       private def self.parse_duration(v : String) : Time::Span
-        m = v.match(/\A(\d+)(s|m|h)?\z/)
+        # .scrub for the same reason as `split_ql_negations` above: `--for $'\xff'` is a
+        # PCRE2 UTF-8 error, not a match failure, and it escaped to `main`. A scrubbed byte
+        # is U+FFFD, which no digit class accepts, so junk still lands on the abort below —
+        # which keeps printing the raw `v` the operator typed.
+        m = v.scrub.match(/\A(\d+)(s|m|h)?\z/)
         abort "gori run: invalid duration '#{v}' (use e.g. 30s, 5m, 1h)" unless m
         # .to_i? (not .to_i): the regex permits arbitrarily many digits, so a value
         # like 99999999999999999999 would overflow Int32 and crash with an unhandled

--- a/src/gori/cli/run/colormarker.cr
+++ b/src/gori/cli/run/colormarker.cr
@@ -54,6 +54,7 @@ module Gori
           p.on("--format=FMT", "text (default) | json") { |v| format = v == "json" ? :json : :text }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
           p.invalid_option { |f| abort "gori run colormarker color list: unknown option: #{f}\n#{p}" }
+          p.missing_option { |f| abort "gori run colormarker color list: missing value for #{f}" }
         end
         parser.parse(args)
         colors = Settings.colormarker_colors
@@ -371,6 +372,7 @@ module Gori
           p.on("--scope=SCOPE", "Which <id>: project (default) | global") { |v| scope = parse_color_scope(v) }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
           p.invalid_option { |f| abort "gori run colormarker rm: unknown option: #{f}\n#{p}" }
+          p.missing_option { |f| abort "gori run colormarker rm: missing value for #{f}" }
         end
         positional = [] of String
         parser.unknown_args { |before, after| positional = before + after }
@@ -423,6 +425,7 @@ module Gori
           p.on("--everywhere", "global rules only: change the default for every project") { everywhere = true }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
           p.invalid_option { |f| abort "gori run colormarker #{action}: unknown option: #{f}\n#{p}" }
+          p.missing_option { |f| abort "gori run colormarker #{action}: missing value for #{f}" }
         end
         positional = [] of String
         parser.unknown_args { |before, after| positional = before + after }
@@ -497,6 +500,7 @@ module Gori
           p.on("--down", "Give the rule lower precedence") { dir = 1 }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
           p.invalid_option { |f| abort "gori run colormarker move: unknown option: #{f}\n#{p}" }
+          p.missing_option { |f| abort "gori run colormarker move: missing value for #{f}" }
         end
         positional = [] of String
         parser.unknown_args { |before, after| positional = before + after }

--- a/src/gori/cli/run/decoder.cr
+++ b/src/gori/cli/run/decoder.cr
@@ -125,6 +125,7 @@ module Gori
           p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
           p.invalid_option { |f| abort "gori run decoder list: unknown option: #{f}\n#{p}" }
+          p.missing_option { |f| abort "gori run decoder list: missing value for #{f}" }
         end
         parser.parse(args)
 

--- a/src/gori/cli/run/discover.cr
+++ b/src/gori/cli/run/discover.cr
@@ -238,15 +238,15 @@ module Gori
         # SIGINT/SIGTERM lands here too (see the trap above) since Engine#stop makes the run end
         # like any other — so this one flush covers the normal, error, AND interrupted paths.
         flush_discover(store, pending) unless no_store
-        report_discover_interrupt(findings, no_store) if interrupted.call
         puts CLI::Output.discover_array_json(findings) if format == :json
+        # `Run.report_interrupted` (exit 130) rather than the local reporter this used to call:
+        # that one only wrote to STDERR and returned, so a Ctrl-C'd crawl fell through to a
+        # plain exit 0 and a scripted `gori run discover … && ./triage.sh` treated a truncated
+        # run as a finished one. Emitting the buffered JSON first, then the interrupt, matches
+        # fuzz.cr / mine.cr / sequence.cr — and it goes BEFORE `exit 1 if had_error` for the
+        # ordering reason interrupt.cr spells out.
+        Run.report_interrupted(findings.size, "finding", no_store ? "collected" : "saved") if interrupted.call
         exit 1 if had_error
-      end
-
-      private def self.report_discover_interrupt(findings : Array(Discover::Finding), no_store : Bool) : Nil
-        verb = no_store ? "collected" : "saved"
-        plural = findings.size == 1 ? "" : "s"
-        STDERR.puts "interrupted — #{findings.size} finding#{plural} #{verb}"
       end
 
       private def self.flush_discover(store : Store,

--- a/src/gori/cli/run/fuzz_args.cr
+++ b/src/gori/cli/run/fuzz_args.cr
@@ -9,7 +9,11 @@ module Gori
         # A plain `partition('-')` splits on the FIRST hyphen, so a negative FROM
         # (e.g. `-10--5`) would leave an empty `from_s`. Match both bounds — each
         # optionally signed — so negative ranges (common in offset/ID fuzzing) work.
-        m = range_part.match(/\A(-?\d+)-(-?\d+)\z/)
+        # .scrub before the match: argv is unvalidated OS bytes and PCRE2 raises
+        # "Regex match error: UTF-8 error" rather than failing to match, which escaped to
+        # `main` (see `split_ql_negations` in ../run.cr). U+FFFD matches no digit class, so a
+        # junk byte still ends at the abort below, with the raw `v` in the message.
+        m = range_part.scrub.match(/\A(-?\d+)-(-?\d+)\z/)
         from = m.try(&.[1].to_i64?)
         to = m.try(&.[2].to_i64?)
         abort "gori run fuzz: invalid --numbers '#{v}' (use FROM-TO[:STEP])" unless from && to

--- a/src/gori/cli/run/oast.cr
+++ b/src/gori/cli/run/oast.cr
@@ -318,11 +318,14 @@ module Gori
           p.on("--once", "Poll once and exit (no loop)") { once = true }
           p.on("--json", "Emit each callback as a JSON line (same shape as MCP)") { json = true }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
-          # This was the ONE parser of 74 under src/gori/cli/ missing these, so OptionParser's
-          # default raised straight past `Run.dispatch` (rescues IO::Error) and `CLI.run`
-          # (rescues Gori::Error) to `main`, printing a Crystal backtrace — the form cli.cr's own
-          # top-level rescue calls "the least usable there is". `gori run oast listen --bogus`
-          # already did it; narrowing the global version scan just routed `--version` there too.
+          # Without these, OptionParser's default raises straight past `Run.dispatch` (rescues
+          # IO::Error) and `CLI.run` (rescues Gori::Error) to `main`, printing a Crystal
+          # backtrace — the form cli.cr's own top-level rescue calls "the least usable there
+          # is". `gori run oast listen --bogus` already did it; narrowing the global version
+          # scan just routed `--version` there too. This parser was fixed first and read as the
+          # only one; a later sweep found eleven more parsers taking a `=VALUE` flag with no
+          # `missing_option`, so the invariant is now pinned by a source grep over every parser
+          # under src/gori/cli/ (spec/cli/run/option_parser_missing_option_spec.cr).
           p.invalid_option { |f| abort "gori run oast listen: unknown option: #{f}\n#{p}" }
           p.missing_option { |f| abort "gori run oast listen: missing value for #{f}" }
         end

--- a/src/gori/cli/run/rewriter.cr
+++ b/src/gori/cli/run/rewriter.cr
@@ -73,6 +73,7 @@ module Gori
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
           p.unknown_args { |before, after| leftover = before + after }
           p.invalid_option { |f| abort "gori run rewriter extract: unknown option: #{f}\n#{p}" }
+          p.missing_option { |f| abort "gori run rewriter extract: missing value for #{f}" }
         end
         parser.parse(args)
         refuse_list_leftovers(leftover, "rewriter extract", "add, rm/delete, enable, disable")
@@ -208,6 +209,7 @@ module Gori
           p.on("--db=PATH", "Explicit SQLite db file to update") { |v| db_path = v }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
           p.invalid_option { |f| abort "gori run rewriter extract #{verb}: unknown option: #{f}\n#{p}" }
+          p.missing_option { |f| abort "gori run rewriter extract #{verb}: missing value for #{f}" }
         end
         rest = [] of String
         parser.unknown_args { |before, after| rest = before + after }
@@ -235,6 +237,7 @@ module Gori
           p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
           p.invalid_option { |f| abort "gori run rewriter bindings: unknown option: #{f}\n#{p}" }
+          p.missing_option { |f| abort "gori run rewriter bindings: missing value for #{f}" }
         end
         parser.parse(args)
 
@@ -528,6 +531,7 @@ module Gori
           p.on("--scope=SCOPE", "Which <id>: project (default) | global") { |v| scope = parse_rule_scope(v) }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
           p.invalid_option { |f| abort "gori run rewriter rm: unknown option: #{f}\n#{p}" }
+          p.missing_option { |f| abort "gori run rewriter rm: missing value for #{f}" }
         end
         positional = [] of String
         parser.unknown_args { |before, after| positional = before + after }
@@ -580,6 +584,7 @@ module Gori
           p.on("--everywhere", "global rules only: change the default for every project") { everywhere = true }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
           p.invalid_option { |f| abort "gori run rewriter #{action}: unknown option: #{f}\n#{p}" }
+          p.missing_option { |f| abort "gori run rewriter #{action}: missing value for #{f}" }
         end
         positional = [] of String
         parser.unknown_args { |before, after| positional = before + after }
@@ -660,6 +665,7 @@ module Gori
           p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
           p.invalid_option { |f| abort "gori run rewriter preview: unknown option: #{f}\n#{p}" }
+          p.missing_option { |f| abort "gori run rewriter preview: missing value for #{f}" }
         end
         parser.parse(args)
 

--- a/src/gori/cookie/rack.cr
+++ b/src/gori/cookie/rack.cr
@@ -16,7 +16,7 @@ module Gori
       extend self
 
       DIGEST  = OpenSSL::Algorithm::SHA1
-      HEX_SIG = /\A[0-9a-fA-F]{40}\z/ # HMAC-SHA1 hex digest
+      SIG_LEN = 40 # hex of an HMAC-SHA1 digest
 
       record Parsed,
         data : String,     # base64 (standard alphabet) of the marshalled session
@@ -26,14 +26,28 @@ module Gori
       # base64 blob that merely contains "--" from being misread as Rack.
       def looks_like?(s : String) : Bool
         idx = s.rindex("--") || return false
-        HEX_SIG.matches?(s[(idx + 2)..])
+        hex_sig?(s[(idx + 2)..])
+      end
+
+      # Byte-level, Regex-free: a cookie is bytes lifted verbatim off the wire and need not be
+      # valid UTF-8, and PCRE2 RAISES `ArgumentError: UTF-8 error` on an invalid byte instead of
+      # not matching — which took `gori run cookie` down with a backtrace on a session cookie
+      # carrying one, and broke `Cookie.verify`'s "false on a structural parse failure too"
+      # contract. `Gori::Url` and `Gori::AsciiBytes` stay byte-level over wire bytes for the
+      # same reason. `rindex` returns a CHAR index, so the caller must keep char-slicing —
+      # `byte_slice` there would cut a multi-byte character in half.
+      private def hex_sig?(tail : String) : Bool
+        b = tail.to_slice
+        return false unless b.size == SIG_LEN
+        b.all? { |c| (0x30_u8 <= c <= 0x39_u8) || (0x41_u8 <= c <= 0x46_u8) || (0x61_u8 <= c <= 0x66_u8) }
       end
 
       def parse(cookie : String) : Parsed
         s = cookie.strip
         idx = s.rindex("--") || raise CookieError.new("not a Rack cookie (missing --signature)")
         sig = s[(idx + 2)..]
-        raise CookieError.new("not a Rack cookie (signature is not a 40-char hex HMAC-SHA1)") unless HEX_SIG.matches?(sig)
+        raise CookieError.new("not a Rack cookie (signature is not a 40-char hex HMAC-SHA1)") unless hex_sig?(sig)
+        # `downcase` is safe here only because the tail is now proven pure ASCII hex.
         Parsed.new(s[0...idx], sig.downcase)
       end
 

--- a/src/gori/discover/calibrate.cr
+++ b/src/gori/discover/calibrate.cr
@@ -76,13 +76,24 @@ module Gori::Discover
       statuses = ok.compact_map(&.status).to_set
       fps = ok.map(&.simhash)
       rt = uniform_redirect(ok)
+      # ORDER IS LOAD-BEARING: the sample-size floor is tested FIRST, ahead of both elevated
+      # kinds. Each of them relaxes `hit?` on the strength of AGREEMENT between the bogus
+      # probes — `WildcardRedirect` trusts one funnel target and scores `redir_div`,
+      # `WildcardOk` earns the raised `fp_weight` — yet `ok` is only what survived
+      # `f.error.nil?`, and both tests pass trivially on a single sample (`cohesive?` returns
+      # true below 2 fingerprints, `uniform_redirect` finds one target unanimous). So two
+      # probes flaking on an ordinary timeout or reset left ONE response awarding a weight
+      # that the cohesion it names was never measured for, and against a dynamic miss page
+      # that turned every wordlist entry into a 0.55 finding — the storm the `echoes` flag
+      # exists to stop, arriving by the other door. `Uncalibratable` reports nothing there,
+      # which is what its enum comment already promises for a baseline this thin.
       kind =
-        if rt
+        if ok.size < 2
+          BaselineKind::Uncalibratable
+        elsif rt
           BaselineKind::WildcardRedirect
         elsif statuses == Set{200} && cohesive?(fps, distance)
           BaselineKind::WildcardOk
-        elsif ok.size < 2
-          BaselineKind::Uncalibratable
         else
           BaselineKind::Normal
         end
@@ -114,7 +125,9 @@ module Gori::Discover
       # `fp_novel` earns the weight `status_div` carries on a wildcard-200 baseline that does
       # NOT echo, and stays a corroborating signal everywhere else. The asymmetry is the kind's
       # whole meaning: `WildcardOk` is assigned only when the bogus probes came back 200 AND
-      # proved COHESIVE (`build`), a stricter calibration than `Normal` is ever held to —
+      # proved COHESIVE with each other (`build`, which tests its sample-size floor ahead of
+      # the kind, so this weight can never rest on a cohesion test that short-circuited on a
+      # single surviving probe), a stricter calibration than `Normal` is ever held to —
       # `Normal` needs two non-erroring probes and no cohesion at all — so on that baseline
       # "outside the cluster" is a calibrated verdict rather than a hint, and status has
       # nothing left to say. On an ECHOING one the cluster proves nothing, so the weight and
@@ -153,10 +166,14 @@ module Gori::Discover
       {hit, (conf * penalty).clamp(0.0, 1.0)}
     end
 
-    # All bogus probes redirected to ONE normalized target ⇒ a login/funnel wildcard.
+    # All bogus probes redirected to ONE normalized target ⇒ a login/funnel wildcard. "All"
+    # means at least two: one probe is unanimous with itself, and `build` stores this as the
+    # baseline's `redirect_target`, where `hit?` scores every non-matching Location at +0.30.
+    # `build` already routes a single-sample baseline to `Uncalibratable`; this keeps the
+    # field it carries from claiming a funnel the probes never agreed on.
     private def self.uniform_redirect(fetched : Array(Fetched)) : String?
       redirs = fetched.compact_map { |f| f.redirect_to.try { |l| normalize_redirect(l) } }
-      return nil if redirs.empty? || redirs.size < fetched.size
+      return nil if redirs.size < 2 || redirs.size < fetched.size
       redirs.uniq.size == 1 ? redirs.first : nil
     end
 

--- a/src/gori/discover/url.cr
+++ b/src/gori/discover/url.cr
@@ -334,13 +334,36 @@ module Gori::Discover
       abs_path =
         if h.starts_with?('/')
           normalize_path(h)
-        elsif lower.matches?(/\A[a-z][a-z0-9+.-]*:/)
+        elsif scheme_prefixed?(lower)
           return nil # some other scheme (ftp:, ws:, …)
         else
           normalize_path(dir_path(base.path) + h)
         end
       url = "#{origin(base)}#{abs_path}"
       hq ? "#{url}?#{hq}" : url
+    end
+
+    # Allocation- and PCRE-free stand-in for `\A[a-z][a-z0-9+.-]*:`, gated for the same reason
+    # `fold_segment` gates its four patterns behind `ascii_only?`: a Regex on invalid UTF-8
+    # raises ArgumentError out of PCRE2. `resolve` is the one link entry point that sees
+    # REMOTE-chosen bytes — a 3xx `Location` reaches it straight off the wire, unscrubbed,
+    # while every page-derived href came through `Extract`, which scrubs — and `downcase`
+    # keeps a lone Latin-1 octet intact, so `caf\xE9/x` used to raise here. That raise lands on
+    # discover's orchestrator fiber, which ends the whole run instead of dropping one link.
+    # The scheme class is pure ASCII, so the byte scan is exact.
+    private def self.scheme_prefixed?(s : String) : Bool
+      bytes = s.to_slice
+      return false if bytes.empty?
+      return false unless 0x61_u8 <= bytes[0] <= 0x7a_u8
+      i = 1
+      while i < bytes.size
+        b = bytes[i]
+        return true if b == 0x3a_u8 # ':'
+        return false unless (0x61_u8 <= b <= 0x7a_u8) || (0x30_u8 <= b <= 0x39_u8) ||
+                            b == 0x2b_u8 || b == 0x2e_u8 || b == 0x2d_u8 # '+' '.' '-'
+        i += 1
+      end
+      false
     end
 
     # Collapse "." and ".." segments (RFC 3986 §5.2.4, simplified). Preserves a leading and

--- a/src/gori/env.cr
+++ b/src/gori/env.cr
@@ -258,7 +258,15 @@ module Gori
       start, stop = span
       current = String.new(head[start, stop - start]).to_i64?
       return head unless current
-      shifted = {current + delta, 0_i64}.max.to_s
+      # SATURATING, in Int128, because `current` is an operator-authored number: `to_i64?`
+      # refuses a literal wider than 64 bits but returns `Int64::MAX` / `Int64::MIN` happily,
+      # and Crystal's checked `+` then raised OverflowError out of the send — on `gori run
+      # repeater` that is a raw backtrace, since `CLI.dispatch` rescues only `Gori::Error`.
+      # `Content-Length: 9223372036854775807` and its negative twin ARE probes, so raising on
+      # them is the one outcome this method's contract rules out (everything it cannot shift,
+      # it leaves byte-exact). The lower bound is the `{…, 0_i64}.max` this replaces; delta is
+      # an Int32, so the Int128 sum cannot itself overflow.
+      shifted = (current.to_i128 + delta).clamp(0_i128, Int64::MAX.to_i128).to_i64.to_s
       buf = IO::Memory.new(head.size + shifted.bytesize)
       buf.write(head[0, start])
       buf << shifted

--- a/src/gori/export/har.cr
+++ b/src/gori/export/har.cr
@@ -62,6 +62,15 @@ module Gori
       # on STDERR, so the caveat is visible without opening the file.
       TRUNCATED_MARK = "gori: body truncated at the capture cap"
 
+      # The head's counterpart to TRUNCATED_MARK. A captured HEAD is not UTF-8: RFC 7230's
+      # field-value is VCHAR / obs-text (%x80-FF), so a Latin-1 `Content-Disposition` filename
+      # or an h2 pseudo-header is stored as raw octets and `Codec::Http1.parse_headers` keeps
+      # them that way on purpose (P7). A HAR is JSON and JSON is UTF-8 (RFC 8259), and unlike a
+      # BODY there is no lossless escape hatch for a head — `emit_body` can fall back to
+      # base64, a header name cannot — so those octets become U+FFFD here. That is a real loss,
+      # so it is named on the entry rather than left silent (#488/#489/#491).
+      SCRUBBED_MARK = "gori: invalid UTF-8 in the captured head replaced with U+FFFD; the store keeps the original bytes"
+
       # gori records one round-trip duration, not a phase breakdown, so `send`/`receive`
       # are the spec's own "not applicable" (-1) rather than a fabricated 0, and `time`
       # stays equal to the sum of the non-negative timings as §timings requires.
@@ -83,6 +92,7 @@ module Gori
         property no_response = 0
         property incomplete = 0
         property truncated = 0
+        property scrubbed = 0
 
         def skipped : Int32
           websocket + no_response + incomplete
@@ -106,6 +116,11 @@ module Gori
             verb = truncated == 1 ? "entry carries" : "entries carry"
             msgs << "#{truncated} #{verb} a body truncated at the capture cap " \
                     "(marked in the HAR: bodySize/content.size is the true wire size, plus a comment)"
+          end
+          if scrubbed > 0
+            verb = scrubbed == 1 ? "entry carries" : "entries carry"
+            msgs << "#{scrubbed} #{verb} a head with invalid UTF-8 replaced by U+FFFD: JSON must be UTF-8 and " \
+                    "HAR has no base64 escape for a head (marked in the HAR by a comment); the store keeps the raw bytes"
           end
           msgs
         end
@@ -163,7 +178,7 @@ module Gori
                       when Skip::NoResponse then report.no_response += 1
                       when Skip::Incomplete then report.incomplete += 1
                       else
-                        entry(j, detail)
+                        report.scrubbed += 1 if entry(j, detail)
                         report.written += 1
                         report.truncated += 1 if detail.request_body_truncated? || detail.response_body_truncated?
                       end
@@ -178,16 +193,18 @@ module Gori
       end
 
       # One entry object. The caller must have checked `skip_reason` first; a flow with no
-      # response head emits nothing rather than a response-less entry.
-      def self.entry(j : JSON::Builder, detail : Store::FlowDetail) : Nil
+      # response head emits nothing rather than a response-less entry. Returns true when the
+      # head had to be scrubbed on the way into the document (see `text` / SCRUBBED_MARK).
+      def self.entry(j : JSON::Builder, detail : Store::FlowDetail) : Bool
         resp_head = detail.response_head
-        return unless resp_head
+        return false unless resp_head
         row = detail.row
         req = Proxy::Codec::Http1.parse_request_head(detail.request_head)
         resp = Proxy::Codec::Http1.parse_response_head(resp_head)
         version = detail.http_version.presence || "HTTP/1.1"
         req_body_size = wire_body_size(request_total(row), detail.request_head, detail.request_body)
         resp_body_size = wire_body_size(row.response_size, resp_head, detail.response_body)
+        scrubbed = lossy_head?(row, req, resp, version)
 
         j.object do
           j.field "startedDateTime", iso_micros(row.created_at)
@@ -196,9 +213,9 @@ module Gori
             j.object do
               # The start-line is the truth (P7): a lowercase or non-standard method is the
               # operator's, and `row.method` is the upcased projection of it.
-              j.field "method", req.method.presence || row.method
-              j.field "url", row.url
-              j.field "httpVersion", version
+              j.field "method", text(req.method.presence || row.method)
+              j.field "url", text(row.url)
+              j.field "httpVersion", text(version)
               j.field "cookies" { request_cookies(j, req.headers) }
               j.field "headers" { headers(j, req.headers) }
               j.field "queryString" { query_string(j, row.target) }
@@ -211,23 +228,23 @@ module Gori
           j.field "response" do
             j.object do
               j.field "status", row.status || resp.status
-              j.field "statusText", resp.reason
+              j.field "statusText", text(resp.reason)
               # The RESPONSE's own version, not the request's. `detail.http_version` is the
               # request column (flow_mapper), so an origin answering HTTP/1.0 to an HTTP/1.1
               # request exported as HTTP/1.1 and re-imported with its response head rewritten
               # — and 1.0 vs 1.1 is semantically load-bearing (no default keep-alive). The
               # truth was already parsed two lines up, from `resp.raw_head`, which is stored
               # verbatim.
-              j.field "httpVersion", resp.version.presence || version
+              j.field "httpVersion", text(resp.version.presence || version)
               j.field "cookies" { response_cookies(j, resp.headers) }
               j.field "headers" { headers(j, resp.headers) }
-              j.field "redirectURL", resp.headers.get?("location") || ""
+              j.field "redirectURL", text(resp.headers.get?("location") || "")
               j.field "headersSize", resp_head.size
               j.field "bodySize", resp_body_size
               j.field "content" do
                 j.object do
                   j.field "size", resp_body_size
-                  j.field "mimeType", row.content_type || resp.headers.get?("content-type") || ""
+                  j.field "mimeType", text(row.content_type || resp.headers.get?("content-type") || "")
                   emit_body(j, detail.response_body)
                   if note = body_note(detail.response_body, resp_body_size, detail.response_body_truncated?)
                     j.field "comment", note
@@ -251,12 +268,52 @@ module Gori
           # ORIGIN invented this request in a PUSH_PROMISE" — the second especially, since
           # a HAR reader has no other way to tell a pushed entry from one the client sent.
           # See `Store::FlowRow#advisory`.
+          # A scrubbed head rides the same field: `advisories` is a fresh array per call, so
+          # appending here cannot leak back into the row.
           advisories = row.advisories
+          advisories << SCRUBBED_MARK if scrubbed
           j.field "comment", advisories.join("\n") unless advisories.empty?
         end
+        scrubbed
       end
 
       # --- fields ------------------------------------------------------------
+
+      # Every head-derived string in this document goes through here. HAR is JSON and JSON is
+      # UTF-8 (RFC 8259); a captured head is neither, so an obs-text octet written straight
+      # through produced a file `jq`, Python and DevTools all reject — and that gori itself
+      # could not read back, because `Import::Builder`'s guard ran PCRE2 over it and the
+      # per-entry rescue then dropped the whole flow. See SCRUBBED_MARK for why U+FFFD is the
+      # lesser loss here and base64 (the BODY's escape hatch, `emit_body`) is not on offer.
+      #
+      # `valid_encoding?` before `scrub`, the same order and for the same measured reason as
+      # `emit_body`: scrub costs ~130µs on a valid 40 KB string against ~9µs for the check, so
+      # the overwhelmingly common clean head pays only the check.
+      private def self.text(s : String) : String
+        s.valid_encoding? ? s : s.scrub
+      end
+
+      # Would any of this entry's head-derived text lose bytes to `text`? Asked once up front
+      # so the entry `comment` can name the substitution instead of leaving it silent; it reads
+      # exactly the sources `text` guards.
+      private def self.lossy_head?(row : Store::FlowRow, req : Proxy::Codec::RawRequest,
+                                   resp : Proxy::Codec::RawResponse, version : String) : Bool
+        return true unless row.url.valid_encoding? && row.target.valid_encoding?
+        # `row.method` and not just `req.method`: `entry` writes `req.method.presence ||
+        # row.method`, so a head with no parseable start-line token falls back to the column,
+        # and checking only the parsed half let such an entry be scrubbed with no comment and
+        # no `report.scrubbed`. Every string `text()` touches has to be answered here.
+        return true unless req.method.valid_encoding? && row.method.valid_encoding?
+        return true unless resp.reason.valid_encoding?
+        return true unless version.valid_encoding? && resp.version.valid_encoding?
+        return true if (ct = row.content_type) && !ct.valid_encoding?
+        {req.headers, resp.headers}.each do |list|
+          list.each do |h|
+            return true unless h.name.valid_encoding? && h.value.valid_encoding?
+          end
+        end
+        false
+      end
 
       # Wire order, duplicates kept, original casing kept. HAR's `headers` is the only
       # place the message's own header block survives, and it is what `Import::Har` reads
@@ -265,8 +322,8 @@ module Gori
         j.array do
           list.each do |h|
             j.object do
-              j.field "name", h.name
-              j.field "value", h.value
+              j.field "name", text(h.name)
+              j.field "value", text(h.value)
             end
           end
         end
@@ -277,7 +334,10 @@ module Gori
       # different string than the one that was sent, and `queryString` is a derived view
       # anyway — the URL is what imports back.
       private def self.query_string(j : JSON::Builder, target : String) : Nil
-        q = target.index('?').try { |i| target[(i + 1)..] } || ""
+        # Scrub BEFORE splitting, not after: the split below indexes by CHARACTER, and char
+        # arithmetic over an invalid-UTF-8 target is not the arithmetic the caller meant.
+        s = text(target)
+        q = s.index('?').try { |i| s[(i + 1)..] } || ""
         j.array do
           next if q.empty?
           q.split('&') do |pair|
@@ -299,7 +359,9 @@ module Gori
         j.array do
           list.each do |h|
             next unless h.name.compare("cookie", case_insensitive: true) == 0
-            h.value.split(';') do |pair|
+            # Scrub the whole value once, before it is split: this is a derived view of the
+            # same header `headers` already wrote through `text`, and the pieces must agree.
+            text(h.value).split(';') do |pair|
               name, _, value = pair.partition('=')
               name = name.strip
               next if name.empty?
@@ -319,7 +381,7 @@ module Gori
         j.array do
           list.each do |h|
             next unless h.name.compare("set-cookie", case_insensitive: true) == 0
-            parts = h.value.split(';')
+            parts = text(h.value).split(';')
             name, _, value = (parts[0]? || "").partition('=')
             name = name.strip
             next if name.empty?
@@ -350,7 +412,7 @@ module Gori
         return if body.nil? || body.empty?
         j.field "postData" do
           j.object do
-            j.field "mimeType", list.get?("content-type") || ""
+            j.field "mimeType", text(list.get?("content-type") || "")
             emit_body(j, body)
             if note = body_note(body, wire_size, truncated)
               j.field "comment", note

--- a/src/gori/fuzz/engine.cr
+++ b/src/gori/fuzz/engine.cr
@@ -535,6 +535,9 @@ module Gori::Fuzz
     # A failed/empty calibration is non-fatal — auto_calibrate then simply suppresses
     # nothing.
     def calibrate_baseline : Nil
+      # A stop that landed before the run fiber's first tick (the TUI publishes `v.engine`
+      # before spawning, so ^X can arrive here) must not open with a burst of real sends.
+      return if @state == State::Stopped
       wanted = CALIBRATION_SAMPLES
       if (cap = @config.max_requests) && cap > 0
         room = cap - 1
@@ -544,6 +547,12 @@ module Gori::Fuzz
       samples = [] of BaselineSample
       interval = pace_interval
       @generator.calibration_requests(wanted).each do |bytes, payload_len|
+        # `stop` only sets the flag and pokes @wake, which this loop never waits on, so the
+        # remaining samples used to go out one by one AFTER the operator asked to stop — and
+        # `pace` below widens that window to a full rate interval each (at rps 0.2, ~25s of
+        # trailing sends under "stopping…"). `dispatch_loop` re-reads the flag every job for
+        # the same reason; this is the same check at the phase that runs BEFORE it.
+        break if @state == State::Stopped
         # Calibration samples are real requests at the target, sent before `start`'s dispatch
         # loop exists — so without this they were the one burst that ignored `--rate` outright.
         pace(interval)

--- a/src/gori/fuzz/payload.cr
+++ b/src/gori/fuzz/payload.cr
@@ -203,6 +203,13 @@ module Gori::Fuzz
     def size : Int64?
       base = @chars.size.to_i64
       return 0_i64 if base == 0
+      # A one-symbol charset is one string per length, and it has to be answered in closed
+      # form: with `base == 1` the overflow guard below reads `pw > Int64::MAX // 1`, which
+      # can never fire, so the inner loop runs its full `len` iterations and the walk costs
+      # ~max²/2 — pure integer arithmetic with no yield point, which on the single-threaded
+      # scheduler froze the whole process (an MCP `brute a:1-100000000` takes weeks, and the
+      # server's ping/cancel reader fiber never runs again). P6: counting must not stall.
+      return (@max.to_i64 - @min.to_i64 + 1) if base == 1
       total = 0_i64
       (@min..@max).each do |len|
         pw = 1_i64

--- a/src/gori/import/builder.cr
+++ b/src/gori/import/builder.cr
@@ -123,12 +123,30 @@ module Gori
       # dropping the bad entry exactly like a bad host). Only CR/LF/NUL: a header VALUE may
       # legally contain a horizontal tab (RFC 7230 §3.2 field-value), so bytes that merely
       # break a value without forging a boundary are left alone.
-      HEADER_INJECT = /[\r\n\x00]/
+      #
+      # A byte SET and not a Regex, and there is deliberately no Regex spelling of it left to
+      # reach for. A header value a THIRD-PARTY HAR recorded (Chrome, Burp) can carry a raw
+      # obs-text octet — RFC 7230 field-value is VCHAR / obs-text %x80-FF, and a Latin-1
+      # filename in a `Content-Disposition` is the everyday one — and PCRE2 raises
+      # `ArgumentError: UTF-8 error` on an invalid-UTF-8 subject rather than not matching.
+      # Every import parser's bare per-entry rescue caught that and dropped the entry SILENTLY,
+      # so an obs-text header cost the whole flow. `Issues::Export.scrub_only` names the same
+      # hazard from the writing side. These three are ASCII, so `inject_bytes?` answers exactly
+      # the same question for every subject and cannot raise; the bytes are never sanitised,
+      # only rejected.
+      HEADER_INJECT = StaticArray[0x0d_u8, 0x0a_u8, 0x00_u8]
+
+      # Whether `s` carries any of them. The one home for the question — matching
+      # HEADER_INJECT with a Regex is what raised, so it is not expressible any more.
+      def self.inject_bytes?(s : String) : Bool
+        s.each_byte { |b| return true if HEADER_INJECT.includes?(b) }
+        false
+      end
 
       # Reject any header whose name/value could forge a message boundary (see HEADER_INJECT).
       def self.reject_header_injection!(headers : Headers) : Nil
         headers.each do |k, v|
-          raise Gori::Error.new("invalid header (control character): #{k.inspect}") if k.matches?(HEADER_INJECT) || v.matches?(HEADER_INJECT)
+          raise Gori::Error.new("invalid header (control character): #{k.inspect}") if inject_bytes?(k) || inject_bytes?(v)
         end
       end
 
@@ -137,7 +155,7 @@ module Gori
       # CR/LF/NUL bytes. (`host` is cleaned by HOST_INVALID; `target` is intentionally NOT —
       # a control byte there is the operator's payload, replayed byte-exact. See DESIGN.md §7.)
       def self.reject_inject!(field : String, label : String) : Nil
-        raise Gori::Error.new("invalid #{label} (control character): #{field.inspect}") if field.matches?(HEADER_INJECT)
+        raise Gori::Error.new("invalid #{label} (control character): #{field.inspect}") if inject_bytes?(field)
       end
 
       # The `Host` header value for a stored request, per RFC 7230 §5.4.
@@ -313,7 +331,14 @@ module Gori
         loop do
           size, pos = chunk_size(body, pos) || return truncated && pos > 0
           return pos == body.size || trailer_only?(body, pos) if size == 0
-          return truncated && pos > 0 if pos + size + 2 > body.size
+          # Bounds-check by SUBTRACTION, never `pos + size + 2`: `chunk_size` accepts any hex
+          # up to Int32::MAX, so a size line of `7fffffff` — a canonical chunk-size-overflow
+          # smuggling payload, exactly what an operator imports a HAR to preserve — made that
+          # checked Int32 add raise OverflowError, and the per-entry rescue in `Import::Har`
+          # turned gori's own arithmetic into a silently skipped entry. `Codec::Body
+          # .chunked_complete?` already states the rule: a chunk declaring more data than is
+          # here is unprovable framing, so say so rather than overflow.
+          return truncated && pos > 0 if size > body.size - pos - 2
           return false unless body[pos + size] == 0x0d_u8 && body[pos + size + 1] == 0x0a_u8
           pos += size + 2
         end

--- a/src/gori/import/oas.cr
+++ b/src/gori/import/oas.cr
@@ -62,7 +62,14 @@ module Gori
       private def self.server_base(spec : JSON::Any) : String
         servers = spec["servers"]?
         if servers && (arr = servers.as_a?) && (first = arr[0]?)
-          url = first["url"]?.to_s
+          # `servers: ["https://api.example.com"]` is a common YAML shorthand but not the
+          # OpenAPI shape, and `as_a?` proves only that the ELEMENT exists, not that it is an
+          # object. `JSON::Any#[]?(String)` raises a raw Exception on a non-Hash raw, and this
+          # call sits outside the per-operation rescue below — so the operator got a Crystal
+          # backtrace. Shape-guard it the way `paths_h` above does, for the same reason.
+          first_h = first.as_h? || raise Gori::Error.new(
+            %(OpenAPI servers[0] is not an object — write `- url: "https://api.example.com"`))
+          url = first_h["url"]?.to_s
           raise Gori::Error.new("OpenAPI spec has no servers[0].url") if url.empty?
           # A relative server URL ("/v3", "./v3", "../v3", "v3") has no host authority:
           # every generated request would prepend "https://" onto it, either yielding an

--- a/src/gori/interceptor.cr
+++ b/src/gori/interceptor.cr
@@ -167,10 +167,17 @@ module Gori
     # Lives here rather than in `H2::StreamGate` because two callers need the same answer: the
     # gate splits the bytes it is about to encode, and the settle surface has to know whether an
     # edit added a body to a head-only hold BEFORE it acks the edit as applied.
+    #
+    # The scan runs over the BYTES. `String#index` counts CHARACTERS, and the number it returns
+    # is used here as an offset INTO `bytes` — so one non-ASCII character in an edited head
+    # (`x-test: café`, a UTF-8 cookie) put the boundary a byte short of the real blank line, and
+    # a head-only edit with no body at all came back reporting one: `Item#refuse_edit` then
+    # refused an edit the operator could not fix except by deleting the character. Held bytes
+    # are not guaranteed to be valid UTF-8 either, which is why `Gori::AsciiBytes` stays
+    # byte-level for the same kind of question.
     def self.split_edit(bytes : Bytes) : {Bytes, Bool}
-      text = String.new(bytes)
-      crlf = text.index("\r\n\r\n")
-      lf = text.index("\n\n")
+      crlf = byte_index(bytes, "\r\n\r\n".to_slice)
+      lf = byte_index(bytes, "\n\n".to_slice)
       idx =
         if crlf && (lf.nil? || crlf < lf)
           crlf + 4
@@ -179,6 +186,25 @@ module Gori
         end
       return {bytes, false} unless idx
       {bytes[0, idx], idx < bytes.size}
+    end
+
+    # First byte offset of `needle` in `hay`, or nil. `"...".to_slice` on a literal points at
+    # static data, so this allocates nothing.
+    #
+    # Guarded on the first byte before comparing the rest: a head is read by
+    # `Codec::Http1.read_head`, which permits up to 256 KiB, and `split_edit` scans it twice —
+    # so a `Slice#==` (a memcmp call) at every offset would be a quarter-million calls per
+    # lookup on the interceptor's synchronous path. Both needles start with CR or LF, which
+    # almost no offset does.
+    private def self.byte_index(hay : Bytes, needle : Bytes) : Int32?
+      first = needle[0]
+      limit = hay.size - needle.size
+      i = 0
+      while i <= limit
+        return i if hay[i] == first && hay[i, needle.size] == needle
+        i += 1
+      end
+      nil
     end
 
     @direction : Direction

--- a/src/gori/mcp/tools/color_rules.cr
+++ b/src/gori/mcp/tools/color_rules.cr
@@ -278,7 +278,14 @@ module Gori
         if reason = Gori::Colormarker.unusable_reason(filter)
           return err(reason, "INVALID_ARGUMENT", field: "when")
         end
-        limit = (int(h, "limit") || Gori::Colormarker::PREVIEW_SCAN.to_i64).to_i.clamp(1, 5000)
+        # Clamp in Int64, THEN narrow: `.to_i` is checked, so clamping after it meant
+        # `{"limit": 10000000000}` — the "no limit" number an LLM reaches for — OverflowError'd
+        # past the INVALID_ARGUMENT arm at `Tools#call` and came back INTERNAL, telling the
+        # agent the server was broken instead of its argument. Still a CLAMP and not
+        # `bounded_int_arg`: this argument has always been forgiving at both ends, and `0` is
+        # the other spelling of "no limit" an agent reaches for — turning that into a hard
+        # INVALID_ARGUMENT would be a second, opposite way to fail the same call.
+        limit = (int(h, "limit") || Gori::Colormarker::PREVIEW_SCAN.to_i64).clamp(1_i64, 5000_i64).to_i
         existing = Gori::Colormarker.merged(store)
         pv = Gori::Colormarker.preview(store, filter, existing, limit)
         Result.new(JSON.build do |j|

--- a/src/gori/mcp/tools/compare.cr
+++ b/src/gori/mcp/tools/compare.cr
@@ -46,7 +46,12 @@ module Gori
         # outright. Folding is the one an agent wants for a long response: it keeps the
         # changes readable in place without claiming the message had nothing else in it.
         diff = if context
-                 Repeater::Diff.fold(full_diff, context.to_i)
+                 # Clamp in Int64 before narrowing. The guard above only rejects a NEGATIVE
+                 # context, so `{"context": 5000000000}` reached a checked `.to_i` and
+                 # OverflowError'd past the INVALID_ARGUMENT arm at `Tools#call`, coming back
+                 # INTERNAL for the caller's own argument. A context at or past the diff's
+                 # length folds nothing, so the ceiling is exact, not an approximation.
+                 Repeater::Diff.fold(full_diff, context.clamp(0_i64, full_diff.size.to_i64).to_i)
                elsif changes_only
                  full_diff.reject { |dl| dl.kind == Repeater::DiffKind::Same }.map { |dl| Repeater::Diff::Folded.new(dl, 0) }
                else

--- a/src/gori/mcp/tools/fuzz.cr
+++ b/src/gori/mcp/tools/fuzz.cr
@@ -559,11 +559,20 @@ module Gori
         v.as_i64? || v.as_s?.try(&.to_i64?)
       end
 
-      # Clamp a length to Int32 so an absurd value from the object form can't
-      # OverflowError past the clean-error handler (the run is still capped by
-      # FUZZ_MAX_REQUESTS regardless).
+      # Clamp a brute-force length so an absurd value can't OverflowError past the
+      # clean-error handler (the run is still capped by FUZZ_MAX_REQUESTS regardless).
+      #
+      # The ceiling is a real length, not Int32::MAX: `BruteIterator` allocates an odometer
+      # of `min` slots up front, so `{"charset":"ab","min":2147483647}` was an 8.6 GB
+      # `Array.new` on the job fiber — and a length that large is never a payload anyone
+      # meant to send. "try every string" is exactly what an agent emits, so bound it here,
+      # at the strict surface, rather than trusting the budget guard: FUZZ_MAX_REQUESTS caps
+      # how MANY payloads are sent, never how long one is. 4096 leaves the one legitimate
+      # long-length shape (a single-character charset used as padding) intact.
+      BRUTE_MAX_LEN = 4096
+
       private def clamp_brute_len(n : Int64) : Int32
-        n.clamp(0_i64, Int64.new(Int32::MAX)).to_i
+        n.clamp(0_i64, BRUTE_MAX_LEN.to_i64).to_i
       end
 
       # numbers set: the compact "FROM-TO[:STEP]" string OR a structured object
@@ -605,10 +614,12 @@ module Gori
         charset, _, lens = s.rpartition(':')
         raise FuzzArgError.new("invalid brute '#{s}' (use CHARSET:MIN-MAX)") if charset.empty? || lens.empty?
         min_s, _, max_s = lens.partition('-')
-        min = min_s.to_i?
-        max = max_s.empty? ? min : max_s.to_i?
+        min = min_s.to_i64?
+        max = max_s.empty? ? min : max_s.to_i64?
         raise FuzzArgError.new("invalid brute lengths '#{lens}'") unless min && max
-        Fuzz::BruteForce.new(charset, min, max)
+        # Same clamp as the object form: the string form is the shape an agent reaches for
+        # first ("a:1-100000000"), and it used to go into BruteForce raw.
+        Fuzz::BruteForce.new(charset, clamp_brute_len(min), clamp_brute_len(max))
       end
 
       private def fuzz_matcher(h) : Fuzz::Matcher
@@ -739,7 +750,7 @@ module Gori
           s.field "auto", boolprop("auto-mark every query/cookie/body param when the template has no § markers")
           s.field "marks", strarrprop("literal tokens to mark as §…§ positions (each occurrence, mirrors CLI --mark); alternative to embedding §…§ in template")
           s.field "mode", strprop("sniper (default) | batteringram | pitchfork | clusterbomb")
-          s.field "payloads", arrprop(%(array of payload sets, e.g. [{"list":["a","b"]},{"list_base64":["gA==","/w=="]},{"preset":"sqli"},{"numbers":"1-100"},{"wordlist":"/p.txt"},{"null":5},{"brute":"abc:1-3"}] — JSON array, NOT a string. "preset" is a built-in curated set — one of #{Fuzz::Presets.names.join(", ")} — for a fast start with no file; add "file":"/extra.txt" to merge a user file into it (built-in first, de-duped). "list_base64" is the byte-exact list: use it for payloads a JSON string cannot carry (0x00, 0x80-0xFF, invalid/overlong UTF-8), since "list" entries go on the wire as their UTF-8 encoding. numbers/brute also accept a structured object: {"numbers":{"from":1,"to":100,"step":2}}, {"brute":{"charset":"abc","min":1,"max":3}}))
+          s.field "payloads", arrprop(%(array of payload sets, e.g. [{"list":["a","b"]},{"list_base64":["gA==","/w=="]},{"preset":"sqli"},{"numbers":"1-100"},{"wordlist":"/p.txt"},{"null":5},{"brute":"abc:1-3"}] — JSON array, NOT a string. "preset" is a built-in curated set — one of #{Fuzz::Presets.names.join(", ")} — for a fast start with no file; add "file":"/extra.txt" to merge a user file into it (built-in first, de-duped). "list_base64" is the byte-exact list: use it for payloads a JSON string cannot carry (0x00, 0x80-0xFF, invalid/overlong UTF-8), since "list" entries go on the wire as their UTF-8 encoding. numbers/brute also accept a structured object: {"numbers":{"from":1,"to":100,"step":2}}, {"brute":{"charset":"abc","min":1,"max":3}}. Brute lengths are capped at #{BRUTE_MAX_LEN}.))
           s.field "processors", arrprop(%(ordered pipeline applied to EVERY payload before it's spliced in (mirrors CLI --prefix/--suffix/--encode/--case/--hash/--regex-replace) — e.g. [{"type":"encode","kind":"url"}]. A payload containing a raw space, CRLF, or other characters unsafe in the position it's marking (a query/body param value has no encoding applied by default — auto-mark finds the position but does NOT encode for it) will otherwise corrupt the request line/framing instead of reaching the app. Entries: {"type":"prefix","text":".."} {"type":"suffix","text":".."} {"type":"encode","kind":"url|urlall|base64|hex"} {"type":"case","kind":"upper|lower"} {"type":"hash","algo":"md5|sha1|sha256"} {"type":"regex_replace","pattern":"..","replacement":".."}))
           s.field "match", jsonprop(%(keep only responses matching, e.g. {"status":"200,500-599","size":">1000","regex":"err"} — object or JSON string. "grpc" matches the grpc-status TRAILER (e.g. "7", ">0", "1-16"): for a gRPC target the HTTP status is 200 on every response, granted or denied, so "status" cannot separate them — every result row also carries grpc_status/grpc_status_name/grpc_message))
           s.field "filter", jsonprop(%(drop responses matching, same shape as match — object or JSON string))

--- a/src/gori/mcp/tools/rules.cr
+++ b/src/gori/mcp/tools/rules.cr
@@ -443,8 +443,14 @@ module Gori
         present?(h, field) ? (str(h, field) || "") : current
       end
 
+      # The same contract for an integer column, bounded in Int64 BEFORE it is narrowed to the
+      # store's Int32: `.to_i32` is checked, so `{"pos_start": 5000000000}` used to
+      # OverflowError past the INVALID_ARGUMENT arm at `Tools#call` and come back INTERNAL for
+      # the caller's own argument. The floor is Int32::MIN rather than 0 so `current` — an
+      # already-stored value this method must be able to pass through untouched — can never be
+      # the thing that raises.
       private def keep_int(h, field : String, current : Int32) : Int32
-        (present?(h, field) ? int(h, field) : current.to_i64).try(&.to_i32) || 0
+        bounded_int_arg(h, field, current.to_i64, min: Int32::MIN.to_i64, max: Int32::MAX.to_i64).to_i
       end
 
       # The enabled state the caller asked for, or nil when they omitted the field. Called
@@ -478,8 +484,9 @@ module Gori
         kind = extract_kind_arg(h, Gori::ExtractKind::Cookie)
         return kind if kind.is_a?(Result)
         selector = str(h, "selector") || ""
-        pos_start = (int(h, "pos_start") || 0_i64).to_i32
-        pos_end = (int(h, "pos_end") || 0_i64).to_i32
+        # Bounded in Int64 before the narrowing, for the reason spelled out at `keep_int`.
+        pos_start = bounded_int_arg(h, "pos_start", 0_i64, min: Int32::MIN.to_i64, max: Int32::MAX.to_i64).to_i
+        pos_end = bounded_int_arg(h, "pos_end", 0_i64, min: Int32::MIN.to_i64, max: Int32::MAX.to_i64).to_i
         if bad = extract_range_error(kind, pos_start, pos_end)
           return bad
         end

--- a/src/gori/media_type.cr
+++ b/src/gori/media_type.cr
@@ -90,9 +90,28 @@ module Gori
     BOUNDARY_RE = /boundary\s*=\s*(?:"([^"]*)"|([^;\s]+))/i
 
     def boundary(value : String?) : String?
-      m = BOUNDARY_RE.match(value || return nil) || return nil
+      # Total on purpose. `of` scrubs, but two probe callers hand us a header value read
+      # straight off the wire (`Http1.parse_headers` builds values with a bare `String.new`,
+      # and obs-text 0x80-0xFF is legal there), and PCRE RAISES on the first illegal byte
+      # instead of not matching — which took out a whole flow's passive+active scan. Scrub the
+      # SUBJECT the way secret_in_url and cors already do before their match. The boundary
+      # grammar is ASCII, so every well-formed value comes back byte-identical.
+      # `valid_encoding?` first rather than an unconditional `scrub`, the rule `Export::Har.text`
+      # states and measures (~9µs against ~130µs on 40 KB): `scrub` returns `self` for a valid
+      # string, but only after walking it.
+      raw = value || return nil
+      valid = raw.valid_encoding?
+      m = BOUNDARY_RE.match(valid ? raw : raw.scrub) || return nil
       v = m[1]? || m[2]? || return nil
-      v.empty? ? nil : v
+      return nil if v.empty?
+      # The scrub is safe for FINDING the boundary and not for returning it. Every caller
+      # (`Graphql.from_body`, twice) uses this string to split the captured body BYTES, so a
+      # token whose own illegal octet became U+FFFD is a delimiter that appears nowhere in
+      # them — worse than admitting there is none, because the caller would go looking. Gated
+      # on the value being invalid in the first place, so a boundary that really does contain
+      # U+FFFD (valid UTF-8, and legal in the token) still comes back.
+      return nil if !valid && v.includes?(Char::REPLACEMENT)
+      v
     end
   end
 end

--- a/src/gori/miner/baseline.cr
+++ b/src/gori/miner/baseline.cr
@@ -38,7 +38,14 @@ module Gori::Miner
       reflects_all : Hash(Location, Bool),
       warning : String?
 
-    def initialize(@backend : Fuzz::Backend, @base : Bytes, @config : Config)
+    # `stopped` is the engine's stop flag, read before every calibration probe. Calibration is
+    # real requests at the target and it runs entirely inside one `calibrate` call, so without
+    # it a ^X / `mine_stop` that lands after `orchestrate`'s own pre-flight check keeps the whole
+    # stability + control wave going — the operator asked gori to stop touching the target and it
+    # kept touching it. Defaults to "never stopped" so a caller that has no engine (specs, the
+    # one-shot calibrate paths) is unchanged.
+    def initialize(@backend : Fuzz::Backend, @base : Bytes, @config : Config,
+                   @stopped : Proc(Bool) = -> { false })
     end
 
     def calibrate(locations : Array(Location)) : Report
@@ -55,6 +62,7 @@ module Gori::Miner
       # from, so the answer must not depend on which fiber finished first.
       slots = Array(Probe?).new(rounds, nil)
       in_parallel(rounds) do |i|
+        next if @stopped.call
         raw = @backend.send(@base)
         slots[i] = Fingerprint.probe(raw) if raw.error.nil?
       end
@@ -81,6 +89,7 @@ module Gori::Miner
       reflects_all = Hash(Location, Bool).new
       signals = Array({Bool, Bool}?).new(locations.size, nil)
       in_parallel(locations.size) do |i|
+        next if @stopped.call
         signals[i] = control_signals(locations[i], base, length_tol, words_tol, lines_tol)
       end
       locations.each_with_index do |loc, i|

--- a/src/gori/miner/engine.cr
+++ b/src/gori/miner/engine.cr
@@ -59,6 +59,9 @@ module Gori::Miner
     @backend : Fuzz::CappedBackend
     @report : Baseline::Report?
     @seen : Set({Location, String})
+    # Locations whose injector returned no spans at all — see `process_bucket`. One entry per
+    # location, so the "nothing could be injected" verdict is reported once and not per bucket.
+    @uninjectable : Set(Location)
     @found : Int32
     @errors : Int64
     @names_done : Int64
@@ -111,6 +114,7 @@ module Gori::Miner
       @events = Channel(Event).new(256)
       @report = nil
       @seen = Set({Location, String}).new
+      @uninjectable = Set(Location).new
       @found = 0
       @errors = 0_i64
       @names_done = 0_i64
@@ -170,7 +174,22 @@ module Gori::Miner
 
     private def orchestrate : Nil
       @names_total = total_names
-      report = Baseline.new(@backend, @base, @config).calibrate(@config.locations)
+      # `stop` can land before this fiber's first tick (`start` spawns, the caller keeps the
+      # engine and the TUI's ^X reaches it immediately) — and calibration is real requests at
+      # the target, so opening with the stability wave would be a burst dispatched entirely
+      # after the operator asked to stop. `drain` re-reads the flag for the same reason.
+      if @state.stopped?
+        @events.send(DoneEvent.new(snapshot, true))
+        return
+      end
+      report = Baseline.new(@backend, @base, @config, -> { @state.stopped? }).calibrate(@config.locations)
+      # A stop that landed DURING calibration, which the check above cannot catch: the predicate
+      # handed to `Baseline` kept the remaining probes off the wire, so `report` describes a wave
+      # that never finished. Publishing it would claim a baseline was established.
+      if @state.stopped?
+        @events.send(DoneEvent.new(snapshot, true))
+        return
+      end
       @report = report
       @events.send(BaselineEvent.new(report.stable, report.warning))
 
@@ -308,6 +327,28 @@ module Gori::Miner
       # a param wordlist carries — or an injected byte colliding with a bound name — expands
       # to the live credential and leaves gori for the target, the run reporting `0 errors`.
       bytes, spans = Inject.apply_with_spans(@base, task.location, pairs, @config.add_content_length_when_missing?)
+      # Nothing was injected, so this location cannot carry candidates in THIS request — e.g.
+      # a request line that is not METHOD SP TARGET SP VERSION, which `inject_query` bails on
+      # unmodified rather than rewrite the operator's bytes (P7, and it is right to). Sending
+      # anyway would put the baseline request back on the wire, see no residual signal, and
+      # fall into the `kind.none?` branch below, which calls every untested name clean: the
+      # worst possible failure mode, a false negative that looks like a clean bill of health
+      # (`Fuzz::Backend#blocked` names it, and `skipped_names` was added for the same class of
+      # invisible coverage loss). `valid_names_for` already pre-filters per location, so an
+      # empty span list never means "these particular names were rejected".
+      if spans.empty? && !task.names.empty?
+        # Counted ONCE per location, not once per bucket. The fact is a property of the
+        # location and this request — every one of that location's buckets bails identically —
+        # so incrementing per bucket would report a 4000-name wordlist as thousands of errors
+        # and let a reader (and the CLI's exit-code logic) read one malformed request line as
+        # that many failed sends.
+        if @uninjectable.add?(task.location)
+          @errors += 1
+          @first_error ||= "#{task.location.label}: nothing could be injected into this request"
+        end
+        mark_done(task.names.size) # keep the bar monotonic; this bucket is inconclusive
+        return [] of Task
+      end
       raw = send_with_retries(bytes, spans)
       if err = raw.error
         # A max-requests cap refusal isn't a network error — don't let it inflate @errors.

--- a/src/gori/oast/providers/boast.cr
+++ b/src/gori/oast/providers/boast.cr
@@ -38,8 +38,11 @@ module Gori::Oast
       {"Authorization" => "Secret #{@token}"}
     end
 
+    # Same hazard as `Session#host`: `URI.parse` raises (not returns nil) on an authority it
+    # cannot frame, and `base_url` is whatever endpoint the operator typed — `normalize_endpoint`
+    # only prepends a scheme. Fall back to the raw string rather than raising mid-payload.
     private def payload_host : String
-      URI.parse(base_url).host || base_url
+      (URI.parse(base_url).host rescue nil) || base_url
     end
 
     private def to_interaction(ev : JSON::Any) : Interaction?

--- a/src/gori/oast/session.cr
+++ b/src/gori/oast/session.cr
@@ -40,8 +40,15 @@ module Gori::Oast
     end
 
     # The payload host (interactsh server host, or the provider's callback host).
+    #
+    # `URI.parse` RAISES on an authority it cannot frame — a bare IPv6 host (`fd00::1:9000`),
+    # a typo'd port (`:8O80`) — so the `||` below only ever guarded a nil return, never the
+    # raise. A custom-http provider registers with no network round-trip, so an operator's
+    # unparseable endpoint is persisted verbatim and this getter is on the resume picker's
+    # render path: the raise reached the TUI tick loop and the third open killed the process.
+    # Rescue and fall back to the raw string, like `FlowRequest.parse_target` already does.
     def host : String
-      URI.parse(@server_url).host || @server_url
+      (URI.parse(@server_url).host rescue nil) || @server_url
     end
   end
 end

--- a/src/gori/probe/analyzer.cr
+++ b/src/gori/probe/analyzer.cr
@@ -239,7 +239,20 @@ module Gori
         opts = Active::Options.new(allow_unsafe: opts.allow_unsafe, aggressive: opts.aggressive, oob: @oob)
         Active::RULES.compact_map do |rule|
           next if Probe.rule_disabled?(rule.info.id, @disabled)
-          next unless rule.dedup_key(detail, opts)
+          # Per-rule isolation, like every sibling that runs rule code over captured bytes
+          # (`Active.analyze` rescues each rule, `run_active_now` supervises the loop). A gate
+          # parses hostile captured bytes, so a rule bug raises here — and this one is called
+          # bare from the TUI's synchronous key path, where the run loop's catch-all kills the
+          # process on the third raise in ten seconds. An estimate is advisory: a rule that
+          # cannot decide is omitted, not fatal.
+          applies =
+            begin
+              !rule.dedup_key(detail, opts).nil?
+            rescue ex
+              ::Log.debug(exception: ex) { "probe: #{rule.info.id} estimate gate raised" }
+              false
+            end
+          next unless applies
           ActiveEstimate.new(rule.info, rule.requests_per_flow)
         end
       end

--- a/src/gori/proxy/conn/client_conn.cr
+++ b/src/gori/proxy/conn/client_conn.cr
@@ -149,6 +149,9 @@ module Gori::Proxy
       # request by `strip_ws_extension_offer`, read by the 101 path: an acceptance is only
       # gori's to remove when gori is the reason nothing was offered. See `WS::Handshake`.
       @ws_offer_stripped = false
+      # One-shot: has this connection already logged an intercept hold that failed open because
+      # the declared body was over the ceiling? See `warn_hold_oversize`.
+      @warned_hold_oversize = false
     end
 
     # The address every upstream dial on THIS connection is pinned to, or nil when nothing
@@ -414,9 +417,11 @@ module Gori::Proxy
       # the captured target the Scope SQL filter sees — see `gate_target` above for the one
       # case they part company) only when intercept + Scope are both on, so the common
       # capture-only path spends nothing here.
+      # A body whose DECLARED length is over the hold ceiling fails open (see the predicate) and
+      # falls through to the streaming path below, byte-exact.
       if (ic = @interceptor) && ic.intercepts_request?(
            method: sent_req.method, host: host, target: gate_target, scheme: scheme,
-           head: sent_head)
+           head: sent_head) && holdable_body_size?(req_framing, req_len, "request")
         return handle_held_request(ic, req, sent_req, sent_head, host, port, scheme,
           created_at, started, req_framing, req_len)
       end
@@ -761,10 +766,13 @@ module Gori::Proxy
       # + can test `status:`. Match the CONDITION against `sent_req` (the rewritten/edited
       # request that was captured + scope-gated), not the original `req`, so a `method:`/`path:`
       # rule that holds the request also holds its response when M&R changed the request line.
+      # A body whose DECLARED length is over the hold ceiling fails open the same way the
+      # request hold does (see `holdable_body_size?`) and streams below, byte-exact.
       if (ic = @interceptor) && ic.intercepts_response?(
            method: sent_req.method, host: host, target: Codec::Http1.gate_target(sent_req),
            scheme: scheme, status: resp.status, head: sent_resp_head) &&
-         !resp_framing.close_delimited? && !sse?(resp) && resp.status != 101
+         !resp_framing.close_delimited? && !sse?(resp) && resp.status != 101 &&
+         holdable_body_size?(resp_framing, resp_len, "response")
         return handle_held_response(ic, upstream, req, sent_req, flow_id, host, port, scheme,
           resp, sent_resp_head, resp_framing, resp_len, ttfb, started)
       end
@@ -1099,8 +1107,20 @@ module Gori::Proxy
     # closes the connection without ever marking the flow — it sits in History as
     # "waiting for response…" forever. Treat a reset the same as a graceful EOF (nil)
     # so the caller's existing "no response from upstream" handling covers it too.
+    #
+    # The read is bounded the same way the CLIENT head read is (`handle_request` above, and the
+    # sibling `Repeater::Engine#read_response_head`): a slowloris ORIGIN dripping the response
+    # head one byte at a time keeps resetting the per-read `io_timeout` armed in
+    # `acquire_and_send`, so without a total head-assembly deadline this fiber, the client fd,
+    # the upstream fd and one of `Server`'s MAX_CONNECTIONS permits are pinned for as long as
+    # the origin cares to trickle (P6). `read_head_deadlined` restores the socket's baseline
+    # read_timeout in its own ensure, so the body read that follows is untouched, and
+    # `underlying_socket` returning nil (a non-socket IO) keeps the original loop. The
+    # IO::TimeoutError it raises is caught below as a nil head — the caller's existing
+    # "no response from upstream" path, so no new failure mode.
     private def safe_read_head(io : IO) : Bytes?
-      Codec::Http1.read_head(io)
+      Codec::Http1.read_head(io,
+        deadline: SocketTuning::HEAD_DEADLINE, timeout_sock: SocketTuning.underlying_socket(io))
     rescue
       nil
     end
@@ -1219,6 +1239,13 @@ module Gori::Proxy
     # Returns whether it relaxed — the caller then streams with a concurrent client-abort watcher
     # (an un-timed upstream read can't otherwise notice a gone client) and won't keep-alive after.
     private def relax_for_streaming_response(resp : Codec::RawResponse, resp_framing : Codec::BodyFraming, upstream : IO) : Bool
+      # A 101 is not a stream, whatever Content-Type the ORIGIN put beside it: `handle_response`
+      # hands @io to `WS::Relay.run` / `Pump.blind_tunnel` instead of closing it, so a relaxed
+      # stream's client-abort watcher — which the guard below relies on `run`'s close to end
+      # (see the comment at the `if relaxed` exit) — would stay parked on `@io.read` and eat the
+      # tunnel's client→server bytes into its scratch buffer. The 101 branch relaxes both legs
+      # itself. Mirrors the `status != 101` the two other `sse?` gates already carry.
+      return false if resp.status == 101
       return false unless resp_framing.close_delimited? || sse?(resp)
       SocketTuning.relax(@io)
       SocketTuning.relax(upstream)
@@ -1778,12 +1805,46 @@ module Gori::Proxy
     # Only gates KNOWN-length (Content-Length) bodies; a chunked body has no declared size
     # to check here and still buffers (bounded only by the peer) — capping that streams a
     # follow-up.
+    #
+    # The intercept HOLD shares it (`holdable_body_size?`): it buffers a whole entity for the
+    # same reason and with the same consequence if it is not bounded.
     MAX_REWRITE_BODY = 16 * 1024 * 1024 # 16 MiB
 
     # Whether a body of this framing/declared-length is small enough to buffer + rewrite.
     # Chunked/unknown-length has no size to gate on, so it isn't blocked here.
     private def rewritable_body_size?(framing : Codec::BodyFraming, len : Int64) : Bool
       !framing.length? || len <= MAX_REWRITE_BODY
+    end
+
+    # Whether an intercept HOLD may buffer a body of this framing/declared-length. A hold reads
+    # the whole entity up front so the human can see and edit it (`Codec::Body.read_complete`,
+    # no `max_bytes`), so without this a multi-GB declared upload/download grows the proxy heap
+    # by its whole size — and does it BEFORE `@sink.on_request`, so the eventual raise loses the
+    # flow from History entirely. Past the ceiling the hold FAILS OPEN: the message is not held
+    # and takes the existing zero-buffer streaming path byte-exact (P6/P7). That is the same
+    # disposition the h2 half of this feature already has (`H2::StreamGate#fail_open` past
+    # `MAX_DEFERRED_BYTES`), and it is the right one — capping the READ instead would truncate
+    # the very upload the operator wanted to edit. Reuses the M&R ceiling rather than inventing
+    # a second one: both answer "is this entity small enough to hold in memory?".
+    #
+    # Only KNOWN-length bodies are gated, exactly as `MAX_REWRITE_BODY` documents — a chunked
+    # body declares no size here and still buffers.
+    private def holdable_body_size?(framing : Codec::BodyFraming, len : Int64, direction : String) : Bool
+      return true if rewritable_body_size?(framing, len)
+      warn_hold_oversize(direction, len)
+      false
+    end
+
+    # Once per connection. Intercept is ON and this message never appeared in the queue, so the
+    # operator has to be told why rather than left waiting on a hold that will not come
+    # (modelled on `H2::StreamGate#warn_overflow`, which says the same thing for h2).
+    private def warn_hold_oversize(direction : String, len : Int64) : Nil
+      return if @warned_hold_oversize
+      @warned_hold_oversize = true
+      ::Log.warn do
+        "intercept: #{direction} body declares #{len} bytes, over the #{MAX_REWRITE_BODY}-byte " \
+        "hold ceiling — forwarding it unheld"
+      end
     end
 
     # Whether the buffered response-body path applies: SOMETHING needs the whole entity, the

--- a/src/gori/proxy/h2/assembler.cr
+++ b/src/gori/proxy/h2/assembler.cr
@@ -68,6 +68,14 @@ module Gori::Proxy::H2
       # after it nothing distinguished a trailer from a real response header. Recorded here
       # so the stored head can say which is which — see HeadCodec::TRAILER_MARKER.
       getter trailer_names = [] of String
+      # Membership index for `trailer_names`, which stays an ordered Array because
+      # `HeadCodec::TRAILER_MARKER` joins the names in arrival order. Deduping with
+      # `Array#includes?` is a linear scan, so one legal 1 MiB trailer block (~174k
+      # distinct names still under the cumulative MAX_HEADER_LIST cap at
+      # `finish_header_block`) cost O(N^2) String compares — ~40s of uninterruptible
+      # CPU inside `@mutex`, which on Crystal's single-threaded scheduler freezes the
+      # TUI, every other connection and the Store writer fiber (P6).
+      getter trailer_seen = Set(String).new
     end
 
     private class Stream
@@ -324,7 +332,7 @@ module Gori::Proxy::H2
         # Remember WHICH names these are before they lose their identity in the merge —
         # after the concat a `grpc-status` that arrived in a trailer reads exactly like one
         # sent in the response head, and for gRPC the trailer is the call's real status.
-        decoded.each { |(n, _)| side.trailer_names << n unless side.trailer_names.includes?(n) }
+        decoded.each { |(n, _)| side.trailer_names << n if side.trailer_seen.add?(n) }
         existing.concat(decoded)
       else
         # First block, OR a status-bearing response block. An interim 1xx (100/103)
@@ -336,7 +344,9 @@ module Gori::Proxy::H2
         side.header_bytes = added
         # A final status block REPLACES an interim one, so anything recorded as a trailer
         # against the interim head belongs to a head that no longer exists.
+        # Both halves, or the index would keep suppressing a name for a head that is gone.
         side.trailer_names.clear
+        side.trailer_seen.clear
       end
     ensure
       # Always reset, even if decode raised (feed rescues HPACK/framing errors and

--- a/src/gori/proxy/tls/client_hello.cr
+++ b/src/gori/proxy/tls/client_hello.cr
@@ -118,7 +118,14 @@ module Gori::Proxy::Tls
         value = r.take(size)
         return nil unless value
         next unless kind == SNI_HOST_NAME
-        name = String.new(value)
+        # scrub: `value` is raw ClientHello bytes from an unauthenticated peer, and PCRE2 RAISES
+        # `ArgumentError: UTF-8 error` on an invalid-UTF-8 subject rather than not matching —
+        # which would break this function's contract that PARSING never raises, and cost the
+        # transparent listener the kernel-original-destination fallback below it (#528). The two
+        # sibling matches on the same attacker-supplied authority already scrub for this exact
+        # reason (`CertBuilder.safe_san?`, `CertBuilder.ipv6?`). U+FFFD is outside the charset,
+        # so a scrubbed name is rejected here — the designed graceful outcome, never a raise.
+        name = String.new(value).scrub
         # A name gori is going to mint a certificate for and dial: reject anything that is not
         # a plausible DNS name rather than passing odd bytes into the cert builder and the
         # scope gate. Also drops the empty-SNI case.

--- a/src/gori/proxy/ws/relay.cr
+++ b/src/gori/proxy/ws/relay.cr
@@ -1,6 +1,7 @@
 require "./frame"
 require "./message_gate"
 require "../sink"
+require "../socket_tuning"
 require "../head_rewriter"
 require "../../interceptor"
 
@@ -122,9 +123,29 @@ module Gori::Proxy::WS
     # 20-30 s ping timer is waiting for (RFC 6455 §5.5.2/§5.5.3) — the exact liveness failure
     # `MessageGate`'s header exists to prevent. Past this many, exactness is given up for that
     # message: everything parked is written out at once and the rest of the message's control
-    # frames overtake it as they always did. §5.5 caps a control payload at 125 bytes, so this
-    # bounds the parked bytes too.
+    # frames overtake it as they always did.
     MAX_PARKED_CONTROLS = 8
+
+    # The largest a §5.5-compliant control frame can be ON THE WIRE: 125 payload bytes plus
+    # the 2-byte header, plus the 4-byte masking key a client→server frame carries (§5.3).
+    # `@parked` holds `ctl.raw`, which is the whole frame — so a ceiling derived from the
+    # PAYLOAD cap alone would fire at seven fully compliant PINGs and make
+    # MAX_PARKED_CONTROLS unreachable for max-size frames.
+    MAX_CONTROL_FRAME_BYTES = 125 + 2 + 4
+
+    # ... and the same ceiling in BYTES, which the count alone does not give.
+    #
+    # §5.5 caps a control payload at 125 bytes, and this constant used to be documented as
+    # bounding the parked bytes for free because of it. It does not: `forward_control`
+    # deliberately does NOT enforce that cap (a peer that advertises more gets its frame
+    # relayed, not its tunnel killed — P7, and see the comment there), so a peer that opens a
+    # message with `TEXT fin=0` and then sends eight 16 MiB PINGs parks a second copy of all
+    # of them — ~128 MiB per direction, outside the MAX_MESSAGE budget that bounds `@buffer`
+    # and `@raw`. Crossing this takes exactly the same disposition as crossing the count:
+    # warn once, write everything parked out ahead of the message, and let this frame and
+    # every later one overtake. Which bytes reach the wire is unchanged; only where they sit
+    # relative to the message's fragments is.
+    MAX_PARKED_BYTES = MAX_PARKED_CONTROLS * MAX_CONTROL_FRAME_BYTES
 
     # The direction column every notice row is written on, and it is NOT the direction the
     # notice is about.
@@ -211,6 +232,22 @@ module Gori::Proxy::WS
           warn_close_deadline(out_gate, in_gate)
         end
       end
+      # Every write below happens BEFORE the two `close` calls, and this tunnel's socket
+      # timeouts were cleared on the way in (`SocketTuning.relax` in ClientConn) so an idle
+      # WebSocket is not reaped — which leaves `close` as the only escape hatch for a blocked
+      # write, and it is sequenced after. A held message is up to MAX_MESSAGE with up to
+      # MessageGate::MAX_DEFERRED_BYTES queued behind it, far past any socket buffer, so an
+      # origin that stopped reading pins this fiber, both pump fibers, both fds and one of the
+      # server's connection slots forever — the fd-exhaustion shape `Pump.blind_tunnel`'s
+      # comment cross-closes to avoid, reached here through the teardown writes instead.
+      # Re-arm a bounded timeout so a stalled peer RAISES: `MessageGate#write_message` and
+      # `AssemblingPump#flush_at_teardown` already rescue a failed write into the "could not be
+      # delivered" disposition, and the closes below then run normally. Armed after the
+      # decision window and not before it, because `arm` sets the READ timeout too — a
+      # surviving pump tripping at exactly CLOSE_TIMEOUT would land in `observed` as a peer
+      # `Reset` that never happened.
+      SocketTuning.arm(client, CLOSE_TIMEOUT)
+      SocketTuning.arm(upstream, CLOSE_TIMEOUT)
       # Resolve both hold queues BEFORE the sockets go. `MessageGate#close` runs from the
       # pump's `ensure`, which is only reached because the two lines below unblocked its
       # read — so a message released there is written to a socket that is already gone. This
@@ -493,9 +530,11 @@ module Gori::Proxy::WS
     # An object rather than a method because it carries per-message state across frames (the
     # assembly buffer, the message opcode, whether the message has fallen back to byte-exact
     # forwarding) — and because `Relay.run` has to reach that state at teardown, while the
-    # sockets are still open (`flush_at_teardown`). One instance per pump fiber, so
-    # nothing here is shared and nothing is locked — the GATE owns the only shared state,
-    # because a wait fiber writes through it.
+    # sockets are still open (`flush_at_teardown`). One instance per pump fiber — and that
+    # last clause is what makes the state shared anyway, because `Relay.run` reaches it from
+    # its OWN fiber while this pump is still reading frames. `@in_frame` is what keeps those
+    # two out of each other's way; the GATE owns the other shared state, because a wait fiber
+    # writes through it.
     #
     # The invariant it keeps: gori's own framing is used ONLY for a message a rule or the
     # operator actually changed. Everything else — binary messages nobody edited, oversized
@@ -523,14 +562,39 @@ module Gori::Proxy::WS
       # armed — even one whose condition matched nothing. Individual frame bytes survived
       # that; the SEQUENCE did not, and the sequence is the §5.4 question.
       #
-      # Bounded by MAX_PARKED_CONTROLS, and only ever populated while this message is still
-      # un-rewritten and un-held: `park_control?` declines on the passthrough path (whose
-      # frames are already on the wire, so the order is kept for free) and `emit_message`
-      # hands them to the gate the moment a hold actually parks the message.
+      # Bounded by MAX_PARKED_CONTROLS and MAX_PARKED_BYTES, and only ever populated while
+      # this message is still un-rewritten and un-held: `park_control?` declines on the
+      # passthrough path (whose frames are already on the wire, so the order is kept for free)
+      # and `emit_message` hands them to the gate the moment a hold actually parks the message.
       @parked = [] of {Int32, Bytes}
+      # What `@parked` currently holds, in bytes. Tracked rather than summed because
+      # `park_control?` asks on every control frame; it is reset wherever `@parked` is emptied.
+      @parked_bytes = 0
       @parked_overflowed = false
       @in_bypass = false # the gate's lock is already held, so writes must not re-take it
       @torn_down = false # `flush_at_teardown` has run; there is nothing left to owe the wire
+      # Whether this pump is part-way through one frame — set for the whole of `step`, which is
+      # everything below the header read: the assembly state (`@buffer`, `@raw`, `@shape`,
+      # `@parked`) and every write to `@dst`. It exists because `Relay.run` reaches
+      # `flush_at_teardown` from ITS OWN fiber while this pump's fiber is alive and mid-message.
+      # Without the guard the teardown flush yields mid-flush (`@sink.on_ws_message`, a store
+      # round-trip; a `@dst.write` that hits EAGAIN; `MessageGate#settle`'s own `Fiber.yield`),
+      # the pump appends the fragment that just arrived, and then the flush's `reset_buffer`
+      # wipes it — the fragment reaching neither the wire nor a row, or the message re-emitted
+      # with its already-flushed leading frames duplicated.
+      #
+      # A plain Bool and not a Mutex, deliberately: gori runs on the single-threaded cooperative
+      # scheduler (AGENTS.md §3), so a flag set and cleared with no yield between is exact — and
+      # a Mutex here DEADLOCKS. `step` blocks in `WS.read_body`'s `read_fully?` waiting for a
+      # payload the peer may never finish, so a lock taken across it is held indefinitely;
+      # `Relay.run` would then block in `flush_at_teardown` and never reach the two `close`
+      # calls that are the only thing able to unblock that read (a socket's `read_timeout`
+      # armed AFTER a fiber has parked does not fire — measured). One truncated frame from
+      # either peer would pin both fds, all three fibers, and one of the server's connection
+      # slots forever. So the teardown flush never waits: it skips a pump that is mid-frame and
+      # lets that pump's own `ensure` flush after the close, where a failed write is already
+      # accounted as teardown loss.
+      @in_frame = false
       @scratch : Bytes
       # The V7 frame-shape accumulator and this direction's ping/pong capture budget. Both
       # pumps have to record identical facts about identical bytes, or an operator's finding
@@ -544,26 +608,25 @@ module Gori::Proxy::WS
         @scratch = Bytes.new(STREAM_CHUNK)
       end
 
+      # What `run` does with one frame, once `step` has handled it.
+      enum Step
+        Continue # keep reading
+        Stop     # end of stream, a truncated frame, or this pump is already torn down
+        Closed   # a CLOSE frame was relayed: the clean half of the §7.1.1 handshake
+      end
+
       # Same contract as `Relay.pump`: HOW this direction ended (see `Ending`).
       def run : Ending
         ending = Ending::Eof
         loop do
           h = WS.read_header(@src) || break
-          unless h.data?
-            break unless forward_control(h)
-            if h.close?
-              ending = Ending::Close
-              break
-            end
-            next
+          case step(h)
+          when Step::Closed
+            ending = Ending::Close
+            break
+          when Step::Stop
+            break
           end
-          start_message(h.opcode) if h.opcode != OP_CONT
-          if h.len > WS::MAX_FRAME
-            break unless forward_oversized(h)
-            next
-          end
-          frame = WS.read_body(@src, h) || break
-          handle_data(frame)
         end
         ending
       rescue
@@ -576,6 +639,34 @@ module Gori::Proxy::WS
         # open — `Relay.run` is parked on `done.receive`); a no-op for the other one, which
         # `run` has already flushed. Either way `flush_at_teardown` runs exactly once.
         flush_at_teardown
+      end
+
+      # One frame, marked `@in_frame` for its whole length (see the declaration) — the body read
+      # included, because a frame is not a unit until its payload is in hand and letting the
+      # teardown flush run between a header and its own body is the same interleave. The wait
+      # that costs is the HEADER read, and that one stays outside: it is where this fiber parks
+      # between frames, and a flush is exactly what should be allowed to happen there.
+      private def step(h : WS::Header) : Step
+        # `Relay.run` has already flushed this pump and is about to close both sockets. What
+        # this loop assembles from here reaches neither the wire nor a row — the flush that
+        # would have put it out has run, and `@torn_down` has disabled the `ensure`'s — so the
+        # direction ends here instead, leaving the bytes on the peer's socket rather than
+        # swallowing them into a buffer nobody will flush.
+        return Step::Stop if @torn_down
+        @in_frame = true
+        unless h.data?
+          return Step::Stop unless forward_control(h)
+          return h.close? ? Step::Closed : Step::Continue
+        end
+        start_message(h.opcode) if h.opcode != OP_CONT
+        if h.len > WS::MAX_FRAME
+          return forward_oversized(h) ? Step::Continue : Step::Stop
+        end
+        frame = WS.read_body(@src, h) || return Step::Stop
+        handle_data(frame)
+        Step::Continue
+      ensure
+        @in_frame = false
       end
 
       # Everything this pump is still WITHHOLDING — a half-assembled message's fragments and
@@ -606,8 +697,17 @@ module Gori::Proxy::WS
       # holds — so what was missing is the sentence saying it never got out. `MessageGate`'s
       # `write_message` states the same contract from the other side ("a `ws_messages` row is
       # gori's claim that the peer saw these bytes"), and a refusal has to name itself.
+      # Called from TWO fibers: this pump's own `ensure`, and `Relay.run`'s teardown while this
+      # pump is still reading. `@in_frame` decides which of them gets to do it — see its
+      # declaration for why that is a flag and not a lock.
       def flush_at_teardown : Nil
         return if @torn_down
+        # Mid-frame: this pump owns the assembly state right now, and half of it is on the
+        # stack of a `step` that has not returned. Leave it alone — `Relay.run` closes the
+        # sockets immediately after this, which ends that `step`, and the `ensure` below its
+        # loop then runs this again from the fiber that does own the state. What is owed goes
+        # out there or is reported by `warn_teardown_loss`; it is never silently dropped.
+        return if @in_frame
         @torn_down = true
         # Snapshotted BEFORE the attempt: `flush_parked` empties `@parked` ahead of its own
         # write, so after a raise there is nothing left to count.
@@ -705,17 +805,24 @@ module Gori::Proxy::WS
       # is no assembling message to interleave it with, when this message's own wire bytes
       # are gone anyway (passthrough, or past the raw cap — in both cases the fragments are
       # already on the wire, so arrival order is preserved by writing straight through), and
-      # once MAX_PARKED_CONTROLS have piled up.
+      # once MAX_PARKED_CONTROLS frames or MAX_PARKED_BYTES bytes have piled up.
       private def park_control?(ctl : WS::Frame) : Bool
         return false if @passthrough || !@raw_kept || @raw.size == 0
+        # A message that never ends must not sit on the peer's PONG, and it must not pin the
+        # proxy's heap either. Either ceiling gives up exactness for this message, says so
+        # once, and lets this frame and every later one overtake.
         if @parked.size >= MAX_PARKED_CONTROLS
-          # A message that never ends must not sit on the peer's PONG. Give up exactness for
-          # this message, say so once, and let this frame and every later one overtake.
-          warn_parking_ceiling
+          warn_parking_ceiling("more than #{MAX_PARKED_CONTROLS} control frames")
+          flush_parked
+          return false
+        end
+        if @parked_bytes + ctl.raw.size > MAX_PARKED_BYTES
+          warn_parking_ceiling("more than #{MAX_PARKED_BYTES} bytes of control frames")
           flush_parked
           return false
         end
         @parked << {@raw.size, ctl.raw.dup}
+        @parked_bytes += ctl.raw.size
         true
       end
 
@@ -726,6 +833,7 @@ module Gori::Proxy::WS
         return if @parked.empty?
         bytes = parked_bytes
         @parked.clear
+        @parked_bytes = 0
         return unless bytes
         if (gate = @gate) && !@in_bypass
           gate.write_control(bytes)
@@ -773,10 +881,15 @@ module Gori::Proxy::WS
       # same "controls, then the message" ordering whether the interleave was preserved or
       # given up. Once per direction per socket, like the warn and like `MAX_CONTROL_CAPTURE`'s
       # marker — its POSITION in the stream is what names the message it applies to.
-      private def warn_parking_ceiling : Nil
+      #
+      # `crossed` names WHICH ceiling gave way — the count or the byte total — because the two
+      # answer different operator questions ("my peer is pinging in a loop" vs "my peer is
+      # sending control frames §5.5 says cannot exist"), and the sentence is the only place
+      # that can say so.
+      private def warn_parking_ceiling(crossed : String) : Nil
         return if @parked_overflowed
         @parked_overflowed = true
-        note = "more than #{MAX_PARKED_CONTROLS} control frames arrived between the fragments " \
+        note = "#{crossed} arrived between the fragments " \
                "of one #{side} message; they were forwarded ahead of it so the peer's ping " \
                "timer still sees a reply. The frames are byte-exact; their position relative " \
                "to that message's fragments is not"
@@ -991,6 +1104,7 @@ module Gori::Proxy::WS
           # the one invariant this pump exists to keep.
           write_direct(interleaved_raw)
           @parked.clear
+          @parked_bytes = 0
         elsif @buffer.size > 0
           flush_parked # re-framed: nowhere to put them but in front
           write_direct(WS.encode(@opcode, @buffer.to_slice, mask: @mask, fin: false))
@@ -1077,6 +1191,7 @@ module Gori::Proxy::WS
         # Whoever ended the message has already disposed of these (written them through, or
         # handed them to the gate); the offsets they carry belong to a buffer that is gone.
         @parked.clear
+        @parked_bytes = 0
       end
     end
 

--- a/src/gori/repeater/minimize.cr
+++ b/src/gori/repeater/minimize.cr
@@ -348,7 +348,7 @@ module Gori::Repeater
         return nil unless idx
         colon = hl[idx].index(':').not_nil!
         prefix = hl[idx][0...colon]
-        crumbs = hl[idx][(colon + 1)..].strip.split(/;\s*/).reject(&.empty?)
+        crumbs = cookie_crumbs(hl[idx])
         crumbs.delete(crumb)
         if crumbs.empty?
           hl.delete_at(idx)
@@ -636,8 +636,22 @@ module Gori::Repeater
       REMOVABLE_HEADERS.includes?(dn) || REMOVABLE_PREFIXES.any? { |p| dn.starts_with?(p) }
     end
 
+    # Split on a Char, never a Regexp: `text` is the request head loaded verbatim from the
+    # store (P7), so a latin-1 or binary cookie value reaches PCRE2 and Crystal's binding
+    # raises `ArgumentError: UTF-8 error` — before any network I/O, and unrescued on the
+    # `gori run repeater minimize` path. `String#split(Char)` and `#strip` both slice bytes,
+    # so the crumbs round-trip exactly and `--apply`'s stored minimized_text stays byte-exact.
+    # `cookie_candidate`'s removal proc calls this too, so the two cannot drift apart again.
+    #
+    # `lstrip` per crumb and NOT `strip`, because the regex this replaces was `/;\s*/`: it ate
+    # the whitespace AFTER a semicolon and none before one. Stripping both ends would rewrite a
+    # crumb the capture carried as `sid=abc ` into `sid=abc`, and `cookie_candidate` rebuilds
+    # the header by joining the survivors with "; " — so that byte would silently leave the
+    # request the operator asked gori to minimize, which is the one thing this method must not
+    # do. A trailing space inside a cookie value is a parser-differential payload, not noise.
     private def self.cookie_crumbs(line : String) : Array(String)
-      (c = line.index(':')) ? line[(c + 1)..].strip.split(/;\s*/).reject(&.empty?) : [] of String
+      return [] of String unless c = line.index(':')
+      line[(c + 1)..].strip.split(';').map(&.lstrip).reject(&.empty?)
     end
 
     private def self.query_segments(request_line : String?) : Array(String)

--- a/src/gori/repeater/ws_engine.cr
+++ b/src/gori/repeater/ws_engine.cr
@@ -147,7 +147,15 @@ module Gori
           handshake, keys = build_handshake(upgrade_request, keep_key)
           upstream.write(handshake)
           upstream.flush
-          head = Proxy::Codec::Http1.read_head(upstream)
+          # Bounded like every other origin head read (`Engine.read_response_head`, and
+          # `ClientConn#safe_read_head` on the proxy path): the per-read `io_timeout` armed on
+          # the dial is reset by every byte, so an origin dripping its 101 handshake one byte at
+          # a time pins this fiber for as long as it cares to trickle. `underlying_socket`
+          # returns nil for an IO with no settable socket, in which case the deadline is skipped
+          # and the behaviour is unchanged.
+          head = Proxy::Codec::Http1.read_head(upstream,
+            deadline: Proxy::SocketTuning::HEAD_DEADLINE,
+            timeout_sock: Proxy::SocketTuning.underlying_socket(upstream))
           # `Engine.no_response_error`, not a local copy of the sentence: a plain `ws://` target
           # behind a proxy that answers the CONNECT and then closes without relaying anything is
           # the same shape as the h1 repeater's clean-EOF case, and a hand-duplicated string here
@@ -469,7 +477,12 @@ module Gori
         io = IO::Memory.new(head.size + 64)
         req_line = lines.empty? ? "GET / HTTP/1.1" : String.new(lines[0])
         io << (Repeater::FlowRequest.rewrite_request_line(req_line) || req_line) << "\r\n"
-        lines[1..].each do |line|
+        # `skip(1)`, not `lines[1..]`: `head_lines` pops trailing blanks, so an empty or
+        # all-blank editor yields `[]` and the Range index raises IndexError. That raise
+        # landed AFTER the dial, so the operator got "Index out of bounds" for a connection
+        # gori had already opened. The line above already declares the intent — synthesize a
+        # request line and let the origin answer — and this negated it.
+        lines.skip(1).each do |line|
           next if line.empty?
           name = header_name(line)
           next if name == "sec-websocket-extensions"

--- a/src/gori/settings.cr
+++ b/src/gori/settings.cr
@@ -58,6 +58,19 @@ module Gori
     # #508 are written around, reached through the base rather than through a write-back.
     @@loaded_raw : String? = nil
 
+    # `load` read a file but could not finish applying it: some section raised and every
+    # section BELOW it is sitting at its factory default. While this is set, `save` refuses —
+    # a document assembled from half the operator's file and half the factory defaults must
+    # never be written back over the real one, whatever the merge would do with it.
+    #
+    # A separate flag rather than a nil base, because the base protects nothing here: with
+    # base = the raw text, an abandoned section is either absent from `serialize` (chosen nil
+    # → dropped) or holds a default (!= base → "mine wins"), so the 3-way merge deletes the
+    # same sections it would delete with no base at all. The only safe answer is not to write.
+    # Contrast the unparseable-file path (`load_root`), where nothing was applied from disk at
+    # all and the next save is a deliberate clean write.
+    @@load_partial = false
+
     # An explicit settings file for THIS process (`gori --config PATH`), overriding both
     # $GORI_CONFIG and the default under GORI_HOME. Set once from CLI.run before any
     # subcommand dispatch, so every surface — TUI, `gori run`, `gori mcp` — reads the same
@@ -86,16 +99,31 @@ module Gori
     # malformed file leaves the defaults (or CLI-provided values) in place.
     def self.load : Nil
       @@loaded_raw = nil
+      @@load_partial = false
       @@load_warning = nil # cleared here, not in load_root, so a file that is fixed OR removed drops it
       raw = load_raw
       return unless raw # no file yet / unreadable — first run, keep defaults
       root = load_root(raw)
       return unless root # present but unparseable — kept a .corrupt copy, keep defaults
-      # Set before `apply_sections` so a section that raises partway still leaves SOME base
-      # behind (a nil base skips the merge entirely, which would let this process's full
-      # state overwrite the file).
-      @@loaded_raw = raw
-      apply_sections(root)
+      begin
+        apply_sections(root)
+      rescue
+        # A malformed individual section — keep whatever loaded so far, and remember that this
+        # is only HALF the operator's file: every section below the raising line is at its
+        # factory default now, so `save` must not write this state back (see `@@load_partial`).
+        # Say so as well, on the same channel `load_root` uses: the silent version of this was
+        # the #594 data loss, where `gori settings import` reported success while replacing a
+        # live config with defaults.
+        #
+        # Scoped to `apply_sections` ALONE, not to the whole method. `serialize` and
+        # `migrate_legacy_sections` below run only after every section applied, so a raise
+        # there leaves nothing at a default — latching the flag for those would refuse every
+        # save for the rest of the process over a file that was read in full.
+        @@load_partial = true
+        note_load_warning("settings: #{path} could not be read in full — the sections gori did " \
+                          "not reach are at their factory defaults, so this run will not overwrite that file")
+        return
+      end
       # Re-base on our OWN serialization of what we just read, the same rule `save` applies
       # to `mine`. See `@@loaded_raw` for why the raw text cannot be the base.
       @@loaded_raw = serialize
@@ -112,7 +140,12 @@ module Gori
       # save. Migrating after makes it a genuine change, which is what it is.
       migrate_legacy_sections(root)
     rescue
-      # a malformed individual section — keep whatever loaded so far
+      # `serialize` or `migrate_legacy_sections` raised. Every section from disk is already
+      # applied by here, so the in-memory state is whole and `save` stays allowed — a
+      # re-base that could not be computed only costs the merge its base, which is the same
+      # position a first run is in. Swallowed, as it was before the partial-load guard
+      # existed; `@@loaded_raw` staying nil already reports it through `load_degraded?`.
+      nil
     end
 
     # Read each top-level section of a parsed settings document into the class properties.
@@ -244,18 +277,22 @@ module Gori
       nil
     end
 
-    # A settings file EXISTS but this process could not use it, so every section is sitting at
-    # its factory default AND the 3-way merge has no base — meaning the next `save` writes those
-    # defaults over the operator's file. Only meaningful after a `load`.
+    # A settings file EXISTS but this process could not use it, so sections are sitting at their
+    # factory defaults — meaning an export writes those defaults out under the operator's name.
+    # Only meaningful after a `load`.
     #
-    # Deliberately NOT `load_warning != nil`. That covers one of the two ways in: `load_root`'s
+    # Two ways in, and the PARTIAL one is the newer: a section that raised leaves everything
+    # below it at defaults while `load_raw` and `load_root` both succeeded, so the file-shaped
+    # test below answers false for it (see `@@load_partial`).
+    #
+    # Deliberately NOT `load_warning != nil`. That covers one of the other ways in: `load_root`'s
     # rescue (present but unparseable) sets the warning, but `load_raw`'s rescue above sets
     # nothing and swallows every READ failure — EACCES on a settings.json left root-owned by a
     # `sudo gori`, a `--config` pointing at a directory, a transient I/O error. A guard keyed on
     # the warning therefore misses exactly the cases that leave no trace at all, which is how
     # `gori settings import` still replaced a live config with defaults and reported success.
     def self.load_degraded? : Bool
-      @@loaded_raw.nil? && File.exists?(path)
+      @@load_partial || (@@loaded_raw.nil? && File.exists?(path))
     end
 
     # Why the last load fell back to defaults, or nil when it did not. Read by the TUI to
@@ -314,12 +351,18 @@ module Gori
         s << "settings: #{path} is not valid JSON — using defaults for this run"
         s << "; your file is preserved at #{path}.corrupt" if kept
       end
-      @@load_warning = warning
-      unless @@load_warning_emitted
-        @@load_warning_emitted = true
-        @@warning_io.try(&.puts(warning))
-      end
+      note_load_warning(warning)
       nil
+    end
+
+    # Record the reason and put it on the warning io at most once — shared with `load`'s rescue
+    # so a PARTIAL read is announced on exactly the channel an unparseable file already was,
+    # rather than being the one degraded outcome that says nothing.
+    private def self.note_load_warning(warning : String) : Nil
+      @@load_warning = warning
+      return if @@load_warning_emitted
+      @@load_warning_emitted = true
+      @@warning_io.try(&.puts(warning))
     end
 
     # load_bool over a Hash (the layout object), same false-preserving semantics as load_bool.
@@ -342,6 +385,12 @@ module Gori
     # Persist the current values. Never raises into the caller (a failed write must
     # not crash the TUI); returns whether it succeeded.
     def self.save : Bool
+      # The last load only got HALF this file in, so what is in memory is the operator's
+      # sections down to the raise and factory defaults after it. Writing that back is the
+      # #594 loss with a different door: the merge cannot recover a section it never read
+      # (see `@@load_partial`), so refuse instead — reported like any other failed write,
+      # which the callers already handle.
+      return false if @@load_partial
       Paths.ensure_dirs
       # With --config / $GORI_CONFIG the file can live outside GORI_HOME, whose directory
       # ensure_dirs above does not create. The temp+rename below would fail on a missing

--- a/src/gori/settings/colormarker.cr
+++ b/src/gori/settings/colormarker.cr
@@ -85,8 +85,9 @@ module Gori::Settings
     self.colormarker_rules = parse_colormarker_rules(node["rules"]?)
     self.colormarker_colors = parse_colormarker_colors(node["colors"]?)
     stored = node["next_rule_id"]?.try(&.as_i64?) || 0_i64
-    # Never go BACKWARDS from the ids actually present, whatever the file says.
-    self.colormarker_next_rule_id = {stored, (colormarker_rules.max_of?(&.id) || 0_i64) + 1, 1_i64}.max
+    # Never go BACKWARDS from the ids actually present, whatever the file says. Saturating at
+    # the top for the same reason the rewriter's counter is — see `next_id_after` there.
+    self.colormarker_next_rule_id = {stored, next_id_after(colormarker_rules.max_of?(&.id) || 0_i64), 1_i64}.max
   end
 
   # Tolerant custom-colour parse, same spirit as the rule parser: a non-array (or absent) node
@@ -179,7 +180,7 @@ module Gori::Settings
   def self.add_colormarker_rule(match_filter : String, color : String, style : String,
                                 name : String = "", enabled : Bool = true) : Int64
     id = colormarker_next_rule_id
-    self.colormarker_next_rule_id = id + 1
+    self.colormarker_next_rule_id = next_id_after(id) # saturating — see `next_id_after`
     self.colormarker_rules = colormarker_rules + [ColormarkerRule.new(id, enabled, name, match_filter, color, style)]
     save ? id : 0_i64
   end

--- a/src/gori/settings/rewriter.cr
+++ b/src/gori/settings/rewriter.cr
@@ -74,7 +74,19 @@ module Gori::Settings
     stored = node["next_rule_id"]?.try(&.as_i64?) || 0_i64
     # Never go BACKWARDS from the ids actually present, whatever the file says: a hand-edited
     # (or truncated) counter must not be able to mint a duplicate id.
-    self.rewriter_next_rule_id = {stored, (rewriter_rules.max_of?(&.id) || 0_i64) + 1, 1_i64}.max
+    self.rewriter_next_rule_id = {stored, next_id_after(rewriter_rules.max_of?(&.id) || 0_i64), 1_i64}.max
+  end
+
+  # One past `highest`, SATURATING. Crystal's `+` is checked, so a hand-edited (or imported)
+  # `"id": 9223372036854775807` made this expression raise OverflowError — inside
+  # `apply_sections`, where a raise abandons every section below it and `load`'s blanket rescue
+  # swallows it. That is the same #594 room `int_field` and `object_section` (settings.cr) each
+  # closed a door into; this is the arithmetic one, and it is why those two rescue rather than
+  # let a value's range decide how much of the file gets read. Saturating can hand out an id
+  # that is already taken, which costs an ambiguous by-id edit at the very top of the Int64
+  # range; raising costs the operator every section below `rewriter`.
+  private def self.next_id_after(highest : Int64) : Int64
+    highest == Int64::MAX ? highest : highest + 1
   end
 
   # Tolerant global-rule parse: a non-array (or absent) node keeps the current value; entries
@@ -117,9 +129,14 @@ module Gori::Settings
   # already-taken id is replaced with one past everything seen so far: two rules sharing an id
   # would make every by-id mutation ambiguous, and dropping the entry would silently lose a
   # rule the operator wrote. (Zero is not a valid id — see `rewriter_next_rule_id`.)
+  #
+  # `Int64::MAX` is renumbered the same way, for the same reason a duplicate is: it is the one
+  # id no counter can be advanced past, so keeping it would make the next mint ambiguous
+  # anyway. The rule itself is kept either way — see `next_id_after` for what raising here
+  # would have cost.
   private def self.claim_id(id : Int64?, seen : Set(Int64)) : Int64
-    return id if id && id > 0 && seen.add?(id)
-    fresh = (seen.max? || 0_i64) + 1
+    return id if id && id > 0 && id < Int64::MAX && seen.add?(id)
+    fresh = next_id_after(seen.max? || 0_i64)
     seen << fresh
     fresh
   end
@@ -166,7 +183,10 @@ module Gori::Settings
                              op : String, match_kind : String, name : String, host : String,
                              body_file : String, enabled : Bool = true) : Int64
     id = rewriter_next_rule_id
-    self.rewriter_next_rule_id = id + 1
+    # Saturating, because the counter itself is parsed from the file (`next_rule_id`) and a
+    # bare `+ 1` on an `Int64::MAX` one raises out of an operator's "add rule" — see
+    # `next_id_after`.
+    self.rewriter_next_rule_id = next_id_after(id)
     self.rewriter_rules = rewriter_rules + [RewriterRule.new(id, enabled, name, target, part,
       pattern, replacement, op, match_kind, host, body_file)]
     save ? id : 0_i64

--- a/src/gori/tui/controllers/probe_controller.cr
+++ b/src/gori/tui/controllers/probe_controller.cr
@@ -18,6 +18,13 @@ module Gori::Tui
     # The two fixed sub-tabs: the scan results/mode view, and the rule-management view.
     SUBTABS = ["Findings", "Rules"]
 
+    # Per-tick ceiling on analyzer events applied on the render fiber, matching every sibling
+    # drain (fuzzer/miner/sequencer/discover/oast controllers, and Runner's FLOW_DRAIN_CAP).
+    # This one was uncapped, and the per-event body yields at `insert_event`, so the analyzer
+    # could refill its 256-slot channel mid-loop and keep one tick going indefinitely.
+    # Whatever is left over is drained on the next tick, 50 ms later.
+    DRAIN_CAP = 512
+
     def initialize(host : Host)
       super(host)
       @probe = ProbeView.new
@@ -286,14 +293,26 @@ module Gori::Tui
     # (channel events can be dropped when the buffer is full). Still refresh here so a
     # delivered IssueEvent never leaves the in-memory view behind. Returns true when
     # anything was drained (forces a redraw — badge/status even if Probe is not focused).
+    #
+    # The list reload is coalesced to ONE per drain and gated on Probe being the active tab,
+    # because `refresh_from_store` is a full-table `probe_issues` SELECT plus filter — the
+    # same cost the Runner's probe_generation poll already refuses to pay off-tab, for the
+    # reason its comment gives ("repainting the whole screen up to 20 times a second" during
+    # a scan). Per-event it was worse still: the reload ran once per IssueEvent, on the render
+    # fiber, which is exactly what probe/event.cr's contract already says it must not do
+    # ("the controller coalesces them into a single list reload per frame"). Off-tab is caught
+    # up by `on_enter` — the only way into the Probe tab is `focus_tab`, which runs it.
     def drain_events : Bool
       drained = false
+      needs_refresh = false
+      n = 0
       events = @host.session.probe.events
-      while ev = nonblocking_event(events)
+      while n < DRAIN_CAP && (ev = nonblocking_event(events))
+        n += 1
         drained = true
         case ev
         when Probe::IssueEvent
-          refresh_from_store
+          needs_refresh = true
           if summary = ev.summary
             # #124: log to the AI event feed regardless of the human notification.
             @host.session.store.insert_event("probe", "issue_found", "success", "Probe: #{summary}", goto_tab: "probe")
@@ -315,6 +334,7 @@ module Gori::Tui
           @host.status("Probe: #{ev.message}") if Settings.notify_toast?
         end
       end
+      refresh_from_store if needs_refresh && @host.active_tab == :probe
       drained
     end
 

--- a/src/gori/tui/repeater_view.cr
+++ b/src/gori/tui/repeater_view.cr
@@ -2335,7 +2335,7 @@ module Gori::Tui
       # anchor — restoring the raw cursor could land inside a now-longer hidden chain.
       anchor = Fuzz::Template.marker_start_at(@editor.text, @chain_marker_cursor) || @chain_marker_cursor
       if updated = Fuzz::Template.set_chain(@editor.text, @chain_marker_cursor, @chain_pane.value)
-        @editor.set_text(updated)
+        @editor.set_text_keeping_eols(updated)
         @editor.place_at_offset(anchor) # back into the marker (set_text reset it) → tooltip stays up
         @dirty = true
       end
@@ -2371,6 +2371,13 @@ module Gori::Tui
     # renders through its chain on send). All delegate to the shared Fuzz::Template helpers.
     # Each of the three that CREATES a marker also declares the buffer a template — see
     # `markers_live?` for why an evidence tab needs to be told.
+    #
+    # They write back through `set_text_keeping_eols`, never plain `set_text`: the Template
+    # helpers take (and must take) `@editor.text`, the CR-free LF projection every offset here
+    # indexes, and a plain `set_text` of that result would store the projection — flattening
+    # the capture's body CRLFs before the tab has sent anything, with auto-CL resyncing the
+    # shortened length behind it. That is exactly what `edit_buffer_text` documents for ^E,
+    # and the Fuzzer's identical five helpers have wrapped it in `restore_wire_eols` all along.
     def auto_mark : String
       return mark_hint unless markable?
       # `Fuzz::Template.auto_mark` is a documented no-op once the text holds ANY `§`, so on a
@@ -2379,7 +2386,7 @@ module Gori::Tui
       # Name that instead of doing it silently.
       return "the capture's own § would become markers and auto-mark adds none — ^T marks at the cursor" if literal_markers?
       declare_markers
-      @editor.set_text(Fuzz::Template.auto_mark(@editor.text))
+      @editor.set_text_keeping_eols(Fuzz::Template.auto_mark(@editor.text))
       @dirty = true
       n = Fuzz::Template.parse(@editor.text).position_count
       "auto-marked #{n} position#{n == 1 ? "" : "s"}"
@@ -2392,7 +2399,7 @@ module Gori::Tui
       return "no word at the cursor — place it on a token (or auto-mark)" if after == before
       note = adopted_literals_note
       declare_markers
-      @editor.set_text(after)
+      @editor.set_text_keeping_eols(after)
       @dirty = true
       msg = Fuzz::Template.parse(after).position_count < Fuzz::Template.parse(before).position_count ? "unmarked position" : "marked position"
       "#{msg}#{note}"
@@ -2419,7 +2426,7 @@ module Gori::Tui
     def clear_marks : String
       return mark_hint unless markable?
       return literal_marker_hint unless markers_live?
-      @editor.set_text(Fuzz::Template.clear_markers(@editor.text))
+      @editor.set_text_keeping_eols(Fuzz::Template.clear_markers(@editor.text))
       @markers_declared = false # back to a buffer with no markers of its own
       invalidate_marker_caches
       @dirty = true
@@ -3453,7 +3460,9 @@ module Gori::Tui
     def strip_marker_span(span : {Int32, Int32}) : Nil
       return unless @focus == :request
       new_text, caret = Fuzz::Template.strip_marker(@editor.text, span)
-      @editor.replace_all(new_text, caret)
+      # LF projection in, terminators back on — see the marking-helpers note above; the
+      # `replace_all` variant so this stays ONE undoable edit and the caret survives.
+      @editor.replace_all_keeping_eols(new_text, caret)
       mark_req_edit
     end
 

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -777,8 +777,8 @@ module Gori::Tui
     end
 
     # Per-tick ceiling on captured-flow events applied to History, matching the cap every
-    # other controller already has (`DRAIN_CAP` in the fuzzer/sequencer/oast/discover
-    # controllers). This drain was the only uncapped one, and it issues a `store.flow_row`
+    # other controller already has (`DRAIN_CAP` in the fuzzer/sequencer/oast/discover/probe
+    # controllers). It issues a `store.flow_row`
     # SELECT per event ON THE UI FIBER — with `Session`'s 1024-deep channel, one tick could
     # therefore fire up to 1024 SQLite round-trips before the frame was allowed to render.
     # Anything left over is drained on the next tick, 50 ms later.

--- a/src/gori/tui/settings_view.cr
+++ b/src/gori/tui/settings_view.cr
@@ -482,8 +482,13 @@ module Gori::Tui
     # Forward-delete (the Del key): remove the character UNDER the caret, leaving the
     # caret where it is — the natural complement to backspace after ←/→ caret moves.
     # No-op on toggle/choice/action rows or with the caret already at end-of-line.
+    # `readonly_field?` belongs here for the same reason it does in `insert`/`backspace`:
+    # a display row must swallow EVERY edit. Without it a ← (which falls through to
+    # move_cursor on a non-bool/non-choice row) pulls the caret off end-of-line, defeating
+    # the `c >= v.size` brake below — so Del would chew up the live summary and flip
+    # `dirty?`, painting a spurious "● unsaved" for an edit the operator never made.
     def delete : Nil
-      return if bool_field? || choice_field? || opener_field?
+      return if bool_field? || choice_field? || opener_field? || readonly_field?
       v = @values[@focused]
       c = @cursor.clamp(0, v.size)
       return if c >= v.size

--- a/src/gori/tui/text_area.cr
+++ b/src/gori/tui/text_area.cr
@@ -491,6 +491,45 @@ module Gori::Tui
       place_at_offset(caret)
     end
 
+    # `set_text`/`replace_all` for a transform that was COMPUTED over `#text` — the CR-free
+    # LF projection — and must not be allowed to write that projection back.
+    #
+    # Every in-buffer transform (the §/¦ marking helpers, ^F replace-all) has to be handed
+    # `#text`, because every offset it works from — `#cursor_offset`, a cached marked span, a
+    # search match — indexes THAT string; handing it wire text would shift each offset by one
+    # per CRLF line and edit the wrong span. But `set_text`/`replace_all` re-derive `@eols`
+    # through `split_wire`, so writing the result straight back resets every terminator in the
+    # buffer to `\n` and a captured body's CRLFs are gone before anything is sent — with
+    # auto-Content-Length resyncing DOWN behind the loss, so nothing on screen says the
+    # request changed. That is the `set_text` comment's own failure, reintroduced one layer up.
+    #
+    # These transforms only ever insert or delete characters WITHIN a line (^F's query and
+    # replacement cannot hold a newline — `handle_search_key` drops control chars), so the
+    # line count is invariant and the terminators can simply be put back. Lifted from
+    # `FuzzerView#restore_wire_eols`, which is the same guard around the same five helpers;
+    # the fallback is its fallback too — better a buffer that lost its CRLFs than one whose
+    # terminators were reattached to the wrong lines.
+    def set_text_keeping_eols(lf_text : String) : Nil
+      set_text(with_wire_eols(lf_text))
+    end
+
+    # ditto, for the transforms that must stay ONE undoable edit (marker strip).
+    def replace_all_keeping_eols(lf_text : String, caret : Int32) : Nil
+      replace_all(with_wire_eols(lf_text), caret)
+    end
+
+    private def with_wire_eols(lf_text : String) : String
+      return lf_text if @eols.all? { |e| e == "\n" || e.empty? } # nothing to restore
+      parts = lf_text.split('\n')
+      return lf_text unless parts.size == @eols.size
+      String.build do |io|
+        parts.each_with_index do |p, i|
+          io << p
+          io << @eols[i]
+        end
+      end
+    end
+
     def insert_newline : Nil
       push_undo
       cut_selection # ↵ over a selection replaces it with the break — see `insert`
@@ -1283,7 +1322,11 @@ module Gori::Tui
       n = 0
       swapped = text.gsub(search_regex(query)) { n += 1; replacement }
       return 0 if n == 0
-      replace_all(swapped, cursor_offset)
+      # `swapped` is the LF projection: writing it back would flatten every CRLF the capture
+      # carried in its BODY, and this editor is the one the Repeater and the Intercept hold
+      # a real request in. `cursor_offset` indexes that same projection, so the gsub has to
+      # run over `text` — the terminators go back on afterwards. See `set_text_keeping_eols`.
+      replace_all_keeping_eols(swapped, cursor_offset)
       n
     end
 


### PR DESCRIPTION

A whole-tree stability audit: 20 areas swept for crash/hang/corruption, every
claim put to an adversarial reviewer, and the survivors fixed with a spec each.
Five shapes accounted for most of them.

Invalid UTF-8 reaching PCRE2, which RAISES rather than not matching. A relative
`Location:` with a Latin-1 byte aborted a whole discover run from its
orchestrator fiber; `gori run repeater minimize` and `gori run cookie` exited
with a Crystal backtrace; an SNI byte dropped a transparent HTTPS connection
instead of falling back to the kernel destination; a multipart boundary silently
voided a flow's entire passive scan and killed the TUI's active-scan estimate; a
non-UTF-8 argv token escaped to `main`. Each is now a byte scan where the grammar
is ASCII, or a scrub of the regex SUBJECT with the original bytes kept.

Work with no bound and no yield point, which on the single-threaded scheduler
freezes everything. A drip-fed response head pinned a connection fiber, both fds
and one of the server's 2048 permits indefinitely — the client head and the
repeater already passed `HEAD_DEADLINE`, `ClientConn#safe_read_head` did not. One
legal 1 MiB h2 trailer block cost ~40s of uninterruptible CPU inside the
assembler mutex (`Array#includes?` dedupe over ~174k names). An MCP
`brute "a:1-100000000"` never returned. The intercept hold buffered a whole
declared body with no ceiling.

Captured bytes rewritten by gori itself. `^F` replace-all and all five Repeater
marking helpers round-tripped through the CR-free `text` projection, so every
CRLF in a multipart or smuggling body became a bare LF before the tab sent
anything — with auto-Content-Length resyncing DOWN behind the loss. The Fuzzer
had guarded this for a year; the fix lifts that guard onto `TextArea`. HAR export
emitted documents that were not valid UTF-8.

Checked integer arithmetic on operator-supplied numbers: `+ 1` on an
`Int64::MAX` rule id aborted every settings section below it, a `7fffffff`
chunk-size line dropped the imported flow, `Content-Length` shifting and four MCP
arguments overflowed past the clean-error handler.

False negatives, the worst outcome for a security tool. A request line that is
not three tokens turned a whole Query mine into a no-op that reported every
candidate name clean, at 100% progress with zero errors. A wildcard baseline was
elevated from a SINGLE surviving probe, turning one wordlist sweep into a
false-positive storm.

Plus: a settings file read only half-way could be written back over the
operator's real one; an OAST session with an unparseable authority killed the TUI
on the third open of the resume picker; a 101 carrying `Content-Type:
text/event-stream` left a client-abort watcher stealing the WebSocket tunnel's
bytes; a stop during fuzz or mine calibration kept sending; eleven CLI parsers
backtraced on a value flag left bare at the end of argv; `gori run discover`
exited 0 after a Ctrl-C.

Two deliberate behaviour changes, both fail-open. An intercept hold now declines
a body whose DECLARED length is over the 16 MiB rewrite ceiling and forwards it
unheld, warning once — capping the read instead would truncate the very upload
the operator wanted to edit, and it is the disposition `H2::StreamGate` already
has. A partially-loaded settings file makes `save` refuse for the rest of the
process rather than write factory defaults over what it could not read.

Known and deliberately left: `serve_short_circuit` shares the unbounded
`read_complete` the hold gate now guards — bounding it needs a drain-to-discard
rather than a gate. Chunked/unknown-length bodies stay uncapped, as
`MAX_REWRITE_BODY` already documented.

8501 examples, 0 failures. No new ameba findings (84 before and after across the
41 changed source files).
