### PR TITLE
Tell every editor which key copies, since `y` there types a `y`

### DIFF
--- a/spec/fuzz/chain_refusal_spec.cr
+++ b/spec/fuzz/chain_refusal_spec.cr
@@ -8,7 +8,7 @@ private alias F = Gori::Fuzz
 # `Template#apply_chains` returns the payload verbatim when its chain does not run, arguing
 # that a streaming fuzz run has nowhere to surface a per-position error. That was written when
 # the only way to reach it was a typo. The saved-chain library added a class that is not a
-# typo: a name the operator saved, that the `^Y` autocomplete offers and `gori run decoder
+# typo: a name the operator saved, that the `^Q` autocomplete offers and `gori run decoder
 # list` prints as an ordinary converter, and that the library registered as an always-raising
 # step precisely so the failure would be VISIBLE. Reproduced on the wire: five marked
 # positions, three naming such a chain, all three carrying the plaintext payload under

--- a/spec/fuzz_spec.cr
+++ b/spec/fuzz_spec.cr
@@ -191,7 +191,7 @@ describe F::Template do
     t = "x=§hi¦base64-encode§ y"                    # open § at 2, ¦ at 5, close § at 19
     F::Template.value_at(t, 4).should eq("hi")      # cursor in the value
     F::Template.value_at(t, 10).should eq("hi")     # cursor in the (concealed) chain
-    F::Template.marker_start_at(t, 10).should eq(2) # stable open-§ anchor for the ^Y commit
+    F::Template.marker_start_at(t, 10).should eq(2) # stable open-§ anchor for the ^Q commit
     F::Template.marker_start_at(t, 19).should eq(2) # even from the closing §
     F::Template.value_at(t, 0).should be_nil        # outside any marker
     F::Template.marker_start_at(t, 0).should be_nil

--- a/spec/tui/confirm_affirmative_spec.cr
+++ b/spec/tui/confirm_affirmative_spec.cr
@@ -25,8 +25,8 @@ describe "ConfirmDialog.affirmative?" do
   end
 
   it "refuses a modified Y — the chord the hint never advertises" do
-    # ^Y is live in the Repeater/Fuzzer panes (repeater.attach-chain), which is exactly where
-    # the marker-removal confirm appears.
+    # ^Y is live in the Repeater/Fuzzer panes — `repeater.copy`/`fuzzer.copy`, since #677 moved
+    # attach-chain to ^Q — which is exactly where the marker-removal confirm appears.
     ConfirmDialog.affirmative?(key(Termisu::Input::Key::LowerY, Termisu::Input::Modifier::Ctrl)).should be_false
     ConfirmDialog.affirmative?(key(Termisu::Input::Key::LowerY, Termisu::Input::Modifier::Alt)).should be_false
     ConfirmDialog.affirmative?(key(Termisu::Input::Key::UpperY, Termisu::Input::Modifier::Ctrl)).should be_false

--- a/spec/tui/editor_footer_copy_key_spec.cr
+++ b/spec/tui/editor_footer_copy_key_spec.cr
@@ -1,0 +1,107 @@
+require "../spec_helper"
+
+# `^Y` is Copy in every text box (see `spec/verbs/core_spec.cr` for the keymap half). The
+# footers were the half that never got told: five INS strips named it, five did not, and the
+# operator's only route to the key was reading the commit that added it.
+#
+# Both rules here are about a footer that describes a mode it is not in.
+#
+#   A. A strip that says "⇧arrows select" and names no copy key. The Fuzzer template editor
+#      was the pure case: it told you a band could be built and then named nothing that
+#      copies one, while the bare `y` the READ strip advertises is — in that mode — a literal
+#      character that REPLACES the band you just built. One keystroke, no toast, selection
+#      gone. That is the bug report `^Y` exists to answer, and the footer is where it lands.
+#
+#   B. A strip that starts with `type ` and still offers `space cmds`. JWT's HEADER, PAYLOAD
+#      and SECRET are always-typing panes (`JwtController#edit_json` / `#edit_secret` insert
+#      the character; `#handle_body_key` only defers ctrl/alt chords), so that space typed a
+#      space. It cost the one token with room to say which key copies — on the three panes
+#      where `^Y` is not the convenient copy but the ONLY one.
+#
+# Checkable in source and cheap to check, which is the reason to: these are hand-written
+# prose strings with no compiler behind them, and the pair of them drifted for ten strips.
+describe "editor key-hint strips" do
+  # Every double-quoted literal on `line`, with `#{…}` chord interpolations blanked (a hint
+  # resolves rebindable chords through `Hotkeys.binding_label`, and the token we are looking
+  # for is the prose beside it) and escaped quotes removed first, so ProjectController's
+  # `"type \"IP host\" · ↵ save · esc cancel"` reads as one literal rather than three.
+  literals = ->(line : String) do
+    code = line.gsub("\\\"", "")
+    code.scan(/"([^"]*)"/).map(&.[1].gsub(/\#\{[^}]*\}/, ""))
+  end
+
+  # A key hint, as opposed to any other string on the line: the strips are ` · `-separated
+  # and every one of them has at least two segments.
+  hint = ->(text : String) { text.includes?(" · ") }
+
+  hint_sources = Dir.glob(File.join(__DIR__, "..", "..", "src", "gori", "tui", "**", "*.cr")).sort
+
+  it "name a copy key whenever they advertise a selection" do
+    offenders = [] of String
+    hint_sources.each do |path|
+      File.read(path).lines.each_with_index do |line, i|
+        next if line.lstrip.starts_with?('#') # a comment quoting a strip is not a strip
+        literals.call(line).each do |text|
+          next unless hint.call(text) && text.includes?("⇧arrows select")
+          next if text.matches?(/\bcop(y|ies)\b/) # Help's rows say "copies", the strips say "copy"
+          offenders << "#{File.basename(path)}:#{i + 1} — #{text}"
+        end
+      end
+    end
+    offenders.should be_empty
+  end
+
+  it "do not offer the space menu from a mode where space types a space" do
+    offenders = [] of String
+    hint_sources.each do |path|
+      File.read(path).lines.each_with_index do |line, i|
+        next if line.lstrip.starts_with?('#')
+        literals.call(line).each do |text|
+          next unless hint.call(text) && text.starts_with?("type ")
+          next unless text.includes?("space cmds")
+          offenders << "#{File.basename(path)}:#{i + 1} — #{text}"
+        end
+      end
+    end
+    offenders.should be_empty
+  end
+
+  # Rule A's blind spot, closed at the file level. A strip that names NEITHER the band nor the
+  # key is silent rather than wrong, so a per-string rule cannot see it — and that is exactly
+  # how the Intercept held-bytes editor kept a registered `^Y` that nothing on screen mentioned
+  # for its whole life. Anchored to the KEYMAP rather than to a hand-kept list: a verb only
+  # earns the ctrl chord because its tab has an editor where bare `y` is a literal character,
+  # so the tab that registers one owes its operator a strip that says so, somewhere.
+  it "every tab whose Copy verb carries ^Y names it somewhere in its own footers" do
+    ids = [] of String
+    Dir.glob(File.join(__DIR__, "..", "..", "src", "gori", "verbs", "*.cr")).sort.each do |path|
+      lines = File.read(path).lines
+      lines.each_with_index do |line, i|
+        next unless m = line.match(/"([a-z]+)\.copy", "Copy"/)
+        # The chord list is the next line or two down (`Verb::Scope::X, [Chord…],`).
+        next unless (i + 1..i + 3).any? { |j| lines[j]?.try(&.includes?(%(Chord.new("y", ctrl: true)))) }
+        ids << m[1]
+      end
+    end
+    ids.should_not be_empty # the scan itself is the thing most likely to rot
+
+    # `issue` → issues_controller, `fuzzer` → fuzzer_controller; the rest are already the stem.
+    controller = ->(id : String) do
+      stem = {"issue" => "issues"}.fetch(id, id)
+      File.join(__DIR__, "..", "..", "src", "gori", "tui", "controllers", "#{stem}_controller.cr")
+    end
+
+    # CODE lines only. A comment explaining why the strip names `^Y` contains the token too,
+    # so a whole-file `includes?` passes on a controller whose strips say nothing — which is
+    # precisely the state this rule exists to fail on. (Caught by control-running the rule
+    # against the reverted Intercept strip: it passed, on the strength of its own comment.)
+    offenders = ids.reject do |id|
+      path = controller.call(id)
+      next false unless File.exists?(path)
+      File.read(path).lines.any? do |line|
+        !line.lstrip.starts_with?('#') && literals.call(line).any?(&.includes?("^Y copy"))
+      end
+    end
+    offenders.should be_empty
+  end
+end

--- a/spec/tui/fuzzer_view_spec.cr
+++ b/spec/tui/fuzzer_view_spec.cr
@@ -217,7 +217,7 @@ describe Gori::Tui::FuzzerView do
     view.focus_chain_pane.should be_nil # in a marker → enters the pane
     view.chain_pane_active?.should be_true
     "rot13".each_char { |c| view.handle_chain_pane_key(Termisu::Event::Key.new(Termisu::Input::Key::LowerA, char: c)) }
-    # While the chain is focused, the ^Y modal renders over the tab with a transform preview.
+    # While the chain is focused, the ^Q modal renders over the tab with a transform preview.
     b = MemoryBackend.new(120, 30)
     view.render(Screen.new(b), Rect.new(0, 0, 120, 30))
     grid = (0...30).map { |y| b.row(y) }.join("\n")
@@ -234,7 +234,7 @@ describe Gori::Tui::FuzzerView do
     grid2.should_not contain("§x¦rot13§")
   end
 
-  it "points a chain-less position at BOTH halves of its setup (^Y and the CONFIG pane)" do
+  it "points a chain-less position at BOTH halves of its setup (^Q and the CONFIG pane)" do
     # A marked position is only half a Fuzzer run: with no payload set in CONFIG the sweep
     # produces nothing, and the two halves live in different panes. The tooltip used to open
     # only for a marker that already HAD a `¦chain` — i.e. never on a freshly auto-marked
@@ -251,7 +251,7 @@ describe Gori::Tui::FuzzerView do
 
   # `template_scroll_view` used to bail on `template_insert?`, so the wheel died the moment `i`
   # was pressed — the same `unless insert?` the Repeater request pane shed, in the one other
-  # pane that had it. `chain_pane_active?` still bails: the ^Y sub-pane owns the wheel then.
+  # pane that had it. `chain_pane_active?` still bails: the ^Q sub-pane owns the wheel then.
   describe "#template_scroll_view" do
     seed = "GET /?x=1 HTTP/1.1\r\nHost: h\r\n" +
            (1..30).map { |i| "X-#{i}: TAG#{i}" }.join("\r\n") + "\r\n\r\n"
@@ -275,7 +275,7 @@ describe Gori::Tui::FuzzerView do
       end
     end
 
-    it "leaves the template alone while the ^Y CHAIN sub-pane owns the wheel" do
+    it "leaves the template alone while the ^Q CHAIN sub-pane owns the wheel" do
       view = FuzzerView.new
       view.load_request("https://h", "§x§ HTTP/1.1\r\nHost: h\r\n" + seed, false, "")
       view.focus_pane(:template)

--- a/spec/tui/jwt_copy_selection_spec.cr
+++ b/spec/tui/jwt_copy_selection_spec.cr
@@ -1,0 +1,252 @@
+require "../spec_helper"
+require "file_utils"
+
+include Gori::Tui
+
+# `JwtController#jwt_copy` is the whole of `^Y` on this tab: `Runner#read_copy` routes `:jwt`
+# straight here, with none of the `read_selection_active? ? copy : copy_all` branch its six
+# siblings get. So the selection-vs-whole-pane decision is this one method's — and it used to
+# make it for exactly one of the four editors.
+#
+#   * INPUT in INS copied `s.input.text`, the WHOLE token, while `jwt_selection_active?` was
+#     reporting the ⇧arrow band as live. That is the split `RepeaterView#pane_selection?`
+#     documents in its own comment: claim a selection, copy something else.
+#   * HEADER and PAYLOAD are always-typing `TextArea`s that grow a band through the same
+#     `handle_motion_key` and were never asked about one at all — and they are the panes where
+#     `^Y` is not the convenient copy but the ONLY one, since a bare `y` types a `y` there.
+#
+# The footers now name `⇧arrows select · ^Y copy` on all three (see
+# `editor_footer_copy_key_spec`), which is what makes the old behaviour a lie rather than
+# merely a gap.
+
+# The narrow shell facade a controller is given, inert except `session` + `status`. File-local
+# rather than shared, matching `jwt_lens_chip_spec` / `rewriter_preview_select_spec`: `Host`
+# is ~35 abstract methods and a shared double would be one more file to keep in sync with it.
+private class FakeHost
+  include Gori::Tui::Host
+
+  getter statuses = [] of String
+
+  def initialize(@session : Gori::Session)
+    @jobs = Gori::Tui::Jobs.new
+    @notifications = Gori::Tui::Notifications.new
+  end
+
+  def session : Gori::Session
+    @session
+  end
+
+  def jobs : Gori::Tui::Jobs
+    @jobs
+  end
+
+  def notifications : Gori::Tui::Notifications
+    @notifications
+  end
+
+  def status(message : String) : Nil
+    @statuses << message
+  end
+
+  def request_overlay(kind : Symbol) : Nil
+  end
+
+  def request_focus(pane : Symbol) : Nil
+  end
+
+  def focus_body : Nil
+  end
+
+  def switch_tab(tab : Symbol) : Nil
+  end
+
+  def goto_tab(tab : Symbol) : Nil
+  end
+
+  def open_palette : Nil
+  end
+
+  def open_space_menu : Nil
+  end
+
+  def open_fuzz_set_editor(edit_index : Int32?) : Nil
+  end
+
+  def open_fuzz_advanced_editor : Nil
+  end
+
+  def reconfigure_sequence : Nil
+  end
+
+  def open_scope_rule_editor(edit_id : Int64?, kind : String, match_type : String, pattern : String) : Nil
+  end
+
+  def open_custom_rule_editor(rule : Gori::Probe::CustomRule?) : Nil
+  end
+
+  def open_rewriter_rule_editor(rule : Gori::Store::MatchRule?) : Nil
+  end
+
+  def open_colormarker_rule_editor(rule : Gori::Store::ColorRule?) : Nil
+  end
+
+  def open_colormarker_color_editor(color : Gori::Settings::ColormarkerColor?) : Nil
+  end
+
+  def open_extract_rule_editor(rule : Gori::Store::ExtractRule?) : Nil
+  end
+
+  def open_chain_save : Nil
+  end
+
+  def open_chain_load : Nil
+  end
+
+  def open_oast_provider_editor(provider : Gori::Oast::ProviderConfig?) : Nil
+  end
+
+  def confirm(title : String, message : String, *, confirm_label : String, danger : Bool,
+              return_to : Symbol = :none, &action : -> Nil) : Nil
+    action.call
+  end
+
+  def overlay : Symbol
+    :none
+  end
+
+  def active_tab : Symbol
+    :jwt
+  end
+
+  def focus : Symbol
+    :body
+  end
+
+  def reveal? : Bool
+    false
+  end
+
+  def toggle_reveal : Nil
+  end
+
+  def pretty? : Bool
+    false
+  end
+
+  def toggle_pretty : Nil
+  end
+
+  def toggle_scope_lens : Nil
+  end
+
+  def toggle_sandbox : Nil
+  end
+
+  def apply_project_network(bind_host : String, bind_port : Int32, upstream : String,
+                            connect_secs : Int32, io_secs : Int32, capture_mib : Int32) : String
+    ""
+  end
+end
+
+# The CA is the one slow part of standing a Session up (a root keypair), and nothing here
+# asserts on it, so it is built once for the file.
+private JWT_COPY_CA = File.tempname("gori-jwt-copy-ca")
+Spec.after_suite { FileUtils.rm_rf(JWT_COPY_CA) }
+
+private def with_jwt_copy_controller(&)
+  root = File.tempname("gori-jwt-copy")
+  # `begin` opens BEFORE the tree exists, not after `Session.open`: a raise from the store
+  # migration, the CA load or the bind would otherwise leave the project directory behind,
+  # since the `after_suite` hook above covers only the shared CA. `session` is nilable for
+  # the same reason — the ensure runs on a failure that happened before it was assigned.
+  session = nil
+  begin
+    Dir.mkdir_p(root)
+    project = Gori::ProjectRegistry.new(root).temp("jwtcopy")
+    session = Gori::Session.open(Gori::Config.new(listen: "127.0.0.1", port: 0),
+      Gori::Proxy::Tls::CertAuthority.load_or_create(JWT_COPY_CA), Gori::Verbs.registry, project)
+    yield JwtController.new(FakeHost.new(session))
+  ensure
+    session.try(&.close)
+    FileUtils.rm_rf(root) if Dir.exists?(root)
+  end
+end
+
+private def key(k : Termisu::Input::Key, mods : Termisu::Input::Modifier = :none,
+                char : Char? = nil) : Termisu::Event::Key
+  Termisu::Event::Key.new(k, mods, char)
+end
+
+private TOKEN = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhIn0.sig"
+
+describe "Gori::Tui::JwtController#jwt_copy_text" do
+  describe "INPUT in INSERT" do
+    it "takes the ⇧arrow band, not the whole token" do
+      with_jwt_copy_controller do |ctl|
+        ctl.jwt_from_text(TOKEN)
+        s = ctl.@sessions[ctl.@idx]
+        ctl.handle_body_key(key(Termisu::Input::Key::LowerI, :none, 'i')) # READ → INS
+        s.input_mode.should eq(InputMode::Insert)
+        5.times { ctl.handle_body_key(key(Termisu::Input::Key::Right, :shift)) }
+
+        s.input.selection_text.should eq("eyJhb")
+        ctl.jwt_selection_active?.should be_true # what the space menu is told…
+        ctl.jwt_copy_text.should eq("eyJhb")     # …and what the copy now agrees with
+      end
+    end
+
+    # The other half of "smart copy": with no band there is nothing to narrow to, so the
+    # whole pane is the answer — `read_copy` has no `*_copy_all` branch to fall back to here.
+    it "takes the whole token when no band is live" do
+      with_jwt_copy_controller do |ctl|
+        ctl.jwt_from_text(TOKEN)
+        ctl.handle_body_key(key(Termisu::Input::Key::LowerI, :none, 'i'))
+        ctl.@sessions[ctl.@idx].input.selection?.should be_false
+        ctl.jwt_copy_text.should eq(TOKEN)
+      end
+    end
+  end
+
+  # The ENCODE lens has no READ mode: these panes always capture keys, so a bare `y` types a
+  # `y` and `^Y` is the only copy they have. They were also the two the case never asked.
+  describe "HEADER / PAYLOAD (always typing)" do
+    it "takes the band in HEADER" do
+      with_jwt_copy_controller do |ctl|
+        ctl.jwt_from_text(TOKEN)
+        ctl.load_decoded # the operator's route onto this lens: seeds the editors + focuses HEADER
+        s = ctl.@sessions[ctl.@idx]
+        s.pane.should eq(:header)
+        s.header.text.should eq(%({\n  "alg": "HS256"\n}))  # pretty-printed by load_decoded
+        ctl.handle_body_key(key(Termisu::Input::Key::Down)) # onto the claim line
+        ctl.handle_body_key(key(Termisu::Input::Key::End, :shift))
+
+        s.header.selection_text.should eq(%(  "alg": "HS256"))
+        ctl.jwt_copy_text.should eq(%(  "alg": "HS256"))
+      end
+    end
+
+    it "takes the band in PAYLOAD" do
+      with_jwt_copy_controller do |ctl|
+        ctl.jwt_from_text(TOKEN)
+        ctl.load_decoded
+        s = ctl.@sessions[ctl.@idx]
+        s.pane = :payload
+        3.times { ctl.handle_body_key(key(Termisu::Input::Key::Right, :shift)) }
+
+        band = s.payload.selection_text
+        band.should_not be_nil
+        ctl.jwt_copy_text.should eq(band)
+      end
+    end
+
+    it "falls back to the whole editor with no band" do
+      with_jwt_copy_controller do |ctl|
+        ctl.jwt_from_text(TOKEN)
+        ctl.load_decoded
+        s = ctl.@sessions[ctl.@idx]
+        s.header.selection?.should be_false
+        ctl.jwt_copy_text.should eq(s.header.text)
+      end
+    end
+  end
+end

--- a/spec/tui/repeater_view_spec.cr
+++ b/spec/tui/repeater_view_spec.cr
@@ -1263,10 +1263,10 @@ describe Gori::Tui::RepeaterView do
     # The request line renders §v§ (the ¦md5 hidden inline), never the full §v¦md5§.
     grid.should contain("§v§ HTTP/1.1")
     grid.should_not contain("§v¦md5§")
-    # ...but the caret tooltip reveals the concealed chain + the ^Y edit affordance.
+    # ...but the caret tooltip reveals the concealed chain + the ^Q edit affordance.
     grid.should contain("md5")         # chain shown in the tooltip
     grid.should contain("^Q edit")     # edit affordance
-    grid.should_not contain("PREVIEW") # the ^Y modal is NOT auto-shown
+    grid.should_not contain("PREVIEW") # the ^Q modal is NOT auto-shown
   end
 
   it "draws ^T:MARK only while the capture's § are INERT, never once they are live" do
@@ -1341,9 +1341,9 @@ describe Gori::Tui::RepeaterView do
     end
   end
 
-  it "offers ^Y over a marker that has NO chain — the state with nothing else on screen" do
+  it "offers ^Q over a marker that has NO chain — the state with nothing else on screen" do
     # The tooltip used to open only for a marker that ALREADY had a `¦chain`, i.e. it explained
-    # the case the operator had already solved and stayed silent on the one they hadn't. ^Y is
+    # the case the operator had already solved and stayed silent on the one they hadn't. ^Q is
     # the sole way into the chain editor and appears on no border, so an unchained marker had
     # no path out of itself.
     view = RepeaterView.new
@@ -1398,7 +1398,7 @@ describe Gori::Tui::RepeaterView do
     end
   end
 
-  it "opens the CHAIN modal (with a transform preview) only after ^Y" do
+  it "opens the CHAIN modal (with a transform preview) only after ^Q" do
     view = RepeaterView.new
     view.restore("https://a.test", "§v¦md5§ HTTP/1.1\nHost: a.test\n\n", false, false)
     view.focus_pane(:request)
@@ -2384,7 +2384,7 @@ describe Gori::Tui::RepeaterView do
       view.request_text.should eq(smuggle)
     end
 
-    it "the ^Y chain commit keeps the terminators" do
+    it "the ^Q chain commit keeps the terminators" do
       view = seed.call
       view.goto_request_line(1)
       view.mark_word

--- a/spec/tui/rewriter_preview_select_spec.cr
+++ b/spec/tui/rewriter_preview_select_spec.cr
@@ -291,4 +291,49 @@ describe "Gori::Tui::RewriterController preview-input selection" do
       end
     end
   end
+
+  # The band the examples above build is copyable — `rewriter_copy` has always taken it — but
+  # the footer named neither the ⇧arrows nor the key. This pane never leaves INSERT, so the
+  # `y` its OUTPUT twin one column right advertises is, here, a literal character that
+  # REPLACES the band; `^Y` is the only copy it has, and now the only copy it names.
+  describe "the footer names the copy this pane actually has" do
+    it "advertises ⇧arrows select and ^Y, not the bare y of a READ pane" do
+      with_preview_focus do |ctl|
+        hint = ctl.body_hint(:body)
+        hint.should contain("⇧arrows select")
+        hint.should contain("^Y copy")
+      end
+    end
+
+    # Through `rewriter_copy_target` — the decision `rewriter_copy` actually makes — and NOT
+    # `rewriter_selection_text`, which is the "Send selection to" payload and derives the same
+    # answer separately. Asserting the send-selection getter here would have left the copy path
+    # free to drift on the one pane whose ^Y is its only copy.
+    it "copies the band it advertises" do
+      with_preview_focus do |ctl|
+        3.times { ctl.handle_body_key(key(Termisu::Input::Key::Right, :shift)) }
+        sel, text = ctl.rewriter_copy_target
+        sel.should be_true
+        text.should eq("GET")
+      end
+    end
+
+    it "falls back to the whole sample when no band is live" do
+      with_preview_focus do |ctl|
+        sel, text = ctl.rewriter_copy_target
+        sel.should be_false
+        text.should eq(ctl.@preview_input.text)
+      end
+    end
+
+    # The chord the footer names has to answer even with nothing to take, or it reads as
+    # unbound on a pane where it is the ONLY copy.
+    it "says so instead of going silent on an empty sample" do
+      with_preview_focus do |ctl|
+        ctl.@preview_input.set_text("")
+        ctl.rewriter_copy
+        ctl.@host.as(FakeHost).statuses.last.should eq("nothing to copy")
+      end
+    end
+  end
 end

--- a/src/gori/tui/chain_overlay.cr
+++ b/src/gori/tui/chain_overlay.cr
@@ -5,7 +5,7 @@ require "./chain_pane"
 require "../decoder"
 
 module Gori::Tui
-  # The ^Y chain editor: a centered modal that edits a §…§ marker's Decoder chain AND
+  # The ^Q chain editor: a centered modal that edits a §…§ marker's Decoder chain AND
   # previews how the marker's value transforms through it (value → each step → output).
   # Replaces the old bottom CHAIN split — the inline chain is concealed now, so the
   # editing surface became a focused popup that can show the wire result before you send.

--- a/src/gori/tui/chain_peek.cr
+++ b/src/gori/tui/chain_peek.cr
@@ -5,7 +5,7 @@ module Gori::Tui
   # A caret-anchored tooltip that reveals the CONCEALED `¦chain` of the §…§ marker under
   # the cursor — the read-time counterpart to inline concealment (only `§value§` is drawn
   # in the editor; the transform chain rides here). Modelled on EnvPeek: anchored at the
-  # caret cell, flipping above/below by available room. Adds a `^Y edit` affordance so the
+  # caret cell, flipping above/below by available room. Adds a `^Q edit` affordance so the
   # (otherwise hidden) edit path stays discoverable. The owning TextArea decides whether
   # the caret sits in a chained marker and feeds the chain via `set`; this holds only open
   # state + drawing.
@@ -14,7 +14,7 @@ module Gori::Tui
     @chain = ""
     @hint = DEFAULT_HINT
 
-    # What `^Y` opens is the same everywhere, so this is the floor — but the marker under the
+    # What `^Q` opens is the same everywhere, so this is the floor — but the marker under the
     # caret means different things per surface, and the Fuzzer chains `^O` onto it (a position
     # with no payload set produces nothing, which the chain alone never says). Owner-fed.
     DEFAULT_HINT = "^Q edit"
@@ -56,7 +56,7 @@ module Gori::Tui
     end
 
     # One tooltip row: a fill band, the accent ▸ chain glyph, the chain spec, then the
-    # muted `^Y edit` hint pushed to the right edge (mirrors an EnvComplete/EnvPeek row so
+    # muted `^Q edit` hint pushed to the right edge (mirrors an EnvComplete/EnvPeek row so
     # the peek reads as the same surface).
     private def draw_row(screen : Screen, x : Int32, y : Int32, w : Int32) : Nil
       bg = Theme.elevated

--- a/src/gori/tui/controllers/fuzzer_controller.cr
+++ b/src/gori/tui/controllers/fuzzer_controller.cr
@@ -140,7 +140,12 @@ module Gori::Tui
           # `↹ text` and not `↹ pane`: Tab types a TAB here (a header value may hold one), the
           # same thing it does in the Repeater's request editor. The old wording promised a
           # focus move Tab has never made from an editor in INSERT.
-          "type · ⇧arrows select · ^Z undo · #{marks} · ^O config · #{run} run · esc read · ↹ text"
+          #
+          # `^Y copy` sits right after the select token it completes: this footer already told
+          # you a band could be built here and then named no key that copies one. In INSERT the
+          # `y` the READ footer advertises is a literal character — and typing it over the band
+          # REPLACES it, which is the whole reason `fuzzer.copy` carries a ctrl chord.
+          "type · ⇧arrows select · ^Y copy · ^Z undo · #{marks} · ^O config · #{run} run · esc read · ↹ text"
         else
           "i/↵ edit · #{read_common} · #{marks} · ^O config · #{run} run · ↹ pane · esc tabs"
         end
@@ -294,7 +299,7 @@ module Gori::Tui
     end
 
     private def handle_escape(v : FuzzerView) : Nil
-      return v.discard_chain_pane if v.chain_pane_active? # esc in the CHAIN pane → cancel + back (^Y again saves)
+      return v.discard_chain_pane if v.chain_pane_active? # esc in the CHAIN pane → cancel + back (^Q again saves)
       if v.focus == :template && v.template_insert?
         v.exit_template_insert!
       elsif v.focus == :target && v.editing_sni?
@@ -308,7 +313,7 @@ module Gori::Tui
       end
     end
 
-    # ^Y: focus the CHAIN pane for the marker under the template cursor (again = save + back).
+    # ^Q: focus the CHAIN pane for the marker under the template cursor (again = save + back).
     def fuzz_focus_chain_pane : Nil
       return unless view = current_view
       if view.chain_pane_active?

--- a/src/gori/tui/controllers/intercept_controller.cr
+++ b/src/gori/tui/controllers/intercept_controller.cr
@@ -35,7 +35,13 @@ module Gori::Tui
     def body_hint(focus : Symbol) : String
       reg = @host.session.registry
       if @intercept.editing?
-        "type to edit · ^R forward · ⇧↹/esc queue"
+        # `⇧arrows select · ^Y copy`: this editor is the one INS strip in the tree that named
+        # NEITHER, which is why the guard spec's "advertises a band, names no copy key" rule
+        # could not see it. Both are live — `handle_edit_key` routes ⇧arrows through
+        # `edit_motion_key`, and `intercept.copy` carries `^Y` on the wider `intercept_copyable?`
+        # gate precisely for this pane. Bare `y` is chordless here (the queue spends the
+        # letters) AND a literal character while typing, so `^Y` is the only copy there is.
+        "type to edit · ⇧arrows select · ^Y copy · ^R forward · ⇧↹/esc queue"
       elsif @intercept.querying?
         "type condition · ↹ complete · ↵ apply · esc clear"
       else

--- a/src/gori/tui/controllers/jwt_controller.cr
+++ b/src/gori/tui/controllers/jwt_controller.cr
@@ -402,6 +402,12 @@ module Gori::Tui
       else
         if c && !ev.ctrl? && !ev.alt?
           ed.insert(c)
+          # The ninth caller of `report_replaced` — the eight siblings have had it since #583
+          # and this arm alone skipped it, so a printable over a ⇧arrow band here cut the band
+          # with no toast and no pointer at ^Z. That is the exact keystroke `^Y` exists to
+          # spare you (`y` is a literal character on this pane), and the footer now teaches
+          # the band that makes it reachable — so the loss has to announce itself.
+          report_replaced(ed.last_replaced)
           ed.set_preedit("")
           recompute_encode(s)
         end
@@ -740,24 +746,51 @@ module Gori::Tui
       end
     end
 
-    # The unified Copy verb: selection (INPUT read) or the focused pane's content.
+    # The unified Copy verb: the selection if one is live, else the focused pane's content.
+    #
+    # EVERY editable pane consults its band, not just INPUT-in-READ. `Runner#read_copy` routes
+    # `:jwt` straight here (no `read_selection_active?` branch like the other tabs get), so the
+    # selection-vs-all decision is this method's alone — and it used to make it for exactly one
+    # of the four editors. In INS on INPUT it copied `s.input.text`, the WHOLE token, while
+    # `jwt_selection_active?` was reporting the ⇧arrow band as live: the same "claims a
+    # selection, copies something else" split `RepeaterView#pane_selection?` documents. HEADER
+    # and PAYLOAD are always-typing TextAreas that grow a band the same way and were never
+    # asked at all.
     def jwt_copy : Nil
+      do_copy(jwt_copy_text)
+    end
+
+    # What the Copy verb would put on the clipboard, without writing it — split out from
+    # `jwt_copy` for the reason every sibling tab is already split this way (`RepeaterView`
+    # has `pane_copy_text`, the controller only copies + toasts): the decision above is worth
+    # asserting on its own, and `Clipboard.copy` writes OSC 52 straight to the tty.
+    #
+    # NOT the same as `jwt_selection_text`, which is the "Send selection to" payload and
+    # deliberately answers "" on the ENCODE panes — that flow lives in the space menu, which
+    # cannot be opened from a pane where space types a space.
+    def jwt_copy_text : String
       s = cur
-      text = case s.pane
-             when :input   then s.input_mode == InputMode::Read ? s.input_read.copy_text(s.input) : s.input.text
-             when :header  then s.header.text
-             when :payload then s.payload.text
-             when :secret  then s.secret
-             when :decoded then s.decoded
-             when :output  then s.output_ok? ? s.output : ""
-             when :attacks then (a = s.attacks[s.view.attacks_selected]?) ? a.token : ""
-             else               ""
-             end
-      do_copy(text)
+      case s.pane
+      when :input   then s.input_mode == InputMode::Read ? s.input_read.copy_text(s.input) : band_or_all(s.input)
+      when :header  then band_or_all(s.header)
+      when :payload then band_or_all(s.payload)
+      when :secret  then s.secret
+      when :decoded then s.decoded
+      when :output  then s.output_ok? ? s.output : ""
+      when :attacks then (a = s.attacks[s.view.attacks_selected]?) ? a.token : ""
+      else               ""
+      end
     end
 
     def jwt_copy_all : Nil
       jwt_copy
+    end
+
+    # An editor's ⇧arrow band, or its whole buffer when no band is live — "smart copy" stated
+    # once for the three panes that share it. `TextArea#selection_text` is nil rather than ""
+    # when there is no band, so this cannot silently copy an empty string over a full buffer.
+    private def band_or_all(ed : TextArea) : String
+      ed.selection_text || ed.text
     end
 
     private def do_copy(text : String, label : String? = nil) : Nil
@@ -806,8 +839,14 @@ module Gori::Tui
       s.input_read.select_line(s.input) if s.pane == :input && s.input_mode == InputMode::Read
     end
 
+    # Clears whichever of the pane's two selection models is the live one. It used to clear
+    # `input_read` unconditionally, so in INSERT — where the band lives on `s.input`, which is
+    # what `jwt_selection_active?` reads — the verb was a no-op on the one mode that now copies
+    # by band. Same INS/READ pair `jwt_copy_text` and `jwt_selection_active?` already split on.
     def jwt_clear_selection : Nil
-      cur.input_read.clear_selection if cur.pane == :input
+      s = cur
+      return unless s.pane == :input
+      s.input_mode == InputMode::Insert ? s.input.clear_selection : s.input_read.clear_selection
     end
 
     def body_hint(focus : Symbol) : String
@@ -827,7 +866,10 @@ module Gori::Tui
       case s.pane
       when :input
         if s.input_mode == InputMode::Insert
-          "type a JWT · esc read · ↓ decoded · #{lens} encode · ^L clear · ^N new · ↑ sub-tabs"
+          # The READ arm below advertises the band and `y`; INSERT kept the band and named
+          # neither it nor the key that copies it. `y` is a literal character while typing —
+          # and typing it over the band REPLACES it — so `^Y` is the copy this mode has.
+          "type a JWT · ⇧arrows select · ^Y copy · esc read · ↓ decoded · #{lens} encode · ^L clear · ^N new · ↑ sub-tabs"
         else
           "i/↵ edit · ⇧arrows select · #{y} copy · space cmds · ↓ decoded · #{lens} encode · ^N new · esc sub-tabs"
         end
@@ -836,9 +878,17 @@ module Gori::Tui
       when :attacks
         "↑/↓ pick · ↵/#{y} copy token · space cmds · ↑-top decoded · #{lens} encode · esc sub-tabs"
       when :header, :payload
-        "type JSON · ↑/↓ move+cross · ^A alg · #{lens} decode · space cmds · esc sub-tabs"
+        # The ENCODE lens has no READ mode at all — its three panes always capture keys — so
+        # `^Y` is the ONLY copy here, and `space cmds` was a lie the moment it was written:
+        # `edit_json`/`edit_secret` insert a literal space (`handle_body_key` only defers
+        # ctrl/alt chords). Naming a menu that types a space instead of opening cost these
+        # strips the one token that had room to say which key copies.
+        "type JSON · ⇧arrows select · ^Y copy · ↑/↓ move+cross · ^A alg · #{lens} decode · esc sub-tabs"
       when :secret
-        "type secret · ^A alg (#{s.alg}) · ↑/↓ cross · #{lens} decode · space cmds · esc sub-tabs"
+        # Same trade as HEADER/PAYLOAD above, minus `⇧arrows select`: SECRET is a plain String
+        # + caret index (JwtSession#secret_cx), not a TextArea, so it has no band to grow.
+        # `^Y` still copies the whole field.
+        "type secret · ^Y copy · ^A alg (#{s.alg}) · ↑/↓ cross · #{lens} decode · esc sub-tabs"
       when :output
         "↑/↓ scroll · #{y} copy token · space cmds · ^A alg · #{lens} decode · esc sub-tabs"
       else

--- a/src/gori/tui/controllers/repeater_controller.cr
+++ b/src/gori/tui/controllers/repeater_controller.cr
@@ -291,7 +291,14 @@ module Gori::Tui
       if v.request_hex?
         "gRPC payload hex — overtype 0-9a-f · Ins/Del length · ^X/esc exit · ^R send"
       elsif v.request_insert?
-        "type head/metadata · esc read · ↹ pane"
+        # `⇧arrows select · ^Y copy` for the same reason the plain-HTTP request footer names
+        # them (see #body_hint's `:request` arm): the band is buildable in INSERT and the `y` that
+        # copies it in READ is a literal character here — one that REPLACES the selection.
+        #
+        # `↹ text`, not `↹ pane`, for the same reason as well: `editor_captures_tab?` is
+        # `request_text_editing?`, which has no gRPC arm, so Tab splices a TAB into the
+        # head/metadata. The old token promised a focus move and silently corrupted a header.
+        "type head/metadata · ⇧arrows select · ^Y copy · esc read · ↹ text"
       else
         msg = v.grpc_reframable? ? "^X hex-edit payload · " : ""
         "i/↵ edit head · #{msg}⇧arrows select · y copy · space cmds · ↹ pane"
@@ -345,7 +352,7 @@ module Gori::Tui
         view.edit_undo
       elsif key.escape?
         if (view = current_view) && view.chain_pane_active?
-          view.discard_chain_pane # esc in the CHAIN pane → cancel + back to the request editor (^Y again saves)
+          view.discard_chain_pane # esc in the CHAIN pane → cancel + back to the request editor (^Q again saves)
         elsif (view = current_view) && view.focus == :target && view.editing_sni?
           view.exit_sni_field # leave the SNI field, back to the URL (value kept)
         elsif (view = current_view) && view.focus == :request && view.request_hex?
@@ -396,7 +403,7 @@ module Gori::Tui
               "GraphQL query/vars"
             end
       mode = v.request_insert? ? "type to edit · ⇧arrows select · ^Y copy" : "i/↵ edit · ⇧arrows select · y copy · space cmds"
-      "#{mode} #{sub} · ^T switch · ^G goto · ^F find · esc read · ↹ pane"
+      "#{mode} #{sub} · ^T switch · ^G goto · ^F find · esc read · #{tab_token(v)}"
     end
 
     private def ws_hint(v : RepeaterView) : String
@@ -404,7 +411,17 @@ module Gori::Tui
       mode = v.request_insert? ? "type to edit · ⇧arrows select · ^Y copy" : "i/↵ edit · ⇧arrows select · y copy · space cmds"
       # `^V http` is listed because this key used to REFUSE here ("transport is fixed"), so
       # nothing in the tab suggested a handshake could be sent as an ordinary request.
-      "#{mode} #{sub} · ^T switch · ^V http · ^G goto · ^F find · esc read · ↹ pane"
+      "#{mode} #{sub} · ^T switch · ^V http · ^G goto · ^F find · esc read · #{tab_token(v)}"
+    end
+
+    # What Tab actually does on the REQUEST column right now. In INSERT it types a TAB
+    # (`editor_captures_tab?` → `request_text_editing?` → `request_tab_insert`), and only in
+    # READ does it advance the pane ring — so a fixed `↹ pane` on a footer that serves both
+    # modes promised a focus move and instead spliced a tab into a header value. The
+    # plain-HTTP `:request` arm has said `↹ text` since it grew its own INSERT branch; these
+    # two (and gRPC) shared one string across the modes and kept the READ token.
+    private def tab_token(v : RepeaterView) : String
+      v.request_insert? ? "↹ text" : "↹ pane"
     end
 
     # The RESPONSE column's footer on a WS tab — the twin of `ws_hint`, naming the card being

--- a/src/gori/tui/controllers/rewriter_controller.cr
+++ b/src/gori/tui/controllers/rewriter_controller.cr
@@ -369,11 +369,14 @@ module Gori::Tui
         # consumed: a caret motion, with or without a selection riding along
       else
         if (c = ev.char || key.to_char) && !ev.ctrl? && !ev.alt? && !c.control?
+          # Space included, deliberately: `Key::Space.to_char` is `' '` and `' '.control?` is
+          # false, so this arm claims it and types it. There used to be an `elsif key.space?`
+          # below opening the space menu — unreachable behind this branch, and correctly so:
+          # the sample is an HTTP message, which cannot be typed without spaces. The footer
+          # names no `space cmds` here for the same reason.
           ed.insert(c)
           report_replaced(ed.last_replaced) # a printable over a selection REPLACES it
           ed.set_preedit("")
-        elsif key.space? && !ev.ctrl? && !ev.alt?
-          @host.open_space_menu
         else
           return false
         end
@@ -545,24 +548,39 @@ module Gori::Tui
     # Same `Clipboard.copy` + status shape every other tab's copy verb uses, so the toast reads
     # the same and the OSC-52 truncation note is not re-derived here.
     def rewriter_copy : Nil
-      return unless @sub == :rules
+      sel, text = rewriter_copy_target
+      return if text.nil? # not a preview pane — the verb's gate should have caught it
+                # "nothing to copy" rather than a silent return: on the INPUT sample `^Y` is the ONLY
+                # copy and the footer names it, so an empty pane swallowing the chord reads as a dead
+                # key. Every sibling tab's `do_copy` answers here; this one returned.
+      return @host.status("nothing to copy") if text.empty?
+      written = Clipboard.copy(text)
+      note = Clipboard.note(written, text)
+      @host.status(sel ? "copied #{written}b to clipboard#{note}" : "copied all (#{written}b)#{note}")
+    end
+
+    # What `rewriter_copy` would put on the clipboard and whether it is a selection, without
+    # writing it — the JWT half of this sweep grew `jwt_copy_text` for the same reason: the
+    # decision is worth asserting on its own, and `Clipboard.copy` writes OSC 52 to the tty.
+    # `nil` text = a focus that has no copy (the rule list).
+    #
+    # This is NOT `rewriter_selection_text`, which is the "Send selection to" payload and
+    # always narrows to the band; a copy with no band falls back to the whole pane.
+    def rewriter_copy_target : {Bool, String?}
+      return {false, nil} unless @sub == :rules
       case @focus
       when :preview_in
         # The editable sample. `^Y` is the only way to copy a selection here: in INS a bare `y`
         # is a literal character, and typing it REPLACES the selection.
         sel = @preview_input.selection?
-        text = sel ? (@preview_input.selection_text || "") : @preview_input.text
+        {sel, sel ? @preview_input.selection_text : @preview_input.text}
       when :preview_out
         sync_preview_out
         sel = @out.selection?
-        text = sel ? @out.copy_text : @out.copy_all
+        {sel, sel ? @out.copy_text : @out.copy_all}
       else
-        return
+        {false, nil}
       end
-      return if text.empty?
-      written = Clipboard.copy(text)
-      note = Clipboard.note(written, text)
-      @host.status(sel ? "copied #{written}b to clipboard#{note}" : "copied all (#{written}b)#{note}")
     end
 
     # True while the OUTPUT pane is the focused one — the `available:` gate for its read verbs.
@@ -803,7 +821,10 @@ module Gori::Tui
       end
       case @focus
       when :preview_in
-        "type sample HTTP · ↑ list · ↓/→ output · esc list"
+        # This pane is ALWAYS typing — there is no READ mode to fall back to — so `^Y` is not
+        # merely the INS spelling of copy here, it is the only one (`rewriter_copy`'s
+        # `:preview_in` arm says the same). The footer named neither the band nor the key.
+        "type sample HTTP · ⇧arrows select · ^Y copy · ↑ list · ↓/→ output · esc list"
       when :preview_out
         "↑/↓ move · ⇧arrows select · y copy · x line · space cmds · ← input · esc input"
       else

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -588,7 +588,7 @@ module Gori::Tui
       @chain_focused && @focus == :template
     end
 
-    # ^Y: focus the CHAIN pane for the marker under the template cursor. Returns a hint
+    # ^Q: focus the CHAIN pane for the marker under the template cursor. Returns a hint
     # string when it can't (surfaced by the controller), nil on success.
     def focus_chain_pane : String?
       return "move to the TEMPLATE pane first (↹)" unless @focus == :template
@@ -1885,7 +1885,7 @@ module Gori::Tui
       template_read_move(dir * @editor.page_rows, 0, selecting: selecting)
     end
 
-    # `chain_pane_active?` still bails — the ^Y chain sub-pane owns the wheel while it is up,
+    # `chain_pane_active?` still bails — the ^Q chain sub-pane owns the wheel while it is up,
     # so scrolling the template underneath it would move a pane the operator is not in.
     # `template_insert?` does NOT, and that was the defect: the guard read the MODE, not the
     # pane, so the wheel died the moment `i` was pressed. Same reasoning as
@@ -2064,7 +2064,7 @@ module Gori::Tui
       return if top.h <= 0
       render_top(screen, top, focused)
       render_bottom(screen, bottom, focused) if bottom.h > 0
-      render_chain_overlay(screen, rect) if @chain_focused # centered ^Y modal ON TOP (replaces the old split)
+      render_chain_overlay(screen, rect) if @chain_focused # centered ^Q modal ON TOP (replaces the old split)
     end
 
     # The body's three horizontal bands — TARGET, the template/config row, and the
@@ -2091,12 +2091,12 @@ module Gori::Tui
       left = Rect.new(rect.x, rect.y, half, rect.h)
       right = Rect.new(rect.x + half + 1, rect.y, {rect.w - half - 1, 0}.max, rect.h)
       tmpl_focused = focused && @focus == :template
-      render_template(screen, left, tmpl_focused && !@chain_focused) # dimmed while the ^Y modal owns focus
+      render_template(screen, left, tmpl_focused && !@chain_focused) # dimmed while the ^Q modal owns focus
       render_config(screen, right, focused && @focus == :config)
     end
 
-    # The ^Y chain editor modal over the whole tab, bound to the marker the cursor sat in
-    # when ^Y was pressed. Shows the value, the editable chain, and a live transform
+    # The ^Q chain editor modal over the whole tab, bound to the marker the cursor sat in
+    # when ^Q was pressed. Shows the value, the editable chain, and a live transform
     # preview. Keys route here via the controller (chain_pane_active?).
     private def render_chain_overlay(screen : Screen, area : Rect) : Nil
       value = Fuzz::Template.value_at(@editor.text, @chain_marker_cursor) || ""
@@ -2242,11 +2242,11 @@ module Gori::Tui
       marker_regions.each_with_index do |region, i|
         a, sep, close = region
         bg << {a, close + 1, Theme.marker_bg(i)} # band spans the whole marker; the conceal-aware paint skips hidden cells
-        conceal << {sep, close} if sep < close   # hide the ¦chain inline (kept in the buffer → tooltip + ^Y overlay)
+        conceal << {sep, close} if sep < close   # hide the ¦chain inline (kept in the buffer → tooltip + ^Q overlay)
       end
       @editor.bg_regions = bg
       @editor.conceal_spans = conceal
-      # A marker WITHOUT a chain gets the tooltip too (`""` → "no chain yet · ^Y edit · ^O
+      # A marker WITHOUT a chain gets the tooltip too (`""` → "no chain yet · ^Q edit · ^O
       # sets"). That is the state a freshly auto-marked template is in for every one of its
       # positions, i.e. the one an operator meets first and the one that used to say nothing.
       # nil (caret outside every marker) still draws nothing.
@@ -3064,7 +3064,7 @@ module Gori::Tui
       top_h = rest.h if rest.h < 6
       half = {(rest.w - 1) // 2, 1}.max
       left = Rect.new(rest.x, rest.y, half, top_h)
-      commit_chain_pane if @chain_focused # a click outside the ^Y modal commits + dismisses it
+      commit_chain_pane if @chain_focused # a click outside the ^Q modal commits + dismisses it
       inner = left.inset(1, 1)
       template_insert? ? @editor.click_to_cursor(inner, mx, my) : @template_read.click(@editor, inner, mx, my)
     end

--- a/src/gori/tui/help_view.cr
+++ b/src/gori/tui/help_view.cr
@@ -113,7 +113,11 @@ module Gori::Tui
         # NOT `y · O`. The `*.copy-all` verbs are gone — `Runner#read_copy` folds it into one
         # key: `y` copies the selection if there is one, else the whole pane. The row was
         # advertising an `O` that stopped existing when they merged.
-        Item.new("y", "copy the selection — or the whole pane when nothing is selected (READ)"),
+        #
+        # `y · ^Y`: the template editor grows a ⇧arrow band in INSERT too, where a bare `y`
+        # types a `y` over it. No verb id — see the JWT row for why the key column would
+        # otherwise drop the `^Y` this row exists to name.
+        Item.new("y · ^Y", "copy selection/pane — `y` in READ, ^Y in INS too"),
         Item.new("⇧arrows", "select text (line or char)"),
         Item.new("^A · ^K · ^T", "auto-mark params · mark word · mark point (manual §)"),
         # NOT `^U clear §` — that was wrong twice over: ^U is fuzz.pretty-template (the tab's
@@ -150,6 +154,17 @@ module Gori::Tui
         Item.new("^L", "clear the session", "jwt.clear"),
         Item.new("↹", "cycle INPUT → DECODED → ATTACKS (decode) / HEADER → PAYLOAD → SECRET → OUTPUT (encode)"),
         Item.new("i / ↵", "enter INS on an editable pane · esc back to READ"),
+        # The tab had no copy row at all, and it is the one tab where the ctrl form is not a
+        # convenience: HEADER/PAYLOAD/SECRET always capture keys, so `^Y` is their ONLY copy.
+        #
+        # NO verb id, unlike the Repeater's row and matching DECODER's `INPUT INS` below:
+        # `build_rows` REPLACES the key column with `binding_label`, which answers the PRIMARY
+        # chord — so passing `jwt.copy` would print a bare `y` next to a description whose whole
+        # point is that `y` types a `y` on three of these panes. Nothing is lost by the literal:
+        # a two-chord verb is not rebindable (`Hotkeys.rebindable?` is single-chord only), so
+        # there is no override for the column to follow.
+        Item.new("y · ^Y", "copy selection/pane — `y` in READ, ^Y while typing (ENCODE panes: ^Y only)"),
+        Item.new("⇧arrows", "select text in INPUT / HEADER / PAYLOAD (not SECRET — single-line field)"),
         Item.new("↑/↓ · ↵", "attacks: select · copy the selected payload"),
         Item.new("^N / ^W", "new / close a sub-tab"),
       ]},
@@ -213,6 +228,11 @@ module Gori::Tui
         Item.new("⇧J / ⇧K", "reorder within a scope — globals apply first, then project rules"),
         Item.new("[ / ]", "switch sub-tab: rules · extract · bindings"),
         Item.new("↓ past the list", "the editable preview sample, and the same message after the rules run"),
+        # NOT "y copies the OUTPUT · ^Y copies the INPUT": `rewriter.copy` is ONE verb with two
+        # chords, and `rewriter_copy` branches on the FOCUSED PANE, not on which chord fired —
+        # `^Y` on OUTPUT copies the OUTPUT. The real split is mode, not pane: the INPUT sample
+        # is always typing, so there `y` is a literal character and `^Y` is the only copy.
+        Item.new("preview", "⇧arrows select · y copy (OUTPUT) · ^Y copy while typing (INPUT sample)"),
       ]},
       {"COLORMARKER", [
         Item.new("a · ↵/e", "add a History row-colour rule · edit the selected one"),

--- a/src/gori/tui/repeater_view.cr
+++ b/src/gori/tui/repeater_view.cr
@@ -2313,7 +2313,7 @@ module Gori::Tui
       @chain_focused && @focus == :request && !request_hex?
     end
 
-    # ^Y: drop focus into the CHAIN pane for the marker under the request cursor. Returns
+    # ^Q: drop focus into the CHAIN pane for the marker under the request cursor. Returns
     # a hint string when it can't (surfaced by the controller), nil on success.
     def focus_chain_pane : String?
       return "not available in hex edit" if request_hex?
@@ -2944,7 +2944,7 @@ module Gori::Tui
       # `switch_req_pane` can `set_text` an editor (commit/re-decode) and reset its caret.
       inner = request_sub_rect(rect, pane) || return
       switch_req_pane(pane)
-      commit_chain_pane if @chain_focused # a click outside the ^Y modal commits + dismisses it, then places the caret
+      commit_chain_pane if @chain_focused # a click outside the ^Q modal commits + dismisses it, then places the caret
       place_request_caret(inner, mx, my)
     end
 
@@ -4406,14 +4406,14 @@ module Gori::Tui
         render_request(screen, env, req_focused && @req_pane == :envelope)
         render_decoded(screen, dec, req_focused && @req_pane == :decoded)
       else
-        render_request(screen, left, req_focused && !@chain_focused) # dimmed while the ^Y modal owns focus
+        render_request(screen, left, req_focused && !@chain_focused) # dimmed while the ^Q modal owns focus
       end
       render_response(screen, right, focused && @focus == :response)
       render_chain_overlay(screen, rect) if @chain_focused # centered modal ON TOP (replaces the old split)
     end
 
-    # The ^Y chain editor: a centered modal over the whole tab, bound to the marker the
-    # cursor sat in when ^Y was pressed. Shows the marker's value, the editable chain, and
+    # The ^Q chain editor: a centered modal over the whole tab, bound to the marker the
+    # cursor sat in when ^Q was pressed. Shows the marker's value, the editable chain, and
     # a live transform preview. Keys route here via the controller (chain_pane_active?).
     private def render_chain_overlay(screen : Screen, area : Rect) : Nil
       value = Fuzz::Template.value_at(@editor.text, @chain_marker_cursor) || ""
@@ -4768,11 +4768,11 @@ module Gori::Tui
       marker_regions.each_with_index do |region, i|
         a, sep, close = region
         bg << {a, close + 1, Theme.marker_bg(i)} # band spans the whole marker; the conceal-aware paint skips hidden cells
-        conceal << {sep, close} if sep < close   # hide the ¦chain inline (kept in the buffer → tooltip + ^Y overlay)
+        conceal << {sep, close} if sep < close   # hide the ¦chain inline (kept in the buffer → tooltip + ^Q overlay)
       end
       @editor.bg_regions = bg
       @editor.conceal_spans = conceal
-      # A marker WITHOUT a chain gets the tooltip too (`""` → "no chain yet · ^Y edit"). The
+      # A marker WITHOUT a chain gets the tooltip too (`""` → "no chain yet · ^Q edit"). The
       # chain pane is reachable by exactly one key that appears nowhere on this pane, so the
       # state with no chain — the one where the operator has nothing on screen to work from —
       # was the state that said nothing at all, while a marker that already had one explained

--- a/src/gori/tui/runner/fuzzer.cr
+++ b/src/gori/tui/runner/fuzzer.cr
@@ -60,7 +60,7 @@ class Gori::Tui::Runner < Gori::Verb::ExecContext
     (v = fuzzer_controller.current_view) && (@toast = v.insert_marker)
   end
 
-  # ^Y: jump focus DOWN into the visible CHAIN pane (the marker under the template
+  # ^Q: jump focus DOWN into the visible CHAIN pane (the marker under the template
   # cursor). The controller gates on cursor-in-marker and toasts otherwise.
   def fuzz_attach_chain : Nil
     fuzzer_controller.fuzz_focus_chain_pane

--- a/src/gori/tui/runner/repeater.cr
+++ b/src/gori/tui/runner/repeater.cr
@@ -131,7 +131,7 @@ class Gori::Tui::Runner < Gori::Verb::ExecContext
     repeater_controller.repeater_clear_marks
   end
 
-  # ^Y: jump focus DOWN into the visible CHAIN pane (the marker under the cursor). The
+  # ^Q: jump focus DOWN into the visible CHAIN pane (the marker under the cursor). The
   # controller gates on the request pane + cursor-in-marker and toasts otherwise.
   def repeater_attach_chain : Nil
     repeater_controller.repeater_focus_chain_pane

--- a/src/gori/tui/text_area.cr
+++ b/src/gori/tui/text_area.cr
@@ -101,7 +101,7 @@ module Gori::Tui
       # rendered line while kept verbatim in the buffer (so `to_bytes`/send are unchanged).
       # Empty for every editor except the Repeater/Fuzzer request editors, which hide the
       # `¦chain` segment of a §…§ marker (only `§value§` shows; the chain rides a tooltip +
-      # the ^Y overlay). All column math (caret, click, h-scroll, marker band) is remapped
+      # the ^Q overlay). All column math (caret, click, h-scroll, marker band) is remapped
       # to the concealed line; when empty the widget is byte-for-byte unchanged.
       @conceal_spans = [] of {Int32, Int32}
       # The FIXED end of an INSERT-mode selection ({cy, cx}), or nil when nothing is
@@ -1244,7 +1244,7 @@ module Gori::Tui
 
     # Inverse of cursor_offset: place the caret at a flat char offset into the LF-joined
     # buffer. Used to restore the caret to a §…§ marker after a set_text that rebuilt the
-    # buffer (e.g. committing the ^Y chain edit) so the marker tooltip keeps showing.
+    # buffer (e.g. committing the ^Q chain edit) so the marker tooltip keeps showing.
     def place_at_offset(offset : Int32) : Nil
       off = {offset, 0}.max
       cy = 0
@@ -1731,7 +1731,7 @@ module Gori::Tui
       cp = @chain_peek
       return false unless cp
       chain = @chain_peek_text
-      # An EMPTY chain draws the affordance only ("no chain yet · ^Y edit"), so it YIELDS to a
+      # An EMPTY chain draws the affordance only ("no chain yet · ^Q edit"), so it YIELDS to a
       # `$KEY` peek under the same caret: `§$HOST§` is an ordinary marker, and the resolved
       # value is a datum nothing else on screen shows, where the hint is a standing reminder
       # that will be there on the next keystroke too. A non-empty chain still wins — it reveals

--- a/src/gori/tui/theme.cr
+++ b/src/gori/tui/theme.cr
@@ -1096,7 +1096,7 @@ module Gori::Tui
     # signal set apart from the plain marker_fg. Uses focus_gold (NOT accent): in the
     # monochrome palettes accent == text_bright == marker_fg, so an accent § would be
     # invisible against the rest of the marker. focus_gold is a distinct, contrast-guarded
-    # gold in every palette, and reads as actionable (matches the ^Y edit affordance).
+    # gold in every palette, and reads as actionable (matches the ^Q edit affordance).
     def self.marker_accent : Color
       focus_gold
     end


### PR DESCRIPTION
`^Y` became Copy in every text box in #677. The **footers only half followed**: five INS strips named it, five did not.

The Fuzzer template editor was the pure case — it told you a ⇧arrow band could be built and then named no key that copies one. The bare `y` its READ strip advertises is, in that mode, a literal character that **replaces** the band you just built. One keystroke, no toast, selection gone. That is the bug report `^Y` exists to answer, and the footer is where it lands.

## The strips

The axis is **a strip describing a mode it is not in**.

| Surface | Before | After |
|---|---|---|
| Fuzzer template INS | `type · ⇧arrows select · ^Z undo · …` | `… select · **^Y copy** · ^Z undo · …` |
| Repeater gRPC INS | `type head/metadata · esc read · ↹ pane` | `… · **⇧arrows select · ^Y copy** · … · ↹ text` |
| Rewriter preview INPUT | `type sample HTTP · ↑ list · …` | `… · **⇧arrows select · ^Y copy** · …` |
| JWT INPUT INS | `type a JWT · esc read · …` | `… · **⇧arrows select · ^Y copy** · …` |
| JWT HEADER / PAYLOAD | `type JSON · … · space cmds · …` | `… · **⇧arrows select · ^Y copy** · …` |
| JWT SECRET | `type secret · … · space cmds · …` | `… · **^Y copy** · …` (no band — single-line field) |
| Intercept held bytes | `type to edit · ^R forward · …` | `… · **⇧arrows select · ^Y copy** · …` |

The Intercept editor named **neither** token, which is how it kept a registered `^Y` that nothing on screen mentioned for its whole life.

On the JWT ENCODE panes and the Rewriter sample there is no READ mode at all, so `^Y` is not the convenient copy — it is the **only** one. Those same strips advertised `space cmds`, which `edit_json`/`edit_secret` insert as a literal space; the menu that never opened was spending the one token with room to say which key copies.

Shown in INS throughout rather than only while a band is live — matching the five strips that already did, and #677's own decision not to gate the key on a selection. `^Y copy` sits right after the select token so it survives an 80-column truncation.

## What the footers promised, made true

A strip that names a band the copy ignores is worse than one that names nothing.

- **`jwt_copy` consulted a band on one of its four editors.** INPUT-in-INS copied the whole token while `jwt_selection_active?` reported the band as live — the split `RepeaterView#pane_selection?` documents in its own comment. HEADER/PAYLOAD were never asked. The four sibling tabs already agreed; JWT was the outlier.
- **`jwt_clear_selection` cleared the READ model** in a mode whose band lives on the editor, so the verb was a no-op exactly where this change makes bands copy-relevant.
- **`edit_json` was the one printable arm of nine missing `report_replaced`** — typing over a band on the pane this change teaches you to build one on lost text with no toast and no pointer at `^Z`.
- **`rewriter_copy` returned without a status on an empty pane** — a dead key on a pane whose `^Y` is its only copy.

## `↹ pane` → `↹ text` on three Repeater INSERT arms

`editor_captures_tab?` is `request_text_editing?`, which has no gRPC or sub-pane exclusion, so Tab **splices a TAB into a header value**. The plain-HTTP arm has said `↹ text` since it grew its own INSERT branch; gRPC, split-decode and WS shared one string across both modes and kept the READ token.

Also retags ~24 comments and `it` descriptions still teaching `^Y` for the chain editor, which moved to `^Q` in #677 — now actively misleading, since `^Y` is live.

## Guard

`spec/tui/editor_footer_copy_key_spec.cr`, three source-grep rules:

1. a strip that advertises a band names a copy key;
2. a `type …` strip does not offer `space cmds`;
3. every tab whose Copy verb carries `^Y` names it in a strip of its own.

Rule 3 is anchored to the keymap rather than a hand-kept list, and is the one that sees a strip saying **neither** token — the Intercept shape rule 1 is structurally blind to. All three were control-run against the pre-fix strings. Rule 3 passed on its first draft because a controller's own explanatory comment contains the token, so it now reads code lines only.

These are hand-written prose strings with no compiler behind them, and the pair drifted across ten strips.

## Verification

- `crystal spec` — 8513 examples, 0 failures (the 8 `capture_status`/`project_registry` failures on this machine are a gori already holding :8070, identical before and after)
- `crystal build --no-codegen` clean; `crystal tool format src spec` clean; no new ameba findings
- Live in the TUI under tmux: Rewriter `copied 3b` on a 3-char band; JWT HEADER `copied (6b)` on a 6-char band where it would previously have said 15b; Fuzzer/JWT/Rewriter strips read as intended on screen