### PR TITLE
Cover the argument parses that produce a different run rather than an error

### DIFF
--- a/spec/cli/run/fuzz_args_spec.cr
+++ b/spec/cli/run/fuzz_args_spec.cr
@@ -1,0 +1,196 @@
+require "../../spec_helper"
+
+# `src/gori/cli/run/fuzz_args.cr` — the payload/processor flag parsers shared by
+# `gori run fuzz` and `gori run discover`.
+#
+# These decide what bytes leave the machine. Each of them has already been wrong in a way
+# that produced a QUIETLY different payload set rather than an error: `--numbers -10--5`
+# split on the first hyphen and lost its lower bound, `--regex-replace /foo//bar/` dropped
+# everything past the second delimiter, `--brute` split its charset on the wrong colon.
+# A parser that mis-reads a flag and still runs is the failure mode worth pinning, because
+# the run looks successful either way.
+#
+# The `abort` branches call `exit`, so only the success paths run here — the same limit
+# spec/cli/run/links_spec.cr works under. The parsers return payload SOURCES with no getters,
+# so each is checked through what it actually produces.
+
+# Private CLI glue — reopen the module for bare-call wrappers.
+module Gori::CLI::Run
+  def self.parse_numbers_for_spec(v : String) : Fuzz::NumberRange
+    parse_numbers(v)
+  end
+
+  def self.parse_preset_for_spec(v : String) : Fuzz::PresetSource
+    parse_preset(v)
+  end
+
+  def self.parse_brute_for_spec(v : String) : Fuzz::BruteForce
+    parse_brute(v)
+  end
+
+  def self.parse_encode_for_spec(v : String) : Symbol
+    parse_encode(v)
+  end
+
+  def self.parse_case_for_spec(v : String) : Symbol
+    parse_case(v)
+  end
+
+  def self.parse_hash_for_spec(v : String) : Symbol
+    parse_hash(v)
+  end
+
+  def self.parse_regex_for_spec(v : String) : Regex
+    parse_regex(v)
+  end
+
+  def self.parse_rate_for_spec(v : String) : Float64?
+    parse_rate(v)
+  end
+
+  def self.parse_nonneg_for_spec(v : String, flag : String? = nil) : Int32
+    parse_nonneg(v, flag)
+  end
+
+  def self.parse_regex_replace_for_spec(v : String) : Fuzz::RegexReplace
+    parse_regex_replace(v)
+  end
+end
+
+private def payloads(src : Gori::Fuzz::PayloadSource) : Array(String)
+  out = [] of String
+  src.each { |v| out << v }
+  out
+end
+
+describe "gori run fuzz --numbers" do
+  it "generates FROM-TO inclusive" do
+    payloads(Gori::CLI::Run.parse_numbers_for_spec("1-4")).should eq(%w[1 2 3 4])
+  end
+
+  it "takes an explicit :STEP" do
+    payloads(Gori::CLI::Run.parse_numbers_for_spec("0-10:5")).should eq(%w[0 5 10])
+  end
+
+  # A plain `partition('-')` splits on the FIRST hyphen, which left a negative FROM with an
+  # empty lower bound — offset and ID fuzzing both walk negative ranges routinely.
+  it "reads a negative FROM and a negative TO" do
+    payloads(Gori::CLI::Run.parse_numbers_for_spec("-2-2")).should eq(%w[-2 -1 0 1 2])
+    payloads(Gori::CLI::Run.parse_numbers_for_spec("-10--8")).should eq(%w[-10 -9 -8])
+  end
+
+  it "walks backwards on a negative step" do
+    payloads(Gori::CLI::Run.parse_numbers_for_spec("3-1:-1")).should eq(%w[3 2 1])
+  end
+
+  it "counts without iterating" do
+    Gori::CLI::Run.parse_numbers_for_spec("1-100").size.should eq(100_i64)
+    Gori::CLI::Run.parse_numbers_for_spec("0-10:5").size.should eq(3_i64)
+  end
+end
+
+describe "gori run fuzz --brute" do
+  # `rpartition`, not `partition`: the charset may itself contain a ':' (it is an arbitrary
+  # alphabet), and only the LAST one separates it from the lengths.
+  it "walks every string of length MIN..MAX over the charset" do
+    payloads(Gori::CLI::Run.parse_brute_for_spec("ab:1-2"))
+      .should eq(%w[a b aa ab ba bb])
+  end
+
+  it "reads a bare length as MIN == MAX" do
+    payloads(Gori::CLI::Run.parse_brute_for_spec("ab:2")).should eq(%w[aa ab ba bb])
+  end
+
+  it "keeps a ':' that belongs to the charset" do
+    payloads(Gori::CLI::Run.parse_brute_for_spec("a::1")).should eq(["a", ":"])
+  end
+
+  it "counts without walking" do
+    Gori::CLI::Run.parse_brute_for_spec("abc:1-3").size.should eq(3_i64 + 9 + 27)
+  end
+end
+
+describe "gori run fuzz --preset" do
+  it "resolves a built-in preset by name" do
+    name = Gori::Fuzz::Presets.names.first
+    src = Gori::CLI::Run.parse_preset_for_spec(name)
+    src.name.should eq(name)
+    src.user_path.should be_nil
+    src.size.not_nil!.should be > 0
+  end
+
+  # Split on the FIRST ':' — preset names carry none, and a unix path after it (`/tmp/a:b`)
+  # has to survive intact.
+  it "splits NAME:FILE on the first colon, keeping the rest as the path" do
+    name = Gori::Fuzz::Presets.names.first
+    src = Gori::CLI::Run.parse_preset_for_spec("#{name}:/tmp/extra:1.txt")
+    src.name.should eq(name)
+    src.user_path.should eq("/tmp/extra:1.txt")
+  end
+
+  it "leaves user_path nil when no colon is given, rather than empty" do
+    Gori::CLI::Run.parse_preset_for_spec(Gori::Fuzz::Presets.names.first).user_path.should be_nil
+  end
+end
+
+describe "gori run fuzz — processor flags" do
+  it "maps every --encode spelling, case-folded" do
+    Gori::CLI::Run.parse_encode_for_spec("url").should eq(:url)
+    Gori::CLI::Run.parse_encode_for_spec("urlall").should eq(:url_all)
+    Gori::CLI::Run.parse_encode_for_spec("base64").should eq(:base64)
+    Gori::CLI::Run.parse_encode_for_spec("HEX").should eq(:hex)
+  end
+
+  it "maps --case and --hash, case-folded" do
+    Gori::CLI::Run.parse_case_for_spec("upper").should eq(:upper)
+    Gori::CLI::Run.parse_case_for_spec("LOWER").should eq(:lower)
+    Gori::CLI::Run.parse_hash_for_spec("md5").should eq(:md5)
+    Gori::CLI::Run.parse_hash_for_spec("sha1").should eq(:sha1)
+    Gori::CLI::Run.parse_hash_for_spec("SHA256").should eq(:sha256)
+  end
+
+  it "compiles a regex flag" do
+    Gori::CLI::Run.parse_regex_for_spec("^a(b)c$").should eq(/^a(b)c$/)
+  end
+
+  # 0 means "unthrottled", and it has to arrive as nil rather than a 0.0 rate that the
+  # pacer would read as "zero requests per second".
+  it "reads --rate, turning 0 into 'no limit'" do
+    Gori::CLI::Run.parse_rate_for_spec("2.5").should eq(2.5)
+    Gori::CLI::Run.parse_rate_for_spec("0").should be_nil
+    Gori::CLI::Run.parse_rate_for_spec("0.0").should be_nil
+  end
+
+  # Unlike parse_count, zero is ALLOWED here — these flags spell "no delay", "no retries".
+  it "accepts zero as a non-negative count" do
+    Gori::CLI::Run.parse_nonneg_for_spec("0").should eq(0)
+    Gori::CLI::Run.parse_nonneg_for_spec("7", "--delay").should eq(7)
+  end
+end
+
+describe "gori run fuzz --regex-replace" do
+  it "applies /pattern/replacement/ as a gsub" do
+    Gori::CLI::Run.parse_regex_replace_for_spec("/foo/bar/").apply("foo-foo").should eq("bar-bar")
+  end
+
+  # Splitting on EVERY delimiter dropped any part of the replacement past a second one, so
+  # `/foo//bar/` silently replaced with "" instead of "/bar".
+  it "keeps a delimiter that appears inside the replacement" do
+    Gori::CLI::Run.parse_regex_replace_for_spec("/foo//bar/").apply("foo").should eq("/bar")
+  end
+
+  it "takes the first character as the delimiter, so a path pattern needs no escaping" do
+    Gori::CLI::Run.parse_regex_replace_for_spec("#/api/v1#/api/v2#").apply("GET /api/v1/x")
+      .should eq("GET /api/v2/x")
+  end
+
+  it "strips exactly one trailing delimiter, and tolerates its absence" do
+    Gori::CLI::Run.parse_regex_replace_for_spec("/a/b").apply("a").should eq("b")
+    Gori::CLI::Run.parse_regex_replace_for_spec("/a/b//").apply("a").should eq("b/")
+  end
+
+  it "carries capture groups into the replacement" do
+    Gori::CLI::Run.parse_regex_replace_for_spec("/id=(\\d+)/id=\\1\\1/").apply("id=7")
+      .should eq("id=77")
+  end
+end

--- a/spec/cli/run/list_leftovers_spec.cr
+++ b/spec/cli/run/list_leftovers_spec.cr
@@ -1,0 +1,75 @@
+require "../../spec_helper"
+
+# `CLI::Run.list_leftover_error` — the one seam behind `refuse_list_leftovers`, which twelve
+# `gori run` dispatchers call.
+#
+# The failure it exists for: every one of those dispatchers routes a first token starting
+# with '-' straight to its LIST command, on the assumption that the rest are list options.
+# So `gori run rewriter --project=t1 rm 1` — the flag-first ordering every other `gori run`
+# command accepts — discarded `rm 1`, listed the rules, and exited 0. A destructive mutation
+# that silently no-ops with a SUCCESS status is the worst thing a scripted surface can do,
+# and a script cannot see it: the exit code says the delete happened.
+#
+# `abort` is not spec-able, which is exactly why the DECISION and the MESSAGE were split out
+# into this function. Everything below drives it directly.
+
+private REWRITER_VERBS = "add, rm/delete, enable, disable, preview, extract, bindings"
+
+describe Gori::CLI::Run do
+  describe ".list_leftover_error" do
+    it "proceeds when the list command was handed no positionals at all" do
+      Gori::CLI::Run.list_leftover_error([] of String, "rewriter", REWRITER_VERBS).should be_nil
+    end
+
+    # The leading-flag route hands the list command its own name back: `cmd_issues` sees
+    # `--project=X` (not a verb token) and calls `cmd_issues_list(["--project=X", "list"])`,
+    # leaving `["list"]` as the leftover. Refusing that turned every `<cmd> --project=X list`
+    # into a usage error whose message listed `list` among the verbs it called unknown.
+    it "does not refuse a lone read verb — that is what the command was about to do anyway" do
+      Gori::CLI::Run.list_leftover_error(["list"], "issues", "create, update, delete/rm, list").should be_nil
+    end
+
+    # `gori run project sandbox` is the only one of the twelve whose read verb is not
+    # spelled `list`, which is why `read_verb` is a parameter rather than a constant.
+    it "honours a command's own read verb, and refuses another command's" do
+      Gori::CLI::Run.list_leftover_error(["status"], "project sandbox",
+        "on/enable, off/disable, status", "status").should be_nil
+
+      # `list` is not this command's read verb, so it IS a discarded verb here.
+      Gori::CLI::Run.list_leftover_error(["list"], "project sandbox",
+        "on/enable, off/disable, status", "status").should_not be_nil
+    end
+
+    it "refuses a discarded mutation verb and names the ordering that works" do
+      msg = Gori::CLI::Run.list_leftover_error(["rm", "1"], "rewriter", REWRITER_VERBS)
+      msg.should eq("gori run rewriter: unknown subcommand 'rm' — global flags go AFTER " \
+                    "the subcommand (`gori run rewriter rm … --project=NAME`). Verbs: #{REWRITER_VERBS}")
+    end
+
+    it "names the FIRST leftover, which is the position the verb was discarded from" do
+      Gori::CLI::Run.list_leftover_error(["delete", "7"], "links", "add, delete/rm, list")
+        .not_nil!.should contain("unknown subcommand 'delete'")
+    end
+
+    # Exactly one token, and exactly that word, is the exemption. `issues --project=X list rm 3`
+    # still names `list` — a real second verb followed it, so something WAS discarded.
+    it "refuses a read verb that is followed by another verb" do
+      Gori::CLI::Run.list_leftover_error(["list", "rm", "3"], "issues",
+        "create, update, delete/rm, list").not_nil!.should contain("unknown subcommand 'list'")
+    end
+
+    it "refuses a read verb repeated, since only one token is exempt" do
+      Gori::CLI::Run.list_leftover_error(["list", "list"], "links", "add, delete/rm, list").should_not be_nil
+    end
+
+    # The message carries the caller's own subcommand path and verb list, so a multi-word
+    # subcommand ("project host-override") reads as the command the operator would retype.
+    it "echoes a multi-word subcommand path verbatim in both the prose and the example" do
+      msg = Gori::CLI::Run.list_leftover_error(["add"], "project host-override",
+        "add, update, delete/rm, list").not_nil!
+      msg.should start_with("gori run project host-override: unknown subcommand 'add'")
+      msg.should contain("(`gori run project host-override add … --project=NAME`)")
+      msg.should contain("Verbs: add, update, delete/rm, list")
+    end
+  end
+end

--- a/spec/cli/run/probe_helpers_spec.cr
+++ b/spec/cli/run/probe_helpers_spec.cr
@@ -1,0 +1,142 @@
+require "../../spec_helper"
+
+# `gori run probe` — the argument parses and id decoding, which are the parts of this
+# subcommand that run before any traffic does.
+#
+# The scan itself is an active sender and is covered with the rest of them (see the header of
+# spec/cli_run_spec.cr). What is here is everything a triage command decides on its own: which
+# rule tier `--kind` names, which STORE a rule id addresses, and how a malformed query is
+# echoed back. The `abort` branches call `exit`, so only the success paths run here — the
+# same limit spec/cli/run/links_spec.cr works under.
+
+# Private CLI glue — reopen the module for bare-call wrappers.
+module Gori::CLI::Run
+  def self.parse_rule_kind_for_spec(v : String) : String
+    parse_rule_kind(v)
+  end
+
+  def self.probe_custom_row_id_for_spec(id : String) : Int64?
+    probe_custom_row_id(id)
+  end
+
+  def self.parse_probe_issue_id_for_spec(v : String?, ctx : String) : Int64?
+    parse_probe_issue_id(v, ctx)
+  end
+
+  def self.truncate_query_for_spec(q : String?) : String?
+    truncate_query(q)
+  end
+
+  def self.parse_severity_for_spec(v : String) : Store::Severity
+    parse_severity(v)
+  end
+
+  def self.parse_probe_category_for_spec(v : String) : String
+    parse_probe_category(v)
+  end
+
+  def self.probe_progress_meter_for_spec(meter : Bool) : Proc(Int32, Int32, Nil)?
+    probe_progress_meter(meter)
+  end
+end
+
+describe "gori run probe — flag parsing" do
+  it "accepts the three rule tiers, trimmed and case-folded" do
+    Gori::CLI::Run.parse_rule_kind_for_spec("passive").should eq("passive")
+    Gori::CLI::Run.parse_rule_kind_for_spec("ACTIVE").should eq("active")
+    Gori::CLI::Run.parse_rule_kind_for_spec("  custom  ").should eq("custom")
+  end
+
+  it "parses every severity level" do
+    Gori::CLI::Run.parse_severity_for_spec("info").should eq(Gori::Store::Severity::Info)
+    Gori::CLI::Run.parse_severity_for_spec("low").should eq(Gori::Store::Severity::Low)
+    Gori::CLI::Run.parse_severity_for_spec("medium").should eq(Gori::Store::Severity::Medium)
+    Gori::CLI::Run.parse_severity_for_spec("high").should eq(Gori::Store::Severity::High)
+    Gori::CLI::Run.parse_severity_for_spec("critical").should eq(Gori::Store::Severity::Critical)
+    Gori::CLI::Run.parse_severity_for_spec("CRITICAL").should eq(Gori::Store::Severity::Critical)
+  end
+
+  # The accepted set is `Probe::FILTER_CATEGORIES` itself, not a copy — so a new category
+  # becomes filterable on this surface the moment the engine grows one.
+  it "accepts every category the engine filters on, case-folded" do
+    Gori::CLI::Run::PROBE_CATEGORIES.should_not be_empty
+    Gori::CLI::Run::PROBE_CATEGORIES.each do |cat|
+      Gori::CLI::Run.parse_probe_category_for_spec(cat).should eq(cat)
+      Gori::CLI::Run.parse_probe_category_for_spec(cat.upcase).should eq(cat)
+    end
+  end
+
+  it "reads a finding id, and treats an absent flag as 'not filtered'" do
+    Gori::CLI::Run.parse_probe_issue_id_for_spec("42", "gori run probe dismiss").should eq(42_i64)
+    Gori::CLI::Run.parse_probe_issue_id_for_spec("-1", "gori run probe dismiss").should eq(-1_i64)
+    Gori::CLI::Run.parse_probe_issue_id_for_spec(nil, "gori run probe dismiss").should be_nil
+  end
+end
+
+# A custom Probe rule id says which STORE it came from: `custom_p_<rowid>` is a row in THIS
+# project's DB, `custom_g_<hex>` a global one in settings.json. Decoding a global id as a row
+# id would send a delete at whatever project row happened to share the number.
+describe "gori run probe rules — which store an id addresses" do
+  it "decodes a project custom id to its row id" do
+    Gori::CLI::Run.probe_custom_row_id_for_spec("custom_p_12").should eq(12_i64)
+    Gori::CLI::Run.probe_custom_row_id_for_spec("custom_p_1").should eq(1_i64)
+  end
+
+  it "refuses a global custom id — it is not a project DB row" do
+    Gori::CLI::Run.probe_custom_row_id_for_spec("custom_g_4f2a").should be_nil
+    Gori::CLI::Run.probe_custom_row_id_for_spec("custom_g_12").should be_nil
+  end
+
+  it "refuses a built-in rule id, which no store row backs" do
+    Gori::CLI::Run.probe_custom_row_id_for_spec("jwt_alg_none").should be_nil
+    Gori::CLI::Run.probe_custom_row_id_for_spec("cors_reflection").should be_nil
+  end
+
+  # The prefix is not enough: everything after it has to be an integer, or the id names
+  # nothing and must not be coerced into one.
+  it "refuses a project-shaped id with a non-numeric tail" do
+    Gori::CLI::Run.probe_custom_row_id_for_spec("custom_p_").should be_nil
+    Gori::CLI::Run.probe_custom_row_id_for_spec("custom_p_abc").should be_nil
+    Gori::CLI::Run.probe_custom_row_id_for_spec("custom_p_1x").should be_nil
+  end
+end
+
+# A malformed QL query can be arbitrarily large — a raw regex term, a pasted body — and it is
+# echoed back inside an error message. Enough to identify the query, not to replay it.
+describe "gori run probe — echoing a query back in an error" do
+  it "passes a short query through unchanged" do
+    Gori::CLI::Run.truncate_query_for_spec("host:example.com").should eq("host:example.com")
+    Gori::CLI::Run.truncate_query_for_spec(nil).should be_nil
+    Gori::CLI::Run.truncate_query_for_spec("").should eq("")
+  end
+
+  it "leaves a query exactly at the limit alone" do
+    q = "a" * Gori::CLI::Run::QUERY_ECHO_LIMIT
+    Gori::CLI::Run.truncate_query_for_spec(q).should eq(q)
+  end
+
+  it "clips a longer one to the limit plus an ellipsis" do
+    truncated = Gori::CLI::Run.truncate_query_for_spec("b" * (Gori::CLI::Run::QUERY_ECHO_LIMIT + 50))
+    truncated.should eq("#{"b" * Gori::CLI::Run::QUERY_ECHO_LIMIT}…")
+  end
+
+  # `q[0, LIMIT]` slices CHARACTERS, not bytes, so a multi-byte query is cut on a character
+  # boundary — slicing bytes here would emit an invalid-UTF-8 error message.
+  it "clips on a character boundary, not a byte one" do
+    q = "한" * (Gori::CLI::Run::QUERY_ECHO_LIMIT + 10)
+    truncated = Gori::CLI::Run.truncate_query_for_spec(q).not_nil!
+    truncated.valid_encoding?.should be_true
+    truncated.size.should eq(Gori::CLI::Run::QUERY_ECHO_LIMIT + 1) # + the ellipsis
+  end
+end
+
+describe "gori run probe — the scan progress meter" do
+  it "is nil when the meter is off, so the scan pays nothing per flow" do
+    Gori::CLI::Run.probe_progress_meter_for_spec(false).should be_nil
+  end
+
+  it "is a callable the scan can hand (i, n) to" do
+    meter = Gori::CLI::Run.probe_progress_meter_for_spec(true).not_nil!
+    meter.call(1, 100).should be_nil # off-beat tick: throttled, prints nothing
+  end
+end

--- a/spec/cli/run/rewriter_spec.cr
+++ b/spec/cli/run/rewriter_spec.cr
@@ -1,0 +1,360 @@
+require "../../spec_helper"
+require "json"
+
+# `gori run rewriter` — the Match & Replace CLI, plus the `extract` sub-CRUD that mints
+# session bindings (#501).
+#
+# What is under test here is the part of the subcommand that has no I/O: the flag → enum
+# parses, the row/JSON projections a script reads, and the refusals `add` makes before a
+# rule ever reaches a store. That is where this surface can be wrong quietly — a rule row
+# that prints the wrong scope letter addresses a different store than the operator's next
+# command does, and a JSON field that changes name breaks a script with no error anywhere.
+#
+# The `abort` branches (`--scope=nope`, `--range=x`, an unparseable stub) are NOT reachable
+# from a spec: `abort` calls `exit`, which would take the whole suite down. Only success
+# paths run here, the same limit spec/cli/run/links_spec.cr works under.
+
+# Private CLI glue — reopen the module for bare-call wrappers.
+module Gori::CLI::Run
+  def self.parse_rule_scope_for_spec(s : String) : Store::RuleScope
+    parse_rule_scope(s)
+  end
+
+  def self.parse_rewriter_op_for_spec(s : String) : Store::RuleOp
+    parse_rewriter_op(s)
+  end
+
+  def self.rewriter_op_tag_for_spec(r : Store::MatchRule) : String
+    rewriter_op_tag(r)
+  end
+
+  def self.rewriter_rule_body_for_spec(r : Store::MatchRule) : String
+    rewriter_rule_body(r)
+  end
+
+  def self.rewriter_rule_row_for_spec(r : Store::MatchRule) : String
+    rewriter_rule_row(r)
+  end
+
+  def self.rewriter_rule_json_for_spec(r : Store::MatchRule) : String
+    JSON.build { |j| rewriter_rule_json(j, r) }
+  end
+
+  def self.extract_rule_row_for_spec(r : Store::ExtractRule) : String
+    extract_rule_row(r)
+  end
+
+  def self.extract_rule_json_for_spec(r : Store::ExtractRule) : String
+    JSON.build { |j| extract_rule_json(j, r) }
+  end
+
+  def self.parse_extract_range_for_spec(raw : String) : {Int32, Int32}
+    parse_extract_range(raw)
+  end
+
+  def self.check_short_circuit_args_for_spec(op : Store::RuleOp, value : String,
+                                             response_file : String?, body_file : String) : String
+    check_short_circuit_args(op, value, response_file, body_file)
+  end
+
+  def self.check_ws_part_for_spec(op : Store::RuleOp, part : Store::RulePart, verb : String) : Nil
+    check_ws_part(op, part, verb)
+  end
+
+  def self.valid_regex_for_spec?(pattern : String) : Bool
+    valid_regex?(pattern)
+  end
+
+  def self.read_stub_response_for_spec(path : String) : String
+    read_stub_response(path)
+  end
+end
+
+private def rule(id = 1_i64, enabled = true,
+                 target = Gori::Store::RuleTarget::Request,
+                 part = Gori::Store::RulePart::Head,
+                 pattern = "old", replacement = "new",
+                 op = Gori::Store::RuleOp::Replace,
+                 match_kind = Gori::Store::MatchKind::Literal,
+                 name = "", host = "", body_file = "",
+                 scope = Gori::Store::RuleScope::Project,
+                 overridden = false) : Gori::Store::MatchRule
+  Gori::Store::MatchRule.new(id, enabled, target, part, pattern, replacement,
+    op, match_kind, name, host, body_file, scope, overridden)
+end
+
+private def extract_rule(id = 1_i64, enabled = true, name = "SESSION", match_filter = "",
+                         kind = Gori::ExtractKind::Cookie, selector = "sid",
+                         pos_start = 0, pos_end = 0, host = "") : Gori::Store::ExtractRule
+  Gori::Store::ExtractRule.new(id, enabled, name, match_filter, kind,
+    selector, pos_start, pos_end, host)
+end
+
+describe "gori run rewriter — flag parsing" do
+  it "parses both --scope spellings, case-insensitively" do
+    Gori::CLI::Run.parse_rule_scope_for_spec("project").project?.should be_true
+    Gori::CLI::Run.parse_rule_scope_for_spec("global").global?.should be_true
+    Gori::CLI::Run.parse_rule_scope_for_spec("GLOBAL").global?.should be_true
+    Gori::CLI::Run.parse_rule_scope_for_spec("Project").project?.should be_true
+  end
+
+  # Unlike `RuleScope.from_label` (tolerant: unknown → Project, the safe direction for a
+  # STORED label), the CLI parse aborts on an unknown word. A typo'd `--op` must not
+  # silently create a `replace` rule the operator did not ask for.
+  it "parses every --op label, case-insensitively" do
+    Gori::CLI::Run.parse_rewriter_op_for_spec("replace").should eq(Gori::Store::RuleOp::Replace)
+    Gori::CLI::Run.parse_rewriter_op_for_spec("add_header").should eq(Gori::Store::RuleOp::AddHeader)
+    Gori::CLI::Run.parse_rewriter_op_for_spec("set_header").should eq(Gori::Store::RuleOp::SetHeader)
+    Gori::CLI::Run.parse_rewriter_op_for_spec("remove_header").should eq(Gori::Store::RuleOp::RemoveHeader)
+    Gori::CLI::Run.parse_rewriter_op_for_spec("short_circuit").should eq(Gori::Store::RuleOp::ShortCircuit)
+    Gori::CLI::Run.parse_rewriter_op_for_spec("SHORT_CIRCUIT").should eq(Gori::Store::RuleOp::ShortCircuit)
+  end
+
+  it "reads an empty --range as 'no range', and A:B as a half-open pair" do
+    Gori::CLI::Run.parse_extract_range_for_spec("").should eq({0, 0})
+    Gori::CLI::Run.parse_extract_range_for_spec("3:9").should eq({3, 9})
+    Gori::CLI::Run.parse_extract_range_for_spec("0:1").should eq({0, 1})
+  end
+
+  it "answers whether --find compiles as a regex without raising out of the parse" do
+    Gori::CLI::Run.valid_regex_for_spec?("^sess_[0-9a-f]{8}$").should be_true
+    Gori::CLI::Run.valid_regex_for_spec?("(unclosed").should be_false
+    Gori::CLI::Run.valid_regex_for_spec?("a{2,1}").should be_false
+  end
+end
+
+describe "gori run rewriter — rule rows" do
+  # The op tag is the only thing in the row that says WHICH part a replace rule rewrites,
+  # so a ws rule rendering as `sub/H` would read as an HTTP head rule — the exact confusion
+  # RulePart#badge is exhaustive to prevent.
+  it "tags every op, carrying the match kind and part for a replace" do
+    Gori::CLI::Run.rewriter_op_tag_for_spec(rule).should eq("sub/H")
+    Gori::CLI::Run.rewriter_op_tag_for_spec(rule(part: Gori::Store::RulePart::Body)).should eq("sub/B")
+    Gori::CLI::Run.rewriter_op_tag_for_spec(rule(part: Gori::Store::RulePart::Ws)).should eq("sub/W")
+    Gori::CLI::Run.rewriter_op_tag_for_spec(
+      rule(match_kind: Gori::Store::MatchKind::Regex)).should eq("re/H")
+    Gori::CLI::Run.rewriter_op_tag_for_spec(
+      rule(match_kind: Gori::Store::MatchKind::Regex, part: Gori::Store::RulePart::Body)).should eq("re/B")
+
+    Gori::CLI::Run.rewriter_op_tag_for_spec(rule(op: Gori::Store::RuleOp::AddHeader)).should eq("+hdr")
+    Gori::CLI::Run.rewriter_op_tag_for_spec(rule(op: Gori::Store::RuleOp::SetHeader)).should eq("~hdr")
+    Gori::CLI::Run.rewriter_op_tag_for_spec(rule(op: Gori::Store::RuleOp::RemoveHeader)).should eq("-hdr")
+    Gori::CLI::Run.rewriter_op_tag_for_spec(rule(op: Gori::Store::RuleOp::ShortCircuit)).should eq("stub")
+  end
+
+  it "prints the pattern alone for remove_header, which has no replacement" do
+    Gori::CLI::Run.rewriter_rule_body_for_spec(
+      rule(op: Gori::Store::RuleOp::RemoveHeader, pattern: "X-Trace", replacement: "")).should eq("X-Trace")
+  end
+
+  # `=>` not `->`: a stub ANSWERS instead of forwarding, and the body is summarised rather
+  # than printed — a canned response is a whole HTTP message and would swallow the row.
+  it "summarises a short-circuit stub with => instead of ->" do
+    Gori::CLI::Run.rewriter_rule_body_for_spec(
+      rule(op: Gori::Store::RuleOp::ShortCircuit, pattern: "/admin",
+        replacement: "200 OK\n\nhi")).should eq("/admin => 200 OK · 2B inline")
+
+    Gori::CLI::Run.rewriter_rule_body_for_spec(
+      rule(op: Gori::Store::RuleOp::ShortCircuit, pattern: "/admin",
+        replacement: "404", body_file: "/tmp/stub.json"))
+      .should eq("/admin => 404 Not Found · file:/tmp/stub.json") # bare status → registered phrase
+
+    Gori::CLI::Run.rewriter_rule_body_for_spec(
+      rule(op: Gori::Store::RuleOp::ShortCircuit, pattern: "/admin",
+        replacement: "not a status line")).should eq("/admin => (unparseable stub response)")
+  end
+
+  it "prints pattern -> replacement for the four rewrite ops" do
+    Gori::CLI::Run.rewriter_rule_body_for_spec(rule(pattern: "a", replacement: "b")).should eq("a -> b")
+    Gori::CLI::Run.rewriter_rule_body_for_spec(
+      rule(op: Gori::Store::RuleOp::AddHeader, pattern: "X-T", replacement: "1")).should eq("X-T -> 1")
+  end
+
+  # The scope letter LEADS the row because the two stores number independently: `#3` alone
+  # does not say which rule `gori run rewriter rm 3` would address.
+  it "leads a row with the scope badge, and marks a project override with *" do
+    Gori::CLI::Run.rewriter_rule_row_for_spec(rule(id: 3_i64))
+      .should eq("P#3 [x] REQ sub/H  old -> new")
+
+    Gori::CLI::Run.rewriter_rule_row_for_spec(
+      rule(id: 3_i64, scope: Gori::Store::RuleScope::Global))
+      .should eq("G#3 [x] REQ sub/H  old -> new")
+
+    Gori::CLI::Run.rewriter_rule_row_for_spec(
+      rule(id: 3_i64, scope: Gori::Store::RuleScope::Global, overridden: true, enabled: false))
+      .should eq("G*#3 [ ] REQ sub/H  old -> new")
+  end
+
+  it "shows the side, the disabled mark, and the optional name/host" do
+    Gori::CLI::Run.rewriter_rule_row_for_spec(
+      rule(id: 7_i64, enabled: false, target: Gori::Store::RuleTarget::Response,
+        name: "strip csp", host: "*.corp.internal",
+        op: Gori::Store::RuleOp::RemoveHeader, pattern: "Content-Security-Policy", replacement: ""))
+      .should eq("P#7 [ ] RES -hdr  [strip csp] @*.corp.internal  Content-Security-Policy")
+  end
+
+  # ljust(5) is what keeps the body column aligned across ops; the shortest tag is 4 chars.
+  it "pads the op tag so the body column lines up across ops" do
+    rows = [
+      Gori::CLI::Run.rewriter_rule_row_for_spec(rule(op: Gori::Store::RuleOp::AddHeader)),
+      Gori::CLI::Run.rewriter_rule_row_for_spec(rule),
+    ]
+    rows.map(&.index("  old")).uniq!.size.should eq(1)
+  end
+end
+
+describe "gori run rewriter --format=json" do
+  # A script reads these names. `enabled` is the EFFECTIVE state in this project; the two
+  # override fields exist only where the two answers can differ.
+  it "omits overridden/default_enabled for a project rule, which has no default" do
+    j = JSON.parse(Gori::CLI::Run.rewriter_rule_json_for_spec(
+      rule(id: 4_i64, name: "n", host: "h", pattern: "p", replacement: "r")))
+    j["id"].as_i64.should eq(4)
+    j["scope"].as_s.should eq("project")
+    j["enabled"].as_bool.should be_true
+    j["target"].as_s.should eq("request")
+    j["part"].as_s.should eq("head")
+    j["op"].as_s.should eq("replace")
+    j["match"].as_s.should eq("literal")
+    j["name"].as_s.should eq("n")
+    j["host"].as_s.should eq("h")
+    j["pattern"].as_s.should eq("p")
+    j["replacement"].as_s.should eq("r")
+    j["body_file"].as_s.should eq("")
+    j.as_h.has_key?("overridden").should be_false
+    j.as_h.has_key?("default_enabled").should be_false
+  end
+
+  # `default_enabled` is read back out of the global library, so a rule this project has
+  # switched OFF still reports the library's ON — that difference is the whole point of the
+  # field, and a script that only read `enabled` could not tell an override from a default.
+  it "reports a global rule's own default beside this project's effective state" do
+    before = Gori::Settings.rewriter_rules
+    begin
+      Gori::Settings.rewriter_rules = [
+        Gori::Settings::RewriterRule.new(9_i64, true, "lib", "request", "head",
+          "old", "new", "replace", "literal", "", ""),
+      ]
+      j = JSON.parse(Gori::CLI::Run.rewriter_rule_json_for_spec(
+        rule(id: 9_i64, enabled: false, scope: Gori::Store::RuleScope::Global, overridden: true)))
+      j["scope"].as_s.should eq("global")
+      j["enabled"].as_bool.should be_false        # off HERE
+      j["overridden"].as_bool.should be_true      # …because this project said so
+      j["default_enabled"].as_bool.should be_true # the library still says on
+    ensure
+      Gori::Settings.rewriter_rules = before
+    end
+  end
+
+  # A global rule whose id is not in the library any more (deleted between the read and the
+  # render) must still produce a row rather than raising — `find` yields nil, and the field
+  # says so instead of guessing a default.
+  it "emits a null default_enabled for a global id the library no longer has" do
+    before = Gori::Settings.rewriter_rules
+    begin
+      Gori::Settings.rewriter_rules = [] of Gori::Settings::RewriterRule
+      j = JSON.parse(Gori::CLI::Run.rewriter_rule_json_for_spec(
+        rule(id: 9_i64, scope: Gori::Store::RuleScope::Global)))
+      j["default_enabled"].raw.should be_nil
+    ensure
+      Gori::Settings.rewriter_rules = before
+    end
+  end
+end
+
+describe "gori run rewriter extract" do
+  it "renders a rule as name <- condition <- where, with the disabled mark and host" do
+    Gori::CLI::Run.extract_rule_row_for_spec(extract_rule(id: 3_i64))
+      .should eq(%(#3 [x] $SESSION <- any message <- cookie "sid"))
+
+    Gori::CLI::Run.extract_rule_row_for_spec(
+      extract_rule(id: 4_i64, enabled: false, match_filter: "status:200 AND path:/login",
+        host: "acme.test"))
+      .should eq(%(#4 [ ] $SESSION <- status:200 AND path:/login <- cookie "sid" @acme.test))
+  end
+
+  # An empty filter is "read every message", not "read none" — printing the empty string
+  # would read as a rule that can never fire.
+  it "spells an empty --when as 'any message'" do
+    Gori::CLI::Run.extract_rule_row_for_spec(extract_rule).should contain("<- any message <-")
+  end
+
+  it "names each extract kind the way the descriptor editor does" do
+    Gori::CLI::Run.extract_rule_row_for_spec(
+      extract_rule(kind: Gori::ExtractKind::Header, selector: "X-Token")).should contain("<- header X-Token")
+    Gori::CLI::Run.extract_rule_row_for_spec(
+      extract_rule(kind: Gori::ExtractKind::Regex, selector: "tok=(\\w+)")).should contain("<- regex /tok=(\\w+)/")
+    Gori::CLI::Run.extract_rule_row_for_spec(
+      extract_rule(kind: Gori::ExtractKind::Position, selector: "", pos_start: 3, pos_end: 9))
+      .should contain("<- body[3...9]")
+    Gori::CLI::Run.extract_rule_row_for_spec(
+      extract_rule(kind: Gori::ExtractKind::JsonPath, selector: "data.token")).should contain("<- jsonpath data.token")
+  end
+
+  # `when`, not `match_filter`: the JSON field mirrors the FLAG (`--when`), which is what a
+  # script author has in front of them.
+  it "emits the flag spellings as JSON field names" do
+    j = JSON.parse(Gori::CLI::Run.extract_rule_json_for_spec(
+      extract_rule(id: 5_i64, enabled: false, name: "CSRF", match_filter: "path:/login",
+        kind: Gori::ExtractKind::Position, selector: "", pos_start: 3, pos_end: 9, host: "acme.test")))
+    j["id"].as_i64.should eq(5)
+    j["enabled"].as_bool.should be_false
+    j["name"].as_s.should eq("CSRF")
+    j["when"].as_s.should eq("path:/login")
+    j["host"].as_s.should eq("acme.test")
+    j["kind"].as_s.should eq("position")
+    j["selector"].as_s.should eq("")
+    j["pos_start"].as_i.should eq(3)
+    j["pos_end"].as_i.should eq(9)
+  end
+end
+
+describe "gori run rewriter add — the refusals before a rule is stored" do
+  it "passes a non-short-circuit value through untouched" do
+    Gori::CLI::Run.check_short_circuit_args_for_spec(
+      Gori::Store::RuleOp::Replace, "new", nil, "").should eq("new")
+    Gori::CLI::Run.check_short_circuit_args_for_spec(
+      Gori::Store::RuleOp::AddHeader, "1", nil, "").should eq("1")
+  end
+
+  it "keeps an inline stub that parses" do
+    stub = "200 OK\nContent-Type: application/json\n\n{\"isAdmin\": true}"
+    Gori::CLI::Run.check_short_circuit_args_for_spec(
+      Gori::Store::RuleOp::ShortCircuit, stub, nil, "").should eq(stub)
+  end
+
+  # --response-file wins over --value: the canned response is multi-line and awkward on a
+  # command line, which is the whole reason the flag exists.
+  it "reads --response-file in place of --value, byte for byte" do
+    path = File.tempname("gori-stub", ".http")
+    begin
+      File.write(path, "403 Forbidden\r\nX-Stub: 1\r\n\r\nnope\n")
+      Gori::CLI::Run.check_short_circuit_args_for_spec(
+        Gori::Store::RuleOp::ShortCircuit, "ignored", path, "")
+        .should eq("403 Forbidden\r\nX-Stub: 1\r\n\r\nnope\n")
+      Gori::CLI::Run.read_stub_response_for_spec(path).should eq("403 Forbidden\r\nX-Stub: 1\r\n\r\nnope\n")
+    ensure
+      File.delete?(path)
+    end
+  end
+
+  # A `--body-file` on a short-circuit rule is legal (it is the stub's body source) and is
+  # NOT read here — it is read per request, so a file written later is a normal way to work.
+  it "accepts a body-file on a short-circuit rule without reading it" do
+    Gori::CLI::Run.check_short_circuit_args_for_spec(
+      Gori::Store::RuleOp::ShortCircuit, "204 No Content", nil, "/does/not/exist/yet")
+      .should eq("204 No Content")
+  end
+
+  # Only `replace` acts on a WebSocket message. The other four are refused rather than
+  # normalised — `Rules.normalize_shape` would coerce the part to `head`, moving the rule to
+  # a different PROTOCOL with nothing on screen to say so.
+  it "allows --part=ws for replace, and any part for an op that stays on the head" do
+    Gori::CLI::Run.check_ws_part_for_spec(
+      Gori::Store::RuleOp::Replace, Gori::Store::RulePart::Ws, "add").should be_nil
+    Gori::CLI::Run.check_ws_part_for_spec(
+      Gori::Store::RuleOp::AddHeader, Gori::Store::RulePart::Head, "add").should be_nil
+    Gori::CLI::Run.check_ws_part_for_spec(
+      Gori::Store::RuleOp::ShortCircuit, Gori::Store::RulePart::Head, "preview").should be_nil
+  end
+end

--- a/spec/cli_run_spec.cr
+++ b/spec/cli_run_spec.cr
@@ -5,14 +5,22 @@ require "json"
 #
 # MOVED to spec/cli/run/<subcommand>_spec.cr, mirroring src/gori/cli/run/:
 #   history · sitemap · notes · issues · links · decoder · jwt · compare · project · import
+#   · rewriter (incl. the `extract` sub-CRUD)
 #   plus spec/cli/run/replay_reconstruct_spec.cr — the P7 "never reject malformed input on
-#   replay" invariant over Repeater::FlowRequest's HOSTILE inputs.
+#   replay" invariant over Repeater::FlowRequest's HOSTILE inputs, and two seams that cut
+#   ACROSS subcommands: spec/cli/run/list_leftovers_spec.cr (the discarded-verb refusal all
+#   twelve list dispatchers share) and spec/cli/run/fuzz_args_spec.cr (the payload flag
+#   parsers `fuzz` and `discover` share).
+#
+# PARTLY moved: the active-sender subcommands whose pure ARGUMENT parsing does not wait on
+# the sender — spec/cli/run/probe_helpers_spec.cr covers `probe`'s flag parses and rule-id
+# decoding, while its scan stays below.
 #
 # STILL HERE, and why:
 #   • describe Gori::Repeater::FlowRequest — the WELL-FORMED reconstruct cases (absolute→
 #     origin rewrite, http2 flag, truncated-capture Content-Length/chunked re-frame).
 #   • describe Gori::CLI::Output — the probe group JSON/text rows. `gori run probe` is an
-#     active-sender subcommand, so its spec waits with the rest of them.
+#     active-sender subcommand, so the SCAN's spec waits with the rest of them.
 #   • describe Gori::Notes — the notes ENGINE (parse/serialize/load/title/line_count), not
 #     the `gori run notes` output; spec/cli/run/notes_spec.cr covers the CLI formatting.
 #   • The active-sender subcommands: repeater send (h1/WS), fuzz/mine/sequence host

--- a/spec/rules_spec.cr
+++ b/spec/rules_spec.cr
@@ -589,4 +589,45 @@ describe Gori::Rules do
       end
     end
   end
+
+  # The one place a rule's {target, part} pair is settled, and every surface that creates or
+  # previews a rule calls it — the TUI's Rewriter form, `gori run rewriter add|preview`, and
+  # the MCP `create_rule`/`preview_rule` tools. If a surface skipped it, a header op stored
+  # with `part: body` would be persisted as a body rule and cost every matching message a
+  # buffer-and-reframe on the proxy hot path, to do a header edit that reads the head.
+  describe ".normalize_shape" do
+    it "forces a header op onto the head, whatever part was asked for" do
+      [Gori::Store::RuleOp::AddHeader, Gori::Store::RuleOp::SetHeader,
+       Gori::Store::RuleOp::RemoveHeader].each do |op|
+        Gori::Rules.normalize_shape(op, Gori::Store::RuleTarget::Response,
+          Gori::Store::RulePart::Body)
+          .should eq({Gori::Store::RuleTarget::Response, Gori::Store::RulePart::Head})
+      end
+    end
+
+    # A header op keeps its SIDE — "strip Content-Security-Policy" is a response rule and
+    # "add X-Trace" a request one. Only the part is decided here.
+    it "leaves a header op's target alone" do
+      Gori::Rules.normalize_shape(Gori::Store::RuleOp::AddHeader,
+        Gori::Store::RuleTarget::Request, Gori::Store::RulePart::Ws)
+        .should eq({Gori::Store::RuleTarget::Request, Gori::Store::RulePart::Head})
+    end
+
+    # A stub ANSWERS a request, so both halves are fixed: a response-side or body-part stub
+    # names a message that, by the time the rule fires, does not exist.
+    it "pins a short-circuit rule to the request head on both axes" do
+      Gori::Rules.normalize_shape(Gori::Store::RuleOp::ShortCircuit,
+        Gori::Store::RuleTarget::Response, Gori::Store::RulePart::Body)
+        .should eq({Gori::Store::RuleTarget::Request, Gori::Store::RulePart::Head})
+    end
+
+    it "passes a replace rule through untouched on every part, including ws" do
+      [Gori::Store::RulePart::Head, Gori::Store::RulePart::Body, Gori::Store::RulePart::Ws].each do |part|
+        [Gori::Store::RuleTarget::Request, Gori::Store::RuleTarget::Response].each do |target|
+          Gori::Rules.normalize_shape(Gori::Store::RuleOp::Replace, target, part)
+            .should eq({target, part})
+        end
+      end
+    end
+  end
 end

--- a/spec/settings_scan_rules_spec.cr
+++ b/spec/settings_scan_rules_spec.cr
@@ -1,0 +1,325 @@
+require "./spec_helper"
+require "file_utils"
+
+# `Settings.scan_rules` — the GLOBAL user-defined Probe match rules (settings:probe rules →
+# global scope), the library half of the same global-base/project-layer split
+# `Settings.rewriter_rules` and `Env.effective_vars` rest on.
+#
+# Two things make this worth its own file. The parse is the boundary a HAND-EDITED
+# settings.json crosses on its way into the match engine: `Probe.custom_rules` maps these
+# straight into the runtime match list, and `ScanRule#side/region/kind/severity` are read as
+# though they were enums. A file that smuggles `"side": "whatever"` past this parse gets a
+# rule that matches nothing, or matches the wrong half of the message, with nothing on any
+# surface to say so — so the clamp is the whole contract. And every CRUD call persists
+# through `save`'s 3-way merge, where an emptied section is the case that has silently
+# undone deletions before (see the `chosen` comment in Settings.merge_with_disk).
+
+# Every example here writes process-wide Settings state and a real settings.json, so each
+# one owns a temp GORI_HOME and puts back the scan rules it found.
+private def with_scan_home(&)
+  dir = File.tempname("gori-scan-rules")
+  Dir.mkdir_p(dir)
+  prev_home = ENV["GORI_HOME"]?
+  before = Gori::Settings.scan_rules
+  begin
+    ENV["GORI_HOME"] = dir
+    Gori::Settings.scan_rules = [] of Gori::Settings::ScanRule
+    yield dir
+  ensure
+    prev_home ? (ENV["GORI_HOME"] = prev_home) : ENV.delete("GORI_HOME")
+    Gori::Settings.scan_rules = before
+    FileUtils.rm_rf(dir)
+  end
+end
+
+private def write_settings(json : String) : Nil
+  File.write(Gori::Settings.path, json)
+end
+
+describe Gori::Settings do
+  describe "scan_rules — the parse a hand-edited file crosses" do
+    it "reads a complete rule field for field" do
+      with_scan_home do
+        write_settings(<<-JSON)
+          {"scan_rules":[{"id":"a1","title":"Leaked key","description":"d",
+            "side":"request","region":"header","kind":"regex","pattern":"sk_live_\\\\w+",
+            "severity":"critical","enabled":false}]}
+          JSON
+        Gori::Settings.load
+        r = Gori::Settings.scan_rules.first
+        {r.id, r.title, r.description}.should eq({"a1", "Leaked key", "d"})
+        {r.side, r.region, r.kind}.should eq({"request", "header", "regex"})
+        {r.pattern, r.severity, r.enabled}.should eq({"sk_live_\\w+", "critical", false})
+      end
+    end
+
+    # id/title/pattern are the three a rule cannot be reconstructed without: no id and no
+    # surface can address it, no pattern and it matches nothing. Dropped rather than
+    # defaulted — a rule with an invented pattern would scan live traffic for it.
+    it "drops an entry missing (or blanking) id, title or pattern" do
+      with_scan_home do
+        write_settings(<<-JSON)
+          {"scan_rules":[
+            {"title":"no id","pattern":"p"},
+            {"id":"b","pattern":"p"},
+            {"id":"c","title":"no pattern"},
+            {"id":"","title":"blank id","pattern":"p"},
+            {"id":"e","title":"","pattern":"p"},
+            {"id":"f","title":"blank pattern","pattern":""},
+            {"id":"ok","title":"kept","pattern":"p"}
+          ]}
+          JSON
+        Gori::Settings.load
+        Gori::Settings.scan_rules.map(&.id).should eq(["ok"])
+      end
+    end
+
+    # The clamp is what makes ScanRule's four label fields total. Each falls back to the
+    # SAFEST choice rather than the first member: a response/body/string/info rule reads
+    # the half of a message the operator most likely meant and files at the lowest severity.
+    it "clamps an unknown side/region/kind/severity to its default" do
+      with_scan_home do
+        write_settings(<<-JSON)
+          {"scan_rules":[{"id":"x","title":"t","pattern":"p",
+            "side":"sideways","region":"middle","kind":"glob","severity":"catastrophic"}]}
+          JSON
+        Gori::Settings.load
+        r = Gori::Settings.scan_rules.first
+        {r.side, r.region, r.kind, r.severity}.should eq({"response", "body", "string", "info"})
+      end
+    end
+
+    it "clamps a non-string (or absent) enum field the same way" do
+      with_scan_home do
+        write_settings(<<-JSON)
+          {"scan_rules":[{"id":"x","title":"t","pattern":"p",
+            "side":7,"region":null,"kind":["regex"],"severity":true}]}
+          JSON
+        Gori::Settings.load
+        r = Gori::Settings.scan_rules.first
+        {r.side, r.region, r.kind, r.severity}.should eq({"response", "body", "string", "info"})
+      end
+    end
+
+    it "accepts the enum labels case-insensitively and stores them lowercase" do
+      with_scan_home do
+        write_settings(<<-JSON)
+          {"scan_rules":[{"id":"x","title":"t","pattern":"p",
+            "side":"REQUEST","region":"Header","kind":"ReGeX","severity":"HIGH"}]}
+          JSON
+        Gori::Settings.load
+        r = Gori::Settings.scan_rules.first
+        {r.side, r.region, r.kind, r.severity}.should eq({"request", "header", "regex", "high"})
+      end
+    end
+
+    it "accepts every allowed value on each axis" do
+      with_scan_home do
+        Gori::Settings::SCAN_RULE_SIDES.each do |side|
+          write_settings(%({"scan_rules":[{"id":"x","title":"t","pattern":"p","side":#{side.to_json}}]}))
+          Gori::Settings.load
+          Gori::Settings.scan_rules.first.side.should eq(side)
+        end
+        Gori::Settings::SCAN_RULE_REGIONS.each do |region|
+          write_settings(%({"scan_rules":[{"id":"x","title":"t","pattern":"p","region":#{region.to_json}}]}))
+          Gori::Settings.load
+          Gori::Settings.scan_rules.first.region.should eq(region)
+        end
+        Gori::Settings::SCAN_RULE_KINDS.each do |kind|
+          write_settings(%({"scan_rules":[{"id":"x","title":"t","pattern":"p","kind":#{kind.to_json}}]}))
+          Gori::Settings.load
+          Gori::Settings.scan_rules.first.kind.should eq(kind)
+        end
+        Gori::Settings::SCAN_RULE_SEVERITIES.each do |sev|
+          write_settings(%({"scan_rules":[{"id":"x","title":"t","pattern":"p","severity":#{sev.to_json}}]}))
+          Gori::Settings.load
+          Gori::Settings.scan_rules.first.severity.should eq(sev)
+        end
+      end
+    end
+
+    # An absent `enabled` means "written by a build that predates the flag", not "off": a
+    # rule the operator added must keep scanning after an upgrade.
+    it "defaults a missing enabled to true, and keeps an explicit false" do
+      with_scan_home do
+        write_settings(<<-JSON)
+          {"scan_rules":[
+            {"id":"a","title":"t","pattern":"p"},
+            {"id":"b","title":"t","pattern":"p","enabled":false},
+            {"id":"c","title":"t","pattern":"p","enabled":"nope"}
+          ]}
+          JSON
+        Gori::Settings.load
+        Gori::Settings.scan_rules.map { |r| {r.id, r.enabled} }
+          .should eq([{"a", true}, {"b", false}, {"c", true}])
+      end
+    end
+
+    it "defaults a missing description to the empty string" do
+      with_scan_home do
+        write_settings(%({"scan_rules":[{"id":"a","title":"t","pattern":"p"}]}))
+        Gori::Settings.load
+        Gori::Settings.scan_rules.first.description.should eq("")
+      end
+    end
+
+    # A non-array node is a malformed file, not an instruction to clear the library — the
+    # same tolerance `parse_hostname_overrides` and `parse_tab_prefs` have.
+    it "keeps the current rules when the node is absent, null or not an array" do
+      with_scan_home do
+        keep = [Gori::Settings::ScanRule.new("k", "kept", "", "response", "body",
+          "string", "p", "info", true)]
+        docs = [
+          %({"theme":"goridark"}), %({"scan_rules":null}),
+          %({"scan_rules":"nope"}), %({"scan_rules":{"id":"x"}}),
+        ]
+        docs.each do |doc|
+          Gori::Settings.scan_rules = keep
+          write_settings(doc)
+          Gori::Settings.load
+          Gori::Settings.scan_rules.map(&.id).should eq(["k"])
+        end
+      end
+    end
+
+    it "drops a non-object entry rather than failing the whole array" do
+      with_scan_home do
+        write_settings(%({"scan_rules":["nope",42,null,{"id":"ok","title":"t","pattern":"p"}]}))
+        Gori::Settings.load
+        Gori::Settings.scan_rules.map(&.id).should eq(["ok"])
+      end
+    end
+  end
+
+  describe "scan_rules — the global library CRUD" do
+    it "mints an id on add and returns it so the caller can select the new rule" do
+      with_scan_home do
+        id = Gori::Settings.add_scan_rule("Leaked key", "d", "request", "header",
+          "regex", "sk_live_", "critical")
+        id.should_not be_empty
+        Gori::Settings.scan_rules.size.should eq(1)
+        r = Gori::Settings.scan_rules.first
+        r.id.should eq(id)
+        {r.title, r.side, r.region, r.kind, r.pattern, r.severity, r.enabled}
+          .should eq({"Leaked key", "request", "header", "regex", "sk_live_", "critical", true})
+      end
+    end
+
+    it "gives each rule a distinct id and appends in creation order" do
+      with_scan_home do
+        a = Gori::Settings.add_scan_rule("a", "", "response", "body", "string", "p1", "info")
+        b = Gori::Settings.add_scan_rule("b", "", "response", "body", "string", "p2", "info")
+        a.should_not eq(b)
+        Gori::Settings.scan_rules.map(&.id).should eq([a, b])
+      end
+    end
+
+    it "creates disabled when asked" do
+      with_scan_home do
+        Gori::Settings.add_scan_rule("a", "", "response", "body", "string", "p", "info", enabled: false)
+        Gori::Settings.scan_rules.first.enabled.should be_false
+      end
+    end
+
+    # The edit form has no enabled checkbox — the list's toggle owns that — so an update
+    # must not quietly switch a disabled rule back on.
+    it "rewrites every field on update EXCEPT enabled, which the toggle owns" do
+      with_scan_home do
+        id = Gori::Settings.add_scan_rule("old", "od", "response", "body", "string", "p", "info",
+          enabled: false)
+        Gori::Settings.update_scan_rule(id, "new", "nd", "request", "header", "regex", "q", "high")
+        r = Gori::Settings.scan_rules.first
+        {r.id, r.title, r.description}.should eq({id, "new", "nd"})
+        {r.side, r.region, r.kind, r.pattern, r.severity}
+          .should eq({"request", "header", "regex", "q", "high"})
+        r.enabled.should be_false
+      end
+    end
+
+    it "leaves the other rules alone on update, toggle and delete" do
+      with_scan_home do
+        a = Gori::Settings.add_scan_rule("a", "", "response", "body", "string", "p1", "info")
+        b = Gori::Settings.add_scan_rule("b", "", "response", "body", "string", "p2", "info")
+
+        Gori::Settings.update_scan_rule(b, "b2", "", "response", "body", "string", "p2", "low")
+        Gori::Settings.scan_rules.map(&.title).should eq(["a", "b2"])
+
+        Gori::Settings.set_scan_rule_enabled(b, false)
+        Gori::Settings.scan_rules.map { |r| {r.id, r.enabled} }.should eq([{a, true}, {b, false}])
+
+        Gori::Settings.delete_scan_rule(a)
+        Gori::Settings.scan_rules.map(&.id).should eq([b])
+      end
+    end
+
+    it "is a no-op for an id no rule has" do
+      with_scan_home do
+        id = Gori::Settings.add_scan_rule("a", "", "response", "body", "string", "p", "info")
+        Gori::Settings.update_scan_rule("nope", "x", "", "request", "head", "regex", "q", "high")
+        Gori::Settings.set_scan_rule_enabled("nope", false)
+        Gori::Settings.delete_scan_rule("nope")
+        Gori::Settings.scan_rules.map { |r| {r.id, r.title, r.enabled} }.should eq([{id, "a", true}])
+      end
+    end
+  end
+
+  describe "scan_rules — persistence" do
+    it "round-trips the whole library through save/load" do
+      with_scan_home do
+        id = Gori::Settings.add_scan_rule("Leaked key", "desc", "request", "header",
+          "regex", "sk_live_\\w+", "critical", enabled: false)
+        Gori::Settings.scan_rules = [] of Gori::Settings::ScanRule
+        Gori::Settings.load
+        r = Gori::Settings.scan_rules.first
+        {r.id, r.title, r.description, r.side, r.region, r.kind, r.pattern, r.severity, r.enabled}
+          .should eq({id, "Leaked key", "desc", "request", "header", "regex", "sk_live_\\w+",
+                      "critical", false})
+      end
+    end
+
+    # An untouched install must never grow a `"scan_rules": []` block — but the section is
+    # still a NAME gori knows, which is what `gori settings export --sections scan_rules`
+    # validates against (see SECTION_KEYS).
+    it "omits the section entirely when the library is empty" do
+      with_scan_home do
+        Gori::Settings.save.should be_true
+        Gori::Settings.document_keys.should_not contain("scan_rules")
+        JSON.parse(File.read(Gori::Settings.path)).as_h.has_key?("scan_rules").should be_false
+        Gori::Settings::SECTION_KEYS.should contain("scan_rules")
+      end
+    end
+
+    # Deleting the LAST rule empties the section, so `serialize` stops emitting the key —
+    # exactly the shape that made `save`'s merge copy a stale block forward (see the `chosen`
+    # comment in merge_with_disk). The delete has to reach the FILE: an emptied library that
+    # still had its block on disk would come back on the next process start, and a rule the
+    # operator removed would keep scanning.
+    it "erases the section from disk when the last rule is deleted" do
+      with_scan_home do
+        id = Gori::Settings.add_scan_rule("a", "", "response", "body", "string", "p", "info")
+        JSON.parse(File.read(Gori::Settings.path)).as_h.has_key?("scan_rules").should be_true
+
+        Gori::Settings.delete_scan_rule(id)
+        JSON.parse(File.read(Gori::Settings.path)).as_h.has_key?("scan_rules").should be_false
+
+        # …and a process starting from the factory default (an empty library, the state
+        # `load` actually runs against) stays empty rather than resurrecting the rule.
+        Gori::Settings.scan_rules = [] of Gori::Settings::ScanRule
+        Gori::Settings.load
+        Gori::Settings.scan_rules.should be_empty
+      end
+    end
+
+    # The flip side of "absent keeps current": that tolerance is what makes a truncated or
+    # half-written file harmless, and it is why the erase above is checked on DISK rather
+    # than through a reload — a reload alone cannot distinguish the two.
+    it "does not let an absent section clear a library already in memory" do
+      with_scan_home do
+        Gori::Settings.add_scan_rule("a", "", "response", "body", "string", "p", "info")
+        write_settings(%({"theme":"goridark"}))
+        Gori::Settings.load
+        Gori::Settings.scan_rules.map(&.title).should eq(["a"])
+      end
+    end
+  end
+end


### PR DESCRIPTION
91 examples over six seams that had none, picked by what they cost when wrong. Every one of them can be wrong and still exit 0: a flag that mis-parses does not raise, it sends different bytes, stores the rule somewhere else, or no-ops a mutation while reporting success.

| file | examples | what it pins |
| --- | --- | --- |
| `spec/cli/run/rewriter_spec.cr` | 23 | `gori run rewriter` — 710 lines that had **no spec at all** |
| `spec/cli/run/fuzz_args_spec.cr` | 22 | the payload flag parsers `fuzz` and `discover` share |
| `spec/settings_scan_rules_spec.cr` | 20 | the global scan-rule library |
| `spec/cli/run/probe_helpers_spec.cr` | 14 | `probe`'s flag parses + rule-id decoding |
| `spec/cli/run/list_leftovers_spec.cr` | 8 | the discarded-verb refusal twelve list dispatchers share |
| `spec/rules_spec.cr` | +4 | `Rules.normalize_shape` |

### How these were picked

Crystal has no working coverage tooling (kcov is Linux-only, `crystal-coverage` is dead), so this used an identifier-index heuristic instead: tokenise all of `spec/`, then count how many of each source file's `def` names appear in that set.

The useful result was the negative one. **gori's public surface is already essentially covered** — of 581 source files, exactly one (`settings/scan_rules.cr`) had its entire public `def self.` surface unmentioned anywhere under `spec/`. So the remaining gaps are in two places, and all six seams here come from them:

- the `private def self.` helpers inside `cli/run/*.cr`, whose names never appear in a spec because the parsing and formatting are all private
- functions whose own comment says they were split out *to be* spec-able — `Run.list_leftover_error` says exactly that and had zero coverage

### What each one costs when wrong

**rewriter** — the scope letter leads a rule row because the project and global stores number independently, so `#3` alone does not say which rule the next command addresses. The JSON projection is what a script reads, and `default_enabled` beside `enabled` is the only way that script can tell an override from a library default. Also the two refusals `add` makes before a rule reaches a store: an unparseable stub (it would answer every matching request with gori's own 502) and `--part=ws` on an op that is not `replace` (normalising it would move the rule to a different PROTOCOL, silently).

**fuzz/discover flags** — each has already been wrong in a way that produced a quietly different payload set: `--numbers -10--5` split on the first hyphen and lost its lower bound, `--regex-replace /foo//bar/` dropped everything past the second delimiter, `--brute` split its charset on the wrong colon. Checked through what each source actually generates, since none of them expose their fields.

**list_leftover_error** — what stops `gori run rewriter --project=t1 rm 1` from listing the rules and exiting 0 with the delete discarded, and what keeps a lone `list` from being called an unknown subcommand by a message that lists `list` among the verbs.

**probe rule ids** — `custom_p_12` is a row in this project's DB, `custom_g_12` lives in settings.json. Reading the global one as a row id would send a delete at whatever project row happened to share the number.

**scan_rules** — its parse is the boundary a hand-edited `settings.json` crosses into the match engine, which reads side/region/kind/severity as though they were enums, so the clamp is the contract. A rule missing id/title/pattern is dropped rather than defaulted, because an invented pattern would scan live traffic for it. The delete of the LAST rule is checked **on disk**, not through a reload: an emptied section stops being serialized, which is the exact shape that has made `save`'s merge copy a stale block forward before.

### Limits

The `abort` branches remain out of reach — `abort` calls `exit`, which would take the suite down — so these cover success paths only, the limit `spec/cli/run/links_spec.cr` already works under. Reaching the refusal paths would need a harness that runs the built binary as a subprocess; there isn't one today, and adding it was left out of scope.

### Verification

- `crystal spec`: **8592 examples, 8 failures** — the same 8 as before this branch (`project_registry` ×5, `capture_status` ×3), all from a gori already listening on `:8070`. No new failures.
- `crystal tool format --check` and ameba: clean on every file touched.
- Source is untouched; this is spec-only, plus a refresh of the now-stale split-status header in `spec/cli_run_spec.cr`.