### PR TITLE
Put Help's two reference pages behind the palette, so looking a key up costs nothing

### DIFF
--- a/spec/support/fake_context.cr
+++ b/spec/support/fake_context.cr
@@ -70,6 +70,14 @@ class FakeExecContext < Gori::Verb::ExecContext
     rec(:open_listeners)
   end
 
+  def open_help_shortcuts : Nil
+    rec(:open_help_shortcuts)
+  end
+
+  def open_help_query(surface : Symbol) : Nil
+    rec(:open_help_query)
+  end
+
   def close_overlay : Nil
     rec(:close_overlay)
   end

--- a/spec/tui/help_popup_overlay_spec.cr
+++ b/spec/tui/help_popup_overlay_spec.cr
@@ -1,0 +1,368 @@
+require "../spec_helper"
+require "../support/memory_backend"
+require "../support/overlay_harness"
+
+include Gori::Tui
+
+# Help's two reference pages as a popup over the current pane. The examples that matter are
+# the ones that pin it to HelpView rather than to itself: the whole reason this overlay is
+# 200 lines and not 400 is that it renders HelpView's rows with HelpView's painter, and the
+# moment it stops doing that the two surfaces start disagreeing about what a key does.
+private def registry
+  Gori::Verbs.registry
+end
+
+private def shortcuts(tab : Symbol = :history) : HelpPopupOverlay
+  HelpPopupOverlay.shortcuts(registry, tab)
+end
+
+private def ev(char : Char, ctrl = false, alt = false) : Termisu::Event::Key
+  mods = Termisu::Input::Modifier::None
+  mods |= Termisu::Input::Modifier::Ctrl if ctrl
+  mods |= Termisu::Input::Modifier::Alt if alt
+  Termisu::Event::Key.new(Termisu::Input::Key::LowerA, char: char, modifiers: mods)
+end
+
+# The FIELDS section of a query page, as {name => help}. Lets an example assert the vocabulary
+# a surface teaches without depending on row order or on the sections around it.
+private def field_rows(rows : Array(Gori::Tui::HelpView::Row)) : Hash(String, String)
+  out = {} of String => String
+  in_fields = false
+  rows.each do |r|
+    if r.kind == :head
+      in_fields = r.a.starts_with?("FIELDS")
+      next
+    end
+    out[r.a.rchop(':')] = r.b if in_fields && r.kind == :item
+  end
+  out
+end
+
+describe Gori::Tui::HelpPopupOverlay do
+  it "renders the SAME rows the Help tab does, for both pages" do
+    # Not "renders something plausible": the row LISTS are compared, so a future edit that
+    # gives the popup its own copy of either page fails here rather than in six months when
+    # a rebind shows up on one surface and not the other.
+    shortcuts.rows.should eq(HelpView.shortcut_rows(registry))
+    HelpPopupOverlay.query_reference.rows.should eq(HelpView.query_rows)
+  end
+
+  it "resolves the key column through the live keymap, not the raw SECTIONS literal" do
+    # `history.repeater`'s row is written as `^R` in SECTIONS and carries a verb id, so a
+    # popup that read SECTIONS directly would still print `^R` and look correct. What proves
+    # the popup went through `binding_label` is a row whose literal and effective label
+    # DIFFER — `app.palette` is chorded `ctrl-p`, which renders as `^P`.
+    rows = shortcuts.rows
+    palette = rows.find { |r| r.kind == :item && r.b.includes?("command palette") }
+    palette.should_not be_nil
+    palette.not_nil!.a.should eq(Gori::Hotkeys.binding_label(registry, "app.palette", "^P"))
+  end
+
+  it "supplies the shell chrome every migrated modal owes" do
+    OverlayHarness.new(shortcuts).assert_chrome(OverlayKind::Help, "SHORTCUTS")
+    OverlayHarness.new(HelpPopupOverlay.query_reference).assert_chrome(OverlayKind::Help, "QUERY LANGUAGE")
+  end
+
+  describe "the per-surface field vocabulary" do
+    # The GRAMMAR is one — every bar parses through FilterAst — but the FIELD LIST is not, and
+    # a reference that lists fields the bar under it rejects, or defines them the other way
+    # round, is worse than no reference. `InterceptFilter::FIELD_HELP`'s own comment says it
+    # was merged-not-copied over QL's to stop exactly this drift.
+
+    it "teaches the Intercept condition's own fields, not QL's" do
+      rows = HelpView.query_rows(Gori::InterceptFilter::FIELDS, Gori::InterceptFilter::FIELD_HELP_PROC)
+      fields = field_rows(rows)
+
+      # The four QL entries a hold gate deliberately redefines.
+      fields["status"].should eq("code/class — and scopes to RESPONSES only")
+      fields["proto"].should eq("http, or ws to opt WebSocket messages IN")
+      fields["header"].should eq("head of the message in hand (this leg only)")
+      fields["body"].should eq("payload in hand — WS messages, extract rules")
+
+      # And none of the nine QL fields a gate can never answer.
+      %w[size reqsize respsize dur stub req.header resp.header req.body resp.body].each do |f|
+        fields.has_key?(f).should be_false, "the intercept reference offers `#{f}:`, which the gate rejects"
+      end
+    end
+
+    it "drops aliases whose target the surface does not have" do
+      # `res.header:` is not "also accepted" where `resp.header:` does not exist.
+      rows = HelpView.query_rows(Gori::InterceptFilter::FIELDS, Gori::InterceptFilter::FIELD_HELP_PROC)
+      rows.any? { |r| r.a.starts_with?("res.header") }.should be_false
+      # QL keeps them.
+      HelpView.query_rows.any? { |r| r.a.starts_with?("res.header") }.should be_true
+    end
+
+    it "teaches Sitemap's own tag:, which never reaches the parser" do
+      rows = HelpView.query_rows(["tag"] + Gori::QL::FIELDS, SitemapView::QL_HELP)
+      field_rows(rows)["tag"].should eq("path memo on this node — set with space → T")
+    end
+
+    it "still teaches the shared grammar on every surface" do
+      [HelpView.query_rows,
+       HelpView.query_rows(Gori::InterceptFilter::FIELDS, Gori::InterceptFilter::FIELD_HELP_PROC),
+       HelpView.query_rows(["tag"] + Gori::QL::FIELDS, SitemapView::QL_HELP)].each do |rows|
+        heads = rows.select(&.kind.== :head).map(&.a)
+        heads.should contain("SYNTAX")
+        heads.should contain("WORTH KNOWING")
+      end
+    end
+
+    it "leaves the Help tab's own Query page on plain QL" do
+      HelpView.query_rows.should eq(HelpView.query_rows(Gori::QL::FIELDS))
+    end
+  end
+
+  describe "the context-aware landing" do
+    it "opens on the section for the tab you came from" do
+      h = OverlayHarness.new(shortcuts(:repeater))
+      rendered = h.render
+      # VISIBLE, not `scroll == head_index`: the offset is clamped against the card height at
+      # render, so a section near the tail settles above its own head. Being on screen is the
+      # property the operator actually has.
+      rendered.contains?("REPEATER").should be_true
+      rendered.contains?("send the request").should be_true
+    end
+
+    it "lands on OTHER TABS for a tab with no section of its own" do
+      HelpPopupOverlay.landing_scroll(HelpView.shortcut_rows(registry), :issues).should_not eq(0)
+      rows = HelpView.shortcut_rows(registry)
+      idx = HelpPopupOverlay.landing_scroll(rows, :issues)
+      rows[idx].a.should eq("OTHER TABS")
+    end
+
+    it "opens at the top from Help itself and from an unmapped tab" do
+      HelpPopupOverlay.landing_scroll(HelpView.shortcut_rows(registry), :help).should eq(0)
+    end
+
+    it "maps every real tab to a section that exists" do
+      # Two failure modes, both silent: a tab missing from TAB_SECTION quietly opens at the
+      # top, and a typo'd title does the same. Neither is visible from the map itself.
+      titles = HelpView::SECTIONS.map { |(t, _)| t }
+      HelpView::TAB_SECTION.each do |tab, title|
+        titles.should contain(title), "TAB_SECTION[#{tab}] names a section that does not exist: #{title}"
+      end
+      Chrome::TABS.each do |(sym, _)|
+        next if sym == :help # deliberately absent — the whole sheet is what that tab already shows
+        HelpView::TAB_SECTION.has_key?(sym).should be_true, "no TAB_SECTION entry for the #{sym} tab"
+      end
+    end
+  end
+
+  describe "the filter" do
+    it "narrows to matching rows and keeps each survivor's section head" do
+      ov = shortcuts
+      before = ov.rows.size
+      OverlayHarness.new(ov).type("hex")
+      ov.rows.size.should be < before
+      ov.rows.none? { |r| r.kind == :gap }.should be_true
+      items = ov.rows.select { |r| r.kind == :item }
+      items.should_not be_empty
+      items.all? { |r| "#{r.a} #{r.b}".downcase.includes?("hex") }.should be_true
+      # A hit has to say WHERE it applies — `y` means different things in HISTORY and JWT.
+      ov.rows.first.kind.should eq(:head)
+    end
+
+    it "restores the full list on backspace" do
+      ov = shortcuts
+      all = ov.rows.size
+      h = OverlayHarness.new(ov)
+      h.type("hex")
+      3.times { h.press(Termisu::Input::Key::Backspace) }
+      ov.rows.size.should eq(all)
+    end
+
+    it "reports the narrowed count on the card, against the same denominator at rest" do
+      total = HelpView.shortcut_rows(registry).count { |r| r.kind == :item }
+      # Unfiltered must count ITEMS too. Counting `@all.size` there put section heads and blank
+      # spacers in the numerator, so the border jumped from "189 rows" to "N of 156" on the
+      # first keystroke — two denominators for one list, which reads as rows disappearing.
+      OverlayHarness.new(shortcuts).rendered?("#{total} rows").should be_true
+
+      ov = shortcuts
+      OverlayHarness.new(ov).type("hex")
+      matched = ov.rows.count { |r| r.kind == :item }
+      OverlayHarness.new(ov).rendered?("#{matched} of #{total}").should be_true
+    end
+
+    it "parks the caret on its own card, not the filter bar it was opened from" do
+      # `Screen#desired_cursor` is last-writer-wins per frame and the tab body draws first, so
+      # an overlay that sets no cursor leaves the caret blinking in the bar underneath — and
+      # this is the one overlay reachable straight from an editing text bar (`?`).
+      area = OverlayHarness::DEFAULT_AREA
+      ov = shortcuts
+      screen = Screen.new(MemoryBackend.new(area.w, area.h))
+      screen.cursor(0, 0) # stand in for the filter bar drawn underneath this frame
+      ov.render(screen, area)
+      box = ov.overlay_box(area).not_nil!
+      screen.desired_cursor.should eq({box.x + 2, box.y + 1})
+    end
+
+    it "says so when nothing matches, instead of drawing an empty card" do
+      ov = shortcuts
+      OverlayHarness.new(ov).type("zzzznotathing")
+      ov.rows.should be_empty
+      OverlayHarness.new(ov).rendered?("no rows match").should be_true
+    end
+  end
+
+  describe "key routing" do
+    it "hops to the palette on ^P" do
+      ov = shortcuts
+      hopped = 0
+      ov.on_palette = -> { hopped += 1; nil }
+      OverlayHarness.new(ov).press(Termisu::Input::Key::LowerP, 'p', ctrl: true).should eq(:open)
+      hopped.should eq(1)
+      ov.query.should be_empty
+    end
+
+    it "drops every OTHER ctrl chord instead of typing its letter into the filter" do
+      # This is what `!ev.ctrl? && !ev.alt?` on the printable arm buys, and it is NOT what the
+      # ^P example above proves: ^P is claimed by an earlier arm, so that one passes with or
+      # without the guard. The real hazard is the rest of the alphabet — `Event::Key#char`
+      # falls back to `key.to_char`, so ^K arrives carrying 'k' and an unguarded arm silently
+      # types it. ^K/^X/^R are muscle memory in six scopes; every one of them would land here
+      # as filter text.
+      ov = shortcuts
+      h = OverlayHarness.new(ov)
+      h.press(Termisu::Input::Key::LowerK, 'k', ctrl: true)
+      h.press(Termisu::Input::Key::LowerX, 'x', ctrl: true)
+      h.press(Termisu::Input::Key::LowerR, 'r', alt: true)
+      ov.query.should be_empty
+      ov.rows.size.should eq(HelpView.shortcut_rows(registry).size)
+    end
+
+    it "types a bare p into the filter" do
+      ov = shortcuts
+      OverlayHarness.new(ov).press(Termisu::Input::Key::LowerP, 'p')
+      ov.query.should eq("p")
+    end
+
+    it "does NOT bind j/k/g/G to motion — they are filter input" do
+      # With a filter bar, a letter arm above the printable arm eats that letter out of every
+      # query someone types (`g` is in "graphql", `k` in "key"). ProjectPicker learned the
+      # same rule from the other side.
+      ov = shortcuts
+      OverlayHarness.new(ov).type("gjkG")
+      ov.query.should eq("gjkG")
+    end
+
+    it "closes on esc and stays open on ↵" do
+      OverlayHarness.new(shortcuts).press(Termisu::Input::Key::Escape).should eq(:closed)
+      # Read-only: there is nothing to commit, and a :commit here would let a stray Enter
+      # close a card the operator is still reading.
+      h = OverlayHarness.new(shortcuts)
+      h.press(Termisu::Input::Key::Enter).should eq(:open)
+      h.commits.should eq(0)
+    end
+
+    it "scrolls with the arrows, the page keys and the wheel" do
+      ov = shortcuts(:help) # starts at the top
+      h = OverlayHarness.new(ov)
+      ov.scroll.should eq(0)
+      h.press(Termisu::Input::Key::Down)
+      ov.scroll.should eq(1)
+      # Drawn first, because the shell always draws before the next key arrives and the page
+      # size is only knowable on that path (see page_step). Without this the step falls back to
+      # the pre-first-frame seed, which is what the raw numbers below would otherwise pin.
+      h.render
+      h.press(Termisu::Input::Key::PageDown)
+      # ⇞/⇟ must move a real page, not a hardcoded guess — the hint says "page". The card in
+      # DEFAULT_AREA (80x24) is 22 rows tall, leaving 18 list rows under the filter bar and
+      # divider, so a page is 17 (one row of overlap) on top of the 1 from ↓.
+      ov.scroll.should eq(18)
+      h.press(Termisu::Input::Key::Home)
+      ov.scroll.should eq(0)
+      h.wheel(3)
+      ov.scroll.should eq(3)
+    end
+  end
+
+  it "degrades to a one-line notice rather than a broken card on a short terminal" do
+    # Height-constrained, which is the case an operator actually hits (a wide, short pane).
+    # The line names its own escape because it is the only thing on screen — the one
+    # placement `overlay_hint_placement_spec` exempts from the hint-lives-in-`hint` rule.
+    short = Rect.new(0, 0, 60, 6)
+    ov = shortcuts
+    ov.overlay_box(short).should be_nil
+    OverlayHarness.new(ov, area: short).rendered?("esc to close").should be_true
+  end
+
+  it "refuses the card rather than truncating rows when the pane is too narrow" do
+    narrow = Rect.new(0, 0, 30, 24)
+    shortcuts.overlay_box(narrow).should be_nil
+  end
+
+  it "is wide enough for the longest row on both pages" do
+    # The point of the popup is reading the sentence that explains a key, so a card that cuts
+    # the longest one has failed at its only job. `draw_row` hands a description `w - 27`
+    # columns on the Shortcuts page — 2 pad + KEY_W + KEY_GAP left, 1 + two borders right.
+    #
+    # This fails when someone adds a description longer than the card, which is the moment to
+    # decide between a shorter sentence and a wider card — not six months later when an
+    # operator finds the row that trails off into `…`.
+    shortcut_desc = HelpView.shortcut_rows(registry).select(&.kind.== :item).max_of(&.b.size)
+    shortcut_desc.should be <= HelpPopupOverlay::MAX_W - 2 - 2 - HelpView::KEY_W - HelpView::KEY_GAP - 1
+
+    query_desc = HelpView.query_rows.select(&.kind.== :item).max_of(&.b.size)
+    query_desc.should be <= HelpPopupOverlay::MAX_W - 2 - 2 - HelpView::QUERY_KEY_W - HelpView::KEY_GAP - 1
+  end
+end
+
+# The `?`-opens-the-QL-reference key, which lives on the three filter bars rather than on the
+# overlay. Driven as a predicate because a controller needs a Host, and a Host needs the Runner,
+# which needs a live tty — the same reason OverlayHarness exists for the modal tier.
+describe "the QL reference key on a filter bar" do
+  it "fires on `?` when the bar is empty" do
+    TabController.ql_help_key?(ev('?'), "").should be_true
+  end
+
+  it "types a literal `?` once anything has been typed" do
+    # EMPTY buffer only, not "after whitespace": `?id=` is a plausible free-text search on a
+    # proxy, and a trigger state the operator cannot see is worse than one that only fires
+    # from a visibly empty bar.
+    TabController.ql_help_key?(ev('?'), "host:acme").should be_false
+    TabController.ql_help_key?(ev('?'), "host:acme ").should be_false
+  end
+
+  it "ignores every other key, and `?` carried by a modifier" do
+    TabController.ql_help_key?(ev('a'), "").should be_false
+    TabController.ql_help_key?(ev('/'), "").should be_false
+    TabController.ql_help_key?(ev('?', ctrl: true), "").should be_false
+    TabController.ql_help_key?(ev('?', alt: true), "").should be_false
+  end
+
+  it "is wired into ALL THREE bars, above each printable arm" do
+    # The three handle_query_key methods are byte-for-byte parallel, so the failure mode is a
+    # partial fix: two bars answer `?` and the third silently types it. Source-scanned because
+    # there is no way to reach a controller without the Runner.
+    dir = File.join(__DIR__, "..", "..", "src", "gori", "tui", "controllers")
+    %w[history_controller sitemap_controller intercept_controller].each do |name|
+      src = File.read(File.join(dir, "#{name}.cr"))
+      src.includes?("TabController.ql_help_key?").should be_true,
+        "#{name}.cr never consults ql_help_key? — its filter bar still types the `?`"
+      # Above the `else` that inserts the char, or the guard never runs.
+      help_at = src.index("TabController.ql_help_key?").not_nil!
+      insert_at = src.index("query_insert(c)").not_nil!
+      help_at.should be < insert_at, "#{name}.cr checks ql_help_key? below its printable arm"
+    end
+  end
+
+  it "is advertised on the cold hint of a bar that has it, and only there" do
+    QuerySuggest.cold_hint(help_key: true).includes?("? reference").should be_true
+    # The Colormarker rule form shares this generator for its `when:` band, where `?` is just
+    # a character — advertising the key there would be a lie.
+    QuerySuggest.cold_hint.includes?("? reference").should be_false
+  end
+
+  it "does not push `-term excludes` off a narrow bar to make room for itself" do
+    # `fits?`/the shrink loop protect `-term excludes` BY INDEX, so anything inserted ahead of
+    # it moves it right on every surface at once — and none of the three bars passes `width`,
+    # so the loop cannot claw it back. Leading with the chip cost 16 columns and newly cut the
+    # token off on terminals 84-99 wide. The new chip goes BEHIND it instead.
+    plain = QuerySuggest.cold_hint
+    with_key = QuerySuggest.cold_hint(help_key: true)
+    with_key.index("-term excludes").should eq(plain.index("-term excludes"))
+    with_key.index("? reference").not_nil!.should be > with_key.index("-term excludes").not_nil!
+  end
+end

--- a/spec/tui/jwt_copy_selection_spec.cr
+++ b/spec/tui/jwt_copy_selection_spec.cr
@@ -66,6 +66,9 @@ private class FakeHost
   def open_palette : Nil
   end
 
+  def open_help_query(surface : Symbol) : Nil
+  end
+
   def open_space_menu : Nil
   end
 

--- a/spec/tui/jwt_lens_chip_spec.cr
+++ b/spec/tui/jwt_lens_chip_spec.cr
@@ -79,6 +79,9 @@ private class FakeHost
   def open_palette : Nil
   end
 
+  def open_help_query(surface : Symbol) : Nil
+  end
+
   def open_space_menu : Nil
   end
 

--- a/spec/tui/oast_callback_cap_spec.cr
+++ b/spec/tui/oast_callback_cap_spec.cr
@@ -75,6 +75,9 @@ private class FakeHost
   def open_palette : Nil
   end
 
+  def open_help_query(surface : Symbol) : Nil
+  end
+
   def open_space_menu : Nil
   end
 

--- a/spec/tui/oast_provider_pick_spec.cr
+++ b/spec/tui/oast_provider_pick_spec.cr
@@ -63,6 +63,9 @@ private class FakeHost
   def open_palette : Nil
   end
 
+  def open_help_query(surface : Symbol) : Nil
+  end
+
   def open_space_menu : Nil
   end
 

--- a/spec/tui/oast_resume_issue_spec.cr
+++ b/spec/tui/oast_resume_issue_spec.cr
@@ -65,6 +65,9 @@ private class FakeHost
   def open_palette : Nil
   end
 
+  def open_help_query(surface : Symbol) : Nil
+  end
+
   def open_space_menu : Nil
   end
 

--- a/spec/tui/overlay_dispatch_spec.cr
+++ b/spec/tui/overlay_dispatch_spec.cr
@@ -29,7 +29,7 @@ end
 private EXPECTED_OVERLAY_SYMS = {
   :none, :detail, :palette, :issue_new, :confirm, :browser, :choice, :tabs_more,
   :comparer_pick, :repeater_subtab, :links, :link_pick, :preferences,
-  :settings, :tabs, :hosts, :env, :hotkeys, :notifications, :passthrough, :listeners, :probe_active,
+  :settings, :tabs, :hosts, :env, :hotkeys, :help, :notifications, :passthrough, :listeners, :probe_active,
   :discover_config, :discover_headers, :fuzz_set, :fuzz_advanced, :oast_provider,
   :oast_provider_pick, :oast_session,
   :probe_rule, :rewriter_rule, :colormarker_rule, :colormarker_color, :extract_rule, :rewriter_stub, :ca_import, :import, :export, :scope_rule, :sequence_config,
@@ -102,6 +102,10 @@ private MIGRATED_KINDS = [
   # OastProviderPick — the GET PAYLOAD FROM / START LISTENING WITH card the OAST tab's `g`
   # and `^R` raise when the provider bar sits on All, born on the seam like its sibling.
   OverlayKind::OastProviderPick,
+  # Help — the cheat-sheet / QL reference popup, born on the seam (the help.hotkeys and
+  # help.query palette entries, plus `?` on an empty filter bar), so likewise never in
+  # MODAL_OVERLAYS.
+  OverlayKind::Help,
 ]
 
 # Never in MODAL_OVERLAYS by design, migrated or not. `None` is "no modal at all" and

--- a/spec/tui/probe_drain_coalesce_spec.cr
+++ b/spec/tui/probe_drain_coalesce_spec.cr
@@ -64,6 +64,9 @@ private class FakeHost
   def open_palette : Nil
   end
 
+  def open_help_query(surface : Symbol) : Nil
+  end
+
   def open_space_menu : Nil
   end
 

--- a/spec/tui/repeater_refusal_inline_spec.cr
+++ b/spec/tui/repeater_refusal_inline_spec.cr
@@ -76,6 +76,9 @@ private class FakeHost
   def open_palette : Nil
   end
 
+  def open_help_query(surface : Symbol) : Nil
+  end
+
   def open_space_menu : Nil
   end
 

--- a/spec/tui/rewriter_preview_select_spec.cr
+++ b/spec/tui/rewriter_preview_select_spec.cr
@@ -70,6 +70,9 @@ private class FakeHost
   def open_palette : Nil
   end
 
+  def open_help_query(surface : Symbol) : Nil
+  end
+
   def open_space_menu : Nil
     @space_menus += 1
   end

--- a/spec/verb/registry_spec.cr
+++ b/spec/verb/registry_spec.cr
@@ -48,6 +48,14 @@ private class FakeContext < ExecContext
     @calls << :open_listeners
   end
 
+  def open_help_shortcuts : Nil
+    @calls << :open_help_shortcuts
+  end
+
+  def open_help_query(surface : Symbol) : Nil
+    @calls << :open_help_query
+  end
+
   def close_overlay : Nil
     @calls << :close_overlay
   end

--- a/src/gori/tui/controllers/history_controller.cr
+++ b/src/gori/tui/controllers/history_controller.cr
@@ -368,10 +368,12 @@ module Gori::Tui
       store = @host.session.store
       return true if query_nav(key)
       case
-      when key.enter?     then query_enter
-      when key.escape?    then query_escape(store)
-      when key.tab?       then (@history.query_complete; schedule_query_reload)
+      when key.enter?  then query_enter
+      when key.escape? then query_escape(store)
+      when key.tab?    then (@history.query_complete; schedule_query_reload)
       when key.backspace? then @history.query_backspace; schedule_query_reload
+      # Above the printable arm below, which would otherwise type the `?` (see ql_help_key?).
+      when TabController.ql_help_key?(ev, @history.query) then @host.open_help_query(:history)
       else
         if c && !ev.ctrl? && !ev.alt?
           @history.query_insert(c)

--- a/src/gori/tui/controllers/intercept_controller.cr
+++ b/src/gori/tui/controllers/intercept_controller.cr
@@ -268,10 +268,12 @@ module Gori::Tui
       ic = @host.session.interceptor
       return true if query_nav(key)
       case
-      when key.enter?     then query_enter(ic)
-      when key.escape?    then query_escape(ic)
-      when key.tab?       then ic.set_filter(@intercept.query) if @intercept.query_complete
+      when key.enter?  then query_enter(ic)
+      when key.escape? then query_escape(ic)
+      when key.tab?    then ic.set_filter(@intercept.query) if @intercept.query_complete
       when key.backspace? then @intercept.query_backspace; ic.set_filter(@intercept.query)
+      # Above the printable arm below, which would otherwise type the `?` (see ql_help_key?).
+      when TabController.ql_help_key?(ev, @intercept.query) then @host.open_help_query(:intercept)
       else
         if c && !ev.ctrl? && !ev.alt?
           @intercept.query_insert(c)

--- a/src/gori/tui/controllers/sitemap_controller.cr
+++ b/src/gori/tui/controllers/sitemap_controller.cr
@@ -143,10 +143,12 @@ module Gori::Tui
       store = @host.session.store
       return true if query_nav(key)
       case
-      when key.enter?     then query_enter
-      when key.escape?    then query_escape(store)
-      when key.tab?       then (@sitemap.query_complete; schedule_query_reload)
+      when key.enter?  then query_enter
+      when key.escape? then query_escape(store)
+      when key.tab?    then (@sitemap.query_complete; schedule_query_reload)
       when key.backspace? then @sitemap.query_backspace; schedule_query_reload
+      # Above the printable arm below, which would otherwise type the `?` (see ql_help_key?).
+      when TabController.ql_help_key?(ev, @sitemap.query) then @host.open_help_query(:sitemap)
       else
         if c && !ev.ctrl? && !ev.alt?
           @sitemap.query_insert(c)

--- a/src/gori/tui/help_popup_overlay.cr
+++ b/src/gori/tui/help_popup_overlay.cr
@@ -1,0 +1,300 @@
+require "./screen"
+require "./theme"
+require "./frame"
+require "./overlay"
+require "./help_view"
+require "../verb"
+
+module Gori::Tui
+  # Help's two reference pages — the keyboard cheat-sheet and the QL reference — as a popup
+  # over whatever you were already doing, opened from the command palette (or, for the Query
+  # page, by `?` on an empty filter bar).
+  #
+  # It exists because the answer lived a tab switch away. Wondering "what key sends this?"
+  # mid-Repeater meant leaving the Repeater: the pane, the selection and the place you were
+  # in all go, and coming back means finding them again. The palette already floats over the
+  # body without disturbing it, so routing Help through it costs nothing to open and nothing
+  # to close — esc puts the operator back on the exact pane they asked from.
+  #
+  # The rows are HelpView's OWN rows (`HelpView.shortcut_rows` / `.query_rows`), painted with
+  # HelpView's own `draw_row`. Nothing about the content lives here. That is deliberate and it
+  # is the same rule the Query page itself was written under (help_view.cr's note on
+  # FILTER_HINT/QUERY_HINT): a second hand-authored copy of a reference drifts from the first,
+  # and the drift is invisible from either side.
+  #
+  # Read-only, so there is no `on_commit` and `handle_key` never answers :commit.
+  class HelpPopupOverlay < Overlay
+    # ^P leaves for the command palette, like every other list overlay. Injected because
+    # raising another modal is the shell's job (see Runner#open_help_shortcuts).
+    property on_palette : Proc(Nil)?
+
+    # Wider than the 72 the rule forms share and the 60 the palette uses, and NOT a round
+    # number picked by eye: these rows are a key gutter plus a description written for the full
+    # width of a tab body, and a card sized like a form cuts them mid-sentence — a reference
+    # that truncates the sentence explaining the key is worse than no popup.
+    #
+    # `draw_row` gives a description `box.w - 27` columns (2 pad + KEY_W + KEY_GAP on the left,
+    # 1 + the two borders on the right), so 126 is the widest SECTIONS description (98, the
+    # Repeater's `^V`) plus that overhead, rounded up. A spec pins it against the real table so
+    # a longer row added later fails there rather than silently truncating here.
+    #
+    # It is still a CAP, not the width: a narrower pane gets `area.w - 4` and a wider one keeps
+    # the card at 126 rather than sprawling across a 200-column monitor.
+    MAX_W = 126
+    MIN_W =  44
+    MIN_H =   8
+
+    # The card's interior rows above the list: the filter bar (+1) and its divider (+2).
+    # Mirrors FilterPickerOverlay::LIST_OFFSET, which lays out the same two bands.
+    LIST_OFFSET = 3
+
+    getter query : String
+
+    def self.shortcuts(registry : Verb::Registry, tab : Symbol) : self
+      rows = HelpView.shortcut_rows(registry)
+      new("SHORTCUTS", rows, HelpView::KEY_W, landing_scroll(rows, tab))
+    end
+
+    # The QL reference. `title`/`rows` are supplied by the caller rather than derived here so
+    # this file needs no knowledge of — and no `require` on — the surfaces that have their own
+    # field vocabulary; the Runner knows them all already and does the mapping (see
+    # Runner#help_query_overlay).
+    def self.query_reference(title : String = "QUERY LANGUAGE",
+                             rows : Array(HelpView::Row) = HelpView.query_rows) : self
+      new(title, rows, HelpView::QUERY_KEY_W, 0)
+    end
+
+    # Where the Shortcuts page opens: the `:head` row for the tab the operator came from, so
+    # the popup answers the question they arrived with instead of making them scroll for it.
+    # 0 (the top) for a tab with no section of its own and for Help itself.
+    #
+    # `render` clamps this against the card height afterwards, so a section near the tail
+    # (COLORMARKER, OVERLAYS) in a tall terminal settles ABOVE its head rather than at it —
+    # correct, and the reason the spec asserts the head is visible rather than at offset 0.
+    def self.landing_scroll(rows : Array(HelpView::Row), tab : Symbol) : Int32
+      return 0 unless title = HelpView::TAB_SECTION[tab]?
+      rows.index { |r| r.kind == :head && r.a == title } || 0
+    end
+
+    def initialize(@title : String, @all : Array(HelpView::Row), @key_w : Int32, @scroll : Int32)
+      @rows = @all
+      @query = ""
+      @preedit = "" # live IME composition on the filter (e.g. Hangul jamo)
+    end
+
+    # --- Overlay contract (see overlay.cr) ---
+    def key : OverlayKind
+      OverlayKind::Help
+    end
+
+    def title : String
+      @title
+    end
+
+    def hint : String
+      "type to filter · ↑/↓ scroll · ⇞/⇟ page · esc close"
+    end
+
+    # Read-only: never :commit. esc closes, ⌫ edits the filter, and every other printable key
+    # goes INTO the filter.
+    #
+    # There is deliberately no j/k/g/G arm. Those are the motions this app uses everywhere
+    # else, and that is exactly why they cannot be here: with a filter bar, a letter arm above
+    # the printable arm eats that letter out of every query an operator types (`g` and `k` are
+    # in "graphql" and "key"). ProjectPicker learned the same rule from the other side — its
+    # `t`/⇧T marks had to become Tab/⇧Tab because the search box claims printables first.
+    #
+    # `!ev.ctrl? && !ev.alt?` on that arm is load-bearing, not defensive: `Event::Key#char`
+    # falls back to `key.to_char`, so ^P arrives carrying 'p'. Without the guard the palette
+    # hop below is unreachable and ^P silently types a `p` into the filter instead.
+    def handle_key(ev : Termisu::Event::Key) : Symbol
+      k = ev.key
+      case
+      when ev.ctrl? && k.lower_p? then on_palette.try(&.call)
+      when k.escape?              then return :cancel
+      when k.up?                  then move(-1)
+      when k.down?                then move(1)
+      when k.page_up?             then move(-page_step)
+      when k.page_down?           then move(page_step)
+      when k.home?                then @scroll = 0
+      when k.end?                 then @scroll = @rows.size
+      when k.backspace?           then backspace
+      when k.enter?               then nil # nothing to commit; must not close the card
+      else
+        if (c = ev.char) && !ev.ctrl? && !ev.alt?
+          query_char(c)
+        end
+      end
+      :stay
+    end
+
+    # Live IME composition, shown under the filter caret without touching the committed query
+    # — the same model TextField and the palette use.
+    def set_preedit(text : String) : Nil
+      @preedit = text
+    end
+
+    def query_char(ch : Char) : Nil
+      return if ch.control?
+      @preedit = "" # a committed char ends any in-progress composition
+      @query += ch
+      refilter
+    end
+
+    def backspace : Nil
+      return if @query.empty?
+      @preedit = ""
+      @query = @query[0, @query.size - 1]
+      refilter
+    end
+
+    # Substring, case-insensitive, over both columns — NOT the fuzzy subsequence the palette
+    # scores commands with. A palette row is a short title where a subsequence is a good guess
+    # at intent; these rows are prose sentences, where almost any few letters appear in almost
+    # any of them and fuzzy matching narrows nothing.
+    #
+    # A surviving item keeps its section head, so a hit still says WHERE the key applies —
+    # `y` means different things in HISTORY and in JWT. Heads whose section emptied are
+    # dropped, and the :gap spacers go with them (they separate sections that are no longer
+    # adjacent).
+    private def refilter : Nil
+      if @query.empty?
+        @rows = @all
+        @scroll = 0
+        return
+      end
+      needle = @query.downcase
+      out = [] of HelpView::Row
+      head = nil.as(HelpView::Row?)
+      @all.each do |row|
+        case row.kind
+        when :head
+          head = row
+        when :item
+          next unless "#{row.a} #{row.b}".downcase.includes?(needle)
+          if h = head
+            out << h
+            head = nil # only once per surviving section
+          end
+          out << row
+        end
+      end
+      @rows = out
+      @scroll = 0
+    end
+
+    def rows : Array(HelpView::Row)
+      @rows
+    end
+
+    # ↑/↓ and the wheel. The top is clamped here and the bottom at render, where the card
+    # height is known — the same split HelpView#move / #clamp_scroll uses.
+    def move(d : Int32) : Nil
+      @scroll = {@scroll + d, 0}.max
+    end
+
+    def scroll : Int32
+      @scroll
+    end
+
+    # A whole viewport less one row of overlap, so ⇞/⇟ keeps a line of context.
+    #
+    # Read from `@page`, which `render` stamps with the real list height — the same trick
+    # `PaletteState#ensure_visible` uses and for the same reason: the card's height is a
+    # function of the area the shell hands it, so it is only known on the draw path. The hint
+    # promises "page", and a hardcoded 10 would move a quarter of a 40-row card while saying
+    # so; this repo already carries two specs about hints drifting from behaviour.
+    #
+    # The seed is the smallest card this overlay will draw (MIN_H less its two chrome bands),
+    # so the one keypress that could land before the first frame still moves a plausible page
+    # rather than a made-up number.
+    @page : Int32 = MIN_H - LIST_OFFSET - 1
+
+    private def page_step : Int32
+      {@page - 1, 1}.max
+    end
+
+    # A click on the gauge scrolls; anywhere else inside the card is inert (there is nothing to
+    # select); outside dismisses. Never :commit — a read-only card that closed itself on a
+    # click would look like it had done something.
+    def handle_click(area : Rect, mx : Int32, my : Int32) : Symbol
+      box = overlay_box(area)
+      return :cancel if box.nil? || !box.contains?(mx, my)
+      # scroll_gauge_top, not scroll_gauge_row: this card's scroll is a real offset the
+      # operator owns, not a window derived from a selection that a re-render would restore.
+      if top = Frame.scroll_gauge_top(list_rect(box), @rows.size, mx, my)
+        @scroll = top
+      end
+      :stay
+    end
+
+    def overlay_box(area : Rect) : Rect?
+      w = {area.w - 4, MAX_W}.min
+      h = area.h - 2
+      return nil if w < MIN_W || h < MIN_H
+      Rect.new(area.x + (area.w - w) // 2, area.y + (area.h - h) // 2, w, h)
+    end
+
+    def render(screen : Screen, area : Rect) : Nil
+      box = overlay_box(area)
+      unless box
+        screen.text(area.x + 1, area.y, "#{@title.downcase} needs a larger window · esc to close", Theme.muted, Theme.bg) unless area.empty?
+        return
+      end
+      Frame.card(screen, box, @title, border: Theme.border_focus)
+      Frame.border_meta(screen, box, @title, meta_label, bg: Theme.panel)
+      render_filter(screen, box)
+      Frame.tee_divider(screen, box, box.y + 2)
+
+      list = list_rect(box)
+      return if list.h <= 0
+      @page = list.h # what ⇞/⇟ steps by — only knowable here (see page_step)
+      @scroll = @scroll.clamp(0, {@rows.size - list.h, 0}.max)
+      if @rows.empty?
+        screen.text(box.x + 3, list.y, "no rows match", Theme.muted, Theme.panel)
+        return
+      end
+      (0...list.h).each do |i|
+        li = @scroll + i
+        break if li >= @rows.size
+        HelpView.draw_row(screen, list, list.y + i, @rows[li], @key_w)
+      end
+      Frame.scroll_gauge(screen, list, @rows.size, @scroll, true, Theme.panel)
+    end
+
+    # Row count on the border, so a filter that narrows 300 rows to 4 says so without the
+    # operator counting. Matches how PassthroughOverlay states its host count.
+    private def meta_label : String
+      # Both branches count ITEMS. `@all.size` would count the section heads and the blank
+      # spacers too, so the border read "189 rows" at rest and "N of 156" the moment a key was
+      # typed — two different denominators for the same list, which reads as rows vanishing.
+      total = @all.count { |r| r.kind == :item }
+      return "#{total} rows" if @query.empty?
+      "#{@rows.count { |r| r.kind == :item }} of #{total}"
+    end
+
+    # The filter bar, mirroring FilterPickerOverlay#render_filter: an idle hint until something
+    # is typed, then the committed query plus any IME composition under a caret.
+    private def render_filter(screen : Screen, box : Rect) : Nil
+      if @query.empty? && @preedit.empty?
+        screen.text(box.x + 2, box.y + 1, "type to filter", Theme.muted, Theme.panel, width: {box.w - 4, 1}.max)
+        # Park the caret on this card even with nothing typed. `Screen#desired_cursor` is
+        # last-writer-wins per frame and the tab body draws BEFORE any overlay, so leaving it
+        # unset lets the caret keep blinking in the filter bar UNDERNEATH — and this is the one
+        # overlay reachable straight from an editing text bar (`?`), where an IME composition
+        # popup would anchor to that stale position too.
+        screen.cursor(box.x + 2, box.y + 1)
+      else
+        px = screen.text(box.x + 2, box.y + 1, "filter: ", Theme.muted, Theme.panel)
+        screen.input_line(px, box.y + 1, @query, @query.size, @preedit, Theme.text_bright,
+          Theme.panel, width: {box.right - 2 - px, 1}.max)
+      end
+    end
+
+    # The card's interior list band: below the filter divider, above the bottom border. The
+    # gauge draws on `list.right`, which is the card's right hairline.
+    private def list_rect(box : Rect) : Rect
+      Rect.new(box.x + 1, box.y + LIST_OFFSET, box.w - 2, {box.bottom - 1 - (box.y + LIST_OFFSET), 0}.max)
+    end
+  end
+end

--- a/src/gori/tui/help_view.cr
+++ b/src/gori/tui/help_view.cr
@@ -36,6 +36,11 @@ module Gori::Tui
         Item.new("^D / ^C ×2", "quit gori"),
         Item.new("q", "back to projects (on the tab bar)"),
         Item.new("?", "open this Help tab", "tab.help"),
+        # The same two pages as a popup over whatever you were doing, so looking a key up
+        # does not cost the pane you were in. Both are palette-only; `binding_label` prints
+        # the literal `^P` here for want of a chord, and follows one if either ever gains it.
+        Item.new("^P", "this page as a popup — 'Keyboard shortcuts'", "help.hotkeys"),
+        Item.new("^P", "the Query page as a popup — also `?` on an empty filter bar", "help.query"),
         Item.new("Settings: Hotkeys", "rebind any shortcut below (^P → Settings: Hotkeys)"),
       ]},
       {"TABS & FOCUS", [
@@ -255,20 +260,55 @@ module Gori::Tui
       ]},
     ]
 
+    # Which SECTIONS entry a tab's shortcuts live under. Read by the palette's Shortcuts
+    # popup, which opens scrolled to the section for the tab you were on — the popup exists
+    # for the "I'm here, what can I press" moment, and landing on GLOBAL every time would
+    # make the operator scroll for the answer they came with.
+    #
+    # The six tabs with no section of their own share OTHER TABS, which holds exactly one
+    # row each; :help itself is absent so opening from Help lands at the top (the whole
+    # sheet is already what that tab shows). A spec pins every Chrome::TABS symbol either
+    # here or deliberately out, and pins every title named here against SECTIONS — a typo'd
+    # title would otherwise silently degrade to "open at the top".
+    TAB_SECTION = {
+      :history     => "HISTORY",
+      :repeater    => "REPEATER",
+      :fuzzer      => "FUZZER",
+      :miner       => "MINER",
+      :oast        => "OAST",
+      :sequencer   => "SEQUENCER",
+      :decoder     => "DECODER",
+      :jwt         => "JWT",
+      :comparer    => "COMPARER",
+      :rewriter    => "REWRITER",
+      :colormarker => "COLORMARKER",
+      :target      => "OTHER TABS",
+      :sitemap     => "OTHER TABS",
+      :issues      => "OTHER TABS",
+      :probe       => "OTHER TABS",
+      :notes       => "OTHER TABS",
+      :project     => "OTHER TABS",
+      :intercept   => "OTHER TABS",
+    }
+
     @rows : Array(Row)
     @scroll : Int32 = 0
 
     def initialize(registry : Verb::Registry? = nil)
-      @rows = build_rows(registry)
+      @rows = HelpView.shortcut_rows(registry)
     end
 
     # Rebuild from the live registry (call after a hotkeys save so Help stays honest).
     def reload(registry : Verb::Registry) : Nil
-      @rows = build_rows(registry)
+      @rows = HelpView.shortcut_rows(registry)
       @scroll = 0
     end
 
-    private def build_rows(registry : Verb::Registry?) : Array(Row)
+    # A class method, not an instance one, because the palette's Shortcuts popup renders the
+    # SAME rows without owning a HelpView. Going through here rather than reading SECTIONS is
+    # what keeps the popup honest: the key column is resolved from the live keymap below, so a
+    # rebind (or the ⌥ alias) reaches both surfaces or neither.
+    def self.shortcut_rows(registry : Verb::Registry?) : Array(Row)
       rows = [] of Row
       SECTIONS.each_with_index do |(title, items), si|
         rows << Row.new(:gap, "", "") if si > 0
@@ -304,7 +344,7 @@ module Gori::Tui
       (0...rect.h).each do |i|
         li = @scroll + i
         break if li >= @rows.size
-        draw_row(screen, rect, rect.y + i, @rows[li])
+        HelpView.draw_row(screen, rect, rect.y + i, @rows[li])
       end
     end
 
@@ -312,8 +352,12 @@ module Gori::Tui
     # QL EXPRESSIONS, not key chords: `NOT (host:cdn OR host:img)` is 26 columns where the widest
     # chord label is 20, and truncating an example query to `NOT (host:cdn OR ho…` would teach the
     # syntax wrong. Same two-column row, one page's worth of extra room.
-    private def draw_row(screen : Screen, rect : Rect, y : Int32, row : Row,
-                         key_w : Int32 = KEY_W) : Nil
+    #
+    # A class method for the same reason `shortcut_rows` is: the palette's Shortcuts/Query popup
+    # paints the same two-column row into its card, and one painter is what stops the two
+    # surfaces disagreeing about where the description column starts. It reads no instance state.
+    def self.draw_row(screen : Screen, rect : Rect, y : Int32, row : Row,
+                      key_w : Int32 = KEY_W) : Nil
       case row.kind
       when :head
         screen.text(rect.x + 1, y, row.a, Theme.accent, attr: Attribute::Bold, width: {rect.w - 2, 1}.max)
@@ -344,6 +388,11 @@ module Gori::Tui
     # `-term` on the two surfaces most likely to be asked for it.
     QUERY_KEY_W = 28
 
+    # The default field-help lookup. A constant proc rather than an inline closure because
+    # `query_rows`'s default argument would otherwise allocate one per call — the same reason
+    # `InterceptFilter::FIELD_HELP_PROC` exists.
+    QL_FIELD_HELP = ->(f : String) { QL.field_help(f) }
+
     # Its own offset, not `@scroll`: the two pages have different lengths, and sharing one would
     # carry the cheat-sheet's position onto this page — where `at_top?` then answers about the
     # wrong page and ↑ pops focus to the strip in the middle of a scroll.
@@ -364,19 +413,37 @@ module Gori::Tui
       (0...rect.h).each do |i|
         li = @query_scroll + i
         break if li >= rows.size
-        draw_row(screen, rect, rect.y + i, rows[li], QUERY_KEY_W)
+        HelpView.draw_row(screen, rect, rect.y + i, rows[li], QUERY_KEY_W)
       end
     end
 
     # Memoised per instance: the tables are constants, so this is the same list every time, and
     # `render_query` runs on the draw path.
     private def query_rows : Array(Row)
-      @query_rows ||= build_query_rows
+      @query_rows ||= HelpView.query_rows
     end
 
     @query_rows : Array(Row)? = nil
 
-    private def build_query_rows : Array(Row)
+    # Built fresh per call, and deliberately NOT memoised on the class: the callers each hold
+    # their own copy for the lifetime they need it (this view above, the palette popup at open
+    # time), and neither is on a draw path that would notice. A class-level `||=` would be
+    # shared mutable state bought for nothing.
+    #
+    # `fields`/`help` are parameters because the FIELD LIST is per-surface even though the
+    # GRAMMAR is not. Every bar parses through `FilterAst`, so SYNTAX and WORTH KNOWING are the
+    # same everywhere — but the Intercept condition accepts nine of QL's eighteen fields and
+    # deliberately redefines four of them (`InterceptFilter::FIELD_HELP`: `status:` "scopes to
+    # RESPONSES only", `header:` "this leg only", …), and Sitemap adds a `tag:` that never
+    # reaches the parser at all.
+    #
+    # Handing this page QL's tables on those surfaces is precisely the drift `FIELD_HELP`'s own
+    # comment says it was merged-not-copied to prevent — a reference stating the opposite of what
+    # the bar under it will do. Aliases are filtered to targets that survive `fields` for the
+    # same reason: `res.header:` is not "also accepted" where `resp.header:` does not exist.
+    def self.query_rows(fields : Array(String) = QL::FIELDS,
+                        help : Proc(String, String?) = QL_FIELD_HELP,
+                        aliases : Hash(String, String) = QL::FIELD_ALIASES) : Array(Row)
       rows = [] of Row
       rows << Row.new(:head, "SYNTAX", "")
       QL::SYNTAX_HELP.each { |(example, meaning)| rows << Row.new(:item, example, meaning) }
@@ -385,14 +452,17 @@ module Gori::Tui
       # agree about what comes first.
       rows << Row.new(:gap, "", "")
       rows << Row.new(:head, "FIELDS  (: matches, ~ is regex)", "")
-      QL::FIELDS.each do |name|
-        rows << Row.new(:item, "#{name}:", QL::FIELD_HELP[name]? || "")
+      fields.each do |name|
+        rows << Row.new(:item, "#{name}:", help.call(name) || "")
       end
 
-      rows << Row.new(:gap, "", "")
-      rows << Row.new(:head, "ALSO ACCEPTED", "")
-      QL::FIELD_ALIASES.each do |from, to|
-        rows << Row.new(:item, "#{from}:", "= #{to}:")
+      live = aliases.select { |_, to| fields.includes?(to) }
+      unless live.empty?
+        rows << Row.new(:gap, "", "")
+        rows << Row.new(:head, "ALSO ACCEPTED", "")
+        live.each do |from, to|
+          rows << Row.new(:item, "#{from}:", "= #{to}:")
+        end
       end
 
       rows << Row.new(:gap, "", "")

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -65,7 +65,7 @@ module Gori::Tui
     # FILTER_HINT sits on the idle bar (press `/` to start filtering); QUERY_HINT sits on the
     # suggestion row at a cold start (already editing, nothing to Tab-complete yet).
     FILTER_HINT = QuerySuggest.idle_hint("/ filter")
-    QUERY_HINT  = QuerySuggest.cold_hint
+    QUERY_HINT  = QuerySuggest.cold_hint(help_key: true)
     # The editing bar's label. A constant because `render_query_popup` has to line the dropdown
     # up under the token, which means knowing exactly how far the query text is indented.
     QUERY_PREFIX = "filter › "

--- a/src/gori/tui/intercept_view.cr
+++ b/src/gori/tui/intercept_view.cr
@@ -34,7 +34,7 @@ module Gori::Tui
     # hold's OPT-IN, and without it no WS message is held however permissive the rest is (#500) —
     # a fact no generator over a field list could know.
     QUERY_HINT = QuerySuggest.cold_hint(InterceptFilter::HINT_FIELDS,
-      note: "proto:ws opts WS messages IN")
+      note: "proto:ws opts WS messages IN", help_key: true)
     # The idle bar, before `/` opens the condition. Same generator as History's and Sitemap's, so
     # the three stop disagreeing about which operators exist.
     IDLE_HINT = QuerySuggest.idle_hint("/ condition", InterceptFilter::HINT_FIELDS)

--- a/src/gori/tui/overlay.cr
+++ b/src/gori/tui/overlay.cr
@@ -38,6 +38,9 @@ module Gori::Tui
     Hosts
     Env
     Hotkeys
+    # Help's cheat-sheet / QL reference as a popup over the current pane (HelpPopupOverlay).
+    # ONE member for both pages: they never coexist, and an overlay's `title` is per instance.
+    Help
     Notifications
     Passthrough
     Listeners

--- a/src/gori/tui/query_suggest.cr
+++ b/src/gori/tui/query_suggest.cr
@@ -182,11 +182,16 @@ module Gori::Tui
     # appended note lands past the operator tail, which is already ~120 columns, so it was
     # permanently truncated on every real terminal — and the shrink below can only protect what it
     # composes itself.
+    # `help_key` advertises the `?`-opens-the-QL-reference affordance (TabController#ql_help_key?).
+    # A flag rather than always-on, because `cold_hint` also dresses the Colormarker rule form's
+    # `when:` band — a plain text field where `?` types a `?`. An unconditional chip would make
+    # this generator advertise a key on a surface that does not have it, which is the exact
+    # failure the hand-written FILTER_HINT/QUERY_HINT pair was replaced for.
     def self.cold_hint(fields : Array(String) = QL::HINT_FIELDS, width : Int32? = nil,
-                       note : String? = nil) : String
+                       note : String? = nil, help_key : Bool = false) : String
       n = {fields.size, HINT_MAX}.min
       loop do
-        line = compose(fields.first(n), note)
+        line = compose(fields.first(n), note, help_key)
         return line if width.nil? || n == 0 || fits?(line, width)
         n -= 1
       end
@@ -197,10 +202,21 @@ module Gori::Tui
     # field-name pool dropped every one of them. Completion cannot teach comparison either — Tab
     # offers names until a `:` is typed — so without this nothing on the bar shows that `status:`
     # takes an operator at all.
-    private def self.compose(fields : Array(String), note : String? = nil) : String
+    private def self.compose(fields : Array(String), note : String? = nil,
+                             help_key : Bool = false) : String
+      # AFTER `-term excludes`, not before it. Leading with the chip read better and was wrong:
+      # it is 16 columns, and `fits?` below protects `-term excludes` by INDEX, so putting
+      # anything ahead of that token pushes it right on every surface at once — measured, it
+      # moved from column 78 to 94 on History, newly cutting it off on any terminal 84-99 wide.
+      # None of the three bars passes `width`, so the shrink loop cannot claw that back either.
+      #
+      # Behind it, every pre-existing token sits exactly where it did, and the new chip takes
+      # its chances with the tail — which is the right trade: a new affordance must not cost an
+      # existing one its place.
+      help = help_key ? "? reference  ·  " : ""
       chips = fields.empty? ? "" : "fields: #{sample(fields)}  ·  "
       tail = note ? "#{note}  ·  " : ""
-      "#{chips}-term excludes  ·  #{tail}OR NOT ( ) group  ·  ~regex  ·  >= < on status size dur"
+      "#{chips}-term excludes  ·  #{help}#{tail}OR NOT ( ) group  ·  ~regex  ·  >= < on status size dur"
     end
 
     # Does the operator that matters survive this width? Not "does the whole line fit" — the tail

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -35,6 +35,7 @@ require "./history_view"
 require "./repeater_view"
 require "./sitemap_view"
 require "./help_view"
+require "./help_popup_overlay"
 require "./issues_view"
 require "./notes_view"
 require "./project_view"
@@ -2602,6 +2603,55 @@ module Gori::Tui
       # and via leave_overlay so no pop-back lands on top of it.
       ov.on_palette = -> { leave_overlay; open_palette }
       open_overlay(ov)
+    end
+
+    # Help's cheat-sheet as a popup over the current pane (the help.hotkeys palette entry).
+    # Read-only, so there is no on_commit.
+    #
+    # `@active_tab` is what makes this worth having over `tab.help`: the card opens on the
+    # section for the tab the operator is standing in, so the question they arrived with is
+    # already on screen. The registry goes through so the key column follows a rebind — the
+    # popup renders HelpView's own rows, not a copy of SECTIONS.
+    def open_help_shortcuts : Nil
+      ov = HelpPopupOverlay.shortcuts(@session.registry, @active_tab)
+      # Same ordering rule as open_passthrough: drop this modal BEFORE raising the palette,
+      # and via leave_overlay so no pop-back lands on top of it.
+      ov.on_palette = -> { jump_to_palette }
+      open_overlay(ov)
+    end
+
+    # The QL reference as a popup (the help.query palette entry, and `?` on an empty filter
+    # bar — see each controller's handle_query_key). Opening it from the bar is why nothing
+    # here touches focus: the query branch is gated on `@overlay.none?`, so the bar simply
+    # stops receiving keys while this is up and resumes with its text intact on esc.
+    def open_help_query(surface : Symbol) : Nil
+      ov = help_query_overlay(surface)
+      ov.on_palette = -> { jump_to_palette }
+      open_overlay(ov)
+    end
+
+    # Which field vocabulary the reference teaches. The GRAMMAR is one — every bar parses
+    # through `FilterAst`, so SYNTAX and WORTH KNOWING are shared — but the field list is not,
+    # and a reference that lists fields the bar under it will reject (or defines them the other
+    # way round) is worse than none.
+    #
+    # The mapping lives here because the Runner is the one place that already knows every
+    # surface; `HelpPopupOverlay` stays free of tab-specific requires.
+    private def help_query_overlay(surface : Symbol) : HelpPopupOverlay
+      case surface
+      when :intercept
+        # Nine fields, not eighteen, and four of them mean something else at a hold gate —
+        # `InterceptFilter::FIELD_HELP` is merged over QL's precisely to state that delta.
+        HelpPopupOverlay.query_reference("INTERCEPT CONDITION",
+          HelpView.query_rows(InterceptFilter::FIELDS, InterceptFilter::FIELD_HELP_PROC))
+      when :sitemap
+        # QL plus this surface's own `tag:`, which never reaches the parser (FilterAst.partition
+        # pulls it out first) and so cannot come from QL's table.
+        HelpPopupOverlay.query_reference("SITEMAP FILTER",
+          HelpView.query_rows(["tag"] + QL::FIELDS, SitemapView::QL_HELP))
+      else
+        HelpPopupOverlay.query_reference
+      end
     end
 
     # Open the additional-listener inventory (the `listeners:N` top-bar chip + the

--- a/src/gori/tui/sitemap_view.cr
+++ b/src/gori/tui/sitemap_view.cr
@@ -49,7 +49,7 @@ module Gori::Tui
     # never mentioned `-term` at all. `tag:` is appended because it is this surface's own field
     # and the shared sample cannot know about it.
     FILTER_HINT = QuerySuggest.idle_hint("/ filter", ["tag"] + QL::HINT_FIELDS)
-    QUERY_HINT  = QuerySuggest.cold_hint(["tag"] + QL::HINT_FIELDS)
+    QUERY_HINT  = QuerySuggest.cold_hint(["tag"] + QL::HINT_FIELDS, help_key: true)
     # The highlighter's field vocabulary: everything QL ACCEPTS (a superset of `QL_FIELDS`, which
     # is only what Tab offers here) plus this surface's own `tag:`, which QL knows nothing about
     # because `partition` pulls it out before the query ever reaches the parser.
@@ -438,6 +438,13 @@ module Gori::Tui
 
     def querying? : Bool
       @querying
+    end
+
+    # The committed filter text. HistoryView and InterceptView have carried this since they
+    # were written; this bar simply never had a reader outside itself until `ql_help_key?`
+    # needed to ask whether it was empty. Same name as its two siblings on purpose.
+    def query : String
+      @query
     end
 
     # True when the tree is a filtered subset (a `/` query or the Scope lens is on).

--- a/src/gori/tui/tab_controller.cr
+++ b/src/gori/tui/tab_controller.cr
@@ -25,6 +25,10 @@ module Gori::Tui
     abstract def goto_tab(tab : Symbol) : Nil         # raw: set active tab + body focus, no on_enter/view_focus_first (e.g. ^R → Repeater)
     abstract def open_palette : Nil                   # open the command palette overlay
     abstract def open_space_menu : Nil                # open the space action menu (bottom-right)
+    # The QL reference popup. Reached from a filter bar (see `ql_help_key?`), where the
+    # question "what fields are there?" actually occurs — a controller cannot open an
+    # overlay itself, so it asks here.
+    abstract def open_help_query(surface : Symbol) : Nil
     # Open the Fuzzer's payload-set editor overlay (nil = add a new set, else edit that
     # index) / the advanced-settings overlay. The Runner builds them from the current view.
     abstract def open_fuzz_set_editor(edit_index : Int32?) : Nil
@@ -513,6 +517,36 @@ module Gori::Tui
       cur = vis.index(current)
       target = cur ? vis[(cur + dir).clamp(0, vis.size - 1)] : (dir < 0 ? vis.first : vis.last)
       target == current ? nil : target
+    end
+
+    # --- QL filter bar: the "show me the reference" key -----------------------
+    # `?` on an EMPTY query bar opens the QL reference popup instead of typing a `?`.
+    #
+    # `?` and not a Ctrl chord, for three reasons. It is ALREADY the app's help key
+    # (`tab.help`), and every text sub-mode — these three bars included — swallowed it, so
+    # this makes an existing gesture stop being dead in the one place people go looking for
+    # QL syntax. It costs no `Hotkeys::CLAIMED_CTRL_LETTERS` entry and cannot shadow a
+    # rebind. And the alternatives lose: there is no free Ctrl+letter to take — every a–z is
+    # claimed between the verb chords, `Hotkeys::CLAIMED_CTRL_LETTERS` and `verb/reserved.cr`
+    # — `Ctrl+Space` collides with the Hangul/IME toggle this bar has preedit handling for,
+    # and F1 is inexpressible as a `Verb::Chord` (`NAMED_KEYS` has no function keys), so it
+    # could never be advertised or rebound.
+    #
+    # EMPTY buffer only, not "after whitespace": `?id=` is a plausible free-text search on a
+    # proxy, and a key whose trigger state the operator cannot see is worse than one that
+    # only fires from a visibly empty bar. The single query this displaces is a bare leading
+    # `?`, which compiles to free text (`LIKE '%?%'` over method/host/target) — "every flow
+    # with a query string", which nobody types deliberately. `path:?` and `url:?` are
+    # untouched.
+    #
+    # Shared here rather than written into the three `handle_query_key`s, which are otherwise
+    # byte-for-byte parallel: a predicate in one place is a class that cannot be half-fixed.
+    # A CLASS method so a spec can drive it without a Host — controllers need the Runner, which
+    # needs a live tty, so an instance-level predicate would be reachable only through the TUI.
+    def self.ql_help_key?(ev : Termisu::Event::Key, query : String) : Bool
+      return false unless query.empty?
+      return false if ev.ctrl? || ev.alt?
+      (ev.char || ev.key.to_char) == '?'
     end
 
     # --- filter bar rendering (shared by every opt-in tab's render_body) ---

--- a/src/gori/verb/context.cr
+++ b/src/gori/verb/context.cr
@@ -52,6 +52,12 @@ module Gori
       # state (which hosts actually got bypassed), not the rule list settings:network edits.
       abstract def open_passthrough : Nil
       abstract def open_listeners : Nil
+      # Help's two reference pages as a popup over the current pane, rather than a jump to the
+      # Help tab. The distinction is the whole point: `tab.help` costs the pane you were in,
+      # and the moment you want a key looked up is the moment you cannot afford that.
+      abstract def open_help_shortcuts : Nil
+      # `surface` picks the field vocabulary: :ql (the palette entry), :sitemap, :intercept.
+      abstract def open_help_query(surface : Symbol) : Nil
       abstract def close_overlay : Nil
 
       # Emergency full repaint: redraw every cell (a full sync, not a diff). Recovers from

--- a/src/gori/verbs/core.cr
+++ b/src/gori/verbs/core.cr
@@ -316,6 +316,25 @@ module Gori
         "tab.help", "Go to Help", "Focus the Help tab (keyboard cheat-sheet)", Verb::Scope::Global,
         [Verb::Chord.new("?")], category: Verb::Category::Navigation) { |ctx| ctx.focus_tab(:help); nil }
 
+      # The same two pages WITHOUT leaving the pane — a popup over whatever is on screen, so
+      # looking a key up costs nothing to undo. Palette-only, and not for want of trying: every
+      # Ctrl+letter a–z is spoken for between the verb chords declared here, the pre-keymap
+      # guards in `Hotkeys::CLAIMED_CTRL_LETTERS` and the terminal-reserved set in
+      # `verb/reserved.cr`, so a chord could only be taken FROM something. A reference page is
+      # not what you spend that on, and the palette is where an operator already goes to ask
+      # "what can I do here".
+      #
+      # The ids carry the search terms the titles cannot. The palette fuzzy-scores
+      # "#{title} #{id}", so `help.hotkeys` is what makes a query of "hotkey" land while the
+      # title says "Keyboard shortcuts" — the two words an operator might reach for are
+      # covered between them.
+      r.register Verb::Definition.new(
+        "help.hotkeys", "Keyboard shortcuts", "Show the keyboard cheat-sheet in a popup (Help's Shortcuts page)",
+        Verb::Scope::Global, category: Verb::Category::System) { |ctx| ctx.open_help_shortcuts; nil }
+      r.register Verb::Definition.new(
+        "help.query", "Query language reference", "Show the filter/query language reference in a popup (Help's Query page)",
+        Verb::Scope::Global, category: Verb::Category::System) { |ctx| ctx.open_help_query(:ql); nil }
+
       # Discover is a sub-tab under Target, so it gets its own "Go to" (Target's own jump
       # lands on the last-active sub-tab).
       r.register Verb::Definition.new(


### PR DESCRIPTION
Wondering "what key sends this?" mid-Repeater meant leaving the Repeater. `?` is a tab jump, so the pane, the selection and the place you were in all go — and coming back means finding them again. The two pages you actually want mid-task are now palette commands that float a card over the current pane, and `esc` puts you back on it.

| Command | Page |
|---|---|
| **Keyboard shortcuts** | Help ▸ Shortcuts |
| **Query language reference** | Help ▸ Query |

**Opens where you are.** The Shortcuts card lands on the section for the tab you were standing in (Repeater tab → REPEATER), not on GLOBAL. Tabs with no section of their own share OTHER TABS; from Help itself it opens at the top.

**Filters as you type.** `copy` narrows 156 rows to the 14 copy keys across every tab, each still under its section head — `y` means different things in HISTORY and JWT. That's the question neither the Help tab nor the space menu could answer.

**Reachable from the filter bar**, where the QL question actually occurs: bare `?` on an **empty** `/` bar in History, Sitemap and Intercept. `?` after any text still types a `?`, and the bar keeps its partial query while the card is up.

## Why `?` and not a chord

Every Ctrl+letter a–z is spoken for between the verb chords, `Hotkeys::CLAIMED_CTRL_LETTERS` and `verb/reserved.cr`, so a chord could only be taken *from* something. `?` was already the app's help key (`tab.help`) and every text sub-mode swallowed it with no consumer — this makes an existing gesture stop being dead where people go looking. No `CLAIMED_CTRL_LETTERS` entry, no `Chord` representability problem, no hotkeys-editor shadowing.

Empty-buffer only, not "after whitespace": `?id=` is a plausible free-text search on a proxy, and a trigger state you can't see is worse than one that only fires from a visibly empty bar. The single query displaced is a bare leading `?`, which compiled to `LIKE '%?%'` over method/host/target.

## The content is not copied

The popup renders `HelpView`'s own rows through `HelpView`'s own painter, so a rebind (or the ⌥ alias) reaches both surfaces or neither. A spec compares the row lists directly.

The **FIELDS** section is per-surface, though, because the field list is. The Intercept condition accepts 9 of QL's 18 fields and deliberately redefines four of them (`status:` → "code/class — and scopes to RESPONSES only", `header:` → "this leg only"); Sitemap adds a `tag:` that never reaches the parser. Handing those bars QL's table is precisely the drift `InterceptFilter::FIELD_HELP` was merged-not-copied to prevent. Aliases are filtered to targets that survive the field list, so `res.header:` is not "also accepted" where `resp.header:` doesn't exist.

## Two things worth a second look

- The `? reference` chip goes **behind** `-term excludes` on the hint row. Leading with it read better and was wrong: `fits?` protects that token by index, so a 16-column prefix moved it from column 78 to 94 and newly cut it off on terminals 84–99 wide — and none of the three bars passes `width`, so the shrink loop couldn't claw it back.
- No `g`/`G`/`j`/`k` motion arms. With a filter bar, a letter arm above the printable arm eats that letter out of every query (`g` is in "graphql", `k` in "key"). Scrolling is arrows / PgUp / PgDn / Home / End / wheel.

## Known limitation

The **SYNTAX** examples are shared across surfaces, so on the Intercept card two of them cite fields a hold gate rejects (`dur:`, `resp.body:`). They teach operators rather than assert availability, and the FIELDS list right below is authoritative — splitting them per surface would cost the comparison-operator lesson on a bar where `status:>=500` is valid. Left as-is deliberately.

## Verification

- `crystal spec` — 8636 examples, 0 failures. (The 8 `Gori::Session` port-bind failures seen locally reproduce on a pristine stash and are environmental — other gori processes holding the port.)
- `crystal tool format --check src spec` — clean.
- Driven in a real terminal via tmux: Shortcuts from Repeater lands on REPEATER with the 98-column `^V` row untruncated; `copy` filter narrows correctly; `esc` returns to the Repeater body unchanged; `?` verified on **all three** bars, including the Intercept card showing `status: code/class — and scopes to RESPONSES only` and the Sitemap card showing `tag:`.

New specs pin what they claim — each was re-run with the fix reverted. That caught one **vacuous** example: an `^P`-doesn't-type-a-`p` test passed with the ctrl guard removed, because the ctrl-P arm sits above the printable arm. It's now `^K`/`^X`/`⌥R`, which produce `"kxr"` without the guard.

No CHANGELOG entry — entries here carry PR numbers and land at release time.
