### PR TITLE
Refresh the project env table the TUI is about to write back

### DIFF
--- a/spec/tui/project_env_pane_spec.cr
+++ b/spec/tui/project_env_pane_spec.cr
@@ -65,6 +65,34 @@ private def row_of(view : ProjectView, rect : Rect, needle : String) : Int32
   (0...rect.h).find { |r| b.row(r).includes?(needle) } || raise "#{needle.inspect} was not drawn"
 end
 
+describe "Gori::Env.load_project" do
+  # Both repeat callers ask on a cadence (`apply_external_change` on every `data_version` move,
+  # which own captures cause; MCP before every outbound tool), and the rev they would bump is
+  # what `TextArea`'s styled buffer and `Rules#subst_snapshot` cache against.
+  it "publishes, and invalidates, only on a real delta" do
+    tmp_store do |store, _project|
+      with_project_vars([] of {String, String}) do
+        Gori::Env.save_project(store, [{"ALPHA", "1"}]).should be_true
+        store.flush
+        Gori::Env.load_project(store)
+        rev = Gori::Env.highlight_rev
+
+        Gori::Env.load_project(store) # same table, twice more
+        Gori::Env.load_project(store)
+        Gori::Env.highlight_rev.should eq(rev)
+        Gori::Settings.project_env_vars.should eq([{"ALPHA", "1"}])
+
+        store.set_setting(Gori::Env::PROJECT_VARS_KEY,
+          Gori::Env.serialize_vars([{"ALPHA", "2"}])).should be_true
+        store.flush
+        Gori::Env.load_project(store)
+        Gori::Env.highlight_rev.should_not eq(rev) # a real change still invalidates
+        Gori::Settings.project_env_vars.should eq([{"ALPHA", "2"}])
+      end
+    end
+  end
+end
+
 describe "ProjectView ENV pane" do
   it "picks the row under the pointer while the prefix editor holds the first line" do
     tmp_store do |store, project|
@@ -157,6 +185,29 @@ describe "ProjectView ENV pane" do
         view.env_commit.should eq(:ok)
         # The edit landed on ALPHA. Against the index alone it hit PEER's slot — or, once the
         # duplicate check saw ALPHA elsewhere, refused the operator's edit as a dup.
+        view.env_vars.should eq([{"PEER", "0"}, {"ALPHA", "19"}])
+      end
+    end
+  end
+
+  # `reload` is the OTHER re-seed site. Nothing on the top-level tab-switch path cancels an open
+  # ENV row — `flush_active_tab_edits` → `ProjectController#commit` saves the description and
+  # the network fields, and `cancel_env_add` lives in `settle_subtab`, which only sub-tab
+  # changes reach. So a Project → History → Project round trip past a peer's write hands the
+  # open row a list that has shifted under its index.
+  it "re-anchors an open edit row across a tab-entry reload too" do
+    tmp_store do |store, project|
+      with_project_vars([{"ALPHA", "1"}]) do
+        view = env_view(store, project)
+        view.env_edit_start
+        type(view, "9") # "ALPHA 19", still open
+
+        Gori::Settings.project_env_vars = [{"PEER", "0"}, {"ALPHA", "1"}]
+        view.reload(project, store) # ← tab entry, not the external-change path
+
+        view.env_commit.should eq(:ok)
+        # In range but stale, the index wrote PEER's slot and `Env.save_project` then persisted
+        # the whole array — the peer's var deleted by the very commit that added the refresh.
         view.env_vars.should eq([{"PEER", "0"}, {"ALPHA", "19"}])
       end
     end
@@ -358,6 +409,14 @@ describe Gori::Tui::ProjectController do
       # was never contradicted — the var was simply gone at the next launch.
       host.statuses.last.should contain("NOT saved")
       host.statuses.last.should_not contain("env var saved")
+
+      # …and the pane + the substitution table agree with the store, which is what the message
+      # claims. `Env.save_project` publishes to the global whatever the store answered, and a
+      # rolled-back write does not move `data_version` — so without the rollback the phantom
+      # var expanded in every send for the rest of the session, and the next committing write
+      # would have made it real.
+      c.view.env_vars.should be_empty
+      Gori::Settings.project_env_vars.should be_empty
     end
   end
 
@@ -375,6 +434,9 @@ describe Gori::Tui::ProjectController do
       c.env_delete_var # FakeHost#confirm runs the action
 
       host.statuses.last.should contain("NOT deleted")
+      # The row is back, because the store still has it — see the save example above.
+      c.view.env_vars.should eq([{"TOKEN", "sekrit"}])
+      Gori::Settings.project_env_vars.should eq([{"TOKEN", "sekrit"}])
     end
   end
 

--- a/spec/tui/project_env_pane_spec.cr
+++ b/spec/tui/project_env_pane_spec.cr
@@ -1,0 +1,419 @@
+require "../spec_helper"
+require "../support/memory_backend"
+require "file_utils"
+
+include Gori::Tui
+
+# The Project tab's ENV pane — the per-project `$KEY` table.
+#
+# It is the only pane on that tab holding its OWN copy of the data it edits (SCOPE and HOST
+# OVERRIDES render straight out of one live object), and `Gori::Env.save_project` persists that copy
+# WHOLESALE. Three of the four regressions below follow from those two facts together:
+#
+#   * a peer process's change never reached the copy, so the next commit here wrote the stale
+#     set back and deleted the peer's vars;
+#   * a rolled-back write said "saved" anyway, and nothing on this surface re-reads the store,
+#     so the row went on showing a value that never landed;
+#   * an open EDIT row named its target by INDEX into a list that could shrink underneath it.
+#
+# The fourth is the add-row's ⌫, which asked about the CARET instead of the ROW.
+
+private def tmp_store(&)
+  path = File.tempname("gori-env-pane", ".db")
+  store = Gori::Store.open(path)
+  begin
+    yield store, Gori::Project.new("p", path)
+  ensure
+    store.close rescue nil
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+# `Settings.project_env_vars` is a process-wide singleton the whole suite shares — snapshot it
+# (and the prefix, which `Env.expand` reads) and always put it back.
+private def with_project_vars(vars : Array({String, String}), &)
+  saved = Gori::Settings.project_env_vars
+  saved_prefix = Gori::Settings.env_prefix
+  Gori::Settings.project_env_vars = vars
+  Gori::Settings.env_prefix = "$"
+  begin
+    yield
+  ensure
+    Gori::Settings.project_env_vars = saved
+    Gori::Settings.env_prefix = saved_prefix
+  end
+end
+
+private def env_view(store : Gori::Store, project : Gori::Project) : ProjectView
+  view = ProjectView.new(Gori::Scope.load(store), Gori::HostOverrides.load(store))
+  view.reload(project, store)
+  view.focus_pane(:env)
+  view
+end
+
+private def type(view : ProjectView, text : String) : Nil
+  text.each_char { |c| view.env_input(c) }
+end
+
+# The screen row a var's KEY is drawn on, so a hit-test can be asserted against the DRAW rather
+# than against a hand-computed offset that would drift with the card geometry.
+private def row_of(view : ProjectView, rect : Rect, needle : String) : Int32
+  b = MemoryBackend.new(rect.w, rect.h)
+  view.render(Screen.new(b), rect, focused: true)
+  (0...rect.h).find { |r| b.row(r).includes?(needle) } || raise "#{needle.inspect} was not drawn"
+end
+
+describe "ProjectView ENV pane" do
+  it "picks the row under the pointer while the prefix editor holds the first line" do
+    tmp_store do |store, project|
+      with_project_vars([{"ALPHA", "1"}, {"BETA", "2"}, {"GAMMA", "3"}]) do
+        view = env_view(store, project)
+        rect = Rect.new(0, 0, 120, 30)
+
+        # Baseline: no sub-mode, the list starts on the first interior line.
+        view.env_row_at(rect, 5, row_of(view, rect, "BETA")).should eq(1)
+
+        # The add row takes that line, and the hit-test has always known about it.
+        view.env_add_start
+        view.env_row_at(rect, 5, row_of(view, rect, "BETA")).should eq(1)
+        view.cancel_env_add
+
+        # …and so does the PREFIX row, which the draw offsets identically and the hit-test
+        # used to ignore — every click landed one row further down the list than the pointer.
+        view.env_prefix_edit_start
+        view.env_row_at(rect, 5, row_of(view, rect, "BETA")).should eq(1)
+        view.env_row_at(rect, 5, row_of(view, rect, "ALPHA")).should eq(0)
+      end
+    end
+  end
+
+  it "keeps a typed line when ⌫ arrives with the caret at the start" do
+    tmp_store do |store, project|
+      with_project_vars([] of {String, String}) do
+        view = env_view(store, project)
+        view.env_add_start
+        type(view, "TOKEN abc123")
+        view.env_move_cursor(-99) # ← to the head of the line
+
+        # True ⇒ "the row still has text", which is what stops the caller closing it. The old
+        # answer was about the CARET, so this ⌫ threw the whole line away.
+        view.env_backspace.should be_true
+        view.env_commit.should eq(:ok)
+        view.env_vars.should eq([{"TOKEN", "abc123"}])
+      end
+    end
+  end
+
+  it "closes the row only once it is genuinely empty" do
+    tmp_store do |store, project|
+      with_project_vars([] of {String, String}) do
+        view = env_view(store, project)
+        view.env_add_start
+        type(view, "ab")
+        view.env_backspace.should be_true
+        view.env_backspace.should be_true
+        view.env_backspace.should be_false # nothing left ⇒ the caller closes the row
+      end
+    end
+  end
+
+  it "adopts a peer's vars instead of writing a stale list back over them" do
+    tmp_store do |store, project|
+      with_project_vars([{"ALPHA", "1"}]) do
+        view = env_view(store, project)
+        view.env_vars.should eq([{"ALPHA", "1"}])
+
+        # A peer process added one and `Runner#apply_external_change` reloaded the global.
+        Gori::Settings.project_env_vars = [{"ALPHA", "1"}, {"PEER", "9"}]
+        view.reload_env_vars
+
+        # The pane's own copy is what `Gori::Env.save_project` persists wholesale, so this IS the
+        # clobber test: adding a var here must not take the peer's with it.
+        view.env_add_start
+        type(view, "MINE 7")
+        view.env_commit.should eq(:ok)
+        Gori::Env.save_project(store, view.env_vars).should be_true
+        store.flush
+        Gori::Env.parse_vars_json(store.setting(Gori::Env::PROJECT_VARS_KEY))
+          .should eq([{"ALPHA", "1"}, {"PEER", "9"}, {"MINE", "7"}])
+      end
+    end
+  end
+
+  it "re-anchors an open edit row by KEY when the peer reordered the list" do
+    tmp_store do |store, project|
+      with_project_vars([{"ALPHA", "1"}]) do
+        view = env_view(store, project)
+        view.env_edit_start # edits ALPHA, at index 0
+        view.cancel_env_add
+        view.env_edit_start
+        type(view, "9") # "ALPHA 19" — the row is still ALPHA
+
+        Gori::Settings.project_env_vars = [{"PEER", "0"}, {"ALPHA", "1"}]
+        view.reload_env_vars # ALPHA is index 1 now
+
+        view.env_commit.should eq(:ok)
+        # The edit landed on ALPHA. Against the index alone it hit PEER's slot — or, once the
+        # duplicate check saw ALPHA elsewhere, refused the operator's edit as a dup.
+        view.env_vars.should eq([{"PEER", "0"}, {"ALPHA", "19"}])
+      end
+    end
+  end
+
+  it "turns an edit row whose var the peer deleted into an add" do
+    tmp_store do |store, project|
+      with_project_vars([{"ALPHA", "1"}]) do
+        view = env_view(store, project)
+        view.env_edit_start
+
+        Gori::Settings.project_env_vars = [] of {String, String}
+        view.reload_env_vars # the row this edit indexed into is gone
+
+        # `@env_items[idx] = …` on the emptied list would have raised IndexError out of a
+        # keystroke; the typed text is re-added instead.
+        view.env_commit.should eq(:ok)
+        view.env_vars.should eq([{"ALPHA", "1"}])
+      end
+    end
+  end
+end
+
+# --- the controller half: what the operator is TOLD, and what a ⌫ does to their line ---------
+#
+# `Gori::Env.save_project` answers whether the write committed. A CLOSED store is the honest seam for
+# "it did not" — `exec_task_ok` catches Channel::ClosedError and answers false, the same false a
+# rolled-back batch produces (see project_desc_persist_spec, which uses it for the same reason).
+
+private class FakeHost
+  include Gori::Tui::Host
+
+  getter statuses = [] of String
+
+  def initialize(@session : Gori::Session)
+    @jobs = Gori::Tui::Jobs.new
+    @notifications = Gori::Tui::Notifications.new
+  end
+
+  def session : Gori::Session
+    @session
+  end
+
+  def jobs : Gori::Tui::Jobs
+    @jobs
+  end
+
+  def notifications : Gori::Tui::Notifications
+    @notifications
+  end
+
+  def status(message : String) : Nil
+    @statuses << message
+  end
+
+  # The delete path is behind a confirm; run the action, which is what pressing "delete" does.
+  def confirm(title : String, message : String, *, confirm_label : String, danger : Bool,
+              return_to : Symbol = :none, &action : -> Nil) : Nil
+    action.call
+  end
+
+  def request_overlay(kind : Symbol) : Nil
+  end
+
+  def request_focus(pane : Symbol) : Nil
+  end
+
+  def focus_body : Nil
+  end
+
+  def switch_tab(tab : Symbol) : Nil
+  end
+
+  def goto_tab(tab : Symbol) : Nil
+  end
+
+  def open_palette : Nil
+  end
+
+  def open_space_menu : Nil
+  end
+
+  def open_fuzz_set_editor(edit_index : Int32?) : Nil
+  end
+
+  def open_fuzz_advanced_editor : Nil
+  end
+
+  def reconfigure_sequence : Nil
+  end
+
+  def open_scope_rule_editor(edit_id : Int64?, kind : String, match_type : String, pattern : String) : Nil
+  end
+
+  def open_custom_rule_editor(rule : Gori::Probe::CustomRule?) : Nil
+  end
+
+  def open_rewriter_rule_editor(rule : Gori::Store::MatchRule?) : Nil
+  end
+
+  def open_colormarker_rule_editor(rule : Gori::Store::ColorRule?) : Nil
+  end
+
+  def open_colormarker_color_editor(color : Gori::Settings::ColormarkerColor?) : Nil
+  end
+
+  def open_extract_rule_editor(rule : Gori::Store::ExtractRule?) : Nil
+  end
+
+  def open_chain_save : Nil
+  end
+
+  def open_chain_load : Nil
+  end
+
+  def open_oast_provider_editor(provider : Gori::Oast::ProviderConfig?) : Nil
+  end
+
+  def overlay : Symbol
+    :none
+  end
+
+  def active_tab : Symbol
+    :project
+  end
+
+  def focus : Symbol
+    :body
+  end
+
+  def reveal? : Bool
+    false
+  end
+
+  def toggle_reveal : Nil
+  end
+
+  def pretty? : Bool
+    false
+  end
+
+  def toggle_pretty : Nil
+  end
+
+  def toggle_scope_lens : Nil
+  end
+
+  def toggle_sandbox : Nil
+  end
+
+  def apply_project_network(bind_host : String, bind_port : Int32, upstream : String,
+                            connect_secs : Int32, io_secs : Int32, capture_mib : Int32) : String
+    ""
+  end
+end
+
+private ENV_PANE_CA_ROOT = File.tempname("gori-env-pane-ca")
+Spec.after_suite { FileUtils.rm_rf(ENV_PANE_CA_ROOT) }
+
+private def with_env_controller(&)
+  root = File.tempname("gori-env-pane-session")
+  Dir.mkdir_p(root)
+  project = Gori::ProjectRegistry.new(root).temp("envpane")
+  session = Gori::Session.open(Gori::Config.new(listen: "127.0.0.1", port: 0),
+    Gori::Proxy::Tls::CertAuthority.load_or_create(ENV_PANE_CA_ROOT), Gori::Verbs.registry, project)
+  saved = Gori::Settings.project_env_vars
+  saved_prefix = Gori::Settings.env_prefix
+  Gori::Settings.env_prefix = "$"
+  begin
+    host = FakeHost.new(session)
+    c = ProjectController.new(host)
+    c.view.focus_pane(:env)
+    yield c, host, session
+  ensure
+    session.close rescue nil
+    FileUtils.rm_rf(root) if Dir.exists?(root)
+    Gori::Settings.project_env_vars = saved
+    Gori::Settings.env_prefix = saved_prefix
+  end
+end
+
+private def key(k : Termisu::Input::Key, char : Char? = nil) : Termisu::Event::Key
+  Termisu::Event::Key.new(k, char: char)
+end
+
+private def type_keys(c : ProjectController, text : String) : Nil
+  text.each_char { |ch| c.handle_body_key(key(Termisu::Input::Key::Unknown, ch)) }
+end
+
+describe Gori::Tui::ProjectController do
+  it "says a rolled-back env write did NOT save, instead of reporting success" do
+    with_env_controller do |c, host, session|
+      c.env_add_var
+      type_keys(c, "TOKEN sekrit")
+      session.store.close # every write from here answers false
+      c.handle_body_key(key(Termisu::Input::Key::Enter))
+
+      # The row keeps showing the value (nothing here re-reads the store), so a false "saved"
+      # was never contradicted — the var was simply gone at the next launch.
+      host.statuses.last.should contain("NOT saved")
+      host.statuses.last.should_not contain("env var saved")
+    end
+  end
+
+  it "says a rolled-back env delete did NOT delete" do
+    with_env_controller do |c, _host, session|
+      Gori::Env.save_project(session.store, [{"TOKEN", "sekrit"}]).should be_true
+      c.view.reload_env_vars
+      c.view.env_vars.size.should eq(1)
+    end
+
+    with_env_controller do |c, host, session|
+      Gori::Env.save_project(session.store, [{"TOKEN", "sekrit"}])
+      c.view.reload_env_vars
+      session.store.close
+      c.env_delete_var # FakeHost#confirm runs the action
+
+      host.statuses.last.should contain("NOT deleted")
+    end
+  end
+
+  # The wiring, one link up from `ProjectView#reload_env_vars`. The link ABOVE this one —
+  # `Runner#apply_external_change` calling `Env.load_project` so the global is fresh when this
+  # runs — needs a live shell (and a tty) to drive, so it is not pinned here; this is the seam
+  # that is.
+  it "adopts a peer's env change on the next external-change tick" do
+    with_env_controller do |c, _host, _session|
+      c.view.env_vars.should be_empty
+      # What `Runner#apply_external_change` leaves behind after reloading the global.
+      Gori::Settings.project_env_vars = [{"PEER", "9"}]
+      c.on_external_change
+      # Stale, this list was about to be written back over the store — deleting PEER.
+      c.view.env_vars.should eq([{"PEER", "9"}])
+    end
+  end
+
+  it "reports the total on a committed save" do
+    with_env_controller do |c, host, _session|
+      c.env_add_var
+      type_keys(c, "TOKEN sekrit")
+      c.handle_body_key(key(Termisu::Input::Key::Enter))
+      host.statuses.last.should contain("env var saved")
+    end
+  end
+
+  it "does not close the add row on a ⌫ with the caret at the start" do
+    with_env_controller do |c, _host, _session|
+      c.env_add_var
+      type_keys(c, "TOKEN abc123")
+      c.handle_body_key(key(Termisu::Input::Key::Left))
+      c.handle_body_key(key(Termisu::Input::Key::Left))
+      12.times { c.handle_body_key(key(Termisu::Input::Key::Left)) }
+      c.handle_body_key(key(Termisu::Input::Key::Backspace))
+
+      c.view.env_adding?.should be_true # the row (and the line in it) survived
+      c.handle_body_key(key(Termisu::Input::Key::Enter))
+      c.view.env_vars.should eq([{"TOKEN", "abc123"}])
+    end
+  end
+end

--- a/src/gori/env.cr
+++ b/src/gori/env.cr
@@ -992,8 +992,20 @@ module Gori
       end
     end
 
+    # Publish (and invalidate) only on a real DELTA. Both repeat callers ask on a cadence —
+    # the TUI's `apply_external_change` fires whenever `data_version` moves, which own captures
+    # do, and MCP's `refresh_project_env` runs before every outbound tool call — while
+    # `bump_highlight_rev` is the invalidation signal for two caches that assume it is rare:
+    # every `TextArea`'s styled buffer, and `Rules#subst_snapshot`, whose own doc names the
+    # bump set as "a settings load, a project env write, a rule edit and every rebind". An
+    # unchanged table publishes nothing, so re-reading it costs one row and one parse.
+    #
+    # `Array({String, String})` compares elementwise, so this is order-sensitive as it must be:
+    # the pane renders the table in stored order.
     def self.load_project(store : Store) : Nil
-      Settings.project_env_vars = parse_vars_json(store.setting(PROJECT_VARS_KEY))
+      vars = parse_vars_json(store.setting(PROJECT_VARS_KEY))
+      return if vars == Settings.project_env_vars
+      Settings.project_env_vars = vars
       bump_highlight_rev
     end
 

--- a/src/gori/tui/controllers/project_controller.cr
+++ b/src/gori/tui/controllers/project_controller.cr
@@ -336,8 +336,13 @@ module Gori::Tui
     # this view renders straight out of; all that is left is to pull the two list selections
     # back inside a list another process may have SHRUNK, so the highlight doesn't sit on a
     # row that no longer exists.
+    #
+    # ENV is the one pane that keeps its OWN copy of the data (and writes it back wholesale),
+    # so it needs the copy re-seeded here rather than only on tab entry — see
+    # `ProjectView#reload_env_vars` for what that copy going stale does to the store.
     def on_external_change : Nil
       @project_view.clamp_selections
+      @project_view.reload_env_vars
     end
 
     def save : Nil
@@ -740,8 +745,13 @@ module Gori::Tui
       @host.confirm("DELETE ENV VAR", "Delete “#{key}”? This can't be undone.",
         confirm_label: "delete", danger: true) do
         if removed = @project_view.env_delete
-          Env.save_project(@host.session.store, @project_view.env_vars)
-          @host.status("env var deleted: #{removed}")
+          # Whether the write COMMITTED, like the host-override sibling above and like MCP's
+          # `delete_env_var` / `gori run project env delete`. `Env.save_project` updates the
+          # in-memory table either way and this view re-seeds from THAT, not from the store —
+          # so a dropped write reported as "deleted" stayed convincing for the whole session
+          # and the var came back at the next launch.
+          ok = Env.save_project(@host.session.store, @project_view.env_vars)
+          @host.status(ok ? "env var deleted: #{removed}" : "env var NOT deleted (project busy or unwritable) — try again")
         end
       end
     end
@@ -786,9 +796,12 @@ module Gori::Tui
 %(env var: need "KEY VALUE" or "KEY=value" — KEY is [A-Za-z_][A-Za-z0-9_]*))
       when :dup then @host.status("env var: KEY already defined")
       when :ok
-        Env.save_project(@host.session.store, @project_view.env_vars)
+        # See `env_delete_var`: the store answers whether the write committed, and this is the
+        # surface where a false "saved" is least recoverable — nothing here re-reads the store,
+        # so the row keeps showing the value that never landed.
+        ok = Env.save_project(@host.session.store, @project_view.env_vars)
         n = @project_view.env_vars.size
-        @host.status("env var saved — #{n} total")
+        @host.status(ok ? "env var saved — #{n} total" : "env var NOT saved (project busy or unwritable) — try again")
       end
     end
 

--- a/src/gori/tui/controllers/project_controller.cr
+++ b/src/gori/tui/controllers/project_controller.cr
@@ -746,14 +746,38 @@ module Gori::Tui
         confirm_label: "delete", danger: true) do
         if removed = @project_view.env_delete
           # Whether the write COMMITTED, like the host-override sibling above and like MCP's
-          # `delete_env_var` / `gori run project env delete`. `Env.save_project` updates the
-          # in-memory table either way and this view re-seeds from THAT, not from the store —
-          # so a dropped write reported as "deleted" stayed convincing for the whole session
-          # and the var came back at the next launch.
-          ok = Env.save_project(@host.session.store, @project_view.env_vars)
+          # `delete_env_var` / `gori run project env delete`. A dropped write reported as
+          # "deleted" stayed convincing for the whole session, and the var came back at the
+          # next launch.
+          ok = persist_env_vars
           @host.status(ok ? "env var deleted: #{removed}" : "env var NOT deleted (project busy or unwritable) — try again")
         end
       end
+    end
+
+    # Persist the pane's list, and put memory back where the store is when it did not commit.
+    #
+    # `Env.save_project` publishes the new array to the process global whatever the store
+    # answered — deliberately, so the TUI list updates without a round trip (see its doc), and
+    # harmlessly for MCP, which reloads from the store before its next active tool. On THIS
+    # surface nothing reloads: a rolled-back write does not move `data_version`, so
+    # `apply_external_change` never fires, and the pane would go on showing — and every
+    # Repeater/Fuzzer/Miner/Intercept send would go on expanding — a var the store does not
+    # have. Then the next write that DOES commit persists that whole array, making the phantom
+    # real (or, after a failed delete, deleting the var for good).
+    #
+    # So the failure arm rolls the global back to the array we handed in and re-seeds the pane
+    # from it: the list, the substitution table and the store all say the same thing, which is
+    # what the "NOT saved" the caller is about to print claims. Rolled back in MEMORY, never by
+    # re-reading — the store that just refused a write is exactly the one a read cannot be
+    # asked of (it may be closing), and the pre-write array is already in hand.
+    private def persist_env_vars : Bool
+      before = Settings.project_env_vars
+      return true if Env.save_project(@host.session.store, @project_view.env_vars)
+      Settings.project_env_vars = before
+      Env.bump_highlight_rev # the failed publish bumped it; the rollback is a change too
+      @project_view.reload_env_vars
+      false
     end
 
     def env_edit_prefix : Nil
@@ -799,7 +823,7 @@ module Gori::Tui
         # See `env_delete_var`: the store answers whether the write committed, and this is the
         # surface where a false "saved" is least recoverable — nothing here re-reads the store,
         # so the row keeps showing the value that never landed.
-        ok = Env.save_project(@host.session.store, @project_view.env_vars)
+        ok = persist_env_vars
         n = @project_view.env_vars.size
         @host.status(ok ? "env var saved — #{n} total" : "env var NOT saved (project busy or unwritable) — try again")
       end

--- a/src/gori/tui/project_view.cr
+++ b/src/gori/tui/project_view.cr
@@ -80,6 +80,9 @@ module Gori::Tui
       @env_adding = false
       @env_prefix_editing = false # non-nil ⇒ the single-line prefix editor is up (shares @env_input)
       @env_edit_idx = nil.as(Int32?)
+      # The KEY an open edit row targets, so `reload_env_vars` can re-anchor the index when a
+      # peer process reorders or shortens the list under it.
+      @env_edit_key = nil.as(String?)
       @env_input = ""
       @env_icx = 0
       @env_preedit = ""
@@ -426,7 +429,16 @@ module Gori::Tui
 
     def env_row_at(rect : Rect, mx : Int32, my : Int32) : Int32?
       return nil unless card = card_rect(rect, :env)
-      row_at(env_list_inner(card.inset(1, 1)), mx, my, @env_adding, @env_sel, @env_items.size)
+      row_at(env_list_inner(card.inset(1, 1)), mx, my, env_row_offset?, @env_sel, @env_items.size)
+    end
+
+    # Whether the ENV list starts ONE ROW DOWN. `render_env_list` gives the first interior line
+    # to EITHER sub-mode — the add/edit row or the prefix row — so both hit-tests have to ask
+    # about both. Passing `@env_adding` alone made every click land on the row after the one
+    # under the pointer while the prefix editor was open. One predicate, three callers (the
+    # draw, `env_row_at`, `env_gauge_row`), which is the lockstep the geometry section promises.
+    private def env_row_offset? : Bool
+      @env_adding || @env_prefix_editing
     end
 
     # Shared row hit-test for the SCOPE/HOST-OVERRIDES list interiors: account for the
@@ -446,7 +458,7 @@ module Gori::Tui
 
     def env_gauge_row(rect : Rect, mx : Int32, my : Int32) : Int32?
       return nil unless card = card_rect(rect, :env)
-      gauge_row(env_list_inner(card.inset(1, 1)), mx, my, @env_adding, @env_items.size)
+      gauge_row(env_list_inner(card.inset(1, 1)), mx, my, env_row_offset?, @env_items.size)
     end
 
     private def gauge_row(inner : Rect, mx : Int32, my : Int32, adding : Bool, n : Int32) : Int32?
@@ -663,6 +675,26 @@ module Gori::Tui
       clamp_ov_sel
     end
 
+    # Re-seed the ENV list after a PEER PROCESS changed it (Runner#apply_external_change has
+    # just reloaded the process global this copies from).
+    #
+    # Unlike SCOPE and HOST OVERRIDES — which this view renders straight out of one live
+    # object — the ENV pane holds its own `@env_items` copy and `Env.save_project` persists it
+    # WHOLESALE. So a stale copy did not merely display wrong: the next commit here wrote the
+    # stale set back over the store, deleting every var the other process had added. Refreshing
+    # only on tab entry left that window open for as long as the operator stayed on the tab.
+    #
+    # An open EDIT row names its target by INDEX, and the list that index pointed into is gone,
+    # so re-anchor by the KEY the row opened on: the commit still updates that var if it
+    # survived, and becomes an ADD if the peer deleted it — which is what the typed text now
+    # means. Either way the operator's half-typed line is untouched, no unrelated row is
+    # overwritten, and the index can no longer point past the end.
+    def reload_env_vars : Nil
+      @env_items = Settings.project_env_vars.dup
+      clamp_env_sel
+      @env_edit_idx = @env_items.index { |(k, _)| k == @env_edit_key } if @env_edit_key
+    end
+
     private def clamp_sel : Nil
       @sel = @sel.clamp(0, {@scope.rules.size - 1, 0}.max)
     end
@@ -717,11 +749,15 @@ module Gori::Tui
       @ov_preedit = ""
     end
 
-    # Backspace the add-row; false when already empty (the controller then closes the row).
+    # Backspace the add-row; false when the ROW is empty (the controller then closes it) —
+    # never merely because the caret sits at 0, which discarded a typed line the operator had
+    # only moved the caret inside. Same rule as `env_backspace`, which spells it out.
     def ov_backspace : Bool
-      return false if @ov_icx == 0
-      @ov_input = "#{@ov_input[0, @ov_icx - 1]}#{@ov_input[@ov_icx..]}"
-      @ov_icx -= 1
+      return false if @ov_input.empty?
+      if @ov_icx > 0
+        @ov_input = "#{@ov_input[0, @ov_icx - 1]}#{@ov_input[@ov_icx..]}"
+        @ov_icx -= 1
+      end
       true
     end
 
@@ -817,6 +853,7 @@ module Gori::Tui
       cancel_env_prefix_edit
       @env_adding = true
       @env_edit_idx = nil
+      @env_edit_key = nil
       @env_input = ""
       @env_icx = 0
       @env_preedit = ""
@@ -829,6 +866,7 @@ module Gori::Tui
       cancel_env_prefix_edit
       @env_adding = true
       @env_edit_idx = @env_sel
+      @env_edit_key = key
       @env_input = "#{key} #{val}"
       @env_icx = @env_input.size
       @env_preedit = ""
@@ -837,6 +875,7 @@ module Gori::Tui
     def cancel_env_add : Nil
       @env_adding = false
       @env_edit_idx = nil
+      @env_edit_key = nil
       @env_input = ""
       @env_icx = 0
       @env_preedit = ""
@@ -875,10 +914,20 @@ module Gori::Tui
       @env_preedit = ""
     end
 
+    # Whether the row still holds text — the callers read this to tell a ⌫ that edited the
+    # line from one on an EMPTY row, which closes the row.
+    #
+    # The question is whether the ROW is empty, NOT whether the caret is at 0. Answering the
+    # caret question threw the line away: ← to the start of a typed "TOKEN abc123" and one ⌫
+    # closed the row with the text unsaved, which is the one thing a ⌫ must never do. A caret
+    # already at 0 with text behind it is an ordinary no-op, and that is what `TextField`
+    # (`EnvOverlay`'s field, the same editor one modal away) has always done.
     def env_backspace : Bool
-      return false if @env_icx == 0
-      @env_input = "#{@env_input[0, @env_icx - 1]}#{@env_input[@env_icx..]}"
-      @env_icx -= 1
+      return false if @env_input.empty?
+      if @env_icx > 0
+        @env_input = "#{@env_input[0, @env_icx - 1]}#{@env_input[@env_icx..]}"
+        @env_icx -= 1
+      end
       true
     end
 
@@ -894,7 +943,10 @@ module Gori::Tui
       key, val = parsed
       idx = @env_edit_idx
       return :dup if @env_items.each_with_index.any? { |(k, _), i| k == key && i != idx }
-      if idx
+      # `idx` is re-anchored by `reload_env_vars` whenever a peer shortens the list, so it is
+      # in range — the bound is checked anyway rather than trusted, because the failure mode of
+      # trusting it is an IndexError raised out of a keystroke.
+      if idx && idx < @env_items.size
         @env_items[idx] = {key, val}
         @env_sel = idx
       else
@@ -1339,12 +1391,10 @@ module Gori::Tui
       return if list.h <= 0
       y = list.y
       rows = list.h
-      if @env_prefix_editing
-        render_env_prefix_row(screen, list, y)
-        y += 1
-        rows -= 1
-      elsif @env_adding
-        render_env_add_row(screen, list, y, focused)
+      if env_row_offset?
+        # The two sub-modes are mutually exclusive and share this line; `env_row_offset?` is
+        # what both hit-tests ask, so the offset cannot drift from the draw.
+        @env_prefix_editing ? render_env_prefix_row(screen, list, y) : render_env_add_row(screen, list, y, focused)
         y += 1
         rows -= 1
       end

--- a/src/gori/tui/project_view.cr
+++ b/src/gori/tui/project_view.cr
@@ -129,8 +129,14 @@ module Gori::Tui
         @desc_read.sync_from(@desc_area)
       end
       load_settings_values
-      @env_items = Settings.project_env_vars.dup
-      @env_sel = @env_sel.clamp(0, {@env_items.size - 1, 0}.max)
+      # THE one re-seed, shared with the external-change path. Tab entry is the other moment
+      # the list can move under an open EDIT row — `flush_active_tab_edits` persists the
+      # description and the network fields on the way out but does not cancel this row (only a
+      # SUB-tab change does, via `settle_subtab`), so a top-level tab round trip past a peer's
+      # write left the row indexing a list that had shifted. Re-seeding without the anchor is
+      # exactly the case `env_commit`'s bound check can no longer catch: an index that is stale
+      # but still IN RANGE writes the wrong row and then persists the whole array.
+      reload_env_vars
     end
 
     # (Re)load the PROJECT SETTINGS network fields from the effective config — the project
@@ -675,8 +681,9 @@ module Gori::Tui
       clamp_ov_sel
     end
 
-    # Re-seed the ENV list after a PEER PROCESS changed it (Runner#apply_external_change has
-    # just reloaded the process global this copies from).
+    # Re-seed the ENV list from the process global — THE one place `@env_items` is refilled,
+    # called from `reload` (tab entry) and from the external-change path once
+    # `Runner#apply_external_change` has refreshed that global.
     #
     # Unlike SCOPE and HOST OVERRIDES — which this view renders straight out of one live
     # object — the ENV pane holds its own `@env_items` copy and `Env.save_project` persists it

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -825,6 +825,23 @@ module Gori::Tui
       # own inline add/edit row is a separate buffer and is untouched by this (only the
       # underlying list changes), so there is nothing to clobber — same as Scope above.
       @session.host_overrides.reload
+      # The per-project `$KEY` table, for the same reason and one more. Env vars live in a
+      # process global (`Settings.project_env_vars`) that `Session.open` fills ONCE, so an
+      # external `gori run project env set` / MCP `set_env_var` was invisible here for the rest
+      # of the session — every Repeater/Fuzzer/Miner/Intercept send expanded the value this
+      # process happened to open with.
+      #
+      # The extra reason is that the Project tab's ENV pane read-modify-WRITES the whole array
+      # (`Env.save_project` persists it wholesale, from the copy `ProjectView#reload` took of
+      # this global), so a stale copy did not just READ wrong — the next edit in the pane wrote
+      # the stale set back and silently DELETED every var the other process had added. MCP
+      # states exactly this hazard as the reason it refreshes per call (see
+      # `MCP::Tools::ENV_REFRESH_TOOLS`); this surface is the one that had no refresh at all.
+      #
+      # Safe in place, like the two above: the pane's inline add/edit row is a separate buffer,
+      # and `@env_items` is re-seeded only on tab entry (`on_enter`) — `on_external_change`
+      # below just pulls the selection back inside a list that may have shrunk.
+      Env.load_project(@session.store)
       # Colour rules are read by ANOTHER tab's render path (History's row loop), so this one
       # cannot ride the active-tab rule below: gating it on `@active_tab == :colormarker`
       # would leave History painting stale colours for the rest of the session after an

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -839,8 +839,14 @@ module Gori::Tui
       # `MCP::Tools::ENV_REFRESH_TOOLS`); this surface is the one that had no refresh at all.
       #
       # Safe in place, like the two above: the pane's inline add/edit row is a separate buffer,
-      # and `@env_items` is re-seeded only on tab entry (`on_enter`) — `on_external_change`
-      # below just pulls the selection back inside a list that may have shrunk.
+      # and re-seeding the list around it is `ProjectView#reload_env_vars`' business — it
+      # re-anchors an open edit row by KEY. `on_external_change` below calls it.
+      #
+      # Cheap on an unchanged table: `load_project` publishes (and bumps the highlight rev)
+      # only on a real delta. This runs on OWN captures too — the poll above cannot tell whose
+      # commit moved `data_version` — so an unconditional bump would invalidate every styled
+      # buffer and `Rules#subst_snapshot` on a cadence, which is the same reason
+      # `colormarker.reload` below bails out on an unchanged rule set.
       Env.load_project(@session.store)
       # Colour rules are read by ANOTHER tab's render path (History's row loop), so this one
       # cannot ride the active-tab rule below: gating it on `@active_tab == :colormarker`


### PR DESCRIPTION
The Project tab's ENV pane is the only pane on that tab holding its **own copy** of the data it edits — SCOPE and HOST OVERRIDES render straight out of one live object — and `Env.save_project` persists that copy **wholesale**. Most of what follows comes from the two halves of that sentence; two smaller ones live next door.

### 1. `apply_external_change` never reloaded the project `$KEY` table

`Session.open` filled the process global (`Settings.project_env_vars`) once and nothing refilled it. `runner.cr`'s external-change handler reloaded scope, host overrides, colour rules and the active tab — not this.

* Every TUI send path (Repeater / Fuzzer / Miner / Intercept) went on expanding the values this process happened to open with, after an external `gori run project env set` or MCP `set_env_var`.
* Worse: the pane's next commit wrote its **stale copy back over the store**, deleting the var the peer had added.

MCP names exactly this hazard as the reason it reloads per call (`MCP::Tools::ENV_REFRESH_TOOLS`); the TUI had no refresh at all. The global is now reloaded beside the host-override reload, and `ProjectController#on_external_change` re-seeds the pane from it.

`Env.load_project` publishes and bumps `highlight_rev` **only on a real delta** now: `apply_external_change` fires on own captures too, and an unconditional bump there would invalidate `Rules#subst_snapshot` — a proxy-hot-path cache whose own comment says the bump set is "a settings load, a project env write, a rule edit and every rebind" — once per captured flow. MCP's per-call `refresh_project_env` gets the same relief.

### 2. An open EDIT row named its target by INDEX

Re-seeding the list hands that index a list it no longer describes. The row now re-anchors by the **key** it opened on: the commit still finds that var if it survived, becomes an ADD if the peer deleted it, and `env_commit` checks the bound instead of trusting it — `@env_items[idx] =` on a shrunk list raised `IndexError` out of a keystroke.

Both re-seed sites go through one method. Tab entry is the second one, and nothing on the top-level tab-switch path cancels an open ENV row (`cancel_env_add` lives in `settle_subtab`, which only a *sub*-tab change reaches) — so Project → History → Project across a peer's write hit the same stale index, silently, since an in-range index no longer raises.

### 2b. A rolled-back write left memory ahead of the store

`Env.save_project` publishes to the process global whatever the store answered — deliberate, and harmless for MCP, which reloads before its next active tool. Nothing reloads here, and a rolled-back write does not move `data_version`, so the pane went on showing (and every send went on expanding) a var the store did not have, until the next committing write made the phantom real. The failure arm now rolls the global back to the array it handed in and re-seeds the pane, in memory — a store that just refused a write is the one a read cannot be asked of.

### 3. Both writes discarded the commit Bool

`Env.save_project` answers whether the write committed (`set_setting`/`delete_setting` are `exec_task_ok`). Both call sites ignored it and said "env var saved" / "env var deleted" regardless. Nothing on this surface re-reads the store, so the false report was never contradicted and the var was simply gone at the next launch. The host-override sibling three methods up already had its `:failed` arm, as do MCP and `gori run project env`.

### 4. `⌫` at the head of a typed line threw the line away

`env_backspace` asked whether the **caret** was at 0 rather than whether the **row** was empty, and the caller reads that as "empty ⇒ close the row". `←` to the start of `TOKEN abc123`, one `⌫`, and the row closed unsaved. `ov_backspace` (HOST OVERRIDES) had it identically and is fixed with it. `EnvOverlay`, one modal away, has always answered the row question via `TextField`.

### 5. Clicks were one row off while the prefix editor was open

The draw gives its first interior line to **either** sub-mode; `env_row_at` / `env_gauge_row` asked only about the add row. One predicate — `env_row_offset?` — now answers for the draw and both hit-tests.

---

### Not fixed here

A multi-line **paste** into the add row commits on the first `\n` and the remainder then runs as commands (`d` opens the delete confirm). That is a seam in the per-keystroke paste design shared with the HOST OVERRIDES row, not an env bug — worth its own change.

### Tests

`spec/tui/project_env_pane_spec.cr`, 13 examples: 1 on `Env.load_project`, 7 on `ProjectView`, 5 driving `ProjectController` through a `FakeHost` + live `Session` (a closed store is the honest "the write did not commit" seam, as `project_desc_persist_spec` already uses it).

**Revert-verified, both rounds**: with the first four fixes backed out, 8 of 11 fail — including an `IndexError` from `env_commit`; with the three review fixes backed out, the 4 examples covering them fail. The ones that still pass either way are the positive controls.

`crystal spec`: 8632 examples, 8 failures — all `Gori::Session` port-bind examples in `project_registry_spec` / `capture_status_spec`, confirmed identical on stashed-clean source (a live `gori` holds `127.0.0.1:8070` on this machine). `crystal tool format --check` clean; ameba unchanged from baseline on the touched files.
