### PR TITLE
Make the Scope SQL lens mean what the live Scope gate means

### DIFF
--- a/spec/scope_spec.cr
+++ b/spec/scope_spec.cr
@@ -272,6 +272,134 @@ describe Gori::Scope do
     end
   end
 
+  # `Rule#host_match?` peels a surrounding bracket pair off the FLOW HOST as well as off the
+  # pattern; `host_cond` peeled the pattern only. A plain-HTTP forward-proxy request to an
+  # IPv6 literal is captured with host `[::1]` (resolve_forward → URI#host, stored verbatim by
+  # FlowMapper), so it was in scope at EVERY live gate while the SQL lens hid it — and there
+  # was no pattern that could reach it, since `[::1]` is bared to `::1` on the way in too.
+  it "SQL filter reaches a BRACKETED IPv6 flow host, like every live gate does" do
+    with_store do |store|
+      capture(store, "[::1]", "/admin")
+      capture(store, "::1", "/admin") # the bare form the CONNECT/tunnel path stores
+
+      scope = Gori::Scope.load(store)
+      scope.add("include", "host", "::1")
+      scope.enable
+
+      store.search(scope.filter, 50).map(&.host).sort.should eq(["::1", "[::1]"])
+      scope.in_scope_url?(url_of("http", "[::1]", "/admin"), "[::1]").should be_true
+      # …and a BRACKETED pattern reaches both spellings too (it is bared on the way in).
+      scope2 = Gori::Scope.load(store)
+      scope2.rules.each { |r| scope2.remove(r.id) }
+      scope2.add("include", "host", "[::1]")
+      scope2.enable
+      store.search(scope2.filter, 50).map(&.host).sort.should eq(["::1", "[::1]"])
+    end
+  end
+
+  # A half-bracketed oddity must peel the same on both sides — the reason HOST_BARE is the
+  # pair test and not `trim(host, '[]')`, which would have peeled one and left the other.
+  it "peels a bracket pair the way HostPattern.bare does, not one bracket at a time" do
+    with_store do |store|
+      capture(store, "[::1", "/x")
+      scope = Gori::Scope.load(store)
+      scope.add("include", "host", "::1")
+      scope.enable
+      store.search(scope.filter, 50).map(&.host).should be_empty
+      scope.in_scope_url?(url_of("http", "[::1", "/x"), "[::1").should be_false
+    end
+  end
+
+  # Crystal's `File.match?` reads `{a,b}` as brace alternation; SQLite's GLOB reads the braces
+  # literally. The include direction hid three matching hosts from History; the EXCLUDE
+  # direction was worse — it carved out nothing in SQL, so out-of-scope hosts stayed listed.
+  it "SQL filter agrees with in_scope_url? on a brace-alternation host glob" do
+    with_store do |store|
+      flows = [{"api.acme.test", "/x"}, {"api.acme.dev", "/x"}, {"api.acme.org", "/x"}]
+      flows.each { |(h, t)| capture(store, h, t) }
+
+      scope = Gori::Scope.load(store)
+      scope.add("include", "host", "*.acme.{test,dev}")
+      scope.enable
+
+      sql = store.search(scope.filter, 50).map(&.host).sort
+      mem = flows.select { |(h, t)| scope.in_scope_url?(url_of("http", h, t), h) }.map(&.[0]).sort
+      sql.should eq(mem)
+      mem.should eq(["api.acme.dev", "api.acme.test"])
+    end
+  end
+
+  it "SQL filter agrees with in_scope_url? on a brace-alternation host EXCLUDE" do
+    with_store do |store|
+      flows = [{"api.acme.test", "/x"}, {"secret.corp.test", "/x"}]
+      flows.each { |(h, t)| capture(store, h, t) }
+
+      scope = Gori::Scope.load(store)
+      scope.add("include", "host", "test")
+      scope.add("exclude", "host", "*.{corp,internal}.test")
+      scope.enable
+
+      sql = store.search(scope.filter, 50).map(&.host).sort
+      mem = flows.select { |(h, t)| scope.in_scope_url?(url_of("http", h, t), h) }.map(&.[0]).sort
+      sql.should eq(mem)
+      mem.should eq(["api.acme.test"]) # the exclude carves out in SQL too, not just in memory
+    end
+  end
+
+  # SQLite's built-in `lower()` folds ASCII only; Crystal's `String#downcase` folds all of
+  # Unicode. Both rule kinds that case-fold were affected.
+  it "SQL filter agrees with in_scope_url? on a non-ASCII string rule" do
+    with_store do |store|
+      capture(store, "acme.test", "/Über")
+      scope = Gori::Scope.load(store)
+      scope.add("include", "string", "/über")
+      scope.enable
+      store.search(scope.filter, 50).map(&.target).should eq(["/Über"])
+      scope.in_scope_url?(url_of("http", "acme.test", "/Über"), "acme.test").should be_true
+    end
+  end
+
+  it "SQL filter agrees with in_scope_url? on a non-ASCII host rule" do
+    with_store do |store|
+      capture(store, "ÄCME.test", "/x")
+      scope = Gori::Scope.load(store)
+      scope.add("include", "host", "äcme.test")
+      scope.enable
+      store.search(scope.filter, 50).map(&.host).should eq(["ÄCME.test"])
+      scope.in_scope_url?(url_of("http", "ÄCME.test", "/x"), "ÄCME.test").should be_true
+    end
+  end
+
+  # The string arm no longer builds a LIKE pattern, so the % / _ literalness it used to get
+  # from QL.like has to come from the substring match itself.
+  it "keeps % and _ literal in a string rule now that it matches by substring" do
+    with_store do |store|
+      capture(store, "x.test", "/a%b")
+      capture(store, "x.test", "/axxb")
+      capture(store, "x.test", "/a_b")
+      capture(store, "x.test", "/aYb")
+      scope = Gori::Scope.load(store)
+      scope.add("include", "string", "/a%b")
+      scope.add("include", "string", "/a_b")
+      scope.enable
+      store.search(scope.filter, 50).map(&.target).sort.should eq(["/a%b", "/a_b"])
+    end
+  end
+
+  it "refuses a rule whose kind is neither include nor exclude" do
+    with_store do |store|
+      scope = Gori::Scope.load(store)
+      # Neither include? nor exclude?: it would be counted by `size` and drawn in the SCOPE
+      # card while matches_url_unlocked? read ZERO includes and passed everything.
+      scope.add("Include", "host", "acme.test").should be_false
+      scope.rules.should be_empty
+      scope.add("include", "host", "acme.test").should be_true
+      id = scope.rules.first.id
+      scope.update(id, "EXCLUDE", "host", "acme.test").should be_false
+      scope.rules.first.kind.should eq("include")
+    end
+  end
+
   it "SQL filter agrees with in_scope_url? when an EXCLUDE rule was stored before the INCLUDE" do
     # #filter emits placeholders include-first, exclude-second, but used to bind values in
     # rule-id order. Add the exclude first and the two orders diverge: the include's `?`

--- a/spec/scope_spec.cr
+++ b/spec/scope_spec.cr
@@ -310,6 +310,29 @@ describe Gori::Scope do
     end
   end
 
+  # `HostPattern::Compiled` peels a surrounding bracket pair for its exact/subdomain arm but
+  # globs against the UN-peeled pattern, so `[2001:db8::*]` matches NOTHING in Crystal (the
+  # outer `[…]` is read as a character class). A host_cond that peels first would GLOB
+  # `2001:db8::*` and match every host under it: a dead INCLUDE whose flows are listed as
+  # in-scope while the Sandbox refuses every request with include_count non-zero — the
+  # "blocks everything" warning stays quiet because a rule IS configured.
+  it "SQL filter agrees with in_scope_url? on a BRACKETED host glob (a rule that matches nothing)" do
+    with_store do |store|
+      flows = [{"2001:db8::2", "/x"}, {"[2001:db8::1]", "/x"}]
+      flows.each { |(h, t)| capture(store, h, t) }
+
+      scope = Gori::Scope.load(store)
+      Gori::Scope.valid?("host", "[2001:db8::*]").should be_true # it IS storable
+      scope.add("include", "host", "[2001:db8::*]")
+      scope.enable
+
+      sql = store.search(scope.filter, 50).map(&.host).sort
+      mem = flows.select { |(h, t)| scope.in_scope_url?(url_of("http", h, t), h) }.map(&.[0]).sort
+      sql.should eq(mem)
+      mem.should be_empty
+    end
+  end
+
   # Crystal's `File.match?` reads `{a,b}` as brace alternation; SQLite's GLOB reads the braces
   # literally. The include direction hid three matching hosts from History; the EXCLUDE
   # direction was worse — it carved out nothing in SQL, so out-of-scope hosts stayed listed.

--- a/spec/tui/project_env_pane_spec.cr
+++ b/spec/tui/project_env_pane_spec.cr
@@ -287,6 +287,9 @@ private class FakeHost
   def open_palette : Nil
   end
 
+  def open_help_query(surface : Symbol) : Nil
+  end
+
   def open_space_menu : Nil
   end
 

--- a/spec/tui/project_view_spec.cr
+++ b/spec/tui/project_view_spec.cr
@@ -442,3 +442,36 @@ describe "ProjectView NETWORK pane" do
     end
   end
 end
+
+# The SCOPE pane's add lands the highlight on the rule it just wrote, the way the HOST
+# OVERRIDES and ENV add rows already do. `scope_rules` is ORDER BY id so an add appends:
+# without this the selection stayed put and, on a list taller than the card, the new rule
+# was drawn off-screen — nothing on screen said the write had landed.
+describe "ProjectView SCOPE pane" do
+  it "selects the rule an add just wrote" do
+    tmp_store do |store|
+      scope = Gori::Scope.load(store)
+      view = ProjectView.new(scope, Gori::HostOverrides.load(store))
+      %w[a.test b.test c.test].each { |h| scope.add("include", "host", h) }
+      view.focus_scope
+      view.selected_rule.try(&.pattern).should eq("a.test") # highlight sits at the top
+
+      view.commit_scope_rule("include", "host", "d.test").should eq(:ok)
+      view.selected_rule.try(&.pattern).should eq("d.test")
+    end
+  end
+
+  it "leaves the highlight on the rule an EDIT changed" do
+    tmp_store do |store|
+      scope = Gori::Scope.load(store)
+      view = ProjectView.new(scope, Gori::HostOverrides.load(store))
+      %w[a.test b.test].each { |h| scope.add("include", "host", h) }
+      view.focus_scope
+      view.scope_select(1)
+      id = view.selected_rule.not_nil!.id
+
+      view.commit_scope_rule("exclude", "host", "b2.test", id).should eq(:ok)
+      view.selected_rule.try(&.pattern).should eq("b2.test")
+    end
+  end
+end

--- a/src/gori/scope.cr
+++ b/src/gori/scope.cr
@@ -582,7 +582,7 @@ module Gori
     end
 
     # True when `host_cond`'s NATIVE SQL spelling provably means the same thing as
-    # `HostPattern::Compiled`. Two things part them, and the PATTERN decides both:
+    # `HostPattern::Compiled`. Three things part them, and the PATTERN decides all three:
     #
     #   · non-ASCII — SQLite's built-in `lower()` folds ASCII only while Crystal's
     #     `String#downcase` folds all of Unicode, so a rule `äcme.test` matched a captured
@@ -591,14 +591,24 @@ module Gori
     #     braces literally. An include `*.acme.{test,dev}` matched three hosts live and none
     #     in History, and an exclude with braces carved out nothing in SQL — fail-OPEN on the
     #     display lens, the direction that matters.
+    #   · a SURROUNDING bracket pair — `HostPattern::Compiled` peels it for the exact/subdomain
+    #     arm (`@bare`) but globs against the UN-peeled `@down`, so `[2001:db8::*]` is a rule
+    #     that matches NOTHING in Crystal (`File.match?` reads the outer `[…]` as a character
+    #     class). host_cond peels first, so its GLOB would match every host under
+    #     `2001:db8::` — a dead INCLUDE listing its flows as in-scope in History while
+    #     `allowlisted_unlocked?` refuses every request, i.e. Sandbox black-holes the proxy
+    #     with `include_count` non-zero and the "blocks everything" warning quiet. Gated on
+    #     the bracket pair alone rather than "bracketed AND globbed": which of Compiled's two
+    #     arms applies is exactly the thing not worth restating here.
     #
     # Anything else routes through `gori_host_match`, which IS HostPattern — so the fast path
     # stays native (host matching runs per row of every scope-filtered reload) and the shapes
-    # it cannot spell have no second dialect at all. `?`, `[…]` and an unbalanced `[` were
-    # checked and agree between the two engines; `/ \ ? # @` and whitespace can't reach a
-    # stored host pattern anyway (validation_error).
+    # it cannot spell have no second dialect at all. `?`, a non-surrounding `[…]` and an
+    # unbalanced `[` were checked and agree between the two engines; `/ \ ? # @` and whitespace
+    # can't reach a stored host pattern anyway (validation_error).
     def self.sql_native_host?(pattern : String) : Bool
-      pattern.ascii_only? && !pattern.includes?('{') && !pattern.includes?('}')
+      pattern.ascii_only? && !pattern.includes?('{') && !pattern.includes?('}') &&
+        bare_host(pattern) == pattern
     end
 
     # The pattern with its :PORT stripped AND surrounding brackets peeled, for the
@@ -668,9 +678,9 @@ module Gori
         # `lower(URL_EXPR) LIKE ?`, and SQLite's built-in `lower()` folds ASCII ONLY: a
         # rule `/über` matched a captured `/Über` in the live gate and nothing in History,
         # breaking the branch-for-branch parity this file's header promises. Nothing is
-        # lost by going through the function — `URL_EXPR` already builds and lowercases a
-        # fresh string per row, so there was no index to give up — and a literal % / _ in
-        # the pattern now needs no LIKE escaping at all.
+        # lost by going through the function: `URL_EXPR` concatenates a fresh string per
+        # row for the old `lower(…) LIKE` to fold and scan, so there was no index to give
+        # up — and a literal % / _ in the pattern now needs no LIKE escaping at all.
         {"gori_ci_contains(#{QL::URL_EXPR}, ?)", [rule.pattern] of DB::Any}
       when "regex"
         # Case-SENSITIVE (no lower()) to match Rule#matches? + the shard's REGEXP.

--- a/src/gori/scope.cr
+++ b/src/gori/scope.cr
@@ -304,6 +304,22 @@ module Gori
       @mutex.synchronize { set_sandbox_unlocked(false) }
     end
 
+    # The `host` column with a SURROUNDING bracket pair peeled — the SQL twin of
+    # `HostPattern.bare`, which `Rule#host_match?` applies to the flow host before matching.
+    # host_cond peeled the PATTERN only, and this file's comment claimed both; a flow captured
+    # as `[::1]` was therefore in scope at every live gate (intercept hold, sandbox, Probe
+    # allowlist, the Sitemap marker) while the History/Sitemap SQL lens hid it — and no host
+    # rule could reach it, since a `[::1]` pattern is bared to `::1` on the way in too. That
+    # host shape is not exotic: `resolve_forward` puts a plain-HTTP forward-proxy request's
+    # absolute-form target through `URI#host`, which hands back IPv6 literals BRACKETED, and
+    # FlowMapper stores it verbatim.
+    #
+    # Spelled as the pair test rather than `trim(host, '[]')` so it peels exactly what
+    # `HostPattern.bare` peels: a half-bracketed oddity like `[::1` keeps its bracket on both
+    # sides of the parity, instead of the two disagreeing again in the other direction.
+    HOST_BARE = "(CASE WHEN substr(host, 1, 1) = '[' AND substr(host, -1) = ']' " \
+                "THEN substr(host, 2, length(host) - 2) ELSE host END)"
+
     # A SQL filter selecting in-scope flows (QL::EMPTY when inactive). The URL the
     # string/regex rules see is `scheme || '://' || host || target` — the same value
     # `in_scope_url?` builds in memory. Combined Burp-style:
@@ -348,7 +364,7 @@ module Gori
     # the answer is simply to look: present ⇒ stored.
     def add(kind : String, match_type : String, pattern : String) : Bool
       pattern = pattern.strip
-      return false if pattern.empty? || !Scope.valid?(match_type, pattern)
+      return false if pattern.empty? || !KINDS.includes?(kind) || !Scope.valid?(match_type, pattern)
       @mutex.synchronize do
         return false if @rules.any? { |r| r.kind == kind && r.match_type == match_type && r.pattern == pattern }
         @store.add_scope_rule(kind, match_type, pattern)
@@ -361,7 +377,7 @@ module Gori
     # no-op self-edit is allowed. Returns false on empty/invalid/duplicate.
     def update(id : Int64, kind : String, match_type : String, pattern : String) : Bool
       pattern = pattern.strip
-      return false if pattern.empty? || !Scope.valid?(match_type, pattern)
+      return false if pattern.empty? || !KINDS.includes?(kind) || !Scope.valid?(match_type, pattern)
       @mutex.synchronize do
         return false if @rules.any? { |r| r.id != id && r.kind == kind && r.match_type == match_type && r.pattern == pattern }
         # The store's answer, not an unconditional `true`. `update_scope_rule` is `exec_task_ok`
@@ -440,6 +456,14 @@ module Gori
     # add`, the History add-host quick-action) — gate on Scope.valid?, defined below in
     # terms of this, so a rejection here keeps a dead rule out of the store regardless of
     # which entry point created it.
+    # `kind` is validated by `add`/`update` against KINDS rather than here, since this
+    # function answers about the (match_type, pattern) pair its callers show the operator. A
+    # stored `"Include"` would be neither `include?` nor `exclude?`: counted by `size` and
+    # drawn in the SCOPE card, but read as ZERO includes by `matches_url_unlocked?`, which
+    # then passes everything. Every write path checks KINDS itself today (MCP, `gori run
+    # project scope add`/`update`, and the TUI overlay, which can only index into KINDS), so
+    # the guard closes no live hole — same argument, and same next-caller guarantee, as the
+    # match_type `else` arm below.
     #   match_type — must be one of TYPES. This case had no `else`, so any other string fell
     #           through to nil and `valid?` said yes: `Scope#add` stored it, and `Rule#matches?`
     #           (whose own `case` DOES end in `else false`) then never matched it. A typo'd
@@ -557,6 +581,26 @@ module Gori
       HostPattern.bare(host)
     end
 
+    # True when `host_cond`'s NATIVE SQL spelling provably means the same thing as
+    # `HostPattern::Compiled`. Two things part them, and the PATTERN decides both:
+    #
+    #   · non-ASCII — SQLite's built-in `lower()` folds ASCII only while Crystal's
+    #     `String#downcase` folds all of Unicode, so a rule `äcme.test` matched a captured
+    #     `ÄCME.test` in the live gate and nothing in History.
+    #   · `{a,b}` — Crystal's `File.match?` reads brace alternation; SQLite's GLOB reads the
+    #     braces literally. An include `*.acme.{test,dev}` matched three hosts live and none
+    #     in History, and an exclude with braces carved out nothing in SQL — fail-OPEN on the
+    #     display lens, the direction that matters.
+    #
+    # Anything else routes through `gori_host_match`, which IS HostPattern — so the fast path
+    # stays native (host matching runs per row of every scope-filtered reload) and the shapes
+    # it cannot spell have no second dialect at all. `?`, `[…]` and an unbalanced `[` were
+    # checked and agree between the two engines; `/ \ ? # @` and whitespace can't reach a
+    # stored host pattern anyway (validation_error).
+    def self.sql_native_host?(pattern : String) : Bool
+      pattern.ascii_only? && !pattern.includes?('{') && !pattern.includes?('}')
+    end
+
     # The pattern with its :PORT stripped AND surrounding brackets peeled, for the
     # rejection message (only called when a port is present). "[::1]:9091" → "::1";
     # "127.0.0.1:9091" → "127.0.0.1". The bare form is the one host matching stores/compares,
@@ -619,9 +663,15 @@ module Gori
       when "host"
         host_cond(rule.pattern)
       when "string"
-        # Case-insensitive substring of the URL; QL.like neutralises % / _ so a literal
-        # %/_ in the pattern matches literally (paired with ESCAPE '\').
-        {"lower(#{QL::URL_EXPR}) LIKE ? ESCAPE '\\'", [QL.like(rule.pattern)] of DB::Any}
+        # Case-insensitive substring of the URL, through the SAME `downcase.includes?`
+        # Rule#matches? runs (Store::ScopeMatch). The native spelling was
+        # `lower(URL_EXPR) LIKE ?`, and SQLite's built-in `lower()` folds ASCII ONLY: a
+        # rule `/über` matched a captured `/Über` in the live gate and nothing in History,
+        # breaking the branch-for-branch parity this file's header promises. Nothing is
+        # lost by going through the function — `URL_EXPR` already builds and lowercases a
+        # fresh string per row, so there was no index to give up — and a literal % / _ in
+        # the pattern now needs no LIKE escaping at all.
+        {"gori_ci_contains(#{QL::URL_EXPR}, ?)", [rule.pattern] of DB::Any}
       when "regex"
         # Case-SENSITIVE (no lower()) to match Rule#matches? + the shard's REGEXP.
         {"#{QL::URL_EXPR} REGEXP ?", [rule.pattern] of DB::Any}
@@ -631,17 +681,21 @@ module Gori
     end
 
     private def host_cond(pattern : String) : {String, Array(DB::Any)}
+      # A pattern the native spelling below cannot express faithfully is matched by the very
+      # object Rule#host_match? uses (Store::ScopeMatch), so the two can't drift.
+      return {"gori_host_match(host, ?)", [pattern] of DB::Any} unless Scope.sql_native_host?(pattern)
       # Peel brackets so a "[::1]" rule compares against the bare "::1" the host column
       # stores — matches Rule#host_match?'s @pattern_host normalization (keeps SQL parity).
       pattern = Scope.bare_host(pattern)
       if pattern.includes?('*')
-        {"lower(host) GLOB ?", [pattern.downcase] of DB::Any}
+        {"lower(#{HOST_BARE}) GLOB ?", [pattern.downcase] of DB::Any}
       else
         d = pattern.downcase
         # The subdomain arm splices the host into a LIKE pattern, so its % / _ must be
         # escaped (keeping the literal leading `%.`) or a host like `a_b.test` would
         # match `aXb.test` in SQL but not in Rule#host_match? — breaking parity.
-        {"(lower(host) = ? OR lower(host) LIKE ? ESCAPE '\\')", [d, "%.#{QL.like_escape(d)}"] of DB::Any}
+        {"(lower(#{HOST_BARE}) = ? OR lower(#{HOST_BARE}) LIKE ? ESCAPE '\\')",
+         [d, "%.#{QL.like_escape(d)}"] of DB::Any}
       end
     end
   end

--- a/src/gori/scope.cr
+++ b/src/gori/scope.cr
@@ -582,7 +582,8 @@ module Gori
     end
 
     # True when `host_cond`'s NATIVE SQL spelling provably means the same thing as
-    # `HostPattern::Compiled`. Three things part them, and the PATTERN decides all three:
+    # `HostPattern::Compiled`. Three things part them, and the PATTERN is what this predicate
+    # reads to decide which of the three can arise:
     #
     #   · non-ASCII — SQLite's built-in `lower()` folds ASCII only while Crystal's
     #     `String#downcase` folds all of Unicode, so a rule `äcme.test` matched a captured
@@ -606,6 +607,11 @@ module Gori
     # it cannot spell have no second dialect at all. `?`, a non-surrounding `[…]` and an
     # unbalanced `[` were checked and agree between the two engines; `/ \ ? # @` and whitespace
     # can't reach a stored host pattern anyway (validation_error).
+    #
+    # The bound this trades for that fast path: the folding case can in principle be triggered
+    # from the HOST side too, by a non-ASCII character whose Unicode lowercase IS ASCII (U+212A
+    # KELVIN SIGN folds to `k`) sitting in a column an ASCII pattern reads. Deciding that per
+    # ROW means the UDF on every row of every reload, for a host no DNS resolver would answer.
     def self.sql_native_host?(pattern : String) : Bool
       pattern.ascii_only? && !pattern.includes?('{') && !pattern.includes?('}') &&
         bare_host(pattern) == pattern

--- a/src/gori/store.cr
+++ b/src/gori/store.cr
@@ -5,6 +5,7 @@ require "json"
 require "./media_type"
 require "./store/models"
 require "./store/safe_regexp"
+require "./store/scope_match"
 require "./store/schema"
 require "./store/compact"
 require "./store/scope_rules"
@@ -329,6 +330,9 @@ module Gori
         # Byte-safe REGEXP before any query runs, so a binary body can't crash a
         # `body~`/`header~` scan or a regex scope rule. See SafeRegexp.
         sqlite.gori_install_safe_regexp
+        # The Scope match functions, for the rule shapes whose native SQL spelling does not
+        # mean what the in-memory lens means (see ScopeMatch).
+        sqlite.gori_install_scope_match
         sqlite.exec("PRAGMA mmap_size = #{MMAP_SIZE}")
       end
     end

--- a/src/gori/store/safe_regexp.cr
+++ b/src/gori/store/safe_regexp.cr
@@ -1,4 +1,9 @@
 require "sqlite3"
+# For `install` below, which registers the Scope match functions alongside this one.
+# Mutually recursive with scope_match.cr's require of this file (it needs `value_bytes`);
+# Crystal resolves the cycle by skipping the re-entry, and neither file reads the other's
+# constants at load time.
+require "./scope_match"
 
 # The shard binds value_text but not value_bytes; add it so the REGEXP haystack can
 # be read by its true byte length (value_text alone is NUL-terminated). Re-opening
@@ -84,7 +89,15 @@ module Gori
     # `Store.configure_connections` block instead of calling both and losing one.
     def self.install(db : DB::Database) : Nil
       db.setup_connection do |conn|
-        conn.as?(SQLite3::Connection).try(&.gori_install_safe_regexp)
+        next unless sqlite = conn.as?(SQLite3::Connection)
+        sqlite.gori_install_safe_regexp
+        # The Scope match functions come with it: no caller wants a handle that can run a
+        # regex scope rule but not a string or non-ASCII/brace host one, and `Scope#filter`
+        # emits calls to these unconditionally — a handle without them fails the QUERY
+        # ("no such function"), it does not merely match differently. Store.open installs
+        # both through its own single setup block; this is the same set for the standalone
+        # handles that don't come through it.
+        sqlite.gori_install_scope_match
       end
     end
   end

--- a/src/gori/store/scope_match.cr
+++ b/src/gori/store/scope_match.cr
@@ -31,6 +31,7 @@ module Gori
     # same single-threaded-fiber argument, as SafeRegexp::CACHE_MAX above it.
     CACHE_MAX = 32
     @@hosts = {} of String => HostPattern::Compiled
+    @@needles = {} of String => String
 
     # :nodoc: — internal (called from the FNs, which need an explicit receiver, so not private)
     def self.compiled(pattern : String) : HostPattern::Compiled
@@ -41,6 +42,19 @@ module Gori
       @@hosts.clear if @@hosts.size >= CACHE_MAX
       @@hosts[pattern] = c
       c
+    end
+
+    # :nodoc: — the needle's lowercased form, memoised for the same reason as `compiled`
+    # above: it is CONSTANT across the scan (one per string rule) but `downcase` allocates,
+    # and this callback fires once per row.
+    def self.folded(needle : String) : String
+      if d = @@needles[needle]?
+        return d
+      end
+      d = needle.downcase
+      @@needles.clear if @@needles.size >= CACHE_MAX
+      @@needles[needle] = d
+      d
     end
 
     # :nodoc: — a SQLite TEXT argument read by its TRUE byte length and scrubbed to valid
@@ -79,7 +93,16 @@ module Gori
       args = Slice.new(argv, 2)
       haystack = ScopeMatch.text(args[0])
       needle = ScopeMatch.text(args[1])
-      LibSQLite3.result_int(context, haystack.downcase.includes?(needle.downcase) ? 1 : 0)
+      matched =
+        begin
+          haystack.downcase.includes?(ScopeMatch.folded(needle))
+        rescue
+          # Same belt as HOST_FN: an exception here unwinds through the C callback and
+          # aborts the WHOLE query, which is the failure mode SafeRegexp exists to prevent.
+          # `text` scrubs, so nothing known raises — that is the point of having it anyway.
+          false
+        end
+      LibSQLite3.result_int(context, matched ? 1 : 0)
       nil
     end
   end

--- a/src/gori/store/scope_match.cr
+++ b/src/gori/store/scope_match.cr
@@ -1,0 +1,96 @@
+require "sqlite3"
+require "./safe_regexp" # re-opens LibSQLite3 with value_bytes, which `text` below needs
+require "../host_pattern"
+
+module Gori
+  # The SQL half of a Scope rule, for the shapes where a NATIVE SQL spelling and the
+  # in-memory evaluation do not mean the same thing.
+  #
+  # `Scope#filter` and `Scope::Rule#matches?` are two implementations of one predicate, and
+  # scope.cr's own invariant is that they "never disagree". Three ways they did:
+  #
+  #   · `lower()` — SQLite's built-in folds ASCII only; Crystal's `String#downcase` folds the
+  #     whole of Unicode. A `string` rule `/über` matched a captured `/Über` in the live gate
+  #     and nothing in History.
+  #   · GLOB vs File.match? — Crystal reads `{a,b}` as brace alternation, SQLite GLOB reads
+  #     the braces literally. An include `*.acme.{test,dev}` matched three hosts live and none
+  #     in History; an EXCLUDE with braces carved out nothing in History (fail-open).
+  #   · brackets — `Rule#host_match?` peels a surrounding `[...]` off the FLOW HOST as well as
+  #     off the pattern, so a flow captured as `[::1]` (what `URI#host` hands back for the
+  #     absolute-form target a plain-HTTP forward-proxy request arrives in) was in scope live
+  #     but unreachable by any host rule in SQL. That one is fixed in SQL directly — see
+  #     `Scope::HOST_BARE` — because it applies to the fast path too.
+  #
+  # Rather than keep a second dialect in sync by hand, the diverging shapes call the FIRST
+  # implementation from SQL: `gori_host_match` is `HostPattern::Compiled`, and
+  # `gori_ci_contains` is `downcase.includes?`. Registered per pooled connection beside the
+  # byte-safe REGEXP (see SafeRegexp and Store.configure_connections).
+  module ScopeMatch
+    # SQLite fires these once per row against a FIXED set of patterns (one per scope rule),
+    # so compiling per row would be O(rows) instead of O(rules). Same bounded memo, and the
+    # same single-threaded-fiber argument, as SafeRegexp::CACHE_MAX above it.
+    CACHE_MAX = 32
+    @@hosts = {} of String => HostPattern::Compiled
+
+    # :nodoc: — internal (called from the FNs, which need an explicit receiver, so not private)
+    def self.compiled(pattern : String) : HostPattern::Compiled
+      if c = @@hosts[pattern]?
+        return c
+      end
+      c = HostPattern::Compiled.new(pattern)
+      @@hosts.clear if @@hosts.size >= CACHE_MAX
+      @@hosts[pattern] = c
+      c
+    end
+
+    # :nodoc: — a SQLite TEXT argument read by its TRUE byte length and scrubbed to valid
+    # UTF-8. `value_text` alone stops at an embedded NUL, and a captured target is bytes a
+    # peer put on the wire, not guaranteed UTF-8 — the same two hazards SafeRegexp documents.
+    def self.text(v : LibSQLite3::SQLite3Value) : String
+      ptr = LibSQLite3.value_text(v)
+      len = LibSQLite3.value_bytes(v)
+      ptr.null? || len <= 0 ? "" : String.new(ptr, len).scrub
+    end
+
+    # `gori_host_match(host, pattern)` — the host column against one host-rule pattern, through
+    # the very object `Scope::Rule#host_match?` uses. Exact/subdomain/glob and the bracket
+    # peeling all come from there, so there is no SQL spelling left to drift.
+    HOST_FN = ->(context : LibSQLite3::SQLite3Context, _argc : Int32, argv : LibSQLite3::SQLite3Value*) do
+      args = Slice.new(argv, 2)
+      host = ScopeMatch.text(args[0])
+      pattern = ScopeMatch.text(args[1])
+      matched =
+        begin
+          ScopeMatch.compiled(pattern).matches?(host)
+        rescue
+          # A malformed glob is non-matching, never an exception unwinding through the C
+          # callback and aborting the whole query (Compiled#matches_bare? rescues the one
+          # documented case; this is the belt for anything else).
+          false
+        end
+      LibSQLite3.result_int(context, matched ? 1 : 0)
+      nil
+    end
+
+    # `gori_ci_contains(haystack, needle)` — case-insensitive substring, folding BOTH sides
+    # with Crystal's Unicode `downcase`, exactly as `Rule#matches?` does for a string rule.
+    # A `%` or `_` in the needle is literal here (there is no LIKE pattern to escape).
+    CONTAINS_FN = ->(context : LibSQLite3::SQLite3Context, _argc : Int32, argv : LibSQLite3::SQLite3Value*) do
+      args = Slice.new(argv, 2)
+      haystack = ScopeMatch.text(args[0])
+      needle = ScopeMatch.text(args[1])
+      LibSQLite3.result_int(context, haystack.downcase.includes?(needle.downcase) ? 1 : 0)
+      nil
+    end
+  end
+end
+
+class SQLite3::Connection
+  # Register the two Scope match functions on this connection's raw SQLite handle. Called
+  # from `Store.configure_connections`' single setup block — see the comment there for why
+  # a second `setup_connection` call would silently drop this one.
+  def gori_install_scope_match : Nil
+    LibSQLite3.create_function(@db, "gori_host_match", 2, 1, nil, Gori::ScopeMatch::HOST_FN, nil, nil)
+    LibSQLite3.create_function(@db, "gori_ci_contains", 2, 1, nil, Gori::ScopeMatch::CONTAINS_FN, nil, nil)
+  end
+end

--- a/src/gori/tui/project_view.cr
+++ b/src/gori/tui/project_view.cr
@@ -656,6 +656,13 @@ module Gori::Tui
              @scope.add(kind, match_type, pattern)
            end
       return :failed unless ok
+      # Land the highlight on the rule that was just written, the way the HOST OVERRIDES and
+      # ENV add rows already do (`ov_commit`, `env_commit`). `scope_rules` is ORDER BY id, so
+      # an ADD always appends: without this the selection stayed where it was and, on a list
+      # taller than the card, the new rule was drawn off-screen — no sign the write landed.
+      if edit_id.nil?
+        @sel = @scope.rules.index { |r| r.kind == kind && r.match_type == match_type && r.pattern == pattern } || @sel
+      end
       clamp_sel
       :ok
     end

--- a/src/gori/tui/runner/scope.cr
+++ b/src/gori/tui/runner/scope.cr
@@ -17,11 +17,43 @@ class Gori::Tui::Runner < Gori::Verb::ExecContext
     # visible window (filter change, trim, follow reload).
     hosts = ids.compact_map { |id| @session.store.flow_row(id).try(&.host) }.uniq!
     return (@toast = "no flows left to add") if hosts.empty?
+    # A host gori itself could not store as a rule — a flow captured with no Host header at
+    # all, say — is named, not counted as added and not blamed on the store below.
+    hosts, unusable = hosts.map(&.strip).partition { |h| !h.empty? && Scope.valid?("host", h) }
+    return (@toast = "no usable host on the selected flow#{ids.size == 1 ? "" : "s"}") if hosts.empty?
+    # `add` answers whether the rule LANDED and `enable` whether the lens flag COMMITTED;
+    # both answers used to be discarded and the toast said "added <host> to scope" either way.
+    # A busy or locked project was therefore told hosts were scoped while the scope had not
+    # changed — the one claim every other scope write path in gori checks (the CLI, MCP, and
+    # the Project pane's own :failed branch). `add` collapses "already there" and "the store
+    # refused it" into ONE false, so neither is read off its return: the rule list says which
+    # is which. Present before ⇒ already scoped; absent after ⇒ the store refused it.
+    known = hosts.select { |h| scope_has_host_include?(h) }
     hosts.each { |h| @scope.add("include", "host", h) }
-    @scope.enable
+    lens = @scope.enable
     history_controller.view.reload(@session.store)
-    added = hosts.size == 1 ? hosts.first : "#{hosts.size} hosts"
-    @toast = "added #{added} to scope (#{@scope.size})"
+    missing = hosts.reject { |h| scope_has_host_include?(h) }
+    added = hosts - known - missing
+    if added.empty?
+      return (@toast = "scope NOT changed (project busy) — nothing was added") unless missing.empty?
+      return (@toast = "already in scope: #{name_hosts(known)}")
+    end
+    msg = "added #{name_hosts(added)} to scope (#{@scope.size})"
+    msg += " · #{known.size} already there" unless known.empty?
+    msg += " · #{missing.size} NOT added (project busy)" unless missing.empty?
+    msg += " · #{unusable.size} skipped (not a host)" unless unusable.empty?
+    msg += " · lens NOT enabled (project busy)" unless lens
+    @toast = msg
+  end
+
+  # One host by name, several by count — the toast has one line and a batch can be 12 hosts.
+  private def name_hosts(hosts : Array(String)) : String
+    hosts.size == 1 ? hosts.first : "#{hosts.size} hosts"
+  end
+
+  # Is `host` already an include/host rule? The read-back behind scope_add_host's report.
+  private def scope_has_host_include?(host : String) : Bool
+    @scope.rules.any? { |r| r.include? && r.host_type? && r.pattern == host }
   end
 
   # Toggle the scope display lens (in-scope-only ⇄ all flows) right from History —

--- a/src/gori/tui/runner/scope.cr
+++ b/src/gori/tui/runner/scope.cr
@@ -34,13 +34,20 @@ class Gori::Tui::Runner < Gori::Verb::ExecContext
     history_controller.view.reload(@session.store)
     missing = hosts.reject { |h| scope_has_host_include?(h) }
     added = hosts - known - missing
-    if added.empty?
-      return (@toast = "scope NOT changed (project busy) — nothing was added") unless missing.empty?
-      return (@toast = "already in scope: #{name_hosts(known)}")
-    end
-    msg = "added #{name_hosts(added)} to scope (#{@scope.size})"
-    msg += " · #{known.size} already there" unless known.empty?
-    msg += " · #{missing.size} NOT added (project busy)" unless missing.empty?
+    # ONE tail for every outcome. Two early returns here dropped `unusable` and `lens`, so
+    # "already in scope: 2 hosts" could be the whole report of a press that ALSO failed to
+    # turn on the lens it was pressed for — the same silence this method is being fixed for.
+    msg =
+      if !added.empty?
+        m = "added #{name_hosts(added)} to scope (#{@scope.size})"
+        m += " · #{known.size} already there" unless known.empty?
+        m
+      elsif !missing.empty?
+        "scope NOT changed (project busy) — nothing was added"
+      else
+        "already in scope: #{name_hosts(known)}"
+      end
+    msg += " · #{missing.size} NOT added (project busy)" unless missing.empty? || added.empty?
     msg += " · #{unusable.size} skipped (not a host)" unless unusable.empty?
     msg += " · lens NOT enabled (project busy)" unless lens
     @toast = msg


### PR DESCRIPTION
`Scope#filter` (History/Sitemap) and `Scope::Rule#matches?` (the intercept hold, the Sandbox, the Probe allowlist, the Sitemap marker) are two implementations of one predicate, and scope.cr's header promises they "never disagree". A review of the Project ▸ Scope surface found four shapes where they did, each verified by running both over the same captured flows.

## The parity breaks

**A flow whose host was captured BRACKETED — `[::1]` — was in scope at every live gate and hidden by the SQL lens, with no host rule able to reach it.** `Rule#host_match?` peels a surrounding bracket pair off the flow host as well as off the pattern; `host_cond` peeled the pattern only, and a `[::1]` pattern is bared to `::1` on the way in, so no spelling matched. Not an exotic host: `resolve_forward` puts a plain-HTTP forward-proxy request's absolute-form target through `URI#host`, which hands IPv6 literals back bracketed, and `FlowMapper` stores it verbatim — `curl -x … 'http://[::1]:9000/admin'` is enough. Measured before the fix:

```
in_scope_url=true  host_in_scope=true  sandbox_blocks=false  matches_url?=true
SQL History=[]     ← the lens hides what every live gate admits
```

Fixed in SQL directly (`Scope::HOST_BARE`), spelled as the bracket-PAIR test rather than `trim(host,'[]')` so a half-bracketed `[::1` peels the same on both sides instead of disagreeing in the other direction.

**`{a,b}` in a host glob.** Crystal's `File.match?` reads brace alternation, SQLite's GLOB reads the braces literally. An include `*.acme.{test,dev}` matched three hosts live and none in History; an EXCLUDE with braces carved out nothing in SQL — fail-OPEN on the display lens.

**Case folding.** SQLite's built-in `lower()` folds ASCII only, Crystal's `String#downcase` folds all of Unicode, so a `string` rule `/über` matched a captured `/Über` live and nothing in History (same for a host rule). ASCII is unaffected — `QL.like` already downcased the pattern.

**A BRACKETED glob, found by the review of the fix above.** `HostPattern::Compiled` peels the pair for its exact/subdomain arm but globs against the UN-peeled pattern, so `[2001:db8::*]` matches nothing in Crystal. Peeling first in SQL would have made it match every host under `2001:db8::` — a dead INCLUDE whose flows History lists as in-scope while `allowlisted_unlocked?` refuses every request, i.e. Sandbox black-holing the proxy with `include_count` non-zero and the "blocks everything" warning quiet.

## The approach

Rather than keep a second dialect in sync by hand — which is what produced all four — the shapes a native spelling cannot express now call the FIRST implementation from SQL: `gori_host_match` **is** `HostPattern::Compiled` and `gori_ci_contains` **is** `downcase.includes?`, registered per pooled connection beside the byte-safe REGEXP (and folded into `SafeRegexp.install`, since no caller wants a handle that can run a regex scope rule but not a string one — `Scope#filter` emits these unconditionally, so a handle without them fails the query, not just the match).

Host rules keep the native fast path whenever `sql_native_host?` proves it agrees — host matching runs per row of every scope-filtered reload. String rules go through the function unconditionally, which costs nothing (`URL_EXPR` already concatenated a fresh string per row for `lower(…) LIKE` to fold and scan, so there was no index to give up) and drops the LIKE escaping with it.

## Three smaller ones on the same surface

- **`scope_add_host` (History `a`) discarded what `add` and `enable` reported** and said "added \<host\> to scope" either way, so a busy project was told hosts were scoped over a scope that had not changed — the one claim the CLI, MCP and the Project pane all check. `add` collapses "already there" and "the store refused it" into one `false`, so neither is read off its return; the rule list is read before and after instead, and one toast tail covers added / already there / NOT added / skipped / lens.
- **The SCOPE pane's add left the highlight where it was.** `scope_rules` is `ORDER BY id` so an add appends: on a list taller than the card the new rule was drawn off-screen, with nothing on screen saying the write had landed. It now selects it, the way the HOST OVERRIDES and ENV add rows already do.
- **`Scope#add`/`#update` now check `kind` against `KINDS`.** A stored `"Include"` is neither `include?` nor `exclude?`: counted by `size` and drawn in the card while `matches_url_unlocked?` reads zero includes and passes everything. Every write path checks it today, so this closes no live hole — same next-caller guarantee as the `match_type` `else` arm beside it.

## Verification

Every new spec is pinned: reverting `HOST_BARE` fails 1, the `sql_native_host?` ASCII/brace gate 3, its bracket gate 1, the string arm 1, the kind guard 1, the selection 1.

`crystal spec` → 8675 examples, 8 failures — the same 8 `Gori::Session` port-bind failures that fail on a clean `origin/main` (confirmed by stashing; a live gori holds the port). `crystal tool format --check src spec bench scripts` clean.

**`scope_add_host` has no spec.** There is no `Runner` harness anywhere in `spec/`, and building one for one toast was out of proportion; it is verified by reading and compile only.

## Note on the first commit

`crystal spec` did not compile on `main`: `Tui::Host` gained an abstract `open_help_query(surface)` that `spec/tui/project_env_pane_spec.cr`'s `FakeHost` never implemented, so the whole suite failed at load. CI runs `crystal spec`, so main is red. Unrelated to this work — kept as its own first commit.