### PR TITLE
Tell the operator why the statusline is blank, and stop killing the script that was about to answer

### DIFF
--- a/docs/content/reference/config.ko.md
+++ b/docs/content/reference/config.ko.md
@@ -292,7 +292,8 @@ TUI 맨 아래에 선택적으로 추가되는 행입니다 (Preferences → **G
   "statusline": {
     "enabled": true,
     "command": "printf 'proj:%s flows:%s' \"$(jq -r .project)\" \"$(jq -r .flows)\"",
-    "interval": 3
+    "interval": 3,
+    "timeout": 10
   }
 }
 ```
@@ -300,10 +301,17 @@ TUI 맨 아래에 선택적으로 추가되는 행입니다 (Preferences → **G
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `enabled` | bool | `false` | statusline 행 표시 여부 |
-| `command` | string | `""` | `/bin/sh -c`로 실행되는 셸 명령. stdout의 첫 줄이 행이 됨 |
+| `command` | string | `""` | `/bin/sh -c`로 실행되는 셸 명령. stdout의 첫 줄이 행이 됨. 비어 있으면 `enabled`여도 행 자체를 잡지 않음 |
 | `interval` | integer | `3` | 실행 간격 초 (최소 `1`) |
+| `timeout` | integer | `10` | 한 번의 실행이 종료되기까지 허용되는 초 (최소 `1`). `interval`보다 커도 됨 |
 
-명령의 stdout은 ANSI/SGR 색상 이스케이프(16색, 256색, truecolor, 그리고 볼드/밑줄 등)를 파싱하므로 색상이 있는 세그먼트를 만들 수 있습니다. 첫 줄만 사용되며, 출력은 터미널 너비로 잘립니다. `interval`초를 초과하는 실행은 종료되고, 실패한 명령은 그냥 행을 비워 둡니다. UI를 절대 막지 않습니다.
+명령의 stdout은 ANSI/SGR 색상 이스케이프(16색, 256색, truecolor, 그리고 볼드/밑줄 등)를 파싱하므로 색상이 있는 세그먼트를 만들 수 있습니다. 첫 줄만 사용되며, 출력은 터미널 너비로 잘립니다. UI를 절대 막지 않습니다.
+
+`timeout`은 `interval`과 의도적으로 분리되어 있습니다. 실행은 겹치지 않으므로(이전 실행이 끝난 뒤에야 다음 실행을 띄웁니다) `interval`보다 느린 스크립트는 매번 죽는 대신 가능한 만큼만 천천히 갱신됩니다. `timeout`을 초과한 실행은 종료되고 행은 `⋯ (timed out)`이 됩니다.
+
+아무것도 출력하지 못하고 실패한 명령은 행을 비워 두는 대신 종료 상태를 보고합니다 — 명령을 찾지 못했으면 `⋯ (exit 127)`, 시그널로 끝났으면 `⋯ (killed)`. 정상 종료했는데 출력이 없으면 행은 비어 있습니다(스크립트가 그렇게 할 수 있는 정당한 선택입니다). 어느 쪽이든 stderr는 버려집니다.
+
+편집은 즉시 반영됩니다. `command` · `interval` · `timeout`을 저장하면 현재 간격이 끝나기를 기다리지 않고 다음 프레임에 다시 실행합니다.
 
 각 실행은 라이브 세션을 설명하는 JSON 컨텍스트를 stdin으로 받으므로, 스크립트는 gori를 쿼리하지 않고도 프록시 상태를 표시할 수 있습니다:
 

--- a/docs/content/reference/config.md
+++ b/docs/content/reference/config.md
@@ -301,7 +301,8 @@ An opt-in extra row at the very bottom of the TUI (Preferences → **General** �
   "statusline": {
     "enabled": true,
     "command": "printf 'proj:%s flows:%s' \"$(jq -r .project)\" \"$(jq -r .flows)\"",
-    "interval": 3
+    "interval": 3,
+    "timeout": 10
   }
 }
 ```
@@ -309,10 +310,17 @@ An opt-in extra row at the very bottom of the TUI (Preferences → **General** �
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `enabled` | bool | `false` | Whether the statusline row is shown |
-| `command` | string | `""` | Shell command, run via `/bin/sh -c`. Its first line of stdout becomes the row |
+| `command` | string | `""` | Shell command, run via `/bin/sh -c`. Its first line of stdout becomes the row. Blank means no row is reserved at all, even when `enabled` |
 | `interval` | integer | `3` | Seconds between runs (minimum `1`) |
+| `timeout` | integer | `10` | Seconds one run may take before it is killed (minimum `1`). May exceed `interval` |
 
-The command's stdout is parsed for ANSI/SGR colour escapes (16-colour, 256-colour, and truecolor, plus bold/underline/etc.), so you can produce coloured segments. Only the first line is used; output is truncated to the terminal width. A run that exceeds `interval` seconds is terminated, and a failing command simply leaves the row blank. It never blocks the UI.
+The command's stdout is parsed for ANSI/SGR colour escapes (16-colour, 256-colour, and truecolor, plus bold/underline/etc.), so you can produce coloured segments. Only the first line is used; output is truncated to the terminal width. It never blocks the UI.
+
+`timeout` is deliberately separate from `interval`. Runs never overlap — gori launches the next one only after the previous has finished — so a script slower than `interval` simply refreshes as fast as it can rather than being killed on every run. A run that does exceed `timeout` is terminated and the row reads `⋯ (timed out)`.
+
+A command that fails without printing anything reports its exit status instead of leaving the row blank — `⋯ (exit 127)` for a command that was not found, `⋯ (killed)` for one a signal ended. A command that exits cleanly having printed nothing leaves the row empty, which is a legitimate thing for a script to do. stderr is discarded either way.
+
+Edits take effect immediately: saving a new `command`, `interval` or `timeout` re-runs the command on the next frame instead of waiting out the current interval.
 
 Each run receives a JSON context on stdin describing the live session, so scripts can display proxy state without querying gori:
 

--- a/spec/tui/statusline_spec.cr
+++ b/spec/tui/statusline_spec.cr
@@ -1,0 +1,148 @@
+require "../spec_helper"
+require "file_utils"
+
+include Gori::Tui
+
+# Settings are class_properties — process-global, not per-example. Snapshot and restore the
+# three statusline knobs (and GORI_HOME, for the load path) so nothing leaks into the next file.
+private def with_statusline_settings(&)
+  enabled = Gori::Settings.statusline_enabled?
+  command = Gori::Settings.statusline_command
+  interval = Gori::Settings.statusline_interval
+  timeout = Gori::Settings.statusline_timeout
+  begin
+    yield
+  ensure
+    Gori::Settings.statusline_enabled = enabled
+    Gori::Settings.statusline_command = command
+    Gori::Settings.statusline_interval = interval
+    Gori::Settings.statusline_timeout = timeout
+  end
+end
+
+private def with_loaded_statusline(json : String, &)
+  dir = File.tempname("gori-statusline")
+  Dir.mkdir_p(dir)
+  prev_home = ENV["GORI_HOME"]?
+  prev_cfg = ENV["GORI_CONFIG"]?
+  begin
+    ENV["GORI_HOME"] = dir
+    ENV.delete("GORI_CONFIG")
+    Gori::Settings.path_override = nil
+    File.write(File.join(dir, "settings.json"), json)
+    Gori::Settings.load
+    yield
+  ensure
+    prev_home ? (ENV["GORI_HOME"] = prev_home) : ENV.delete("GORI_HOME")
+    prev_cfg ? (ENV["GORI_CONFIG"] = prev_cfg) : ENV.delete("GORI_CONFIG")
+    Gori::Settings.path_override = nil
+    FileUtils.rm_rf(dir)
+  end
+end
+
+describe Gori::Tui::Statusline do
+  it "renders the first line of stdout and hands the context JSON to the script" do
+    Statusline.run("printf 'hello\\nsecond\\n'", "{}", 2.seconds).should eq("hello")
+    Statusline.run("cat", %({"version":1,"project":"acme"}), 2.seconds)
+      .should eq(%({"version":1,"project":"acme"}))
+  end
+
+  it "marks a run that outlives its timeout" do
+    Statusline.run("sleep 3; printf 'ready\\n'", "{}", 1.second).should eq("⋯ (timed out)")
+  end
+
+  # The timeout is the RUN's, not the refresh interval's: a script slower than the interval
+  # used to be killed at its deadline on every single run and never render at all.
+  it "renders a script slower than the refresh interval, given a longer timeout" do
+    interval = {Gori::Settings::DEFAULT_STATUSLINE_INTERVAL, 1}.max
+    timeout = {Gori::Settings::DEFAULT_STATUSLINE_TIMEOUT, 1}.max
+    timeout.should be > interval # the defaults themselves must leave headroom
+    Statusline.run("sleep #{interval + 1}; printf 'ready\\n'", "{}", timeout.seconds).should eq("ready")
+  end
+
+  # `sh` always spawns, so a typo'd command exits 127 with EMPTY stdout — indistinguishable
+  # on screen from a script that printed nothing until the status is surfaced.
+  it "reports a failing command's exit status instead of a blank row" do
+    Statusline.run("gori-no-such-binary-xyz", "{}", 2.seconds).should eq("⋯ (exit 127)")
+    Statusline.run("exit 3", "{}", 2.seconds).should eq("⋯ (exit 3)")
+  end
+
+  it "reports a signal-killed command as killed" do
+    Statusline.run("kill -TERM $$", "{}", 2.seconds).should eq("⋯ (killed)")
+  end
+
+  it "leaves the row empty for a command that exits cleanly having printed nothing" do
+    Statusline.run("true", "{}", 2.seconds).should eq("")
+  end
+
+  # A non-empty first line wins over the status: the script said something, so show it even
+  # if it goes on to fail (and even if it is still running).
+  it "keeps output from a command that printed a line and then failed" do
+    Statusline.run("printf 'up\\n'; exit 9", "{}", 2.seconds).should eq("up")
+  end
+
+  it "does not wait on a command that backgrounds a child holding the pipe" do
+    t0 = Time.instant
+    Statusline.run("printf 'now\\n'; (sleep 5) &", "{}", 3.seconds).should eq("now")
+    (Time.instant - t0).should be < 2.seconds
+  end
+end
+
+describe Gori::Settings, "statusline" do
+  # The layout reserves a bottom row on this predicate and the controller clears the row on
+  # it, so "enabled" alone would hold a row open that a blank command never draws into.
+  it "is active only when enabled AND given a command to run" do
+    with_statusline_settings do
+      Gori::Settings.statusline_enabled = true
+      Gori::Settings.statusline_command = "printf hi"
+      Gori::Settings.statusline_active?.should be_true
+
+      Gori::Settings.statusline_command = ""
+      Gori::Settings.statusline_active?.should be_false
+
+      Gori::Settings.statusline_command = "   \t "
+      Gori::Settings.statusline_active?.should be_false
+
+      Gori::Settings.statusline_command = "printf hi"
+      Gori::Settings.statusline_enabled = false
+      Gori::Settings.statusline_active?.should be_false
+    end
+  end
+
+  it "loads the timeout and floors it at 1 second" do
+    with_statusline_settings do
+      with_loaded_statusline(%({"statusline":{"enabled":true,"command":"printf hi","timeout":25}})) do
+        Gori::Settings.statusline_timeout.should eq(25)
+      end
+      with_loaded_statusline(%({"statusline":{"timeout":0}})) do
+        Gori::Settings.statusline_timeout.should eq(1)
+      end
+      with_loaded_statusline(%({"statusline":{"timeout":-9}})) do
+        Gori::Settings.statusline_timeout.should eq(1)
+      end
+    end
+  end
+
+  # `parse_statusline` is tolerant by design: an absent key keeps the value already in
+  # memory rather than resetting it. Pinned with a NON-default in place first — asserting
+  # the default here would pass on a parser that never read the key at all.
+  it "keeps the current timeout when the section omits it" do
+    with_statusline_settings do
+      Gori::Settings.statusline_timeout = 37
+      with_loaded_statusline(%({"statusline":{"command":"printf hi"}})) do
+        Gori::Settings.statusline_timeout.should eq(37)
+      end
+    end
+  end
+
+  it "round-trips the timeout through save" do
+    with_statusline_settings do
+      with_loaded_statusline(%({"statusline":{"enabled":true,"command":"printf hi","timeout":42}})) do
+        Gori::Settings.save.should be_true
+        Gori::Settings.statusline_timeout = 1
+        Gori::Settings.load
+        Gori::Settings.statusline_timeout.should eq(42)
+      end
+    end
+  end
+end

--- a/src/gori/settings/display.cr
+++ b/src/gori/settings/display.cr
@@ -21,6 +21,13 @@ module Gori::Settings
   DEFAULT_STATUSLINE_ENABLED  = false
   DEFAULT_STATUSLINE_COMMAND  = ""
   DEFAULT_STATUSLINE_INTERVAL = 3 # seconds between runs (min 1)
+  # How long a single run may take before it is killed. SEPARATE from the interval on
+  # purpose: it used to BE the interval, which meant a script slower than the refresh
+  # rate was killed at its deadline on every single run and the row read "timed out"
+  # forever — and the only way to give the script more time was to make the row staler.
+  # Runs still cannot pile up (the controller launches one at a time), so a timeout
+  # longer than the interval simply refreshes as fast as the script allows.
+  DEFAULT_STATUSLINE_TIMEOUT = 10 # seconds one run may take (min 1)
   # Display (settings:display): message-body rendering prefs. detail_pane = which pane a
   # freshly-opened History flow shows first; history_time_format = list time column;
   # show_gutter = line-number gutter on the message body views; preview_body_kib = how many
@@ -74,6 +81,7 @@ module Gori::Settings
   class_property? statusline_enabled : Bool = DEFAULT_STATUSLINE_ENABLED
   class_property statusline_command : String = DEFAULT_STATUSLINE_COMMAND
   class_property statusline_interval : Int32 = DEFAULT_STATUSLINE_INTERVAL
+  class_property statusline_timeout : Int32 = DEFAULT_STATUSLINE_TIMEOUT
   # Display prefs (settings:display). detail_pane/history_time_format are validated to their
   # two-value sets on load; show_gutter follows the LAYOUT bools (plain accessor); the History
   # list preview reads preview_body_cap (bytes) so the preview never pulls a multi-MiB body.
@@ -125,7 +133,16 @@ module Gori::Settings
     end
   end
 
-  # Tolerant statusline section: absent/non-object keeps current; interval floored at 1.
+  # Whether the statusline row is actually LIVE — enabled AND given something to run.
+  # "Enabled" alone is not enough: an enabled-but-blank command reserved a row at the
+  # bottom that nothing ever drew into, so the body lost a line to a permanently empty
+  # strip. The single source both the layout (which must reserve the row) and the
+  # controller (which must clear it) gate on, so the two can never disagree.
+  def self.statusline_active? : Bool
+    statusline_enabled? && !statusline_command.blank?
+  end
+
+  # Tolerant statusline section: absent/non-object keeps current; interval/timeout floored at 1.
   private def self.parse_statusline(node : JSON::Any?) : Nil
     return unless o = node.try(&.as_h?)
     self.statusline_enabled = load_bool_h(o, "enabled", statusline_enabled?)
@@ -134,6 +151,9 @@ module Gori::Settings
     end
     if iv = int_field(o, "interval")
       self.statusline_interval = {iv, 1}.max
+    end
+    if to = int_field(o, "timeout")
+      self.statusline_timeout = {to, 1}.max
     end
   end
 
@@ -215,12 +235,14 @@ module Gori::Settings
   private def self.serialize_statusline(j : JSON::Builder) : Nil
     unless statusline_enabled? == DEFAULT_STATUSLINE_ENABLED &&
            statusline_command == DEFAULT_STATUSLINE_COMMAND &&
-           statusline_interval == DEFAULT_STATUSLINE_INTERVAL
+           statusline_interval == DEFAULT_STATUSLINE_INTERVAL &&
+           statusline_timeout == DEFAULT_STATUSLINE_TIMEOUT
       j.field "statusline" do
         j.object do
           j.field "enabled", statusline_enabled?
           j.field "command", statusline_command
           j.field "interval", statusline_interval
+          j.field "timeout", statusline_timeout
         end
       end
     end

--- a/src/gori/tui/controllers/statusline_controller.cr
+++ b/src/gori/tui/controllers/statusline_controller.cr
@@ -15,15 +15,21 @@ module Gori::Tui
     # command (`yes`, `cat /dev/zero`) ballooning memory before the timeout fires.
     MAX_CAPTURE = 64 * 1024
 
+    # How long the empty-output path may wait for the child's exit status before giving
+    # up on it. Only reached once stdout has already hit EOF, so in practice the status
+    # is there already; the bound just means the pathological child (stdout closed, still
+    # alive) costs one short pause rather than wedging the worker.
+    STATUS_GRACE = 200.milliseconds
+
     # Run `command` via `/bin/sh -c`, feeding `stdin_json` on stdin, and return the
-    # FIRST line of its stdout (styling still embedded). On timeout or spawn failure,
-    # return a short marker instead of raising.
+    # FIRST line of its stdout (styling still embedded). On timeout, failure or spawn
+    # error, return a short marker instead of raising.
     #
-    # Both the success and timeout paths converge on a single teardown: close stdout
-    # (so a reader fiber blocked in `read` unblocks — critical when the command
-    # backgrounds a descendant that keeps the pipe open), kill the child, and reap it
-    # on a detached fiber. We deliberately do NOT block this fiber on `process.wait`,
-    # so a child still writing more output can never wedge us.
+    # Every path converges on one teardown: close stdout (so a reader fiber blocked in
+    # `read` unblocks — critical when the command backgrounds a descendant that keeps the
+    # pipe open), kill the child unless it has already been reaped, and reap it on a
+    # detached fiber. This fiber never blocks on a bare `process.wait`, so a child still
+    # writing more output can never wedge us.
     def self.run(command : String, stdin_json : String, timeout_span : Time::Span) : String
       process = Process.new("/bin/sh", ["-c", command],
         input: Process::Redirect::Pipe,
@@ -45,20 +51,63 @@ module Gori::Tui
         done.send("")
       end
 
+      timed_out = false
       result =
         select
         when line = done.receive
           line
         when timeout(timeout_span)
+          timed_out = true
           "⋯ (timed out)"
         end
 
+      line = first_line(result)
+      # Empty stdout, and the script ran to completion: ask the exit status what happened.
+      # `sh` itself always spawns successfully, so a typo'd command exits 127 having
+      # printed nothing — byte-identical on screen to a script that deliberately prints
+      # nothing. stderr is discarded (draining a second pipe would need its own reader
+      # fiber and its own cap), which leaves the status as the only evidence to show.
+      #
+      # The wait is spawned HERE, not up front, and that ordering is load-bearing twice
+      # over: `Process#wait`'s own `ensure` closes `process.output` and releases the pid,
+      # so a wait racing the reader could swallow output that had no trailing newline, and
+      # a wait that won the race left the `terminate` below signalling a pid we no longer
+      # own. By this point the reader is finished with `output`, and `reaped` tells the
+      # teardown to keep its hands off an already-reaped child.
+      reaped = false
+      status_ch = nil.as(Channel(Process::Status)?)
+      if !timed_out && line.empty?
+        ch = Channel(Process::Status).new(1)
+        status_ch = ch
+        spawn(name: "gori-statusline-reap") { ch.send(process.wait) rescue nil }
+        select
+        when st = ch.receive
+          reaped = true
+          line = exit_marker(st) unless st.success?
+        when timeout(STATUS_GRACE)
+          # status not in yet — the fiber above is still in `wait` and will reap it
+        end
+      end
+
       output.close rescue nil # unblock the reader fiber if still in read()
-      process.terminate(graceful: false) rescue nil
-      spawn(name: "gori-statusline-reap") { process.wait rescue nil } # reap; never zombie
-      first_line(result)
+      unless reaped
+        process.terminate(graceful: false) rescue nil
+        # Exactly one `wait` per process, ever: only spawn one when the branch above did not.
+        spawn(name: "gori-statusline-reap") { process.wait rescue nil } if status_ch.nil?
+      end
+      line
     rescue File::NotFoundError | RuntimeError | IO::Error
       "⋯ (statusline failed)"
+    end
+
+    # The row shown for a run that produced nothing and failed. Short by necessity — it
+    # shares one terminal row with whatever the script would have printed.
+    private def self.exit_marker(status : Process::Status) : String
+      if code = status.exit_code?
+        "⋯ (exit #{code})"
+      else
+        "⋯ (killed)"
+      end
     end
 
     # Read stdout up to the first newline, bounded by MAX_CAPTURE. Stops early on the
@@ -99,53 +148,70 @@ module Gori::Tui
   # main fiber, from `tick`. The worker never touches them.
   class StatuslineController
     getter segments : Array(Ansi::Segment)
+    @last_spec : {String, Time::Span, Time::Span}
 
     def initialize(@session : Gori::Session)
       @work_ch = Channel({String, String, Time::Span}).new(1) # {command, ctx_json, timeout}
       @result_ch = Channel(String).new(1)                     # latest-wins raw first line
       @segments = [] of Ansi::Segment
-      @running = false     # a run is in flight (guards against overlapping launches)
-      @started = false     # the worker fiber has been spawned (lazy — only once enabled)
-      @was_enabled = false # last-seen Settings.statusline_enabled? (for the disable edge)
+      @rendered = nil.as(String?) # raw line the row currently shows (nil = nothing painted)
+      @running = false            # a run is in flight (guards against overlapping launches)
+      @started = false            # the worker fiber has been spawned (lazy — only once active)
+      @was_active = false         # last-seen Settings.statusline_active? (for the off edge)
+      @discard = false            # drop the in-flight result: it belongs to a superseded run
       @last_run = nil.as(Time::Instant?)
+      @last_spec = current_spec # the {command, interval, timeout} the last launch used
     end
 
     # Called every main-loop tick. Drains a finished result and (re-)launches the
     # command when its interval has elapsed. Returns true if the row changed (→ dirty).
-    # Self-gated on Settings.statusline_enabled? so it's a cheap no-op while disabled.
+    # Self-gated on Settings.statusline_active? so it's a cheap no-op while off.
     def tick(now : Time::Instant) : Bool
-      enabled = Settings.statusline_enabled?
-      # 1. Drain a finished script result (non-blocking). While disabled we still drain
+      active = Settings.statusline_active?
+      # 1. Drain a finished script result (non-blocking). While off we still drain
       #    (to clear @running for an in-flight run) but do NOT paint it — so a result
       #    produced after the user disabled can't flash on the next re-enable.
-      changed = drain_result(apply: enabled)
+      changed = drain_result(apply: active)
 
-      # 2. Enable→disable edge: drop the row immediately. We leave @running as-is — an
+      # 2. On→off edge: drop the row immediately. We leave @running as-is — an
       #    in-flight run clears it via drain above when it finishes; resetting it here
       #    would let a re-enable launch a second overlapping run.
-      if @was_enabled && !enabled
+      if @was_active && !active
         changed = true unless @segments.empty?
         @segments = [] of Ansi::Segment
+        @rendered = nil # so a re-enable repaints even if the output is unchanged
         @last_run = nil
+        @discard = true if @running
       end
-      @was_enabled = enabled
-      return changed unless enabled
+      @was_active = active
+      return changed unless active
 
-      # 3. (Re-)launch when idle and the interval has elapsed.
+      # 3. A settings edit takes effect NOW, not at the end of the current interval. The
+      #    row used to keep showing the PREVIOUS command's output for up to a full
+      #    interval after the operator saved a new one, with nothing on screen saying so.
+      #    An in-flight run belongs to the superseded command, so it is dropped rather
+      #    than painted for one interval under the new one.
+      spec = current_spec
+      if spec != @last_spec
+        @last_spec = spec
+        @last_run = nil
+        @discard = true if @running
+      end
+
+      # 4. (Re-)launch when idle and the interval has elapsed.
       return changed if @running
-      cmd = Settings.statusline_command.strip
-      return changed if cmd.empty?
-      interval = {Settings.statusline_interval, 1}.max.seconds
+      cmd, interval, timeout_span = spec
       last = @last_run
       return changed unless last.nil? || now - last >= interval
 
       ensure_started
       ctx = build_context_json
-      # Cap the run at the interval so a slow script is killed before the next launch
-      # (backs the @running guard so runs can never pile up). Advance @last_run / mark
+      # The run is capped by its OWN timeout, not by the interval: runs cannot pile up
+      # regardless (the @running guard launches one at a time), so a script slower than
+      # the refresh rate now renders late instead of never. Advance @last_run / mark
       # running ONLY on a successful send, so a full channel just retries next tick.
       select
-      when @work_ch.send({cmd, ctx, interval})
+      when @work_ch.send({cmd, ctx, timeout_span})
         @last_run = now
         @running = true
       else
@@ -154,18 +220,34 @@ module Gori::Tui
       changed
     end
 
+    # The live {command, interval, timeout} triple a launch is configured from. Compared
+    # against the last launch's to notice a settings edit.
+    private def current_spec : {String, Time::Span, Time::Span}
+      {Settings.statusline_command.strip,
+       {Settings.statusline_interval, 1}.max.seconds,
+       {Settings.statusline_timeout, 1}.max.seconds}
+    end
+
     # Apply a finished script result if one is waiting (non-blocking). Always clears
-    # @running so the next run can launch; paints @segments only when `apply` (enabled).
+    # @running so the next run can launch; paints @segments only when `apply` (active).
     # Returns true if the row changed. Runs on the main fiber — the only @segments writer.
     private def drain_result(apply : Bool) : Bool
       select
       when line = @result_ch.receive
         @running = false
-        if apply
-          @segments = Ansi.parse(line)
-          return true
+        if @discard # superseded command / turned off mid-run — this output is stale
+          @discard = false
+          return false
         end
-        false
+        return false unless apply
+        # Byte-identical to what the row already shows ⇒ NOT dirty. The render loop only
+        # repaints when something reports dirty, so returning true unconditionally bought
+        # a whole frame that painted not one different cell, once per interval, forever —
+        # the exact thing ResourceMeter's idle-zero-CPU invariant exists to prevent.
+        return false if @rendered == line
+        @rendered = line
+        @segments = Ansi.parse(line)
+        true
       else
         false
       end

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -571,7 +571,8 @@ module Gori::Tui
               dirty = true
             end
             # Statusline: drain a finished script result and (re-)launch on its interval.
-            # Self-gated on Settings.statusline_enabled? — a no-op (zero cost) while disabled.
+            # Self-gated on Settings.statusline_active? — a no-op (zero cost) while the row
+            # is off or has no command, and it only reports dirty when the row's bytes change.
             dirty = true if @statusline.tick(now)
             # Resource meter: re-sample CPU/RSS on its own interval. Like the clock below, it
             # only reports true when the RENDERED string changes, so a parked gori doesn't
@@ -1888,9 +1889,11 @@ module Gori::Tui
 
     # Whether the extra bottom statusline row is reserved. MUST gate every Layout.compute
     # call (render + mouse hit-test + space-menu guard) identically, or the click geometry
-    # drifts a row from what was drawn.
+    # drifts a row from what was drawn. Delegated to Settings so the CONTROLLER gates on
+    # the same predicate — "enabled" alone left an enabled-but-blank command holding a row
+    # the controller never drew into.
     private def statusline_active? : Bool
-      Settings.statusline_enabled?
+      Settings.statusline_active?
     end
 
     # Reflect the open project and active tab in the terminal-window title

--- a/src/gori/tui/settings_view.cr
+++ b/src/gori/tui/settings_view.cr
@@ -99,6 +99,8 @@ module Gori::Tui
         "shell command (/bin/sh -c) — receives a JSON context (project, capture, flows, proxy) on stdin"),
       Field.new("Interval (s)",
         "how often to re-run the command — seconds (min 1)"),
+      Field.new("Timeout (s)",
+        "how long one run may take before it is killed — seconds (min 1); may exceed the interval"),
     ]
     # Display: message-body + chrome prefs (three choice fields, three bools, a text cap).
     DISPLAY_PANE_CHOICES = ["request", "response"]
@@ -214,7 +216,7 @@ module Gori::Tui
                 when :keys          then keys_values
                 when :theme         then [Theme.canonical(Settings.theme)]
                 when :layout        then layout_values
-                when :statusline    then [Settings.statusline_enabled? ? "on" : "off", Settings.statusline_command, Settings.statusline_interval.to_s]
+                when :statusline    then statusline_values
                 when :display       then display_values
                 when :companion     then companion_values
                 when :notifications then [Settings.notify_bell? ? "on" : "off", Settings.notify_toast? ? "on" : "off", Settings.notify_retention.to_s]
@@ -262,6 +264,7 @@ module Gori::Tui
                   Settings::DEFAULT_STATUSLINE_ENABLED ? "on" : "off",
                   Settings::DEFAULT_STATUSLINE_COMMAND,
                   Settings::DEFAULT_STATUSLINE_INTERVAL.to_s,
+                  Settings::DEFAULT_STATUSLINE_TIMEOUT.to_s,
                 ]
                 when :display then [
                   Settings::DEFAULT_DETAIL_PANE,
@@ -383,6 +386,15 @@ module Gori::Tui
         Settings.issues_preview ? "on" : "off",
         order_label(Settings.history_list_order),
         depth_label(Settings.sitemap_expand_depth),
+      ]
+    end
+
+    private def statusline_values : Array(String)
+      [
+        Settings.statusline_enabled? ? "on" : "off",
+        Settings.statusline_command,
+        Settings.statusline_interval.to_s,
+        Settings.statusline_timeout.to_s,
       ]
     end
 
@@ -605,10 +617,16 @@ module Gori::Tui
           @status = "invalid interval"
           return "settings: invalid statusline interval #{@values[2].inspect} (seconds, min 1)"
         end
+        to = @values[3].strip.to_i?
+        unless to && to >= 1
+          @status = "invalid timeout"
+          return "settings: invalid statusline timeout #{@values[3].inspect} (seconds, min 1)"
+        end
         Settings.statusline_enabled = @values[0] == "on"
-        Settings.statusline_command = @values[1] # blank is valid (no-op while enabled)
+        Settings.statusline_command = @values[1] # blank is valid (the row is simply not reserved)
         Settings.statusline_interval = iv
-        @values = [Settings.statusline_enabled? ? "on" : "off", Settings.statusline_command, iv.to_s]
+        Settings.statusline_timeout = to
+        @values = statusline_values
         return persist
       end
       if @section == :display


### PR DESCRIPTION
The statusline had four ways to look exactly like "nothing to report", and one of them was a script that could never work no matter how it was configured. Found by driving the real TUI under tmux; every fix below is verified the same way.

### The run timeout WAS the refresh interval

`tick` passed `interval` straight in as `timeout_span`, so a script slower than the interval was killed at its deadline on **every** run: the row read `⋯ (timed out)` forever while a doomed `sh` respawned each interval. The only lever that bought the script more time was the one that also made the row staler — at the default 3s that ruled out anything doing a network call.

`timeout` is now its own setting (default 10s) and may exceed the interval. Runs still cannot pile up (the controller has always launched one at a time), so a slow script renders **late instead of never** — a 5s script at interval 2 now refreshes on its own 5s cadence.

### A failing command was indistinguishable from a silent one

stderr is discarded and `sh` itself always spawns, so a typo'd command exited 127 with empty stdout and drew a blank row — byte-identical to a script that chose to print nothing, and to an enabled-but-blank command. `⋯ (statusline failed)` was unreachable in practice.

The exit status is now surfaced when the output is empty: `⋯ (exit 127)`, or `⋯ (killed)` for a signal. A clean exit with no output stays blank, which is a legitimate thing for a script to do.

The `wait` that collects it is spawned only once the reader has finished, never up front. `Process#wait`'s own `ensure` closes `process.output` and releases the pid, so a wait racing the reader could swallow output with no trailing newline, and a wait that won the race left the teardown's `terminate` signalling a pid we no longer own (ESRCH on every failing and every silent run — harmless today, a stray SIGKILL the day that pid is reused). The teardown now skips `terminate` outright once the status is in.

### An unchanging row bought a full render pass per interval

`drain_result` returned dirty on every result, identical or not. Measured with `tmux pipe-pane` at a 2s interval with constant output: **17 of 19 frames in 20 seconds painted zero cells**, against 6 of 7 for an idle gori with the row off. It now compares the raw line first — the contract `ResourceMeter`'s idle-zero-CPU invariant already spells out. After the fix: 7 empty frames, exactly the statusline-off baseline.

### Two smaller ones from the same read

- **An enabled-but-blank command reserved a row nothing drew into**, so the body lost a line to an empty strip. The layout and the controller now gate on one `Settings.statusline_active?` that requires a command.
- **A saved edit only took effect at the end of the current interval** — up to 45s of the previous command's output on a slow refresh, with nothing on screen saying so. The controller now notices the command/interval/timeout changing, relaunches on the next frame, and drops the in-flight result belonging to the superseded command. Measured: <1s to update, was 13-23s at interval 45.

### Verification

`spec/tui/statusline_spec.cr` is new — `Statusline.run` had no spec at all, and neither did the statusline settings. Every example was confirmed to fail with its fix reverted. Full suite green (8697 examples), `crystal tool format --check` clean.

Behaviour confirmed live in a real TUI for all five: slow script cadence, `⋯ (exit 127)`, blank command reclaiming its row, sub-second edit latency, and the frame-count drop. ANSI colour, CSI/OSC/C0 sanitisation, width truncation and the disable edge were checked unchanged.