### PR TITLE
Find a sub-tab by its number, and by what each one actually holds

### DIFF
--- a/spec/tui/subtab_picker_spec.cr
+++ b/spec/tui/subtab_picker_spec.cr
@@ -37,6 +37,44 @@ describe Gori::Tui::SubtabPicker do
     p.selected_index.should eq(2) # both terms hit only the checkout row
   end
 
+  it "matches an all-digit term against the row's own number" do
+    # The labels had their "N:" stripped, so the number a chip advertises ("2:search api")
+    # lived only in the picker's № column — and typing it found nothing.
+    p = sample_picker
+    p.query_char('2') # no row TEXT contains a 2
+    p.entry_count.should eq(1)
+    p.selected_index.should eq(1)
+
+    colon = sample_picker
+    "3:".each_char { |c| colon.query_char(c) } # the chip's own spelling works too
+    colon.entry_count.should eq(1)
+    colon.selected_index.should eq(2)
+  end
+
+  it "keeps the substring arm for digits, so a port still matches by text" do
+    p = SubtabPicker.new("FIND SUB-TAB", [
+      SubtabPicker::Row.new(0, "local", "GET / http://127.0.0.1:8080"),
+      SubtabPicker::Row.new(1, "prod", "GET / https://app.example.com"),
+    ])
+    "8080".each_char { |c| p.query_char(c) }
+    p.selected_index.should eq(0) # the port, not "session 8080"
+  end
+
+  it "searches Row#extra (request content) without ever drawing it" do
+    rows = [
+      SubtabPicker::Row.new(0, "login", "POST /login https://app.example.com", "Authorization: Bearer sekret-tok"),
+      SubtabPicker::Row.new(1, "search api", "GET /api/search https://api.example.com"),
+    ]
+    p = SubtabPicker.new("FIND SUB-TAB", rows)
+    "sekret-tok".each_char { |c| p.query_char(c) }
+    p.entry_count.should eq(1)
+    p.selected_index.should eq(0)
+
+    backend = MemoryBackend.new(100, 30)
+    SubtabPicker.new("FIND SUB-TAB", rows).render(Screen.new(backend), Rect.new(0, 0, 100, 30))
+    backend.contains?("sekret-tok").should be_false # haystack only — never a column
+  end
+
   it "reports no match when the filter excludes every row" do
     p = sample_picker
     "zzz".each_char { |c| p.query_char(c) }

--- a/spec/tui/subtab_search_rows_spec.cr
+++ b/spec/tui/subtab_search_rows_spec.cr
@@ -1,5 +1,6 @@
 require "../spec_helper"
 require "file_utils"
+require "base64"
 
 include Gori::Tui
 
@@ -161,7 +162,7 @@ private def with_session(&)
     session = Gori::Session.open(Gori::Config.new(listen: "127.0.0.1", port: 0),
       Gori::Proxy::Tls::CertAuthority.load_or_create(SEARCH_ROWS_CA), Gori::Verbs.registry, project)
     session.store.insert_repeater("https://shop.example.com/cart",
-      "POST /cart/checkout HTTP/1.1\r\nHost: shop.example.com\r\n\r\n".to_slice, false, true, nil, 0)
+      "POST /cart/checkout HTTP/1.1\r\nHost: shop.example.com\r\nX-Api-Token: tok-sekret-9\r\n\r\n".to_slice, false, true, nil, 0)
     yield FakeHost.new(session)
   ensure
     session.try(&.close)
@@ -197,6 +198,63 @@ describe "TabController#subtab_search_rows" do
       RepeaterController.new(host).subtab_search_rows.each do |row|
         row.detail.size.should be <= Gori::Tui::TabController::SEARCH_DETAIL_MAX
       end
+    end
+  end
+
+  it "carries the request content in the searchable extra, capped and off the drawn columns" do
+    with_session do |host|
+      row = RepeaterController.new(host).subtab_search_rows.first
+      # A header lives only in the wire text — summary/target never show it, so before the
+      # extra the one session sending this token was unfindable by it.
+      row.extra.should contain("X-Api-Token: tok-sekret-9")
+      row.detail.should_not contain("tok-sekret-9")
+      row.extra.size.should be <= Gori::Tui::TabController::SEARCH_EXTRA_MAX
+
+      # An empty session contributes no searchable text (a fresh Decoder conversion).
+      DecoderController.new(host).subtab_search_rows.each(&.extra.strip.should(be_empty))
+    end
+  end
+
+  it "fills the fuzzer's extra from its template" do
+    with_session do |host|
+      fc = FuzzerController.new(host)
+      fc.fuzz_new
+      # load_blank seeds "GET / HTTP/1.1\r\nHost: example.com..." — findable by a header
+      # the summary (request line only) never shows.
+      fc.subtab_search_rows.first.extra.should contain("Host: example.com")
+    end
+  end
+
+  it "searches the WHOLE note body, past the 200-column detail cap" do
+    with_session do |host|
+      nc = NotesController.new(host)
+      body = "title line\n" + ("filler word " * 40) + "BURIEDWORD tail"
+      body.size.should be > Gori::Tui::TabController::SEARCH_DETAIL_MAX # the word is past detail's reach
+      nc.view.replace_current(body)
+      row = nc.subtab_search_rows.first
+      row.detail.should_not contain("BURIEDWORD") # the drawn column stops at 200
+      row.extra.should contain("BURIEDWORD")      # the picker still finds it
+    end
+  end
+
+  it "searches the decoder's input and its decoded output" do
+    with_session do |host|
+      dc = DecoderController.new(host)
+      dc.decoder_from_text("aGVsbG8td29ybGQ") # base64 of "hello-world", no chain yet
+      row = dc.subtab_search_rows.last
+      row.extra.should contain("aGVsbG8td29ybGQ") # the pasted input
+    end
+  end
+
+  it "searches the JWT's decoded header and payload, not its opaque token" do
+    with_session do |host|
+      jc = JwtController.new(host)
+      header = Base64.urlsafe_encode(%({"alg":"HS256","typ":"JWT"}), padding: false)
+      payload = Base64.urlsafe_encode(%({"role":"admin","iss":"gori-test"}), padding: false)
+      jc.jwt_from_text("#{header}.#{payload}.sig")
+      extra = jc.subtab_search_rows.last.extra
+      extra.should contain("admin")     # a claim the operator remembers ...
+      extra.should contain("gori-test") # ... found in the DECODED payload
     end
   end
 end

--- a/src/gori/tui/comparer_view.cr
+++ b/src/gori/tui/comparer_view.cr
@@ -118,6 +118,14 @@ module Gori::Tui
       Repeater::SubtabFilter::Subject.new(@name, summ, targets, methods, [] of String)
     end
 
+    # The ⌕ picker's searchable content: the REQUEST lines of both slots. Request-side only
+    # — those are the memorable half (the header/param the operator chose to compare), and
+    # `lines(:request)` is the cheap projection (no body decode/scrub), memoized so this
+    # warms the very cache render is about to read.
+    def search_text : String
+      [@slot_a, @slot_b].compact.flat_map(&.lines(:request)).join('\n')
+    end
+
     # Identity for rename/apply (view object, not content) — mirrors MinerView/RepeaterView.
     def same?(other : ComparerView) : Bool
       object_id == other.object_id

--- a/src/gori/tui/controllers/comparer_controller.cr
+++ b/src/gori/tui/controllers/comparer_controller.cr
@@ -54,6 +54,12 @@ module Gori::Tui
       @sessions.map(&.filter_subject)
     end
 
+    # The ⌕ picker searches both slots' request lines (capped) — a comparison is findable
+    # by a header the operator diffed, not just the two targets the summary names.
+    def subtab_search_extras : Array(String)
+      @sessions.map { |v| search_extra(v.search_text) }
+    end
+
     # Filter-aware strip nav: ←/→ skip hidden chips; ^1-9 to a hidden chip drops the
     # filter (chip numbers are absolute). Sessions are in-memory, so no persist on switch.
     def move_subtab(dir : Int32) : Nil

--- a/src/gori/tui/controllers/decoder_controller.cr
+++ b/src/gori/tui/controllers/decoder_controller.cr
@@ -136,6 +136,16 @@ module Gori::Tui
       end
     end
 
+    # The ⌕ picker searches the full input AND the decoded output — the memorable string
+    # is as often what came OUT (`admin` in a decoded JWT) as what the operator pasted in.
+    # The 200-column filter detail carries only chain + a slice of input; this goes further.
+    def subtab_search_extras : Array(String)
+      @sessions.map do |s|
+        bytes = s.result.output
+        search_extra(bytes ? "#{s.input.text} #{String.new(bytes)}" : s.input.text)
+      end
+    end
+
     # The chip label: the custom name if set, else a compact preview of the chain
     # spec (or "empty" when blank), capped to ~18 cols like Repeater/Notes.
     private def session_label(s : DecoderSession) : String

--- a/src/gori/tui/controllers/fuzzer_controller.cr
+++ b/src/gori/tui/controllers/fuzzer_controller.cr
@@ -101,6 +101,13 @@ module Gori::Tui
       end
     end
 
+    # The ⌕ picker also searches each session's TEMPLATE (base hook, capped): a fuzz
+    # session is findable by a header or §marker§ the operator remembers, not just the
+    # request line its summary shows.
+    def subtab_search_extras : Array(String)
+      @fuzzers.map { |t| search_extra(t.view.template_text) }
+    end
+
     def view_at(idx : Int32) : FuzzerView?
       (0 <= idx < @fuzzers.size) ? @fuzzers[idx].view : nil
     end

--- a/src/gori/tui/controllers/jwt_controller.cr
+++ b/src/gori/tui/controllers/jwt_controller.cr
@@ -149,6 +149,15 @@ module Gori::Tui
       end
     end
 
+    # The ⌕ picker searches the DECODED claims, not the opaque token the summary carries:
+    # an operator remembers a token by something inside it (`admin`, an `iss`, a `kid`),
+    # never by its base64. `decoded` holds that text in decode mode; header/payload hold it
+    # in encode mode (the operator is drafting the claims) — both, so either direction is
+    # findable by what it says.
+    def subtab_search_extras : Array(String)
+      @sessions.map { |s| search_extra("#{s.decoded} #{s.header.text} #{s.payload.text}") }
+    end
+
     # The chip label: the custom name, else the token's alg (or "empty"), capped ~18 cols.
     private def session_label(s : JwtSession) : String
       raw = (n = s.view.name) ? n : token_summary(s)

--- a/src/gori/tui/controllers/miner_controller.cr
+++ b/src/gori/tui/controllers/miner_controller.cr
@@ -353,6 +353,12 @@ module Gori::Tui
       end
     end
 
+    # The ⌕ picker searches the mined request itself (wire bytes, capped) — a header or
+    # parameter the operator recalls, beyond the request line the summary shows.
+    def subtab_search_extras : Array(String)
+      @miners.map { |t| search_extra(t.view.request_bytes) }
+    end
+
     # --- sub-tab nav (filter-aware: ←/→ skip hidden chips; ^1-9 escapes the filter) ---
     def move_subtab(dir : Int32) : Nil
       if t = step_visible(@current_idx, dir)

--- a/src/gori/tui/controllers/notes_controller.cr
+++ b/src/gori/tui/controllers/notes_controller.cr
@@ -271,6 +271,13 @@ module Gori::Tui
       end
     end
 
+    # The ⌕ picker searches the WHOLE note body (capped), not just the 200-column detail
+    # the drawn projection stops at: a note exists to be found by any word it holds, and
+    # the words worth remembering are as often in paragraph three as the first line.
+    def subtab_search_extras : Array(String)
+      @notes.filter_rows.map { |(_, body)| search_extra(body) }
+    end
+
     def body_badge : Symbol
       @notes.insert_mode? ? :editor : :body
     end

--- a/src/gori/tui/controllers/repeater_controller.cr
+++ b/src/gori/tui/controllers/repeater_controller.cr
@@ -134,15 +134,16 @@ module Gori::Tui
       @repeaters.map_with_index { |tab, i| "#{i + 1}:#{tab.view.label(18)}#{tab.view.tags_label(12)}" }
     end
 
-    # Overridden for the LABEL only: 40 columns rather than the chip's 18, which the
+    # Overridden for the LABEL: 40 columns rather than the chip's 18, which the
     # full-width picker card has room for and reads better in. The detail column is what
     # the base would build (see TabController#search_detail) — a dim, searchable request
     # line so a session is findable by host/path/tag even when a custom name hides its
-    # summary.
+    # summary. The extra is the request itself (wire text, capped), so a session is also
+    # findable by a header or body fragment the operator remembers typing.
     def subtab_search_rows : Array(SubtabPicker::Row)
       @repeaters.map_with_index do |tab, i|
         v = tab.view
-        SubtabPicker::Row.new(i, v.label(40), search_detail(filter_subject(v)))
+        SubtabPicker::Row.new(i, v.label(40), search_detail(filter_subject(v)), search_extra(v.request_text))
       end
     end
 

--- a/src/gori/tui/controllers/sequencer_controller.cr
+++ b/src/gori/tui/controllers/sequencer_controller.cr
@@ -469,6 +469,12 @@ module Gori::Tui
       end
     end
 
+    # The ⌕ picker searches the captured request itself (wire bytes, capped) — findable by
+    # a header or parameter the operator recalls, beyond the summary's request line.
+    def subtab_search_extras : Array(String)
+      @sessions.map { |t| search_extra(t.view.request_bytes) }
+    end
+
     # --- sub-tab nav ---
     def move_subtab(dir : Int32) : Nil
       if t = step_visible(@current_idx, dir)

--- a/src/gori/tui/subtab_picker.cr
+++ b/src/gori/tui/subtab_picker.cr
@@ -16,20 +16,24 @@ module Gori::Tui
   # session to an issue or note, opened as a child of LinksOverlay).
   class SubtabPicker < FilterPickerOverlay
     # `index` is the sub-tab's absolute position — the value handed back on commit;
-    # `label` is the chip text, `detail` the dim searchable request line.
-    record Row, index : Int32, label : String, detail : String
+    # `label` is the chip text, `detail` the dim searchable request line. `extra` is
+    # searched but never drawn — request/template content far too long for a column
+    # (TabController#subtab_search_extras fills it, capped at SEARCH_EXTRA_MAX).
+    record Row, index : Int32, label : String, detail : String, extra : String = ""
 
     # Doubles as `Overlay#title` on purpose: the pre-seam `focus_label` read this field
     # (`@subtab_picker.try(&.title)`), so "FIND SUB-TAB" / "PICK REPEATER" is both the card
     # heading and the focus badge. Intended here — but a field quietly satisfying an
     # abstract method is a real hazard in Crystal (no `override`), so it is spelled out.
     getter title : String
-    getter action : String          # verb shown in the ↵ hint ("jump" for search, "link" when picking a link target)
-    @indexed : Array({Row, String}) # each row paired with its precomputed filter haystack
+    getter action : String                  # verb shown in the ↵ hint ("jump" for search, "link" when picking a link target)
+    @indexed : Array({Row, String, String}) # each row with its precomputed filter haystack + its 1-based number
 
     def initialize(@title : String, @rows : Array(Row), @action : String = "jump")
-      # Precompute each row's filter haystack ONCE (not per keystroke).
-      @indexed = @rows.map { |row| {row, "#{row.label} #{row.detail}".downcase} }
+      # Precompute each row's filter haystack ONCE (not per keystroke). The number kept
+      # beside it is the SAME one draw_row paints and the chip wears (`3:login`) — matched
+      # whole in refilter, so "3" finds session 3 without also claiming 13/30.
+      @indexed = @rows.map { |row| {row, "#{row.label} #{row.detail} #{row.extra}".downcase, (row.index + 1).to_s} }
       @filtered = @rows
     end
 
@@ -58,10 +62,15 @@ module Gori::Tui
     end
 
     # Recompute the visible rows from the precomputed haystacks: every whitespace-
-    # separated term must appear (case-insensitive). Resets the cursor to the top.
+    # separated term must appear (case-insensitive). An all-digit term ("3", or "3:" as
+    # the chip spells it) ALSO matches the row whose number it is: the labels had their
+    # `N:` stripped (subtab_search_rows), so without this arm the one name every chip
+    # advertises was the one string the picker could not find. A widening only — the
+    # substring arm still runs, so "8080" keeps matching a port in a request line.
+    # Resets the cursor to the top.
     protected def refilter : Nil
-      terms = @query.downcase.split
-      @filtered = terms.empty? ? @rows : @indexed.select { |(_, hay)| terms.all? { |t| hay.includes?(t) } }.map(&.first)
+      terms = @query.downcase.split.map { |t| {t, (m = t.match(/\A(\d+):?\z/)) ? m[1] : nil} }
+      @filtered = terms.empty? ? @rows : @indexed.select { |(_, hay, num)| terms.all? { |(t, n)| hay.includes?(t) || n == num } }.map(&.first)
       @selected = 0
       @scroll = 0
     end

--- a/src/gori/tui/tab_controller.cr
+++ b/src/gori/tui/tab_controller.cr
@@ -471,6 +471,11 @@ module Gori::Tui
     # word it holds — and `SubtabPicker` precomputes one lowercased haystack per row.
     SEARCH_DETAIL_MAX = 200
 
+    # Cap for `subtab_search_extras` text: the request line + headers + the start of a
+    # body, and small enough that a multi-MiB capture can't make N sessions × its size
+    # the picker's per-open cost.
+    SEARCH_EXTRA_MAX = 2048
+
     # Rows for the "find sub-tab" search picker (the strip's ⌕ affordance, or space → search).
     #
     # The detail column is the SAME projection the `/` filter bar matches on: every session
@@ -484,13 +489,34 @@ module Gori::Tui
     # Built once per open (SubtabPicker caches the haystacks), so nothing here is per-keystroke.
     def subtab_search_rows : Array(SubtabPicker::Row)
       subjects = filter_subjects
+      extras = subtab_search_extras
       (subtab_labels || [] of String).map_with_index do |label, i|
         # Drop the leading "N:" — the picker draws the index in a column of its own, so the
         # label would otherwise read "3   3:login".
         num_end, _ = Chrome.chip_zones(label)
         detail = (s = subjects[i]?) ? search_detail(s) : ""
-        SubtabPicker::Row.new(i, label[num_end..], detail)
+        SubtabPicker::Row.new(i, label[num_end..], detail, extras[i]? || "")
       end
+    end
+
+    # Per-session text the picker SEARCHES but never draws — request/template content
+    # (Repeater wire text, Fuzzer templates), parallel to subtab_labels by index. Kept out
+    # of `detail` because that column is drawn: 200 columns of header soup would bury the
+    # request line it exists to show. Default empty — most tabs have nothing beyond their
+    # filter_subjects projection. Overrides cap each entry with `search_extra`.
+    def subtab_search_extras : Array(String)
+      [] of String
+    end
+
+    protected def search_extra(text : String) : String
+      text[0, SEARCH_EXTRA_MAX]
+    end
+
+    # Bytes variant (captured requests: Miner/Sequencer). Cap the SLICE before building the
+    # String so a multi-MiB capture never allocates in full just to be truncated — and so an
+    # invalid-UTF-8 body (a real capture holds them) is scrubbed over 2KB, not megabytes.
+    protected def search_extra(bytes : Bytes) : String
+      String.new(bytes[0, {bytes.size, SEARCH_EXTRA_MAX}.min])
     end
 
     # One searchable line for a session: what it does, where it goes, and how it is tagged.


### PR DESCRIPTION
## What

The ⌕ sub-tab picker (`f` from any chip) could only match chip labels and the dim request line it draws. Two things you'd reach for weren't findable:

- **The number.** Every chip wears one (`3:login`), but the picker strips the `N:` off the label and draws the index in its own column — so typing `3` matched nothing.
- **The content.** The thing that makes a session memorable — a header you set, a note's third paragraph, a claim inside a JWT — was never in the search haystack. Only the label and a 200-column request line were.

## Changes

- **Number search.** An all-digit term (`3`, or `3:` as the chip spells it) matches the row's own number. It's a widening only — the substring arm still runs, so `8080` keeps matching a port in a request line rather than "session 8080".
- **Per-tab content search.** A new `Row#extra` field is *searched but never drawn*, filled with content tailored to each tab:
  | Tab | Searchable content |
  |---|---|
  | Repeater / Miner / Sequencer | captured request wire bytes |
  | Fuzzer | request template (incl. `§markers§`) |
  | Notes | the whole note body (past the 200-col detail cap) |
  | Decoder | input + decoded output |
  | JWT | decoded claims (decode mode) + drafted header/payload (encode mode) |
  | Comparer | both slots' request lines |
- Capped at **2KB** per session (`SEARCH_EXTRA_MAX`); the bytes variant slices *before* `String.new` so a multi-MiB capture never allocates in full. Built once per picker open, so nothing is per-keystroke.

All eight strips that have the picker get content matched to what they hold; the five fixed strips (Help/Probe/Project/OAST/Target) have no picker and need none. Same rows feed the note/issue **link picker**, so number + content search work there too.

## Tests

TUI suite green (2923 examples). New specs cover: number match (`2`, `3:`), the digit-substring fallback (port `8080`), `extra` searched-but-not-rendered, and per-tab content for Repeater / Fuzzer / Notes (buried word past the detail cap) / Decoder / JWT (decoded claim).

🤖 Generated with [Claude Code](https://claude.com/claude-code)