### PR TITLE
Keep a stray byte from crashing the CLI, and a stale cursor from taking the TUI down

### DIFF
--- a/src/gori/cli/run.cr
+++ b/src/gori/cli/run.cr
@@ -275,6 +275,26 @@ module Gori
         end
       end
 
+      # Read an operator-named input file, reporting a clean CLI error instead of a
+      # backtrace. `File.exists? && !File.directory?` is NOT enough on its own: it passes
+      # for a file that exists but cannot be opened (mode 000, an unreadable parent, a
+      # foreign-owned path), and it is a TOCTOU window besides — the path can be deleted
+      # between the check and the read. `File.read` then raises `File::AccessDeniedError` /
+      # `File::NotFoundError`, and `File::Error < IO::Error` is re-raised by `Run.dispatch`
+      # (which only absorbs EPIPE), so it escapes `CLI.run`'s `Gori::Error`-only rescue.
+      # Mirrors the guard `run/rewriter.cr`'s `read_stub_response` already had. `stdin:` is
+      # opt-in rather than the default so this stays a pure robustness change: only the one
+      # caller that already spelled `-` as stdin keeps that meaning, and the flags that used
+      # to reject `-` as an unreadable path go on rejecting it instead of quietly blocking
+      # on a terminal read.
+      private def self.read_input_file(path : String, what : String, *, stdin : Bool = false) : String
+        return STDIN.gets_to_end if stdin && path == "-"
+        abort "#{what}: not a readable file: #{path}" if File.directory?(path)
+        File.read(path)
+      rescue ex : File::Error
+        abort "#{what}: cannot read '#{path}': #{ex.message}"
+      end
+
       # Opening a non-SQLite file (or a path we can't read) raises deep in the driver;
       # turn that into a clean CLI error instead of an unhandled backtrace.
       private def self.open_store(project : Project) : Store

--- a/src/gori/cli/run/fuzz.cr
+++ b/src/gori/cli/run/fuzz.cr
@@ -224,8 +224,7 @@ module Gori
       private def self.fuzz_source(flow_id : Int64?, request_file : String?,
                                    project_name : String?, db_path : String?) : {String, String?, Bool, Bool}
         if file = request_file
-          abort "gori run fuzz: not a readable file: #{file}" unless File.exists?(file) && !File.directory?(file)
-          {File.read(file), nil, false, false}
+          {read_input_file(file, "gori run fuzz"), nil, false, false}
         elsif id = flow_id
           store = open_store(resolve_read_project(project_name, db_path))
           detail = begin

--- a/src/gori/cli/run/intercept.cr
+++ b/src/gori/cli/run/intercept.cr
@@ -405,8 +405,7 @@ module Gori
         item_id = positional[0].to_i64? || abort("gori run intercept edit: invalid item id '#{positional[0]}'")
 
         content = if f = raw_file
-                    abort "gori run intercept edit: --raw-file '#{f}' is not readable" unless File.exists?(f) && !File.directory?(f)
-                    File.read(f)
+                    read_input_file(f, "gori run intercept edit: --raw-file")
                   elsif r = raw
                     r
                   else

--- a/src/gori/cli/run/mine.cr
+++ b/src/gori/cli/run/mine.cr
@@ -176,8 +176,7 @@ module Gori
       private def self.mine_source(flow_id : Int64?, request_file : String?,
                                    project_name : String?, db_path : String?) : {String, String?, Bool, Bool}
         if file = request_file
-          abort "gori run mine: not a readable file: #{file}" unless File.exists?(file) && !File.directory?(file)
-          {File.read(file), nil, false, false}
+          {read_input_file(file, "gori run mine"), nil, false, false}
         elsif id = flow_id
           store = open_store(resolve_read_project(project_name, db_path))
           detail = begin

--- a/src/gori/cli/run/sequence.cr
+++ b/src/gori/cli/run/sequence.cr
@@ -186,7 +186,7 @@ module Gori
       end
 
       private def self.read_token_list(file : String) : Array(String)
-        raw = file == "-" ? STDIN.gets_to_end : (File.exists?(file) && !File.directory?(file) ? File.read(file) : abort("gori run sequence: not a readable file: #{file}"))
+        raw = read_input_file(file, "gori run sequence", stdin: true)
         # Token lists are usually text, but a stray non-UTF-8 byte (0xff/0xfe) makes the
         # PCRE2 regex split raise "Regex match error: UTF-8 error" and kill the run. Scrub
         # to valid UTF-8 first (bad bytes → U+FFFD) so a lone junk byte doesn't abort the
@@ -217,8 +217,7 @@ module Gori
       private def self.sequence_source(flow_id : Int64?, request_file : String?,
                                        project_name : String?, db_path : String?) : {Bytes, String?, Bool, Bool}
         if file = request_file
-          abort "gori run sequence: not a readable file: #{file}" unless File.exists?(file) && !File.directory?(file)
-          {File.read(file).to_slice, nil, false, false}
+          {read_input_file(file, "gori run sequence").to_slice, nil, false, false}
         elsif id = flow_id
           store = open_store(resolve_read_project(project_name, db_path))
           detail = begin

--- a/src/gori/decoder/codecs.cr
+++ b/src/gori/decoder/codecs.cr
@@ -823,7 +823,15 @@ module Gori::Decoder
           k += PUNY_BASE
         end
         bias = puny_adapt(i - oldi, acc.size + 1, oldi == 0)
-        n += (i // (acc.size + 1)).to_i32
+        # Accumulate in Int64 and range-check BEFORE narrowing. The loop guard above only
+        # bounds `i` at Int32::MAX, so with `acc.size + 1 == 1` the addition itself could
+        # carry `n` past Int32 and raise a raw `OverflowError` — the one exit from this
+        # module that was not the `DecoderError` its callers are written around. (The chain's
+        # blanket rescue caught it, so the step merely read "Arithmetic overflow" instead of
+        # naming punycode.) Matches the explicit overflow guards at the two `raise`s above.
+        n_wide = n.to_i64 + (i // (acc.size + 1))
+        raise DecoderError.new("punycode overflow") if n_wide > Int32::MAX
+        n = n_wide.to_i32
         raise DecoderError.new("invalid punycode: U+#{n.to_s(16).upcase} is not a Unicode scalar value") unless puny_scalar?(n)
         i = i % (acc.size + 1)
         acc.insert(i.to_i32, n.unsafe_chr)

--- a/src/gori/discover/plan.cr
+++ b/src/gori/discover/plan.cr
@@ -189,8 +189,13 @@ module Gori::Discover
       # or an SNI. Left deferred it shipped as the literal `$SESSION` — every send failing DNS,
       # and `Outbound.scope_url` asked about `https://$SESSION/a`, a URL no rule can match, so
       # the run was refused as out-of-scope, naming the wrong gate.
-      refuse_unresolved(Env.unresolved(raw.strip, deferred: nil))
-      target = Env.expand(raw.strip)
+      # `.scrub` the seed once, up front: it is a raw `--target` / MCP argument, and the
+      # scheme test below is a PCRE2 call that raises `ArgumentError` on a non-UTF-8
+      # subject. The call site rescues only `PlanError`, and this runs AFTER `open_store`,
+      # so an escaping raise also strands a half-migrated DB + WAL behind it.
+      stripped = raw.scrub.strip
+      refuse_unresolved(Env.unresolved(stripped, deferred: nil))
+      target = Env.expand(stripped)
       raise PlanError.new(PlanError::Reason::NoTarget, "no seed target") if target.empty?
       target.matches?(/\Ahttps?:\/\//i) ? target : "https://#{target}"
     end

--- a/src/gori/discover/types.cr
+++ b/src/gori/discover/types.cr
@@ -28,8 +28,12 @@ module Gori
       end
 
       # Lenient CLI/MCP token decode (case + separators ignored).
+      # `.scrub` first: the token arrives straight from `--containment` / an MCP arg, and the
+      # `gsub` is a PCRE2 call that raises `ArgumentError` on a non-UTF-8 subject — inside
+      # the OptionParser handler, ahead of every command-level rescue. A scrubbed token
+      # simply matches no branch and returns nil, which is the intended "unknown token" path.
       def self.parse?(token : String) : Containment?
-        case token.downcase.strip.gsub(/[\s_]+/, "-")
+        case token.scrub.downcase.strip.gsub(/[\s_]+/, "-")
         when "same-origin", "origin", "strict"                                                 then SameOrigin
         when "host", "subdomains", "host+subdomains", "host-and-subdomains", "host-subdomains" then HostAndSubdomains
         when "scope", "scope-aware", "scoped"                                                  then ScopeAware

--- a/src/gori/env.cr
+++ b/src/gori/env.cr
@@ -936,7 +936,11 @@ module Gori
     # whitespace, not on the `=` buried inside the value. Returns nil when KEY is
     # invalid.
     def self.parse_line(text : String) : {String, String}?
-      raw = text.strip
+      # `.scrub` first: `text` is an operator-supplied env line (`gori run project env set
+      # KEY VALUE`, the TUI env editor), and both the `index(/\s/)` and `split(/\s+/, 2)`
+      # below are PCRE2 calls, which raise `ArgumentError` on a subject that is not valid
+      # UTF-8. That escapes `CLI.run`'s `Gori::Error`-only rescue as a raw backtrace.
+      raw = text.scrub.strip
       return nil if raw.empty?
       eq = raw.index('=')
       ws = raw.index(/\s/)

--- a/src/gori/fuzz/engine.cr
+++ b/src/gori/fuzz/engine.cr
@@ -677,9 +677,17 @@ module Gori::Fuzz
       @concurrency.times { @finished.receive }
       # Every worker has left run_one, so no fiber can be holding a checked-out socket:
       # release the keep-alive pool's parked ones instead of waiting for GC to finalize
-      # them (a stopped 50-worker run would otherwise sit on 50 fds).
-      @backend.close
+      # them (a stopped 50-worker run would otherwise sit on 50 fds). `rescue nil` for the
+      # same reason `Discover::Engine#orchestrate` guards its teardown: a raise here used to
+      # skip the `@events.close` below, and a synchronous consumer (`Engine#run`, the CLI,
+      # the MCP job fiber) sits in `while ev = @events.receive?` forever — which for MCP also
+      # means `finalize_job` never runs, pinning the job at `:running` and blocking
+      # `switch_project`/`delete_project` for the rest of the session.
+      @backend.close rescue nil
       @events.send(DoneEvent.new(snapshot, @state == State::Stopped))
+    ensure
+      # ALWAYS close, on every exit path: closing is what turns the consumer's blocking
+      # `receive?` into a nil and lets it finish. `Channel#close` is idempotent.
       @events.close
     end
 

--- a/src/gori/fuzz/matcher.cr
+++ b/src/gori/fuzz/matcher.cr
@@ -437,8 +437,18 @@ module Gori::Fuzz
       nil # a runaway --extract regex yields no capture rather than a dead worker (see regex_pass?)
     end
 
+    # Cap the INFLATE at the same ceiling the capture read already enforces. Left at
+    # `ContentDecode`'s 32 MiB default this was the one decode site in the active engines
+    # with no cap of its own (discover passes `MAX_BODY`, every probe rule passes
+    # `BODY_CAP`), so a hostile target answering every request `Content-Encoding: gzip`
+    # could inflate an 8 MiB capture toward 32 MiB per in-flight worker — and `--concurrency`
+    # goes to `MAX_CONCURRENCY` = 1000, which is tens of GB of transient allocation and an
+    # OOM kill no worker-loop rescue can catch. Pinning it to `CAPTURE_READ_MAX` removes the
+    # decompression AMPLIFICATION without inventing a truncation policy: the raw body is
+    # already bounded there, so no response that fits the capture can have its length,
+    # word/line counts or regex text changed by this cap.
     private def decode(raw : Repeater::Result) : Bytes
-      decoded, _ = Proxy::Codec::ContentDecode.decode(raw.head, raw.body)
+      decoded, _ = Proxy::Codec::ContentDecode.decode(raw.head, raw.body, Proxy::Codec::Body::CAPTURE_READ_MAX)
       decoded || raw.body || Bytes.empty
     end
 

--- a/src/gori/hotkeys.cr
+++ b/src/gori/hotkeys.cr
@@ -198,6 +198,13 @@ module Gori
     # of them, and it can be deleted wholesale if the guards ever move into the keymap.
     def self.retag(s : String) : String
       return s unless alias_active?
+      # PCRE2 raises `ArgumentError: Regex match error: UTF-8 error` on a subject that is
+      # not valid UTF-8, and this funnel takes ARBITRARY display text — including status
+      # toasts interpolating captured wire bytes (a flow's host/method, built by
+      # `String.new(bytes)` without a scrub). The raise would land inside `render`, and a
+      # toast persists across frames, so it re-raises every tick until the tick-error
+      # breaker exits the session. A malformed string has no claimed caret to rewrite.
+      return s unless s.valid_encoding?
       s.gsub(CLAIMED_CARET_RE) { "⌥#{$1}" }
     end
 

--- a/src/gori/import/har.cr
+++ b/src/gori/import/har.cr
@@ -68,7 +68,9 @@ module Gori
             http_version, req_declared)
         end
 
-        status = resp["status"]?.try(&.as_i).try(&.to_i32) || 0
+        # `number_i64`, not `as_i`: a fractional `"status": 200.5` raises `TypeCastError`
+        # out of `as_i`, which the per-entry rescue turned into a dropped request.
+        status = number_i64(resp["status"]?).try(&.clamp(0_i64, Int32::MAX.to_i64)).try(&.to_i32) || 0
         # Prefer the HAR's own statusText. Only invent a phrase for HTTP/1.x when the
         # field is absent — HTTP/2 has no reason phrase on the wire, and inventing "OK"
         # (or a trailing space on an empty phrase) broke the export→import fixed point.
@@ -112,9 +114,27 @@ module Gori
       # spec's own "not available" is -1, and a generator that writes 0 for a body it did
       # ship is saying nothing useful either — only a positive number is a claim.
       private def self.declared_size(node : JSON::Any?) : Int64?
-        return nil unless node
-        n = node.as_i64? || node.as_f?.try(&.to_i64)
+        n = number_i64(node)
         n && n > 0 ? n : nil
+      end
+
+      # A HAR number as an Int64, or nil when it is absent, not a number, or too large to
+      # represent. Every numeric field here goes through this because the obvious spellings
+      # RAISE on values a JSON parser accepts: `Float64#to_i64` raises `OverflowError` past
+      # ~9.2e18 (`"bodySize": 1e30`), and `JSON::Any#as_i` raises `TypeCastError` on a
+      # fractional number (`"status": 200.5`). Either one unwound to the per-entry
+      # `rescue nil` in `parse`, which then dropped an OTHERWISE VALID request — one junk
+      # metadata field cost the whole captured exchange. Degrading the FIELD to "not
+      # available" keeps the request and loses only the number that was unusable.
+      private def self.number_i64(node : JSON::Any?) : Int64?
+        return nil unless node
+        if i = node.as_i64?
+          return i
+        end
+        f = node.as_f?
+        return nil unless f && f.finite?
+        return nil unless f >= Int64::MIN.to_f64 && f <= Int64::MAX.to_f64
+        f.to_i64
       end
 
       # HAR `time` is milliseconds; the store keeps micros.
@@ -127,8 +147,13 @@ module Gori
       # shapes, so an integer `"time": 0` needs no separate branch.)
       private def self.parse_time(node : JSON::Any?) : Int64?
         ms = node.try(&.as_f?)
-        return nil unless ms && ms >= 0
-        (ms * 1_000).round.to_i64
+        # `finite?` and the range test for the reason `number_i64` spells out: `to_i64` on a
+        # huge (or non-finite) Float64 raises `OverflowError`, and that raise used to cost
+        # the entire entry rather than just its duration.
+        return nil unless ms && ms.finite? && ms >= 0
+        us = (ms * 1_000).round
+        return nil unless us <= Int64::MAX.to_f64
+        us.to_i64
       end
 
       # An ORDERED list of {name, value} — a HAR response commonly has several Set-Cookie

--- a/src/gori/links.cr
+++ b/src/gori/links.cr
@@ -68,7 +68,10 @@ module Gori
 
     private def self.resolve_miner(store : Store, link : Store::EntityLink) : Resolved
       if rec = store.get_miner_session(link.ref_id)
-        label = rec.name || first_line(String.new(rec.request)) || "miner ##{rec.id}"
+        # `.scrub` for parity with `resolve_repeater` above: this label is DISPLAY text built
+        # from captured wire bytes, and the TUI funnels display text through
+        # `Hotkeys.retag`, whose regex raises on a non-UTF-8 subject.
+        label = rec.name || first_line(String.new(rec.request).scrub) || "miner ##{rec.id}"
         Resolved.new(link, link.ref_kind.tag, label, rec.target)
       else
         Resolved.new(link, link.ref_kind.tag, "miner ##{link.ref_id} (gone)", "miner ##{link.ref_id}", stale: true)

--- a/src/gori/mcp/request_builder.cr
+++ b/src/gori/mcp/request_builder.cr
@@ -274,7 +274,12 @@ module Gori
         # the case-insensitive Host/Content-Length dedup and puts a second, conflicting
         # line on the wire (name "Content-Length:0" writes `Content-Length:0: x` next to
         # the auto `Content-Length: <bodylen>`).
-        if name =~ /[^!#$%&'*+\-.^_`|~0-9A-Za-z]/
+        # `valid_encoding?` first: PCRE2 raises `ArgumentError` on a non-UTF-8 subject, and
+        # `reject_token_breakers` deliberately allows bytes >= 0x80 through — so a header
+        # name carrying one reached this regex and surfaced as an INTERNAL error instead of
+        # the INVALID_ARGUMENT this check exists to report. A name that is not valid UTF-8
+        # cannot be an RFC 7230 token either, so it fails the same way, with the right words.
+        if !name.valid_encoding? || name =~ /[^!#$%&'*+\-.^_`|~0-9A-Za-z]/
           raise Gori::Error.new("illegal character in header name #{name.inspect} (must be an RFC 7230 token)")
         end
         raise Gori::Error.new("illegal CR/LF/NUL in value of header #{name.inspect}") if injection_char?(value)
@@ -313,17 +318,44 @@ module Gori
       # PUBLIC because `intercept_forward_edit` needs the identical rule: it used to
       # gsub the WHOLE message, silently rewriting 0x0A bytes inside the body it was
       # meant to forward verbatim. One rule, one implementation.
+      # Done in BYTE space, not through a regex `gsub`. Two reasons, and the byte-exactness
+      # contract above is the important one:
+      #
+      #   * PCRE2 raises `ArgumentError` on a subject that is not valid UTF-8, so a `raw`
+      #     carrying a deliberately malformed byte (a desync primitive, a binary body, a
+      #     smuggling probe — exactly what this tool exists to send) failed here instead of
+      #     being sent, and surfaced to the caller as an INTERNAL error.
+      #   * `.scrub`bing it to appease the regex is NOT the fix: that would rewrite the
+      #     operator's bytes and send something other than what was asked for.
+      #
+      # The boundary rule is unchanged (first of `\r\n\r\n` / `\n\n`, terminator included),
+      # only moved from char indices to byte indices — which is what a byte-exact sender
+      # wanted all along.
       def self.normalize_raw(raw : String) : Bytes
-        crlf = raw.index("\r\n\r\n")
-        lf = raw.index("\n\n")
+        bytes = raw.to_slice
+        crlf = raw.byte_index("\r\n\r\n")
+        lf = raw.byte_index("\n\n")
         ends = [] of Int32
         ends << crlf + 4 if crlf
         ends << lf + 2 if lf
-        head_len = ends.min? || raw.size
-        String.build do |io|
-          io << raw[0, head_len].gsub(/\r?\n/, "\r\n")
-          io << raw[head_len..]
-        end.to_slice
+        head_len = ends.min? || bytes.size
+        io = IO::Memory.new(bytes.size + 16)
+        i = 0
+        while i < head_len
+          b = bytes[i]
+          if b == 0x0D_u8 && i + 1 < head_len && bytes[i + 1] == 0x0A_u8
+            io.write_byte(0x0D_u8); io.write_byte(0x0A_u8) # already CRLF
+            i += 2
+          elsif b == 0x0A_u8
+            io.write_byte(0x0D_u8); io.write_byte(0x0A_u8) # lone LF promoted
+            i += 1
+          else
+            io.write_byte(b)
+            i += 1
+          end
+        end
+        io.write(bytes[head_len..]) if head_len < bytes.size
+        io.to_slice
       end
     end
   end

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -171,6 +171,11 @@ module Gori
       # Ceiling on History flows recorded per run (record_history), so `all` on a
       # huge run can't unboundedly grow the project database.
       FUZZ_HISTORY_MAX = 5_000
+      # Ceiling on how many times ONE job may log from its per-event rescues. Those sit on
+      # the per-result path, so a persistent failure logs once per request sent; a client
+      # that does not drain stderr then fills the pipe and parks the job fiber, wedging the
+      # job at `:running`. The count itself is never capped — only the writes.
+      DRAIN_LOG_CAP = 20
 
       # Param-miner safety rails (same intent as the fuzz caps).
       MINE_MAX_REQUESTS    = 100_000_i64
@@ -367,6 +372,15 @@ module Gori
         property grpc_requests = 0_i64
         property grpc_stale_reason : String? = nil
         property error_msg : String? = nil
+        # How many times the drain / history-record rescues have fired for this job. Those
+        # rescues log, and they sit on the per-EVENT path: a persistent failure (a broken
+        # store, a full disk) fires once per result, so an unbounded log would write one
+        # stderr line per request sent. An MCP client that does not drain stderr fills the
+        # 64 KB pipe, `Log` then blocks the job fiber, every fuzz worker parks on
+        # `@events.send`, and the job wedges at `:running` — which also blocks
+        # `switch_project`/`delete_project` for the rest of the session. Callers still see
+        # the true count in `error_msg`; only the LOGGING is capped (see LOG_CAP).
+        property drain_errors = 0
         getter results = [] of Fuzz::Result
         # History flow ids for the stored (matched) results, index-aligned with
         # `results`; nil when record_history was off or the record failed.

--- a/src/gori/mcp/tools/discover.cr
+++ b/src/gori/mcp/tools/discover.cr
@@ -193,6 +193,15 @@ module Gori
           # last ProgressEvent happened to carry — it is the number the status below reports.
           djob.queued = ev.progress.queued
           djob.stats = ev.stats
+          # Flush the tail HERE, while the job is still :running. `jobs_running?` is what
+          # refuses a concurrent `switch_project`, and it keys on that status — so once the
+          # terminal status below is assigned, the flush that used to happen after
+          # `engine.run` returned was racing a project swap across a fiber yield, and
+          # `flush_discover_persist` reads the LIVE `store` getter. The loser wrote up to
+          # `DISCOVER_PERSIST_MAX` findings into whichever project had just been bound.
+          # The read side already refuses a cross-project read (`job_project_mismatch`);
+          # this is the write side of the same guarantee.
+          flush_discover_persist(djob)
           # Discover has no fixed candidate total (a live crawl's denominator moves), so the
           # shortfall cannot be derived the way fuzz and mine derive it from `done_count <
           # total`. The ENGINE says it: `DoneEvent#budget_exhausted` is `cap_reached? &&
@@ -253,6 +262,16 @@ module Gori
       private def flush_discover_persist(djob : DiscoverJob) : Nil
         djob.persist_at = Time.instant # stamped even when empty: this is the FLUSH clock
         return if djob.persist_buf.empty?
+        # Never write a job's findings into a project it did not run against. The DoneEvent
+        # branch now flushes while the job still blocks `switch_project`, so this should not
+        # fire — but `store` is a LIVE getter, and silently persisting a crawl of one target
+        # into somebody else's project is the worst outcome available here. Same comparison
+        # `job_project_mismatch` makes on the read side.
+        if djob.db_path != @db_path
+          Log.warn { "discover job #{djob.id}: dropping #{djob.persist_buf.size} unflushed finding(s) — project changed since the run started" }
+          djob.persist_buf.clear
+          return
+        end
         store.insert_import_batch(djob.persist_buf)
         djob.persist_buf.clear
       rescue

--- a/src/gori/mcp/tools/fuzz.cr
+++ b/src/gori/mcp/tools/fuzz.cr
@@ -79,7 +79,14 @@ module Gori
           fjob.ended_at_ms ||= Time.utc.to_unix_ms
         end
       rescue ex
-        Log.error(exception: ex) { "fuzz job #{fjob.id} drain error" }
+        # Bounded logging — see `FuzzJob#drain_errors`. This rescue is on the per-EVENT
+        # path, so a persistent failure would otherwise emit one stderr line per request
+        # and can park the job fiber on a full pipe.
+        fjob.drain_errors += 1
+        if fjob.drain_errors <= DRAIN_LOG_CAP
+          Log.error(exception: ex) { "fuzz job #{fjob.id} drain error" }
+          Log.error { "fuzz job #{fjob.id}: further drain errors suppressed" } if fjob.drain_errors == DRAIN_LOG_CAP
+        end
         fjob.status = :error if fjob.status == :running
         fjob.error_msg ||= ex.message || "internal fuzz drain error"
       end
@@ -97,14 +104,14 @@ module Gori
           fjob.history_truncated = true
           return nil
         end
-        fid = record_fuzz_flow(req, fjob.origin, fjob.http2?, r)
+        fid = record_fuzz_flow(fjob, req, fjob.origin, fjob.http2?, r)
         fjob.recorded_flows += 1 if fid
         fid
       end
 
       # Reconstruct a History flow (request head/body + response head/body) from a
       # fuzz Result. Stored raw; get_flow redacts sensitive headers on read.
-      private def record_fuzz_flow(request : Bytes, origin : Fuzz::Origin, http2 : Bool, r : Fuzz::Result) : Int64?
+      private def record_fuzz_flow(fjob : FuzzJob, request : Bytes, origin : Fuzz::Origin, http2 : Bool, r : Fuzz::Result) : Int64?
         head, body = split_wire_request(request)
         method, target, version = Proxy::Codec::Http1.authored_start_line(head)
         fid = store.insert_flow(Store::CapturedRequest.new(
@@ -125,7 +132,10 @@ module Gori
         end
         fid
       rescue ex
-        Log.warn(exception: ex) { "fuzz history record failed" }
+        # Bounded for the same reason as the drain rescue: history recording runs per
+        # result, so a store that fails every insert would log once per request.
+        fjob.drain_errors += 1
+        Log.warn(exception: ex) { "fuzz history record failed" } if fjob.drain_errors <= DRAIN_LOG_CAP
         nil
       end
 
@@ -586,6 +596,11 @@ module Gori
           return Fuzz::NumberRange.new(from, to, fuzz_int(obj["step"]?) || 1_i64)
         end
         s = v.as_s? || raise FuzzArgError.new(%('numbers' must be a string 'FROM-TO[:STEP]' or an object {from,to,step}))
+        # `.scrub`: `s` is a JSON string argument, and the `match` below is a PCRE2 call that
+        # raises `ArgumentError` on a non-UTF-8 subject — which escaped as an INTERNAL error
+        # instead of the FuzzArgError ("invalid numbers ...") this method reports for every
+        # other unusable spelling. Lossless for any spec that could actually parse.
+        s = s.scrub
         range_part, _, step_part = s.partition(':')
         if md = range_part.match(/^(-?\d+)-(-?\d+)$/)
           from = md[1].to_i64?

--- a/src/gori/mcp/tools/repeater.cr
+++ b/src/gori/mcp/tools/repeater.cr
@@ -411,6 +411,12 @@ module Gori
       # set, and nothing else. Deliberately narrow: `hello=world` is a payload, not a spec,
       # and misreading it would mean gori sending something other than what was asked for.
       private def ws_frame_spec?(s : String) : Bool
+        # `valid_encoding?` guard, NOT a scrub: an invalid-UTF-8 message is a legitimate
+        # WebSocket TEXT payload to send (`send.cr` keeps it unscrubbed on purpose), so the
+        # string must not be rewritten — but PCRE2 raises `ArgumentError` on it, which
+        # surfaced as an INTERNAL error instead of sending the frame. Such a string cannot
+        # start with one of these ASCII keys anyway, so "not a spec" is the right answer.
+        return false unless s.valid_encoding?
         s.matches?(/\A(opcode|fin|rsv|mask|mask_key|len|hex|b64|text)=/)
       end
 

--- a/src/gori/miner/engine.cr
+++ b/src/gori/miner/engine.cr
@@ -205,7 +205,10 @@ module Gori::Miner
       # socket: release the keep-alive pool's parked ones instead of waiting for GC to
       # finalize them (a stopped 40-worker run would otherwise sit on 40 fds). Same close
       # `Fuzz::Engine#coordinate` performs, at the miner's equivalent seam.
-      @backend.close
+      # `rescue nil` so a raising close cannot skip the `@events.close` on the next line —
+      # that close is what ends the consumer's blocking `receive?`, and without it an MCP
+      # job fiber never reaches `finalize_job` and stays pinned at `:running`.
+      @backend.close rescue nil
       @events.close
     end
 

--- a/src/gori/miner/fingerprint.cr
+++ b/src/gori/miner/fingerprint.cr
@@ -22,8 +22,12 @@ module Gori::Miner
   end
 
   module Fingerprint
+    # Cap the INFLATE at the capture ceiling for the same reason `Fuzz::Matcher#decode`
+    # does — this and that were the two decode sites in the active engines still taking
+    # `ContentDecode`'s 32 MiB default, so a compressible response inflated ~4x past the
+    # 8 MiB the capture read already bounds, once per in-flight worker.
     def self.probe(raw : Repeater::Result) : Probe
-      decoded, _ = Proxy::Codec::ContentDecode.decode(raw.head, raw.body)
+      decoded, _ = Proxy::Codec::ContentDecode.decode(raw.head, raw.body, Proxy::Codec::Body::CAPTURE_READ_MAX)
       body = decoded || raw.body || Bytes.empty
       words, lines = count_metrics(body)
       metrics = Fuzz::Metrics.new(

--- a/src/gori/notes.cr
+++ b/src/gori/notes.cr
@@ -60,7 +60,14 @@ module Gori
 
     # Parse the JSON document set; nil on malformed data so callers can fall back.
     def self.parse(raw : String) : Doc?
-      doc = JSON.parse(raw)
+      # Read the root through `as_h?` rather than indexing the JSON::Any directly:
+      # `JSON::Any#[]?` RAISES a bare Exception ("Expected Hash for #[]?") when the
+      # root is valid JSON that is not an object (`[]`, `42`, `null`), which the
+      # `JSON::ParseException` rescue below does not catch. A corrupt or externally
+      # written "notes.docs" row would then escape as a backtrace out of `gori run
+      # notes`, and re-raise every TUI tick until the tick-error breaker exits.
+      doc = JSON.parse(raw).as_h?
+      return nil unless doc
       arr = doc["notes"]?.try(&.as_a?)
       return nil unless arr
       cur = doc["cur"]?.try(&.as_i?) || 0

--- a/src/gori/pacing.cr
+++ b/src/gori/pacing.cr
@@ -24,9 +24,18 @@ module Gori
     # `rps` wins over `throttle_ms` when both are set — a requests-per-second budget is the
     # more specific statement of intent, and the two would otherwise compose into a rate
     # neither knob names.
+    # The largest gap worth expressing. `(1.0 / rps).seconds` on an absurdly small rate
+    # (`--rate=1e-20` → 1e20 seconds) raises `OverflowError` building the Span; the engine
+    # loops catch it, but the operator was then told "Arithmetic overflow" rather than
+    # anything about the rate they typed. Clamping keeps the knob monotonic — smaller rate,
+    # longer wait — and tops out at a gap no run outlives anyway.
+    MAX_INTERVAL_SECONDS = 86_400.0
+
     private def pace_interval : Time::Span?
       if (rps = @config.rps) && rps > 0
-        (1.0 / rps).seconds
+        secs = 1.0 / rps
+        secs = MAX_INTERVAL_SECONDS unless secs.finite? && secs < MAX_INTERVAL_SECONDS
+        secs.seconds
       elsif (t = @config.throttle_ms) && t > 0
         t.milliseconds
       end

--- a/src/gori/probe/passive.cr
+++ b/src/gori/probe/passive.cr
@@ -84,8 +84,25 @@ module Gori
         return [] of Detection if detail.row.short_circuited?
         ctx = Context.new(detail, ws_messages)
         acc = [] of Detection
-        RULES.each { |r| r.check(ctx, acc) unless Probe.rule_disabled?(r.info.id, disabled) }
-        custom.each(&.check(ctx, acc))
+        # Per-RULE containment, matching `Active.analyze`. Without it one rule raising on a
+        # hostile body (a regex PCRE2 refuses, an unexpected shape) discarded the findings of
+        # every rule after it in the list — the flow's whole scan was lost to one bad rule,
+        # and which rules survived depended on their order. The raise was caught a layer up
+        # (`Probe::Scan`, `supervise`), so this changes no crash behaviour; it changes how
+        # much of the scan survives.
+        RULES.each do |r|
+          next if Probe.rule_disabled?(r.info.id, disabled)
+          begin
+            r.check(ctx, acc)
+          rescue ex
+            Log.debug(exception: ex) { "passive rule #{r.info.id} failed on flow #{detail.row.id}" }
+          end
+        end
+        custom.each do |r|
+          r.check(ctx, acc)
+        rescue ex
+          Log.debug(exception: ex) { "custom passive rule failed on flow #{detail.row.id}" }
+        end
         acc
       end
 

--- a/src/gori/project.cr
+++ b/src/gori/project.cr
@@ -97,13 +97,25 @@ module Gori
     end
 
     # Best-effort last-activity time (DB file mtime), for the picker.
+    #
+    # `File.info?` + rescue, not `File.exists?` then `File.info`: that pair is a TOCTOU
+    # window a PEER closes routinely — `ProjectRegistry#delete` and MCP `delete_project`
+    # `rm_rf` the workspace, so the file can vanish between the two calls and `File.info`
+    # raises `File::NotFoundError` out of `ProjectRegistry#list`'s `sort_by!`, the picker's
+    # row render and MCP `list_projects`. `File.info?` closes the vanish case; the rescue
+    # covers the one it does not (an unreadable parent raises `File::AccessDeniedError`).
+    # `disk_size` below already takes exactly this stance per entry.
     def last_modified : Time?
-      File.exists?(@db_path) ? File.info(@db_path).modification_time : nil
+      File.info?(@db_path).try(&.modification_time)
+    rescue File::Error
+      nil
     end
 
     # On-disk size of the SQLite DB (shown as "DB Size" in the Project tab).
     def db_size : Int64
-      File.exists?(@db_path) ? File.info(@db_path).size : 0_i64
+      File.info?(@db_path).try(&.size) || 0_i64
+    rescue File::Error
+      0_i64
     end
 
     # Total bytes of every file under the project directory (DB + WAL/SHM + the dotfile
@@ -146,8 +158,9 @@ module Gori
     # Best-effort project creation time (project dir mtime from mkdir in registry;
     # falls back to earliest flow activity inside the Project tab view).
     def created : Time?
-      d = dir
-      Dir.exists?(d) ? File.info(d).modification_time : nil
+      File.info?(dir).try { |i| i.directory? ? i.modification_time : nil }
+    rescue File::Error
+      nil # same best-effort stance as `last_modified` — a peer may be deleting this project
     end
 
     # Remove the workspace from disk (temp projects only).

--- a/src/gori/project_registry.cr
+++ b/src/gori/project_registry.cr
@@ -326,7 +326,19 @@ module Gori
     # silent, total loss of everything captured after the delete.
     def delete(project : Project) : Nil
       return unless Dir.exists?(project.dir)
-      raise Gori::Error.new("project is in use by another gori instance — stop its capture first") if CaptureLock.held?(project.dir)
+      # `CaptureLock.try_at` deliberately RE-RAISES a non-contention failure so it is never
+      # read as "someone else holds it" (see its comment). That contract is right, and it
+      # makes translating the failure this caller's job: on an unwritable or read-only
+      # project directory the probe raises `File::AccessDeniedError`, which is not a
+      # `Gori::Error` and so sailed past `CLI.run`'s rescue as a raw backtrace on
+      # `gori run project delete`. Refuse the delete with a sentence instead — a directory
+      # we cannot even open a lock file in is not one to start `rm_rf`-ing.
+      held = begin
+        CaptureLock.held?(project.dir)
+      rescue ex : File::Error
+        raise Gori::Error.new("cannot check the capture lock for '#{project.name}': #{ex.message}")
+      end
+      raise Gori::Error.new("project is in use by another gori instance — stop its capture first") if held
       # Capturing is not the only way to be writing to a project. An MCP server takes no capture
       # lock and still writes issues, notes, repeaters and fuzz history, so the guard above saw
       # nothing while one MCP server deleted the project another was serving — after which the

--- a/src/gori/repeater/ws_frame_spec.cr
+++ b/src/gori/repeater/ws_frame_spec.cr
@@ -166,7 +166,12 @@ module Gori
       # Hex digits, optionally 0x-prefixed and with `:`/`-`/spaces between octets — the forms
       # a mask key or a payload gets pasted in. An odd digit count is an error, not a guess.
       protected def self.hex(v : String) : Bytes?
-        s = v.strip.gsub(/\A0[xX]/, "").gsub(/[\s:_-]/, "")
+        # `.scrub` first: `v` is a raw `--message-frame` value off the command line, and
+        # PCRE2 raises `ArgumentError` on a subject that is not valid UTF-8 — which would
+        # break this module's documented "Never raises" contract (see `parse` above) and
+        # escape `CLI.run`, whose rescue only covers `Gori::Error`. Lossless in practice:
+        # anything a scrub touches fails the hex-digit check two lines down regardless.
+        s = v.scrub.strip.gsub(/\A0[xX]/, "").gsub(/[\s:_-]/, "")
         return Bytes.empty if s.empty?
         return nil unless s.size.even? && s.matches?(/\A[0-9a-fA-F]+\z/)
         s.hexbytes

--- a/src/gori/scope.cr
+++ b/src/gori/scope.cr
@@ -88,7 +88,14 @@ module Gori
           r = @regex
           return false unless r
           begin
-            r.matches?(url)
+            # `.scrub` the SUBJECT, not just rescue it. PCRE2 raises `ArgumentError` on a
+            # non-UTF-8 subject, and `request_target` does not scrub what came off the wire,
+            # so a request whose target carries a raw byte >= 0x80 used to take the rescue
+            # below — reporting "no match". On an EXCLUDE rule "no match" means NOT excluded,
+            # i.e. the gate fails OPEN, and a peer can dodge a regex exclude by planting one
+            # invalid byte in the target. Scrubbing evaluates the rule as written instead.
+            # The rescue stays as defense-in-depth for anything else PCRE2 refuses.
+            r.matches?(url.scrub)
           rescue
             false
           end
@@ -118,7 +125,25 @@ module Gori
       # filter/active?) while the TUI fiber mutates them (add/remove/update/toggle).
       # Guard every cross-fiber access with a mutex — only the TUI mutates, so its own
       # render reads are race-free, but proxy reads vs TUI writes need the lock.
+      #
+      # Guards those fields ONLY, and every critical section it has is a field read or a
+      # pointer swap. The store round-trips that used to sit inside it do not: `exec_task`
+      # parks the calling fiber on its reply channel, and with `busy_timeout=5000` a PEER
+      # process holding the write lock parks it for up to five seconds. `sandbox_blocks?` /
+      # `sandbox_blocks_host?` / `in_scope_url?` / `may_match_host?` take this same mutex on
+      # every proxied request, so holding it across a write stalled every dial, intercept
+      # gate and sandbox decision in the process for as long as the peer held the lock —
+      # and `reload`, which the TUI's data_version poll and headless capture's reload fiber
+      # call on a timer, did three store reads inside it. `HostOverrides` measured and fixed
+      # exactly this; `Scope` is the sibling that had the same shape.
       @mutex = Mutex.new
+      # Serialises WRITERS through this instance, so the dedupe-then-write-then-verify
+      # sequences below stay atomic against each other now that they no longer hold
+      # @mutex for their duration. Same scope as `HostOverrides#@write_mutex`: it covers
+      # this object, not the table — MCP and the CLI each load a `Scope` of their own, and
+      # are answered the way a peer PROCESS is (the UNIQUE triple plus the post-write
+      # verify), which is the case that has to work regardless.
+      @write_mutex = Mutex.new
     end
 
     def self.load(store : Store) : Scope
@@ -293,15 +318,15 @@ module Gori
     # merely "does not survive restart": the next `reload` re-reads the PERSISTED value and
     # silently reverts the gate a surface has already reported as on.
     def toggle_sandbox : Bool
-      @mutex.synchronize { set_sandbox_unlocked(!@sandbox) }
+      @write_mutex.synchronize { set_sandbox(!@mutex.synchronize { @sandbox }) }
     end
 
     def enable_sandbox : Bool
-      @mutex.synchronize { set_sandbox_unlocked(true) }
+      @write_mutex.synchronize { set_sandbox(true) }
     end
 
     def disable_sandbox : Bool
-      @mutex.synchronize { set_sandbox_unlocked(false) }
+      @write_mutex.synchronize { set_sandbox(false) }
     end
 
     # The `host` column with a SURROUNDING bracket pair peeled — the SQL twin of
@@ -365,11 +390,11 @@ module Gori
     def add(kind : String, match_type : String, pattern : String) : Bool
       pattern = pattern.strip
       return false if pattern.empty? || !KINDS.includes?(kind) || !Scope.valid?(match_type, pattern)
-      @mutex.synchronize do
-        return false if @rules.any? { |r| r.kind == kind && r.match_type == match_type && r.pattern == pattern }
+      @write_mutex.synchronize do
+        return false if rules_snapshot.any? { |r| r.kind == kind && r.match_type == match_type && r.pattern == pattern }
         @store.add_scope_rule(kind, match_type, pattern)
-        reload_rules_unlocked
-        @rules.any? { |r| r.kind == kind && r.match_type == match_type && r.pattern == pattern }
+        reload_rules
+        rules_snapshot.any? { |r| r.kind == kind && r.match_type == match_type && r.pattern == pattern }
       end
     end
 
@@ -378,8 +403,8 @@ module Gori
     def update(id : Int64, kind : String, match_type : String, pattern : String) : Bool
       pattern = pattern.strip
       return false if pattern.empty? || !KINDS.includes?(kind) || !Scope.valid?(match_type, pattern)
-      @mutex.synchronize do
-        return false if @rules.any? { |r| r.id != id && r.kind == kind && r.match_type == match_type && r.pattern == pattern }
+      @write_mutex.synchronize do
+        return false if rules_snapshot.any? { |r| r.id != id && r.kind == kind && r.match_type == match_type && r.pattern == pattern }
         # The store's answer, not an unconditional `true`. `update_scope_rule` is `exec_task_ok`
         # and has always reported whether the UPDATE committed; `remove` below returns it, and
         # `HostOverrides#update` next door returns it with the note "false also when the store
@@ -396,7 +421,7 @@ module Gori
         # then violates the table's UNIQUE triple and rolls back. That is the reachable path,
         # and it is the one that used to report success.
         committed = @store.update_scope_rule(id, kind, match_type, pattern)
-        reload_rules_unlocked
+        reload_rules
         committed
       end
     end
@@ -411,25 +436,25 @@ module Gori
     # flag, and the CLI re-read the reloaded rule list. One dropped return value, three
     # treatments — so it is returned here instead.
     def remove(id : Int64) : Bool
-      @mutex.synchronize do
+      @write_mutex.synchronize do
         ok = @store.remove_scope_rule(id)
-        reload_rules_unlocked
+        reload_rules
         ok
       end
     end
 
     def toggle : Nil
-      @mutex.synchronize { set_enabled_unlocked(!@enabled) }
+      @write_mutex.synchronize { set_enabled(!@mutex.synchronize { @enabled }) }
     end
 
     # Returns whether the persisted enabled flag committed (false = store busy/locked).
     def enable : Bool
-      @mutex.synchronize { set_enabled_unlocked(true) }
+      @write_mutex.synchronize { set_enabled(true) }
     end
 
     # Returns whether the persisted enabled flag committed (false = store busy/locked).
     def disable : Bool
-      @mutex.synchronize { set_enabled_unlocked(false) }
+      @write_mutex.synchronize { set_enabled(false) }
     end
 
     # Re-read rules + the enabled/sandbox flags from the store after an EXTERNAL change —
@@ -441,10 +466,17 @@ module Gori
     # reload fiber (App#spawn_reload_loop), the same two call sites Rules#reload already
     # has.
     def reload : Nil
+      # All three store reads run OUTSIDE @mutex, then swap together — this is called on a
+      # TIMER (the TUI data_version poll, headless capture's reload fiber), so doing them
+      # under the hot-path lock stalled every proxied request on each tick for as long as
+      # the store took to answer.
+      fresh = Scope.load_rules(@store)
+      enabled = @store.setting(SETTING_ENABLED) == "1"
+      sandbox = @store.setting(SETTING_SANDBOX) == "1"
       @mutex.synchronize do
-        reload_rules_unlocked
-        @enabled = @store.setting(SETTING_ENABLED) == "1"
-        @sandbox = @store.setting(SETTING_SANDBOX) == "1"
+        @rules = fresh
+        @enabled = enabled
+        @sandbox = sandbox
       end
     end
 
@@ -640,17 +672,30 @@ module Gori
     # Re-read the rules from the store after every mutation so in-memory == DB
     # (authoritative ids + UNIQUE dedup reflected). exec_task is synchronous, so the
     # just-written row is committed and visible to this pool read.
-    private def reload_rules_unlocked : Nil
-      @rules = Scope.load_rules(@store)
+    # The rule list as the hot path sees it. Read under @mutex; the array is rebuilt rather
+    # than edited in place, so a concurrent matcher reads either the whole old list or the
+    # whole new one.
+    private def rules_snapshot : Array(Rule)
+      @mutex.synchronize { @rules }
     end
 
-    private def set_enabled_unlocked(value : Bool) : Bool
-      @enabled = value
+    # Re-read the rules and swap them in. The SELECT runs OUTSIDE @mutex — see the
+    # constructor — and only the pointer swap is guarded.
+    private def reload_rules : Nil
+      fresh = Scope.load_rules(@store)
+      @mutex.synchronize { @rules = fresh }
+    end
+
+    # Flag writers: the in-memory field is swapped under @mutex (the hot path reads it
+    # there), and the persisting write runs outside it. Callers hold @write_mutex, which is
+    # what keeps a concurrent toggle from interleaving between the read and the write.
+    private def set_enabled(value : Bool) : Bool
+      @mutex.synchronize { @enabled = value }
       @store.set_setting(SETTING_ENABLED, value ? "1" : "0")
     end
 
-    private def set_sandbox_unlocked(value : Bool) : Bool
-      @sandbox = value
+    private def set_sandbox(value : Bool) : Bool
+      @mutex.synchronize { @sandbox = value }
       @store.set_setting(SETTING_SANDBOX, value ? "1" : "0")
     end
 

--- a/src/gori/sequencer/engine.cr
+++ b/src/gori/sequencer/engine.cr
@@ -123,7 +123,10 @@ module Gori::Sequencer
       # stopped or raising run leaks no fd — the same standard `Fuzz::Engine` and
       # `Discover::Engine` hold. A no-op for manual mode (no backend) and for the
       # connection-per-send doubles, whose `close` is empty by default.
-      @backend.try(&.close)
+      # `rescue nil` so a raising close cannot skip the `@events.close` on the next line —
+      # that close is what ends the consumer's blocking `receive?`, and without it an MCP
+      # job fiber never reaches `finalize_job` and stays pinned at `:running`.
+      @backend.try(&.close) rescue nil
       @events.close
     end
 

--- a/src/gori/store.cr
+++ b/src/gori/store.cr
@@ -1273,13 +1273,24 @@ module Gori
     # not know whether the frame was masked, which is not the same as knowing it was not.
     def self.read_ws_shape(rs : DB::ResultSet) : WsShape
       fin = rs.read(Int64) != 0
-      rsv = rs.read(Int64).to_i
+      rsv = ws_i32(rs.read(Int64))
       masked = rs.read(Int64?).try { |m| m != 0 }
       mask_key = rs.read(Bytes?)
-      frames = rs.read(Int64).to_i
-      declared = rs.read(Int64?).try(&.to_i)
+      frames = ws_i32(rs.read(Int64))
+      declared = rs.read(Int64?).try { |v| ws_i32(v) }
       WsShape.new(fin: fin, rsv: rsv, masked: masked, mask_key: mask_key,
         frames: frames, declared_len: declared)
+    end
+
+    # Narrow a stored column to Int32 by CLAMPING rather than with a bare `to_i`. SQLite
+    # columns are dynamically typed and nothing constrains these three, so a corrupt or
+    # hand-written row holding a value outside Int32 made `to_i` raise `OverflowError` out
+    # of the WS message list — into the detail view and `gori run show`, and in the TUI into
+    # the tick-error breaker. Clamping keeps a plausible row readable instead of taking the
+    # pane down; a value out of range was never meaningful for a 3-bit RSV, a frame count or
+    # a declared length anyway.
+    private def self.ws_i32(v : Int64) : Int32
+      v.clamp(Int32::MIN.to_i64, Int32::MAX.to_i64).to_i32
     end
 
     private def now_us : Int64

--- a/src/gori/store/reads.cr
+++ b/src/gori/store/reads.cr
@@ -275,6 +275,12 @@ module Gori
 
     def count : Int64
       @db.scalar("SELECT COUNT(*) FROM flows").as(Int64)
+    rescue
+      # Degrade like `data_version` rather than raise: this is a POLL reader (the Project
+      # tab's periodic refresh, MCP `get_context`/`list_projects`), so a transient
+      # SQLITE_BUSY under a checkpoint would otherwise burn the TUI's tick-error budget and
+      # void the MCP response instead of showing a stale number for one tick.
+      0_i64
     end
 
     # Hard-delete one History flow and its captured dependents (WS messages, FTS row,
@@ -486,6 +492,8 @@ module Gori
     def total_size : Int64
       sql = "SELECT COALESCE(SUM(request_size + COALESCE(response_size, 0)), 0) FROM flows"
       @db.scalar(sql).as(Int64)
+    rescue
+      0_i64 # same poll-reader degrade as `count`/`data_version` above
     end
 
     # Distinct (host, method, target) endpoints for building the Sitemap tree,

--- a/src/gori/tui/decoder_view.cr
+++ b/src/gori/tui/decoder_view.cr
@@ -122,28 +122,15 @@ module Gori::Tui
       paint_input_read_chrome(screen, body, input, read, reading) if reading && read
     end
 
+    # The shared over-paint — see `TextReadState#paint_chrome`, which carries the reasoning
+    # (including the `sync_from` this pane's own copy omitted: `^L` clears the INPUT buffer
+    # without resetting the read cursor, so a caret parked on line >= 1 then indexed off the
+    # end of the one-line snapshot and took the render down every tick until the tick-error
+    # breaker exited the session). Routing here also makes the band wrap-correct, by
+    # inverting the row list the editor actually drew instead of assuming `li - scroll`.
     private def paint_input_read_chrome(screen : Screen, rect : Rect, ed : TextArea,
                                         read : TextReadState, focused : Bool) : Nil
-      return unless focused
-      lines = ed.lines_snapshot
-      return if lines.empty?
-      scr = ed.scroll
-      sel_bg = Theme.accent_bg
-      read.cursor.highlight_spans(lines).each do |(li, x0, x1)|
-        next unless li >= scr && li < scr + rect.h
-        row = li - scr
-        paint_char_span_bg(screen, rect.x, rect.y + row, lines[li], x0, x1, sel_bg)
-      end
-      cy, cx = read.cursor.cy, read.cursor.cx
-      return unless cy >= scr && cy < scr + rect.h
-      row = cy - scr
-      line = lines[cy]
-      px = rect.x + Screen.draw_width(line[0, cx])
-      if px < rect.x + rect.w
-        ch = cx < line.size ? line[cx] : ' '
-        screen.cell(px, rect.y + row, ch, Theme.bg, Theme.accent_bg)
-        screen.cursor(px, rect.y + row)
-      end
+      read.paint_chrome(screen, rect, ed, focused)
     end
 
     # CHAIN — a framed single-line spec field with a "›" prompt; gold when focused.
@@ -269,27 +256,6 @@ module Gori::Tui
 
     def output_clear_selection : Nil
       @out.clear_selection
-    end
-
-    private def paint_char_span_bg(screen : Screen, x : Int32, y : Int32, line : String,
-                                   x0 : Int32, x1 : Int32, bg : Color) : Nil
-      return if x0 >= x1
-      # Cluster-wise, matching the base draw and the caret. Summing draw_width over single
-      # CHARS is exactly the retired per-codepoint measure: it drifts right by each
-      # cluster's inflation (1 column for a skin tone, 9 for a ZWJ family), and drawing
-      # char-by-char also SHREDS a cluster across cells, stranding a bare combining mark in
-      # one of its own. Span edges snap outward so the tint covers whole glyphs.
-      a = Screen.cluster_start(line, {x0, line.size}.min)
-      b = Screen.cluster_end(line, {x1, line.size}.min)
-      px = x + Screen.draw_width(line[0, a])
-      i = a
-      while i < b
-        e = Screen.cluster_end(line, i + 1)
-        seg = line[i...e]
-        screen.text(px, y, seg, Theme.text, bg)
-        px += Screen.draw_width(seg)
-        i = e
-      end
     end
 
     # The displayed OUTPUT split into lines, cached until the next recompute / mode

--- a/src/gori/tui/jwt_view.cr
+++ b/src/gori/tui/jwt_view.cr
@@ -266,42 +266,14 @@ module Gori::Tui
       decoded.empty? ? ["(paste or send a JWT into INPUT to decode)"] : decoded.split('\n')
     end
 
+    # The shared over-paint — see `TextReadState#paint_chrome`, which carries the reasoning
+    # (including the `sync_from` this pane's own copy omitted: `^L` clears the INPUT buffer
+    # without resetting the read cursor, so a caret parked on line >= 1 then indexed off the
+    # end of the one-line snapshot and took the render down every tick until the tick-error
+    # breaker exited the session). Routing here also makes the band wrap-correct, by
+    # inverting the row list the editor actually drew instead of assuming `li - scroll`.
     private def paint_read_chrome(screen : Screen, rect : Rect, ed : TextArea, read : TextReadState) : Nil
-      lines = ed.lines_snapshot
-      return if lines.empty?
-      scr = ed.scroll
-      read.cursor.highlight_spans(lines).each do |(li, x0, x1)|
-        next unless li >= scr && li < scr + rect.h
-        paint_span_bg(screen, rect.x, rect.y + (li - scr), lines[li], x0, x1)
-      end
-      cy, cx = read.cursor.cy, read.cursor.cx
-      return unless cy >= scr && cy < scr + rect.h
-      line = lines[cy]
-      px = rect.x + Screen.draw_width(line[0, cx.clamp(0, line.size)])
-      return if px >= rect.x + rect.w
-      ch = cx < line.size ? line[cx] : ' '
-      screen.cell(px, rect.y + (cy - scr), ch, Theme.bg, Theme.accent_bg)
-      screen.cursor(px, rect.y + (cy - scr))
-    end
-
-    private def paint_span_bg(screen : Screen, x : Int32, y : Int32, line : String, x0 : Int32, x1 : Int32) : Nil
-      return if x0 >= x1
-      # Cluster-wise, matching the base draw and the caret. Summing draw_width over single
-      # CHARS is exactly the retired per-codepoint measure: it drifts right by each
-      # cluster's inflation (1 column for a skin tone, 9 for a ZWJ family), and drawing
-      # char-by-char also SHREDS a cluster across cells, stranding a bare combining mark in
-      # one of its own. Span edges snap outward so the tint covers whole glyphs.
-      a = Screen.cluster_start(line, {x0, line.size}.min)
-      b = Screen.cluster_end(line, {x1, line.size}.min)
-      px = x + Screen.draw_width(line[0, a])
-      i = a
-      while i < b
-        e = Screen.cluster_end(line, i + 1)
-        seg = line[i...e]
-        screen.text(px, y, seg, Theme.text, Theme.accent_bg)
-        px += Screen.draw_width(seg)
-        i = e
-      end
+      read.paint_chrome(screen, rect, ed)
     end
 
     # ---- scroll / selection mutators (called by the controller) ----

--- a/src/gori/tui/text_field.cr
+++ b/src/gori/tui/text_field.cr
@@ -125,7 +125,21 @@ module Gori::Tui
     def delete_selection : Bool
       span = @sel.selection_span(@caret)
       return false unless span
+      # Clamp both ends: `selection_span` reports the raw anchor/caret pair without bounding
+      # it to the CURRENT value, so any path that shrinks `@value` while an anchor is live
+      # leaves `x1 > @value.size`, and `@value[x1..]` raises IndexError. `undo` was that
+      # path; clamping here keeps the next one from reaching the render loop.
       x0, x1 = span
+      x0 = x0.clamp(0, @value.size)
+      x1 = x1.clamp(x0, @value.size)
+      # `selection_span` never reports an empty span, so the two can only meet here when the
+      # whole selection sat past the end of the current value — a fully stale anchor with
+      # nothing left to cut. Drop it and report "took nothing" so the caller falls back to
+      # its own single-character delete.
+      if x0 == x1
+        @sel.clear_selection
+        return false
+      end
       @value = "#{@value[0, x0]}#{@value[x1..]}"
       @caret = x0
       @sel.clear_selection
@@ -343,6 +357,12 @@ module Gori::Tui
       state = @undo_stack.pop
       @value = state.value
       @caret = state.caret.clamp(0, @value.size)
+      # Same reason `set` does it: restoring an earlier (usually SHORTER) value leaves any
+      # live ⇧arrow anchor pointing past the new end, and `selection_span` does not clamp.
+      # The next edit key then ran `@value[x1..]` with `x1 > size`, which raises IndexError
+      # (only `x1 == size` is legal) — out of the render loop and into the tick-error
+      # breaker. `TextArea#undo` already drops its anchor for exactly this reason.
+      @sel.clear_selection
       @preedit = ""
     end
   end

--- a/src/gori/update.cr
+++ b/src/gori/update.cr
@@ -102,6 +102,28 @@ module Gori
       raise Error.new("#{what}: #{ex.message.presence || ex.class}")
     end
 
+    # `URI.parse` on a NETWORK-supplied string. Every URL this module parses past the first
+    # one comes from the release JSON (`browser_download_url`) or a `Location` header, and
+    # `URI.parse` raises on both a malformed authority (`URI::Error`) and an out-of-range
+    # port (`OverflowError`, e.g. `host:9999999999`). Neither is a `Gori::Error`, so an
+    # unguarded parse backtraces straight out of `gori update` — `CLI.run` rescues only
+    # `Gori::Error`, and `io_guard` covers only `IO::Error`/`OpenSSL::Error`.
+    private def self.parse_url(url : String, what : String) : URI
+      URI.parse(url)
+    rescue ex : URI::Error | OverflowError
+      raise Error.new("#{what}: #{ex.message.presence || ex.class}")
+    end
+
+    # A `Location` header resolved against the URL it came from. Absolute targets pass
+    # through; a relative one is resolved, which PARSES the server-supplied value and so
+    # carries the same raise surface `parse_url` guards — wrapped rather than left bare.
+    private def self.resolve_redirect(url : String, location : String) : String
+      return location if location.starts_with?("http://") || location.starts_with?("https://")
+      parse_url(url, "invalid download URL: #{url}").resolve(location).to_s
+    rescue ex : URI::Error | OverflowError
+      raise Error.new("invalid redirect target #{location.inspect} from #{url}: #{ex.message.presence || ex.class}")
+    end
+
     def self.resolve_executable_path : String
       path = Process.executable_path
       raise Error.new("could not determine the running gori executable path") unless path
@@ -311,7 +333,7 @@ module Gori
     def self.fetch_latest_release_json(api_url : String? = nil, *,
                                        timeout : Time::Span = HTTP_TIMEOUT) : String
       url = resolve_api_url(api_url)
-      uri = URI.parse(url)
+      uri = parse_url(url, "invalid API URL: #{url}")
       headers = HTTP::Headers{
         "Accept"     => "application/vnd.github+json",
         "User-Agent" => USER_AGENT,
@@ -343,7 +365,7 @@ module Gori
                          force_progress : Bool = false) : Int64
       raise Error.new("too many redirects downloading #{url}") if redirects_left < 0
 
-      uri = URI.parse(url)
+      uri = parse_url(url, "invalid download URL: #{url}")
       host = uri.host || raise Error.new("invalid download URL: #{url}")
       port = uri.port || (uri.scheme == "https" ? 443 : 80)
       tls = uri.scheme == "https"
@@ -364,8 +386,7 @@ module Gori
               location = response.headers["Location"]?
               raise Error.new("redirect without Location from #{url}") unless location
               response.body_io.gets_to_end
-              # Resolve relative redirects against the current URL.
-              redirect_url = location.starts_with?("http://") || location.starts_with?("https://") ? location : URI.parse(url).resolve(location).to_s
+              redirect_url = resolve_redirect(url, location)
               next
             end
             unless code == 200

--- a/src/gori/update/asset.cr
+++ b/src/gori/update/asset.cr
@@ -6,8 +6,17 @@ module Gori::Update
   # Release asset naming (pure)
   # ---------------------------------------------------------------------------
 
+  # SCRUB FIRST: `version` is a release tag straight off the update endpoint, and
+  # every consumer below eventually feeds it to a regex — `version_cmp` splits on
+  # /[.+-]/, and PCRE2 raises `ArgumentError: Regex match error: UTF-8 error` on a
+  # subject holding a byte >= 0x80 that is not valid UTF-8. That raise lands on the
+  # TUI's main fiber with no rescue under it. Worse, `notice_version` persists the
+  # normalized tag as the read-once marker BEFORE anything else validates it, so a
+  # poisoned tag would be re-read from settings.json on every later launch and
+  # crash the process again from cache. Scrubbing here is the one choke point all
+  # four callers (version_cmp, notice_version, display_version, asset_name) share.
   def self.normalize_version(version : String) : String
-    v = version
+    v = version.scrub
     v = v[1..] if v.starts_with?('v') || v.starts_with?('V')
     v
   end

--- a/src/gori/update/verify.cr
+++ b/src/gori/update/verify.cr
@@ -145,7 +145,11 @@ module Gori::Update
   # string, or nil when absent/unsupported (older API, GHE, non-sha256 algo).
   def self.parse_sha256_digest(digest : String?) : String?
     return nil unless digest
-    d = digest.strip.downcase
+    # `.scrub`: the digest is copied verbatim out of the release JSON, and `matches?` is a
+    # PCRE2 call that raises `ArgumentError` on a non-UTF-8 subject — from inside
+    # `verify_download!`, which has no rescue below `CLI.run`. A scrubbed digest simply
+    # fails the hex test and returns nil, which is this method's documented "unsupported".
+    d = digest.scrub.strip.downcase
     return nil unless d.starts_with?("sha256:")
     hex = d.lchop("sha256:")
     HEX_SHA256.matches?(hex) ? hex : nil
@@ -158,7 +162,11 @@ module Gori::Update
   def self.parse_checksums(text : String) : Hash(String, String)
     sums = {} of String => String
     text.each_line do |line|
-      parts = line.strip.split(/\s+/, 2)
+      # `.scrub` per line: the SHA256SUMS body is fetched over the network, and the
+      # `split(/\s+/, 2)` is a PCRE2 call that raises `ArgumentError` on a non-UTF-8
+      # subject — which would break this method's documented contract that a malformed
+      # line is SKIPPED rather than raised on.
+      parts = line.scrub.strip.split(/\s+/, 2)
       next unless parts.size == 2
       hex = parts[0].downcase
       next unless HEX_SHA256.matches?(hex)


### PR DESCRIPTION
A crash audit across the proxy, parsers, TUI, active engines, store and MCP surfaces. The proxy net-layer and the decoders turned out to be **already hardened** — nothing malformed off the wire could crash them. Everything here was found elsewhere, and it lands as two root causes rather than 24 separate bugs.

## Non-UTF-8 string → PCRE2 → `ArgumentError` (9 sites)

`"v1\xff.0".split(/[.+-]/)` raises — PCRE2 refuses a subject that is not valid UTF-8, and `CLI.run` rescues only `Gori::Error`. The fix differs by whether the bytes may be rewritten, and picking the wrong one would be its own bug:

| Situation | Fix |
|---|---|
| String is only inspected | `.scrub` — release tag, env line, `--containment`, seed target, network digest / SHA256SUMS |
| Value must be sent **verbatim** | `valid_encoding?` guard — an invalid-UTF-8 WebSocket payload is a legitimate thing to send, so scrubbing would alter the operator's request |
| Must be byte-exact **and** must not raise | byte-wise rewrite — `MCP::RequestBuilder.normalize_raw` now walks bytes via `byte_index` instead of `gsub(/\r?\n/)`, head/body rule unchanged |

`Update.normalize_version` is worth calling out: a poisoned tag was persisted to `settings.json` **before** the compare that raised, so every later launch re-read it and crashed again from cache. Scrubbed at the single choke point its four callers share.

## Stale TUI index → `IndexError` → tick-error breaker → process exit (3 sites)

Decoder and JWT held the last two hand-rolled copies of the read-chrome over-paint; five other panes already delegate to `TextReadState#paint_chrome`, which carries the `sync_from` and `[]?` those copies omitted. `^L` cleared the buffer without resetting the read cursor, so `lines[cy]` raised every tick until the breaker exited the session. Both routed to the shared implementation, duplicate span-painters deleted.

Separately, `TextField#undo` restored a shorter value while leaving the selection anchor live (`TextArea#undo` already cleared it), so the next edit key sliced past the end.

## The sibling usually already had the fix

| Already correct | Was missing it |
|---|---|
| `HostOverrides` split `@mutex`/`@write_mutex` | `Scope` held the hot-path lock across store round-trips — stalling every dial, intercept gate and sandbox decision for up to `busy_timeout` (5s), including on the timer-driven `reload` |
| `Discover::Engine` guarded teardown | fuzz / miner / sequencer could skip `@events.close`, parking a consumer forever and pinning an MCP job at `:running` (blocking `switch_project`/`delete_project`) |
| `data_version` degrade-rescue | `count` / `total_size` spent the TUI tick-error budget on a transient `SQLITE_BUSY` |
| `Active.analyze` per-rule rescue | `Passive.analyze` let one raising rule discard every later rule's findings |
| `run/rewriter.cr` `File::Error` rescue | five CLI `File.read` sites guarded only by `File.exists?`, which passes for an unreadable file |

## Also

- **`Notes.parse`** — `JSON::Any#[]?` raises a *bare* `Exception` on a non-object root, which `rescue JSON::ParseException` does not catch. Now read via `as_h?`.
- **fuzz/miner decode** now passes `CAPTURE_READ_MAX`. Left at `ContentDecode`'s 32 MiB default, a compressible response inflated ~4× past the capture cap, once per in-flight worker, and concurrency goes to 1000.
- **MCP discover** flushed its tail *after* going terminal, where `jobs_running?` no longer blocks a switch — findings could land in another project. Flush moved ahead of the status, plus a `db_path` guard on the write side matching `job_project_mismatch` on the read side.
- **scope regex rules** `.scrub` their subject: the old `rescue false` made an EXCLUDE rule fail **open** on a non-UTF-8 target, which is scope evasion.
- **HAR import** degrades a junk numeric *field* instead of letting the per-entry rescue drop the whole valid request. (`1e400` never parses — the real hazard is an in-range `1e30`, and `200.5` through `as_i`.)
- Smaller: ws_shape `Int64`→`Int32` clamp on a corrupt row, `File.info?` + rescue for the project stat TOCTOU, capture-lock errors translated to `Gori::Error`, a per-job MCP log cap, a pacing clamp, punycode accumulating in `Int64`, and a scrub parity fix in `links.cr`.

## Verification

- Full suite: **8787 examples, 0 failures**.
- ameba finding count **unchanged** from the branch point (`download_to` actually drops 16 → 14 after extracting `resolve_redirect`).
- Before/after checked against built binaries:

```
discover --containment (non-UTF-8)
  before: Unhandled exception: Regex match error ... (ArgumentError)
  after : gori run discover: invalid --containment '?' (same-origin|...)

fuzz --request (unreadable file)
  before: Unhandled exception: ... Permission denied (File::AccessDeniedError)
  after : gori run fuzz: cannot read 'unreadable.http': ... Permission denied
```

## Upstream

Nothing was blocked upstream — all five Crystal stdlib behaviours behind these crashes were defensible here. Only `JSON::Any#[]?` raising a bare `Exception` is worth filing with crystal-lang (the `?` suffix promises nil, and the untyped exception can't be rescued selectively). `termisu` was not implicated in any finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)