### PR TITLE
Give Project Scope, Host overrides, and Env the empty-tab card treatment

### DIFF
--- a/spec/tui/empty_art_spec.cr
+++ b/spec/tui/empty_art_spec.cr
@@ -20,8 +20,8 @@ end
 # no art forever and nothing else would ever mention it.
 EXPECTED_ART = [
   :history, :sitemap, :intercept, :repeater, :fuzzer, :fuzzer_results, :probe, :issues,
-  :notes, :project_desc, :discover, :comparer, :miner, :miner_results, :sequencer,
-  :sequencer_samples, :oast,
+  :notes, :project_desc, :project_scope, :project_overrides, :project_env, :discover,
+  :comparer, :miner, :miner_results, :sequencer, :sequencer_samples, :oast,
 ]
 
 describe Gori::Tui::EmptyArt do

--- a/spec/tui/project_view_spec.cr
+++ b/spec/tui/project_view_spec.cr
@@ -201,7 +201,7 @@ describe "ProjectView created time" do
 end
 
 describe "ProjectView SCOPE list" do
-  it "shows the empty-state hint (add via popup, not an inline row)" do
+  it "shows the onboarding card (art + TARGETS card) when empty" do
     tmp_store do |store|
       view = ProjectView.new(Gori::Scope.load(store), Gori::HostOverrides.load(store))
       project = Gori::Project.new("t", File.tempname("gori-scope-empty"))
@@ -209,10 +209,11 @@ describe "ProjectView SCOPE list" do
       view.focus_pane(:scope)
       b = MemoryBackend.new(120, 30)
       view.render(Screen.new(b), Rect.new(0, 0, 120, 30), focused: true)
-      # The wording every empty list in gori uses: what is missing, then `press a to add`.
-      # This pane used to say `(no rules — a to add)`, in parentheses and with a bare key.
-      b.contains?("no scope rules").should be_true
-      b.contains?("press a to add").should be_true
+      # The empty pane now draws the shared onboarding card (variant :project_scope) instead of
+      # a single muted line — an inner TARGETS card explaining the include/exclude split, with
+      # `a` still the add key.
+      b.contains?("TARGETS").should be_true
+      b.contains?("include or exclude").should be_true
     end
   end
 end

--- a/spec/tui/short_pane_clamp_spec.cr
+++ b/spec/tui/short_pane_clamp_spec.cr
@@ -165,7 +165,7 @@ describe TrafficEmptyState do
   # already-granted full tier, so it is the art gate — not the card gate — that decides whether
   # those extra rows fit; sweeping one fixed width never exercises `FULL_MIN_W` or a figure's
   # own `min_w`, and the art path adds a second reason a renderer can outgrow its rect.
-  {% for variant in [:history, :sitemap, :intercept, :repeater, :fuzzer, :fuzzer_results, :probe, :issues, :notes, :project_desc, :discover, :comparer, :miner, :miner_results, :sequencer, :sequencer_samples, :oast] %}
+  {% for variant in [:history, :sitemap, :intercept, :repeater, :fuzzer, :fuzzer_results, :probe, :issues, :notes, :project_desc, :project_scope, :project_overrides, :project_env, :discover, :comparer, :miner, :miner_results, :sequencer, :sequencer_samples, :oast] %}
     it "never draws {{ variant.id }} below its rect, at any size the gate admits" do
       (8..26).each do |h|
         [30, 40, 42, 43, 46, 50, 60, 100].each do |w|
@@ -184,7 +184,7 @@ describe TrafficEmptyState do
   # …and nothing may run off the RIGHT edge either. A figure is centred on its ink extent, so a
   # block wider than the pane would paint past `rect.right` — where `Screen`'s bounds check
   # silently drops it in the app but a narrower rect inside a wider backend makes it visible.
-  {% for variant in [:history, :fuzzer_results, :notes, :project_desc, :sequencer, :oast] %}
+  {% for variant in [:history, :fuzzer_results, :notes, :project_desc, :project_scope, :project_overrides, :project_env, :sequencer, :oast] %}
     it "never draws {{ variant.id }} past its right edge" do
       (8..26).each do |h|
         [42, 46, 50, 60].each do |w|

--- a/spec/tui/traffic_empty_state_spec.cr
+++ b/spec/tui/traffic_empty_state_spec.cr
@@ -160,6 +160,34 @@ describe Gori::Tui::TrafficEmptyState do
     backend.contains?("^N").should be_true
   end
 
+  # The three Project list sub-tabs. Each renders inside a card the pane already titled, so the
+  # inner card takes a DIFFERENT name (TARGETS / DNS MAP / VARIABLES) rather than echoing the
+  # border, and — being CENTERED — draws no headline.
+  it "renders the scope targets card" do
+    backend = MemoryBackend.new(60, 12)
+    TrafficEmptyState.render(Screen.new(backend), Rect.new(0, 0, 60, 12), variant: :project_scope)
+    backend.contains?("TARGETS").should be_true
+    backend.contains?("which hosts you're testing").should be_true
+    backend.contains?("include or exclude").should be_true
+    backend.contains?("no scope rules yet").should be_false # CENTERED: headline suppressed
+  end
+
+  it "renders the host-overrides DNS map card" do
+    backend = MemoryBackend.new(60, 12)
+    TrafficEmptyState.render(Screen.new(backend), Rect.new(0, 0, 60, 12), variant: :project_overrides)
+    backend.contains?("DNS MAP").should be_true
+    backend.contains?("Pin a hostname").should be_true
+    backend.contains?("map a host to an IP").should be_true
+  end
+
+  it "renders the env variables card" do
+    backend = MemoryBackend.new(60, 12)
+    TrafficEmptyState.render(Screen.new(backend), Rect.new(0, 0, 60, 12), variant: :project_env)
+    backend.contains?("VARIABLES").should be_true
+    backend.contains?("reuse across requests").should be_true
+    backend.contains?("add a $KEY variable").should be_true
+  end
+
   # The four engine tabs whose "nothing open yet" state used to be one muted line, while their
   # siblings (Repeater, Fuzzer) reached this module from the identical container-level branch.
   # Discover is the sharpest case: it sits in the same tab as Sitemap, which has always drawn a
@@ -263,7 +291,7 @@ describe Gori::Tui::TrafficEmptyState do
   # Each new variant must degrade like the older ones. A variant added to `render_full` but not
   # to the medium/minimal dispatches falls through to `else`, which prints the headline and
   # nothing else — passing any test that only checks the full card.
-  {% for variant in [:discover, :comparer, :miner, :sequencer, :oast] %}
+  {% for variant in [:discover, :comparer, :miner, :sequencer, :oast, :project_scope, :project_overrides, :project_env] %}
     it "degrades {{ variant.id }} to compact lines on a narrow pane" do
       backend = MemoryBackend.new(34, 6)
       TrafficEmptyState.render(Screen.new(backend), Rect.new(0, 0, 34, 6), variant: {{ variant }})

--- a/src/gori/tui/empty_art.cr
+++ b/src/gori/tui/empty_art.cr
@@ -215,6 +215,30 @@ module Gori::Tui
       "╰───────────────╯",
     ])
 
+    # The scope boundary as a shape: the host under test lit inside the fence, out-of-scope
+    # traffic dimmed either side of it — include and exclude in one picture.
+    PROJECT_SCOPE = Block.new([
+      "       ╭─────────╮",
+      " ▓▓▓   │  █████  │   ▓▓▓",
+      "       ╰─────────╯",
+    ])
+
+    # A hostname forking at the resolver: dashed to the DNS answer it bypasses, solid
+    # down-and-over to the pinned address — the pinned one wins, so it is the lit one.
+    PROJECT_OVERRIDES = Block.new([
+      " ▓▓▓▓▓▓┬┄> ▓▓▓▓",
+      "       │",
+      "       ╰──> ██████",
+    ])
+
+    # A named $KEY token expanding into the request it is typed in — substitution, drawn.
+    # The key is the lit part because writing one is what the empty pane is asking for.
+    PROJECT_ENV = Block.new([
+      "╭──────╮",
+      "│ $██  │ ┄┄> ▓▓▓▓▓▓",
+      "╰──────╯",
+    ])
+
     # A root fanning out into the endpoints a crawl turns up.
     DISCOVER = Block.new([
       "      ╭── ▓▓▓▓",
@@ -285,6 +309,9 @@ module Gori::Tui
       :issues            => ISSUES,
       :notes             => NOTES,
       :project_desc      => PROJECT_DESC,
+      :project_scope     => PROJECT_SCOPE,
+      :project_overrides => PROJECT_OVERRIDES,
+      :project_env       => PROJECT_ENV,
       :discover          => DISCOVER,
       :comparer          => COMPARER,
       :miner             => MINER,

--- a/src/gori/tui/project_view.cr
+++ b/src/gori/tui/project_view.cr
@@ -1614,7 +1614,7 @@ module Gori::Tui
       return if rows <= 0
 
       if rules.empty?
-        screen.text(inner.x, y, "no scope rules — press a to add", Theme.muted, Theme.bg)
+        TrafficEmptyState.render(screen, inner, variant: :project_scope)
         return
       end
 
@@ -1667,6 +1667,13 @@ module Gori::Tui
     # a persistent format-example header on the first row (parity with the settings editor).
     private def render_overrides_list(screen : Screen, inner : Rect, focused : Bool) : Nil
       return if inner.h <= 0 || inner.w <= 0
+      # Nothing mapped yet, and not mid-add: the shared onboarding card owns the whole
+      # interior — the format hint below only makes sense once there is a row to read it
+      # against, and it reappears the moment `a` opens the add-row.
+      if @host_overrides.entries.empty? && !@ov_adding
+        TrafficEmptyState.render(screen, inner, variant: :project_overrides)
+        return
+      end
       # Always-visible format example so the "IP HOSTNAME" entry shape is clear at a glance
       # (IP first so it survives truncation in a narrow pane).
       screen.text(inner.x, inner.y, "IP HOSTNAME · e.g. 10.0.0.1 example.com", Theme.muted, width: inner.w)
@@ -1683,10 +1690,9 @@ module Gori::Tui
       end
       return if rows <= 0
 
-      if entries.empty?
-        screen.text(list.x, y, "no overrides — press a to add", Theme.muted, Theme.bg) unless @ov_adding
-        return
-      end
+      # Empty here means the add-row is open on a fresh pane (the onboarding card handled the
+      # standing-empty case up top): nothing to window, so skip the list and gauge.
+      return if entries.empty?
 
       scroll = scroll_for(@ov_sel, entries.size, rows)
       shown = {rows, entries.size - scroll}.min
@@ -1743,6 +1749,12 @@ module Gori::Tui
 
     private def render_env_list(screen : Screen, inner : Rect, focused : Bool) : Nil
       return if inner.h <= 0 || inner.w <= 0
+      # Nothing set yet, and not mid add/prefix-edit: the onboarding card owns the interior.
+      # The format hint and the input row return together the instant either editor opens.
+      if @env_items.empty? && !env_row_offset?
+        TrafficEmptyState.render(screen, inner, variant: :project_env)
+        return
+      end
       screen.text(inner.x, inner.y, "KEY VALUE · e.g. HOST api.example.com", Theme.muted, width: inner.w)
       list = env_list_inner(inner)
       return if list.h <= 0
@@ -1756,10 +1768,9 @@ module Gori::Tui
         rows -= 1
       end
       return if rows <= 0
-      if @env_items.empty?
-        screen.text(list.x, y, "no env vars — press a to add", Theme.muted, Theme.bg) unless @env_adding || @env_prefix_editing
-        return
-      end
+      # Empty here means an add/prefix row is open on a fresh pane (the onboarding card
+      # handled the standing-empty case up top): nothing to window.
+      return if @env_items.empty?
       scroll = scroll_for(@env_sel, @env_items.size, rows)
       shown = {rows, @env_items.size - scroll}.min
       shown.times do |i|

--- a/src/gori/tui/traffic_empty_state.cr
+++ b/src/gori/tui/traffic_empty_state.cr
@@ -103,14 +103,16 @@ module Gori::Tui
       when :oast              then 5 + 1 # six, and flat — see render_oast_full
       when :notes             then 5 + 1
       when :project_desc      then 5 + 1
+      when :project_scope, :project_overrides, :project_env then 5 + 1
       else                         0 # unknown variant — render_full draws nothing, as before
       end
     end
 
     # Variants whose card centres in the WHOLE rect, with no headline row riding above it.
-    # Both are editor panes reached by a sub-tab that already names them on its chip, so a
+    # All are panes reached by a sub-tab that already names them on its chip (and the three
+    # Project list panes sit inside an outer card that names them AGAIN on its border), so a
     # headline would repeat the label the operator just clicked.
-    CENTERED = {:notes, :project_desc}
+    CENTERED = {:notes, :project_desc, :project_scope, :project_overrides, :project_env}
 
     # Rows the full card needs inside `rect`: its interior plus two borders, plus the headline
     # row that rides above it for every variant except the CENTERED ones.
@@ -141,6 +143,9 @@ module Gori::Tui
       when :oast              then "no callbacks yet"
       when :notes             then "empty note"
       when :project_desc      then "no description yet"
+      when :project_scope     then "no scope rules yet"
+      when :project_overrides then "no host overrides yet"
+      when :project_env       then "no env variables yet"
       else                         "nothing here yet"
       end
     end
@@ -166,6 +171,9 @@ module Gori::Tui
       when :oast              then render_oast_full(screen, rect, headline, has_provider)
       when :notes             then render_notes_full(screen, rect)
       when :project_desc      then render_project_desc_full(screen, rect)
+      when :project_scope     then render_project_scope_full(screen, rect)
+      when :project_overrides then render_project_overrides_full(screen, rect)
+      when :project_env       then render_project_env_full(screen, rect)
       end
     end
 
@@ -207,6 +215,12 @@ module Gori::Tui
                 medium_notes(headline)
               when :project_desc
                 medium_project_desc(headline)
+              when :project_scope
+                medium_project_scope(headline)
+              when :project_overrides
+                medium_project_overrides(headline)
+              when :project_env
+                medium_project_env(headline)
               else
                 [headline]
               end
@@ -251,6 +265,12 @@ module Gori::Tui
                "^N new note · start typing"
              when :project_desc
                "i/↵ describe this engagement · ^E $EDITOR"
+             when :project_scope
+               "a add rule · space menu"
+             when :project_overrides
+               "a map host→IP · space menu"
+             when :project_env
+               "a add $KEY · space prefix"
              else
                headline
              end
@@ -661,9 +681,60 @@ module Gori::Tui
       draw_chord_hint(screen, ix, y, iw, " ^E ", "open in $EDITOR", bullet: "▸ ")
     end
 
+    # The Project tab's SCOPE card with no rules. Titled TARGETS, not SCOPE — the outer card
+    # already says SCOPE on its border, and the rules are the list of targets.
+    private def render_project_scope_full(screen : Screen, rect : Rect) : Nil
+      desc = "Scope rules mark which hosts you're testing."
+      hint = "incl keeps a host in · excl passes it through"
+      inner, ix, iw = begin_centered_card(screen, rect, :project_scope, "TARGETS",
+        full_inner_h(:project_scope), {Screen.display_width(desc), Screen.display_width(hint)}.max)
+      y = inner.y
+
+      draw_wrapped_message(screen, ix, y, iw, desc)
+      y += 2
+      screen.text(ix, y, hint, Theme.muted, Theme.bg, width: iw)
+      y += 2
+      y = draw_chord_hint(screen, ix, y, iw, " a ", "add an include or exclude rule", bullet: "▸ ")
+      draw_chord_hint(screen, ix, y, iw, " space ", "rule actions", bullet: "▸ ")
+    end
+
+    # The Project tab's HOST OVERRIDES card with no entries. DNS MAP because that is what an
+    # entry does — resolve past DNS — where "overrides" only repeats the border.
+    private def render_project_overrides_full(screen : Screen, rect : Rect) : Nil
+      desc = "Pin a hostname to a chosen IP for this project."
+      hint = "requests resolve there before real DNS"
+      inner, ix, iw = begin_centered_card(screen, rect, :project_overrides, "DNS MAP",
+        full_inner_h(:project_overrides), {Screen.display_width(desc), Screen.display_width(hint)}.max)
+      y = inner.y
+
+      draw_wrapped_message(screen, ix, y, iw, desc)
+      y += 2
+      screen.text(ix, y, hint, Theme.muted, Theme.bg, width: iw)
+      y += 2
+      y = draw_chord_hint(screen, ix, y, iw, " a ", "map a host to an IP", bullet: "▸ ")
+      draw_chord_hint(screen, ix, y, iw, " space ", "override actions", bullet: "▸ ")
+    end
+
+    # The Project tab's ENVIRONMENT card with no vars. The copy hardcodes the default `$`
+    # sigil: an empty pane means a fresh project, and the live prefix rides the outer border.
+    private def render_project_env_full(screen : Screen, rect : Rect) : Nil
+      desc = "Store $KEY values to reuse across requests."
+      hint = "$KEY in a request expands when you send"
+      inner, ix, iw = begin_centered_card(screen, rect, :project_env, "VARIABLES",
+        full_inner_h(:project_env), {Screen.display_width(desc), Screen.display_width(hint)}.max)
+      y = inner.y
+
+      draw_wrapped_message(screen, ix, y, iw, desc)
+      y += 2
+      screen.text(ix, y, hint, Theme.muted, Theme.bg, width: iw)
+      y += 2
+      y = draw_chord_hint(screen, ix, y, iw, " a ", "add a $KEY variable", bullet: "▸ ")
+      draw_chord_hint(screen, ix, y, iw, " space ", "vars & prefix", bullet: "▸ ")
+    end
+
     # `begin_card` for a CENTERED variant: the same figure-and-card block, but centred in the
-    # whole rect because these two draw no headline. Narrower floor than `begin_card`'s 50 —
-    # both are editor panes, where a wide card over an empty buffer reads as chrome.
+    # whole rect because these draw no headline. Narrower floor than `begin_card`'s 50 —
+    # all sit inside a pane that is otherwise empty, where a wide card reads as chrome.
     private def begin_centered_card(screen : Screen, rect : Rect, variant : Symbol,
                                     card_title : String, inner_h : Int32, min_w : Int32 = 0) : {Rect, Int32, Int32}
       card_w = card_width(rect, min_w, 46)
@@ -756,6 +827,18 @@ module Gori::Tui
 
     private def medium_project_desc(headline) : Array(String)
       [headline, "target · scope · credentials · rules", "i/↵ edit · ^E $EDITOR"]
+    end
+
+    private def medium_project_scope(headline) : Array(String)
+      [headline, "incl / excl ──► scope lens", "a add rule · space menu"]
+    end
+
+    private def medium_project_overrides(headline) : Array(String)
+      [headline, "host ──► your IP", "a add · e edit · d delete"]
+    end
+
+    private def medium_project_env(headline) : Array(String)
+      [headline, "$KEY ──► value on send", "a add var · space prefix"]
     end
 
     private def draw_medium_lines(screen : Screen, rect : Rect, lines : Array(String)) : Nil


### PR DESCRIPTION
## What

The Project tab's Description sub-tab already draws the shared onboarding card (art + card) when empty; its three siblings — **Scope**, **Host overrides**, **Env** — still showed a single muted line (`no scope rules — press a to add`). This gives all three the same empty-state treatment, following the existing `TrafficEmptyState` / `EmptyArt` pattern.

## Figures (`empty_art.cr`)

Three 3-row figures (single-cell glyphs only; `█`=subject / `▓`=mass):
- `:project_scope` — target host lit inside the scope fence, out-of-scope traffic dimmed either side (include vs exclude)
- `:project_overrides` — a hostname forking at the resolver: dashed to the DNS it bypasses, solid to the pinned IP that wins
- `:project_env` — a `$KEY` token in its box expanding into the request it's typed in

## Cards (`traffic_empty_state.cr`)

All three join `CENTERED` like `:project_desc` — no headline, card centered in the pane, nested inside the outer card that already names the pane. Inner titles differ from the border: **TARGETS** / **DNS MAP** / **VARIABLES**. Each has full / medium / minimal tiers.

## Call sites (`project_view.cr`)

Empty-card branch runs first, gated off during add/prefix-edit so the format-hint row + inline editor return exactly as before the moment `a` is pressed. Hit-tests need no change (they already return nil on empty lists). 3-row figures (vs `:project_desc`'s 4) so the art actually shows at 100×30.

## Tests

- `crystal build --no-codegen src/main.cr` clean
- Targeted specs + full `spec/tui/` suite (2935 examples) pass
- Specs updated: `empty_art_spec` (`EXPECTED_ART`), `short_pane_clamp_spec` (both sweeps), `traffic_empty_state_spec` (per-variant examples + medium loop), `project_view_spec` (pinned wording → card assertions)