### PR TITLE
Point the binary-body hex hint at the real ^X chord

### DIFF
--- a/src/gori/repeater/message_lines.cr
+++ b/src/gori/repeater/message_lines.cr
@@ -13,6 +13,11 @@ module Gori
       # Bounded so a multi-MiB body is O(1) to classify.
       BINARY_SNIFF_LIMIT = 8192
 
+      # No "press x"/hex-view pointer here, unlike the History detail pane's placeholder:
+      # this text is shared by the Comparer tab (no hex view; `x` there selects the diff
+      # row instead — see `comparer.select-line`) and by the non-interactive CLI/MCP
+      # `compare` output, where no keypress applies at all.
+
       # The head, a blank separator, then the body — each split into rstripped lines.
       # A BINARY body (NUL in its prefix) is shown as a one-line placeholder, never as
       # text: rendering raw non-UTF-8 bytes here (Comparer + the Repeater response diff)
@@ -31,7 +36,7 @@ module Gori
         if b && !b.empty?
           lines << ""
           if binary?(b)
-            lines << "— binary body (#{b.size} bytes) — not shown as text; press x for the hex view —"
+            lines << "— binary body (#{b.size} bytes) — not shown as text —"
           else
             lines.concat(bytes_to_lines(b))
           end

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -2819,12 +2819,12 @@ module Gori::Tui
       # bytes as UTF-8 and rendering them yields garbage AND — worse — the accidental
       # wide/emoji graphemes among the bytes desync the terminal's cursor tracking, so
       # the diff-renderer leaves stray glyphs it can never reach (the reported "잔상").
-      # Show a placeholder and point at the byte-exact hex view (x), like Burp/mitmproxy.
+      # Show a placeholder and point at the byte-exact hex view (^X), like Burp/mitmproxy.
       if (b = src) && !b.empty? && binary_body?(b)
         head_lines = Highlight.message_windowed(head, nil, request).head
         head_lines << Highlight::Line.new
         head_lines << [Highlight::Span.new(
-          "— binary body (#{Fmt.size(b.size.to_i64)}) — not shown as text; press x for the hex view —", Theme.muted)]
+          "— binary body (#{Fmt.size(b.size.to_i64)}) — not shown as text; press ^X for the hex view —", Theme.muted)]
         return DetailView.new(head_lines, EMPTY_BODY, :text, trailer, binary: true)
       end
       # Pretty-print AFTER decode (so JSON/XML/… are reflowed from the decoded bytes),


### PR DESCRIPTION
## Summary
- History's binary-body placeholder said "press x for the hex view" but the hex toggle verb (`history.hex`) is bound to Ctrl-X (`^X`), matching the `^X:hex` chip already drawn elsewhere in the same view.
- The same placeholder string is shared (via `Repeater::MessageLines.of`) by the Comparer tab and the CLI/MCP `compare` output. Comparer has no hex view at all, and `x` there is already bound to a different action (`comparer.select-line`, selecting the diff row); CLI/MCP output isn't interactive. So that shared copy drops the false keypress instruction instead of naming a key.

## Test plan
- [x] `crystal build --no-codegen src/main.cr` passes