### PR TITLE
Fix stale message_lines spec after dropping the "press x" hint

### DIFF
--- a/spec/repeater/message_lines_spec.cr
+++ b/spec/repeater/message_lines_spec.cr
@@ -32,8 +32,8 @@ describe Gori::Repeater::MessageLines do
     lines = MessageLines.of(head, body, decode: false)
     lines[0].should eq("HTTP/1.1 200 OK")
     lines[1].should eq("")
-    lines[2].should contain("binary body")
-    lines[2].should contain("press x") # never the raw bytes (which desync the terminal)
+    lines[2].should contain("binary body") # never the raw bytes (which desync the terminal)
+    lines[2].should_not contain("press") # shared by Comparer/CLI/MCP, which have no hex view
   end
 
   it "scrubs stray non-UTF-8 bytes in an otherwise-text body (no wide-grapheme desync)" do

--- a/spec/repeater/message_lines_spec.cr
+++ b/spec/repeater/message_lines_spec.cr
@@ -33,7 +33,7 @@ describe Gori::Repeater::MessageLines do
     lines[0].should eq("HTTP/1.1 200 OK")
     lines[1].should eq("")
     lines[2].should contain("binary body") # never the raw bytes (which desync the terminal)
-    lines[2].should_not contain("press") # shared by Comparer/CLI/MCP, which have no hex view
+    lines[2].should_not contain("press")   # shared by Comparer/CLI/MCP, which have no hex view
   end
 
   it "scrubs stray non-UTF-8 bytes in an otherwise-text body (no wide-grapheme desync)" do

--- a/spec/tui/history_view_spec.cr
+++ b/spec/tui/history_view_spec.cr
@@ -637,7 +637,7 @@ describe Gori::Tui::HistoryView do
       backend.contains?("hex view").should be_true    # points at the hex view
       backend.contains?("RIFF").should be_false       # raw bytes NOT rendered as text
 
-      # The byte-exact hex view is still one keypress away (x).
+      # The byte-exact hex view is still one keypress away (^X).
       view.toggle_detail_hex
       hex = MemoryBackend.new(80, 16)
       view.render_detail(Screen.new(hex), Rect.new(0, 0, 80, 16))


### PR DESCRIPTION
## Summary
- Main's CI is red: `spec/repeater/message_lines_spec.cr:36` still asserted the old `"press x for the hex view"` placeholder text.
- #703 intentionally dropped that instruction from `MessageLines` (Comparer/CLI/MCP `compare` output has no hex view), but the spec wasn't updated to match — breaking `tests (1.20.2)` and `tests (1.21.0)`.
- Also fixed a stray comment in `history_view_spec.cr` still referencing the old `x` binding instead of `^X`.

## Test plan
- [x] `crystal build --no-codegen src/main.cr`
- [x] `crystal spec spec/repeater/message_lines_spec.cr`
- [x] `crystal spec spec/tui/history_view_spec.cr -e "shows a placeholder for a binary response body"`
- [ ] Full `crystal spec` suite (running)