### PR TITLE
ci: require Crystal >= 1.21.0 and drop 1.20 from CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,19 +29,11 @@ on:
 jobs:
   build-crystal:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        # The floor shard.yml declares (`>= 1.20.2`) and the version development
-        # actually happens on. 1.21 is not incidental: the termisu fork and the
-        # ameba master pin in shard.yml exist specifically because upstream does
-        # not compile under it, so leaving 1.21 untested would test a toolchain
-        # nobody uses.
-        crystal-version: [1.20.2, 1.21.0]
     steps:
       - uses: actions/checkout@v6
       - uses: crystal-lang/install-crystal@v1
         with:
-          crystal: ${{ matrix.crystal-version }}
+          crystal: 1.21.0
       - name: Install native link dependencies
         # brotli/zstd are linked via `@[Link(pkg_config:)]` (proxy/codec), sqlite3
         # via the sqlite3 shard. The rest (openssl, yaml, gmp, pcre2, gc, zlib)
@@ -94,9 +86,9 @@ jobs:
       - uses: actions/checkout@v6
       - uses: crystal-lang/install-crystal@v1
         with:
-          # One version, not the build matrix, for the same reason `format` pins one: the
-          # harnesses compile against the same `src` the matrix already builds twice, so a
-          # second version here would re-test the compiler rather than this repo.
+          # One version, for the same reason `format` pins one: the harnesses
+          # compile against the same `src` that `build-crystal` already builds, so
+          # an extra version here would re-test the compiler rather than this repo.
           crystal: 1.21.0
       - name: Install native link dependencies
         run: |
@@ -117,14 +109,11 @@ jobs:
   # always red is a check nobody reads, but one that is green by exclusion is worse.
   tests:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        crystal-version: [1.20.2, 1.21.0]
     steps:
       - uses: actions/checkout@v6
       - uses: crystal-lang/install-crystal@v1
         with:
-          crystal: ${{ matrix.crystal-version }}
+          crystal: 1.21.0
       - name: Install native link dependencies
         run: |
           sudo apt-get update

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ only — please keep contributions aligned with that purpose.
 
 ## Getting set up
 
-Requires [Crystal](https://crystal-lang.org) `>= 1.20.2` and the native libraries used
+Requires [Crystal](https://crystal-lang.org) `>= 1.21.0` and the native libraries used
 for HTTP body decode:
 
 - macOS: `brew install crystal brotli zstd sqlite`

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ nix profile install github:hahwul/gori   # or keep it
 
 ### From source
 
-Requires [Crystal](https://crystal-lang.org/) `>= 1.20.2` and `pkg-config`.
+Requires [Crystal](https://crystal-lang.org/) `>= 1.21.0` and `pkg-config`.
 
 ```bash
 git clone https://github.com/hahwul/gori.git

--- a/docs/content/getting-started/installation.ko.md
+++ b/docs/content/getting-started/installation.ko.md
@@ -168,7 +168,7 @@ sudo ln -sf /usr/local/opt/gori/gori /usr/local/bin/gori
 
 ### 사전 요구 사항 {#prerequisites}
 
-- **Crystal** `>= 1.20.2`
+- **Crystal** `>= 1.21.0`
 - **pkg-config**
 - 리포지터리를 클론할 **Git**
 

--- a/docs/content/getting-started/installation.md
+++ b/docs/content/getting-started/installation.md
@@ -168,7 +168,7 @@ sudo ln -sf /usr/local/opt/gori/gori /usr/local/bin/gori
 
 ### Prerequisites
 
-- **Crystal** `>= 1.20.2`
+- **Crystal** `>= 1.21.0`
 - **pkg-config**
 - **Git**, to clone the repository
 

--- a/flake.nix
+++ b/flake.nix
@@ -17,10 +17,10 @@
         inherit (pkgs) lib;
 
         # nixpkgs still ships Crystal 1.19.1, which is below shard.yml's
-        # `crystal: '>= 1.20.2'` and does not compile gori: src/gori/proxy/
+        # `crystal: '>= 1.21.0'` and does not compile gori: src/gori/proxy/
         # socket_tuning.cr reopens OpenSSL::SSL::Socket to reach `#bio`, which only
         # exists from 1.20 on. So pin the version gori's CI builds with instead.
-        # Delete this override (and use pkgs.crystal) once nixpkgs is >= 1.20.2.
+        # Delete this override (and use pkgs.crystal) once nixpkgs is >= 1.21.0.
         crystalVersion = "1.21.0";
         crystal = pkgs.crystal_1_19.overrideAttrs (old: {
           version = crystalVersion;

--- a/shard.yml
+++ b/shard.yml
@@ -8,7 +8,7 @@ targets:
   gori:
     main: src/main.cr
 
-crystal: '>= 1.20.2'
+crystal: '>= 1.21.0'
 
 license: Apache-2.0
 


### PR DESCRIPTION
## Description

- Update `.github/workflows/ci.yml` to drop Crystal 1.20 and run jobs (`build-crystal`, `tests`, `format`, `benchmarks`) on Crystal 1.21.0.
- Update minimum Crystal requirement to `>= 1.21.0` in `shard.yml`, `README.md`, `CONTRIBUTING.md`, `docs/`, and `flake.nix`.