### PR TITLE
fix(cli): refuse silent leftover mutations and other gori run honesty bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- `gori run`: leftover reserved verbs after a leading `--project`/`--db` no longer silently list or scan (session, history, probe, colormarker color, sitemap tag); `history clear --yes 42` no longer wipes the project; extra ids on one-target deletes abort; `--query` dotted negations and OR-grouping with a trailing `-path:` work as documented; `--bind-from`/`--slot` hydrate when `--request` is the template; `oast listen` deregisters on stop; a second Ctrl-C during a sweep exits 130; capture Ctrl-C exits 130; `probe rules delete` and `oast release` report a failed write
 - Authorize: a new tab that replays a captured request under a set of identities and reads each response against a baseline, to find broken access control. Identities are header overlays saved with the project, `p` turns on passive replay of what the browser touches, and the same plan drives `gori run authorize` and the MCP tools (#707, #710)
 - Fuzzer: a Race condition (last-byte-sync) attack mode over HTTP/1.1 — N connections held at the final byte and released together — on all three surfaces, with an optional warm-up (#705)
 - Scope: a regex EXCLUDE rule no longer fails **open** on a target that is not valid UTF-8 — it scrubbed nothing and `rescue false` read as "does not match", which is scope evasion. The History/Sitemap SQL lens also now agrees with the live gate on bracketed IPv6 hosts, brace globs and non-ASCII case (#688, #699)

--- a/spec/cli/run/argv_non_utf8_spec.cr
+++ b/spec/cli/run/argv_non_utf8_spec.cr
@@ -51,4 +51,11 @@ describe "CLI::Run.split_ql_negations — non-UTF-8 argv" do
     neg.should eq(["-path:/b"])
     rest.should eq(["host:x", "-n50", "-k"])
   end
+
+  it "classifies a dotted-field negation as a QL term, not an unknown option" do
+    neg, rest = Gori::CLI::Run.split_ql_negations_for_spec(
+      ["host:x", "-resp.body:secret", "-req.header:Cookie", "-n50"])
+    neg.should eq(["-resp.body:secret", "-req.header:Cookie"])
+    rest.should eq(["host:x", "-n50"])
+  end
 end

--- a/spec/cli/run/list_leftovers_spec.cr
+++ b/spec/cli/run/list_leftovers_spec.cr
@@ -72,4 +72,30 @@ describe Gori::CLI::Run do
       msg.should contain("Verbs: add, update, delete/rm, list")
     end
   end
+
+  describe ".reserved_query_verb_error" do
+    it "proceeds for a positional QL term" do
+      Gori::CLI::Run.reserved_query_verb_error(["host:x"], "history",
+        ["delete", "rm", "clear", "show"], "delete/rm, clear, show").should be_nil
+    end
+
+    it "proceeds when there is no leftover" do
+      Gori::CLI::Run.reserved_query_verb_error([] of String, "history",
+        ["delete", "rm", "clear", "show"], "delete/rm, clear, show").should be_nil
+    end
+
+    it "refuses a discarded mutation verb and names the ordering that works" do
+      msg = Gori::CLI::Run.reserved_query_verb_error(["delete", "42"], "history",
+        ["delete", "rm", "clear", "show"], "delete/rm, clear, show")
+      msg.should eq("gori run history: unknown subcommand 'delete' — global flags go AFTER " \
+                    "the subcommand (`gori run history delete … --project=NAME`). Verbs: delete/rm, clear, show")
+    end
+
+    it "refuses probe's reserved scan-dispatcher verbs" do
+      msg = Gori::CLI::Run.reserved_query_verb_error(["dismiss", "5"], "probe",
+        ["issues", "dismiss", "promote", "delete", "rm", "rules", "mode"],
+        "issues, dismiss, promote, delete/rm, rules, mode")
+      msg.not_nil!.should contain("unknown subcommand 'dismiss'")
+    end
+  end
 end

--- a/spec/cli/run/repeater_headers_spec.cr
+++ b/spec/cli/run/repeater_headers_spec.cr
@@ -1,5 +1,13 @@
 require "../../spec_helper"
 
+module Gori::CLI::Run
+  def self.build_single_flow_request_for_spec(head : Bytes, body : Bytes, headers : Array(String),
+                                              body_override : String?, target_override : String?,
+                                              removed : Array(String) = [] of String) : {Bytes, Bool}
+    build_single_flow_request(head, body, headers, body_override, target_override, removed)
+  end
+end
+
 # `gori run repeater <flow-id>` header editing: `-H` and `--rm-header`.
 #
 # The two shapes pinned here are ones an operator testing a target's header handling has to

--- a/spec/cli/run/repeater_result_json_spec.cr
+++ b/spec/cli/run/repeater_result_json_spec.cr
@@ -64,6 +64,8 @@ describe "gori run repeater --format json — a lossy response head" do
     j["head"].as_s.should contain("HTTP/2 200")
     j["body"]["text"].as_s.should eq(%({"partial":))
     j["incomplete"].as_bool.should be_true
+    j["body"]["truncated"].as_bool.should be_true
+    j["body"]["wire_truncated"].as_bool.should be_true
   end
 end
 

--- a/spec/cli/run/session_spec.cr
+++ b/spec/cli/run/session_spec.cr
@@ -179,7 +179,7 @@ describe "gori run — --slot ordering" do
 
   it "offers --slot on every command that sends" do
     root = File.join(__DIR__, "..", "..", "..", "src", "gori", "cli", "run")
-    {"fuzz", "mine", "sequence", "discover", "repeater"}.each do |cmd|
+    {"fuzz", "mine", "sequence", "discover", "repeater", "repeater_minimize"}.each do |cmd|
       File.read(File.join(root, "#{cmd}.cr")).should contain("--slot=NAME")
     end
   end

--- a/spec/cli/run_spec.cr
+++ b/spec/cli/run_spec.cr
@@ -979,7 +979,7 @@ end
 describe "CLI::Run.compose_history_query" do
   it "ANDs negation terms into an explicit --query instead of dropping them" do
     q, dropped = Gori::CLI::Run.compose_history_query("host:x", [] of String, ["-path:/b"])
-    q.should eq("host:x -path:/b")
+    q.should eq("(host:x) -path:/b")
     dropped.should be_nil
   end
 
@@ -999,8 +999,14 @@ describe "CLI::Run.compose_history_query" do
 
   it "ANDs negations AND reports the swallowed positional when both are present" do
     q, dropped = Gori::CLI::Run.compose_history_query("host:x", ["status:404"], ["-path:/b", "-method~PO"])
-    q.should eq("host:x -path:/b -method~PO")
+    q.should eq("(host:x) -path:/b -method~PO")
     dropped.should eq("status:404")
+  end
+
+  it "parenthesizes --query so a trailing negation cannot bind only the last OR arm" do
+    q, dropped = Gori::CLI::Run.compose_history_query("host:a OR host:b", [] of String, ["-path:/admin"])
+    q.should eq("(host:a OR host:b) -path:/admin")
+    dropped.should be_nil
   end
 
   it "joins positionals and negations when there is no --query (unchanged)" do

--- a/spec/oast/sessions_spec.cr
+++ b/spec/oast/sessions_spec.cr
@@ -192,8 +192,9 @@ describe Gori::Oast::Sessions do
           "q".to_slice, nil, Time.utc.to_unix_ms * 1000)
         store.flush
         bound = O::Sessions.bind(store, id, [] of O::ProviderConfig).as(O::Sessions::Bound)
-        # Never raises: a release runs during teardown, where an error is noise.
-        O::Sessions.release(bound, ExplodingHttp.new)
+        # Returns false rather than raising: a release can run during teardown, where an
+        # exception is noise, but the CLI still needs to know it failed.
+        O::Sessions.release(bound, ExplodingHttp.new).should be_false
         # This releases the LISTENER, not the evidence.
         store.oast_sessions.map(&.id).should contain(id)
         store.oast_callback_count(id).should eq(1)

--- a/src/gori/app.cr
+++ b/src/gori/app.cr
@@ -253,7 +253,9 @@ module Gori
     # capture is the whole point here), streams one line per completed/errored flow
     # (`:text` = the legacy format, `:json` = JSON-Lines), and runs until INT/TERM,
     # an optional wall-clock `every` duration, or an optional completed-flow `max`.
-    def run_capture(project : Project, format : Symbol, max : Int32?, every : Time::Span?) : Nil
+    # Returns true when shutdown came from INT/TERM (caller should exit 130), false
+    # when `--for` / `--max` ended the run on purpose.
+    def run_capture(project : Project, format : Symbol, max : Int32?, every : Time::Span?) : Bool
       setup_logging(STDERR)
       session =
         begin
@@ -272,7 +274,8 @@ module Gori
       print_banner(session)
       spawn { capture_printer(session, format, max) }
       reload_stop = spawn_reload_loop(session)
-      install_signal_traps
+      signaled = false
+      install_signal_traps { signaled = true }
       if span = every
         # Wall-clock terminator: nudge the same shutdown channel the signal traps use.
         spawn do
@@ -286,6 +289,7 @@ module Gori
       # to make no further store calls — safe to close the store right after.
       reload_stop.send(nil) rescue nil
       session.close
+      signaled
     end
 
     # `{outcome, error}`. `outcome` is :quit (leave gori) or :back (return to the picker);
@@ -447,8 +451,8 @@ module Gori
     # buffered send from the signal fiber wakes it and the normal teardown (reload fiber stop,
     # then session.close) runs on the real stack. The interactive TUI cannot use this shape —
     # see SignalGuard.
-    private def install_signal_traps : Nil
-      CAPTURE_SIGNALS.each { |sig| sig.trap { @shutdown.send(nil) rescue nil } }
+    private def install_signal_traps(&on_signal : ->) : Nil
+      CAPTURE_SIGNALS.each { |sig| sig.trap { on_signal.call; @shutdown.send(nil) rescue nil } }
     end
 
     private def setup_logging(io : IO) : Nil

--- a/src/gori/cli/run.cr
+++ b/src/gori/cli/run.cr
@@ -708,7 +708,17 @@ module Gori
       def self.compose_history_query(query : String?, positional : Array(String),
                                      neg_terms : Array(String)) : {String?, String?}
         if q = query
-          combined = neg_terms.empty? ? q : ([q] + neg_terms).join(' ')
+          # Parenthesize the flag value when a negation is appended. QL is
+          # `NOT > AND > OR`, so `host:a OR host:b -path:/admin` is
+          # `host:a OR (host:b AND NOT path:/admin)` — every `/admin` hit on host
+          # `a` stays, which is the silently BROADER set this helper exists to
+          # prevent. AND-only `--query` is unchanged in meaning: `(host:x) -path:/b`
+          # is the same filter as `host:x -path:/b`.
+          combined = if neg_terms.empty?
+                       q
+                     else
+                       "(#{q}) #{neg_terms.join(' ')}"
+                     end
           {combined, positional.empty? ? nil : positional.join(' ')}
         else
           pq = (positional + neg_terms).join(' ')
@@ -765,7 +775,11 @@ module Gori
         # ArgumentError. Same remedy as `read_token_list` in ./run/sequence.cr. `scrub` returns
         # self for valid UTF-8, and it is `a` (not `a.scrub`) that is kept, so the operator's
         # query bytes reach QL exactly as typed.
-        args.each { |a| a.scrub.matches?(/\A-[A-Za-z]+[:~]/) ? (neg << a) : (rest << a) }
+        # Dotted field names (`-resp.body:x`, `-req.header:Cookie`) are the documented
+        # QL spelling. `[A-Za-z]+` stops at the first `.`, so those stayed in argv and
+        # OptionParser aborted them as unknown options — the positional form the
+        # splitter was written for, and the one the TUI bar / docs teach.
+        args.each { |a| a.scrub.matches?(/\A-[A-Za-z]+(?:\.[A-Za-z]+)*[:~]/) ? (neg << a) : (rest << a) }
         {neg, rest}
       end
 
@@ -837,6 +851,18 @@ module Gori
         "the subcommand (`gori run #{sub} #{leftover[0]} … --project=NAME`). Verbs: #{verbs}"
       end
 
+      # History / probe / sitemap take a positional QL, so `refuse_list_leftovers` cannot sit
+      # on their list/scan command — `history host:x` is the operator's filter. A leftover
+      # that IS a reserved verb is still the flag-before-verb discard: `history --project=X
+      # delete 42` listed instead of deleting, `probe --project=X dismiss 5` scanned with
+      # the free-text `dismiss 5`. Same sentence as `list_leftover_error`.
+      def self.reserved_query_verb_error(leftover : Array(String), sub : String,
+                                         reserved : Array(String), verbs : String) : String?
+        first = leftover.first?
+        return nil unless first && reserved.includes?(first)
+        list_leftover_error(leftover, sub, verbs)
+      end
+
       private def self.take_flow_id(rest : Array(String), sub : String) : Int64
         abort "gori run #{sub}: missing <flow-id>" if rest.empty?
         abort "gori run #{sub}: too many arguments (expected one <flow-id>, got: #{rest.join(" ")})" if rest.size > 1
@@ -872,6 +898,14 @@ module Gori
         # ArgumentError. Treat an out-of-range duration as a clean usage error.
         n = m[1].to_i? || abort("gori run: --for '#{v}' is out of range")
         abort "gori run: --for must be greater than 0 (got '#{v}')" if n == 0
+        # `n.hours` / `n.minutes` build a Span in nanoseconds. An Int32-fitting value
+        # like 2562048h still overflows Int64 and wraps to a tiny/negative sleep.
+        unit_ns = case m[2]?
+                  when "m" then 60_000_000_000_i64
+                  when "h" then 3_600_000_000_000_i64
+                  else          1_000_000_000_i64
+                  end
+        abort "gori run: --for '#{v}' is out of range" if n.to_i64 > Int64::MAX // unit_ns
         case m[2]?
         when "m" then n.minutes
         when "h" then n.hours

--- a/src/gori/cli/run/authorize.cr
+++ b/src/gori/cli/run/authorize.cr
@@ -84,6 +84,10 @@ module Gori
         # (`outbound` keeps its OWN connection open on purpose: that is what lets a mid-run
         # scope/Sandbox change stop an in-flight sweep.)
         store.close
+        if query && (plan.targets.size + plan.skipped.size) >= limit
+          STDERR.puts "gori run authorize: --query was capped at --limit #{limit} — " \
+                      "matching flows past that were not replayed (raise --limit to include them)"
+        end
         begin
           run_authorize(plan, format)
         ensure
@@ -102,10 +106,6 @@ module Gori
         ids = plan.identities.size
         STDERR.puts "authorizing #{total} request#{total == 1 ? "" : "s"} × #{ids} identities " \
                     "(#{plan.identities.map(&.name).join(", ")}) = #{plan.total_sends} requests"
-        if query && (plan.targets.size + plan.skipped.size) >= limit
-          STDERR.puts "gori run authorize: --query was capped at --limit #{limit} — " \
-                      "matching flows past that were not replayed (raise --limit to include them)"
-        end
         report_authorize_skips(plan.skipped)
 
         buffered = [] of Authorize::Target

--- a/src/gori/cli/run/authorize.cr
+++ b/src/gori/cli/run/authorize.cr
@@ -102,6 +102,10 @@ module Gori
         ids = plan.identities.size
         STDERR.puts "authorizing #{total} request#{total == 1 ? "" : "s"} × #{ids} identities " \
                     "(#{plan.identities.map(&.name).join(", ")}) = #{plan.total_sends} requests"
+        if query && (plan.targets.size + plan.skipped.size) >= limit
+          STDERR.puts "gori run authorize: --query was capped at --limit #{limit} — " \
+                      "matching flows past that were not replayed (raise --limit to include them)"
+        end
         report_authorize_skips(plan.skipped)
 
         buffered = [] of Authorize::Target

--- a/src/gori/cli/run/capture.cr
+++ b/src/gori/cli/run/capture.cr
@@ -45,7 +45,8 @@ module Gori
         project = resolve_capture_project(project_name, db_path)
         config = Config.new(listen, port, project.db_path, Paths.default_ca_dir,
           insecure_upstream: insecure)
-        App.new(config).run_capture(project, format: format, max: max, every: every)
+        signaled = App.new(config).run_capture(project, format: format, max: max, every: every)
+        exit 130 if signaled
       end
     end
   end

--- a/src/gori/cli/run/colormarker.cr
+++ b/src/gori/cli/run/colormarker.cr
@@ -47,16 +47,19 @@ module Gori
 
       private def self.cmd_colormarker_color_list(args : Array(String)) : Nil
         format = :text
+        leftover = [] of String
         parser = OptionParser.new do |p|
           p.banner = "Usage: gori run colormarker color list [--format=text|json]\n\n" \
                      "The GLOBAL custom colours, offered in every project's picker alongside the\n" \
                      "six built-ins. A built-in tracks the active theme; a custom is an absolute hex."
-          p.on("--format=FMT", "text (default) | json") { |v| format = v == "json" ? :json : :text }
+          p.on("--format=FMT", "text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
+          p.unknown_args { |before, after| leftover = before + after }
           p.invalid_option { |f| abort "gori run colormarker color list: unknown option: #{f}\n#{p}" }
           p.missing_option { |f| abort "gori run colormarker color list: missing value for #{f}" }
         end
         parser.parse(args)
+        refuse_list_leftovers(leftover, "colormarker color", "add, update/edit, rm/delete, list")
         colors = Settings.colormarker_colors
         if format == :json
           puts(JSON.build do |j|
@@ -263,7 +266,7 @@ module Gori
           p.on("--project=NAME", "Project to read (default: most-recently-active)") { |v| project_name = v }
           p.on("--db=PATH", "Explicit SQLite db file to read") { |v| db_path = v }
           p.on("--scope=SCOPE", "Show only project | global rules") { |v| scope = parse_color_scope(v) }
-          p.on("--format=FMT", "text (default) | json") { |v| format = v == "json" ? :json : :text }
+          p.on("--format=FMT", "text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
           p.invalid_option { |f| abort "gori run colormarker: unknown option: #{f}\n#{p}" }
           p.missing_option { |f| abort "gori run colormarker: missing value for #{f}" }
@@ -272,7 +275,7 @@ module Gori
         # silently and a typo'd subcommand would list instead of erroring.
         parser.unknown_args { |before, after| leftover = before + after }
         parser.parse(args)
-        refuse_list_leftovers(leftover, "colormarker", "add, rm/delete, enable, disable, move, preview")
+        refuse_list_leftovers(leftover, "colormarker", "add, rm/delete, enable, disable, move, preview, color")
 
         project = resolve_read_project(project_name, db_path)
         store = open_store(project)
@@ -557,8 +560,8 @@ module Gori
           p.on("--project=NAME", "Project to read (default: most-recently-active)") { |v| project_name = v }
           p.on("--db=PATH", "Explicit SQLite db file to read") { |v| db_path = v }
           p.on("-wFILTER", "--when=FILTER", "Condition to test (required)") { |v| filter = v }
-          p.on("--limit=N", "Recent flows to scan (default #{Colormarker::PREVIEW_SCAN})") { |v| limit = v.to_i? || limit }
-          p.on("--format=FMT", "text (default) | json") { |v| format = v == "json" ? :json : :text }
+          p.on("--limit=N", "Recent flows to scan (default #{Colormarker::PREVIEW_SCAN})") { |v| limit = parse_count(v, "--limit") }
+          p.on("--format=FMT", "text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
           p.invalid_option { |f| abort "gori run colormarker preview: unknown option: #{f}\n#{p}" }
           p.missing_option { |f| abort "gori run colormarker preview: missing value for #{f}" }

--- a/src/gori/cli/run/decoder.cr
+++ b/src/gori/cli/run/decoder.cr
@@ -50,13 +50,15 @@ module Gori
           puts decoder_json(result, output_mode)
         else
           if final_bytes = result.output
-            rendered, _ = Decoder.display(final_bytes, output_mode)
-            # Decoder input is routinely attacker-controlled captured traffic (base64/hex/
-            # gzip blobs); an auto/text render of a decoded ANSI/OSC escape would otherwise
-            # write raw control bytes to the live terminal. Neutralize them like every other
-            # captured-text view (run.cr#print_message_text). --format json and --output
-            # hex/base64 stay byte-exact for scripts.
-            STDOUT.puts CLI::Output.term_safe_multiline(rendered)
+            rendered, render = Decoder.display(final_bytes, output_mode)
+            # Neutralize ANSI/OSC on a live terminal for auto/text. A pipe or an explicit
+            # hex/base64 render stays byte-exact — the default job of this command is
+            # "give me the decoded bytes".
+            if STDOUT.tty? && render.text?
+              STDOUT.puts CLI::Output.term_safe_multiline(rendered)
+            else
+              STDOUT.puts rendered
+            end
           end
           report_convert_failure(result) unless result.ok?
         end

--- a/src/gori/cli/run/discover.cr
+++ b/src/gori/cli/run/discover.cr
@@ -31,6 +31,7 @@ module Gori
         no_store = false
         format = :text
         headers = [] of String
+        leftover = [] of String
 
         parser = OptionParser.new do |p|
           p.banner = "Usage: gori run discover --target URL [options]"
@@ -61,10 +62,16 @@ module Gori
           p.on("--no-store", "Do not write findings into the project (Sitemap)") { no_store = true }
           p.on("--format=FMT", "Output: text (default) | json | jsonl") { |v| format = parse_format(v, [:text, :json, :jsonl]) }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
+          p.unknown_args { |before, after| leftover = before + after }
           p.invalid_option { |f| abort "gori run discover: unknown option: #{f}\n#{p}" }
           p.missing_option { |f| abort "gori run discover: missing value for #{f}" }
         end
         parser.parse(args)
+        if leftover.size == 1 && target_override.nil?
+          target_override = leftover[0]
+        elsif !leftover.empty?
+          abort "gori run discover: unexpected argument#{leftover.size == 1 ? "" : "s"} #{leftover.join(" ").inspect} — pass the seed as --target URL"
+        end
 
         # The two checks that read ONLY the flags, made before the project is resolved. The
         # builder makes them too and is the authority — but `--db PATH` is create-or-reopened

--- a/src/gori/cli/run/fuzz.cr
+++ b/src/gori/cli/run/fuzz.cr
@@ -124,9 +124,14 @@ module Gori
         parser.parse(args)
 
         abort "gori run fuzz: too many arguments (expected at most one <flow-id>)" if positional.size > 1
+        abort "gori run fuzz: --request and --flow cannot be combined — pick one template source" if request_file && flow_id
+        abort "gori run fuzz: <flow-id> and --flow/--request cannot be combined" if positional.size == 1 && (flow_id || request_file)
         flow_id ||= positional.first?.try { |s| parse_flow_id(s, "gori run fuzz") }
 
-        hydrate_project_env(project_name, db_path) if (project_name || db_path) && flow_id.nil?
+        # Named project / --db always hydrates, even when `--request` is the template:
+        # `--flow` used to skip this and `--request` then skipped `open_store`, so
+        # `--slot` / `--bind-from` lied with SLOT_NO_PROJECT despite `--project`.
+        hydrate_project_env(project_name, db_path) if project_name || db_path
         text, default_target, src_h2, evidence = fuzz_source(flow_id, request_file, project_name, db_path)
         http2 = force_h2 || src_h2
 

--- a/src/gori/cli/run/fuzz_args.cr
+++ b/src/gori/cli/run/fuzz_args.cr
@@ -18,6 +18,7 @@ module Gori
         to = m.try(&.[2].to_i64?)
         abort "gori run fuzz: invalid --numbers '#{v}' (use FROM-TO[:STEP])" unless from && to
         step = step_part.empty? ? 1_i64 : (step_part.to_i64? || abort("gori run fuzz: invalid --numbers step '#{step_part}'"))
+        abort "gori run fuzz: --numbers step must not be 0" if step == 0
         Fuzz::NumberRange.new(from, to, step)
       end
 
@@ -37,6 +38,7 @@ module Gori
         min = min_s.to_i?
         max = max_s.empty? ? min : max_s.to_i?
         abort "gori run fuzz: invalid --brute lengths '#{lens}' (use MIN-MAX)" unless min && max
+        abort "gori run fuzz: --brute MIN (#{min}) is greater than MAX (#{max})" if min > max
         Fuzz::BruteForce.new(charset, min, max)
       end
 

--- a/src/gori/cli/run/history.cr
+++ b/src/gori/cli/run/history.cr
@@ -61,6 +61,7 @@ module Gori
         db_path : String? = nil
         project_name : String? = nil
         yes = false
+        leftover = [] of String
 
         parser = OptionParser.new do |p|
           p.banner = "Usage: gori run history clear --yes\n\n" \
@@ -69,10 +70,16 @@ module Gori
           p.on("--db=PATH", "Explicit SQLite db file to update") { |v| db_path = v }
           p.on("--yes", "Actually do it (required — there is no interactive prompt here)") { yes = true }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
+          p.unknown_args { |before, after| leftover = before + after }
           p.invalid_option { |f| abort "gori run history clear: unknown option: #{f}\n#{p}" }
           p.missing_option { |f| abort "gori run history clear: missing value for #{f}" }
         end
         parser.parse(args)
+        unless leftover.empty?
+          abort "gori run history clear: unexpected argument#{leftover.size == 1 ? "" : "s"} " \
+                "#{leftover.join(" ").inspect} — this deletes ALL flows, not those ids. " \
+                "To delete one flow: `gori run history delete <id>`"
+        end
 
         store = open_store(resolve_read_project(project_name, db_path))
         begin
@@ -114,6 +121,13 @@ module Gori
         args = normalize_query_flag(args)
         neg_terms, opt_args = split_ql_negations(args)
         parser.parse(opt_args)
+        # `--project=X delete 42` lands here because the dispatcher keys on args.first?.
+        # `delete` is not QL; it is the discarded verb. Refuse it rather than search
+        # for the free-text "delete 42" and exit 0 with the flow still on disk.
+        if err = Run.reserved_query_verb_error(positional, "history",
+             ["delete", "rm", "clear", "show"], "delete/rm, clear, show")
+          abort err
+        end
         # Accept a positional QL too ("gori run history status:404" / "-status:404"),
         # mirroring the TUI's `/` bar — otherwise a positional query was silently dropped
         # and EVERY flow dumped.

--- a/src/gori/cli/run/interrupt.cr
+++ b/src/gori/cli/run/interrupt.cr
@@ -28,19 +28,32 @@ module Gori
       def self.install_interrupt_trap(fiber_name : String, notice : String,
                                       &stop : -> Nil) : -> Bool
         interrupted = false
+        seen = false
         shutdown = Channel(Nil).new(1)
-        Signal::INT.trap { shutdown.send(nil) rescue nil }
-        Signal::TERM.trap { shutdown.send(nil) rescue nil }
+        # Escalate on the SECOND signal inside the trap, not after `stop` returns. The
+        # previous second `receive` sat behind `stop.call`, so a drain blocked on
+        # in-flight retries never reached it; a third `send` then blocked inside the
+        # trap (capacity-1 channel, `send` waits rather than raising) and INT/TERM
+        # stayed trapped — SIGKILL was the only way out, the failure this helper's
+        # header says it exists to close.
+        escalate = -> {
+          if seen
+            STDERR.puts "\ninterrupted again — exiting without finishing"
+            exit 130
+          end
+          seen = true
+          select
+          when shutdown.send(nil)
+          else
+          end
+        }
+        Signal::INT.trap { escalate.call }
+        Signal::TERM.trap { escalate.call }
         spawn(name: fiber_name) do
           shutdown.receive
           interrupted = true
           STDERR.puts "\n#{notice}"
           stop.call
-          # Still parked here on the happy path — the process exits right after the command
-          # returns, so the fiber goes with it.
-          shutdown.receive
-          STDERR.puts "\ninterrupted again — exiting without finishing"
-          exit 130
         end
         -> { interrupted }
       end

--- a/src/gori/cli/run/issues.cr
+++ b/src/gori/cli/run/issues.cr
@@ -147,6 +147,7 @@ module Gori
         end
         parser.parse(args)
 
+        abort "gori run issues delete: too many arguments (expected one <id>, got: #{positional.join(" ")})" if positional.size > 1
         id_s = positional.first? || abort("gori run issues delete: <id> is required")
         id = id_s.to_i64? || abort("gori run issues delete: invalid issue id #{id_s.inspect}")
 

--- a/src/gori/cli/run/mine.cr
+++ b/src/gori/cli/run/mine.cr
@@ -62,13 +62,15 @@ module Gori
         parser.parse(args)
 
         abort "gori run mine: too many arguments (expected at most one <flow-id>)" if positional.size > 1
+        abort "gori run mine: --request and --flow cannot be combined — pick one template source" if request_file && flow_id
+        abort "gori run mine: <flow-id> and --flow/--request cannot be combined" if positional.size == 1 && (flow_id || request_file)
         flow_id ||= positional.first?.try { |s| parse_flow_id(s, "gori run mine") }
 
         # Load the named project's env vars so `$VAR` in a --request/stdin body resolves the
         # same way it does for a flow (whose read already hydrates them via open_store).
-        # Explicit, as in cmd_fuzz: it used to fall out of cli_host_overrides opening a
-        # store, and that helper ends in `rescue; nil`.
-        hydrate_project_env(project_name, db_path) if (project_name || db_path) && flow_id.nil?
+        # Always, not only when `flow_id` is nil: `--request` + `--flow` used to skip
+        # this and then skip `open_store`, so `--slot` lied about no project.
+        hydrate_project_env(project_name, db_path) if project_name || db_path
         text, default_target, src_h2, evidence = mine_source(flow_id, request_file, project_name, db_path)
 
         config = Miner::Config.new

--- a/src/gori/cli/run/notes.cr
+++ b/src/gori/cli/run/notes.cr
@@ -186,7 +186,7 @@ module Gori
           doc.texts.each_with_index do |text, i|
             puts "" if i > 0
             puts "=== note #{i + 1}: #{CLI::Output.note_label(i, text)}#{doc.cur == i ? " *" : ""} ==="
-            STDOUT.puts text
+            STDOUT.puts Issues::Export.scrub_controls(text)
           end
         end
       end

--- a/src/gori/cli/run/oast.cr
+++ b/src/gori/cli/run/oast.cr
@@ -268,18 +268,20 @@ module Gori
         verb = enabled ? "enable" : "disable"
         db_path : String? = nil
         project_name : String? = nil
-        id : String? = nil
+        leftover = [] of String
 
         parser = OptionParser.new do |p|
           p.banner = "Usage: gori run oast providers #{verb} <id>"
           p.on("--project=NAME", "Project to update (default: most-recently-active)") { |v| project_name = v }
           p.on("--db=PATH", "Explicit SQLite db file to update") { |v| db_path = v }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
-          p.unknown_args { |before, after| id = (before + after).first? }
+          p.unknown_args { |before, after| leftover = before + after }
           p.invalid_option { |f| abort "gori run oast providers #{verb}: unknown option: #{f}\n#{p}" }
           p.missing_option { |f| abort "gori run oast providers #{verb}: missing value for #{f}" }
         end
         parser.parse(args)
+        abort "gori run oast providers #{verb}: too many arguments (expected one <id>, got: #{leftover.join(" ")})" if leftover.size > 1
+        id = leftover.first?
 
         store = open_store(resolve_read_project(project_name, db_path))
         begin
@@ -294,18 +296,20 @@ module Gori
       private def self.cmd_oast_provider_delete(args : Array(String)) : Nil
         db_path : String? = nil
         project_name : String? = nil
-        id : String? = nil
+        leftover = [] of String
 
         parser = OptionParser.new do |p|
           p.banner = "Usage: gori run oast providers delete <id>"
           p.on("--project=NAME", "Project to update (default: most-recently-active)") { |v| project_name = v }
           p.on("--db=PATH", "Explicit SQLite db file to update") { |v| db_path = v }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
-          p.unknown_args { |before, after| id = (before + after).first? }
+          p.unknown_args { |before, after| leftover = before + after }
           p.invalid_option { |f| abort "gori run oast providers delete: unknown option: #{f}\n#{p}" }
           p.missing_option { |f| abort "gori run oast providers delete: missing value for #{f}" }
         end
         parser.parse(args)
+        abort "gori run oast providers delete: too many arguments (expected one <id>, got: #{leftover.join(" ")})" if leftover.size > 1
+        id = leftover.first?
 
         store = open_store(resolve_read_project(project_name, db_path))
         begin
@@ -548,7 +552,7 @@ module Gori
         store = open_store(resolve_read_project(project_name, db_path))
         begin
           bound = oast_bind_session(store, id, "release")
-          Oast::Sessions.release(bound, Oast::HttpClient.new)
+          abort "gori run oast release: could not deregister session ##{id} (provider error) — payloads minted from it may still resolve" unless Oast::Sessions.release(bound, Oast::HttpClient.new)
           puts "released OAST session ##{id} — its #{store.oast_callback_count(id)} callback(s) stay."
         ensure
           store.close
@@ -641,28 +645,38 @@ module Gori
           Signal::TERM.trap { stop.send(nil) rescue nil }
         end
         once_failed = false
-        loop do
-          interactions = begin
-            prov.poll(http, session)
-          rescue ex
-            STDERR.puts "poll error: #{ex.message}"
-            once_failed = true
-            [] of Oast::Interaction
-          end
-          interactions.each do |i|
-            next if seen.includes?(i.unique_id)
-            seen << i.unique_id
-            if json
-              puts Oast::Present.interaction(i, kind.label).to_json
-            else
-              puts "#{i.at.to_rfc3339}  #{i.protocol}\t#{i.method || "-"}\t#{i.source_ip || "-"}\t#{i.full_id}"
+        begin
+          loop do
+            interactions = begin
+              prov.poll(http, session)
+            rescue ex
+              STDERR.puts "poll error: #{ex.message}"
+              once_failed = true
+              [] of Oast::Interaction
             end
-            STDOUT.flush
+            interactions.each do |i|
+              next if seen.includes?(i.unique_id)
+              seen << i.unique_id
+              if json
+                puts Oast::Present.interaction(i, kind.label).to_json
+              else
+                puts "#{i.at.to_rfc3339}  #{i.protocol}\t#{i.method || "-"}\t#{i.source_ip || "-"}\t#{i.full_id}"
+              end
+              STDOUT.flush
+            end
+            break if once
+            break if oast_wait_or_stop(stop, interval.seconds)
           end
-          break if once
-          break if oast_wait_or_stop(stop, interval.seconds)
+        ensure
+          # Help says listen's registration ends with the process. `--once` used to be
+          # the only path that deregistered; Ctrl-C left a live interactsh/BOAST
+          # registration whose payload still resolved with nobody watching.
+          begin
+            prov.deregister(http, session)
+          rescue ex
+            STDERR.puts "gori run oast: deregister failed: #{ex.message}"
+          end
         end
-        prov.deregister(http, session) if once
         # A --once run whose single poll FAILED must not exit 0 — a scripted caller can't
         # otherwise tell "polled, found nothing" from "the poll errored". (#416)
         exit 1 if once && once_failed

--- a/src/gori/cli/run/oast.cr
+++ b/src/gori/cli/run/oast.cr
@@ -490,10 +490,7 @@ module Gori
         # interval sleep swallows Ctrl-C until the next tick. (--once polls exactly once, so it
         # keeps the default Ctrl-C = immediate-exit behavior and installs no trap.)
         stop = Channel(Nil).new(1)
-        unless once
-          Signal::INT.trap { stop.send(nil) rescue nil }
-          Signal::TERM.trap { stop.send(nil) rescue nil }
-        end
+        install_oast_stop_trap(stop) unless once
         once_failed = false
         loop do
           interactions = begin
@@ -533,7 +530,7 @@ module Gori
       private def self.cmd_oast_session_release(args : Array(String)) : Nil
         db_path : String? = nil
         project_name : String? = nil
-        id_arg : String? = nil
+        leftover = [] of String
 
         parser = OptionParser.new do |p|
           p.banner = "Usage: gori run oast release <id>\n\n" \
@@ -542,13 +539,14 @@ module Gori
           p.on("--project=NAME", "Project to read (default: most-recently-active)") { |v| project_name = v }
           p.on("--db=PATH", "Explicit SQLite db file to read") { |v| db_path = v }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
-          p.unknown_args { |before, after| id_arg = (before + after).first? }
+          p.unknown_args { |before, after| leftover = before + after }
           p.invalid_option { |f| abort "gori run oast release: unknown option: #{f}\n#{p}" }
           p.missing_option { |f| abort "gori run oast release: missing value for #{f}" }
         end
         parser.parse(args)
+        abort "gori run oast release: too many arguments (expected one <id>, got: #{leftover.join(" ")})" if leftover.size > 1
 
-        id = oast_session_id(id_arg, "release")
+        id = oast_session_id(leftover.first?, "release")
         store = open_store(resolve_read_project(project_name, db_path))
         begin
           bound = oast_bind_session(store, id, "release")
@@ -640,10 +638,7 @@ module Gori
         # than only at the next tick. (--once polls exactly once and returns, so it keeps the
         # default Ctrl-C = immediate-exit behavior and installs no trap.)
         stop = Channel(Nil).new(1)
-        unless once
-          Signal::INT.trap { stop.send(nil) rescue nil }
-          Signal::TERM.trap { stop.send(nil) rescue nil }
-        end
+        install_oast_stop_trap(stop) unless once
         once_failed = false
         begin
           loop do
@@ -686,6 +681,25 @@ module Gori
       # INT/TERM trap sends to `stop`) so the poll loop breaks promptly, or false on timeout
       # to poll again. Split out both to keep oast_listen readable and to be unit-testable
       # without delivering a real signal.
+      # Second signal exits 130 instead of blocking in a full Channel#send (the
+      # same hole install_interrupt_trap closed). Shared by listen and resume.
+      private def self.install_oast_stop_trap(stop : Channel(Nil)) : Nil
+        stopped = false
+        escalate = -> {
+          if stopped
+            STDERR.puts "\ninterrupted again — exiting without finishing"
+            exit 130
+          end
+          stopped = true
+          select
+          when stop.send(nil)
+          else
+          end
+        }
+        Signal::INT.trap { escalate.call }
+        Signal::TERM.trap { escalate.call }
+      end
+
       private def self.oast_wait_or_stop(stop : Channel(Nil), interval : Time::Span) : Bool
         select
         when stop.receive

--- a/src/gori/cli/run/probe.cr
+++ b/src/gori/cli/run/probe.cr
@@ -89,6 +89,12 @@ module Gori
         # `split_ql_negations` reclassified it out of argv on their behalf.
         query, dropped = Run.compose_history_query(query, positional, neg_terms)
         Run.warn_dropped_query_terms("probe", dropped)
+        # `--project=X delete 5` lands here because reserved verbs are recognised only
+        # as args.first?. `delete 5` is not a QL filter; it is the discarded mutation.
+        if err = Run.reserved_query_verb_error(positional, "probe",
+             PROBE_SUBCOMMANDS.keys.to_a, "issues, dismiss, promote, delete/rm, rules, mode")
+          abort err
+        end
 
         filter : QL::Filter? = nil
         if q = query
@@ -178,6 +184,7 @@ module Gori
         host : String? = nil
         include_closed = false
         format = :text
+        leftover = [] of String
 
         parser = OptionParser.new do |p|
           p.banner = "Usage: gori run probe issues [options]\n\n" \
@@ -192,10 +199,12 @@ module Gori
           p.on("--host=HOST", "Only show findings for this exact host") { |v| host = v }
           p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
+          p.unknown_args { |before, after| leftover = before + after }
           p.invalid_option { |f| abort "gori run probe issues: unknown option: #{f}\n#{p}" }
           p.missing_option { |f| abort "gori run probe issues: missing value for #{f}" }
         end
         parser.parse(args)
+        refuse_list_leftovers(leftover, "probe issues", "dismiss, promote, delete/rm, list")
 
         store = open_store(resolve_read_project(project_name, db_path))
         issues = begin
@@ -238,6 +247,7 @@ module Gori
         end
         parser.parse(args)
 
+        abort "gori run probe dismiss: too many arguments (expected one <id>, got: #{positional.join(" ")})" if positional.size > 1
         id = parse_probe_issue_id(positional.first?, "gori run probe dismiss")
         selectors = [id, code, host].count { |v| !v.nil? }
         if selectors != 1
@@ -283,6 +293,7 @@ module Gori
         end
         parser.parse(args)
 
+        abort "gori run probe promote: too many arguments (expected one <id>, got: #{positional.join(" ")})" if positional.size > 1
         id = parse_probe_issue_id(positional.first?, "gori run probe promote")
         abort "gori run probe promote: <id> is required (see `gori run probe issues`)" unless id
 
@@ -329,6 +340,7 @@ module Gori
         end
         parser.parse(args)
 
+        abort "gori run probe delete: too many arguments (expected one <id>, got: #{positional.join(" ")})" if positional.size > 1
         id = parse_probe_issue_id(positional.first?, "gori run probe delete")
         abort "gori run probe delete: pass <id> or --all" if id.nil? && !all
         abort "gori run probe delete: <id> and --all are mutually exclusive" if id && all
@@ -536,7 +548,7 @@ module Gori
         store = open_store(resolve_read_project(project_name, db_path))
         begin
           abort "gori run probe rules delete: no custom rule with id '#{id}'" unless store.probe_custom_rules.any? { |r| r.id == row_id }
-          store.delete_probe_custom_rule(row_id)
+          abort "gori run probe rules delete: custom rule '#{id}' NOT deleted (project busy)" unless store.delete_probe_custom_rule(row_id)
           puts "Custom rule '#{id}' deleted."
         ensure
           store.close

--- a/src/gori/cli/run/project.cr
+++ b/src/gori/cli/run/project.cr
@@ -576,16 +576,23 @@ module Gori
         db_path : String? = nil
         project_name : String? = nil
         action = enable ? "enable" : "disable"
+        leftover = [] of String
 
         parser = OptionParser.new do |p|
           p.banner = "Usage: gori run project scope #{action} [options]"
           p.on("--project=NAME", "Project to update (default: most-recently-active)") { |v| project_name = v }
           p.on("--db=PATH", "Explicit SQLite db file to update") { |v| db_path = v }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
+          p.unknown_args { |before, after| leftover = before + after }
           p.invalid_option { |f| abort "gori run project scope #{action}: unknown option: #{f}\n#{p}" }
           p.missing_option { |f| abort "gori run project scope #{action}: missing value for #{f}" }
         end
         parser.parse(args)
+        unless leftover.empty?
+          abort "gori run project scope #{action}: unexpected argument#{leftover.size == 1 ? "" : "s"} " \
+                "#{leftover.join(" ").inspect} — this #{action}s the whole filter, not a rule id. " \
+                "Per-rule change: `gori run project scope update <id>`"
+        end
 
         project = resolve_read_project(project_name, db_path)
         store = open_store(project)
@@ -1049,7 +1056,7 @@ module Gori
           end
           unless ov.update(id, h, i)
             store.close
-            abort "gori run project host-override update: failed (duplicate host, empty, or invalid)"
+            abort "gori run project host-override update: NOT updated (duplicate host, or store busy or unwritable)"
           end
           puts "Host override ##{id} updated: #{i} → #{OverrideHost.key(h)}" # the stored form, not the typed one
         ensure

--- a/src/gori/cli/run/repeater.cr
+++ b/src/gori/cli/run/repeater.cr
@@ -68,8 +68,7 @@ module Gori
         abort "gori run repeater h2: --target is required" if tgt.nil? || tgt.empty?
         file = fields_file
         abort "gori run repeater h2: --fields is required" if file.nil? || file.empty?
-        abort "gori run repeater h2: --fields file '#{file}' is not readable" unless File.exists?(file) && !File.directory?(file)
-        fields, body = parse_h2_fields_file(File.read(file))
+        fields, body = parse_h2_fields_file(read_input_file(file, "gori run repeater h2"))
 
         overrides = begin
           store = open_store(resolve_read_project(project_name, db_path))
@@ -252,8 +251,7 @@ module Gori
 
         req_content = ""
         if file = request_file
-          abort "gori run repeater create: request-file '#{file}' is not readable" unless File.exists?(file) && !File.directory?(file)
-          req_content = File.read(file)
+          req_content = read_input_file(file, "gori run repeater create")
         elsif raw = request_raw
           req_content = raw
         else
@@ -544,7 +542,12 @@ module Gori
         # overrides it for this send. Both mean the same thing: dial the h1/h2 engine and read
         # the 101 as a response. `Engine` already treats 101 as terminal and bodyless, and
         # `ConnPool` already refuses to park an upgraded socket, so nothing else has to change.
-        if plan.websocket? && !(http_only.nil? ? rec.ws_http_only? : http_only)
+        use_ws = plan.websocket? && !(http_only.nil? ? rec.ws_http_only? : http_only)
+        if !use_ws && (!ws_messages.empty? || idle_ms)
+          outbound.close
+          abort "gori run repeater send: --message / --message-frame / --idle-ms apply to a WebSocket exchange — session ##{id} is being sent as HTTP"
+        end
+        if use_ws
           # `rec.flow_id` IS the provenance test, the same one the engine tabs and the h1
           # flow-replay path make: only a `--flow` / MCP `flow_id` seed sets it, and only a
           # seed puts CAPTURED frames in `ws_messages`. A session built from `--request-raw`
@@ -948,9 +951,8 @@ module Gori
         custom_headers = {} of String => Array(String)
         custom_order = [] of {String, String}
         headers.each do |h_str|
-          next unless h_str.includes?(':')
-          name, _, val = h_str.partition(':')
-          next if name.strip.empty?
+          name, sep, val = h_str.partition(':')
+          abort "gori run repeater: header #{h_str.inspect} rejected — write it as 'Name: value'" if sep.empty? || name.strip.empty?
           lname = name.strip.downcase
           custom_order << {lname, name} unless custom_headers.has_key?(lname)
           # The VALUE is the operator's draft, so it expands; the NAME is not (a `$` is not
@@ -1366,7 +1368,7 @@ module Gori
               j.field "head_lossy", true
               j.field "head_base64", Base64.strict_encode(result.head)
             end
-            emit_body_json(j, "body", result.head, result.body, false)
+            emit_body_json(j, "body", result.head, result.body, result.incomplete?)
             if d = diff
               j.field "changed_lines", Repeater::Diff.change_count(d)
               # Sibling to changed_lines, exactly as `cmd_compare`'s JSON carries it: a

--- a/src/gori/cli/run/repeater_minimize.cr
+++ b/src/gori/cli/run/repeater_minimize.cr
@@ -13,6 +13,7 @@ module Gori
         verbatim = false
         format = :text
         allow_unscoped = false
+        slot : String? = nil
         positional = [] of String
 
         parser = OptionParser.new do |p|
@@ -27,6 +28,7 @@ module Gori
           p.on("--verbatim", "Send the stored bytes as-is: no $VAR expansion, no Content-Length resync (same meaning as `repeater send --verbatim`; body params stop being candidates because their framing could not be kept honest)") { verbatim = true }
           p.on("-k", "--insecure", "Do not verify the upstream TLS certificate") { insecure = true }
           p.on("--allow-unscoped", "Minimize even if the target is outside the project scope (Sandbox/exclude still apply)") { allow_unscoped = true }
+          p.on("--slot=NAME", "Send as this SESSION SLOT — its header overlay, and its binding table for $NAME") { |v| slot = v.strip }
           p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
           p.unknown_args { |before, after| positional = before + after }
@@ -35,6 +37,7 @@ module Gori
         end
         parser.parse(args)
 
+        abort "gori run repeater minimize: too many arguments (expected one <repeater-id>, got: #{positional.join(" ")})" if positional.size > 1
         id_s = positional.first? || abort("gori run repeater minimize: <repeater-id> is required")
         id = id_s.to_i64? || abort("gori run repeater minimize: invalid repeater id #{id_s.inspect}")
 
@@ -56,6 +59,7 @@ module Gori
           store.close
         end
         abort "gori run repeater minimize: no repeater session ##{id}" unless rec
+        activate_slot(slot, "gori run repeater minimize")
         outbound = project_outbound(project_name, db_path, allow_unscoped)
 
         text = String.new(rec.request)

--- a/src/gori/cli/run/rewriter.cr
+++ b/src/gori/cli/run/rewriter.cr
@@ -214,6 +214,7 @@ module Gori
         rest = [] of String
         parser.unknown_args { |before, after| rest = before + after }
         parser.parse(args)
+        abort "gori run rewriter extract #{verb}: too many arguments (expected one <id>, got: #{rest.join(" ")})" if rest.size > 1
         id = rest.first?.try(&.to_i64?) || abort("gori run rewriter extract #{verb}: expected a rule id")
         {id, open_store(resolve_read_project(project_name, db_path))}
       end

--- a/src/gori/cli/run/sequence.cr
+++ b/src/gori/cli/run/sequence.cr
@@ -113,6 +113,8 @@ module Gori
         end
 
         abort "gori run sequence: too many arguments (expected at most one <flow-id>)" if positional.size > 1
+        abort "gori run sequence: --request and --flow cannot be combined — pick one template source" if request_file && flow_id
+        abort "gori run sequence: <flow-id> and --flow/--request cannot be combined" if positional.size == 1 && (flow_id || request_file)
         flow_id ||= positional.first?.try { |s| parse_flow_id(s, "gori run sequence") }
         k = kind
         abort "gori run sequence: specify a token location (--cookie/--header/--regex/--position/--jsonpath) or use --tokens" unless k
@@ -122,7 +124,7 @@ module Gori
         # only GLOBAL vars would resolve — a `$TOKEN` defined in the project would go out
         # literally. Explicit and identical to cmd_fuzz, rather than relying on the store that
         # `cli_host_overrides` happens to open below (see run.cr's open_store).
-        hydrate_project_env(project_name, db_path) if (project_name || db_path) && flow_id.nil?
+        hydrate_project_env(project_name, db_path) if project_name || db_path
         bytes, default_target, src_h2, evidence = sequence_source(flow_id, request_file, project_name, db_path)
         token_loc = build_token_loc(k, selector)
 

--- a/src/gori/cli/run/session.cr
+++ b/src/gori/cli/run/session.cr
@@ -124,6 +124,7 @@ module Gori
         project_name : String? = nil
         format = :text
         show_values = false
+        leftover = [] of String
         parser = OptionParser.new do |p|
           p.banner = "Usage: gori run session [list] [options]\n\n" \
                      "The project's session slots: named identities, each a header overlay plus the\n" \
@@ -137,10 +138,12 @@ module Gori
           p.on("--show-values", "Print set-header values instead of [REDACTED]") { show_values = true }
           p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
           p.on("-h", "--help", "Show this help") { puts p; exit 0 }
+          p.unknown_args { |before, after| leftover = before + after }
           p.invalid_option { |f| abort "gori run session: unknown option: #{f}\n#{p}" }
           p.missing_option { |f| abort "gori run session: missing value for #{f}" }
         end
         parser.parse(args)
+        refuse_list_leftovers(leftover, "session", "add, edit, rm/delete, baseline, show, list")
 
         store, slots = session_slots(project_name, db_path)
         begin
@@ -182,6 +185,7 @@ module Gori
           p.missing_option { |f| abort "gori run session show: missing value for #{f}" }
         end
         parser.parse(args)
+        abort "gori run session show: too many arguments (expected one name, got: #{positional.join(" ")})" if positional.size > 1
         name = positional.first?
         abort "gori run session show: name a slot (`gori run session list` shows them)" if name.nil?
 
@@ -300,6 +304,7 @@ module Gori
           p.missing_option { |f| abort "gori run session rm: missing value for #{f}" }
         end
         parser.parse(args)
+        abort "gori run session rm: too many arguments (expected one name, got: #{positional.join(" ")})" if positional.size > 1
         name = positional.first?
         abort "gori run session rm: name the slot to delete (`gori run session list`)" if name.nil?
 
@@ -330,6 +335,7 @@ module Gori
           p.missing_option { |f| abort "gori run session baseline: missing value for #{f}" }
         end
         parser.parse(args)
+        abort "gori run session baseline: too many arguments (expected one name, got: #{positional.join(" ")})" if positional.size > 1
         name = positional.first?
         abort "gori run session baseline: name the slot (`gori run session list`)" if name.nil?
 

--- a/src/gori/cli/run/sitemap.cr
+++ b/src/gori/cli/run/sitemap.cr
@@ -155,6 +155,9 @@ module Gori
         # STDERR to say a term had gone.
         query, dropped = Run.compose_history_query(query, positional, neg_terms)
         Run.warn_dropped_query_terms("sitemap", dropped)
+        if err = Run.reserved_query_verb_error(positional, "sitemap", ["tag"], "tag")
+          abort err
+        end
 
         # Parse/validate the QL BEFORE opening the store: abort skips ensure blocks, so a
         # bad query must not leave a store handle open.

--- a/src/gori/decoder.cr
+++ b/src/gori/decoder.cr
@@ -27,6 +27,8 @@ module Gori::Decoder
       {data.hexstring, RenderAs::Hex}
     when RenderAs::Base64
       {Base64.strict_encode(data), RenderAs::Base64}
+    when RenderAs::Text
+      {String.new(data), RenderAs::Text}
     else
       s = String.new(data)
       s.valid_encoding? ? {s, RenderAs::Text} : {Base64.strict_encode(data), RenderAs::Base64}

--- a/src/gori/import.cr
+++ b/src/gori/import.cr
@@ -129,15 +129,19 @@ module Gori
       raise Gori::Error.new("file not found: #{expanded}") unless File.exists?(expanded)
       raise Gori::Error.new("not a file: #{expanded}") unless File.file?(expanded)
 
-      parsed = case kind
-               when :har      then from_har(expanded)
-               when :urls     then from_urls(expanded)
-               when :oas      then from_oas(expanded)
-               when :postman  then from_postman(expanded)
-               when :insomnia then from_insomnia(expanded)
-               when :burp     then from_burp(expanded)
-               else                raise Gori::Error.new("unknown import kind: #{kind}")
-               end
+      parsed = begin
+        case kind
+        when :har      then from_har(expanded)
+        when :urls     then from_urls(expanded)
+        when :oas      then from_oas(expanded)
+        when :postman  then from_postman(expanded)
+        when :insomnia then from_insomnia(expanded)
+        when :burp     then from_burp(expanded)
+        else                raise Gori::Error.new("unknown import kind: #{kind}")
+        end
+      rescue ex : File::Error
+        raise Gori::Error.new("cannot read #{expanded}: #{ex.message}")
+      end
       if parsed.flows.empty?
         # Preserve WHY nothing landed: if every entry was skipped as malformed, say so
         # (with the count) instead of the generic "no flows found", which hid the real

--- a/src/gori/oast/providers/interactsh.cr
+++ b/src/gori/oast/providers/interactsh.cr
@@ -87,8 +87,6 @@ module Gori::Oast
     def deregister(http : Http, session : Session) : Nil
       body = {"correlation-id" => session.correlation_id, "secret-key" => session.secret}.to_json
       http.request("POST", "#{session.server_url}/deregister", json_headers, body)
-    rescue
-      # best-effort
     end
 
     # ---- internals ----

--- a/src/gori/oast/providers/interactsh.cr
+++ b/src/gori/oast/providers/interactsh.cr
@@ -86,7 +86,9 @@ module Gori::Oast
 
     def deregister(http : Http, session : Session) : Nil
       body = {"correlation-id" => session.correlation_id, "secret-key" => session.secret}.to_json
-      http.request("POST", "#{session.server_url}/deregister", json_headers, body)
+      resp = http.request("POST", "#{session.server_url}/deregister", json_headers, body)
+      return if {200, 201, 204, 404, 409}.includes?(resp.status)
+      raise Gori::Error.new("interactsh deregister failed: HTTP #{resp.status}")
     end
 
     # ---- internals ----

--- a/src/gori/oast/sessions.cr
+++ b/src/gori/oast/sessions.cr
@@ -116,12 +116,13 @@ module Gori::Oast
     end
 
     # Release the server-side registration. The local row and every callback it collected
-    # stay — this releases the LISTENER, not the evidence. Never raises (`Provider#deregister`
-    # is documented not to, and the rescue is the belt to that braces).
-    def release(bound : Bound, http : Http) : Nil
+    # stay — this releases the LISTENER, not the evidence. Returns false when deregister
+    # raised (network / provider error) so a surface can refuse to print "released".
+    def release(bound : Bound, http : Http) : Bool
       bound.provider.deregister(http, bound.session)
+      true
     rescue
-      nil
+      false
     end
 
     # Persist one polled interaction against its session, with the interaction's OWN time

--- a/src/gori/store/probe_rules.cr
+++ b/src/gori/store/probe_rules.cr
@@ -102,8 +102,8 @@ module Gori
       exec_task_ok ->(c : DB::Connection) { c.exec("UPDATE probe_custom_rules SET enabled = ? WHERE id = ?", enabled ? 1 : 0, id); nil }
     end
 
-    def delete_probe_custom_rule(id : Int64) : Nil
-      exec_task ->(c : DB::Connection) { c.exec("DELETE FROM probe_custom_rules WHERE id = ?", id); nil }
+    def delete_probe_custom_rule(id : Int64) : Bool
+      exec_task_ok ->(c : DB::Connection) { c.exec("DELETE FROM probe_custom_rules WHERE id = ?", id); nil }
     end
   end
 end


### PR DESCRIPTION
## Summary

`gori run` had several script-hostile failure modes: a leading `--project`/`--db` discarded a reserved verb and exited 0 (list/scan instead of delete), leftover ids on one-target deletes were ignored, QL dotted negations and OR + trailing `-path:` were composed wrong, `--slot`/`--bind-from` lied about no project when `--request` was the template, `oast listen` left the provider registration live after Ctrl-C, and a second SIGINT during a sweep could leave the process unkillable short of SIGKILL.

A first-pass review of the branch found that the authorize `--query` cap warning referenced `cmd_authorize` locals from `run_authorize` and did not compile on the real dispatch path. That is fixed in the last commit. MCP still ignores the new `Bool` returns from `Sessions.release` and `delete_probe_custom_rule` (follow-up; this PR is the CLI surface).

## What changed

- Leftover reserved verbs after a leading flag abort (`history`, `probe`, `session`, `colormarker color`, `sitemap tag`). `history clear --yes 42` no longer wipes the project.
- Extra ids on one-target mutations abort instead of deleting only the first.
- `--query` + `-path:` parenthesizes the flag value; `-resp.body:x` is classified as QL.
- `oast listen` deregisters on stop; `oast release` reports provider failure and refuses extra ids; second SIGINT escalates.
- Capture Ctrl-C exits 130. Interrupt helper no longer waits for `stop` before escalating.
- Send-path: `--message` on HTTP aborts; `--request`/`--flow`/`<id>` cannot be combined; discover accepts a bare URL or refuses leftovers; `-H` without a colon aborts; minimize has `--slot`.
- Busy writes, `--format`, piped decoder output, and import `File::Error` no longer lie.

## Test plan

- [x] `crystal spec spec/cli` (418)
- [x] `spec/oast`, `spec/authorize`, `spec/import`, `spec/decoder_spec.cr`, `spec/probe/custom_rule_spec.cr`, `spec/mcp/oast_sessions_spec.cr`, `spec/layering_spec.cr`
- [x] `crystal build src/main.cr` after the authorize compile fix
- [ ] CI on the prospective merge