### PR TITLE
build: add `just docker-build` / `docker-run` for the relocated Dockerfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -4,6 +4,7 @@ alias t := test
 alias vc := version-check
 alias vu := version-update
 alias bm := benchmark
+alias db := docker-build
 alias ds := docs-serve
 
 # List available tasks.
@@ -32,6 +33,29 @@ nix-build:
 nix-shards:
     nix run nixpkgs#crystal2nix
     mv shards.nix nix/shards.nix
+
+# Nothing builds the image on a PR any more — ci.yml dropped its `build-docker`
+# job, and publish-ghcr.yml only runs on a push to `main` — so this recipe is the
+# pre-merge check that docker/Dockerfile still compiles.
+#
+# BuildKit is pinned because the ignore list lives at
+# `docker/Dockerfile.dockerignore`: only BuildKit reads a Dockerfile-adjacent
+# one. The classic builder looks for `.dockerignore` in the context root, finds
+# none, and ships `bin/`, `lib/` and `.git/` into the build context instead.
+
+# Build the container image locally (host arch only).
+[group('docker')]
+docker-build tag="gori:dev":
+    DOCKER_BUILDKIT=1 docker build -f docker/Dockerfile -t {{tag}} .
+
+# Bare, it starts the TUI, which needs the TTY `-it` gives it; state lives in the
+# `gori` volume so the CA survives a run. Trailing args pick a headless
+# subcommand: `just docker-run gori:dev run history`.
+
+# Run the image `docker-build` produced.
+[group('docker')]
+docker-run tag="gori:dev" *args:
+    docker run --rm -it -v gori:/data {{tag}} {{args}}
 
 # Run all tests.
 [group('development')]


### PR DESCRIPTION
## Why

The Dockerfile moved to `docker/` in #726, and nothing builds the image on a PR any more: `ci.yml` dropped its `build-docker` job, and `publish-ghcr.yml` only runs on a push to `main`. A Dockerfile break is therefore caught one merge late — and there was no local one-liner to check it either, since the path, the ignore-file convention and the run flags all had to be remembered.

## What

Two recipes in a new `[docker]` group:

```just
just docker-build              # -> gori:dev
just docker-run                # TUI
just docker-run gori:dev run history   # headless subcommand
```

- **`DOCKER_BUILDKIT=1` is pinned deliberately.** The ignore list is `docker/Dockerfile.dockerignore` — the Dockerfile-adjacent convention only BuildKit reads. The classic builder looks for `.dockerignore` in the context root, finds none, and ships `bin/`, `lib/` and `.git/` into the build context. Modern Docker defaults to BuildKit, but the dependency should be visible rather than assumed.
- **`docker-run` carries the two flags the image needs**, both documented in the Dockerfile itself: `-it` (bare `gori` is the TUI and wants a TTY) and `-v gori:/data` (`GORI_HOME`, without which the root CA is regenerated — and must be re-trusted — on every run).
- Each summary line sits on its own after a blank line, because `just --list` shows only the **last** contiguous comment line. Without the split, the BuildKit rationale would have become the listed description — the rot `check` and `nix-shards` already show.

## Verification

- `just --list` renders the group with correct descriptions
- `just --dry-run` expands both recipes, including the variadic `*args`
- `docker build --check -f docker/Dockerfile .` → *Check complete, no warnings found*
- The full static release build was **not** run (long); this change does not touch the Dockerfile.