### PR TITLE
fix(issues,notes): a rolled-back write is not a save, and captured bytes are not JSON

### DIFF
--- a/spec/cli/run/notes_spec.cr
+++ b/spec/cli/run/notes_spec.cr
@@ -57,7 +57,7 @@ describe "gori run notes show --format json" do
     parsed = JSON.parse(doc)
     parsed["title"].as_s.should eq("hi\u{FFFD}")
     parsed["text"].as_s.should contain('\n') # a note is multi-line BY DESIGN — not collapsed
-    parsed["bytes"].as_i.should eq(5)         # the STORED size, not the scrubbed one
+    parsed["bytes"].as_i.should eq(5)        # the STORED size, not the scrubbed one
 
     arr = Gori::CLI::Output.notes_array_json(
       Gori::Notes::Doc.new(0, [entry], 2_i64), with_text: true)

--- a/spec/cli/run/notes_spec.cr
+++ b/spec/cli/run/notes_spec.cr
@@ -46,6 +46,25 @@ describe "gori run notes show --format json" do
     summary["title"].as_s.should eq("Title")
   end
 
+  it "scrubs invalid UTF-8 out of the title and body so the document stays valid" do
+    # `gori run notes create` takes its body from STDIN — piping a gzip/binary response body
+    # (or a file $EDITOR wrote) stores raw bytes the settings KV round-trips verbatim. JSON
+    # escapes control characters but passes an invalid BYTE straight through, so `--format
+    # json` was writing a document whose own valid_encoding? was false.
+    entry = Gori::Notes::NoteEntry.new(1_i64, String.new(Bytes[0x68, 0x69, 0x80, 0x0a, 0x78]))
+    doc = Gori::CLI::Output.note_object_json(0, entry, current: true, with_text: true)
+    doc.valid_encoding?.should be_true
+    parsed = JSON.parse(doc)
+    parsed["title"].as_s.should eq("hi\u{FFFD}")
+    parsed["text"].as_s.should contain('\n') # a note is multi-line BY DESIGN — not collapsed
+    parsed["bytes"].as_i.should eq(5)         # the STORED size, not the scrubbed one
+
+    arr = Gori::CLI::Output.notes_array_json(
+      Gori::Notes::Doc.new(0, [entry], 2_i64), with_text: true)
+    arr.valid_encoding?.should be_true
+    JSON.parse(arr)
+  end
+
   it "emits a null title for a blank note rather than the positional fallback" do
     # The listing's "note 3" is a DISPLAY fallback; JSON must report the absence so a
     # script can tell "untitled" from a note literally titled "note 3".

--- a/spec/issues_export_spec.cr
+++ b/spec/issues_export_spec.cr
@@ -93,6 +93,50 @@ describe Gori::Issues::Export do
     end
   end
 
+  describe ".json" do
+    it "scrubs a linked flow's url/label so the report stays valid UTF-8" do
+      with_store do |store|
+        # `target` is built by a plain `String.new` over the wire (h2 `:path` included), so a
+        # raw 0x80 round-trips through SQLite into Links.resolve's `url`/`label`. Unscrubbed it
+        # made Export.json's own return value invalid UTF-8 — and Serialize.issue delegates
+        # this very array, so the same byte went out on an MCP JSON-RPC line.
+        primary = store.insert_flow(Gori::Store::CapturedRequest.new(
+          created_at: 1_i64, scheme: "http", host: "h.test", port: 80,
+          method: "GET", target: "/a", http_version: "HTTP/1.1",
+          head: "GET /a HTTP/1.1\r\n\r\n".to_slice, body: nil))
+        linked = store.insert_flow(Gori::Store::CapturedRequest.new(
+          created_at: 2_i64, scheme: "http", host: "h.test", port: 80,
+          method: "GET", target: String.new(Bytes[0x2f, 0x80, 0x61]), http_version: "HTTP/1.1",
+          head: "GET /b HTTP/1.1\r\n\r\n".to_slice, body: nil))
+        iid = store.insert_issue("t", Gori::Store::Severity::Low, "h.test", primary)
+        store.add_link(Gori::Store::LinkOwnerKind::Issue, iid, Gori::Store::LinkRefKind::Flow, linked)
+
+        json = Gori::Issues::Export.json(store.issues, store)
+        json.valid_encoding?.should be_true
+        JSON.parse(json) # and it is still parseable
+      end
+    end
+
+    it "keeps a linked flow's url on one line" do
+      with_store do |store|
+        primary = store.insert_flow(Gori::Store::CapturedRequest.new(
+          created_at: 1_i64, scheme: "http", host: "h.test", port: 80,
+          method: "GET", target: "/a", http_version: "HTTP/1.1",
+          head: "GET /a HTTP/1.1\r\n\r\n".to_slice, body: nil))
+        linked = store.insert_flow(Gori::Store::CapturedRequest.new(
+          created_at: 2_i64, scheme: "http", host: "h.test", port: 80,
+          method: "GET", target: "/b\nX", http_version: "HTTP/1.1",
+          head: "GET /b HTTP/1.1\r\n\r\n".to_slice, body: nil))
+        iid = store.insert_issue("t", Gori::Store::Severity::Low, "h.test", primary)
+        store.add_link(Gori::Store::LinkOwnerKind::Issue, iid, Gori::Store::LinkRefKind::Flow, linked)
+
+        link = JSON.parse(Gori::Issues::Export.json(store.issues, store))[0]["links"][0]
+        link["url"].as_s.should_not contain('\n')
+        link["label"].as_s.should_not contain('\n')
+      end
+    end
+  end
+
   describe ".markdown" do
     it "keeps an attacker-controlled body (``` + headings) inside its code fence" do
       with_store do |store|

--- a/spec/mcp/notes_json_utf8_spec.cr
+++ b/spec/mcp/notes_json_utf8_spec.cr
@@ -1,0 +1,93 @@
+require "../spec_helper"
+require "json"
+
+# `gori run notes create` takes its body from --text, positional args, or STDIN — and its own
+# banner suggests `some-tool | gori run notes create`, so piping a gzip/binary response body
+# (or a file the external $EDITOR wrote) stores raw non-UTF-8 bytes. The settings KV
+# round-trips them verbatim, so the note-reading MCP tools were emitting an invalid byte onto
+# a JSON-RPC line — the exact protocol violation `Serialize.text`'s contract exists to prevent
+# ("every string that ORIGINATED OUTSIDE gori must pass through here before it reaches
+# JSON::Builder"), and the same one `Serialize.issue` already guards for an issue's fields.
+private def with_notes_store(text : String, &)
+  path = File.tempname("gori-mcp-notes", ".db")
+  store = Gori::Store.open(path)
+  begin
+    store.set_setting(Gori::Notes::DOCS_KEY,
+      Gori::Notes.serialize(0, [Gori::Notes::NoteEntry.new(7_i64, text)], 8_i64))
+    yield Gori::MCP::Tools.new(store, allow_actions: true, verify_upstream: false)
+  ensure
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+describe "MCP note tools — JSON-RPC UTF-8" do
+  it "list_notes scrubs an invalid byte res of the title" do
+    with_notes_store(String.new(Bytes[0x68, 0x69, 0x80, 0x0a, 0x78])) do |tools|
+      res = tools.call("list_notes", JSON.parse("{}")).text
+      res.valid_encoding?.should be_true
+      JSON.parse(res)["notes"][0]["title"].as_s.should eq("hi\u{FFFD}")
+    end
+  end
+
+  it "get_note scrubs an invalid byte res of the body and the title" do
+    with_notes_store(String.new(Bytes[0x68, 0x69, 0x80, 0x0a, 0x78])) do |tools|
+      res = tools.call("get_note", JSON.parse(%({"id":7}))).text
+      res.valid_encoding?.should be_true
+      note = JSON.parse(res)
+      note["text"].as_s.valid_encoding?.should be_true
+      # `scrub_only`, not `one_line`: a note is multi-line BY DESIGN, so its line break stays.
+      note["text"].as_s.should contain('\n')
+      note["title"].as_s.should eq("hi\u{FFFD}")
+    end
+  end
+
+  it "leaves a valid note untouched" do
+    with_notes_store("# Findings\nbody") do |tools|
+      note = JSON.parse(tools.call("get_note", JSON.parse(%({"id":7}))).text)
+      note["text"].as_s.should eq("# Findings\nbody")
+      note["title"].as_s.should eq("# Findings")
+    end
+  end
+
+  it "still reports Untitled for a blank note" do
+    with_notes_store("   \n\t") do |tools|
+      note = JSON.parse(tools.call("get_note", JSON.parse(%({"id":7}))).text)
+      note["title"].as_s.should eq("Untitled")
+    end
+  end
+end
+
+describe "MCP issue tools — JSON-RPC UTF-8" do
+  it "scrubs a linked flow's url/label, not just the issue's own fields" do
+    path = File.tempname("gori-mcp-issues", ".db")
+    store = Gori::Store.open(path)
+    begin
+      primary = store.insert_flow(Gori::Store::CapturedRequest.new(
+        created_at: 1_i64, scheme: "http", host: "h.test", port: 80,
+        method: "GET", target: "/a", http_version: "HTTP/1.1",
+        head: "GET /a HTTP/1.1\r\n\r\n".to_slice, body: nil))
+      linked = store.insert_flow(Gori::Store::CapturedRequest.new(
+        created_at: 2_i64, scheme: "http", host: "h.test", port: 80,
+        method: "GET", target: String.new(Bytes[0x2f, 0x80, 0x61]), http_version: "HTTP/1.1",
+        head: "GET /b HTTP/1.1\r\n\r\n".to_slice, body: nil))
+      iid = store.insert_issue("t", Gori::Store::Severity::Low, "h.test", primary)
+      store.add_link(Gori::Store::LinkOwnerKind::Issue, iid, Gori::Store::LinkRefKind::Flow, linked)
+
+      tools = Gori::MCP::Tools.new(store, allow_actions: true, verify_upstream: false)
+      %w[list_issues get_issue].each do |name|
+        args = name == "get_issue" ? JSON.parse(%({"id":#{iid}})) : JSON.parse("{}")
+        res = tools.call(name, args).text
+        res.valid_encoding?.should be_true
+        JSON.parse(res)
+      end
+    ensure
+      store.close
+      File.delete?(path)
+      File.delete?("#{path}-wal")
+      File.delete?("#{path}-shm")
+    end
+  end
+end

--- a/spec/mcp/notes_json_utf8_spec.cr
+++ b/spec/mcp/notes_json_utf8_spec.cr
@@ -83,6 +83,11 @@ describe "MCP issue tools — JSON-RPC UTF-8" do
         res.valid_encoding?.should be_true
         JSON.parse(res)
       end
+
+      # `list_links` resolves the SAME Links::Resolved pair onto the same transport.
+      links = tools.call("list_links", JSON.parse(%({"owner_kind":"issue","owner_id":#{iid}}))).text
+      links.valid_encoding?.should be_true
+      JSON.parse(links)["links"][0]["url"].as_s.valid_encoding?.should be_true
     ensure
       store.close
       File.delete?(path)

--- a/spec/tui/issues_view_spec.cr
+++ b/spec/tui/issues_view_spec.cr
@@ -410,6 +410,65 @@ describe Gori::Tui::IssuesView do
       view.detail_issue.try(&.id).should eq(id)
     end
   end
+
+  # A closed store is the spec-reachable stand-in for the real case: `exec_task_ok` answers
+  # false for a rolled-back batch (cross-process SQLite busy/lock) exactly as it does when the
+  # writer channel is shut. Reads still work, which is what makes the silent revert possible.
+  describe "a write that does not commit" do
+    it "save_notes keeps the typed text AND insert mode instead of discarding them" do
+      path = File.tempname("gori-fnd-busy", ".db")
+      store = Gori::Store.open(path)
+      store.insert_issue("t", Gori::Store::Severity::Low, "h.test", nil)
+      view = IssuesView.new
+      view.reload(store)
+      view.open_detail(store)
+      view.enter_notes_insert!
+      "writeup".each_char { |c| view.notes_insert(c) }
+      store.close
+
+      view.save_notes(store).should be_false
+      # The whole point: refresh_detail would have set_text'd the buffer back to the STORED
+      # (empty) notes, so the operator's writeup vanished with no toast and nothing to retry.
+      view.notes_copy_all.should contain("writeup")
+      view.notes_insert_mode?.should be_true
+
+      File.delete?(path)
+      File.delete?("#{path}-wal")
+      File.delete?("#{path}-shm")
+    end
+
+    it "severity_delta / status_delta report the rollback instead of silently snapping back" do
+      path = File.tempname("gori-fnd-busy2", ".db")
+      store = Gori::Store.open(path)
+      store.insert_issue("t", Gori::Store::Severity::Low, "h.test", nil)
+      view = IssuesView.new
+      view.reload(store)
+      view.open_detail(store)
+      store.close
+
+      view.severity_delta(1, store).should be_false
+      view.status_delta(1, store).should be_false
+      view.detail_issue.try(&.severity).should eq(Gori::Store::Severity::Low)
+
+      File.delete?(path)
+      File.delete?("#{path}-wal")
+      File.delete?("#{path}-shm")
+    end
+
+    it "save_notes still reports success on a healthy store" do
+      tmp_store do |store|
+        store.insert_issue("t", Gori::Store::Severity::Low, "h.test", nil)
+        view = IssuesView.new
+        view.reload(store)
+        view.open_detail(store)
+        view.enter_notes_insert!
+        "ok".each_char { |c| view.notes_insert(c) }
+        view.save_notes(store).should be_true
+        view.notes_insert_mode?.should be_false
+        view.detail_issue.try(&.notes).should eq("ok")
+      end
+    end
+  end
 end
 
 describe "Issues verbs" do

--- a/spec/tui/notes_view_spec.cr
+++ b/spec/tui/notes_view_spec.cr
@@ -251,10 +251,44 @@ describe Gori::Tui::NotesView do
       Gori::Notes::NoteEntry.new(2_i64, "shared-EDITED"), # I edited note 2
       Gori::Notes::NoteEntry.new(9_i64, "my-new"),        # I added note 9
     ]
-    merged = Gori::Notes.merge(persisted, mine, Set{3_i64}, 0, 4_i64) # I deleted note 3
+    merged = Gori::Notes.merge(persisted, mine, Set{3_i64}, 2_i64, 4_i64) # I deleted note 3
     merged.notes.map { |n| {n.id, n.text} }.should eq(
       [{1_i64, "peer-only"}, {2_i64, "shared-EDITED"}, {9_i64, "my-new"}])
     merged.next_id.should eq(10_i64) # past the max surviving id
+  end
+
+  it "Notes.merge keeps the ACTIVE note active across a peer's insert (id, not index)" do
+    # My list is [mine-new]; the peer meanwhile persisted a note of its own. The merge puts
+    # the peer's note first (persisted order) and appends mine — so the index I would have
+    # passed (0, "my first note") named the PEER's note in the merged list. An id can't drift.
+    persisted = Gori::Notes::Doc.new(0, [Gori::Notes::NoteEntry.new(5_i64, "peer")], 6_i64)
+    mine = [Gori::Notes::NoteEntry.new(9_i64, "mine-new")]
+    merged = Gori::Notes.merge(persisted, mine, Set(Int64).new, 9_i64, 10_i64)
+    merged.notes.map(&.id).should eq([5_i64, 9_i64])
+    merged.cur.should eq(1) # my note, not the peer's
+    merged.notes[merged.cur].text.should eq("mine-new")
+  end
+
+  it "Notes.merge falls back to the first note when the active one is gone" do
+    persisted = Gori::Notes::Doc.new(1, [
+      Gori::Notes::NoteEntry.new(1_i64, "a"),
+      Gori::Notes::NoteEntry.new(2_i64, "b"),
+    ], 3_i64)
+    merged = Gori::Notes.merge(persisted, [] of Gori::Notes::NoteEntry, Set{2_i64}, 2_i64, 3_i64)
+    merged.notes.map(&.id).should eq([1_i64])
+    merged.cur.should eq(0)
+  end
+
+  it "Doc#note_id refuses a negative position instead of wrapping to the last note" do
+    # Crystal's Array#[]? counts a negative index from the END, and the delete path walks
+    # `cur - 1` looking for the neighbour before the first slot.
+    doc = Gori::Notes::Doc.new(0, [
+      Gori::Notes::NoteEntry.new(1_i64, "a"),
+      Gori::Notes::NoteEntry.new(2_i64, "b"),
+    ], 3_i64)
+    doc.note_id(-1).should be_nil
+    doc.note_id(0).should eq(1_i64)
+    doc.note_id(2).should be_nil
   end
 
   it "migrates a legacy single-note document into the first note" do

--- a/src/gori/cli/output.cr
+++ b/src/gori/cli/output.cr
@@ -9,6 +9,7 @@ require "../discover"
 require "../sitemap"
 require "../probe/group"
 require "../notes"
+require "../issues_export" # Issues::Export.one_line / .scrub_only
 require "../jwt"
 require "../authorize/engine"
 
@@ -727,16 +728,27 @@ module Gori
         JSON.build { |j| note_object_fields(j, idx, entry, current: current, with_text: with_text) }
       end
 
+      # The TEXT listing above reads `doc.texts`, which is already terminal-scrubbed. JSON is
+      # not a terminal, so ESC/CR stay (JSON escapes them and a note is multi-line BY DESIGN) —
+      # but the UTF-8 half of that guarantee still applies here, and this path had neither.
+      # A note body does not always originate inside gori: `gori run notes create` takes it from
+      # STDIN (its own banner suggests `some-tool | gori run notes create`) or from whatever the
+      # external $EDITOR wrote, so piping a gzip/binary response body stores raw non-UTF-8 bytes
+      # that the settings KV round-trips verbatim — and `--format json` then emitted a document
+      # whose `valid_encoding?` was false. Same split `Issues::Export.json` makes: `scrub_only`
+      # for the multi-line body, `one_line` for the single-line title. `title` stays NILABLE —
+      # its null for a blank note is the documented contract, distinct from the listing's
+      # positional "note 3" fallback.
       def self.note_object_fields(j : JSON::Builder, idx : Int32, entry : Notes::NoteEntry, current : Bool, with_text : Bool) : Nil
         text = entry.text
         j.object do
           j.field "id", entry.id
           j.field "index", idx + 1
-          j.field "title", Notes.title(text)
+          j.field "title", Notes.title(text).try { |t| Issues::Export.one_line(t) }
           j.field "lines", Notes.line_count(text)
           j.field "bytes", text.bytesize
           j.field "current", current
-          j.field "text", text if with_text
+          j.field "text", Issues::Export.scrub_only(text) if with_text
         end
       end
 

--- a/src/gori/cli/run/links.cr
+++ b/src/gori/cli/run/links.cr
@@ -84,8 +84,11 @@ module Gori
                   j.field "id", r.link.id
                   j.field "ref_kind", r.link.ref_kind.label
                   j.field "ref_id", r.link.ref_id
-                  j.field "label", r.label
-                  j.field "url", r.url
+                  # Captured bytes (see Links.resolve_flow) — `one_line` so a raw 0x80 in an
+                  # h2 `:path` can't make this document invalid UTF-8, the same guard
+                  # `Issues::Export.append_links_json` and MCP `list_links` carry.
+                  j.field "label", Issues::Export.one_line(r.label)
+                  j.field "url", Issues::Export.one_line(r.url)
                   j.field "stale", r.stale?
                 end
               end
@@ -98,7 +101,11 @@ module Gori
           return
         end
         resolved.each do |r|
-          puts "#{r.line}#{r.stale? ? "  (stale)" : ""}"
+          # `Resolved#line` is "[tag] label", and the label is `"#{row.method} #{loc}"` off the
+          # wire — so an OSC 52 / set-window-title sequence in a captured request line drove the
+          # operator's terminal on every `gori run links`. Every other CLI printer of captured
+          # text goes through `term_safe`; this one did not.
+          puts "#{CLI::Output.term_safe(r.line)}#{r.stale? ? "  (stale)" : ""}"
         end
       end
 

--- a/src/gori/cli/run/notes.cr
+++ b/src/gori/cli/run/notes.cr
@@ -102,8 +102,11 @@ module Gori
           # so every persisted note is kept and just the delta is added.
           persisted = Notes.load(store)
           new_id = persisted.next_id
+          # `cur` = the note just created, named by its id: `gori run notes create` is the
+          # operator saying "this is what I am working on now", the same thing `^N` means in
+          # the TUI, and an index would have to guess where the merge appended it.
           merged = Notes.merge(persisted, [Notes::NoteEntry.new(new_id, body)], Set(Int64).new,
-            persisted.size, persisted.next_id + 1)
+            new_id, persisted.next_id + 1)
           # set_setting returns false when the write didn't commit (store busy/locked):
           # don't claim success then — same guard as issues/rewriter/project mutations.
           unless store.set_setting(Notes::DOCS_KEY, Notes.serialize(merged.cur, merged.notes, merged.next_id))
@@ -147,8 +150,15 @@ module Gori
           # Delete by the note's STABLE id (not its list position) and merge, so a concurrent
           # writer's other notes aren't clobbered by a blind overwrite. See Notes.merge.
           target_id = persisted.notes[n - 1].id
+          # Keep the ACTIVE note active across the delete, by id. `persisted.cur` is a
+          # position, and removing a note ahead of it slides every later one up — so deleting
+          # note 1 while note 3 was active left `cur` on 3, which is now the note that used to
+          # be 4. When the active note is the one being deleted, fall to its neighbour (next,
+          # else previous), which is what closing a sub-tab does in the TUI.
+          keep_id = persisted.note_id(persisted.cur)
+          keep_id = persisted.note_id(persisted.cur + 1) || persisted.note_id(persisted.cur - 1) if keep_id == target_id
           merged = Notes.merge(persisted, [] of Notes::NoteEntry, Set{target_id},
-            persisted.cur, persisted.next_id)
+            keep_id, persisted.next_id)
           unless store.set_setting(Notes::DOCS_KEY, Notes.serialize(merged.cur, merged.notes, merged.next_id))
             store.close
             abort "gori run notes delete: project is busy (write did not commit) — try again"

--- a/src/gori/issues_export.cr
+++ b/src/gori/issues_export.cr
@@ -138,8 +138,20 @@ module Gori
           j.object do
             j.field "kind", res.link.ref_kind.label
             j.field "ref_id", res.link.ref_id
-            j.field "url", res.url
-            j.field "label", res.label
+            # `one_line`, exactly like the title/host fields of the object this array sits in —
+            # and like `append_related_links`, the Markdown sibling twenty lines up, which has
+            # always one_line'd this same pair. Both values are built from CAPTURED bytes
+            # (`Links.resolve_flow` composes them from the flow's method/host/target, which
+            # `Codec::Http1.parse_request_head` builds with a plain `String.new` over the wire),
+            # so an h2 `:path` carrying a raw 0x80 landed here verbatim: `Export.json` returned a
+            # string whose `valid_encoding?` was FALSE, and `Serialize.issue` — which delegates
+            # this array — put that byte on a JSON-RPC line, breaking the WHOLE response for a
+            # strict client. That is the very gap `Serialize.issue`'s own comment claims to close
+            # for title/host/notes one field earlier, and `Serialize.text`'s contract ("every
+            # string that ORIGINATED OUTSIDE gori must pass through here before it reaches
+            # JSON::Builder") names as mandatory.
+            j.field "url", one_line(res.url)
+            j.field "label", one_line(res.label)
             j.field "stale", res.stale?
           end
         end

--- a/src/gori/mcp/tools/links.cr
+++ b/src/gori/mcp/tools/links.cr
@@ -1,6 +1,7 @@
 require "json"
 require "../../store"
 require "../../links"
+require "../../issues_export" # Issues::Export.one_line
 require "../../notes"
 
 module Gori
@@ -28,8 +29,14 @@ module Gori
                     j.field "id", r.link.id
                     j.field "ref_kind", r.link.ref_kind.label
                     j.field "ref_id", r.link.ref_id
-                    j.field "label", r.label
-                    j.field "url", r.url
+                    # `one_line`, like every other captured value MCP emits (see
+                    # `Serialize.text`'s contract). Both are built from wire bytes —
+                    # `Links.resolve_flow` composes them from the flow's method/host/target,
+                    # which `Codec::Http1.parse_request_head` builds with a plain `String.new`
+                    # — so an h2 `:path` carrying a raw 0x80 made this whole JSON-RPC response
+                    # line invalid UTF-8. Same pair, same fix as `Issues::Export.append_links_json`.
+                    j.field "label", Issues::Export.one_line(r.label)
+                    j.field "url", Issues::Export.one_line(r.url)
                     # A link whose target was pruned/deleted. Kept (not hidden) so the caller
                     # can tell "no evidence" from "evidence that no longer exists".
                     j.field "stale", true if r.stale?

--- a/src/gori/mcp/tools/notes.cr
+++ b/src/gori/mcp/tools/notes.cr
@@ -1,5 +1,6 @@
 require "json"
 require "../../notes"
+require "../../issues_export" # Issues::Export.one_line / .scrub_only
 
 module Gori
   module MCP
@@ -14,7 +15,7 @@ module Gori
                 doc.notes.each_with_index do |entry, idx|
                   j.object do
                     j.field "id", entry.id
-                    j.field "title", Notes.title(entry.text) || "Untitled"
+                    j.field "title", note_title(entry)
                     j.field "line_count", Notes.line_count(entry.text)
                     j.field "current", doc.cur == idx
                   end
@@ -35,8 +36,16 @@ module Gori
         Result.new(JSON.build do |j|
           j.object do
             j.field "id", entry.id
-            j.field "text", entry.text
-            j.field "title", Notes.title(entry.text) || "Untitled"
+            # A note body does NOT always originate inside gori: `gori run notes create` takes
+            # it from --text, positional args, or STDIN — and its own banner suggests
+            # `some-tool | gori run notes create`, so piping a gzip/binary response body (or a
+            # file the external $EDITOR wrote) stores raw non-UTF-8 bytes, which the settings KV
+            # round-trips verbatim. Unscrubbed, that byte reached JSON::Builder and broke this
+            # tool's whole JSON-RPC line. See `Serialize.text`'s contract; `scrub_only` (not
+            # `one_line`) because a note is multi-line BY DESIGN, the same split
+            # `Serialize.issue` makes for an issue's free-text `notes`.
+            j.field "text", Issues::Export.scrub_only(entry.text)
+            j.field "title", note_title(entry)
             j.field "current", doc.cur == idx
           end
         end)
@@ -108,6 +117,14 @@ module Gori
             j.field "message", "Note deleted successfully"
           end
         end)
+      end
+
+      # The note's display title, scrubbed for the JSON-RPC wire. `one_line` rather than
+      # `scrub_only`: `Notes.title` returns the first non-blank LINE, so it is a single-line
+      # field here exactly as an issue's `title` is — and a lone CR or a stray C0 inside that
+      # line would otherwise ride out into a field a client renders inline.
+      private def note_title(entry : Notes::NoteEntry) : String
+        Issues::Export.one_line(Notes.title(entry.text) || "").presence || "Untitled"
       end
 
       # The tools/list schemas for the note tools, kept beside the handlers that

--- a/src/gori/notes.cr
+++ b/src/gori/notes.cr
@@ -39,7 +39,13 @@ module Gori
         notes.map { |n| Issues::Export.scrub_controls(n.text) }
       end
 
+      # The stable id at sub-tab position `idx`, or nil when there is no such position.
+      # The explicit `idx < 0` guard is not belt-and-braces: Crystal's `Array#[]?` counts a
+      # NEGATIVE index from the END, so a bare `notes[-1]?` answers "the last note" for a
+      # caller that meant "the slot before the first one" — and every caller here is walking
+      # neighbours around a position it is about to remove.
       def note_id(idx : Int32) : Int64?
+        return nil if idx < 0
         notes[idx]?.try(&.id)
       end
     end
@@ -123,8 +129,16 @@ module Gori
     #   - a note only THIS session has (new)      → appended
     # (`mine` carry cross-session-unique ids, so a peer's new note can't be mistaken
     # for an edit of ours.) next_id advances past every surviving id.
+    #
+    # The active note arrives as `cur_id`, a STABLE ID, not as an index. The merged order is
+    # the persisted one (minus this session's deletes) with this session's new notes appended,
+    # which is NOT the caller's own list order — so an index meant "my note #2" and landed on
+    # whatever the merge happened to put there. Two ways that bit: a peer adding a note ahead
+    # of ours parked the persisted `cur` on the PEER's note instead of the one being typed in,
+    # and `gori run notes delete 1` left `cur` on its old number, i.e. one note further down
+    # than the one that was active. An id cannot drift. Unresolvable (a peer deleted it) → 0.
     def self.merge(persisted : Doc, mine : Array(NoteEntry), deleted : Set(Int64),
-                   cur : Int32, next_id : Int64) : Doc
+                   cur_id : Int64?, next_id : Int64) : Doc
       mine_by_id = {} of Int64 => String
       mine.each { |n| mine_by_id[n.id] = n.text }
       result = [] of NoteEntry
@@ -140,6 +154,7 @@ module Gori
         seen << n.id
       end
       max_id = result.max_of?(&.id) || 0_i64
+      cur = cur_id.try { |id| result.index { |n| n.id == id } } || 0
       Doc.new(cur.clamp(0, {result.size - 1, 0}.max), result, {next_id, max_id + 1}.max)
     end
 

--- a/src/gori/tui/controllers/issues_controller.cr
+++ b/src/gori/tui/controllers/issues_controller.cr
@@ -293,15 +293,24 @@ module Gori::Tui
       @issues.reload(@host.session.store)
     end
 
+    # The flush the shell runs on a tab switch and on `commit_pending_edits` (quit /
+    # leave-project). NO retry hint here, unlike the `esc` path: on a tab switch the buffer
+    # really is still there, but on the quit path the Runner is torn down immediately after —
+    # nothing more is drawn and the text goes with the session. That last case is pre-existing
+    # and deliberate (quit wins; `NotesView#save` keeps `@dirty` on a failed write and nobody
+    # blocks the exit on it either), so this reports without promising a retry that one of its
+    # three callers cannot honour.
     def commit : Nil
-      save_notes_or_report if @issues.notes_insert_mode?
+      return unless @issues.notes_insert_mode?
+      return if @issues.save_notes(@host.session.store)
+      @host.status("notes NOT saved — project busy")
     end
 
-    # `esc` out of the notes editor, and the tab-switch/quit flush. IssuesView#save_notes
-    # returns false when the write was rolled back (cross-process SQLite busy/lock) and then
-    # leaves the buffer AND insert mode exactly as they were, so the typed text is still on
-    # screen and a second `esc` is a real retry. Say so — reporting nothing is what made a busy
-    # project look like it had saved while it had discarded the writeup.
+    # `esc` out of the notes editor. IssuesView#save_notes returns false when the write was
+    # rolled back (cross-process SQLite busy/lock) and then leaves the buffer AND insert mode
+    # exactly as they were, so the typed text is still on screen and a second `esc` is a real
+    # retry. Say so — reporting nothing is what made a busy project look like it had saved
+    # while it had discarded the writeup.
     private def save_notes_or_report : Nil
       return if @issues.save_notes(@host.session.store)
       @host.status("notes NOT saved — project busy; your text is still here, esc to retry")

--- a/src/gori/tui/controllers/issues_controller.cr
+++ b/src/gori/tui/controllers/issues_controller.cr
@@ -228,7 +228,7 @@ module Gori::Tui
         # is a literal character, and typing it would REPLACE the selection). ⌥⌫ and ⌥/⌃
         # motion are this editor's own and are excluded above.
         return false
-      when key.escape? then @issues.save_notes(@host.session.store)
+      when key.escape? then save_notes_or_report
       when key.enter?  then @issues.notes_newline
         # Before plain ⌫, which would swallow the modified form as a one-character delete.
       when @issues.notes_word_delete_key?(ev) then @issues.notes_motion_key(ev)
@@ -294,7 +294,17 @@ module Gori::Tui
     end
 
     def commit : Nil
-      @issues.save_notes(@host.session.store) if @issues.notes_insert_mode?
+      save_notes_or_report if @issues.notes_insert_mode?
+    end
+
+    # `esc` out of the notes editor, and the tab-switch/quit flush. IssuesView#save_notes
+    # returns false when the write was rolled back (cross-process SQLite busy/lock) and then
+    # leaves the buffer AND insert mode exactly as they were, so the typed text is still on
+    # screen and a second `esc` is a real retry. Say so — reporting nothing is what made a busy
+    # project look like it had saved while it had discarded the writeup.
+    private def save_notes_or_report : Nil
+      return if @issues.save_notes(@host.session.store)
+      @host.status("notes NOT saved — project busy; your text is still here, esc to retry")
     end
 
     def issues_notes_read_mode? : Bool
@@ -435,12 +445,17 @@ module Gori::Tui
       end
     end
 
+    # `]`/`[` and `}`/`{`. A rolled-back write leaves the issue on its OLD value, which the
+    # re-read then paints back — indistinguishable from "the key did nothing" unless it says
+    # so. Same sentence Runner#apply_issue_choice uses for the picker path.
     def issue_severity(delta : Int32) : Nil
-      @issues.severity_delta(delta, @host.session.store)
+      return if @issues.severity_delta(delta, @host.session.store)
+      @host.status("severity NOT changed — project busy; try again")
     end
 
     def issue_status(delta : Int32) : Nil
-      @issues.status_delta(delta, @host.session.store)
+      return if @issues.status_delta(delta, @host.session.store)
+      @host.status("status NOT changed — project busy; try again")
     end
 
     def issue_edit_notes : Nil

--- a/src/gori/tui/issues_view.cr
+++ b/src/gori/tui/issues_view.cr
@@ -325,20 +325,28 @@ module Gori::Tui
     # Max link rows shown in the detail pane (the rest scroll).
     LINKS_VISIBLE = 4
 
-    def severity_delta(delta : Int32, store : Store) : Nil
+    # The hidden `]`/`[` one-step cycle. Returns whether the write COMMITTED, like the
+    # picker path (`Runner#apply_issue_choice`) and `delete_ids` beside it — an
+    # `exec_task_ok` false means a cross-process SQLite busy/lock rolled the batch back, and
+    # `refresh_detail` then re-reads the OLD row, so the chip silently snaps back to where it
+    # was with nothing said. The caller reports it.
+    def severity_delta(delta : Int32, store : Store) : Bool
       issue = @detail
-      return unless issue
+      return true unless issue
       level = (issue.severity.value + delta).clamp(0, 4)
-      store.update_issue(issue.id, severity: Store::Severity.new(level))
+      return false unless store.update_issue(issue.id, severity: Store::Severity.new(level))
       refresh_detail(store)
+      true
     end
 
-    def status_delta(delta : Int32, store : Store) : Nil
+    # ditto for the `}`/`{` triage-status cycle.
+    def status_delta(delta : Int32, store : Store) : Bool
       issue = @detail
-      return unless issue
+      return true unless issue
       level = (issue.status.value + delta).clamp(0, 3)
-      store.update_issue(issue.id, status: Store::Status.new(level))
+      return false unless store.update_issue(issue.id, status: Store::Status.new(level))
       refresh_detail(store)
+      true
     end
 
     # The issue currently open in the detail view (for title-edit / evidence
@@ -670,20 +678,30 @@ module Gori::Tui
       @notes.set_preedit(text) if notes_insert_mode?
     end
 
-    def save_notes(store : Store) : Nil
-      return unless issue = @detail
+    def save_notes(store : Store) : Bool
+      return true unless issue = @detail
       # `#text`, not `#to_bytes`. `to_bytes` joins with CRLF because it exists for WIRE text;
       # this is prose in a DB column, and the CRLF made `issues.notes` mean two different
       # things depending on the writer — the TUI stored `a\r\nb` while MCP `update_issue` and
       # `gori run issues` store the caller's LF string verbatim, so `get_issue` and the export
       # hand an agent one or the other. The TUI hid it from itself because `set_text` rstrips
       # `\r` on load. `NotesView` uses `#text` throughout for exactly this reason.
-      store.update_issue(issue.id, notes: @notes.text)
+      #
+      # Returns whether the write COMMITTED. On a rollback NOTHING local moves: the buffer
+      # keeps the typed text and the pane stays in INS. That is not cosmetic — every step
+      # below is destructive to the edit. `refresh_detail` re-reads the row and (once INS is
+      # off) `set_text`s the notes buffer back to the STORED text, so swallowing the false
+      # made a busy project silently throw away the operator's writeup and show them the old
+      # one, with no toast and nothing left to retry from. Leaving INS on is what keeps the
+      # text on screen and a second `esc` a real retry. Same correction `NotesView#save` and
+      # `ProjectView#save` already carry.
+      return false unless store.update_issue(issue.id, notes: @notes.text)
       exit_notes_insert!
       # refresh_detail already re-syncs @notes from the re-fetched @detail (now that
       # notes-insert mode is off), and it nil-guards a peer-deleted issue — so no
       # separate (unsafe) set_text here.
       refresh_detail(store)
+      true
     end
 
     # Leave the notes editor WITHOUT persisting (^W) — discards the in-buffer

--- a/src/gori/tui/notes_view.cr
+++ b/src/gori/tui/notes_view.cr
@@ -427,7 +427,9 @@ module Gori::Tui
     def save(store : Store) : Nil
       return unless @dirty
       mine = @notes.map { |n| Notes::NoteEntry.new(n.id, n.area.text) }
-      merged = Notes.merge(Notes.load(store), mine, @deleted_ids, @current, @next_id)
+      # The active note by stable ID — `@current` is an index into THIS session's list, and
+      # the merged order is the persisted one plus our appends. See Notes.merge.
+      merged = Notes.merge(Notes.load(store), mine, @deleted_ids, @notes[@current]?.try(&.id), @next_id)
       wrote = store.set_setting(DOCS_KEY, Notes.serialize(merged.cur, merged.notes, merged.next_id))
       # `next_id` advances either way: it only has to stay monotonic, and holding it back would
       # let a retry reuse an id the merge already handed out.

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -1733,15 +1733,34 @@ module Gori::Tui
       title = "untitled issue" if title.empty?
       if id = form.edit_id
         # editing an existing issue's title + severity (from its detail view)
-        @session.store.update_issue(id, title: title, severity: form.severity)
+        # A rolled-back write (cross-process SQLite busy/lock) leaves the issue on its OLD
+        # title/severity, and `resync` re-reads exactly that — so "issue updated" was a
+        # phantom, and returning true dropped the form with the retyped title inside it.
+        # FALSE keeps the card up, which is the only place that text still exists.
+        unless @session.store.update_issue(id, title: title, severity: form.severity)
+          @toast = "issue NOT updated — project busy; the form is still here, ↵ to retry"
+          return false
+        end
         issues_controller.view.resync(@session.store)
         @toast = "issue updated"
       else
         new_id = @session.store.insert_issue(title, form.severity, form.host, form.flow_id)
+        # `insert_issue` returns 0 — NOT nil — when the write never committed, and 0 is TRUTHY
+        # in Crystal: the same trap `Probe::Triage.promote` and `sequencer_promote` both name.
+        # Everything below takes `new_id` as an owner id, so swallowing it filed entity_links
+        # against a nonexistent issue #0 and then reported "issue created" (or, on the
+        # create-and-link path, put up an "issue #0 created and linked" confirm). Nothing was
+        # written, so keep the form: its title is the only copy left.
+        if new_id == 0
+          @toast = "could not file the issue (store busy) — nothing was written, ↵ to retry"
+          return false
+        end
         # `insert_issue` writes notes '' — it has no notes parameter, and giving it one would
         # touch every caller. A second write is fine here: this is a one-off create, not the
         # data path, and it is skipped entirely unless the open-site supplied evidence.
-        @session.store.update_issue(new_id, notes: form.notes) if new_id != 0 && !form.notes.empty?
+        # The issue itself is already filed, so a failure here is a HALF landing, not a
+        # rollback — name which half, like `sequencer_promote` does, rather than claim both.
+        notes_lost = !form.notes.empty? && !@session.store.update_issue(new_id, notes: form.notes)
         # History's marked set beyond the primary evidence flow (#442) — one issue, N flows.
         # insert_issue already linked form.flow_id, so exclude it and never re-link. A flow the
         # store can't resolve (a stale mark) is dropped rather than filing an orphan link row, and
@@ -1762,7 +1781,8 @@ module Gori::Tui
           # Name the extra evidence too — this branch is reached from the picker's "+ New issue…",
           # which is exactly where a marked set arrives, so reporting only the picker's own ref
           # would leave the N flows just attached unmentioned.
-          @toast = attached > 1 ? "issue ##{new_id} created and linked · #{attached} flows attached" : "issue ##{new_id} created and linked"
+          msg = attached > 1 ? "issue ##{new_id} created and linked · #{attached} flows attached" : "issue ##{new_id} created and linked"
+          @toast = notes_lost ? "#{msg} — but its notes did not save (store busy)" : msg
           # Ask open-vs-stay (default stay). FALSE, not true: offer_open_created has just
           # put a confirm up, and "close the overlay" would be asking the shell to close a
           # form it is no longer holding. close_active_overlay's identity check would make
@@ -1773,7 +1793,8 @@ module Gori::Tui
           @active_tab = :issues
           @focus = :body
           issues_controller.view.reload(@session.store)
-          @toast = attached > 1 ? "issue created with #{attached} flows attached" : "issue created"
+          msg = attached > 1 ? "issue created with #{attached} flows attached" : "issue created"
+          @toast = notes_lost ? "#{msg} — but its notes did not save (store busy)" : msg
         end
       end
       true


### PR DESCRIPTION
Audit of the **Issues** and **Notes** features end to end (store → CLI → MCP → TUI). Three defect classes, all verified against running code before the fix.

## 1. The Issues tab was the one surface that swallowed a failed write

`exec_task_ok` returns false when a batch rolls back (cross-process SQLite busy/lock). Every other caller in the tree says so — MCP, the CLI, `Probe::Triage.promote`, `sequencer_promote`, `NotesView#save`, `apply_issue_choice`, `delete_ids`. Four sites in Issues did not:

| site | what happened |
|---|---|
| `IssuesView#save_notes` | ignored it, then ran `refresh_detail`, which re-reads the row and `set_text`s the buffer back to the **stored** text — a busy project silently threw the operator's writeup away and showed them the old one, no toast, nothing to retry from |
| `severity_delta` / `status_delta` (`]`/`[`, `}`/`{`) | snapped back to the old value, indistinguishable from "the key did nothing" |
| `create_issue_from_form`, create | `insert_issue` returns **0, not nil**, and 0 is truthy — every line after took it as an owner id, so `entity_links` were filed against a nonexistent issue #0 and the shell reported "issue created" (or raised an "issue #0 created and linked" confirm) |
| `create_issue_from_form`, edit | reported "issue updated" over a rollback and dropped the form with the retyped title inside it |

`save_notes` now returns the commit result and, on false, leaves the buffer **and** insert mode intact — the text stays on screen and a second `esc` is a real retry. The form stays up on a failed create/edit: its title is the only copy left. A failed notes write on an otherwise-successful create names which half landed, the way `sequencer_promote` already does.

## 2. Captured bytes reached `JSON::Builder` unscrubbed

`Serialize.text`'s contract: *every string that ORIGINATED OUTSIDE gori must pass through here before it reaches JSON::Builder.* `Serialize.issue`'s own comment claims that guard for title/host/notes — and then delegates its `links` array to `Issues::Export.append_links_json`, which emitted `url`/`label` verbatim. Both are built from a flow's method/host/target, which `Codec::Http1.parse_request_head` composes with a plain `String.new` over the wire.

Measured before the fix, with a linked flow whose target holds one raw `0x80`:

```
list_issues: valid_utf8=false
get_issue:   valid_utf8=false
list_notes:  valid_utf8=false
get_note:    valid_utf8=false
```

…plus `gori run issues --format json`, `gori run notes --format json`, MCP `list_links`, and `gori run links --format json`. The Markdown sibling had `one_line`'d the same pair all along.

The Notes half has its own ingress: a note body does **not** always originate inside gori — `gori run notes create` takes it from STDIN (its own banner suggests `some-tool | gori run notes create`) or from whatever `$EDITOR` wrote, and the settings KV round-trips raw bytes verbatim. Same split the issue serializer makes: `scrub_only` for a body that is multi-line by design, `one_line` for the single-line title.

`gori run links`' text view also printed `Resolved#line` straight to the terminal with no `term_safe`, so an OSC 52 / set-window-title sequence in a captured request line drove the operator's terminal.

## 3. `Notes.merge` took the active note as an index, not an id

The merged order is the persisted one plus this session's appends — not the caller's list order. Two ways that bit:

- a peer adding a note ahead of ours parked `cur` on the **peer's** note instead of the one being typed in;
- `gori run notes delete 1` left `cur` on its old number — one note further down than the one that was active.

Verified against the built binary:

```
--- before (active = two) ---      --- after delete 1 ---
  1  one                          * 1  two      ← was "three"
* 2  two                            2  three
  3  three                          3  four
  4  four
```

`Doc#note_id` grew an `idx < 0` guard while it was being used for the first time: Crystal's `Array#[]?` counts a negative index from the **end**, and the delete path walks `cur - 1` looking for the slot before the first.

## Verification

- `crystal spec` — 9795 examples, 0 failures
- `crystal tool format --check src spec bench scripts` — clean
- ameba on every touched file — identical to baseline, no new findings
- `gori run notes create/delete/list` smoke-tested against the built binary
- `/code-review high`; its four findings are addressed (two fixed here, one had already landed, one documented as pre-existing teardown-wins behaviour)