### PR TITLE
fix(intercept): a WS hold is not an HTTP head, and turning catch off is a bulk forward

### DIFF
--- a/spec/cli/run/intercept_spec.cr
+++ b/spec/cli/run/intercept_spec.cr
@@ -282,6 +282,99 @@ describe "Gori::MCP::Serialize.head_and_body" do
   end
 end
 
+# A held WebSocket message is ALL body — no start line, no headers, no blank-line separator —
+# exactly as the TUI's `InterceptView#ws_window_for` already models it. Run through the HTTP
+# splitter it came back the other way round: the WHOLE payload as `head`, and `body_size: 0` for
+# every held WS message on BOTH cross-process surfaces. That is the one number a WS row is about
+# (`Item#label` ends a WS message with its byte count), and `gori run intercept list` printed
+# `(0b body)` beside it. A payload that CONTAINS a blank line was worse: the split landed inside
+# it, so the preview stopped there and `body_size` described a fragment.
+private def ws_message_held(payload : String, binary : Bool = false, kind : String = "wsout") : Gori::Store::HeldRow
+  Gori::Store::HeldRow.new(
+    session_token: "t", item_id: 9_i64, kind: kind, method: "GET", host: "h", port: 80,
+    scheme: "http", target: "/ws", raw: payload.to_slice, held_at_ms: 0_i64, binary: binary)
+end
+
+describe "Gori::MCP::Serialize.held_head_and_body" do
+  it "gives a WebSocket message an empty head and the whole payload as body" do
+    head, body = Gori::MCP::Serialize.held_head_and_body(ws_message_held(%({"cmd":"buy"})))
+    head.should eq("")
+    String.new(body).should eq(%({"cmd":"buy"}))
+  end
+
+  # The regression this exists for: a blank line inside a chat/pretty-printed payload is a
+  # BYTE, not a head terminator.
+  it "does not split a payload that contains a blank line" do
+    _, body = Gori::MCP::Serialize.held_head_and_body(ws_message_held("line one\n\nline two"))
+    body.size.should eq("line one\n\nline two".bytesize)
+  end
+
+  it "leaves an HTTP hold on the head/body splitter it always used" do
+    head, body = Gori::MCP::Serialize.held_head_and_body(
+      desync_held("POST /x HTTP/1.1\nHost: h\nContent-Length: 8\n\nSMUGGLED"))
+    head.should eq("POST /x HTTP/1.1\nHost: h\nContent-Length: 8")
+    String.new(body).should eq("SMUGGLED")
+  end
+
+  it "reports the payload size and preview on both projections, and no head field" do
+    row = ws_message_held(%({"cmd":"buy","qty":100}))
+    {
+      JSON.parse(JSON.build { |j| Gori::MCP::Serialize.intercept_item_row(j, row, true, 0_i64) }),
+      JSON.parse(JSON.build { |j| Gori::MCP::Serialize.intercept_item_detail(j, row, true, 0_i64) }),
+    }.each do |obj|
+      obj["body_size"].as_i.should eq(23)
+      obj["body_preview"].as_s.should eq(%({"cmd":"buy","qty":100}))
+      obj["head"]?.should be_nil
+      obj["head_preview"]?.should be_nil
+    end
+  end
+
+  # opcode 2 is protobuf/msgpack/CBOR: a text preview of it is a wall of U+FFFD, so the row
+  # says the size and `binary_note` names the byte channel. The TUI refuses the same case.
+  it "withholds the text preview for a BINARY frame but still reports its size" do
+    row = ws_message_held("\xff\xfe\x00\x01", binary: true)
+    obj = JSON.parse(JSON.build { |j| Gori::MCP::Serialize.intercept_item_row(j, row, true, 0_i64) })
+    obj["body_size"].as_i.should eq(4)
+    obj["body_preview"]?.should be_nil
+    obj["binary"].as_bool.should be_true
+  end
+
+  # A WS payload used to reach the caller through `head`/`head_preview`, i.e. through
+  # `redact_head`. Giving it a field of its own must not also give it a way past the
+  # `include_sensitive` gate: for any text message under the preview cap `body_preview` IS the
+  # full raw payload that `raw_base64` is deliberately gated on, and the same object still
+  # reports `raw_redacted: true`.
+  it "redacts a credential line in a WS payload unless include_sensitive" do
+    row = ws_message_held("CONNECT\nauthorization:Bearer eyJhbGciOi\naccept-version:1.2")
+    guarded = JSON.parse(JSON.build { |j| Gori::MCP::Serialize.intercept_item_detail(j, row, false, 0_i64) })
+    guarded["body_preview"].as_s.should_not contain("eyJhbGciOi")
+    guarded["body_preview"].as_s.should contain("[REDACTED]")
+    guarded["body_preview"].as_s.should contain("accept-version:1.2")
+    guarded["raw_redacted"].as_bool.should be_true
+
+    opened = JSON.parse(JSON.build { |j| Gori::MCP::Serialize.intercept_item_detail(j, row, true, 0_i64) })
+    opened["body_preview"].as_s.should contain("eyJhbGciOi")
+  end
+
+  # `redact_head` skips line 0 (an HTTP start line) and stops at the first blank line (the end
+  # of an HTTP header block). A WebSocket message has neither, so both exemptions are holes.
+  it "redacts the FIRST line and lines after a blank one, which redact_head does not" do
+    first = Gori::MCP::Serialize.redact_message_lines("cookie: sid=secret\nx: 1", false)
+    first.should_not contain("sid=secret")
+    after = Gori::MCP::Serialize.redact_message_lines("hello\n\nauthorization: Bearer secret", false)
+    after.should_not contain("Bearer secret")
+    # The HTTP head rule is untouched — it still exempts both, because an HTTP head has both.
+    Gori::MCP::Serialize.redact_head("cookie: sid=secret\nx: 1", false).should contain("sid=secret")
+  end
+
+  it "keeps an HTTP row on head_preview" do
+    row = desync_held("POST /x HTTP/1.1\nHost: h\nContent-Length: 8\n\nSMUGGLED")
+    obj = JSON.parse(JSON.build { |j| Gori::MCP::Serialize.intercept_item_row(j, row, true, 0_i64) })
+    obj["head_preview"].as_s.should contain("POST /x")
+    obj["body_preview"]?.should be_nil
+  end
+end
+
 # The scanner both shapes come from. `head_body_boundary` (body start) and
 # `head_body_separator` ({offset, width}) must never disagree, because a caller that renders
 # the head as TEXT needs the offset and cannot derive it by subtracting a fixed 4.

--- a/spec/interceptor_spec.cr
+++ b/spec/interceptor_spec.cr
@@ -708,3 +708,123 @@ describe "Interceptor scope gates over an ABSOLUTE-FORM target" do
     end
   end
 end
+
+# The intercept forward is the THIRD send seam (with `Repeater::Sender` and `Fuzz::Sender`), so
+# the active session slot's header overlay applies to a held REQUEST going back on the wire —
+# `Interceptor#overlay_slot` says so. It applied on `forward`/`forward_all` and NOT on
+# `toggle`, so a project browsing as the "admin" slot had the requests released by turning
+# catch off reach the origin as a DIFFERENT identity than every other request in the session,
+# with nothing saying so.
+#
+# `release_all` is the ONE release that must NOT overlay, and its spec is below: `Session#close`
+# drops the binding layer immediately before calling it, so an overlay there is either a no-op
+# or — when the layer has since been rebound by another `Session.open` — this project's held
+# requests stamped with ANOTHER project's slot headers.
+private def with_slot_layer(store, &)
+  slots = Gori::SessionSlots.load(store)
+  slots.save([Gori::SessionSlot.new("admin", set_headers: [{"X-Who", "admin"}])])
+  bindings = Gori::Bindings.load(store, slots)
+  slots.activate("admin")
+  previous = Gori::Env.layer
+  Gori::Env.layer = bindings
+  begin
+    yield
+  ensure
+    Gori::Env.layer = previous
+  end
+end
+
+private def hold_one(ic) : Channel(Gori::Interceptor::Decision)
+  ch = Channel(Gori::Interceptor::Decision).new
+  spawn do
+    ch.send(ic.hold_request("GET /me HTTP/1.1\r\nHost: h\r\n\r\n".to_slice,
+      method: "GET", target: "/me", host: "h", port: 80, scheme: "http"))
+  end
+  Fiber.yield
+  ch
+end
+
+describe "Gori::Interceptor — the session-slot overlay on every release" do
+  it "applies it on forward, forward_all and toggle-off alike" do
+    {
+      "forward"     => ->(ic : Gori::Interceptor) { ic.forward(ic.pending.first.id); nil },
+      "forward_all" => ->(ic : Gori::Interceptor) { ic.forward_all; nil },
+      "toggle-off"  => ->(ic : Gori::Interceptor) { ic.toggle; nil },
+    }.each do |name, release|
+      with_store do |store|
+        with_slot_layer(store) do
+          ic = Gori::Interceptor.new(Gori::Scope.load(store))
+          ic.toggle
+          ch = hold_one(ic)
+          release.call(ic)
+          sent = String.new(ch.receive.bytes)
+          fail "#{name} skipped the session-slot overlay: #{sent.inspect}" unless sent.includes?("X-Who: admin")
+        end
+      end
+    end
+  end
+
+  # Shutdown is the exception, and it has to stay one. `Session#close` runs
+  # `Env.layer = nil if Env.layer.same?(@bindings)` on the line ABOVE `@interceptor.release_all`
+  # — deliberately, so a `$SESSION` cannot resolve against a closed project's table. If the
+  # guard does not fire (a second `Session.open`, or MCP's `bind_binding_layer`, rebound the
+  # layer first) the layer that survives belongs to a DIFFERENT project, and overlaying with it
+  # is the cross-project leak that drop exists to prevent.
+  it "leaves release_all byte-exact, even with a slot layer still installed" do
+    with_store do |store|
+      with_slot_layer(store) do
+        ic = Gori::Interceptor.new(Gori::Scope.load(store))
+        ic.toggle
+        ch = hold_one(ic)
+        ic.release_all
+        String.new(ch.receive.bytes).should_not contain("X-Who")
+      end
+    end
+  end
+
+  # A held RESPONSE is travelling to the operator's own browser and a WS frame has no header
+  # lines — `overlay_slot`'s two other gates. The bulk releases inherit them by construction
+  # (one helper), and this pins that they do.
+  it "leaves a held response byte-exact on toggle-off" do
+    with_store do |store|
+      with_slot_layer(store) do
+        ic = Gori::Interceptor.new(Gori::Scope.load(store))
+        ic.toggle
+        ch = Channel(Gori::Interceptor::Decision).new
+        spawn do
+          ch.send(ic.hold_response("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n".to_slice,
+            flow_id: 1_i64, method: "GET", target: "200 OK", host: "h", port: 80, scheme: "http"))
+        end
+        Fiber.yield
+        ic.toggle
+        String.new(ch.receive.bytes).should_not contain("X-Who")
+      end
+    end
+  end
+end
+
+# Turning catch OFF forwards every held message irreversibly, exactly as `forward_all` does —
+# and `forward_all` returns its count because "this toast is the operator's only record of how
+# many irreversible decisions just went out". `toggle` returned a bare Bool, so every surface
+# said "intercept off" for a flip that had just released four held requests.
+describe "Gori::Interceptor::ToggleResult" do
+  it "counts what the flip actually released, and reports 0 when turning ON" do
+    with_store do |store|
+      ic = Gori::Interceptor.new(Gori::Scope.load(store))
+      on = ic.toggle
+      on.enabled?.should be_true
+      on.released.should eq(0)
+
+      2.times { hold_one(ic) }
+      ic.pending_count.should eq(2)
+
+      off = ic.toggle
+      off.enabled?.should be_false
+      off.released.should eq(2)
+      ic.pending_count.should eq(0)
+
+      # Nothing held → nothing claimed, the same answer `forward_all` gives.
+      ic.toggle.released.should eq(0)
+    end
+  end
+end

--- a/src/gori/cli/run/intercept.cr
+++ b/src/gori/cli/run/intercept.cr
@@ -177,7 +177,11 @@ module Gori
             puts "No items currently held."
           else
             items.each do |r|
-              _, body = MCP::Serialize.head_and_body(r.raw)
+              # `held_head_and_body`, not `head_and_body(r.raw)`: a WebSocket message has no
+              # head to split off, so the HTTP splitter put the whole payload in `head` and
+              # this row printed `(0b body)` for every held WS message — the one number a WS
+              # row is about. See its doc comment.
+              _, body = MCP::Serialize.held_head_and_body(r)
               # method/scheme/host/target are parsed off the wire (a held request's request
               # line / Host header, or a held response) — CLI::Output.term_safe neutralizes
               # any ANSI/OSC/CSI escapes before they hit the live terminal (see its doc
@@ -194,6 +198,29 @@ module Gori
             end
           end
         end
+      end
+
+      # How much of a held WebSocket payload `intercept get` prints as text. A WS message runs
+      # to `WS::Relay::MAX_MESSAGE` (16 MiB) and this goes straight to a terminal; the HTTP
+      # branch opposite it is bounded by the head codec's own 256 KiB ceiling, so this makes
+      # the same bound explicit rather than inheriting one it does not have.
+      WS_PAYLOAD_PRINT_MAX = 256 * 1024
+
+      # The payload of a held WebSocket message, for the text `get`. No-op for anything else —
+      # an HTTP hold's head is printed by the caller and its body is deliberately not.
+      #
+      # Redacted unless `--include-sensitive`, exactly as the head branch beside it is. A WS
+      # payload used to be printed THROUGH `redact_head` (it arrived in the `head` slot), so
+      # printing it raw here would put a line-oriented protocol's credential on the terminal
+      # for a command that did not ask for one — see `Serialize.redact_message_lines`, which
+      # is the same rule without the two HTTP-shaped exemptions.
+      private def self.emit_ws_payload(row : Store::HeldRow, include_sensitive : Bool) : Nil
+        return unless row.ws? && !row.binary?
+        raw = row.raw
+        cut = raw.size > WS_PAYLOAD_PRINT_MAX
+        text = String.new(cut ? raw[0, WS_PAYLOAD_PRINT_MAX] : raw).scrub
+        puts CLI::Output.term_safe_multiline(MCP::Serialize.redact_message_lines(text, include_sensitive)).rstrip
+        puts "[… truncated at #{WS_PAYLOAD_PRINT_MAX} bytes]" if cut
       end
 
       # "gori will not apply an edit to this message, and here is why" — printed before the
@@ -271,17 +298,23 @@ module Gori
           if format == :json
             puts(JSON.build { |j| MCP::Serialize.intercept_item_detail(j, row, include_sensitive, now_ms) })
           else
-            head, body = MCP::Serialize.head_and_body(row.raw)
+            head, body = MCP::Serialize.held_head_and_body(row)
             redacted = MCP::Serialize.redact_head(head, include_sensitive)
             # ABOVE the head, because this is the reason not to start typing one: an edit gori
             # will not apply is decided when the message is HELD, and until it was carried on
             # the row this command printed an ordinary editable message and let the operator
             # find out from `intercept edit`'s exit code.
             emit_edit_warning(row)
-            puts CLI::Output.term_safe_multiline(redacted).rstrip
+            # A WebSocket message is ALL body, so `redacted` is empty for one and its PAYLOAD
+            # is what there is to print. A BINARY frame prints nothing (opcode 2 is
+            # protobuf/msgpack/CBOR — a wall of U+FFFD; the TUI answers the same case with a
+            # hex editor, and here the byte channel is `--format json --include-sensitive`).
+            puts CLI::Output.term_safe_multiline(redacted).rstrip unless redacted.empty?
+            emit_ws_payload(row, include_sensitive)
             unless body.empty?
               puts ""
-              puts "[#{body.size} bytes of body — use --format json --include-sensitive for the raw bytes]"
+              what = row.ws? ? "payload" : "body"
+              puts "[#{body.size} bytes of #{what} — use --format json --include-sensitive for the raw bytes]"
             end
           end
         ensure

--- a/src/gori/interceptor.cr
+++ b/src/gori/interceptor.cr
@@ -304,9 +304,31 @@ module Gori
       @revision.add(1)
     end
 
-    # Toggle on/off. Turning OFF auto-forwards everything currently held (so
-    # traffic never wedges). Returns the new state.
-    def toggle : Bool
+    # What a `toggle` DID: the state it left intercept in, and how many held messages the
+    # flip put on the wire on its way out.
+    #
+    # The count is not decoration. Turning catch off is an operator gesture that forwards
+    # every message in the queue irreversibly, exactly as `forward_all` does — and
+    # `forward_all` returns its count for a reason it states: "this toast is the operator's
+    # only record of how many irreversible decisions just went out". A bare `Bool` left every
+    # surface saying "intercept off" for a flip that had just released four held requests.
+    #
+    # A preceding `pending_count` is NOT the same answer, which is why this rides on the
+    # release itself: a proxy fiber holding a message between the count and the flip has it
+    # forwarded too.
+    record ToggleResult, enabled : Bool, released : Int32 do
+      def enabled? : Bool
+        enabled
+      end
+    end
+
+    # Toggle on/off. Turning OFF auto-forwards everything currently held (so traffic never
+    # wedges) with NO SURFACE'S IN-PROGRESS EDIT — the fail-open disposition every involuntary
+    # release in this file takes, and the one thing that separates this from `forward_all`,
+    # which carries the editor's bytes. The bytes are not "untouched", though: the active
+    # session slot's overlay applies below, exactly as it does on `forward`. Returns what
+    # happened (see `ToggleResult`).
+    def toggle : ToggleResult
       released = [] of Item
       now_on = @mutex.synchronize do
         @enabled = !@enabled
@@ -317,8 +339,13 @@ module Gori
         @enabled
       end
       @revision.add(1) # enabled flipped (and possibly the queue cleared)
-      released.each { |it| it.reply.send(Decision.new(Action::Forward, it.raw)) }
-      now_on
+      # `overlay_slot`, not `it.raw`: these requests are going ON THE WIRE, and the active
+      # session slot is the same operator instruction `forward`/`forward_all` obey two
+      # methods down. Turning catch off is a bulk forward — a request that escaped the
+      # overlay here reached the origin as a different identity than every other request in
+      # the same session, silently.
+      released.each { |it| it.reply.send(Decision.new(Action::Forward, overlay_slot(it, it.raw))) }
+      ToggleResult.new(now_on, released.size)
     end
 
     # Conservative HOST-level gate: is holding even possible for this host? Scope rules that
@@ -630,6 +657,14 @@ module Gori
         @items.clear
         vals
       end
+      # `it.raw`, and deliberately NOT `overlay_slot` the way `toggle` and `forward` do.
+      # `Session#close` DROPS the binding layer immediately before calling this ("a `$SESSION`
+      # resolved against a closed project's table would be the worst kind of cross-project
+      # leak"), so an overlay here is a no-op in the normal case — and in the case where the
+      # guard does not fire, because another `Session.open` or MCP's `bind_binding_layer` has
+      # rebound `Env.layer` in the meantime, it would stamp THIS project's held requests with
+      # ANOTHER project's slot headers. That is precisely the leak the drop exists to prevent,
+      # reached from the one caller that runs after it.
       items.each { |it| it.reply.send(Decision.new(Action::Forward, it.raw)) }
     end
   end

--- a/src/gori/mcp/serialize.cr
+++ b/src/gori/mcp/serialize.cr
@@ -156,12 +156,73 @@ module Gori
         end
       end
 
+      # How many characters of a held message's PREVIEW any surface will render (`String#size`,
+      # matching the head preview this was lifted out of).
+      HELD_PREVIEW_MAX = 1024
+
+      # {head text, body bytes} of a HELD row, which is NOT `head_and_body(row.raw)`.
+      #
+      # A WebSocket message is ALL body — no start line, no headers, no blank-line separator —
+      # exactly as the TUI's `InterceptView#ws_window_for` already models it ("an empty head
+      # and the payload as lazy BodyLines"). Run through the HTTP splitter it came back the
+      # other way round: the WHOLE payload as `head`, and `body_size: 0` for every held WS
+      # message on both cross-process surfaces. That is the one fact a WS row IS about —
+      # `Item#label` ends a WS message with its byte count, and `gori run intercept list`
+      # prints `(0b body)` beside a 40 KB frame. A payload that happens to CONTAIN a blank
+      # line (a pretty-printed JSON message, a multi-line chat body) was worse than useless:
+      # the split landed inside it, so the preview stopped there and `body_size` described a
+      # fragment. `redact_head` then ran header redaction over a message with no headers.
+      def self.held_head_and_body(row : Store::HeldRow) : {String, Bytes}
+        return {"", row.raw} if row.ws?
+        head_and_body(row.raw)
+      end
+
+      # A held WS message's payload as previewable text, or nil when there is nothing to show
+      # (a BINARY frame — opcode 2 is protobuf/msgpack/CBOR, and rendering it is a wall of
+      # U+FFFD; `binary`/`binary_note` and `body_size` are what that row has to say). Mirrors
+      # the TUI's `ws_preview`, which refuses the same case for the same reason.
+      #
+      # `include_sensitive` is NOT optional here, and the reason is the whole of why this
+      # takes the argument at all. Before a WS payload had a field of its own it reached the
+      # caller through `head`/`head_preview` — i.e. through `redact_head`. Handing it back
+      # unredacted would put a line-oriented protocol's credential (STOMP's
+      # `CONNECT\nauthorization:Bearer …`, any framing with header-shaped lines) into an
+      # `intercept_get` that did NOT ask for sensitive values, in the same object that still
+      # reports `raw_redacted: true` — and for any text message under the preview cap this
+      # field IS the full raw payload that `raw_base64` is deliberately gated on.
+      def self.held_body_preview(row : Store::HeldRow, include_sensitive : Bool) : String?
+        return nil unless row.ws? && !row.binary?
+        text = redact_message_lines(String.new(row.raw).scrub, include_sensitive)
+        text.size > HELD_PREVIEW_MAX ? "#{text[0, HELD_PREVIEW_MAX]}…" : text
+      end
+
+      # `redact_head`'s rule applied to a message that has NO head: every line is eligible.
+      #
+      # `redact_head` skips line 0 (an HTTP start line) and stops at the first blank line (the
+      # end of an HTTP header block). A WebSocket message has neither — it is all payload — so
+      # a credential on its first line, or after a blank line inside it, would be handed back
+      # in the clear by the HTTP rule. Same `SENSITIVE_HEADERS` list, same `[REDACTED]`, same
+      # line endings preserved; only the two HTTP-shaped exemptions are dropped.
+      def self.redact_message_lines(text : String, include_sensitive : Bool) : String
+        return text if include_sensitive || !text.includes?(':')
+        text.split('\n').map do |line|
+          colon = line.index(':')
+          next line unless colon
+          name = line[0, colon]
+          next line unless sensitive_header?(name)
+          "#{name}: [REDACTED]#{"\r" if line.ends_with?('\r')}"
+        end.join('\n')
+      end
+
       # List projection: metadata + a redacted, truncated head preview (no body). age_seconds
       # is derived from the wall-clock held_at_ms (stable across snapshot republishes).
+      #
+      # `head_preview` is emitted only for a message that HAS a head; a WebSocket row carries
+      # `body_preview` instead (see `held_head_and_body`). Two names rather than one field
+      # meaning different things per kind, because an agent reading `head_preview` on a WS row
+      # was reading a body and had nothing telling it so.
       def self.intercept_item_row(j : JSON::Builder, row : Store::HeldRow, include_sensitive : Bool, now_ms : Int64) : Nil
-        head, body = head_and_body(row.raw)
-        preview = redact_head(head, include_sensitive)
-        preview = "#{preview[0, 1024]}…" if preview.size > 1024
+        head, body = held_head_and_body(row)
         j.object do
           j.field "item_id", row.item_id
           j.field "kind", text(row.kind)
@@ -177,7 +238,13 @@ module Gori
           j.field "edited", row.edited
           emit_edit_warning(j, row)
           j.field "body_size", body.size
-          j.field "head_preview", preview
+          if row.ws?
+            held_body_preview(row, include_sensitive).try { |t| j.field "body_preview", text(t) }
+          else
+            preview = redact_head(head, include_sensitive)
+            preview = "#{preview[0, HELD_PREVIEW_MAX]}…" if preview.size > HELD_PREVIEW_MAX
+            j.field "head_preview", preview
+          end
         end
       end
 
@@ -214,7 +281,7 @@ module Gori
       # Cookie header bytes the `head` field carefully redacts. Redacting inside raw is NOT an
       # option (it would corrupt the bytes the agent round-trips), so we gate instead.
       def self.intercept_item_detail(j : JSON::Builder, row : Store::HeldRow, include_sensitive : Bool, now_ms : Int64) : Nil
-        head, body = head_and_body(row.raw)
+        head, body = held_head_and_body(row)
         j.object do
           j.field "item_id", row.item_id
           j.field "kind", text(row.kind)
@@ -228,7 +295,12 @@ module Gori
           j.field "age_seconds", ((now_ms - row.held_at_ms) // 1000)
           j.field "edited", row.edited
           emit_edit_warning(j, row)
-          j.field "head", redact_head(head, include_sensitive)
+          # `head`/`body_preview` split by kind, for the reason `held_head_and_body` states.
+          if row.ws?
+            held_body_preview(row, include_sensitive).try { |t| j.field "body_preview", text(t) }
+          else
+            j.field "head", redact_head(head, include_sensitive)
+          end
           j.field "body_size", body.size
           j.field "raw_size", row.raw.size
           if include_sensitive

--- a/src/gori/mcp/tools/intercept.cr
+++ b/src/gori/mcp/tools/intercept.cr
@@ -302,12 +302,15 @@ module Gori
           "available:false when no bridge has ever been published; capturing:false (with a " \
           "growing heartbeat_age_seconds) when the last capturing instance is no longer live, " \
           "in which case mutating verbs refuse. Header values redacted unless " \
-          "include_sensitive:true." do |s|
+          "include_sensitive:true. An HTTP row carries head_preview + body_size; a WebSocket " \
+          "row has no head at all, so it carries body_preview (omitted for a BINARY frame) and " \
+          "body_size is the whole payload." do |s|
           s.field "include_sensitive", boolprop("show Authorization/Cookie/etc header values instead of [REDACTED] (default false)")
         end
 
         tool j, "intercept_get",
-          "Full detail for ONE held intercept item (redacted head + body size). Pass " \
+          "Full detail for ONE held intercept item (redacted head + body size; a WebSocket " \
+          "message has no head, so it returns body_preview and body_size is the payload). Pass " \
           "include_sensitive:true to ALSO get the full raw message base64 (unredacted; edit it " \
           "and send it back as intercept_forward_edit's raw_base64 for a byte-exact round " \
           "trip) — otherwise raw is withheld " \

--- a/src/gori/tui/controllers/intercept_controller.cr
+++ b/src/gori/tui/controllers/intercept_controller.cr
@@ -523,9 +523,26 @@ module Gori::Tui
 
     # --- verbs (delegated from the Runner's ExecContext; also called inline above) ---
     def intercept_toggle : Nil
-      on = @host.session.interceptor.toggle
+      result = @host.session.interceptor.toggle
       @intercept.reload(@host.session.interceptor)
-      @host.status(on ? "intercept ON — held traffic waits (HTTPS→h1 for in-scope; gRPC may fail)" : "intercept off")
+      @host.status(toggle_status(result))
+    end
+
+    # What turning catch OFF actually did. `forward_all` names its count because "this toast is
+    # the operator's only record of how many irreversible decisions just went out"; toggle-off
+    # is the same act reached from a different key, and it said only "intercept off" — for a
+    # flip that had just put four held requests on the wire.
+    #
+    # It names the EDITOR, not the bytes. "unedited" would be a false claim: `Interceptor#toggle`
+    # still applies the active session slot's overlay, as every send seam does. What the flip
+    # drops is the one thing ⇧F carries — an open editor's in-progress changes — and that is
+    # the difference the operator has to be able to see between the two keys.
+    private def toggle_status(result : Interceptor::ToggleResult) : String
+      return "intercept ON — held traffic waits (HTTPS→h1 for in-scope; gRPC may fail)" if result.enabled?
+      return "intercept off" if result.released == 0
+      n = result.released
+      "intercept off — auto-forwarded #{n} held message#{n == 1 ? "" : "s"} " \
+      "(an open editor's changes were NOT applied — ⇧F forwards all WITH them)"
     end
 
     # Forward the effective target set: every marked hold, else the cursor row. The editor

--- a/src/gori/tui/runner/intercept_bridge.cr
+++ b/src/gori/tui/runner/intercept_bridge.cr
@@ -124,13 +124,7 @@ class Gori::Tui::Runner < Gori::Verb::ExecContext
       end
       true
     when "toggle"
-      # Desired-state (idempotent): flip only if current != requested, so a re-applied command
-      # can't oscillate. NOTE: enabling only affects NEW connections (h2→h1 downgrade gate).
-      want = cmd.arg == "true"
-      ic.toggle if ic.enabled? != want
-      store.ack_intercept_command(cmd.id, "toggled", "enabled=#{ic.enabled?}")
-      push_config_note("agent #{ic.enabled? ? "enabled" : "disabled"} intercept")
-      true
+      apply_intercept_toggle(ic, store, cmd)
     when "set_filter"
       q = cmd.arg || ""
       ic.set_filter(q)
@@ -151,6 +145,25 @@ class Gori::Tui::Runner < Gori::Verb::ExecContext
       store.ack_intercept_command(cmd.id, "error", "unknown verb #{cmd.verb}")
       false
     end
+  end
+
+  # Desired-state (idempotent): flip only if current != requested, so a re-applied command
+  # can't oscillate. NOTE: enabling only affects NEW connections (h2→h1 downgrade gate).
+  #
+  # The ack names how many held messages the flip FORWARDED, for the reason
+  # `Interceptor::ToggleResult` exists: disabling catch is a bulk irreversible forward, and
+  # `enabled=false` alone told the agent nothing about the four requests it had just released.
+  # The detail names the EDITOR, not the bytes: a toggle is a fail-open release, so it carries
+  # no surface's in-progress edit — but the active session slot's overlay still applies, as it
+  # does on every forward, so calling the bytes "unedited" would be a false claim.
+  private def apply_intercept_toggle(ic : Interceptor, store : Store, cmd : Store::CommandRow) : Bool
+    want = cmd.arg == "true"
+    released = ic.enabled? == want ? 0 : ic.toggle.released
+    detail = "enabled=#{ic.enabled?}"
+    detail += ", auto-forwarded #{released} held message(s) with no in-progress edit applied" if released > 0
+    store.ack_intercept_command(cmd.id, "toggled", detail)
+    push_config_note("agent #{ic.enabled? ? "enabled" : "disabled"} intercept")
+    true
   end
 
   # An agent config action (toggle/filter/direction) has no held item, so it jumps to the


### PR DESCRIPTION
Three defects found auditing the Intercept feature end to end (core → h1/h2/WS gates → TUI/CLI/MCP). Each was reproduced before the fix and is pinned by a spec that fails without it.

### A held WebSocket message was projected through the HTTP head/body splitter

MCP `intercept_list`/`intercept_get` and `gori run intercept list`/`get` all ran `Serialize.head_and_body(row.raw)` on a WS payload — which has no start line, no headers and no blank-line separator. The TUI already models it correctly (`InterceptView#ws_window_for`: *"a WebSocket message is ALL body"*), so this was a two-surface drift from the one that had it right.

```
{"kind":"wsout", ..., "body_size":0, "head_preview":"{\"cmd\":\"buy\",\"qty\":100}"}
```

* a 40 KB frame reported `body_size: 0`, and `gori run intercept list` printed `(0b body)` — the one number a WS row is about, since `Item#label` ends a WS message with its byte count
* a payload that *contains* a blank line (pretty-printed JSON, a multi-line chat body) was worse: the split landed inside it, so the preview stopped there and `body_size` described a fragment
* `redact_head` ran header redaction over a message with no headers

`held_head_and_body` branches on the kind. A WS row now carries `body_preview` (omitted for a BINARY frame — opcode 2 is protobuf/msgpack/CBOR) and a `body_size` that is the payload.

Redaction moved with it rather than being dropped: a WS payload used to reach the caller *through* `redact_head`, so giving it a field of its own must not also give it a way past the `include_sensitive` gate — for any text message under the preview cap `body_preview` **is** the full raw payload that `raw_base64` is deliberately gated on. `redact_message_lines` applies the same `SENSITIVE_HEADERS` rule without `redact_head`'s two HTTP-head exemptions (skip line 0, stop at the first blank line), which are holes on a payload: a STOMP `CONNECT\nauthorization:Bearer …` is redacted on both surfaces unless the caller asks.

### The session-slot overlay skipped the release that turning catch off performs

The intercept forward is the third send seam (with `Repeater::Sender` and `Fuzz::Sender`); `forward`/`forward_all` apply `Env.overlay_slot` for it and `toggle` did not. The same held request went out with the active slot's headers under ⇧F and without them under `i` — reaching the origin as a different identity than every other request in the session, silently.

`release_all` deliberately stays byte-exact, and there is now a spec saying so: `Session#close` runs `Env.layer = nil if Env.layer.same?(@bindings)` on the line *above* it, so an overlay there is a no-op at best — and when the guard does not fire because a second `Session.open` (or MCP's `bind_binding_layer`) has rebound the layer, it would stamp this project's held requests with **another project's** slot headers. That is exactly the cross-project leak the drop exists to prevent.

### Turning catch off forwarded every held message with no receipt

`forward_all` returns its count for a stated reason: *"this toast is the operator's only record of how many irreversible decisions just went out"*. `toggle` returned a bare `Bool`, so the TUI said `intercept off` and MCP acked `enabled=false` for a flip that had just put four held requests on the wire.

It returns a `ToggleResult{enabled, released}` now. Both surfaces name the count and the one thing the flip drops that ⇧F carries — an open editor's in-progress changes. They deliberately do **not** call the bytes "unedited": the slot overlay above still applies.

### Verification

* full suite green — **9793 examples, 0 failures**
* 11 new specs; control-run with the fixes reverted confirms each one catches its defect
* `crystal build --no-codegen src/main.cr` clean, `crystal tool format --check` clean
* ameba on the diff: only pre-existing violations, and `apply_intercept_command`'s complexity drops 22 → 20 (the toggle branch was extracted)

Findings 1–4 from an adversarial review of the first draft of this branch are folded in — the `release_all` overlay and the lost `include_sensitive` gate were both introduced by that draft and are fixed here.