### PR TITLE
Rewriter: three ways a rule did something other than what its row said

### DIFF
--- a/spec/rules_spec.cr
+++ b/spec/rules_spec.cr
@@ -669,4 +669,46 @@ describe Gori::Rules do
       end
     end
   end
+  # `normalize_shape` above is what every CRUD surface applies BEFORE a rule is written. A
+  # hand-edited settings.json goes around all of them — it is a supported way to write a global
+  # rule, which is why the enum fields read as the labels `gori run rewriter` prints — and
+  # `parse_rewriter_rules` used to clamp the four of them INDEPENDENTLY. So `{op: "set_header",
+  # part: "ws"}`, a pair the CLI and the MCP tools both refuse outright, parsed.
+  #
+  # It is not merely inert once parsed. `part` is what the FAST-PATH counts key on, and those
+  # counts are not "which rules apply" — they are "which of gori's byte-fidelity shortcuts this
+  # connection loses": `part: ws` takes `WS::Relay` off its byte-exact pump (frame boundaries,
+  # mask keys, fragmentation), `part: body` buffers every body AND costs the host HTTP/2. A rule
+  # that can never fire was paying all of that.
+  describe "a rule whose op and part disagree" do
+    it "does not take a WebSocket direction off the byte-exact pump" do
+      with_globals do
+        Gori::Settings.rewriter_rules = [
+          Gori::Settings::RewriterRule.new(1_i64, true, "hand-edited", "request", "ws",
+            "X-Bad", "v", "set_header", "literal", "", ""),
+        ]
+        with_store do |store|
+          rules = Gori::Rules.load(store)
+          rules.rewrites_ws_out_for_host?("a.test").should be_false
+          # …and it never could have fired: `apply` filtered it out all along.
+          payload = "hello".to_slice
+          rules.rewrite_ws_out(payload, "a.test").should eq(payload)
+        end
+      end
+    end
+
+    it "does not buy a body buffer (or cost the host HTTP/2) for a head-only op" do
+      with_globals do
+        Gori::Settings.rewriter_rules = [
+          Gori::Settings::RewriterRule.new(1_i64, true, "hand-edited", "request", "body",
+            "X-Bad", "v", "add_header", "literal", "", ""),
+        ]
+        with_store do |store|
+          rules = Gori::Rules.load(store)
+          rules.rewrites_request_body?.should be_false
+          rules.rewrites_body_for_host?("a.test").should be_false
+        end
+      end
+    end
+  end
 end

--- a/spec/settings/rewriter_rules_spec.cr
+++ b/spec/settings/rewriter_rules_spec.cr
@@ -1,0 +1,112 @@
+require "../spec_helper"
+require "file_utils"
+
+# `Settings.rewriter_rules` — the GLOBAL half of the Match & Replace rule set, the library
+# every project reads. The parse is the boundary a HAND-EDITED settings.json crosses on its way
+# into the live rewrite engine, and hand-editing is a supported way to write these: the enum
+# fields are stored as the same labels `gori run rewriter` prints, precisely so the file reads
+# the way the CLI does.
+#
+# Which is what makes the SHAPE the parse's business too. The four enum fields are clamped
+# INDEPENDENTLY, so `{op: "set_header", part: "ws"}` — a pair the CLI and MCP tools both REFUSE
+# outright rather than normalize — used to arrive in the rule list intact. A header op acts by
+# header NAME and only a head has header lines, so it can never fire; `Rules`' own `rewrites?`
+# keeps it out of the counts and the select. This file pins the parse half: the entry is
+# DROPPED, never coerced onto the head. Coercion is what `Rules.normalize_shape` calls "a
+# different protocol, not a narrower shape" — and it would take a rule that does nothing and
+# put it on every request head in every project, live, on the strength of a parse.
+private def with_rewriter_home(&)
+  dir = File.tempname("gori-rewriter-rules")
+  Dir.mkdir_p(dir)
+  prev_home = ENV["GORI_HOME"]?
+  before = Gori::Settings.rewriter_rules
+  counter = Gori::Settings.rewriter_next_rule_id
+  begin
+    ENV["GORI_HOME"] = dir
+    Gori::Settings.rewriter_rules = [] of Gori::Settings::RewriterRule
+    yield dir
+  ensure
+    prev_home ? (ENV["GORI_HOME"] = prev_home) : ENV.delete("GORI_HOME")
+    Gori::Settings.rewriter_rules = before
+    Gori::Settings.rewriter_next_rule_id = counter
+    FileUtils.rm_rf(dir)
+  end
+end
+
+private def write_settings(json : String) : Nil
+  File.write(Gori::Settings.path, json)
+end
+
+private def shapes : Array({String, String, String})
+  Gori::Settings.rewriter_rules.map { |r| {r.op, r.target, r.part} }
+end
+
+describe "Gori::Settings rewriter rule shape" do
+  it "drops a header op that names a part with no header lines" do
+    with_rewriter_home do
+      write_settings(<<-JSON)
+        {"rewriter": {"rules": [
+          {"id": 1, "enabled": true, "pattern": "X-Bad", "op": "set_header", "part": "ws", "target": "response"},
+          {"id": 2, "enabled": true, "pattern": "X-Also-Bad", "op": "remove_header", "part": "body", "target": "request"}
+        ]}}
+        JSON
+      Gori::Settings.load
+      Gori::Settings.rewriter_rules.should be_empty
+    end
+  end
+
+  # The neighbours in the same array survive — one impossible entry is not a reason to lose the
+  # file, which is the whole disposition this parse is built on (see `clamp_field`).
+  it "keeps every other rule in the array" do
+    with_rewriter_home do
+      write_settings(<<-JSON)
+        {"rewriter": {"rules": [
+          {"id": 1, "enabled": true, "pattern": "X-Bad", "op": "add_header", "part": "ws", "target": "request"},
+          {"id": 2, "enabled": true, "pattern": "csp", "op": "remove_header", "part": "head", "target": "response"}
+        ]}}
+        JSON
+      Gori::Settings.load
+      shapes.should eq([{"remove_header", "response", "head"}])
+      Gori::Settings.rewriter_rules.first.id.should eq(2)
+    end
+  end
+
+  # Only the pair that cannot fire is touched. A `replace` rule means something on all three
+  # parts (`ws` is a WebSocket message), and a `short_circuit` rule ignores its part and target
+  # at match time — normalizing either here would be the coercion this drop exists to avoid.
+  it "leaves every shape that can actually fire alone, ws included" do
+    with_rewriter_home do
+      write_settings(<<-JSON)
+        {"rewriter": {"rules": [
+          {"id": 1, "enabled": true, "pattern": "a", "op": "replace", "part": "ws", "target": "response"},
+          {"id": 2, "enabled": true, "pattern": "b", "op": "replace", "part": "body", "target": "request"},
+          {"id": 3, "enabled": true, "pattern": "/admin", "op": "short_circuit", "part": "head", "target": "request"}
+        ]}}
+        JSON
+      Gori::Settings.load
+      shapes.should eq([
+        {"replace", "response", "ws"},
+        {"replace", "request", "body"},
+        {"short_circuit", "request", "head"},
+      ])
+    end
+  end
+
+  it "keeps a well-shaped rule's id, pattern, host and enabled state" do
+    with_rewriter_home do
+      write_settings(<<-JSON)
+        {"rewriter": {"rules": [
+          {"id": 7, "enabled": true, "name": "strip", "pattern": "X-Bad", "replacement": "v",
+           "op": "remove_header", "part": "head", "target": "response", "host": "*.corp.internal"}
+        ]}}
+        JSON
+      Gori::Settings.load
+      rule = Gori::Settings.rewriter_rules.first
+      rule.id.should eq(7)
+      rule.enabled.should be_true
+      rule.name.should eq("strip")
+      rule.pattern.should eq("X-Bad")
+      rule.host.should eq("*.corp.internal")
+    end
+  end
+end

--- a/spec/tui/rewriter_duplicate_preview_spec.cr
+++ b/spec/tui/rewriter_duplicate_preview_spec.cr
@@ -1,0 +1,253 @@
+require "../spec_helper"
+require "../support/memory_backend"
+require "file_utils"
+
+include Gori::Tui
+
+# Two things the Rewriter tab did to a rule the operator was looking at.
+#
+# `c` (duplicate) built the copy through `Rules#add`, whose `enabled` defaults to true because
+# "add a rule" means "start rewriting". Duplicating is not adding: the row the key was pressed
+# on says `·` or `✓`, and a copy of a DISABLED rule coming back armed is a live traffic rewrite
+# nobody asked for — for a `stub` rule, an endpoint that stops reaching the origin at all.
+#
+# The PREVIEW pair passed `RuleTarget::Request` unconditionally, so every `RES` rule in the list
+# — half of what the tab can express — previewed as "nothing happened", with nothing on screen
+# saying the pane could not test it. The side is now read off the sample's own first line.
+
+private class FakeHost
+  include Gori::Tui::Host
+
+  getter statuses = [] of String
+  property active_tab : Symbol = :rewriter
+
+  def initialize(@session : Gori::Session)
+    @jobs = Gori::Tui::Jobs.new
+    @notifications = Gori::Tui::Notifications.new
+  end
+
+  def session : Gori::Session
+    @session
+  end
+
+  def jobs : Gori::Tui::Jobs
+    @jobs
+  end
+
+  def notifications : Gori::Tui::Notifications
+    @notifications
+  end
+
+  def status(message : String) : Nil
+    @statuses << message
+  end
+
+  def request_overlay(kind : Symbol) : Nil
+  end
+
+  def request_focus(pane : Symbol) : Nil
+  end
+
+  def focus_body : Nil
+  end
+
+  def switch_tab(tab : Symbol) : Nil
+  end
+
+  def goto_tab(tab : Symbol) : Nil
+  end
+
+  def open_palette : Nil
+  end
+
+  def open_help_query(surface : Symbol) : Nil
+  end
+
+  def open_space_menu : Nil
+  end
+
+  def open_fuzz_set_editor(edit_index : Int32?) : Nil
+  end
+
+  def open_fuzz_advanced_editor : Nil
+  end
+
+  def open_authorize_identities : Nil
+  end
+
+  def reconfigure_sequence : Nil
+  end
+
+  def open_scope_rule_editor(edit_id : Int64?, kind : String, match_type : String, pattern : String) : Nil
+  end
+
+  def open_custom_rule_editor(rule : Gori::Probe::CustomRule?) : Nil
+  end
+
+  def open_rewriter_rule_editor(rule : Gori::Store::MatchRule?) : Nil
+  end
+
+  def open_colormarker_rule_editor(rule : Gori::Store::ColorRule?) : Nil
+  end
+
+  def open_colormarker_color_editor(color : Gori::Settings::ColormarkerColor?) : Nil
+  end
+
+  def open_extract_rule_editor(rule : Gori::Store::ExtractRule?) : Nil
+  end
+
+  def open_chain_save : Nil
+  end
+
+  def open_chain_load : Nil
+  end
+
+  def open_oast_provider_editor(provider : Gori::Oast::ProviderConfig?) : Nil
+  end
+
+  def confirm(title : String, message : String, *, confirm_label : String, danger : Bool,
+              return_to : Symbol = :none, &action : -> Nil) : Nil
+    action.call
+  end
+
+  def overlay : Symbol
+    :none
+  end
+
+  def focus : Symbol
+    :body
+  end
+
+  def reveal? : Bool
+    false
+  end
+
+  def toggle_reveal : Nil
+  end
+
+  def pretty? : Bool
+    false
+  end
+
+  def toggle_pretty : Nil
+  end
+
+  def toggle_scope_lens : Nil
+  end
+
+  def toggle_sandbox : Nil
+  end
+
+  def apply_project_network(bind_host : String, bind_port : Int32, upstream : String,
+                            connect_secs : Int32, io_secs : Int32, capture_mib : Int32) : String
+    ""
+  end
+end
+
+# The CA is the one slow part of standing a Session up (a root keypair) and no example asserts
+# anything about it, so it is built once.
+private REWRITER_DUP_CA = File.tempname("gori-rewriter-dup-ca")
+Spec.after_suite { FileUtils.rm_rf(REWRITER_DUP_CA) }
+
+private def with_rewriter_controller(&)
+  root = File.tempname("gori-rewriter-dup")
+  Dir.mkdir_p(root)
+  project = Gori::ProjectRegistry.new(root).temp("rewriterdup")
+  session = Gori::Session.open(Gori::Config.new(listen: "127.0.0.1", port: 0),
+    Gori::Proxy::Tls::CertAuthority.load_or_create(REWRITER_DUP_CA), Gori::Verbs.registry, project)
+  begin
+    host = FakeHost.new(session)
+    yield RewriterController.new(host), host, session
+  ensure
+    session.close
+    FileUtils.rm_rf(root) if Dir.exists?(root)
+  end
+end
+
+describe "Gori::Tui::RewriterController#rewriter_duplicate" do
+  it "keeps a disabled rule disabled in the copy" do
+    with_rewriter_controller do |ctl, host, session|
+      rules = session.rules
+      rules.add(Gori::Store::RuleTarget::Request, Gori::Store::RulePart::Head, "secret", "x",
+        name: "redact", enabled: false)
+      ctl.selected_rule.try(&.enabled?).should be_false
+
+      host.statuses.clear
+      ctl.rewriter_duplicate
+
+      copies = session.rules.rules
+      copies.size.should eq(2)
+      # The copy is the operator's rule as they were looking at it: same bytes, same state.
+      copy = copies.last
+      copy.name.should eq("redact copy")
+      copy.pattern.should eq("secret")
+      copy.enabled?.should be_false
+      # And the toast says so, because an off rule is the one case where "duplicated" alone
+      # would leave the operator unsure which of the two answers they got.
+      host.statuses.first.should eq("rule duplicated (disabled, like the original)")
+    end
+  end
+
+  it "keeps an enabled rule enabled, and says nothing extra" do
+    with_rewriter_controller do |ctl, host, session|
+      session.rules.add(Gori::Store::RuleTarget::Request, Gori::Store::RulePart::Head, "a", "b")
+      host.statuses.clear
+      ctl.rewriter_duplicate
+      session.rules.rules.map(&.enabled?).should eq([true, true])
+      host.statuses.first.should eq("rule duplicated")
+    end
+  end
+end
+
+describe "Gori::Tui::RewriterController#preview_target" do
+  it "reads the side off the sample, so a RESPONSE rule can be previewed at all" do
+    with_rewriter_controller do |ctl, _host, session|
+      # A response-side rule: before this it could not be tried anywhere in the TUI.
+      session.rules.add(Gori::Store::RuleTarget::Response, Gori::Store::RulePart::Head,
+        "200 OK", "418 I'm a teapot")
+      ctl.preview_target.should eq(Gori::Store::RuleTarget::Request) # the default sample
+
+      ctl.@preview_input.set_text("HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\nhi")
+      ctl.preview_target.should eq(Gori::Store::RuleTarget::Response)
+      ctl.@out.source([] of String)
+      ctl.render_body(Screen.new(MemoryBackend.new(100, 40)), Rect.new(0, 0, 100, 40), :body)
+      ctl.@out.copy_all.should contain("418 I'm a teapot")
+    end
+  end
+
+  # …and the badge the side goes on has to say the OTHER half of "does this rule fire here".
+  # An empty host matches only an UNSCOPED rule, and a response head carries no `Host:` line —
+  # so a rule scoped `*.example.com` produces an unchanged pane, which reads exactly like a
+  # pattern that missed. The pane names the host it used instead.
+  it "names the host it scoped on, and says so when there is none" do
+    with_rewriter_controller do |ctl, _host, session|
+      session.rules.add(Gori::Store::RuleTarget::Response, Gori::Store::RulePart::Head,
+        "200 OK", "418", host: "example.com")
+      screen = Screen.new(MemoryBackend.new(100, 40))
+
+      # A response sample: no Host: line anywhere, so the host-scoped rule cannot fire.
+      ctl.@preview_input.set_text("HTTP/1.1 200 OK\r\n\r\nhi")
+      ctl.render_body(screen, Rect.new(0, 0, 100, 40), :body)
+      ctl.preview_host.should eq("")
+      ctl.@out.copy_all.should_not contain("418")
+
+      # `host_from_sample` reads a `Host:` line wherever it appears, which is how an operator
+      # previews a host-scoped RESPONSE rule at all.
+      ctl.@preview_input.set_text("HTTP/1.1 200 OK\r\nHost: api.example.com\r\n\r\nhi")
+      ctl.render_body(screen, Rect.new(0, 0, 100, 40), :body)
+      ctl.preview_host.should eq("api.example.com")
+      ctl.@out.copy_all.should contain("418")
+    end
+  end
+
+  it "leaves a request sample on the request side" do
+    with_rewriter_controller do |ctl, _host, session|
+      session.rules.add(Gori::Store::RuleTarget::Response, Gori::Store::RulePart::Head,
+        "200 OK", "418 I'm a teapot")
+      ctl.preview_target.should eq(Gori::Store::RuleTarget::Request)
+      ctl.render_body(Screen.new(MemoryBackend.new(100, 40)), Rect.new(0, 0, 100, 40), :body)
+      # A RES rule must not touch a REQ sample — the preview has to mirror the proxy path.
+      ctl.@out.copy_all.should_not contain("418")
+    end
+  end
+end

--- a/src/gori/rules.cr
+++ b/src/gori/rules.cr
@@ -86,14 +86,32 @@ module Gori
       @unbound_reported_rev = 0_u64
     end
 
+    # Whether this rule is a live REWRITE rule for {target, part} — the ONE shape test the
+    # counts, the per-host gates and `apply`'s own select all share. A nil `target` asks about
+    # both sides.
+    #
+    # `op.header? && !part.head?` is the clause that has to be here rather than only in
+    # `apply`. A header op names a header, so it can only act on a head, and every CRUD
+    # surface forces that shape (`normalize_shape`) — but a hand-edited settings.json is a
+    # supported way to write a global rule, and `parse_rewriter_rules` clamps the four enum
+    # fields INDEPENDENTLY, so `{op: set_header, part: ws}` used to parse. `apply` filtered
+    # it out, and the counts did not: the rule landed in `@ws_out_count`, which is what
+    # decides whether `WS::Relay` keeps its byte-exact pump — so a rule that can never fire
+    # took every message on that socket off frame-exact forwarding (P7). `part: body` is the
+    # same defect one notch louder: it makes `rewrites_body_for_host?` true, which buffers
+    # every body AND costs the host HTTP/2 (`tls/tunnel.cr`). Counting on the same predicate
+    # that applies is what keeps "a rule is live" from meaning two different things.
+    private def rewrites?(rule : Store::MatchRule, target : Store::RuleTarget?,
+                          part : Store::RulePart) : Bool
+      rule.enabled? && rule.op.rewrite? && !rule.pattern.empty? && rule.part == part &&
+        !(rule.op.header? && !part.head?) && (target.nil? || rule.target == target)
+    end
+
     # Count enabled, non-empty-pattern REWRITE rules matching an optional target + a part.
     # Short-circuit rules are never counted here — see `stub_count`.
     private def active_count(rules : Array(Store::MatchRule), target : Store::RuleTarget? = nil,
                              *, part : Store::RulePart) : Int32
-      rules.count do |r|
-        r.enabled? && r.op.rewrite? && !r.pattern.empty? && r.part == part &&
-          (target.nil? || r.target == target)
-      end
+      rules.count { |r| rewrites?(r, target, part) }
     end
 
     # Count enabled short-circuit rules whose stub is usable. A rule with an unparseable head
@@ -430,7 +448,7 @@ module Gori
       return false if @req_body_count.get == 0 && @resp_body_count.get == 0 # lock-free fast path
       @mutex.synchronize do
         @rules.any? do |r|
-          r.enabled? && r.op.rewrite? && !r.pattern.empty? && r.part.body? && host_matches?(r.host, host)
+          rewrites?(r, nil, Store::RulePart::Body) && host_matches?(r.host, host)
         end
       end
     end
@@ -465,8 +483,7 @@ module Gori
       return false if count.get == 0 # lock-free fast path
       @mutex.synchronize do
         @rules.any? do |r|
-          r.enabled? && r.op.rewrite? && !r.pattern.empty? && r.part.ws? &&
-            r.target == target && host_matches?(r.host, host)
+          rewrites?(r, target, Store::RulePart::Ws) && host_matches?(r.host, host)
         end
       end
     end
@@ -611,10 +628,7 @@ module Gori
                       count : Atomic(Int32), host : String, report : Bool = true) : Bytes
       return bytes if count.get == 0 # lock-free fast path: no rules to apply
       active = @mutex.synchronize do
-        @rules.select do |r|
-          r.enabled? && r.op.rewrite? && r.target == target && r.part == part && !r.pattern.empty? &&
-            !(r.op.header? && !part.head?) && host_matches?(r.host, host)
-        end
+        @rules.select { |r| rewrites?(r, target, part) && host_matches?(r.host, host) }
       end
       return bytes if active.empty? # nothing in scope → same bytes, byte-fidelity preserved
       text = String.new(bytes)

--- a/src/gori/settings/rewriter.cr
+++ b/src/gori/settings/rewriter.cr
@@ -91,7 +91,8 @@ module Gori::Settings
 
   # Tolerant global-rule parse: a non-array (or absent) node keeps the current value; entries
   # missing a pattern are dropped (a rule with no pattern can never match, and `Rules#add`
-  # refuses it anyway); the four enum fields are clamped to their allowed sets.
+  # refuses it anyway), as is a header op on a non-head part (`impossible_shape?`, same
+  # reasoning); the four enum fields are clamped to their allowed sets.
   #
   # Clamping rather than `from_label` is the point: those raise on an unknown label, and a
   # single typo in a hand-edited settings.json would take the whole file down through `load`'s
@@ -109,20 +110,42 @@ module Gori::Settings
       next unless o = e.as_h?
       pattern = o["pattern"]?.try(&.as_s?)
       next if pattern.nil? || pattern.empty?
+      op = clamp_field(o["op"]?.try(&.as_s?), RULE_OPS, "replace")
+      target = clamp_field(o["target"]?.try(&.as_s?), RULE_TARGETS, "request")
+      part = clamp_field(o["part"]?.try(&.as_s?), RULE_PARTS, "head")
+      next if impossible_shape?(op, part)
       list << RewriterRule.new(
         claim_id(o["id"]?.try(&.as_i64?), seen),
         o["enabled"]?.try(&.as_bool?) || false,
         o["name"]?.try(&.as_s?) || "",
-        clamp_field(o["target"]?.try(&.as_s?), RULE_TARGETS, "request"),
-        clamp_field(o["part"]?.try(&.as_s?), RULE_PARTS, "head"),
+        target, part,
         pattern,
         o["replacement"]?.try(&.as_s?) || "",
-        clamp_field(o["op"]?.try(&.as_s?), RULE_OPS, "replace"),
+        op,
         clamp_field(o["match_kind"]?.try(&.as_s?), RULE_KINDS, "literal"),
         o["host"]?.try(&.as_s?) || "",
         o["body_file"]?.try(&.as_s?) || "")
     end
     list
+  end
+
+  # Whether this op/part pair names a rule that could never rewrite anything: a header op
+  # (add/set/remove) on a part that is not the head. A header op acts by header NAME, and only
+  # a head has header lines.
+  #
+  # DROPPED, not coerced onto the head, and the distinction is the whole point. The pair cannot
+  # arrive through any CRUD surface — the CLI and MCP REFUSE it outright rather than normalize
+  # it, and `Rules.normalize_shape` says why: moving a rule off WebSocket messages and onto
+  # HTTP heads is "a different protocol, not a narrower shape". Coercing it HERE would do
+  # exactly that behind the operator's back, and worse: the rule is inert today (`Rules`'
+  # `rewrites?` filters it from both the counts and the select), so the coercion would take a
+  # rule that does nothing and put it on every request head in every project, live, on the
+  # strength of a parse.
+  #
+  # Same disposition, and the same sentence, as the entry with no pattern above: a rule that
+  # can never match, which `Rules#add` refuses anyway.
+  private def self.impossible_shape?(op : String, part : String) : Bool
+    part != "head" && (op == "add_header" || op == "set_header" || op == "remove_header")
   end
 
   # The id this parsed entry gets to keep, recording it in `seen`. A missing, non-positive or
@@ -159,13 +182,16 @@ module Gori::Settings
       name = o["name"]?.try(&.as_s?)
       pattern = o["pattern"]?.try(&.as_s?)
       next if name.nil? || name.empty? || pattern.nil? || pattern.empty?
+      op = clamp_field(o["op"]?.try(&.as_s?), RULE_OPS, "replace")
+      target = clamp_field(o["target"]?.try(&.as_s?), RULE_TARGETS, "request")
+      part = clamp_field(o["part"]?.try(&.as_s?), RULE_PARTS, "head")
+      next if impossible_shape?(op, part)
       list << RewriterRule.new(
         (list.size + 1).to_i64, false, name,
-        clamp_field(o["target"]?.try(&.as_s?), RULE_TARGETS, "request"),
-        clamp_field(o["part"]?.try(&.as_s?), RULE_PARTS, "head"),
+        target, part,
         pattern,
         o["replacement"]?.try(&.as_s?) || "",
-        clamp_field(o["op"]?.try(&.as_s?), RULE_OPS, "replace"),
+        op,
         clamp_field(o["match_kind"]?.try(&.as_s?), RULE_KINDS, "literal"),
         o["host"]?.try(&.as_s?) || "",
         o["body_file"]?.try(&.as_s?) || "")

--- a/src/gori/tui/controllers/rewriter_controller.cr
+++ b/src/gori/tui/controllers/rewriter_controller.cr
@@ -39,6 +39,8 @@ module Gori::Tui
       # message before and after a rule, so they have to agree about what a row is.
       @out = ReadPane.new(wrap: true)
       @last_body = Rect.new(0, 0, 0, 0) # last content rect — click/wheel geometry
+      # The host the last transform scoped rules on — see `preview_host`.
+      @preview_host = ""
     end
 
     def tab : Symbol
@@ -146,9 +148,10 @@ module Gori::Tui
       list = rule_list
       @sel = @sel.clamp(0, {list.size - 1, 0}.max)
       ensure_visible(inner, list.size)
-      sync_preview_out
+      target = preview_target
+      sync_preview_out(target)
       @view.render(screen, inner, list, @sel, @scroll, rules_engine.enabled_count,
-        @focus, body_focused, rules_engine.active?, @preview_input, @out)
+        @focus, body_focused, rules_engine.active?, @preview_input, @out, target, @preview_host)
     end
 
     private def render_extract(screen : Screen, inner : Rect, body_focused : Bool) : Nil
@@ -194,20 +197,45 @@ module Gori::Tui
     end
 
     # Point the OUTPUT pane at the current transform. Recomputed rather than cached, exactly as
-    # the old per-frame `preview_output` call was — `transform_message` over one sample is cheap
-    # next to a frame, and any cache key would have to track the sample AND every enabled rule.
-    # Called from `render_rules` and from each selection/copy delegator, so a verb never reads a
-    # pane pointed at a stale transform.
-    private def sync_preview_out : Nil
-      text = preview_output
-      @out.source(text.empty? ? ["(empty)"] : text.split('\n'))
+    # the old per-frame call was — `transform_message` over one sample is cheap next to a frame,
+    # and any cache key would have to track the sample AND every enabled rule. Called from
+    # `render_rules` and from each selection/copy delegator, so a verb never reads a pane
+    # pointed at a stale transform.
+    #
+    # `target` is passed in by the render (which needs it for the badge anyway) so the frame
+    # asks the sample which side it is exactly once. The sample is joined ONCE here and the
+    # host read off the same String: `TextArea#text` has no cache, and this is the pane an
+    # operator pastes a multi-MB captured message into.
+    private def sync_preview_out(target : Store::RuleTarget = preview_target) : Nil
+      text = @preview_input.text
+      @preview_host = host_from_sample(text)
+      transformed = rules_engine.transform_message(text, target, @preview_host)
+      @out.source(transformed.empty? ? ["(empty)"] : transformed.split('\n'))
     end
 
-    # Enabled rules applied to the sample (request side; host from Host: header).
-    private def preview_output : String
-      text = @preview_input.text
-      host = host_from_sample(text)
-      rules_engine.transform_message(text, Store::RuleTarget::Request, host)
+    # WHICH SIDE the sample is, read off the sample itself: a message whose first line is a
+    # status line is a response, everything else is a request.
+    #
+    # This pane used to pass `Request` unconditionally. Half the rule list is `RES` — the row
+    # draws the badge — and every one of those rules previewed as "nothing happened", with
+    # nothing on screen to say the pane could not test them. The preview is the only place a
+    # rule can be tried before it is rewriting live traffic, so a side it silently cannot
+    # reach is the half of the feature that most needs one.
+    #
+    # `first_nonblank_line`, not `text`: this runs per frame and `text` joins the whole buffer.
+    def preview_target : Store::RuleTarget
+      first = @preview_input.first_nonblank_line || ""
+      first.starts_with?("HTTP/") ? Store::RuleTarget::Response : Store::RuleTarget::Request
+    end
+
+    # The host the last transform scoped rules on, which the OUTPUT badge names. Empty matches
+    # ONLY an unscoped rule (`Rules.host_matches?`), and a RESPONSE head structurally carries no
+    # `Host:` line — so a rule scoped `*.example.com` previews as a rule that did nothing. Naming
+    # the host on the pane is what keeps the `RES rules` badge from asserting the opposite; an
+    # operator who wants that rule previewed can put a `Host:` line in the sample, which
+    # `host_from_sample` reads wherever it appears.
+    def preview_host : String
+      @preview_host
     end
 
     private def host_from_sample(text : String) : String
@@ -685,14 +713,22 @@ module Gori::Tui
       j < 0 || j >= scoped.size
     end
 
+    # The copy inherits the ORIGINAL's on/off state, which `add`'s default (enabled, because
+    # "add" means "start rewriting") would have overridden. Duplicating is not adding: the
+    # operator is copying a rule they can see, and the row they pressed the key on says `·`
+    # or `✓`. A disabled rule silently coming back armed is a live traffic rewrite nobody
+    # asked for — and for a `stub` rule it is an endpoint that stops reaching the origin at
+    # all. For a global rule `enabled?` is its state HERE, which is the state on that row.
     def rewriter_duplicate : Nil
       rule = selected_rule || return @host.status("no rewrite rule selected")
       name = rule.name.empty? ? "" : "#{rule.name} copy"
       unless rules_engine.add(rule.target, rule.part, rule.pattern, rule.replacement,
-               rule.op, rule.match_kind, name, rule.host, rule.body_file, scope: rule.scope)
+               rule.op, rule.match_kind, name, rule.host, rule.body_file, scope: rule.scope,
+               enabled: rule.enabled?)
         return @host.status("rule NOT duplicated (project busy or settings not writable)")
       end
-      @host.status(rule.global? ? "global rule duplicated" : "rule duplicated")
+      state = rule.enabled? ? "" : " (disabled, like the original)"
+      @host.status(rule.global? ? "global rule duplicated#{state}" : "rule duplicated#{state}")
     end
 
     # `s`: move the selected rule between the global library and this project. The rule keeps

--- a/src/gori/tui/rewriter_view.cr
+++ b/src/gori/tui/rewriter_view.cr
@@ -67,15 +67,16 @@ module Gori::Tui
 
     def render(screen : Screen, rect : Rect, rules : Array(Store::MatchRule), sel : Int32,
                scroll : Int32, enabled_count : Int32, focus : Symbol, body_focused : Bool,
-               live : Bool, preview_input : TextArea, preview_out : ReadPane) : Nil
+               live : Bool, preview_input : TextArea, preview_out : ReadPane,
+               target : Store::RuleTarget = Store::RuleTarget::Request, host : String = "") : Nil
       return if rect.w < 6 || rect.h < 2
       render_sub_strip(screen, rect, :rules, body_focused)
       list_r, pin_r, pout_r = layout(rect)
       render_list(screen, list_r, rules, sel, scroll, enabled_count,
         body_focused && focus == :list, live)
       unless pin_r.empty?
-        render_preview_input(screen, pin_r, preview_input, body_focused && focus == :preview_in)
-        render_preview_output(screen, pout_r, preview_out, body_focused && focus == :preview_out)
+        render_preview_input(screen, pin_r, preview_input, body_focused && focus == :preview_in, target)
+        render_preview_output(screen, pout_r, preview_out, body_focused && focus == :preview_out, target, host)
       end
     end
 
@@ -340,20 +341,41 @@ module Gori::Tui
       x + 3
     end
 
-    private def render_preview_input(screen : Screen, rect : Rect, ed : TextArea, focused : Bool) : Nil
+    # The sample. Its badge is the SIDE the controller read off the sample's own first line
+    # (`RewriterController#preview_target`), because that is what decides which half of the
+    # rule list runs — and the pane that silently ran only the REQ half is exactly why it is
+    # spelled out here rather than left to be inferred from the text.
+    private def render_preview_input(screen : Screen, rect : Rect, ed : TextArea, focused : Bool,
+                                     target : Store::RuleTarget) : Nil
       return if rect.w < 4 || rect.h < 2
       Frame.card(screen, rect, "PREVIEW INPUT", bg: Theme.bg, border: Frame.pane_border(focused))
+      Frame.border_meta(screen, rect, "PREVIEW INPUT", target.request? ? "REQ" : "RES")
       body = rect.inset(1, 1)
       return if body.empty?
-      ed.render(screen, body, cursor: focused, highlight: :request, gauge: true, gauge_focused: focused)
+      # …and the syntax overlay follows it too: a pasted response painted with the REQUEST
+      # highlighter reads its status line as a request line.
+      ed.render(screen, body, cursor: focused, highlight: target.request? ? :request : :response,
+        gauge: true, gauge_focused: focused)
     end
 
     # The transformed sample. The pane owns its scroll, caret, selection and gauge — this used
     # to be a plain windowed draw over a `String` with no caret at all, so the one pane that
     # shows what a rule DID to a message was the one you could not copy a line out of.
-    private def render_preview_output(screen : Screen, rect : Rect, pane : ReadPane, focused : Bool) : Nil
+    private def render_preview_output(screen : Screen, rect : Rect, pane : ReadPane, focused : Bool,
+                                      target : Store::RuleTarget, host : String) : Nil
       return if rect.w < 4 || rect.h < 2
       Frame.card(screen, rect, "PREVIEW OUTPUT", bg: Theme.bg, border: Frame.pane_border(focused))
+      # Which half of the list ran, and WHICH HOST it ran them for — the two questions that
+      # decide whether a rule fires here. `REQ`/`RES` is the same badge every rule ROW carries.
+      #
+      # The host half is not decoration. An empty host matches ONLY an unscoped rule
+      # (`Rules.host_matches?`), and a response head carries no `Host:` line, so a rule scoped
+      # `*.example.com` previews as a rule that changed nothing — indistinguishable from a
+      # pattern that missed. Saying "unscoped only" is the difference between the pane
+      # reporting a result and the pane reporting one it could not produce.
+      side = target.request? ? "REQ" : "RES"
+      Frame.border_meta(screen, rect, "PREVIEW OUTPUT",
+        host.empty? ? "#{side} rules · unscoped only" : "#{side} rules @#{host}")
       body = rect.inset(1, 1)
       return if body.empty?
       pane.render(screen, body, focused)


### PR DESCRIPTION
An audit of the Match & Replace lens — `Rules`, the global rule library, the Rewriter tab. Each defect is a place where the rule the operator is looking at is not the rule that runs.

### 1. A rule whose op and part disagree cost traffic its byte-fidelity for nothing

`Rules#apply` refuses a header op on a non-head part — a header op acts by header NAME and only a head has header lines. The lock-free **counts** did not, and those counts are not "which rules apply", they are *which shortcut this connection loses*:

| stored shape | what it did | what it could ever do |
|---|---|---|
| `{op: set_header, part: ws}` | took `WS::Relay` off its byte-exact pump — frame boundaries, mask keys, fragmentation | nothing |
| `{op: add_header, part: body}` | buffered every body **and** cost the host HTTP/2 (`tls/tunnel.cr`) | nothing |

Both now key on the one `rewrites?` predicate `apply` uses, so "a rule is live" stops meaning two different things.

The pair reaches memory only through a hand-edited `settings.json` — a supported way to write a global rule, since the enum fields are stored as the labels `gori run rewriter` prints — because `parse_rewriter_rules` clamps the four fields *independently*. That entry is **dropped** there, the way an entry with no pattern already is.

Deliberately **not** coerced onto the head. `Rules.normalize_shape` already says why the CLI and MCP refuse this pair rather than normalize it — *"a different protocol, not a narrower shape"* — and coercing at parse time would take a rule that does nothing and put it on every request head in every project, live, on the strength of a parse. (Caught in review; the first version of this branch had it backwards.)

### 2. Duplicating a disabled rule armed the copy

`c` built the copy through `Rules#add`, whose `enabled` defaults to true because "add" means "start rewriting". Duplicating is not adding: the row the key was pressed on says `·`, and for a `stub` rule the copy silently stops an endpoint reaching the origin.

### 3. Half the rule list could not be previewed

The PREVIEW pair passed `RuleTarget::Request` unconditionally, so every `RES` rule — half of what the tab can express — previewed as "nothing happened", with nothing on screen saying the pane could not test it. The preview is the only place a rule can be tried *before* it rewrites live traffic.

- the side is read off the sample's own first line (via `first_nonblank_line`, so no whole-buffer join per frame)
- both cards carry the REQ/RES badge the rule rows already do, and the syntax overlay follows
- the OUTPUT badge also names the **host** the rules were scoped on. An empty host matches only an unscoped rule, and a response head carries no `Host:` line — so `RES rules · unscoped only` is the difference between reporting a result and reporting one the pane could not produce.

### Verification

- `crystal build --no-codegen src/main.cr` clean
- full suite green — **9792 examples, 0 failures**
- 11 new examples; each fix **control-run** against its spec (revert the fix, watch it fail)
- ameba on touched files: only the two pre-existing `CyclomaticComplexity` warnings on methods this PR does not touch

### Not fixed, deliberately

An h2 **response** head is scoped on the CONNECT host, so on a coalesced connection (RFC 9113 §9.1.1) a rule scoped to that host fires on another authority's responses and one scoped to that authority fires on none.

Reading the stream's authority back out of the assembler looked like the fix, and this branch carried it for a while — but the assembler stores the **post-rewrite** fields, so a live `set_header Host:` rule would re-scope every response rule on that stream. That is a new h1/h2 divergence in the *common* case, traded for an over-match that needs a non-conformant client (gori's leaf carries a SAN of exactly the requested host, so a conformant client cannot coalesce onto one). Doing it properly means recording the client's own authority per stream in the assembler; out of scope here. The request side already warns about coalescing via `notice_coalesced`.