### PR TITLE
perf(scope,rules): drop per-request and per-message allocation on the hot gates

### DIFF
--- a/bench/rules_rewrite_bench.cr
+++ b/bench/rules_rewrite_bench.cr
@@ -1,0 +1,101 @@
+# Match&Replace rewrite micro-benchmark: the per-MESSAGE rewrite path.
+#
+# `rewrite_request` / `rewrite_response` run on the HEAD of every proxied message, and
+# `rewrite_*_body` on every buffered body, through `Rules#apply`. That path was never
+# measured. Three costs it pays even in the common cases this harness pins:
+#
+#   1. The lock-free fast path (atomic count == 0): what a rule-free project pays per
+#      message. Must stay ~free — most flows have no rule for their side/part.
+#   2. One matching rule: `@mutex.synchronize { @rules.select {…} }` mints a select Array
+#      per message, then `String.new(bytes)` copies the whole head/body before a single
+#      `gsub`. On a large body that copy dominates.
+#   3. Host-scoped rules that DON'T match the flow's host: still take the lock + select +
+#      String copy, then match nothing — the cost of a rule that will never fire here.
+#
+# Build: crystal build bench/rules_rewrite_bench.cr -o bin/rules_rewrite_bench --release
+# Run:   bin/rules_rewrite_bench
+require "benchmark"
+require "../src/gori"
+
+include Gori
+
+db_path = File.tempname("gori-rules-bench", ".db")
+store = Store.open(db_path, retention_flows: 0)
+
+def mrule(id, target, part, pattern, replacement, op = Store::RuleOp::Replace,
+          kind = Store::MatchKind::Literal, name = "", host = "")
+  Store::MatchRule.new(id.to_i64, true, target, part, pattern, replacement,
+    op, kind, name, host, "", Store::RuleScope::Project, false)
+end
+
+REQ_HEAD = ("GET /api/v1/users/12345/profile?include=avatar,bio HTTP/1.1\r\n" +
+            "Host: api.example.com\r\n" +
+            "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)\r\n" +
+            "Accept: application/json\r\n" +
+            "Cookie: session=abc123def456; csrf=xyz789; theme=dark\r\n\r\n").to_slice
+
+RESP_HEAD = ("HTTP/1.1 200 OK\r\n" +
+             "Content-Type: application/json; charset=utf-8\r\n" +
+             "Content-Length: 8192\r\n" +
+             "Server: nginx/1.25.0\r\n" +
+             "Set-Cookie: session=renewed; Path=/; HttpOnly\r\n\r\n").to_slice
+
+# A JSON-ish response body ~32 KB — the size a body rule actually runs over.
+BODY = begin
+  io = IO::Memory.new
+  512.times { |i| io << %({"id":#{i},"name":"user#{i}","token":"tok_#{i}abcdef","active":true},\n) }
+  io.to_slice
+end
+
+HOST = "api.example.com"
+
+# --- scenario 1: no rules at all (the lock-free fast path) ------------------------------
+none = Rules.new(store, [] of Store::MatchRule)
+
+# --- scenario 2: one head rule + one body rule that MATCH this host ----------------------
+matching = Rules.new(store, [
+  mrule(1, Store::RuleTarget::Response, Store::RulePart::Head,
+    "nginx", "cloudflare", host: ""),
+  mrule(2, Store::RuleTarget::Response, Store::RulePart::Body,
+    "active\":true", "active\":false", host: ""),
+])
+
+# --- scenario 3: rules that exist but are host-scoped to a DIFFERENT host ----------------
+# Live for the side/part (so the atomic count gate passes), then match nothing on THIS host.
+other_host = Rules.new(store, [
+  mrule(1, Store::RuleTarget::Response, Store::RulePart::Head,
+    "nginx", "cloudflare", host: "other.test"),
+  mrule(2, Store::RuleTarget::Response, Store::RulePart::Body,
+    "active\":true", "active\":false", host: "other.test"),
+])
+
+# --- scenario 4: a body rule that IS in scope for this host but whose pattern is ABSENT ---
+# The realistic steady state: a body rule fires on the rare matching response, so nearly
+# every body it runs over does NOT contain its pattern. `String#gsub` short-circuits on a
+# miss (returns self), so this measures the floor of an in-scope body rewrite: the one
+# `String.new(bytes)` copy `apply` must make to hand the body to `gsub` at all.
+active_nomatch = Rules.new(store, [
+  mrule(1, Store::RuleTarget::Response, Store::RulePart::Body,
+    "ZZ_PATTERN_NOT_IN_BODY_ZZ", "x", host: ""),
+])
+
+puts "req head=#{REQ_HEAD.size}B  resp head=#{RESP_HEAD.size}B  body=#{BODY.size}B\n"
+
+puts "\n== HEAD rewrite (per message) =="
+Benchmark.ips do |x|
+  x.report("no rules (fast path)") { none.rewrite_response(RESP_HEAD, HOST) }
+  x.report("1 matching head rule") { matching.rewrite_response(RESP_HEAD, HOST) }
+  x.report("head rule, other host") { other_host.rewrite_response(RESP_HEAD, HOST) }
+end
+
+puts "\n== BODY rewrite (per message, #{BODY.size}B) =="
+Benchmark.ips do |x|
+  x.report("no rules (fast path)") { none.rewrite_response_body(BODY, HOST) }
+  x.report("1 matching body rule") { matching.rewrite_response_body(BODY, HOST) }
+  x.report("in-scope, pattern absent") { active_nomatch.rewrite_response_body(BODY, HOST) }
+  x.report("body rule, other host") { other_host.rewrite_response_body(BODY, HOST) }
+end
+
+store.close
+File.delete(db_path) rescue nil
+puts "\ndone"

--- a/bench/scope_match_bench.cr
+++ b/bench/scope_match_bench.cr
@@ -73,6 +73,11 @@ HOSTS = ["app.example.com", "evil.other.net", "telemetry.example.com", "api.acme
     x.report("may_match_host? (per CONNECT)") do
       HOSTS.each { |h| display.may_match_host?(h) }
     end
+    # The active-sender audit trail (Outbound#evaluate): the id of the include that
+    # allowlisted a fuzz/mine/probe/repeater request. Same @includes + one-downcase path.
+    x.report("matching_include_id (active send)") do
+      URLS.each { |(u, h)| display.matching_include_id(u, h) }
+    end
   end
 end
 

--- a/bench/scope_match_bench.cr
+++ b/bench/scope_match_bench.cr
@@ -1,0 +1,81 @@
+# Scope evaluation micro-benchmark: the per-request containment gate.
+#
+# `in_scope_url?`, `sandbox_blocks?` and `may_match_host?` are on the PROXY hot path —
+# ClientConn calls one of them for every request (and `may_match_host?` once per CONNECT),
+# under @mutex, while the TUI mutates rules. None of these were measured before; the store
+# and codec paths were, but the gate that runs just as often was not. This harness pins the
+# cost per decision and, more importantly, exposes the allocation the shared evaluators do:
+# `matches_url_unlocked?` / `allowlisted_unlocked?` / `host_in_scope_unlocked?` each call
+# `@rules.select(&.include?)`, minting a fresh Array on every request, and a `string` rule
+# calls `url.downcase` (a whole-URL copy) once PER rule it is compared against.
+#
+# Build: crystal build bench/scope_match_bench.cr -o bin/scope_match_bench --release
+# Run:   bin/scope_match_bench           (BENCH_RULES=50 to sweep a big excludes list)
+require "benchmark"
+require "../src/gori"
+
+include Gori
+
+# A Scope needs a Store only for its ctor (add/remove round-trip through it); every hot-path
+# reader below touches @rules/@enabled/@sandbox/@mutex ONLY, never the store. Open an empty
+# throwaway DB so construction succeeds, then drive the in-memory rule list directly.
+db_path = File.tempname("gori-scope-bench", ".db")
+store = Store.open(db_path, retention_flows: 0)
+
+EXTRA = (ENV["BENCH_RULES"]? || "0").to_i # extra exclude rules to simulate a big carve-out list
+
+def rule(id, kind, type, pat)
+  Scope::Rule.new(id.to_i64, kind, type, pat)
+end
+
+# The realistic small scope a live engagement runs with: a couple of host includes plus a
+# handful of path/regex excludes (logout, admin, a tracking host).
+def base_rules(extra : Int32) : Array(Scope::Rule)
+  rs = [
+    rule(1, "include", "host", "*.example.com"),
+    rule(2, "include", "host", "api.acme.io"),
+    rule(3, "exclude", "string", "/logout"),
+    rule(4, "exclude", "regex", "/admin(/|$)"),
+    rule(5, "exclude", "host", "telemetry.example.com"),
+  ]
+  # A power-user scope can carry dozens of excludes; sweep that with BENCH_RULES.
+  extra.times { |i| rs << rule(100 + i, "exclude", "string", "/skip#{i}/") }
+  rs
+end
+
+# The URLs a request stream actually hits: in-scope host, in-scope but excluded path,
+# out-of-scope host, and a deep path that has to be compared against every string exclude.
+URLS = [
+  {"https://app.example.com/dashboard?tab=1", "app.example.com"},
+  {"https://app.example.com/logout", "app.example.com"},
+  {"https://evil.other.net/", "evil.other.net"},
+  {"https://api.acme.io/v1/users/42/profile?include=avatar", "api.acme.io"},
+]
+HOSTS = ["app.example.com", "evil.other.net", "telemetry.example.com", "api.acme.io"]
+
+[0, EXTRA].uniq.each do |extra|
+  rules = base_rules(extra)
+  puts "\n== scope with #{rules.size} rules (#{rules.count(&.include?)} include / #{rules.count(&.exclude?)} exclude) =="
+
+  display = Scope.new(store, rules, enabled: true, sandbox: false)
+  sandbox = Scope.new(store, rules, enabled: true, sandbox: true)
+
+  Benchmark.ips do |x|
+    # Per-REQUEST gate under the display lens (ClientConn's precise hold gate + SQL parity).
+    x.report("in_scope_url? (per request)") do
+      URLS.each { |(u, h)| display.in_scope_url?(u, h) }
+    end
+    # Per-REQUEST hard containment (Sandbox on) — the allowlist eval, the safe-testing gate.
+    x.report("sandbox_blocks? (per request)") do
+      URLS.each { |(u, h)| sandbox.sandbox_blocks?(u, h) }
+    end
+    # Once per CONNECT: the coarse host gate before any request line exists.
+    x.report("may_match_host? (per CONNECT)") do
+      HOSTS.each { |h| display.may_match_host?(h) }
+    end
+  end
+end
+
+store.close
+File.delete(db_path) rescue nil
+puts "\ndone"

--- a/src/gori/outbound.cr
+++ b/src/gori/outbound.cr
@@ -368,7 +368,7 @@ module Gori
       # They need opposite remedies, so ask the exclude question separately rather than
       # letting the caller guess from a single out_of_scope.
       return {OUT_OF_SCOPE, nil, s.excluded?(url, host)} unless s.matches_url?(url, host)
-      {IN_SCOPE, s.rules.find { |r| r.include? && r.matches?(url, host) }.try(&.id), false}
+      {IN_SCOPE, s.matching_include_id(url, host), false}
     end
 
     # Throttled in-place reload of the scope from its store so a mid-run rule / Sandbox

--- a/src/gori/rules.cr
+++ b/src/gori/rules.cr
@@ -627,19 +627,32 @@ module Gori
     private def apply(bytes : Bytes, target : Store::RuleTarget, part : Store::RulePart,
                       count : Atomic(Int32), host : String, report : Bool = true) : Bytes
       return bytes if count.get == 0 # lock-free fast path: no rules to apply
-      active = @mutex.synchronize do
-        @rules.select { |r| rewrites?(r, target, part) && host_matches?(r.host, host) }
+      # `@rules` is REPLACED on every edit, never mutated in place (see `refresh`), so a bare
+      # reference read under the lock is a consistent snapshot with NO allocation — where the
+      # old path minted a filtered `select` Array on EVERY proxied head and buffered body. The
+      # scope predicate is re-checked inline in the loop instead, and `String.new(bytes)` — the
+      # whole-body copy — is deferred to the FIRST rule that is actually in scope for this
+      # {target, part, host}, so a message no rule targets (e.g. a body rule scoped to another
+      # host) pays neither the Array nor the copy. `host_matches?`/`apply_rule` already ran
+      # outside the lock (the old `active.each` did), so nothing new is read unsynchronised.
+      rules = @mutex.synchronize { @rules }
+      text = nil.as(String?)
+      rules.each do |r|
+        next unless rewrites?(r, target, part) && host_matches?(r.host, host)
+        cur = text
+        if cur.nil?
+          cur = String.new(bytes)
+          # A WS message is arbitrary application bytes, and `gsub` over a String holding
+          # invalid UTF-8 turns those bytes into U+FFFD — so a rule would corrupt a payload it
+          # never even matched. Gate rather than `scrub`: 9 µs vs 130 µs on a 40 KB payload, and
+          # this is a per-MESSAGE path, not a per-response one. Heads and bodies keep their
+          # pre-existing behaviour (a body rule simply won't match a compressed body).
+          return bytes if part.ws? && !cur.valid_encoding?
+        end
+        text = apply_rule(cur, r, report)
       end
-      return bytes if active.empty? # nothing in scope → same bytes, byte-fidelity preserved
-      text = String.new(bytes)
-      # A WS message is arbitrary application bytes, and `gsub` over a String holding
-      # invalid UTF-8 turns those bytes into U+FFFD — so a rule would corrupt a payload it
-      # never even matched. Gate rather than `scrub`: 9 µs vs 130 µs on a 40 KB payload, and
-      # this is a per-MESSAGE path, not a per-response one. Heads and bodies keep their
-      # pre-existing behaviour (a body rule simply won't match a compressed body).
-      return bytes if part.ws? && !text.valid_encoding?
-      active.each { |r| text = apply_rule(text, r, report) }
-      text.to_slice
+      t = text
+      t ? t.to_slice : bytes # no rule in scope → same bytes, byte-fidelity preserved
     end
 
     # Apply ONE rule to `text` (a head or a body already decoded to a String). Returns a

--- a/src/gori/scope.cr
+++ b/src/gori/scope.cr
@@ -79,11 +79,22 @@ module Gori
       # bare host. Mirrors the SQL `filter` branch-for-branch so the live lens and the
       # History/Sitemap SQL view never disagree.
       def matches?(url : String, host : String) : Bool
+        matches?(url, host, url.downcase)
+      end
+
+      # Same match, but the caller supplies the already-lowercased url. A `string` rule
+      # compares against `url.downcase`, and a Scope evaluator runs EVERY rule against the
+      # SAME url — so the 2-arg form re-lowercased the whole url once per string rule (53
+      # copies for a 53-exclude scope, on every proxied request). The evaluators lower it
+      # ONCE and pass it here; `url_down` is IGNORED for host/regex rules, so the result is
+      # byte-identical to the 2-arg form. `url` (unlowered) is kept for the regex subject,
+      # which scrubs but must not case-fold.
+      def matches?(url : String, host : String, url_down : String) : Bool
         case @match_type
         when "host"
           host_match?(host)
         when "string"
-          url.downcase.includes?(@pattern_down)
+          url_down.includes?(@pattern_down)
         when "regex"
           r = @regex
           return false unless r
@@ -120,7 +131,19 @@ module Gori
     # the TUI render fiber (the sole writer), matching `enabled?`'s discipline.
     getter? sandbox : Bool
 
+    # The include/exclude partition of @rules, precomputed once per rule-list swap. Every
+    # per-request evaluator below split @rules with `@rules.select(&.include?)` — a fresh
+    # Array minted on EVERY proxied request (and CONNECT). The rules are immutable and only
+    # ever REPLACED (never edited in place, see the ctor note), so the partition is derived
+    # here alongside the pointer swap instead, exactly as each Rule precomputes its own
+    # regex/lowercased pattern. Swapped together with @rules under @mutex, so a matcher reads
+    # a consistent {rules, includes, excludes} triple. `assign_rules` is the one writer.
+    @includes : Array(Rule)
+    @excludes : Array(Rule)
+
     def initialize(@store : Store, @rules : Array(Rule), @enabled : Bool, @sandbox : Bool = false)
+      @includes = @rules.select(&.include?)
+      @excludes = @rules.select(&.exclude?)
       # @rules/@enabled are read on the PROXY hot path (in_scope_url?/may_match_host?/
       # filter/active?) while the TUI fiber mutates them (add/remove/update/toggle).
       # Guard every cross-fiber access with a mutex — only the TUI mutates, so its own
@@ -203,11 +226,10 @@ module Gori
     # short-circuits its own inactive case before calling, so it never reaches the guard.
     private def host_in_scope_unlocked?(host : String) : Bool
       return false if @rules.empty?
-      includes = @rules.select(&.include?)
-      inc_ok = includes.empty? ||
-               includes.any? { |r| r.host_type? && r.matches?("", host) } ||
-               includes.any? { |r| !r.host_type? }
-      excluded = @rules.any? { |r| r.exclude? && r.host_type? && r.matches?("", host) }
+      inc_ok = @includes.empty? ||
+               @includes.any? { |r| r.host_type? && r.matches?("", host) } ||
+               @includes.any? { |r| !r.host_type? }
+      excluded = @excludes.any? { |r| r.host_type? && r.matches?("", host) }
       inc_ok && !excluded
     end
 
@@ -235,7 +257,8 @@ module Gori
     # scanner (Discover) applies in every containment mode, INDEPENDENT of includes and the
     # display lens. (matches_url? requires includes; this asks only "is it carved out?".)
     def excluded?(url : String, host : String) : Bool
-      @mutex.synchronize { @rules.any? { |r| r.exclude? && r.matches?(url, host) } }
+      url_down = url.downcase # once, OUTSIDE the hot-path lock — see Rule#matches?(_, _, url_down)
+      @mutex.synchronize { @excludes.any? { |r| r.matches?(url, host, url_down) } }
     end
 
     # The ALLOWLIST evaluation (callers hold @mutex): true ⇔ at least one INCLUDE rule
@@ -246,10 +269,10 @@ module Gori
     # because an empty or excludes-only scope is not an "allowed range" to probe or let
     # through — it's the whole internet minus a few hosts.
     private def allowlisted_unlocked?(url : String, host : String) : Bool
-      includes = @rules.select(&.include?)
-      return false if includes.empty?
-      includes.any?(&.matches?(url, host)) &&
-        @rules.none? { |r| r.exclude? && r.matches?(url, host) }
+      return false if @includes.empty?
+      url_down = url.downcase
+      @includes.any? { |r| r.matches?(url, host, url_down) } &&
+        @excludes.none? { |r| r.matches?(url, host, url_down) }
     end
 
     # Pure Burp evaluation (includes empty ⇒ match all; then carve excludes). Shared by
@@ -257,9 +280,9 @@ module Gori
     # requires that); still guards empty for defense-in-depth.
     private def matches_url_unlocked?(url : String, host : String) : Bool
       return false if @rules.empty?
-      includes = @rules.select(&.include?)
-      inc_ok = includes.empty? || includes.any?(&.matches?(url, host))
-      inc_ok && @rules.none? { |r| r.exclude? && r.matches?(url, host) }
+      url_down = url.downcase
+      inc_ok = @includes.empty? || @includes.any? { |r| r.matches?(url, host, url_down) }
+      inc_ok && @excludes.none? { |r| r.matches?(url, host, url_down) }
     end
 
     # Conservative HOST-level check behind `Interceptor#intercepts_host?`, made BEFORE any
@@ -308,11 +331,10 @@ module Gori
     # its path might match on this host) AND no HOST-level exclude fully covers it. Mirrors
     # host_in_scope_unlocked? but with the allowlist's empty-includes ⇒ false rule.
     private def host_allowlisted_unlocked?(host : String) : Bool
-      includes = @rules.select(&.include?)
-      return false if includes.empty?
-      inc_ok = includes.any? { |r| r.host_type? && r.matches?("", host) } ||
-               includes.any? { |r| !r.host_type? }
-      excluded = @rules.any? { |r| r.exclude? && r.host_type? && r.matches?("", host) }
+      return false if @includes.empty?
+      inc_ok = @includes.any? { |r| r.host_type? && r.matches?("", host) } ||
+               @includes.any? { |r| !r.host_type? }
+      excluded = @excludes.any? { |r| r.host_type? && r.matches?("", host) }
       inc_ok && !excluded
     end
 
@@ -516,7 +538,7 @@ module Gori
       enabled = @store.setting(SETTING_ENABLED) == "1"
       sandbox = @store.setting(SETTING_SANDBOX) == "1"
       @mutex.synchronize do
-        @rules = fresh
+        assign_rules(fresh)
         @enabled = enabled
         @sandbox = sandbox
       end
@@ -725,7 +747,16 @@ module Gori
     # constructor — and only the pointer swap is guarded.
     private def reload_rules : Nil
       fresh = Scope.load_rules(@store)
-      @mutex.synchronize { @rules = fresh }
+      @mutex.synchronize { assign_rules(fresh) }
+    end
+
+    # Swap in a new rule list and re-derive the include/exclude partition from it. The one
+    # writer of @rules/@includes/@excludes — callers hold @mutex, so the three stay a
+    # consistent triple for any concurrent matcher.
+    private def assign_rules(fresh : Array(Rule)) : Nil
+      @rules = fresh
+      @includes = fresh.select(&.include?)
+      @excludes = fresh.select(&.exclude?)
     end
 
     # Flag writers: the in-memory field is swapped under @mutex (the hot path reads it

--- a/src/gori/scope.cr
+++ b/src/gori/scope.cr
@@ -261,6 +261,17 @@ module Gori
       @mutex.synchronize { @excludes.any? { |r| r.matches?(url, host, url_down) } }
     end
 
+    # The id of the first INCLUDE rule that matches — the audit trail the active-sender gate
+    # (`Outbound#evaluate`) stamps on a request it has ALREADY confirmed allowlisted. It used
+    # to re-walk the whole rule list (`rules.find { |r| r.include? && r.matches? }`) and
+    # re-lower the url once per include; this reuses the precomputed @includes and lowers the
+    # url once, like the allowlist evaluators, and reads under @mutex rather than off the bare
+    # getter. @includes keeps @rules order, so the first match is the same rule as before.
+    def matching_include_id(url : String, host : String) : Int64?
+      url_down = url.downcase
+      @mutex.synchronize { @includes.find { |r| r.matches?(url, host, url_down) }.try(&.id) }
+    end
+
     # The ALLOWLIST evaluation (callers hold @mutex): true ⇔ at least one INCLUDE rule
     # matches AND no EXCLUDE matches. Empty includes ⇒ false — "nothing is explicitly
     # allowed". SHARED by the Probe Active gate (matches_url?) and the Sandbox block gate


### PR DESCRIPTION
## What

Two proxy hot paths — the Scope containment gate (every request/CONNECT) and the Match&Replace rewrite (every head and buffered body) — allocated a fresh `Array` on each call. Neither had a benchmark. This adds one for each and removes the avoidable per-call allocation. **Behavior-preserving**: `just check`, the full `crystal spec` (10111 examples), the 111 scope+rules specs, and `scripts/bench_check.sh` (48 harnesses) are all green.

## Why this shape

Both `Scope#@rules` and `Rules#@rules` are immutable lists that are only ever **replaced** on an edit (never mutated in place). That is the same property each `Scope::Rule` already exploits to compile its regex and lowercase its pattern once. So the derived data can live alongside the pointer swap instead of being rebuilt per request.

### Scope (`in_scope_url?` / `sandbox_blocks?` / `may_match_host?`)

- The four evaluators each split the list with `@rules.select(&.include?)` — a new `Array` on **every proxied request and CONNECT**. The include/exclude partition is now precomputed once per swap into `@includes`/`@excludes` (one writer, `assign_rules`, under the same mutex that guards `@rules`).
- A `string` rule matched with `url.downcase`, re-lowercasing the whole URL **once per rule** (53 copies for a 53-exclude scope, per request). The evaluators now lower it once and pass it to a `Rule#matches?(url, host, url_down)` overload; `host`/`regex` rules ignore `url_down`, so the result is byte-identical. The existing specs pin exactly this — L188 (uppercase `/ADMIN`, case-insensitive) and L437 (non-ASCII `/über`, Crystal's Unicode downcase vs SQLite's ASCII `lower()` parity).

**Measured** (`bench/scope_match_bench.cr`, before → after):

| scope | metric | before | after |
| --- | --- | --- | --- |
| 5 rules | `in_scope_url?` | 832 B/req · 1.05 µs | **624 B/req · 0.93 µs** |
| 55 rules | `in_scope_url?` | 7.84 KB/req · 8.8 µs | **624 B/req · 5.9 µs** |
| 55 rules | `may_match_host?` | 784 B · 0.97 µs | **528 B · 0.50 µs** |

The allocation no longer scales with rule count.

### Rules / Match&Replace (`rewrite_request` / `rewrite_response` / `rewrite_*_body`)

- `apply` built a filtered `select` `Array` under the lock on every head and every buffered body. It now takes a bare reference snapshot (`@mutex.synchronize { @rules }`) and filters inline in a single pass, deferring `String.new(bytes)` to the first rule actually in scope — so a message no rule targets (e.g. a body rule scoped to another host) pays neither the array nor the copy. Rule order, the WS invalid-UTF-8 gate, and the unbound-`$NAME` reporting are all preserved.

**Measured** (`bench/rules_rewrite_bench.cr`, before → after):

| scenario | before | after |
| --- | --- | --- |
| 1 head rule (match) | 0.99 KB/msg | **720 B/msg** |
| head rule, other host | 128 B | **96 B** |
| body rule, other host | 128 B | **96 B** |
| 1 body rule (match), 34 KB | 164 KB | 164 KB (unchanged) |
| in-scope, pattern absent, 34 KB | 33.5 KB | 33.2 KB (unchanged) |

## What I ruled out

The whole-body `String.new(bytes)` copy for a body that IS in scope is the floor of a string-based rewrite — a `gsub` needs a `String`. I first added an `includes?` pre-scan to skip the `gsub` rebuild on a miss, but a before/after control run showed it saved nothing (33.5 → 33.2 KB) and cost a redundant scan: `String#gsub(str, &)` already does `byte_index` first and `return self unless index`, so it short-circuits on a miss on its own. That guard was removed.

No CHANGELOG entry: behavior-preserving internal perf, nothing a user would notice differently. No DESIGN.md change: SQL parity, fail-open/closed, and byte-fidelity are all preserved.

## Follow-up from code review

The review found one incomplete generalization (no correctness issue): `Outbound#evaluate` re-walked the whole rule list a second time to name the include rule that allowlisted an active-sender request, re-lowercasing the URL per include. A second commit routes that through `Scope#matching_include_id`, which reuses `@includes` + the one-downcase path (464 B/call, constant across scope size). `outbound_spec` pins the reported id.
