### PR TITLE
feat(cli/mcp): install the MCP server into Hermes' config.yaml (#785)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- `gori mcp --install-hermes` writes the server into Hermes' `~/.hermes/config.yaml` (or `$HERMES_HOME`), the first YAML client alongside the JSON and TOML ones. Sibling servers, their `env:` keys and the comments around them are left as they are. (#785)
+
 - The History and Target filter bars are clickable: `v:` opens the view picker, `f:follow`, `g:fold` and `⇧S scope` toggle what their chords do, and a click on the query readout beside them opens the filter for typing. (#782)
 
 - History views: `v` picks a named filter the list narrows to, and it is a **mode** rather than a query you retype. `src:` made the common scopings expressible; this makes them stick. The view is ANDed **over** the filter bar, exactly as the `⇧S` scope lens is — so `/ status:5xx` refines the view instead of replacing it, which is the whole difference between a mode and a query. A lowercase `v:name` chip sits left of `f:follow` — abbreviated where the name is wider than the row (`History + Repeater` shows as `v:history+rptr`) — and the choice persists per project across restarts.

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ gori mcp --install-claude        # Claude Desktop
 gori mcp --install-codex         # OpenAI Codex
 gori mcp --install-agy           # Antigravity CLI
 gori mcp --install-grok          # Grok
+gori mcp --install-hermes        # Hermes        (~/.hermes/config.yaml)
 ```
 
 Add `--read-only` to hand a project to an untrusted agent (read tools only, no live requests). The

--- a/docs/content/getting-started/ai-setup.ko.md
+++ b/docs/content/getting-started/ai-setup.ko.md
@@ -8,7 +8,7 @@ gori는 하나의 프로젝트와 하나의 엔진 위에 세 가지 진입점�
 
 TUI 안에는 채팅 창이 없습니다. 모델과 클라이언트는 직접 골라 가져오고, gori는 프로젝트를 깔끔한 도구 인터페이스로 노출합니다. 그러면 에이전트가 트래픽을 읽고 사용자와 똑같은 도구를 구동합니다. 전체 도구 목록과 더 깊은 주제(라이브 인터셉트, 설계 근거)는 [MCP 서버 가이드](/ko/guide/mcp/)를 참고하세요.
 
-> **시작하기 전에.** [gori를 설치](/ko/getting-started/installation/)하고 MCP를 지원하는 클라이언트(Claude Code, Claude Desktop, OpenAI Codex, Antigravity, Grok 등)를 준비하세요.
+> **시작하기 전에.** [gori를 설치](/ko/getting-started/installation/)하고 MCP를 지원하는 클라이언트(Claude Code, Claude Desktop, OpenAI Codex, Antigravity, Grok, Hermes 등)를 준비하세요.
 
 ## 1. 클라이언트에 서버 설치하기 {#1-install-the-server-into-your-client}
 
@@ -20,6 +20,7 @@ gori mcp --install-claude        # Claude Desktop
 gori mcp --install-codex         # OpenAI Codex
 gori mcp --install-agy           # Antigravity CLI
 gori mcp --install-grok          # Grok
+gori mcp --install-hermes        # Hermes
 ```
 
 | 플래그 | 클라이언트 | 작성되는 설정 |
@@ -29,10 +30,11 @@ gori mcp --install-grok          # Grok
 | `--install-codex` | OpenAI Codex | `~/.codex/config.toml` (`[mcp_servers.gori]`) |
 | `--install-agy` | Antigravity CLI | `~/.gemini/antigravity-cli/mcp_config.json` |
 | `--install-grok` | Grok | `~/.grok/config.toml` (`[mcp_servers.gori]`) |
+| `--install-hermes` | Hermes | `~/.hermes/config.yaml` (`mcp_servers.gori`), 또는 `$HERMES_HOME` |
 
-각 명령은 작성한 파일과 기록한 정확한 실행 명령을 출력합니다. Codex와 Grok은 JSON이 아니라 TOML `[mcp_servers.gori]` 테이블을 사용합니다. 설치 후에는 클라이언트를 재시작하거나 세션을 다시 열어 MCP 서버를 다시 로드하세요.
+각 명령은 작성한 파일과 기록한 정확한 실행 명령을 출력합니다. Codex와 Grok은 TOML `[mcp_servers.gori]` 테이블을, Hermes는 YAML `mcp_servers:` 항목을 사용합니다(JSON이 아닙니다). 설치 후에는 클라이언트를 재시작하거나 세션을 다시 열어 MCP 서버를 다시 로드하세요.
 
-플랫폼마다 위치가 달라지는 건 Claude Desktop뿐입니다. Electron의 앱 데이터 디렉터리를 따라 macOS는 `~/Library/Application Support/Claude/`, Windows는 `%APPDATA%\Claude\`, Linux는 `$XDG_CONFIG_HOME/Claude/`(기본값 `~/.config/Claude/`)에 씁니다. gori가 이 변수를 읽으므로 Nix나 home-manager처럼 값을 옮겨 둔 세션도 따라갑니다. Flatpak 빌드는 예외로, 샌드박스 안쪽의 값을 읽기 때문에 출력된 파일을 `~/.var/app/<app-id>/config/Claude/`로 직접 복사해야 합니다.
+플랫폼마다 위치가 달라지는 건 Claude Desktop과 Hermes뿐입니다. Hermes는 `$HERMES_HOME`이 설정돼 있으면 그 값을, 없으면 `~/.hermes`(Windows는 `%LOCALAPPDATA%\hermes`)를 읽습니다. Claude Desktop은 Electron의 앱 데이터 디렉터리를 따라 macOS는 `~/Library/Application Support/Claude/`, Windows는 `%APPDATA%\Claude\`, Linux는 `$XDG_CONFIG_HOME/Claude/`(기본값 `~/.config/Claude/`)에 씁니다. gori가 이 변수를 읽으므로 Nix나 home-manager처럼 값을 옮겨 둔 세션도 따라갑니다. Flatpak 빌드는 예외로, 샌드박스 안쪽의 값을 읽기 때문에 출력된 파일을 `~/.var/app/<app-id>/config/Claude/`로 직접 복사해야 합니다.
 
 직접 연결하고 싶다면? 서버는 그저 stdio 위의 `gori mcp` 명령입니다. 추가 인자 없이 이 명령을 MCP 클라이언트에 가리키기만 하면 됩니다.
 

--- a/docs/content/getting-started/ai-setup.md
+++ b/docs/content/getting-started/ai-setup.md
@@ -8,7 +8,7 @@ gori has three entry points over one project and one engine: `gori` (the TUI, fo
 
 There is no chat window inside the TUI. You bring your own model and client; gori exposes the project over a clean tool interface, and the agent reads your traffic and drives the same tools you do. For the full tool catalog and deeper topics (live intercept, the design rationale), see the [MCP Server guide](/guide/mcp/).
 
-> **Before you begin.** [Install gori](/getting-started/installation/) and have an MCP-capable client ready (Claude Code, Claude Desktop, OpenAI Codex, Antigravity, Grok, and others).
+> **Before you begin.** [Install gori](/getting-started/installation/) and have an MCP-capable client ready (Claude Code, Claude Desktop, OpenAI Codex, Antigravity, Grok, Hermes, and others).
 
 ## 1. Install the server into your client
 
@@ -20,6 +20,7 @@ gori mcp --install-claude        # Claude Desktop
 gori mcp --install-codex         # OpenAI Codex
 gori mcp --install-agy           # Antigravity CLI
 gori mcp --install-grok          # Grok
+gori mcp --install-hermes        # Hermes
 ```
 
 | Flag | Client | Config written |
@@ -29,10 +30,11 @@ gori mcp --install-grok          # Grok
 | `--install-codex` | OpenAI Codex | `~/.codex/config.toml` (`[mcp_servers.gori]`) |
 | `--install-agy` | Antigravity CLI | `~/.gemini/antigravity-cli/mcp_config.json` |
 | `--install-grok` | Grok | `~/.grok/config.toml` (`[mcp_servers.gori]`) |
+| `--install-hermes` | Hermes | `~/.hermes/config.yaml` (`mcp_servers.gori`), or `$HERMES_HOME` |
 
-Each command prints the file it wrote and the exact launch command it recorded. Codex and Grok use a TOML `[mcp_servers.gori]` table, not JSON. Restart the client (or reopen the session) afterward so it reloads its MCP servers.
+Each command prints the file it wrote and the exact launch command it recorded. Codex and Grok use a TOML `[mcp_servers.gori]` table, and Hermes a YAML `mcp_servers:` entry, rather than JSON. Restart the client (or reopen the session) afterward so it reloads its MCP servers.
 
-Only Claude Desktop's location differs per platform — it follows Electron's app-data directory: `~/Library/Application Support/Claude/` on macOS, `%APPDATA%\Claude\` on Windows, and `$XDG_CONFIG_HOME/Claude/` (default `~/.config/Claude/`) on Linux, which gori reads so a Nix or home-manager session that moves it is followed too. A Flatpak build is the exception: it reads that variable inside its own sandbox, so copy the printed file into `~/.var/app/<app-id>/config/Claude/` yourself.
+Only Claude Desktop and Hermes vary per platform. Hermes reads `$HERMES_HOME` when it is set, and otherwise `~/.hermes` (`%LOCALAPPDATA%\hermes` on Windows). Claude Desktop's location — it follows Electron's app-data directory: `~/Library/Application Support/Claude/` on macOS, `%APPDATA%\Claude\` on Windows, and `$XDG_CONFIG_HOME/Claude/` (default `~/.config/Claude/`) on Linux, which gori reads so a Nix or home-manager session that moves it is followed too. A Flatpak build is the exception: it reads that variable inside its own sandbox, so copy the printed file into `~/.var/app/<app-id>/config/Claude/` yourself.
 
 Wiring it up by hand instead? The server is just the `gori mcp` command over stdio. Point any MCP client at that command with no extra arguments.
 

--- a/docs/content/guide/mcp.ko.md
+++ b/docs/content/guide/mcp.ko.md
@@ -74,8 +74,9 @@ gori는 널리 쓰이는 클라이언트의 MCP 설정을 대신 작성해 줍�
 | `--install-codex` | OpenAI Codex | `~/.codex/config.toml` (`[mcp_servers.gori]`) |
 | `--install-agy` | Antigravity CLI | `~/.gemini/antigravity-cli/mcp_config.json` |
 | `--install-grok` | Grok | `~/.grok/config.toml` (`[mcp_servers.gori]`) |
+| `--install-hermes` | Hermes | `~/.hermes/config.yaml` (`mcp_servers.gori`), 또는 `$HERMES_HOME` |
 
-Claude Desktop을 뺀 나머지 클라이언트는 macOS·Linux·Windows에서 모두 같은 위치에 설정을 둡니다. Claude Desktop만 Electron의 앱 데이터 디렉터리를 따릅니다. macOS는 `~/Library/Application Support/Claude/`, Windows는 `%APPDATA%\Claude\`, Linux는 `$XDG_CONFIG_HOME/Claude/`(기본값 `~/.config/Claude/`)입니다. gori는 이 변수를 읽으므로 Nix나 home-manager처럼 세션에서 값을 옮겨 둔 환경도 그대로 따라갑니다.
+Claude Desktop과 Hermes를 뺀 나머지 클라이언트는 macOS·Linux·Windows에서 모두 같은 위치에 설정을 둡니다. Hermes는 `$HERMES_HOME`이 설정돼 있으면 그 값을, 없으면 `~/.hermes`(Windows는 `%LOCALAPPDATA%\hermes`)를 읽습니다. Claude Desktop만 Electron의 앱 데이터 디렉터리를 따릅니다. macOS는 `~/Library/Application Support/Claude/`, Windows는 `%APPDATA%\Claude\`, Linux는 `$XDG_CONFIG_HOME/Claude/`(기본값 `~/.config/Claude/`)입니다. gori는 이 변수를 읽으므로 Nix나 home-manager처럼 세션에서 값을 옮겨 둔 환경도 그대로 따라갑니다.
 
 예외는 **Flatpak** Claude Desktop입니다. 이 빌드는 샌드박스 안쪽의 `XDG_CONFIG_HOME`(`~/.var/app/<app-id>/config/Claude/`)을 읽는데, 호스트 셸에서 실행되는 gori는 그 값을 볼 수 없습니다. 이 경우 gori는 `~/.config/Claude/claude_desktop_config.json`에 쓰고 그 경로를 출력하니, 파일을 샌드박스 디렉터리로 직접 복사하세요. 설치 명령은 항상 실제로 쓴 파일을 출력하므로, 그 줄을 사용 중인 빌드가 읽는 위치와 맞춰 보세요.
 
@@ -83,10 +84,11 @@ Claude Desktop을 뺀 나머지 클라이언트는 macOS·Linux·Windows에서 �
 gori mcp --install-claude-code
 gori mcp --install-codex
 gori mcp --install-grok
+gori mcp --install-hermes
 gori mcp --install-claude-code --install-codex  # 한 번에 여러 클라이언트
 ```
 
-Codex와 Grok은 JSON이 아니라 `[mcp_servers.gori]` 테이블이 있는 TOML을 사용합니다. 설치 후 클라이언트를 재시작하거나 세션을 다시 열어 MCP 서버를 다시 로드하세요. 기존 설정 파일은 제자리에서 갱신됩니다. 다른 서버·테이블·주석은 그대로 두고, 파일 권한도 유지하며, 교체는 원자적이라 설치가 중간에 끊겨도 파일이 잘려 나가지 않습니다.
+Codex와 Grok은 `[mcp_servers.gori]` 테이블이 있는 TOML을, Hermes는 `mcp_servers:` 항목이 있는 YAML을 사용합니다(JSON이 아닙니다). 설치 후 클라이언트를 재시작하거나 세션을 다시 열어 MCP 서버를 다시 로드하세요. 기존 설정 파일은 제자리에서 갱신됩니다. 다른 서버·테이블·주석은 그대로 두고, 파일 권한도 유지하며, 교체는 원자적이라 설치가 중간에 끊겨도 파일이 잘려 나가지 않습니다. gori는 이 파일들을 파싱 트리에서 다시 뽑아내지 않고 텍스트로 편집하므로 설정 주변에 적어 둔 메모가 그대로 남습니다. 안전하게 끼워 넣을 수 없는 설정 파일은 고쳐 쓰지 않고 그 사실을 알립니다.
 
 클라이언트가 리포지토리 디렉터리 밖에서 MCP를 시작해도 서버는 unbound로 연결되며, 에이전트가 도구로 프로젝트를 고르거나 만들 수 있습니다. 설치 시점에 고정 engagement를 박아 두려면 선택자를 넘기세요. 예: `gori mcp --project my-engagement --install-codex`.
 

--- a/docs/content/guide/mcp.md
+++ b/docs/content/guide/mcp.md
@@ -74,8 +74,9 @@ gori can write the MCP configuration for common clients for you:
 | `--install-codex` | OpenAI Codex | `~/.codex/config.toml` (`[mcp_servers.gori]`) |
 | `--install-agy` | Antigravity CLI | `~/.gemini/antigravity-cli/mcp_config.json` |
 | `--install-grok` | Grok | `~/.grok/config.toml` (`[mcp_servers.gori]`) |
+| `--install-hermes` | Hermes | `~/.hermes/config.yaml` (`mcp_servers.gori`), or `$HERMES_HOME` |
 
-Every client except Claude Desktop keeps its config in the same place on macOS, Linux and Windows. Claude Desktop follows Electron's app-data directory instead: `~/Library/Application Support/Claude/` on macOS, `%APPDATA%\Claude\` on Windows, and `$XDG_CONFIG_HOME/Claude/` — defaulting to `~/.config/Claude/` — on Linux. gori reads that variable, so a Nix or home-manager session that moves it is followed too.
+Every client except Claude Desktop and Hermes keeps its config in the same place on macOS, Linux and Windows. Hermes reads `$HERMES_HOME` when it is set, and otherwise `~/.hermes` (`%LOCALAPPDATA%\hermes` on Windows). Claude Desktop follows Electron's app-data directory instead: `~/Library/Application Support/Claude/` on macOS, `%APPDATA%\Claude\` on Windows, and `$XDG_CONFIG_HOME/Claude/` — defaulting to `~/.config/Claude/` — on Linux. gori reads that variable, so a Nix or home-manager session that moves it is followed too.
 
 The exception is a **Flatpak** Claude Desktop: it reads `XDG_CONFIG_HOME` from inside its own sandbox (`~/.var/app/<app-id>/config/Claude/`), which the host shell running gori cannot see. There gori writes `~/.config/Claude/claude_desktop_config.json` and prints that path — copy it into the app's sandbox directory yourself. Every install command prints the file it wrote, so check that line against where your build actually reads.
 
@@ -83,10 +84,11 @@ The exception is a **Flatpak** Claude Desktop: it reads `XDG_CONFIG_HOME` from i
 gori mcp --install-claude-code
 gori mcp --install-codex
 gori mcp --install-grok
+gori mcp --install-hermes
 gori mcp --install-claude-code --install-codex  # several clients in one run
 ```
 
-Codex and Grok use TOML with an `[mcp_servers.gori]` table (not JSON). Restart the client (or re-open the session) after installing so it reloads MCP servers. Existing config files are updated in place: other servers, tables and comments are preserved, the file's permissions are kept, and the replacement is atomic so an interrupted install can never truncate it.
+Codex and Grok use TOML with an `[mcp_servers.gori]` table, and Hermes YAML with an `mcp_servers:` entry, rather than JSON. Restart the client (or re-open the session) after installing so it reloads MCP servers. Existing config files are updated in place: other servers, tables and comments are preserved, the file's permissions are kept, and the replacement is atomic so an interrupted install can never truncate it. gori edits these files as text rather than re-emitting them from a parse tree, so the documentation you keep around your own settings survives the install; a config it cannot splice safely is reported and left alone rather than rewritten.
 
 If a client starts MCP outside your repository directory, the server starts unbound and the agent can pick or create a project over tools. To pin a fixed engagement at install time instead, pass a selector, for example `gori mcp --project my-engagement --install-codex`.
 

--- a/docs/content/playbooks/run-an-ai-co-pilot.ko.md
+++ b/docs/content/playbooks/run-an-ai-co-pilot.ko.md
@@ -9,7 +9,7 @@ group = "마무리"
 
 gori에는 채팅 창이 없고, 이는 의도적입니다. 인텔리전스는 도구 바깥에 살고, MCP로 도달합니다. 당신이 모델과 클라이언트를 가져오면 gori는 프로젝트를 깔끔한 도구 인터페이스로 노출합니다. 그래서 무엇이 돌지 당신이 고르고, 트래픽은 당신이 의도하지 않은 어디로도 실려 가지 않으며, 에이전트의 모든 동작이 이미 당신이 보고 있는 그 TUI에 나타납니다. 이 플레이북은 이미 캡처한 프로젝트에 에이전트를 붙여 일을 시킵니다 — 약 10분이며, 대부분은 한 번뿐인 설치입니다.
 
-> **시작하기 전에.** 캡처된 트래픽이 담긴 기존 프로젝트가 필요합니다 — 앞선 플레이북의 그 프로젝트가 이상적입니다 — 그리고 MCP를 지원하는 클라이언트(Claude Code, Claude Desktop, OpenAI Codex, Antigravity, Grok 등)가 필요합니다. 에이전트는 실제 요청을 보낼 수 있으니, 테스트 권한이 있는 대상으로 프로젝트 스코프를 잡아 두세요.
+> **시작하기 전에.** 캡처된 트래픽이 담긴 기존 프로젝트가 필요합니다 — 앞선 플레이북의 그 프로젝트가 이상적입니다 — 그리고 MCP를 지원하는 클라이언트(Claude Code, Claude Desktop, OpenAI Codex, Antigravity, Grok, Hermes 등)가 필요합니다. 에이전트는 실제 요청을 보낼 수 있으니, 테스트 권한이 있는 대상으로 프로젝트 스코프를 잡아 두세요.
 
 ## 1. MCP 서버 설치 {#1-install-the-mcp-server}
 
@@ -19,7 +19,7 @@ gori에는 채팅 창이 없고, 이는 의도적입니다. 인텔리전스는 �
 gori mcp --install-claude-code   # Claude Code
 ```
 
-다른 호스트도 같은 방식으로 설치합니다: `--install-claude`(Claude Desktop), `--install-codex`(OpenAI Codex), `--install-agy`(Antigravity), `--install-grok`(Grok). 각 명령은 쓴 파일과 기록한 정확한 실행 명령을 출력합니다. Codex와 Grok은 JSON이 아니라 TOML `[mcp_servers.gori]` 테이블을 씁니다. 이후 클라이언트를 재시작(또는 세션을 다시 열기)해 MCP 서버를 다시 읽게 하세요.
+다른 호스트도 같은 방식으로 설치합니다: `--install-claude`(Claude Desktop), `--install-codex`(OpenAI Codex), `--install-agy`(Antigravity), `--install-grok`(Grok), `--install-hermes`(Hermes). 각 명령은 쓴 파일과 기록한 정확한 실행 명령을 출력합니다. Codex와 Grok은 TOML `[mcp_servers.gori]` 테이블을, Hermes는 YAML `mcp_servers:` 항목을 씁니다(JSON이 아닙니다). 이후 클라이언트를 재시작(또는 세션을 다시 열기)해 MCP 서버를 다시 읽게 하세요.
 
 두 가지 선택이 그 기록된 명령에 함께 실립니다. **읽기 전용 대 전체 접근**: 기본적으로 에이전트는 액티브 도구(`send_request`, 이슈 쓰기, 인터셉트 뮤테이터)도 받습니다. `--read-only`를 더하면 읽기 도구만 노출됩니다. **어느 프로젝트**: 엔게이지먼트의 Git 저장소 안에서 설치를 실행하면 gori가 그 워크스페이스를 자체 프로젝트에 경로-바인딩합니다. 그 밖에서는 서버가 언바운드로 시작하고 에이전트가 도구로 프로젝트를 고릅니다. `--project`나 `--db`로 명시적으로 고정하면, 절대 경로로 기록된 명령에 쓰입니다:
 

--- a/docs/content/playbooks/run-an-ai-co-pilot.md
+++ b/docs/content/playbooks/run-an-ai-co-pilot.md
@@ -9,7 +9,7 @@ group = "Wrap up"
 
 gori has no chat window, and that is deliberate: the intelligence lives outside the tool, reached over MCP. You bring the model and the client; gori exposes the project over a clean tool interface, so you choose what runs, your traffic isn't shipped anywhere you didn't intend, and every move the agent makes shows up in the same TUI you're already watching. This playbook connects an agent to a project you already captured and puts it to work — about ten minutes, most of it a one-time install.
 
-> **Before you begin.** You need an existing project with captured traffic — ideally the one from the earlier playbooks — and an MCP-capable client (Claude Code, Claude Desktop, OpenAI Codex, Antigravity, Grok, and others). An agent can send real requests, so keep the project scoped to a target you are authorized to test.
+> **Before you begin.** You need an existing project with captured traffic — ideally the one from the earlier playbooks — and an MCP-capable client (Claude Code, Claude Desktop, OpenAI Codex, Antigravity, Grok, Hermes, and others). An agent can send real requests, so keep the project scoped to a target you are authorized to test.
 
 ## 1. Install the MCP server
 
@@ -19,7 +19,7 @@ gori has no chat window, and that is deliberate: the intelligence lives outside 
 gori mcp --install-claude-code   # Claude Code
 ```
 
-Other hosts install the same way: `--install-claude` (Claude Desktop), `--install-codex` (OpenAI Codex), `--install-agy` (Antigravity), `--install-grok` (Grok). Each command prints the file it wrote and the exact launch command it recorded; Codex and Grok write a TOML `[mcp_servers.gori]` table rather than JSON. Restart the client (or reopen the session) afterward so it reloads its MCP servers.
+Other hosts install the same way: `--install-claude` (Claude Desktop), `--install-codex` (OpenAI Codex), `--install-agy` (Antigravity), `--install-grok` (Grok), `--install-hermes` (Hermes). Each command prints the file it wrote and the exact launch command it recorded; Codex and Grok write a TOML `[mcp_servers.gori]` table and Hermes a YAML `mcp_servers:` entry, rather than JSON. Restart the client (or reopen the session) afterward so it reloads its MCP servers.
 
 Two choices ride along into that recorded command. **Read-only vs. full access**: by default the agent also gets the action tools (`send_request`, issue writes, the intercept mutators); add `--read-only` to expose only the read tools. **Which project**: run the install from inside your engagement's Git repository and gori path-binds that workspace to its own project; from anywhere else the server starts unbound and the agent picks a project over tools. Pin one explicitly with `--project` or `--db`, and it is written into the recorded command with an absolute path:
 

--- a/docs/content/reference/cli.ko.md
+++ b/docs/content/reference/cli.ko.md
@@ -969,6 +969,7 @@ MCP stdio 서버입니다. 도구 세부사항은 [MCP 가이드](/ko/guide/mcp/
 | `--install-codex` | OpenAI Codex `~/.codex/config.toml` `[mcp_servers.gori]` 기록 |
 | `--install-agy` | Antigravity `~/.gemini/antigravity-cli/mcp_config.json` 기록 |
 | `--install-grok` | Grok `~/.grok/config.toml` `[mcp_servers.gori]` 기록 |
+| `--install-hermes` | Hermes `~/.hermes/config.yaml` `mcp_servers.gori` 기록 (또는 `$HERMES_HOME`) |
 
 `--install-*`은 한 번에 여러 개 지정할 수 있습니다. 클라이언트마다 따로 설정하고 따로 보고하며, 하나가 실패해도 나머지는 그대로 진행됩니다. 커맨드라인의 다른 플래그(`--db`, `--project`, `--no-project`, `--use-active-project`, `--read-only`, `--insecure-upstream`, 전역 `--config`)는 모두 설치되는 커맨드에 기록되고, 경로는 절대 경로로 바뀝니다. 기존 설정 파일은 제자리에서 갱신됩니다. 다른 항목·테이블·주석은 유지되고, 권한도 보존되며, 교체는 원자적입니다.
 

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -1003,6 +1003,7 @@ MCP stdio server. See the [MCP guide](/guide/mcp/) for tool details.
 | `--install-codex` | Write OpenAI Codex `~/.codex/config.toml` `[mcp_servers.gori]` |
 | `--install-agy` | Write Antigravity `~/.gemini/antigravity-cli/mcp_config.json` |
 | `--install-grok` | Write Grok `~/.grok/config.toml` `[mcp_servers.gori]` |
+| `--install-hermes` | Write Hermes `~/.hermes/config.yaml` `mcp_servers.gori` (or `$HERMES_HOME`) |
 
 Several `--install-*` flags may be given in one run; each named client is configured and reported separately, and one unwritable config does not stop the others. Every other flag on the command line — `--db`, `--project`, `--no-project`, `--use-active-project`, `--read-only`, `--insecure-upstream`, and the global `--config` — is written into the installed command, with paths made absolute. Existing config files are updated in place: other entries, tables and comments survive, permissions are preserved, and the replacement is atomic.
 

--- a/spec/mcp/install_spec.cr
+++ b/spec/mcp/install_spec.cr
@@ -11,6 +11,21 @@ describe Gori::MCP::Install do
       Gori::MCP::Install.config_path("grok").should eq(File.join(ENV["HOME"], ".grok", "config.toml"))
     end
 
+    it "maps hermes to ~/.hermes/config.yaml, or HERMES_HOME" do
+      # Pinned to a literal, not rebuilt from `hermes_home`: an expectation that calls the
+      # function under test moves with it, and only the `config.yaml` half would have failed.
+      old_hermes = ENV["HERMES_HOME"]?
+      ENV.delete("HERMES_HOME")
+      begin
+        Gori::MCP::Install.config_path("hermes").should eq(
+          File.join(ENV["HOME"], ".hermes", "config.yaml"))
+        ENV["HERMES_HOME"] = "/opt/hermes-eng"
+        Gori::MCP::Install.config_path("hermes").should eq("/opt/hermes-eng/config.yaml")
+      ensure
+        old_hermes ? (ENV["HERMES_HOME"] = old_hermes) : ENV.delete("HERMES_HOME")
+      end
+    end
+
     it "maps claude-code to ~/.claude.json" do
       Gori::MCP::Install.config_path("claude-code").should eq(File.join(ENV["HOME"], ".claude.json"))
     end
@@ -72,6 +87,246 @@ describe Gori::MCP::Install do
         .should eq("/home/u/.config/Claude/claude_desktop_config.json")
       Gori::MCP::Install.claude_desktop_path(home, :linux, xdg_config_home: ".config")
         .should eq("/home/u/.config/Claude/claude_desktop_config.json")
+    end
+  end
+
+  describe ".hermes_home" do
+    # Same rule as claude_desktop_path: every branch asserted from every host, because the
+    # one branch this platform cannot execute is the one that stays wrong.
+    home = "/home/u"
+
+    it "uses ~/.hermes on darwin and linux" do
+      Gori::MCP::Install.hermes_home(home, :darwin, hermes_home_env: nil, local_appdata: nil)
+        .should eq("/home/u/.hermes")
+      Gori::MCP::Install.hermes_home(home, :linux, hermes_home_env: nil, local_appdata: nil)
+        .should eq("/home/u/.hermes")
+    end
+
+    it "uses %LOCALAPPDATA% on windows, falling back to AppData/Local" do
+      Gori::MCP::Install.hermes_home(home, :windows, hermes_home_env: nil,
+        local_appdata: "C:/Users/u/AppData/Local").should eq("C:/Users/u/AppData/Local/hermes")
+      Gori::MCP::Install.hermes_home(home, :windows, hermes_home_env: nil, local_appdata: nil)
+        .should eq("/home/u/AppData/Local/hermes")
+      Gori::MCP::Install.hermes_home(home, :windows, hermes_home_env: nil, local_appdata: "")
+        .should eq("/home/u/AppData/Local/hermes")
+    end
+
+    it "lets HERMES_HOME win on every platform" do
+      # A profile-per-engagement setup moves it, and the agent reads the variable on every
+      # launch — install anywhere else and the client never sees the server.
+      Gori::MCP::Install.hermes_home(home, :darwin, hermes_home_env: "/opt/h").should eq("/opt/h")
+      Gori::MCP::Install.hermes_home(home, :linux, hermes_home_env: "/opt/h").should eq("/opt/h")
+      Gori::MCP::Install.hermes_home(home, :windows, hermes_home_env: "D:/h").should eq("D:/h")
+    end
+
+    it "ignores an empty or all-whitespace HERMES_HOME" do
+      # Hermes strips the variable before testing it, so " " is unset to the agent; honoring
+      # it here would install into a directory named " " that nothing reads.
+      Gori::MCP::Install.hermes_home(home, :linux, hermes_home_env: "").should eq("/home/u/.hermes")
+      Gori::MCP::Install.hermes_home(home, :linux, hermes_home_env: "   ").should eq("/home/u/.hermes")
+    end
+  end
+
+  describe ".upsert_yaml_server" do
+    body = ["command: \"/bin/gori\"", "args:", "  - \"mcp\""]
+
+    it "appends the whole block to a file that has no mcp_servers" do
+      text = Gori::MCP::Install.upsert_yaml_server("model:\n  default: claude-sonnet-5\n",
+        "mcp_servers", "gori", body)
+      text.should eq(<<-YAML)
+        model:
+          default: claude-sonnet-5
+
+        mcp_servers:
+          gori:
+            command: "/bin/gori"
+            args:
+              - "mcp"\n
+        YAML
+    end
+
+    it "writes the block into an empty document" do
+      Gori::MCP::Install.upsert_yaml_server("", "mcp_servers", "gori", body)
+        .should eq("mcp_servers:\n  gori:\n    command: \"/bin/gori\"\n    args:\n      - \"mcp\"\n")
+    end
+
+    it "keeps sibling servers, their secrets, and the comments around them" do
+      # The whole reason this splices lines instead of re-emitting a parse tree: a hermes
+      # config.yaml is mostly commented documentation, and the servers beside gori hold
+      # their own API keys.
+      existing = <<-YAML
+        model:
+          provider: anthropic
+
+        # ── MCP servers ──────────────────────────────
+        mcp_servers:
+          github:
+            command: "npx"
+            args: ["-y", "@modelcontextprotocol/server-github"]
+            env:
+              GITHUB_PERSONAL_ACCESS_TOKEN: "ghp_secret"
+
+        plugins:
+          enabled:
+            - orca-status\n
+        YAML
+      text = Gori::MCP::Install.upsert_yaml_server(existing, "mcp_servers", "gori", body)
+      text.should contain("# ── MCP servers ──────────────────────────────")
+      text.should contain("GITHUB_PERSONAL_ACCESS_TOKEN: \"ghp_secret\"")
+      text.should contain("provider: anthropic")
+      text.should contain("    - orca-status")
+      # The new entry sits inside the block, not after the `plugins:` section that follows it.
+      text.index("  gori:").not_nil!.should be < text.index("plugins:").not_nil!
+      YAML.parse(text)["mcp_servers"]["gori"]["command"].as_s.should eq("/bin/gori")
+      YAML.parse(text)["plugins"]["enabled"][0].as_s.should eq("orca-status")
+    end
+
+    it "replaces an existing gori entry instead of adding a second one" do
+      existing = <<-YAML
+        mcp_servers:
+          gori:
+            command: "/old/gori"
+            args:
+              - "mcp"
+              - "--project=old"
+            env:
+              STALE: "1"
+          keep:
+            command: "keep"\n
+        YAML
+      text = Gori::MCP::Install.upsert_yaml_server(existing, "mcp_servers", "gori", body)
+      text.scan("  gori:").size.should eq(1)
+      text.should_not contain("/old/gori")
+      text.should_not contain("--project=old")
+      text.should_not contain("STALE")
+      parsed = YAML.parse(text)
+      parsed["mcp_servers"]["gori"]["args"].as_a.map(&.as_s).should eq(["mcp"])
+      parsed["mcp_servers"]["keep"]["command"].as_s.should eq("keep")
+    end
+
+    it "keeps the block's own indentation" do
+      # A four-space block gets a four-space entry: one entry at a different depth from its
+      # siblings is a parse error, not a style difference.
+      text = Gori::MCP::Install.upsert_yaml_server(
+        "mcp_servers:\n    other:\n        command: \"o\"\n", "mcp_servers", "gori", body)
+      text.should contain("\n    gori:\n        command: \"/bin/gori\"\n        args:\n")
+      YAML.parse(text)["mcp_servers"]["other"]["command"].as_s.should eq("o")
+    end
+
+    it "expands an inline-empty mcp_servers into a block" do
+      ["mcp_servers: {}", "mcp_servers: null", "mcp_servers: ~"].each do |line|
+        text = Gori::MCP::Install.upsert_yaml_server("#{line}\nmodel: x\n",
+          "mcp_servers", "gori", body)
+        YAML.parse(text)["mcp_servers"]["gori"]["command"].as_s.should eq("/bin/gori")
+        YAML.parse(text)["model"].as_s.should eq("x")
+      end
+    end
+
+    it "refuses an mcp_servers written as a populated flow mapping" do
+      # Splicing indented lines under it would leave the servers already inside unreachable.
+      expect_raises(Exception, /written inline/) do
+        Gori::MCP::Install.upsert_yaml_server(%(mcp_servers: {github: {command: "npx"}}\n),
+          "mcp_servers", "gori", body)
+      end
+    end
+
+    it "refuses an mcp_servers that holds a sequence" do
+      expect_raises(Exception, /sequence/) do
+        Gori::MCP::Install.upsert_yaml_server("mcp_servers:\n  - name: github\n",
+          "mcp_servers", "gori", body)
+      end
+    end
+
+    it "does not mistake a nested args sequence for one" do
+      # `args:`' items are sequence lines too; only the block's OWN indent decides.
+      text = Gori::MCP::Install.upsert_yaml_server(
+        "mcp_servers:\n  other:\n    args:\n      - \"-y\"\n", "mcp_servers", "gori", body)
+      YAML.parse(text)["mcp_servers"]["gori"]["command"].as_s.should eq("/bin/gori")
+    end
+
+    it "does not end the block at a column-0 comment between entries" do
+      existing = "mcp_servers:\n  a:\n    command: \"a\"\n# a note\n  b:\n    command: \"b\"\n"
+      text = Gori::MCP::Install.upsert_yaml_server(existing, "mcp_servers", "gori", body)
+      text.should contain("# a note")
+      parsed = YAML.parse(text)
+      parsed["mcp_servers"]["a"]["command"].as_s.should eq("a")
+      parsed["mcp_servers"]["b"]["command"].as_s.should eq("b")
+      parsed["mcp_servers"]["gori"]["command"].as_s.should eq("/bin/gori")
+    end
+
+    it "matches a quoted key and leaves a look-alike nested key alone" do
+      existing = "mcp_servers:\n  \"gori\":\n    command: \"/old\"\n  other:\n    gori: \"no\"\n"
+      text = Gori::MCP::Install.upsert_yaml_server(existing, "mcp_servers", "gori", body)
+      text.should_not contain("/old")
+      parsed = YAML.parse(text)
+      parsed["mcp_servers"]["gori"]["command"].as_s.should eq("/bin/gori")
+      parsed["mcp_servers"]["other"]["gori"].as_s.should eq("no")
+    end
+
+    it "leaves an ordinary mcp_servers line exactly as the user wrote it" do
+      # Re-emitting the key canonically looked free: it deletes a comment on that line and
+      # unquotes a quoted key, and the readback guard cannot see either — the gori entry is
+      # perfect while the line above it lost what the user wrote.
+      text = Gori::MCP::Install.upsert_yaml_server(
+        "mcp_servers:  # my servers, do not remove\n  a:\n    command: \"a\"\n",
+        "mcp_servers", "gori", body)
+      text.should contain("mcp_servers:  # my servers, do not remove")
+      text = Gori::MCP::Install.upsert_yaml_server(
+        "\"mcp_servers\":\n  a:\n    command: \"a\"\n", "mcp_servers", "gori", body)
+      text.should contain("\"mcp_servers\":")
+      YAML.parse(text)["mcp_servers"]["gori"]["command"].as_s.should eq("/bin/gori")
+    end
+
+    it "expands an inline-empty mcp_servers that carries a comment or inner spaces" do
+      # `{}` is the case the expansion exists for, and a placeholder line is exactly where a
+      # trailing comment lives — refusing that shape refuses the most common first install.
+      {"mcp_servers: {} # none yet", "mcp_servers: {  }", "mcp_servers: ~  # unset"}.each do |line|
+        text = Gori::MCP::Install.upsert_yaml_server("#{line}\nmodel: x\n",
+          "mcp_servers", "gori", body)
+        YAML.parse(text)["mcp_servers"]["gori"]["command"].as_s.should eq("/bin/gori")
+        YAML.parse(text)["model"].as_s.should eq("x")
+      end
+      # The comment survives the value being dropped.
+      Gori::MCP::Install.upsert_yaml_server("mcp_servers: {} # none yet\n",
+        "mcp_servers", "gori", body).should contain("mcp_servers: # none yet")
+    end
+
+    it "appends above a trailing comment inside the block, not below it" do
+      # `# add more servers below` is an invitation, not a caption for whatever lands under
+      # it — and appending past it made it read as gori's own.
+      text = Gori::MCP::Install.upsert_yaml_server(
+        "mcp_servers:\n  a:\n    command: \"a\"\n\n  # add more servers below\n",
+        "mcp_servers", "gori", body)
+      text.index("  gori:").not_nil!.should be < text.index("# add more servers below").not_nil!
+      YAML.parse(text)["mcp_servers"]["gori"]["command"].as_s.should eq("/bin/gori")
+    end
+
+    it "leaves a mostly-LF file on LF, one stray CRLF line and all" do
+      # A whole-file `includes?("\r\n")` turned an installer that adds one entry into a
+      # whole-file diff in somebody's dotfiles repo.
+      text = Gori::MCP::Install.upsert_yaml_server(
+        "model: x\r\nplugins: y\nmcp_servers:\n  a:\n    command: \"a\"\n",
+        "mcp_servers", "gori", body)
+      text.should contain("model: x\r\n") # the line that had one keeps it
+      text.should contain("plugins: y\n")
+      text.should_not contain("plugins: y\r")
+      text.should contain("  gori:\n") # a line gori added follows the majority (LF)
+      YAML.parse(text)["mcp_servers"]["gori"]["command"].as_s.should eq("/bin/gori")
+    end
+
+    it "keeps a CRLF file on CRLF" do
+      text = Gori::MCP::Install.upsert_yaml_server("model: x\r\n", "mcp_servers", "gori", body)
+      text.should_not match(/[^\r]\n/)
+      YAML.parse(text)["mcp_servers"]["gori"]["command"].as_s.should eq("/bin/gori")
+    end
+  end
+
+  describe ".yaml_string" do
+    it "always quotes, and escapes what would re-parse" do
+      Gori::MCP::Install.yaml_string("/bin/gori").should eq(%("/bin/gori"))
+      Gori::MCP::Install.yaml_string(%(a"b\\c)).should eq(%("a\\"b\\\\c"))
+      Gori::MCP::Install.yaml_string("a\nb\tc").should eq(%("a\\nb\\tc"))
+      Gori::MCP::Install.yaml_string("a\u0001b").should eq(%("a\\x01b"))
     end
   end
 
@@ -371,6 +626,171 @@ describe Gori::MCP::Install do
           text.should_not contain(%(command = "/opt/gori"\n))
         ensure
           old_home ? (ENV["HOME"] = old_home) : ENV.delete("HOME")
+        end
+      end
+    end
+
+    it "writes a YAML mcp_servers.gori entry for hermes and updates in place" do
+      Dir.tempdir.try do |base|
+        home = File.join(base, "home-hermes-#{Random::Secure.hex(4)}")
+        hermes_dir = File.join(home, ".hermes")
+        Dir.mkdir_p(hermes_dir)
+        config = File.join(hermes_dir, "config.yaml")
+        File.write(config, <<-YAML)
+          model:
+            provider: anthropic
+
+          # keep me
+          mcp_servers:
+            github:
+              command: "npx"
+              env:
+                GITHUB_PERSONAL_ACCESS_TOKEN: "ghp_secret"\n
+          YAML
+        old_home = ENV["HOME"]?
+        old_hermes = ENV["HERMES_HOME"]?
+        ENV["HOME"] = home
+        ENV.delete("HERMES_HOME")
+        begin
+          path = Gori::MCP::Install.install("hermes", exe_path: "/opt/gori/bin/gori",
+            project: "demo")
+          path.should eq(config)
+          # Second install updates rather than duplicating.
+          Gori::MCP::Install.install("hermes", exe_path: "/opt/gori2", read_only: true)
+          text = File.read(config)
+          text.should contain("# keep me")
+          text.scan("  gori:").size.should eq(1)
+          text.should_not contain("--project=demo")
+          parsed = YAML.parse(text)
+          parsed["model"]["provider"].as_s.should eq("anthropic")
+          parsed["mcp_servers"]["github"]["env"]["GITHUB_PERSONAL_ACCESS_TOKEN"].as_s
+            .should eq("ghp_secret")
+          parsed["mcp_servers"]["gori"]["command"].as_s.should eq("/opt/gori2")
+          parsed["mcp_servers"]["gori"]["args"].as_a.map(&.as_s).should eq(["mcp", "--read-only"])
+        ensure
+          old_home ? (ENV["HOME"] = old_home) : ENV.delete("HOME")
+          old_hermes ? (ENV["HERMES_HOME"] = old_hermes) : ENV.delete("HERMES_HOME")
+        end
+      end
+    end
+
+    it "creates the hermes config under HERMES_HOME when there is none yet" do
+      Dir.tempdir.try do |base|
+        home = File.join(base, "home-hermes-env-#{Random::Secure.hex(4)}")
+        profile = File.join(home, "profiles", "engagement")
+        Dir.mkdir_p(home)
+        old_home = ENV["HOME"]?
+        old_hermes = ENV["HERMES_HOME"]?
+        old_appdata = ENV["LOCALAPPDATA"]?
+        ENV["HOME"] = home
+        ENV["HERMES_HOME"] = profile
+        # A Windows host reads LOCALAPPDATA on the default path; HERMES_HOME wins over it,
+        # and the var is kept inside the temp tree so a regression cannot escape the sandbox.
+        ENV["LOCALAPPDATA"] = File.join(home, "AppData", "Local")
+        begin
+          path = Gori::MCP::Install.install("hermes", exe_path: "/opt/gori")
+          path.should eq(File.join(profile, "config.yaml"))
+          YAML.parse(File.read(path))["mcp_servers"]["gori"]["command"].as_s.should eq("/opt/gori")
+        ensure
+          old_home ? (ENV["HOME"] = old_home) : ENV.delete("HOME")
+          old_hermes ? (ENV["HERMES_HOME"] = old_hermes) : ENV.delete("HERMES_HOME")
+          old_appdata ? (ENV["LOCALAPPDATA"] = old_appdata) : ENV.delete("LOCALAPPDATA")
+        end
+      end
+    end
+
+    it "refuses to clobber a hermes config that is not valid YAML" do
+      # The file holds the user's providers, plugins and every other server's keys — a
+      # hand-edit error must not be answered by replacing it with a two-line file.
+      Dir.tempdir.try do |base|
+        home = File.join(base, "home-hermes-bad-#{Random::Secure.hex(4)}")
+        Dir.mkdir_p(File.join(home, ".hermes"))
+        bad = File.join(home, ".hermes", "config.yaml")
+        File.write(bad, "model: [unterminated\n")
+        old_home = ENV["HOME"]?
+        old_hermes = ENV["HERMES_HOME"]?
+        ENV["HOME"] = home
+        ENV.delete("HERMES_HOME")
+        begin
+          expect_raises(Exception, /Refusing to overwrite/) do
+            Gori::MCP::Install.install("hermes", exe_path: "/opt/gori")
+          end
+          File.read(bad).should eq("model: [unterminated\n")
+        ensure
+          old_home ? (ENV["HOME"] = old_home) : ENV.delete("HOME")
+          old_hermes ? (ENV["HERMES_HOME"] = old_hermes) : ENV.delete("HERMES_HOME")
+        end
+      end
+    end
+
+    it "refuses a hermes config whose document is not a mapping" do
+      Dir.tempdir.try do |base|
+        home = File.join(base, "home-hermes-seq-#{Random::Secure.hex(4)}")
+        Dir.mkdir_p(File.join(home, ".hermes"))
+        bad = File.join(home, ".hermes", "config.yaml")
+        File.write(bad, "- a\n- b\n")
+        old_home = ENV["HOME"]?
+        old_hermes = ENV["HERMES_HOME"]?
+        ENV["HOME"] = home
+        ENV.delete("HERMES_HOME")
+        begin
+          expect_raises(Exception, /isn't a YAML mapping/) do
+            Gori::MCP::Install.install("hermes", exe_path: "/opt/gori")
+          end
+          File.read(bad).should eq("- a\n- b\n")
+        ensure
+          old_home ? (ENV["HOME"] = old_home) : ENV.delete("HOME")
+          old_hermes ? (ENV["HERMES_HOME"] = old_hermes) : ENV.delete("HERMES_HOME")
+        end
+      end
+    end
+
+    it "refuses a hermes config where the spliced entry would not be the one read back" do
+      # Two documents, and `mcp_servers` lives in the second: the splice edits the first one
+      # it finds and the client parses a different one. Text editing can be wrong in ways
+      # only a re-read catches, which is why install_yaml re-parses before it writes — and
+      # why the file on disk is still the one the user had.
+      Dir.tempdir.try do |base|
+        home = File.join(base, "home-hermes-docs-#{Random::Secure.hex(4)}")
+        Dir.mkdir_p(File.join(home, ".hermes"))
+        config = File.join(home, ".hermes", "config.yaml")
+        original = "model: x\n---\nmcp_servers:\n  other:\n    command: \"o\"\n"
+        File.write(config, original)
+        old_home = ENV["HOME"]?
+        old_hermes = ENV["HERMES_HOME"]?
+        ENV["HOME"] = home
+        ENV.delete("HERMES_HOME")
+        begin
+          expect_raises(Exception, /did not read back as written/) do
+            Gori::MCP::Install.install("hermes", exe_path: "/opt/gori")
+          end
+          File.read(config).should eq(original)
+        ensure
+          old_home ? (ENV["HOME"] = old_home) : ENV.delete("HOME")
+          old_hermes ? (ENV["HERMES_HOME"] = old_hermes) : ENV.delete("HERMES_HOME")
+        end
+      end
+    end
+
+    it "keeps the hermes config's permissions and leaves no temp file behind" do
+      Dir.tempdir.try do |base|
+        home = File.join(base, "home-hermes-perm-#{Random::Secure.hex(4)}")
+        dir = File.join(home, ".hermes")
+        Dir.mkdir_p(dir)
+        config = File.join(dir, "config.yaml")
+        File.write(config, "model:\n  provider: anthropic\n")
+        File.chmod(config, 0o600)
+        old_home = ENV["HOME"]?
+        old_hermes = ENV["HERMES_HOME"]?
+        ENV["HOME"] = home
+        ENV.delete("HERMES_HOME")
+        begin
+          Gori::MCP::Install.install("hermes", exe_path: "/opt/gori")
+          File.info(config).permissions.should eq(File::Permissions.new(0o600))
+          Dir.children(dir).sort.should eq(["config.yaml"])
+        ensure
+          old_home ? (ENV["HOME"] = old_home) : ENV.delete("HOME")
+          old_hermes ? (ENV["HERMES_HOME"] = old_hermes) : ENV.delete("HERMES_HOME")
         end
       end
     end

--- a/src/gori/cli/mcp.cr
+++ b/src/gori/cli/mcp.cr
@@ -38,6 +38,7 @@ module Gori::CLI
       p.on("--install-claude", "Install gori as an MCP server in Claude Desktop config") { install_targets << "claude" }
       p.on("--install-claude-code", "Install gori as an MCP server in Claude Code (~/.claude.json)") { install_targets << "claude-code" }
       p.on("--install-grok", "Install gori as an MCP server in Grok (~/.grok/config.toml)") { install_targets << "grok" }
+      p.on("--install-hermes", "Install gori as an MCP server in Hermes ($HERMES_HOME, default ~/.hermes/config.yaml)") { install_targets << "hermes" }
       p.on("-h", "--help", "Show this help") { puts p; exit 0 }
       p.invalid_option { |flag| abort "unknown option: #{flag}\n#{p}" }
       p.missing_option { |flag| abort "missing value for #{flag}" }

--- a/src/gori/mcp/install.cr
+++ b/src/gori/mcp/install.cr
@@ -1,11 +1,14 @@
 require "json"
+require "yaml"
 require "../durable_file"
 
 module Gori
   module MCP
     # Writes client-specific MCP configuration so agents can spawn `gori mcp`.
     # JSON clients (Claude Desktop, Claude Code, Antigravity) get an `mcpServers`
-    # entry; TOML clients (OpenAI Codex, Grok) get an `[mcp_servers.gori]` table.
+    # entry; TOML clients (OpenAI Codex, Grok) get an `[mcp_servers.gori]` table;
+    # YAML clients (Hermes) get an `mcp_servers:` entry. Three file formats, one shape:
+    # a server named `gori` with a `command` and an `args` array.
     module Install
       SERVER_NAME = "gori"
 
@@ -43,7 +46,7 @@ module Gori
         {% end %}
 
       # Returns the absolute config path for *target* (`agy`, `codex`, `claude`,
-      # `claude-code`, `grok`). Raises on unknown targets.
+      # `claude-code`, `grok`, `hermes`). Raises on unknown targets.
       def self.config_path(target : String) : String
         home = ENV["HOME"]? || ENV["USERPROFILE"]? || abort "HOME is not set"
         case target
@@ -61,6 +64,18 @@ module Gori
         when "grok"
           # Grok Build TUI: GROK_HOME is not standard; config lives under ~/.grok.
           File.join(home, ".grok", "config.toml")
+        when "hermes"
+          # Hermes agent: `<HERMES_HOME>/config.yaml` (`hermes_constants.py` get_config_path),
+          # servers under a snake_case `mcp_servers` key (`tools/mcp_tool.py`'s module docs).
+          #
+          # `expand_path` here rather than inside hermes_home, which answers for a NAMED
+          # platform: this is the host-side path and the method above promises an absolute
+          # one. Hermes hands HERMES_HOME straight to `Path()`, so a relative value resolves
+          # against ITS working directory and gori cannot make the two match — but gori is
+          # the one that PRINTS where it wrote, so it can at least name a real file. Not
+          # `home: true`, for the same fidelity reason: a quoted `~/x` is a literal directory
+          # named `~` to Hermes, and expanding one here writes where the agent never looks.
+          File.expand_path(File.join(hermes_home(home), "config.yaml"))
         else
           raise ArgumentError.new("Unknown install target: #{target}")
         end
@@ -101,8 +116,39 @@ module Gori
         File.join(base, "Claude", "claude_desktop_config.json")
       end
 
+      # Hermes' home directory, the one `config.yaml` lives in. `HERMES_HOME` wins when set
+      # (the agent reads it from the process environment on every launch, and a
+      # profile-per-engagement setup is exactly what sets it); otherwise the default is
+      # `~/.hermes` everywhere except Windows, where it is `%LOCALAPPDATA%\hermes`. Both
+      # halves are `hermes_constants.py` (`_hermes_home_from_env`, `_get_platform_default_
+      # hermes_home`) — the client's own resolution, not a guess at it.
+      #
+      # Parameterized for the reason claude_desktop_path is: a compile-time `{% if %}` branch
+      # is one no host but that platform can execute, and this installer's worst failure is
+      # writing a real file to a real path the client never reads.
+      def self.hermes_home(home : String, platform : Platform = NATIVE_PLATFORM,
+                           hermes_home_env : String? = ENV["HERMES_HOME"]?,
+                           local_appdata : String? = ENV["LOCALAPPDATA"]?) : String
+        # `.strip` before `.presence` because that is what Hermes itself does with the
+        # variable: an all-whitespace HERMES_HOME is unset to the agent, and honoring it
+        # here would install into a directory named " " that nothing ever reads.
+        if env = hermes_home_env.try(&.strip).presence
+          return env
+        end
+        case platform
+        in Platform::Windows
+          File.join(local_appdata.presence || File.join(home, "AppData", "Local"), "hermes")
+        in Platform::Darwin, Platform::Linux
+          File.join(home, ".hermes")
+        end
+      end
+
       def self.toml_target?(target : String) : Bool
         target == "codex" || target == "grok"
+      end
+
+      def self.yaml_target?(target : String) : Bool
+        target == "hermes"
       end
 
       # Build the argv passed to the gori binary after the executable path.
@@ -167,6 +213,8 @@ module Gori
 
         if toml_target?(target)
           install_toml(config_path, exe_path, args)
+        elsif yaml_target?(target)
+          install_yaml(config_path, exe_path, args)
         else
           install_json(config_path, exe_path, args)
         end
@@ -244,6 +292,334 @@ module Gori
           io << "args = #{toml_string_array(args)}\n"
         end
         write_atomic(config_path, upsert_toml_table(existing, table, body))
+      end
+
+      # --- YAML clients (Hermes) ------------------------------------------------
+
+      # Hermes reads `<HERMES_HOME>/config.yaml` and takes a stdio server as
+      # `mcp_servers: {<name>: {command:, args:}}` — the same two keys the JSON and TOML
+      # clients take, in a third file format.
+      def self.install_yaml(config_path : String, exe_path : String, args : Array(String)) : Nil
+        existing = File.file?(config_path) ? File.read(config_path) : ""
+
+        # Refuse a file that is not a YAML mapping, for the reason install_json refuses a
+        # non-JSON one: this is the user's whole agent config — model and provider choice,
+        # plugins, and every other MCP server with its own `env:` block of API keys — so a
+        # transient hand-edit error must not be answered by replacing it with a two-line file.
+        unless existing.strip.empty?
+          parsed =
+            begin
+              YAML.parse(existing)
+            rescue ex : YAML::ParseException
+              raise "Refusing to overwrite #{config_path}: it exists but isn't valid YAML " \
+                    "(#{ex.message}). Fix or remove it, then re-run the installer."
+            end
+          unless parsed.raw.nil? || parsed.as_h?
+            raise "Refusing to overwrite #{config_path}: it exists but isn't a YAML mapping. " \
+                  "Fix or remove it, then re-run the installer."
+          end
+        end
+
+        updated = upsert_yaml_server(existing, "mcp_servers", SERVER_NAME,
+          yaml_server_body(exe_path, args))
+
+        # Read the splice back BEFORE it reaches disk. Everything above edits YAML as text,
+        # and text editing goes wrong in ways a value comparison catches and an eyeball does
+        # not: an entry spliced under the wrong key, a `mcp_servers:` that was really a line
+        # inside a block scalar, a second `---` document further down that an append landed
+        # after. Any of those and gori prints "installed" over a config the client parses
+        # happily and finds no gori server in — the failure mode this installer is worst at,
+        # because the path is real, the file is real, and nothing looks wrong until the
+        # tools are silently absent.
+        verify_yaml_entry!(config_path, updated, exe_path, args)
+        write_atomic(config_path, updated)
+      end
+
+      # The lines that go UNDER the `gori:` key, indentation relative to it.
+      def self.yaml_server_body(exe_path : String, args : Array(String)) : Array(String)
+        body = ["command: #{yaml_string(exe_path)}"]
+        if args.empty?
+          body << "args: []"
+        else
+          body << "args:"
+          args.each { |arg| body << "  - #{yaml_string(arg)}" }
+        end
+        body
+      end
+
+      private def self.verify_yaml_entry!(config_path : String, content : String,
+                                          exe_path : String, args : Array(String)) : Nil
+        entry =
+          begin
+            YAML.parse(content).dig?("mcp_servers", SERVER_NAME)
+          rescue ex : YAML::ParseException
+            raise "Refusing to write #{config_path}: the updated file would not have been " \
+                  "valid YAML (#{ex.message}). Add the gori server to mcp_servers by hand."
+          end
+        command = entry.try(&.dig?("command")).try(&.as_s?)
+        written = entry.try(&.dig?("args")).try(&.as_a?).try(&.map(&.as_s?))
+        return if command == exe_path && written == args
+        raise "Refusing to write #{config_path}: the gori entry did not read back as written. " \
+              "Add it to mcp_servers by hand instead."
+      end
+
+      # Replace (or insert) `<root>.<name>` in a YAML document by editing LINES.
+      #
+      # Deliberately not parse-and-re-emit. A Hermes `config.yaml` is mostly commented
+      # documentation the user reads and edits in place, and the sibling servers under
+      # `mcp_servers` carry `env:` blocks holding their own API keys. Comments are not in a
+      # parse tree and key order is not promised, so `YAML.parse(...).to_yaml` hands back a
+      # file with everything the user wrote around the values gone — from an installer whose
+      # entire job was adding one entry. `upsert_toml_table` above is the same decision.
+      #
+      # Whatever it cannot place safely it RAISES on rather than guessing, and install_yaml
+      # re-parses the result before writing, so a wrong splice fails loudly and unwritten.
+      def self.upsert_yaml_server(content : String, root : String, name : String,
+                                  body : Array(String)) : String
+        # Every existing line keeps its OWN terminator — `strip` and `yaml_indent` both
+        # ignore a trailing `\r`, so nothing below has to care — and only the lines gori adds
+        # take the file's majority style. A whole-file `content.includes?("\r\n")` would have
+        # rewritten every LF line in a config that held one stray CRLF, turning an installer
+        # that added one entry into a whole-file diff in somebody's dotfiles repo.
+        lines = content.split('\n')
+        lines.pop if !lines.empty? && lines.last.empty?
+        crlf = lines.count(&.ends_with?('\r')) * 2 > lines.size
+        eol = ->(line : String) { crlf ? line + '\r' : line }
+        join = ->(out : Array(String)) { out.join('\n') + "\n" }
+
+        root_at, inline = find_yaml_root(lines, root)
+
+        unless root_at
+          # No `mcp_servers:` at all — append the whole block, after a blank line so it does
+          # not read as a continuation of whatever the file ended on.
+          lines << eol.call("") unless lines.empty? || lines.last.strip.empty?
+          lines << eol.call("#{root}:")
+          lines << eol.call("  #{name}:")
+          body.each { |line| lines << eol.call("    #{line}") }
+          return join.call(lines)
+        end
+
+        clear_yaml_inline_value!(lines, root_at, root, name, inline)
+
+        block_end = yaml_block_end(lines, root_at)
+        indent = yaml_entry_indent(lines, root_at, block_end)
+        if seq = yaml_sequence_line?(lines, root_at, block_end, indent)
+          raise "Refusing to edit #{root} in place: it holds a sequence, not named servers " \
+                "(`#{seq.strip}`). Add the #{name} server by hand."
+        end
+
+        # The entry's children step down by the same amount the block's own keys did — the
+        # root sits at column 0, so that step IS `indent`. A four-space file keeps its shape
+        # instead of gaining one entry indented differently from every sibling.
+        rendered = [eol.call("#{" " * indent}#{name}:")]
+        body.each { |line| rendered << eol.call("#{" " * (indent * 2)}#{line}") }
+
+        # Replace the existing entry's lines, or append after the block's last real entry
+        # line — walking back over trailing comments and blanks. A `# add more servers below`
+        # at the end of the block is an invitation, not a label for whatever lands under it;
+        # appending past it would have made it read as gori's own caption. (A column-0
+        # comment introducing the NEXT top-level section is already outside the block.)
+        first, last = find_yaml_entry(lines, root_at, block_end, indent, name) ||
+                      yaml_append_at(lines, root_at, block_end)
+        join.call(lines[0...first] + rendered + lines[(last + 1)..])
+      end
+
+      # Make room for an indented block under `<root>:` — and ONLY that.
+      #
+      # `mcp_servers: {}` (and the null spellings) is an empty mapping written inline: the
+      # value has to go before children can be indented under it. Any OTHER inline value is a
+      # flow mapping that already holds servers, and line-splicing into one would drop them —
+      # so that is a refusal, not a rewrite.
+      #
+      # An ordinary `mcp_servers:` line is TOUCHED BY NOTHING here. Re-emitting it in a
+      # canonical spelling looked free and is not: it deletes a trailing comment on the key
+      # and unquotes a quoted one, and verify_yaml_entry! cannot see either — the gori entry
+      # reads back perfectly while the line above it lost what the user wrote. That is the
+      # exact "your file came back rewritten" the whole method exists to avoid.
+      private def self.clear_yaml_inline_value!(lines : Array(String), root_at : Int32,
+                                                root : String, name : String,
+                                                inline : String) : Nil
+        return if inline.empty? || inline.starts_with?('#')
+        value, comment = yaml_split_comment(inline)
+        unless YAML_EMPTY_INLINE.includes?(value.delete(' '))
+          raise "Refusing to edit #{root} in place: it is written inline (`#{root}: #{inline}`). " \
+                "Rewrite it as an indented block, or add the #{name} server by hand."
+        end
+        # Drop the empty value only — the key stays spelled the way the user spelled it, and
+        # a comment that followed it stays on the line.
+        return unless colon = lines[root_at].index(':')
+        tail = lines[root_at].ends_with?('\r') ? "\r" : ""
+        lines[root_at] = "#{lines[root_at][0..colon]}#{comment.empty? ? "" : " #{comment}"}#{tail}"
+      end
+
+      # Where a NEW entry goes, as the `{first, last}` empty range find_yaml_entry would have
+      # returned. Walks back over trailing comments and blanks: a `# add more servers below`
+      # at the end of the block is an invitation, not a label for whatever lands under it, and
+      # appending past it made it read as gori's own caption. (A column-0 comment introducing
+      # the NEXT top-level section is already outside the block.)
+      private def self.yaml_append_at(lines : Array(String), root_at : Int32,
+                                      block_end : Int32) : {Int32, Int32}
+        at = block_end
+        while at > root_at && (lines[at].strip.empty? || lines[at].strip.starts_with?('#'))
+          at -= 1
+        end
+        {at + 1, at}
+      end
+
+      # The spellings of "this mapping is empty" that can appear after `mcp_servers:` and
+      # still be safe to replace with an indented block. Tested against the value with its
+      # spaces removed, so `{ }` and `{}` are one case. `""` is deliberately NOT a member:
+      # an absent value means an ordinary block key, and that line is left untouched.
+      YAML_EMPTY_INLINE = {"{}", "null", "Null", "NULL", "~"}
+
+      # A scalar and its trailing comment. A `#` opens a comment in YAML only after
+      # whitespace, and a `#` inside a quoted flow value therefore stays in the value — where
+      # it makes the empty-mapping test fail and the caller refuse, which is the safe answer.
+      private def self.yaml_split_comment(value : String) : {String, String}
+        idx = value.index(" #")
+        return {value, ""} unless idx
+        {value[0, idx].rstrip, value[(idx + 1)..]}
+      end
+
+      # The index of the top-level `<root>:` line, plus whatever followed the colon on it.
+      private def self.find_yaml_root(lines : Array(String), root : String) : {Int32?, String}
+        lines.each_with_index do |line, idx|
+          next unless yaml_indent(line).zero?
+          stripped = line.strip
+          next if stripped.empty? || stripped.starts_with?('#')
+          colon = stripped.index(':')
+          next unless colon
+          next unless yaml_key_name(stripped[0, colon]) == root
+          return {idx, stripped[(colon + 1)..].strip}
+        end
+        {nil, ""}
+      end
+
+      # The index of the LAST line belonging to the block under *root_at* — *root_at* itself
+      # when the block is empty. Blank lines and comments do not end it: a comment sitting at
+      # column 0 between two entries is legal YAML, and ending the block there would splice
+      # gori's entry into the middle of the mapping.
+      private def self.yaml_block_end(lines : Array(String), root_at : Int32) : Int32
+        last = root_at
+        i = root_at + 1
+        while i < lines.size
+          line = lines[i]
+          stripped = line.strip
+          if stripped.empty?
+            i += 1
+            next
+          end
+          indent = yaml_indent(line)
+          break if indent.zero? && !stripped.starts_with?('#')
+          last = i if indent > 0
+          i += 1
+        end
+        last
+      end
+
+      # How deep this block's own keys sit. Taken from the file rather than assumed, so an
+      # `mcp_servers:` block a user (or another installer) wrote at four spaces keeps its
+      # shape instead of gaining one entry at a different depth.
+      private def self.yaml_entry_indent(lines : Array(String), root_at : Int32,
+                                         block_end : Int32) : Int32
+        indent = nil.as(Int32?)
+        (root_at + 1..block_end).each do |i|
+          stripped = lines[i].strip
+          next if stripped.empty? || stripped.starts_with?('#')
+          at = yaml_indent(lines[i])
+          next if at.zero?
+          indent = at if indent.nil? || at < indent
+        end
+        indent || 2
+      end
+
+      # The block's first line that is a SEQUENCE item rather than a key — checked only at
+      # the block's own indent, because `args:`'s items are sequence lines too and they sit
+      # deeper.
+      private def self.yaml_sequence_line?(lines : Array(String), root_at : Int32,
+                                           block_end : Int32, indent : Int32) : String?
+        (root_at + 1..block_end).each do |i|
+          next unless yaml_indent(lines[i]) == indent
+          stripped = lines[i].strip
+          next if stripped.empty? || stripped.starts_with?('#')
+          return lines[i] if stripped == "-" || stripped.starts_with?("- ")
+        end
+        nil
+      end
+
+      # The inclusive line range `{first, last}` the `<name>:` entry occupies, or nil.
+      private def self.find_yaml_entry(lines : Array(String), root_at : Int32, block_end : Int32,
+                                       indent : Int32, name : String) : {Int32, Int32}?
+        first = nil.as(Int32?)
+        (root_at + 1..block_end).each do |i|
+          next unless yaml_indent(lines[i]) == indent
+          stripped = lines[i].strip
+          next if stripped.empty? || stripped.starts_with?('#')
+          colon = stripped.index(':')
+          next unless colon
+          next unless yaml_key_name(stripped[0, colon]) == name
+          first = i
+          break
+        end
+        return nil unless start = first
+
+        # Ends at the next line that is NOT deeper than the entry key. A comment at the
+        # entry's own indent stops it too: it introduces the sibling below it far more often
+        # than it trails the entry above, and keeping it costs nothing.
+        last = start
+        i = start + 1
+        while i <= block_end
+          if lines[i].strip.empty?
+            i += 1
+            next
+          end
+          break if yaml_indent(lines[i]) <= indent
+          last = i
+          i += 1
+        end
+        {start, last}
+      end
+
+      private def self.yaml_indent(line : String) : Int32
+        line.size - line.lstrip(' ').size
+      end
+
+      # A mapping key with its quotes taken off, so `"gori":` and `gori:` are one entry.
+      private def self.yaml_key_name(raw : String) : String
+        key = raw.strip
+        return key unless key.size >= 2
+        if (key.starts_with?('"') && key.ends_with?('"')) ||
+           (key.starts_with?('\'') && key.ends_with?('\''))
+          key[1..-2]
+        else
+          key
+        end
+      end
+
+      # Always double-quoted, for the reason toml_string always quotes: a path or a flag can
+      # hold characters that mean something to the parser. `--db=/x` is a plain scalar YAML
+      # would take, but `-` leads a sequence, `:` a mapping and `#` a comment, and one of
+      # those in a project name is all it takes.
+      def self.yaml_string(value : String) : String
+        String.build do |io|
+          io << '"'
+          value.each_char do |ch|
+            case ch
+            when '"'  then io << "\\\""
+            when '\\' then io << "\\\\"
+            when '\n' then io << "\\n"
+            when '\r' then io << "\\r"
+            when '\t' then io << "\\t"
+            else
+              if ch.ord < 0x20 || ch.ord == 0x7f
+                io << "\\x" << ch.ord.to_s(16).rjust(2, '0')
+              else
+                io << ch
+              end
+            end
+          end
+          io << '"'
+        end
       end
 
       # --- Durable writes -------------------------------------------------------


### PR DESCRIPTION
`gori mcp --install-hermes` writes the gori server into Hermes' config, alongside the five clients the installer already knows.

## The client

Confirmed against Hermes' own source rather than guessed at, and both citations are in the code comments:

- `hermes_constants.py` — config is `<HERMES_HOME>/config.yaml`; `HERMES_HOME` wins when set (stripped first, so an all-whitespace value is unset), otherwise `~/.hermes`, or `%LOCALAPPDATA%\hermes` on Windows.
- `tools/mcp_tool.py` — stdio servers live under a **snake_case** `mcp_servers:` key as `{command, args}`. Same shape the JSON and TOML clients take, third file format.

## Why it splices lines instead of re-emitting YAML

A hermes `config.yaml` is mostly commented documentation the user reads and edits in place, and the servers beside gori carry `env:` blocks holding their own API keys. Comments are not in a parse tree and key order is not promised, so `YAML.parse(...).to_yaml` hands the file back stripped of everything written around the values — from an installer whose entire job was adding one entry. `upsert_toml_table` is the same decision one format over.

The rule that follows from it: **touch nothing you were not asked to.** An ordinary `mcp_servers:` line is left byte-for-byte, including a trailing comment on it and a quoted key. Existing lines keep their own terminators, so one stray CRLF line does not convert the file. A new entry is appended *above* a trailing `# add more servers below`, not under it.

## Why it re-reads before it writes

Line editing goes wrong in ways a value comparison catches and an eyeball does not. Two shapes splice cleanly and still leave the client with no gori server:

- a **duplicate** top-level `mcp_servers:` — the later one wins at parse time, the splice edits the first
- a second `---` **document** further down that an append lands after

`verify_yaml_entry!` parses the result and compares `command`/`args` before anything reaches disk; both cases above are refused with the file untouched. The worst failure this installer has is not an exception — it is printing "installed" over a real file at a real path where the tools are silently absent, and nothing looks wrong until an agent has none of them.

Refusals, all leaving the original in place: a config that is not valid YAML or not a mapping; an `mcp_servers` written as a *populated* flow mapping (splicing under it would orphan the servers inside); one holding a sequence. An inline-*empty* one (`{}`, `{  }`, `null`, `~`, with or without a trailing comment) is expanded into a block, which is the case the expansion exists for.

`hermes_home` takes its platform and env as parameters rather than reading a compile-time `{% if %}`, for the reason `claude_desktop_path` above it does: a branch only one platform can execute is the branch that stays wrong, and every branch is asserted from every host.

## Verified

- Ran the installer against a **copy** of a real `~/.hermes/config.yaml`: 45 lines of commented documentation came back untouched, one block added. Re-ran it — updated in place, no second entry.
- Ran it into a populated `mcp_servers` block with interleaved comments and a sibling holding a PAT: comment, sibling and secret all intact, entry inside the block rather than after the section following it.
- Parsed both results with **PyYAML** — the parser Hermes itself uses, not gori's.
- Adversarial pass over duplicate keys, a second document, inline entries, `~`-valued entries, quoted keys, 4-space blocks, sequences and mixed line endings.
- `crystal spec` 10143 examples green · `crystal tool format --check` · `scripts/bench_check.sh` (46 harnesses) · `seed_demo.cr` type-check. ameba clean on the touched files (the file's one remaining warning is pre-existing, on `upsert_toml_table`).

Docs updated in both languages: README, AI Setup, MCP guide, the co-pilot playbook and the CLI reference. The "only Claude Desktop varies per platform" line was true until this PR and is corrected everywhere it appears.