### PR TITLE
Seed the lists beside History, and fix what that found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- A Colormarker or Rewriter rule named in wide characters (Hangul, an emoji) drew its own row over itself: every field after the name was placed by counting CHARACTERS, so the filter behind it landed inside the name and the two-column glyphs whose lead cell it overwrote came out blank. Those rows now advance by the columns they actually drew; the OAST callbacks table's PROVIDER column takes the width it needs instead of a fixed 17 with a hundred blank ones beside it; and a card's border annotation (`8/9 enabled`, `REQ`, a bare count) is spaced clear of the hairline it used to butt into (#787).
+
 - A truncated brotli body decoded to exactly 65,536 bytes and a multi-frame zstd body to its first frame only; both now decode in full, which the detail view, the Comparer and every headless read of a decoded body see (#786).
 
 - The Decoder reads brotli, zstd, MessagePack and CBOR, and a MessagePack or CBOR body renders as JSON in the detail pane when its `Content-Type` says so. The JSON is a projection — `$bin`, `$tag` and `$ext` name what JSON cannot hold — never bytes to send back (#786).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## Unreleased
 
-- A Colormarker or Rewriter rule named in wide characters (Hangul, an emoji) drew its own row over itself: every field after the name was placed by counting CHARACTERS, so the filter behind it landed inside the name and the two-column glyphs whose lead cell it overwrote came out blank. Those rows now advance by the columns they actually drew; the OAST callbacks table's PROVIDER column takes the width it needs instead of a fixed 17 with a hundred blank ones beside it; and a card's border annotation (`8/9 enabled`, `REQ`, a bare count) is spaced clear of the hairline it used to butt into (#787).
+- The History detail's MESSAGES pane shows a WebSocket frame's shape, as `gori run show` and the Repeater transcript already did: a PING, a PONG, a CLOSE with its code and reason, a message reassembled from several frames, an RSV bit and a client frame sent UNMASKED were all one indistinguishable `«binary Nb»` line in the one place an operator reads while working a socket (#787).
+
+- The two pairs of identically-titled cards say which list they are: Settings' ENVIRONMENT and HOSTNAME OVERRIDES are marked `global`, the Project tab's ENVIRONMENT and HOST OVERRIDES `project` — the global pair is layered under the project one, and neither said so (#787).
+
+- A Colormarker or Rewriter rule named in wide characters (Hangul, an emoji) drew its own row over itself: every field after the name was placed by counting CHARACTERS, so the filter behind it landed inside the name and the two-column glyphs whose lead cell it overwrote came out blank. Those rows now advance by the columns they actually drew; the OAST callbacks table's PROVIDER column takes the width it needs out of whatever DESTINATION does not, instead of a fixed 17 with a hundred blank columns beside it; and a card's border annotation (`8/9 enabled`, `REQ`, a bare count) is spaced clear of the hairline it used to butt into (#787).
 
 - A truncated brotli body decoded to exactly 65,536 bytes and a multi-frame zstd body to its first frame only; both now decode in full, which the detail view, the Comparer and every headless read of a decoded body see (#786).
 

--- a/scripts/seed_demo.cr
+++ b/scripts/seed_demo.cr
@@ -7,8 +7,13 @@
 #   Colormarker                                                       — History row-colour rules
 #   OAST                                                              — an out-of-band listener with callbacks
 #   Probe                                                             — passive scan + active findings + custom rules
-#   Decoder / JWT / Comparer                                          — pre-loaded sub-tabs and material
+#   Decoder                                                           — pre-loaded conversion sub-tabs
+#   Authorize                                                         — the identities (session slots) to replay as
 #   Env (bindings)                                                    — project `$KEY` vars a Repeater tab uses
+#
+# The JWT and Comparer tabs keep NO per-project state, so nothing can be seeded into them.
+# Their material is one keystroke away instead: the Decoder's `session JWT` sub-tab holds the
+# token, and History's space menu sends any flow to either tab.
 #
 # The captured traffic covers every PROTO label History can print — HTTP/HTTPS, WS/WSS,
 # GRPC/GRPCS, SSE/SSES and a short-circuited STUB — over both transports, plus the shapes
@@ -24,6 +29,12 @@
 # run, a zero-width space, a body the capture cap cut at 2 KB of 2.5 GB, and a 3.5-hour long
 # poll. That is the "Act five" section, and it exists to be LOOKED AT: a rendering defect in
 # a column is not something a spec can assert, only something a demo can show.
+#
+# "Act six" carries that exercise into the lists that are NOT History — a colour rule, a
+# rewrite rule, a binding, a sitemap tag, a Repeater tab and two issues named in Hangul or
+# Hebrew, because a row of user text laid out by hand is a column too. It also fills the
+# three panes that used to open empty: the Repeater's stored RESPONSE (including one send
+# that never connected), the saved-view library, and the Authorize identity list.
 #
 #   crystal run scripts/seed_demo.cr
 #
@@ -1664,10 +1675,14 @@ store.set_repeater_tags(ids[:repeater_ssrf], "ssrf oast")
 
 # One tab opens with its LAST response already in the pane (V11 persists it), so the
 # Repeater tab isn't empty until you send — and the Comparer has a second body to diff.
-idor_resp_head = "HTTP/1.1 200 OK\r\nServer: nginx/1.25.3\r\nContent-Type: application/json\r\nContent-Length: 96\r\n\r\n"
+# Content-Length off the body rather than a literal: it was 96 over 82 bytes of JSON, which
+# is a truncated response as far as every reader of these bytes is concerned. Act six seeds
+# three more of these; that helper does the same arithmetic for the same reason.
+idor_resp_body = %({"id":2,"name":"Bob","email":"bob@demo.test","role":"admin","phone":"+1-555-0102"})
+idor_resp_head = "HTTP/1.1 200 OK\r\nServer: nginx/1.25.3\r\nContent-Type: application/json\r\n" \
+                 "Content-Length: #{idor_resp_body.bytesize}\r\n\r\n"
 store.update_repeater_response(ids[:repeater_idor], idor_resp_head.to_slice,
-  %({"id":2,"name":"Bob","email":"bob@demo.test","role":"admin","phone":"+1-555-0102"}).to_slice,
-  nil, 34_000_i64)
+  idor_resp_body.to_slice, nil, 34_000_i64)
 
 fuzz_template = replay_req("GET", "api.demo.test", "/v1/users/§1§",
   {"Authorization" => "Bearer #{jwt}"})
@@ -2167,7 +2182,7 @@ add_flow(store, tick.call, host: "xn--352bl7khqr.xn--3e0b707e", target: "/이벤
 # arithmetic has to be measuring DISPLAY columns and not bytes or characters — a Hangul
 # syllable is one character, three bytes and two columns wide, and only one of those three
 # numbers lays the column out correctly.
-add_flow(store, tick.call, host: "쇼핑몰.한국", target: "/api/주문/9",
+ids[:hangul_order] = add_flow(store, tick.call, host: "쇼핑몰.한국", target: "/api/주문/9",
   req_headers: {"Authorization" => "Bearer #{jwt}"},
   status: 200, reason: "OK", ctype: "application/json",
   resp_body: %({"주문번호":9,"상태":"결제완료","금액":3998}), dur_us: 74_000_i64)
@@ -2590,6 +2605,136 @@ store.add_link(S::LinkOwnerKind::Note, NOTE_LINKS, S::LinkRefKind::Flow, ws_id)
 store.add_link(S::LinkOwnerKind::Note, NOTE_LINKS, S::LinkRefKind::Repeater, ids[:repeater_hahwul])
 
 puts "• inserted entity links on issues + notes"
+
+# --- Act six: the lists beside History, and the tabs that opened empty -------
+# Act five stressed History's columns. Every OTHER tab draws the same kind of row — a
+# fixed strip of user-supplied text, laid out by hand — and until now the demo handed
+# every one of them nothing but short ASCII: rules called "legacy stack", hosts called
+# `api.demo.test`, tabs called "XSS PoC". A list that has never been given a Hangul
+# name has never had its width arithmetic tested, and that arithmetic is exactly what
+# a demo can show and a spec cannot guess at.
+#
+# It also fills three tabs that opened with nothing in them at all — the Repeater's
+# RESPONSE pane, the History view library, and the Authorize identity list — because
+# "this tab is empty" and "this tab is broken" look the same from the outside.
+
+# ## Repeater responses
+#
+# `repeaters` carries the LAST response beside the request (`response_head` / `_body` /
+# `_error` / `_duration_us`), and the tab restores it on open — so a seeded tab can
+# arrive already answered instead of reading "— not sent — press ^R to resend —". That
+# is what gives `d:diff`, `^X:hex` and `p:pretty` something to work on before the
+# operator has sent anything, and it is the only way the demo shows a repeater send that
+# FAILED without making a network call. (The IDOR tab already carried one — these are the
+# other three, and they share its Content-Length-from-the-body rule.)
+repeater_resp = ->(status : String, headers : String, body : String) {
+  head = "HTTP/1.1 #{status}\r\nDate: Thu, 19 Jun 2026 09:20:00 GMT\r\n#{headers}" \
+         "Content-Length: #{body.bytesize}\r\n\r\n"
+  {head.to_slice, body.to_slice}
+}
+
+# The XSS tab, answered: the payload comes back inside the page, so the diff against the
+# captured flow is the finding itself.
+xss_body = "<!doctype html><html><head><title>Search — Demo Shop</title></head><body>" \
+           "<h1>Results for <script>alert(1)</script></h1><p>0 products found.</p></body></html>\n"
+xss_head, xss_bytes = repeater_resp.call("200 OK", "Content-Type: text/html; charset=utf-8\r\n", xss_body)
+store.update_repeater_response(ids[:repeater_xss], xss_head, xss_bytes, nil, 61_000_i64)
+
+# The OAuth tab, answered with a REFUSAL — a send that reached the origin and came back
+# 4xx is a different state from one that never connected, and the tab has to show both.
+token_body = %({"error":"invalid_grant","error_description":"refresh token expired"})
+token_head, token_bytes = repeater_resp.call("401 Unauthorized",
+  "Content-Type: application/json\r\nWWW-Authenticate: Bearer error=\"invalid_grant\"\r\n", token_body)
+store.update_repeater_response(ids[:repeater_token], token_head, token_bytes, nil, 121_000_i64)
+
+# …and the tab whose send never got an answer at all. `response_error` with an empty head
+# is the shape a dial failure leaves behind, and it is the one a demo can never produce by
+# running something.
+store.update_repeater_response(ids[:repeater_bound], Bytes.empty, nil,
+  "dial tcp: no route to host (api.demo.test:443)", 5_002_000_i64)
+
+# ## The History view library (#776)
+#
+# `v` opens the view picker; with an empty library it opens onto nothing. These are the
+# lenses this dataset actually rewards — each one is a query that returns a different
+# slice of the same 120-odd flows. The global half of the library lives in settings.json;
+# these are the project's own, and they follow the db rather than the operator.
+store.insert_saved_view("errors", "status:5xx OR status:4xx")
+store.insert_saved_view("sent by gori", "src:gori")
+store.insert_saved_view("sockets", "proto:ws OR proto:wss")
+store.insert_saved_view("webdav", "method:PROPFIND OR method:PROPPATCH OR method:REPORT OR method:SEARCH")
+store.insert_saved_view("slow (>1s)", "dur:>1s")
+store.insert_saved_view("big bodies", "size:>100k")
+# A view named in Hangul, for the same reason the rules below are: the picker lays each
+# query out in a column beside the name, and no name it had ever been given was wider on
+# screen than it is long in characters.
+store.insert_saved_view("한글 호스트", "host:쇼핑몰.한국 OR host:xn--352bl7khqr.xn--3e0b707e")
+
+# ## Authorize identities (= session slots)
+#
+# The Authorize tab replays one request as several identities; the identities are project
+# state (`Store::SESSION_SLOTS_KEY`) and the queue is not, so this is the half a seeder can
+# fill — and without it the tab's `i` list is empty and "send to Authorize" has nothing to
+# replay AS. `customer` claims the `token` extract rule, so its `$token` resolves from ITS
+# OWN binding table rather than the global one; `anonymous` strips credentials instead of
+# setting them, which is the comparison that finds a missing authorization check.
+admin_jwt = make_jwt(WEAK_SECRET,
+  %({"alg":"HS256","typ":"JWT"}),
+  %({"sub":"2","name":"bob","role":"admin","iss":"api.demo.test","iat":1718787600,"exp":1718791200}))
+store.set_setting(S::SESSION_SLOTS_KEY, SessionSlot.serialize([
+  SessionSlot.as_captured,
+  SessionSlot.new("anonymous", remove_headers: ["Authorization", "Cookie"]),
+  SessionSlot.new("customer", [{"Authorization", "Bearer $token"}], rules: ["token"]),
+  SessionSlot.new("admin", [{"Authorization", "Bearer #{admin_jwt}"}, {"X-Demo-Role", "admin"}]),
+]))
+
+# ## The wide-character half
+#
+# Everything below is the Act-five exercise applied to the lists that are NOT History. Each
+# row is a plausible artefact of working a Korean-language target — which is the point: none
+# of it is a synthetic torture string, and all of it is text a rule name, an issue title or a
+# tab name will really hold.
+store.insert_color_rule("host:쇼핑몰.한국 OR host:xn--352bl7khqr.xn--3e0b707e",
+  S::MarkerColor::Blue.label, S::MarkerStyle::Strip, "한글 호스트 (U-label · A-label)")
+
+store.insert_rule(S::RuleTarget::Response, S::RulePart::Body,
+  "결제완료", "결제취소",
+  op: S::RuleOp::Replace, match_kind: S::MatchKind::Literal,
+  name: "주문 상태 뒤집기 (한글 본문)", host: "쇼핑몰.한국", enabled: false)
+
+store.insert_extract_rule("주문번호", "host:쇼핑몰.한국 path:/api/주문",
+  ExtractKind::JsonPath, selector: "주문번호", host: "쇼핑몰.한국", enabled: false)
+
+store.set_sitemap_tag("쇼핑몰.한국", "/api/주문/9", "주문 조회 — 인증 없음")
+
+# A tab whose NAME, TAGS and TARGET are all wide — the sub-tab strip measures all three.
+hangul_req = replay_req("GET", "쇼핑몰.한국", "/api/주문/9",
+  {"Authorization" => "Bearer #{jwt}"})
+ids[:repeater_hangul] = store.insert_repeater("https://쇼핑몰.한국", hangul_req.to_slice,
+  false, true, ids[:hangul_order], 7)
+store.set_repeater_name(ids[:repeater_hangul], "주문 조회 재전송")
+store.set_repeater_tags(ids[:repeater_hangul], "한글 idor")
+
+# Two issues in the two scripts the list has never had to lay out: a Hangul title against
+# the longest host in the dataset (the two runs compete for the same row), and a
+# right-to-left title, which reverses the visual order of everything in the cell.
+h1 = store.insert_issue(
+  "주문 조회 API가 다른 사용자의 개인정보(주소·전화번호)를 그대로 반환함 🔥",
+  S::Severity::High, "쇼핑몰.한국", ids[:hangul_order])
+store.update_issue(h1, notes: "customer 토큰으로 /api/주문/9 를 호출하면 다른 사용자의 " \
+                              "주문·주소·전화번호가 그대로 내려온다.\n객체 단위 인가 검사가 없음.\n" \
+                              "Fix: 인증 주체가 해당 주문의 소유자인지 확인할 것.", status: S::Status::Confirmed)
+
+h2 = store.insert_issue("דוח מכירות רבעוני נגיש ללא אימות", S::Severity::Medium,
+  "acme-corporation-staging-eu-central-1.tenants.internal.services.demo.test", nil)
+store.update_issue(h2, notes: "The quarterly sales report under /api/v3/... is served to an " \
+                              "unauthenticated request. Title kept in the reporter's own language on purpose: " \
+                              "the ISSUES list right-aligns the host against it, and a right-to-left run is where " \
+                              "a cell laid out by character count comes apart.")
+
+puts "• inserted act-six list stress: 3 repeater responses (1 dial failure), 7 saved views, " \
+     "4 session slots, and Hangul/RTL names on a colour rule, a rewrite rule, a binding, " \
+     "a sitemap tag, a repeater tab and 2 issues"
 
 # --- Notes doc (multi-tab, stable ids for entity_links) --------------------
 NOTE_TOOLS = 3_i64

--- a/spec/tui/colormarker_view_spec.cr
+++ b/spec/tui/colormarker_view_spec.cr
@@ -83,4 +83,24 @@ describe Gori::Tui::ColormarkerView do
       end
     end
   end
+
+  # The row's own width arithmetic. Every field right of the swatch is user text, and `render_row`
+  # used to advance `x` by `String#size` — CHARACTERS — after drawing it. For a rule named in
+  # Hangul that is half the cells it actually painted, so the match filter behind the name was
+  # written back over it and the row came out as
+  # `[한글 규칙 이름 — 아주 길게 늘 host:      .  국 ]`. The fix is to advance by what
+  # `screen.text` returns (the x it reached, in columns), which is what the Sitemap's tag column
+  # already does.
+  describe "#render" do
+    it "does not draw a rule's filter back over a name written in wide characters" do
+      backend = MemoryBackend.new(90, 5)
+      rule = Gori::Store::ColorRule.new(1_i64, true, "host:쇼핑몰.한국", "cyan",
+        Gori::Store::MarkerStyle::Strip, "한글 규칙 이름")
+      view.render(Screen.new(backend), Rect.new(0, 0, 90, 5), [rule], 0, 0, 1, false)
+      # Compacted, because a width-2 glyph owns two grid cells and only fills the first: what
+      # matters is that every glyph of both runs survives, in order, with the filter AFTER the
+      # closing bracket instead of on top of the name.
+      backend.row(1).delete(' ').should contain("[한글규칙이름]host:쇼핑몰.한국")
+    end
+  end
 end

--- a/spec/tui/history_view_spec.cr
+++ b/spec/tui/history_view_spec.cr
@@ -544,6 +544,38 @@ describe Gori::Tui::HistoryView do
     end
   end
 
+  # The MESSAGES pane was the last of three renderers of the same rows, and the only one that
+  # showed none of V7's frame shape: `gori run show` printed `[PING] hb` and
+  # `[CLOSE] 1000 session expired`, the Repeater transcript printed the same through
+  # `shape_label`, and this pane printed `«binary 2b»` for both. What an operator reads while
+  # working a socket was the surface that could not tell a heartbeat from a teardown.
+  it "names a control frame, a fragmented message and a masking violation in MESSAGES" do
+    tmp_store do |store|
+      id = add_flow(store, "GET", "/ws", 101)
+      # §5.1 says a client frame MUST be masked, so `masked: false` outbound is the violation
+      # worth a word — and the same flag inbound is the norm, which is why it is not one.
+      store.insert_ws_message(id, "out", 1, "subscribe".to_slice,
+        shape: Gori::Store::WsShape.new(masked: false))
+      store.insert_ws_message(id, "in", 1, "reassembled".to_slice,
+        shape: Gori::Store::WsShape.new(frames: 3))
+      store.insert_ws_message(id, "out", 9, "hb".to_slice)
+      # §5.5.1: two bytes of status code, then the reason.
+      store.insert_ws_message(id, "in", 8, Bytes[0x03, 0xE8] + "session expired".to_slice)
+
+      view = HistoryView.new
+      view.reload(store)
+      view.open_detail(store).should be_true
+      view.toggle_pane # request -> MESSAGES
+
+      backend = MemoryBackend.new(120, 16)
+      view.render_detail(Screen.new(backend), Rect.new(0, 0, 120, 16))
+      backend.contains?("[UNMASKED] subscribe").should be_true
+      backend.contains?("[3 frames] reassembled").should be_true
+      backend.contains?("[PING] hb").should be_true
+      backend.contains?("[CLOSE] 1000 session expired").should be_true
+    end
+  end
+
   # `Proto` is the single source of truth the PROTO column and the QL `proto:` filter both
   # defer to, and it read only the RESPONSE's content type — so a gRPC call showed as GRPC
   # exactly when it SUCCEEDED. A still-Pending one, and one answered by a proxy's `text/html`

--- a/spec/tui/shared_chrome_spec.cr
+++ b/spec/tui/shared_chrome_spec.cr
@@ -152,9 +152,21 @@ describe Gori::Tui::Frame do
     it "right-aligns the annotation two cells inside the card's right edge" do
       backend = MemoryBackend.new(40, 10)
       Frame.border_meta(Screen.new(backend), card, "SCOPE", "7 rules")
-      # "7 rules" is 7 cells ending at x = 37, so it starts at 31 — two clear of the edge, which
-      # is where `Frame.card` puts its right border and corner.
-      backend.row(0)[31, 7].should eq("7 rules")
+      # The run is ` 7 rules ` (padded like the card title and every badge), 9 cells ending at
+      # x = 37 — two clear of the edge, where `Frame.card` puts its right border and corner.
+      # So the text itself sits at 30, and cell 37 is the trailing space that keeps it off the
+      # hairline resuming behind it.
+      backend.row(0)[30, 7].should eq("7 rules")
+      backend.row(0)[29].should eq(' ')
+      backend.row(0)[37].should eq(' ')
+    end
+
+    it "answers the same left edge it drew at" do
+      # `border_meta_x` is what a caller whose chrome must clear the meta reads; the draw and
+      # that answer may not drift (the gRPC transcript's chip limit is derived from it).
+      backend = MemoryBackend.new(40, 10)
+      x = Frame.border_meta(Screen.new(backend), card, "SCOPE", "7 rules")
+      x.should eq(Frame.border_meta_x(card, "7 rules"))
     end
 
     it "draws nothing rather than landing on the title" do

--- a/src/gori/cli/output.cr
+++ b/src/gori/cli/output.cr
@@ -194,33 +194,6 @@ module Gori
         String.build { |io| s.each_char { |c| io << ((c.control? && c != '\n' && c != '\t') ? '·' : c) } }
       end
 
-      # A WebSocket message's frame shape, as a bracketed note, EMPTY when there is nothing
-      # unusual to say. Silence is the point for the ordinary case: annotating every TEXT
-      # frame with `[TEXT fin=1 rsv=0]` would bury the one line that is not ordinary. A
-      # control frame always names itself, because until V7 it did not appear at all.
-      def self.ws_shape_note(m : Store::WsMessage) : String
-        s = m.shape
-        parts = [] of String
-        parts << (Store::WsOutMessage::OPCODE_NAMES[m.opcode]? || "op#{m.opcode}") if m.control?
-        parts << "fin=0" unless s.fin
-        parts << "rsv=#{s.rsv}" if s.rsv != 0
-        parts << "UNMASKED" if s.masked == false && m.direction == "out"
-        parts << "#{s.frames} frames" if s.frames > 1
-        parts.empty? ? "" : "[#{parts.join(' ')}]"
-      end
-
-      # The part of a control frame worth reading: a CLOSE's code and reason, a ping/pong's
-      # payload. This is the diagnostic that existed nowhere on the proxy path.
-      def self.ws_control_detail(m : Store::WsMessage) : String
-        if code = m.close_code
-          reason = m.close_reason.try { |r| String.new(r).scrub }
-          return reason && !reason.empty? ? "#{code} #{term_safe(reason)}" : code.to_s
-        end
-        return "(no payload)" if m.payload.empty?
-        body = String.new(m.payload)
-        body.valid_encoding? ? term_safe(body) : "0x#{m.payload.hexstring}"
-      end
-
       # "#42  GET   https  example.com:443/users  200  1.2kB  3ms  [Complete]"
       # Columns are padded for scannability; status/state make capture progress legible.
       def self.flow_row_text(row : Store::FlowRow) : String

--- a/src/gori/cli/run/history.cr
+++ b/src/gori/cli/run/history.cr
@@ -975,9 +975,13 @@ module Gori
       # (scrubbed) payload; binary frames print a size + short hex preview.
       private def self.ws_message_text(m : Store::WsMessage) : String
         arrow = m.direction == "out" ? "→" : "←"
-        shape = Output.ws_shape_note(m)
+        # `Store::WsMessage#shape_note` / `#control_detail`, not a local copy: the TUI's History
+        # pane reads the same two, and a helper it calls cannot live under `CLI::`. `term_safe`
+        # stays HERE because it is this surface's question — these bytes are about to be written
+        # to a real terminal.
+        shape = m.shape_note
         if m.control?
-          "#{arrow} #{shape} #{Output.ws_control_detail(m)}"
+          "#{arrow} #{shape} #{Output.term_safe(m.control_detail)}"
         elsif m.text?
           "#{arrow}#{shape.empty? ? "" : " #{shape}"} #{CLI::Output.term_safe_multiline(String.new(m.payload).scrub)}"
         else

--- a/src/gori/store/models.cr
+++ b/src/gori/store/models.cr
@@ -412,6 +412,46 @@ module Gori
         @payload[2, @payload.size - 2]
       end
 
+      # This message's frame shape as a bracketed note, EMPTY when there is nothing unusual to
+      # say. Silence is the point for the ordinary case: annotating every TEXT frame with
+      # `[TEXT fin=1 rsv=0]` would bury the one line that is not ordinary. A control frame
+      # always names itself, because until V7 it did not appear at all.
+      #
+      # On the MODEL and not in `CLI::Output`, where it began, for the reason `emit_shape_json`
+      # below gives at length: three renderers read it — `gori run show`, the TUI's History
+      # MESSAGES pane and (through `WsOutMessage#shape_label`) the Repeater transcript — and a
+      # helper the TUI has to call may not live in the CLI. That edge is exactly how the
+      # History pane came to be the only one of the three showing none of this: a PING, a
+      # CLOSE with its code, a 3-frame message and an §5.1 masking violation all rendered
+      # `«binary Nb»` there while the other two spelled them out.
+      def shape_note : String
+        s = shape
+        parts = [] of String
+        parts << (WsOutMessage::OPCODE_NAMES[@opcode]? || "op#{@opcode}") if control?
+        parts << "fin=0" unless s.fin
+        parts << "rsv=#{s.rsv}" if s.rsv != 0
+        parts << "UNMASKED" if s.masked == false && @direction == "out"
+        parts << "#{s.frames} frames" if s.frames > 1
+        parts.empty? ? "" : "[#{parts.join(' ')}]"
+      end
+
+      # The part of a control frame worth reading: a CLOSE's code and reason, a ping/pong's
+      # payload. This is the diagnostic that existed nowhere on the proxy path.
+      #
+      # Returns the bytes as they are (scrubbed only for UTF-8 validity). A caller writing to a
+      # real terminal owns the control-character question — `CLI::Output.term_safe` for the
+      # CLI, `Screen`'s own cell mapping for the TUI — and answering it here would double-escape
+      # on one of the two.
+      def control_detail : String
+        if code = close_code
+          reason = close_reason.try { |r| String.new(r).scrub }
+          return reason && !reason.empty? ? "#{code} #{reason}" : code.to_s
+        end
+        return "(no payload)" if @payload.empty?
+        body = String.new(@payload)
+        body.valid_encoding? ? body.scrub : "0x#{@payload.hexstring}"
+      end
+
       # This message's frame SHAPE as JSON fields, emitted into an open object. Only what
       # departs from the default is written, so an ordinary message's object is exactly the
       # shape it was before V7 — a script keying off field presence is not broken by a feature

--- a/src/gori/tui/colormarker_view.cr
+++ b/src/gori/tui/colormarker_view.cr
@@ -148,12 +148,16 @@ module Gori::Tui
 
       fg = rule.enabled? ? (selected ? Theme.text_bright : Theme.text) : Theme.muted
       style = rule.style.label.ljust(5)
-      screen.text(x, py, style, Theme.muted, bg)
-      x += style.size + 1
+      x = screen.text(x, py, style, Theme.muted, bg) + 1
       unless rule.name.empty?
+        # `screen.text` answers the x it actually reached, in COLUMNS. `x += nm.size` counted
+        # CHARACTERS, so a rule named in Hangul (or with an emoji in it) advanced by half the
+        # cells it drew and the filter behind it was written back over the name — the row read
+        # `[한글 규칙 이름 — 아주 길게 늘 host:      .  국 ]`, with the wide glyphs whose lead
+        # cell got overwritten left as blanks. Same measure/draw split as `draw_tag_column` in
+        # the Sitemap: never re-derive a width the draw already returned.
         nm = "[#{rule.name}]"
-        screen.text(x, py, nm, Theme.accent, bg, width: {rect.right - x, 0}.max)
-        x += nm.size + 1
+        x = screen.text(x, py, nm, Theme.accent, bg, width: {rect.right - x, 0}.max) + 1
       end
       screen.text(x, py, rule.match_filter, fg, bg, width: {rect.right - x, 1}.max) if x < rect.right
     end

--- a/src/gori/tui/controllers/oast_controller.cr
+++ b/src/gori/tui/controllers/oast_controller.cr
@@ -880,7 +880,7 @@ module Gori::Tui
       screen.text(inner.x + 2, header_y, "PROTO", Theme.muted, Theme.bg)
       screen.text(inner.x + 9, header_y, "METHOD", Theme.muted, Theme.bg)
       screen.text(inner.x + 18, header_y, "SOURCE", Theme.muted, Theme.bg)
-      screen.text(inner.x + 36, header_y, "DESTINATION", Theme.muted, Theme.bg)
+      screen.text(inner.x + DEST_COL_X, header_y, "DESTINATION", Theme.muted, Theme.bg)
       screen.text(inner.right - pw, header_y, "PROVIDER", Theme.muted, Theme.bg)
       rows_rect = Rect.new(inner.x, inner.y + 1, inner.w, inner.h - 1)
       visible = rows_rect.h
@@ -901,14 +901,28 @@ module Gori::Tui
     # provider named after its own domain (`Demo OAST (oast.demo.test)`) truncated to
     # `Demo OAST (oast.…` on a 200-column terminal while a hundred blank columns sat in
     # DESTINATION beside it — the one field with a bounded, known length losing to the one that
-    # can be any length. It takes what the widest provider IN THE WHOLE FILTERED LIST needs
-    # (never just the visible slice, or the column would jitter as the list scrolls), floored at
-    # the 17 it always had and capped at a third of the pane so DESTINATION keeps the majority.
+    # can be any length.
+    #
+    # So it takes what the widest provider needs, but only out of the SLACK: DESTINATION is
+    # served first, and PROVIDER may grow into what is left over. A share of the pane (a third,
+    # say) is the wrong ceiling and was the first thing tried — at 80 columns it handed PROVIDER
+    # 24 and squeezed DESTINATION to `a1b2c3d4.o…`, which inverts the priority, since the
+    # destination is the evidence and the provider is a label. With no slack this returns the 17
+    # it always was, so a narrow pane lays out exactly as it did before.
+    #
+    # Both measures are over the WHOLE filtered list, never the visible slice: a width derived
+    # from what is on screen makes the column jitter as the list scrolls.
     PROVIDER_COL_MIN = 17
+
+    # Where DESTINATION starts, relative to the table's left edge.
+    DEST_COL_X = 36
 
     private def provider_col_w(inner : Rect, rows : Array(CbRow)) : Int32
       widest = rows.max_of? { |r| Screen.draw_width(r.provider) } || 0
-      widest.clamp(PROVIDER_COL_MIN, {inner.w // 3, PROVIDER_COL_MIN}.max)
+      dest_need = rows.max_of? { |r| Screen.draw_width(r.destination) } || 0
+      # -1 for the blank column `draw_callback_row` keeps between the two runs.
+      slack = inner.w - DEST_COL_X - 1 - dest_need
+      widest.clamp(PROVIDER_COL_MIN, {slack, PROVIDER_COL_MIN}.max)
     end
 
     private def draw_callback_row(screen : Screen, rect : Rect, py : Int32, row : CbRow, sel : Bool,
@@ -921,8 +935,8 @@ module Gori::Tui
       screen.text(rect.x + 18, py, row.source || "—", Theme.accent, bg, width: 17)
       # One blank column between the two variable-width runs, so a destination that fills its
       # cell does not read as one token with the provider behind it.
-      dw = {rect.right - pw - 1 - (rect.x + 36), 6}.max
-      screen.text(rect.x + 36, py, row.destination, sel ? Theme.text_bright : Theme.text, bg, width: dw)
+      dw = {rect.right - pw - 1 - (rect.x + DEST_COL_X), 6}.max
+      screen.text(rect.x + DEST_COL_X, py, row.destination, sel ? Theme.text_bright : Theme.text, bg, width: dw)
       screen.text(rect.right - pw, py, row.provider, Theme.muted, bg, width: pw)
     end
 

--- a/src/gori/tui/controllers/oast_controller.cr
+++ b/src/gori/tui/controllers/oast_controller.cr
@@ -876,11 +876,12 @@ module Gori::Tui
         return
       end
       header_y = inner.y
+      pw = provider_col_w(inner, ordered)
       screen.text(inner.x + 2, header_y, "PROTO", Theme.muted, Theme.bg)
       screen.text(inner.x + 9, header_y, "METHOD", Theme.muted, Theme.bg)
       screen.text(inner.x + 18, header_y, "SOURCE", Theme.muted, Theme.bg)
       screen.text(inner.x + 36, header_y, "DESTINATION", Theme.muted, Theme.bg)
-      screen.text(inner.right - 18, header_y, "PROVIDER", Theme.muted, Theme.bg)
+      screen.text(inner.right - pw, header_y, "PROVIDER", Theme.muted, Theme.bg)
       rows_rect = Rect.new(inner.x, inner.y + 1, inner.w, inner.h - 1)
       visible = rows_rect.h
       return if visible <= 0 # a collapsed pane (tiny terminal) has no rows to draw; a negative slice count would raise
@@ -892,20 +893,37 @@ module Gori::Tui
       ordered[@cb_scroll, visible]?.try &.each_with_index do |row, i|
         py = rows_rect.y + i
         abs = @cb_scroll + i
-        draw_callback_row(screen, rows_rect, py, row, abs == @cb_sel, focused)
+        draw_callback_row(screen, rows_rect, py, row, abs == @cb_sel, focused, pw)
       end
     end
 
-    private def draw_callback_row(screen : Screen, rect : Rect, py : Int32, row : CbRow, sel : Bool, focused : Bool) : Nil
+    # The PROVIDER column's width. It was pinned at 17 columns hard against the right edge, so a
+    # provider named after its own domain (`Demo OAST (oast.demo.test)`) truncated to
+    # `Demo OAST (oast.…` on a 200-column terminal while a hundred blank columns sat in
+    # DESTINATION beside it — the one field with a bounded, known length losing to the one that
+    # can be any length. It takes what the widest provider IN THE WHOLE FILTERED LIST needs
+    # (never just the visible slice, or the column would jitter as the list scrolls), floored at
+    # the 17 it always had and capped at a third of the pane so DESTINATION keeps the majority.
+    PROVIDER_COL_MIN = 17
+
+    private def provider_col_w(inner : Rect, rows : Array(CbRow)) : Int32
+      widest = rows.max_of? { |r| Screen.draw_width(r.provider) } || 0
+      widest.clamp(PROVIDER_COL_MIN, {inner.w // 3, PROVIDER_COL_MIN}.max)
+    end
+
+    private def draw_callback_row(screen : Screen, rect : Rect, py : Int32, row : CbRow, sel : Bool,
+                                  focused : Bool, pw : Int32) : Nil
       bg = sel ? (focused ? Theme.accent_bg : Theme.selection_dim) : Theme.bg
       screen.fill(Rect.new(rect.x, py, rect.w, 1), bg)
       screen.cell(rect.x, py, sel ? '▎' : ' ', Theme.accent, bg)
       screen.text(rect.x + 2, py, row.protocol, protocol_hue(row.protocol), bg, width: 6)
       screen.text(rect.x + 9, py, row.method || "—", Theme.text, bg, width: 8)
       screen.text(rect.x + 18, py, row.source || "—", Theme.accent, bg, width: 17)
-      dw = {rect.right - 18 - (rect.x + 36), 6}.max
+      # One blank column between the two variable-width runs, so a destination that fills its
+      # cell does not read as one token with the provider behind it.
+      dw = {rect.right - pw - 1 - (rect.x + 36), 6}.max
       screen.text(rect.x + 36, py, row.destination, sel ? Theme.text_bright : Theme.text, bg, width: dw)
-      screen.text(rect.right - 18, py, row.provider, Theme.muted, bg, width: 17)
+      screen.text(rect.right - pw, py, row.provider, Theme.muted, bg, width: pw)
     end
 
     private def protocol_hue(proto : String) : Color

--- a/src/gori/tui/env_overlay.cr
+++ b/src/gori/tui/env_overlay.cr
@@ -349,7 +349,12 @@ module Gori::Tui
         return
       end
       Frame.card(screen, box, "ENVIRONMENT", border: Theme.border_focus)
-      meta = "#{@items.size} var#{@items.size == 1 ? "" : "s"}"
+      # `global` in the meta, because this card has a TWIN: the Project tab's Env pane, with the
+      # same title, holding a different list. This one is layered UNDER it (the project wins on
+      # a clash), and an operator reading `ENVIRONMENT · no env vars` here while `$API` resolves
+      # in the editor behind it has been told nothing about which of the two they are looking at.
+      # Same word the Rewriter and Colormarker rows carry as `G`.
+      meta = "global · #{@items.size} var#{@items.size == 1 ? "" : "s"}"
       Frame.border_meta(screen, box, "ENVIRONMENT", meta, bg: Theme.panel)
       draw_prefix_row(screen, box, box.y + 1)
       screen.text(box.x + 3, box.y + 2, "KEY VALUE · e.g. HOST api.example.com", Theme.muted, Theme.panel, width: {box.w - 5, 1}.max)

--- a/src/gori/tui/frame.cr
+++ b/src/gori/tui/frame.cr
@@ -84,18 +84,33 @@ module Gori::Tui
     # Returns the x it drew at, or nil when it drew nothing — so a caller can CHAIN something
     # further left (the Repeater hangs an `⚠ incomplete` marker off the meta it just placed)
     # without re-deriving a position this method already computed.
+    # The annotation rides the hairline as ` META `, the same padded run `Frame.card` gives
+    # its title and every badge helper below gives its label. Unpadded it butted straight into
+    # the dashes on both sides — `╭─ COLORMARKER ─────8/9 enabled─╮`, and a one-token meta
+    # (`╭─ PREVIEW INPUT ────REQ─╮`, `╭─ FINDINGS ─────0─╮`) read as debris on the border
+    # rather than as a label. This was the ONLY border decoration in the module that did not
+    # pad itself.
     def self.border_meta(screen : Screen, rect : Rect, title : String, meta : String,
                          bg : Color = Theme.bg, fg : Color = Theme.muted,
                          min_x : Int32? = nil, right_edge : Int32? = nil) : Int32?
       return nil if meta.empty? || rect.w < 4
       stop = min_x || (rect.x + 2 + (title.empty? ? 0 : Screen.draw_width(title) + 2))
-      # `right_edge` (exclusive) for a border that ALREADY carries a badge: the meta right-aligns
-      # to the left of it instead of to the card's corner. Discover's RUNS card is the case —
-      # `border_meta` ran before the run badge and was simply overpainted by it.
-      x = (right_edge || (rect.right - 2)) - Screen.draw_width(meta)
+      x = border_meta_x(rect, meta, right_edge)
       return nil if x <= stop
-      screen.text(x, rect.y, meta, fg, bg)
+      screen.text(x, rect.y, " #{meta} ", fg, bg)
       x
+    end
+
+    # Where `border_meta` puts that run's left edge — padding included, and the x it returns.
+    # Exposed so a caller whose own chrome must stop clear of the meta reads the number off
+    # the same derivation instead of rebuilding it (the gRPC transcript's ` p: ` chip limit
+    # did, and would have drifted by the padding).
+    #
+    # `right_edge` (exclusive) for a border that ALREADY carries a badge: the meta right-aligns
+    # to the left of it instead of to the card's corner. Discover's RUNS card is the case —
+    # `border_meta` ran before the run badge and was simply overpainted by it.
+    def self.border_meta_x(rect : Rect, meta : String, right_edge : Int32? = nil) : Int32
+      (right_edge || (rect.right - 2)) - Screen.draw_width(meta) - 2
     end
 
     # A slim vertical scroll gauge riding the right border of a framed content area.

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -2559,8 +2559,10 @@ module Gori::Tui
       # Left: the live count. Right: keyed toggle badges (sort value · matched · dist) so
       # each results toggle's shortcut rides the border, not just the bottom hint bar.
       count = results_count_label
-      screen.text(rect.x + 11, rect.y, count, Theme.muted, Theme.bg) # +11 clears the " RESULTS " title
-      min_x = rect.x + 11 + count.size + 1                           # badges never overwrite the count
+      # +11 clears the " RESULTS " title; the trailing space keeps the count off the hairline
+      # that resumes after it (`╭─ RESULTS 0 sent · 0 hit────` read as one glued token).
+      screen.text(rect.x + 11, rect.y, "#{count} ", Theme.muted, Theme.bg)
+      min_x = rect.x + 11 + count.size + 1 # badges never overwrite the count
       rx = Frame.toggle_badge(screen, rect.right - 1, rect.y, min_x, "v", "DIST", @show_dist)
       rx = Frame.toggle_badge(screen, rx, rect.y, min_x, "m", "MATCH", @matched_only)
       Frame.toggle_badge(screen, rx, rect.y, min_x, "o", @sort.to_s, false) # sort: a value chip, never lit

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -3316,11 +3316,32 @@ module Gori::Tui
       end
     end
 
+    # One line per captured frame: direction, the frame's SHAPE where it departs from an
+    # ordinary masked TEXT frame, then what it carried.
+    #
+    # This pane used to read `text?` and nothing else, so every other frame collapsed into
+    # `«binary Nb»` — a PING, a PONG, a CLOSE with its §5.5.1 code and reason, a message
+    # reassembled from three frames, an RSV bit set, a client frame sent UNMASKED in violation
+    # of §5.1 were all one indistinguishable line. `gori run show` and the Repeater transcript
+    # both spelled them out, off `Store::WsMessage#shape_note` and `WsOutMessage#shape_label`;
+    # this was the third renderer of the same rows, and the one an operator actually reads
+    # while working a socket. The facts are V7's; only this pane could not see them.
+    #
+    # No `term_safe` pass: `Screen` maps a control byte to its own cell, and `^B` reveals
+    # whitespace across the whole detail view. Scrubbing here would take that choice away.
     private def ws_lines(msgs : Array(Store::WsMessage)) : Array(String)
       return ["(no websocket messages)"] if msgs.empty?
       msgs.map do |m|
         arrow = m.direction == "out" ? "→" : "←"
-        m.text? ? "#{arrow} #{String.new(m.payload)}" : "#{arrow} «binary #{m.payload.size}b»"
+        note = m.shape_note
+        prefix = note.empty? ? arrow : "#{arrow} #{note}"
+        if m.control?
+          "#{prefix} #{m.control_detail}"
+        elsif m.text?
+          "#{prefix} #{String.new(m.payload)}"
+        else
+          "#{prefix} «binary #{m.payload.size}b»"
+        end
       end
     end
 

--- a/src/gori/tui/hosts_overlay.cr
+++ b/src/gori/tui/hosts_overlay.cr
@@ -315,7 +315,10 @@ module Gori::Tui
         return
       end
       Frame.card(screen, box, "HOSTNAME OVERRIDES", border: Theme.border_focus)
-      meta = "#{@items.size} entr#{@items.size == 1 ? "y" : "ies"}"
+      # `global`, for the reason `EnvOverlay` gives: the Project tab's HOST OVERRIDES pane is
+      # this card's twin under a title one word apart, and the layering between them (project
+      # wins) is invisible unless each says which it is.
+      meta = "global · #{@items.size} entr#{@items.size == 1 ? "y" : "ies"}"
       Frame.border_meta(screen, box, "HOSTNAME OVERRIDES", meta, bg: Theme.panel)
       # A brief format example so the "IP HOSTNAME" entry shape is clear at a glance.
       screen.text(box.x + 3, box.y + 1, "IP HOSTNAME · e.g. 10.0.0.1 example.com", Theme.muted, Theme.panel, width: {box.w - 5, 1}.max)

--- a/src/gori/tui/project_view.cr
+++ b/src/gori/tui/project_view.cr
@@ -1657,7 +1657,9 @@ module Gori::Tui
       return if rect.w < 2 || rect.h < 2
       Frame.card(screen, rect, "HOST OVERRIDES", bg: Theme.bg, border: Frame.pane_border(focused))
       n = @host_overrides.size
-      Frame.border_meta(screen, rect, "HOST OVERRIDES", n.to_s,
+      # `project`, against Settings' near-identically titled HOSTNAME OVERRIDES — these are
+      # layered OVER those, and a bare count said nothing about which list you are editing.
+      Frame.border_meta(screen, rect, "HOST OVERRIDES", "project · #{n}",
         fg: n > 0 ? Theme.text_bright : Theme.muted)
       render_overrides_list(screen, rect.inset(1, 1), focused)
     end
@@ -1743,7 +1745,9 @@ module Gori::Tui
       return if rect.w < 2 || rect.h < 2
       Frame.card(screen, rect, "ENVIRONMENT", bg: Theme.bg, border: Frame.pane_border(focused))
       n = @env_items.size
-      Frame.border_meta(screen, rect, "ENVIRONMENT", "prefix #{Settings.env_prefix} · #{n}")
+      # `project`, against the identically-titled GLOBAL card in Settings → Env that these
+      # vars are layered OVER. See `EnvOverlay#render`.
+      Frame.border_meta(screen, rect, "ENVIRONMENT", "project · prefix #{Settings.env_prefix} · #{n}")
       render_env_list(screen, rect.inset(1, 1), focused)
     end
 

--- a/src/gori/tui/repeater_view/render_response.cr
+++ b/src/gori/tui/repeater_view/render_response.cr
@@ -67,7 +67,7 @@ class Gori::Tui::RepeaterView
   # sitting on a border where the draw painted nothing at all.
   private def grpc_chrome_limit(rect : Rect) : Int32
     if d = @result.try(&.duration_us)
-      rect.right - 2 - Screen.draw_width(Fmt.dur(d)) # border_meta's own left edge
+      Frame.border_meta_x(rect, Fmt.dur(d)) # the meta's own left edge, padding included
     else
       rect.right - 1 # keep the corner
     end

--- a/src/gori/tui/rewriter_view.cr
+++ b/src/gori/tui/rewriter_view.cr
@@ -158,9 +158,10 @@ module Gori::Tui
       # the same two colours the editors use. That is the operator's answer to "did my login
       # actually bind it" without leaving the row.
       nm = "$#{rule.name}"
-      screen.text(x, py, nm, bound ? Theme.env_known : Theme.env_unknown, bg,
-        bound ? Attribute::None : Attribute::Italic)
-      x += nm.size + 1
+      # `width:` like every other run on the row: an unclipped draw of a name the operator
+      # typed paints straight through the card's right hairline on a narrow terminal.
+      x = screen.text(x, py, nm, bound ? Theme.env_known : Theme.env_unknown, bg,
+        bound ? Attribute::None : Attribute::Italic, width: {rect.right - x, 0}.max) + 1
       fg = rule.enabled? ? (selected ? Theme.text_bright : Theme.text) : Theme.muted
       cond = rule.match_filter.presence || "any message"
       x = clipped(screen, rect, x, py, "⟵ #{cond}", fg, bg)
@@ -170,11 +171,15 @@ module Gori::Tui
 
     # Draw one clipped run and answer where the next one starts. Returns `x` unchanged once
     # the row is full, so a following run draws nothing rather than wrapping.
+    #
+    # Where the next run starts is what `screen.text` RETURNS — the x it reached, in columns.
+    # Deriving it again as `x + text.size + 1` counted characters, so a run holding Hangul (a
+    # `$세션토큰` binding, a `path:/로그인` filter) advanced by half its cells and the run
+    # after it was drawn back over the one before: `$세션 ⟵ path:/로그⟵ jsonpath $.토`.
     private def clipped(screen : Screen, rect : Rect, x : Int32, py : Int32,
                         text : String, fg : Color, bg : Color) : Int32
       return x if x >= rect.right
-      screen.text(x, py, text, fg, bg, width: {rect.right - x, 0}.max)
-      x + text.size + 1
+      screen.text(x, py, text, fg, bg, width: {rect.right - x, 0}.max) + 1
     end
 
     private def render_binding_row(screen : Screen, rect : Rect, row : Bindings::Row,
@@ -184,19 +189,16 @@ module Gori::Tui
       screen.cell(rect.x, py, selected ? '▎' : ' ', Theme.accent, bg)
       x = rect.x + 2
       nm = "$#{row.name}"
-      screen.text(x, py, nm, row.bound? ? Theme.env_known : Theme.env_unknown, bg,
-        row.bound? ? Attribute::None : Attribute::Italic)
-      x += nm.size + 1
+      x = screen.text(x, py, nm, row.bound? ? Theme.env_known : Theme.env_unknown, bg,
+        row.bound? ? Attribute::None : Attribute::Italic, width: {rect.right - x, 0}.max) + 1
       # `preview`, never the value: this row is the ONE place the operator sees a binding at
       # all, and it is still masked. The full value exists only in the captured traffic it
       # came from, where P7 says it must stay readable.
-      screen.text(x, py, row.preview, row.bound? ? Theme.text : Theme.muted, bg,
-        width: {rect.right - x, 0}.max)
-      x += row.preview.size + 2
+      x = screen.text(x, py, row.preview, row.bound? ? Theme.text : Theme.muted, bg,
+        width: {rect.right - x, 0}.max) + 2
       if x < rect.right
         age = (t = row.bound_at) ? relative_time(now - t) : (row.enabled ? "waiting" : "rule off")
-        screen.text(x, py, age, Theme.muted, bg, width: {rect.right - x, 0}.max)
-        x += age.size + 2
+        x = screen.text(x, py, age, Theme.muted, bg, width: {rect.right - x, 0}.max) + 2
       end
       screen.text(x, py, row.descriptor, Theme.muted, bg, width: {rect.right - x, 0}.max) if x < rect.right
     end
@@ -312,17 +314,17 @@ module Gori::Tui
       screen.text(x, py, rule.target.request? ? "REQ" : "RES", fg, bg)
       x += 4
       tag = op_tag(rule)
-      screen.text(x, py, tag, fg, bg)
-      x += tag.size + 1
+      x = screen.text(x, py, tag, fg, bg) + 1
+      # Column count, not character count — see `clipped` above. A rule named or scoped in
+      # Hangul used to have its own name overwritten by the `@host` and the description
+      # behind it.
       unless rule.name.empty?
         nm = "[#{rule.name}]"
-        screen.text(x, py, nm, Theme.accent, bg, width: {rect.right - x, 0}.max)
-        x += nm.size + 1
+        x = screen.text(x, py, nm, Theme.accent, bg, width: {rect.right - x, 0}.max) + 1
       end
       unless rule.host.empty?
         hs = "@#{rule.host}"
-        screen.text(x, py, hs, Theme.muted, bg, width: {rect.right - x, 0}.max)
-        x += hs.size + 1
+        x = screen.text(x, py, hs, Theme.muted, bg, width: {rect.right - x, 0}.max) + 1
       end
       desc = describe(rule)
       screen.text(x, py, desc, fg, bg, width: {rect.right - x, 1}.max) if x < rect.right


### PR DESCRIPTION
Act five gave History's columns something to break on. This does the same for the tabs
beside it, and fixes what that found.

## Act six: the lists beside History, and the tabs that opened empty

Every other tab draws the same hand-laid row of user text History does — a rule name, a
binding, a tab title, an issue — and until now the demo handed all of them nothing but short
ASCII: rules called `legacy stack`, hosts called `api.demo.test`, tabs called `XSS PoC`. A
list that has never been given a Hangul name has never had its width arithmetic tested.

So the seeder now plants the Hangul/RTL half: a colour rule, a rewrite rule, an extract rule,
a sitemap tag, a Repeater tab (name, tags and target all wide), two issues — one Hangul
against the longest host in the dataset, one right-to-left. None of it is a synthetic torture
string; all of it is text those fields really hold when the target is Korean.

It also fills three panes that opened with nothing in them, because "this tab is empty" and
"this tab is broken" look identical from outside:

* **Repeater responses.** `repeaters` has carried `response_head`/`_body`/`_error`/
  `_duration_us` since V11 and the tab restores them, so a seeded tab can arrive already
  answered instead of reading `— not sent —`. Three of them, including one that never
  connected (`response_error` with an empty head) — the one state no demo run can produce.
* **The saved-view library (#776).** `v` opened onto an empty picker.
* **Authorize identities.** `Store::SESSION_SLOTS_KEY` is project state; the queue is not, so
  this is the half a seeder can fill. Without it the tab's `i` list is empty and
  "send to Authorize" has nothing to replay *as*.

Two corrections while in there: the header claimed JWT and Comparer were "pre-loaded" — they
keep no per-project state, so nothing can be seeded into them — and the IDOR repeater
response carried a literal `Content-Length: 96` over 82 bytes of JSON. The stored-response
path has no `incomplete` column, so nothing warned about it; it was simply false bytes.

## What the demo found

**Wide characters made three list renderers draw over themselves.** Every field after the
name was placed by advancing `x` with `String#size` — characters, not columns — which for a
Hangul name is half the cells it painted, so each run was written back over the one before
it and the two-column glyphs whose lead cell got overwritten came out blank:

```
[한글 규칙 이름 — 아주 길게 늘 host:      .  국 ]     Colormarker
$세션 ⟵ path:/로그⟵ jsonpath $.토 @쇼핑몰.한국      Rewriter / Extract
[주문 상태 뒤집기 (한글 본 @    몰.결제완료 → …      Rewriter / Rules
```

`screen.text` already answers the x it reached, in columns. Five sites now read that instead
of re-deriving it (`colormarker_view`, `rewriter_view`'s three row renderers and its
`clipped` helper), which is the same fix `draw_tag_column` took in the Sitemap. Surveying by
shape — `grep 'x += .*\.size'` — the remaining hits are all fixed ASCII labels.

**The History MESSAGES pane showed none of a WebSocket frame's shape.** It read `text?` and
nothing else, so a PING, a PONG, a CLOSE with its §5.5.1 code and reason, a message
reassembled from three frames, an RSV bit and a §5.1 masking violation were one
indistinguishable `«binary Nb»` line — in the one place an operator reads while working a
socket. `gori run show` and the Repeater transcript both spell them out.

The cause was structural: `ws_shape_note`/`ws_control_detail` lived in `CLI::Output`, which
the TUI cannot call. They move onto `Store::WsMessage` — the seam the model's own
`emit_shape_json` comment already prescribes for exactly this — and the CLI keeps `term_safe`
on top, because writing to a real terminal is that surface's question. Verified line-for-line
against `gori run show` on the same flow; the binary row stays `«binary 13b»` in the TUI
against the CLI's `[binary 13B] <hex>`, matching the Repeater transcript's spelling next door
(the TUI has `^X:hex` for the bytes, the CLI does not).

**Two pairs of cards share a title and differ in scope.** Settings' `ENVIRONMENT` and
`HOSTNAME OVERRIDES` are layered *under* the Project tab's `ENVIRONMENT` and `HOST
OVERRIDES`, and nothing on screen said which was which — the global env card reads
`no env vars — press a to add` while `$API` is resolving in the editor behind it. Each border
now carries `global` or `project`, the word the rule lists already carry as `G`/`P`.

**Three border-chrome nits.** `Frame.border_meta` was the only decoration in the module that
did not pad itself, so it butted into the hairline on both sides (`──8/9 enabled─╮`,
`──REQ─╮`, `──0─╮`) while the card title and every badge use `" X "`. Padding it moved a
number one caller re-derived by hand, so `Frame.border_meta_x` is exposed and the gRPC
transcript's chip stop reads it instead. The Fuzzer's `RESULTS 0 sent · 0 hit────` count got
its trailing space. And the OAST callbacks table pinned PROVIDER to 17 columns hard against
the right edge, so `Demo OAST (oast.demo.test)` truncated on a 200-column terminal with a
hundred blank columns sitting in DESTINATION beside it.

## What was ruled out

* **The OAST column's first shape was wrong and the 80-column check caught it.** Capping
  PROVIDER at a third of the pane handed it 24 columns at 80 and squeezed DESTINATION to
  `a1b2c3d4.o…` — the evidence losing to the label. It now takes only the slack DESTINATION
  leaves, so with none it returns to exactly the 17 it always was. Checked at 80, 120 and 200.
* **Column widths are measured over the whole filtered list, never the visible slice**, or the
  column jitters as the list scrolls.
* Reported but not changed: the Rewriter's PREVIEW INPUT clips while PREVIEW OUTPUT wraps
  (TextArea vs ReadPane — the two panes of one comparison disagree, but that is a structural
  change); the project DESCRIPTION character-wraps mid-word; `─0─` on an empty pane's border
  reads as debris; the Sitemap prints a 40-character method unclamped where History clamps at
  8; the 2.5 GB truncation banner is a trailer, so it needs a scroll to the end — deliberate,
  since gori's own sentence sits below the wire's bytes.

## Verification

`crystal spec` 10325 examples / 0 failures, `scripts/bench_check.sh` 48 harnesses,
`crystal tool format --check src spec bench scripts`, and `crystal build --no-codegen
scripts/seed_demo.cr` (nothing else compiles it). Every claim above was read off a real
render: `just seed-demo` into an isolated `GORI_HOME`, then the TUI under tmux at 200×50,
120×30, 100×40, 80×24 and 74×30.
