### PR TITLE
feat(probe): add COOP, CSP base-uri, JWT key-injection, broad-domain cookie, MIME-confusion and error-based SQLi checks

### DIFF
--- a/spec/probe/error_based_sqli_spec.cr
+++ b/spec/probe/error_based_sqli_spec.cr
@@ -1,0 +1,179 @@
+require "../spec_helper"
+# The rule is not wired into Active::RULES / active.cr yet (the orchestrator does registration
+# separately), so require the file directly to load the class for these unit tests.
+require "../../src/gori/probe/active/error_based_sqli"
+
+private alias P = Gori::Probe
+
+# ── store + flow helpers (copied from probe_spec.cr — this codebase duplicates these per file) ──
+
+private def with_store(&)
+  path = File.tempname("gori-probe", ".db")
+  store = Gori::Store.open(path)
+  begin
+    yield store
+  ensure
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+# Insert a flow + response and return its full FlowDetail (what the analyzer feeds an active rule).
+private def capture_flow(store, resp_head : String, *, scheme = "https", host = "acme.test",
+                         target = "/", status = 200, content_type : String? = "text/html",
+                         body : String? = nil, method = "GET", req_headers = "",
+                         req_body : String? = nil) : Gori::Store::FlowDetail
+  head = String.build do |io|
+    io << method << " " << target << " HTTP/1.1\r\nHost: " << host << "\r\n" << req_headers << "\r\n"
+  end
+  req = Gori::Store::CapturedRequest.new(
+    created_at: 1_000_i64, scheme: scheme, host: host, port: scheme == "https" ? 443 : 80,
+    method: method, target: target, http_version: "HTTP/1.1",
+    head: head.to_slice, body: req_body.try(&.to_slice), source: Gori::FlowSource::Kind::Proxy)
+  id = store.insert_flow(req)
+  store.update_response(Gori::Store::CapturedResponse.new(
+    flow_id: id, status: status, head: resp_head.to_slice, body: body.try(&.to_slice),
+    reason: "OK", content_type: content_type, duration_us: 1_i64))
+  store.get_flow(id).not_nil!
+end
+
+# A hand-built Repeater::Result for a probe/baseline response (status 200 + body).
+private def resp(body : String, status : Int32 = 200) : Gori::Repeater::Result
+  head = "HTTP/1.1 #{status} X\r\nContent-Type: text/html\r\n\r\n"
+  Gori::Repeater::Result.new(head.to_slice, body.empty? ? Bytes.empty : body.to_slice, nil, 1_i64)
+end
+
+describe "Gori::Probe::Active::ErrorBasedSqli" do
+  rule = Gori::Probe::Active::ErrorBasedSqli.new
+
+  it "plans a baseline + one payload-appended probe per query param" do
+    with_store do |store|
+      detail = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/s?id=42")
+      plan = rule.plan(detail).not_nil!
+      plan.params.map(&.name).should eq(["id"])
+      plan.followups.size.should eq(2)                             # 2nd baseline + one probe
+      String.new(plan.request).should contain("/s?id=42 ")         # baseline: value unchanged
+      String.new(plan.followups[0]).should contain("/s?id=42 ")    # 2nd baseline: value unchanged
+      String.new(plan.followups[1]).should contain("id=42%27%22 ") # probe: id=42'"
+    end
+  end
+
+  it "caps probed params at MAX_PROBE_PARAMS (in query order); aggressive raises it" do
+    with_store do |store|
+      detail = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/s?a=1&b=2&c=3&d=4")
+      rule.plan(detail).not_nil!.params.map(&.name).should eq(["a", "b", "c"])
+      wide = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/s?" + (0...6).map { |i| "p#{i}=v" }.join("&"))
+      rule.plan(wide).not_nil!.params.size.should eq(P::Active::ErrorBasedSqli::MAX_PROBE_PARAMS)
+      rule.plan(wide, P::Active::Options.new(aggressive: true)).not_nil!.params.size.should eq(6)
+    end
+  end
+
+  it "fires High/ACTIVE when a MySQL error appears only in the probe" do
+    with_store do |store|
+      detail = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/s?id=42")
+      plan = rule.plan(detail).not_nil!
+      results = [resp("<p>ok</p>"), resp("<p>ok</p>"),
+                 resp("You have an error in your SQL syntax; check the manual")]
+      dets = rule.detections_all(plan, results, detail)
+      dets.size.should eq(1)
+      dets.first.code.should eq("sqli_error_based")
+      dets.first.category.should eq(P::Category::ACTIVE)
+      dets.first.severity.should eq(Gori::Store::Severity::High)
+      dets.first.title.should eq("Error-based SQL injection (database error induced)")
+      dets.first.evidence.not_nil!.should contain("id")
+    end
+  end
+
+  it "does NOT fire when the same error is present in the baseline too (permanently-broken endpoint)" do
+    with_store do |store|
+      detail = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/s?id=42")
+      plan = rule.plan(detail).not_nil!
+      err = "You have an error in your SQL syntax; check the manual"
+      rule.detections_all(plan, [resp(err), resp(err), resp(err)], detail).should be_empty
+    end
+  end
+
+  it "declines when the DB error is present in the SECOND baseline (self-varying endpoint)" do
+    with_store do |store|
+      detail = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/s?id=42")
+      plan = rule.plan(detail).not_nil!
+      err = "You have an error in your SQL syntax; check the manual"
+      # baseline1 clean, baseline2 already shows the error (endpoint jitter), probe shows it too:
+      # absent-from-BOTH-baselines is not satisfied, so we decline rather than false-fire.
+      rule.detections_all(plan, [resp("<p>ok</p>"), resp(err), resp(err)], detail).should be_empty
+    end
+  end
+
+  it "declines when the second baseline is missing (no stable reference)" do
+    with_store do |store|
+      detail = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/s?id=42")
+      plan = rule.plan(detail).not_nil!
+      # Only one baseline came back — decline rather than diff against a single sample.
+      rule.detections_all(plan, [resp("<p>ok</p>")], detail).should be_empty
+    end
+  end
+
+  it "does NOT fire on a bare reflection of the payload with no DB error" do
+    with_store do |store|
+      detail = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/s?id=42")
+      plan = rule.plan(detail).not_nil!
+      # The probe echoes the '" payload but shows no database diagnostic.
+      rule.detections_all(plan, [resp("<p>searched for 42</p>"), resp("<p>searched for 42</p>"), resp("<p>searched for 42'\"</p>")], detail).should be_empty
+    end
+  end
+
+  it "fires on an Oracle ORA-##### diagnostic (regex)" do
+    with_store do |store|
+      detail = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/s?id=42")
+      plan = rule.plan(detail).not_nil!
+      dets = rule.detections_all(plan, [resp("<p>ok</p>"), resp("<p>ok</p>"), resp("ORA-00933: SQL command not properly ended")], detail)
+      dets.size.should eq(1)
+      dets.first.evidence.not_nil!.should contain("id")
+    end
+  end
+
+  it "returns nil plan for a flow with no query params" do
+    with_store do |store|
+      rule.plan(capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/s")).should be_nil
+    end
+  end
+
+  it "gates unsafe methods: POST nil by default, non-nil under allow_unsafe" do
+    with_store do |store|
+      post = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/s?id=42", method: "POST")
+      rule.plan(post).should be_nil
+      rule.plan(post, P::Active::Options.new(allow_unsafe: true)).should_not be_nil
+      # HEAD stays out even under the opt-in (no body to diff).
+      head = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/s?id=42", method: "HEAD")
+      rule.plan(head, P::Active::Options.new(allow_unsafe: true)).should be_nil
+    end
+  end
+
+  it "dedup_key stays identical to plan.dedup_key (equivalence invariant)" do
+    with_store do |store|
+      ["/s?id=42", "/s?a=1&b=2&c=3&d=4", "/s?flag&x=9", "/s"].each do |t|
+        detail = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: t)
+        rule.dedup_key(detail).should eq(rule.plan(detail).try(&.dedup_key))
+      end
+      # A no-param flow → both nil.
+      none = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/s")
+      rule.dedup_key(none).should be_nil
+      rule.plan(none).should be_nil
+    end
+  end
+
+  it "requests_per_flow begins at >= 3 (two baselines + at least one probe)" do
+    (rule.requests_per_flow.begin >= 3).should be_true
+  end
+
+  it "adds an ORA word boundary so a larger token does not false-match" do
+    with_store do |store|
+      detail = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/s?id=42")
+      plan = rule.plan(detail).not_nil!
+      # 'aurora-12345' contains 'ora-12345' but is not an Oracle diagnostic — must NOT fire.
+      rule.detections_all(plan, [resp("<p>ok</p>"), resp("<p>ok</p>"), resp("region aurora-12345 ready")], detail).should be_empty
+    end
+  end
+end

--- a/spec/probe/passive/cookies_domain_spec.cr
+++ b/spec/probe/passive/cookies_domain_spec.cr
@@ -1,0 +1,155 @@
+require "../../spec_helper"
+
+# --- file-local harness (mirrors spec/probe/passive/jwt_spec.cr's private with_store/capture_flow) ---
+
+private def with_store(&)
+  path = File.tempname("gori-cookie-domain-rule", ".db")
+  store = Gori::Store.open(path)
+  begin
+    yield store
+  ensure
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+private def capture_flow(store, resp_head : String = "HTTP/1.1 200 OK\r\n\r\n", *,
+                         scheme = "https", host = "acme.test", target = "/", status = 200,
+                         content_type : String? = "text/html", body : String? = nil,
+                         method = "GET", req_headers = "") : Gori::Store::FlowDetail
+  head = String.build do |io|
+    io << method << " " << target << " HTTP/1.1\r\nHost: " << host << "\r\n" << req_headers << "\r\n"
+  end
+  req = Gori::Store::CapturedRequest.new(
+    created_at: 1_000_i64, scheme: scheme, host: host, port: scheme == "https" ? 443 : 80,
+    method: method, target: target, http_version: "HTTP/1.1", head: head.to_slice, body: nil, source: Gori::FlowSource::Kind::Proxy)
+  id = store.insert_flow(req)
+  store.update_response(Gori::Store::CapturedResponse.new(
+    flow_id: id, status: status, head: resp_head.to_slice, body: body.try(&.to_slice),
+    reason: "OK", content_type: content_type, duration_us: 1_i64))
+  store.get_flow(id).not_nil!
+end
+
+# Only the cookie rule's detections.
+private def cookies(store, **kw) : Array(Gori::Probe::Detection)
+  Gori::Probe::Passive.analyze(capture_flow(store, **kw)).select(&.code.starts_with?("cookie_"))
+end
+
+private def codes(dets) : Array(String)
+  dets.map(&.code)
+end
+
+# A response head carrying exactly one Set-Cookie line.
+private def set_cookie(line : String) : String
+  "HTTP/1.1 200 OK\r\nSet-Cookie: #{line}\r\n\r\n"
+end
+
+describe "Gori::Probe::Passive::Cookies (Domain scope)" do
+  it "flags a cookie scoped to a parent of the request host" do
+    with_store do |store|
+      dets = cookies(store, host: "app.example.com",
+        resp_head: set_cookie("sid=x; Domain=example.com; Secure; HttpOnly"))
+      codes(dets).should contain("cookie_broad_domain")
+      d = dets.find { |x| x.code == "cookie_broad_domain" }.not_nil!
+      d.severity.should eq(Gori::Store::Severity::Info)
+      d.category.should eq(Gori::Probe::Category::COOKIES)
+      d.title.should eq("Cookie scoped to a parent domain")
+      d.evidence.should eq("sid (Domain=example.com)")
+      # The evidence has to survive Store.merge_evidence, which splits on ", ".
+      d.evidence.not_nil!.should_not contain(", ")
+    end
+  end
+
+  it "normalises the leading-dot Domain spelling" do
+    with_store do |store|
+      dets = cookies(store, host: "app.example.com",
+        resp_head: set_cookie("sid=x; Domain=.example.com; Secure; HttpOnly"))
+      d = dets.find { |x| x.code == "cookie_broad_domain" }.not_nil!
+      d.evidence.should eq("sid (Domain=example.com)")
+    end
+  end
+
+  it "flags from a deeper subdomain of the same parent" do
+    with_store do |store|
+      dets = cookies(store, host: "a.b.example.com",
+        resp_head: set_cookie("sid=x; Domain=example.com; Secure; HttpOnly"))
+      d = dets.find { |x| x.code == "cookie_broad_domain" }.not_nil!
+      d.evidence.should eq("sid (Domain=example.com)")
+      d.host.should eq("a.b.example.com")
+    end
+  end
+
+  it "does NOT flag an apex host setting a cookie on its own domain" do
+    with_store do |store|
+      dets = cookies(store, host: "example.com",
+        resp_head: set_cookie("sid=x; Domain=example.com; Secure; HttpOnly"))
+      codes(dets).should_not contain("cookie_broad_domain")
+    end
+  end
+
+  it "does NOT flag a host-only cookie (no Domain attribute)" do
+    with_store do |store|
+      dets = cookies(store, host: "app.example.com",
+        resp_head: set_cookie("sid=x; Path=/; Secure; HttpOnly"))
+      codes(dets).should_not contain("cookie_broad_domain")
+    end
+  end
+
+  it "does NOT flag a Domain that does not cover the request host" do
+    with_store do |store|
+      # The browser rejects this outright, so the cookie is shared with nobody.
+      dets = cookies(store, host: "app.example.com",
+        resp_head: set_cookie("sid=x; Domain=other.test; Secure; HttpOnly"))
+      codes(dets).should_not contain("cookie_broad_domain")
+      # Nor a suffix that is not a domain boundary ("notexample.com" ends with "example.com").
+      dets2 = cookies(store, host: "notexample.com",
+        resp_head: set_cookie("sid=x; Domain=example.com; Secure; HttpOnly"))
+      codes(dets2).should_not contain("cookie_broad_domain")
+    end
+  end
+
+  it "does NOT flag a cookie being deleted, even on a subdomain" do
+    with_store do |store|
+      dets = cookies(store, host: "app.example.com",
+        resp_head: set_cookie("sid=; Domain=example.com; Max-Age=0; Secure; HttpOnly"))
+      codes(dets).should_not contain("cookie_broad_domain")
+      # The deletion guard suppresses the whole cookie, not just this check.
+      dets.should be_empty
+    end
+  end
+
+  it "does NOT flag an empty or bare Domain attribute" do
+    with_store do |store|
+      codes(cookies(store, host: "app.example.com",
+        resp_head: set_cookie("sid=x; Domain=; Secure; HttpOnly"))).should_not contain("cookie_broad_domain")
+      codes(cookies(store, host: "app.example.com",
+        resp_head: set_cookie("sid=x; Domain=.; Secure; HttpOnly"))).should_not contain("cookie_broad_domain")
+    end
+  end
+
+  it "leaves the existing flag checks firing alongside it" do
+    with_store do |store|
+      dets = cookies(store, host: "app.example.com",
+        resp_head: set_cookie("sid=x; Domain=example.com"))
+      found = codes(dets)
+      found.should contain("cookie_broad_domain")
+      found.should contain("cookie_no_samesite")
+      found.should contain("cookie_no_secure")
+      found.should contain("cookie_no_httponly")
+    end
+  end
+
+  it "reports each widened cookie of a multi-cookie response separately" do
+    with_store do |store|
+      head = "HTTP/1.1 200 OK\r\n" \
+             "Set-Cookie: sid=x; Domain=example.com; Secure; HttpOnly; SameSite=Lax\r\n" \
+             "Set-Cookie: csrf=y; Path=/; Secure; HttpOnly; SameSite=Lax\r\n\r\n"
+      dets = cookies(store, host: "app.example.com", resp_head: head)
+      broad = dets.select(&.code.==("cookie_broad_domain"))
+      broad.size.should eq(1)
+      broad.first.evidence.should eq("sid (Domain=example.com)")
+    end
+  end
+end

--- a/spec/probe/passive/jwt_key_injection_spec.cr
+++ b/spec/probe/passive/jwt_key_injection_spec.cr
@@ -1,0 +1,168 @@
+require "../../spec_helper"
+require "base64"
+
+# --- file-local harness (mirrors spec/probe/passive/jwt_spec.cr) -------------------------
+
+private def with_store(&)
+  path = File.tempname("gori-jwt-keyinj-rule", ".db")
+  store = Gori::Store.open(path)
+  begin
+    yield store
+  ensure
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+private def capture_flow(store, resp_head : String = "HTTP/1.1 200 OK\r\n\r\n", *,
+                         scheme = "https", host = "acme.test", target = "/", status = 200,
+                         content_type : String? = "text/html", body : String? = nil,
+                         method = "GET", req_headers = "") : Gori::Store::FlowDetail
+  head = String.build do |io|
+    io << method << " " << target << " HTTP/1.1\r\nHost: " << host << "\r\n" << req_headers << "\r\n"
+  end
+  req = Gori::Store::CapturedRequest.new(
+    created_at: 1_000_i64, scheme: scheme, host: host, port: scheme == "https" ? 443 : 80,
+    method: method, target: target, http_version: "HTTP/1.1", head: head.to_slice, body: nil, source: Gori::FlowSource::Kind::Proxy)
+  id = store.insert_flow(req)
+  store.update_response(Gori::Store::CapturedResponse.new(
+    flow_id: id, status: status, head: resp_head.to_slice, body: body.try(&.to_slice),
+    reason: "OK", content_type: content_type, duration_us: 1_i64))
+  store.get_flow(id).not_nil!
+end
+
+# Only the JWT rule's detections.
+private def jwt(store, **kw) : Array(Gori::Probe::Detection)
+  Gori::Probe::Passive.analyze(capture_flow(store, **kw)).select(&.code.starts_with?("jwt_"))
+end
+
+private def codes(dets) : Array(String)
+  dets.map(&.code)
+end
+
+# Build a token from raw header/payload JSON (unpadded base64url, as on the wire).
+private def token(header : String, payload : String, sig : String = "c2ln") : String
+  b64 = ->(s : String) { Base64.urlsafe_encode(s, padding: false) }
+  "#{b64.call(header)}.#{b64.call(payload)}.#{sig}"
+end
+
+# The one detection under test, or nil.
+private def key_inj(dets) : Gori::Probe::Detection?
+  dets.find { |d| d.code == "jwt_key_injection_header" }
+end
+
+describe Gori::Probe::Passive::JwtWeaknesses do
+  describe "jwt_key_injection_header" do
+    it "flags a header carrying jku (a JWKS URL the token chose itself)" do
+      with_store do |store|
+        tok = token(%({"alg":"RS256","jku":"https://evil.test/keys"}),
+          %({"sub":"1","exp":9999999999}))
+        dets = jwt(store, req_headers: "Authorization: Bearer #{tok}\r\n")
+        codes(dets).should contain("jwt_key_injection_header")
+        d = key_inj(dets).not_nil!
+        d.severity.should eq(Gori::Store::Severity::Medium)
+        d.category.should eq(Gori::Probe::Category::HEADERS)
+        d.title.should eq("JWT header carries a key-injection parameter (jku/x5u/jwk)")
+        d.evidence.should eq("Authorization: header has jku")
+        # The URL is attacker content; evidence names the PARAMETER, never its value.
+        d.evidence.to_s.should_not contain("evil.test")
+      end
+    end
+
+    it "flags a header carrying x5u" do
+      with_store do |store|
+        tok = token(%({"alg":"RS256","x5u":"https://evil.test/chain.pem"}),
+          %({"sub":"1","exp":9999999999}))
+        d = key_inj(jwt(store, req_headers: "Authorization: Bearer #{tok}\r\n")).not_nil!
+        d.severity.should eq(Gori::Store::Severity::Medium)
+        d.evidence.should eq("Authorization: header has x5u")
+      end
+    end
+
+    it "flags a header embedding a jwk public key" do
+      with_store do |store|
+        tok = token(%({"alg":"RS256","jwk":{"kty":"RSA","n":"AQAB","e":"AQAB"}}),
+          %({"sub":"1","exp":9999999999}))
+        d = key_inj(jwt(store, req_headers: "Authorization: Bearer #{tok}\r\n")).not_nil!
+        d.evidence.should eq("Authorization: header has jwk")
+      end
+    end
+
+    it "emits ONE detection naming both params, in jku/x5u/jwk order" do
+      with_store do |store|
+        # Declared jwk-first on the wire; the evidence order is the fixed registry order.
+        tok = token(%({"alg":"RS256","jwk":{"kty":"RSA"},"jku":"https://evil.test/keys"}),
+          %({"sub":"1","exp":9999999999}))
+        dets = jwt(store, req_headers: "Authorization: Bearer #{tok}\r\n")
+        codes(dets).count("jwt_key_injection_header").should eq(1)
+        key_inj(dets).not_nil!.evidence.should eq("Authorization: header has jku/jwk")
+      end
+    end
+
+    it "does NOT flag kid, which is ubiquitous and not itself a weakness" do
+      with_store do |store|
+        tok = token(%({"alg":"HS256","kid":"abc","typ":"JWT"}), %({"sub":"1","exp":9999999999}))
+        dets = jwt(store, req_headers: "Authorization: Bearer #{tok}\r\n")
+        codes(dets).should_not contain("jwt_key_injection_header")
+        dets.should be_empty # kid alone is a clean token
+      end
+    end
+
+    it "flags a token carried in a request Cookie and names the cookie" do
+      with_store do |store|
+        tok = token(%({"alg":"RS256","jku":"https://evil.test/keys"}),
+          %({"sub":"1","exp":9999999999}))
+        dets = jwt(store, req_headers: "Cookie: theme=dark; session=#{tok}\r\n")
+        codes(dets).should contain("jwt_key_injection_header")
+        key_inj(dets).not_nil!.evidence.should eq("Cookie session: header has jku")
+      end
+    end
+
+    it "flags a token issued in a response Set-Cookie" do
+      with_store do |store|
+        tok = token(%({"alg":"RS256","x5u":"https://evil.test/c.pem"}),
+          %({"sub":"1","exp":9999999999}))
+        head = "HTTP/1.1 200 OK\r\nSet-Cookie: auth=#{tok}; Path=/; HttpOnly\r\n\r\n"
+        key_inj(jwt(store, resp_head: head)).not_nil!.evidence.should eq("Set-Cookie auth: header has x5u")
+      end
+    end
+
+    it "matches the param names case-insensitively" do
+      with_store do |store|
+        tok = token(%({"alg":"RS256","JKU":"https://evil.test/keys"}),
+          %({"sub":"1","exp":9999999999}))
+        key_inj(jwt(store, req_headers: "Authorization: Bearer #{tok}\r\n")).not_nil!
+          .evidence.should eq("Authorization: header has jku")
+      end
+    end
+
+    it "leaves the existing checks unchanged on a token without these params" do
+      with_store do |store|
+        tok = token(%({"alg":"none","typ":"JWT"}), %({"sub":"1","exp":9999999999}), "")
+        dets = jwt(store, req_headers: "Authorization: Bearer #{tok}\r\n")
+        codes(dets).should contain("jwt_alg_none")
+        codes(dets).should_not contain("jwt_key_injection_header")
+      end
+    end
+
+    it "still reports alg:none alongside the key-injection param" do
+      with_store do |store|
+        tok = token(%({"alg":"none","jku":"https://evil.test/keys"}),
+          %({"sub":"1","exp":9999999999}), "")
+        codes(jwt(store, req_headers: "Authorization: Bearer #{tok}\r\n"))
+          .should contain("jwt_alg_none")
+        codes(jwt(store, req_headers: "Authorization: Bearer #{tok}\r\n"))
+          .should contain("jwt_key_injection_header")
+      end
+    end
+
+    it "does not raise on an undecodable or non-object header" do
+      with_store do |store|
+        jwt(store, req_headers: "Cookie: sid=eyJnot-base64!!.xx.yy\r\n").should be_empty
+        jwt(store, req_headers: "Authorization: Bearer abc.def.ghi\r\n").should be_empty
+      end
+    end
+  end
+end

--- a/spec/probe/passive/mime_confusion_spec.cr
+++ b/spec/probe/passive/mime_confusion_spec.cr
@@ -1,0 +1,165 @@
+require "../../spec_helper"
+# The rule is not yet in Passive::RULES, so require it directly and drive `check` by hand
+# (rather than going through Passive.analyze, which only runs registered rules).
+require "../../../src/gori/probe/passive/mime_confusion"
+
+# --- file-local harness (mirrors spec/probe_spec.cr's private with_store/capture_flow) ---
+
+private def with_store(&)
+  path = File.tempname("gori-mime-rule", ".db")
+  store = Gori::Store.open(path)
+  begin
+    yield store
+  ensure
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+private def capture_flow(store, resp_head : String = "HTTP/1.1 200 OK\r\n\r\n", *,
+                         scheme = "https", host = "acme.test", target = "/", status = 200,
+                         content_type : String? = "text/html", body : String? = nil,
+                         method = "GET", req_headers = "") : Gori::Store::FlowDetail
+  head = String.build do |io|
+    io << method << " " << target << " HTTP/1.1\r\nHost: " << host << "\r\n" << req_headers << "\r\n"
+  end
+  req = Gori::Store::CapturedRequest.new(
+    created_at: 1_000_i64, scheme: scheme, host: host, port: scheme == "https" ? 443 : 80,
+    method: method, target: target, http_version: "HTTP/1.1", head: head.to_slice, body: nil, source: Gori::FlowSource::Kind::Proxy)
+  id = store.insert_flow(req)
+  store.update_response(Gori::Store::CapturedResponse.new(
+    flow_id: id, status: status, head: resp_head.to_slice, body: body.try(&.to_slice),
+    reason: "OK", content_type: content_type, duration_us: 1_i64))
+  store.get_flow(id).not_nil!
+end
+
+# Drive ONLY this rule over one captured flow. `ctx.ct_low` reads the stored content_type
+# column (Context#content_type -> row.content_type), which is what `content_type:` sets;
+# `resp_head` matters only for header lookups the rule makes off ctx.response (nosniff).
+private def mime(store, **kw) : Array(Gori::Probe::Detection)
+  ctx = Gori::Probe::Passive::Context.new(capture_flow(store, **kw))
+  acc = [] of Gori::Probe::Detection
+  Gori::Probe::Passive::MimeConfusion.new.check(ctx, acc)
+  acc
+end
+
+private def codes(dets) : Array(String)
+  dets.map(&.code)
+end
+
+describe Gori::Probe::Passive::MimeConfusion do
+  it "has one rule id even though it emits two codes" do
+    info = Gori::Probe::Passive::MimeConfusion.new.info
+    info.id.should eq("mime_confusion")
+    info.category.should eq(Gori::Probe::Category::HEADERS)
+  end
+
+  it "flags a JSON body served as text/html" do
+    with_store do |store|
+      dets = mime(store, content_type: "text/html", body: %({"user":"<script>alert(1)</script>"}))
+      codes(dets).should contain("mime_json_as_html")
+      codes(dets).should_not contain("mime_sniff_html")
+      d = dets.find { |x| x.code == "mime_json_as_html" }.not_nil!
+      d.severity.should eq(Gori::Store::Severity::Low)
+      d.category.should eq(Gori::Probe::Category::HEADERS)
+      d.title.should eq("JSON body served as text/html")
+      d.evidence.should eq("declared text/html")
+    end
+  end
+
+  it "does not flag an HTML body under text/html (the correct type)" do
+    with_store do |store|
+      mime(store, content_type: "text/html", body: "<html><body>hi</body></html>").should be_empty
+    end
+  end
+
+  it "flags an HTML body served as text/plain without nosniff" do
+    with_store do |store|
+      dets = mime(store, content_type: "text/plain", body: "<!doctype html><script>alert(1)</script>")
+      codes(dets).should contain("mime_sniff_html")
+      codes(dets).should_not contain("mime_json_as_html")
+      d = dets.find { |x| x.code == "mime_sniff_html" }.not_nil!
+      d.severity.should eq(Gori::Store::Severity::Low)
+      d.category.should eq(Gori::Probe::Category::HEADERS)
+      d.title.should eq("Sniffable content served under a non-HTML type")
+      d.evidence.should eq("declared text/plain; body is HTML")
+    end
+  end
+
+  it "stays quiet when X-Content-Type-Options: nosniff is present" do
+    with_store do |store|
+      head = "HTTP/1.1 200 OK\r\nX-Content-Type-Options: nosniff\r\n\r\n"
+      mime(store, resp_head: head, content_type: "text/plain",
+        body: "<!doctype html><script>alert(1)</script>").should be_empty
+    end
+  end
+
+  it "flags an HTML body with no declared Content-Type at all" do
+    with_store do |store|
+      dets = mime(store, content_type: nil, body: "<html><head><title>x</title></head></html>")
+      codes(dets).should contain("mime_sniff_html")
+      dets.find { |x| x.code == "mime_sniff_html" }.not_nil!
+        .evidence.should eq("no Content-Type; body is HTML")
+    end
+  end
+
+  it "does not flag JSON served as application/json" do
+    with_store do |store|
+      mime(store, content_type: "application/json", body: %({"a":1})).should be_empty
+    end
+  end
+
+  it "does not flag plain text with no markup" do
+    with_store do |store|
+      mime(store, content_type: "text/plain", body: "just some text, no markup").should be_empty
+    end
+  end
+
+  it "does not flag an HTML page that merely contains a brace (invalid JSON)" do
+    with_store do |store|
+      mime(store, content_type: "text/html", body: "<div>{not json</div>").should be_empty
+    end
+  end
+
+  it "does not flag an HTML page that STARTS with a brace but is not JSON" do
+    with_store do |store|
+      # The prefix test alone would fire here; the real JSON.parse is what rejects it.
+      mime(store, content_type: "text/html", body: "{{ template }}<html><body>hi</body></html>").should be_empty
+    end
+  end
+
+  it "sniffs past a BOM and leading whitespace" do
+    with_store do |store|
+      codes(mime(store, content_type: "text/plain", body: "\uFEFF\r\n  <html><body>x</body></html>"))
+        .should contain("mime_sniff_html")
+    end
+  end
+
+  it "ignores Content-Type parameters when deciding sniffability" do
+    with_store do |store|
+      codes(mime(store, content_type: "text/plain; charset=utf-8", body: "<html>x</html>"))
+        .should contain("mime_sniff_html")
+    end
+  end
+
+  it "does not fire without a real scorable response" do
+    with_store do |store|
+      # status 0 == no response captured; Context#response returns nil.
+      mime(store, status: 0, content_type: "text/plain", body: "<html>x</html>").should be_empty
+    end
+  end
+
+  it "does not fire on a 3xx redirect (body is discarded, never rendered)" do
+    with_store do |store|
+      redir = "HTTP/1.1 302 Found\r\nLocation: /x\r\n\r\n"
+      # An HTML body under text/plain, or a JSON body under text/html, would sniff/render only if
+      # the browser rendered it — but on a 3xx it follows the Location and discards the body.
+      mime(store, resp_head: redir, status: 302, content_type: "text/plain",
+        body: "<html><script>x</script></html>").should be_empty
+      mime(store, resp_head: redir, status: 302, content_type: "text/html",
+        body: %({"a":1})).should be_empty
+    end
+  end
+end

--- a/spec/probe/passive/security_headers_additions_spec.cr
+++ b/spec/probe/passive/security_headers_additions_spec.cr
@@ -1,0 +1,191 @@
+require "../../spec_helper"
+
+# --- file-local harness (mirrors spec/probe/passive/jwt_spec.cr's private with_store/capture_flow) ---
+
+private def with_store(&)
+  path = File.tempname("gori-sec-hdr-rule", ".db")
+  store = Gori::Store.open(path)
+  begin
+    yield store
+  ensure
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+private def capture_flow(store, resp_head : String = "HTTP/1.1 200 OK\r\n\r\n", *,
+                         scheme = "https", host = "acme.test", target = "/", status = 200,
+                         content_type : String? = "text/html", body : String? = nil,
+                         method = "GET", req_headers = "") : Gori::Store::FlowDetail
+  head = String.build do |io|
+    io << method << " " << target << " HTTP/1.1\r\nHost: " << host << "\r\n" << req_headers << "\r\n"
+  end
+  req = Gori::Store::CapturedRequest.new(
+    created_at: 1_000_i64, scheme: scheme, host: host, port: scheme == "https" ? 443 : 80,
+    method: method, target: target, http_version: "HTTP/1.1", head: head.to_slice, body: nil, source: Gori::FlowSource::Kind::Proxy)
+  id = store.insert_flow(req)
+  store.update_response(Gori::Store::CapturedResponse.new(
+    flow_id: id, status: status, head: resp_head.to_slice, body: body.try(&.to_slice),
+    reason: "OK", content_type: content_type, duration_us: 1_i64))
+  store.get_flow(id).not_nil!
+end
+
+# Only the SecurityHeaders rule's detections, taken straight off the rule (not the whole
+# registry) so an unrelated rule's code can never satisfy or spoil an assertion here.
+private def sec(store, **kw) : Array(Gori::Probe::Detection)
+  detail = capture_flow(store, **kw)
+  acc = [] of Gori::Probe::Detection
+  Gori::Probe::Passive::SecurityHeaders.new.check(Gori::Probe::Passive::Context.new(detail), acc)
+  acc
+end
+
+private def codes(dets) : Array(String)
+  dets.map(&.code)
+end
+
+describe Gori::Probe::Passive::SecurityHeaders do
+  describe "missing_coop" do
+    it "flags an HTML 200 with no Cross-Origin-Opener-Policy" do
+      with_store do |store|
+        dets = sec(store)
+        codes(dets).should contain("missing_coop")
+        d = dets.find { |x| x.code == "missing_coop" }.not_nil!
+        d.title.should eq("Missing Cross-Origin-Opener-Policy")
+        d.severity.should eq(Gori::Store::Severity::Info)
+        d.category.should eq(Gori::Probe::Category::HEADERS)
+      end
+    end
+
+    it "does not flag when Cross-Origin-Opener-Policy: same-origin is set" do
+      with_store do |store|
+        head = "HTTP/1.1 200 OK\r\nCross-Origin-Opener-Policy: same-origin\r\n\r\n"
+        codes(sec(store, resp_head: head)).should_not contain("missing_coop")
+      end
+    end
+
+    it "treats any COOP value as present (unsafe-none is the default, not a finding)" do
+      with_store do |store|
+        head = "HTTP/1.1 200 OK\r\nCross-Origin-Opener-Policy: unsafe-none\r\n\r\n"
+        codes(sec(store, resp_head: head)).should_not contain("missing_coop")
+      end
+    end
+
+    it "does not flag a missing COEP/CORP on their own" do
+      with_store do |store|
+        head = "HTTP/1.1 200 OK\r\nCross-Origin-Opener-Policy: same-origin\r\n\r\n"
+        codes(sec(store, resp_head: head)).each do |c|
+          c.should_not contain("coep")
+          c.should_not contain("corp")
+        end
+      end
+    end
+  end
+
+  describe "csp_missing_base_uri" do
+    it "flags an enforcing CSP that has no base-uri directive" do
+      with_store do |store|
+        head = "HTTP/1.1 200 OK\r\nContent-Security-Policy: default-src 'self'\r\n\r\n"
+        dets = sec(store, resp_head: head)
+        codes(dets).should contain("csp_missing_base_uri")
+        d = dets.find { |x| x.code == "csp_missing_base_uri" }.not_nil!
+        d.title.should eq("CSP without base-uri (base-tag hijacking)")
+        d.severity.should eq(Gori::Store::Severity::Low)
+        d.category.should eq(Gori::Probe::Category::HEADERS)
+      end
+    end
+
+    it "does not flag a CSP that declares base-uri 'self'" do
+      with_store do |store|
+        head = "HTTP/1.1 200 OK\r\n" \
+               "Content-Security-Policy: default-src 'self'; base-uri 'self'\r\n\r\n"
+        codes(sec(store, resp_head: head)).should_not contain("csp_missing_base_uri")
+      end
+    end
+
+    it "matches base-uri case-insensitively (parse_csp downcases directive names)" do
+      with_store do |store|
+        head = "HTTP/1.1 200 OK\r\n" \
+               "Content-Security-Policy: default-src 'self'; BASE-URI 'none'\r\n\r\n"
+        codes(sec(store, resp_head: head)).should_not contain("csp_missing_base_uri")
+      end
+    end
+
+    it "does not fire when no CSP is present at all (missing_csp covers that)" do
+      with_store do |store|
+        dets = sec(store)
+        codes(dets).should contain("missing_csp")
+        codes(dets).should_not contain("csp_missing_base_uri")
+      end
+    end
+
+    it "does not fire on a report-only-only response" do
+      with_store do |store|
+        head = "HTTP/1.1 200 OK\r\n" \
+               "Content-Security-Policy-Report-Only: default-src 'self'\r\n\r\n"
+        dets = sec(store, resp_head: head)
+        codes(dets).should contain("csp_report_only")
+        codes(dets).should_not contain("csp_missing_base_uri")
+      end
+    end
+
+    it "still fires when the enforcing CSP is also weak (both codes, independent axes)" do
+      with_store do |store|
+        head = "HTTP/1.1 200 OK\r\n" \
+               "Content-Security-Policy: default-src 'self' 'unsafe-inline'\r\n\r\n"
+        c = codes(sec(store, resp_head: head))
+        c.should contain("weak_csp")
+        c.should contain("csp_missing_base_uri")
+      end
+    end
+
+    it "does not fire on a transport/frame-only CSP (no script source to bypass)" do
+      with_store do |store|
+        head = "HTTP/1.1 200 OK\r\n" \
+               "Content-Security-Policy: upgrade-insecure-requests; frame-ancestors 'none'\r\n\r\n"
+        # No script-src/default-src/object-src allowlist for a rebased <base> to walk around, so
+        # base-uri is moot — CSP Evaluator only flags the gap in that context.
+        codes(sec(store, resp_head: head)).should_not contain("csp_missing_base_uri")
+      end
+    end
+  end
+
+  describe "document gating" do
+    it "emits neither code on a 3xx redirect (never rendered)" do
+      with_store do |store|
+        head = "HTTP/1.1 302 Found\r\nLocation: /login\r\n\r\n"
+        c = codes(sec(store, resp_head: head, status: 302))
+        c.should_not contain("missing_coop")
+        c.should_not contain("csp_missing_base_uri")
+      end
+    end
+
+    it "emits neither code on a non-HTML response" do
+      with_store do |store|
+        head = "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n"
+        c = codes(sec(store, resp_head: head, content_type: "application/json"))
+        c.should_not contain("missing_coop")
+        c.should_not contain("csp_missing_base_uri")
+      end
+    end
+
+    it "still emits both on a 4xx error page (a rendered document)" do
+      with_store do |store|
+        head = "HTTP/1.1 404 Not Found\r\nContent-Security-Policy: default-src 'self'\r\n\r\n"
+        c = codes(sec(store, resp_head: head, status: 404))
+        c.should contain("missing_coop")
+        c.should contain("csp_missing_base_uri")
+      end
+    end
+  end
+
+  it "surfaces both new codes through the registered Passive.analyze pipeline" do
+    with_store do |store|
+      detail = capture_flow(store, resp_head: "HTTP/1.1 200 OK\r\nContent-Security-Policy: default-src 'self'\r\n\r\n")
+      c = Gori::Probe::Passive.analyze(detail).map(&.code)
+      c.should contain("missing_coop")
+      c.should contain("csp_missing_base_uri")
+    end
+  end
+end

--- a/spec/probe_spec.cr
+++ b/spec/probe_spec.cr
@@ -3148,11 +3148,11 @@ describe "Gori::Probe::Active (manual run estimate)" do
       a = Gori::Probe::Analyzer.new(store, Gori::Scope.load(store),
         Channel(Gori::Store::FlowEvent).new(1), Gori::Probe::Mode::Passive, true)
       est = a.active_estimate(detail)
-      # reflected_param, cors_reflection, backslash_powered all apply — plus crlf_injection and ssti,
-      # which reuse the same reflectable-query-param gate.
-      est.map(&.info.id).sort.should eq(["backslash_powered", "cors_reflection", "crlf_injection", "reflected_param", "ssti"])
-      # reflected_param (1) + cors_reflection (1) + backslash_powered (≤8) + crlf_injection (1) + ssti (2) = 13
-      est.sum { |e| e.requests.end }.should eq(13)
+      # reflected_param, cors_reflection, backslash_powered all apply — plus crlf_injection, ssti,
+      # and sqli_error_based, which reuse the same reflectable-query-param gate.
+      est.map(&.info.id).sort.should eq(["backslash_powered", "cors_reflection", "crlf_injection", "reflected_param", "sqli_error_based", "ssti"])
+      # reflected_param (1) + cors_reflection (1) + backslash_powered (≤8) + crlf_injection (1) + ssti (2) + sqli_error_based (≤5) = 18
+      est.sum { |e| e.requests.end }.should eq(18)
     end
   end
 
@@ -3164,9 +3164,9 @@ describe "Gori::Probe::Active (manual run estimate)" do
         target: "/search?q=hi")
       a = Gori::Probe::Analyzer.new(store, Gori::Scope.load(store),
         Channel(Gori::Store::FlowEvent).new(1), Gori::Probe::Mode::Passive, true)
-      # RULES order (cors_reflection disabled): reflected_param, backslash_powered, then the other
-      # reflectable-query-param rules crlf_injection and ssti.
-      a.active_estimate(detail).map(&.info.id).should eq(["reflected_param", "backslash_powered", "crlf_injection", "ssti"])
+      # RULES order (cors_reflection disabled): reflected_param, backslash_powered, sqli_error_based,
+      # then the other reflectable-query-param rules crlf_injection and ssti.
+      a.active_estimate(detail).map(&.info.id).should eq(["reflected_param", "backslash_powered", "sqli_error_based", "crlf_injection", "ssti"])
     end
   end
 
@@ -4509,8 +4509,10 @@ describe "Gori::Probe.cwe" do
   it "leaves exactly the deliberately unmapped codes without a CWE" do
     unmapped = Gori::Probe::REMEDIATION.keys.reject { |c| Gori::Probe::CWE.has_key?(c) }
     # jwt_in_body/jwt_in_ws are Info notes on where tokens flow — handing the client its own
-    # token is the design, not a weakness (see Passive::Secrets::JWT).
-    unmapped.sort.should eq(["jwt_in_body", "jwt_in_ws"])
+    # token is the design, not a weakness (see Passive::Secrets::JWT). cookie_broad_domain is an
+    # Info hardening note (a Domain scoped to a parent domain) that no CWE fits cleanly — 1275 is
+    # SameSite, 565/732/668 all overreach — so it stays unmapped rather than borrowing a wrong id.
+    unmapped.sort.should eq(["cookie_broad_domain", "jwt_in_body", "jwt_in_ws"])
   end
 
   it "renders the canonical CWE-<id> identifier and name" do

--- a/src/gori/probe/active.cr
+++ b/src/gori/probe/active.cr
@@ -1,5 +1,6 @@
 require "./active/types"
 require "./active/reflected_param"
+require "./active/error_based_sqli"
 require "./active/cors_reflection"
 require "./active/forbidden_bypass"
 require "./active/nginx_alias_traversal"
@@ -35,6 +36,7 @@ module Gori
 
       RULES = [PRIMARY, CorsReflection.new, ForbiddenBypass.new,
                NginxAliasTraversal.new, BackslashPowered.new,
+               ErrorBasedSqli.new,
                GraphqlIntrospection.new, LfiParamTraversal.new,
                OpenRedirect.new, HostHeaderInjection.new,
                CrlfInjection.new, PathNormalizationBypass.new,

--- a/src/gori/probe/active/error_based_sqli.cr
+++ b/src/gori/probe/active/error_based_sqli.cr
@@ -1,0 +1,301 @@
+require "uri"
+require "./types"
+require "../../miner/inject"
+require "../../fuzz/content_length"
+require "../../proxy/codec/http1"
+require "../../proxy/codec/content_decode"
+
+module Gori
+  module Probe
+    module Active
+      # Active error-based SQL injection probe. When a query parameter is concatenated into a SQL
+      # statement, a value that BREAKS the SQL string/number literal makes the database refuse to
+      # parse the statement, and a verbose backend echoes the parser's own diagnostic ("You have an
+      # error in your SQL syntax…", `ORA-00933`, "Unclosed quotation mark after the character
+      # string…") straight into the response. That leaked, database-specific error message is the
+      # tell this rule confirms.
+      #
+      # For each query parameter it sends a baseline (the ORIGINAL query, unchanged) plus one probe
+      # per param whose value is the param's ORIGINAL value with a syntax-breaking suffix appended
+      # (URL-encoded `'"`), every other param left alone. A param is flagged ONLY when a specific
+      # DB-error signature appears in the PROBE body and is ABSENT from the baseline body.
+      #
+      # Two FP guards stack — the same shape the SSTI rule uses to prove EVALUATION rather than
+      # reflection:
+      #   * the DIFFERENTIAL — the signature must be present after the break and absent before it.
+      #     An endpoint that is PERMANENTLY broken (always renders a DB error, e.g. a misconfigured
+      #     page) carries the signature in the baseline too, so the difference is empty and nothing
+      #     fires. Only a NEW error induced by our syntax break counts.
+      #   * a SPECIFIC signature we NEVER send ourselves — the payload is only `'"`, never any of the
+      #     signature strings, so a matched signature is the database talking, not our input echoed
+      #     back. (Ordinary reflection of the `'"` payload — with no DB error — matches nothing.)
+      # The signature set is deliberately narrow (curated DB diagnostics, no bare "error"/"sql"/
+      # "syntax"), matched case-insensitively against the DECODED, scrubbed, capped body text so an
+      # invalid-UTF-8 byte can never make the PCRE `ORA-\d{5}` scan raise.
+      #
+      # This COMPLEMENTS `backslash_powered`, which is structural and error-message-FREE (it reads a
+      # `\` vs `\\` asymmetry and never needs the backend to leak a string). This rule instead
+      # catches the endpoints that DO leak a verbose DB error — including NUMERIC contexts (`id=42`
+      # → `id=42'"`), where the backslash-escaping asymmetry does not appear because a lone `\` in a
+      # numeric literal is not an escape. The two together cover both the quiet (structural) and the
+      # loud (error-leaking) faces of the same injection surface.
+      class ErrorBasedSqli < Rule
+        # Probe at most this many query params per flow (in query order). Bounds the request count
+        # so a wide query stays light-touch; AGGRESSIVE (opts.aggressive) raises the cap.
+        MAX_PROBE_PARAMS            =  3
+        MAX_PROBE_PARAMS_AGGRESSIVE = 10
+
+        # Appended (URL-encoded) to a param's ORIGINAL value. Decodes server-side to a single quote
+        # followed by a double quote — one of the two breaks whichever string literal the value
+        # sits in, and the unmatched quote errors most numeric contexts too. We only ever send this;
+        # we never send any signature string, so a matched signature is proof of a real DB error.
+        PAYLOAD = "%27%22" # → '"
+
+        # Curated, DB-specific parser/driver diagnostics, matched case-insensitively as substrings
+        # against the decoded body. Kept narrow ON PURPOSE — no bare "error"/"sql"/"syntax", which
+        # would false-match ordinary prose. Oracle's numbered `ORA-\d{5}` is handled by regex below.
+        SIGNATURES = [
+          # MySQL / MariaDB
+          "you have an error in your sql syntax",
+          "warning: mysql",
+          "mysqli_",
+          "mysql_fetch",
+          "valid mysql result",
+          "mysqlexception",
+          # PostgreSQL
+          "pg_query()",
+          "pg_exec()",
+          "postgresql query failed",
+          "psqlexception",
+          "unterminated quoted string at or near",
+          "syntax error at or near",
+          # MS SQL Server
+          "microsoft ole db provider for sql server",
+          "unclosed quotation mark after the character string",
+          "system.data.sqlclient.sqlexception",
+          "incorrect syntax near",
+          # Oracle (ORA-##### handled by ORA_SIGNATURE below)
+          "quoted string not properly terminated",
+          "sql command not properly ended",
+          # SQLite
+          "sqlite3::",
+          "sqlite3.operationalerror",
+          "sqlite_error",
+          "unrecognized token:",
+          # Generic drivers — kept specific: bare "jdbc" was dropped (it matches any page
+          # documenting a JDBC connection string or a Java stack trace, and the differential
+          # cannot suppress it when the surrounding content varies between baseline and probe).
+          "sqlstate[",
+          "odbc sql",
+        ]
+
+        # Oracle's numbered diagnostic (e.g. ORA-00933). WORD-BOUNDED so it cannot match inside a
+        # larger token — without the `\b`, `aurora-12345` contains `ora-12345` and false-fires.
+        # Run ONLY on the decoded+scrubbed String, so the regex can never see an invalid-UTF-8 byte.
+        ORA_SIGNATURE = /\bORA-\d{5}\b/i
+
+        def info : RuleInfo
+          RuleInfo.new("sqli_error_based", "Error-based SQL injection",
+            "Appends a SQL-syntax-breaking payload to each query parameter; flags a parameter where a " \
+            "database-error signature appears in the probe response but not in the clean baseline.",
+            Category::ACTIVE)
+        end
+
+        # 2 baselines (the second proves the endpoint answers the same request the same way twice,
+        # so a self-varying error page is not mistaken for an induced one) + up to MAX_PROBE_PARAMS
+        # probes. Static annotation for the Rules sub-tab + the manual-run estimate (the analyzer
+        # sends the exact count for the flow at hand; AGGRESSIVE can send more).
+        def requests_per_flow : Range(Int32, Int32)
+          3..(2 + MAX_PROBE_PARAMS)
+        end
+
+        # Dedup key WITHOUT rebuilding probes — derived from the same `injectables` gate `plan` uses,
+        # so it is byte-identical to `plan(detail).dedup_key` and nil in exactly the same cases
+        # (verified by the equivalence spec).
+        def dedup_key(detail : Store::FlowDetail, opts : Options = Options::DEFAULT) : String?
+          g = injectables(detail, opts)
+          return nil unless g
+          method_up, path, pairs, probe = g
+          build_dedup_key(detail, method_up, path, probe.map { |i| decode_name(pair_name(pairs[i])) })
+        end
+
+        def plan(detail : Store::FlowDetail, opts : Options = Options::DEFAULT) : Plan?
+          g = injectables(detail, opts)
+          return nil unless g
+          method_up, path, pairs, probe = g
+          body = detail.request_body
+          # Baseline: the ORIGINAL query, unchanged (results[0]).
+          baseline = rebuild_query(detail.request_head, body, path, pairs.join('&'))
+          # A SECOND identical baseline, sent first among the follow-ups (results[1]) — the
+          # stability guard BackslashPowered uses. This rule is a difference test against the
+          # baseline; on a self-varying endpoint (an intermittent 5xx that renders a verbose
+          # DB-error page under load, a rate limiter, a rotating backend) an error page landing on
+          # a probe leg but not a SINGLE baseline reproduces the exact differential we report, once
+          # per param. Requiring the signature to be absent from BOTH baselines turns "we cannot
+          # tell" into a decline instead of a High false positive.
+          followups = [rebuild_query(detail.request_head, body, path, pairs.join('&'))]
+          params = [] of Param
+          probe.each do |idx|
+            pair = pairs[idx]
+            eq = pair.index('=').not_nil!
+            name = pair[0...eq]
+            value = pair[(eq + 1)..]
+            # One followup per param: that param's value = original + PAYLOAD, all others verbatim.
+            # Appended after the two baselines, so params[i]'s probe is results[2 + i].
+            followups << rebuild_query(detail.request_head, body, path, with_value(pairs, idx, name, value + PAYLOAD))
+            params << Param.new("query", decode_name(name), value)
+          end
+          key = build_dedup_key(detail, method_up, path, params.map(&.name))
+          Plan.new(baseline, params, key, followups)
+        end
+
+        # results[0] and results[1] are the two baselines; results[2 + i] is the probe for
+        # params[i]. Fire a param when a DB-error signature is present in its probe body and ABSENT
+        # from BOTH baselines. One grouped Detection per host, listing the affected params + the
+        # signature each leaked.
+        def detections_all(plan : Plan, results : Array(Repeater::Result), detail : Store::FlowDetail) : Array(Detection)
+          base1 = results[0]?
+          base2 = results[1]?
+          # Both baselines must have come back ok — without a stable reference we decline rather
+          # than risk a false positive (mirrors BackslashPowered#stable_baseline). The combined
+          # text means a signature present in EITHER baseline suppresses the finding.
+          return [] of Detection unless base1 && base1.ok? && base2 && base2.ok?
+          base_body = "#{decoded_text(base1)}\n#{decoded_text(base2)}"
+          base_low = base_body.downcase
+          hits = [] of String
+          plan.params.each_with_index do |param, i|
+            probe = results[2 + i]?
+            next unless probe && probe.ok?
+            probe_body = decoded_text(probe)
+            next if probe_body.empty?
+            sig = new_db_error(probe_body, base_body, base_low)
+            hits << "param `#{param.name}`: #{sig.inspect}" if sig
+          end
+          return [] of Detection if hits.empty?
+          [Detection.new("sqli_error_based", Category::ACTIVE, detail.row.host, detail.row.url,
+            "Error-based SQL injection (database error induced)", Store::Severity::High,
+            hits.join(", ")[0, 120], detail.row.id)]
+        rescue
+          [] of Detection
+        end
+
+        # Single-response fallback (module facade / a one-shot caller): the differential needs two
+        # baselines + a probe, so one response alone yields nothing (results[1] is absent → decline).
+        # The analyzer always calls detections_all with the full set.
+        def detections(plan : Plan, result : Repeater::Result, detail : Store::FlowDetail) : Array(Detection)
+          detections_all(plan, [result], detail)
+        end
+
+        # The first DB-error signature present in `probe_body` but ABSENT from the baseline
+        # (`base_low` is the pre-lowercased baseline). Returns a short, SAFE label for evidence — a
+        # DB error string is not a secret — capped so it can't bloat the row. nil when the probe
+        # leaks no new signature.
+        private def new_db_error(probe_body : String, base_body : String, base_low : String) : String?
+          probe_low = probe_body.downcase
+          SIGNATURES.each do |sig|
+            return sig[0, 40] if probe_low.includes?(sig) && !base_low.includes?(sig)
+          end
+          if m = ORA_SIGNATURE.match(probe_body)
+            ora = m[0]
+            return ora[0, 40] unless ORA_SIGNATURE.matches?(base_body)
+          end
+          nil
+        end
+
+        # Shared gate for plan + dedup_key so the two can't drift (equivalence-spec invariant).
+        # Returns {METHOD, path, all query pairs verbatim, indices of the first ≤MAX_PROBE_PARAMS
+        # pairs that are real k=v params} for a GET carrying ≥1 such param, else nil.
+        private def injectables(detail : Store::FlowDetail, opts : Options) : {String, String, Array(String), Array(Int32)}?
+          method, target, malformed = Proxy::Codec::Http1.parse_request_line(detail.request_head)
+          return nil if malformed
+          method_up = method.upcase
+          # Body-differential gate: the comparison reads response BODIES (HEAD has none), so HEAD is
+          # always out. By default GET only — the automatic scan never auto-re-sends a state-changing
+          # method — but opts.allow_unsafe (manual per-flow scan / AGGRESSIVE mode) widens to
+          # POST/PUT/PATCH/DELETE, whose query params can still reach a SQL statement.
+          return nil unless diff_method_allowed?(method_up, opts)
+          path, query = split_target(Active.origin_form(target))
+          return nil if query.empty?
+          cap = opts.aggressive ? MAX_PROBE_PARAMS_AGGRESSIVE : MAX_PROBE_PARAMS
+          pairs = query.split('&')
+          probe = [] of Int32
+          pairs.each_with_index do |pair, i|
+            next if pair.empty?
+            eq = pair.index('=')
+            next unless eq
+            next if pair[0...eq].empty?
+            probe << i
+            break if probe.size >= cap
+          end
+          return nil if probe.empty?
+          {method_up, path, pairs, probe}
+        end
+
+        # Key by rule + host:PORT + METHOD + path + sorted (length-prefixed) probed-param names, so
+        # the same host on another port/service is a distinct surface and a name containing ','/':'
+        # can't collide with a different set. Sorted → a reordered query dedups to one probe.
+        private def build_dedup_key(detail : Store::FlowDetail, method_upcase : String, path : String,
+                                    names : Array(String)) : String
+          sig = names.map { |n| "#{n.bytesize}:#{n}" }.sort!.join(",")
+          "sqli_error_based|#{detail.row.host}:#{detail.row.port}|#{method_upcase}|#{path}|#{sig}"
+        end
+
+        private def pair_name(pair : String) : String
+          eq = pair.index('=')
+          eq ? pair[0...eq] : pair
+        end
+
+        # A copy of the query pairs with pair `idx` replaced by "name=value" (every other segment,
+        # including bare flags and empties, kept verbatim).
+        private def with_value(pairs : Array(String), idx : Int32, name : String, value : String) : String
+          dup = pairs.dup
+          dup[idx] = "#{name}=#{value}"
+          dup.join('&')
+        end
+
+        private def decode_name(name : String) : String
+          URI.decode_www_form(name)
+        rescue
+          name
+        end
+
+        # {path, query-without-'?'} — query is "" when the target has none.
+        private def split_target(target : String) : {String, String}
+          qi = target.index('?')
+          return {target, ""} unless qi
+          {target[0...qi], target[(qi + 1)..]}
+        end
+
+        # Decode + scrub the response body to text, capped at BODY_CAP. Scrubbing makes the
+        # substring and PCRE scans byte-safe on an invalid-UTF-8 origin.
+        private def decoded_text(result : Repeater::Result) : String
+          decoded, _ = Proxy::Codec::ContentDecode.decode(result.head, result.body, BODY_CAP)
+          bytes = decoded || result.body
+          return "" if bytes.nil? || bytes.empty?
+          String.new(bytes[0, {bytes.size, BODY_CAP}.min]).scrub
+        rescue
+          ""
+        end
+
+        # Reassemble the request with a new query on the request line, preserving the original body
+        # and re-syncing Content-Length (mirrors BackslashPowered#rebuild_query).
+        private def rebuild_query(orig_head : Bytes, body : Bytes?, path : String, new_query : String) : Bytes
+          head, _, eol = Miner::Inject.split(orig_head)
+          lines = String.new(head).split(eol)
+          unless lines.empty?
+            parts = lines[0].split(' ')
+            if parts.size == 3
+              target = new_query.empty? ? path : "#{path}?#{new_query}"
+              lines[0] = "#{parts[0]} #{target} #{parts[2]}"
+            end
+          end
+          io = IO::Memory.new
+          io << lines.join(eol) << eol << eol
+          b = body || Bytes.empty
+          io.write(b) unless b.empty?
+          Fuzz::ContentLength.sync(io.to_slice, false)
+        end
+      end
+    end
+  end
+end

--- a/src/gori/probe/issue.cr
+++ b/src/gori/probe/issue.cr
@@ -114,12 +114,17 @@ module Gori
       "weak_referrer_policy"           => "Replace Referrer-Policy: unsafe-url with strict-origin-when-cross-origin or no-referrer so full URLs (and query tokens) are not leaked cross-origin.",
       "missing_permissions_policy"     => "Send a Permissions-Policy that disables or tightly scopes powerful features (camera, microphone, geolocation, payment, …) by default.",
       "weak_permissions_policy"        => "Do not allow high-risk features for all origins (*); use () to disable or (self) / an explicit origin allowlist.",
+      "missing_coop"                   => "Send Cross-Origin-Opener-Policy: same-origin (or same-origin-allow-popups where popups must keep their opener) so a cross-origin page opened from — or opening — this document cannot retain a window.opener reference for tabnabbing or cross-window XS-Leaks.",
+      "csp_missing_base_uri"           => "Add a base-uri directive (base-uri 'self' or 'none') to the CSP: base-uri has no default-src fallback, so without it an injected <base href> re-points every relative script/resource URL at an attacker origin and walks around the script-src allowlist.",
+      "mime_sniff_html"                => "Serve the response with its true Content-Type and send X-Content-Type-Options: nosniff so a browser never sniffs a body into HTML; the body here is HTML/script under a sniffable type, so it can execute in this origin. Serve user-supplied files from a separate origin or as Content-Disposition: attachment.",
+      "mime_json_as_html"              => "Label JSON responses application/json (with charset=utf-8), not text/html: rendering an API payload as a document makes any user-controlled value in it execute as markup (stored/reflected XSS).",
       "cacheable_json"                 => "Send Cache-Control: no-store (and typically no-cache, private) on JSON/API responses so browsers and shared caches do not retain tokens, PII, or account data.",
       "cookie_no_secure"               => "Add the Secure attribute so the cookie is only sent over HTTPS.",
       "cookie_no_httponly"             => "Add HttpOnly so client-side script cannot read the cookie.",
       "cookie_no_samesite"             => "Add SameSite=Lax/Strict to reduce CSRF exposure.",
       "cookie_samesite_none_insecure"  => "SameSite=None requires the Secure attribute; add Secure or use SameSite=Lax/Strict.",
       "cookie_prefix_violation"        => "A __Host-/__Secure- prefixed cookie must satisfy its rules or the browser silently rejects it: both require Secure, and __Host- also requires Path=/ and no Domain attribute.",
+      "cookie_broad_domain"            => "Drop the Domain attribute so the cookie stays host-only, or scope it to the narrowest domain that needs it — a parent Domain ships the cookie to every sibling subdomain, so a takeover or a vulnerable app on any of them can read the session or overwrite it (cookie tossing).",
       "insecure_basic_auth"            => "Serve authentication over HTTPS only; HTTP Basic credentials are Base64 (effectively cleartext) and are exposed to any network observer over http://.",
       "secret_in_url"                  => "Move credentials/tokens out of the URL (they leak via logs, history, and Referer) into headers or the body.",
       "cors_wildcard"                  => "Avoid Access-Control-Allow-Origin: * for credentialed/sensitive endpoints; echo a vetted allowlisted origin instead.",
@@ -138,6 +143,7 @@ module Gori
       "insecure_form_action"           => "Point the form action at an HTTPS URL; a form submitting to http:// sends everything the user enters (credentials included) in cleartext.",
       "reflected_param"                => "Context-encode reflected input; this parameter echoes attacker-controlled data and may enable XSS.",
       "backslash_powered"              => "A probe found this parameter reaches a server-side string interpreter: appending a lone backslash perturbed the response while a doubled (escaped) backslash did not — the tell of an unescaped injection context (SQL, template/expression, command, …). Treat the value as untrusted: use parameterized queries / a safe API, or context-correctly escape it, then confirm the injection class manually.",
+      "sqli_error_based"               => "A probe appended a quote to this parameter and the server returned a database parser error, so the value reaches a SQL statement unescaped (error-based SQL injection). Use parameterized queries / prepared statements — never string-concatenate user input into SQL — return generic errors to clients (log the detail server-side), and confirm the injection manually.",
       "graphql_introspection"          => "Disable GraphQL introspection in production; the full schema it returns maps the entire API surface for an attacker.",
       "lfi_param_traversal"            => "A probe re-fetched the same resource through a folded `..` in this parameter (e.g. file=x/../doc.pdf returned byte-identical content while a control subdir did not), so the value is used as a filesystem path with `..` resolved — a path-traversal / local-file-inclusion vector. Canonicalize the resolved path and confirm it stays within an allowlisted base directory; reject `..`, encoded separators, and absolute paths, or map the parameter to an internal id instead of a path.",
       "open_redirect"                  => "A probe confirmed this parameter controls the redirect target: replacing it with an external host made the server issue a Location to that host. Validate redirect targets against an allowlist (or permit only relative, same-origin paths), and never build a Location from an unvalidated request parameter.",
@@ -155,6 +161,7 @@ module Gori
       "jwt_weak_alg"                   => "The token's alg is outside the standard JWS set, so how the verifier handles it is unpredictable. Use a registered algorithm (EdDSA / ES256 / RS256, or HS256 with a high-entropy secret) and validate it against a server-side allowlist.",
       "jwt_no_expiry"                  => "The token carries no exp claim, so it stays valid until the signing key changes. Issue short-lived access tokens with exp (and refresh tokens for longevity), and reject tokens without one.",
       "jwt_sensitive_claims"           => "JWT payloads are base64url, not encrypted — anything in them is readable by the client and by anyone who sees the token. Keep roles/permissions and personal data server-side (or in an encrypted JWE) and reference them by an opaque subject id.",
+      "jwt_key_injection_header"       => "The token's header carries jku/x5u/jwk — it names, or embeds, the key the verifier should trust. Pin verification to a preconfigured server-side key set: never fetch a token-supplied jku/x5u URL and never trust an embedded jwk, and reject tokens whose header carries them. Otherwise an attacker signs with their own key (and jku/x5u also make the server fetch an attacker URL — SSRF).",
       "sourcemap_exposed"              => "The script points at its source map, from which the original, unminified sources are reconstructable. Stop deploying .map files to production (or serve them only to authenticated/internal clients) and drop the sourceMappingURL comment from production builds.",
       "missing_sri"                    => "A cross-origin script/stylesheet is loaded with no integrity hash, so whoever controls that third party controls this page. Add integrity=\"sha384-…\" plus crossorigin=\"anonymous\", pin the exact version, or self-host the asset.",
       "exposed_config"                 => "A server-side configuration or diagnostic artifact is being served to clients (the evidence names which). Remove it from the web root or block it at the edge, then treat every credential it contained as compromised and rotate it: a readable .env / wp-config / .htpasswd hands over live secrets outright, a .git/config lets the whole repository be reconstructed, and phpinfo() / Spring actuator env expose paths, versions, and environment variables that make every other attack cheaper. Deny dotfiles and VCS directories at the reverse proxy rather than relying on the application not to route them.",
@@ -194,6 +201,9 @@ module Gori
     #     own token is the design (see Secrets::JWT), so stamping a CWE on it would re-create the
     #     exact "a High that fires everywhere" problem splitting these codes out was meant to fix.
     #   * `custom_*` — the operator's own rule; only they know what it means.
+    #   * `cookie_broad_domain` — an Info hardening note (a Domain scoped to a parent domain).
+    #     No CWE fits it cleanly (1275 is SameSite; 565/732/668 all overreach), so it stays
+    #     unmapped rather than borrowing a specific-sounding but wrong id.
     # `cwe` returns nil for these, and every surface omits the field rather than inventing one.
     CWE = {
       # --- transport / headers -----------------------------------------------------------
@@ -209,6 +219,8 @@ module Gori
       "missing_x_content_type_options" => {693, "Protection Mechanism Failure"},
       "missing_permissions_policy"     => {693, "Protection Mechanism Failure"},
       "weak_permissions_policy"        => {693, "Protection Mechanism Failure"},
+      "missing_coop"                   => {693, "Protection Mechanism Failure"},
+      "csp_missing_base_uri"           => {693, "Protection Mechanism Failure"},
       "missing_x_frame_options"        => {1021, "Improper Restriction of Rendered UI Layers or Frames"},
       "missing_referrer_policy"        => {200, "Exposure of Sensitive Information to an Unauthorized Actor"},
       "weak_referrer_policy"           => {200, "Exposure of Sensitive Information to an Unauthorized Actor"},
@@ -242,6 +254,8 @@ module Gori
       "reflected_param"           => {79, "Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"},
       "dom_xss"                   => {79, "Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"},
       "inline_js_uri"             => {79, "Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"},
+      "mime_sniff_html"           => {79, "Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"},
+      "mime_json_as_html"         => {79, "Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"},
       "prototype_pollution"       => {1321, "Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution')"},
       "prototype_pollution_param" => {1321, "Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution')"},
       "dom_clobbering"            => {913, "Improper Control of Dynamically-Managed Code Resources"},
@@ -253,6 +267,7 @@ module Gori
       "open_redirect"          => {601, "URL Redirection to Untrusted Site ('Open Redirect')"},
       "crlf_injection"         => {113, "Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Request/Response Splitting')"},
       "ssti"                   => {1336, "Improper Neutralization of Special Elements Used in a Template Engine"},
+      "sqli_error_based"       => {89, "Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')"},
       "backslash_powered"      => {20, "Improper Input Validation"},
       "host_header_injection"  => {20, "Improper Input Validation"},
       "request_smuggling_clte" => {444, "Inconsistent Interpretation of HTTP Requests ('HTTP Request/Response Smuggling')"},
@@ -265,6 +280,7 @@ module Gori
       "nextjs_action_no_auth"     => {306, "Missing Authentication for Critical Function"},
       "ssrf_oast"                 => {918, "Server-Side Request Forgery (SSRF)"},
       "jwt_alg_none"              => {347, "Improper Verification of Cryptographic Signature"},
+      "jwt_key_injection_header"  => {347, "Improper Verification of Cryptographic Signature"},
       "jwt_weak_alg"              => {327, "Use of a Broken or Risky Cryptographic Algorithm"},
       "jwt_no_expiry"             => {613, "Insufficient Session Expiration"},
     }

--- a/src/gori/probe/passive.cr
+++ b/src/gori/probe/passive.cr
@@ -4,6 +4,7 @@ require "./passive/rule"
 require "./passive/tech"
 require "./passive/secret_in_url"
 require "./passive/security_headers"
+require "./passive/mime_confusion"
 require "./passive/cacheable_api"
 require "./passive/cookies"
 require "./passive/cors"
@@ -38,6 +39,7 @@ module Gori
         Tech.new,
         SecretInUrl.new,
         SecurityHeaders.new,
+        MimeConfusion.new,
         CacheableApi.new,
         Cookies.new,
         Cors.new,

--- a/src/gori/probe/passive/cookies.cr
+++ b/src/gori/probe/passive/cookies.cr
@@ -11,10 +11,13 @@ module Gori
       # A cookie that is being CLEARED (empty value + Max-Age=0 or an Expires attribute — the
       # logout/reset pattern) carries no secret, so its missing flags are suppressed as noise;
       # only live cookies are scored.
+      #
+      # Also scores the cookie's Domain= SCOPE, which is hygiene of a different kind: not a
+      # missing flag but a deliberately widened audience (see `broad_domain`).
       class Cookies < Rule
         def info : RuleInfo
           RuleInfo.new("cookies", "Cookie flags",
-            "Checks Set-Cookie hygiene: Secure, HttpOnly, SameSite, and __Host-/__Secure- prefix rules.",
+            "Checks Set-Cookie hygiene: Secure, HttpOnly, SameSite, __Host-/__Secure- prefix rules, and an over-broad Domain scope.",
             Category::COOKIES)
         end
 
@@ -38,6 +41,20 @@ module Gori
             expires_val = segs[1..].map(&.strip).find(&.downcase.starts_with?("expires=")).try(&.partition('=').[2].strip)
             # A cookie being deleted holds no secret — skip its hygiene (avoids logout/reset FPs).
             next if deletion?(value, flags, expires_val)
+
+            # Scope, not flags: a Domain= naming a PARENT of the request host ships this cookie
+            # to every sibling subdomain too. Emitted with Detection.new rather than the
+            # `cookie` helper because that helper fixes the evidence at the bare cookie name,
+            # and the operator needs to see WHICH domain it was widened to.
+            # NOT for a __Host- cookie: that prefix forbids Domain outright, so the browser
+            # REJECTS the whole cookie — it is shared with nobody, so the "widened audience"
+            # claim would be false here. `check_prefix` already reports that as
+            # cookie_prefix_violation; a broad-domain finding on top of it is a pure FP.
+            if !name.starts_with?(HOST_PREFIX) && (dom = broad_domain(ctx, flags))
+              acc << Detection.new("cookie_broad_domain", Category::COOKIES, ctx.host, ctx.url,
+                "Cookie scoped to a parent domain", Store::Severity::Info,
+                "#{name} (Domain=#{dom})", ctx.fid)
+            end
 
             has_secure = flags.includes?("secure")
             prefixed = check_prefix(ctx, name, flags, has_secure, acc)
@@ -120,6 +137,32 @@ module Gori
         private def emit_prefix(ctx : Context, name : String, missing : Array(String), acc : Array(Detection)) : Nil
           acc << cookie(ctx, "cookie_prefix_violation", "Cookie violates its #{name.starts_with?(HOST_PREFIX) ? "__Host-" : "__Secure-"} prefix rules",
             Store::Severity::Medium, "#{name}: needs #{missing.join(" + ")}")
+        end
+
+        # The cookie's Domain= — normalised, leading "." dropped — when it scopes the cookie to a
+        # STRICT PARENT of the request host; nil otherwise. `app.example.com` setting
+        # `Domain=example.com` also sends the cookie to `anything-else.example.com`, so one
+        # attacker-influenced sibling (a subdomain takeover, a vulnerable app next door) can read
+        # the session or toss a cookie back. Info, not a finding: a broad Domain is frequently
+        # deliberate (SSO shared across subdomains), so this is a hardening note.
+        #
+        # Only the STRICT widening fires, which is what keeps it quiet:
+        #   * host == domain — the apex serving its own cookie — is the common, intended shape,
+        #     and flagging it would put an Info on nearly every site.
+        #   * a Domain that does not cover the host at all is browser-REJECTED, so the cookie is
+        #     never shared with anyone and there is nothing to report.
+        #   * no Domain attribute is a host-only cookie: correctly scoped by construction.
+        # `flags` arrives already stripped + lowercased, so the comparison needs only the host
+        # downcased to match it.
+        private def broad_domain(ctx : Context, flags : Array(String)) : String?
+          domain = flags.find(&.starts_with?("domain=")).try { |f| f.split('=', 2)[1]?.try(&.strip) }
+          return nil if domain.nil? || domain.empty?
+          # A single leading dot is the RFC 2965 spelling of the same scope (".example.com"),
+          # not a different domain — normalise it away so the evidence reads consistently.
+          domain = domain.lchop('.')
+          return nil if domain.empty?
+          host = ctx.host.downcase
+          (host != domain && host.ends_with?(".#{domain}")) ? domain : nil
         end
 
         private def cookie(ctx : Context, code : String, title : String, sev : Store::Severity, name : String) : Detection

--- a/src/gori/probe/passive/jwt.cr
+++ b/src/gori/probe/passive/jwt.cr
@@ -8,7 +8,7 @@ module Gori
       # What a captured JWT PLAINLY STATES about itself. `secret_in_url` already flags a
       # JWT-shaped value carried in the query string (a leak); this rule goes one level in and
       # decodes the tokens a flow actually authenticates with — `Authorization: Bearer …`, a
-      # request `Cookie` value, and a response `Set-Cookie` value — reporting four things the
+      # request `Cookie` value, and a response `Set-Cookie` value — reporting five things the
       # header/payload declare outright:
       #
       #   * `alg: "none"`      — an unsigned token in live use (High; unmistakable binary signal)
@@ -16,6 +16,8 @@ module Gori
       #                          is anyone's guess (Low)
       #   * no `exp` claim     — the token never expires on its own (Low)
       #   * sensitive claims   — role/permission/PII claim NAMES in the payload (Info)
+      #   * `jku`/`x5u`/`jwk`  — key-resolution parameters in the HEADER: the token telling the
+      #                          verifier which key to trust (Medium)
       #
       # Zero-request and DECODE-ONLY: passive analysis cannot verify a signature or recover a
       # secret, so nothing here asserts the server would *accept* a tampered token — that is the
@@ -30,7 +32,7 @@ module Gori
       class JwtWeaknesses < Rule
         def info : RuleInfo
           RuleInfo.new("jwt", "JWT weaknesses",
-            "Decodes JWTs carried in Authorization/Cookie/Set-Cookie and flags alg:none, non-standard algorithms, missing expiry, and sensitive claim names.",
+            "Decodes JWTs carried in Authorization/Cookie/Set-Cookie and flags alg:none, non-standard algorithms, key-injection header parameters (jku/x5u/jwk), missing expiry, and sensitive claim names.",
             Category::HEADERS)
         end
 
@@ -58,6 +60,12 @@ module Gori
                             "email", "email_address", "phone", "phone_number", "mobile",
                             "ssn", "birthdate", "address", "gender"]
         MAX_CLAIM_NAMES = 6 # cap the evidence list; the sample flow has the rest
+
+        # JOSE header parameters that tell the verifier WHERE the signing key comes from, in a
+        # fixed order so the evidence string is stable across flows and merges into one issue
+        # group. Matched case-insensitively against top-level header keys (JOSE parameter names
+        # are lowercase by registry, but a hand-rolled issuer is not bound by that).
+        KEY_INJECTION_PARAMS = ["jku", "x5u", "jwk"]
 
         def check(ctx : Context, acc : Array(Detection)) : Nil
           seen = Set(String).new
@@ -118,10 +126,17 @@ module Gori
         # --- checks -------------------------------------------------------------------------
 
         private def inspect_token(ctx : Context, acc : Array(Detection), location : String, token : String) : Nil
-          alg = Gori::Jwt.token_alg(token)
-          return if alg.nil? # header doesn't base64url-decode to a JSON object with an alg
+          # Decode the header ONCE and share it: `alg` and the jku/x5u/jwk params both live in it,
+          # and this is the always-on passive path (every flow, up to MAX_TOKENS per flow). The nil
+          # guard is exactly the old `Gori::Jwt.token_alg(token).nil?` one — a header that isn't a
+          # JSON object, or carries no string `alg`, is not a token we can say anything about.
+          header = header_object(token)
+          return if header.nil?
+          alg = header["alg"]?.try(&.as_s?)
+          return if alg.nil?
           check_alg(ctx, acc, location, alg)
           check_claims(ctx, acc, location, token)
+          check_header_params(ctx, acc, location, header)
         end
 
         private def check_alg(ctx : Context, acc : Array(Detection), location : String, alg : String) : Nil
@@ -149,6 +164,31 @@ module Gori
             "Sensitive claims in a JWT payload", Store::Severity::Info, names.join(", "))
         end
 
+        # `jku` and `x5u` point the verifier at a URL CARRIED IN THE TOKEN to fetch the signing
+        # key (JWK Set / X.509 chain) from; `jwk` embeds the public key in the token outright. A
+        # verifier that trusts any of them accepts a key the token's bearer chose, so an attacker
+        # signs with their own key — or hosts their own JWKS, which additionally makes the
+        # verifier fetch an attacker-named URL (SSRF) — and forges arbitrary valid tokens: a full
+        # authentication bypass. Legitimate first-party tokens essentially never carry these, so
+        # the mere presence is high-signal and low-FP.
+        #
+        # Medium, not High: consistent with this file's decode-only philosophy, a passive decode
+        # cannot tell whether the verifier HONOURS the parameter — only that the token declares
+        # it. Confirming it is the active/manual `jwt_attacks` path.
+        #
+        # `kid` is deliberately NOT flagged: it is present in the majority of real tokens and is
+        # not itself a weakness — its injection risk lives entirely in how the server resolves
+        # it (SQL/path lookup), which nothing in the token can reveal.
+        private def check_header_params(ctx : Context, acc : Array(Detection), location : String,
+                                        header : Hash(String, JSON::Any)) : Nil
+          keys = header.keys.map(&.downcase)
+          found = KEY_INJECTION_PARAMS.select { |name| keys.includes?(name) }
+          return if found.empty?
+          acc << det(ctx, "jwt_key_injection_header", Category::HEADERS,
+            "JWT header carries a key-injection parameter (jku/x5u/jwk)", Store::Severity::Medium,
+            "#{location}: header has #{found.join("/")}")
+        end
+
         # Top-level claim names that are in SENSITIVE_CLAIMS, in SENSITIVE_CLAIMS order (so the
         # evidence string is stable across flows and merges cleanly into one issue group).
         private def sensitive_names(claims : Hash(String, JSON::Any)) : Array(String)
@@ -166,6 +206,17 @@ module Gori
         # or plain garbage — all of which are outside what a passive decode can say anything about).
         private def payload_object(token : String) : Hash(String, JSON::Any)?
           seg = token.split('.')[1]?
+          return nil if seg.nil? || seg.empty?
+          JSON.parse(String.new(Base64.decode(seg))).as_h?
+        rescue
+          nil
+        end
+
+        # The header segment as a JSON object, or nil when it isn't one — the same decode-or-nil
+        # contract as `payload_object`, on segment [0]. `token_alg` already reads this segment,
+        # but only for `alg`; the header params need the whole object.
+        private def header_object(token : String) : Hash(String, JSON::Any)?
+          seg = token.split('.')[0]?
           return nil if seg.nil? || seg.empty?
           JSON.parse(String.new(Base64.decode(seg))).as_h?
         rescue

--- a/src/gori/probe/passive/mime_confusion.cr
+++ b/src/gori/probe/passive/mime_confusion.cr
@@ -1,0 +1,157 @@
+require "json"
+require "./rule"
+
+module Gori
+  module Probe
+    module Passive
+      # MIME type confusion (category "headers"): the BODY the server sent and the Content-Type
+      # it declared disagree, in one of the two shapes a browser can be talked into rendering as
+      # HTML. Zero-request and response-gated — everything below is read off the captured flow.
+      #
+      # Case 1 — `mime_sniff_html`: the body plainly IS an HTML/script document, but it is served
+      # under a type browsers content-sniff, with no `X-Content-Type-Options: nosniff`. All three
+      # conditions are load-bearing and the rule fires only when every one holds:
+      #
+      #   * the body sniffs as HTML — a leading `<!doctype html` / `<html` / `<head` / `<body` /
+      #     `<script` / `<svg`, or a `<script` inside the sniffed prefix. Anything vaguer (a lone
+      #     `<` , a `<p>` in prose) is not markup a sniffer commits on, and would be noise;
+      #   * the DECLARED type is one browsers actually sniff. That set is small: a missing
+      #     Content-Type, `text/plain`, and `application/octet-stream`. `application/json` and the
+      #     other `application/*` types are deliberately EXCLUDED — modern browsers do not
+      #     upgrade those to HTML, so an HTML-looking JSON body is a mislabelling curiosity, not
+      #     an XSS. `text/html` is excluded too: an HTML body under `text/html` is simply correct;
+      #   * `nosniff` is ABSENT. `X-Content-Type-Options: nosniff` is precisely the switch that
+      #     tells the browser to honour the declared type and never sniff — with it present the
+      #     body is rendered as text/downloaded and there is no path to execution, so firing
+      #     would be a pure false positive. (SecurityHeaders separately flags the header's absence
+      #     as a hardening gap; this rule only cares that its absence turns a sniffable body into
+      #     a live one.)
+      #
+      #   Together they describe the classic MIME-sniffing XSS: an upload/echo endpoint that
+      #   stores attacker markup and serves it back as `text/plain`, which IE/legacy sniffers —
+      #   and, for `application/octet-stream` downloads opened in-page, still today's — will
+      #   happily execute in the site's origin.
+      #
+      # Case 2 — `mime_json_as_html`: the body is real JSON but the response claims `text/html`.
+      # The browser then parses an API payload as a document: any value echoing user input that
+      # contains markup is rendered, not escaped, which is a stored/reflected XSS with no need
+      # for sniffing at all. The label is wrong regardless, which is why this is reported even
+      # when nosniff IS present — nosniff enforces the declared type, and here the declared type
+      # is the dangerous one.
+      #
+      #   The FP guard is that the body must ACTUALLY PARSE as JSON, not merely open with a brace.
+      #   A genuine HTML page can start with `{` (a templating artefact, a stray `{{ }}` mustache,
+      #   a CSS-ish preamble), and a prefix test alone flagged those. Requiring `JSON.parse` to
+      #   succeed makes the check exact: only a document that a JSON consumer would accept counts.
+      #   The parse runs inside a rescue (malformed input IS the payload here), and it is reached
+      #   only for the small slice of traffic that both declares text/html and opens with `{`/`[`,
+      #   so the tree build is not on the general passive path. Note the body text is capped
+      #   (Context::BODY_CAP), so a JSON document larger than the cap parses as truncated and does
+      #   NOT fire — a deliberate miss rather than a guess.
+      #
+      # Byte-safety: `ctx.body_text` arrives already content-decoded, capped and `.scrub`bed, so
+      # every test here is a plain String operation — no PCRE over raw bytes.
+      class MimeConfusion < Rule
+        def info : RuleInfo
+          RuleInfo.new("mime_confusion", "MIME type confusion",
+            "Flags responses whose body type disagrees with the Content-Type in a way that enables MIME-sniffing XSS (HTML body under a sniffable type without nosniff; JSON served as text/html).",
+            Category::HEADERS)
+        end
+
+        # How much of the (whitespace/BOM-trimmed) body is examined for the HTML sniff. Browsers
+        # decide on a short leading window; a `<script` further in than this is a page's content,
+        # not its shape.
+        SNIFF_PREFIX = 512
+
+        # Leading markers that make a body unambiguously an HTML/script document. Kept tight and
+        # HTML-specific on purpose — this list IS the false-positive budget for case 1.
+        HTML_STARTS = ["<!doctype html", "<html", "<head", "<body", "<script", "<svg"]
+
+        # The declared media types a browser will content-sniff into HTML. Deliberately excludes
+        # every `application/*` type except octet-stream, and excludes text/html itself.
+        SNIFFABLE_TYPES = ["text/plain", "application/octet-stream"]
+
+        def check(ctx : Context, acc : Array(Detection)) : Nil
+          return unless resp = ctx.response
+          # Render-context gate, mirroring SecurityHeaders#rendered_document?: a 3xx redirect body
+          # is discarded (the UA follows the Location) and a 204 carries none, so a mis-served body
+          # on those statuses is never rendered — there is no sniffing/execution path, and firing
+          # would be a false positive. A 4xx/5xx error page IS rendered, so it keeps the checks.
+          return unless rendered_document?(resp.status)
+          body = ctx.body_text
+          return if body.nil? || body.empty?
+
+          # One trimmed view shared by both cases: leading whitespace and a UTF-8 BOM removed, so
+          # a body that merely starts with a newline or a BOM is judged on its first real byte.
+          trimmed = body.lstrip { |c| c.whitespace? || c == '\uFEFF' }
+          return if trimmed.empty?
+          head_low = trimmed[0, {trimmed.size, SNIFF_PREFIX}.min].downcase
+
+          ct = ctx.ct_low
+
+          # --- case 2: JSON body under text/html -------------------------------------------
+          if ct && ct.includes?("text/html") && json_body?(trimmed)
+            acc << det(ctx, "mime_json_as_html", "JSON body served as text/html",
+              Store::Severity::Low, "declared #{ct}")
+          end
+
+          # --- case 1: sniffable HTML body -------------------------------------------------
+          # The two cases are mutually exclusive by construction (case 2 needs text/html, which
+          # sniffable_type? rejects), but each is applied independently so neither depends on
+          # the other's gate staying as it is.
+          if html_body?(head_low) && sniffable_type?(ct) && !nosniff?(resp)
+            evidence = ct.nil? ? "no Content-Type; body is HTML" : "declared #{ct}; body is HTML"
+            acc << det(ctx, "mime_sniff_html", "Sniffable content served under a non-HTML type",
+              Store::Severity::Low, evidence)
+          end
+        end
+
+        # A 3xx redirect is never rendered (the UA follows it) and a 204 carries no body, so their
+        # bodies cannot be sniffed or rendered — same render-context gate SecurityHeaders uses for
+        # its document headers. A 4xx/5xx error page IS a rendered document and keeps the checks.
+        private def rendered_document?(status : Int32) : Bool
+          !((300..399).includes?(status) || status == 204)
+        end
+
+        # The body looks like a document a sniffer would commit to HTML: an HTML/script/SVG
+        # opening tag, or a `<script` anywhere in the sniffed prefix.
+        private def html_body?(head_low : String) : Bool
+          return true if HTML_STARTS.any? { |m| head_low.starts_with?(m) }
+          head_low.includes?("<script")
+        end
+
+        # Real JSON, not just a leading brace. The cheap prefix test comes first so the parse is
+        # attempted only for a body that could plausibly be JSON; the parse itself is the actual
+        # decision. A parse failure means "not JSON" — never an error for the caller.
+        private def json_body?(trimmed : String) : Bool
+          return false unless trimmed.starts_with?('{') || trimmed.starts_with?('[')
+          begin
+            JSON.parse(trimmed)
+            true
+          rescue
+            false
+          end
+        end
+
+        # A missing Content-Type, or a declared media type (parameters stripped) browsers sniff.
+        private def sniffable_type?(ct : String?) : Bool
+          return true if ct.nil?
+          semi = ct.index(';')
+          media = (semi ? ct[0...semi] : ct).strip
+          SNIFFABLE_TYPES.includes?(media)
+        end
+
+        # `X-Content-Type-Options: nosniff` present ⇒ the browser honours the declared type and
+        # never sniffs, so case 1 has no path to execution.
+        private def nosniff?(resp : Proxy::Codec::RawResponse) : Bool
+          resp.headers.get?("X-Content-Type-Options").try(&.downcase.strip) == "nosniff"
+        end
+
+        private def det(ctx : Context, code : String, title : String, sev : Store::Severity,
+                        evidence : String? = nil) : Detection
+          Detection.new(code, Category::HEADERS, ctx.host, ctx.url, title, sev, evidence, ctx.fid)
+        end
+      end
+    end
+  end
+end

--- a/src/gori/probe/passive/security_headers.cr
+++ b/src/gori/probe/passive/security_headers.cr
@@ -20,8 +20,9 @@ module Gori
 
         def info : RuleInfo
           RuleInfo.new("security_headers", "Security headers",
-            "Checks for missing or weak HSTS, CSP (incl. report-only-only), X-Frame-Options, " \
-            "X-Content-Type-Options, Referrer-Policy, and Permissions-Policy.",
+            "Checks for missing or weak HSTS, CSP (incl. report-only-only and a missing base-uri), " \
+            "X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy, and " \
+            "Cross-Origin-Opener-Policy.",
             Category::HEADERS)
         end
 
@@ -67,6 +68,22 @@ module Gori
           if csp
             dirs = parse_csp(csp)
             acc << hdr(ctx, "weak_csp", "Weak Content-Security-Policy", Store::Severity::Low, csp[0, 80]) if weak_csp?(dirs)
+            # base-uri is one of the few directives with NO fallback to default-src: omit it and
+            # the document's base URL stays attacker-controllable. An injected `<base href>` (a
+            # single tag, no script execution needed) re-points every RELATIVE script/resource URL
+            # at the attacker's origin, so a carefully allowlisted script-src is walked around
+            # rather than broken. Google's CSP Evaluator flags the same gap. Only asked of the
+            # ENFORCING policy (this branch) — a report-only header blocks nothing, and the
+            # report-only-only case already gets csp_report_only.
+            #
+            # Gated on there being a resource-source allowlist to WALK AROUND — script-src, its
+            # default-src fallback, or object-src. A transport/clickjacking-only policy
+            # (`upgrade-insecure-requests`, `frame-ancestors 'none'`) restricts no script source,
+            # so there is nothing for a rebased relative URL to bypass and base-uri is moot;
+            # firing there would be pure noise (this is also the only context CSP Evaluator flags).
+            if dirs["base-uri"]?.nil? && (dirs.has_key?("script-src") || dirs.has_key?("default-src") || dirs.has_key?("object-src"))
+              acc << hdr(ctx, "csp_missing_base_uri", "CSP without base-uri (base-tag hijacking)", Store::Severity::Low)
+            end
           else
             dirs = nil
             # Report-Only alone does not enforce — flag that specifically instead of a bare
@@ -93,6 +110,16 @@ module Gori
           if h.get?("X-Content-Type-Options").try(&.downcase.strip) != "nosniff"
             acc << hdr(ctx, "missing_x_content_type_options", "Missing X-Content-Type-Options: nosniff", Store::Severity::Low)
           end
+          # Of the three Cross-Origin-* isolation headers, only COOP is worth a standalone
+          # finding. COEP and CORP matter for `crossOriginIsolated` (SharedArrayBuffer, precise
+          # timers) — a capability most sites neither have nor want, so flagging their absence is
+          # pure noise. COOP absence is a real hardening gap on its own: without it a page opened
+          # via window.open / target=_blank keeps a cross-origin `window.opener` reference, which
+          # is the lever for tabnabbing and the browsing-context XS-Leaks. PRESENCE is the whole
+          # test — any value counts, `unsafe-none` included: it is the browser default, so
+          # flagging it would just re-report every unset document under a second code. Info, not
+          # Low: broad hardening, not a directly exploitable defect.
+          acc << hdr(ctx, "missing_coop", "Missing Cross-Origin-Opener-Policy", Store::Severity::Info) if h.get?("Cross-Origin-Opener-Policy").nil?
           check_referrer_policy(ctx, h, acc)
           check_permissions_policy(ctx, h, acc)
         end

--- a/src/gori/store/probe_issues.cr
+++ b/src/gori/store/probe_issues.cr
@@ -110,7 +110,7 @@ module Gori
       "secret_in_body", "error_stack_leak", "secret_in_ws",
       "missing_sri", "jwt_sensitive_claims", "secret_in_url", "exposed_config",
       "cookie_no_secure", "cookie_no_httponly", "cookie_no_samesite",
-      "cookie_samesite_none_insecure", "cookie_prefix_violation",
+      "cookie_samesite_none_insecure", "cookie_prefix_violation", "cookie_broad_domain",
     }
 
     def self.accumulate_evidence?(code : String) : Bool


### PR DESCRIPTION
Adds six lightweight probe checks that fill gaps in the current rule set, chosen to stay within the "light scan" size (five zero-request passive, one single-flow differential active) and tuned for low FP/FN.

## Passive (zero-request)
- **`missing_coop`** (Info) — Cross-Origin-Opener-Policy absent on a rendered HTML document. Consistent with the existing `missing_permissions_policy`/`missing_referrer_policy` Info header notes. COEP/CORP are deliberately not flagged (their standalone absence is noise).
- **`csp_missing_base_uri`** (Low) — an enforcing CSP without a `base-uri` directive (base-tag hijacking; `base-uri` has no `default-src` fallback). Only fires when the policy has a script/`default-src`/`object-src` allowlist to walk around.
- **`jwt_key_injection_header`** (Medium) — a JWT header carrying `jku`/`x5u`/`jwk` (attacker-chosen signing key / SSRF). Decode-only, in line with the rest of the JWT rule.
- **`cookie_broad_domain`** (Info) — a `Set-Cookie` `Domain=` scoped to a strict parent of the request host (shared with sibling subdomains). Suppressed for `__Host-` cookies the browser rejects outright.
- **`mime_confusion`** (new rule) — `mime_sniff_html` / `mime_json_as_html` (Low): a body whose type disagrees with `Content-Type` in a way that enables MIME-sniffing XSS. Gated to rendered documents; requires a real `JSON.parse` for the JSON case and a missing `nosniff` + sniffable declared type for the HTML case.

## Active (single-flow differential, GET-only by default)
- **`error_based_sqli`** (new rule) — `sqli_error_based` (High): appends a quote to each query param and flags a curated, word-bounded DB-error signature present in the probe but absent from **two** clean baselines (stability guard against a self-varying endpoint). Complements the structural, error-message-free `backslash_powered`; the payload is only `'"`, never a signature string, so a match is the database talking.

## Wiring
REMEDIATION + CWE for every new code (`cookie_broad_domain` intentionally unmapped — no CWE fits cleanly), `cookie_broad_domain` registered as accumulating evidence, and the probe rule-enumeration specs updated. Each new rule ships with a dedicated spec.

## Verification
- `crystal build --no-codegen src/main.cr` — clean
- `crystal spec` — 10385 examples, 0 failures
- `crystal tool format --check src spec bench scripts` — clean
- `scripts/bench_check.sh` — 48 harnesses build