### PR TITLE
fix(tui): step the issue form's severity with the arrows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- The NEW / EDIT ISSUE card's severity steps with `←`/`→`, the way every other cycler in the TUI does; `⇥` now moves between the title and the severity row rather than being the only control that changed it (#789).
+
 - The History detail's MESSAGES pane shows a WebSocket frame's shape, as `gori run show` and the Repeater transcript already did: a PING, a PONG, a CLOSE with its code and reason, a message reassembled from several frames, an RSV bit and a client frame sent UNMASKED were all one indistinguishable `«binary Nb»` line in the one place an operator reads while working a socket (#787).
 
 - The two pairs of identically-titled cards say which list they are: Settings' ENVIRONMENT and HOSTNAME OVERRIDES are marked `global`, the Project tab's ENVIRONMENT and HOST OVERRIDES `project` — the global pair is layered under the project one, and neither said so (#787).

--- a/spec/tui/issue_form_spec.cr
+++ b/spec/tui/issue_form_spec.cr
@@ -5,7 +5,7 @@ require "../support/overlay_harness"
 include Gori::Tui
 
 describe Gori::Tui::IssueForm do
-  it "cycles severity (tab) and carries an edit id for re-titling" do
+  it "cycles severity and carries an edit id for re-titling" do
     form = IssueForm.new("GET /x", "acme.test", 7_i64)
     form.severity.should eq(Gori::Store::Severity::Medium) # default
     form.severity_cycle(1)
@@ -70,14 +70,76 @@ describe Gori::Tui::IssueForm do
     form.title.should eq("ISSUE")
   end
 
-  it "cycles severity on tab / shift-tab without touching the title" do
+  # ⇥ used to BE the severity control, which left this the one cycler in the tree the arrows
+  # did not drive. It now picks the row, and ←/→ step whatever row it picked — the model
+  # CustomRuleOverlay, FuzzSetOverlay and PreferencesView all already ran.
+  it "moves the row cursor on tab / shift-tab without touching the title or the severity" do
     h = OverlayHarness.new(IssueForm.new("keep"))
     form = h.overlay.as(IssueForm)
     h.press(Termisu::Input::Key::Tab)
-    form.severity.should eq(Gori::Store::Severity::High)
+    form.sel.should eq(IssueForm::ROW_SEV)
     h.press(Termisu::Input::Key::BackTab)
-    form.severity.should eq(Gori::Store::Severity::Medium)
+    form.sel.should eq(IssueForm::ROW_TITLE)
+    form.severity.should eq(Gori::Store::Severity::Medium) # ⇥ alone changes nothing now
     form.issue_title.should eq("keep")
+  end
+
+  # Two rows, so the cursor wraps: ⇥ off the severity row lands back on the title rather than
+  # sticking at the end of a form this small.
+  it "wraps the row cursor and also moves it with ↑/↓" do
+    h = OverlayHarness.new(IssueForm.new)
+    form = h.overlay.as(IssueForm)
+    h.press(Termisu::Input::Key::Down)
+    form.sel.should eq(IssueForm::ROW_SEV)
+    h.press(Termisu::Input::Key::Tab) # wraps
+    form.sel.should eq(IssueForm::ROW_TITLE)
+    h.press(Termisu::Input::Key::Up) # wraps the other way
+    form.sel.should eq(IssueForm::ROW_SEV)
+  end
+
+  it "steps severity with ←/→ once the row cursor is on it" do
+    h = OverlayHarness.new(IssueForm.new("keep"))
+    form = h.overlay.as(IssueForm)
+    h.press(Termisu::Input::Key::Tab)
+    h.press(Termisu::Input::Key::Right)
+    form.severity.should eq(Gori::Store::Severity::High)
+    h.press(Termisu::Input::Key::Left)
+    h.press(Termisu::Input::Key::Left)
+    form.severity.should eq(Gori::Store::Severity::Low)
+    form.issue_title.should eq("keep") # the caret never moved, and no character was eaten
+  end
+
+  # Clamped, like the Issues list's own `[`/`]` step — a held → parks on CRITICAL instead of
+  # rolling over to INFO on the form that decides how loud the finding reads.
+  it "clamps the severity step at both ends" do
+    h = OverlayHarness.new(IssueForm.new)
+    form = h.overlay.as(IssueForm)
+    h.press(Termisu::Input::Key::Tab)
+    5.times { h.press(Termisu::Input::Key::Right) }
+    form.severity.should eq(Gori::Store::Severity::Critical)
+    9.times { h.press(Termisu::Input::Key::Left) }
+    form.severity.should eq(Gori::Store::Severity::Info)
+  end
+
+  # A card opened to be typed into must not swallow the first characters because the cursor
+  # is parked on a cycler that has no use for them. Same rule FuzzSetOverlay's Type row runs.
+  it "pulls the row cursor back to the title when a character is typed on the severity row" do
+    h = OverlayHarness.new(IssueForm.new)
+    form = h.overlay.as(IssueForm)
+    h.press(Termisu::Input::Key::Tab)
+    h.type("hi")
+    form.issue_title.should eq("hi")
+    form.sel.should eq(IssueForm::ROW_TITLE)
+    form.severity.should eq(Gori::Store::Severity::Medium) # the letters were not read as steps
+  end
+
+  # The hint strip is the only surface that says what ←/→ do right now, and `hint` is re-read
+  # every frame (Runner#key_hints), so it has to track the row cursor.
+  it "names the keys the focused row actually answers to" do
+    h = OverlayHarness.new(IssueForm.new)
+    h.overlay.hint.should contain("←/→ caret")
+    h.press(Termisu::Input::Key::Tab)
+    h.overlay.hint.should contain("←/→ severity")
   end
 
   it "commits on ↵ and cancels on esc" do
@@ -141,7 +203,7 @@ describe Gori::Tui::IssueForm do
     h.overlay.as(IssueForm).issue_title.should eq("ab!")
   end
 
-  # The severity row draws `severity ‹ MEDIUM ›  (tab to change)`. The chevrons and the hint
+  # The severity row draws `severity ‹ MEDIUM ›  (←/→ to change)`. The chevrons and the hint
   # both promise a step; before this the row was drawn and dead.
   it "steps severity from the row's own chevrons" do
     h = OverlayHarness.new(IssueForm.new)
@@ -150,6 +212,20 @@ describe Gori::Tui::IssueForm do
     form.severity.should eq(Gori::Store::Severity::Low)
     h.click_in_box(2 + IssueForm::SEV_PREFIX.size + form.severity.label.size + 1, IssueForm::SEV_ROW) # the › cell
     form.severity.should eq(Gori::Store::Severity::Medium)
+    form.sel.should eq(IssueForm::ROW_SEV) # the click also aimed the arrows at the row it hit
+  end
+
+  # …and the title row takes the cursor back, so a click-to-place-the-caret is immediately
+  # followed by arrows that MOVE that caret rather than the severity behind it.
+  it "returns the row cursor to the title when the title row is clicked" do
+    h = OverlayHarness.new(IssueForm.new("abcdef"))
+    form = h.overlay.as(IssueForm)
+    h.press(Termisu::Input::Key::Tab)
+    h.click_in_box(13, IssueForm::TITLE_ROW)
+    form.sel.should eq(IssueForm::ROW_TITLE)
+    h.press(Termisu::Input::Key::Left)
+    h.type("X")
+    form.issue_title.should eq("abXcdef")
   end
 
   it "treats a click on the severity label as the forward step its hint advertises" do

--- a/src/gori/tui/issue_form.cr
+++ b/src/gori/tui/issue_form.cr
@@ -22,10 +22,20 @@ module Gori::Tui
     # cell the card never drew there.
     TITLE_PREFIX = "title › "
     SEV_PREFIX   = "severity ‹ "
-    SEV_SUFFIX   = " ›  (tab to change)"
-    TITLE_ROW    = 1
-    SEV_ROW      = 3
-    CARD_H       = 6
+    SEV_SUFFIX   = " ›  (←/→ to change)"
+    # The same row unfocused: the chevrons still mark it as a cycler, but the keys that step
+    # it belong to the OTHER row right now, so the hint names the way back instead.
+    SEV_SUFFIX_BLUR = " ›  (⇥ to focus)"
+    TITLE_ROW       = 1
+    SEV_ROW         = 3
+    CARD_H          = 6
+
+    # Row cursor. Two rows, so ⇥/⇧⇥ and ↑/↓ simply wrap between them — the same row model
+    # every other form in the tree runs (CustomRuleOverlay, FuzzSetOverlay, the rule cards):
+    # ⇥ picks the field, ←/→ adjust the field it picked.
+    ROW_TITLE = 0
+    ROW_SEV   = 1
+    ROW_COUNT = 2
 
     getter issue_title : String
     getter host : String?
@@ -33,6 +43,8 @@ module Gori::Tui
     getter severity : Store::Severity
     getter edit_id : Int64?
     getter link_ref : {Store::LinkRefKind, Int64}?
+    # Which row the arrows act on — ROW_TITLE (caret) or ROW_SEV (the cycler).
+    getter sel : Int32
     # Additional flows to attach as evidence beyond `flow_id` — History's multi-select
     # (#442): mark 5 flows, ⇧F, and the ONE issue you create carries all five. Captured here
     # for the same reason as `link_ref`: cancelling the form drops the pending attachments
@@ -53,6 +65,9 @@ module Gori::Tui
                    @notes : String = "")
       @cx = @issue_title.size
       @preedit = ""
+      # Opens on the title: it is the field the form exists to fill, and the one every
+      # open-site pre-seeds a draft into.
+      @sel = ROW_TITLE
     end
 
     # --- Overlay contract (see overlay.cr) ---
@@ -66,27 +81,44 @@ module Gori::Tui
       "ISSUE"
     end
 
+    # Row-aware, because the arrows do different work on each row and the strip is the only
+    # place that says so. Re-read every frame (Runner#key_hints), so it tracks ⇥.
     def hint : String
-      "type title · ↵ create · esc cancel"
+      if @sel == ROW_SEV
+        "←/→ severity · ⇥ title · ↵ create · esc cancel"
+      else
+        "type title · ←/→ caret · ⇥ severity · ↵ create · esc cancel"
+      end
     end
 
-    # ↵ commits, esc cancels, Tab/Shift-Tab cycle severity, ←/→ move the title caret, and
-    # every other printable is inserted.
+    # ↵ commits, esc cancels, ⇥/⇧⇥ and ↑/↓ pick the row, ←/→ act on it (title caret or
+    # severity step), and every other printable is inserted.
+    #
+    # Severity used to be bound to ⇥ ALONE, which made this the one cycler in the tree the
+    # arrows did not drive — an operator who learned ←/→ on the rule cards, the fuzz-set
+    # form or the preferences rows found it dead here, with only the row's own hint to say
+    # so. ⇥ now means what it means everywhere else: move to the next field.
     def handle_key(ev : Termisu::Event::Key) : Symbol
       key = ev.key
       # Not `ev.char || key.to_char`, which the pre-seam handler wrote: Termisu's
       # `Event::Key#char` IS `@char || key.to_char`, so the second half could never run.
       c = ev.char
       case
-      when key.escape?    then return :cancel
-      when key.enter?     then return :commit
-      when key.tab?       then severity_cycle(1)
-      when key.back_tab?  then severity_cycle(-1)
-      when key.left?      then move(-1)
-      when key.right?     then move(1)
-      when key.backspace? then backspace
+      when key.escape?            then return :cancel
+      when key.enter?             then return :commit
+      when key.tab?, key.down?    then move_row(1)
+      when key.back_tab?, key.up? then move_row(-1)
+      when key.left?              then step(-1)
+      when key.right?             then step(1)
+      when key.backspace?         then focus_title; backspace
       else
         if c && !ev.ctrl? && !ev.alt?
+          # Text belongs to the title wherever the row cursor happens to sit: typing on the
+          # severity row would otherwise be swallowed by a cycler that has no use for it, and
+          # this card is opened to be TYPED INTO. Pulling focus with the character keeps what
+          # is drawn (the caret) and where the character lands the same cell. FuzzSetOverlay's
+          # Type row does the same thing for the same reason.
+          focus_title
           insert(c)
           set_preedit("") # commit any preedit
         end
@@ -94,7 +126,7 @@ module Gori::Tui
       :stay
     end
 
-    # This was inert on purpose, carrying the pre-seam shell's lack of a click arm forward and
+    # Inert on purpose, carrying the pre-seam shell's lack of a click arm forward and
     # naming caret placement as the follow-up. It is the follow-up. Inert made this the ONE
     # modal in the tree a click-away could not dismiss — the base `Overlay#handle_click` gives
     # every other one that, and `PickerOverlay` repeats it for the seven pickers — so an
@@ -104,16 +136,19 @@ module Gori::Tui
     # Inside the card, the two rows the draw makes look interactive now are:
     #   · the title row → place the caret at the pointer (the same inverse `TextField` uses)
     #   · the DRAWN span of the severity row → step the cycler, `‹` back and the rest forward,
-    #     which is what the chevrons and the row's own "(tab to change)" already promise
+    #     which is what the chevrons and the row's own hint already promise
+    # Either one also takes the row cursor with it, so the arrows land on the row just clicked.
     # Anything else inside — including the empty tail of the severity row past its label — is
     # swallowed, so it neither leaks to the pane underneath nor makes dead cells do something.
     def handle_click(area : Rect, mx : Int32, my : Int32) : Symbol
       box = overlay_box(area)
       return :cancel if box.nil? || !box.contains?(mx, my)
       if my == box.y + TITLE_ROW
+        focus_title
         @cx = Screen.column_for_click(@issue_title, mx - title_base(box)) # already clamped to the string
         @preedit = ""                                                     # a caret move ends any in-progress composition, as `insert` does
       elsif my == box.y + SEV_ROW && (lo = sev_back_x(box)) && mx >= lo && mx <= sev_forward_end(box)
+        @sel = ROW_SEV
         severity_cycle(mx == lo ? -1 : 1)
       end
       :stay
@@ -125,7 +160,22 @@ module Gori::Tui
     def handle_wheel(step : Int32) : Nil
     end
 
-    # Tab / Shift-Tab cycle severity (left/right stay title-cursor moves).
+    # ←/→ on the row the cursor sits on: the cycler, or the title caret.
+    def step(delta : Int32) : Nil
+      @sel == ROW_SEV ? severity_cycle(delta) : move(delta)
+    end
+
+    # ⇥/⇧⇥/↑/↓. Wraps, since there are only the two rows and a cursor that stuck at either
+    # end would need the OTHER key to come back from a form this small.
+    def move_row(delta : Int32) : Nil
+      @sel = (@sel + delta) % ROW_COUNT
+      # A composition in flight is aimed at the title; leaving the row drops it rather than
+      # letting it hang underlined on a field the keys no longer feed.
+      @preedit = "" unless @sel == ROW_TITLE
+    end
+
+    # Clamped, not wrapped — the same step the Issues list's hidden `[`/`]` chords take
+    # (IssuesView#severity_delta), so a held → parks on CRITICAL instead of rolling over to INFO.
     def severity_cycle(delta : Int32) : Nil
       @severity = Store::Severity.new((@severity.value + delta).clamp(0, 4))
     end
@@ -147,9 +197,15 @@ module Gori::Tui
     end
 
     # IME composing text, drawn (underlined) at the caret without touching the
-    # committed title — same model as TextArea. Cleared when a char commits.
+    # committed title — same model as TextArea. Cleared when a char commits. A composition
+    # is text, so it takes the row cursor to the title for the same reason a printable does.
     def set_preedit(text : String) : Nil
+      focus_title unless text.empty?
       @preedit = text
+    end
+
+    private def focus_title : Nil
+      @sel = ROW_TITLE
     end
 
     # The card `render` draws — extracted from it so the click-away hit test and the draw are
@@ -165,13 +221,29 @@ module Gori::Tui
       box = overlay_box(area)
       return unless box
       w = box.w
+      on_title = @sel == ROW_TITLE
       Frame.card(screen, box, @heading, border: Theme.border_focus)
-      screen.text(box.x + 2, box.y + TITLE_ROW, TITLE_PREFIX, Theme.accent, Theme.panel)
-      screen.input_line(title_base(box), box.y + TITLE_ROW, @issue_title, @cx, @preedit,
-        Theme.text_bright, Theme.panel, width: w - TITLE_PREFIX.size - 4)
-      sx = screen.text(box.x + 2, box.y + SEV_ROW, SEV_PREFIX, Theme.accent, Theme.panel)
+      # The `▎` gutter mark every other row-form in the tree draws on its selected row. Here it
+      # carries the whole cue on the severity row, which has no caret of its own to show focus.
+      screen.cell(box.x + 1, box.y + (on_title ? TITLE_ROW : SEV_ROW), '▎', Theme.accent, Theme.panel)
+
+      screen.text(box.x + 2, box.y + TITLE_ROW, TITLE_PREFIX, on_title ? Theme.accent : Theme.muted, Theme.panel)
+      tw = w - TITLE_PREFIX.size - 4
+      if on_title
+        screen.input_line(title_base(box), box.y + TITLE_ROW, @issue_title, @cx, @preedit,
+          Theme.text_bright, Theme.panel, width: tw)
+      else
+        # No caret while the arrows belong to the other row: a block caret that no keypress
+        # moves is the same lie as a dead chevron, pointed the other way.
+        screen.text(title_base(box), box.y + TITLE_ROW, @issue_title, Theme.text, Theme.panel, width: {tw, 0}.max)
+      end
+
+      sx = screen.text(box.x + 2, box.y + SEV_ROW, SEV_PREFIX, on_title ? Theme.muted : Theme.accent, Theme.panel)
       sx = screen.text(sx, box.y + SEV_ROW, @severity.label.upcase, sev_color(@severity), Theme.panel, Attribute::Bold)
-      screen.text(sx, box.y + SEV_ROW, SEV_SUFFIX, Theme.muted, Theme.panel)
+      # Width-clipped, unlike the two draws above it: this is the row's longest run and the
+      # card narrows with the terminal, so an unclipped write would spill past the border.
+      screen.text(sx, box.y + SEV_ROW, on_title ? SEV_SUFFIX_BLUR : SEV_SUFFIX, Theme.muted, Theme.panel,
+        width: {box.right - 1 - sx, 0}.max)
     end
 
     # Content column the title text starts at — `screen.text`'s own advance over the prefix,
@@ -182,15 +254,15 @@ module Gori::Tui
 
     # The `‹` cell on the severity row, measured off SEV_PREFIX itself rather than re-typed —
     # the only cell that steps BACKWARD, everything from there to `sev_forward_end` reads as the
-    # forward step the label's own "(tab to change)" names.
+    # forward step the row's own hint names.
     private def sev_back_x(box : Rect) : Int32
       i = SEV_PREFIX.index('‹') || 0
       box.x + 2 + Screen.draw_width(SEV_PREFIX[0, i])
     end
 
     # Last cell of the interactive span: the closing `›`, one column past the label, which is
-    # where `render`'s third `screen.text` puts it (SEV_SUFFIX opens with a space). The cells
-    # after it hold the "(tab to change)" hint and then nothing — a click there must be inert.
+    # where `render`'s third `screen.text` puts it (both suffixes open with a space). The cells
+    # after it hold the row's key hint and then nothing — a click there must be inert.
     private def sev_forward_end(box : Rect) : Int32
       box.x + 2 + Screen.draw_width(SEV_PREFIX) + Screen.draw_width(@severity.label.upcase) + 1
     end


### PR DESCRIPTION
## What

The NEW / EDIT ISSUE card bound its severity cycler to `Tab` alone. That made it the one cycler in the tree the arrows did not drive — an operator who learned `←`/`→` on the Colormarker/Rewriter/custom-rule cards, the fuzz-set form or the Preferences rows found them dead here, with only the row's own `(tab to change)` hint to say otherwise.

The card now runs the same row model every other form in the tree already does:

- `Tab` / `Shift-Tab` and `↑` / `↓` pick the row (two rows, so it wraps).
- `←` / `→` act on the row they picked: the title caret, or the severity step.
- The severity step stays **clamped** at INFO and CRITICAL, matching `IssuesView#severity_delta` — the hidden `[` / `]` chords on the Issues list — rather than wrapping. A held `→` on the form that decides how loud a finding reads should park on CRITICAL, not roll over to INFO.

```
╭─ NEW ISSUE ──────────────────────────────╮      ╭─ NEW ISSUE ──────────────────────────────╮
│▎title › SQLi on /login                   │      │ title › SQLi on /login                   │
│                                          │  ⇥→  │                                          │
│ severity ‹ MEDIUM ›  (⇥ to focus)        │      │▎severity ‹ HIGH ›  (←/→ to change)       │
╰──────────────────────────────────────────╯      ╰──────────────────────────────────────────╯
```

## Two decisions worth naming

**Text always belongs to the title, wherever the row cursor sits.** A printable (or an IME composition) typed on the severity row pulls the cursor back to the title and lands there. This card is opened *to be typed into* — several open-sites pre-seed a draft — and a cycler silently eating the first characters of a finding's title is a worse failure than a slightly surprising focus jump. `FuzzSetOverlay#handle_type_row` already does exactly this, for exactly this reason.

**The caret is drawn only while the arrows move it.** With the cursor on the severity row the title renders without its block caret, and the focused row carries the `▎` gutter mark the other row-forms draw. A caret that no keypress moves is the same lie as a dead chevron, pointed the other way — and the severity row has no caret of its own to show focus with, so it needed the mark.

Both the row's own trailing hint (`(⇥ to focus)` ↔ `(←/→ to change)`) and the shell's hint strip (`hint` is re-read every frame by `Runner#key_hints`) are row-aware, so the keys under the operator's fingers are always named. The row's longest run is now width-clipped against the card border; the previous unclipped write would spill on a narrow terminal.

Clicks are unchanged in what they do, and additionally take the row cursor with them — click to place the caret and the arrows move *that* caret, not the severity behind it. The documented inert span (the `severity` label text, the tail past the closing `›`) stays inert.

## Testing

- `spec/tui/issue_form_spec.cr`: the example that pinned `Tab` as the severity control now pins it as a row move; new coverage for the arrow step, the clamp at both ends, row wrapping via `Tab`/`↑`/`↓`, typing on the severity row, the row-aware hint, and the click-to-focus on both rows. 27 examples in that file, `spec/tui` 3266, all green.
- `crystal spec`: 10394 examples, 8 failures — the known sandbox TCP-bind failures in `project_registry_spec.cr` / `capture_status_spec.cr`, which are pre-existing and touch nothing in this diff.
- `crystal tool format --check src spec bench scripts`, ameba, and `scripts/bench_check.sh` clean.
