### PR TITLE
fix(rewriter): stop header ops from eating a bare-LF neighbour, anchor the host glob

### DIFF
--- a/spec/rules_spec.cr
+++ b/spec/rules_spec.cr
@@ -75,6 +75,14 @@ describe Gori::Rules do
       Gori::Rules.host_matches?("*example.com", "notexample.com").should be_true
     end
 
+    it "anchors the wildcard at the ABSOLUTE end, so a trailing newline is not a match" do
+      # `$` in PCRE2 also matches just before a final newline, and a host is not always a
+      # parsed name: an h2 `:authority` is peer-controlled HPACK bytes. `\z` is what makes
+      # this test mean "the whole host", the way the DNS-label branch already does.
+      Gori::Rules.host_matches?("*.example.com", "api.example.com\n").should be_false
+      Gori::Rules.host_matches?("*.example.com", "api.example.com").should be_true
+    end
+
     it "handles a leading-dot glob and a bracketed IPv6 literal (the store's host spelling)" do
       Gori::Rules.host_matches?(".example.com", "api.example.com").should be_true
       Gori::Rules.host_matches?(".example.com", "example.com").should be_false
@@ -219,6 +227,52 @@ describe Gori::Rules do
       out.should contain("User-Agent: gori") # value replaced, original name casing kept
       out.should_not contain("Cookie:")      # removed
       out.should contain("Host: a")          # untouched
+    end
+  end
+
+  # A head is SUPPOSED to be CRLF the whole way down, but a bare-LF header line is exactly the
+  # shape a smuggling probe puts on the wire — and gori is the tool an operator points at one.
+  # The three header ops used to split the head on ONE spelling (`eol_of`, answered for the
+  # whole head), so a single bare-LF break made them read two headers as one line.
+  it "treats a bare-LF header line as its own line, in every header op" do
+    with_store do |store|
+      rules = Gori::Rules.load(store)
+      rules.add(Gori::Store::RuleTarget::Request, Gori::Store::RulePart::Head,
+        "Host", "", op: Gori::Store::RuleOp::RemoveHeader)
+      mixed = "GET / HTTP/1.1\r\nHost: a\nX-Keep: 1\r\n\r\n".to_slice
+      # `X-Keep` used to go with it: the two were one "line" after a CRLF split.
+      String.new(rules.rewrite_request(mixed, "")).should eq("GET / HTTP/1.1\r\nX-Keep: 1\r\n\r\n")
+    end
+
+    with_store do |store|
+      rules = Gori::Rules.load(store)
+      rules.add(Gori::Store::RuleTarget::Request, Gori::Store::RulePart::Head,
+        "Host", "z", op: Gori::Store::RuleOp::SetHeader)
+      mixed = "GET / HTTP/1.1\r\nHost: a\nX-Keep: 1\r\n\r\n".to_slice
+      # …and `set_header` overwrote it out of existence, which is worse: nothing says it went.
+      # Each line keeps the terminator it arrived with (P7).
+      String.new(rules.rewrite_request(mixed, "")).should eq("GET / HTTP/1.1\r\nHost: z\nX-Keep: 1\r\n\r\n")
+    end
+  end
+
+  # `add_header` located the blank line with `rindex(eol + eol)`, one spelling for the whole
+  # head, so a head terminated `\n\n` with a CRLF anywhere above it had the new header appended
+  # AFTER the terminator — into the BODY, where an origin never reads it as a header at all.
+  it "puts an added header before the blank line whichever way the terminator is spelled" do
+    with_store do |store|
+      rules = Gori::Rules.load(store)
+      rules.add(Gori::Store::RuleTarget::Request, Gori::Store::RulePart::Head,
+        "X-Trace", "on", op: Gori::Store::RuleOp::AddHeader)
+      String.new(rules.rewrite_request("GET / HTTP/1.1\r\nHost: a\n\n".to_slice, ""))
+        .should eq("GET / HTTP/1.1\r\nHost: a\nX-Trace: on\r\n\n")
+      String.new(rules.rewrite_request("GET / HTTP/1.1\r\nHost: a\r\n\r\n".to_slice, ""))
+        .should eq("GET / HTTP/1.1\r\nHost: a\r\nX-Trace: on\r\n\r\n")
+      String.new(rules.rewrite_request("GET / HTTP/1.1\nHost: a\n\n".to_slice, ""))
+        .should eq("GET / HTTP/1.1\nHost: a\nX-Trace: on\n\n")
+      # A head with no terminator at all — what the preview seam hands `apply` after
+      # `split_message` has taken the blank line off. Trailing bare LF, CRLF above it.
+      rules.transform_message("GET / HTTP/1.1\r\nHost: a\n", Gori::Store::RuleTarget::Request, "")
+        .should eq("GET / HTTP/1.1\r\nHost: a\nX-Trace: on\r\n")
     end
   end
 

--- a/spec/tui/rewriter_rule_overlay_spec.cr
+++ b/spec/tui/rewriter_rule_overlay_spec.cr
@@ -62,6 +62,21 @@ describe Gori::Tui::RewriterRuleOverlay do
     ov.valid?.should be_true # "()" compiles
   end
 
+  # `replacement` has always kept its spaces ("a header value or a replacement may legitimately
+  # contain them"); `pattern` stripped them, and for every op but the header three that field is
+  # BYTES the rule matches against. `gori run rewriter add` and the MCP `create_rule` do not
+  # strip, so opening such a rule here and saving any other field silently changed what it
+  # matched.
+  it "keeps a replace pattern's whitespace verbatim, and strips only a header NAME" do
+    rule = Gori::Store::MatchRule.new(1_i64, true, Gori::Store::RuleTarget::Request,
+      Gori::Store::RulePart::Body, " token ", "x")
+    RewriterRuleOverlay.editing(rule).pattern.should eq(" token ")
+
+    named = Gori::Store::MatchRule.new(2_i64, true, Gori::Store::RuleTarget::Request,
+      Gori::Store::RulePart::Head, " X-Trace ", "on", Gori::Store::RuleOp::AddHeader)
+    RewriterRuleOverlay.editing(named).pattern.should eq("X-Trace")
+  end
+
   it "seeds edit mode from an existing rule" do
     rule = Gori::Store::MatchRule.new(7_i64, true, Gori::Store::RuleTarget::Response,
       Gori::Store::RulePart::Body, "old", "new",

--- a/src/gori/rules.cr
+++ b/src/gori/rules.cr
@@ -926,54 +926,93 @@ module Gori
       "#{items[0..-2].join(", ")} and #{items[-1]}"
     end
 
-    # The line terminator a head uses — CRLF for real HTTP, LF as a fallback so a
-    # hand-authored / test head still round-trips.
+    # The EOL to give a header line this code ADDS — CRLF for real HTTP, LF as a fallback so
+    # a hand-authored / test head still round-trips. It answers for the head as a WHOLE, which
+    # is all a new line needs; existing lines keep whatever spelling they arrived with, which
+    # is `head_lines`' job.
     private def eol_of(text : String) : String
       text.includes?("\r\n") ? "\r\n" : "\n"
     end
 
-    # Append `Name: value` as the LAST header, just before the terminating blank line
-    # (preserving the head's own EOL). If the head has no blank-line terminator, append.
+    # `head` split at its LINE breaks, every line still carrying its own trailing `\r` when it
+    # had one. The last element is the remainder after the final newline (usually ""), not a
+    # line.
+    #
+    # Splitting on LF and keeping the CR is the whole point. A head is SUPPOSED to be CRLF the
+    # whole way down, but a bare-LF header line is exactly the shape a request-smuggling probe
+    # puts on the wire — and gori is the tool an operator points at those. The three ops below
+    # used to split on `eol_of`, one answer for the whole head, so a single bare-LF break made
+    # them read two headers as one "line":
+    #
+    #   `GET / HTTP/1.1\r\nHost: a\nX-Keep: 1\r\n\r\n`
+    #     remove_header "Host"  dropped `X-Keep: 1` with it
+    #     set_header    "Host"  overwrote `X-Keep: 1` out of existence
+    #
+    # …and a head whose terminator was `\n\n` while a CRLF appeared earlier had
+    # `add_header`'s `rindex("\r\n\r\n")` miss, so the new header was appended AFTER the blank
+    # line — into the BODY, where the origin never reads it as a header at all. All three are
+    # silent: the operator sees a rule that "ran" and a header that is gone, or absent.
+    private def head_lines(head : String) : Array(String)
+      head.split('\n')
+    end
+
+    # Whether a `head_lines` entry is a BLANK line: empty, or the lone `\r` such an entry keeps
+    # when the head is CRLF-delimited. Everything else below reads the entry as-is — a `:` and
+    # the field name in front of it both sit before the trailing CR, so nothing has to chomp it
+    # off (and allocate a second String per header line on a per-message path) to find them.
+    private def blank_line?(line : String) : Bool
+      line.empty? || line == "\r"
+    end
+
+    # Where the blank line that TERMINATES the head sits in `head_lines`, or nil when the head
+    # carries none — the preview path splits the separator off (`split_message`) and a
+    # hand-authored sample may simply not have one. Index 0 is the start line and the trailing
+    # element is the remainder after the last newline, so neither is a candidate.
+    private def terminator_index(lines : Array(String)) : Int32?
+      (1...lines.size - 1).find { |i| blank_line?(lines[i]) }
+    end
+
+    # Append `Name: value` as the LAST header, just before the terminating blank line. If the
+    # head has no blank-line terminator, append at the end.
     private def head_add_header(head : String, name : String, value : String) : String
       eol = eol_of(head)
       line = "#{name}: #{value}"
-      term = eol + eol
-      if idx = head.rindex(term)
-        "#{head[0, idx]}#{eol}#{line}#{head[idx..]}"
-      elsif head.ends_with?(eol)
+      lines = head_lines(head)
+      if i = terminator_index(lines)
+        lines.insert(i, eol == "\r\n" ? "#{line}\r" : line)
+        lines.join('\n')
+      elsif head.ends_with?('\n')
         "#{head}#{line}#{eol}"
       else
         "#{head}#{eol}#{line}"
       end
     end
 
-    # Replace the value of every header named `name` (case-insensitive, original casing
-    # kept); if none exists, append it (upsert). The start line and blank line are left
-    # untouched.
+    # Replace the value of every header named `name` (case-insensitive, original casing and
+    # the line's own terminator kept); if none exists, append it (upsert). The start line and
+    # blank lines are left untouched.
     private def head_set_header(head : String, name : String, value : String) : String
-      eol = eol_of(head)
       target = name.downcase
       found = false
-      out = head.split(eol).map_with_index do |ln, i|
-        next ln if i == 0 || ln.empty?
+      out = head_lines(head).map_with_index do |ln, i|
+        next ln if i == 0 || blank_line?(ln)
         if (ci = ln.index(':')) && ln[0, ci].strip.downcase == target
           found = true
-          "#{ln[0, ci]}: #{value}"
+          ln.ends_with?('\r') ? "#{ln[0, ci]}: #{value}\r" : "#{ln[0, ci]}: #{value}"
         else
           ln
         end
       end
-      found ? out.join(eol) : head_add_header(head, name, value)
+      found ? out.join('\n') : head_add_header(head, name, value)
     end
 
     # Drop every header line named `name` (case-insensitive). The start line (index 0)
     # and any blank lines are always kept, so the head stays well-formed.
     private def head_remove_header(head : String, name : String) : String
-      eol = eol_of(head)
       target = name.downcase
       kept = [] of String
-      head.split(eol).each_with_index do |ln, i|
-        if i == 0 || ln.empty?
+      head_lines(head).each_with_index do |ln, i|
+        if i == 0 || blank_line?(ln)
           kept << ln
         elsif (ci = ln.index(':')) && ln[0, ci].strip.downcase == target
           # drop this header
@@ -981,7 +1020,7 @@ module Gori
           kept << ln
         end
       end
-      kept.join(eol)
+      kept.join('\n')
     end
 
     private def host_matches?(glob : String, host : String) : Bool
@@ -1006,7 +1045,11 @@ module Gori
         # runs on the hot path for EVERY request/response head while any head rule is active
         # (including messages the rule doesn't target — the scope test is what decides that),
         # so an uncached Regex.new here was a PCRE2 compile per message. SafeRegexp memoises.
-        rx = "^#{Regex.escape(g).gsub("\\*", ".*")}$"
+        # `\A`/`\z`, not `^`/`$`: PCRE2's `$` also matches just BEFORE a trailing newline, so
+        # a host carrying one — an `:authority` is peer-controlled HPACK bytes, not a parsed
+        # name — satisfied a glob it does not equal. The absolute anchors are what make this
+        # test mean "the whole host", the way the DNS-label branch below already does.
+        rx = "\\A#{Regex.escape(g).gsub("\\*", ".*")}\\z"
         begin
           SafeRegexp.compile(rx).matches?(h)
         rescue

--- a/src/gori/tui/controllers/rewriter_controller.cr
+++ b/src/gori/tui/controllers/rewriter_controller.cr
@@ -594,8 +594,16 @@ module Gori::Tui
       @out.select_line
     end
 
+    # Both panes, for the same reason `rewriter_selection_active?` answers for both: the verb
+    # that calls this is gated on THAT predicate, so a ⇧arrow band built in the INPUT editor
+    # made "Clear selection" appear in the menu and then do nothing — the one gesture that
+    # offers itself and refuses.
     def rewriter_clear_selection : Nil
-      @out.clear_selection
+      return unless @sub == :rules
+      case @focus
+      when :preview_in  then @preview_input.clear_selection
+      when :preview_out then @out.clear_selection
+      end
     end
 
     # `y`: the selection, or the whole transformed sample when nothing is selected. The pane is

--- a/src/gori/tui/rewriter_rule_overlay.cr
+++ b/src/gori/tui/rewriter_rule_overlay.cr
@@ -126,8 +126,17 @@ module Gori::Tui
       @fields[:host].value.strip
     end
 
+    # The find pattern — or, for a header op, the header NAME.
+    #
+    # Stripped only for the NAME case: ` X-Trace ` and `X-Trace` name one header and the
+    # spaces could only ever be a typo. Every other op matches this field against BYTES, so it
+    # is kept verbatim, exactly as `replacement` below is. A `replace` rule finding `" token "`
+    # or a regex anchored on a trailing space is an ordinary thing to write — and `gori run
+    # rewriter add` / the MCP `create_rule` do not strip, so opening such a rule HERE and
+    # saving any other field silently changed which bytes it matched.
     def pattern : String
-      @fields[:pattern].value.strip
+      raw = @fields[:pattern].value
+      header_op? ? raw.strip : raw
     end
 
     # The replacement / header value keeps interior + trailing spaces (a header value or


### PR DESCRIPTION
Four defects found reviewing the Rewriter. Each was reproduced with a failing test before it was fixed, and each keeps a regression spec.

## 1. Header ops split a head on ONE line-ending spelling

`eol_of` answers `\r\n` or `\n` for the **whole head**, and all three header ops split on that answer. A single bare-LF break — exactly the shape a request-smuggling probe puts on the wire, which is the traffic gori is pointed at — then made them read two headers as one "line".

On `GET / HTTP/1.1\r\nHost: a\nX-Keep: 1\r\n\r\n`:

| op | before |
|---|---|
| `remove_header "Host"` | dropped `X-Keep: 1` with it |
| `set_header "Host"` | overwrote `X-Keep: 1` out of existence, silently |

…and `add_header` located the terminator with `rindex(eol + eol)`, so a head terminated `\n\n` with a CRLF anywhere above it had the new header appended **after** the blank line — into the BODY, where an origin never reads it as a header at all. A head ending in a bare LF got a spurious blank line inserted ahead of it for the same reason.

Heads now split on LF with every line still carrying its own `\r`, so each line round-trips with the terminator it arrived with (P7). `blank_line?` reads an entry as-is rather than chomping — a `:` and the field name in front of it both sit before the trailing CR, so nothing allocates a second String per header line on a per-message path.

## 2. `Rules.host_matches?` did not anchor its wildcard at the absolute end

The glob branch compiled `^…$`, and PCRE2's `$` also matches just **before** a trailing newline. An h2 `:authority` is peer-controlled HPACK bytes, not a parsed name, so `*.example.com` matched `"api.example.com\n"`. `\A`/`\z` is what makes this test mean "the whole host", the way the DNS-label branch beside it already did.

## 3. The TUI rule editor stripped `pattern`

For every op but the header three, `pattern` is BYTES the rule matches against — `replacement` right beside it has always kept its spaces for that reason. `gori run rewriter add` and the MCP `create_rule` do not strip, so opening such a rule in the editor and saving any **other** field silently changed which bytes it matched. Stripped only for the header-NAME case now.

## 4. `rewriter_clear_selection` only cleared the OUTPUT pane

The predicate gating its verb (`rewriter_selection_active?`) answers for the INPUT editor too, so a ⇧arrow band built there offered "Clear selection" in the menu and then did nothing.

## Testing

- `crystal spec` — 10392 examples, 8 failures, all of them the pre-existing `project_registry` / `capture_status` Session port-bind failures that fail identically on the base commit in this sandbox.
- `spec/tui spec/proxy spec/mcp spec/store spec/bindings_spec.cr spec/env_spec.cr` — 4933 examples, 0 failures.
- Rewriter slice (`rules`, `rules/short_circuit`, `proxy/h2/head_rewrite`, `verbs/rewriter`, `cli/run/rewriter`, `settings/rewriter_rules`) — 135 examples, 0 failures.
- `crystal tool format --check src spec bench scripts` clean.

## Noted, not changed

- `Store#match_rules` reads `target`/`part` through `RuleTarget.from_label` / `RulePart.from_label`, which are `parse` and **raise** on an unknown label, while every sibling enum (`RuleOp`, `MatchKind`, `RuleScope`) is tolerant and the settings parser explicitly clamps. A hand-edited DB or a downgrade therefore takes `Rules.merged` down. Left alone because the right disposition — coerce vs. drop — is the same call `impossible_shape?` argues about, and it is a decision rather than a fix.
- `ClientConn#restore_framing_headers` carries the same one-spelling assumption, but `read_head` only ever hands it a CRLFCRLF-terminated head and a bare-LF-merged line is re-emitted verbatim from `orig_framing`, so no defect reproduces there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5qGzSapkuGHyyaiGt3wQm