### PR TITLE
feat(probe): shared insertion-point model for active value-injection rules

### DIFF
--- a/spec/probe/insertion_points_spec.cr
+++ b/spec/probe/insertion_points_spec.cr
@@ -1,0 +1,242 @@
+require "../spec_helper"
+require "../../src/gori/probe/active/insertion_points"
+require "../../src/gori/probe/active/reflected_param"
+require "../../src/gori/probe/active/ssti"
+require "../../src/gori/probe/active/error_based_sqli"
+require "../../src/gori/probe/active/backslash_powered"
+require "../../src/gori/probe/active/lfi_param_traversal"
+
+private alias IP = Gori::Probe::Active::InsertionPoints
+private alias Loc = Gori::Miner::Location
+
+# ── store + flow helpers (copied from probe_spec.cr — this codebase duplicates these per file) ──
+
+private def with_store(&)
+  path = File.tempname("gori-probe", ".db")
+  store = Gori::Store.open(path)
+  begin
+    yield store
+  ensure
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+private def capture_flow(store, resp_head : String, *, scheme = "https", host = "acme.test",
+                         target = "/", status = 200, content_type : String? = "text/html",
+                         body : String? = nil, method = "GET", req_headers = "",
+                         req_body : String? = nil) : Gori::Store::FlowDetail
+  head = String.build do |io|
+    io << method << " " << target << " HTTP/1.1\r\nHost: " << host << "\r\n" << req_headers << "\r\n"
+  end
+  req = Gori::Store::CapturedRequest.new(
+    created_at: 1_000_i64, scheme: scheme, host: host, port: scheme == "https" ? 443 : 80,
+    method: method, target: target, http_version: "HTTP/1.1",
+    head: head.to_slice, body: req_body.try(&.to_slice), source: Gori::FlowSource::Kind::Proxy)
+  id = store.insert_flow(req)
+  store.update_response(Gori::Store::CapturedResponse.new(
+    flow_id: id, status: status, head: resp_head.to_slice, body: body.try(&.to_slice),
+    reason: "OK", content_type: content_type, duration_us: 1_i64))
+  store.get_flow(id).not_nil!
+end
+
+private def resp(body : String, status : Int32 = 200) : Gori::Repeater::Result
+  head = "HTTP/1.1 #{status} X\r\nContent-Type: text/html\r\n\r\n"
+  Gori::Repeater::Result.new(head.to_slice, body.empty? ? Bytes.empty : body.to_slice, nil, 1_i64)
+end
+
+private def unsafe
+  Gori::Probe::Active::Options.new(allow_unsafe: true)
+end
+
+private def aggressive
+  Gori::Probe::Active::Options.new(allow_unsafe: true, aggressive: true)
+end
+
+describe "Gori::Probe::Active::InsertionPoints" do
+  describe ".enumerate" do
+    it "enumerates query params in order" do
+      with_store do |store|
+        d = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/s?a=1&flag&b=2")
+        s = IP.enumerate(d, Gori::Probe::Active::Options::DEFAULT, [Loc::Query]).not_nil!
+        s.method.should eq("GET")
+        s.path.should eq("/s")
+        s.slots.map(&.name).should eq(["a", "b"]) # bare flag skipped
+        s.slots.map(&.loc.label).uniq.should eq(["query"])
+      end
+    end
+
+    it "enumerates form + JSON body params on a body-bearing request" do
+      with_store do |store|
+        form = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/p", method: "POST",
+          req_headers: "Content-Type: application/x-www-form-urlencoded\r\n", req_body: "u=bob&pw=x")
+        IP.enumerate(form, Gori::Probe::Active::Options::DEFAULT, [Loc::Query, Loc::Form, Loc::Json])
+          .not_nil!.slots.map { |s| {s.loc.label, s.name} }.should eq([{"form", "u"}, {"form", "pw"}])
+
+        js = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/p", method: "POST",
+          req_headers: "Content-Type: application/json\r\n", req_body: %({"id":"42","n":7}))
+        IP.enumerate(js, Gori::Probe::Active::Options::DEFAULT, [Loc::Query, Loc::Form, Loc::Json])
+          .not_nil!.slots.map { |s| {s.loc.label, s.name} }.should eq([{"json", "id"}]) # only string field
+      end
+    end
+
+    it "enumerates headers + cookies only under aggressive, skipping forbidden + request-critical" do
+      with_store do |store|
+        d = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/", method: "POST",
+          req_headers: "User-Agent: curl\r\nAuthorization: Bearer t\r\n" \
+                       "Content-Type: application/json\r\nCookie: sid=abc; theme=dark\r\n",
+          req_body: %({"x":"y"}))
+        locs = [Loc::Query, Loc::Headers, Loc::Cookies]
+        IP.enumerate(d, Gori::Probe::Active::Options::DEFAULT, locs).not_nil!.slots.should be_empty
+        got = IP.enumerate(d, aggressive, locs).not_nil!.slots.map { |s| {s.loc.label, s.name} }
+        got.should contain({"headers", "User-Agent"})
+        got.should contain({"cookies", "sid"})
+        got.should contain({"cookies", "theme"})
+        names = got.map { |(_, n)| n.downcase }
+        names.should_not contain("host")          # forbidden/framing header excluded
+        names.should_not contain("authorization") # request-critical: mutating it breaks the request
+        names.should_not contain("content-type")  # request-critical: changes body interpretation
+      end
+    end
+
+    it "returns nil only for a malformed request line" do
+      with_store do |store|
+        # A HEAD/no-param flow is NOT nil here (the method gate + cap live in the rule); enumerate
+        # nils only on a malformed start line, which capture_flow can't produce, so assert the
+        # non-nil, empty-slot shape instead.
+        d = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/s")
+        IP.enumerate(d, Gori::Probe::Active::Options::DEFAULT, [Loc::Query]).not_nil!.slots.should be_empty
+      end
+    end
+  end
+
+  describe ".build" do
+    it "REPLACE URL-encodes a query value; empty changes reproduce the request line" do
+      with_store do |store|
+        d = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/s?a=1&b=2")
+        s = IP.enumerate(d, Gori::Probe::Active::Options::DEFAULT, [Loc::Query]).not_nil!
+        base = String.new(IP.build(d, [] of {IP::Slot, IP::Change}))
+        base.should contain("/s?a=1&b=2 ")
+        req = String.new(IP.build(d, [{s.slots[0], IP::Change.new(replace: "x y")}]))
+        req.should contain("/s?a=x%20y&b=2 ") # space_to_plus:false, other param verbatim
+      end
+    end
+
+    it "RAW suffix is not re-encoded (single-encoded payload survives)" do
+      with_store do |store|
+        d = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/s?id=42")
+        s = IP.enumerate(d, Gori::Probe::Active::Options::DEFAULT, [Loc::Query]).not_nil!
+        String.new(IP.build(d, [{s.slots[0], IP::Change.new(suffix: "%27%22")}]))
+          .should contain("id=42%27%22 ")
+      end
+    end
+
+    it "REPLACE rewrites a header by name (a non-UTF-8 header before it can't desync it)" do
+      with_store do |store|
+        # A binary/non-UTF-8 header sits BEFORE the injectable one. Name-addressing means build
+        # finds User-Agent by matching, not by a positional index the byte-safe walk skipped.
+        head = "GET / HTTP/1.1\r\nHost: acme.test\r\nX-Bin: \xff\xfe\r\nUser-Agent: curl\r\n\r\n"
+        req = Gori::Store::CapturedRequest.new(created_at: 1_i64, scheme: "https", host: "acme.test",
+          port: 443, method: "GET", target: "/", http_version: "HTTP/1.1",
+          head: head.to_slice, body: nil, source: Gori::FlowSource::Kind::Proxy)
+        id = store.insert_flow(req)
+        store.update_response(Gori::Store::CapturedResponse.new(flow_id: id, status: 200,
+          head: "HTTP/1.1 200 OK\r\n\r\n".to_slice, body: nil, reason: "OK",
+          content_type: "text/html", duration_us: 1_i64))
+        d = store.get_flow(id).not_nil!
+        s = IP.enumerate(d, aggressive, [Loc::Headers]).not_nil!
+        ua = s.slots.find { |x| x.name == "User-Agent" }.not_nil!
+        out = String.new(IP.build(d, [{ua, IP::Change.new(replace: "CANARY")}]))
+        out.should contain("User-Agent: CANARY\r\n") # the right header was rewritten
+      end
+    end
+
+    it "rewrites cookie crumbs by name, preserving the `; ` separator" do
+      with_store do |store|
+        d = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/",
+          req_headers: "Cookie: sid=abc; theme=dark\r\n")
+        s = IP.enumerate(d, aggressive, [Loc::Cookies]).not_nil!
+        theme = s.slots.find { |x| x.name == "theme" }.not_nil!
+        String.new(IP.build(d, [{theme, IP::Change.new(replace: "C")}]))
+          .should contain("Cookie: sid=abc; theme=C\r\n")
+      end
+    end
+
+    it "REPLACE re-serializes a JSON string field and resyncs an existing Content-Length" do
+      with_store do |store|
+        d = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/p", method: "POST",
+          req_headers: "Content-Type: application/json\r\nContent-Length: 17\r\n",
+          req_body: %({"id":"42","n":7}))
+        s = IP.enumerate(d, Gori::Probe::Active::Options::DEFAULT, [Loc::Json]).not_nil!
+        req = String.new(IP.build(d, [{s.slots[0], IP::Change.new(replace: "CANARY")}]))
+        req.should contain(%("id":"CANARY"))
+        req.should contain(%("n":7))                 # untouched field carried through
+        req.should contain("Content-Length: 21\r\n") # 17 → 21, resynced to the new body
+      end
+    end
+  end
+end
+
+# ── widened-coverage integration: the differential rules now reach form / JSON body params ──
+
+describe "insertion-point coverage (body params)" do
+  it "error-based SQLi fires on a JSON body param (under allow_unsafe)" do
+    with_store do |store|
+      detail = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/api", method: "POST",
+        req_headers: "Content-Type: application/json\r\n", req_body: %({"id":"42"}))
+      rule = Gori::Probe::Active::ErrorBasedSqli.new
+      plan = rule.plan(detail, unsafe).not_nil!
+      plan.params.map { |p| {p.location, p.name} }.should eq([{"json", "id"}])
+      String.new(plan.followups[1]).should contain(%("id":"42'\\"")) # value + '"  (JSON-escaped)
+      dets = rule.detections_all(plan,
+        [resp(%({"ok":true})), resp(%({"ok":true})),
+         resp("You have an error in your SQL syntax; check the manual")], detail)
+      dets.size.should eq(1)
+      dets.first.code.should eq("sqli_error_based")
+      dets.first.severity.should eq(Gori::Store::Severity::High)
+    end
+  end
+
+  it "error-based SQLi fires on a form body param (under allow_unsafe)" do
+    with_store do |store|
+      detail = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/login", method: "POST",
+        req_headers: "Content-Type: application/x-www-form-urlencoded\r\n", req_body: "user=bob")
+      rule = Gori::Probe::Active::ErrorBasedSqli.new
+      plan = rule.plan(detail, unsafe).not_nil!
+      plan.params.map { |p| {p.location, p.name} }.should eq([{"form", "user"}])
+      String.new(plan.followups[1]).should contain("user=bob%27%22")
+      dets = rule.detections_all(plan,
+        [resp("ok"), resp("ok"), resp("Unclosed quotation mark after the character string")], detail)
+      dets.size.should eq(1)
+    end
+  end
+
+  it "SSTI reaches a JSON body param (under allow_unsafe)" do
+    with_store do |store|
+      detail = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/render", method: "POST",
+        req_headers: "Content-Type: application/json\r\n", req_body: %({"tpl":"hi"}))
+      rule = Gori::Probe::Active::Ssti.new
+      plan = rule.plan(detail, unsafe).not_nil!
+      plan.params.map { |p| {p.location, p.name} }.should eq([{"json", "tpl"}])
+      c = plan.params.first.canary
+      dets = rule.detections_all(plan, [resp("x#{c}49#{c}y"), resp("x#{c}56#{c}y")], detail)
+      dets.size.should eq(1)
+      dets.first.code.should eq("ssti")
+    end
+  end
+
+  it "reflected-param does NOT mutate header/cookie in its single batched probe (deferred)" do
+    # Header/cookie injection needs a per-slot multi-probe model (mutating Authorization/Cookie in
+    # the one batched request would break every other param's reflection). Until that lands, the
+    # value-injection rules stay on the body surfaces even under aggressive.
+    with_store do |store|
+      detail = capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n", target: "/?q=1",
+        req_headers: "User-Agent: curl\r\nCookie: sid=abc\r\n")
+      rule = Gori::Probe::Active::ReflectedParam.new
+      plan = rule.plan(detail, aggressive).not_nil!
+      plan.params.map(&.location).uniq.should eq(["query"])
+    end
+  end
+end

--- a/src/gori/miner/inject.cr
+++ b/src/gori/miner/inject.cr
@@ -699,9 +699,10 @@ module Gori::Miner
 
     # Yield each CRLF/LF-delimited line of `bytes` as a String, skipping any line that is not
     # valid UTF-8 (a binary multipart part) rather than scrubbing it into one. EMPTY lines are
-    # yielded: `multipart_names` reads the blank line as the end of a part's header block, and
-    # the head walkers ignore a line with no colon anyway.
-    private def self.each_ascii_line(bytes : Bytes, & : String ->) : Nil
+    # yielded: `multipart_names` reads the blank line as the end of a part.'s header block, and
+    # the head walkers ignore a line with no colon anyway. Public so Probe::Active::InsertionPoints
+    # walks request-head lines with the SAME byte-safe (invalid-UTF-8-skipping) semantics.
+    def self.each_ascii_line(bytes : Bytes, & : String ->) : Nil
       start = 0
       i = 0
       while i <= bytes.size
@@ -753,8 +754,9 @@ module Gori::Miner
       c.ascii_letter? || c.ascii_number? || "!#$%&'*+-.^_`|~".includes?(c)
     end
 
-    # Strip CR/LF from an injected header/cookie value (header smuggling guard).
-    private def self.sanitize_value(v : String) : String
+    # Strip CR/LF from an injected header/cookie value (header smuggling guard). Public so
+    # Probe::Active::InsertionPoints shares the one header-smuggling guard.
+    def self.sanitize_value(v : String) : String
       v.delete("\r\n")
     end
   end

--- a/src/gori/probe/active.cr
+++ b/src/gori/probe/active.cr
@@ -1,4 +1,5 @@
 require "./active/types"
+require "./active/insertion_points"
 require "./active/reflected_param"
 require "./active/error_based_sqli"
 require "./active/cors_reflection"

--- a/src/gori/probe/active/backslash_powered.cr
+++ b/src/gori/probe/active/backslash_powered.cr
@@ -1,8 +1,7 @@
 require "uri"
 require "./types"
-require "../../miner/inject"
-require "../../fuzz/engine"
-require "../../fuzz/content_length"
+require "./insertion_points"
+require "../../miner/types"
 require "../../proxy/codec/http1"
 require "../../proxy/codec/content_decode"
 
@@ -15,7 +14,7 @@ module Gori
       # string INTERPRETER (SQL, a template/expression engine, a shell, …) — without relying on a
       # specific error message — by exploiting how a backslash escapes.
       #
-      # For each query parameter it sends three requests that carry the param's ORIGINAL value with a
+      # For each parameter it sends three requests that carry the param's ORIGINAL value with a
       # suffix appended:
       #   baseline  value          (unchanged)
       #   single    value\         (a lone trailing backslash)
@@ -38,15 +37,16 @@ module Gori
       # out; by default GET only (POST/PUT/… are never auto-probed — they mutate state), but an
       # explicit opt-in (Options#allow_unsafe: the manual per-flow scan or AGGRESSIVE mode) widens
       # it to any body-bearing method. Capped at MAX_PROBE_PARAMS params (raised under AGGRESSIVE)
-      # so a wide query can't blow up the request count.
+      # so a wide param set can't blow up the request count. Insertion points come from the shared
+      # `InsertionPoints` model (query today).
       class BackslashPowered < Rule
-        # Probe at most this many params per flow (in query order). Bounds the request count and
-        # keeps the automatic scan light-touch; a wider query is still covered for its first params.
-        # AGGRESSIVE (opts.aggressive) raises the cap for deeper coverage on an authorized target.
+        # Probe at most this many params per flow (in enumeration order, across all locations).
+        # Bounds the request count and keeps the automatic scan light-touch; a wider set is still
+        # covered for its first params. AGGRESSIVE (opts.aggressive) raises the cap.
         MAX_PROBE_PARAMS            =  3
         MAX_PROBE_PARAMS_AGGRESSIVE = 10
 
-        # Appended (URL-encoded, so it decodes to a real backslash server-side) to a param's value.
+        # Appended (URL-encoded, wire-ready, so it decodes to a real backslash server-side).
         SINGLE = "%5C"    # one backslash  →  value\
         DOUBLE = "%5C%5C" # two backslashes →  value\\
 
@@ -64,22 +64,14 @@ module Gori
           4..(2 + 2 * MAX_PROBE_PARAMS)
         end
 
-        # Dedup key WITHOUT rebuilding probes — derived from the same `injectables` gate `plan` uses,
-        # so it is byte-identical to `plan(detail).dedup_key` and nil in exactly the same cases
-        # (verified by the equivalence spec).
         def dedup_key(detail : Store::FlowDetail, opts : Options = Options::DEFAULT) : String?
-          g = injectables(detail, opts)
-          return nil unless g
-          method_up, path, pairs, probe = g
-          build_dedup_key(detail, method_up, path, probe.map { |i| decode_name(pair_name(pairs[i])) })
+          s, slots = injectables(detail, opts) || return nil
+          InsertionPoints.dedup_key("backslash_powered", detail, s.method, s.path, slots)
         end
 
         def plan(detail : Store::FlowDetail, opts : Options = Options::DEFAULT) : Plan?
-          g = injectables(detail, opts)
-          return nil unless g
-          method_up, path, pairs, probe = g
-          body = detail.request_body
-          baseline = rebuild_query(detail.request_head, body, path, pairs.join('&'))
+          s, slots = injectables(detail, opts) || return nil
+          baseline = InsertionPoints.build(detail, InsertionPoints::NO_CHANGES)
           # A SECOND, identical baseline, sent first among the follow-ups. The whole rule is a
           # difference test against the baseline fingerprint, which silently assumed the endpoint
           # answers the same request the same way twice. When it does not — an intermittent 503, a
@@ -87,21 +79,17 @@ module Gori
           # on a `\` leg and not its `\\` leg reproduces the exact asymmetry this rule reports, and
           # every param gets its own roll of that die. Measuring the endpoint against itself costs
           # one request and turns "we cannot tell" into a decline instead of a finding.
-          followups = [rebuild_query(detail.request_head, body, path, pairs.join('&'))]
+          followups = [InsertionPoints.build(detail, InsertionPoints::NO_CHANGES)]
           params = [] of Param
-          probe.each do |idx|
-            pair = pairs[idx]
-            eq = pair.index('=').not_nil!
-            name = pair[0...eq]
-            value = pair[(eq + 1)..]
+          slots.each do |slot|
             # Order matters: single (`\`) then double (`\\`) — detections_all reads them back at
             # results[2 + 2*i] / results[3 + 2*i] for the i-th param (results[0] and results[1]
             # are the two baselines).
-            followups << rebuild_query(detail.request_head, body, path, with_value(pairs, idx, name, value + SINGLE))
-            followups << rebuild_query(detail.request_head, body, path, with_value(pairs, idx, name, value + DOUBLE))
-            params << Param.new("query", decode_name(name), value)
+            followups << InsertionPoints.build(detail, [{slot, InsertionPoints::Change.new(suffix: SINGLE)}])
+            followups << InsertionPoints.build(detail, [{slot, InsertionPoints::Change.new(suffix: DOUBLE)}])
+            params << Param.new(slot.loc.label, slot.name, slot.raw_value)
           end
-          key = build_dedup_key(detail, method_up, path, params.map(&.name))
+          key = InsertionPoints.dedup_key("backslash_powered", detail, s.method, s.path, slots)
           Plan.new(baseline, params, key, followups)
         end
 
@@ -139,54 +127,19 @@ module Gori
         end
 
         # Shared gate for plan + dedup_key so the two can't drift (equivalence-spec invariant).
-        # Returns {METHOD, path, all query pairs verbatim, indices of the first ≤MAX_PROBE_PARAMS
-        # pairs that are real k=v params} for a GET carrying ≥1 such param, else nil.
-        private def injectables(detail : Store::FlowDetail, opts : Options) : {String, String, Array(String), Array(Int32)}?
-          method, target, malformed = Proxy::Codec::Http1.parse_request_line(detail.request_head)
-          return nil if malformed
-          method_up = method.upcase
+        # Returns {surface, the first ≤cap injectable slots} for an eligible flow, else nil. The cap
+        # spans ALL enumerated locations at once, so a wide param set can't blow up the request count.
+        private def injectables(detail : Store::FlowDetail, opts : Options) : {InsertionPoints::Surface, Array(InsertionPoints::Slot)}?
+          s = InsertionPoints.enumerate(detail, opts, InsertionPoints::DEFAULT_LOCATIONS) || return nil
           # Body-differential gate: the comparison reads response BODIES (HEAD has none), so HEAD is
           # always out. By default GET only — the automatic scan never auto-re-sends a state-changing
           # method — but opts.allow_unsafe (manual per-flow scan / AGGRESSIVE mode) widens to
-          # POST/PUT/PATCH/DELETE, whose query params can still be interpreted server-side.
-          return nil unless diff_method_allowed?(method_up, opts)
-          path, query = split_target(Active.origin_form(target))
-          return nil if query.empty?
+          # POST/PUT/PATCH/DELETE, whose params can still be interpreted server-side.
+          return nil unless diff_method_allowed?(s.method, opts)
           cap = opts.aggressive ? MAX_PROBE_PARAMS_AGGRESSIVE : MAX_PROBE_PARAMS
-          pairs = query.split('&')
-          probe = [] of Int32
-          pairs.each_with_index do |pair, i|
-            next if pair.empty?
-            eq = pair.index('=')
-            next unless eq
-            next if pair[0...eq].empty?
-            probe << i
-            break if probe.size >= cap
-          end
-          return nil if probe.empty?
-          {method_up, path, pairs, probe}
-        end
-
-        # Key by rule + host:PORT + METHOD + path + sorted (length-prefixed) probed-param names, so
-        # the same host on another port/service is a distinct surface and a name containing ','/':'
-        # can't collide with a different set. Sorted → a reordered query dedups to one probe.
-        private def build_dedup_key(detail : Store::FlowDetail, method_upcase : String, path : String,
-                                    names : Array(String)) : String
-          sig = names.map { |n| "#{n.bytesize}:#{n}" }.sort!.join(",")
-          "backslash_powered|#{detail.row.host}:#{detail.row.port}|#{method_upcase}|#{path}|#{sig}"
-        end
-
-        private def pair_name(pair : String) : String
-          eq = pair.index('=')
-          eq ? pair[0...eq] : pair
-        end
-
-        # A copy of the query pairs with pair `idx` replaced by "name=value" (every other segment,
-        # including bare flags and empties, kept verbatim).
-        private def with_value(pairs : Array(String), idx : Int32, name : String, value : String) : String
-          dup = pairs.dup
-          dup[idx] = "#{name}=#{value}"
-          dup.join('&')
+          slots = s.slots.first(cap)
+          return nil if slots.empty?
+          {s, slots}
         end
 
         # {baseline fingerprint, whether body LENGTH is part of it} — but only when the endpoint
@@ -274,39 +227,6 @@ module Gori
           else
             ""
           end
-        end
-
-        # {path, query-without-'?'} — query is "" when the target has none.
-        private def split_target(target : String) : {String, String}
-          qi = target.index('?')
-          return {target, ""} unless qi
-          {target[0...qi], target[(qi + 1)..]}
-        end
-
-        private def decode_name(name : String) : String
-          URI.decode_www_form(name)
-        rescue
-          name
-        end
-
-        # Reassemble the request with a new query on the request line, preserving the original body
-        # and re-syncing Content-Length (mirrors ReflectedParam#rebuild; a lone GET has no body, so
-        # this just carries any CL through untouched).
-        private def rebuild_query(orig_head : Bytes, body : Bytes?, path : String, new_query : String) : Bytes
-          head, _, eol = Miner::Inject.split(orig_head)
-          lines = String.new(head).split(eol)
-          unless lines.empty?
-            parts = lines[0].split(' ')
-            if parts.size == 3
-              target = new_query.empty? ? path : "#{path}?#{new_query}"
-              lines[0] = "#{parts[0]} #{target} #{parts[2]}"
-            end
-          end
-          io = IO::Memory.new
-          io << lines.join(eol) << eol << eol
-          b = body || Bytes.empty
-          io.write(b) unless b.empty?
-          Fuzz::ContentLength.sync(io.to_slice, false)
         end
       end
     end

--- a/src/gori/probe/active/error_based_sqli.cr
+++ b/src/gori/probe/active/error_based_sqli.cr
@@ -1,7 +1,7 @@
 require "uri"
 require "./types"
-require "../../miner/inject"
-require "../../fuzz/content_length"
+require "./insertion_points"
+require "../../miner/types"
 require "../../proxy/codec/http1"
 require "../../proxy/codec/content_decode"
 
@@ -15,10 +15,10 @@ module Gori
       # string…") straight into the response. That leaked, database-specific error message is the
       # tell this rule confirms.
       #
-      # For each query parameter it sends a baseline (the ORIGINAL query, unchanged) plus one probe
-      # per param whose value is the param's ORIGINAL value with a syntax-breaking suffix appended
-      # (URL-encoded `'"`), every other param left alone. A param is flagged ONLY when a specific
-      # DB-error signature appears in the PROBE body and is ABSENT from the baseline body.
+      # For each injectable parameter it sends a baseline (the ORIGINAL request, unchanged) plus one
+      # probe per param whose value is the param's ORIGINAL value with a syntax-breaking suffix
+      # appended (URL-encoded `'"`), every other param left alone. A param is flagged ONLY when a
+      # specific DB-error signature appears in the PROBE body and is ABSENT from the baseline body.
       #
       # Two FP guards stack — the same shape the SSTI rule uses to prove EVALUATION rather than
       # reflection:
@@ -38,17 +38,18 @@ module Gori
       # catches the endpoints that DO leak a verbose DB error — including NUMERIC contexts (`id=42`
       # → `id=42'"`), where the backslash-escaping asymmetry does not appear because a lone `\` in a
       # numeric literal is not an escape. The two together cover both the quiet (structural) and the
-      # loud (error-leaking) faces of the same injection surface.
+      # loud (error-leaking) faces of the same injection surface. Insertion points come from the
+      # shared `InsertionPoints` model (query today).
       class ErrorBasedSqli < Rule
-        # Probe at most this many query params per flow (in query order). Bounds the request count
-        # so a wide query stays light-touch; AGGRESSIVE (opts.aggressive) raises the cap.
+        # Probe at most this many params per flow (in enumeration order, across all locations).
+        # Bounds the request count so a wide param set stays light-touch; AGGRESSIVE raises the cap.
         MAX_PROBE_PARAMS            =  3
         MAX_PROBE_PARAMS_AGGRESSIVE = 10
 
-        # Appended (URL-encoded) to a param's ORIGINAL value. Decodes server-side to a single quote
-        # followed by a double quote — one of the two breaks whichever string literal the value
-        # sits in, and the unmatched quote errors most numeric contexts too. We only ever send this;
-        # we never send any signature string, so a matched signature is proof of a real DB error.
+        # Appended (URL-encoded, wire-ready) to a param's ORIGINAL value. Decodes server-side to a
+        # single quote followed by a double quote — one of the two breaks whichever string literal
+        # the value sits in, and the unmatched quote errors most numeric contexts too. We only ever
+        # send this; we never send any signature string, so a matched signature proves a real DB error.
         PAYLOAD = "%27%22" # → '"
 
         # Curated, DB-specific parser/driver diagnostics, matched case-insensitively as substrings
@@ -109,23 +110,15 @@ module Gori
           3..(2 + MAX_PROBE_PARAMS)
         end
 
-        # Dedup key WITHOUT rebuilding probes — derived from the same `injectables` gate `plan` uses,
-        # so it is byte-identical to `plan(detail).dedup_key` and nil in exactly the same cases
-        # (verified by the equivalence spec).
         def dedup_key(detail : Store::FlowDetail, opts : Options = Options::DEFAULT) : String?
-          g = injectables(detail, opts)
-          return nil unless g
-          method_up, path, pairs, probe = g
-          build_dedup_key(detail, method_up, path, probe.map { |i| decode_name(pair_name(pairs[i])) })
+          s, slots = injectables(detail, opts) || return nil
+          InsertionPoints.dedup_key("sqli_error_based", detail, s.method, s.path, slots)
         end
 
         def plan(detail : Store::FlowDetail, opts : Options = Options::DEFAULT) : Plan?
-          g = injectables(detail, opts)
-          return nil unless g
-          method_up, path, pairs, probe = g
-          body = detail.request_body
-          # Baseline: the ORIGINAL query, unchanged (results[0]).
-          baseline = rebuild_query(detail.request_head, body, path, pairs.join('&'))
+          s, slots = injectables(detail, opts) || return nil
+          # Baseline: the ORIGINAL request, unchanged (results[0]).
+          baseline = InsertionPoints.build(detail, InsertionPoints::NO_CHANGES)
           # A SECOND identical baseline, sent first among the follow-ups (results[1]) — the
           # stability guard BackslashPowered uses. This rule is a difference test against the
           # baseline; on a self-varying endpoint (an intermittent 5xx that renders a verbose
@@ -133,19 +126,15 @@ module Gori
           # a probe leg but not a SINGLE baseline reproduces the exact differential we report, once
           # per param. Requiring the signature to be absent from BOTH baselines turns "we cannot
           # tell" into a decline instead of a High false positive.
-          followups = [rebuild_query(detail.request_head, body, path, pairs.join('&'))]
+          followups = [InsertionPoints.build(detail, InsertionPoints::NO_CHANGES)]
           params = [] of Param
-          probe.each do |idx|
-            pair = pairs[idx]
-            eq = pair.index('=').not_nil!
-            name = pair[0...eq]
-            value = pair[(eq + 1)..]
+          slots.each do |slot|
             # One followup per param: that param's value = original + PAYLOAD, all others verbatim.
-            # Appended after the two baselines, so params[i]'s probe is results[2 + i].
-            followups << rebuild_query(detail.request_head, body, path, with_value(pairs, idx, name, value + PAYLOAD))
-            params << Param.new("query", decode_name(name), value)
+            # Appended after the two baselines, so slots[i]'s probe is results[2 + i].
+            followups << InsertionPoints.build(detail, [{slot, InsertionPoints::Change.new(suffix: PAYLOAD)}])
+            params << Param.new(slot.loc.label, slot.name, slot.raw_value)
           end
-          key = build_dedup_key(detail, method_up, path, params.map(&.name))
+          key = InsertionPoints.dedup_key("sqli_error_based", detail, s.method, s.path, slots)
           Plan.new(baseline, params, key, followups)
         end
 
@@ -203,67 +192,19 @@ module Gori
         end
 
         # Shared gate for plan + dedup_key so the two can't drift (equivalence-spec invariant).
-        # Returns {METHOD, path, all query pairs verbatim, indices of the first ≤MAX_PROBE_PARAMS
-        # pairs that are real k=v params} for a GET carrying ≥1 such param, else nil.
-        private def injectables(detail : Store::FlowDetail, opts : Options) : {String, String, Array(String), Array(Int32)}?
-          method, target, malformed = Proxy::Codec::Http1.parse_request_line(detail.request_head)
-          return nil if malformed
-          method_up = method.upcase
+        # Returns {surface, the first ≤cap injectable slots} for an eligible flow, else nil. The cap
+        # spans ALL enumerated locations at once, so a wide param set can't blow up the request count.
+        private def injectables(detail : Store::FlowDetail, opts : Options) : {InsertionPoints::Surface, Array(InsertionPoints::Slot)}?
+          s = InsertionPoints.enumerate(detail, opts, InsertionPoints::DEFAULT_LOCATIONS) || return nil
           # Body-differential gate: the comparison reads response BODIES (HEAD has none), so HEAD is
           # always out. By default GET only — the automatic scan never auto-re-sends a state-changing
           # method — but opts.allow_unsafe (manual per-flow scan / AGGRESSIVE mode) widens to
-          # POST/PUT/PATCH/DELETE, whose query params can still reach a SQL statement.
-          return nil unless diff_method_allowed?(method_up, opts)
-          path, query = split_target(Active.origin_form(target))
-          return nil if query.empty?
+          # POST/PUT/PATCH/DELETE, whose params can still reach a SQL statement.
+          return nil unless diff_method_allowed?(s.method, opts)
           cap = opts.aggressive ? MAX_PROBE_PARAMS_AGGRESSIVE : MAX_PROBE_PARAMS
-          pairs = query.split('&')
-          probe = [] of Int32
-          pairs.each_with_index do |pair, i|
-            next if pair.empty?
-            eq = pair.index('=')
-            next unless eq
-            next if pair[0...eq].empty?
-            probe << i
-            break if probe.size >= cap
-          end
-          return nil if probe.empty?
-          {method_up, path, pairs, probe}
-        end
-
-        # Key by rule + host:PORT + METHOD + path + sorted (length-prefixed) probed-param names, so
-        # the same host on another port/service is a distinct surface and a name containing ','/':'
-        # can't collide with a different set. Sorted → a reordered query dedups to one probe.
-        private def build_dedup_key(detail : Store::FlowDetail, method_upcase : String, path : String,
-                                    names : Array(String)) : String
-          sig = names.map { |n| "#{n.bytesize}:#{n}" }.sort!.join(",")
-          "sqli_error_based|#{detail.row.host}:#{detail.row.port}|#{method_upcase}|#{path}|#{sig}"
-        end
-
-        private def pair_name(pair : String) : String
-          eq = pair.index('=')
-          eq ? pair[0...eq] : pair
-        end
-
-        # A copy of the query pairs with pair `idx` replaced by "name=value" (every other segment,
-        # including bare flags and empties, kept verbatim).
-        private def with_value(pairs : Array(String), idx : Int32, name : String, value : String) : String
-          dup = pairs.dup
-          dup[idx] = "#{name}=#{value}"
-          dup.join('&')
-        end
-
-        private def decode_name(name : String) : String
-          URI.decode_www_form(name)
-        rescue
-          name
-        end
-
-        # {path, query-without-'?'} — query is "" when the target has none.
-        private def split_target(target : String) : {String, String}
-          qi = target.index('?')
-          return {target, ""} unless qi
-          {target[0...qi], target[(qi + 1)..]}
+          slots = s.slots.first(cap)
+          return nil if slots.empty?
+          {s, slots}
         end
 
         # Decode + scrub the response body to text, capped at BODY_CAP. Scrubbing makes the
@@ -275,25 +216,6 @@ module Gori
           String.new(bytes[0, {bytes.size, BODY_CAP}.min]).scrub
         rescue
           ""
-        end
-
-        # Reassemble the request with a new query on the request line, preserving the original body
-        # and re-syncing Content-Length (mirrors BackslashPowered#rebuild_query).
-        private def rebuild_query(orig_head : Bytes, body : Bytes?, path : String, new_query : String) : Bytes
-          head, _, eol = Miner::Inject.split(orig_head)
-          lines = String.new(head).split(eol)
-          unless lines.empty?
-            parts = lines[0].split(' ')
-            if parts.size == 3
-              target = new_query.empty? ? path : "#{path}?#{new_query}"
-              lines[0] = "#{parts[0]} #{target} #{parts[2]}"
-            end
-          end
-          io = IO::Memory.new
-          io << lines.join(eol) << eol << eol
-          b = body || Bytes.empty
-          io.write(b) unless b.empty?
-          Fuzz::ContentLength.sync(io.to_slice, false)
         end
       end
     end

--- a/src/gori/probe/active/insertion_points.cr
+++ b/src/gori/probe/active/insertion_points.cr
@@ -1,0 +1,382 @@
+require "uri"
+require "json"
+require "./types"
+require "../../miner/types"
+require "../../miner/inject"
+require "../../fuzz/content_length"
+require "../../proxy/codec/http1"
+
+module Gori
+  module Probe
+    module Active
+      # The shared INSERTION-POINT model for the active value-injection rules. Before this, each
+      # rule (reflected_param, ssti, error_based_sqli, backslash_powered, lfi_param_traversal)
+      # re-implemented the same query parsing, value mutation, request rebuild, and dedup-key
+      # construction — and most only ever touched query parameters. This module owns that logic
+      # once, across query / form / JSON / header / cookie, so a rule declares WHICH locations it
+      # cares about and WHAT it does to a value, and nothing else.
+      #
+      # Two design constraints shape every method here:
+      #   * PURITY / equivalence. `enumerate` is a pure function of (detail, opts, locations); a
+      #     rule feeds the SAME enumeration into both `dedup_key` and `plan`, so the analyzer's
+      #     cheap pre-plan dedup key can never drift from the built plan's (the per-rule
+      #     equivalence spec). `enumerate` therefore applies only STRUCTURAL/location gates — the
+      #     method gate and the per-rule param cap stay in the rule, applied identically on both
+      #     paths.
+      #   * BYTE PRESERVATION. Captured bytes may be invalid UTF-8, and a probe must re-send an
+      #     operator's untouched fields verbatim (never as U+FFFD). So query/form parsing slices on
+      #     byte offsets found by scanning (never scrubs what is re-sent), JSON carries non-injected
+      #     fields through as their parsed `JSON::Any`, and header/cookie walking is byte-safe. The
+      #     ONE decoded value a rule inspects (`Slot#value`) is exposed UNSCRUBBED; a rule that runs
+      #     a PCRE over it scrubs at the point of use (only lfi does).
+      module InsertionPoints
+        # One injectable EXISTING value in a captured request. `index`/`raw_name`/`raw_value` are
+        # the addressing + on-wire bytes `build` needs to splice a new value back and leave every
+        # other byte untouched; `name`/`value` are the decoded views a rule reads.
+        #
+        #   loc       — the insertion surface (query/form/json/headers/cookies).
+        #   index     — position in that surface's ORDERED member list: the index into the FULL
+        #               `split('&')` list for query/form (so non-slot pairs pass through verbatim)
+        #               and the head-line index for headers; -1 for json/cookies, which `build`
+        #               re-addresses by `name` (JSON top-level key / cookie crumb name).
+        #   name      — DECODED name. Becomes `Param.name` and the dedup token. UNSCRUBBED.
+        #   raw_name  — on-wire name, spliced back verbatim.
+        #   value     — DECODED current value. UNSCRUBBED — inspection/gating only, never re-sent.
+        #   raw_value — on-wire value substring, for byte-preserving RAW prefix/suffix.
+        record Slot,
+          loc : Miner::Location,
+          index : Int32,
+          name : String,
+          raw_name : String,
+          value : String,
+          raw_value : String
+
+        # What a rule does to ONE slot's value. Exactly one strategy per change:
+        #   REPLACE — `replace` is a DECODED value; `build` encodes it for the slot's location
+        #             (URL-encode for query/form, JSON string for json, sanitized literal for
+        #             header/cookie). Used by reflected_param (canary+marker) and ssti (polyglot).
+        #   RAW     — `prefix`/`suffix` are WIRE-READY text wrapped around the slot's raw_value with
+        #             NO decode/re-encode, so bytes are preserved exactly (`42` + `%27%22` stays
+        #             `42%27%22`, never double-encoded). Used by error_based_sqli / backslash_powered
+        #             (suffix) and lfi_param_traversal (prefix). JSON honours REPLACE only.
+        record Change, replace : String? = nil, prefix : String = "", suffix : String = ""
+
+        # The insertion surfaces the value-injection rules inject by default: the parameter-bearing
+        # bodies. Headers/Cookies are NOT here — mutating an existing header/cookie value in the
+        # single batched request a rule builds today can clobber Authorization/Content-Type/session
+        # and break every OTHER param's probe, so header/cookie injection needs a per-slot multi-probe
+        # rule model (a future rule passes an explicit `[..., Headers, Cookies]` list).
+        DEFAULT_LOCATIONS = [Miner::Location::Query, Miner::Location::Form, Miner::Location::Json]
+
+        # The empty change-set: `build(detail, NO_CHANGES)` reproduces the original request (a
+        # differential rule's baseline). A shared constant so the differential rules don't each
+        # re-declare the typed empty array.
+        NO_CHANGES = [] of {Slot, Change}
+
+        # Request-semantics-critical headers never offered as injection slots even under aggressive:
+        # replacing Authorization breaks auth (the response is an error page, not a reflection) and
+        # replacing Content-Type changes how the body is parsed. `valid_header_name?` already drops
+        # the hop-by-hop/framing set; this adds the two whose VALUE carries request meaning, not data.
+        HEADER_INJECT_SKIP = Set{"authorization", "content-type"}
+
+        # The enumerated request: its method (upcased), origin-form path (no query), and the
+        # ordered injectable slots. Slot order is stable — query, then form/json body, then
+        # headers, then cookies — so a rule's `.first(cap)` is deterministic and identical between
+        # dedup_key and plan.
+        record Surface, method : String, path : String, slots : Array(Slot)
+
+        # Enumerate the injectable slots of `detail` across the requested `locations`. Returns nil
+        # ONLY when the request line is malformed (the single case every rule declines on). Applies
+        # location gates ONLY: Content-Type for form/json, `opts.aggressive` for headers/cookies,
+        # and Inject's forbidden/hop-by-hop filter for headers. The method gate and the param cap
+        # are the rule's to apply, on both the dedup_key and plan paths.
+        def self.enumerate(detail : Store::FlowDetail, opts : Options,
+                           locations : Array(Miner::Location)) : Surface?
+          method, target, malformed = Proxy::Codec::Http1.parse_request_line(detail.request_head)
+          return nil if malformed
+          method_up = method.upcase
+          path, query = split_target(Active.origin_form(target))
+          slots = [] of Slot
+
+          if locations.includes?(Miner::Location::Query)
+            each_pair(query) do |idx, raw_name, raw_value|
+              slots << Slot.new(Miner::Location::Query, idx, decode(raw_name), raw_name,
+                decode(raw_value), raw_value)
+            end
+          end
+
+          want_form = locations.includes?(Miner::Location::Form)
+          want_json = locations.includes?(Miner::Location::Json)
+          body = detail.request_body
+          if (want_form || want_json) && body && !body.empty?
+            # Full head parse ONLY when a body exists — reuse HeaderList#get? so the Content-Type
+            # last-match / case-insensitive semantics stay identical to the old per-rule reads. A
+            # bodyless query-only GET/HEAD never reaches here, so its dedup key never allocates the
+            # header block (the reflected_param fast path).
+            ct = content_type(detail.request_head)
+            if want_form && ct.includes?("x-www-form-urlencoded")
+              # Not `.scrub`: this is the body the probe re-sends. `each_pair` slices on scanned
+              # byte offsets, so an untouched field carrying a raw non-UTF-8 byte survives verbatim.
+              each_pair(String.new(body)) do |idx, raw_name, raw_value|
+                slots << Slot.new(Miner::Location::Form, idx, decode(raw_name), raw_name,
+                  decode(raw_value), raw_value)
+              end
+            elsif want_json && ct.includes?("json")
+              each_json_string_key(body) do |k, v|
+                slots << Slot.new(Miner::Location::Json, -1, k, k, v, v)
+              end
+            end
+          end
+
+          if opts.aggressive
+            want_headers = locations.includes?(Miner::Location::Headers)
+            want_cookies = locations.includes?(Miner::Location::Cookies)
+            if want_headers || want_cookies
+              enumerate_head(detail.request_head, want_headers, want_cookies) { |s| slots << s }
+            end
+          end
+
+          Surface.new(method_up, path, slots)
+        end
+
+        # The dedup key for `slots` — rule + host:PORT + METHOD + path + sorted, length-prefixed
+        # `name@location` tokens. Length-prefixing stops a name containing '@'/','/':' from
+        # colliding with a different set; sorting makes a reordered query dedup to one probe. This
+        # is exactly reflected_param's historic format, now shared so every rule keys the same way.
+        def self.dedup_key(rule_id : String, detail : Store::FlowDetail, method_upcase : String,
+                           path : String, slots : Array(Slot)) : String
+          sig = slots.map { |s| "#{s.name.bytesize}:#{s.name}@#{s.loc.label}" }.sort!.join(",")
+          "#{rule_id}|#{detail.row.host}:#{detail.row.port}|#{method_upcase}|#{path}|#{sig}"
+        end
+
+        # Rebuild `detail`'s request with each (slot ⇒ change) applied and every other byte
+        # verbatim, the request line normalized to origin-form, per-location encoding, and
+        # Content-Length re-synced once. An EMPTY `changes` reproduces the original request
+        # (re-normalized + CL-synced) — the baseline the differential rules send.
+        def self.build(detail : Store::FlowDetail, changes : Array({Slot, Change})) : Bytes
+          head_bytes, _, eol = Miner::Inject.split(detail.request_head)
+          _, target, _ = Proxy::Codec::Http1.parse_request_line(detail.request_head)
+          path, query = split_target(Active.origin_form(target))
+          body = detail.request_body
+          new_body = body
+
+          # Query: rebuild from the FULL split list so bare flags / empty / no-'=' segments pass
+          # through verbatim; splitting-then-joining an unchanged query is the identity.
+          q_changes = changes.select { |(s, _)| s.loc.query? }
+          unless q_changes.empty? && query.empty?
+            pairs = query.split('&')
+            q_changes.each { |(s, c)| pairs[s.index] = render_pair(s.raw_name, s.raw_value, c) if s.index < pairs.size }
+            query = pairs.join('&')
+          end
+
+          # Form body: same pair rewrite over the urlencoded body.
+          f_changes = changes.select { |(s, _)| s.loc.form? }
+          if !f_changes.empty? && body && !body.empty?
+            pairs = String.new(body).split('&')
+            f_changes.each { |(s, c)| pairs[s.index] = render_pair(s.raw_name, s.raw_value, c) if s.index < pairs.size }
+            new_body = pairs.join('&').to_slice
+          end
+
+          # JSON body: re-serialize top-level object with chosen string keys replaced, every other
+          # field carried through as its parsed JSON::Any (byte-preserving for untouched fields).
+          j_changes = changes.select { |(s, _)| s.loc.json? }
+          if !j_changes.empty? && body && !body.empty?
+            rebuilt = rebuild_json(body, j_changes)
+            new_body = rebuilt if rebuilt
+          end
+
+          lines = String.new(head_bytes).split(eol)
+          unless lines.empty?
+            parts = lines[0].split(' ')
+            if parts.size == 3
+              t = query.empty? ? path : "#{path}?#{query}"
+              lines[0] = "#{parts[0]} #{t} #{parts[2]}"
+            end
+          end
+
+          # Header / cookie value rewrites (aggressive-only surfaces).
+          h_changes = changes.select { |(s, _)| s.loc.headers? }
+          apply_header_changes(lines, h_changes) unless h_changes.empty?
+          c_changes = changes.select { |(s, _)| s.loc.cookies? }
+          apply_cookie_changes(lines, c_changes) unless c_changes.empty?
+
+          io = IO::Memory.new
+          io << lines.join(eol) << eol << eol
+          b = new_body || Bytes.empty
+          io.write(b) unless b.empty?
+          Fuzz::ContentLength.sync(io.to_slice, false)
+        end
+
+        # ── internals ────────────────────────────────────────────────────────────────
+
+        # "#{name}=#{value}" for one slot, encoded by strategy. REPLACE URL-encodes the decoded
+        # value (space_to_plus:false — a `+` is not universally decoded back to a space, and the
+        # markers/polyglots carry chars that must not sit raw on the request line). RAW wraps the
+        # ON-WIRE value with no re-encode, so an already-encoded payload stays single-encoded.
+        private def self.render_pair(raw_name : String, raw_value : String, change : Change) : String
+          if r = change.replace
+            "#{raw_name}=#{URI.encode_www_form(r, space_to_plus: false)}"
+          else
+            "#{raw_name}=#{change.prefix}#{raw_value}#{change.suffix}"
+          end
+        end
+
+        # Re-serialize a JSON object body with the chosen top-level string fields mutated. nil unless
+        # the root parses as an object (matching each_json_string_key, so build never gets a json
+        # change on a body that yielded no json slot). REPLACE substitutes the decoded value; RAW
+        # wraps the decoded string value with the payload URL-DECODED first — the rules' RAW payloads
+        # are URL-wire form (`%27%22`, `%5C`) for the query/form layer, so in a JSON string the
+        # decoded character (`'"`, `\`) is what a server actually concatenates into its SQL/template.
+        # Not `.scrub`: JSON.parse does not require valid UTF-8 inside a string, and to_json
+        # round-trips the untouched fields' bytes as-is.
+        private def self.rebuild_json(body : Bytes, changes : Array({Slot, Change})) : Bytes?
+          h = begin
+            JSON.parse(String.new(body)).as_h?
+          rescue JSON::ParseException
+            nil
+          end
+          return nil unless h
+          by_name = {} of String => Change
+          changes.each { |(s, c)| by_name[s.name] = c }
+          merged = {} of String => JSON::Any
+          h.each do |k, v|
+            if c = by_name[k]?
+              if r = c.replace
+                merged[k] = JSON::Any.new(r)
+              elsif base = v.as_s?
+                merged[k] = JSON::Any.new("#{decode(c.prefix)}#{base}#{decode(c.suffix)}")
+              else
+                merged[k] = v
+              end
+            else
+              merged[k] = v
+            end
+          end
+          merged.to_json.to_slice
+        end
+
+        # Yield {full-list index, raw name, raw value} for each valid k=v of an &-joined string.
+        # Same skip rules every rule used (empty pair / no '=' / empty name are skipped) — the
+        # index counts ALL segments so a rebuilder can pass the skipped ones through untouched.
+        private def self.each_pair(text : String, & : Int32, String, String ->)
+          return if text.empty?
+          text.split('&').each_with_index do |pair, i|
+            next if pair.empty?
+            eq = pair.index('=')
+            next unless eq
+            name = pair[0...eq]
+            next if name.empty?
+            yield i, name, pair[(eq + 1)..]
+          end
+        end
+
+        # Yield {key, string value} for every top-level JSON object field with a string value —
+        # the fields reflected_param#canary_json canaries. Not `.scrub`: must read the same bytes
+        # build re-serializes, and JSON.parse tolerates non-UTF-8 inside a string value.
+        private def self.each_json_string_key(body : Bytes, & : String, String ->)
+          h = begin
+            JSON.parse(String.new(body)).as_h?
+          rescue JSON::ParseException
+            nil
+          end
+          return unless h
+          h.each { |k, v| yield k, v.as_s if v.as_s? }
+        end
+
+        # Enumerate header / cookie slots from the head bytes. Byte-safe line walk (skips a line
+        # that is not valid UTF-8, via the shared Miner::Inject.each_ascii_line) so a binary/garbled
+        # header can never make this raise. BOTH headers and cookie crumbs are addressed by NAME
+        # (index -1), so `build` locates the target line by matching — a non-UTF-8 line the walk
+        # skipped can never desync a positional index. Only names Inject deems injectable qualify
+        # (forbidden/hop-by-hop headers excluded), minus the request-semantics-critical HEADER_INJECT_SKIP.
+        private def self.enumerate_head(head : Bytes, want_headers : Bool, want_cookies : Bool,
+                                        & : Slot ->)
+          first = true
+          Miner::Inject.each_ascii_line(head) do |line|
+            if first
+              first = false
+              next # request line
+            end
+            colon = line.index(':')
+            next unless colon
+            name = line[0...colon].strip
+            value = line[(colon + 1)..].strip
+            if want_cookies && name.downcase == "cookie"
+              value.split(';').each do |crumb|
+                eq = crumb.index('=') || next
+                cname = crumb[0...eq].strip
+                next unless Miner::Inject.valid_cookie_name?(cname)
+                cval = crumb[(eq + 1)..].strip
+                yield Slot.new(Miner::Location::Cookies, -1, cname, cname, cval, cval)
+              end
+            elsif want_headers && Miner::Inject.valid_header_name?(name) &&
+                  !HEADER_INJECT_SKIP.includes?(name.downcase)
+              yield Slot.new(Miner::Location::Headers, -1, name, name, value, value)
+            end
+          end
+        end
+
+        # Rewrite the value of each targeted header, matched by NAME (first case-insensitive match).
+        # REPLACE sanitizes CR/LF out of the injected value (header-smuggling guard); RAW wraps the
+        # existing value. The name portion (original case + spacing before the colon) is preserved.
+        private def self.apply_header_changes(lines : Array(String), changes : Array({Slot, Change}))
+          changes.each do |(s, c)|
+            target = s.raw_name.downcase
+            lines.each_with_index do |line, i|
+              next if i == 0
+              colon = line.index(':') || next
+              next unless line[0...colon].strip.downcase == target
+              name_part = line[0...colon]
+              newval = c.replace ? Miner::Inject.sanitize_value(c.replace.not_nil!) : "#{c.prefix}#{s.raw_value}#{c.suffix}"
+              lines[i] = "#{name_part}: #{newval}"
+              break
+            end
+          end
+        end
+
+        # Rewrite the targeted crumb(s) inside the (first) Cookie: header line, matched by name.
+        private def self.apply_cookie_changes(lines : Array(String), changes : Array({Slot, Change}))
+          by_name = {} of String => Change
+          changes.each { |(s, c)| by_name[s.name] = c }
+          lines.each_with_index do |line, i|
+            colon = line.index(':') || next
+            next unless line[0...colon].strip.downcase == "cookie"
+            crumbs = line[(colon + 1)..].split(';').map do |crumb|
+              eq = crumb.index('=')
+              next crumb unless eq
+              cname = crumb[0...eq].strip
+              c = by_name[cname]? || next crumb
+              lead = crumb[0...eq] # preserve any leading space before the name
+              newval = c.replace ? Miner::Inject.sanitize_value(c.replace.not_nil!) : "#{c.prefix}#{crumb[(eq + 1)..].strip}#{c.suffix}"
+              "#{lead}=#{newval}"
+            end
+            lines[i] = "#{line[0...colon]}:#{crumbs.join(';')}"
+            break
+          end
+        end
+
+        # The request's Content-Type (last match, case-insensitive, lower-cased), or "".
+        private def self.content_type(head : Bytes) : String
+          req = Proxy::Codec::Http1.parse_request_head(head)
+          (req.headers.get?("Content-Type") || "").downcase
+        rescue
+          ""
+        end
+
+        # {path, query-without-'?'} — query is "" when the target has none.
+        private def self.split_target(target : String) : {String, String}
+          qi = target.index('?')
+          return {target, ""} unless qi
+          {target[0...qi], target[(qi + 1)..]}
+        end
+
+        # Percent-decoded name/value. UNSCRUBBED (a rule that PCREs it scrubs at the point of use).
+        private def self.decode(s : String) : String
+          URI.decode_www_form(s)
+        rescue
+          s
+        end
+      end
+    end
+  end
+end

--- a/src/gori/probe/active/lfi_param_traversal.cr
+++ b/src/gori/probe/active/lfi_param_traversal.cr
@@ -1,7 +1,7 @@
 require "uri"
 require "./types"
-require "../../miner/inject"
-require "../../fuzz/content_length"
+require "./insertion_points"
+require "../../miner/types"
 require "../../proxy/codec/http1"
 require "../../proxy/codec/content_decode"
 
@@ -9,7 +9,7 @@ module Gori
   module Probe
     module Active
       # Active parameter path-traversal / LFI probe (a self-referential byte differential, sibling of
-      # NginxAliasTraversal but keyed on a PARAMETER value instead of the URL path). When a query
+      # NginxAliasTraversal but keyed on a PARAMETER value instead of the URL path). When a
       # parameter names a file the server reads off disk (`?file=doc.pdf`, `?page=home.html`), an
       # un-canonicalized read resolves `..` segments — the local-file-inclusion / path-traversal
       # class. Passive analysis cannot tell such a parameter apart from any other string.
@@ -31,12 +31,13 @@ module Gori
       #   * 2xx captured status with a non-empty body — there must be a real served resource + baseline.
       #   * a PATH-LIKE parameter (value holds a `/` or a file extension, or a known file-ish name) whose
       #     value does not already contain `..` — so arbitrary params aren't probed.
+      # Insertion points come from the shared `InsertionPoints` model (query today).
       class LfiParamTraversal < Rule
         FOLD     = "x/../"      # value -> x/../value          (literal ..)
         ENC_FOLD = "x/%2e%2e/"  # value -> x/%2e%2e/value      (encoded .. — defeats a literal-".." filter)
         CONTROL  = "x/zzznope/" # value -> x/zzznope/value     (a real subdir that cannot normalize back)
 
-        # Query-param names that conventionally carry a filesystem path/filename — and little else.
+        # Param names that conventionally carry a filesystem path/filename — and little else.
         # `name`, `url`, `view`, `page`, and `load` were dropped: `?name=John`, `?view=grid`, and
         # `?page=2` are ordinary application parameters, and this name list is checked REGARDLESS
         # of the value, so each of them alone sent three probes at a large share of all traffic.
@@ -63,20 +64,19 @@ module Gori
         end
 
         def dedup_key(detail : Store::FlowDetail, opts : Options = Options::DEFAULT) : String?
-          g = gate(detail, opts) || return nil
-          key_string(detail, g[0], g[1], g[4])
+          s, slot = gate(detail, opts) || return nil
+          InsertionPoints.dedup_key("lfi_param_traversal", detail, s.method, s.path, [slot])
         end
 
         def plan(detail : Store::FlowDetail, opts : Options = Options::DEFAULT) : Plan?
-          g = gate(detail, opts) || return nil
-          method_up, path, pairs, idx, name = g
-          body = detail.request_body
-          fold = rebuild_query(detail.request_head, body, path, with_prefix(pairs, idx, FOLD))
+          s, slot = gate(detail, opts) || return nil
+          fold = InsertionPoints.build(detail, [{slot, InsertionPoints::Change.new(prefix: FOLD)}])
           followups = [
-            rebuild_query(detail.request_head, body, path, with_prefix(pairs, idx, ENC_FOLD)),
-            rebuild_query(detail.request_head, body, path, with_prefix(pairs, idx, CONTROL)),
+            InsertionPoints.build(detail, [{slot, InsertionPoints::Change.new(prefix: ENC_FOLD)}]),
+            InsertionPoints.build(detail, [{slot, InsertionPoints::Change.new(prefix: CONTROL)}]),
           ]
-          Plan.new(fold, [Param.new("query", name, "")], key_string(detail, method_up, path, name), followups)
+          key = InsertionPoints.dedup_key("lfi_param_traversal", detail, s.method, s.path, [slot])
+          Plan.new(fold, [Param.new(slot.loc.label, slot.name, "")], key, followups)
         end
 
         # The differential: flag High iff a folded variant (literal or encoded `..`) returned
@@ -118,47 +118,26 @@ module Gori
           nil
         end
 
-        # Shared gate for plan + dedup_key. Returns {METHOD, path, all query pairs verbatim, the index
-        # of the first path-like pair, its DECODED name} for an eligible GET with such a param, else nil.
-        private def gate(detail : Store::FlowDetail, opts : Options) : {String, String, Array(String), Int32, String}?
-          method, target, malformed = Proxy::Codec::Http1.parse_request_line(detail.request_head)
-          return nil if malformed
-          method_up = method.upcase
-          return nil unless diff_method_allowed?(method_up, opts)
+        # Shared gate for plan + dedup_key. Returns {surface, the first path-like slot (name
+        # scrubbed for PCRE/evidence safety)} for an eligible flow, else nil. The scrub stays here
+        # rather than in InsertionPoints: `path_like?` runs PCRE (`FILE_EXT`/`NUMERIC_VALUE`) over
+        # the value, and Crystal's Regex RAISES on non-UTF-8; the module keeps values UNSCRUBBED so
+        # rules that re-send them (all the others) preserve bytes, and lfi scrubs at the point of use.
+        private def gate(detail : Store::FlowDetail, opts : Options) : {InsertionPoints::Surface, InsertionPoints::Slot}?
+          s = InsertionPoints.enumerate(detail, opts, InsertionPoints::DEFAULT_LOCATIONS) || return nil
+          return nil unless diff_method_allowed?(s.method, opts)
           status = detail.row.status
           return nil unless status && (200..299).includes?(status)
           rb = detail.response_body
           return nil if rb.nil? || rb.empty?
-          path, query = split_target(Active.origin_form(target))
-          return nil if query.empty?
-          pairs = query.split('&')
-          found = first_pathlike(pairs) || return nil
-          {method_up, path, pairs, found[0], found[1]}
-        end
-
-        # {index, decoded name} of the first path-like query pair whose value does not already contain
-        # `..`, or nil.
-        private def first_pathlike(pairs : Array(String)) : {Int32, String}?
-          pairs.each_with_index do |pair, i|
-            next if pair.empty?
-            eq = pair.index('=')
-            next unless eq
-            raw_name = pair[0...eq]
-            next if raw_name.empty?
-            raw_value = pair[(eq + 1)..]
-            next if raw_value.empty?
-            dvalue = decode(raw_value)
-            next if dvalue.includes?("..") # already-traversing / degenerate
-            dname = decode(raw_name)
-            return {i, dname} if path_like?(dname, dvalue)
+          found = s.slots.find do |slot|
+            next false if slot.raw_value.empty?
+            v = slot.value.scrub
+            next false if v.includes?("..") # already-traversing / degenerate
+            path_like?(slot.name.scrub, v)
           end
-          nil
-        end
-
-        # rule + host:PORT + METHOD + path + param name (a traversal is per-parameter). Length-prefix
-        # the name so an odd char can't collide with the path segment.
-        private def key_string(detail : Store::FlowDetail, method_upcase : String, path : String, name : String) : String
-          "lfi_param_traversal|#{detail.row.host}:#{detail.row.port}|#{method_upcase}|#{path}|#{name.bytesize}:#{name}"
+          return nil unless found
+          {s, found.copy_with(name: found.name.scrub)}
         end
 
         # Path-like: the value carries a `/` or a file-extension tell, or the name is a conventional
@@ -167,38 +146,6 @@ module Gori
           return true if value.includes?('/')
           return true if FILE_EXT.matches?(value)
           KNOWN_FILE_PARAMS.includes?(name.downcase) && !NUMERIC_VALUE.matches?(value)
-        end
-
-        # A copy of the query pairs with pair `idx`'s value prefixed (name kept verbatim, every other
-        # segment untouched).
-        private def with_prefix(pairs : Array(String), idx : Int32, prefix : String) : String
-          dup = pairs.dup
-          pair = dup[idx]
-          if eq = pair.index('=')
-            dup[idx] = "#{pair[0...eq]}=#{prefix}#{pair[(eq + 1)..]}"
-          end
-          dup.join('&')
-        end
-
-        # Percent-decoded AND scrubbed. The scrub is not cosmetic: `path_like?` runs PCRE
-        # (`FILE_EXT`, `NUMERIC_VALUE`) over this, and Crystal's Regex RAISES
-        # `ArgumentError: UTF-8 error: illegal byte` on a subject that is not valid UTF-8 —
-        # which `%FF` decodes to. Every other rule that PCREs a URL scrubs first and says why
-        # (`passive/secret_in_url.cr`, `security_headers.cr`, `cors.cr`); this one did not, and
-        # its callers make that a crash rather than a skipped rule: the TUI's `A` estimate
-        # reaches it through `Analyzer#active_estimate` with no `rescue` in the event loop, and
-        # `scan_detail`'s blanket rescue silently drops every ACTIVE rule registered after it.
-        private def decode(s : String) : String
-          URI.decode_www_form(s).scrub
-        rescue
-          s.scrub
-        end
-
-        # {path, query-without-'?'} — query is "" when the target has none.
-        private def split_target(target : String) : {String, String}
-          qi = target.index('?')
-          return {target, ""} unless qi
-          {target[0...qi], target[(qi + 1)..]}
         end
 
         private def probe_status(result : Repeater::Result) : Int32
@@ -217,25 +164,6 @@ module Gori
           decoded, _ = Proxy::Codec::ContentDecode.decode(head, body, BODY_CAP)
           b = decoded || body
           b[0, {b.size, BODY_CAP}.min]
-        end
-
-        # Reassemble the request with a new query on the request line, preserving the body and
-        # re-syncing Content-Length (mirrors ReflectedParam#rebuild / BackslashPowered#rebuild_query).
-        private def rebuild_query(orig_head : Bytes, body : Bytes?, path : String, new_query : String) : Bytes
-          head, _, eol = Miner::Inject.split(orig_head)
-          lines = String.new(head).split(eol)
-          unless lines.empty?
-            parts = lines[0].split(' ')
-            if parts.size == 3
-              target = new_query.empty? ? path : "#{path}?#{new_query}"
-              lines[0] = "#{parts[0]} #{target} #{parts[2]}"
-            end
-          end
-          io = IO::Memory.new
-          io << lines.join(eol) << eol << eol
-          b = body || Bytes.empty
-          io.write(b) unless b.empty?
-          Fuzz::ContentLength.sync(io.to_slice, false)
         end
       end
     end

--- a/src/gori/probe/active/reflected_param.cr
+++ b/src/gori/probe/active/reflected_param.cr
@@ -1,10 +1,9 @@
 require "uri"
 require "json"
 require "./types"
+require "./insertion_points"
 require "../../miner/types"
-require "../../miner/inject"
 require "../../fuzz/engine"
-require "../../fuzz/content_length"
 require "../../proxy/codec/http1"
 require "../../proxy/codec/content_decode"
 
@@ -15,6 +14,11 @@ module Gori
       # (query / form / JSON) with a distinct canary, sends ONE request, and reports the
       # parameters whose canary echoes back — grading each by whether the echo was ENCODED.
       # Gated to safe methods so an automatic probe never mutates server state.
+      #
+      # Insertion points come from the shared `InsertionPoints` model (query + form + JSON); the
+      # rule keeps its own method gate + param cap + canary-grading. A GET/HEAD rarely carries a
+      # body, so the form/JSON surfaces materialize almost only under `allow_unsafe` (which admits
+      # body-bearing methods) — the method gate, not a special case, does that.
       #
       # The canary carries a MARKER of the four characters that decide whether a reflection is
       # exploitable: `"`, `'`, `<`, `>`. An alphanumeric canary on its own cannot answer that
@@ -30,7 +34,7 @@ module Gori
       #   * none survived       — the value was escaped, stripped, or encoded. Still worth knowing
       #                           as a reflection point, so it is reported at Info rather than
       #                           dropped, but it is not an XSS finding.
-      # A partial survival is read in order, so `"'&lt;&gt;` reports `"'` — an escaped `<` stops
+      # A partial survival is read in order, so `"'<>` reports `"'` — an escaped `<` stops
       # the run exactly where the server's filter did.
       class ReflectedParam < Rule
         # Appended to every canary. Sent URL-encoded (query/form) or JSON-escaped (body), so the
@@ -50,125 +54,32 @@ module Gori
             Category::ACTIVE)
         end
 
-        # The dedup key WITHOUT generating canaries or rebuilding the request — extracts the same
-        # (name, location) set `plan` derives from canary_pairs/canary_json (same skip rules), so
-        # the key is byte-identical to `plan(detail).dedup_key`. Returns nil in exactly the cases
-        # `plan` does (malformed / unsafe method / no params / too many). Verified against `plan`
-        # by the equivalence spec.
+        # The dedup key WITHOUT generating canaries or rebuilding the request — derived from the
+        # same `InsertionPoints.enumerate` gate `plan` uses (same skip rules, same cap), so it is
+        # byte-identical to `plan(detail).dedup_key` and nil in exactly the same cases.
         def dedup_key(detail : Store::FlowDetail, opts : Options = Options::DEFAULT) : String?
-          # Start-line-only fast path: the key needs only method + target, so a non-eligible method
-          # or malformed head is rejected WITHOUT allocating the whole header block. The dominant
-          # bodyless GET/HEAD never parses headers; only a request that actually carries a body
-          # falls through to a full parse (for Content-Type). Byte-identical to plan's key.
-          method, target, malformed = Proxy::Codec::Http1.parse_request_line(detail.request_head)
-          return nil if malformed
-          method_up = method.upcase
-          return nil unless method_allowed?(method_up, opts)
-          path, query = split_target(Active.origin_form(target))
-          names = [] of {String, String} # {name, location}, matching Param.{name, location}
-          each_param_name(query) { |raw| names << {decode_name(raw), "query"} }
-          body = detail.request_body
-          if body && !body.empty?
-            # Full parse ONLY when a body exists — reuse HeaderList#get? so the Content-Type
-            # last-match / case-insensitive semantics stay IDENTICAL to plan's (never hand-rolled).
-            req = Proxy::Codec::Http1.parse_request_head(detail.request_head)
-            ct = (req.headers.get?("Content-Type") || "").downcase
-            if ct.includes?("x-www-form-urlencoded")
-              # Not `.scrub`: the body is captured bytes and this key must stay
-              # byte-identical to `plan`'s (see `canary_pairs` below), which reads the
-              # same un-scrubbed text to build the request it actually SENDS.
-              each_param_name(String.new(body)) { |raw| names << {decode_name(raw), "form"} }
-            elsif ct.includes?("json")
-              each_json_string_key(body) { |k| names << {k, "json"} }
-            end
-          end
-          return nil if names.empty? || names.size > opts.max_params
-          build_dedup_key(detail, method_up, path, names)
+          s = InsertionPoints.enumerate(detail, opts, InsertionPoints::DEFAULT_LOCATIONS) || return nil
+          return nil unless method_allowed?(s.method, opts)
+          return nil if s.slots.empty? || s.slots.size > opts.max_params
+          InsertionPoints.dedup_key("reflected_param", detail, s.method, s.path, s.slots)
         end
 
         # Build a probe from a captured flow, or nil if there is nothing reflectable.
         def plan(detail : Store::FlowDetail, opts : Options = Options::DEFAULT) : Plan?
-          req = Proxy::Codec::Http1.parse_request_head(detail.request_head)
-          return nil if req.malformed?
-          return nil unless method_allowed?(req.method.upcase, opts)
-          # A plaintext forward-proxy flow is captured ABSOLUTE-form ("GET http://h/p"); the
-          # probe is sent DIRECT to the origin (Fuzz::Sender → Repeater::Engine, no rewrite),
-          # so normalize to origin-form here the way the regular repeater path (FlowRequest)
-          # does — some origins reject an absolute-form target on a non-proxied request.
-          path, query = split_target(Active.origin_form(req.target))
+          s = InsertionPoints.enumerate(detail, opts, InsertionPoints::DEFAULT_LOCATIONS) || return nil
+          return nil unless method_allowed?(s.method, opts)
+          return nil if s.slots.empty? || s.slots.size > opts.max_params
 
           params = [] of Param
-          new_query, qp = canary_pairs(query, "query")
-          params.concat(qp)
-
-          body = detail.request_body
-          new_body = body
-          if body && !body.empty?
-            ct = (req.headers.get?("Content-Type") || "").downcase
-            if ct.includes?("x-www-form-urlencoded")
-              # Not `.scrub`: this rebuilds the BODY THE PROBE SENDS. `canary_pairs` only
-              # ever emits a fresh canary for a param's VALUE — never reads it back — but
-              # every param NAME and every pair the split/`=` scan skips (no `=`, empty
-              # name) is copied out of this text verbatim. Scrubbing first meant an
-              # untouched, unrelated field carrying a raw non-UTF-8 byte reached the origin
-              # as three `U+FFFD` bytes instead of the one the operator's capture had.
-              # `String#split(Char)`/`#index`/`#[]` only slice on byte offsets found by
-              # scanning, so the un-scrubbed text is safe to split.
-              nb, fp = canary_pairs(String.new(body), "form")
-              params.concat(fp)
-              new_body = nb.to_slice
-            elsif ct.includes?("json")
-              nb, jp = canary_json(body)
-              if nb
-                params.concat(jp)
-                new_body = nb
-              end
-            end
+          changes = [] of {InsertionPoints::Slot, InsertionPoints::Change}
+          s.slots.each do |slot|
+            canary = Miner::Canary.fresh
+            params << Param.new(slot.loc.label, slot.name, canary)
+            changes << {slot, InsertionPoints::Change.new(replace: ReflectedParam.probe_value(canary))}
           end
-
-          return nil if params.empty? || params.size > opts.max_params
-          request = rebuild(detail.request_head, path, new_query, new_body)
-          # Same key builder `dedup_key` uses, fed the built params — so the pre-build dedup key
-          # and this one can't drift.
-          key = build_dedup_key(detail, req.method.upcase, path, params.map { |p| {p.name, p.location} })
+          request = InsertionPoints.build(detail, changes)
+          key = InsertionPoints.dedup_key("reflected_param", detail, s.method, s.path, s.slots)
           Plan.new(request, params, key)
-        end
-
-        # Key by rule + host:PORT + METHOD + path + (name@location) so the same host on a different
-        # port/service is a distinct surface. Length-prefix each name so a param name containing
-        # '@'/','/':' can't collide with a different multi-param set. Sorted → order-independent.
-        private def build_dedup_key(detail : Store::FlowDetail, method_upcase : String, path : String,
-                                    names : Array({String, String})) : String
-          sig = names.map { |(name, loc)| "#{name.bytesize}:#{name}@#{loc}" }.sort!.join(",")
-          "reflected_param|#{detail.row.host}:#{detail.row.port}|#{method_upcase}|#{path}|#{sig}"
-        end
-
-        # The valid k=v names of an &-joined string — the SAME skip rules canary_pairs applies
-        # (empty pair / no '=' / empty name are skipped), yielding the RAW (pre-decode) name.
-        private def each_param_name(text : String, & : String ->)
-          return if text.empty?
-          text.split('&').each do |pair|
-            next if pair.empty?
-            eq = pair.index('=')
-            next unless eq
-            name = pair[0...eq]
-            next if name.empty?
-            yield name
-          end
-        end
-
-        # The top-level JSON keys with a STRING value — the SAME fields canary_json canaries.
-        # Not `.scrub`: must read the same bytes `canary_json` does, or a key name carrying
-        # invalid UTF-8 would compute a different dedup key than `plan` does. `JSON.parse`
-        # does not require valid UTF-8 inside a string body to parse it.
-        private def each_json_string_key(body : Bytes, & : String ->)
-          h = begin
-            JSON.parse(String.new(body)).as_h?
-          rescue JSON::ParseException
-            nil
-          end
-          return unless h
-          h.each { |k, v| yield k if v.as_s? }
         end
 
         # Interpret the probe's response: at most ONE Detection, graded by the strongest echo seen
@@ -270,96 +181,6 @@ module Gori
           (Proxy::Codec::Http1.parse_response_head(result.head).headers.get?("Content-Type") || "").downcase
         rescue
           ""
-        end
-
-        # {path, query-without-'?'} — query is "" when the target has none.
-        private def split_target(target : String) : {String, String}
-          qi = target.index('?')
-          return {target, ""} unless qi
-          {target[0...qi], target[(qi + 1)..]}
-        end
-
-        # Replace every k=v value in an &-joined string with a fresh canary, keeping bare flags
-        # and empty segments verbatim. Returns {rebuilt string, params}.
-        private def canary_pairs(text : String, location : String) : {String, Array(Param)}
-          params = [] of Param
-          return {text, params} if text.empty?
-          rebuilt = text.split('&').map do |pair|
-            next pair if pair.empty?
-            eq = pair.index('=')
-            next pair unless eq
-            name = pair[0...eq]
-            next pair if name.empty?
-            canary = Miner::Canary.fresh
-            params << Param.new(location, decode_name(name), canary)
-            # URL-encoded: the marker carries `"'<>`, which have no business sitting raw in a
-            # request line (the alnum canary alone needed no encoding). space_to_plus:false for
-            # the same reason Ssti#inject uses it — `+` is not universally decoded back to a space.
-            "#{name}=#{URI.encode_www_form(ReflectedParam.probe_value(canary), space_to_plus: false)}"
-          end.join('&')
-          {rebuilt, params}
-        end
-
-        private def decode_name(name : String) : String
-          URI.decode_www_form(name)
-        rescue
-          name
-        end
-
-        # Replace top-level JSON string values with canaries; nil unless the root is an object
-        # with at least one string field.
-        #
-        # Not `.scrub`: this rebuilds the BODY THE PROBE SENDS. Every string field NOT chosen
-        # for a canary is carried through as the `JSON::Any` this parse produced (`merged[k] =
-        # v`), so scrubbing first meant any non-canaried string field holding a raw non-UTF-8
-        # byte reached the origin as `U+FFFD`. `JSON.parse` does not require its input to be
-        # valid UTF-8 to parse a string value's bytes, and `to_json` round-trips them as-is.
-        private def canary_json(body : Bytes) : {Bytes?, Array(Param)}
-          params = [] of Param
-          h = begin
-            JSON.parse(String.new(body)).as_h?
-          rescue JSON::ParseException
-            nil
-          end
-          return {nil, params} unless h
-          merged = {} of String => JSON::Any
-          h.each do |k, v|
-            if v.as_s?
-              canary = Miner::Canary.fresh
-              params << Param.new("json", k, canary)
-              # `to_json` escapes the marker's `"` for the wire; the server decodes it back, so
-              # what it reflects is the real character — exactly what `survived` needs to read.
-              merged[k] = JSON::Any.new(ReflectedParam.probe_value(canary))
-            else
-              merged[k] = v
-            end
-          end
-          return {nil, params} if params.empty?
-          {merged.to_json.to_slice, params}
-        end
-
-        # Reassemble the request with the canary-stuffed request-line + body, re-syncing
-        # Content-Length when the body changed.
-        private def rebuild(orig_head : Bytes, path : String, new_query : String,
-                            new_body : Bytes?) : Bytes
-          # detail.request_head always ends in CRLFCRLF (read_head contract) and a well-formed
-          # head has no earlier blank line, so Inject.split keys off that terminator regardless
-          # of whether the body is appended. Splitting orig_head directly is byte-identical to
-          # the old "concat head+body, split, discard the body half" — one alloc+copy fewer.
-          head, _, eol = Miner::Inject.split(orig_head)
-          lines = String.new(head).split(eol)
-          unless lines.empty?
-            parts = lines[0].split(' ')
-            if parts.size == 3
-              new_target = new_query.empty? ? path : "#{path}?#{new_query}"
-              lines[0] = "#{parts[0]} #{new_target} #{parts[2]}"
-            end
-          end
-          io = IO::Memory.new
-          io << lines.join(eol) << eol << eol
-          body = new_body || Bytes.empty
-          io.write(body) unless body.empty?
-          Fuzz::ContentLength.sync(io.to_slice, false)
         end
       end
     end

--- a/src/gori/probe/active/ssti.cr
+++ b/src/gori/probe/active/ssti.cr
@@ -1,8 +1,7 @@
 require "uri"
 require "./types"
+require "./insertion_points"
 require "../../miner/types"
-require "../../miner/inject"
-require "../../fuzz/content_length"
 require "../../proxy/codec/http1"
 require "../../proxy/codec/content_decode"
 
@@ -27,7 +26,8 @@ module Gori
       #   * the DOUBLE product — a coincidental constant would have to read `49` in A and `56` in B at
       #     the same canary region, which distinct fresh canaries make impossible.
       # Gated to body-comparable methods (GET by default, HEAD out; Options#allow_unsafe widens), since
-      # the confirmation reads response bodies.
+      # the confirmation reads response bodies. Insertion points come from the shared
+      # `InsertionPoints` model (query today).
       class Ssti < Rule
         # Fresh-canary-wrapped polyglot values are built per param; these are the two arithmetic
         # products (chosen away from common page constants like 7 / 100).
@@ -47,28 +47,29 @@ module Gori
         end
 
         def dedup_key(detail : Store::FlowDetail, opts : Options = Options::DEFAULT) : String?
-          method, target, malformed = Proxy::Codec::Http1.parse_request_line(detail.request_head)
-          return nil if malformed
-          method_up = method.upcase
-          return nil unless diff_method_allowed?(method_up, opts)
-          path, query = split_target(Active.origin_form(target))
-          names = [] of String
-          each_param_name(query) { |raw| names << decode_name(raw) }
-          return nil if names.empty? || names.size > opts.max_params
-          build_dedup_key(detail, method_up, path, names)
+          s = InsertionPoints.enumerate(detail, opts, InsertionPoints::DEFAULT_LOCATIONS) || return nil
+          return nil unless diff_method_allowed?(s.method, opts)
+          return nil if s.slots.empty? || s.slots.size > opts.max_params
+          InsertionPoints.dedup_key("ssti", detail, s.method, s.path, s.slots)
         end
 
         def plan(detail : Store::FlowDetail, opts : Options = Options::DEFAULT) : Plan?
-          method, target, malformed = Proxy::Codec::Http1.parse_request_line(detail.request_head)
-          return nil if malformed
-          method_up = method.upcase
-          return nil unless diff_method_allowed?(method_up, opts)
-          path, query = split_target(Active.origin_form(target))
-          params = harvest(query)
-          return nil if params.empty? || params.size > opts.max_params
-          probe_a = rebuild(detail.request_head, path, inject(query, params, EXPR_A), detail.request_body)
-          probe_b = rebuild(detail.request_head, path, inject(query, params, EXPR_B), detail.request_body)
-          key = build_dedup_key(detail, method_up, path, params.map(&.name))
+          s = InsertionPoints.enumerate(detail, opts, InsertionPoints::DEFAULT_LOCATIONS) || return nil
+          return nil unless diff_method_allowed?(s.method, opts)
+          return nil if s.slots.empty? || s.slots.size > opts.max_params
+
+          params = [] of Param
+          changes_a = [] of {InsertionPoints::Slot, InsertionPoints::Change}
+          changes_b = [] of {InsertionPoints::Slot, InsertionPoints::Change}
+          s.slots.each do |slot|
+            canary = Miner::Canary.fresh
+            params << Param.new(slot.loc.label, slot.name, canary)
+            changes_a << {slot, InsertionPoints::Change.new(replace: polyglot(canary, EXPR_A))}
+            changes_b << {slot, InsertionPoints::Change.new(replace: polyglot(canary, EXPR_B))}
+          end
+          probe_a = InsertionPoints.build(detail, changes_a)
+          probe_b = InsertionPoints.build(detail, changes_b)
+          key = InsertionPoints.dedup_key("ssti", detail, s.method, s.path, s.slots)
           Plan.new(probe_a, params, key, [probe_b])
         end
 
@@ -118,71 +119,6 @@ module Gori
           canary + "{{" + expr + "}}" + "${" + expr + "}" + "\#{" + expr + "}" + "<%= " + expr + " %>" + canary
         end
 
-        # A copy of the query with every k=v value replaced by the canary-wrapped polyglot for `expr`
-        # (URL-encoded so the markers survive the request line; the alnum canary passes through).
-        private def inject(query : String, params : Array(Param), expr : String) : String
-          idx = 0
-          query.split('&').map do |pair|
-            next pair if pair.empty?
-            eq = pair.index('=')
-            next pair unless eq
-            name = pair[0...eq]
-            next pair if name.empty?
-            p = params[idx]
-            idx += 1
-            # space_to_plus:false → spaces become %20, not +. The `<%= E %>` (ERB) branch has spaces;
-            # a server that url-decodes %XX but leaves `+` literal would otherwise see `<%=+E+%>` and
-            # never evaluate it. %20 is decoded to a space universally.
-            "#{name}=#{URI.encode_www_form(polyglot(p.canary, expr), space_to_plus: false)}"
-          end.join('&')
-        end
-
-        # One Param{query, decoded name, fresh canary} per valid k=v query pair — canary shared across
-        # the A/B probes so `between` locates the same region in each.
-        private def harvest(query : String) : Array(Param)
-          params = [] of Param
-          return params if query.empty?
-          query.split('&').each do |pair|
-            next if pair.empty?
-            eq = pair.index('=')
-            next unless eq
-            name = pair[0...eq]
-            next if name.empty?
-            params << Param.new("query", decode_name(name), Miner::Canary.fresh)
-          end
-          params
-        end
-
-        private def each_param_name(query : String, & : String ->)
-          return if query.empty?
-          query.split('&').each do |pair|
-            next if pair.empty?
-            eq = pair.index('=')
-            next unless eq
-            name = pair[0...eq]
-            next if name.empty?
-            yield name
-          end
-        end
-
-        private def build_dedup_key(detail : Store::FlowDetail, method_upcase : String, path : String,
-                                    names : Array(String)) : String
-          sig = names.map { |n| "#{n.bytesize}:#{n}@query" }.sort!.join(",")
-          "ssti|#{detail.row.host}:#{detail.row.port}|#{method_upcase}|#{path}|#{sig}"
-        end
-
-        private def decode_name(name : String) : String
-          URI.decode_www_form(name)
-        rescue
-          name
-        end
-
-        private def split_target(target : String) : {String, String}
-          qi = target.index('?')
-          return {target, ""} unless qi
-          {target[0...qi], target[(qi + 1)..]}
-        end
-
         private def decoded_text(result : Repeater::Result) : String
           decoded, _ = Proxy::Codec::ContentDecode.decode(result.head, result.body, BODY_CAP)
           bytes = decoded || result.body
@@ -190,23 +126,6 @@ module Gori
           String.new(bytes[0, {bytes.size, BODY_CAP}.min]).scrub
         rescue
           ""
-        end
-
-        private def rebuild(orig_head : Bytes, path : String, new_query : String, body : Bytes?) : Bytes
-          head, _, eol = Miner::Inject.split(orig_head)
-          lines = String.new(head).split(eol)
-          unless lines.empty?
-            parts = lines[0].split(' ')
-            if parts.size == 3
-              target = new_query.empty? ? path : "#{path}?#{new_query}"
-              lines[0] = "#{parts[0]} #{target} #{parts[2]}"
-            end
-          end
-          io = IO::Memory.new
-          io << lines.join(eol) << eol << eol
-          b = body || Bytes.empty
-          io.write(b) unless b.empty?
-          Fuzz::ContentLength.sync(io.to_slice, false)
         end
       end
     end


### PR DESCRIPTION
## What

Adds `Active::InsertionPoints` — one pure, byte-preserving module that owns request **slot enumeration + rebuild** across query / form / JSON (plus header/cookie groundwork) — and routes the five value-injection rules (`reflected_param`, `ssti`, `error_based_sqli`, `backslash_powered`, `lfi_param_traversal`) through it, replacing their per-file query parsing, value mutation, request rebuild, and dedup-key construction.

## Why

The active scanner had **no shared insertion-point model**. `reflected_param` handled query/form/JSON, but SSTI, error-based SQLi, backslash-powered, and LFI were **query-parameter only** and passed the request body through untouched — so a JSON/form API was effectively invisible to them (`error_based_sqli` only probed the first 3 *query* params; a JSON-body endpoint has none). `Miner::Inject` was a universal injector but only for parameter *discovery* (append semantics), not scanning (mutate-existing-value).

## Coverage

| Rule | Before | After |
|---|---|---|
| `reflected_param` | query + form + json | query + form + json |
| `ssti` / `error_based_sqli` / `backslash_powered` / `lfi_param_traversal` | **query only** | query + **form + json** |

Body params only fire on body-bearing methods, which the differential rules already gate behind `allow_unsafe` — so the new coverage lands in manual/aggressive runs and **never re-POSTs during automatic scans**. The combined per-rule cap spans all locations.

## Design

- `InsertionPoints.enumerate` feeds **both** `dedup_key` and `plan`, preserving the byte-identical `dedup_key == plan.dedup_key` equivalence invariant.
- Two change strategies: **REPLACE** (module encodes per location) and **RAW** (wire-ready prefix/suffix, byte-preserved for query/form; URL-decoded before wrapping a JSON string).
- Non-UTF-8 safety preserved (unscrubbed re-sent bytes, byte-safe head walk via the now-shared `Miner::Inject.each_ascii_line`, lfi scrubs only at its PCRE).
- Header/cookie enumeration/build is kept as **aggressive-gated, name-addressed, unit-tested groundwork — not wired into any rule yet**: the single batched `reflected_param` probe can't safely mutate `Authorization`/`Cookie`/`Content-Type` (it would break every other param's reflection). Doing it right needs a per-slot multi-probe rule model — a focused follow-up.

## Testing

- No dispatch-loop changes (`active.cr` / `analyzer.cr` untouched); all existing probe specs stay green **with zero edits** — byte + key parity is the acceptance proof.
- New `spec/probe/insertion_points_spec.cr` covers the module (enumerate/build across locations, RAW-vs-REPLACE, header-by-name, non-UTF-8 desync guard) and the widened body-param coverage (JSON/form SQLi, JSON SSTI).
- `crystal spec spec/probe_spec.cr spec/probe/` → 606 examples, 0 failures. Full project type-checks; `crystal tool format --check src spec` clean.

## Review addressed

A code review flagged that wiring header/cookie into `reflected_param`'s single-request model was a regression (batching auth/content-type mutation broke all detection under aggressive) and a header-index desync — both fixed here by deferring the rule-side header/cookie wiring and addressing header/cookie slots by name. Also single-sourced the CR/LF guard + byte-safe line walk from `Miner::Inject`, and added shared `NO_CHANGES` / `DEFAULT_LOCATIONS` constants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)