### PR TITLE
feat(import): WSDL 1.1 / SOAP source

### DIFF
--- a/.github/DESIGN.md
+++ b/.github/DESIGN.md
@@ -1680,3 +1680,46 @@ two would drift. The first-byte test on this listener is the TWO-byte `ClientHel
 a non-HTTP protocol is most likely to arrive — `ssh -D` is what most people point at one — and
 feeding an SSH banner into an OpenSSL server handshake because its first octet happened to be
 0x16 helps nobody.
+
+### 2026-08-23: a service description is a document, not the operator's payload
+
+**Decision.** `Import::XmlMini` — the namespace-aware reader `Import::Wsdl` is built on —
+REFUSES a `<!DOCTYPE>` outright, rather than ignoring it and carrying on. That is stricter than
+P7, and the strictness is the point: the axis P7 actually names is provenance, and a WSDL is
+not the class of bytes P7 protects.
+
+`Import::Raw` is the P7 path. A Burp item's `<request>` holds the wire bytes the operator
+captured and will replay; a lying `Content-Length`, a CRLF in the target and a duplicate `Host`
+are the payload, and `import/burp.cr` goes out of its way not to scrub them. `Import::Burp`'s
+own fixtures carry a benign DOCTYPE, because Burp writes one.
+
+A WSDL holds no such bytes. It is a description gori READS in order to build a request that did
+not exist before, and every octet of it reaches the wire only after passing through the XSD
+skeleton generator. Nothing in it is evidence. So the two questions a DOCTYPE raises have
+different answers than they would on the capture path:
+
+* **Ignoring is not neutral.** An undeclared `&payload;` left in the document decodes to
+  nothing, and the `<soap:address location="&payload;/svc">` it sat in becomes a silently WRONG
+  endpoint — an import reported as a success that seeds requests at the wrong host. A refusal
+  with a message is strictly better than a quietly corrupted seed request.
+* **Refusing costs nothing.** Neither WSDL 1.1 nor XML Schema has any use for a DTD, so a
+  DOCTYPE in a `.wsdl` is a generator bug or an attack, and no working document is lost.
+
+The security consequence is a side effect of that, not the argument for it, and it is closed at
+the root rather than by a counter someone has to remember to check. No external entity can be
+declared, and `XmlMini` has no file or network I/O to dereference one with — so there is no XXE.
+No internal general entity and no parameter entity can be declared, and `XmlText::NAMED_ENTITIES`
+is the fixed five-entry XML predefined table where an unknown `&foo;` stays VERBATIM rather than
+expanding — so entity expansion is O(1) in the input by construction, and billion-laughs has
+nothing to expand. The same reasoning is why `Import::Wsdl` never follows an `xsd:import`
+`schemaLocation`: an importer that fetches one is an importer with the I/O this reader exists
+to not have.
+
+Two smaller consequences of the same distinction. `XmlMini` SCRUBS invalid UTF-8 on the way in,
+where `Import::Burp` must not — a byte that cannot be text has no meaning in a document whose
+only outputs are names, URLs and placeholder values. And an out-of-scope PORT (an
+`http:binding`, a JMS transport, a relative address) is reported as a NOTE rather than counted
+in `skipped`: `skipped` means a malformed entry, and a .NET WSDL publishing `FooHttpGet` beside
+`FooSoap` is not damaged. When nothing at all was generated the first note becomes the error
+message, so "every port here is HTTP GET/POST" is a sentence the operator gets to read instead
+of the generic "no flows found".

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- A `--wsdl` import source: a WSDL 1.1 service description becomes one SOAP request template per operation on every SOAP port it publishes, from the palette (`Import: WSDL`), `gori run import --wsdl PATH`, and the MCP `import_flows` tool. SOAP 1.1 and 1.2 bindings both, with bodies built from the XSD inline in the document; external schemas are never fetched and a `<!DOCTYPE>` is refused.
+
 - The NEW / EDIT ISSUE card's severity steps with `←`/`→`, the way every other cycler in the TUI does; `⇥` now moves between the title and the severity row rather than being the only control that changed it (#789).
 
 - The History detail's MESSAGES pane shows a WebSocket frame's shape, as `gori run show` and the Repeater transcript already did: a PING, a PONG, a CLOSE with its code and reason, a message reassembled from several frames, an RSV bit and a client frame sent UNMASKED were all one indistinguishable `«binary Nb»` line in the one place an operator reads while working a socket (#787).

--- a/docs/content/guide/mcp.ko.md
+++ b/docs/content/guide/mcp.ko.md
@@ -146,7 +146,7 @@ Codex와 Grok은 `[mcp_servers.gori]` 테이블이 있는 TOML을, Hermes는 `mc
 | `create_rule` / `update_rule` / `set_rule_enabled` / `delete_rule` | Match & Replace 규칙 생성, 편집, 토글, 삭제(오가는 요청/응답의 헤드 또는 본문을 그 자리에서 재작성). 각각 `scope`를 받습니다 — `project`(기본값) 또는 모든 프로젝트에 적용되는 `global` |
 | `create_view` / `update_view` / `delete_view` | 저장된 History [뷰](/ko/guide/proxy/#views) 생성, 편집, 스코프 이동, 삭제. 각각 `scope`를 받습니다 — `project`(기본값) 또는 `global`. 쿼리는 들어올 때 검사합니다. 모든 항이 버려질 쿼리는 거절하는데, 아무것도 좁히지 못하면서 모든 표면의 칩은 좁히고 있다고 주장하게 되기 때문입니다 |
 | `preview_rule` | 규칙을 만들기 전에, 저장된 플로우 중 몇 개가 바뀌었을지 추정 |
-| `import_flows` | HAR / URL 목록 / OpenAPI / Postman / Insomnia / Burp 파일을 History로 일괄 임포트 |
+| `import_flows` | HAR / URL 목록 / OpenAPI / Postman / Insomnia / Burp / WSDL 파일을 History로 일괄 임포트 |
 | `delete_flow` / `clear_history` | 플로우 하나 삭제, 또는 캡처된 History 전체 삭제 |
 | `set_sitemap_tag` | Sitemap 경로에 자유 형식 메모 고정 |
 | `create_project` / `switch_project` / `delete_project` | 프로젝트 생성 또는 다시 열기, 이 서버를 다른 프로젝트로 전환, 프로젝트 삭제. 삭제는 2단계로, `dry_run` 후 확인 토큰 필요 |

--- a/docs/content/guide/mcp.md
+++ b/docs/content/guide/mcp.md
@@ -147,7 +147,7 @@ Every flag you pass alongside `--install-*` is written into the installed comman
 | `create_rule` / `update_rule` / `set_rule_enabled` / `delete_rule` | Create, edit, toggle, and delete Match & Replace rules (rewrites on in-flight request/response head or body). Each takes `scope` — `project` (default) or `global`, which applies in every project |
 | `create_view` / `update_view` / `delete_view` | Create, edit, re-home and delete saved History [views](/guide/proxy/#views). Each takes `scope` — `project` (default) or `global`. The query is validated on the way in: one whose every term would be dropped is refused, because it would narrow nothing while every surface showed a chip claiming it does |
 | `preview_rule` | Estimate how many stored flows a rule would change, before creating it |
-| `import_flows` | Bulk-import a HAR / URL list / OpenAPI / Postman / Insomnia / Burp file into History |
+| `import_flows` | Bulk-import a HAR / URL list / OpenAPI / Postman / Insomnia / Burp / WSDL file into History |
 | `delete_flow` / `clear_history` | Remove one flow, or wipe captured History |
 | `set_sitemap_tag` | Pin a free-text memo onto a sitemap path |
 | `create_project` / `switch_project` / `delete_project` | Create or reopen a project, point this server at another one, or delete one. Deletion is two-step: a `dry_run` first, then a confirmation token |

--- a/docs/content/guide/proxy.ko.md
+++ b/docs/content/guide/proxy.ko.md
@@ -485,6 +485,7 @@ Content-Type: application/json
 | **Import: Postman** | Postman Collection v2 익스포트 → 저장된 요청마다 요청 템플릿 하나 |
 | **Import: Insomnia** | Insomnia v4 JSON 익스포트 → 저장된 요청마다 요청 템플릿 하나 |
 | **Import: Burp** | Burp Suite 저장 항목(XML) → 전체 요청/응답 플로우, 바이트 단위 그대로 |
+| **Import: WSDL** | WSDL 1.1 서비스 설명서(XML) → 오퍼레이션마다 SOAP 요청 템플릿 하나 |
 
 형식이 잘못된 항목은 전체 임포트를 중단시키지 않고 건너뜁니다. 임포트된 플로우는 캡처된 트래픽처럼 History에 들어오므로, 똑같이 필터링하고 Repeater로 재전송하거나 퍼징·스캔할 수 있습니다.
 
@@ -494,7 +495,9 @@ Content-Type: application/json
 
 **Burp** 항목은 저장된 그대로의 wire 바이트를 유지합니다. 이상한 공백, 중복 헤더, 일부러 틀린 `Content-Length`, 요청 타깃 안의 CRLF까지 그대로입니다. 손으로 만든 요청이 Repeater에서 바이트 단위로 똑같이 재전송된다는 점이, 요청을 다시 기술하는 대신 Burp에서 가져오는 이유입니다.
 
-같은 소스를 헤드리스에서도 다룰 수 있습니다. `gori run import --postman PATH`(그리고 `--har` / `--urls` / `--oas` / `--insomnia` / `--burp`)와 MCP의 `import_flows` 도구입니다.
+**WSDL**은 서비스가 게시한 SOAP 포트마다 오퍼레이션당 SOAP 요청 템플릿 하나를 만듭니다. SOAP 1.1(`SOAPAction`, `text/xml`)과 SOAP 1.2(`action` 미디어 타입 파라미터, `application/soap+xml`)를 모두 다루므로, 두 버전을 함께 게시하는 엔드포인트는 요청 하나가 아니라 둘로 들어옵니다. 본문은 `<wsdl:types>` 안의 XSD에서 뽑아낸 스켈레톤이며, 내장 타입마다 유효한 플레이스홀더를 채워 스키마를 검증하는 게이트웨이도 시드 요청을 통과시킵니다. 재귀 타입은 첫 반복에서 멈추고 직접 중첩하라는 주석을 남깁니다. WSDL 1.1만 읽고, `http:binding`(GET/POST) 포트와 HTTP가 아닌 트랜스포트는 이유와 함께 건너뛸 뿐 손상으로 세지 않으며, 외부 `xsd:import` 파일은 가져오지 않고, `<!DOCTYPE>`는 아예 거부합니다 — 서비스 설명서는 문서이지, 재전송해 달라고 건넨 wire 바이트가 아니기 때문입니다.
+
+같은 소스를 헤드리스에서도 다룰 수 있습니다. `gori run import --postman PATH`(그리고 `--har` / `--urls` / `--oas` / `--insomnia` / `--burp` / `--wsdl`)와 MCP의 `import_flows` 도구입니다.
 
 ## 호스트 오버라이드 {#host-overrides}
 

--- a/docs/content/guide/proxy.md
+++ b/docs/content/guide/proxy.md
@@ -489,6 +489,7 @@ You don't have to capture everything live. From the command palette (`Ctrl-P`):
 | **Import: Postman** | Postman Collection v2 export → one request template per saved request |
 | **Import: Insomnia** | Insomnia v4 JSON export → one request template per saved request |
 | **Import: Burp** | Burp Suite saved items (XML) → full request/response flows, byte-exact |
+| **Import: WSDL** | WSDL 1.1 service description (XML) → one SOAP request template per operation |
 
 Malformed entries are skipped rather than aborting the whole import. Imported flows land in History like captured traffic, so you can filter, Repeater, Fuzz, and scan them the same way.
 
@@ -498,7 +499,9 @@ Malformed entries are skipped rather than aborting the whole import. Imported fl
 
 **Burp** items keep their wire bytes exactly as saved — odd spacing, duplicate headers, a deliberately wrong `Content-Length`, a CRLF in the request target. A hand-forged request replays from the Repeater byte-for-byte, which is the point of importing from Burp rather than re-describing the request.
 
-The same sources are scriptable headless: `gori run import --postman PATH` (and `--har` / `--urls` / `--oas` / `--insomnia` / `--burp`), and the MCP `import_flows` tool.
+**WSDL** builds one SOAP request template per operation, for every SOAP port a service publishes — SOAP 1.1 (`SOAPAction`, `text/xml`) and SOAP 1.2 (the `action` media-type parameter, `application/soap+xml`) alike, so a dual-stack endpoint arrives as two requests rather than one. The body is a skeleton derived from the XSD inline in `<wsdl:types>`, with a valid placeholder for each built-in type so a schema-validating gateway lets the seed request through; a recursive type stops at its first repetition with a comment where you nest it by hand. WSDL 1.1 only, `http:binding` (GET/POST) ports and non-HTTP transports are skipped with a reason rather than counted as damage, external `xsd:import` files are never fetched, and a `<!DOCTYPE>` is refused outright — a service description is a document, not the wire bytes you asked gori to replay.
+
+The same sources are scriptable headless: `gori run import --postman PATH` (and `--har` / `--urls` / `--oas` / `--insomnia` / `--burp` / `--wsdl`), and the MCP `import_flows` tool.
 
 ## Host Overrides
 

--- a/docs/content/reference/cli.ko.md
+++ b/docs/content/reference/cli.ko.md
@@ -69,7 +69,7 @@ gori run <subcommand> [verb] [options]
 | `probe issues` · `dismiss` · `promote` · `delete` | 저장된 Probe 발견 항목 트리아지 |
 | `probe rules` · `mode` | 스캔 규칙 목록 / 무장, 스캔 모드 조회 및 설정 |
 | `discover` | 엔드포인트를 스파이더링 & 브루트포스하여 Sitemap으로 반영 |
-| `import` | HAR / URL 목록 / OpenAPI / Postman / Insomnia / Burp 파일에서 History로 플로우 일괄 임포트 |
+| `import` | HAR / URL 목록 / OpenAPI / Postman / Insomnia / Burp / WSDL 파일에서 History로 플로우 일괄 임포트 |
 | `sitemap [QL]` | 호스트 → 경로 엔드포인트 트리 |
 | `sitemap tag` | Sitemap 경로에 자유 텍스트 메모를 고정 / 해제 / 목록 |
 | `oast listen` · `presets` | 아웃오브밴드 콜백 리스너 (interactsh 및 유사 서비스) |
@@ -472,6 +472,7 @@ gori run import --postman api.postman_collection.json --db ./assessment.db --for
 | `--postman=PATH` | Postman Collection v2 익스포트(JSON) |
 | `--insomnia=PATH` | Insomnia v4 익스포트(JSON) |
 | `--burp=PATH` | Burp Suite 항목 익스포트(XML) — 요청 **과** 응답, 바이트 단위 그대로 |
+| `--wsdl=PATH` | WSDL 1.1 서비스 설명서(XML) — 오퍼레이션마다 SOAP 요청 템플릿 하나 |
 | `--project=NAME` | 임포트할 프로젝트(기본값: 가장 최근에 사용한 프로젝트) |
 | `--db=PATH` | 임포트할 SQLite db 파일을 직접 지정(없으면 생성) |
 | `--format` | `text`(기본) 또는 `json` |

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -69,7 +69,7 @@ gori run <subcommand> [verb] [options]
 | `probe issues` · `dismiss` · `promote` · `delete` | Triage persisted Probe findings |
 | `probe rules` · `mode` | List / arm scan rules; get or set the scan mode |
 | `discover` | Spider and brute-force endpoints into the Sitemap |
-| `import` | Bulk-import flows into History from a HAR / URL list / OpenAPI / Postman / Insomnia / Burp file |
+| `import` | Bulk-import flows into History from a HAR / URL list / OpenAPI / Postman / Insomnia / Burp / WSDL file |
 | `sitemap [QL]` | Host → path endpoint tree |
 | `sitemap tag` | Pin, clear, or list a free-text memo on a sitemap path |
 | `oast listen` · `presets` | Out-of-band callback listener (interactsh & friends) |
@@ -505,6 +505,7 @@ gori run import --postman api.postman_collection.json --db ./assessment.db --for
 | `--postman=PATH` | A Postman Collection v2 export (JSON) |
 | `--insomnia=PATH` | An Insomnia v4 export (JSON) |
 | `--burp=PATH` | A Burp Suite item export (XML) — request **and** response, byte-exact |
+| `--wsdl=PATH` | A WSDL 1.1 service description (XML) — one SOAP request template per operation |
 | `--project=NAME` | Project to import into (default: most-recently-active) |
 | `--db=PATH` | Explicit SQLite db file to import into (created if absent) |
 | `--format` | `text` (default) or `json` |

--- a/spec/cli/run/import_spec.cr
+++ b/spec/cli/run/import_spec.cr
@@ -30,7 +30,8 @@ end
 describe "gori run import" do
   it "maps each source flag to its {kind, path}" do
     {har: "a.har", urls: "urls.txt", oas: "api.yaml",
-     postman: "c.postman_collection.json", insomnia: "i.json", burp: "items.xml"}.each do |kind, path|
+     postman: "c.postman_collection.json", insomnia: "i.json", burp: "items.xml",
+     wsdl: "service.wsdl"}.each do |kind, path|
       Gori::CLI::Run.import_source_for_spec(only(kind, path)).should eq({kind, path})
     end
   end
@@ -77,7 +78,7 @@ describe "gori run import" do
     # One table (Import::LABELS) feeds the CLI line, the overlay title and the TUI toast, so
     # they cannot drift apart as sources are added.
     {har: "HAR", urls: "URLs", oas: "OpenAPI",
-     postman: "Postman", insomnia: "Insomnia", burp: "Burp"}.each do |kind, label|
+     postman: "Postman", insomnia: "Insomnia", burp: "Burp", wsdl: "WSDL"}.each do |kind, label|
       Gori::CLI::Run.import_result_text_for_spec(kind, "f", Gori::Import::Result.new(count: 1))
         .should eq("imported 1 flow from #{label} · f")
       Gori::Tui::ImportOverlay.new(kind).label.should eq(label)

--- a/spec/import/wsdl_spec.cr
+++ b/spec/import/wsdl_spec.cr
@@ -122,6 +122,17 @@ describe Gori::Import::Wsdl do
     head_of(result).should contain(%(SOAPAction: ""))
   end
 
+  it "escapes a quote in soapAction rather than closing the quoted-string early" do
+    # `&quot;` in the WSDL decodes to a real quote, which would otherwise end the SOAPAction
+    # value (and, on SOAP 1.2, the `action=` media-type parameter) where the endpoint parses it.
+    result = parse(wsdl(bindings: %(<wsdl:binding name="B" type="tns:PT">) +
+                                  %(<soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>) +
+                                  %(<wsdl:operation name="Add"><soap:operation soapAction="a&quot;b"/>) +
+                                  %(<wsdl:input><soap:body use="literal"/></wsdl:input>) +
+                                  %(</wsdl:operation></wsdl:binding>)))
+    head_of(result).should contain(%(SOAPAction: "a\\"b"))
+  end
+
   it "builds an rpc/literal body from the message parts, in declaration order" do
     # The one structural difference from document/literal, and where a doc-only reader emits
     # a silently wrong envelope: ONE wrapper named by the OPERATION, whose children are one
@@ -358,6 +369,78 @@ describe Gori::Import::Wsdl do
       body = body_of(result)
       body.scan(/<ns1:child>/).size.should eq(1)
       body.should contain("recursive type {urn:t}Node")
+    end
+
+    it "stops an element `ref` cycle instead of recursing until the process dies" do
+      # A SECOND way to recurse forever, which neither of the type guards saw: an element
+      # carrying an INLINE anonymous complexType names no type, so nothing reached the cycle
+      # trail, and the depth counter used to restart at 1 on every hop through a `ref`. The
+      # result was a stack overflow — a signal, not an exception, so the per-operation rescue
+      # could not turn it into a `skipped`; it took the whole CLI/TUI/MCP process down.
+      result = parse(wsdl(types: <<-XSD))
+        <s:element name="Add"><s:complexType><s:sequence>
+          <s:element ref="tns:Add"/>
+        </s:sequence></s:complexType></s:element>
+        XSD
+      result.flows.size.should eq(1)
+      result.skipped.should eq(0)
+      body_of(result).should contain("recursive element {urn:t}Add")
+    end
+
+    it "charges a repeated subtree so the node budget bounds the EMITTED body" do
+      # `render` writes the subtree string `reps` times but builds it once, so a
+      # charge-on-construction budget grew linearly while the emitted count grew as the
+      # PRODUCT of the reps. Nested `maxOccurs="unbounded"` levels built a multi-gigabyte body
+      # and still reported `skipped: 0`. Now the copies are charged, so the operation is
+      # skipped and COUNTED rather than eating the machine.
+      levels = 20
+      types = String.build do |io|
+        io << %(<s:element name="Add" type="tns:T0"/>)
+        levels.times do |i|
+          io << %(<s:complexType name="T#{i}"><s:sequence>)
+          io << %(<s:element name="e#{i}" maxOccurs="unbounded" type="tns:T#{i + 1}"/>)
+          io << %(</s:sequence></s:complexType>)
+        end
+        io << %(<s:complexType name="T#{levels}"><s:sequence>) +
+              %(<s:element name="leaf" type="s:string"/></s:sequence></s:complexType>)
+      end
+      result = parse(wsdl(types: types))
+      result.flows.should be_empty
+      result.skipped.should eq(1)
+    end
+
+    it "replaces the base content model on a complexContent restriction, never appends to it" do
+      # Extension APPENDS and restriction REPLACES; sharing one branch both duplicated the
+      # particles a restriction kept and re-added the ones it removed, so a schema-validating
+      # gateway rejected the body before it reached any business logic.
+      result = parse(wsdl(types: <<-XSD))
+        <s:element name="Add" type="tns:Derived"/>
+        <s:complexType name="Base"><s:sequence>
+          <s:element name="a" type="s:string"/>
+          <s:element name="b" type="s:string"/>
+        </s:sequence></s:complexType>
+        <s:complexType name="Derived"><s:complexContent><s:restriction base="tns:Base">
+          <s:sequence><s:element name="a" type="s:string"/></s:sequence>
+        </s:restriction></s:complexContent></s:complexType>
+        XSD
+      body = body_of(result)
+      body.scan(/<ns1:a>/).size.should eq(1)
+      body.should_not contain("<ns1:b>")
+    end
+
+    it "keeps the base type's required attributes through a simpleContent extension" do
+      result = parse(wsdl(types: <<-XSD))
+        <s:element name="Add"><s:complexType><s:sequence>
+          <s:element name="amount" type="tns:Money"/>
+        </s:sequence></s:complexType></s:element>
+        <s:complexType name="Base"><s:simpleContent><s:extension base="s:decimal">
+          <s:attribute name="scale" type="s:int" use="required"/>
+        </s:extension></s:simpleContent></s:complexType>
+        <s:complexType name="Money"><s:simpleContent><s:extension base="tns:Base">
+          <s:attribute name="currency" type="s:string" fixed="USD"/>
+        </s:extension></s:simpleContent></s:complexType>
+        XSD
+      body_of(result).should contain(%(<ns1:amount scale="1" currency="USD">1.0</ns1:amount>))
     end
 
     it "comments an unresolvable type and names the schema it did not fetch" do

--- a/spec/import/wsdl_spec.cr
+++ b/spec/import/wsdl_spec.cr
@@ -1,0 +1,475 @@
+require "../spec_helper"
+
+# src/gori/import/wsdl.cr — WSDL 1.1 (SOAP 1.1 + 1.2) → response-less SOAP request templates.
+# Inline temp files rather than fixtures, matching spec/import/postman_spec.cr.
+
+private def with_store(&)
+  path = File.tempname("gori-wsdl", ".db")
+  store = Gori::Store.open(path)
+  begin
+    yield store
+  ensure
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+private def with_wsdl(xml : String, &)
+  path = File.tempname("gori", ".wsdl")
+  File.write(path, xml)
+  begin
+    yield path
+  ensure
+    File.delete?(path)
+  end
+end
+
+private def parse(xml : String) : Gori::Import::ParseResult
+  with_wsdl(xml) { |path| Gori::Import::Wsdl.parse_file(path) }
+end
+
+private def body_of(result : Gori::Import::ParseResult, i = 0) : String
+  String.new(result.flows[i].request.body.not_nil!)
+end
+
+private def head_of(result : Gori::Import::ParseResult, i = 0) : String
+  String.new(result.flows[i].request.head)
+end
+
+# A document/literal WSDL with every section replaceable, so an example shows only the part
+# it is about — a full WSDL runs ~50 lines and repeating it a dozen times buries the
+# assertion under boilerplate.
+private def wsdl(types = %(<s:element name="Add"><s:complexType><s:sequence>) +
+                   %(<s:element name="a" type="s:int"/></s:sequence></s:complexType></s:element>),
+                 messages = %(<wsdl:message name="AddIn"><wsdl:part name="parameters" element="tns:Add"/></wsdl:message>),
+                 port_type = %(<wsdl:portType name="PT"><wsdl:operation name="Add">) +
+                   %(<wsdl:input message="tns:AddIn"/></wsdl:operation></wsdl:portType>),
+                 bindings = %(<wsdl:binding name="B" type="tns:PT"><soap:binding style="document") +
+                   %( transport="http://schemas.xmlsoap.org/soap/http"/><wsdl:operation name="Add">) +
+                   %(<soap:operation soapAction="urn:Add"/><wsdl:input><soap:body use="literal"/>) +
+                   %(</wsdl:input></wsdl:operation></wsdl:binding>),
+                 ports = %(<wsdl:port name="P" binding="tns:B">) +
+                   %(<soap:address location="https://svc.test/endpoint"/></wsdl:port>),
+                 schema_attrs = %(elementFormDefault="qualified" targetNamespace="urn:t")) : String
+  <<-XML
+    <?xml version="1.0" encoding="utf-8"?>
+    <wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                      xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                      xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/"
+                      xmlns:http="http://schemas.xmlsoap.org/wsdl/http/"
+                      xmlns:s="http://www.w3.org/2001/XMLSchema"
+                      xmlns:tns="urn:t" targetNamespace="urn:t">
+      <wsdl:types><s:schema #{schema_attrs}>#{types}</s:schema></wsdl:types>
+      #{messages}
+      #{port_type}
+      #{bindings}
+      <wsdl:service name="Svc">#{ports}</wsdl:service>
+    </wsdl:definitions>
+    XML
+end
+
+describe Gori::Import::Wsdl do
+  it "builds one request template per operation of a document/literal service" do
+    result = parse(wsdl(
+      types: %(<s:element name="Add"><s:complexType><s:sequence><s:element name="a" type="s:int"/>) +
+             %(</s:sequence></s:complexType></s:element>) +
+             %(<s:element name="Sub"><s:complexType><s:sequence><s:element name="b" type="s:string"/>) +
+             %(</s:sequence></s:complexType></s:element>),
+      messages: %(<wsdl:message name="AddIn"><wsdl:part name="p" element="tns:Add"/></wsdl:message>) +
+                %(<wsdl:message name="SubIn"><wsdl:part name="p" element="tns:Sub"/></wsdl:message>),
+      port_type: %(<wsdl:portType name="PT">) +
+                 %(<wsdl:operation name="Add"><wsdl:input message="tns:AddIn"/></wsdl:operation>) +
+                 %(<wsdl:operation name="Sub"><wsdl:input message="tns:SubIn"/></wsdl:operation></wsdl:portType>),
+      bindings: %(<wsdl:binding name="B" type="tns:PT">) +
+                %(<soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>) +
+                %(<wsdl:operation name="Add"><soap:operation soapAction="urn:Add"/>) +
+                %(<wsdl:input><soap:body use="literal"/></wsdl:input></wsdl:operation>) +
+                %(<wsdl:operation name="Sub"><soap:operation soapAction="urn:Sub"/>) +
+                %(<wsdl:input><soap:body use="literal"/></wsdl:input></wsdl:operation></wsdl:binding>)))
+
+    result.flows.size.should eq(2)
+    result.skipped.should eq(0)
+    req = result.flows[0].request
+    req.method.should eq("POST")
+    req.host.should eq("svc.test")
+    req.target.should eq("/endpoint")
+    result.flows[0].response.should be_nil # a template, never a fabricated response
+
+    head = head_of(result)
+    head.should contain("Content-Type: text/xml; charset=utf-8")
+    # ALWAYS quoted: a bare `SOAPAction: urn:Add` violates SOAP 1.1 §6.1.1 and stacks route
+    # on this header, so the quotes decide dispatch.
+    head.should contain(%(SOAPAction: "urn:Add"))
+
+    body = body_of(result)
+    body.should contain(%(<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"))
+    body.should contain("<soapenv:Body>")
+    body.should contain(":Add>")
+    body.should contain(">1</") # xsd:int placeholder
+    head_of(result, 1).should contain(%(SOAPAction: "urn:Sub"))
+  end
+
+  it "writes an empty soapAction as the empty QUOTED string, not as an absent header" do
+    # SOAP 1.1 defines `SOAPAction: ""` as "no intent stated". Omitting the line entirely is
+    # a DIFFERENT statement, and .NET/Axis answer that with a 500.
+    result = parse(wsdl(bindings: %(<wsdl:binding name="B" type="tns:PT">) +
+                                  %(<soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>) +
+                                  %(<wsdl:operation name="Add"><soap:operation soapAction=""/>) +
+                                  %(<wsdl:input><soap:body use="literal"/></wsdl:input>) +
+                                  %(</wsdl:operation></wsdl:binding>)))
+    head_of(result).should contain(%(SOAPAction: ""))
+  end
+
+  it "builds an rpc/literal body from the message parts, in declaration order" do
+    # The one structural difference from document/literal, and where a doc-only reader emits
+    # a silently wrong envelope: ONE wrapper named by the OPERATION, whose children are one
+    # accessor per part — always UNQUALIFIED, whatever elementFormDefault says.
+    result = parse(wsdl(
+      types: "",
+      messages: %(<wsdl:message name="AddIn"><wsdl:part name="alpha" type="s:int"/>) +
+                %(<wsdl:part name="beta" type="s:string"/></wsdl:message>),
+      bindings: %(<wsdl:binding name="B" type="tns:PT">) +
+                %(<soap:binding style="rpc" transport="http://schemas.xmlsoap.org/soap/http"/>) +
+                %(<wsdl:operation name="Add"><soap:operation soapAction="urn:Add"/>) +
+                %(<wsdl:input><soap:body use="literal" namespace="urn:svc"/></wsdl:input>) +
+                %(</wsdl:operation></wsdl:binding>)))
+    body = body_of(result)
+    body.should contain(%(xmlns:ns1="urn:svc"))
+    body.should contain("<ns1:Add>")
+    body.should contain("<alpha>1</alpha>")
+    body.should contain("<beta>string</beta>")
+    body.index("<alpha>").not_nil!.should be < body.index("<beta>").not_nil!
+  end
+
+  it "adds encodingStyle and xsi:type for an rpc/encoded operation instead of skipping it" do
+    # rpc/encoded is legacy .NET/Axis, i.e. exactly the target a security tool exists to
+    # reach. Best-effort single-reference form, not the multi-reference href/id encoding.
+    result = parse(wsdl(
+      types: "",
+      messages: %(<wsdl:message name="AddIn"><wsdl:part name="alpha" type="s:int"/></wsdl:message>),
+      bindings: %(<wsdl:binding name="B" type="tns:PT">) +
+                %(<soap:binding style="rpc" transport="http://schemas.xmlsoap.org/soap/http"/>) +
+                %(<wsdl:operation name="Add"><soap:operation soapAction="urn:Add"/>) +
+                %(<wsdl:input><soap:body use="encoded" namespace="urn:svc"/></wsdl:input>) +
+                %(</wsdl:operation></wsdl:binding>)))
+    body = body_of(result)
+    body.should contain(%(soapenv:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"))
+    body.should contain(%(<alpha xsi:type="xsd:int">1</alpha>))
+  end
+
+  it "uses the SOAP 1.2 envelope and media-type action for a soap12 binding" do
+    result = parse(wsdl(bindings: %(<wsdl:binding name="B" type="tns:PT">) +
+                                  %(<soap12:binding transport="http://schemas.xmlsoap.org/soap/http"/>) +
+                                  %(<wsdl:operation name="Add"><soap12:operation soapAction="urn:Add"/>) +
+                                  %(<wsdl:input><soap12:body use="literal"/></wsdl:input>) +
+                                  %(</wsdl:operation></wsdl:binding>),
+      ports: %(<wsdl:port name="P" binding="tns:B">) +
+             %(<soap12:address location="https://svc.test/endpoint"/></wsdl:port>)))
+    head = head_of(result)
+    head.should contain(%(Content-Type: application/soap+xml; charset=utf-8; action="urn:Add"))
+    # There is NO SOAPAction header in SOAP 1.2, and sending one beside the parameter is a
+    # SOAP 1.1 signal some dual-stack endpoints dispatch on — which misroutes.
+    head.should_not contain("SOAPAction")
+    body_of(result).should contain(%(xmlns:soapenv="http://www.w3.org/2003/05/soap-envelope"))
+  end
+
+  it "omits the SOAP 1.2 action parameter entirely when no soapAction is declared" do
+    # An empty parameter is a positive claim of an empty action URI, which is not what
+    # "absent" means.
+    result = parse(wsdl(bindings: %(<wsdl:binding name="B" type="tns:PT">) +
+                                  %(<soap12:binding transport="http://schemas.xmlsoap.org/soap/http"/>) +
+                                  %(<wsdl:operation name="Add"><soap12:operation/>) +
+                                  %(<wsdl:input><soap12:body use="literal"/></wsdl:input>) +
+                                  %(</wsdl:operation></wsdl:binding>),
+      ports: %(<wsdl:port name="P" binding="tns:B">) +
+             %(<soap12:address location="https://svc.test/endpoint"/></wsdl:port>)))
+    head_of(result).should contain("Content-Type: application/soap+xml; charset=utf-8\r\n")
+    head_of(result).should_not contain("action=")
+  end
+
+  it "imports each SOAP port and skips a non-SOAP one without counting it as damage" do
+    # The canonical .NET shape: FooSoap / FooSoap12 / FooHttpGet over ONE portType. The HTTP
+    # port is out of scope, but it is not malformed, so it must not inflate `skipped`.
+    result = parse(wsdl(
+      bindings: %(<wsdl:binding name="B11" type="tns:PT">) +
+                %(<soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>) +
+                %(<wsdl:operation name="Add"><soap:operation soapAction="urn:Add"/>) +
+                %(<wsdl:input><soap:body use="literal"/></wsdl:input></wsdl:operation></wsdl:binding>) +
+                %(<wsdl:binding name="B12" type="tns:PT">) +
+                %(<soap12:binding transport="http://schemas.xmlsoap.org/soap/http"/>) +
+                %(<wsdl:operation name="Add"><soap12:operation soapAction="urn:Add"/>) +
+                %(<wsdl:input><soap12:body use="literal"/></wsdl:input></wsdl:operation></wsdl:binding>) +
+                %(<wsdl:binding name="BGet" type="tns:PT"><http:binding verb="GET"/></wsdl:binding>),
+      ports: %(<wsdl:port name="P11" binding="tns:B11">) +
+             %(<soap:address location="https://svc.test/basic"/></wsdl:port>) +
+             %(<wsdl:port name="P12" binding="tns:B12">) +
+             %(<soap12:address location="https://svc.test/secure"/></wsdl:port>) +
+             %(<wsdl:port name="PGet" binding="tns:BGet">) +
+             %(<http:address location="https://svc.test/get"/></wsdl:port>)))
+    result.flows.size.should eq(2)
+    result.skipped.should eq(0)
+    result.flows.map(&.request.target).should eq(["/basic", "/secure"])
+  end
+
+  it "skips a port bound over a non-HTTP transport" do
+    parse(wsdl(bindings: %(<wsdl:binding name="B" type="tns:PT">) +
+                         %(<soap:binding transport="http://schemas.xmlsoap.org/soap/jms"/>) +
+                         %(<wsdl:operation name="Add"><soap:operation soapAction="urn:Add"/>) +
+                         %(<wsdl:input><soap:body use="literal"/></wsdl:input>) +
+                         %(</wsdl:operation></wsdl:binding>)))
+    fail "expected a clean error"
+  rescue ex : Gori::Error
+    ex.message.not_nil!.should contain("not HTTP")
+  end
+
+  it "collapses two ports that produce byte-identical requests, but not two SOAP versions" do
+    # The dedupe key is the REQUEST. An alias port at the same address collapses; a SOAP 1.1
+    # and a SOAP 1.2 port at the same address do NOT, because a dual-stack endpoint where
+    # one version bypasses a filter written for the other is the finding.
+    result = parse(wsdl(
+      bindings: %(<wsdl:binding name="B" type="tns:PT">) +
+                %(<soap:binding transport="http://schemas.xmlsoap.org/soap/http"/>) +
+                %(<wsdl:operation name="Add"><soap:operation soapAction="urn:Add"/>) +
+                %(<wsdl:input><soap:body use="literal"/></wsdl:input></wsdl:operation></wsdl:binding>),
+      ports: %(<wsdl:port name="P" binding="tns:B">) +
+             %(<soap:address location="https://svc.test/endpoint"/></wsdl:port>) +
+             %(<wsdl:port name="Alias" binding="tns:B">) +
+             %(<soap:address location="https://svc.test/endpoint"/></wsdl:port>)))
+    result.flows.size.should eq(1)
+  end
+
+  describe "the XSD skeleton" do
+    it "builds a nested complexType into typed placeholders" do
+      result = parse(wsdl(types: <<-XSD))
+        <s:element name="Add"><s:complexType><s:sequence>
+          <s:element name="note" type="tns:Note"/>
+        </s:sequence></s:complexType></s:element>
+        <s:complexType name="Note">
+          <s:sequence>
+            <s:element name="body" type="s:string"/>
+            <s:element name="when" type="s:dateTime"/>
+            <s:element name="ok" type="s:boolean"/>
+          </s:sequence>
+          <s:attribute name="id" type="s:int" use="required"/>
+        </s:complexType>
+        XSD
+      body = body_of(result)
+      body.should contain(%(<ns1:note id="1">))
+      body.should contain("<ns1:body>string</ns1:body>")
+      body.should contain("<ns1:when>2024-01-01T00:00:00Z</ns1:when>")
+      body.should contain("<ns1:ok>true</ns1:ok>")
+    end
+
+    it "leaves a local name unqualified when the schema does not say elementFormDefault" do
+      # Unqualified is the XSD default; .NET emits qualified and Axis often does not, so it
+      # cannot be guessed. A default `xmlns=` on the wrapper would be shorter and would pull
+      # every unqualified child into the wrong namespace.
+      result = parse(wsdl(schema_attrs: %(targetNamespace="urn:t"),
+        types: %(<s:element name="Add"><s:complexType><s:sequence>) +
+               %(<s:element name="a" type="s:int"/></s:sequence></s:complexType></s:element>)))
+      body = body_of(result)
+      body.should contain("<ns1:Add>") # a GLOBAL element is qualified regardless
+      body.should contain("<a>1</a>")  # the LOCAL one is not
+      body.should_not contain(%(<soapenv:Body>\n    <ns1:Add xmlns=))
+    end
+
+    it "prefers the first enumeration value over the base type's placeholder" do
+      # A value outside the enumeration is the commonest reason a schema-validating gateway
+      # rejects a seed request before it reaches any business logic.
+      result = parse(wsdl(types: <<-XSD))
+        <s:element name="Add"><s:complexType><s:sequence>
+          <s:element name="kind" type="tns:Kind"/>
+        </s:sequence></s:complexType></s:element>
+        <s:simpleType name="Kind"><s:restriction base="s:string">
+          <s:enumeration value="memo"/><s:enumeration value="alert"/>
+        </s:restriction></s:simpleType>
+        XSD
+      body_of(result).should contain("<ns1:kind>memo</ns1:kind>")
+    end
+
+    it "emits a repeating accessor twice, never maxOccurs times" do
+      result = parse(wsdl(types: %(<s:element name="Add"><s:complexType><s:sequence>) +
+                                 %(<s:element name="tag" maxOccurs="9999" type="s:string"/>) +
+                                 %(</s:sequence></s:complexType></s:element>)))
+      body_of(result).scan(/<ns1:tag>/).size.should eq(2)
+    end
+
+    it "emits an optional element rather than hiding it" do
+      # Deleting an element you can see is trivial; inventing one the skeleton hid means
+      # going back to the WSDL.
+      result = parse(wsdl(types: %(<s:element name="Add"><s:complexType><s:sequence>) +
+                                 %(<s:element name="maybe" minOccurs="0" type="s:string"/>) +
+                                 %(</s:sequence></s:complexType></s:element>)))
+      body_of(result).should contain("<ns1:maybe>string</ns1:maybe>")
+    end
+
+    it "renders only the first branch of a choice" do
+      result = parse(wsdl(types: %(<s:element name="Add"><s:complexType><s:choice>) +
+                                 %(<s:element name="byId" type="s:int"/>) +
+                                 %(<s:element name="byName" type="s:string"/>) +
+                                 %(</s:choice></s:complexType></s:element>)))
+      body = body_of(result)
+      body.should contain("<ns1:byId>1</ns1:byId>")
+      body.should_not contain("byName")
+    end
+
+    it "puts the base type's particles before the extension's" do
+      # XSD extension APPENDS. A server unmarshalling by position rejects the reversed body,
+      # so the order is not cosmetic.
+      result = parse(wsdl(types: <<-XSD))
+        <s:element name="Add" type="tns:Derived"/>
+        <s:complexType name="Base"><s:sequence>
+          <s:element name="first" type="s:string"/>
+        </s:sequence></s:complexType>
+        <s:complexType name="Derived"><s:complexContent><s:extension base="tns:Base">
+          <s:sequence><s:element name="second" type="s:string"/></s:sequence>
+        </s:extension></s:complexContent></s:complexType>
+        XSD
+      body = body_of(result)
+      body.index("<ns1:first>").not_nil!.should be < body.index("<ns1:second>").not_nil!
+    end
+
+    it "turns simpleContent into text plus the extension's attributes" do
+      result = parse(wsdl(types: <<-XSD))
+        <s:element name="Add"><s:complexType><s:sequence>
+          <s:element name="amount" type="tns:Money"/>
+        </s:sequence></s:complexType></s:element>
+        <s:complexType name="Money"><s:simpleContent><s:extension base="s:decimal">
+          <s:attribute name="currency" type="s:string" fixed="USD"/>
+        </s:extension></s:simpleContent></s:complexType>
+        XSD
+      body_of(result).should contain(%(<ns1:amount currency="USD">1.0</ns1:amount>))
+    end
+
+    it "stops a recursive type at the first repetition instead of recursing forever" do
+      # A CYCLE, which the depth cap alone would let expand to 2^XSD_MAX_DEPTH elements
+      # before stopping. The flow is still produced — the comment is inside the element, not
+      # instead of it, so the generator never presents a partial body as complete.
+      result = parse(wsdl(types: <<-XSD))
+        <s:element name="Add" type="tns:Node"/>
+        <s:complexType name="Node"><s:sequence>
+          <s:element name="child" type="tns:Node"/>
+        </s:sequence></s:complexType>
+        XSD
+      result.flows.size.should eq(1)
+      result.skipped.should eq(0)
+      body = body_of(result)
+      body.scan(/<ns1:child>/).size.should eq(1)
+      body.should contain("recursive type {urn:t}Node")
+    end
+
+    it "comments an unresolvable type and names the schema it did not fetch" do
+      result = parse(wsdl(types: <<-XSD))
+        <s:import namespace="urn:other" schemaLocation="other.xsd"/>
+        <s:element name="Add"><s:complexType><s:sequence>
+          <s:element xmlns:o="urn:other" name="far" type="o:Thing"/>
+        </s:sequence></s:complexType></s:element>
+        XSD
+      body = body_of(result)
+      body.should contain("unresolved type {urn:other}Thing")
+      body.should contain("other.xsd")
+    end
+  end
+
+  describe "the skip / raise contract" do
+    it "skips one malformed operation instead of discarding the service" do
+      result = parse(wsdl(
+        types: "",
+        messages: %(<wsdl:message name="AddIn"><wsdl:part name="a" type="s:int"/></wsdl:message>) +
+                  %(<wsdl:message name="BadIn"><wsdl:part name="oops"/></wsdl:message>),
+        port_type: %(<wsdl:portType name="PT">) +
+                   %(<wsdl:operation name="Add"><wsdl:input message="tns:AddIn"/></wsdl:operation>) +
+                   %(<wsdl:operation name="Bad"><wsdl:input message="tns:BadIn"/></wsdl:operation>) +
+                   %(<wsdl:operation name="Gone"><wsdl:input message="tns:Missing"/></wsdl:operation>) +
+                   %(</wsdl:portType>),
+        bindings: %(<wsdl:binding name="B" type="tns:PT">) +
+                  %(<soap:binding style="rpc" transport="http://schemas.xmlsoap.org/soap/http"/>) +
+                  %(<wsdl:operation name="Add"><soap:operation soapAction="urn:Add"/>) +
+                  %(<wsdl:input><soap:body use="literal" namespace="urn:s"/></wsdl:input></wsdl:operation>) +
+                  %(<wsdl:operation name="Bad"><soap:operation soapAction="urn:Bad"/>) +
+                  %(<wsdl:input><soap:body use="literal" namespace="urn:s"/></wsdl:input></wsdl:operation>) +
+                  %(<wsdl:operation name="Gone"><soap:operation soapAction="urn:Gone"/>) +
+                  %(<wsdl:input><soap:body use="literal" namespace="urn:s"/></wsdl:input></wsdl:operation>) +
+                  %(</wsdl:binding>)))
+      result.flows.size.should eq(1)
+      result.skipped.should eq(2)
+    end
+
+    it "raises a clean error on a relative soap:address and names the port" do
+      # `Builder.endpoint` only catches the EMPTY-host case, so "./svc" would be stored with
+      # host "." — a flow that can never be sent, imported as a success.
+      parse(wsdl(ports: %(<wsdl:port name="Rel" binding="tns:B">) +
+                        %(<soap:address location="/services/Calc"/></wsdl:port>)))
+      fail "expected a clean error"
+    rescue ex : Gori::Error
+      msg = ex.message.not_nil!
+      msg.should contain("absolute")
+      msg.should contain(%("Rel")) # WHICH port, so the operator can go and look
+    end
+
+    it "raises on a port whose address is not an HTTP transport" do
+      parse(wsdl(ports: %(<wsdl:port name="Q" binding="tns:B">) +
+                        %(<soap:address location="jms://queue/Calc"/></wsdl:port>)))
+      fail "expected a clean error"
+    rescue ex : Gori::Error
+      ex.message.not_nil!.should contain("not a transport gori speaks")
+    end
+
+    it "raises a clean error on a non-WSDL file, a WSDL 2.0 file, and a portless one" do
+      expect_raises(Gori::Error, /not a WSDL 1.1 document/) do
+        parse(%(<html><body>not a service description</body></html>))
+      end
+      expect_raises(Gori::Error, /WSDL 2.0/) do
+        parse(%(<description xmlns="http://www.w3.org/ns/wsdl"/>))
+      end
+      expect_raises(Gori::Error, /no <wsdl:service> port/) do
+        parse(wsdl(ports: ""))
+      end
+    end
+  end
+
+  describe "security" do
+    it "refuses a DOCTYPE without reading the entity it names" do
+      # `Import::Burp`'s fixtures deliberately CARRY a benign DOCTYPE, because Burp writes
+      # one and those bytes are the operator's evidence. A WSDL is a document DESCRIBING
+      # requests, not the operator's wire bytes, so it gets the stricter rule — see the
+      # DOCTYPE note in xml_mini.cr.
+      err = expect_raises(Gori::Error, /DOCTYPE/) do
+        parse(%(<!DOCTYPE d [ <!ENTITY e SYSTEM "file:///etc/passwd"> ]>) + wsdl)
+      end
+      err.message.not_nil!.should_not contain("root:")
+
+      expect_raises(Gori::Error, /DOCTYPE/) do
+        parse(%(<!DOCTYPE d [ <!ENTITY a "aa"> <!ENTITY b "&a;&a;&a;&a;"> ]>) + wsdl)
+      end
+    end
+
+    it "does not read an imported schema off the filesystem" do
+      # The same stance `Import::Postman` takes on a `file`-mode body: an importer reads the
+      # file it was handed and nothing else.
+      result = parse(wsdl(types: %(<s:import namespace="urn:secret" schemaLocation="file:///etc/passwd"/>) +
+                                 %(<s:element name="Add"><s:complexType><s:sequence>) +
+                                 %(<s:element name="a" type="s:int"/></s:sequence></s:complexType></s:element>)))
+      body_of(result).should_not contain("root:")
+      body_of(result).should contain("<ns1:a>1</ns1:a>")
+    end
+  end
+
+  it "imports end to end through Import.import_file" do
+    with_wsdl(wsdl) do |path|
+      with_store do |store|
+        result = Gori::Import.import_file(store, :wsdl, path)
+        result.count.should eq(1)
+        row = store.search(Gori::QL::EMPTY, 10).first
+        row.host.should eq("svc.test")
+        row.method.should eq("POST")
+        row.target.should eq("/endpoint")
+        row.status.should be_nil # a template, never a fabricated response
+        body = String.new(store.get_flow(row.id).not_nil!.request_body.not_nil!)
+        body.should contain(":Add>")
+      end
+    end
+  end
+end

--- a/spec/import/xml_mini_spec.cr
+++ b/spec/import/xml_mini_spec.cr
@@ -80,6 +80,15 @@ describe Gori::Import::XmlMini do
       root.qname_attr?("type").should eq({"http://www.w3.org/2001/XMLSchema", "string"})
     end
 
+    it "measures the trailing-colon rule in characters, not bytes" do
+      # `String#index` answers in CHARS; comparing it against `bytesize` made the rule depend
+      # on how wide the name's characters are, so `"a:"` stayed whole while `"ä:"` split into a
+      # prefix and raised instead of reaching the caller's error message.
+      XmlMini.split_qname("a:").should eq({"", "a:"})
+      XmlMini.split_qname("\u{e4}:").should eq({"", "\u{e4}:"})
+      XmlMini.split_qname("\u{e4}:x").should eq({"\u{e4}", "x"})
+    end
+
     it "raises on a QName value whose prefix was never declared" do
       root = parse(%(<a type="ghost:Foo"/>))
       expect_raises(Gori::Error, /undeclared XML namespace prefix "ghost"/) { root.qname("ghost:Foo") }

--- a/spec/import/xml_mini_spec.cr
+++ b/spec/import/xml_mini_spec.cr
@@ -1,0 +1,209 @@
+require "../spec_helper"
+
+# src/gori/import/xml_mini.cr — the namespace-aware XML reader `Import::Wsdl` is built on.
+# Its own spec rather than riding on wsdl_spec.cr: the three NAME RESOLUTION rules below
+# disagree with each other by design, and the DOCTYPE refusal is a security boundary that
+# must stay pinned at this seam even if wsdl.cr is rewritten around it.
+
+private alias XmlMini = Gori::Import::XmlMini
+
+private def parse(xml : String) : XmlMini::Node
+  XmlMini.parse(xml)
+end
+
+describe Gori::Import::XmlMini do
+  describe "namespaces" do
+    it "inherits the default namespace from an ancestor element" do
+      root = parse(%(<definitions xmlns="http://schemas.xmlsoap.org/wsdl/"><service/></definitions>))
+      root.uri.should eq("http://schemas.xmlsoap.org/wsdl/")
+      root.local.should eq("definitions")
+      root.children[0].uri.should eq("http://schemas.xmlsoap.org/wsdl/")
+    end
+
+    it "undeclares the default namespace on xmlns=\"\" instead of binding it to an empty URI" do
+      # XML Names §6.2. Binding "" => "" would put every unprefixed descendant into a
+      # namespace literally called "", which compares equal to nothing real.
+      root = parse(%(<a xmlns="urn:x"><b xmlns=""><c/></b></a>))
+      root.uri.should eq("urn:x")
+      root.children[0].uri.should eq("")
+      root.children[0].children[0].uri.should eq("")
+    end
+
+    it "rebinds a prefix on an inner element without leaking back out" do
+      # The bug this catches: a WSDL carrying two <xsd:schema> sections that bind `tns`
+      # differently, where the second subtree's binding leaks onto the first's siblings and
+      # every type resolves against the wrong namespace.
+      root = parse(<<-XML)
+        <root xmlns:s="urn:A">
+          <inner xmlns:s="urn:B"><x/></inner>
+          <after/>
+        </root>
+        XML
+      root.ns["s"].should eq("urn:A")
+      root.element?("", "inner").not_nil!.ns["s"].should eq("urn:B")
+      root.element?("", "after").not_nil!.ns["s"].should eq("urn:A")
+    end
+
+    it "binds the xml: prefix implicitly" do
+      root = parse(%(<a xml:lang="en"/>))
+      root.attr?("lang", "http://www.w3.org/XML/1998/namespace").should eq("en")
+    end
+
+    it "refuses an undeclared prefix rather than resolving it to no namespace" do
+      expect_raises(Gori::Error, /undeclared XML namespace prefix "nope"/) do
+        parse(%(<nope:a/>))
+      end
+    end
+  end
+
+  describe "the three name rules" do
+    it "puts an unprefixed attribute NAME in no namespace, unlike an element name" do
+      # XML Names §6.2, and the rule that decides whether `targetNamespace` is findable
+      # inside a schema that declares a default namespace.
+      root = parse(%(<schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:t"/>))
+      root.uri.should eq("http://www.w3.org/2001/XMLSchema") # element name DID take it
+      root.attr?("targetNamespace").should eq("urn:t")       # attribute name did NOT
+      root.attr?("targetNamespace", "http://www.w3.org/2001/XMLSchema").should be_nil
+    end
+
+    it "resolves a QName in an attribute VALUE, not just in element names" do
+      # WSDL's entire cross-reference graph lives in attribute values. A reader that
+      # namespaces only elements silently matches `tns:Foo` against `other:Foo`.
+      root = parse(%(<a xmlns:tns="urn:t" type="tns:Foo"/>))
+      root.qname_attr?("type").should eq({"urn:t", "Foo"})
+    end
+
+    it "resolves an unprefixed QName VALUE against the default namespace" do
+      # The asymmetry with the attribute-NAME rule above, and how a chameleon schema's
+      # `type="string"` means xsd:string.
+      root = parse(%(<a xmlns="http://www.w3.org/2001/XMLSchema" type="string"/>))
+      root.qname_attr?("type").should eq({"http://www.w3.org/2001/XMLSchema", "string"})
+    end
+
+    it "raises on a QName value whose prefix was never declared" do
+      root = parse(%(<a type="ghost:Foo"/>))
+      expect_raises(Gori::Error, /undeclared XML namespace prefix "ghost"/) { root.qname("ghost:Foo") }
+    end
+  end
+
+  describe "syntax" do
+    it "treats a self-closing element as an empty one" do
+      parse(%(<a><x/></a>)).children[0].children.should be_empty
+      parse(%(<a><x></x></a>)).children[0].children.should be_empty
+      parse(%(<a><soap:address xmlns:soap="urn:s" location="https://h/svc"/></a>))
+        .children[0].attr?("location").should eq("https://h/svc")
+    end
+
+    it "keeps CDATA content verbatim, markup and all" do
+      parse(%(<a><![CDATA[<b>&amp;</b>]]></a>)).text.should eq("<b>&amp;</b>")
+    end
+
+    it "decodes the five predefined entities and numeric character references" do
+      parse(%(<a>&lt;&gt;&amp;&quot;&apos;</a>)).text.should eq(%(<>&"'))
+      parse(%(<a>&#65;&#x41;</a>)).text.should eq("AA")
+      parse(%(<a v="&lt;&#65;"/>)).attr?("v").should eq("<A")
+    end
+
+    it "leaves an unknown entity verbatim rather than dropping or expanding it" do
+      # Pinned because it IS the entity-expansion story: gori resolves five entities and
+      # nothing else, so there is no expansion to bound.
+      parse(%(<a>&foo;</a>)).text.should eq("&foo;")
+    end
+
+    it "drops whitespace-only runs between tags but keeps real text" do
+      parse("<a>\n  <b/>\n</a>").text.should eq("")
+      parse("<a>  hi  </a>").text.should eq("  hi  ")
+    end
+
+    it "skips the XML declaration, comments and a BOM" do
+      root = parse(%(\u{feff}<?xml version="1.0" encoding="UTF-8"?><!-- note --><a><!--x--><b/></a>))
+      root.local.should eq("a")
+      root.children.size.should eq(1)
+    end
+
+    it "accepts single-quoted attribute values and refuses unquoted ones" do
+      parse(%(<a v='x'/>)).attr?("v").should eq("x")
+      expect_raises(Gori::Error, /unquoted attribute value/) { parse(%(<a v=x/>)) }
+    end
+
+    it "refuses a duplicate attribute rather than picking one" do
+      expect_raises(Gori::Error, /duplicate attribute "location"/) do
+        parse(%(<a location="https://one" location="https://two"/>))
+      end
+    end
+
+    it "refuses an unclosed or mismatched tag rather than guessing" do
+      expect_raises(Gori::Error, /mismatched closing tag/) { parse(%(<a><b></a></b>)) }
+      expect_raises(Gori::Error, /unclosed element <a>/) { parse(%(<a>)) }
+      expect_raises(Gori::Error, /unexpected closing tag/) { parse(%(<a/></b>)) }
+    end
+
+    it "refuses a document with no root, two roots, or text outside the root" do
+      expect_raises(Gori::Error, /no root element/) { parse(%(<!-- only a comment -->)) }
+      expect_raises(Gori::Error, /more than one root element/) { parse(%(<a/><b/>)) }
+      expect_raises(Gori::Error, /text outside the root element/) { parse(%(<a/>trailing)) }
+    end
+
+    it "matches a closing tag on the resolved name, not the spelling" do
+      parse(%(<x:a xmlns:x="urn:t" xmlns:y="urn:t"></y:a>)).uri.should eq("urn:t")
+    end
+
+    it "names the line an error is on" do
+      expect_raises(Gori::Error, /line 3/) { parse("<a>\n  <b>\n  </c>\n</a>") }
+    end
+  end
+
+  describe "limits" do
+    it "refuses a document larger than the byte cap" do
+      small = XmlMini::Limits.new(max_bytes: 32)
+      expect_raises(Gori::Error, /too large/) { XmlMini.parse("<a>#{"x" * 100}</a>", small) }
+    end
+
+    it "refuses nesting deeper than the depth cap" do
+      shallow = XmlMini::Limits.new(max_depth: 4)
+      deep = "<a>" * 10 + "</a>" * 10
+      expect_raises(Gori::Error, /deeper than 4 levels/) { XmlMini.parse(deep, shallow) }
+    end
+
+    it "charges attributes against the node budget, not just elements" do
+      tight = XmlMini::Limits.new(max_nodes: 3)
+      expect_raises(Gori::Error, /more than 3 nodes/) do
+        XmlMini.parse(%(<a p="1" q="2" r="3"/>), tight)
+      end
+    end
+  end
+
+  describe "security" do
+    it "refuses a DOCTYPE declaration, internal subset or not" do
+      expect_raises(Gori::Error, /DOCTYPE/) { parse(%(<!DOCTYPE a><a/>)) }
+      expect_raises(Gori::Error, /DOCTYPE/) do
+        parse(%(<!DOCTYPE a [ <!ENTITY x "y"> ]><a>&x;</a>))
+      end
+    end
+
+    it "refuses an external-entity declaration without reading the file it names" do
+      # The refusal happens at the `<!DOCTYPE` token, before any entity is even parsed —
+      # so there is no code path that could open the URL.
+      err = expect_raises(Gori::Error, /DOCTYPE/) do
+        parse(%(<!DOCTYPE r [ <!ENTITY e SYSTEM "file:///etc/passwd"> ]><r>&e;</r>))
+      end
+      err.message.not_nil!.should_not contain("root:")
+    end
+
+    it "cannot expand a billion-laughs payload because no entity can be declared" do
+      expect_raises(Gori::Error, /DOCTYPE/) do
+        parse(<<-XML)
+          <!DOCTYPE lolz [
+            <!ENTITY lol "lol">
+            <!ENTITY lol2 "&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;">
+          ]>
+          <lolz>&lol2;</lolz>
+          XML
+      end
+    end
+
+    it "refuses any other markup declaration" do
+      expect_raises(Gori::Error, /markup declaration/) { parse(%(<a><!ENTITY x "y"></a>)) }
+    end
+  end
+end

--- a/spec/support/fake_context.cr
+++ b/spec/support/fake_context.cr
@@ -1602,6 +1602,10 @@ class FakeExecContext < Gori::Verb::ExecContext
   def import_burp : Nil
     rec(:import_burp)
   end
+
+  def import_wsdl : Nil
+    rec(:import_wsdl)
+  end
 end
 
 # Fire one verb on a fresh recording context and return the intents it dispatched, IN

--- a/spec/tui/import_overlay_spec.cr
+++ b/spec/tui/import_overlay_spec.cr
@@ -15,7 +15,8 @@ end
 describe Gori::Tui::ImportOverlay do
   it "titles and describes the card by import kind" do
     {:har => "HAR", :urls => "URLs", :oas => "OpenAPI",
-     :postman => "Postman", :insomnia => "Insomnia", :burp => "Burp"}.each do |kind, want|
+     :postman => "Postman", :insomnia => "Insomnia", :burp => "Burp",
+     :wsdl => "WSDL"}.each do |kind, want|
       ov = ImportOverlay.new(kind)
       ov.label.should eq(want)
       backend = MemoryBackend.new(100, 30)
@@ -34,6 +35,7 @@ describe Gori::Tui::ImportOverlay do
      :postman  => "Build request templates from a Postman Collection v2 export.",
      :insomnia => "Build request templates from an Insomnia v4 JSON export.",
      :burp     => "Load saved Burp items into History — request and response, byte-exact.",
+     :wsdl     => "Build request templates from a WSDL 1.1 service — one per operation.",
     }.each do |kind, fragment|
       backend = MemoryBackend.new(100, 30)
       ImportOverlay.new(kind).render(Screen.new(backend), Rect.new(0, 0, 100, 30))
@@ -41,7 +43,7 @@ describe Gori::Tui::ImportOverlay do
       backend.contains?("Load flows into History.").should be_false
     end
     # Every registered kind is described — no source can be added without a blurb.
-    Gori::Import::LABELS.size.should eq(6)
+    Gori::Import::LABELS.size.should eq(7)
   end
 
   it "centers the card in the body area" do

--- a/spec/verb/registry_spec.cr
+++ b/spec/verb/registry_spec.cr
@@ -1492,6 +1492,10 @@ private class FakeContext < ExecContext
   def import_burp : Nil
     @calls << :import_burp
   end
+
+  def import_wsdl : Nil
+    @calls << :import_wsdl
+  end
 end
 
 describe Gori::Verb do

--- a/spec/verbs/import_spec.cr
+++ b/spec/verbs/import_spec.cr
@@ -12,6 +12,7 @@ describe "Gori::Verbs.register_import" do
     "import.postman"  => :import_postman,
     "import.insomnia" => :import_insomnia,
     "import.burp"     => :import_burp,
+    "import.wsdl"     => :import_wsdl,
   }
 
   it "registers one Global, chordless verb per import source" do

--- a/src/gori/cli/run/import.cr
+++ b/src/gori/cli/run/import.cr
@@ -1,9 +1,9 @@
 # `gori run import` — bulk-import captured flows into the project's History from a
 # HAR export, a URL list, an OpenAPI/Swagger spec, a Postman or Insomnia collection,
-# or a Burp item export (the CLI counterpart of the TUI's Import overlay). Exactly one
-# source flag is required. Import WRITES flows, so it resolves its target like
-# `discover` (--db create-or-reopen, else an existing project — never silently a fresh
-# default).
+# a Burp item export, or a WSDL 1.1 service description (the CLI counterpart of the
+# TUI's Import overlay). Exactly one source flag is required. Import WRITES flows, so it
+# resolves its target like `discover` (--db create-or-reopen, else an existing project —
+# never silently a fresh default).
 module Gori
   module CLI
     module Run
@@ -12,7 +12,8 @@ module Gori
         project_name : String? = nil
         format = :text
         # One entry per source flag, in the order they appear in --help. Adding a format
-        # means adding a row here and a `p.on` below — nothing else in this file.
+        # means a row here, a bullet in the banner ABOVE the flags, and a `p.on` below —
+        # the banner spells every flag out by hand, so three edits, not two.
         sources = {
           :har      => nil.as(String?),
           :urls     => nil.as(String?),
@@ -20,23 +21,26 @@ module Gori
           :postman  => nil.as(String?),
           :insomnia => nil.as(String?),
           :burp     => nil.as(String?),
+          :wsdl     => nil.as(String?),
         }
 
         parser = OptionParser.new do |p|
-          p.banner = "Usage: gori run import (--har PATH | --urls PATH | --oas PATH | --postman PATH | --insomnia PATH | --burp PATH) [options]\n\n" \
+          p.banner = "Usage: gori run import (--har PATH | --urls PATH | --oas PATH | --postman PATH | --insomnia PATH | --burp PATH | --wsdl PATH) [options]\n\n" \
                      "Bulk-import flows into the project's History. Exactly one source is required:\n" \
                      "  --har       a browser/proxy HAR (HTTP Archive) export\n" \
                      "  --urls      a text file of URLs, one per line (# comments and blanks ignored)\n" \
                      "  --oas       request templates from an OpenAPI/Swagger spec (JSON or YAML)\n" \
                      "  --postman   request templates from a Postman Collection v2 export (JSON)\n" \
                      "  --insomnia  request templates from an Insomnia v4 export (JSON)\n" \
-                     "  --burp      saved Burp items (XML) — request AND response, byte-exact"
+                     "  --burp      saved Burp items (XML) — request AND response, byte-exact\n" \
+                     "  --wsdl      SOAP request templates from a WSDL 1.1 service description (XML)"
           p.on("--har=PATH", "Import a HAR (HTTP Archive) export") { |v| sources[:har] = v }
           p.on("--urls=PATH", "Import a URL list (one URL per line)") { |v| sources[:urls] = v }
           p.on("--oas=PATH", "Import an OpenAPI/Swagger spec (JSON or YAML)") { |v| sources[:oas] = v }
           p.on("--postman=PATH", "Import a Postman Collection v2 export") { |v| sources[:postman] = v }
           p.on("--insomnia=PATH", "Import an Insomnia v4 JSON export") { |v| sources[:insomnia] = v }
           p.on("--burp=PATH", "Import a Burp Suite item export (XML)") { |v| sources[:burp] = v }
+          p.on("--wsdl=PATH", "Import a WSDL 1.1 service description (SOAP 1.1/1.2)") { |v| sources[:wsdl] = v }
           p.on("--project=NAME", "Project to import into (default: most-recently-active)") { |v| project_name = v }
           p.on("--db=PATH", "Explicit SQLite db file to import into (created if absent)") { |v| db_path = v }
           p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }

--- a/src/gori/import.cr
+++ b/src/gori/import.cr
@@ -5,6 +5,8 @@ require "./import/oas"
 require "./import/postman"
 require "./import/insomnia"
 require "./import/burp"
+require "./import/xml_mini"
+require "./import/wsdl"
 
 module Gori
   # Bulk-import captured flows from HAR files, URL lists, OpenAPI specs, Postman or
@@ -29,7 +31,7 @@ module Gori
 
     # The human name of each source, in ONE place. The TUI card title, the TUI toast and the
     # CLI result line all read it, so they cannot drift apart as sources are added — the
-    # comment in `ImportOverlay#label` promised one source of truth and, with six formats,
+    # comment in `ImportOverlay#label` promised one source of truth and, with seven formats,
     # three parallel `case`s is where that promise breaks.
     LABELS = {
       :har      => "HAR",
@@ -38,6 +40,7 @@ module Gori
       :postman  => "Postman",
       :insomnia => "Insomnia",
       :burp     => "Burp",
+      :wsdl     => "WSDL",
     }
 
     def self.label(kind : Symbol) : String
@@ -85,6 +88,10 @@ module Gori
 
     def self.from_burp(path : String, prov : Provenance = Provenance.none) : ParseResult
       Burp.parse_file(path, prov)
+    end
+
+    def self.from_wsdl(path : String, prov : Provenance = Provenance.none) : ParseResult
+      Wsdl.parse_file(path, prov)
     end
 
     # Pairs per store write. The whole file used to go in as ONE `insert_import_batch`, which
@@ -155,6 +162,7 @@ module Gori
         when :postman  then from_postman(expanded, prov)
         when :insomnia then from_insomnia(expanded, prov)
         when :burp     then from_burp(expanded, prov)
+        when :wsdl     then from_wsdl(expanded, prov)
         else                raise Gori::Error.new("unknown import kind: #{kind}")
         end
       rescue ex : File::Error

--- a/src/gori/import/burp.cr
+++ b/src/gori/import/burp.cr
@@ -2,6 +2,7 @@ require "base64"
 require "time"
 require "./builder"
 require "./raw"
+require "./xml_text"
 
 module Gori
   module Import
@@ -172,10 +173,12 @@ module Gori
         el = element(src, name)
         return "" unless el
         _, inner = el
-        text = cdata?(inner) ? uncdata(inner) : unescape(inner)
+        text = XmlText.cdata?(inner) ? XmlText.uncdata(inner) : XmlText.unescape(inner)
         text.valid_encoding? ? text : text.scrub
       end
 
+      # The wire-byte path. `XmlText.unescape` is byte-wise for THIS caller's sake — see
+      # the contract note in xml_text.cr.
       # `<request base64="true">` is the default; `base64="false"` means the message sits
       # inline as CDATA (Burp only does this for wholly-textual messages).
       private def self.bytes_of(src : String, name : String) : Bytes?
@@ -186,103 +189,8 @@ module Gori
         if attrs.includes?(%(base64="true")) || attrs.includes?("base64='true'")
           Base64.decode(inner.strip)
         else
-          (cdata?(inner) ? uncdata(inner) : unescape(inner)).to_slice
+          (XmlText.cdata?(inner) ? XmlText.uncdata(inner) : XmlText.unescape(inner)).to_slice
         end
-      end
-
-      private def self.cdata?(inner : String) : Bool
-        inner.lstrip.starts_with?("<![CDATA[")
-      end
-
-      # CDATA content is literal by definition — never entity-decoded.
-      private def self.uncdata(inner : String) : String
-        s = inner.strip
-        s = s[9..] if s.starts_with?("<![CDATA[")
-        s = s[0...-3] if s.ends_with?("]]>")
-        s
-      end
-
-      AMP       = 0x26_u8 # '&'
-      HASH      = 0x23_u8 # '#'
-      LOWER_X   = 0x78_u8 # 'x'
-      SEMICOLON = 0x3B_u8 # ';'
-
-      # `&name;` / `&#123;` / `&#x1f;` decoding, done BYTE-wise.
-      #
-      # This was `text.gsub(ENTITY) { … }` over `/&(#x[0-9a-fA-F]+|#\d+|[a-zA-Z]+);/`, and a
-      # Regexp gsub walks its subject as chars — `bytes_of` calls this for a non-base64
-      # `<request>` that is not CDATA-wrapped, i.e. on wire bytes (see `parse_file`). The
-      # grammar is entirely ASCII, so a byte scan reads exactly what that pattern did and
-      # copies everything else through untouched.
-      private def self.unescape(text : String) : String
-        raw = text.to_slice
-        return text unless raw.includes?(AMP)
-        io = IO::Memory.new(raw.size)
-        i = 0
-        while i < raw.size
-          if raw[i] == AMP && (hit = entity_at(raw, i))
-            replacement, width = hit
-            io << replacement
-            i += width
-          else
-            io.write_byte(raw[i])
-            i += 1
-          end
-        end
-        String.new(io.to_slice)
-      end
-
-      # {replacement text, bytes consumed} for the entity starting at `raw[at] == '&'`, or
-      # nil when what follows is not one — in which case the caller copies the `&` through,
-      # which is what the old pattern's "no match" did. Deliberately as strict as that
-      # pattern was, uppercase `&#X41;` included: it never matched `#x[0-9a-fA-F]+`, so it
-      # stayed verbatim then and stays verbatim now.
-      private def self.entity_at(raw : Bytes, at : Int32) : {String, Int32}?
-        j = at + 1
-        return nil if j >= raw.size
-        numeric = raw[j] == HASH
-        j += 1 if numeric
-        hex = numeric && j < raw.size && raw[j] == LOWER_X
-        j += 1 if hex
-        stop = entity_body_end(raw, j, numeric, hex)
-        return nil unless stop
-        name = String.new(raw[j, stop - j])
-        text = numeric ? numeric_entity(name, hex) : NAMED_ENTITIES[name]?
-        text ? {text, stop + 1 - at} : nil
-      end
-
-      # Index of the `;` closing an entity body that starts at `from`, or nil when what sits
-      # there is not one: an empty body, a byte outside the branch's class, or no `;` at all.
-      private def self.entity_body_end(raw : Bytes, from : Int32, numeric : Bool, hex : Bool) : Int32?
-        j = from
-        while j < raw.size && entity_body_byte?(raw[j], numeric, hex)
-          j += 1
-        end
-        return nil if j == from || j >= raw.size || raw[j] != SEMICOLON
-        j
-      end
-
-      # An unknown named entity resolves to nil, i.e. stays verbatim rather than vanishing.
-      NAMED_ENTITIES = {"amp" => "&", "lt" => "<", "gt" => ">", "quot" => "\"", "apos" => "'"}
-
-      # `&#123;` / `&#x1f;`. nil for a codepoint that is not a `Char` (out of range, or a
-      # lone surrogate) and for one too large to parse — both stay verbatim, as they did.
-      private def self.numeric_entity(digits : String, hex : Bool) : String?
-        (hex ? digits.to_i?(16) : digits.to_i?).try { |cp| safe_chr(cp) }
-      end
-
-      # `[0-9a-fA-F]` / `[0-9]` / `[a-zA-Z]`, per the branch the `&` opened.
-      private def self.entity_body_byte?(b : UInt8, numeric : Bool, hex : Bool) : Bool
-        digit = 0x30_u8 <= b <= 0x39_u8
-        return digit || (0x61_u8 <= b <= 0x66_u8) || (0x41_u8 <= b <= 0x46_u8) if hex
-        return digit if numeric
-        (0x61_u8 <= b <= 0x7A_u8) || (0x41_u8 <= b <= 0x5A_u8)
-      end
-
-      private def self.safe_chr(codepoint : Int32) : String?
-        return nil unless 0 <= codepoint <= Char::MAX_CODEPOINT
-        return nil if 0xD800 <= codepoint <= 0xDFFF # lone surrogate — not a Char
-        codepoint.unsafe_chr.to_s
       end
     end
   end

--- a/src/gori/import/wsdl.cr
+++ b/src/gori/import/wsdl.cr
@@ -235,13 +235,22 @@ module Gori
         case version
         in Version::V11
           h << {"Content-Type", "text/xml; charset=utf-8"}
-          h << {"SOAPAction", %("#{action}")}
+          h << {"SOAPAction", quoted(action)}
         in Version::V12
           ct = "application/soap+xml; charset=utf-8"
-          ct += %(; action="#{action}") unless action.empty?
+          ct += "; action=#{quoted(action)}" unless action.empty?
           h << {"Content-Type", ct}
         end
         h
+      end
+
+      # `action` as an RFC 2045 quoted-string. A `soapAction` carrying a `"` — which is an
+      # ordinary attribute value in the WSDL, and one `&quot;` decodes to — would otherwise
+      # close the string early and hand the endpoint a `SOAPAction` / `Content-Type` it
+      # misparses. `Builder.reject_header_injection!` catches the CR/LF/NUL that would forge a
+      # message boundary; it has nothing to say about a quote that merely breaks a value.
+      private def self.quoted(action : String) : String
+        %("#{action.gsub('\\', "\\\\").gsub('"', "\\\"")}")
       end
 
       # --- the walk ------------------------------------------------------------

--- a/src/gori/import/wsdl.cr
+++ b/src/gori/import/wsdl.cr
@@ -1,0 +1,496 @@
+require "uri"
+require "./builder"
+require "./xml_mini"
+require "./wsdl_body"
+
+module Gori
+  module Import
+    # WSDL 1.1 service descriptions → one SOAP request template per callable operation.
+    #
+    # Like `Oas`/`Postman`/`Insomnia` this describes requests rather than captured traffic,
+    # so every operation lands as a response-less template via `Builder.pending_request` and
+    # shows as `Pending` in History until it is sent.
+    #
+    # SCOPE, stated so the bounds are not mistaken for bugs:
+    #   * WSDL **1.1** only. A WSDL 2.0 document is refused by name rather than misparsed.
+    #   * `soap:` (SOAP 1.1) and `soap12:` (SOAP 1.2) bindings over HTTP. A `http:binding`
+    #     (GET/POST) port, or one over JMS/SMTP, is SKIPPED with a note — not counted as
+    #     damage, because a .NET WSDL publishing FooHttpGet beside FooSoap is not damaged.
+    #   * document/literal and rpc/literal, plus a deliberately partial rpc/encoded (see
+    #     `rpc_body`).
+    #   * The request body is built from the XSD **inline** in `<wsdl:types>`. An external
+    #     `xsd:import`/`include` is NEVER followed — an importer that fetches a
+    #     schemaLocation is an importer with file and network I/O, which is precisely the
+    #     surface `XmlMini` exists to not have. An unresolvable type degrades to a comment
+    #     naming the file that would have defined it, never to a crash or a silent omission.
+    #   * Only the INPUT message is generated. The output message describes the response,
+    #     which is the origin's to send.
+    module Wsdl
+      alias QName = XmlMini::QName
+      alias Node = XmlMini::Node
+
+      WSDL_NS   = "http://schemas.xmlsoap.org/wsdl/"
+      WSDL2_NS  = "http://www.w3.org/ns/wsdl"
+      SOAP11_NS = "http://schemas.xmlsoap.org/wsdl/soap/"
+      SOAP12_NS = "http://schemas.xmlsoap.org/wsdl/soap12/"
+      XSD_NS    = "http://www.w3.org/2001/XMLSchema"
+      XSI_NS    = "http://www.w3.org/2001/XMLSchema-instance"
+      ENV11_NS  = "http://schemas.xmlsoap.org/soap/envelope/"
+      ENV12_NS  = "http://www.w3.org/2003/05/soap-envelope"
+      SOAP_ENC  = "http://schemas.xmlsoap.org/soap/encoding/"
+      SOAP_HTTP = "http://schemas.xmlsoap.org/soap/http"
+
+      enum Version
+        V11
+        V12
+
+        def envelope_ns : String
+          self == V11 ? ENV11_NS : ENV12_NS
+        end
+
+        def binding_ns : String
+          self == V11 ? SOAP11_NS : SOAP12_NS
+        end
+      end
+
+      # A hostile or machine-generated WSDL must not insert 200 000 rows into History. Well
+      # above any real service — the largest published enterprise WSDLs run a few hundred
+      # operations across a handful of ports.
+      MAX_FLOWS = 2_000
+
+      # --- the model -----------------------------------------------------------
+
+      record Part, name : String, element : QName?, type : QName?
+      record Message, name : String, parts : Array(Part)
+      record Op, name : String, input_name : String?, input : QName?
+      record PortType, name : String, ops : Array(Op)
+      record HeaderRef, message : QName, part : String
+
+      record BindingOp, name : String, input_name : String?, action : String,
+        style : String, use : String, body_ns : String?, parts : Array(String)?,
+        headers : Array(HeaderRef)
+
+      # `ops` is an ARRAY, not a name-keyed Hash: WSDL 1.1 permits two `<operation
+      # name="Foo">` in one portType distinguished by their `<input name=…>`, and both are
+      # genuinely callable. A Hash would silently keep one of them.
+      record Binding, name : String, version : Version, port_type : QName,
+        ops : Array(BindingOp)
+
+      record Port, service : String, name : String, binding : QName, location : String?
+
+      class Doc
+        getter target_ns : String
+        getter messages : Hash(QName, Message)
+        getter port_types : Hash(QName, PortType)
+        # SOAP-over-HTTP bindings only. Everything else lands in `unusable_bindings` with
+        # the sentence explaining why, so a port pointing at one can say so.
+        getter bindings : Hash(QName, Binding)
+        getter unusable_bindings : Hash(QName, String)
+        getter ports : Array(Port)
+        getter schemas : Schemas
+
+        def initialize(@target_ns : String, @messages : Hash(QName, Message),
+                       @port_types : Hash(QName, PortType), @bindings : Hash(QName, Binding),
+                       @unusable_bindings : Hash(QName, String), @ports : Array(Port),
+                       @schemas : Schemas)
+        end
+      end
+
+      # --- entry point ---------------------------------------------------------
+
+      def self.parse_file(path : String, prov : Provenance = Provenance.none) : ParseResult
+        root = XmlMini.parse(File.read(path))
+        check_root!(root, path)
+        doc = build(root)
+        if doc.ports.empty?
+          raise Gori::Error.new(
+            "WSDL declares no <wsdl:service> port: an interface-only WSDL publishes no " \
+            "endpoint address, so there is nothing to call — #{path}")
+        end
+
+        now = Time.utc.to_unix * 1_000_000
+        pairs = [] of Builder::FlowPair
+        skipped = 0
+        notes = [] of String
+        seen = Set(String).new
+
+        doc.ports.each do |port|
+          loc = port_endpoint(doc, port) { |why| notes << why }
+          next unless loc
+          binding = doc.bindings[port.binding]?
+          unless binding
+            notes << %(port #{port.name.inspect} references an undefined binding)
+            next
+          end
+          pt = doc.port_types[binding.port_type]?
+          unless pt
+            notes << %(binding #{binding.name.inspect} references an undefined portType)
+            next
+          end
+
+          binding.ops.each do |bop|
+            break if pairs.size >= MAX_FLOWS
+            # ONE malformed operation — an unresolvable input message, a part declaring
+            # neither `element=` nor `type=`, a body that blows the node budget — skips.
+            # It must never take the other 39 operations of a working service with it.
+            begin
+              action, body = render(doc, loc, binding, pt, bop)
+              next unless seen.add?(dedupe_key(loc, binding.version, action, body))
+              pairs << Builder.pending_request(now, loc, "POST",
+                headers_for(binding.version, action), body.to_slice,
+                source_surface: prov.surface, source_ref: prov.ref)
+            rescue
+              skipped += 1
+            end
+          end
+        end
+
+        # Nothing generated: say WHY. `import_file`'s generic "no flows found in …" would
+        # hide a WSDL whose only ports are `http:binding`, which is a fact the operator can
+        # act on. The notes are the reason they exist.
+        if pairs.empty? && skipped == 0 && (why = notes.first?)
+          raise Gori::Error.new("no SOAP requests generated from #{path} — #{why}")
+        end
+        ParseResult.new(pairs, skipped)
+      end
+
+      private def self.check_root!(root : Node, path : String) : Nil
+        return if root.uri == WSDL_NS && root.local == "definitions"
+        if root.uri == WSDL2_NS
+          raise Gori::Error.new(
+            "#{path} is a WSDL 2.0 document — gori reads WSDL 1.1; re-export the service as WSDL 1.1")
+        end
+        raise Gori::Error.new(
+          "not a WSDL 1.1 document — the root element is <#{root.display_name}>, " \
+          "expected <wsdl:definitions>: #{path}")
+      end
+
+      # The absolute http(s) endpoint this port publishes, or nil after yielding the sentence
+      # saying why it cannot become a request.
+      #
+      # None of these are `skipped`: an out-of-scope port is not a malformed entry, and
+      # counting it would report a perfectly good .NET WSDL's FooHttpGet port as damage. The
+      # location comes back rather than being re-read by the caller so there is no second,
+      # unchecked read of `port.location` to get wrong.
+      private def self.port_endpoint(doc : Doc, port : Port, & : String ->) : String?
+        if why = doc.unusable_bindings[port.binding]?
+          yield why
+          return nil
+        end
+        loc = port.location
+        if loc.nil? || loc.empty?
+          yield %(port #{port.name.inspect} declares no <soap:address location="…">)
+          return nil
+        end
+        uri = begin
+          URI.parse(loc)
+        rescue
+          yield %(port #{port.name.inspect} has an unparseable address #{loc.inspect})
+          return nil
+        end
+        scheme = uri.scheme
+        if scheme.nil?
+          # `Builder.endpoint` only catches the EMPTY-host case, so "./svc" would become
+          # host "." and produce silent garbage. Refuse it here, the way `Oas.server_base`
+          # refuses a relative `servers[0].url`, and say what to do about it.
+          yield %(port #{port.name.inspect} has a relative <soap:address location=#{loc.inspect}> — ) +
+                %(a WSDL must publish an absolute endpoint, e.g. "https://host/svc")
+          return nil
+        end
+        unless scheme.downcase.in?("http", "https")
+          # Not "missing scheme": `Builder.normalize_url` would say that, and it reads as a
+          # parse failure when the real answer is that gori does not speak this transport.
+          yield %(port #{port.name.inspect} publishes a #{scheme}: address, which is not a transport gori speaks)
+          return nil
+        end
+        loc
+      end
+
+      # The key is the REQUEST, not the WSDL component that produced it. A shape-level rule
+      # ("one flow per portType") would collapse a SOAP 1.1 and a SOAP 1.2 port into one and
+      # throw away the version difference that is the whole reason to look at a dual-stack
+      # endpoint. Two ports that genuinely produce the same bytes collapse; two that do not,
+      # do not.
+      private def self.dedupe_key(url : String, version : Version, action : String, body : String) : String
+        "#{version} #{url} #{action} #{body}"
+      end
+
+      # SOAP 1.1 and SOAP 1.2 state the action in DIFFERENT places, and the empty case means
+      # different things too.
+      #
+      # SOAP 1.1 — its own header, ALWAYS present, ALWAYS quoted. A bare `SOAPAction: urn:x`
+      #   violates SOAP 1.1 §6.1.1, and stacks route on this header, so dropping the quotes
+      #   or the line changes dispatch. An absent/empty `soapAction=` becomes the empty
+      #   QUOTED string, which SOAP 1.1 defines as "no intent stated" — omitting the header
+      #   entirely is a DIFFERENT statement and .NET/Axis answer it with a 500.
+      #
+      # SOAP 1.2 — there is NO SOAPAction header. The action is an optional PARAMETER of the
+      #   application/soap+xml media type (SOAP 1.2 Part 2 §7.1.3, RFC 3902). Sending a
+      #   SOAPAction line beside it is not merely redundant: it is a SOAP 1.1 signal that
+      #   some dual-stack endpoints dispatch on, and that misroutes. An empty soapAction
+      #   OMITS the parameter rather than writing `action=""`, because an empty parameter is
+      #   a positive claim of an empty action URI, which is not what "absent" means.
+      private def self.headers_for(version : Version, action : String) : Builder::Headers
+        h = Builder::Headers.new
+        case version
+        in Version::V11
+          h << {"Content-Type", "text/xml; charset=utf-8"}
+          h << {"SOAPAction", %("#{action}")}
+        in Version::V12
+          ct = "application/soap+xml; charset=utf-8"
+          ct += %(; action="#{action}") unless action.empty?
+          h << {"Content-Type", ct}
+        end
+        h
+      end
+
+      # --- the walk ------------------------------------------------------------
+
+      private def self.build(root : Node) : Doc
+        tns = root.attr?("targetNamespace") || ""
+        unusable = {} of QName => String
+        Doc.new(tns, messages_of(root, tns), port_types_of(root, tns),
+          bindings_of(root, tns, unusable), unusable, ports_of(root), Schemas.build(root))
+      end
+
+      private def self.messages_of(root : Node, tns : String) : Hash(QName, Message)
+        messages = {} of QName => Message
+        root.elements(WSDL_NS, "message").each do |m|
+          name = m.attr?("name")
+          next unless name
+          parts = m.elements(WSDL_NS, "part").compact_map do |p|
+            pname = p.attr?("name")
+            pname ? Part.new(pname, p.qname_attr?("element"), p.qname_attr?("type")) : nil
+          end
+          messages[{tns, name}] = Message.new(name, parts)
+        end
+        messages
+      end
+
+      private def self.port_types_of(root : Node, tns : String) : Hash(QName, PortType)
+        port_types = {} of QName => PortType
+        root.elements(WSDL_NS, "portType").each do |pt|
+          name = pt.attr?("name")
+          next unless name
+          ops = pt.elements(WSDL_NS, "operation").compact_map do |o|
+            oname = o.attr?("name")
+            next nil unless oname
+            inp = o.element?(WSDL_NS, "input")
+            Op.new(oname, inp.try(&.attr?("name")), inp.try(&.qname_attr?("message")))
+          end
+          port_types[{tns, name}] = PortType.new(name, ops)
+        end
+        port_types
+      end
+
+      # SOAP-over-HTTP bindings, plus a sentence in `unusable` for every one that is not.
+      private def self.bindings_of(root : Node, tns : String,
+                                   unusable : Hash(QName, String)) : Hash(QName, Binding)
+        bindings = {} of QName => Binding
+        root.elements(WSDL_NS, "binding").each do |b|
+          name = b.attr?("name")
+          next unless name
+          qn = {tns, name}
+          pt_ref = b.qname_attr?("type")
+          unless pt_ref
+            unusable[qn] = %(binding #{name.inspect} names no portType)
+            next
+          end
+          version, sb = soap_binding(b)
+          unless sb
+            unusable[qn] = %(binding #{name.inspect} is not a SOAP binding — ) +
+                           "WSDL http: (GET/POST) bindings are out of scope"
+            next
+          end
+          transport = sb.attr?("transport")
+          # An ABSENT transport is treated as HTTP: the spec requires it, but it is omitted
+          # often enough that refusing would throw away working WSDLs.
+          if transport && !transport.empty? && transport != SOAP_HTTP
+            unusable[qn] = %(binding #{name.inspect} uses the #{transport} transport, which is not HTTP)
+            next
+          end
+          default_style = sb.attr?("style").presence || "document"
+          bindings[qn] = Binding.new(name, version, pt_ref,
+            binding_ops(b, version.binding_ns, default_style))
+        end
+        bindings
+      end
+
+      # A <wsdl:binding> is SOAP iff it HAS a <soap:binding>/<soap12:binding> child, and WHICH
+      # of the two decides the version. The `type=` attribute names a portType and says nothing
+      # about the protocol, and the .NET generator everybody's WSDL came out of emits FooSoap,
+      # FooSoap12, FooHttpGet and FooHttpPost over the SAME portType — so classification is by
+      # the extension element, NEVER by the binding's name. A binding called "FooSoap12"
+      # carrying an http:binding exists in the wild and would be misread.
+      private def self.soap_binding(b : Node) : {Version, Node?}
+        if sb = b.element?(SOAP11_NS, "binding")
+          return {Version::V11, sb}
+        end
+        {Version::V12, b.element?(SOAP12_NS, "binding")}
+      end
+
+      private def self.binding_ops(b : Node, soap_ns : String, default_style : String) : Array(BindingOp)
+        b.elements(WSDL_NS, "operation").compact_map do |o|
+          oname = o.attr?("name")
+          next nil unless oname
+          so = o.element?(soap_ns, "operation")
+          inp = o.element?(WSDL_NS, "input")
+          body = inp.try(&.element?(soap_ns, "body"))
+          headers = [] of HeaderRef
+          if inp
+            inp.elements(soap_ns, "header").each do |h|
+              msg = h.qname_attr?("message")
+              hp = h.attr?("part")
+              headers << HeaderRef.new(msg, hp) if msg && hp
+            end
+          end
+          BindingOp.new(oname, inp.try(&.attr?("name")),
+            so.try(&.attr?("soapAction")) || "",
+            so.try(&.attr?("style")).presence || default_style,
+            body.try(&.attr?("use")).presence || "literal",
+            body.try(&.attr?("namespace")).presence,
+            body.try(&.attr?("parts")).try(&.split),
+            headers)
+        end
+      end
+
+      private def self.ports_of(root : Node) : Array(Port)
+        ports = [] of Port
+        root.elements(WSDL_NS, "service").each do |svc|
+          sname = svc.attr?("name") || ""
+          svc.elements(WSDL_NS, "port").each do |p|
+            pname = p.attr?("name")
+            next unless pname
+            bref = p.qname_attr?("binding")
+            next unless bref
+            loc = p.element?(SOAP11_NS, "address").try(&.attr?("location")) ||
+                  p.element?(SOAP12_NS, "address").try(&.attr?("location"))
+            ports << Port.new(sname, pname, bref, loc)
+          end
+        end
+        ports
+      end
+
+      # --- rendering one operation --------------------------------------------
+
+      # {soapAction, envelope}
+      private def self.render(doc : Doc, loc : String, binding : Binding,
+                              pt : PortType, bop : BindingOp) : {String, String}
+        op = find_op(pt, bop) ||
+             raise Gori::Error.new("operation #{bop.name.inspect} is not declared on portType #{pt.name.inspect}")
+        msg_qn = op.input ||
+                 raise Gori::Error.new("operation #{bop.name.inspect} declares no input message")
+        msg = doc.messages[msg_qn]? ||
+              raise Gori::Error.new("operation #{bop.name.inspect} names an undefined input message")
+
+        w = Writer.new(doc.schemas)
+        parts = select_parts(msg, bop)
+        rpc = bop.style == "rpc"
+        # SOAP 1.2 dropped §5 encoding, so `use="encoded"` there is a generator artefact:
+        # generate the literal form and ignore it rather than emitting an impossible body.
+        encoded = bop.use == "encoded" && binding.version == Version::V11
+
+        body = rpc ? rpc_body(doc, w, bop, parts, encoded) : document_body(w, parts)
+        header = header_markup(doc, w, bop)
+        {bop.action, envelope(binding.version, w, header, body)}
+      end
+
+      private def self.find_op(pt : PortType, bop : BindingOp) : Op?
+        cands = pt.ops.select { |o| o.name == bop.name }
+        return nil if cands.empty?
+        # An overloaded name is disambiguated by the binding's `<input name=…>`; when the
+        # binding does not state one there is only one operation to mean.
+        if iname = bop.input_name
+          if match = cands.find { |o| o.input_name == iname }
+            return match
+          end
+        end
+        cands.first
+      end
+
+      # `soap:body parts="a b"` is a whitespace-separated filter; an absent attribute means
+      # every part, which is the common case.
+      private def self.select_parts(msg : Message, bop : BindingOp) : Array(Part)
+        filter = bop.parts
+        return msg.parts unless filter
+        msg.parts.select { |p| filter.includes?(p.name) }
+      end
+
+      # document/literal: each body child IS the part's global element, rendered from the
+      # schema. The operation name appears nowhere in the body — the "wrapped" convention
+      # makes the element happen to share it, which is a convention, not a rule.
+      private def self.document_body(w : Writer, parts : Array(Part)) : String
+        String.build do |io|
+          parts.each { |part| io << w.part_markup(part, 2, false) }
+        end
+      end
+
+      # rpc: ONE wrapper element named by the OPERATION, in the namespace from
+      # `<soap:body namespace=…>` (falling back to definitions/@targetNamespace), whose
+      # children are one accessor per part.
+      #
+      # rpc/encoded is generated BEST-EFFORT: the same accessor shape plus
+      # `soapenv:encodingStyle` on the wrapper and `xsi:type` on each simple-typed accessor.
+      # What is NOT generated is SOAP encoding's multi-reference form (href/id) and its
+      # SOAP-Array attributes — a single-reference encoded body is legal SOAP 1.1 §5 and
+      # every stack accepts one, so this is a simplification, not a wrong body.
+      private def self.rpc_body(doc : Doc, w : Writer, bop : BindingOp,
+                                parts : Array(Part), encoded : Bool) : String
+        ns = bop.body_ns || doc.target_ns
+        tag = ns.empty? ? bop.name : "#{w.prefix_for(ns)}:#{bop.name}"
+        inner = String.build do |io|
+          parts.each { |part| io << w.part_markup(part, 3, true, encoded) }
+        end
+        attrs = encoded ? %( soapenv:encodingStyle="#{SOAP_ENC}") : ""
+        String.build do |io|
+          io << "    <" << tag << attrs << ">\n" << inner << "    </" << tag << ">\n"
+        end
+      end
+
+      # soap:header parts are almost always the interesting ones — AuthHeader, LicenseHeader,
+      # a session token — so they are generated, not dropped. A header naming a message that
+      # does not resolve skips THAT HEADER only; the operation still imports.
+      private def self.header_markup(doc : Doc, w : Writer, bop : BindingOp) : String
+        String.build do |io|
+          bop.headers.each do |h|
+            msg = doc.messages[h.message]?
+            next unless msg
+            part = msg.parts.find { |p| p.name == h.part }
+            next unless part
+            io << w.part_markup(part, 2, false)
+          end
+        end
+      end
+
+      # Every prefix the body allocated is declared on the Envelope — the outermost element,
+      # therefore in scope for the Header and the Body alike. Declaring each one on the
+      # element that first used it would be shorter and WRONG: a URI first used deep in one
+      # subtree and used again in a SIBLING subtree would be out of scope for the sibling.
+      # One declaration block on the root makes the scoping unarguable, and is what every
+      # SOAP tool's generated request looks like.
+      private def self.envelope(version : Version, w : Writer, header : String, body : String) : String
+        String.build do |io|
+          io << %(<?xml version="1.0" encoding="UTF-8"?>) << '\n'
+          io << %(<soapenv:Envelope xmlns:soapenv=") << version.envelope_ns << '"'
+          w.declarations.each do |(prefix, uri)|
+            io << " xmlns:" << prefix << %(=") << Writer.esc_attr(uri) << '"'
+          end
+          io << '>' << '\n'
+          if header.empty?
+            # Emitted even when the binding declares no header parts. It costs 22 bytes, and
+            # it is the element an operator adds wsse:Security, a routing header or a
+            # mustUnderstand probe to — the difference between an edit and a lookup.
+            io << "  <soapenv:Header/>" << '\n'
+          else
+            io << "  <soapenv:Header>" << '\n' << header << "  </soapenv:Header>" << '\n'
+          end
+          # <Header> MUST precede <Body>. A generator that appends headers after rendering
+          # the body emits an invalid envelope that most stacks still accept, so it is not
+          # caught by trying it against one server.
+          io << "  <soapenv:Body>" << '\n' << body << "  </soapenv:Body>" << '\n'
+          io << "</soapenv:Envelope>" << '\n'
+        end
+      end
+    end
+  end
+end

--- a/src/gori/import/wsdl_body.cr
+++ b/src/gori/import/wsdl_body.cr
@@ -1,0 +1,510 @@
+require "./xml_mini"
+
+module Gori
+  module Import
+    module Wsdl
+      # The XSD declared INLINE in `<wsdl:types>`, indexed by expanded name.
+      #
+      # Every `<xsd:schema>` under `<wsdl:types>` is MERGED into one index. WSDL 1.1 allows
+      # several schemas with different targetNamespaces there, and an `<xsd:import
+      # namespace="…"/>` carrying no schemaLocation is exactly how one inline schema
+      # references another — so merging resolves that (very common) case with no import
+      # following at all.
+      class Schemas
+        getter elements : Hash(QName, Node)
+        # complexType AND simpleType share ONE table because they share one symbol space in
+        # XSD (§3.4.1: a complexType and a simpleType cannot share a name in one target
+        # namespace), so a second table would only ever add a miss to handle.
+        getter types : Hash(QName, Node)
+        # targetNamespaces whose schema says `elementFormDefault="qualified"`. Per-schema in
+        # XSD; indexed per-namespace here, which differs only for two inline schemas sharing
+        # a targetNamespace and disagreeing — a shape no generator produces.
+        getter qualified : Set(String)
+        # namespace => the schemaLocation gori did NOT follow. Read only to make an
+        # unresolvable type's comment say which file would have defined it.
+        getter unresolved : Hash(String, String)
+
+        def initialize(@elements : Hash(QName, Node), @types : Hash(QName, Node),
+                       @qualified : Set(String), @unresolved : Hash(String, String))
+        end
+
+        def self.build(root : Node) : Schemas
+          elements = {} of QName => Node
+          types = {} of QName => Node
+          qualified = Set(String).new
+          unresolved = {} of String => String
+          present = Set(String).new
+
+          schemas = [] of Node
+          root.elements(WSDL_NS, "types").each do |t|
+            t.elements(XSD_NS, "schema").each { |s| schemas << s }
+          end
+
+          schemas.each do |s|
+            tns = s.attr?("targetNamespace") || ""
+            present << tns
+            qualified << tns if s.attr?("elementFormDefault") == "qualified"
+            s.elements(XSD_NS, "element").each do |e|
+              if name = e.attr?("name")
+                elements[{tns, name}] = e
+              end
+            end
+            {"complexType", "simpleType"}.each do |kind|
+              s.elements(XSD_NS, kind).each do |t|
+                if name = t.attr?("name")
+                  types[{tns, name}] = t
+                end
+              end
+            end
+          end
+
+          # External schema following is OUT OF SCOPE: an importer that fetches a
+          # schemaLocation is an importer with file and network I/O, which is the XXE
+          # surface `XmlMini` was written to not have — and a relative schemaLocation beside
+          # the .wsdl is only sometimes on disk anyway.
+          #
+          # Recorded ONLY when the import carries a schemaLocation AND its namespace has no
+          # inline schema: a schemaLocation-less import between two inline schemas resolves
+          # normally above and must not be reported as missing.
+          schemas.each do |s|
+            {"import", "include"}.each do |kind|
+              s.elements(XSD_NS, kind).each do |imp|
+                loc = imp.attr?("schemaLocation")
+                next if loc.nil? || loc.empty?
+                ns = imp.attr?("namespace") || s.attr?("targetNamespace") || ""
+                next if present.includes?(ns)
+                unresolved[ns] = loc
+              end
+            end
+          end
+
+          new(elements, types, qualified, unresolved)
+        end
+      end
+
+      # Turns a message part into SOAP body markup, allocating namespace prefixes as it goes.
+      #
+      # One Writer per generated request: the prefix table it fills is what `Wsdl.envelope`
+      # declares on the Envelope element, so a Writer shared between two requests would
+      # declare prefixes one of them never uses.
+      class Writer
+        # Two independent guards, because they stop different shapes, plus a width backstop.
+        #
+        #   XSD_MAX_DEPTH  bounds a deep-but-finite tree. A schema 30 wrapper types deep is
+        #                  legal and useless as a seed request.
+        #   the path stack bounds a CYCLE (see `content_of`). The depth cap alone would let
+        #                  a self-referencing type expand to 2^12 elements before stopping.
+        #   MAX_BODY_NODES bounds WIDTH — a choice of 400 branches under a sequence of 40 is
+        #                  neither deep nor cyclic and would still produce an unreadable
+        #                  body. Blowing it raises, so the operation is skipped and COUNTED
+        #                  rather than silently truncated; 2 000 elements in one SOAP body is
+        #                  already past the point of being editable in the Repeater.
+        XSD_MAX_DEPTH  =    12
+        MAX_BODY_NODES = 2_000
+
+        # `maxOccurs` is honoured as "once" or "more than once", never literally: a declared
+        # maxOccurs="9999" means 2 accessors, not 9999. The operator needs to SEE that the
+        # accessor repeats — array handling is where the bugs are — and then set the count by
+        # hand; a body that is megabytes of identical stubs cannot be read at all.
+        REPEAT = 2
+
+        PARTICLES = {"element", "sequence", "choice", "all", "any", "group"}
+
+        # Every value is VALID for its type on purpose. A gateway that XSD-validates before
+        # dispatch has to let the seed request through to the business logic, or the import
+        # bought nothing — which rules out SoapUI's `?` convention, invalid for every
+        # numeric, boolean and date type in the language.
+        BUILTIN = {
+          "string"             => "string",
+          "normalizedString"   => "string",
+          "token"              => "string",
+          "language"           => "en",
+          "Name"               => "name",
+          "NCName"             => "name",
+          "NMTOKEN"            => "token",
+          "ID"                 => "id1",
+          "IDREF"              => "id1",
+          "QName"              => "string",
+          "anyURI"             => "http://example.com/",
+          "anyType"            => "string",
+          "anySimpleType"      => "string",
+          "boolean"            => "true",
+          "byte"               => "1",
+          "short"              => "1",
+          "int"                => "1",
+          "long"               => "1",
+          "integer"            => "1",
+          "unsignedByte"       => "1",
+          "unsignedShort"      => "1",
+          "unsignedInt"        => "1",
+          "unsignedLong"       => "1",
+          "positiveInteger"    => "1",
+          "nonNegativeInteger" => "1",
+          # The sign-constrained pair needs its OWN value: "1" fails validation for both,
+          # which is exactly the class of failure this table exists to avoid.
+          "negativeInteger"    => "-1",
+          "nonPositiveInteger" => "0",
+          "decimal"            => "1.0",
+          "float"              => "1.0",
+          "double"             => "1.0",
+          "duration"           => "P1D",
+          "dateTime"           => "2024-01-01T00:00:00Z",
+          "date"               => "2024-01-01",
+          "time"               => "00:00:00Z",
+          "gYear"              => "2024",
+          "gYearMonth"         => "2024-01",
+          "gMonth"             => "--01",
+          "gMonthDay"          => "--01-01",
+          "gDay"               => "---01",
+          "base64Binary"       => "Z29yaQ==",
+          "hexBinary"          => "676f7269",
+        }
+
+        # An element's markup and, separately, the attributes that ride on its own tag.
+        # `text` and `children` are alternatives: simple content sets the first, a particle
+        # walk sets the second, and an empty element sets neither.
+        record Content, text : String? = nil, children : String = "", attrs : String = ""
+
+        getter declarations : Array({String, String})
+
+        def initialize(@schemas : Schemas)
+          @prefixes = {} of String => String
+          @used = Set(String).new(["soapenv"])
+          @declarations = [] of {String, String}
+          @budget = MAX_BODY_NODES
+        end
+
+        def prefix_for(uri : String, hint : String? = nil) : String
+          if existing = @prefixes[uri]?
+            return existing
+          end
+          prefix = hint
+          if prefix.nil? || @used.includes?(prefix)
+            n = @prefixes.size + 1
+            while @used.includes?("ns#{n}")
+              n += 1
+            end
+            prefix = "ns#{n}"
+          end
+          @used << prefix
+          @prefixes[uri] = prefix
+          @declarations << {prefix, uri}
+          prefix
+        end
+
+        # One message part as body markup at `depth`.
+        #
+        # `rpc` names the accessor after the PART and leaves it UNQUALIFIED — rpc accessors
+        # are never namespace-qualified, whatever `elementFormDefault` says, and routing them
+        # through the document-path qualification logic is the easiest way to get this wrong.
+        # `xsi_type` is the rpc/encoded extra.
+        def part_markup(part : Part, depth : Int32, rpc : Bool, xsi_type : Bool = false) : String
+          el = part.element
+          ty = part.type
+          # WS-I BP R2204 says document/literal parts use `element=` and rpc parts use
+          # `type=`, and BOTH violations ship in the wild — so neither is a skip. Declaring
+          # NEITHER (or both) is genuinely malformed, and raising here is what the caller's
+          # per-operation rescue turns into one `skipped`.
+          if el && ty
+            raise Gori::Error.new("message part #{part.name.inspect} declares both element= and type=")
+          end
+          if el
+            decl = @schemas.elements[el]?
+            unless decl
+              return comment_line(depth, "unresolved element #{qn_s(el)}#{hint_for(el[0])}")
+            end
+            return global_element(decl, el[0], depth, [] of QName, 1)
+          end
+          unless ty
+            raise Gori::Error.new("message part #{part.name.inspect} declares neither element= nor type=")
+          end
+          content = content_of(ty, lookup(ty), ty[0], depth + 1, 1, [] of QName)
+          extra = ""
+          if xsi_type && ty[0] == XSD_NS
+            extra = %( #{prefix_for(XSI_NS, "xsi")}:type="#{prefix_for(XSD_NS, "xsd")}:#{ty[1]}")
+          end
+          render(part.name, content, depth, 1, extra)
+        end
+
+        # --- element declarations ------------------------------------------------
+
+        private def global_element(decl : Node, ns : String, depth : Int32,
+                                   path : Array(QName), reps : Int32) : String
+          name = decl.attr?("name")
+          return comment_line(depth, "global element declaration with no name") unless name
+          content = decl_content(decl, ns, depth + 1, 1, path)
+          # A GLOBAL element is qualified by its own schema's targetNamespace, always —
+          # elementFormDefault governs LOCAL names only.
+          tag = ns.empty? ? name : "#{prefix_for(ns)}:#{name}"
+          render(tag, content, depth, reps)
+        end
+
+        private def element_markup(decl : Node, owner_ns : String, depth : Int32,
+                                   level : Int32, path : Array(QName)) : String
+          if ref = decl.qname_attr?("ref")
+            target = @schemas.elements[ref]?
+            unless target
+              return comment_line(depth, "unresolved element reference #{qn_s(ref)}#{hint_for(ref[0])}")
+            end
+            # The referenced global element brings its own name, namespace and qualification;
+            # only the occurrence count comes from the reference.
+            return global_element(target, ref[0], depth, path, occurs(decl))
+          end
+          name = decl.attr?("name")
+          return "" unless name
+          content = decl_content(decl, owner_ns, depth + 1, level + 1, path)
+          # `elementFormDefault="qualified"` (per schema, overridden by `form=` on one
+          # element) decides whether LOCAL names are namespace-qualified. The default is
+          # UNQUALIFIED; .NET emits qualified and Axis often does not, so it cannot be
+          # guessed — and a qualified name gets an explicit prefix rather than a default
+          # `xmlns=` on the wrapper, which would silently pull every unqualified CHILD into
+          # the same namespace and produce a body that looks right and validates wrong.
+          tag = qualified?(decl, owner_ns) && !owner_ns.empty? ? "#{prefix_for(owner_ns)}:#{name}" : name
+          render(tag, content, depth, occurs(decl))
+        end
+
+        # An inline anonymous type when the declaration has one, else its named `type=`,
+        # else xsd:anyType.
+        private def decl_content(decl : Node, owner_ns : String, depth : Int32,
+                                 level : Int32, path : Array(QName)) : Content
+          inline = decl.element?(XSD_NS, "complexType") || decl.element?(XSD_NS, "simpleType")
+          return content_of(nil, inline, owner_ns, depth, level, path) if inline
+          ty = decl.qname_attr?("type")
+          return Content.new(text: "string") unless ty
+          content_of(ty, lookup(ty), ty[0], depth, level, path)
+        end
+
+        # --- types ---------------------------------------------------------------
+
+        private def content_of(type_qn : QName?, type_node : Node?, owner_ns : String,
+                               depth : Int32, level : Int32, path : Array(QName)) : Content
+          if type_qn && type_qn[0] == XSD_NS
+            return Content.new(text: builtin_text(type_qn[1]))
+          end
+          if type_qn && type_node.nil?
+            # An unresolvable type renders as a COMMENT naming it and the schemaLocation
+            # that would have defined it, so the operator can see WHICH file to paste in —
+            # never as a silent omission, which would present an incomplete body as complete.
+            return Content.new(children: comment_line(depth, "unresolved type #{qn_s(type_qn)}#{hint_for(type_qn[0])}"))
+          end
+          return Content.new(text: "string") unless type_node
+          if type_qn
+            if path.includes?(type_qn)
+              return Content.new(children: comment_line(depth, "recursive type #{qn_s(type_qn)} — expand by hand"))
+            end
+            path = path + [type_qn]
+          end
+          if level > XSD_MAX_DEPTH
+            return Content.new(children: comment_line(depth, "nesting past #{XSD_MAX_DEPTH} levels — expand by hand"))
+          end
+          case type_node.local
+          when "simpleType"  then simple_content(type_node, owner_ns, depth, level, path)
+          when "complexType" then complex_content(type_node, owner_ns, depth, level, path)
+          else                    Content.new(text: "string")
+          end
+        end
+
+        private def simple_content(node : Node, owner_ns : String, depth : Int32,
+                                   level : Int32, path : Array(QName)) : Content
+          if r = node.element?(XSD_NS, "restriction")
+            # An enumeration wins over the base type's placeholder. A value outside the
+            # enumeration is the single most common cause of a schema-validating gateway
+            # rejecting a seed request before it reaches any business logic.
+            if e = r.element?(XSD_NS, "enumeration")
+              return Content.new(text: e.attr?("value") || "string")
+            end
+            if base = r.qname_attr?("base")
+              return content_of(base, lookup(base), base[0], depth, level + 1, path)
+            end
+            if inner = r.element?(XSD_NS, "simpleType")
+              return content_of(nil, inner, owner_ns, depth, level + 1, path)
+            end
+          end
+          if l = node.element?(XSD_NS, "list")
+            if item = l.qname_attr?("itemType")
+              return content_of(item, lookup(item), item[0], depth, level + 1, path)
+            end
+          end
+          if u = node.element?(XSD_NS, "union")
+            if mt = u.attr?("memberTypes")
+              if first = mt.split.first?
+                qn = u.qname(first)
+                return content_of(qn, lookup(qn), qn[0], depth, level + 1, path)
+              end
+            end
+            if inner = u.element?(XSD_NS, "simpleType")
+              return content_of(nil, inner, owner_ns, depth, level + 1, path)
+            end
+          end
+          Content.new(text: "string")
+        end
+
+        private def complex_content(node : Node, owner_ns : String, depth : Int32,
+                                    level : Int32, path : Array(QName)) : Content
+          # simpleContent: the base's placeholder becomes the element's TEXT and the
+          # extension's attributes ride on the same tag — `<amount currency="USD">1.0</amount>`
+          # is this branch.
+          if sc = node.element?(XSD_NS, "simpleContent")
+            if ext = sc.element?(XSD_NS, "extension") || sc.element?(XSD_NS, "restriction")
+              base = ext.qname_attr?("base")
+              text = base ? (content_of(base, lookup(base), base[0], depth, level + 1, path).text || "string") : "string"
+              return Content.new(text: text, attrs: attrs_of(ext))
+            end
+          end
+          if cc = node.element?(XSD_NS, "complexContent")
+            if ext = cc.element?(XSD_NS, "extension") || cc.element?(XSD_NS, "restriction")
+              children = ""
+              attrs = ""
+              if base = ext.qname_attr?("base")
+                # XSD extension APPENDS, so the BASE's particles go FIRST. Order is not
+                # cosmetic: a server unmarshalling by position rejects the reversed body.
+                bc = content_of(base, lookup(base), base[0], depth, level + 1, path)
+                children += bc.children
+                attrs += bc.attrs
+              end
+              children += particles_of(ext.children, owner_ns, depth, level, path)
+              attrs += attrs_of(ext)
+              return Content.new(children: children, attrs: attrs)
+            end
+          end
+          Content.new(children: particles_of(node.children, owner_ns, depth, level, path),
+            attrs: attrs_of(node))
+        end
+
+        private def particles_of(nodes : Array(Node), owner_ns : String, depth : Int32,
+                                 level : Int32, path : Array(QName)) : String
+          String.build do |io|
+            nodes.each do |c|
+              next unless c.uri == XSD_NS
+              case c.local
+              when "sequence", "all"
+                io << particles_of(c.children, owner_ns, depth, level, path)
+              when "choice"
+                # The FIRST branch only, and with no explanatory comment: the body has to
+                # stay a sendable document, and a "you could also send B" note would be
+                # noise on every later send. The alternatives are one lookup away in the
+                # WSDL the operator just imported.
+                first = c.children.find { |g| g.uri == XSD_NS && PARTICLES.includes?(g.local) }
+                if first
+                  io << particles_of([first], owner_ns, depth, level, path)
+                end
+              when "element"
+                io << element_markup(c, owner_ns, depth, level, path)
+              when "any"
+                io << comment_line(depth, "<xsd:any> — insert the element the service expects")
+              when "group"
+                io << comment_line(depth, "<xsd:group> reference — expand by hand")
+              end
+            end
+          end
+        end
+
+        # `use="required"`, or an attribute the schema states a `fixed`/`default` for — in
+        # which case the value is the schema's, not one gori invented. An OPTIONAL attribute
+        # with no stated value is skipped: unlike an element it is trivially typed by hand
+        # onto a tag the operator is already looking at, and SOAP bodies carry few of them.
+        #
+        # Always written unqualified. `attributeFormDefault` defaults to unqualified and a
+        # qualified attribute in a SOAP body is vanishingly rare.
+        private def attrs_of(container : Node) : String
+          String.build do |io|
+            container.elements(XSD_NS, "attribute").each do |a|
+              name = a.attr?("name")
+              next unless name
+              stated = a.attr?("fixed") || a.attr?("default")
+              next unless stated || a.attr?("use") == "required"
+              io << ' ' << name << %(=") << Writer.esc_attr(stated || attr_placeholder(a)) << '"'
+            end
+          end
+        end
+
+        private def attr_placeholder(a : Node) : String
+          ty = a.qname_attr?("type")
+          return builtin_text(ty[1]) if ty && ty[0] == XSD_NS
+          "string"
+        end
+
+        # --- emitting ------------------------------------------------------------
+
+        private def render(tag : String, content : Content, depth : Int32,
+                           reps : Int32, extra : String = "") : String
+          pad = "  " * depth
+          String.build do |io|
+            reps.times do
+              charge
+              io << pad << '<' << tag << content.attrs << extra
+              if t = content.text
+                io << '>' << Writer.esc_text(t) << "</" << tag << '>' << '\n'
+              elsif content.children.empty?
+                io << "/>" << '\n'
+              else
+                io << '>' << '\n' << content.children << pad << "</" << tag << '>' << '\n'
+              end
+            end
+          end
+        end
+
+        private def comment_line(depth : Int32, message : String) : String
+          "#{"  " * depth}<!-- #{message.gsub("--", "- -")} -->\n"
+        end
+
+        private def charge : Nil
+          @budget -= 1
+          if @budget < 0
+            raise Gori::Error.new(
+              "the SOAP body would exceed #{MAX_BODY_NODES} elements — this schema is too " \
+              "wide to seed automatically")
+          end
+        end
+
+        # --- small helpers -------------------------------------------------------
+
+        # A builtin never resolves through the type table; everything else does.
+        private def lookup(qn : QName) : Node?
+          return nil if qn[0] == XSD_NS
+          @schemas.types[qn]?
+        end
+
+        private def builtin_text(local : String) : String
+          BUILTIN[local]? || "string"
+        end
+
+        private def occurs(decl : Node) : Int32
+          mo = decl.attr?("maxOccurs")
+          return 1 unless mo
+          return REPEAT if mo == "unbounded"
+          (mo.to_i? || 1) > 1 ? REPEAT : 1
+        end
+
+        # `minOccurs="0"` still emits, deliberately: deleting an element you can see is
+        # trivial, while inventing one the skeleton hid means going back to the WSDL. A seed
+        # request is for maximum reachable surface, so optional means present. `nillable`
+        # renders normally too — a body pre-filled with `xsi:nil` reaches no business logic
+        # at all, which is the opposite of the point.
+        private def qualified?(decl : Node, owner_ns : String) : Bool
+          if form = decl.attr?("form")
+            return form == "qualified"
+          end
+          @schemas.qualified.includes?(owner_ns)
+        end
+
+        private def qn_s(qn : QName) : String
+          qn[0].empty? ? qn[1] : "{#{qn[0]}}#{qn[1]}"
+        end
+
+        private def hint_for(ns : String) : String
+          loc = @schemas.unresolved[ns]?
+          loc ? " (declared in #{loc}, which gori does not fetch)" : ""
+        end
+
+        def self.esc_text(s : String) : String
+          s.gsub('&', "&amp;").gsub('<', "&lt;")
+        end
+
+        def self.esc_attr(s : String) : String
+          esc_text(s).gsub('"', "&quot;")
+        end
+      end
+    end
+  end
+end

--- a/src/gori/import/wsdl_body.cr
+++ b/src/gori/import/wsdl_body.cr
@@ -160,6 +160,13 @@ module Gori
           "hexBinary"          => "676f7269",
         }
 
+        # One named XSD component on the chain currently being expanded, for the cycle guard in
+        # `content_of` / `global_element`. Elements and types are BOTH tracked and kept apart by
+        # `element`, because XSD gives them separate symbol spaces: `{urn:t}Add` can legitimately
+        # be a global element AND a complexType, and one flat list would call that a cycle.
+        record Step, element : Bool, name : QName
+        alias Trail = Array(Step)
+
         # An element's markup and, separately, the attributes that ride on its own tag.
         # `text` and `children` are alternatives: simple content sets the first, a particle
         # walk sets the second, and an empty element sets neither.
@@ -171,7 +178,7 @@ module Gori
           @prefixes = {} of String => String
           @used = Set(String).new(["soapenv"])
           @declarations = [] of {String, String}
-          @budget = MAX_BODY_NODES
+          @spent = 0
         end
 
         def prefix_for(uri : String, hint : String? = nil) : String
@@ -213,12 +220,12 @@ module Gori
             unless decl
               return comment_line(depth, "unresolved element #{qn_s(el)}#{hint_for(el[0])}")
             end
-            return global_element(decl, el[0], depth, [] of QName, 1)
+            return global_element(decl, el[0], depth, Trail.new, 1, 1)
           end
           unless ty
             raise Gori::Error.new("message part #{part.name.inspect} declares neither element= nor type=")
           end
-          content = content_of(ty, lookup(ty), ty[0], depth + 1, 1, [] of QName)
+          content = content_of(ty, lookup(ty), ty[0], depth + 1, 1, Trail.new)
           extra = ""
           if xsi_type && ty[0] == XSD_NS
             extra = %( #{prefix_for(XSI_NS, "xsi")}:type="#{prefix_for(XSD_NS, "xsd")}:#{ty[1]}")
@@ -229,10 +236,24 @@ module Gori
         # --- element declarations ------------------------------------------------
 
         private def global_element(decl : Node, ns : String, depth : Int32,
-                                   path : Array(QName), reps : Int32) : String
+                                   path : Trail, reps : Int32, level : Int32) : String
           name = decl.attr?("name")
           return comment_line(depth, "global element declaration with no name") unless name
-          content = decl_content(decl, ns, depth + 1, 1, path)
+          # An `<xsd:element ref=…>` cycle is a SECOND way to recurse forever, and neither of
+          # `content_of`'s guards sees it: `level` used to restart at 1 on every hop through
+          # here, and an element carrying an INLINE anonymous complexType names no type, so
+          # nothing was appended to the trail either. `<element name="A"><complexType><sequence>
+          # <element ref="tns:A"/>` then recursed until the process died on a stack overflow —
+          # a signal, not an exception, so `Wsdl.parse_file`'s per-operation rescue could not
+          # turn it into a `skipped`; it took the whole CLI, TUI or MCP server with it.
+          step = Step.new(true, {ns, name})
+          if path.includes?(step)
+            return comment_line(depth, "recursive element #{qn_s({ns, name})} — expand by hand")
+          end
+          trail = path + [step]
+          before = @spent
+          content = decl_content(decl, ns, depth + 1, level + 1, trail)
+          charge((reps - 1) * (@spent - before)) if reps > 1
           # A GLOBAL element is qualified by its own schema's targetNamespace, always —
           # elementFormDefault governs LOCAL names only.
           tag = ns.empty? ? name : "#{prefix_for(ns)}:#{name}"
@@ -240,7 +261,7 @@ module Gori
         end
 
         private def element_markup(decl : Node, owner_ns : String, depth : Int32,
-                                   level : Int32, path : Array(QName)) : String
+                                   level : Int32, path : Trail) : String
           if ref = decl.qname_attr?("ref")
             target = @schemas.elements[ref]?
             unless target
@@ -248,11 +269,19 @@ module Gori
             end
             # The referenced global element brings its own name, namespace and qualification;
             # only the occurrence count comes from the reference.
-            return global_element(target, ref[0], depth, path, occurs(decl))
+            return global_element(target, ref[0], depth, path, occurs(decl), level + 1)
           end
           name = decl.attr?("name")
           return "" unless name
+          before = @spent
           content = decl_content(decl, owner_ns, depth + 1, level + 1, path)
+          reps = occurs(decl)
+          # `render` writes the subtree string `reps` times, but it was BUILT — and therefore
+          # charged — once. Charging the copies here is what makes MAX_BODY_NODES bound the
+          # EMITTED body: under nested repeats the emitted count grows as the PRODUCT of the
+          # reps while a charge-on-construction budget grows linearly, so a 1.5 KB WSDL built a
+          # 1.27 GB body and still reported `skipped: 0`.
+          charge((reps - 1) * (@spent - before)) if reps > 1
           # `elementFormDefault="qualified"` (per schema, overridden by `form=` on one
           # element) decides whether LOCAL names are namespace-qualified. The default is
           # UNQUALIFIED; .NET emits qualified and Axis often does not, so it cannot be
@@ -260,13 +289,13 @@ module Gori
           # `xmlns=` on the wrapper, which would silently pull every unqualified CHILD into
           # the same namespace and produce a body that looks right and validates wrong.
           tag = qualified?(decl, owner_ns) && !owner_ns.empty? ? "#{prefix_for(owner_ns)}:#{name}" : name
-          render(tag, content, depth, occurs(decl))
+          render(tag, content, depth, reps)
         end
 
         # An inline anonymous type when the declaration has one, else its named `type=`,
         # else xsd:anyType.
         private def decl_content(decl : Node, owner_ns : String, depth : Int32,
-                                 level : Int32, path : Array(QName)) : Content
+                                 level : Int32, path : Trail) : Content
           inline = decl.element?(XSD_NS, "complexType") || decl.element?(XSD_NS, "simpleType")
           return content_of(nil, inline, owner_ns, depth, level, path) if inline
           ty = decl.qname_attr?("type")
@@ -277,7 +306,7 @@ module Gori
         # --- types ---------------------------------------------------------------
 
         private def content_of(type_qn : QName?, type_node : Node?, owner_ns : String,
-                               depth : Int32, level : Int32, path : Array(QName)) : Content
+                               depth : Int32, level : Int32, path : Trail) : Content
           if type_qn && type_qn[0] == XSD_NS
             return Content.new(text: builtin_text(type_qn[1]))
           end
@@ -289,10 +318,11 @@ module Gori
           end
           return Content.new(text: "string") unless type_node
           if type_qn
-            if path.includes?(type_qn)
+            step = Step.new(false, type_qn)
+            if path.includes?(step)
               return Content.new(children: comment_line(depth, "recursive type #{qn_s(type_qn)} — expand by hand"))
             end
-            path = path + [type_qn]
+            path = path + [step]
           end
           if level > XSD_MAX_DEPTH
             return Content.new(children: comment_line(depth, "nesting past #{XSD_MAX_DEPTH} levels — expand by hand"))
@@ -305,7 +335,7 @@ module Gori
         end
 
         private def simple_content(node : Node, owner_ns : String, depth : Int32,
-                                   level : Int32, path : Array(QName)) : Content
+                                   level : Int32, path : Trail) : Content
           if r = node.element?(XSD_NS, "restriction")
             # An enumeration wins over the base type's placeholder. A value outside the
             # enumeration is the single most common cause of a schema-validating gateway
@@ -340,30 +370,49 @@ module Gori
         end
 
         private def complex_content(node : Node, owner_ns : String, depth : Int32,
-                                    level : Int32, path : Array(QName)) : Content
+                                    level : Int32, path : Trail) : Content
           # simpleContent: the base's placeholder becomes the element's TEXT and the
           # extension's attributes ride on the same tag — `<amount currency="USD">1.0</amount>`
           # is this branch.
           if sc = node.element?(XSD_NS, "simpleContent")
-            if ext = sc.element?(XSD_NS, "extension") || sc.element?(XSD_NS, "restriction")
-              base = ext.qname_attr?("base")
-              text = base ? (content_of(base, lookup(base), base[0], depth, level + 1, path).text || "string") : "string"
-              return Content.new(text: text, attrs: attrs_of(ext))
+            derive = sc.element?(XSD_NS, "extension")
+            widen = !derive.nil?
+            derive ||= sc.element?(XSD_NS, "restriction")
+            if derive
+              text = "string"
+              inherited = ""
+              if base = derive.qname_attr?("base")
+                bc = content_of(base, lookup(base), base[0], depth, level + 1, path)
+                text = bc.text || "string"
+                # The base's own attributes, which a simpleContent EXTENSION inherits — a base
+                # that is itself a simpleContent complexType can declare `use="required"` ones,
+                # and dropping them emits a tag the service rejects. A RESTRICTION re-states
+                # what it keeps, so nothing carries over.
+                inherited = bc.attrs if widen
+              end
+              return Content.new(text: text, attrs: inherited + attrs_of(derive))
             end
           end
           if cc = node.element?(XSD_NS, "complexContent")
-            if ext = cc.element?(XSD_NS, "extension") || cc.element?(XSD_NS, "restriction")
+            derive = cc.element?(XSD_NS, "extension")
+            widen = !derive.nil?
+            derive ||= cc.element?(XSD_NS, "restriction")
+            if derive
               children = ""
               attrs = ""
-              if base = ext.qname_attr?("base")
-                # XSD extension APPENDS, so the BASE's particles go FIRST. Order is not
-                # cosmetic: a server unmarshalling by position rejects the reversed body.
+              # EXTENSION and RESTRICTION are not the same operation and must not share a
+              # branch. Extension APPENDS to the base's content model, so the base's particles
+              # go FIRST and order is not cosmetic — a server unmarshalling by position rejects
+              # the reversed body. Restriction REPLACES it: the derived type re-states every
+              # particle it keeps, so emitting the base's beside them both duplicates what was
+              # kept and re-adds what the restriction removed.
+              if widen && (base = derive.qname_attr?("base"))
                 bc = content_of(base, lookup(base), base[0], depth, level + 1, path)
                 children += bc.children
                 attrs += bc.attrs
               end
-              children += particles_of(ext.children, owner_ns, depth, level, path)
-              attrs += attrs_of(ext)
+              children += particles_of(derive.children, owner_ns, depth, level, path)
+              attrs += attrs_of(derive)
               return Content.new(children: children, attrs: attrs)
             end
           end
@@ -372,7 +421,7 @@ module Gori
         end
 
         private def particles_of(nodes : Array(Node), owner_ns : String, depth : Int32,
-                                 level : Int32, path : Array(QName)) : String
+                                 level : Int32, path : Trail) : String
           String.build do |io|
             nodes.each do |c|
               next unless c.uri == XSD_NS
@@ -448,9 +497,10 @@ module Gori
           "#{"  " * depth}<!-- #{message.gsub("--", "- -")} -->\n"
         end
 
-        private def charge : Nil
-          @budget -= 1
-          if @budget < 0
+        private def charge(n : Int32 = 1) : Nil
+          return if n <= 0
+          @spent += n
+          if @spent > MAX_BODY_NODES
             raise Gori::Error.new(
               "the SOAP body would exceed #{MAX_BODY_NODES} elements — this schema is too " \
               "wide to seed automatically")

--- a/src/gori/import/xml_mini.cr
+++ b/src/gori/import/xml_mini.cr
@@ -176,7 +176,11 @@ module Gori
       # message rather than silently producing an empty half.
       def self.split_qname(value : String) : {String, String}
         i = value.index(':')
-        return {"", value} unless i && i > 0 && i < value.bytesize - 1
+        # `size`, not `bytesize`: `String#index` answers in CHARS, and comparing that against a
+        # byte count made the trailing-colon rule depend on how wide the name's characters are —
+        # `"a:"` correctly stayed whole while `"ä:"` split into a prefix `"ä"` that then raised
+        # `undeclared XML namespace prefix` instead of reaching the caller's error message.
+        return {"", value} unless i && i > 0 && i < value.size - 1
         {value[0...i], value[(i + 1)..]}
       end
 

--- a/src/gori/import/xml_mini.cr
+++ b/src/gori/import/xml_mini.cr
@@ -1,0 +1,526 @@
+require "./xml_text"
+
+module Gori
+  module Import
+    # A small, namespace-aware XML tree reader — enough of XML 1.0 + XML Names to read a
+    # WSDL and the XML Schema inside it, and deliberately no more.
+    #
+    # WHY NOT `require "xml"`. libxml2 is not linked into gori, and linking it would mean
+    # adding `libxml2-dev` + `libxml2-static` (and its transitive static deps) to every
+    # packaging path that builds `--static` — docker/Dockerfile, the release workflow,
+    # flake.nix, Homebrew, AUR, snap. `import/burp.cr` states the same reasoning for its
+    # flat scanner; this is that decision applied to a document that actually needs a tree.
+    #
+    # WHY NOT `Import::Burp`'s scanner. That one matches `<name` by string index over a
+    # machine-generated, flat, prefix-free export. A WSDL breaks all three assumptions: the
+    # same element arrives as `<wsdl:portType>`, `<portType>` or `<w:portType>` depending on
+    # the generator; every cross-reference is a QName carried in an ATTRIBUTE VALUE
+    # (`type="tns:Foo"`) resolved against prefixes bound arbitrarily far up the tree; and
+    # `<xsd:sequence>` nests recursively. Prefix-blind matching silently mis-resolves.
+    #
+    # WHAT IT IS NOT. No DTD, no external entities, no XInclude, no namespace fixup, no
+    # schema validation, no round-trip serialization. It reads a document into nodes.
+    module XmlMini
+      # {namespace uri, local name}. `Import::Wsdl` reuses this alias for its own tables.
+      alias QName = {String, String}
+
+      # prefix ("" = the default namespace) => namespace URI.
+      alias NsMap = Hash(String, String)
+
+      # `xml:` is bound implicitly and may not be rebound (XML Names §3). Every other
+      # prefix, `xmlns:` included, has to be declared before it can be used.
+      ROOT_NS = {"xml" => "http://www.w3.org/XML/1998/namespace"} of String => String
+
+      # A resolved attribute. `uri` is "" for the ordinary unprefixed case — see `Node#attr?`
+      # for why that is the RULE and not a fallback.
+      record Attr, uri : String, local : String, value : String
+
+      # A parsed element.
+      #
+      # A class rather than a record: children are appended during the parse and the same
+      # node is referenced from several of `Import::Wsdl`'s index tables, so a struct would
+      # copy on every assignment. There is deliberately no `parent` link — every walk in
+      # this importer runs downward, and a back-reference buys nothing but a cycle.
+      class Node
+        getter uri : String
+        getter local : String
+        # Kept for ERROR MESSAGES only ("expected </soap:address>"), so a message names the
+        # element the way the file spells it. Never match on this: the prefix is arbitrary
+        # and `uri` is the identity.
+        getter prefix : String
+        getter attrs : Array(Attr)
+        getter children : Array(Node)
+        # The prefixes in scope AT THIS ELEMENT. Carried per node so `qname` resolves an
+        # attribute VALUE in O(1) with no parent walk — see `Parser#child_ns` for why this
+        # is one shared Hash for almost every node rather than one per node.
+        getter ns : NsMap
+
+        def initialize(@uri : String, @local : String, @prefix : String,
+                       @attrs : Array(Attr), @ns : NsMap)
+          @children = [] of Node
+          @text = nil.as(String?)
+        end
+
+        # Character data directly inside this element. Whitespace-only runs BETWEEN tags are
+        # dropped (a WSDL is mostly those, and no caller wants them); CDATA is always kept
+        # verbatim, whitespace included.
+        def text : String
+          @text || ""
+        end
+
+        # :nodoc:
+        def add_text(s : String) : Nil
+          if t = @text
+            @text = t + s
+          else
+            @text = s
+          end
+        end
+
+        def name : QName
+          {@uri, @local}
+        end
+
+        def display_name : String
+          @prefix.empty? ? @local : "#{@prefix}:#{@local}"
+        end
+
+        # An unprefixed ATTRIBUTE NAME is in NO namespace (XML Names §6.2) — it does NOT
+        # take the default namespace the way an element name does. That is why `uri`
+        # defaults to "" here: inside `<xsd:schema xmlns="…/XMLSchema">`, the attributes
+        # `targetNamespace`, `name`, `type` and `elementFormDefault` are all in no
+        # namespace, and looking them up under the schema namespace finds nothing.
+        def attr?(local : String, uri : String = "") : String?
+          @attrs.each { |a| return a.value if a.local == local && a.uri == uri }
+          nil
+        end
+
+        # Direct children with this expanded name.
+        def elements(uri : String, local : String) : Array(Node)
+          @children.select { |c| c.uri == uri && c.local == local }
+        end
+
+        def element?(uri : String, local : String) : Node?
+          @children.find { |c| c.uri == uri && c.local == local }
+        end
+
+        def elements(name : QName) : Array(Node)
+          elements(name[0], name[1])
+        end
+
+        def element?(name : QName) : Node?
+          element?(name[0], name[1])
+        end
+
+        # Resolve a QName carried as an attribute VALUE (`type="tns:Foo"`, `binding="tns:B"`,
+        # `base="xsd:string"`). This is the THIRD name rule and it agrees with neither of the
+        # other two: an unprefixed QName VALUE *does* take the default namespace — that is
+        # exactly how a chameleon schema written as
+        # `<schema xmlns="http://www.w3.org/2001/XMLSchema"> … type="string"` means
+        # `xsd:string`. Do not fold this together with `attr?`'s rule; the divergence is the
+        # point.
+        #
+        # An undeclared prefix raises rather than resolving to "": binding `tns:Foo` to no
+        # namespace produces a lookup miss three layers later and an unexplained empty body.
+        def qname(value : String) : QName
+          prefix, local = XmlMini.split_qname(value)
+          if prefix.empty?
+            return {@ns[""]? || "", local}
+          end
+          uri = @ns[prefix]? ||
+                raise Gori::Error.new("undeclared XML namespace prefix #{prefix.inspect} in #{value.inspect}")
+          {uri, local}
+        end
+
+        def qname_attr?(local : String, uri : String = "") : QName?
+          attr?(local, uri).try { |v| qname(v) }
+        end
+      end
+
+      # Structural ceilings. Each stops a DIFFERENT shape, so none of them subsumes another.
+      #
+      #   max_bytes — checked BEFORE parsing. Nothing downstream is size-aware, so a 200 MB
+      #               "WSDL" would build 200 MB of Nodes before any other guard fired.
+      #               8 MiB is well above a large enterprise WSDL with inline XSD (1–2 MB).
+      #               `Saml::MAX_XML` is the same shape of ceiling for the same reason.
+      #   max_depth — `<a><a><a>…` costs one frame per level in the WSDL walk and again in
+      #               the body generator. 256 is ~10x the deepest real schema.
+      #   max_nodes — the backstop for a file legitimately under max_bytes but pathological
+      #               (millions of `<a/>`), and the ONLY guard bounding attribute count,
+      #               since attributes are charged against the same budget as elements.
+      record Limits,
+        max_bytes : Int32 = 8 * 1024 * 1024,
+        max_nodes : Int32 = 200_000,
+        max_depth : Int32 = 256 do
+        def self.default : Limits
+          new
+        end
+      end
+
+      def self.parse(src : String, limits : Limits = Limits.default) : Node
+        if src.bytesize > limits.max_bytes
+          raise Gori::Error.new(
+            "XML document is too large (#{src.bytesize} bytes; the limit is #{limits.max_bytes})")
+        end
+        # SCRUBBED, and this is the deliberate divergence from `Import::Burp`, which must
+        # NOT scrub because its bytes ARE the wire message it stores. A WSDL is a text
+        # DOCUMENT whose only output is names, URLs and placeholder text, so a byte that
+        # cannot be text has no meaning in it — and scrubbing once here makes every String
+        # materialized below safe to hand to `URI.parse` and to PCRE2.
+        text = src.valid_encoding? ? src : src.scrub
+        Parser.new(text, limits).run
+      end
+
+      # {prefix, local} for a QName. No colon means no prefix; a leading or trailing colon
+      # is not a prefix either, and is left as part of the name for the caller's error
+      # message rather than silently producing an empty half.
+      def self.split_qname(value : String) : {String, String}
+        i = value.index(':')
+        return {"", value} unless i && i > 0 && i < value.bytesize - 1
+        {value[0...i], value[(i + 1)..]}
+      end
+
+      private class Parser
+        LT       = 0x3c_u8 # '<'
+        GT       = 0x3e_u8 # '>'
+        SLASH    = 0x2f_u8 # '/'
+        BANG     = 0x21_u8 # '!'
+        QUESTION = 0x3f_u8 # '?'
+        EQ       = 0x3d_u8 # '='
+        DQ       = 0x22_u8 # '"'
+        SQ       = 0x27_u8 # '\''
+        LF       = 0x0a_u8
+
+        def initialize(@src : String, @limits : Limits)
+          @raw = @src.to_slice
+          @pos = 0
+          @budget = @limits.max_nodes
+          @stack = [] of Node
+          @root = nil.as(Node?)
+        end
+
+        def run : Node
+          skip_bom
+          while @pos < @raw.size
+            @raw[@pos] == LT ? dispatch : text_run
+          end
+          unless @stack.empty?
+            raise err("unclosed element <#{@stack.last.display_name}> at end of document")
+          end
+          @root || raise err("XML document has no root element")
+        end
+
+        # --- dispatch ------------------------------------------------------------
+
+        private def dispatch : Nil
+          nxt = @raw[@pos + 1]? || raise err("stray `<` at end of document")
+          case nxt
+          when QUESTION then skip_pi
+          when BANG     then bang
+          when SLASH    then close_tag
+          else               open_tag
+          end
+        end
+
+        # A processing instruction is skipped, the `<?xml …?>` declaration included. Its
+        # `encoding=` is IGNORED on purpose: gori reads every import source as UTF-8, and a
+        # declaration claiming otherwise would describe bytes we have already scrubbed.
+        private def skip_pi : Nil
+          close = index_of("?>", @pos + 2) || raise err("unterminated processing instruction")
+          @pos = close + 2
+        end
+
+        private def bang : Nil
+          if starts_at?(@pos, "<!--")
+            close = index_of("-->", @pos + 4) || raise err("unterminated XML comment")
+            @pos = close + 3
+          elsif starts_at?(@pos, "<![CDATA[")
+            close = index_of("]]>", @pos + 9) || raise err("unterminated CDATA section")
+            # CDATA is literal by definition — never entity-decoded, and its whitespace is
+            # kept even though a whitespace-only text RUN is dropped: the author wrote the
+            # section deliberately.
+            node = @stack.last? || raise err("CDATA outside the root element")
+            node.add_text(String.new(@raw[(@pos + 9)...close]))
+            @pos = close + 3
+          elsif starts_at?(@pos, "<!DOCTYPE")
+            refuse_doctype!
+          else
+            raise err("unexpected markup declaration — this reader accepts elements, comments and CDATA only")
+          end
+        end
+
+        # DOCTYPE is REFUSED outright, not ignored. Refusing is the stronger rule and costs
+        # nothing here: neither WSDL 1.1 nor XML Schema has any use for a DTD, so a DOCTYPE
+        # in a .wsdl is a generator bug or an attack. IGNORING it would leave `&payload;` in
+        # the document, which then decodes to nothing and yields a silently WRONG endpoint
+        # URL — a refusal with a message is strictly better than a quietly corrupted seed
+        # request.
+        #
+        # The two attacks this closes, at their root rather than by a counter:
+        #   XXE            — no external entity can be declared, and this reader has no file
+        #                    or network I/O of any kind to dereference one WITH.
+        #   billion laughs — no internal general entity and no parameter entity can be
+        #                    declared, so there is no expansion to bound.
+        #                    `XmlText::NAMED_ENTITIES` is a fixed five-entry table and an
+        #                    unknown `&foo;` stays VERBATIM rather than expanding, so entity
+        #                    expansion is O(1) in the input by construction.
+        #
+        # This is stricter than P7 ("malformed input is the payload") on purpose, and the
+        # distinction is provenance: a WSDL is a document DESCRIBING requests, not the
+        # operator's own wire bytes. `Import::Raw` is the P7 path; this is not it.
+        private def refuse_doctype! : NoReturn
+          raise err("XML DOCTYPE declarations are refused (external-entity and " \
+                    "entity-expansion risk) — a WSDL needs no DTD; remove the <!DOCTYPE …> line")
+        end
+
+        # --- tags ----------------------------------------------------------------
+
+        private def open_tag : Nil
+          @pos += 1
+          name = read_name
+          raise err("empty element name") if name.empty?
+          raws, decls, self_closing = read_attributes(name)
+
+          parent_ns = @stack.last?.try(&.ns) || ROOT_NS
+          ns = child_ns(parent_ns, decls)
+
+          prefix, local = XmlMini.split_qname(name)
+          uri =
+            if prefix.empty?
+              # An unprefixed ELEMENT name DOES take the default namespace — the one place
+              # the three name rules agree with intuition.
+              ns[""]? || ""
+            else
+              ns[prefix]? || raise err("undeclared XML namespace prefix #{prefix.inspect} on <#{name}>")
+            end
+
+          attrs = raws.map do |(an, av)|
+            ap, al = XmlMini.split_qname(an)
+            au = ap.empty? ? "" : (ns[ap]? || raise err("undeclared XML namespace prefix #{ap.inspect} on attribute #{an.inspect}"))
+            Attr.new(au, al, av)
+          end
+
+          charge(1 + attrs.size)
+          node = Node.new(uri, local, prefix, attrs, ns)
+
+          if parent = @stack.last?
+            parent.children << node
+          else
+            raise err("XML document has more than one root element") if @root
+            @root = node
+          end
+
+          return if self_closing
+          # A self-closing `<x/>` is pushed and popped in one step above, so it is
+          # indistinguishable downstream from `<x></x>` — which is what XML says they are.
+          @stack << node
+          if @stack.size > @limits.max_depth
+            raise err("XML nesting is deeper than #{@limits.max_depth} levels")
+          end
+        end
+
+        # `{ordinary attributes, xmlns declarations, was it self-closing}` for the start tag
+        # whose name has just been read. Split out of `open_tag` because the two do different
+        # jobs — this one scans, that one resolves names and builds the node.
+        private def read_attributes(name : String) : {Array({String, String}), Array({String, String}), Bool}
+          raws = [] of {String, String}
+          decls = [] of {String, String}
+          seen = Set(String).new
+          loop do
+            skip_ws
+            b = @raw[@pos]? || raise err("unterminated start tag <#{name}>")
+            if b == GT
+              @pos += 1
+              return {raws, decls, false}
+            end
+            if b == SLASH
+              raise err("malformed start tag <#{name}>") unless @raw[@pos + 1]? == GT
+              @pos += 2
+              return {raws, decls, true}
+            end
+
+            aname = read_name
+            raise err("malformed attribute in <#{name}>") if aname.empty?
+            value = read_attribute_value(name, aname)
+            # A duplicate attribute is not well-formed, and on `location=` silently keeping
+            # one of the two is picking an endpoint at random.
+            raise err("duplicate attribute #{aname.inspect} on <#{name}>") unless seen.add?(aname)
+
+            if aname == "xmlns"
+              decls << {"", value}
+            elsif aname.starts_with?("xmlns:")
+              prefix = aname[6..]
+              raise err("empty namespace prefix in `xmlns:` on <#{name}>") if prefix.empty?
+              decls << {prefix, value}
+            else
+              raws << {aname, value}
+            end
+          end
+        end
+
+        private def read_attribute_value(name : String, aname : String) : String
+          skip_ws
+          unless @raw[@pos]? == EQ
+            raise err("attribute #{aname.inspect} in <#{name}> has no value")
+          end
+          @pos += 1
+          skip_ws
+          quote = @raw[@pos]?
+          # An unquoted attribute value is REFUSED rather than read to the next space. That
+          # shape is not XML, and tolerating it means guessing where the value ends — on
+          # `location=` that is guessing the endpoint.
+          if quote.nil? || !(quote == DQ || quote == SQ)
+            raise err("unquoted attribute value for #{aname.inspect} in <#{name}>")
+          end
+          @pos += 1
+          stop = @raw.index(quote, @pos) ||
+                 raise err("unterminated attribute value for #{aname.inspect} in <#{name}>")
+          value = XmlText.unescape(String.new(@raw[@pos...stop]))
+          @pos = stop + 1
+          value
+        end
+
+        private def close_tag : Nil
+          @pos += 2
+          name = read_name
+          skip_ws
+          raise err("malformed closing tag </#{name}>") unless @raw[@pos]? == GT
+          @pos += 1
+
+          node = @stack.pop? || raise err("unexpected closing tag </#{name}> with no open element")
+          prefix, local = XmlMini.split_qname(name)
+          # Matched on the RESOLVED name, not the spelling: `</x:foo>` closes `<y:foo>` when
+          # both prefixes are bound to the same URI, and does not when they are not.
+          uri =
+            if prefix.empty?
+              node.ns[""]? || ""
+            else
+              node.ns[prefix]? || raise err("undeclared XML namespace prefix #{prefix.inspect} on </#{name}>")
+            end
+          unless uri == node.uri && local == node.local
+            raise err("mismatched closing tag </#{name}> (expected </#{node.display_name}>)")
+          end
+        end
+
+        # --- text ----------------------------------------------------------------
+
+        private def text_run : Nil
+          start = @pos
+          while @pos < @raw.size && @raw[@pos] != LT
+            @pos += 1
+          end
+          chunk = String.new(@raw[start...@pos])
+          if @stack.empty?
+            # The prolog and epilog may hold whitespace and nothing else.
+            raise err("text outside the root element") unless chunk.blank?
+            return
+          end
+          # A whitespace-only run between two tags is dropped. A WSDL is mostly those, no
+          # caller wants them, and keeping them would allocate a String per indent. Mixed
+          # content is not a shape WSDL or XML Schema produces; CDATA (above) is kept
+          # regardless, which is the escape hatch for a document that means its whitespace.
+          return if chunk.blank?
+          @stack.last.add_text(XmlText.unescape(chunk))
+        end
+
+        # --- namespaces ----------------------------------------------------------
+
+        # The child's in-scope prefix map.
+        #
+        # When an element declares no `xmlns:*` — which is essentially every element in a
+        # real WSDL, since generators put every binding on `<definitions>` — the PARENT'S
+        # map is shared BY REFERENCE, so a 40 000-node document allocates one Hash rather
+        # than 40 000. A declaration forces a copy, and that copy is what gives the inner
+        # scope its own lifetime. `ns` is never mutated after construction, which is what
+        # makes the sharing sound.
+        private def child_ns(parent : NsMap, decls : Array({String, String})) : NsMap
+          return parent if decls.empty?
+          merged = parent.dup
+          decls.each do |(prefix, uri)|
+            # `xmlns=""` UNDECLARES the default namespace (XML Names §6.2). It does not bind
+            # the empty prefix to the empty URI — that would make every unprefixed descendant
+            # resolve into a namespace literally called "". Delete the key instead.
+            if prefix.empty? && uri.empty?
+              merged.delete("")
+            else
+              merged[prefix] = uri
+            end
+          end
+          merged
+        end
+
+        # --- scanning primitives -------------------------------------------------
+
+        private def skip_bom : Nil
+          @pos = 3 if starts_at?(0, "\u{feff}")
+        end
+
+        private def skip_ws : Nil
+          while @pos < @raw.size && ws?(@raw[@pos])
+            @pos += 1
+          end
+        end
+
+        private def ws?(b : UInt8) : Bool
+          b == 0x20_u8 || b == 0x09_u8 || b == 0x0a_u8 || b == 0x0d_u8
+        end
+
+        # A name runs to the first byte that cannot be in one. Every XML delimiter is ASCII,
+        # so a byte scan reads exactly what a char scan would and needs no decoding.
+        private def read_name : String
+          start = @pos
+          while @pos < @raw.size
+            b = @raw[@pos]
+            break if ws?(b) || b == GT || b == SLASH || b == EQ
+            @pos += 1
+          end
+          String.new(@raw[start...@pos])
+        end
+
+        private def starts_at?(at : Int32, s : String) : Bool
+          b = s.to_slice
+          return false if at + b.size > @raw.size
+          b.each_with_index { |x, k| return false if @raw[at + k] != x }
+          true
+        end
+
+        # Byte-wise, NOT `String#index`: `@pos` is a byte offset and `String#index` answers
+        # in CHARS, so the two disagree the moment the document holds one non-ASCII byte.
+        private def index_of(needle : String, from : Int32) : Int32?
+          n = needle.to_slice
+          return nil if n.empty?
+          i = from
+          last = @raw.size - n.size
+          while i <= last
+            if @raw[i] == n[0]
+              j = 1
+              while j < n.size && @raw[i + j] == n[j]
+                j += 1
+              end
+              return i if j == n.size
+            end
+            i += 1
+          end
+          nil
+        end
+
+        private def charge(n : Int32) : Nil
+          @budget -= n
+          raise err("XML document has more than #{@limits.max_nodes} nodes") if @budget < 0
+        end
+
+        # Errors name a LINE, because that is what the operator can go and look at. Counting
+        # is O(n) but an error is terminal, so it happens at most once.
+        private def err(message : String) : Gori::Error
+          line = 1
+          i = 0
+          while i < @pos && i < @raw.size
+            line += 1 if @raw[i] == LF
+            i += 1
+          end
+          Gori::Error.new("#{message} (line #{line})")
+        end
+      end
+    end
+  end
+end

--- a/src/gori/import/xml_text.cr
+++ b/src/gori/import/xml_text.cr
@@ -1,0 +1,113 @@
+module Gori
+  module Import
+    # Text-level XML decoding shared by the two importers that read XML without libxml2:
+    # `Import::Burp`'s flat item scanner and `Import::XmlMini`'s tree parser.
+    #
+    # MOVED OUT OF `burp.cr` UNCHANGED, bodies and comments both. `unescape` sits on the
+    # path that produces byte-exact wire bytes for a `base64="false"` `<request>`, so its
+    # byte-wise scan and its exact strictness — uppercase `&#X41;` never matched, an unknown
+    # `&foo;` stays verbatim, a lone surrogate stays verbatim — are a CONTRACT, not an
+    # implementation detail. Do not "tidy" them.
+    #
+    # `NAMED_ENTITIES` holding only the five XML predefined entities is deliberate and is
+    # the whole anti-XXE story for `XmlMini`: gori resolves no other entity, so entity
+    # expansion is O(1) in the input by construction rather than by a counter someone has
+    # to remember to check.
+    module XmlText
+      def self.cdata?(inner : String) : Bool
+        inner.lstrip.starts_with?("<![CDATA[")
+      end
+
+      # CDATA content is literal by definition — never entity-decoded.
+      def self.uncdata(inner : String) : String
+        s = inner.strip
+        s = s[9..] if s.starts_with?("<![CDATA[")
+        s = s[0...-3] if s.ends_with?("]]>")
+        s
+      end
+
+      AMP       = 0x26_u8 # '&'
+      HASH      = 0x23_u8 # '#'
+      LOWER_X   = 0x78_u8 # 'x'
+      SEMICOLON = 0x3B_u8 # ';'
+
+      # `&name;` / `&#123;` / `&#x1f;` decoding, done BYTE-wise.
+      #
+      # This was `text.gsub(ENTITY) { … }` over `/&(#x[0-9a-fA-F]+|#\d+|[a-zA-Z]+);/`, and a
+      # Regexp gsub walks its subject as chars — `Burp.bytes_of` calls this for a non-base64
+      # `<request>` that is not CDATA-wrapped, i.e. on wire bytes. The grammar is entirely
+      # ASCII, so a byte scan reads exactly what that pattern did and copies everything else
+      # through untouched.
+      def self.unescape(text : String) : String
+        raw = text.to_slice
+        return text unless raw.includes?(AMP)
+        io = IO::Memory.new(raw.size)
+        i = 0
+        while i < raw.size
+          if raw[i] == AMP && (hit = entity_at(raw, i))
+            replacement, width = hit
+            io << replacement
+            i += width
+          else
+            io.write_byte(raw[i])
+            i += 1
+          end
+        end
+        String.new(io.to_slice)
+      end
+
+      # {replacement text, bytes consumed} for the entity starting at `raw[at] == '&'`, or
+      # nil when what follows is not one — in which case the caller copies the `&` through,
+      # which is what the old pattern's "no match" did. Deliberately as strict as that
+      # pattern was, uppercase `&#X41;` included: it never matched `#x[0-9a-fA-F]+`, so it
+      # stayed verbatim then and stays verbatim now.
+      private def self.entity_at(raw : Bytes, at : Int32) : {String, Int32}?
+        j = at + 1
+        return nil if j >= raw.size
+        numeric = raw[j] == HASH
+        j += 1 if numeric
+        hex = numeric && j < raw.size && raw[j] == LOWER_X
+        j += 1 if hex
+        stop = entity_body_end(raw, j, numeric, hex)
+        return nil unless stop
+        name = String.new(raw[j, stop - j])
+        text = numeric ? numeric_entity(name, hex) : NAMED_ENTITIES[name]?
+        text ? {text, stop + 1 - at} : nil
+      end
+
+      # Index of the `;` closing an entity body that starts at `from`, or nil when what sits
+      # there is not one: an empty body, a byte outside the branch's class, or no `;` at all.
+      private def self.entity_body_end(raw : Bytes, from : Int32, numeric : Bool, hex : Bool) : Int32?
+        j = from
+        while j < raw.size && entity_body_byte?(raw[j], numeric, hex)
+          j += 1
+        end
+        return nil if j == from || j >= raw.size || raw[j] != SEMICOLON
+        j
+      end
+
+      # An unknown named entity resolves to nil, i.e. stays verbatim rather than vanishing.
+      NAMED_ENTITIES = {"amp" => "&", "lt" => "<", "gt" => ">", "quot" => "\"", "apos" => "'"}
+
+      # `&#123;` / `&#x1f;`. nil for a codepoint that is not a `Char` (out of range, or a
+      # lone surrogate) and for one too large to parse — both stay verbatim, as they did.
+      private def self.numeric_entity(digits : String, hex : Bool) : String?
+        (hex ? digits.to_i?(16) : digits.to_i?).try { |cp| safe_chr(cp) }
+      end
+
+      # `[0-9a-fA-F]` / `[0-9]` / `[a-zA-Z]`, per the branch the `&` opened.
+      private def self.entity_body_byte?(b : UInt8, numeric : Bool, hex : Bool) : Bool
+        digit = 0x30_u8 <= b <= 0x39_u8
+        return digit || (0x61_u8 <= b <= 0x66_u8) || (0x41_u8 <= b <= 0x46_u8) if hex
+        return digit if numeric
+        (0x61_u8 <= b <= 0x7A_u8) || (0x41_u8 <= b <= 0x5A_u8)
+      end
+
+      private def self.safe_chr(codepoint : Int32) : String?
+        return nil unless 0 <= codepoint <= Char::MAX_CODEPOINT
+        return nil if 0xD800 <= codepoint <= 0xDFFF # lone surrogate — not a Char
+        codepoint.unsafe_chr.to_s
+      end
+    end
+  end
+end

--- a/src/gori/mcp/tools/import.cr
+++ b/src/gori/mcp/tools/import.cr
@@ -6,10 +6,10 @@ module Gori
   module MCP
     class Tools
       # Bulk-import flows into the project's History from a HAR export, a URL list, an
-      # OpenAPI/Swagger spec, a Postman or Insomnia collection, or a Burp item export —
-      # the MCP counterpart of `gori run import`. `path` is resolved on the MCP SERVER's
-      # filesystem (same trust boundary as send_request/repeater — this process runs
-      # locally alongside the agent).
+      # OpenAPI/Swagger spec, a Postman or Insomnia collection, a Burp item export, or a
+      # WSDL 1.1 service description — the MCP counterpart of `gori run import`. `path` is
+      # resolved on the MCP SERVER's filesystem (same trust boundary as send_request/repeater
+      # — this process runs locally alongside the agent).
       KINDS = {
         "har"      => :har,
         "urls"     => :urls,
@@ -17,6 +17,7 @@ module Gori
         "postman"  => :postman,
         "insomnia" => :insomnia,
         "burp"     => :burp,
+        "wsdl"     => :wsdl,
       }
 
       private def import_flows(h) : Result
@@ -59,12 +60,12 @@ module Gori
 
         tool j, "import_flows",
           "Bulk-import flows into the project's History from a HAR export, a URL list, an " \
-          "OpenAPI/Swagger spec, a Postman Collection v2 or Insomnia v4 export, or a Burp Suite " \
-          "item export — the MCP equivalent of `gori run import`. `path` is read from " \
-          "the MCP SERVER's local filesystem (this process runs locally, same trust boundary as " \
-          "send_request). Only `har` and `burp` carry responses; the rest import request " \
-          "templates with no response." do |s|
-          s.field "kind", strprop("har | urls | oas | postman | insomnia | burp"), required: true
+          "OpenAPI/Swagger spec, a Postman Collection v2 or Insomnia v4 export, a Burp Suite " \
+          "item export, or a WSDL 1.1 service description (SOAP 1.1/1.2) — the MCP equivalent " \
+          "of `gori run import`. `path` is read from the MCP SERVER's local filesystem (this " \
+          "process runs locally, same trust boundary as send_request). Only `har` and `burp` " \
+          "carry responses; the rest import request templates with no response." do |s|
+          s.field "kind", strprop("har | urls | oas | postman | insomnia | burp | wsdl"), required: true
           s.field "path", strprop("filesystem path to the source file"), required: true
         end
       end

--- a/src/gori/tui/import_overlay.cr
+++ b/src/gori/tui/import_overlay.cr
@@ -8,7 +8,7 @@ require "../import"
 
 module Gori::Tui
   # Centered popup collecting the source path for palette → "Import: HAR / URLs /
-  # OpenAPI". One path field with an inline PathComplete dropdown — CAImportOverlay's
+  # OpenAPI / …". One path field with an inline PathComplete dropdown — CAImportOverlay's
   # shape minus its second field.
   #
   # This REPLACED a one-row prompt on the status bar. A filesystem path is long and the
@@ -52,6 +52,7 @@ module Gori::Tui
       when :postman  then "Build request templates from a Postman Collection v2 export."
       when :insomnia then "Build request templates from an Insomnia v4 JSON export."
       when :burp     then "Load saved Burp items into History — request and response, byte-exact."
+      when :wsdl     then "Build request templates from a WSDL 1.1 service — one per operation."
       else                "Load flows into History."
       end
     end

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -3213,7 +3213,7 @@ module Gori::Tui
       screen.text({rect.right - hint.size - 1, x + iw}.max, rect.y, hint, Theme.muted, Theme.panel)
     end
 
-    # --- Import path popup (palette → import.har/urls/oas/postman/insomnia/burp) ---
+    # --- Import path popup (palette → import.har/urls/oas/postman/insomnia/burp/wsdl) ---
 
     private def open_import(kind : Symbol) : Nil
       ov = ImportOverlay.new(kind)
@@ -4716,6 +4716,10 @@ module Gori::Tui
 
     def import_burp : Nil
       open_import(:burp)
+    end
+
+    def import_wsdl : Nil
+      open_import(:wsdl)
     end
 
     # Palette / verb entry (`settings.*`): nothing to return to, so an editor opened here

--- a/src/gori/verb/context.cr
+++ b/src/gori/verb/context.cr
@@ -168,6 +168,7 @@ module Gori
       abstract def import_postman : Nil
       abstract def import_insomnia : Nil
       abstract def import_burp : Nil
+      abstract def import_wsdl : Nil
     end
   end
 end

--- a/src/gori/verbs/import.cr
+++ b/src/gori/verbs/import.cr
@@ -21,6 +21,9 @@ module Gori
       r.register Verb::Definition.new(
         "import.burp", "Import: Burp", "Import saved Burp items (request + response) into History",
         Verb::Scope::Global, category: Verb::Category::Action) { |ctx| ctx.import_burp; nil }
+      r.register Verb::Definition.new(
+        "import.wsdl", "Import: WSDL", "Import SOAP request templates from a WSDL 1.1 service description",
+        Verb::Scope::Global, category: Verb::Category::Action) { |ctx| ctx.import_wsdl; nil }
     end
   end
 end


### PR DESCRIPTION
A seventh import source. A WSDL 1.1 service description becomes one SOAP request template per operation on every SOAP port it publishes, reachable from the palette (`Import: WSDL`), `gori run import --wsdl PATH`, and the MCP `import_flows` tool.

REST is covered by OpenAPI/Postman/Insomnia; SOAP had no way in at all. Legacy enterprise targets (.NET WCF/ASMX, Axis) are where SOAP still lives, and for those a WSDL is the whole callable surface — up to now the only way to reach it was writing Envelopes by hand into the Repeater.

## What it produces

```
POST /Calc.asmx HTTP/1.1
Host: calc.test
Content-Type: text/xml; charset=utf-8
SOAPAction: "http://tempuri.org/Add"

<?xml version="1.0" encoding="UTF-8"?>
<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://tempuri.org/">
  <soapenv:Header>
    <ns1:AuthHeader><ns1:token>string</ns1:token></ns1:AuthHeader>
  </soapenv:Header>
  <soapenv:Body>
    <ns1:Add>
      <ns1:intA>1</ns1:intA>
      <ns1:note id="1">
        <ns1:when>2024-01-01T00:00:00Z</ns1:when>
        <ns1:kind>memo</ns1:kind>
      </ns1:note>
    </ns1:Add>
  </soapenv:Body>
</soapenv:Envelope>
```

## The shape decisions

**Both SOAP versions, and they are not one request.** SOAP 1.1 and 1.2 differ in envelope namespace, `Content-Type`, and whether the action rides in a header or a media-type parameter. A dual-stack endpoint where one version bypasses a filter written for the other is a finding, so both are emitted. Dedupe is on the REQUEST — an alias port at the same address still collapses to one flow; a shape-level rule ("one per portType") would have thrown the version difference away.

`SOAPAction` is always present and always quoted (SOAP 1.1 §6.1.1 — stacks route on it, and `SOAPAction: ""` means "no intent stated", which omitting the line does not). SOAP 1.2 gets no `SOAPAction` at all: sending one beside `action=` is a 1.1 signal that misroutes on dual-stack endpoints, and an empty soapAction omits the parameter rather than writing `action=""`.

**Bodies come from the inline XSD, with valid placeholders.** Every builtin gets a value valid for its type, so a schema-validating gateway lets the seed request through — SoapUI's `?` is invalid for every numeric, boolean and date type in the language. An enumeration takes its first declared value for the same reason. `minOccurs="0"` still emits (deleting a visible element is trivial; inventing a hidden one means going back to the WSDL) and `maxOccurs` renders twice, never literally.

**`elementFormDefault` is honoured rather than guessed** — .NET emits qualified, Axis often does not — and a qualified name gets an explicit prefix instead of a default `xmlns=` on the wrapper, which would silently pull every unqualified child into the wrong namespace and produce a body that looks right and validates wrong.

**rpc/encoded is best-effort, not skipped.** It is legacy .NET/Axis, i.e. exactly what a security tool exists to reach. Single-reference form with `encodingStyle` and `xsi:type`; the multi-reference `href`/`id` encoding is not generated, and the comment says so rather than claiming full support.

## Parsing without libxml2

`require "xml"` would put `libxml2-static` on every packaging path that builds `--static` — docker/Dockerfile, the release workflow, flake.nix, Homebrew, AUR, snap — for one format. `import/burp.cr` already documents that trade for its flat scanner, but that scanner cannot be reused: WSDL's whole cross-reference graph is QNames in ATTRIBUTE VALUES resolved against prefixes bound arbitrarily far up the tree.

So `Import::XmlMini` is new: a namespace-aware tree reader that gets the three name-resolution rules right (an unprefixed element name takes the default namespace, an unprefixed attribute NAME does not, an unprefixed QName VALUE does). Each element shares its parent's prefix map by reference unless it declares one, so a 40 000-node document allocates one Hash rather than 40 000.

`Import::Burp`'s entity decoder moved out to `Import::XmlText` unchanged rather than being written twice — `spec/import/burp_spec.cr` passing **unmodified** is the proof that move is byte-neutral.

## The strictness, and where it departs from P7

A `<!DOCTYPE>` is refused outright and external schemas are never fetched. That is stricter than P7, deliberately: the axis P7 names is provenance, and a WSDL is a document gori READS to build a request that did not exist before — not the operator's wire bytes it replays byte-exact. `Import::Raw` is the P7 path; this is not it. Ignoring a DOCTYPE is not neutral either, since a leftover `&payload;` in a `<soap:address>` decodes to nothing and yields a silently wrong endpoint. XXE and billion-laughs are closed at the root as a consequence: no entity can be declared, and there is no file or network I/O to dereference one with. `.github/DESIGN.md` §7 carries the reasoning.

An out-of-scope PORT (`http:binding`, a JMS transport, a relative address) is reported as a note, **not** counted in `skipped` — a .NET WSDL publishing `FooHttpGet` beside `FooSoap` is not damaged. When nothing was generated the first note becomes the error message, so "every port here is HTTP GET/POST" is a sentence the operator reads instead of the generic "no flows found".

## What review caught

`/code-review high` found six, two of which killed the process rather than the entry, and both were reproduced before and after:

- An `<xsd:element ref=…>` cycle recursed until the stack ran out — 1.5 KB of WSDL took down the CLI, TUI or a long-lived MCP server. A stack overflow is a signal, so the per-operation rescue could not catch it. Now `recursive element {urn:t}Add` in 0.2 ms.
- `render` re-emitted an already-built subtree `reps` times while charging once, so the node budget bounded nothing: a 1.5 KB WSDL built a **1.27 GB** body and reported `skipped: 0`. Now refused in 1.1 ms and counted.
- `<complexContent><restriction>` was treated as an extension, emitting the base's particles beside the restricted ones. Extension appends, restriction replaces.
- `<simpleContent><extension>` dropped the base type's required attributes.
- `split_qname` compared a char index against `bytesize`, so `"ä:"` split into a prefix where `"a:"` correctly did not.
- `soapAction` reached the `SOAPAction` header and the 1.2 `action=` parameter unescaped, so a quote closed the string early.

Each has a regression spec.

## Verification

Full suite green: **10,458 examples, 0 failures**, 60 of them new. `crystal tool format --check src spec bench scripts`, `just benchmark-check` and ameba (clean on every new file) all pass.

Exercised end-to-end through the real binary on all four surfaces: `gori run import --wsdl` (`count: 2`), MCP `import_flows` with `kind: "wsdl"`, and the TUI palette → overlay → `imported 2 flows from WSDL` toast, driven headlessly. The fixture is a .NET-shaped WSDL with soap11 + soap12 + httpGet ports over one portType, so the two SOAP ports import and the HTTP one is noted rather than counted.
