### PR TITLE
fix(decoder): bound the JSON a CBOR/MessagePack body renders to

### DIFF
--- a/spec/cbor_spec.cr
+++ b/spec/cbor_spec.cr
@@ -491,4 +491,43 @@ describe Gori::Cbor do
       json.should contain("max_items")
     end
   end
+
+  # The depth and item ceilings bound the INPUT walk. Neither bounds the OUTPUT, and a map
+  # keyed on a MAP is where the two part company: `map_item` renders a non-string key as its
+  # own JSON text and uses that text as the member name, so every level nests the level below
+  # inside a JSON string and the escaping roughly doubles it. `a1` is one byte per level.
+  describe "the output bound" do
+    it "bounds a map keyed on a map" do
+      # 28 bytes. Before the ceiling this reached 2^32 and raised `IO::EOFError` out of
+      # `String::Builder`, ten seconds in — from a body a target can put on the wire and an
+      # operator only has to LOOK at (`Pretty#try_binary_doc`, `gori run show --format json`).
+      json, ok = CB.to_json(Bytes.new(28) { 0xa1_u8 })
+      ok.should be_false
+      json.bytesize.should be < Gori::Cbor::MAX_JSON_BYTES
+      json.should contain("max_bytes")
+    end
+
+    it "bounds one whose keys all terminate, not only a truncated one" do
+      # `a1`*22 then `f6`*23 — every map closed, nothing running out of input, so the parse
+      # has no other reason to stop. 45 bytes rendered 16.7 MB before the ceiling.
+      io = IO::Memory.new
+      22.times { io.write_byte(0xa1_u8) }
+      23.times { io.write_byte(0xf6_u8) }
+      json, ok = CB.to_json(io.to_slice)
+      ok.should be_false
+      json.bytesize.should be < Gori::Cbor::MAX_JSON_BYTES
+      json.should contain("max_bytes")
+    end
+
+    it "bounds it at the depth ceiling too, where the walk itself is legal" do
+      # Every level is inside MAX_DEPTH, so nothing about the INPUT is out of bounds.
+      json, _ = CB.to_json(Bytes.new(5_000) { 0xa1_u8 })
+      json.bytesize.should be < Gori::Cbor::MAX_JSON_BYTES
+    end
+
+    it "leaves an ordinary document untouched" do
+      # The ceiling is a ceiling, not a rewrite: a body nowhere near it renders as it did.
+      whole("a26161016162820203").should eq(%({"a":1,"b":[2,3]}))
+    end
+  end
 end

--- a/spec/msgpack_spec.cr
+++ b/spec/msgpack_spec.cr
@@ -179,6 +179,41 @@ describe Gori::Msgpack do
       JSON.parse(json)
     end
 
+    # The depth and item ceilings bound the INPUT walk. Neither bounds the OUTPUT, and a map
+    # keyed on a MAP is where the two part company: `map` renders a non-string key as its own
+    # JSON text and uses that text as the member name, so every level nests the level below
+    # inside a JSON string and the escaping roughly doubles it. `81` is one byte per level.
+    it "bounds the OUTPUT of a map keyed on a map" do
+      # `81`*29, a nil key at the bottom, then a nil value per level — every map closed, so the
+      # parse has no other reason to stop. 59 bytes raised `IO::EOFError` out of
+      # `String::Builder` before the ceiling, from a body a target can put on the wire and an
+      # operator only has to LOOK at (`Pretty#try_binary_doc`, `gori run show --format json`).
+      io = IO::Memory.new
+      29.times { io.write_byte(0x81_u8) }
+      30.times { io.write_byte(0xc0_u8) }
+      json, ok = Gori::Msgpack.to_json(io.to_slice)
+      ok.should be_false
+      json.bytesize.should be < Gori::Msgpack::MAX_JSON_BYTES
+      json.should contain("$partial")
+      JSON.parse(json) # and it is still a document
+    end
+
+    it "leaves an ordinary document untouched" do
+      # The ceiling is a ceiling, not a rewrite: a body nowhere near it renders as it did.
+      json_of(mp(0x82, 0xa1, 0x61, 0x01, 0xa1, 0x62, 0x92, 0x02, 0x03)).should eq(%({"a":1,"b":[2,3]}))
+    end
+
+    it "names the stop when a map gives up on its KEY" do
+      # `81`*40 — the depth ceiling trips inside the key render, which writes into a scratch
+      # builder, so nothing had been written into the map itself and it closed as a bare `{}`:
+      # "an empty map", with `complete` false and no reason anywhere in the text. The CBOR
+      # sibling has always named it.
+      json, ok = Gori::Msgpack.to_json(Bytes.new(40) { 0x81_u8 })
+      ok.should be_false
+      json.should contain("$partial")
+      JSON.parse(json)
+    end
+
     it "does not allocate on a length no body could satisfy" do
       # bin32 claiming 4 GiB with four bytes behind it, and array32 / map32 claiming 4 G
       # elements. A count that cannot be an Int32 never reaches a loop or an allocation.

--- a/src/gori/cbor.cr
+++ b/src/gori/cbor.cr
@@ -44,6 +44,23 @@ module Gori
     # emitted — only the decimal spelling is dropped.
     MAX_BIGNUM_BYTES = 512
 
+    # Output ceiling for ONE document. The three above bound the INPUT walk, and none of them
+    # bounds the OUTPUT — which is not a function of the input's size here.
+    #
+    # A non-string map KEY is rendered as its own JSON text and that text becomes the member
+    # name (see `map_item`), so a map keyed on a MAP nests the inner rendering inside a JSON
+    # string once per level — and each level's escaping roughly doubles it. `a1 a1 a1 …`, one
+    # byte per level, therefore grows the output as 2^depth: 26 bytes produced 536 MB, and 28
+    # bytes reached the point where `String::Builder` refuses to grow and raised `IO::EOFError`
+    # straight out of `render` — the one thing this module promises never to do. `MAX_DEPTH`
+    # cannot fix it (the blow-up is well inside 32 levels) and a per-key length cap cannot
+    # either (`MAX_ITEMS` keys at any cap is still that cap × 100 000).
+    #
+    # Charged across the whole document, scratch key renders included, so it bounds the WORK
+    # and not merely what survives into the text. 8 MiB is `Pretty::MAX_OUT_PRETTY` — the cap
+    # the display path, which runs on every drawn flow, already discards above.
+    MAX_JSON_BYTES = 8 * 1024 * 1024
+
     # Render `data`, with everything a caller needs to decide whether the rendering is about
     # THIS body: see `BinaryDocument::Rendering`. `indent` pretty-prints; nil is compact.
     #
@@ -52,11 +69,16 @@ module Gori
     # body and often the point of it, and re-parsing would keep one and drop the other.
     def render(data : Bytes, *, max_depth : Int32 = MAX_DEPTH,
                indent : String? = nil) : BinaryDocument::Rendering
-      reader = Reader.new(data, max_depth)
-      text = JSON.build(indent) { |j| reader.item(j, 0) }
+      # An `IO::Memory` we own rather than `JSON.build`'s hidden `String::Builder`, so the
+      # reader can see how much it has produced and stop at `MAX_JSON_BYTES`. `JSON.build(io,
+      # indent)` is the same stdlib entry point the one-argument form wraps, so the text is
+      # byte-identical.
+      sink = IO::Memory.new
+      reader = Reader.new(data, max_depth, sink)
+      JSON.build(sink, indent) { |j| reader.item(j, 0) }
       reader.note_trailing
-      BinaryDocument::Rendering.new(text, reader.complete?, reader.pos, reader.stop)
-    rescue JSON::Error
+      BinaryDocument::Rendering.new(sink.to_s, reader.complete?, reader.pos, reader.stop)
+    rescue JSON::Error | IO::Error
       internal_rendering
     end
 
@@ -73,6 +95,11 @@ module Gori
       # number. The contract here ("never raises") is stronger than the belief
       # that the parser is right about all three, and the cost of being wrong is
       # an unhandled exception thrown while rendering someone's captured body.
+      #
+      # `IO::Error` is caught for that reason and not for a reachable case:
+      # `String::Builder` answers a document past 2 GiB with `IO::EOFError`, which
+      # is how the unbounded-output defect surfaced, and `MAX_JSON_BYTES` is what
+      # actually stops it. The belief that the ceiling holds is not the contract.
       BinaryDocument::Rendering.new("{\"$partial\":\"internal\"}", false, 0, "internal")
     end
 
@@ -87,10 +114,30 @@ module Gori
     private class Reader
       getter? complete : Bool = true
 
-      def initialize(@data : Bytes, @max_depth : Int32)
+      def initialize(@data : Bytes, @max_depth : Int32, @sink : IO::Memory)
         @pos = 0
         @items = 0
+        @spent = 0_i64
         @stop = nil.as(String?)
+      end
+
+      # Output bytes this document has cost so far: what is in the buffer being written now,
+      # plus every scratch key render that has already finished. The finished ones are counted
+      # even where their text was thrown away, because the ceiling bounds the WORK — a key
+      # rendered and discarded was still built. See `MAX_JSON_BYTES` and `key_name`.
+      #
+      # `Int64`, and not because a legal document reaches it: the sum this replaced was an
+      # `Int32` and the very shape the ceiling exists for overflowed it before the ceiling
+      # could be consulted, turning one unhandled exception into another.
+      private def produced : Int64
+        @spent + @sink.bytesize
+      end
+
+      # `partial`'s bookkeeping without the builder — for a stop discovered where there is no
+      # value position to write into (a key render that has already finished).
+      private def stop_at(reason : String) : Nil
+        @complete = false
+        @stop ||= reason
       end
 
       # One item's head: major type, additional info, and the argument the info
@@ -126,6 +173,9 @@ module Gori
         return partial(j, "max_depth") if depth > @max_depth
         @items += 1
         return partial(j, "max_items") if @items > MAX_ITEMS
+        # Entering: what has already been produced, including finished key renders. `key_name`
+        # tests again on the way OUT, and that one is the load-bearing half — see there.
+        return partial(j, "max_bytes") if produced >= MAX_JSON_BYTES
 
         head, why = read_head
         return partial(j, why) unless head
@@ -410,9 +460,28 @@ module Gori
         end
         @pos = save
         ok = true
-        # A separate builder, so a key that fails writes nothing into the map.
-        text = JSON.build { |kj| ok = item(kj, depth) }
-        {text, false, ok}
+        # A separate builder, so a key that fails writes nothing into the map. `@sink` follows
+        # it for the duration: this scratch render is where the output blow-up happens (a key
+        # that is itself a map renders a whole subtree, and the level above nests THAT inside a
+        # JSON string), so it has to be inside `MAX_JSON_BYTES` while it runs and not only
+        # after it returns. Whatever it produced is charged either way — a key rendered is a
+        # key built, kept or not.
+        scratch = IO::Memory.new
+        outer, @sink = @sink, scratch
+        JSON.build(scratch) { |kj| ok = item(kj, depth) }
+        @sink = outer
+        @spent += scratch.bytesize
+        # ON THE WAY OUT, and that is the whole guard. A map keyed on a map grows as the stack
+        # UNWINDS — every level nests the level below's finished text inside a JSON string —
+        # so the check `item` makes on the way IN sees an empty budget at every level and
+        # passes all of them. Testing here caps one level at roughly twice the one under it,
+        # so the first level to cross the ceiling is the last one built: a `false` `ok` stops
+        # `pair`, which stops `map_item`, and every level above it renders the marker instead.
+        if produced >= MAX_JSON_BYTES
+          stop_at("max_bytes")
+          return {"{\"$partial\":\"max_bytes\"}", false, false}
+        end
+        {scratch.to_s, false, ok}
       end
 
       # --- tags ---------------------------------------------------------------

--- a/src/gori/msgpack.cr
+++ b/src/gori/msgpack.cr
@@ -38,6 +38,24 @@ module Gori
     # `0x90` (empty fixarray) is cheap per item and unbounded in aggregate.
     MAX_ITEMS = 100_000
 
+    # Output ceiling for ONE document. The two above bound the INPUT walk, and neither bounds
+    # the OUTPUT — which is not a function of the input's size here.
+    #
+    # A non-string map KEY is rendered as its own JSON text and that text becomes the member
+    # name (see `map`), so a map keyed on a MAP nests the inner rendering inside a JSON string
+    # once per level — and each level's escaping roughly doubles it. `81 81 81 …`, one byte per
+    # level, therefore grows the output as 2^depth: 57 bytes produced 1.6 GB, and 59 bytes
+    # reached the point where `String::Builder` refuses to grow and raised `IO::EOFError`
+    # straight out of `render` — the one thing this module promises never to do. `MAX_DEPTH`
+    # cannot fix it (the blow-up is well inside 32 levels) and a per-key length cap cannot
+    # either (`MAX_ITEMS` keys at any cap is still that cap × 100 000).
+    #
+    # Charged across the whole document, scratch key renders included, so it bounds the WORK
+    # and not merely what survives into the text. 8 MiB is `Pretty::MAX_OUT_PRETTY` — the cap
+    # the display path, which runs on every drawn flow, already discards above. The CBOR
+    # sibling carries the same ceiling for the same shape.
+    MAX_JSON_BYTES = 8 * 1024 * 1024
+
     # Render `data`, with everything a caller needs to decide whether the rendering is about
     # THIS body: see `BinaryDocument::Rendering`. `indent` pretty-prints; nil is compact.
     #
@@ -46,8 +64,14 @@ module Gori
     # body and often the point of it, and re-parsing would keep one and drop the other.
     def render(data : Bytes, *, max_depth : Int32 = MAX_DEPTH,
                indent : String? = nil) : BinaryDocument::Rendering
-      p = Parser.new(data, max_depth)
-      json = JSON.build(indent) { |j| p.value(j, 0) }
+      # An `IO::Memory` we own rather than `JSON.build`'s hidden `String::Builder`, so the
+      # parser can see how much it has produced and stop at `MAX_JSON_BYTES`. `JSON.build(io,
+      # indent)` is the same stdlib entry point the one-argument form wraps, so the text is
+      # byte-identical.
+      sink = IO::Memory.new
+      p = Parser.new(data, max_depth, sink)
+      JSON.build(sink, indent) { |j| p.value(j, 0) }
+      json = sink.to_s
       # Trailing bytes are not an error the parse can report from inside — MessagePack has no
       # document terminator, and a body may legitimately be a stream of concatenated objects —
       # but they DO mean this rendering is not the whole body, which is what `complete` means.
@@ -56,9 +80,13 @@ module Gori
       trailing = p.ok? && p.pos < data.size
       BinaryDocument::Rendering.new(json, p.ok? && p.pos == data.size, p.pos,
         trailing ? "trailing" : p.stop)
-    rescue JSON::Error
+    rescue JSON::Error | IO::Error
       # `JSON.build` can only fail on a builder misuse, which would be a bug here rather than
       # bad input. Report it as an incomplete parse rather than unwinding into a TUI draw (P7).
+      # `IO::Error` is caught for that reason and not for a reachable case: `String::Builder`
+      # answers a document past 2 GiB with `IO::EOFError`, which is how the unbounded-output
+      # defect surfaced, and `MAX_JSON_BYTES` is what actually stops it. The belief that the
+      # ceiling holds is not the contract.
       BinaryDocument::Rendering.new("{\"$partial\":\"internal\"}", false, 0, "internal")
     end
 
@@ -79,9 +107,21 @@ module Gori
       # running out of input is what happened, and every level above it only reports that.
       getter stop : String?
 
-      def initialize(@data : Bytes, @max_depth : Int32)
+      def initialize(@data : Bytes, @max_depth : Int32, @sink : IO::Memory)
         @items = 0
+        @spent = 0_i64
         @stop = nil.as(String?)
+      end
+
+      # Output bytes this document has cost so far: what is in the buffer being written now,
+      # plus every scratch key render that has already finished. The finished ones are counted
+      # even where their text was thrown away, because the ceiling bounds the WORK — a key
+      # rendered and discarded was still built. See `MAX_JSON_BYTES` and `key_text`.
+      #
+      # `Int64`, and not because a legal document reaches it: the very shape the ceiling exists
+      # for overflows an `Int32` sum, which would turn one unhandled exception into another.
+      private def produced : Int64
+        @spent + @sink.bytesize
       end
 
       # Read one value at `depth` and write it to `j`. Every exit that cannot continue clears
@@ -92,6 +132,9 @@ module Gori
         return bail(j, "max_depth") if depth > @max_depth
         @items += 1
         return bail(j, "max_items") if @items > MAX_ITEMS
+        # Entering: what has already been produced, including finished key renders. `key_text`
+        # tests again on the way OUT, and that one is the load-bearing half — see there.
+        return bail(j, "max_bytes") if produced >= MAX_JSON_BYTES
         b = byte || return bail(j, "truncated")
         # The one-byte forms, where the header IS the value or carries the length in its low
         # bits. Everything else has a separate length or width and goes to `headed`.
@@ -140,8 +183,35 @@ module Gori
       # used verbatim: `{"1": …}` for the integer 1, `{"[1,2]": …}` for an array. The map
       # carries `"$keys": "non-string"` beside it so the reader is not left guessing whether
       # `"1"` was a string on the wire.
+      #
+      # `@sink` follows the scratch buffer for the duration: this render is where the output
+      # blow-up happens (a key that is itself a map renders a whole subtree, and the level
+      # above nests THAT inside a JSON string), so it has to be inside `MAX_JSON_BYTES` while
+      # it runs and not only after it returns. Whatever it produced is charged either way — a
+      # key rendered is a key built, kept or not.
       def key_text(depth : Int32) : String
-        JSON.build { |j| value(j, depth) }
+        scratch = IO::Memory.new
+        outer, @sink = @sink, scratch
+        JSON.build(scratch) { |j| value(j, depth) }
+        @sink = outer
+        @spent += scratch.bytesize
+        # ON THE WAY OUT, and that is the whole guard. A map keyed on a map grows as the stack
+        # UNWINDS — every level nests the level below's finished text inside a JSON string —
+        # so the check `value` makes on the way IN sees an empty budget at every level and
+        # passes all of them. Testing here caps one level at roughly twice the one under it,
+        # so the first level to cross the ceiling is the last one built; clearing `@ok` stops
+        # `map`, and every level above it renders the marker instead.
+        #
+        # `@ok` alone would in fact stop the unwind today, because `value` refuses to run once
+        # it is clear. That is a property of this parser and not of the shape, and the CBOR
+        # sibling — which has no such latch — needed the explicit test; both carry it, so
+        # neither depends on the other's control flow staying as it is.
+        if produced >= MAX_JSON_BYTES
+          @ok = false
+          @stop ||= "max_bytes"
+          return %({"$partial":"max_bytes"})
+        end
+        scratch.to_s
       end
 
       # A declared count is NOT checked against the bytes that remain, and that is deliberate:
@@ -164,7 +234,16 @@ module Gori
             # one that really was. The CBOR sibling tests `head.major == 3` for this reason.
             str_key = string_header?(peek)
             k = key_text(depth + 1)
-            break unless @ok
+            unless @ok
+              # The KEY ran out (or hit a ceiling), so its marker went into the scratch builder
+              # and nothing has been written here — leaving the map to close as a bare `{}`,
+              # which says "an empty map" rather than "this stopped". `81 81 81 …` rendered
+              # exactly that: `{}`, with `complete` false and no reason anywhere in the text,
+              # and `Decoder::Codecs#document`'s `$partial` test then read it as a decode that
+              # worked. The CBOR sibling has always named it; this is the same sentence.
+              j.field("$partial", @stop || "stopped")
+              break
+            end
             if str_key && k.starts_with?('"')
               j.field(JSON.parse(k).as_s) { value(j, depth + 1) }
             else

--- a/src/gori/msgpack.cr
+++ b/src/gori/msgpack.cr
@@ -166,8 +166,8 @@ module Gori
       private def sized(j : JSON::Builder, b : UInt8, depth : Int32) : Nil
         case b
         when 0xc4..0xc6 then bin(j, len(1 << (b - 0xc4)))
-        when 0xc7..0xc9 then ext(j, len(1 << (b - 0xc7)), depth)
-        when 0xd4..0xd8 then ext(j, 1 << (b - 0xd4), depth, fixed: true)
+        when 0xc7..0xc9 then ext(j, len(1 << (b - 0xc7)))
+        when 0xd4..0xd8 then ext(j, 1 << (b - 0xd4))
         when 0xd9..0xdb then str(j, len(1 << (b - 0xd9)))
         when 0xdc, 0xdd then array(j, len(b == 0xdc ? 2 : 4), depth)
         when 0xde, 0xdf then map(j, len(b == 0xde ? 2 : 4), depth)
@@ -288,7 +288,7 @@ module Gori
       # msgpack-based protocol uses, so it is exactly what an operator is looking at. Type -1 is
       # the one the spec itself defines (a timestamp), and it is decoded because a timestamp
       # rendered as base64 is a fact withheld.
-      private def ext(j : JSON::Builder, n : Int32, depth : Int32, fixed : Bool = false) : Nil
+      private def ext(j : JSON::Builder, n : Int32) : Nil
         return bail(j, "malformed") if n < 0
         t = byte || return bail(j, "truncated")
         raw = take(n) || return bail(j, "truncated")


### PR DESCRIPTION
`MAX_DEPTH` and `MAX_ITEMS` bound the INPUT walk. Nothing bounded the OUTPUT, and
for one shape the two are not related at all.

A non-string map key is rendered as its own JSON text and that text becomes the
member name, so a map keyed on a MAP nests the inner rendering inside a JSON
string once per level — and each level's escaping roughly doubles it. `a1` (CBOR)
and `81` (msgpack) are one byte per level, so the output grows as 2^depth:

| body | before |
| --- | --- |
| CBOR `a1`×22 + `f6`×23 (45 B) | 16.7 MB |
| CBOR `a1`×26 (26 B) | 536 MB, 20 s |
| **CBOR `a1`×28 (28 B)** | **`IO::EOFError` after 9.8 s** |
| msgpack `81`×28 + `c0`×29 (57 B) | 1.6 GB, 58 s |
| **msgpack `81`×29 + `c0`×30 (59 B)** | **`IO::EOFError`** |

The raise comes out of `String::Builder` refusing to grow past 2 GiB, and
`render` caught only `JSON::Error` — so it left the module, which both headers
promise it never does (P7). Before that it is a stall: the process is
single-threaded, so the proxy data path stops with it (P6).

Reachable from a body a target puts on the wire, with `Content-Type:
application/cbor`, that an operator only has to LOOK at:

* `Pretty#try_binary_doc` — the TUI body view. Its `rescue nil` swallows the
  raise but not the gigabytes, and its `MAX_OUT_PRETTY` test runs *after* the
  render.
* `DecodedView#emit_binary_documents` — `gori run show --format json` and MCP
  `get_flow`. **No rescue at all.**
* `Decoder::Codecs#{cbor,msgpack}_to_json` — the Decoder tab, `gori run decoder`,
  MCP `decode`.

## The fix

A fourth structural ceiling beside the three that already exist,
`MAX_JSON_BYTES = 8 MiB` (`Pretty::MAX_OUT_PRETTY`, the cap the display path
discards above anyway). Charged across the whole document, scratch key renders
included, so it bounds the WORK and not only what survives into the text.

Tested on the way **out** of a key render, which is the load-bearing half: the
growth happens as the stack UNWINDS — every level nests the level below's
finished text — so a check on the way in sees an empty budget at every level and
passes all of them. (It was written that way first; CBOR still blew up, and the
`Int32` sum overflowed before the ceiling could be consulted. The counter is
`Int64` now for that reason.) Testing on the way out caps one level at roughly
twice the one under it, so the first level to cross the ceiling is the last one
built and every level above it renders the marker instead.

A per-key length cap was considered and is not enough on its own: `MAX_ITEMS`
keys at any cap is still that cap × 100 000.

`render`'s rescue also widens to `JSON::Error | IO::Error`. With the ceiling in
place the `IO::EOFError` is unreachable, which is exactly what `internal_rendering`'s
existing comment says is not the contract.

## Blast radius

`stop == "max_bytes"` ⇒ `describes?` false ⇒ `BinaryDocument.render` returns nil
⇒ the TUI falls back to the binary placeholder and the hex view, which is the
right answer for a body that cannot be rendered inside the ceiling. An ordinary
document is byte-identical — `JSON.build(io, indent)` is the same stdlib entry
point the one-argument form wraps.

## Also here

The msgpack `map` marker is part of this fix, not a drive-by: the budget stop
happens inside `key_text`, which writes into a scratch builder, so the map closed
as a bare `{}` — "an empty map", with `complete` false and the reason nowhere in
the text, and `Decoder::Codecs#document`'s `$partial` test then read it as a
decode that worked. Without it msgpack reports nothing at all when the ceiling
trips. The CBOR sibling has always named it.

`ext`'s unused `fixed`/`depth` parameters go in their own commit.

## Why no spec caught it

`spec/cbor_spec.cr` and `spec/msgpack_spec.cr` both test nesting through
**values** (`a1 61 61` / `81 a1 61`) and through arrays and tag chains. Neither
tests a key that is itself a container. Seven specs added, and the assertion is
partly that they finish at all.

## Verification

`crystal spec` 10601 examples green · `crystal tool format --check src spec bench scripts` ·
`scripts/bench_check.sh` (48 harnesses) · `shards build`.