### PR TITLE
fix(import): stop XML text runs accumulating quadratically

### DIFF
--- a/spec/import/xml_mini_spec.cr
+++ b/spec/import/xml_mini_spec.cr
@@ -180,6 +180,42 @@ describe Gori::Import::XmlMini do
         XmlMini.parse(%(<a p="1" q="2" r="3"/>), tight)
       end
     end
+
+    it "charges text runs too, since nothing else counts them" do
+      # A comment is skipped without a charge, so `x<!---->` repeated is a text run every 8
+      # bytes and a million of them sit comfortably under max_bytes. `max_nodes` is the only
+      # ceiling in a position to say no.
+      tight = XmlMini::Limits.new(max_nodes: 4)
+      expect_raises(Gori::Error, /more than 4 nodes/) do
+        XmlMini.parse("<a>" + "x<!---->" * 10 + "</a>", tight)
+      end
+    end
+
+    it "does not charge the whitespace between two tags" do
+      # Which is most of a real WSDL: those runs are dropped, so they cost nothing.
+      tight = XmlMini::Limits.new(max_nodes: 3)
+      XmlMini.parse("<a>\n  <b/>\n  <c/>\n</a>", tight).children.size.should eq(2)
+    end
+  end
+
+  describe "character data" do
+    it "joins the runs a comment splits apart" do
+      parse("<a>x<!---->y<!---->z</a>").text.should eq("xyz")
+    end
+
+    it "stays linear in the number of runs" do
+      # `@text = t + s` per run copies everything already there, so a document that splits its
+      # character data finely was quadratic: 2 MB took 4.5 s and the 8 MiB ceiling ~70 s, on a
+      # path that runs on the TUI's own fiber with nothing to yield to (P6). 100 000 runs is
+      # the shape at ~800 KB; the assertion is that this spec finishes at all.
+      n = 100_000
+      doc = String.build do |io|
+        io << "<a>"
+        n.times { io << "x<!---->" }
+        io << "</a>"
+      end
+      XmlMini.parse(doc, XmlMini::Limits.new(max_nodes: n + 10)).text.size.should eq(n)
+    end
   end
 
   describe "security" do

--- a/src/gori/import/xml_mini.cr
+++ b/src/gori/import/xml_mini.cr
@@ -58,23 +58,30 @@ module Gori
         def initialize(@uri : String, @local : String, @prefix : String,
                        @attrs : Array(Attr), @ns : NsMap)
           @children = [] of Node
+          @runs = nil.as(Array(String)?)
           @text = nil.as(String?)
         end
 
         # Character data directly inside this element. Whitespace-only runs BETWEEN tags are
         # dropped (a WSDL is mostly those, and no caller wants them); CDATA is always kept
         # verbatim, whitespace included.
+        #
+        # Joined ON READ and memoized. The runs were concatenated on ARRIVAL (`@text = t + s`),
+        # which copies everything already there once per run: anything that splits character
+        # data — a comment, a CDATA section, an entity — makes another run, so `x<!---->`
+        # repeated is one run per 8 bytes and the copying is quadratic in the file. A 2 MB
+        # document took 4.5 s and the 8 MiB ceiling ~70 s, on a path that runs on the TUI's own
+        # fiber with nothing to yield to (P6): one import stalled the proxy with it.
         def text : String
-          @text || ""
+          runs = @runs
+          return "" unless runs
+          @text ||= runs.join
         end
 
         # :nodoc:
         def add_text(s : String) : Nil
-          if t = @text
-            @text = t + s
-          else
-            @text = s
-          end
+          (@runs ||= [] of String) << s
+          @text = nil
         end
 
         def name : QName
@@ -146,8 +153,11 @@ module Gori
       #   max_depth — `<a><a><a>…` costs one frame per level in the WSDL walk and again in
       #               the body generator. 256 is ~10x the deepest real schema.
       #   max_nodes — the backstop for a file legitimately under max_bytes but pathological
-      #               (millions of `<a/>`), and the ONLY guard bounding attribute count,
-      #               since attributes are charged against the same budget as elements.
+      #               (millions of `<a/>`), and the ONLY guard bounding attribute count and
+      #               TEXT-RUN count, since both are charged against the same budget as
+      #               elements. Text runs are charged because nothing else counts them: a
+      #               comment is skipped without a charge, so `x<!---->` repeated is a run
+      #               every 8 bytes and a million of them fit under max_bytes.
       record Limits,
         max_bytes : Int32 = 8 * 1024 * 1024,
         max_nodes : Int32 = 200_000,
@@ -244,6 +254,7 @@ module Gori
             # kept even though a whitespace-only text RUN is dropped: the author wrote the
             # section deliberately.
             node = @stack.last? || raise err("CDATA outside the root element")
+            charge(1)
             node.add_text(String.new(@raw[(@pos + 9)...close]))
             @pos = close + 3
           elsif starts_at?(@pos, "<!DOCTYPE")
@@ -424,6 +435,10 @@ module Gori
           # content is not a shape WSDL or XML Schema produces; CDATA (above) is kept
           # regardless, which is the escape hatch for a document that means its whitespace.
           return if chunk.blank?
+          # Charged like an element: a KEPT run is a thing this document made us hold, and
+          # `max_nodes` is the only ceiling that counts them. A whitespace-only run is dropped
+          # above and costs nothing, which is most of a real WSDL.
+          charge(1)
           @stack.last.add_text(XmlText.unescape(chunk))
         end
 


### PR DESCRIPTION
`XmlMini::Node#add_text` concatenated on arrival (`@text = t + s`), which copies
everything already there once per run. Anything that splits character data makes
another run — a comment, a CDATA section, an entity — so `x<!---->` repeated is
one run per 8 bytes and the copying is quadratic in the file:

| document | before |
| --- | --- |
| 2 MB | 4.46 s |
| 8 MiB (`max_bytes`) | ~70 s (extrapolated; 4× per doubling confirmed) |

`Runner#apply_import` (`src/gori/tui/runner.cr:3239`) calls this **synchronously
on the TUI's own fiber**, and it is pure CPU with no yield point — so one import
stalls the TUI, the proxy and the store writer with it (P6).

The module header says the three ceilings each stop a different shape and none
subsumes another. This shape gets past all three: comments are skipped without a
`charge`, so `max_nodes` (200 000) never fires, and a million runs sit
comfortably under `max_bytes`.

## The fix

Runs are collected and joined ON READ, memoized. Text runs and CDATA sections are
now charged against `max_nodes` too, because nothing else counts them — a
whitespace-only run between two tags is still dropped and still costs nothing,
which is most of a real WSDL.

After: the same 2 MB document is **0.015 s**, and the node ceiling refuses it by
name rather than grinding through it.

`Node#text` has no consumer in `src/` today (`wsdl_body.cr`'s `Content#text` is a
different type), so the representation change is API-compatible and low risk.

## Verification

`crystal spec` 10598 examples green · `crystal tool format --check src spec bench scripts` ·
`scripts/bench_check.sh` (48 harnesses). Four specs added: the join across a
comment, the two new charges, and a 100 000-run document whose assertion is
partly that it finishes.