### PR TITLE
fix(proxy): tell a silent SOCKS5 client from one that stopped mid-handshake

### DIFF
--- a/spec/proxy/socks5_spec.cr
+++ b/spec/proxy/socks5_spec.cr
@@ -42,6 +42,26 @@ end
 # VER=5, one method, NO-AUTH — the greeting every client that reaches this listener sends.
 GREETING = Bytes[5_u8, 1_u8, 0_u8]
 
+# A peer that hands over `head` and then holds the socket open saying nothing. `IO::Memory`
+# cannot model this — it answers EOF, which is the OTHER thing a quiet client can do and the
+# one the listener deliberately records nothing for.
+private class StallingIO < IO
+  def initialize(@head : Bytes)
+    @pos = 0
+  end
+
+  def read(slice : Bytes) : Int32
+    raise IO::TimeoutError.new("read timed out") if @pos >= @head.size
+    n = Math.min(slice.size, @head.size - @pos)
+    slice[0, n].copy_from(@head[@pos, n])
+    @pos += n
+    n
+  end
+
+  def write(slice : Bytes) : Nil
+  end
+end
+
 # --- socket-level helpers ------------------------------------------------------------------
 
 private def start_plain_origin(seen : Channel(String)) : Int32
@@ -242,6 +262,21 @@ describe Gori::Proxy::Socks5 do
     truncated.target.should be_nil
     truncated.refusal.to_s.should contain("closed in the middle")
     truncated.refusal.to_s.should_not contain("address type")
+  end
+
+  it "tells a client that says nothing from one that stops part-way through" do
+    # Both are `IO::TimeoutError` on the way up and were filed as the same thing: a flow saying
+    # the peer never spoke. Only the first is that. The second had sent a greeting and a method
+    # list, which is a client doing something — and the listener records the two differently.
+    silent = Socks5.negotiate(StallingIO.new(Bytes.empty), nil)
+    silent.silent?.should be_true
+    silent.timed_out?.should be_true
+    silent.refusal.to_s.should contain("no greeting")
+
+    partial = Socks5.negotiate(StallingIO.new(GREETING), nil)
+    partial.silent?.should be_false
+    partial.timed_out?.should be_false
+    partial.refusal.to_s.should contain("part-way through")
   end
 end
 

--- a/spec/repeater/ws_engine_spec.cr
+++ b/spec/repeater/ws_engine_spec.cr
@@ -411,6 +411,11 @@ describe Gori::Repeater::WsEngine do
       end
       conn << "HTTP/1.1 200 Connection Established\r\n\r\n"
       conn.flush rescue nil
+      # Drain the tunnelled request before closing. Unread bytes in the receive queue make the
+      # kernel answer close() with RST rather than FIN, and the client then reads ECONNRESET
+      # instead of the clean EOF this spec is about — which it did, intermittently, under the
+      # load of the full suite. No relay either way: the tunnel still produces nothing.
+      Gori::Proxy::Codec::Http1.read_head(conn) rescue nil
       conn.close rescue nil # no relay — the tunnel produced nothing
     end
 

--- a/src/gori/fuzz/plan.cr
+++ b/src/gori/fuzz/plan.cr
@@ -362,7 +362,7 @@ module Gori::Fuzz
         # part had occurrences that were all already inside a `§…§`, and no part made a new
         # position. With `&&` the operator got no note at all that their `--mark` did nothing.
         if texts = ws_texts
-          texts.map_with_index do |t, i|
+          texts.each_with_index do |t, i|
             t2, c2, sh2 = wrap_token(t, tok)
             texts[i] = t2
             count += c2

--- a/src/gori/proxy/server.cr
+++ b/src/gori/proxy/server.cr
@@ -404,19 +404,20 @@ module Gori::Proxy
       # A LOCAL, and it has to be: one `Proxy::Server` serves every connection this listener
       # accepts, each in its own fiber, so a per-connection fact kept on the object would be
       # read back by whichever connection asked next.
-      result = begin
-        Socks5.negotiate(client, bind)
-      rescue IO::TimeoutError
-        # A client that connected and said NOTHING — the #755 shape, and this listener is one
-        # more place it can land (a client waiting for a banner it will never get, or a
-        # speculative connection). Nothing was named yet, so there is nothing to name it by.
-        ClientConn.record_silent_client(@sink, "http", "", 0, client_tls: false)
-        return close_client(client)
-      end
+      result = Socks5.negotiate(client, bind)
       if target = result.target
         return unless socks5_allowed?(client, target, bind, local_host)
         Socks5.grant(client, bind)
         serve_socks5_target(client, target, local_host)
+      elsif result.timed_out?
+        # A client that connected and said NOTHING while still holding the socket — the #755
+        # shape, and this listener is one more place it can land (a peer waiting for a banner
+        # it will never get, a speculative connection). Nothing was named, so there is nothing
+        # to name it by. `Socks5.negotiate` decides this and not a rescue here: a timeout PAST
+        # the greeting is a client that did speak, and the two used to arrive here as the same
+        # `IO::TimeoutError` and be filed as this one.
+        ClientConn.record_silent_client(@sink, "http", "", 0, client_tls: false)
+        close_client(client)
       else
         # A connection that closed WITHOUT SAYING ANYTHING is not recorded, and this is the one
         # refusal that is not: a bare connect-and-close is a port scan, a health check or a

--- a/src/gori/proxy/socks5.cr
+++ b/src/gori/proxy/socks5.cr
@@ -85,13 +85,22 @@ module Gori::Proxy
     # why it was refused. Exactly one is non-nil. A refusal has ALREADY been answered on the
     # wire in the form the RFC defines where there was one to send; the sentence is for the
     # operator, who otherwise gets a connection that closed for no stated reason.
-    record Negotiation, target : Target?, refusal : String?, silent : Bool = false do
-      # Did the client close without saying ANYTHING — no greeting at all? Its own answer,
-      # because a caller has to tell "a client did something gori refuses" (worth recording on
-      # the project) from "a TCP connection opened and closed" (a port scan, a health check, a
-      # speculative preconnect — which every other listener mode records nothing for).
+    record Negotiation, target : Target?, refusal : String?, silent : Bool = false,
+      timed_out : Bool = false do
+      # Did the client say ANYTHING — was there a greeting at all? Its own answer, because a
+      # caller has to tell "a client did something gori refuses" (worth recording on the
+      # project) from "a TCP connection opened and went nowhere" (a port scan, a health check,
+      # a speculative preconnect — which every other listener mode records nothing for).
       def silent? : Bool
         silent
+      end
+
+      # Silent AND still holding the socket open — the #755 shape, and a different fact from a
+      # silent client that HUNG UP. One is a peer waiting for a banner gori will never send
+      # (server-speaks-first on a port somebody redirected here), which is worth a flow; the
+      # other is a scan, which is not. Only ever true beside `silent`.
+      def timed_out? : Bool
+        timed_out
       end
     end
 
@@ -101,8 +110,21 @@ module Gori::Proxy
     # successful request: the caller has checks of its own to make (a target naming gori's own
     # listener is the obvious one) and `succeeded` is unsendable once retracted. Call `grant`
     # when the target is acceptable, `refuse` when it is not.
+    #
+    # A read that TIMES OUT is answered here rather than raised at the caller, and the point of
+    # that is the GREETING: a peer that connects and says nothing at all is the #755 shape and
+    # gets its own flow, while one that stops part-way through a handshake it started is a
+    # client doing something — two different records. Raised out of here, both arrived at the
+    # caller as one `IO::TimeoutError` and were filed as the first, so a client that had sent a
+    # greeting and a method list was recorded as never having spoken.
     def self.negotiate(io : IO, bind : Socket::IPAddress?) : Negotiation
-      greeting = read_exactly(io, 2)
+      greeting =
+        begin
+          read_exactly(io, 2)
+        rescue IO::TimeoutError
+          return Negotiation.new(nil, "the client opened a connection to this SOCKS5 listener " \
+                                      "and sent no greeting", silent: true, timed_out: true)
+        end
       unless greeting
         return Negotiation.new(nil, "the client closed before sending a SOCKS5 greeting", silent: true)
       end
@@ -123,6 +145,11 @@ module Gori::Proxy
       io.write(Bytes[VERSION, AUTH_NONE])
       io.flush
       request(io, bind)
+    rescue IO::TimeoutError
+      # PAST the greeting, so this client is not silent: it opened a SOCKS5 handshake and then
+      # stopped part-way through one. On the record like every other refusal where the client
+      # actually said something.
+      refused("the client stopped part-way through the SOCKS5 handshake and sent no more")
     end
 
     # VER CMD RSV ATYP DST.ADDR DST.PORT (§4).


### PR DESCRIPTION
Three small things from the same audit pass as #797, none of them related enough
to ride either of the other branches.

**SOCKS5 silent vs. mid-handshake.** `serve_socks5` wrapped the whole of
`Socks5.negotiate` in `rescue IO::TimeoutError` and recorded every timeout as the
#755 silent-client flow. But a peer that connects and says nothing and a client
that sent a greeting and a method list and then stopped are two different facts,
and only the first is "this peer never spoke". `Negotiation` gains `timed_out?`,
`negotiate` answers the greeting read's timeout itself and refuses everything
past it, and `serve_socks5` branches three ways: timed out ⇒ the silent-client
flow, silent (EOF) ⇒ nothing recorded (a port scan, as the existing comment
argues), otherwise ⇒ the ordinary refusal record.

**`Fuzz::Plan`** used `map_with_index` for a side-effect walk over the WebSocket
parts, building an array it throws away → `each_with_index`.

**`spec/repeater/ws_engine_spec.cr:405`** failed intermittently under the load of
the full suite (`Connection reset by peer` where it expects the proxy-tunnel
diagnosis) and passed every time in isolation. The fake proxy closed the socket
immediately after `200 Connection Established`, so the client's upgrade request
landed in a receive queue nobody drained — and the kernel answers `close()` with
RST rather than FIN when there is unread data, which the client reads as
ECONNRESET instead of the clean EOF the spec is about. It now drains the
tunnelled request first. Product behaviour unchanged.

## Verification

`crystal spec` 10595 examples green (including the previously flaky one, in a
full-suite run) · `crystal tool format --check src spec bench scripts` ·
`scripts/bench_check.sh` (48 harnesses). One spec added, pinning the two SOCKS5
timeout paths apart.