### PR TITLE
fix(tui): ↑ at the top of the Authorize list returns to the tab bar

### DIFF
--- a/spec/tui/authorize_controller_spec.cr
+++ b/spec/tui/authorize_controller_spec.cr
@@ -43,7 +43,10 @@ private class AuthorizeFakeHost
   def request_overlay(kind : Symbol) : Nil
   end
 
+  getter focus_requests = [] of Symbol
+
   def request_focus(pane : Symbol) : Nil
+    @focus_requests << pane
   end
 
   def focus_body : Nil
@@ -548,6 +551,35 @@ describe Gori::Tui::AuthorizeController do
         c.view.selected_trial.not_nil!.identity.should eq("as-captured")
         c.handle_body_key(Termisu::Event::Key.new(Termisu::Input::Key::BackTab)).should be_true
         c.view.selected_trial.not_nil!.identity.should eq("anonymous")
+      end
+    end
+  end
+
+  # esc was the ONLY way back to the tab bar: ↑ clamped at row 0 and did nothing at all on the
+  # empty placeholder, so the key an operator reaches for to walk out of a list read as dead.
+  describe "↑ at the top of the list" do
+    it "pops focus to the tab bar from the first request, after walking back to it" do
+      with_authorize_controller do |c, host, session|
+        first = seed_capture(session.store, "/orders", "session=A")
+        second = seed_capture(session.store, "/invoices", "session=A")
+        c.seed_flows([first, second])
+        c.view.move_row(1)
+
+        c.handle_body_key(Termisu::Event::Key.new(Termisu::Input::Key::Up)).should be_true
+        host.focus_requests.should be_empty # still inside the list — the cursor moved
+        c.view.selected_entry.not_nil!.detail.row.id.should eq(first)
+
+        c.handle_body_key(Termisu::Event::Key.new(Termisu::Input::Key::Up)).should be_true
+        host.focus_requests.should eq([:menu])
+        c.view.selected_entry.not_nil!.detail.row.id.should eq(first) # cursor stays put
+      end
+    end
+
+    it "pops focus to the tab bar from the empty placeholder" do
+      with_authorize_controller do |c, host, _|
+        c.view.any_requests?.should be_false
+        c.handle_body_key(Termisu::Event::Key.new(Termisu::Input::Key::Up)).should be_true
+        host.focus_requests.should eq([:menu])
       end
     end
   end

--- a/src/gori/tui/authorize_view.cr
+++ b/src/gori/tui/authorize_view.cr
@@ -376,6 +376,14 @@ module Gori::Tui
       @detail_scroll = 0
     end
 
+    # True when ↑ has nowhere further to go inside the list, so the controller can hand
+    # focus back to the tab bar instead. The EMPTY queue counts as the top: the placeholder
+    # has no cursor at all, and leaving ↑ inert there made the tab a dead end you could
+    # only leave with esc.
+    def at_top? : Bool
+      @entries.empty? || @sel <= 0
+    end
+
     def move_row(delta : Int32) : Nil
       return if @entries.empty?
       @sel = (@sel + delta).clamp(0, @entries.size - 1)

--- a/src/gori/tui/controllers/authorize_controller.cr
+++ b/src/gori/tui/controllers/authorize_controller.cr
@@ -807,7 +807,11 @@ module Gori::Tui
       key = ev.key
       case
       when key.up?, key.lower_k?
-        @view.move_row(-1)
+        # ↑ on the first request — or on the empty placeholder, which has no cursor —
+        # pops focus back to the tab bar, the same exit esc takes. Clamping there instead
+        # left the one key an operator reaches for to walk out of the list looking dead
+        # (History/Issues/Intercept all pop from their top row).
+        @view.at_top? ? @host.request_focus(:menu) : @view.move_row(-1)
         true
       when key.down?, key.lower_j?
         @view.move_row(1)


### PR DESCRIPTION
## What

In the Authorize tab, `esc` was the only way back to the tab bar. `↑` clamped at row 0, and on the empty placeholder — which has no cursor at all — it did nothing, so the key an operator reaches for to walk out of a list read as dead at exactly the spot they press it.

`↑` / `k` now pops focus to the tab bar when there is nowhere further up to go, the same exit `esc` takes. This is the focus ring History / Issues / Intercept already have. The cursor stays put, so coming back lands where you left.

## Changes

- `AuthorizeView#at_top?` — true on the first request, and on an **empty** queue (the placeholder has no cursor, and leaving `↑` inert there made the tab a dead end).
- `AuthorizeController#handle_body_key` — `↑`/`k` routes to `request_focus(:menu)` at the top, else `move_row(-1)`.
- Specs: the fake host now records `request_focus` calls; two examples pin walking back to row 0 and then out, and the empty-placeholder case.

## Test

- `crystal spec spec/tui/authorize_controller_spec.cr` — 16 examples, 0 failures
- `crystal spec spec/tui/authorize_view_spec.cr spec/tui/authorize_identity_overlay_spec.cr` — 71 examples, 0 failures
- `crystal tool format --check src spec bench scripts` — clean

## Note

The same pattern (`↑` cannot reach the tab bar) remains in comparer / decoder / discover / jwt / notes / oast / probe / project / sitemap. Left alone here: in several of those `↑` is text-editor or multi-pane motion, so whether it should pop is a per-tab call rather than a sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014msbLFZF9N2UXCy2agpMos