### PR TITLE
fix(tui): y with nothing selected copies the whole pane, in the five panes where it did not

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- `y` with nothing selected copies the WHOLE pane, not the caret's own line: the History detail's Request/Response, the Project description, an Issue's notes and the JWT INPUT pane in READ all fell back to one line, so each disagreed with the `^Y` beside it and with every other read pane.
+- `y` with nothing selected copies the WHOLE pane, not the caret's own line: the History detail's Request/Response, the Project description, an Issue's notes and the JWT INPUT pane in READ all fell back to one line, so each disagreed with the `^Y` beside it and with every other read pane. In the OAST callback detail the same key was dead altogether, along with the `x` beside it in the footer — that pane swallowed every key it did not handle itself.
 
 - A `--wsdl` import source: a WSDL 1.1 service description becomes one SOAP request template per operation on every SOAP port it publishes, from the palette (`Import: WSDL`), `gori run import --wsdl PATH`, and the MCP `import_flows` tool. SOAP 1.1 and 1.2 bindings both, with bodies built from the XSD inline in the document; external schemas are never fetched and a `<!DOCTYPE>` is refused.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- `y` in the History detail copies the WHOLE Request/Response pane when nothing is selected, instead of the caret's own line — the rule every other read pane already followed.
+- `y` with nothing selected copies the WHOLE pane, not the caret's own line: the History detail's Request/Response, the Project description, an Issue's notes and the JWT INPUT pane in READ all fell back to one line, so each disagreed with the `^Y` beside it and with every other read pane.
 
 - A `--wsdl` import source: a WSDL 1.1 service description becomes one SOAP request template per operation on every SOAP port it publishes, from the palette (`Import: WSDL`), `gori run import --wsdl PATH`, and the MCP `import_flows` tool. SOAP 1.1 and 1.2 bindings both, with bodies built from the XSD inline in the document; external schemas are never fetched and a `<!DOCTYPE>` is refused.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- `y` in the History detail copies the WHOLE Request/Response pane when nothing is selected, instead of the caret's own line — the rule every other read pane already followed.
+
 - A `--wsdl` import source: a WSDL 1.1 service description becomes one SOAP request template per operation on every SOAP port it publishes, from the palette (`Import: WSDL`), `gori run import --wsdl PATH`, and the MCP `import_flows` tool. SOAP 1.1 and 1.2 bindings both, with bodies built from the XSD inline in the document; external schemas are never fetched and a `<!DOCTYPE>` is refused.
 
 - The Fuzzer sweeps a WebSocket exchange: mark `§…§` positions in the outbound frames (and in the handshake) and each payload runs one full RFC 6455 session, with the inbound frames matched as the response body and the close code on every row. `gori run fuzz --repeater N` and MCP `fuzz_start` seed a WebSocket session's frames instead of refusing it, `--message` / `--message-frame` / `--idle-ms` / `--ws-keep-key` author them, and `--ws-http-only` sweeps the handshake as a plain request (#795).

--- a/spec/support/fake_context.cr
+++ b/spec/support/fake_context.cr
@@ -198,8 +198,8 @@ class FakeExecContext < Gori::Verb::ExecContext
     rec(:scroll_detail, delta)
   end
 
-  def detail_copy_selection : Nil
-    rec(:detail_copy_selection)
+  def detail_copy : Nil
+    rec(:detail_copy)
   end
 
   def toggle_detail_pane : Nil

--- a/spec/tui/history_view_spec.cr
+++ b/spec/tui/history_view_spec.cr
@@ -761,6 +761,36 @@ describe Gori::Tui::HistoryView do
     end
   end
 
+  it "copies the WHOLE detail pane when nothing is selected (not just the caret's line)" do
+    tmp_store do |store|
+      id = store.insert_flow(Gori::Store::CapturedRequest.new(
+        created_at: 1_i64, scheme: "https", host: "h.test", port: 443,
+        method: "GET", target: "/api", http_version: "HTTP/1.1",
+        head: "GET /api HTTP/1.1\r\nHost: h.test\r\n\r\n".to_slice, body: nil, source: Gori::FlowSource::Kind::Proxy))
+      store.update_response(Gori::Store::CapturedResponse.new(
+        flow_id: id, status: 200,
+        head: "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\n".to_slice,
+        body: "LINE1\nLINE2\nLINE3\nLINE4".to_slice, content_type: "text/plain"))
+
+      view = HistoryView.new
+      view.reload(store)
+      view.open_detail(store).should be_true
+      view.toggle_pane # request -> response
+
+      view.detail_selection?.should be_false
+      all = view.detail_copy_all
+      # Every body line, in order — the pane, not the row the caret happens to sit on.
+      %w[LINE1 LINE2 LINE3 LINE4].each { |l| all.should contain(l) }
+      all.should contain("200 OK")                                        # the head is part of the pane too
+      all.index("LINE1").not_nil!.should be < all.index("LINE4").not_nil! # document order
+
+      # With a selection held, `y` still means the selection.
+      view.detail_select_line
+      view.detail_selection?.should be_true
+      view.detail_copy_text.should_not eq(all)
+    end
+  end
+
   it "opens on the strip, flips to the body level, and resets to the strip on re-open" do
     tmp_store do |store|
       add_flow(store, "GET", "/api", 200)

--- a/spec/tui/jwt_copy_selection_spec.cr
+++ b/spec/tui/jwt_copy_selection_spec.cr
@@ -185,6 +185,10 @@ end
 
 private TOKEN = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhIn0.sig"
 
+# A multi-line INPUT buffer: the whole point of the READ arm below is that its no-band answer
+# has to be more than the line the caret sits on, which a single-line token cannot show.
+private MULTILINE = "one\ntwo\nthree"
+
 describe "Gori::Tui::JwtController#jwt_copy_text" do
   describe "INPUT in INSERT" do
     it "takes the ⇧arrow band, not the whole token" do
@@ -209,6 +213,36 @@ describe "Gori::Tui::JwtController#jwt_copy_text" do
         ctl.handle_body_key(key(Termisu::Input::Key::LowerI, :none, 'i'))
         ctl.@sessions[ctl.@idx].input.selection?.should be_false
         ctl.jwt_copy_text.should eq(TOKEN)
+      end
+    end
+  end
+
+  # INPUT in READ is the pane that reads its band off the READ CURSOR rather than the editor,
+  # and it was the one arm of the four that fell back to the caret's LINE instead of the whole
+  # buffer — the rule `Runner#read_copy` states for every read pane in the tree, and the rule
+  # this tab's other three panes already followed through `band_or_all`. Multi-line INPUT is
+  # ordinary: `edit_input` maps ↵ to `insert_newline`, and a selection sent here from another
+  # tool arrives with whatever line breaks it had.
+  describe "INPUT in READ" do
+    it "takes the whole buffer when no band is live, not the caret's line" do
+      with_jwt_copy_controller do |ctl|
+        ctl.jwt_from_text(MULTILINE)
+        s = ctl.@sessions[ctl.@idx]
+        s.input_mode.should eq(InputMode::Read) # the pane opens in READ
+        s.input_read.selection?.should be_false
+        s.input_read.copy_text(s.input).should eq("one") # the old payload: line 0 alone
+        ctl.jwt_copy_text.should eq(MULTILINE)
+      end
+    end
+
+    it "takes the ⇧arrow band when one is live" do
+      with_jwt_copy_controller do |ctl|
+        ctl.jwt_from_text(MULTILINE)
+        s = ctl.@sessions[ctl.@idx]
+        3.times { ctl.handle_body_key(key(Termisu::Input::Key::Right, :shift)) }
+
+        s.input_read.selection?.should be_true
+        ctl.jwt_copy_text.should eq("one")
       end
     end
   end

--- a/spec/tui/read_copy_key_fallback_spec.cr
+++ b/spec/tui/read_copy_key_fallback_spec.cr
@@ -1,0 +1,252 @@
+require "../spec_helper"
+require "file_utils"
+
+# `y` with NOTHING selected copies the WHOLE focused pane. That is the rule `Runner#read_copy`
+# states for every read pane in the tree ("selection if active, else the whole focused pane"),
+# and the two panes here are the ones where the operator's `y` never reached it: both are
+# raw-dispatched by their controller AHEAD of the keymap, and both fell back to the caret's own
+# LINE instead. So the pane's two copy keys disagreed — `^Y` (project.copy / issue.copy → the
+# verb → read_copy) copied the whole description/notes, `y` copied one line of it.
+#
+# The assertions are on WHICH branch ran, read off the toast, because the two branches word
+# their status differently ("copied Nb to clipboard" for a selection, "copied description/notes
+# to clipboard (Nb)" for the whole pane). `Settings.clipboard_osc52` is off for the duration:
+# `Clipboard.copy` then returns 0 without touching the tty, which is what keeps a spec run from
+# writing OSC 52 at the developer's terminal and taking their clipboard with it.
+
+private class FakeHost
+  include Gori::Tui::Host
+
+  getter statuses = [] of String
+
+  def initialize(@session : Gori::Session)
+    @jobs = Gori::Tui::Jobs.new
+    @notifications = Gori::Tui::Notifications.new
+  end
+
+  def session : Gori::Session
+    @session
+  end
+
+  def jobs : Gori::Tui::Jobs
+    @jobs
+  end
+
+  def notifications : Gori::Tui::Notifications
+    @notifications
+  end
+
+  def status(message : String) : Nil
+    @statuses << message
+  end
+
+  def request_overlay(kind : Symbol) : Nil
+  end
+
+  def request_focus(pane : Symbol) : Nil
+  end
+
+  def focus_body : Nil
+  end
+
+  def switch_tab(tab : Symbol) : Nil
+  end
+
+  def goto_tab(tab : Symbol) : Nil
+  end
+
+  def open_palette : Nil
+  end
+
+  def open_help_query(surface : Symbol) : Nil
+  end
+
+  def open_space_menu : Nil
+  end
+
+  def open_fuzz_set_editor(edit_index : Int32?) : Nil
+  end
+
+  def open_fuzz_advanced_editor : Nil
+  end
+
+  def open_authorize_identities : Nil
+  end
+
+  def reconfigure_sequence : Nil
+  end
+
+  def open_scope_rule_editor(edit_id : Int64?, kind : String, match_type : String, pattern : String) : Nil
+  end
+
+  def open_custom_rule_editor(rule : Gori::Probe::CustomRule?) : Nil
+  end
+
+  def open_rewriter_rule_editor(rule : Gori::Store::MatchRule?) : Nil
+  end
+
+  def open_colormarker_rule_editor(rule : Gori::Store::ColorRule?) : Nil
+  end
+
+  def open_colormarker_color_editor(color : Gori::Settings::ColormarkerColor?) : Nil
+  end
+
+  def open_extract_rule_editor(rule : Gori::Store::ExtractRule?) : Nil
+  end
+
+  def open_chain_save : Nil
+  end
+
+  def open_chain_load : Nil
+  end
+
+  def open_oast_provider_editor(provider : Gori::Oast::ProviderConfig?) : Nil
+  end
+
+  def confirm(title : String, message : String, *, confirm_label : String, danger : Bool,
+              return_to : Symbol = :none, &action : -> Nil) : Nil
+    action.call
+  end
+
+  def overlay : Symbol
+    :none
+  end
+
+  def active_tab : Symbol
+    :project
+  end
+
+  def focus : Symbol
+    :body
+  end
+
+  def reveal? : Bool
+    false
+  end
+
+  def toggle_reveal : Nil
+  end
+
+  def pretty? : Bool
+    false
+  end
+
+  def toggle_pretty : Nil
+  end
+
+  def toggle_scope_lens : Nil
+  end
+
+  def toggle_sandbox : Nil
+  end
+
+  def apply_project_network(bind_host : String, bind_port : Int32, upstream : String,
+                            connect_secs : Int32, io_secs : Int32, capture_mib : Int32) : String
+    ""
+  end
+end
+
+# The CA is the slow part of standing a Session up and nothing here asserts about it.
+private READ_COPY_CA = File.tempname("gori-read-copy-ca")
+Spec.after_suite { FileUtils.rm_rf(READ_COPY_CA) }
+
+private def with_session(&)
+  root = File.tempname("gori-read-copy")
+  session = nil
+  begin
+    Dir.mkdir_p(root)
+    project = Gori::ProjectRegistry.new(root).temp("readcopy")
+    session = Gori::Session.open(Gori::Config.new(listen: "127.0.0.1", port: 0),
+      Gori::Proxy::Tls::CertAuthority.load_or_create(READ_COPY_CA), Gori::Verbs.registry, project)
+    host = FakeHost.new(session)
+    prev = Gori::Settings.clipboard_osc52?
+    Gori::Settings.clipboard_osc52 = false
+    begin
+      yield host, session
+    ensure
+      Gori::Settings.clipboard_osc52 = prev
+    end
+  ensure
+    session.try(&.close)
+    FileUtils.rm_rf(root) if Dir.exists?(root)
+  end
+end
+
+private def key(k : Termisu::Input::Key, mods : Termisu::Input::Modifier = :none,
+                char : Char? = nil) : Termisu::Event::Key
+  Termisu::Event::Key.new(k, mods, char)
+end
+
+private Y = -> { key(Termisu::Input::Key::LowerY, :none, 'y') }
+
+private TEXT = "alpha\nbravo\ncharlie"
+
+describe "bare `y` in a raw-dispatched read pane" do
+  describe "the Project description" do
+    it "copies the WHOLE description when nothing is selected" do
+      with_session do |host, _session|
+        ctl = Gori::Tui::ProjectController.new(host)
+        ctl.view.replace_desc(TEXT)
+        ctl.view.pane.should eq(:desc)
+        ctl.view.desc_selection?.should be_false
+        # What the pane's own getter answers with no band — the caret's line, and the old
+        # payload of this keypress.
+        ctl.view.desc_copy_text.should eq("alpha")
+        ctl.view.desc_copy_all.should eq(TEXT)
+
+        ctl.handle_body_key(Y.call).should be_true
+        host.statuses.last.should start_with("copied description to clipboard")
+      end
+    end
+
+    it "still copies just the selection when one is held" do
+      with_session do |host, _session|
+        ctl = Gori::Tui::ProjectController.new(host)
+        ctl.view.replace_desc(TEXT)
+        ctl.view.desc_select_line
+        ctl.view.desc_selection?.should be_true
+
+        ctl.handle_body_key(Y.call).should be_true
+        host.statuses.last.should start_with("copied 0b to clipboard") # 0b: the clipboard is off
+      end
+    end
+  end
+
+  describe "an Issue's notes" do
+    it "copies the WHOLE notes when nothing is selected" do
+      with_session do |host, session|
+        store = session.store
+        id = store.insert_issue("reflected param", Gori::Store::Severity::Medium, "acme.test", nil)
+        store.update_issue(id, notes: TEXT).should be_true
+        ctl = Gori::Tui::IssuesController.new(host)
+        ctl.view.reload(store)
+        ctl.view.open_detail(store).should be_true
+        ctl.view.notes_select_line     # the one public route into the notes pane…
+        ctl.view.notes_clear_selection # …minus the selection it plants
+        ctl.view.notes_focused?.should be_true
+        ctl.view.notes_selection?.should be_false
+        ctl.view.notes_copy_text.should eq("alpha")
+        ctl.view.notes_copy_all.should eq(TEXT)
+
+        ctl.handle_detail_key(Y.call).should be_true
+        host.statuses.last.should start_with("copied notes to clipboard")
+      end
+    end
+
+    it "still copies just the selection when one is held" do
+      with_session do |host, session|
+        store = session.store
+        id = store.insert_issue("reflected param", Gori::Store::Severity::Medium, "acme.test", nil)
+        store.update_issue(id, notes: TEXT).should be_true
+        ctl = Gori::Tui::IssuesController.new(host)
+        ctl.view.reload(store)
+        ctl.view.open_detail(store).should be_true
+        ctl.view.notes_select_line
+        ctl.view.notes_selection?.should be_true
+
+        ctl.handle_detail_key(Y.call).should be_true
+        host.statuses.last.should start_with("copied 0b to clipboard")
+      end
+    end
+  end
+end

--- a/spec/tui/read_copy_key_fallback_spec.cr
+++ b/spec/tui/read_copy_key_fallback_spec.cr
@@ -181,6 +181,20 @@ private Y = -> { key(Termisu::Input::Key::LowerY, :none, 'y') }
 
 private TEXT = "alpha\nbravo\ncharlie"
 
+# One interaction as the poller would deliver it — enough lines in the raw request for the
+# detail pane to have a caret line that is not the whole pane.
+private def interaction : Gori::Oast::Interaction
+  Gori::Oast::Interaction.new(
+    unique_id: "uid-000001",
+    protocol: "dns",
+    method: nil,
+    source_ip: "203.0.113.7",
+    full_id: "000001.oast.test",
+    raw_request: ";; QUESTION SECTION:\n;000001.oast.test. IN A\n;; trailing",
+    raw_response: ";; ANSWER SECTION:\n000001.oast.test. 60 IN A 203.0.113.1",
+    at: Time.unix(1_700_000_000_i64))
+end
+
 describe "bare `y` in a raw-dispatched read pane" do
   describe "the Project description" do
     it "copies the WHOLE description when nothing is selected" do
@@ -247,6 +261,32 @@ describe "bare `y` in a raw-dispatched read pane" do
         ctl.handle_detail_key(Y.call).should be_true
         host.statuses.last.should start_with("copied 0b to clipboard")
       end
+    end
+  end
+end
+
+# Not a fallback bug like the two above but the same key in the same kind of pane: OAST's
+# callback detail swallowed EVERY key it did not itself handle, so the `y copy · x line` its
+# footer names were both dead — `y` reached no copy at all and `x` never got out to its chord.
+describe "bare `y` in the OAST callback detail" do
+  it "copies the callback, and leaves `x` to the keymap" do
+    with_session do |host, session|
+      store = session.store
+      sid = store.insert_oast_session(nil, "interactsh", "https://oast.test",
+        "c0rr3lat10n", "s3cret", nil, nil)
+      ctl = Gori::Tui::OastController.new(host)
+      ctl.callbacks_sub?.should be_true
+      ctl.@oast_events.send(Gori::Oast::CallbackEvent.new(sid, interaction))
+      ctl.drain_events.should be_true
+
+      ctl.handle_body_key(key(Termisu::Input::Key::Enter)).should be_true # ↵ opens the detail
+      ctl.oast_detail_readable?.should be_true
+
+      ctl.handle_body_key(Y.call).should be_true
+      host.statuses.last.should start_with("copied all (")
+
+      # `x` is oast.select-line, a plain chord: the pane must hand it back, not eat it.
+      ctl.handle_body_key(key(Termisu::Input::Key::LowerX, :none, 'x')).should be_false
     end
   end
 end

--- a/spec/verb/registry_spec.cr
+++ b/spec/verb/registry_spec.cr
@@ -164,8 +164,8 @@ private class FakeContext < ExecContext
     @calls << :scroll_detail
   end
 
-  def detail_copy_selection : Nil
-    @calls << :detail_copy_selection
+  def detail_copy : Nil
+    @calls << :detail_copy
   end
 
   def toggle_detail_pane : Nil

--- a/spec/verbs/history_spec.cr
+++ b/spec/verbs/history_spec.cr
@@ -162,7 +162,7 @@ describe "Gori::Verbs.register_history" do
 
     it "keeps the in-place actions from closing the detail" do
       verb_intents(r, "detail.compare").should eq([:comparer_add_selected])
-      verb_intents(r, "detail.copy").should eq([:detail_copy_selection])
+      verb_intents(r, "detail.copy").should eq([:detail_copy])
       verb_intents(r, "detail.copy-flow").should eq([:copy_selection])
       verb_intents(r, "detail.copy-as").should eq([:copy_as_open])
       verb_intents(r, "detail.add-host").should eq([:scope_add_host])

--- a/src/gori/tui/controllers/history_controller.cr
+++ b/src/gori/tui/controllers/history_controller.cr
@@ -322,7 +322,7 @@ module Gori::Tui
       when key.right?, key.lower_l?       then @history.detail_move(0, 1)
       when key.up?, key.lower_k?          then detail_body_up
       when key.down?, key.lower_j?        then @history.scroll_detail(1)
-      when ev.char == 'y' || key.lower_y? then detail_copy_selection
+      when ev.char == 'y' || key.lower_y? then detail_copy
         # Home/End are the LINE's edges here, like every other multi-line pane. The MODIFIED
         # form is deliberately not claimed: ⌃/⌥+Home/End falls through to the shell's
         # ±JUMP_ROWS and keeps the jump-to-top/bottom this pane has always had (and which
@@ -746,14 +746,22 @@ module Gori::Tui
       @history.detail_at_top?
     end
 
-    def detail_copy_selection : Nil
-      text = @history.detail_copy_text
+    # `y` in the detail: the selection when one is held, else the WHOLE pane. The fallback used
+    # to be the caret's own LINE, which on a request/response dump is the one thing nobody
+    # reaches for `y` to get — and it made this pane the last holdout against the rule every
+    # other read pane follows (`Runner#read_copy`: selection if active, else the whole pane).
+    # `detail_selection_text` keeps the line fallback: "Send selection to" is gated on a live
+    # selection, so its payload is never the fallback anyway.
+    def detail_copy : Nil
+      sel = @history.detail_selection?
+      text = sel ? @history.detail_copy_text : @history.detail_copy_all
       if text.empty?
         @host.status("nothing to copy")
         return
       end
       written = Clipboard.copy(text)
-      @host.status("copied #{written}b to clipboard#{Clipboard.note(written, text)}")
+      note = Clipboard.note(written, text)
+      @host.status(sel ? "copied #{written}b to clipboard#{note}" : "copied all (#{written}b)#{note}")
     end
 
     # The detail pane's selection (or current line) text without copying — "Send selection to".

--- a/src/gori/tui/controllers/issues_controller.cr
+++ b/src/gori/tui/controllers/issues_controller.cr
@@ -233,7 +233,7 @@ module Gori::Tui
       when key.right?                        then @issues.notes_read_move(0, 1, selecting: selecting)
       when @issues.notes_read_motion_key(ev) then nil # Home/End/Page — the shared editor set
       when c == 'x'                          then @issues.notes_select_line
-      when c == 'y'                          then issues_copy
+      when c == 'y'                          then issues_notes_copy
       else
         return false
       end
@@ -584,6 +584,14 @@ module Gori::Tui
       end
       written = Clipboard.copy(text)
       @host.status("copied notes to clipboard (#{written}b)#{Clipboard.note(written, text)}")
+    end
+
+    # `y` in the notes pane: the selection when one is held, else the WHOLE notes. The keymap's
+    # `issue.copy` (-> Runner#read_copy) has always answered that way, but this pane raw-
+    # dispatches `y` ahead of the keymap and fell back to the caret's LINE — so the chord the
+    # verb registers and the key the operator actually presses gave different answers.
+    def issues_notes_copy : Nil
+      issues_notes_selection_active? ? issues_copy : issues_copy_all
     end
 
     # Write the issue report to `path` (the destination came from ExportOverlay — this used

--- a/src/gori/tui/controllers/jwt_controller.cr
+++ b/src/gori/tui/controllers/jwt_controller.cr
@@ -780,7 +780,7 @@ module Gori::Tui
     def jwt_copy_text : String
       s = cur
       case s.pane
-      when :input   then s.input_mode == InputMode::Read ? s.input_read.copy_text(s.input) : band_or_all(s.input)
+      when :input   then s.input_mode == InputMode::Read ? read_or_all(s.input_read, s.input) : band_or_all(s.input)
       when :header  then band_or_all(s.header)
       when :payload then band_or_all(s.payload)
       when :secret  then s.secret
@@ -791,6 +791,8 @@ module Gori::Tui
       end
     end
 
+    # `jwt_copy` already answers "selection, else the whole pane" for every pane, so the
+    # copy-all half of the unified Copy is the same call rather than a second decision.
     def jwt_copy_all : Nil
       jwt_copy
     end
@@ -800,6 +802,16 @@ module Gori::Tui
     # when there is no band, so this cannot silently copy an empty string over a full buffer.
     private def band_or_all(ed : TextArea) : String
       ed.selection_text || ed.text
+    end
+
+    # `band_or_all` for a pane in READ mode, where the band lives on the read cursor rather
+    # than on the editor. `TextReadState#copy_text` falls back to the caret's LINE, which is
+    # what INPUT-in-READ used to copy — the one pane of the four that did, and the one place
+    # the tab disagreed with the rest of the tree (`Runner#read_copy`: selection if active,
+    # else the whole pane). The selection test comes first because `copy_text`'s own fallback
+    # cannot be told apart from a one-line selection after the fact.
+    private def read_or_all(read : TextReadState, ed : TextArea) : String
+      read.selection? ? read.copy_text(ed) : read.copy_all(ed)
     end
 
     private def do_copy(text : String, label : String? = nil) : Nil

--- a/src/gori/tui/controllers/oast_controller.cr
+++ b/src/gori/tui/controllers/oast_controller.cr
@@ -1130,9 +1130,17 @@ module Gori::Tui
             with_cb_pane { @cb_pane.move(-1, 0, selecting: ev.shift?) }
           end
         when key.down?, key.lower_j? then with_cb_pane { @cb_pane.move(1, 0, selecting: ev.shift?) }
+        when c == 'y'                then oast_detail_copy
         else
-          with_cb_pane { @cb_pane.motion_key(ev) } # Home / End / PgUp / PgDn, ⇧ extending
-          return true
+          # Home / End / PgUp / PgDn, ⇧ extending — and FALL THROUGH on anything else, which is
+          # what `x` (oast.select-line, a plain chord) needs to reach the keymap. The old
+          # unconditional `return true` swallowed every unhandled key, so the two this pane's
+          # footer names — `y copy · x line` — were both dead here: `y` had no chord to reach
+          # (it is raw-dispatched above, as it is in the callbacks LIST) and `x` never got out.
+          # Same fall-through the list below hands `g`/`r`/`a` to the keymap with.
+          handled = false
+          with_cb_pane { handled = @cb_pane.motion_key(ev) }
+          return handled
         end
         return true
       end

--- a/src/gori/tui/controllers/project_controller.cr
+++ b/src/gori/tui/controllers/project_controller.cr
@@ -413,7 +413,7 @@ module Gori::Tui
       when key.right?                             then @project_view.desc_read_move(0, 1, selecting: selecting)
       when @project_view.desc_read_motion_key(ev) then nil # Home/End/Page — the shared editor set
       when c == 'x'                               then @project_view.desc_select_line
-      when c == 'y'                               then project_copy
+      when c == 'y'                               then project_desc_copy
       end
     end
 
@@ -460,6 +460,15 @@ module Gori::Tui
       end
       written = Clipboard.copy(text)
       @host.status("copied description to clipboard (#{written}b)#{Clipboard.note(written, text)}")
+    end
+
+    # Bare `y` in the description: the selection when one is held, else the WHOLE description.
+    # `^Y` (project.copy -> Runner#read_copy) has always answered that way; `y` is raw-dispatched
+    # here (see verbs/core.cr for why it has no chord) and fell back to the caret's LINE, so one
+    # pane's two copy keys disagreed about what "copy with nothing selected" means. This routes
+    # both through the same choice — the rule stated once per pane, as every sibling tab does it.
+    def project_desc_copy : Nil
+      project_desc_selection_active? ? project_copy : project_copy_all
     end
 
     # --- SCOPE pane: browse the rule list; a/e open the Miner-style popup overlay ---

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -1479,6 +1479,25 @@ module Gori::Tui
       @detail_read.selection_text(size, line_at) || @detail_read.current_line(size, line_at)
     end
 
+    # Every line of the pane, for the "copy the whole pane" fallback `y` takes with nothing
+    # selected (`HistoryController#detail_copy`) — the twin of `ReadPane#copy_all`, which every
+    # other read pane in the tree already offers. Materialises the text on purpose: it is going
+    # to the clipboard, which is one string either way, and the 64KB ceiling plus the
+    # "clipped from Nb" note live in `Clipboard`.
+    #
+    # Off the hot path by construction — one keypress, never a frame — so the lazy line source
+    # is walked once here rather than being kept lazy for a caller that needs all of it.
+    def detail_copy_all : String
+      size, line_at = detail_line_source
+      return "" if size <= 0
+      String.build do |io|
+        (0...size).each do |i|
+          io << '\n' if i > 0
+          io << line_at.call(i)
+        end
+      end
+    end
+
     # The "copy as X" menu for the open detail pane: {picker title, options}. REQUEST
     # offers url/headers/body/cookies/curl/raw (parsed from the captured bytes + the
     # flow's target URL); RESPONSE offers status+headers/body/raw. Decoded panes

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -4255,15 +4255,13 @@ module Gori::Tui
 
     # --- comparer (diff two arbitrary flows) ---
 
-    # The unified Copy verbs whose base title is now plain "Copy" (routed through
-    # read_copy — selection if active, else the whole focused pane; copy-all is
-    # gone). detail.copy is DELIBERATELY excluded: History detail has no whole-pane
-    # alternative (read_copy's :history branch always falls back to
-    # detail_copy_selection), so its title stays the static "Copy selection" —
-    # flipping it here would be a no-op at best and misleading at worst (no
-    # selection ⇒ it still only copies the current line, not "the whole pane").
+    # The unified Copy verbs whose base title is now plain "Copy" (selection if active,
+    # else the whole focused pane; copy-all is gone). detail.copy joins them: the History
+    # detail grew its whole-pane half (HistoryView#detail_copy_all), so "Copy" is now the
+    # honest base title there too — it used to be excluded because with no selection it
+    # only ever copied the caret's line.
     READ_COPY_VERBS = %w[
-      notes.copy repeater.copy decoder.copy issue.copy project.copy fuzzer.copy
+      notes.copy repeater.copy decoder.copy issue.copy project.copy fuzzer.copy detail.copy
     ]
 
     def space_menu_title(verb_id : String) : String?
@@ -4552,9 +4550,9 @@ module Gori::Tui
       when :sequencer then sequencer_controller.sequencer_copy
       when :miner     then miner_controller.miner_copy
       when :history
-        # No whole-rendered-pane delegator exists for the detail text pane — both
-        # branches fall back to the selection-or-current-line copy.
-        detail_copy_selection if @overlay.detail?
+        # One delegator, like the group above: HistoryController#detail_copy makes the
+        # selection-vs-whole-pane choice itself (it also words its own toast).
+        detail_copy if @overlay.detail?
       end
     end
 

--- a/src/gori/tui/runner/history.cr
+++ b/src/gori/tui/runner/history.cr
@@ -94,8 +94,8 @@ class Gori::Tui::Runner < Gori::Verb::ExecContext
     history_controller.scroll_detail(delta)
   end
 
-  def detail_copy_selection : Nil
-    history_controller.detail_copy_selection
+  def detail_copy : Nil
+    history_controller.detail_copy
   end
 
   def toggle_detail_pane : Nil

--- a/src/gori/verb/context/history.cr
+++ b/src/gori/verb/context/history.cr
@@ -35,8 +35,9 @@ abstract class Gori::Verb::ExecContext
 
   # detail view
   abstract def scroll_detail(delta : Int32) : Nil
-  # Copy the selection (or current line) from the navigable detail text pane.
-  abstract def detail_copy_selection : Nil
+  # Copy from the navigable detail text pane: the selection when one is held, else the
+  # whole pane — the same rule read_copy applies on every other tab.
+  abstract def detail_copy : Nil
   # (There is no horizontal companion to scroll_detail: the detail's req/res panes
   # soft-wrap, so a long line is already on the next row rather than off the edge.)
   abstract def toggle_detail_pane : Nil

--- a/src/gori/verb/context/repeater.cr
+++ b/src/gori/verb/context/repeater.cr
@@ -38,6 +38,6 @@ abstract class Gori::Verb::ExecContext
   # `open_response_external` for a response that is not a stored flow but the result of the
   # send in hand. Two intents rather than one because the two read their bytes from
   # different places (a `Store::FlowDetail` vs the live `Repeater::Result`), which is the
-  # same split `repeater_copy` / `detail_copy_selection` already draw.
+  # same split `repeater_copy` / `detail_copy` already draw.
   abstract def repeater_open_response_external : Nil
 end

--- a/src/gori/verbs/history.cr
+++ b/src/gori/verbs/history.cr
@@ -469,12 +469,14 @@ module Gori
         "detail.open-browser", "Open response in browser", "Write this flow's decoded response body to a file and open it in the desktop viewer",
         Verb::Scope::HistoryDetail, mnemonic: 'B', group: :view) { |ctx| ctx.open_response_external; nil }
 
-      # Copy the selection (or current line) from the navigable detail text — flow copy
-      # lives in the space menu only (history.copy / detail.copy-flow).
+      # The single smart Copy over the navigable detail text: the selection when one is held,
+      # else the whole pane (the rule every other tab's Copy already follows — see
+      # repeater.copy above). Flow copy lives in the space menu only (history.copy /
+      # detail.copy-flow).
       r.register Verb::Definition.new(
-        "detail.copy", "Copy selection", "Copy the selected text (or current line) to the clipboard",
+        "detail.copy", "Copy", "Copy the selected text, or the whole pane if nothing is selected, to the clipboard",
         Verb::Scope::HistoryDetail, [Verb::Chord.new("y")],
-        mnemonic: 'y', group: :copy) { |ctx| ctx.detail_copy_selection; nil }
+        mnemonic: 'y', group: :copy) { |ctx| ctx.detail_copy; nil }
 
       # "Copy as X" for the drill-in: same focus-aware format picker as Repeater, over the
       # REQUEST/RESPONSE pane bytes. Menu key 'Y' pairs with copy's 'y' (free in the


### PR DESCRIPTION
`y` in the History detail's Request/Response copied the caret's **line** when nothing was selected, not the pane. That is the opposite of the rule the rest of the tree follows — `Runner#read_copy`: *selection if active, else the whole focused pane* — and `runner.cr` carried a comment saying History was excluded from it precisely because the whole-pane half did not exist there.

It turned out not to be one pane.

## What was wrong

| pane | bare `y` | `^Y` / the verb |
|---|---|---|
| History detail REQ/RES | caret's line | caret's line (no whole-pane path existed) |
| Project description | caret's line (raw-dispatched ahead of the keymap) | whole description |
| An Issue's notes | caret's line (raw-dispatched ahead of the keymap) | whole notes |
| JWT INPUT in READ | caret's line | same — `jwt_copy_all` is an alias of `jwt_copy` |
| OAST callback detail | **nothing at all** | space menu only |

The middle three are the same defect in three places: the pane claims `y` before the keymap can route it, so the operator's key and the chord printed next to it in the footer gave different answers about what "copy with nothing selected" means. JWT's INPUT was the one arm of that tab's four that read its band off the read cursor instead of the editor, and so missed the `band_or_all` its three siblings share.

OAST is a different failure with the same symptom: `handle_callbacks_key` returned `true` for every key the detail did not handle itself, so both keys its footer advertises — `y copy · x line` — were dead, `y` with no chord to reach and `x` never getting out to the one it has.

## What changed

- `HistoryView#detail_copy_all` — the missing whole-pane half, walking the lazy line source once (one keypress, never a frame). The 64KB ceiling and the "clipped from Nb" note stay in `Clipboard`.
- The facade intent `detail_copy_selection` → `detail_copy`, which lets `detail.copy` join `READ_COPY_VERBS` and drop its now-false "Copy selection" title.
- Project / Issues: the raw `y` delegates to the same selection-vs-all choice the verb path makes, so the two routes cannot disagree. One line each — deliberately a delegation rather than a second implementation, since a second implementation is how they drifted.
- JWT: `read_or_all`, the read-cursor twin of `band_or_all`.
- OAST: `y` raw-dispatched like the callbacks list does it; everything else falls through to the keymap, which is the idiom the same method already uses to hand `g`/`r`/`a` over.

## Verification

Each fix has a spec that was confirmed to fail against the old code and pass against the new: `spec/tui/read_copy_key_fallback_spec.cr` (Project, Issues, OAST — driven through the real key handlers, with `clipboard_osc52` off so a spec run cannot write OSC 52 at the developer's terminal), plus new examples in `history_view_spec` and `jwt_copy_selection_spec`.

`just check` and `just benchmark-check` green. Full suite: 10614 examples, 8 failures — all of them the pre-existing `Session` capture/proxy specs that fail on TCP bind in this sandbox, on `main` as well.
