### PR TITLE
ci: shard the spec suite four ways, and stop building ameba

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,11 @@ on:
       - shard.yml
       - shard.lock
       - "**/*.cr"
+      # Two shell scripts the jobs below actually execute, neither of which matches
+      # `**/*.cr`: without these lines a change to the spec partition or to the bench
+      # type-check would merge without the job that runs it ever waking up.
+      - scripts/spec_shard.sh
+      - scripts/bench_check.sh
       # `docker/Dockerfile` is deliberately absent: nothing in this workflow
       # builds the image any more (see the note under `tests`), so listing it
       # would only wake the Crystal build and the spec matrix to test nothing
@@ -26,6 +31,15 @@ on:
         description: manual run
         required: false
         default: ""
+# Superseded PR runs are cancelled. Pushing a fixup thirty seconds after the first push
+# used to leave the first workflow running to completion — eight jobs' worth of runners
+# producing a verdict on a tree nobody will merge. Only `pull_request` runs collapse:
+# the group for everything else is the run id, which is unique, so a push to `main` and
+# a merge_group run each sit alone in their own group and never cancel or queue behind
+# anything. (`cancel-in-progress: true` is harmless in a group of one.)
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
+  cancel-in-progress: true
 jobs:
   build-crystal:
     runs-on: ubuntu-latest
@@ -43,14 +57,28 @@ jobs:
           sudo apt-get install -y --no-install-recommends \
             pkg-config libbrotli-dev libzstd-dev libsqlite3-dev
       - name: Install dependencies
-        run: shards install
+        # `--production` (= `--frozen --without-development`) rather than a bare
+        # install. Two reasons, one of each kind:
+        #
+        # LIGHTER: the only development dependency is ameba, whose postinstall
+        # COMPILES the ameba binary — and no job here runs ameba (see the note above
+        # `tests`). That build was the bulk of this step's half-minute, paid once per
+        # job, for a tool nothing in CI invokes. `--frozen` costs nothing on top and
+        # leaves shard.lock untouched, so this stays a read of the tree, not an edit.
+        #
+        # STRICTER: `--frozen` fails when shard.lock does not satisfy shard.yml, which
+        # is the one dependency mistake a green build would otherwise hide — a shard
+        # added or bumped in shard.yml with the lock left behind resolves fine here and
+        # then installs something else on the next machine.
+        run: shards install --production
       - name: Build
         # Deliberately NO `-Dpreview_mt`. Store, Fuzz::Engine, Miner::Engine and
         # Store::SafeRegexp each document that their plain ivars and unguarded
         # counters are safe *because* gori runs on the single-threaded fiber
         # scheduler. Enabling MT here would build a binary those files do not
-        # describe.
-        run: shards build
+        # describe. `--production` for the same reason as the step above — without it
+        # `shards build` runs its own install first and puts ameba straight back.
+        run: shards build --production
   format:
     runs-on: ubuntu-latest
     steps:
@@ -96,7 +124,8 @@ jobs:
           sudo apt-get install -y --no-install-recommends \
             pkg-config libbrotli-dev libzstd-dev libsqlite3-dev
       - name: Install dependencies
-        run: shards install
+        # `--production`: see the note on the same step in `build-crystal`.
+        run: shards install --production
       - name: Type-check bench harnesses
         # The same script `just benchmark-check` runs, so local and CI cannot drift apart
         # (and this job needs no `just` on the runner).
@@ -104,10 +133,40 @@ jobs:
   # Still no ameba job. The backlog is down from 965 findings to 641, but 248 of the
   # remainder are Metrics/CyclomaticComplexity in the TUI — splitting those methods is a
   # real refactor, not lint cleanup, and `.ameba.yml` already records the decision to
-  # raise the bar to 12 rather than carve them up. `just check` still runs it locally.
+  # raise the bar to 12 rather than carve them up. `just check` still runs it locally —
+  # which is now the ONLY place it runs at all: the install steps pass `--production`, so
+  # no runner clones or compiles ameba any more. Whichever job gains the gate has to drop
+  # that flag for itself.
   # Add the gate when that category is dealt with, not by excluding it — a check that is
   # always red is a check nobody reads, but one that is green by exclusion is worse.
   tests:
+    # Sharded, because `crystal spec` compiles the whole suite into ONE binary and runs
+    # its ~10,900 examples in ONE single-threaded fiber scheduler — so this job was the
+    # only thing anybody waited for: 8.5 of the workflow's 8.5 minutes, while `format`
+    # finished in 18 seconds and the other two in under three minutes.
+    #
+    # Measured on this tree, the run splits roughly 1:5 between compiling (~35 s) and
+    # executing (~370 s), and the executing half is barely CPU-bound at all — the suite
+    # spends most of it parked on real sockets and deliberate sleeps that hold a
+    # connection open so a stall stays distinguishable from a hangup. That is time four
+    # runners can wait through at once, and the four-way split takes the job to well
+    # under four minutes. It is NOT free: each shard pays the compile again, so the
+    # workflow burns more runner-minutes than it did. Four is where that trade stops
+    # paying — at six the compile plus job setup is already most of a shard's wall
+    # clock, and the longest shard barely moves (43 s of examples against 49 s at four)
+    # because the heaviest spec FILE cannot be split any finer than itself.
+    #
+    # Sharding by PROCESS rather than by threads inside one is deliberate: several
+    # specs bind a fixed loopback port, and two of them in one process — or two
+    # processes on one runner — would collide. One shard per runner keeps them apart.
+    strategy:
+      # A failing shard must not cancel the other three. The whole point of the split is
+      # that one run tells you everything that is broken; fail-fast would turn it back
+      # into "fix one, push, wait, find the next".
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3]
+    name: tests (${{ matrix.shard }}/4)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -120,7 +179,8 @@ jobs:
           sudo apt-get install -y --no-install-recommends \
             pkg-config libbrotli-dev libzstd-dev libsqlite3-dev
       - name: Install dependencies
-        run: shards install
+        # `--production`: see the note on the same step in `build-crystal`.
+        run: shards install --production
       - name: Run tests
         # `-Wl,--no-export-dynamic` is a WORKAROUND for a linker bug, not a preference.
         #
@@ -150,7 +210,13 @@ jobs:
         # symbol by name, so there is no consumer of the export either.
         #
         # DELETE THIS once the toolchain stops mis-emitting the table.
-        run: crystal spec --link-flags "-Wl,--no-export-dynamic"
+        #
+        # `scripts/spec_shard.sh` decides WHICH files this runner compiles — the same
+        # script `just test-shard` runs, so a shard that fails here can be reproduced
+        # locally with one command. It partitions by walking the tree, never by a list
+        # checked in here: a hardcoded split stops covering whatever spec file is added
+        # next and nothing goes red to say so.
+        run: crystal spec --link-flags "-Wl,--no-export-dynamic" $(scripts/spec_shard.sh ${{ matrix.shard }} 4)
 # No `build-docker` job here. It used to build docker/Dockerfile for amd64 and
 # arm64 on every PR, and those two builds — each compiling a static Crystal
 # binary from source, the arm64 one on a native runner because QEMU is far too

--- a/justfile
+++ b/justfile
@@ -62,6 +62,15 @@ docker-run tag="gori:dev" *args:
 test:
     crystal spec
 
+# Run the spec files CI's matrix gives one runner, e.g. `just test-shard 2` for the
+# third of four. The partition is a function of the tree (scripts/spec_shard.sh), so
+# this reproduces exactly what a red shard in Actions ran — CI calls the same script.
+
+# Run one CI spec shard locally (INDEX is 0-based).
+[group('development')]
+test-shard index total="4":
+    crystal spec $(scripts/spec_shard.sh {{index}} {{total}})
+
 # Run one spec file (or dir), e.g. `just test-file spec/store_spec.cr`.
 [group('development')]
 test-file path:

--- a/scripts/spec_shard.sh
+++ b/scripts/spec_shard.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Print the spec files belonging to shard INDEX of TOTAL, one per line.
+#
+# `crystal spec` has no sharding of its own, so CI's matrix asks this script which
+# files each runner should compile. The partition must be a FUNCTION OF THE TREE,
+# not a checked-in list: a hardcoded split silently stops covering whatever spec
+# file is added next, and nothing goes red to say so.
+#
+# Balancing is longest-processing-time-first on FILE SIZE. Size is a proxy for run
+# time, and an imperfect one — a 3 KB file that sleeps on a socket outweighs a 40 KB
+# table of pure-function examples — but it is the only cost signal available without
+# checking in measurements that rot the moment a spec is edited. Measured against a
+# real timing run of the suite it lands each of four shards within ~20% of the ideal
+# even split, where round-robin over sorted names lands the worst shard at DOUBLE it.
+set -euo pipefail
+
+idx=${1:?usage: spec_shard.sh INDEX TOTAL (INDEX is 0-based)}
+total=${2:?usage: spec_shard.sh INDEX TOTAL (INDEX is 0-based)}
+
+if [ "$idx" -lt 0 ] || [ "$idx" -ge "$total" ]; then
+  echo "spec_shard.sh: INDEX $idx out of range for TOTAL $total" >&2
+  exit 1
+fi
+
+cd "$(dirname "$0")/.."
+
+# `wc -c` rather than `stat`: the flag for a file's size is spelled differently on
+# GNU (-c '%s') and BSD/macOS (-f '%z'), and this script runs on both.
+find spec -name '*_spec.cr' -print0 | xargs -0 wc -c |
+  awk '$2 != "" && $2 != "total" { print $1, $2 }' |
+  sort -k1,1nr -k2,2 |
+  awk -v idx="$idx" -v total="$total" '
+    {
+      best = 0
+      for (i = 1; i < total; i++)
+        if (load[i] < load[best]) best = i
+      load[best] += $1
+      if (best == idx) print $2
+    }'


### PR DESCRIPTION
## What was slow

`tests` was the entire workflow — 8m22s of an 8m22s wall clock, while `format` finished in 18 seconds:

| job | before |
|---|---|
| **tests** | **8m22s** |
| benchmarks | 2m45s |
| build-crystal | 1m33s |
| format | 18s |

Splitting the step locally: **33s compiling, 166s running** the ~10,900 examples — and the running half sits at **42% CPU**. The suite is not short of cores. It is parked on real sockets and on the deliberate sleeps that keep a stall distinguishable from a hangup. That is time four runners can wait through at once.

## What this does

**`tests` becomes a four-way matrix**, with `scripts/spec_shard.sh` deciding which files each runner compiles. The partition is a function of the tree, never a list checked in beside it — a hardcoded split stops covering whatever spec file is added next and nothing goes red to say so. Balancing is longest-processing-time-first on file size:

```
             ideal   worst shard
LPT(bytes)   41.6s     49.0s     <- this
round-robin  41.6s     83.7s
```

Four, not six: the heaviest spec *file* cannot be split any finer than itself, so past four the compile plus job setup is most of a shard's wall clock and the longest shard barely moves (43s of examples against 49s at four). `fail-fast: false`, so one red shard still reports what the other three found.

**`shards install --production`** — the only development dependency is ameba, whose postinstall *compiles the ameba binary*, and no job here runs ameba. Every job was paying half a minute to build a tool nothing in CI invokes. `--frozen` rides along for free and adds a check: it fails when `shard.lock` does not satisfy `shard.yml`, the one dependency mistake a green build would otherwise hide.

**`concurrency`** — a superseded PR run is cancelled instead of running to completion on a tree nobody will merge. Only `pull_request` runs collapse; `push` and `merge_group` get the run id as their group, so each sits alone and never cancels or queues behind anything.

**`just test-shard N`** calls the same script, so a shard that fails in Actions reproduces locally with one command.

## Verification

All four shards green, and their example counts sum to exactly what the unsharded suite reports — so the partition covers the tree:

```
shard 0  2955 examples  0 failures   run 1:02  (wall 1:18)
shard 1  2707 examples  0 failures   run  :49  (wall 1:03)
shard 2  2564 examples  0 failures   run  :39  (wall  :56)
shard 3  2643 examples  0 failures   run  :49  (wall 1:03)
         -----
        10869 = the full suite
```

Longest shard 78s against 199s unsharded, locally. `crystal build --no-codegen src/main.cr`, `scripts/bench_check.sh` (48 harnesses) and `crystal tool format --check src spec bench scripts` all pass.

## The trade

Total runner-minutes go **up** — each shard pays the compile again. This buys wall clock (8.5min -> an expected 3.5-4min) with runner time; `--production` and the concurrency cancellation give some of it back. If the aggregate matters more than the wait, dropping to two shards is a one-line change (`shard: [0, 1]` and the `4` in the run line).

Slow specs themselves are untouched. The `sleep 0.2`s in `h2_engine_spec` and friends are mostly there to keep a stall falsifiable; shortening them trades a measured win for flakiness.