### PR TITLE
chore(deps): pin ameba to the 1.7.0 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,11 +60,10 @@ jobs:
         # `--production` (= `--frozen --without-development`) rather than a bare
         # install. Two reasons, one of each kind:
         #
-        # LIGHTER: the only development dependency is ameba, whose postinstall
-        # COMPILES the ameba binary — and no job here runs ameba (see the note above
-        # `tests`). That build was the bulk of this step's half-minute, paid once per
-        # job, for a tool nothing in CI invokes. `--frozen` costs nothing on top and
-        # leaves shard.lock untouched, so this stays a read of the tree, not an edit.
+        # LIGHTER: the only development dependency is ameba — and no job here runs it
+        # (see the note above `tests`), so `--without-development` skips a clone paid
+        # once per job for a tool nothing in CI invokes. `--frozen` costs nothing on top
+        # and leaves shard.lock untouched, so this stays a read of the tree, not an edit.
         #
         # STRICTER: `--frozen` fails when shard.lock does not satisfy shard.yml, which
         # is the one dependency mistake a green build would otherwise hide — a shard
@@ -135,8 +134,9 @@ jobs:
   # real refactor, not lint cleanup, and `.ameba.yml` already records the decision to
   # raise the bar to 12 rather than carve them up. `just check` still runs it locally —
   # which is now the ONLY place it runs at all: the install steps pass `--production`, so
-  # no runner clones or compiles ameba any more. Whichever job gains the gate has to drop
-  # that flag for itself.
+  # no runner clones ameba any more. Whichever job gains the gate has to drop that flag
+  # for itself, and compile `lib/ameba/bin/ameba.cr` itself: since 1.7.0 the shard ships
+  # no postinstall, so installing it no longer leaves a binary behind.
   # Add the gate when that category is dealt with, not by excluding it — a check that is
   # always red is a check nobody reads, but one that is green by exclusion is worse.
   tests:

--- a/shard.lock
+++ b/shard.lock
@@ -2,7 +2,7 @@ version: 2.0
 shards:
   ameba:
     git: https://github.com/crystal-ameba/ameba.git
-    version: 1.7.0-dev+git.commit.cdd58b34b0d8a9c785d67183a7a8f07541549e55
+    version: 1.7.0
 
   cvss:
     git: https://github.com/hahwul/cvss.cr.git

--- a/shard.yml
+++ b/shard.yml
@@ -38,8 +38,4 @@ dependencies:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    branch: master
-    # master (1.7.0-dev) rather than the 1.6.4 release: 1.6.4's postinstall does not
-    # compile under Crystal 1.21 (`next_string_array_token` undefined for
-    # Crystal::Lexer), and that failure aborts `shards build` for the whole project.
-    # Move back to a version constraint once 1.7.0 is released.
+    version: ~> 1.7.0


### PR DESCRIPTION
## Why

`development_dependencies.ameba` was pinned to `branch: master` as a workaround — 1.6.4's postinstall did not compile under Crystal 1.21 (`next_string_array_token` undefined for `Crystal::Lexer`), and that failure aborted `shards build` for the whole project. The comment said to move back to a version constraint once 1.7.0 shipped.

[ameba v1.7.0](https://github.com/crystal-ameba/ameba/releases/tag/v1.7.0) was released on 2026-08-26, so the pin becomes `version: ~> 1.7.0`.

## Verification

- `crystal build lib/ameba/src/cli.cr` succeeds under Crystal 1.21.0 — the original blocker is gone.
- **Control run.** The 1.7.0 binary and the previously locked master commit (`cdd58b34`) were both built and run over this tree: identical `1386 inspected, 901 failures`, and identical per-rule counts (diffed). The bump adds no findings, so `.ameba.yml`'s 1.7-rule exclusions stay exactly as they are.
- `shards install --production` (the CI install path, `--frozen`) resolves cleanly — the lock satisfies `shard.yml`.
- `crystal build --no-codegen src/main.cr` passes.
- `just check`'s entrypoint (`lib/ameba/bin/ameba.cr`, run as a source file) works against the released shard.

## ci.yml comments

Two comments still described 1.6.4's postinstall compiling the ameba binary. 1.7.0 ships no postinstall, so:

- `--production` now saves a **clone**, not a compile — the "bulk of this step's half-minute" claim no longer holds.
- Whichever job eventually gains the lint gate has to compile `lib/ameba/bin/ameba.cr` itself; installing the shard no longer leaves a binary behind.

Corrected in place. No behavioural change to the workflow (`ci.yml` still parses).