### PR TITLE
feat(proxy,tui): configure socks proxy with authentication, route egress through upstream proxy

### DIFF
--- a/.github/DESIGN.md
+++ b/.github/DESIGN.md
@@ -1815,6 +1815,40 @@ lensed and an all-hidden list reads `no flows in scope` (plus `⇧S toggles the 
 For the same reason the open-site passes `raise_on_error: true`: `Store#search` otherwise degrades
 a SQLite failure to an empty result, which on this card is indistinguishable from an empty scope.
 
+### 2026-08-26: upstream proxying is fail-closed for app-owned egress
+
+Refines: [P1](#p1), [P4](#p4), [P5](#p5). #434.
+
+`network.upstream_proxy` used to govern the proxy/send engines but not the updater or OAST's
+stdlib HTTP clients. That made the setting read as a catch-all while two owned request paths
+could still leave directly. The routing decision now stays in `Settings.upstream_route(host)`
+and every app-owned socket, including those service clients, is opened by `Proxy::Upstream`.
+An invalid declaration or a failed HTTP CONNECT/SOCKS handshake is a proxy error before any
+origin socket; there is no direct retry. The existing blank project pin and ordered `direct`
+rules remain explicit operator choices, not accidental fallbacks.
+
+The scalar and ordered rules use the conventional SOCKS distinction uniformly: `socks5`
+resolves destination names locally and sends an address literal, while `socks5h` sends RFC 1928
+`ATYP DOMAIN` for proxy-side DNS. The local lookup is an intentional operator choice, visible in
+both settings editors and the reference documentation rather than an implicit leak. Resolution
+failure is a DNS error before the proxy socket is opened; there is still no direct retry. The
+proxy endpoint itself is always resolved locally.
+
+Project-scoped proxy authentication is one JSON value in the owner-only project DB, with the
+method derived from the pinned route: HTTP Basic for an HTTP CONNECT proxy, RFC 1929 for
+SOCKS5. Enabling it turns an inherited catch-all into an explicit project pin; otherwise a
+later global edit or first-match rule could send the credential to a different proxy. A
+malformed value or credentials without that pin is an invalid route for a matching
+destination and fails before an origin socket. The Project editor shows the password only
+while its row is focused and masks it again on leave; object inspection and status text remain redacted. Global rules retain
+their environment-variable indirection so a shareable `settings.json` still contains no
+proxy password.
+
+`net.upstream_destination_host` is a project-only gate in front of the routing precedence.
+Missing or `*` preserves the old proxy-all behaviour; a non-match is explicitly direct and
+does not fall through to the global rule table or scalar. The same loader installs the gate
+for TUI, headless and MCP surfaces, so every gori-owned dial receives the same answer.
+
 ### 2026-08-27: agent presence is a flock+sidecar marker, not a DB row
 
 Refines: [P1](#p1), [P6](#p6). #815.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Proxy: with `network.strip_alt_svc` off, a response advertising `Alt-Svc: h3=…` now says so on the flow instead of passing silently — the advertisement still reaches the client byte-for-byte, but a client leaving for QUIC is a reported blind spot rather than an unexplained gap in History (#835)
 - TUI: the project picker marks a project an MCP client is bound to, and an open project shows a clickable `mcp:<client>` top-bar chip that lists the attached agents (#815)
 - TUI: the Comparer flow picker follows the active project Scope lens, and says `no flows in scope` rather than `no flows captured yet` when the lens hides everything; turning the lens off still exposes every captured flow (#809)
+- Proxy: distinguish SOCKS5 local DNS from SOCKS5H proxy DNS (existing SOCKS5 rules that need remote resolution should switch to SOCKS5H), add project-scoped proxy authentication and destination filtering, and route updater/OAST traffic through the same fail-closed upstream path. Project proxy passwords are shown only while editing and stored in the owner-only project database (#434)
 
 ## v0.4.0
 

--- a/docs/content/reference/config.ko.md
+++ b/docs/content/reference/config.ko.md
@@ -43,7 +43,7 @@ gori는 전역 환경설정을 `settings.json`에, 각 프로젝트를 자체 SQ
 |-----|------|---------|-------------|
 | `bind_host` | string | `127.0.0.1` | 전역 기본 리스닝 주소 (프로젝트에 `net.bind_host`가 없을 때 사용) |
 | `bind_port` | integer | `8070` | 전역 기본 리스닝 포트 (프로젝트에 `net.bind_port`가 없을 때 사용) |
-| `upstream_proxy` | string | `""` | 전역 기본 업스트림(`host:port`); 비어 있으면 직접 연결. 설정 시 프로젝트 `net.upstream_proxy`가 우선 |
+| `upstream_proxy` | string | `""` | 전역 기본 업스트림: 기존 `host:port`/`http://…` 또는 `socks5://…`/`socks5h://…`; 비어 있으면 직접 연결. 설정 시 프로젝트 `net.upstream_proxy`가 우선 |
 | `verify_upstream` | bool | `true` | 시스템 CA 트러스트 스토어로 업스트림 TLS 인증서 검증(표준 위치에서 자동 탐색하며 `SSL_CERT_FILE` / `SSL_CERT_DIR` 존중; 스토어를 못 찾으면 HTTPS 검증 실패 — `SSL_CERT_FILE` 지정 또는 끄기). 토글하면 재시작 없이 실행 중인 프록시, 액티브 프로브, Repeater / Fuzzer / Miner 전송기에 즉시 반영됩니다. `--insecure-upstream`은 해당 세션에만 끈 상태로 시작 |
 | `serve_landing` | bool | `true` | 내장 안내 / CA 다운로드 페이지 제공. 리슨 주소로 직접 접속한 경우와, 이미 프록시를 설정한 클라이언트가 예약 호스트 `http://gori.proxy/`(또는 `http://gori/`)로 접속한 경우 모두 해당 |
 | `connect_timeout_secs` | integer | `30` | 업스트림 연결 타임아웃(초, 최소 `1`) |
@@ -228,7 +228,11 @@ gori가 `succeeded`로 답하기 전에 두 가지를 검사하고, 각각 연�
 
 ### upstream_rules
 
-목적지별 업스트림 라우팅입니다. `network.upstream_proxy`는 *모든* 트래픽에 대한 단일 주소인 반면, 규칙 테이블은 "`*.corp.internal`은 사내 프록시로, 나머지는 직결"을 표현할 수 있고 자격증명을 실을 수 있으며 SOCKS 프록시에 접근할 수 있습니다.
+`network.upstream_proxy`는 catch-all 경로입니다. `host:port`, `http://…`(기존 `https://…` 표기 포함)는 HTTP CONNECT 프록시를 사용합니다. `socks5://…`는 대상 이름을 **로컬에서** 해석해 주소 리터럴을 보내고, `socks5h://…`는 호스트 이름을 `ATYP DOMAIN`으로 보내 **프록시가** 해석합니다. 둘 다 기본 포트는 1080입니다. URI 자격증명은 거부됩니다. Project 탭에서 직접 자격증명을 설정하거나 `username`과 `password_env`를 가진 `upstream_rules` 항목을 사용하세요.
+
+캡처·재전송·스캔 엔진, 업데이트 확인, OAST 제공자 통신을 포함해 gori가 소유한 모든 네트워크 연결은 이 라우팅 결정을 사용합니다. 설정된 프록시가 잘못되었거나 연결할 수 없거나 터널을 거부하면 직결로 재시도하지 않고 실패합니다. 빈 프로젝트 고정값과 일치하는 `direct` 규칙은 명시적인 운영자 예외로 유지됩니다.
+
+목적지별 규칙은 "`*.corp.internal`은 사내 프록시로, 나머지는 직결"을 표현하고 자격증명을 실으며 서로 다른 프록시를 선택할 수 있습니다.
 
 규칙은 **순서가 있고 첫 일치가 이깁니다**. 구체적인 규칙을 위에 두세요. 편집은 `gori settings --edit`.
 
@@ -243,7 +247,7 @@ gori가 `succeeded`로 답하기 전에 두 가지를 검사하고, 각각 연�
       "username": "alice",
       "password_env": "CORP_PROXY_PASS"
     },
-    { "host": "*.onion", "kind": "socks5", "addr": "127.0.0.1:9050" }
+    { "host": "*.onion", "kind": "socks5h", "addr": "127.0.0.1:9050" }
   ]
 }
 ```
@@ -251,14 +255,14 @@ gori가 `succeeded`로 답하기 전에 두 가지를 검사하고, 각각 연�
 | Key | Type | Description |
 |-----|------|-------------|
 | `host` | string | 호스트 패턴. 스코프 `host` 룰과 같은 문법 — `corp.internal`은 해당 호스트와 서브도메인, `*.corp.internal`은 글롭, `*`는 catch-all. 대소문자 무관 |
-| `kind` | string | `direct`, `http`, `socks5`. 알 수 없는 kind는 규칙을 버립니다(`direct`로 취급하면 의도한 프록시를 조용히 비활성화하게 되므로) |
-| `addr` | string | 프록시 `host:port`. 포트 기본값은 `http`가 `8080`, `socks5`가 `1080`. `direct`에는 없어야 합니다 |
-| `username` | string | 선택. `http`는 HTTP Basic(RFC 7617), `socks5`는 RFC 1929 교환으로 전송 |
+| `kind` | string | `direct`, `http`, `socks5`(로컬 DNS), `socks5h`(프록시 DNS). 알 수 없는 kind는 규칙을 버립니다(`direct`로 취급하면 의도한 프록시를 조용히 비활성화하게 되므로) |
+| `addr` | string | 프록시 `host:port`. 포트 기본값은 `http`가 `8080`, 두 SOCKS kind가 `1080`. `direct`에는 없어야 합니다 |
+| `username` | string | 선택. `http`는 HTTP Basic(RFC 7617), 두 SOCKS kind는 RFC 1929 교환으로 전송 |
 | `password_env` | string | 선택. 비밀번호를 담은 **OS 환경변수의 이름** |
 
-**자격증명은 `settings.json`에 저장되지 않습니다.** 사용자명과 환경변수 *이름*만 기록되고, 비밀번호는 dial 시점에 OS 환경에서 읽습니다. 따라서 `export CORP_PROXY_PASS=…`가 재시작 없이 반영됩니다. gori 자체의 `env` 섹션은 의도적으로 쓰지 않습니다 — 그 변수들은 `settings.json`에 평문으로 저장되므로, 결국 다른 경로로 비밀을 파일에 넣는 셈이고 설정 공유·내보내기([#439](https://github.com/hahwul/gori/issues/439))를 무의미하게 만듭니다. `$`가 포함된 `password_env`는 거부됩니다 — 값이 아니라 변수 이름을 담는 필드입니다.
+**전역 규칙 비밀번호는 `settings.json`에 저장되지 않습니다.** 사용자명과 환경변수 *이름*만 기록되고, 비밀번호는 dial 시점에 OS 환경에서 읽습니다. 따라서 `export CORP_PROXY_PASS=…`가 재시작 없이 반영됩니다. gori 자체의 `env` 섹션은 의도적으로 쓰지 않습니다 — 그 변수들은 `settings.json`에 평문으로 저장되므로, 결국 다른 경로로 비밀을 파일에 넣는 셈이고 설정 공유·내보내기([#439](https://github.com/hahwul/gori/issues/439))를 무의미하게 만듭니다. `$`가 포함된 `password_env`는 거부됩니다 — 값이 아니라 변수 이름을 담는 필드입니다. Project settings에서 직접 입력한 자격증명의 저장 방식은 [프로젝트별 오버라이드](#per-project-overrides)를 참고하세요.
 
-`socks5`의 경우 호스트명 대상은 `ATYP DOMAIN`으로 전송되어 **프록시가** 이름을 해석합니다(`socks5h` 동작). Tor나 점프호스트 뒤의 도달 불가 네트워크가 이 덕분에 동작하며, gori 자체는 dial 경로에서 이름을 해석하지 않습니다.
+스칼라와 규칙은 같은 DNS 구분을 사용합니다. `socks5`는 gori 호스트에서 대상 이름을 조회하고, `socks5h`는 프록시에 조회를 맡깁니다. Tor, 분할 DNS, 로컬에서 해석할 수 없는 이름을 아는 점프호스트에는 `socks5h`를 사용하세요. 로컬 조회가 실패하면 프록시에 연결하기 전에 중단되며 원 서버 직결로 폴백하지 않습니다.
 
 우선순위(높은 것부터):
 
@@ -444,7 +448,7 @@ TUI 맨 아래에 선택적으로 추가되는 행입니다 (Preferences → **G
 | `capturing` | bool | 프록시가 현재 캡처 중인지 여부 |
 | `flows` | integer | 캡처한 플로우 수 |
 | `proxy.host` / `proxy.port` / `proxy.addr` | string / integer / string | 프록시가 실제로 리스닝 중인 주소 |
-| `upstream` | string | **캐치올** 업스트림 프록시 `host:port`, 직접 연결이면 비어 있음. [업스트림 규칙](#upstream_rules)에 걸린 목적지는 다른 경로로 나가며, 이 필드는 그것을 반영하지 않음 |
+| `upstream` | string | **캐치올** 업스트림 프록시 주소/URI, 직접 연결이면 비어 있음. [업스트림 규칙](#upstream_rules)에 걸린 목적지는 다른 경로로 나가며, 이 필드는 그것을 반영하지 않음 |
 | `upstream_rules` | integer | 적용 중인 [업스트림 규칙](#upstream_rules) 수. 0이 아니면 라우팅이 목적지별로 갈라지므로 `upstream` 하나로는 트래픽 경로를 설명할 수 없음 |
 
 ### display {#display}
@@ -758,13 +762,19 @@ Fuzzer의 Payload 오버레이가 기억하는 워드리스트 경로입니다. 
 
 ## 프로젝트별 오버라이드 {#per-project-overrides}
 
-프로젝트는 전역 파일을 수정하지 않고도 자체 네트워크 설정을 고정할 수 있습니다. 이 값들은 프로젝트 데이터베이스에 저장되며(키 `net.bind_host`, `net.bind_port`, `net.upstream_proxy`, `net.connect_timeout_secs`, `net.io_timeout_secs`, `net.capture_max_mib`), **Project** 탭의 **PROJECT SETTINGS** 서브탭에서 편집합니다.
+프로젝트는 전역 파일을 수정하지 않고도 자체 네트워크 설정을 고정할 수 있습니다. 이 값들은 프로젝트 데이터베이스에 저장되며(키 `net.bind_host`, `net.bind_port`, `net.upstream_proxy`, `net.upstream_destination_host`, `net.upstream_auth`, `net.connect_timeout_secs`, `net.io_timeout_secs`, `net.capture_max_mib`), **Project** 탭의 **Project settings** 서브탭에서 편집합니다.
+
+**Destination host**는 프록시 라우팅을 대소문자를 구분하지 않는 하나의 호스트 패턴으로 제한합니다. 기본값 `*`는 모든 목적지를 프록시 대상으로 허용합니다. `example.com`은 해당 호스트와 서브도메인을 포함하고, `*.example.com`은 서브도메인만 포함합니다. 도메인, IPv4, IPv6 및 `*` 기반 IP 패턴을 사용할 수 있습니다. 일치하지 않는 목적지는 항상 직접 연결되며 `upstream_rules`나 `network.upstream_proxy`로 폴백하지 않습니다. 이 게이트는 프로젝트가 활성화된 동안 캡처, 재생, 스캐너, 업데이터 및 OAST 트래픽을 포함해 gori가 여는 모든 연결에 적용됩니다.
+
+인증하려면 **Proxy protocol**을 고르고 **Proxy host**와 **Proxy port**를 입력한 뒤 **Proxy auth**를 켜고 **Username**과 **Password**를 입력합니다. **SOCKS5**는 대상 이름을 로컬에서, **SOCKS5H**는 프록시에서 해석합니다. HTTP는 Basic 인증을, 두 SOCKS 프로토콜은 RFC 1929 사용자명/비밀번호 인증을 사용합니다. NTLM은 지원하지 않습니다. 인증을 켜면 표시 중인 업스트림 주소가 전역 설정에서 상속된 값이더라도 항상 프로젝트에 고정됩니다. 따라서 나중에 전역 경로나 목적지 규칙이 바뀌어 자격증명이 다른 프록시로 전송되지 않습니다.
+
+비밀번호는 **Password** 행에 포커스가 있어 편집하는 동안 표시되고, 포커스가 벗어나면 다시 마스킹됩니다. 캡처된 engagement 데이터와 함께 소유자 전용(`0600`) 프로젝트 SQLite 데이터베이스에는 평문으로 저장됩니다. 프로젝트에 비밀을 저장하면 안 되는 경우 `password_env`를 쓰는 전역 `upstream_rules` 항목을 사용하세요. 일치하는 목적지에서는 잘못되거나 업스트림 주소 없이 남은 프로젝트 인증 값이 원 서버 연결 전에 fail-closed 처리됩니다.
 
 타임아웃과 캡처 상한 키는 머신 속성이 아니라 engagement 속성입니다 — 느린 내부 장비는 자체 유휴 타임아웃이 필요하고, 아주 큰 응답을 주는 대상은 자체 캡처 상한이 필요합니다. 어느 쪽이든 전역으로 올리면 다른 모든 프로젝트가 비용을 치릅니다.
 
-**어느 표면에 어느 키가 적용되는가.** bind 키 둘은 gori가 리스닝 소켓을 여는 곳에서만 의미가 있고, 나머지 넷은 gori가 밖으로 다이얼하거나 바디를 저장하는 모든 곳에 적용됩니다.
+**어느 표면에 어느 키가 적용되는가.** bind 키 둘은 gori가 리스닝 소켓을 여는 곳에서만 의미가 있고, 프록시 인증을 포함한 나머지 키는 gori가 밖으로 다이얼하거나 바디를 저장하는 모든 곳에 적용됩니다.
 
-| 표면 | `bind_host` / `bind_port` | `upstream_proxy` / `connect_timeout_secs` / `io_timeout_secs` / `capture_max_mib` |
+| 표면 | `bind_host` / `bind_port` | 업스트림 / 목적지 / 인증 / 타임아웃 / 캡처 상한 |
 |------|---------------------------|-----------------------------------------------------------------------------------|
 | TUI (`gori`) | 적용 — 프록시가 고정된 주소로 리슨 | 적용 |
 | `gori run capture` | 적용 — 리슨하는 유일한 헤드리스 서브커맨드 (핀이 `--listen`/`--port`보다 우선) | 적용 |
@@ -775,12 +785,12 @@ Fuzzer의 Payload 오버레이가 기억하는 워드리스트 경로입니다. 
 
 | Priority | Source |
 |----------|--------|
-| 1 (최우선) | 설정되어 있으면 프로젝트 DB `net.bind_host` / `net.bind_port` / `net.upstream_proxy` / `net.connect_timeout_secs` / `net.io_timeout_secs` / `net.capture_max_mib` |
+| 1 (최우선) | 설정되어 있으면 프로젝트 DB `net.bind_host` / `net.bind_port` / `net.upstream_proxy` / `net.upstream_destination_host` / `net.upstream_auth` / 타임아웃 / 캡처 상한 |
 | 2 | CLI `--listen` / `--port` (전역 계층의 프로세스 한정 오버라이드) |
 | 3 | `settings.json` `network.*` |
 | 4 (최하위) | 공장 기본값 `127.0.0.1:8070` / 직접 연결 |
 
-현재 전역 값과 같은 Project 탭 필드를 저장하면 해당 KV 키가 삭제되므로, 프로젝트는 중복을 고정하는 대신 이후의 전역 변경을 계속 상속합니다.
+현재 전역 값과 같은 Project 탭 필드를 저장하면 해당 KV 키가 삭제되므로, 프로젝트는 중복을 고정하는 대신 이후의 전역 변경을 계속 상속합니다. **Destination host**에는 전역 대응 값이 없으며, 기본값 `*`를 저장하면 프로젝트 키가 삭제됩니다.
 
 ## 프로젝트와 데이터베이스 {#projects-database}
 

--- a/docs/content/reference/config.md
+++ b/docs/content/reference/config.md
@@ -43,7 +43,7 @@ Its location resolves as `--config PATH` → `$GORI_CONFIG` → `$GORI_HOME/sett
 |-----|------|---------|-------------|
 | `bind_host` | string | `127.0.0.1` | Global default listen address (used when a project has no `net.bind_host`) |
 | `bind_port` | integer | `8070` | Global default listen port (used when a project has no `net.bind_port`) |
-| `upstream_proxy` | string | `""` | Global default upstream (`host:port`); empty = direct. Project `net.upstream_proxy` wins when set |
+| `upstream_proxy` | string | `""` | Global default upstream: legacy `host:port`/`http://…`, or `socks5://…`/`socks5h://…`; empty = direct. Project `net.upstream_proxy` wins when set |
 | `verify_upstream` | bool | `true` | Verify upstream TLS certificates against the system CA trust store, resolved automatically from standard locations (honouring `SSL_CERT_FILE` / `SSL_CERT_DIR`); if none is found, HTTPS verification fails — set `SSL_CERT_FILE` or turn this off. Toggling it re-syncs the running proxy, the active prober, and the Repeater / Fuzzer / Miner senders without a restart. `--insecure-upstream` seeds it off for one session |
 | `serve_landing` | bool | `true` | Serve the built-in info / CA-download page, both when the listen address is hit directly and at the reserved host `http://gori.proxy/` (or `http://gori/`) for a client already pointed at the proxy |
 | `connect_timeout_secs` | integer | `30` | Upstream connect timeout in seconds (minimum `1`) |
@@ -228,7 +228,11 @@ Every refusal is recorded in the project as a flow carrying its reason, too. A c
 
 ### upstream_rules
 
-Per-destination upstream routing. `network.upstream_proxy` is a single address for *everything*; a rule table can say "route `*.corp.internal` through the internal proxy, everything else direct", carry credentials, and reach a SOCKS proxy.
+`network.upstream_proxy` is the catch-all route. Bare `host:port`, `http://…` (and the legacy `https://…` spelling) use an HTTP CONNECT proxy. `socks5://…` resolves destination names **locally** and sends an address literal; `socks5h://…` sends hostname targets as `ATYP DOMAIN` so the **proxy** resolves them. Both default to port 1080. URI credentials are refused—configure direct credentials in the Project tab, or use an `upstream_rules` entry with `username` and `password_env`.
+
+All networking owned by gori uses this routing decision, including capture/replay/scan engines, the updater, and OAST provider traffic. A configured proxy that is malformed, unreachable, or refuses a tunnel fails closed; gori does not retry the destination directly. A blank project pin and a matching `direct` rule remain explicit operator exceptions.
+
+Per-destination upstream routing can say "route `*.corp.internal` through the internal proxy, everything else direct", carry credentials, and choose different proxies.
 
 Rules are **ordered** and the **first match wins**, so specific rules go above general ones. Edit them with `gori settings --edit`.
 
@@ -243,7 +247,7 @@ Rules are **ordered** and the **first match wins**, so specific rules go above g
       "username": "alice",
       "password_env": "CORP_PROXY_PASS"
     },
-    { "host": "*.onion", "kind": "socks5", "addr": "127.0.0.1:9050" }
+    { "host": "*.onion", "kind": "socks5h", "addr": "127.0.0.1:9050" }
   ]
 }
 ```
@@ -251,14 +255,14 @@ Rules are **ordered** and the **first match wins**, so specific rules go above g
 | Key | Type | Description |
 |-----|------|-------------|
 | `host` | string | Host pattern, same dialect as scope `host` rules: `corp.internal` covers that host and its subdomains, `*.corp.internal` is a glob, `*` is the catch-all. Case-insensitive |
-| `kind` | string | `direct`, `http`, or `socks5`. An unknown kind drops the rule rather than being treated as `direct`, which would quietly disable an intended proxy |
-| `addr` | string | Proxy `host:port`. Port defaults to `8080` for `http` and `1080` for `socks5`. Must be absent for `direct` |
-| `username` | string | Optional. Sent as HTTP Basic (RFC 7617) for `http`, or via the RFC 1929 exchange for `socks5` |
+| `kind` | string | `direct`, `http`, `socks5` (local DNS), or `socks5h` (proxy DNS). An unknown kind drops the rule rather than being treated as `direct`, which would quietly disable an intended proxy |
+| `addr` | string | Proxy `host:port`. Port defaults to `8080` for `http` and `1080` for either SOCKS kind. Must be absent for `direct` |
+| `username` | string | Optional. Sent as HTTP Basic (RFC 7617) for `http`, or via the RFC 1929 exchange for either SOCKS kind |
 | `password_env` | string | Optional. The **name** of an OS environment variable holding the password |
 
-**Credentials are never stored in `settings.json`.** Only the username and the environment-variable *name* are written; the password is read from the OS environment at dial time, so `export CORP_PROXY_PASS=…` takes effect without a restart. gori's own `env` section is deliberately not used for this — those variables live in `settings.json` in plaintext, which would put the secret in the file by another route and defeat sharing or exporting a config (see [#439](https://github.com/hahwul/gori/issues/439)). A `password_env` containing `$` is rejected: it holds a variable name, not a value.
+**Global-rule passwords are never stored in `settings.json`.** Only the username and the environment-variable *name* are written; the password is read from the OS environment at dial time, so `export CORP_PROXY_PASS=…` takes effect without a restart. gori's own `env` section is deliberately not used for this — those variables live in `settings.json` in plaintext, which would put the secret in the file by another route and defeat sharing or exporting a config (see [#439](https://github.com/hahwul/gori/issues/439)). A `password_env` containing `$` is rejected: it holds a variable name, not a value. Direct credentials entered in Project settings have different storage described under [Per-Project Overrides](#per-project-overrides).
 
-For `socks5`, a hostname target is sent as `ATYP DOMAIN` so the **proxy** resolves it (the `socks5h` behaviour). That is what makes Tor and a jump host into an otherwise unreachable network work; gori does not resolve names on the dial path itself.
+The scalar and rules use the same DNS distinction: `socks5` performs the destination lookup on the gori host, while `socks5h` delegates it to the proxy. Use `socks5h` for Tor, split DNS, or a jump host that can resolve names unavailable locally. A failed local lookup stops before connecting to the proxy and never falls back to a direct origin connection.
 
 Precedence, highest first:
 
@@ -268,6 +272,10 @@ Precedence, highest first:
 | 2 | `upstream_rules`, first host match |
 | 3 | `network.upstream_proxy` — the implicit catch-all |
 | 4 (lowest) | Direct |
+
+For an open project, **Destination host** is evaluated before this table. `*` (the default)
+leaves the precedence above unchanged; a non-matching destination goes direct without falling
+through to a global rule or scalar proxy.
 
 A rule is matched against the **original** hostname, before any [host override](#hostname_overrides) is applied — an override only changes which IP is dialled.
 
@@ -452,7 +460,7 @@ Each run receives a JSON context on stdin describing the live session, so script
 | `capturing` | bool | Whether the proxy is currently capturing |
 | `flows` | integer | Number of captured flows |
 | `proxy.host` / `proxy.port` / `proxy.addr` | string / integer / string | The address the proxy is actually listening on |
-| `upstream` | string | The **catch-all** upstream proxy `host:port`, or empty when connecting directly. A destination matched by an [upstream rule](#upstream_rules) routes elsewhere — this field does not reflect that |
+| `upstream` | string | The **catch-all** upstream proxy address/URI, or empty when connecting directly. A destination matched by an [upstream rule](#upstream_rules) routes elsewhere — this field does not reflect that |
 | `upstream_rules` | integer | Number of [upstream rules](#upstream_rules) in effect. Non-zero means routing is per-destination and `upstream` alone does not describe where traffic goes |
 
 ### display
@@ -772,13 +780,19 @@ Omitted until you apply or star a wordlist.
 
 ## Per-Project Overrides
 
-A project can pin its own network settings without editing the global file. These are stored in the project database (keys `net.bind_host`, `net.bind_port`, `net.upstream_proxy`, `net.connect_timeout_secs`, `net.io_timeout_secs`, `net.capture_max_mib`) and edited from the **Project** tab's **PROJECT SETTINGS** sub-tab.
+A project can pin its own network settings without editing the global file. These are stored in the project database (keys `net.bind_host`, `net.bind_port`, `net.upstream_proxy`, `net.upstream_destination_host`, `net.upstream_auth`, `net.connect_timeout_secs`, `net.io_timeout_secs`, `net.capture_max_mib`) and edited from the **Project** tab's **Project settings** sub-tab.
+
+**Destination host** limits proxy routing to one case-insensitive host pattern. `*` is the default and makes every destination eligible; `example.com` covers that host and its subdomains, while `*.example.com` covers subdomains only. Domain, IPv4, IPv6, and `*`-based IP patterns are accepted. A non-match always goes direct and does not fall through to `upstream_rules` or `network.upstream_proxy`. This gate applies to every gori-owned dial while the project is active, including capture, replay, scanners, the updater, and OAST traffic.
+
+To authenticate, choose a **Proxy protocol**, enter the **Proxy host** and **Proxy port**, turn **Proxy auth** on, then enter **Username** and **Password**. **SOCKS5** resolves destination names locally; **SOCKS5H** resolves them at the proxy. HTTP uses Basic authentication, while either SOCKS protocol uses RFC 1929 username/password authentication. NTLM is not supported. Turning authentication on always pins the displayed upstream address to the project—even when it was inherited from the global setting—so the credentials cannot later follow a changed global route or a destination rule.
+
+The password is visible while the **Password** row is focused for editing and masked again when focus leaves. It is stored as plaintext inside the project's owner-only (`0600`) SQLite database, alongside captured engagement data that may already contain credentials. Use a global `upstream_rules` entry with `password_env` instead when the secret must not be stored in a project. For a matching destination, a malformed or orphaned project auth value fails closed before an origin connection.
 
 The timeout and capture-limit keys are engagement properties rather than machine ones: a slow internal appliance needs its own idle timeout, and one target returning very large responses needs its own capture cap — raising either globally would tax every other project.
 
-**Which surfaces apply which keys.** The two bind keys only mean something where gori opens a listening socket; the other four apply wherever gori dials out or stores a body.
+**Which surfaces apply which keys.** The two bind keys only mean something where gori opens a listening socket; all other keys, including proxy authentication, apply wherever gori dials out or stores a body.
 
-| Surface | `bind_host` / `bind_port` | `upstream_proxy` / `connect_timeout_secs` / `io_timeout_secs` / `capture_max_mib` |
+| Surface | `bind_host` / `bind_port` | upstream / destination / auth / timeouts / capture limit |
 |---------|---------------------------|-----------------------------------------------------------------------------------|
 | TUI (`gori`) | applied — the proxy listens on the pinned address | applied |
 | `gori run capture` | applied — the one headless subcommand that listens (the pin wins over `--listen`/`--port`) | applied |
@@ -789,12 +803,12 @@ The timeout and capture-limit keys are engagement properties rather than machine
 
 | Priority | Source |
 |----------|--------|
-| 1 (highest) | Project DB `net.bind_host` / `net.bind_port` / `net.upstream_proxy` / `net.connect_timeout_secs` / `net.io_timeout_secs` / `net.capture_max_mib` when set |
+| 1 (highest) | Project DB `net.bind_host` / `net.bind_port` / `net.upstream_proxy` / `net.upstream_destination_host` / `net.upstream_auth` / timeouts / capture limit when set |
 | 2 | CLI `--listen` / `--port` (process-only override of the global layer) |
 | 3 | `settings.json` `network.*` |
 | 4 (lowest) | Factory defaults `127.0.0.1:8070` / direct |
 
-Saving a Project-tab field that equals the current global value deletes that KV key, so the project keeps inheriting future global edits instead of freezing a duplicate.
+Saving a Project-tab field that equals the current global value deletes that KV key, so the project keeps inheriting future global edits instead of freezing a duplicate. **Destination host** has no global counterpart; saving its default `*` deletes its project key.
 
 ## Projects & Database
 

--- a/spec/capture_status_spec.cr
+++ b/spec/capture_status_spec.cr
@@ -1,5 +1,6 @@
 require "./spec_helper"
 require "file_utils"
+require "socket"
 
 private def with_root(&)
   root = File.tempname("gori-projects")
@@ -67,6 +68,23 @@ describe Gori::CaptureLock do
 end
 
 describe Gori::Session, "capture status sidecar" do
+  # Session.open replaces its Config bind with the effective Settings bind. Isolate these
+  # examples from a developer's live proxy on the default port, then restore the global layer.
+  around_each do |example|
+    saved_bind_port = Gori::Settings.bind_port
+    saved_cli_bind_port = Gori::Settings.cli_bind_port
+    available = TCPServer.new("127.0.0.1", 0)
+    Gori::Settings.bind_port = available.local_address.port
+    Gori::Settings.cli_bind_port = nil
+    available.close
+    begin
+      example.run
+    ensure
+      Gori::Settings.bind_port = saved_bind_port
+      Gori::Settings.cli_bind_port = saved_cli_bind_port
+    end
+  end
+
   it "writes status on open and clears on close" do
     with_root do |root|
       ca = Gori::Proxy::Tls::CertAuthority.load_or_create(File.join(root, "ca"))

--- a/spec/cli/run_spec.cr
+++ b/spec/cli/run_spec.cr
@@ -698,7 +698,7 @@ end
 # #538 — `CLI::Run.open_store` is the second caller of Settings.load_project_network. Every
 # `gori run` subcommand except `capture` reads its project through here, and none of them
 # LISTENS (capture opens its project through Session.open instead), so the loader is called
-# with bind: false: the pinned upstream / timeouts / capture cap apply, the bind pair does not.
+# with bind: false: the pinned upstream/auth / timeouts / capture cap apply, the bind pair does not.
 module Gori::CLI::Run
   def self.open_store_for_spec(project : Project) : Store
     open_store(project)
@@ -712,6 +712,9 @@ describe "Gori::CLI::Run.open_store per-project network overrides" do
     seed.set_setting(Gori::Settings::PROJECT_BIND_HOST_KEY, "0.0.0.0")
     seed.set_setting(Gori::Settings::PROJECT_BIND_PORT_KEY, "9100")
     seed.set_setting(Gori::Settings::PROJECT_UPSTREAM_KEY, "jump:8888")
+    seed.set_setting(Gori::Settings::PROJECT_UPSTREAM_DESTINATION_KEY, "*.example.com")
+    seed.set_setting(Gori::Settings::PROJECT_UPSTREAM_AUTH_KEY,
+      Gori::Settings::ProjectProxyAuth.new("basic", "runner", "secret").to_json)
     seed.set_setting(Gori::Settings::PROJECT_CONNECT_TIMEOUT_KEY, "7")
     seed.set_setting(Gori::Settings::PROJECT_IO_TIMEOUT_KEY, "9")
     seed.set_setting(Gori::Settings::PROJECT_CAPTURE_MAX_KEY, "16")
@@ -721,7 +724,10 @@ describe "Gori::CLI::Run.open_store per-project network overrides" do
     begin
       # The dial decision the fuzzer/miner/repeater actually consult.
       route = Gori::Settings.upstream_route("example.com")
+      route.direct?.should be_true
+      route = Gori::Settings.upstream_route("api.example.com")
       {route.kind, route.host, route.port}.should eq({"http", "jump", 8888})
+      {route.username, route.password}.should eq({"runner", "secret"})
       Gori::Settings.effective_connect_timeout_secs.should eq(7)
       Gori::Settings.effective_io_timeout_secs.should eq(9)
       Gori::Settings.effective_capture_max_mib.should eq(16)
@@ -732,6 +738,9 @@ describe "Gori::CLI::Run.open_store per-project network overrides" do
     ensure
       store.close
       Gori::Settings.project_upstream_proxy = nil
+      Gori::Settings.project_upstream_destination = nil
+      Gori::Settings.project_upstream_auth = nil
+      Gori::Settings.project_upstream_auth_error = nil
       Gori::Settings.project_connect_timeout_secs = nil
       Gori::Settings.project_io_timeout_secs = nil
       Gori::Settings.project_capture_max_mib = nil
@@ -747,6 +756,7 @@ describe "Gori::CLI::Run.open_store per-project network overrides" do
     store = Gori::CLI::Run.open_store_for_spec(Gori::Project.new("plain", path))
     begin
       Gori::Settings.project_upstream_proxy.should be_nil
+      Gori::Settings.project_upstream_destination.should be_nil
       Gori::Settings.effective_capture_max_mib.should eq(Gori::Settings.capture_max_mib)
       Gori::Settings.effective_connect_timeout_secs.should eq(Gori::Settings.connect_timeout_secs)
     ensure

--- a/spec/egress_seam_spec.cr
+++ b/spec/egress_seam_spec.cr
@@ -1,0 +1,24 @@
+require "./spec_helper"
+
+# Keep app-owned socket and HTTP-client constructors behind the reviewed routing seams.
+# Comments may name the APIs; executable lines may not grow a second dial policy.
+describe "egress seams" do
+  it "keeps sockets and HTTP clients in their single owners" do
+    root = File.expand_path(File.join(__DIR__, ".."))
+    offenders = [] of String
+    Dir.glob(File.join(root, "src", "gori", "**", "*.cr")).sort.each do |path|
+      relative = Path[path].relative_to(root).to_s
+      File.read_lines(path).each_with_index do |line, index|
+        next if line.lstrip.starts_with?('#')
+        if line.matches?(/\b(?:TCPSocket|UDPSocket)\.new|\bSocket\.(?:tcp|udp)/) &&
+           relative != "src/gori/proxy/upstream.cr"
+          offenders << "#{relative}:#{index + 1}: direct socket: #{line.strip}"
+        end
+        if line.includes?("HTTP::Client.new") && relative != "src/gori/http_transport.cr"
+          offenders << "#{relative}:#{index + 1}: direct HTTP client: #{line.strip}"
+        end
+      end
+    end
+    fail("app egress bypasses its routing seam:\n#{offenders.join("\n")}") unless offenders.empty?
+  end
+end

--- a/spec/http_transport_spec.cr
+++ b/spec/http_transport_spec.cr
@@ -1,0 +1,113 @@
+require "./spec_helper"
+require "socket"
+
+private def reset_http_transport_proxy : Nil
+  Gori::Settings.upstream_rules = [] of Gori::Settings::UpstreamRule
+  Gori::Settings.upstream_proxy = ""
+  Gori::Settings.project_upstream_proxy = nil
+  Gori::Settings.project_upstream_destination = nil
+end
+
+# A one-shot SOCKS5 tunnel whose far side is a tiny HTTP origin. The hostname is deliberately
+# not resolvable locally; receiving it as ATYP DOMAIN is proof the target lookup stayed remote.
+private def with_socks_http_response(body : String, &)
+  server = TCPServer.new("127.0.0.1", 0)
+  seen = Channel({UInt8, String, String}).new(1)
+  spawn do
+    conn = server.accept
+    greeting = Bytes.new(2)
+    conn.read_fully(greeting)
+    conn.read_fully(Bytes.new(greeting[1].to_i))
+    conn.write(Bytes[5_u8, 0_u8])
+    request = Bytes.new(4)
+    conn.read_fully(request)
+    len = Bytes.new(1)
+    conn.read_fully(len)
+    host_bytes = Bytes.new(len[0].to_i)
+    conn.read_fully(host_bytes)
+    port = Bytes.new(2)
+    conn.read_fully(port)
+    conn.write(Bytes[5_u8, 0_u8, 0_u8, 1_u8, 0_u8, 0_u8, 0_u8, 0_u8, 0_u8, 0_u8])
+    conn.flush
+    head = String::Builder.new
+    while (line = conn.gets("\r\n", chomp: true)) && !line.empty?
+      head << line << "\n"
+    end
+    seen.send({request[3], String.new(host_bytes), head.to_s})
+    conn << "HTTP/1.1 200 OK\r\nContent-Length: #{body.bytesize}\r\nConnection: close\r\n\r\n#{body}"
+    conn.flush
+    conn.close rescue nil
+  rescue
+  end
+  begin
+    yield server.local_address.port, seen
+  ensure
+    server.close rescue nil
+  end
+end
+
+describe Gori::HttpTransport do
+  it "performs HTTP over scalar SOCKS5H with proxy-side DNS and the correct Host header" do
+    with_socks_http_response("ok") do |port, seen|
+      Gori::Settings.upstream_proxy = "socks5h://127.0.0.1:#{port}"
+      uri = URI.parse("http://remote-only.invalid/resource")
+      client = Gori::HttpTransport.client(uri)
+      begin
+        client.get(uri.request_target).body.should eq("ok")
+      ensure
+        client.close
+      end
+      atyp, host, head = seen.receive
+      atyp.should eq(3_u8)
+      host.should eq("remote-only.invalid")
+      head.should contain("Host: remote-only.invalid")
+    end
+  ensure
+    reset_http_transport_proxy
+  end
+
+  it "carries Update and OAST through the same routed client" do
+    release = %({"tag_name":"v9.9.9","assets":[]})
+    with_socks_http_response(release) do |port, seen|
+      Gori::Settings.upstream_proxy = "socks5h://127.0.0.1:#{port}"
+      Gori::Update.fetch_latest_release_json("http://updates.remote-only.invalid/latest").should eq(release)
+      seen.receive[1].should eq("updates.remote-only.invalid")
+    end
+
+    with_socks_http_response("callbacks") do |port, seen|
+      Gori::Settings.upstream_proxy = "socks5h://127.0.0.1:#{port}"
+      response = Gori::Oast::HttpClient.new.request("GET", "http://oast.remote-only.invalid/poll")
+      response.body.should eq("callbacks")
+      seen.receive[1].should eq("oast.remote-only.invalid")
+    end
+  ensure
+    reset_http_transport_proxy
+  end
+
+  it "does not fall back to the origin when the configured proxy is unreachable" do
+    origin = TCPServer.new("127.0.0.1", 0)
+    accepted = Channel(Nil).new(1)
+    spawn do
+      conn = origin.accept
+      accepted.send(nil)
+      conn.close
+    rescue
+    end
+    dead = TCPServer.new("127.0.0.1", 0)
+    dead_port = dead.local_address.port
+    dead.close
+    Gori::Settings.upstream_proxy = "socks5://127.0.0.1:#{dead_port}"
+
+    expect_raises(Gori::HttpTransport::Error) do
+      Gori::HttpTransport.client(URI.parse("http://127.0.0.1:#{origin.local_address.port}/"))
+    end
+    select
+    when accepted.receive
+      fail("origin was contacted after the proxy failed")
+    when timeout(50.milliseconds)
+    end
+  ensure
+    origin.try(&.close) rescue nil
+    reset_http_transport_proxy
+  end
+end

--- a/spec/mcp_spec.cr
+++ b/spec/mcp_spec.cr
@@ -4715,7 +4715,7 @@ describe "MCP get_current_context" do
 end
 
 # #538 — the MCP server is the third caller of Settings.load_project_network. It never opens
-# a listening socket (OAST polls a remote collector), so it binds the four outbound/capture
+# a listening socket (OAST polls a remote collector), so it binds the outbound/capture
 # keys and none of the bind pair.
 describe "MCP per-project network overrides" do
   it "installs the project's upstream/timeouts/capture cap at bind time, and no bind address" do
@@ -4723,6 +4723,9 @@ describe "MCP per-project network overrides" do
       store.set_setting(Gori::Settings::PROJECT_BIND_HOST_KEY, "0.0.0.0")
       store.set_setting(Gori::Settings::PROJECT_BIND_PORT_KEY, "9100")
       store.set_setting(Gori::Settings::PROJECT_UPSTREAM_KEY, "jump:8888")
+      store.set_setting(Gori::Settings::PROJECT_UPSTREAM_DESTINATION_KEY, "*.example.com")
+      store.set_setting(Gori::Settings::PROJECT_UPSTREAM_AUTH_KEY,
+        Gori::Settings::ProjectProxyAuth.new("basic", "agent", "secret").to_json)
       store.set_setting(Gori::Settings::PROJECT_CONNECT_TIMEOUT_KEY, "7")
       store.set_setting(Gori::Settings::PROJECT_IO_TIMEOUT_KEY, "9")
       store.set_setting(Gori::Settings::PROJECT_CAPTURE_MAX_KEY, "16")
@@ -4730,18 +4733,25 @@ describe "MCP per-project network overrides" do
       Gori::MCP::Tools.new(store, allow_actions: true, verify_upstream: false)
 
       Gori::Settings.project_upstream_proxy.should eq("jump:8888")
+      Gori::Settings.project_upstream_destination.should eq("*.example.com")
       Gori::Settings.project_connect_timeout_secs.should eq(7)
       Gori::Settings.project_io_timeout_secs.should eq(9)
       Gori::Settings.project_capture_max_mib.should eq(16)
       # The dial decision Upstream.dial consults — the actual defect in #538 was `send_request`
       # and `fuzz_start` reaching a pinned project's targets DIRECT.
       route = Gori::Settings.upstream_route("example.com")
+      route.direct?.should be_true
+      route = Gori::Settings.upstream_route("api.example.com")
       {route.kind, route.host, route.port}.should eq({"http", "jump", 8888})
+      {route.username, route.password}.should eq({"agent", "secret"})
       # Nothing on this surface listens, so the bind pin must not be installed.
       Gori::Settings.project_bind_host.should be_nil
       Gori::Settings.project_bind_port.should be_nil
     ensure
       Gori::Settings.project_upstream_proxy = nil
+      Gori::Settings.project_upstream_destination = nil
+      Gori::Settings.project_upstream_auth = nil
+      Gori::Settings.project_upstream_auth_error = nil
       Gori::Settings.project_connect_timeout_secs = nil
       Gori::Settings.project_io_timeout_secs = nil
       Gori::Settings.project_capture_max_mib = nil
@@ -4751,14 +4761,21 @@ describe "MCP per-project network overrides" do
   it "clears a previous project's pins when it binds an unpinned project" do
     with_store do |store|
       Gori::Settings.project_upstream_proxy = "stale:8888"
+      Gori::Settings.project_upstream_destination = "stale.test"
+      Gori::Settings.project_upstream_auth = Gori::Settings::ProjectProxyAuth.new("basic", "stale", "old")
       Gori::Settings.project_capture_max_mib = 64
 
       Gori::MCP::Tools.new(store, allow_actions: true, verify_upstream: false)
 
       Gori::Settings.project_upstream_proxy.should be_nil
+      Gori::Settings.project_upstream_destination.should be_nil
+      Gori::Settings.project_upstream_auth.should be_nil
       Gori::Settings.project_capture_max_mib.should be_nil
     ensure
       Gori::Settings.project_upstream_proxy = nil
+      Gori::Settings.project_upstream_destination = nil
+      Gori::Settings.project_upstream_auth = nil
+      Gori::Settings.project_upstream_auth_error = nil
       Gori::Settings.project_capture_max_mib = nil
     end
   end

--- a/spec/project_registry_spec.cr
+++ b/spec/project_registry_spec.cr
@@ -230,6 +230,24 @@ describe Gori::ProjectRegistry do
 end
 
 describe Gori::Session do
+  # Session.open installs the effective Settings bind over its Config, so these examples must
+  # not inherit the developer's real default port. A running gori on 8070 otherwise turns every
+  # "first" session below into capture-off before the behavior under test is reached.
+  around_each do |example|
+    saved_bind_port = Gori::Settings.bind_port
+    saved_cli_bind_port = Gori::Settings.cli_bind_port
+    available = TCPServer.new("127.0.0.1", 0)
+    Gori::Settings.bind_port = available.local_address.port
+    Gori::Settings.cli_bind_port = nil
+    available.close
+    begin
+      example.run
+    ensure
+      Gori::Settings.bind_port = saved_bind_port
+      Gori::Settings.cli_bind_port = saved_cli_bind_port
+    end
+  end
+
   it "opens a project store + proxy and captures, then cleans up a temp project" do
     with_root do |root|
       ca_dir = File.join(root, "ca")

--- a/spec/proxy/upstream_rules_spec.cr
+++ b/spec/proxy/upstream_rules_spec.cr
@@ -6,6 +6,9 @@ private def reset_upstream : Nil
   Gori::Settings.upstream_rules = [] of Gori::Settings::UpstreamRule
   Gori::Settings.upstream_proxy = ""
   Gori::Settings.project_upstream_proxy = nil
+  Gori::Settings.project_upstream_destination = nil
+  Gori::Settings.project_upstream_auth = nil
+  Gori::Settings.project_upstream_auth_error = nil
 end
 
 private def rule(host : String, kind : String, addr : String = "",
@@ -164,11 +167,17 @@ describe "upstream rules" do
       reset_upstream
     end
 
-    it "defaults the port per kind: 8080 for http, 1080 for socks5" do
-      Gori::Settings.upstream_rules = [rule("a.test", "http", "p.test"), rule("b.test", "socks5", "s.test")]
+    it "defaults the port per kind: 8080 for http, 1080 for either SOCKS mode" do
+      Gori::Settings.upstream_rules = [
+        rule("a.test", "http", "p.test"),
+        rule("b.test", "socks5", "s.test"),
+        rule("c.test", "socks5h", "h.test"),
+      ]
       Gori::Settings.upstream_route("a.test").port.should eq(8080)
       Gori::Settings.upstream_route("b.test").port.should eq(1080)
       Gori::Settings.upstream_route("b.test").socks5?.should be_true
+      Gori::Settings.upstream_route("c.test").port.should eq(1080)
+      Gori::Settings.upstream_route("c.test").remote_dns?.should be_true
     ensure
       reset_upstream
     end
@@ -192,6 +201,52 @@ describe "upstream rules" do
       route = Gori::Settings.upstream_route("anything.test")
       route.host.should eq("pinned.test")
       route.port.should eq(9)
+    ensure
+      reset_upstream
+    end
+
+    it "uses the project destination pattern as a direct-or-proxy gate" do
+      Gori::Settings.upstream_rules = [rule("*", "http", "table.test:1")]
+      Gori::Settings.project_upstream_destination = "*.corp.test"
+
+      Gori::Settings.upstream_route("corp.test").direct?.should be_true
+      route = Gori::Settings.upstream_route("api.corp.test")
+      {route.kind, route.host, route.port}.should eq({"http", "table.test", 1})
+      Gori::Settings.upstream_route("outside.test").direct?.should be_true
+
+      Gori::Settings.project_upstream_destination = "10.*"
+      Gori::Settings.upstream_route("10.2.3.4").host.should eq("table.test")
+      Gori::Settings.upstream_route("11.2.3.4").direct?.should be_true
+
+      Gori::Settings.project_upstream_destination = "*"
+      Gori::Settings.upstream_route("outside.test").host.should eq("table.test")
+    ensure
+      reset_upstream
+    end
+
+    it "keeps credentials on matching destinations and sends non-matches direct" do
+      Gori::Settings.project_upstream_proxy = "http://proxy.test:8080"
+      Gori::Settings.project_upstream_destination = "target.test"
+      Gori::Settings.project_upstream_auth =
+        Gori::Settings::ProjectProxyAuth.new("basic", "alice", "secret")
+
+      route = Gori::Settings.upstream_route("api.target.test")
+      {route.host, route.username, route.password}.should eq({"proxy.test", "alice", "secret"})
+      Gori::Settings.upstream_route("outside.test").direct?.should be_true
+    ensure
+      reset_upstream
+    end
+
+    it "fails closed when a persisted destination pattern is invalid" do
+      Gori::Settings.project_upstream_destination = "https://target.test"
+      route = Gori::Settings.upstream_route("target.test")
+      route.invalid?.should be_true
+      route.configuration_error.to_s.should contain("destination proxy filter is invalid")
+
+      socket, error = Gori::Proxy::Upstream.dial_result("target.test", 443)
+      socket.should be_nil
+      error.try(&.kind).should eq(Gori::Proxy::Upstream::DialErrorKind::Proxy)
+      error.try(&.detail).to_s.should contain("origin was never contacted")
     ensure
       reset_upstream
     end
@@ -222,17 +277,53 @@ describe "upstream rules" do
       reset_upstream
     end
 
-    # A hand-edited file can hold a rule the validator would have rejected. Degrading to
-    # direct beats failing every dial for the host.
-    it "degrades a proxy rule with no address to direct" do
+    # A hand-edited file can hold a rule the validator would have rejected. Sending direct in
+    # that case would leak the exact destination the operator intended to proxy.
+    it "fails a proxy rule with no address closed" do
       Gori::Settings.upstream_rules = [rule("a.test", "http", "")]
-      Gori::Settings.upstream_route("a.test").direct?.should be_true
+      route = Gori::Settings.upstream_route("a.test")
+      route.invalid?.should be_true
+      route.direct?.should be_false
+
+      sock, err = Gori::Proxy::Upstream.dial_result("a.test", 443)
+      sock.should be_nil
+      err.try(&.kind).should eq(Gori::Proxy::Upstream::DialErrorKind::Proxy)
+      err.try(&.detail).to_s.should contain("origin was never contacted")
+    ensure
+      reset_upstream
+    end
+
+    it "fails a malformed host pattern closed instead of falling through to direct" do
+      Gori::Settings.upstream_rules = [rule("[", "http", "proxy.test:8080")]
+
+      route = Gori::Settings.upstream_route("origin.test")
+      route.invalid?.should be_true
+      route.direct?.should be_false
+      route.configuration_error.to_s.should contain("invalid upstream rule host pattern")
     ensure
       reset_upstream
     end
   end
 
   describe "HTTP proxy authentication" do
+    it "sends the Basic credentials saved in Project settings" do
+      with_capturing_http_proxy do |pport, head|
+        Gori::Settings.project_upstream_proxy = "http://127.0.0.1:#{pport}"
+        Gori::Settings.project_upstream_auth =
+          Gori::Settings::ProjectProxyAuth.new("basic", "project-user", "project-pass")
+
+        sock = Gori::Proxy::Upstream.dial("example.test", 443)
+        sock.should_not be_nil
+        sent = head.receive
+        sock.try(&.close) rescue nil
+
+        sent.should contain("CONNECT example.test:443 HTTP/1.1")
+        sent.should contain("Proxy-Authorization: Basic #{Base64.strict_encode("project-user:project-pass")}")
+      end
+    ensure
+      reset_upstream
+    end
+
     # The headline fix: before upstream rules, gori emitted no Proxy-Authorization at all, so
     # an authenticating proxy could not be used.
     it "sends Basic Proxy-Authorization when the rule carries credentials" do
@@ -286,16 +377,51 @@ describe "upstream rules" do
   end
 
   describe "SOCKS5" do
-    it "reaches a hostname target through a SOCKS5 proxy, letting the proxy resolve it" do
-      with_socks5_proxy do |sport, seen|
-        Gori::Settings.upstream_rules = [rule("*", "socks5", "127.0.0.1:#{sport}")]
-        sock = Gori::Proxy::Upstream.dial("example.test", 443)
+    it "uses Project settings credentials and delegates SOCKS5H DNS to the proxy" do
+      with_socks5_proxy(auth_method: 2_u8) do |sport, seen|
+        Gori::Settings.project_upstream_proxy = "socks5h://127.0.0.1:#{sport}"
+        Gori::Settings.project_upstream_auth =
+          Gori::Settings::ProjectProxyAuth.new("socks5", "project-user", "project-pass")
+
+        sock = Gori::Proxy::Upstream.dial("remote-only.test", 443)
         sock.should_not be_nil
         got = seen.receive
         sock.try(&.close) rescue nil
 
-        got[:atyp].should eq(3_u8) # ATYP DOMAIN — remote resolution ("socks5h"), not a local lookup
-        got[:addr].should eq("example.test")
+        got[:user].should eq("project-user")
+        got[:pass].should eq("project-pass")
+        got[:atyp].should eq(3_u8)
+        got[:addr].should eq("remote-only.test")
+      end
+    ensure
+      reset_upstream
+    end
+
+    it "uses the scalar socks5h:// form and sends hostnames as ATYP DOMAIN" do
+      with_socks5_proxy do |sport, seen|
+        Gori::Settings.upstream_proxy = "socks5h://127.0.0.1:#{sport}"
+        sock = Gori::Proxy::Upstream.dial("remote-only.test", 80)
+        sock.should_not be_nil
+        got = seen.receive
+        sock.try(&.close) rescue nil
+
+        got[:atyp].should eq(3_u8)
+        got[:addr].should eq("remote-only.test")
+      end
+    ensure
+      reset_upstream
+    end
+
+    it "resolves a hostname locally for a SOCKS5 rule and sends its address literal" do
+      with_socks5_proxy do |sport, seen|
+        Gori::Settings.upstream_rules = [rule("*", "socks5", "127.0.0.1:#{sport}")]
+        sock = Gori::Proxy::Upstream.dial("localhost", 443)
+        sock.should_not be_nil
+        got = seen.receive
+        sock.try(&.close) rescue nil
+
+        [1_u8, 4_u8].includes?(got[:atyp]).should be_true
+        got[:addr].should_not eq("localhost")
         got[:port].should eq(443)
       end
     ensure
@@ -338,7 +464,7 @@ describe "upstream rules" do
       ENV["GORI_SPEC_SOCKS_PASS"] = "socks-pass"
       with_socks5_proxy(auth_method: 2_u8) do |sport, seen|
         Gori::Settings.upstream_rules = [
-          rule("*", "socks5", "127.0.0.1:#{sport}", "alice", "GORI_SPEC_SOCKS_PASS"),
+          rule("*", "socks5h", "127.0.0.1:#{sport}", "alice", "GORI_SPEC_SOCKS_PASS"),
         ]
         sock = Gori::Proxy::Upstream.dial("example.test", 443)
         sock.should_not be_nil
@@ -347,6 +473,8 @@ describe "upstream rules" do
 
         got[:user].should eq("alice")
         got[:pass].should eq("socks-pass")
+        got[:atyp].should eq(3_u8)
+        got[:addr].should eq("example.test")
       end
     ensure
       ENV.delete("GORI_SPEC_SOCKS_PASS")
@@ -357,7 +485,7 @@ describe "upstream rules" do
       ENV["GORI_SPEC_SOCKS_PASS"] = "wrong"
       with_socks5_proxy(auth_method: 2_u8, auth_ok: false) do |sport, _seen|
         Gori::Settings.upstream_rules = [
-          rule("*", "socks5", "127.0.0.1:#{sport}", "alice", "GORI_SPEC_SOCKS_PASS"),
+          rule("*", "socks5h", "127.0.0.1:#{sport}", "alice", "GORI_SPEC_SOCKS_PASS"),
         ]
         Gori::Proxy::Upstream.dial("example.test", 443).should be_nil
       end
@@ -366,11 +494,51 @@ describe "upstream rules" do
       reset_upstream
     end
 
+    it "reports rejected Project settings credentials as a proxy error" do
+      with_socks5_proxy(auth_method: 2_u8, auth_ok: false) do |sport, _seen|
+        Gori::Settings.project_upstream_proxy = "socks5h://127.0.0.1:#{sport}"
+        Gori::Settings.project_upstream_auth =
+          Gori::Settings::ProjectProxyAuth.new("socks5", "project-user", "wrong")
+
+        sock, error = Gori::Proxy::Upstream.dial_result("example.test", 443)
+        sock.should be_nil
+        error.try(&.kind).should eq(Gori::Proxy::Upstream::DialErrorKind::Proxy)
+        error.try(&.detail).to_s.should contain("refused the tunnel")
+      end
+    ensure
+      reset_upstream
+    end
+
+    it "fails a local-DNS SOCKS5 dial before contacting the proxy when resolution fails" do
+      server = TCPServer.new("127.0.0.1", 0)
+      Gori::Settings.upstream_proxy = "socks5://127.0.0.1:#{server.local_address.port}"
+
+      sock, error = Gori::Proxy::Upstream.dial_result("does-not-exist.invalid", 443)
+      sock.should be_nil
+      error.try(&.kind).should eq(Gori::Proxy::Upstream::DialErrorKind::Dns)
+
+      accepted = Channel(Nil).new(1)
+      spawn do
+        conn = server.accept
+        conn.close rescue nil
+        accepted.send(nil)
+      rescue
+      end
+      contacted = select
+      when accepted.receive then true
+      when timeout(20.milliseconds) then false
+      end
+      contacted.should be_false
+    ensure
+      server.try(&.close) rescue nil
+      reset_upstream
+    end
+
     # 0xFF is "no acceptable methods" — the dial must fail rather than proceed onto a socket
     # that is not a tunnel.
     it "fails the dial when the proxy accepts no offered auth method" do
       with_socks5_proxy(auth_method: 0xFF_u8) do |sport, _seen|
-        Gori::Settings.upstream_rules = [rule("*", "socks5", "127.0.0.1:#{sport}")]
+        Gori::Settings.upstream_rules = [rule("*", "socks5h", "127.0.0.1:#{sport}")]
         Gori::Proxy::Upstream.dial("example.test", 443).should be_nil
       end
     ensure
@@ -383,6 +551,7 @@ describe "upstream rules" do
       Gori::Settings.upstream_rule_error(rule("*", "direct")).should be_nil
       Gori::Settings.upstream_rule_error(rule("a.test", "http", "p.test:3128")).should be_nil
       Gori::Settings.upstream_rule_error(rule("a.test", "socks5", "127.0.0.1:1080")).should be_nil
+      Gori::Settings.upstream_rule_error(rule("a.test", "socks5h", "127.0.0.1:1080")).should be_nil
     end
 
     it "rejects a missing host, an unknown kind, and a proxy rule with no address" do
@@ -414,6 +583,20 @@ describe "upstream rules" do
   # ORIGIN, a machine gori had never tried to contact. These assert the reason survives the
   # dialer and reaches the send path.
   describe "a refused CONNECT" do
+    it "identifies rejected Project settings credentials without printing the password" do
+      with_refusing_http_proxy(407, "Proxy Authentication Required") do |pport|
+        Gori::Settings.project_upstream_proxy = "http://127.0.0.1:#{pport}"
+        Gori::Settings.project_upstream_auth =
+          Gori::Settings::ProjectProxyAuth.new("basic", "alice", "do-not-print")
+        _, err = Gori::Proxy::Upstream.dial_result("example.test", 443)
+        detail = err.try(&.detail).to_s
+        detail.should contain("configured upstream proxy credentials were rejected")
+        detail.should_not contain("do-not-print")
+      end
+    ensure
+      reset_upstream
+    end
+
     it "names the proxy and the status it returned, not the origin" do
       with_refusing_http_proxy(407, "Proxy Authentication Required") do |pport|
         Gori::Settings.upstream_rules = [rule("*", "http", "127.0.0.1:#{pport}")]

--- a/spec/settings_spec.cr
+++ b/spec/settings_spec.cr
@@ -5,6 +5,9 @@ private def reset_net
   Gori::Settings.project_bind_host = nil
   Gori::Settings.project_bind_port = nil
   Gori::Settings.project_upstream_proxy = nil
+  Gori::Settings.project_upstream_destination = nil
+  Gori::Settings.project_upstream_auth = nil
+  Gori::Settings.project_upstream_auth_error = nil
   Gori::Settings.project_connect_timeout_secs = nil
   Gori::Settings.project_io_timeout_secs = nil
   Gori::Settings.project_capture_max_mib = nil
@@ -121,6 +124,69 @@ describe Gori::Settings do
       route = Gori::Settings.upstream_route("example.com")
       {route.host, route.port}.should eq({"2001:db8::1", 3128})
     ensure
+      Gori::Settings.upstream_proxy = ""
+    end
+
+    it "keeps the SOCKS5 local-DNS and SOCKS5H proxy-DNS kinds distinct" do
+      Gori::Settings.upstream_proxy = "socks5://proxy.local"
+      route = Gori::Settings.upstream_route("not-locally-resolvable.test")
+      {route.kind, route.host, route.port}.should eq({"socks5", "proxy.local", 1080})
+
+      Gori::Settings.upstream_proxy = "socks5h://[::1]:9050/"
+      route = Gori::Settings.upstream_route("not-locally-resolvable.test")
+      {route.kind, route.host, route.port}.should eq({"socks5h", "::1", 9050})
+      route.remote_dns?.should be_true
+    ensure
+      Gori::Settings.upstream_proxy = ""
+    end
+
+    it "projects and composes the split proxy fields without changing storage shape" do
+      Gori::Settings.upstream_proxy_fields("proxy.local").should eq({"http", "proxy.local", "8080"})
+      Gori::Settings.upstream_proxy_fields("socks5h://[::1]:9050").should eq({"socks5h", "::1", "9050"})
+      Gori::Settings.upstream_proxy_fields("").should eq({"none", "", ""})
+      Gori::Settings.upstream_proxy_fields("socks4://bad").should be_nil
+
+      Gori::Settings.build_upstream_proxy("http", "proxy.local", "3128").should eq(
+        {"http://proxy.local:3128", nil})
+      Gori::Settings.build_upstream_proxy("socks5h", "2001:db8::1", "1080").should eq(
+        {"socks5h://[2001:db8::1]:1080", nil})
+      Gori::Settings.build_upstream_proxy("none", "ignored", "9999").should eq({"", nil})
+      Gori::Settings.build_upstream_proxy("socks5", "", "1080")[1].to_s.should contain("host is required")
+      Gori::Settings.build_upstream_proxy("http", "proxy.local", "0")[1].to_s.should contain("between 1 and 65535")
+    end
+
+    it "marks malformed non-blank proxy declarations invalid instead of direct" do
+      ["socks4://proxy.test:1080", "socks5://user:pass@proxy.test", "socks5://proxy.test/path",
+       "socks5://proxy.test:", "proxy.test:8O80"].each do |value|
+        Gori::Settings.upstream_proxy = value
+        route = Gori::Settings.upstream_route("example.com")
+        route.invalid?.should be_true
+        route.direct?.should be_false
+        route.configuration_error.should_not be_nil
+      end
+    ensure
+      Gori::Settings.upstream_proxy = ""
+    end
+  end
+
+  it "retains a malformed persisted upstream-rule host as a fail-closed load error" do
+    dir = File.tempname("gori-settings-upstream-host")
+    Dir.mkdir_p(dir)
+    prev_home = ENV["GORI_HOME"]?
+    begin
+      ENV["GORI_HOME"] = dir
+      File.write(Gori::Settings.path,
+        %({"upstream_rules":[{"host":"[","kind":"http","addr":"proxy.test:8080"}]}))
+      Gori::Settings.load
+
+      route = Gori::Settings.upstream_route("origin.test")
+      route.invalid?.should be_true
+      route.direct?.should be_false
+      route.configuration_error.to_s.should contain("invalid upstream rule host pattern")
+    ensure
+      prev_home ? (ENV["GORI_HOME"] = prev_home) : ENV.delete("GORI_HOME")
+      FileUtils.rm_rf(dir)
+      Gori::Settings.upstream_rules = [] of Gori::Settings::UpstreamRule
       Gori::Settings.upstream_proxy = ""
     end
   end
@@ -1881,11 +1947,16 @@ describe Gori::Settings do
         Gori::Settings.project_bind_host = "10.9.9.9"
         Gori::Settings.project_bind_port = 9100
         Gori::Settings.project_upstream_proxy = "corp:8888"
+        Gori::Settings.project_upstream_destination = "*.project-only.test"
+        Gori::Settings.project_upstream_auth =
+          Gori::Settings::ProjectProxyAuth.new("basic", "alice", "project-only-secret")
         Gori::Settings.save.should be_true
         raw = File.read(Gori::Settings.path)
         raw.includes?("10.9.9.9").should be_false
         raw.includes?("9100").should be_false
         raw.includes?("corp:8888").should be_false
+        raw.includes?("project-only.test").should be_false
+        raw.includes?("project-only-secret").should be_false
       ensure
         prev ? (ENV["GORI_HOME"] = prev) : ENV.delete("GORI_HOME")
         FileUtils.rm_rf(dir)
@@ -1911,12 +1982,15 @@ describe Gori::Settings do
   # #538 — the ONE loader every surface that opens a project store calls. Session.open passes
   # bind: true (it listens), CLI::Run.open_store and the MCP bind path pass bind: false.
   describe ".load_project_network" do
-    it "installs all six keys with bind: true" do
+    it "installs every key with bind: true, including the destination and proxy credentials" do
       with_net_store do |store|
         reset_net
+        auth = Gori::Settings::ProjectProxyAuth.new("basic", "alice", "s3cret")
         store.set_setting(Gori::Settings::PROJECT_BIND_HOST_KEY, "0.0.0.0")
         store.set_setting(Gori::Settings::PROJECT_BIND_PORT_KEY, "9100")
         store.set_setting(Gori::Settings::PROJECT_UPSTREAM_KEY, "jump:8888")
+        store.set_setting(Gori::Settings::PROJECT_UPSTREAM_DESTINATION_KEY, "*.example.com")
+        store.set_setting(Gori::Settings::PROJECT_UPSTREAM_AUTH_KEY, auth.to_json)
         store.set_setting(Gori::Settings::PROJECT_CONNECT_TIMEOUT_KEY, "7")
         store.set_setting(Gori::Settings::PROJECT_IO_TIMEOUT_KEY, "9")
         store.set_setting(Gori::Settings::PROJECT_CAPTURE_MAX_KEY, "16")
@@ -1926,12 +2000,16 @@ describe Gori::Settings do
         Gori::Settings.effective_bind_host.should eq("0.0.0.0")
         Gori::Settings.effective_bind_port.should eq(9100)
         Gori::Settings.effective_upstream_proxy.should eq("jump:8888")
+        Gori::Settings.effective_project_upstream_destination.should eq("*.example.com")
         Gori::Settings.effective_connect_timeout_secs.should eq(7)
         Gori::Settings.effective_io_timeout_secs.should eq(9)
         Gori::Settings.effective_capture_max_mib.should eq(16)
         # The routing decision Upstream.dial actually consults, not just the scalar.
         route = Gori::Settings.upstream_route("example.com")
+        route.direct?.should be_true
+        route = Gori::Settings.upstream_route("api.example.com")
         {route.kind, route.host, route.port}.should eq({"http", "jump", 8888})
+        {route.username, route.password}.should eq({"alice", "s3cret"})
       ensure
         reset_net
       end
@@ -1940,12 +2018,14 @@ describe Gori::Settings do
     # The whole point of the named flag: a headless command that never opens a socket must
     # not end up holding a bind address, because effective_bind_* is also read for display
     # and for the listeners duplicate check.
-    it "with bind: false applies the four outbound/capture keys and CLEARS the two bind keys" do
+    it "with bind: false applies the outbound/capture keys and CLEARS the two bind keys" do
       with_net_store do |store|
         reset_net
+        auth = Gori::Settings::ProjectProxyAuth.new("basic", "alice", "s3cret")
         store.set_setting(Gori::Settings::PROJECT_BIND_HOST_KEY, "0.0.0.0")
         store.set_setting(Gori::Settings::PROJECT_BIND_PORT_KEY, "9100")
         store.set_setting(Gori::Settings::PROJECT_UPSTREAM_KEY, "jump:8888")
+        store.set_setting(Gori::Settings::PROJECT_UPSTREAM_AUTH_KEY, auth.to_json)
         store.set_setting(Gori::Settings::PROJECT_CONNECT_TIMEOUT_KEY, "7")
         store.set_setting(Gori::Settings::PROJECT_IO_TIMEOUT_KEY, "9")
         store.set_setting(Gori::Settings::PROJECT_CAPTURE_MAX_KEY, "16")
@@ -1960,6 +2040,8 @@ describe Gori::Settings do
         Gori::Settings.effective_bind_host.should eq("127.0.0.1") # the global
         Gori::Settings.effective_bind_port.should eq(8070)
         Gori::Settings.effective_upstream_proxy.should eq("jump:8888")
+        route = Gori::Settings.upstream_route("example.com")
+        {route.username, route.password}.should eq({"alice", "s3cret"})
         Gori::Settings.effective_connect_timeout_secs.should eq(7)
         Gori::Settings.effective_io_timeout_secs.should eq(9)
         Gori::Settings.effective_capture_max_mib.should eq(16)
@@ -1976,12 +2058,18 @@ describe Gori::Settings do
         Gori::Settings.upstream_proxy = "glob:3128"
         # Whatever the previously-bound project left behind.
         Gori::Settings.project_upstream_proxy = "stale:8888"
+        Gori::Settings.project_upstream_destination = "stale.test"
+        Gori::Settings.project_upstream_auth = Gori::Settings::ProjectProxyAuth.new("basic", "stale", "old")
         Gori::Settings.project_connect_timeout_secs = 7
         Gori::Settings.project_capture_max_mib = 16
 
         Gori::Settings.load_project_network(store, bind: true)
 
         Gori::Settings.project_upstream_proxy.should be_nil
+        Gori::Settings.project_upstream_destination.should be_nil
+        Gori::Settings.effective_project_upstream_destination.should eq("*")
+        Gori::Settings.project_upstream_auth.should be_nil
+        Gori::Settings.project_upstream_auth_error.should be_nil
         Gori::Settings.project_connect_timeout_secs.should be_nil
         Gori::Settings.project_capture_max_mib.should be_nil
         Gori::Settings.effective_upstream_proxy.should eq("glob:3128")
@@ -2018,6 +2106,111 @@ describe Gori::Settings do
         Gori::Settings.load_project_network(store, bind: true)
         Gori::Settings.effective_upstream_proxy.should eq("")
         Gori::Settings.upstream_route("example.com").direct?.should be_true
+      ensure
+        reset_net
+      end
+    end
+
+    it "fails closed on malformed or orphaned project proxy authentication" do
+      with_net_store do |store|
+        reset_net
+        store.set_setting(Gori::Settings::PROJECT_UPSTREAM_AUTH_KEY, %({"method":"basic","username":"alice"}))
+        Gori::Settings.load_project_network(store, bind: true)
+
+        route = Gori::Settings.upstream_route("example.com")
+        route.invalid?.should be_true
+        route.configuration_error.to_s.should contain("malformed")
+
+        store.set_setting(Gori::Settings::PROJECT_UPSTREAM_AUTH_KEY,
+          Gori::Settings::ProjectProxyAuth.new("basic", "alice", "secret").to_json)
+        Gori::Settings.load_project_network(store, bind: true)
+        route = Gori::Settings.upstream_route("example.com")
+        route.invalid?.should be_true
+        route.configuration_error.to_s.should contain("no project upstream proxy")
+
+        store.set_setting(Gori::Settings::PROJECT_UPSTREAM_KEY, "socks5://proxy.test:1080")
+        store.set_setting(Gori::Settings::PROJECT_UPSTREAM_AUTH_KEY,
+          Gori::Settings::ProjectProxyAuth.new("basic", "alice", "secret").to_json)
+        Gori::Settings.load_project_network(store, bind: true)
+        route = Gori::Settings.upstream_route("example.com")
+        route.invalid?.should be_true
+        route.configuration_error.to_s.should contain("does not match the socks5 proxy")
+      ensure
+        reset_net
+      end
+    end
+  end
+
+  describe ".build_project_proxy_auth" do
+    it "chooses Basic for HTTP and RFC 1929 for SOCKS5" do
+      basic, basic_error = Gori::Settings.build_project_proxy_auth("http://proxy.test:8080", true, "alice", "secret")
+      basic_error.should be_nil
+      basic.try(&.method).should eq("basic")
+
+      socks, socks_error = Gori::Settings.build_project_proxy_auth("socks5h://proxy.test:1080", true, "bob", "pass")
+      socks_error.should be_nil
+      socks.try(&.method).should eq("socks5")
+    end
+
+    it "rejects credentials that cannot be encoded safely" do
+      _, error = Gori::Settings.build_project_proxy_auth("proxy.test:8080", true, "a:b", "secret")
+      error.to_s.should contain("cannot contain ':'")
+
+      _, error = Gori::Settings.build_project_proxy_auth("socks5://proxy.test", true, "bob", "")
+      error.to_s.should contain("1-255 bytes")
+    end
+
+    it "redacts the password from string and inspection output" do
+      auth = Gori::Settings::ProjectProxyAuth.new("basic", "alice", "do-not-print")
+      auth.to_s.should_not contain("do-not-print")
+      auth.inspect.should_not contain("do-not-print")
+      auth.to_json.should contain("do-not-print")
+    end
+  end
+
+  describe ".upstream_destination_error" do
+    it "accepts the shared host wildcard dialect and IP literals" do
+      ["*", "example.com", "*.example.com", "10.*", "127.0.0.1", "::1", "[::1]"].each do |value|
+        Gori::Settings.upstream_destination_error(value).should be_nil
+      end
+    end
+
+    it "rejects values that cannot match a bare destination host" do
+      ["", "https://example.com", "example.com/path", "example.com:443", "bad host", "[::1]:443"].each do |value|
+        Gori::Settings.upstream_destination_error(value).should_not be_nil
+      end
+    end
+  end
+
+  describe ".save_project_network" do
+    it "pins an inherited proxy when saving auth and removes both pins when auth is disabled" do
+      with_net_store do |store|
+        reset_net
+        Gori::Settings.upstream_proxy = "http://proxy.test:8080"
+        auth = Gori::Settings::ProjectProxyAuth.new("basic", "alice", "secret")
+        config = Gori::Settings::ProjectNetworkConfig.new(
+          "127.0.0.1", 8070, "http://proxy.test:8080", auth, 30, 30, 2, "*.example.test"
+        )
+
+        Gori::Settings.save_project_network(store, config).should be_true
+        # Equal-to-global normally deletes a project row. Auth is the exception: its address
+        # must remain pinned so a later global edit cannot move the credential.
+        store.setting(Gori::Settings::PROJECT_UPSTREAM_KEY).should eq("http://proxy.test:8080")
+        store.setting(Gori::Settings::PROJECT_UPSTREAM_DESTINATION_KEY).should eq("*.example.test")
+        stored = store.setting(Gori::Settings::PROJECT_UPSTREAM_AUTH_KEY).not_nil!
+        stored.should contain("secret")
+        Gori::Settings.project_upstream_proxy.should eq("http://proxy.test:8080")
+        Gori::Settings.upstream_route("example.test").direct?.should be_true
+        Gori::Settings.upstream_route("api.example.test").username.should eq("alice")
+
+        without_auth = config.copy_with(auth: nil, destination_host: "*")
+        Gori::Settings.save_project_network(store, without_auth).should be_true
+        store.setting(Gori::Settings::PROJECT_UPSTREAM_KEY).should be_nil
+        store.setting(Gori::Settings::PROJECT_UPSTREAM_AUTH_KEY).should be_nil
+        store.setting(Gori::Settings::PROJECT_UPSTREAM_DESTINATION_KEY).should be_nil
+        Gori::Settings.project_upstream_proxy.should be_nil
+        Gori::Settings.project_upstream_destination.should be_nil
+        Gori::Settings.project_upstream_auth.should be_nil
       ensure
         reset_net
       end

--- a/spec/settings_spec.cr
+++ b/spec/settings_spec.cr
@@ -167,6 +167,14 @@ describe Gori::Settings do
     ensure
       Gori::Settings.upstream_proxy = ""
     end
+
+    # Both credential homes, because this same parse backs the PROJECT pin — a user who typed
+    # URI credentials there was being sent to the one place that could not hold them.
+    it "names both credential homes when a proxy URI carries them" do
+      message = Gori::Settings.upstream_proxy_error("http://alice:secret@proxy.test:8080").to_s
+      message.should contain("Project settings proxy auth")
+      message.should contain("password_env")
+    end
   end
 
   it "retains a malformed persisted upstream-rule host as a fail-closed load error" do
@@ -187,6 +195,33 @@ describe Gori::Settings do
       prev_home ? (ENV["GORI_HOME"] = prev_home) : ENV.delete("GORI_HOME")
       FileUtils.rm_rf(dir)
       Gori::Settings.upstream_rules = [] of Gori::Settings::UpstreamRule
+      Gori::Settings.upstream_proxy = ""
+    end
+  end
+
+  # The load error is retained OUTSIDE the scalar, so the editor that corrects the value has to
+  # retire it too: settings:network assigns and SAVES, it never reloads. A setter that only
+  # wrote the string left every dial failing closed on the old complaint until restart.
+  it "retires a retained upstream_proxy load error when the scalar is reassigned" do
+    dir = File.tempname("gori-settings-upstream-scalar")
+    Dir.mkdir_p(dir)
+    prev_home = ENV["GORI_HOME"]?
+    begin
+      ENV["GORI_HOME"] = dir
+      File.write(Gori::Settings.path, %({"network":{"upstream_proxy":8080}}))
+      Gori::Settings.load
+
+      route = Gori::Settings.upstream_route("origin.test")
+      route.invalid?.should be_true
+      route.configuration_error.to_s.should contain("must be a string")
+
+      Gori::Settings.upstream_proxy = "http://proxy.test:8080"
+      fixed = Gori::Settings.upstream_route("origin.test")
+      fixed.invalid?.should be_false
+      {fixed.kind, fixed.host, fixed.port}.should eq({"http", "proxy.test", 8080})
+    ensure
+      prev_home ? (ENV["GORI_HOME"] = prev_home) : ENV.delete("GORI_HOME")
+      FileUtils.rm_rf(dir)
       Gori::Settings.upstream_proxy = ""
     end
   end
@@ -2175,6 +2210,18 @@ describe Gori::Settings do
       end
     end
 
+    # Underscore names are not legal DNS, but the scope editor this dialect is shared with has
+    # always taken them and internal networks use them. Since the same validator runs over
+    # EXISTING upstream_rules at load — where one rejected rule refuses every route — rejecting
+    # them would brick egress on upgrade for a pattern gori itself accepted.
+    it "accepts underscore labels the shared scope dialect already matches" do
+      ["internal_api.corp", "_service._tcp.corp.test", "*_staging.test"].each do |value|
+        Gori::Settings.upstream_destination_error(value).should be_nil
+      end
+      rule = Gori::Settings::UpstreamRule.new("internal_api.corp", "http", "proxy.test:8080")
+      Gori::Settings.upstream_rule_error(rule).should be_nil
+    end
+
     it "rejects values that cannot match a bare destination host" do
       ["", "https://example.com", "example.com/path", "example.com:443", "bad host", "[::1]:443"].each do |value|
         Gori::Settings.upstream_destination_error(value).should_not be_nil
@@ -2211,6 +2258,31 @@ describe Gori::Settings do
         Gori::Settings.project_upstream_proxy.should be_nil
         Gori::Settings.project_upstream_destination.should be_nil
         Gori::Settings.project_upstream_auth.should be_nil
+      ensure
+        reset_net
+      end
+    end
+
+    # The pin, the credential and the destination gate are one decision about where this
+    # project's traffic goes. Written as three tasks, a busy row could commit the credential
+    # beside the address the project used to have — and the next open would send the secret
+    # there — so they share one writer task, sets and deletes together.
+    it "writes the pin, its credential and the destination gate in one store task" do
+      with_net_store do |store|
+        reset_net
+        store.set_settings([
+          {Gori::Settings::PROJECT_UPSTREAM_KEY, "http://old.test:8080".as(String?)},
+          {Gori::Settings::PROJECT_UPSTREAM_AUTH_KEY, %({"method":"basic","username":"a","password":"b"}).as(String?)},
+        ] of {String, String?}).should be_true
+
+        store.set_settings([
+          {Gori::Settings::PROJECT_UPSTREAM_KEY, "http://new.test:8080".as(String?)},
+          {Gori::Settings::PROJECT_UPSTREAM_AUTH_KEY, nil.as(String?)},
+          {Gori::Settings::PROJECT_UPSTREAM_DESTINATION_KEY, "*.example.test".as(String?)},
+        ] of {String, String?}).should be_true
+        store.setting(Gori::Settings::PROJECT_UPSTREAM_KEY).should eq("http://new.test:8080")
+        store.setting(Gori::Settings::PROJECT_UPSTREAM_AUTH_KEY).should be_nil
+        store.setting(Gori::Settings::PROJECT_UPSTREAM_DESTINATION_KEY).should eq("*.example.test")
       ensure
         reset_net
       end

--- a/spec/tui/bind_fallback_spec.cr
+++ b/spec/tui/bind_fallback_spec.cr
@@ -14,7 +14,7 @@ include Gori::Tui
 #
 # Both branches destroyed the port the operator deliberately pinned. Via the PROJECT layer,
 # because `ProjectView#load_settings_values` seeds its dirty BASELINE from `effective_*` and
-# `ProjectController#commit_project_network` writes all six network fields whenever any ONE of
+# `ProjectController#commit_project_network` writes all network fields whenever any ONE of
 # them is dirty — so editing the idle timeout silently re-pinned the fallback port. Via the
 # GLOBAL layer, because `Settings.bind_port` is what `Settings.save` serializes into
 # settings.json on every unrelated save (the companion toggle, tabs, hotkeys, env), which the NEXT
@@ -48,6 +48,9 @@ private def reset_projnet
   Gori::Settings.project_bind_host = nil
   Gori::Settings.project_bind_port = nil
   Gori::Settings.project_upstream_proxy = nil
+  Gori::Settings.project_upstream_destination = nil
+  Gori::Settings.project_upstream_auth = nil
+  Gori::Settings.project_upstream_auth_error = nil
   Gori::Settings.project_connect_timeout_secs = nil
   Gori::Settings.project_io_timeout_secs = nil
   Gori::Settings.project_capture_max_mib = nil
@@ -82,10 +85,12 @@ describe "startup port fallback" do
       view.settings_dirty?.should be_false      # an untouched pane has nothing to commit
 
       # Now the operator edits ONLY the idle timeout. `commit_project_network` hands
-      # `apply_project_network` all six fields, so whatever sits in the port slot here is what
+      # `apply_project_network` all fields, so whatever sits in the port slot here is what
       # gets persisted — it must still be 8080.
       view.focus_pane(:settings)
-      view.select_setting(ProjectView::SETTINGS_FIELD_BASE + 4) # rows: host, port, upstream, connect, IDLE, cap
+      # fields: host, port, protocol, proxy host, proxy port, destination, auth, user,
+      # pass, connect, IDLE, cap
+      view.select_setting(ProjectView::SETTINGS_FIELD_BASE + 10)
       view.set_backspace.should be_true
       view.set_input('9')
       view.settings_dirty?.should be_true

--- a/spec/tui/project_desc_persist_spec.cr
+++ b/spec/tui/project_desc_persist_spec.cr
@@ -85,9 +85,9 @@ describe Gori::Tui::NotesView do
   end
 end
 
-# The contract the Project SETTINGS pane's fix rests on. `Runner#set_or_clear` now returns this
-# Bool and `apply_project_network` refuses to say "saved" when any of its six fields answers
-# false — that pane cannot be driven without a live Session, so the seam it depends on is pinned
+# The contract the Project SETTINGS pane's persistence report rests on. Store setting writes
+# return this Bool, and `apply_project_network` refuses to say "saved" when any field answers
+# false. That pane cannot be driven without a live Session, so the seam it depends on is pinned
 # here instead.
 describe "per-project setting writes report whether they committed" do
   it "answers false for both store calls once the project can no longer be written" do

--- a/spec/tui/project_env_pane_spec.cr
+++ b/spec/tui/project_env_pane_spec.cr
@@ -241,6 +241,7 @@ private class FakeHost
   include Gori::Tui::Host
 
   getter statuses = [] of String
+  getter applied_config : Gori::Settings::ProjectNetworkConfig? = nil
 
   def initialize(@session : Gori::Session)
     @jobs = Gori::Tui::Jobs.new
@@ -372,6 +373,11 @@ private class FakeHost
     ""
   end
 
+  def apply_project_network(config : Gori::Settings::ProjectNetworkConfig) : String
+    @applied_config = config
+    "project network captured"
+  end
+
   def apply_project_protos(spec : String) : String
     ""
   end
@@ -411,6 +417,39 @@ private def type_keys(c : ProjectController, text : String) : Nil
 end
 
 describe Gori::Tui::ProjectController do
+  it "hands inline proxy credentials to the secret-bearing project save seam" do
+    with_env_controller do |c, host, _session|
+      Gori::Settings.upstream_proxy = "http://proxy.test:8080"
+      c.view.refresh_settings
+      c.view.focus_pane(:settings)
+
+      c.view.select_setting(Gori::Tui::ProjectView::SETTINGS_DESTINATION_ROW)
+      c.handle_body_key(key(Termisu::Input::Key::Backspace))
+      type_keys(c, "*.target.test")
+      c.view.select_setting(Gori::Tui::ProjectView::SETTINGS_AUTH_ROW)
+      c.handle_body_key(key(Termisu::Input::Key::Enter))
+      c.view.select_setting(Gori::Tui::ProjectView::SETTINGS_USERNAME_ROW)
+      type_keys(c, "alice")
+      c.view.select_setting(Gori::Tui::ProjectView::SETTINGS_PASSWORD_ROW)
+      type_keys(c, "secret")
+      c.handle_body_key(key(Termisu::Input::Key::Enter))
+
+      config = host.applied_config.not_nil!
+      config.upstream.should eq("http://proxy.test:8080")
+      config.destination_host.should eq("*.target.test")
+      config.auth.try(&.method).should eq("basic")
+      config.auth.try(&.username).should eq("alice")
+      config.auth.try(&.password).should eq("secret")
+      host.statuses.last.should eq("project network captured")
+    ensure
+      Gori::Settings.upstream_proxy = ""
+      Gori::Settings.project_upstream_proxy = nil
+      Gori::Settings.project_upstream_destination = nil
+      Gori::Settings.project_upstream_auth = nil
+      Gori::Settings.project_upstream_auth_error = nil
+    end
+  end
+
   it "says a rolled-back env write did NOT save, instead of reporting success" do
     with_env_controller do |c, host, session|
       c.env_add_var

--- a/spec/tui/project_view_spec.cr
+++ b/spec/tui/project_view_spec.cr
@@ -26,6 +26,9 @@ private def reset_projnet
   Gori::Settings.project_bind_host = nil
   Gori::Settings.project_bind_port = nil
   Gori::Settings.project_upstream_proxy = nil
+  Gori::Settings.project_upstream_destination = nil
+  Gori::Settings.project_upstream_auth = nil
+  Gori::Settings.project_upstream_auth_error = nil
   Gori::Settings.bind_host = "127.0.0.1"
   Gori::Settings.bind_port = 8070
   Gori::Settings.upstream_proxy = ""
@@ -355,7 +358,7 @@ describe "ProjectView#pane_at" do
 end
 
 describe "ProjectView PROJECT SETTINGS pane" do
-  it "renders the scope-lens + sandbox toggles + the network fields with an inherit marker" do
+  it "renders proxy authentication, protobuf, and inherited network fields" do
     tmp_store do |store|
       reset_projnet
       view = ProjectView.new(Gori::Scope.load(store), Gori::HostOverrides.load(store))
@@ -375,8 +378,16 @@ describe "ProjectView PROJECT SETTINGS pane" do
       b.contains?("Sandbox").should be_true
       b.contains?("Bind IP").should be_true
       b.contains?("Bind Port").should be_true
-      b.contains?("Upstream proxy").should be_true
+      b.contains?("Proxy protocol").should be_true
+      b.contains?("Proxy host").should be_true
+      b.contains?("Proxy port").should be_true
+      b.contains?("Destination host").should be_true
+      b.contains?("· default").should be_true
+      b.contains?("Proxy auth").should be_true
+      b.contains?("Username").should be_true
+      b.contains?("Password").should be_true
       b.contains?("Proto schema").should be_true
+      b.contains?("None").should be_true
       b.contains?("127.0.0.1").should be_true # inherited global bind host
       b.contains?("· global").should be_true  # no override yet → inheriting
     ensure
@@ -400,6 +411,57 @@ describe "ProjectView PROJECT SETTINGS pane" do
     end
   end
 
+  it "splits the effective proxy and applies smart ports while cycling protocols" do
+    tmp_store do |store|
+      reset_projnet
+      Gori::Settings.upstream_proxy = "http://proxy.test:8080"
+      view = ProjectView.new(Gori::Scope.load(store), Gori::HostOverrides.load(store))
+      view.refresh_settings
+
+      values = view.settings_values
+      {values[2], values[3], values[4]}.should eq({"HTTP", "proxy.test", "8080"})
+      view.select_setting(ProjectView::SETTINGS_PROTOCOL_ROW)
+      view.cycle_settings_protocol
+      values = view.settings_values
+      {values[2], values[3], values[4]}.should eq({"SOCKS5", "proxy.test", "1080"})
+      view.settings_upstream_proxy.should eq({"socks5://proxy.test:1080", nil})
+
+      view.select_setting(ProjectView::SETTINGS_PROXY_PORT_ROW)
+      4.times { view.set_backspace }
+      "9051".each_char { |c| view.set_input(c) }
+      view.select_setting(ProjectView::SETTINGS_PROTOCOL_ROW)
+      view.cycle_settings_protocol
+      view.settings_values[4].should eq("9051")
+      view.settings_upstream_proxy.should eq({"socks5h://proxy.test:9051", nil})
+
+      view.cycle_settings_protocol # SOCKS5H → None
+      view.select_setting(ProjectView::SETTINGS_PROXY_HOST_ROW)
+      view.settings_text_row?.should be_false
+      view.select_setting(ProjectView::SETTINGS_PROXY_PORT_ROW)
+      view.settings_text_row?.should be_false
+      view.settings_upstream_proxy.should eq({"", nil})
+    ensure
+      reset_projnet
+    end
+  end
+
+  it "defaults Destination host to all traffic and edits one project pattern" do
+    tmp_store do |store|
+      reset_projnet
+      view = ProjectView.new(Gori::Scope.load(store), Gori::HostOverrides.load(store))
+      view.refresh_settings
+      view.settings_values[ProjectView::SETTINGS_DESTINATION_INDEX].should eq("*")
+
+      view.select_setting(ProjectView::SETTINGS_DESTINATION_ROW)
+      view.set_backspace.should be_true
+      "*.target.test".each_char { |char| view.set_input(char) }
+      view.settings_values[ProjectView::SETTINGS_DESTINATION_INDEX].should eq("*.target.test")
+      view.settings_dirty?.should be_true
+    ensure
+      reset_projnet
+    end
+  end
+
   it "hit-tests a settings row and edits a text field (dirty-tracked)" do
     tmp_store do |store|
       reset_projnet
@@ -418,8 +480,7 @@ describe "ProjectView PROJECT SETTINGS pane" do
       view.settings_text_row?.should be_true
       view.set_input('9')
       view.set_input('9')
-      _, port, _ = view.settings_values
-      port.should eq("807099") # inserted at the caret (field end)
+      view.settings_values[1].should eq("807099") # inserted at the caret (field end)
       view.settings_dirty?.should be_true
 
       view.set_backspace
@@ -430,7 +491,7 @@ describe "ProjectView PROJECT SETTINGS pane" do
   end
 
   # #823: the proto-schema path is its OWN field with its OWN baseline, so editing it neither
-  # marks the network half dirty (which would re-apply and re-BIND six unchanged values on the
+  # marks the network half dirty (which would re-apply and re-BIND unchanged values on the
   # next tab-leave) nor is marked dirty by a network edit.
   it "keeps the proto-schema field on a baseline of its own" do
     tmp_store do |store|
@@ -440,7 +501,7 @@ describe "ProjectView PROJECT SETTINGS pane" do
       view.protos_value.should eq("")
       view.protos_dirty?.should be_false
 
-      view.select_setting(2 + Gori::Tui::ProjectView::SETTINGS_PROTOS_FIELD) # the "Proto schema" row
+      view.select_setting(2 + Gori::Tui::ProjectView::SETTINGS_PROTOS_FIELD)
       view.settings_text_row?.should be_true
       "api.desc".each_char { |c| view.set_input(c) }
       view.protos_value.should eq("api.desc")
@@ -451,6 +512,53 @@ describe "ProjectView PROJECT SETTINGS pane" do
       view.set_input('9')
       view.settings_dirty?.should be_true
       view.protos_dirty?.should be_true # …and the proto edit is still pending, not swallowed
+    ensure
+      reset_projnet
+    end
+  end
+
+  it "shows the password while editing and masks it after focus leaves" do
+    tmp_store do |store|
+      reset_projnet
+      Gori::Settings.project_upstream_proxy = "http://proxy.test:8080"
+      Gori::Settings.project_upstream_auth =
+        Gori::Settings::ProjectProxyAuth.new("basic", "alice", "do-not-render")
+      view = ProjectView.new(Gori::Scope.load(store), Gori::HostOverrides.load(store))
+      view.refresh_settings
+      view.focus_pane(:settings)
+      view.select_setting(ProjectView::SETTINGS_PASSWORD_ROW)
+      b = MemoryBackend.new(120, 30)
+      view.render(Screen.new(b), Rect.new(0, 0, 120, 30), focused: true)
+
+      b.contains?("alice").should be_true
+      b.contains?("Basic").should be_true
+      b.contains?("do-not-render").should be_true
+      view.settings_values[8].should eq("do-not-render")
+
+      view.select_setting(ProjectView::SETTINGS_USERNAME_ROW)
+      masked = MemoryBackend.new(120, 30)
+      view.render(Screen.new(masked), Rect.new(0, 0, 120, 30), focused: true)
+      masked.contains?("do-not-render").should be_false
+      masked.contains?("•••••••••••••").should be_true
+    ensure
+      reset_projnet
+    end
+  end
+
+  it "enables credential rows only when proxy authentication is on" do
+    tmp_store do |store|
+      reset_projnet
+      view = ProjectView.new(Gori::Scope.load(store), Gori::HostOverrides.load(store))
+      view.refresh_settings
+
+      view.select_setting(ProjectView::SETTINGS_USERNAME_ROW)
+      view.settings_text_row?.should be_false
+      view.select_setting(ProjectView::SETTINGS_AUTH_ROW)
+      view.settings_auth_row?.should be_true
+      view.toggle_settings_auth
+      view.settings_values[6].should eq("on")
+      view.select_setting(ProjectView::SETTINGS_USERNAME_ROW)
+      view.settings_text_row?.should be_true
     ensure
       reset_projnet
     end
@@ -482,6 +590,28 @@ describe "ProjectView PROJECT SETTINGS pane" do
       view.settings_values[1].should end_with("9") # the half-typed port survives
       view.settings_dirty?.should be_true
       view.protos_dirty?.should be_false
+    ensure
+      reset_projnet
+    end
+  end
+
+  it "windows the expanded card and hit-tests the selected credential row on a short terminal" do
+    tmp_store do |store|
+      reset_projnet
+      Gori::Settings.project_upstream_proxy = "socks5://proxy.test:1080"
+      Gori::Settings.project_upstream_auth =
+        Gori::Settings::ProjectProxyAuth.new("socks5", "alice", "secret")
+      view = ProjectView.new(Gori::Scope.load(store), Gori::HostOverrides.load(store))
+      view.refresh_settings
+      view.focus_pane(:settings)
+      view.select_setting(ProjectView::SETTINGS_PASSWORD_ROW)
+      rect = Rect.new(0, 0, 80, 16)
+      b = MemoryBackend.new(80, 16)
+      view.render(Screen.new(b), rect, focused: true)
+
+      b.contains?("Password").should be_true
+      hits = (rect.y...rect.bottom).compact_map { |y| view.set_row_at(rect, rect.x + 4, y) }
+      hits.should contain(ProjectView::SETTINGS_PASSWORD_ROW)
     ensure
       reset_projnet
     end

--- a/spec/tui/project_view_spec.cr
+++ b/spec/tui/project_view_spec.cr
@@ -462,6 +462,34 @@ describe "ProjectView PROJECT SETTINGS pane" do
     end
   end
 
+  # The credential rows only draw a marker once auth is ON (before that they render "—"), and
+  # settings.json has no proxy username/password to inherit — so "· global" there would name a
+  # source that cannot exist and send the operator to the wrong editor looking for it.
+  it "marks the project-only credential rows · default rather than · global" do
+    tmp_store do |store|
+      reset_projnet
+      Gori::Settings.upstream_proxy = "http://proxy.test:8080"
+      view = ProjectView.new(Gori::Scope.load(store), Gori::HostOverrides.load(store))
+      view.refresh_settings
+      view.focus_pane(:settings)
+      view.select_setting(ProjectView::SETTINGS_AUTH_ROW)
+      view.toggle_settings_auth
+      b = MemoryBackend.new(120, 30)
+      view.render(Screen.new(b), Rect.new(0, 0, 120, 30), focused: true)
+
+      username = (0...30).map { |y| b.row(y) }.find(&.includes?("Username")).to_s
+      password = (0...30).map { |y| b.row(y) }.find(&.includes?("Password")).to_s
+      username.should contain("· default")
+      username.should_not contain("· global")
+      password.should contain("· default")
+      password.should_not contain("· global")
+      # The proxy host beside them DOES inherit settings.json, so it keeps naming that source.
+      (0...30).map { |y| b.row(y) }.find(&.includes?("Proxy host")).to_s.should contain("· global")
+    ensure
+      reset_projnet
+    end
+  end
+
   it "hit-tests a settings row and edits a text field (dirty-tracked)" do
     tmp_store do |store|
       reset_projnet

--- a/spec/tui/settings_view_spec.cr
+++ b/spec/tui/settings_view_spec.cr
@@ -53,6 +53,60 @@ describe SettingsView do
     end
   end
 
+  it "edits split proxy fields with smart defaults and preserves custom ports" do
+    dir = File.tempname("gori-settings-proxy-fields")
+    Dir.mkdir_p(dir)
+    prev_home = ENV["GORI_HOME"]?
+    prev = Gori::Settings.upstream_proxy
+    begin
+      ENV["GORI_HOME"] = dir
+      Gori::Settings.upstream_proxy = "http://proxy.local:8080"
+      v = SettingsView.new
+      v.reload(:network)
+      2.times { v.move_field(1) } # Proxy protocol: HTTP
+      v.toggle_or_move(1)         # SOCKS5, automatic 8080 → 1080
+      v.save
+      Gori::Settings.upstream_proxy.should eq("socks5://proxy.local:1080")
+
+      v.reload(:network)
+      4.times { v.move_field(1) } # Proxy port
+      set_text(v, "9051")
+      2.times { v.move_field(-1) } # Proxy protocol
+      v.toggle_or_move(1)          # SOCKS5H; custom port survives
+      v.save
+      Gori::Settings.upstream_proxy.should eq("socks5h://proxy.local:9051")
+
+      v.reload(:network)
+      2.times { v.move_field(1) }
+      v.toggle_or_move(1) # SOCKS5H → None
+      v.save
+      Gori::Settings.upstream_proxy.should eq("")
+    ensure
+      prev_home ? (ENV["GORI_HOME"] = prev_home) : ENV.delete("GORI_HOME")
+      Gori::Settings.upstream_proxy = prev
+      FileUtils.rm_rf(dir)
+    end
+  end
+
+  it "shows and preserves an invalid raw proxy declaration until it is repaired" do
+    prev = Gori::Settings.upstream_proxy
+    begin
+      Gori::Settings.upstream_proxy = "socks4://bad.test:1080"
+      v = SettingsView.new
+      v.reload(:network)
+      b = MemoryBackend.new(120, 30)
+      v.render(Screen.new(b), Rect.new(0, 0, 120, 30))
+      b.contains?("Invalid · socks4://bad.test:1080").should be_true
+
+      v.move_field(1) # edit only Bind Port
+      set_text(v, "9090")
+      v.save.should contain("unsupported upstream proxy scheme")
+      Gori::Settings.upstream_proxy.should eq("socks4://bad.test:1080")
+    ensure
+      Gori::Settings.upstream_proxy = prev
+    end
+  end
+
   it "toggles Verify upstream TLS off, then resets it to the default on save" do
     dir = File.tempname("gori-settings-verify")
     Dir.mkdir_p(dir)
@@ -63,11 +117,9 @@ describe SettingsView do
       Gori::Settings.verify_upstream = true
       v = SettingsView.new
       v.reload(:network)
-      v.move_field(1)      # Bind IP → Bind Port
-      v.move_field(1)      # → Upstream proxy
-      v.move_field(1)      # → Verify upstream TLS (index 3, the bool)
-      v.toggle_or_move(-1) # flip the bool off
-      v.save               # persists the working copy back to the live Settings
+      5.times { v.move_field(1) } # Bind IP → … → Verify upstream TLS (index 5)
+      v.toggle_or_move(-1)        # flip the bool off
+      v.save                      # persists the working copy back to the live Settings
       Gori::Settings.verify_upstream?.should be_false
 
       v.reset_to_defaults
@@ -90,7 +142,7 @@ describe SettingsView do
       Gori::Settings.serve_landing = true
       v = SettingsView.new
       v.reload(:network)
-      4.times { v.move_field(1) } # Bind IP → Port → Upstream → Verify → Info page (index 4)
+      6.times { v.move_field(1) } # Bind IP → … → Info page (index 6)
       v.toggle_or_move(-1)        # flip the Info-page bool off
       v.save
       Gori::Settings.serve_landing?.should be_false
@@ -272,12 +324,12 @@ describe SettingsView do
       Gori::Settings.capture_max_mib = 2
       v = SettingsView.new
       v.reload(:network)
-      # Bind IP → Port → Upstream → Verify → Info page → Connect timeout (index 5, text)
-      5.times { v.move_field(1) }
+      # Bind IP → … → Connect timeout (index 7, text)
+      7.times { v.move_field(1) }
       set_text(v, "5")
-      v.move_field(1) # → Idle timeout (index 6, text)
+      v.move_field(1) # → Idle timeout (index 8, text)
       set_text(v, "7")
-      v.move_field(1) # → Capture body limit (index 7, text)
+      v.move_field(1) # → Capture body limit (index 9, text)
       set_text(v, "9")
       v.save
       Gori::Settings.connect_timeout_secs.should eq(5)

--- a/src/gori/cli.cr
+++ b/src/gori/cli.cr
@@ -465,6 +465,7 @@ module Gori
       end
       parser.parse(args)
       begin
+        Settings.load
         Update.run(exec_package_commands: exec_pkg)
       rescue ex : Error
         abort "gori update: #{ex.message}"

--- a/src/gori/cli/run.cr
+++ b/src/gori/cli/run.cr
@@ -389,7 +389,7 @@ module Gori
         # The project's pinned upstream / dial timeouts / capture cap (#538). `bind: false`:
         # not one command routed through here LISTENS — `gori run capture` is the only
         # subcommand that binds and it opens its project through `Session.open` instead — so
-        # the two bind keys are deliberately left out and the other four apply. Without this,
+        # the two bind keys are deliberately left out and the outbound/capture keys apply. Without this,
         # a project pinned to a jump host was dialled DIRECT by every `gori run` active
         # command, and an imported/replayed body was capped at the global limit.
         Settings.load_project_network(store, bind: false)

--- a/src/gori/host_pattern.cr
+++ b/src/gori/host_pattern.cr
@@ -1,8 +1,8 @@
 module Gori
-  # The ONE host-pattern dialect, shared by Scope's `host` rules (Scope::Rule#host_match?)
-  # and the TLS passthrough list (Settings.tls_passthrough). Shared deliberately: a pattern
-  # the operator learned in the scope editor must mean the same thing in the passthrough
-  # field, and two copies of the glob/suffix decision would be two places to drift.
+  # The ONE host-pattern dialect, shared by Scope's `host` rules (Scope::Rule#host_match?),
+  # TLS passthrough, upstream rules and the project's Destination host gate. Shared
+  # deliberately: a pattern the operator learned in one editor must mean the same thing in
+  # another, and copies of the glob/suffix decision would be places to drift.
   #
   #   acme.test    → the host itself AND any subdomain (api.acme.test)
   #   *.acme.test  → a glob (File.match?) — matches subdomains but NOT the bare host
@@ -10,7 +10,7 @@ module Gori
   #
   # Matching is case-insensitive. Patterns are COMPILED once (see Compiled) because both
   # callers evaluate the same patterns repeatedly on the proxy hot path — per captured row
-  # for scope, per CONNECT for passthrough.
+  # for scope and per destination dial for routing/passthrough.
   module HostPattern
     # "[::1]" → "::1". Host matching compares bare forms so an IPv6 pattern matches whether
     # the host arrived bracketed (some URL paths) or bare (the CONNECT/tunnel path).

--- a/src/gori/http_transport.cr
+++ b/src/gori/http_transport.cr
@@ -1,0 +1,99 @@
+require "http/client"
+require "openssl"
+require "uri"
+require "./proxy/upstream"
+
+module Gori
+  # One-shot HTTP clients for gori's own service traffic (the updater and OAST providers).
+  # The security-testing send engines keep their byte-exact codecs; this seam exists only so
+  # stdlib HTTP::Client cannot quietly open a direct socket beside Proxy::Upstream.
+  module HttpTransport
+    class Error < Gori::Error
+    end
+
+    # A client created over an existing IO cannot reconnect. Crystal's retry path otherwise
+    # mistakes that already-open first connection for a reused one, closes it after EOF/a
+    # response-block exception, and then raises "cannot be reconnected". More importantly, a
+    # future reconnect implementation must not be allowed to bypass the routed dial. One routed
+    # socket means one attempt; callers that want another request create another routed client.
+    private class RoutedClient < HTTP::Client
+      private def should_retry_request?(request, exception, reusing_connection) : Bool
+        false
+      end
+    end
+
+    def self.client(uri : URI, *, verify_tls : Bool = true,
+                    connect_timeout : Time::Span = Settings.connect_timeout,
+                    read_timeout : Time::Span = Settings.io_timeout) : HTTP::Client
+      host, tls, port = endpoint(uri)
+      io = routed_io(host, port, tls, verify_tls, connect_timeout, read_timeout)
+      build_client(io, host, port, tls, connect_timeout, read_timeout)
+    rescue ex : Error
+      raise ex
+    rescue ex
+      io.try(&.close) rescue nil
+      raise Error.new("HTTP connection to #{host || "unknown host"} failed: #{ex.message.presence || ex.class}")
+    end
+
+    private def self.endpoint(uri : URI) : {String, Bool, Int32}
+      scheme = uri.scheme.try(&.downcase)
+      unless scheme == "http" || scheme == "https"
+        raise Error.new("unsupported HTTP URL scheme #{scheme.inspect}")
+      end
+      host = uri.host
+      raise Error.new("HTTP URL needs a host") unless host
+      host = bare_host(host)
+      tls = scheme == "https"
+      port = uri.port || (tls ? 443 : 80)
+      {host, tls, port}
+    end
+
+    private def self.routed_io(host : String, port : Int32, tls : Bool, verify_tls : Bool,
+                               connect_timeout : Time::Span, read_timeout : Time::Span) : IO
+      tcp, dial_error = Proxy::Upstream.dial_result(host, port, connect_timeout, read_timeout,
+        apply_host_overrides: false)
+      unless tcp
+        detail = dial_error.try(&.detail) || "#{host}:#{port} is unreachable"
+        raise Error.new("#{detail}#{dial_error.try(&.because) || ""}")
+      end
+
+      tls ? wrap_tls(tcp, host, verify_tls) : tcp.as(IO)
+    end
+
+    private def self.build_client(io : IO, host : String, port : Int32, tls : Bool,
+                                  connect_timeout : Time::Span,
+                                  read_timeout : Time::Span) : HTTP::Client
+      client = RoutedClient.new(io, host, port)
+      client.connect_timeout = connect_timeout
+      client.read_timeout = read_timeout
+      # Existing-IO clients do not know that `io` is TLS, so stdlib would render :443 in Host.
+      # Set the URI authority after its defaults and keep redirects/new origins independent.
+      authority = authority(host, port, tls)
+      client.before_request { |request| request.headers["Host"] = authority }
+      client
+    end
+
+    private def self.wrap_tls(tcp : TCPSocket, host : String,
+                              verify : Bool) : OpenSSL::SSL::Socket::Client
+      context = OpenSSL::SSL::Context::Client.new
+      if verify
+        Proxy::Upstream.apply_system_trust(context)
+      else
+        context.verify_mode = OpenSSL::SSL::VerifyMode::NONE
+      end
+      OpenSSL::SSL::Socket::Client.new(tcp, context: context, sync_close: true, hostname: host)
+    rescue ex
+      tcp.close rescue nil
+      raise ex
+    end
+
+    private def self.bare_host(host : String) : String
+      host.starts_with?('[') && host.ends_with?(']') ? host[1...-1] : host
+    end
+
+    private def self.authority(host : String, port : Int32, tls : Bool) : String
+      rendered = host.includes?(':') ? "[#{host}]" : host
+      port == (tls ? 443 : 80) ? rendered : "#{rendered}:#{port}"
+    end
+  end
+end

--- a/src/gori/oast/http.cr
+++ b/src/gori/oast/http.cr
@@ -1,11 +1,13 @@
 require "http/client"
 require "uri"
+require "../http_transport"
 
 module Gori::Oast
   # The outbound-HTTP seam every provider talks through. Abstracting it lets specs drive
   # register/poll with a scripted fake (no sockets) while production dials real servers.
-  # OAST talks to THIRD-PARTY interaction servers directly (not through gori's proxy /
-  # host-override machinery) — same stance as the self-updater.
+  # OAST talks to THIRD-PARTY interaction servers outside the active-testing scope gate. The
+  # production client follows configured upstream routing but skips target host overrides —
+  # the same stance as the self-updater.
   abstract class Http
     record Response, status : Int32, body : String
 
@@ -14,7 +16,7 @@ module Gori::Oast
                          body : String? = nil) : Response
   end
 
-  # Production client over stdlib HTTP::Client (template: Gori::Update#fetch_latest_release_json).
+  # Production client over the shared routed HTTP transport.
   # A fresh client per call, keyed on the URL's own origin — the poll cadence is seconds,
   # not a hot path, and each provider may hit a different host.
   class HttpClient < Http
@@ -37,15 +39,8 @@ module Gori::Oast
       uri = URI.parse(url)
       host = uri.host
       raise Gori::Error.new("OAST: invalid URL #{url}") unless host
-      tls = uri.scheme == "https"
-      port = uri.port || (tls ? 443 : 80)
-
-      client = HTTP::Client.new(host, port, tls)
-      client.connect_timeout = TIMEOUT
-      client.read_timeout = TIMEOUT
-      # A public interactsh/webhook host we don't (and can't) pin; the callback content is
-      # decrypted/verified out of band, so an unverified transport is acceptable here.
-      client.tls.try(&.verify_mode = OpenSSL::SSL::VerifyMode::NONE) unless @verify_tls
+      client = Gori::HttpTransport.client(uri, verify_tls: @verify_tls,
+        connect_timeout: TIMEOUT, read_timeout: TIMEOUT)
 
       hdrs = HTTP::Headers.new
       headers.each { |k, v| hdrs[k] = v }

--- a/src/gori/proxy/upstream.cr
+++ b/src/gori/proxy/upstream.cr
@@ -34,8 +34,10 @@ module Gori::Proxy
                   connect_timeout : Time::Span = Settings.connect_timeout,
                   io_timeout : Time::Span = Settings.io_timeout,
                   *, overrides : Gori::HostOverrides? = nil,
-                  pin : String? = nil) : TCPSocket?
-      dial_result(host, port, connect_timeout, io_timeout, overrides: overrides, pin: pin)[0]
+                  pin : String? = nil,
+                  apply_host_overrides : Bool = true) : TCPSocket?
+      dial_result(host, port, connect_timeout, io_timeout, overrides: overrides, pin: pin,
+        apply_host_overrides: apply_host_overrides)[0]
     end
 
     # Like `dial`, but also says WHY there is no socket. Every dial failure used to collapse
@@ -48,14 +50,17 @@ module Gori::Proxy
                          connect_timeout : Time::Span = Settings.connect_timeout,
                          io_timeout : Time::Span = Settings.io_timeout,
                          *, overrides : Gori::HostOverrides? = nil,
-                         pin : String? = nil) : {TCPSocket?, DialError?}
-      target, target_port = connect_target(host, port, overrides, pin)
+                         pin : String? = nil,
+                         apply_host_overrides : Bool = true) : {TCPSocket?, DialError?}
+      target, target_port = apply_host_overrides ? connect_target(host, port, overrides, pin) : {pin || host, port}
       # ONE decision point for "how do we reach this host": Settings.upstream_route folds the
       # project pin, the rule table and the legacy scalar together. Resolved on the ORIGINAL
       # host, not `target` — a rule is written against the name the operator sees, and a
       # hostname override only changes where we dial (see connect_target).
       route = Settings.upstream_route(host)
-      if route.direct?
+      if err = route.configuration_error
+        {nil, DialError.new(DialErrorKind::Proxy, "#{err} — the origin was never contacted")}
+      elsif route.direct?
         direct_dial_result(target, target_port, connect_timeout, io_timeout)
       elsif route.socks5?
         dial_via_socks5(route, target, target_port, connect_timeout, io_timeout)
@@ -387,7 +392,8 @@ module Gori::Proxy
     # How an error names the upstream proxy. One spelling so a 407 and an unreachable proxy
     # point at the same line of settings.json.
     private def self.proxy_label(route : Settings::UpstreamRoute) : String
-      "upstream #{route.socks5? ? "SOCKS5" : "HTTP"} proxy #{route.host}:#{route.port}"
+      transport = route.socks5? ? route.kind.upcase : "HTTP"
+      "upstream #{transport} proxy #{route.host}:#{route.port}"
     end
 
     # `proxy_label`, but nil for a direct route — the question a FAILURE BUILDER asks once it
@@ -451,14 +457,43 @@ module Gori::Proxy
       if err = route.credential_error
         return {nil, DialError.new(DialErrorKind::Proxy, "#{proxy_label(route)}: #{err}")}
       end
-      sock = direct_dial(route.host, route.port, connect_timeout, io_timeout)
-      return {nil, DialError.new(DialErrorKind::Connect, "#{proxy_label(route)} unreachable (DNS/refused/timeout) — the origin was never contacted")} unless sock
-      return {sock, nil} if socks5_handshake(sock, route, host, port)
-      sock.close rescue nil
+      sock = nil.as(TCPSocket?)
+      targets = socks5_targets(route, host, port)
+      if targets.empty?
+        return {nil, DialError.new(DialErrorKind::Dns, "destination name resolved to no addresses")}
+      end
+      handshake_error = false
+      targets.each do |target|
+        begin
+          sock = direct_dial(route.host, route.port, connect_timeout, io_timeout)
+          return {nil, DialError.new(DialErrorKind::Connect, "#{proxy_label(route)} unreachable (DNS/refused/timeout) — the origin was never contacted")} unless sock
+          return {sock, nil} if socks5_handshake(sock, route, target, port)
+        rescue
+          handshake_error = true
+        end
+        sock.try(&.close) rescue nil
+        sock = nil
+      end
+      if handshake_error
+        return {nil, DialError.new(DialErrorKind::Proxy, "#{proxy_label(route)}: the SOCKS5 handshake failed")}
+      end
       {nil, DialError.new(DialErrorKind::Proxy, "#{proxy_label(route)} refused the tunnel to #{host}:#{port}")}
-    rescue
+    rescue ex : Socket::Addrinfo::Error
       sock.try(&.close) rescue nil
-      {nil, DialError.new(DialErrorKind::Proxy, "#{proxy_label(route)}: the SOCKS5 handshake failed")}
+      {nil, DialError.new(DialErrorKind::Dns, cause: exception_cause(ex))}
+    end
+
+    # SOCKS5 resolves locally and sends an address literal; SOCKS5H preserves the hostname
+    # for proxy-side resolution. Each local result gets a fresh tunnel because a failed
+    # SOCKS CONNECT reply leaves that socket unusable for another request.
+    private def self.socks5_targets(route : Settings::UpstreamRoute,
+                                    host : String, port : Int32) : Array(String)
+      return [host] if route.remote_dns?
+      bare = bare_host(host)
+      return [bare] if parse_ip(bare)
+      addresses = Socket::Addrinfo.tcp(bare, port).map(&.ip_address.address)
+      addresses.uniq!
+      addresses
     end
 
     # Method negotiation → optional auth → CONNECT. False on any refusal, so the caller closes.
@@ -497,10 +532,8 @@ module Gori::Proxy
     # The CONNECT request, then the reply (whose BND.ADDR must be drained by its own address
     # type, or the socket would be left mid-reply and the origin stream would start desynced).
     #
-    # An IP literal target is sent as ATYP IPV4/IPV6; a hostname is sent as ATYP DOMAIN, so the
-    # SOCKS proxy resolves it (the "socks5h" behaviour). That is the right default here: it is
-    # what makes Tor and a jump host into a network gori cannot otherwise see work at all, and
-    # gori deliberately does not resolve names on the dial path anyway (see parse_ip).
+    # An IP literal target is sent as ATYP IPV4/IPV6; a hostname is sent as ATYP DOMAIN.
+    # `socks5_targets` ensures only SOCKS5H reaches this method with a hostname.
     private def self.socks5_connect(sock : TCPSocket, host : String, port : Int32) : Bool
       sock.write(Bytes[Socks5::VERSION, Socks5::CMD_CONNECT, 0_u8])
       return false unless socks5_write_address(sock, host)
@@ -596,9 +629,9 @@ module Gori::Proxy
       case code
       when 407
         if authenticating?(route)
-          " — the credentials on the matching upstream rule were rejected"
+          " — the configured upstream proxy credentials were rejected"
         else
-          " — the proxy requires authentication; set `username` + `password_env` on the matching upstream rule"
+          " — the proxy requires authentication; configure it in Project settings or on a matching upstream rule"
         end
       when 403 then " — the proxy's ACL does not permit CONNECT to that host/port"
       when 502, 503, 504

--- a/src/gori/session.cr
+++ b/src/gori/session.cr
@@ -78,9 +78,9 @@ module Gori
       begin
         # Per-project network overrides: pull this project's pinned bind/upstream (if any) into
         # the Settings runtime layer BEFORE binding, so the proxy listens on the project's address
-        # and Upstream.dial (reads Settings.effective_upstream_proxy) tunnels through its upstream.
+        # and Upstream.dial (reads Settings.upstream_route) tunnels through its upstream.
         # `bind: true` — a Session is the one surface that LISTENS (the TUI and `gori run capture`
-        # both open the project this way), so all six keys apply here; the headless callers of
+        # both open the project this way), so all eight keys apply here; the headless callers of
         # `CLI::Run.open_store` and the MCP bind path pass `bind: false`. Mutating `config` is
         # safe — App re-seeds it from the global Settings on every project open. Inside the begin
         # so a failing settings read is torn down below rather than leaking store+channels.

--- a/src/gori/settings.cr
+++ b/src/gori/settings.cr
@@ -112,6 +112,7 @@ module Gori
       @@loaded_raw = nil
       @@load_partial = false
       @@load_unreadable = false
+      reset_upstream_route_errors
       # A full load rewrites every section's class properties, including the two
       # `reload_section` folds and caches. Dropping the cache here keeps "we already folded
       # these bytes" from outliving the memory it was an assertion about — a load that ends in
@@ -221,7 +222,7 @@ module Gori
       if net = object_section(root, "network")
         self.bind_host = net["bind_host"]?.try(&.as_s?) || bind_host
         self.bind_port = int_field(net, "bind_port") || bind_port
-        self.upstream_proxy = net["upstream_proxy"]?.try(&.as_s?) || upstream_proxy
+        apply_upstream_proxy(net["upstream_proxy"]?)
         self.verify_upstream = load_bool(net, "verify_upstream", verify_upstream?)
         self.serve_landing = load_bool(net, "serve_landing", serve_landing?)
         int_field(net, "connect_timeout_secs").try { |v| self.connect_timeout_secs = {v, 1}.max }
@@ -239,7 +240,7 @@ module Gori
         self.editor_markdown = load_bool(ed, "markdown", editor_markdown)
       end
       parse_hooks(root["hooks"]?)
-      self.upstream_rules = parse_upstream_rules(root["upstream_rules"]?)
+      apply_upstream_rules(root["upstream_rules"]?)
       self.outbound_tls = parse_outbound_tls(root["outbound_tls"]?)
       parse_retention(root["retention"]?)
       self.listeners = parse_listeners(root["listeners"]?)

--- a/src/gori/settings/network.cr
+++ b/src/gori/settings/network.cr
@@ -87,7 +87,19 @@ module Gori::Settings
 
   class_property bind_host : String = DEFAULT_BIND_HOST
   class_property bind_port : Int32 = DEFAULT_BIND_PORT
-  class_property upstream_proxy : String = DEFAULT_UPSTREAM_PROXY # HTTP/SOCKS URI or legacy host:port; "" = direct
+  class_getter upstream_proxy : String = DEFAULT_UPSTREAM_PROXY # HTTP/SOCKS URI or legacy host:port; "" = direct
+
+  # Assigning the scalar RETIRES the retained load error. A non-string `network.upstream_proxy`
+  # makes every route fail closed (apply_upstream_proxy), and the settings editor corrects it by
+  # assigning here and saving — it does not reload. A setter that only wrote the value therefore
+  # left the refusal standing until restart: the operator saw the fix applied and still could
+  # not dial. The value now in memory is the one upstream_route must judge.
+  def self.upstream_proxy=(value : String) : String
+    @@upstream_proxy = value
+    @@upstream_proxy_load_error = nil
+    value
+  end
+
   # Whether the proxy/probe/repeater verify the UPSTREAM TLS certificate. The launch
   # flag --insecure-upstream seeds this false for the session (see CLI.run_tui); the
   # settings:network editor toggles it live via Session#set_verify_upstream. Global-only
@@ -456,27 +468,26 @@ module Gori::Settings
   # or follow a later global edit. `*` is represented by an absent destination row so every
   # pre-feature project keeps the same proxy-all behaviour without migration. Each Store call
   # reports commit success; all are attempted so an independently busy row cannot leave the
-  # rest of the live edit unapplied.
+  # rest of the live edit unapplied — except the three ROUTING rows, which go in one task
+  # (below) because they are only meaningful together.
   def self.save_project_network(store : Store, config : ProjectNetworkConfig) : Bool
     auth = config.auth
-    upstream_saved = if auth
-                       store.set_setting(PROJECT_UPSTREAM_KEY, config.upstream)
-                     else
-                       set_or_clear_project(store, PROJECT_UPSTREAM_KEY, config.upstream, upstream_proxy)
-                     end
-    auth_saved = auth ? store.set_setting(PROJECT_UPSTREAM_AUTH_KEY, auth.to_json) : store.delete_setting(PROJECT_UPSTREAM_AUTH_KEY)
     destination = config.destination_host.strip
-    destination_saved = if destination == DEFAULT_PROJECT_UPSTREAM_DESTINATION
-                          store.delete_setting(PROJECT_UPSTREAM_DESTINATION_KEY)
-                        else
-                          store.set_setting(PROJECT_UPSTREAM_DESTINATION_KEY, destination)
-                        end
+    # The pin, its credentials and the destination gate are ONE decision about where this
+    # project's traffic goes. Written as three tasks, a busy row could commit the credentials
+    # beside the address the project used to have — and the next open would send the secret
+    # there. Auth pins the upstream unconditionally; without it the pin follows the
+    # equals-global-means-inherit rule the other rows use.
+    routing_saved = store.set_settings([
+      {PROJECT_UPSTREAM_KEY, auth ? config.upstream : project_row(config.upstream, upstream_proxy)},
+      {PROJECT_UPSTREAM_AUTH_KEY, auth.try(&.to_json)},
+      {PROJECT_UPSTREAM_DESTINATION_KEY,
+       destination == DEFAULT_PROJECT_UPSTREAM_DESTINATION ? nil : destination},
+    ] of {String, String?})
     persisted = [
       set_or_clear_project(store, PROJECT_BIND_HOST_KEY, config.bind_host, bind_host),
       set_or_clear_project(store, PROJECT_BIND_PORT_KEY, config.bind_port.to_s, bind_port.to_s),
-      upstream_saved,
-      auth_saved,
-      destination_saved,
+      routing_saved,
       set_or_clear_project(store, PROJECT_CONNECT_TIMEOUT_KEY, config.connect_secs.to_s, connect_timeout_secs.to_s),
       set_or_clear_project(store, PROJECT_IO_TIMEOUT_KEY, config.io_secs.to_s, io_timeout_secs.to_s),
       set_or_clear_project(store, PROJECT_CAPTURE_MAX_KEY, config.capture_mib.to_s, capture_max_mib.to_s),
@@ -497,6 +508,12 @@ module Gori::Settings
   private def self.set_or_clear_project(store : Store, key : String,
                                         value : String, global : String) : Bool
     value == global ? store.delete_setting(key) : store.set_setting(key, value)
+  end
+
+  # `set_or_clear_project`'s decision as a VALUE, for rows batched into one write task:
+  # nil means "drop the key so the project inherits the global".
+  private def self.project_row(value : String, global : String) : String?
+    value == global ? nil : value
   end
 
   private def self.load_project_upstream_auth(raw : String?) : Nil

--- a/src/gori/settings/network.cr
+++ b/src/gori/settings/network.cr
@@ -7,11 +7,12 @@ require "../store"
 # body capture cap, and per-project overrides of the same. See settings.cr for the
 # module-level overview and the load/save/serialize orchestration.
 module Gori::Settings
-  DEFAULT_BIND_HOST       = "127.0.0.1"
-  DEFAULT_BIND_PORT       = 8070
-  DEFAULT_UPSTREAM_PROXY  = ""
-  DEFAULT_VERIFY_UPSTREAM = true
-  DEFAULT_SERVE_LANDING   = true
+  DEFAULT_BIND_HOST                    = "127.0.0.1"
+  DEFAULT_BIND_PORT                    = 8070
+  DEFAULT_UPSTREAM_PROXY               = ""
+  DEFAULT_PROJECT_UPSTREAM_DESTINATION = "*"
+  DEFAULT_VERIFY_UPSTREAM              = true
+  DEFAULT_SERVE_LANDING                = true
   # Outbound dial timeouts (settings:network). connect = how long a TCP/upstream connect
   # may take; io = the initial read/write timeout on the upstream socket (relaxed to nil
   # for long-lived streaming tunnels — that clearing is orthogonal). Seconds, min 1.
@@ -86,7 +87,7 @@ module Gori::Settings
 
   class_property bind_host : String = DEFAULT_BIND_HOST
   class_property bind_port : Int32 = DEFAULT_BIND_PORT
-  class_property upstream_proxy : String = DEFAULT_UPSTREAM_PROXY # "host:port" HTTP proxy; "" = connect directly
+  class_property upstream_proxy : String = DEFAULT_UPSTREAM_PROXY # HTTP/SOCKS URI or legacy host:port; "" = direct
   # Whether the proxy/probe/repeater verify the UPSTREAM TLS certificate. The launch
   # flag --insecure-upstream seeds this false for the session (see CLI.run_tui); the
   # settings:network editor toggles it live via Session#set_verify_upstream. Global-only
@@ -312,9 +313,15 @@ module Gori::Settings
   # while the global settings:network editor keeps writing the shared defaults. Stored in the
   # project's generic KV `settings` table under these keys
   # (Store#setting/#set_setting/#delete_setting).
-  PROJECT_BIND_HOST_KEY = "net.bind_host"
-  PROJECT_BIND_PORT_KEY = "net.bind_port"
-  PROJECT_UPSTREAM_KEY  = "net.upstream_proxy"
+  PROJECT_BIND_HOST_KEY            = "net.bind_host"
+  PROJECT_BIND_PORT_KEY            = "net.bind_port"
+  PROJECT_UPSTREAM_KEY             = "net.upstream_proxy"
+  PROJECT_UPSTREAM_DESTINATION_KEY = "net.upstream_destination_host"
+  # One atomic JSON value rather than three independent KV rows: a busy Store cannot commit
+  # the method without its password (or vice versa) and leave a half-authenticated project.
+  # Unlike global settings.json, the project DB already holds captured credentials and is
+  # owner-only (0600); the password deliberately stays scoped to this engagement.
+  PROJECT_UPSTREAM_AUTH_KEY = "net.upstream_auth"
   # Promoted from global-only (#440). These are ENGAGEMENT properties, not machine ones: a slow
   # internal appliance needs its own idle timeout, and one target returning fat JSON needs its
   # own capture cap — raising either globally taxes every other project.
@@ -324,9 +331,42 @@ module Gori::Settings
   class_property project_bind_host : String? = nil
   class_property project_bind_port : Int32? = nil
   class_property project_upstream_proxy : String? = nil
+  @@project_upstream_destination : String? = nil
+  @@project_upstream_destination_compiled = HostPattern::Compiled.new(DEFAULT_PROJECT_UPSTREAM_DESTINATION)
+  @@project_upstream_destination_error : String? = nil
+  class_property project_upstream_auth : ProjectProxyAuth? = nil
+  class_property project_upstream_auth_error : String? = nil
   class_property project_connect_timeout_secs : Int32? = nil
   class_property project_io_timeout_secs : Int32? = nil
   class_property project_capture_max_mib : Int32? = nil
+
+  def self.project_upstream_destination : String?
+    @@project_upstream_destination
+  end
+
+  # Compile the project routing gate when the project is loaded/saved, never on the dial hot
+  # path. Keep an invalid hand-edited value as an error rather than turning it into `*`: a
+  # malformed pattern must not silently send a destination through (or around) a proxy.
+  def self.project_upstream_destination=(value : String?) : String?
+    @@project_upstream_destination = value.try(&.strip)
+    pattern = effective_project_upstream_destination
+    @@project_upstream_destination_error = upstream_destination_error(pattern)
+    @@project_upstream_destination_compiled = HostPattern::Compiled.new(pattern) unless @@project_upstream_destination_error
+    value
+  end
+
+  def self.effective_project_upstream_destination : String
+    project_upstream_destination || DEFAULT_PROJECT_UPSTREAM_DESTINATION
+  end
+
+  # The routing decision asks this before considering any proxy layer. nil means the pattern
+  # itself is unusable, so the caller must fail closed rather than guess direct/proxy.
+  protected def self.project_upstream_destination_match(dest_host : String) : {Bool?, String?}
+    if error = @@project_upstream_destination_error
+      return {nil, error}
+    end
+    {@@project_upstream_destination_compiled.matches?(dest_host), nil}
+  end
 
   # Install *store*'s per-project network overrides into the runtime layer above. THE one
   # implementation, called by every surface that opens a project store — `Session.open` (TUI
@@ -339,7 +379,7 @@ module Gori::Settings
   # a surface that switches projects (MCP `switch_project`, the TUI project picker) must not
   # carry the previous project's upstream into the next one.
   #
-  # `bind:` is REQUIRED, and gates the two LISTEN keys only. The four outbound/capture keys
+  # `bind:` is REQUIRED, and gates the two LISTEN keys only. The outbound/capture keys
   # apply on every surface — anything that dials reads `upstream_route` + `connect_timeout` /
   # `io_timeout`, and anything that stores a body reads `capture_max` — but a bind address is
   # meaningless where nothing binds, and worse than meaningless if left set: `effective_bind_*`
@@ -351,9 +391,124 @@ module Gori::Settings
     self.project_bind_host = bind ? store.setting(PROJECT_BIND_HOST_KEY) : nil
     self.project_bind_port = bind ? store.setting(PROJECT_BIND_PORT_KEY).try(&.to_i?) : nil
     self.project_upstream_proxy = store.setting(PROJECT_UPSTREAM_KEY)
+    self.project_upstream_destination = store.setting(PROJECT_UPSTREAM_DESTINATION_KEY)
+    load_project_upstream_auth(store.setting(PROJECT_UPSTREAM_AUTH_KEY))
     self.project_connect_timeout_secs = store.setting(PROJECT_CONNECT_TIMEOUT_KEY).try(&.to_i?)
     self.project_io_timeout_secs = store.setting(PROJECT_IO_TIMEOUT_KEY).try(&.to_i?)
     self.project_capture_max_mib = store.setting(PROJECT_CAPTURE_MAX_KEY).try(&.to_i?)
+  end
+
+  # The direct project credential stored in the owner-only project DB. `inspect` is redacted:
+  # this object is threaded through the TUI save seam, and an innocent debug interpolation
+  # must not turn the password into a log/status line.
+  record ProjectProxyAuth, method : String, username : String, password : String do
+    METHODS = ["basic", "socks5"]
+
+    def to_json(json : JSON::Builder) : Nil
+      json.object do
+        json.field "method", method
+        json.field "username", username
+        json.field "password", password
+      end
+    end
+
+    def self.parse?(raw : String) : ProjectProxyAuth?
+      obj = JSON.parse(raw).as_h?
+      return nil unless obj
+      method = obj["method"]?.try(&.as_s?)
+      username = obj["username"]?.try(&.as_s?)
+      password = obj["password"]?.try(&.as_s?)
+      return nil unless method && username && password
+      new(method, username, password)
+    rescue JSON::ParseException
+      nil
+    end
+
+    def inspect(io : IO) : Nil
+      io << "Gori::Settings::ProjectProxyAuth(method="
+      method.inspect(io)
+      io << ", username="
+      username.inspect(io)
+      io << ", password=[REDACTED])"
+    end
+
+    def to_s(io : IO) : Nil
+      inspect(io)
+    end
+  end
+
+  # One normalized hand-off from the Project Settings card to the Runner. Keeping auth and the
+  # destination gate inside the value prevents the already-long positional save signature
+  # growing tails whose order every test Host has to guess.
+  record ProjectNetworkConfig,
+    bind_host : String,
+    bind_port : Int32,
+    upstream : String,
+    auth : ProjectProxyAuth?,
+    connect_secs : Int32,
+    io_secs : Int32,
+    capture_mib : Int32,
+    destination_host : String = DEFAULT_PROJECT_UPSTREAM_DESTINATION
+
+  # Persist one Project Settings network edit and install the same values in the live runtime
+  # layer. Auth deliberately pins the displayed upstream even when it equals the global: a
+  # credential must stay attached to the proxy the operator saw, never fall through to a rule
+  # or follow a later global edit. `*` is represented by an absent destination row so every
+  # pre-feature project keeps the same proxy-all behaviour without migration. Each Store call
+  # reports commit success; all are attempted so an independently busy row cannot leave the
+  # rest of the live edit unapplied.
+  def self.save_project_network(store : Store, config : ProjectNetworkConfig) : Bool
+    auth = config.auth
+    upstream_saved = if auth
+                       store.set_setting(PROJECT_UPSTREAM_KEY, config.upstream)
+                     else
+                       set_or_clear_project(store, PROJECT_UPSTREAM_KEY, config.upstream, upstream_proxy)
+                     end
+    auth_saved = auth ? store.set_setting(PROJECT_UPSTREAM_AUTH_KEY, auth.to_json) : store.delete_setting(PROJECT_UPSTREAM_AUTH_KEY)
+    destination = config.destination_host.strip
+    destination_saved = if destination == DEFAULT_PROJECT_UPSTREAM_DESTINATION
+                          store.delete_setting(PROJECT_UPSTREAM_DESTINATION_KEY)
+                        else
+                          store.set_setting(PROJECT_UPSTREAM_DESTINATION_KEY, destination)
+                        end
+    persisted = [
+      set_or_clear_project(store, PROJECT_BIND_HOST_KEY, config.bind_host, bind_host),
+      set_or_clear_project(store, PROJECT_BIND_PORT_KEY, config.bind_port.to_s, bind_port.to_s),
+      upstream_saved,
+      auth_saved,
+      destination_saved,
+      set_or_clear_project(store, PROJECT_CONNECT_TIMEOUT_KEY, config.connect_secs.to_s, connect_timeout_secs.to_s),
+      set_or_clear_project(store, PROJECT_IO_TIMEOUT_KEY, config.io_secs.to_s, io_timeout_secs.to_s),
+      set_or_clear_project(store, PROJECT_CAPTURE_MAX_KEY, config.capture_mib.to_s, capture_max_mib.to_s),
+    ].all?
+
+    self.project_bind_host = config.bind_host == bind_host ? nil : config.bind_host
+    self.project_bind_port = config.bind_port == bind_port ? nil : config.bind_port
+    self.project_upstream_proxy = auth || config.upstream != upstream_proxy ? config.upstream : nil
+    self.project_upstream_destination = destination == DEFAULT_PROJECT_UPSTREAM_DESTINATION ? nil : destination
+    self.project_upstream_auth = auth
+    self.project_upstream_auth_error = nil
+    self.project_connect_timeout_secs = config.connect_secs == connect_timeout_secs ? nil : config.connect_secs
+    self.project_io_timeout_secs = config.io_secs == io_timeout_secs ? nil : config.io_secs
+    self.project_capture_max_mib = config.capture_mib == capture_max_mib ? nil : config.capture_mib
+    persisted
+  end
+
+  private def self.set_or_clear_project(store : Store, key : String,
+                                        value : String, global : String) : Bool
+    value == global ? store.delete_setting(key) : store.set_setting(key, value)
+  end
+
+  private def self.load_project_upstream_auth(raw : String?) : Nil
+    self.project_upstream_auth = nil
+    self.project_upstream_auth_error = nil
+    return unless raw
+    if auth = ProjectProxyAuth.parse?(raw)
+      self.project_upstream_auth = auth
+    else
+      self.project_upstream_auth_error =
+        "project proxy authentication is malformed — edit Project settings before sending"
+    end
   end
 
   # A `-l` / `-p` (`gori tui`, `gori run capture`) override for THIS PROCESS only, nil when the
@@ -470,9 +625,9 @@ module Gori::Settings
   DEFAULT_HTTP_PROXY_PORT = 8080
   DEFAULT_SOCKS_PORT      = 1080
 
-  # The shared "host:port" parse behind the legacy scalar and the upstream RULE table (which
-  # needs a different default port per kind). Accepts an optional "http://" prefix and a
-  # bracketed IPv6 literal; nil when blank or when the host part is empty.
+  # The shared strict authority parse behind legacy scalar addresses and the upstream RULE
+  # table (which needs a different default port per kind). Accepts the historical HTTP scheme
+  # prefix and bracketed IPv6; nil when any authority component is malformed.
   #
   # There is deliberately no `upstream_proxy_addr` helper wrapping this over the scalar any
   # more. It existed when the scalar WAS the routing decision; once `upstream_route` folded
@@ -483,23 +638,45 @@ module Gori::Settings
     value = value.strip
     return nil if value.empty?
     value = value.sub(/\Ahttps?:\/\//, "").rstrip('/')
+    return nil if unsafe_proxy_authority?(value)
     # Bracketed IPv6 ("[::1]" / "[::1]:8080"): host is inside the brackets, the
     # optional port follows ']'. Without this the rindex(':') below would split
     # inside the IPv6 literal and yield a garbage host/port.
-    if value.starts_with?('[')
-      if close = value.index(']')
-        host = value[1...close]
-        return nil if host.empty?
-        rest = value[(close + 1)..]
-        return {host, rest.starts_with?(':') ? (rest[1..].to_i? || default_port) : default_port}
-      end
-    end
+    return bracketed_proxy_addr(value, default_port) if value.starts_with?('[')
+    plain_proxy_addr(value, default_port)
+  end
+
+  private def self.unsafe_proxy_authority?(value : String) : Bool
+    value.empty? || value.includes?('/') || value.includes?('?') ||
+      value.includes?('#') || value.includes?('@') || value.matches?(/\s/)
+  end
+
+  private def self.bracketed_proxy_addr(value : String,
+                                        default_port : Int32) : {String, Int32}?
+    close = value.index(']')
+    return nil unless close
+    host = value[1...close]
+    return nil if host.empty?
+    rest = value[(close + 1)..]
+    return {host, default_port} if rest.empty?
+    return nil unless rest.starts_with?(':') && rest.size > 1
+    parsed_proxy_addr(host, rest[1..])
+  end
+
+  private def self.plain_proxy_addr(value : String,
+                                    default_port : Int32) : {String, Int32}?
     idx = value.rindex(':')
     return {value, default_port} unless idx
     host = value[0...idx]
     return nil if host.empty?
     return {value, default_port} if host.includes?(':') # unbracketed IPv6 literal → no port
-    {host, value[(idx + 1)..].to_i? || default_port}
+    parsed_proxy_addr(host, value[(idx + 1)..])
+  end
+
+  private def self.parsed_proxy_addr(host : String, port_segment : String) : {String, Int32}?
+    port = port_segment.to_i?
+    return nil unless port && 0 <= port <= 65_535
+    {host, port}
   end
 
   # nil if `host` is an acceptable proxy BIND address; an error message otherwise. Accepts
@@ -549,20 +726,22 @@ module Gori::Settings
   # instead of silently resolving to 8080 (upstream_proxy_addr) and failing every captured
   # flow later, far from the mistake. Shared by settings:network AND the Project settings pane.
   def self.upstream_proxy_port_error(value : String) : String?
-    return nil if value.empty?
-    bare = value.sub(/\Ahttps?:\/\//, "").rstrip('/')
-    if bare.starts_with?('[') # bracketed IPv6 literal: [::1] or [::1]:port — the port is after ']'
-      return nil unless close = bare.index(']')
-      rest = bare[(close + 1)..]
-      return nil unless rest.starts_with?(':') && rest.size > 1 # no explicit port → defaults fine
-      seg = rest[1..]
-    else
-      i = bare.rindex(':')
-      return nil unless i && i < bare.size - 1 # no explicit port → defaults fine
-      return nil if bare[0...i].includes?(':') # pre-colon host has a ':' → unbracketed IPv6 literal, no port
-      seg = bare[(i + 1)..]
+    error = upstream_proxy_error(value)
+    return nil unless error
+    bare = value.sub(/\A[A-Za-z][A-Za-z0-9+.-]*:\/\//, "").rstrip('/')
+    segment = nil.as(String?)
+    if bare.starts_with?('[')
+      if close = bare.index(']')
+        rest = bare[(close + 1)..]
+        segment = rest[1..] if rest.starts_with?(':') && rest.size > 1
+      end
+    elsif (i = bare.rindex(':')) && !bare[0...i].includes?(':') && i < bare.size - 1
+      segment = bare[(i + 1)..]
     end
-    p = seg.to_i?
-    (p && 0 <= p <= 65535) ? nil : "settings: invalid upstream proxy port #{seg.inspect}"
+    if segment
+      port = segment.to_i?
+      return "settings: invalid upstream proxy port #{segment.inspect}" unless port && 0 <= port <= 65_535
+    end
+    error
   end
 end

--- a/src/gori/settings/upstream_rules.cr
+++ b/src/gori/settings/upstream_rules.cr
@@ -1,4 +1,5 @@
 require "json"
+require "uri"
 require "../host_pattern"
 
 # UPSTREAM RULES section (settings:network → Upstream rules): per-destination upstream
@@ -8,11 +9,12 @@ require "../host_pattern"
 #
 # WHY a table: one global proxy address cannot say "route *.corp.internal through the
 # internal proxy, everything else direct", cannot carry credentials (so gori was unusable
-# behind an authenticating proxy at all), and cannot reach a SOCKS proxy.
+# behind an authenticating proxy at all), and can choose different proxies per destination.
 module Gori::Settings
   # The transports a rule can route through. "direct" is a real, useful rule: it is how an
   # exception is carved out of a broader proxy rule below it in the table.
-  UPSTREAM_KINDS = ["direct", "http", "socks5"]
+  UPSTREAM_KINDS     = ["direct", "http", "socks5", "socks5h"]
+  UPSTREAM_PROTOCOLS = ["none", "http", "socks5", "socks5h"]
 
   # One routing rule. `host` is a HostPattern (see Gori::HostPattern) — the same dialect as
   # scope host rules, with "*" as the catch-all. Rules are ORDERED and the FIRST match wins,
@@ -35,7 +37,11 @@ module Gori::Settings
     end
 
     def socks5? : Bool
-      kind == "socks5"
+      kind == "socks5" || kind == "socks5h"
+    end
+
+    def remote_dns? : Bool
+      kind == "socks5h"
     end
 
     # The password, read from the OS environment at DIAL time (not at load), so exporting a
@@ -74,19 +80,33 @@ module Gori::Settings
     port : Int32 = 0,
     username : String = "",
     password : String? = nil,
-    credential_error : String? = nil do
+    credential_error : String? = nil,
+    configuration_error : String? = nil do
     def direct? : Bool
       kind == "direct"
     end
 
     def socks5? : Bool
-      kind == "socks5"
+      kind == "socks5" || kind == "socks5h"
+    end
+
+    def remote_dns? : Bool
+      kind == "socks5h"
+    end
+
+    def invalid? : Bool
+      !configuration_error.nil?
     end
 
     DIRECT = new("direct")
   end
 
   @@upstream_rules : Array(UpstreamRule) = [] of UpstreamRule
+  # Load-time shape errors cannot be represented by UpstreamRule without inventing a host or
+  # transport. Keep them beside the parsed table and turn them into an invalid route before a
+  # socket is opened. A hand-edited proxy declaration must never disappear into DIRECT.
+  @@upstream_rules_load_error : String? = nil
+  @@upstream_proxy_load_error : String? = nil
   # Patterns compiled once per assignment, paired with their rule — the proxy resolves a route
   # per dial, so the glob/suffix decision must not be re-derived there.
   @@upstream_rules_compiled : Array({HostPattern::Compiled, UpstreamRule}) = [] of {HostPattern::Compiled, UpstreamRule}
@@ -98,6 +118,16 @@ module Gori::Settings
   def self.upstream_rules=(rules : Array(UpstreamRule)) : Array(UpstreamRule)
     @@upstream_rules = rules
     @@upstream_rules_compiled = rules.map { |r| {HostPattern::Compiled.new(r.host), r} }
+    # A malformed host pattern never matches, so without retaining its error the route lookup
+    # would skip the rule and fall through to the scalar/direct path. Validate on assignment as
+    # well as persisted load: tests and settings editors install arrays through this setter.
+    @@upstream_rules_load_error = nil
+    rules.each do |rule|
+      if err = upstream_rule_host_error(rule.host)
+        @@upstream_rules_load_error = err
+        break
+      end
+    end
     rules
   end
 
@@ -111,70 +141,272 @@ module Gori::Settings
 
   # How to reach `dest_host`. Precedence, highest first:
   #
+  #   0. the PROJECT destination gate — a non-match is explicitly direct;
   #   1. the PROJECT upstream override (net.upstream_proxy) — an explicit per-project pin,
   #      unchanged from before rules existed, so an upgrade can't reroute a pinned project;
   #   2. the rule table (first host match);
   #   3. the global `network.upstream_proxy` scalar — the implicit catch-all;
   #   4. direct.
   #
-  # A project override deliberately bypasses the table wholesale: "this project goes through
-  # this proxy, period". Per-project RULES are a separate change (#440).
+  # A project override deliberately bypasses the table wholesale. Its Destination host gate
+  # is orthogonal: `*` keeps "this project goes through this proxy, period", while a narrower
+  # pattern makes every non-match direct before the table/scalar can claim it.
   def self.upstream_route(dest_host : String) : UpstreamRoute
+    destination_match, destination_error = project_upstream_destination_match(dest_host)
+    if destination_error
+      return invalid_upstream_route("#{destination_error} — the destination proxy filter is invalid")
+    end
+    return UpstreamRoute::DIRECT unless destination_match
+
     if pinned = project_upstream_proxy
       # An explicit project "" means direct and must beat a non-blank global (the same
       # nil-vs-empty distinction effective_upstream_proxy relies on).
-      return UpstreamRoute::DIRECT if pinned.strip.empty?
-      return http_route(pinned) || UpstreamRoute::DIRECT
+      return project_upstream_route(pinned)
+    end
+    if err = project_upstream_auth_error
+      return invalid_upstream_route(err)
+    end
+    if project_upstream_auth
+      return invalid_upstream_route(
+        "project proxy authentication has no project upstream proxy"
+      )
+    end
+    if err = @@upstream_rules_load_error
+      return invalid_upstream_route(err)
     end
     if rule = upstream_rule_for(dest_host)
       return rule_route(rule)
     end
-    http_route(upstream_proxy) || UpstreamRoute::DIRECT
+    if err = @@upstream_proxy_load_error
+      return invalid_upstream_route(err)
+    end
+    parse_upstream_proxy(upstream_proxy)
   end
 
-  # A rule turned into a route. An unparseable/blank addr degrades to DIRECT rather than
-  # failing every dial for the host: the save-time validator rejects such a rule, so reaching
-  # here means a hand-edited file, and refusing to connect at all would be a worse outcome
-  # than ignoring one bad line (which the log records via upstream_rule_error at load).
+  # A rule turned into a route. Save-time validation catches these errors in the normal path;
+  # a hand-edited file can still reach here, and must fail closed rather than silently sending
+  # the destination direct.
   private def self.rule_route(rule : UpstreamRule) : UpstreamRoute
+    if err = upstream_rule_error(rule)
+      return invalid_upstream_route(err)
+    end
     return UpstreamRoute::DIRECT if rule.direct?
     addr = proxy_addr(rule.addr, default_port: rule.socks5? ? DEFAULT_SOCKS_PORT : DEFAULT_HTTP_PROXY_PORT)
-    return UpstreamRoute::DIRECT unless addr
+    return invalid_upstream_route("settings: invalid #{rule.kind} upstream proxy #{rule.addr.inspect}") unless addr
     UpstreamRoute.new(rule.kind, addr[0], addr[1], rule.username, rule.password, rule.credential_error)
   end
 
-  # An "host:port" string as an unauthenticated HTTP-proxy route, or nil when blank/unparseable.
-  private def self.http_route(value : String) : UpstreamRoute?
-    addr = proxy_addr(value, default_port: DEFAULT_HTTP_PROXY_PORT)
-    addr ? UpstreamRoute.new("http", addr[0], addr[1]) : nil
+  # The scalar/project upstream grammar follows the conventional SOCKS URI distinction:
+  # `socks5` resolves destination names locally; `socks5h` sends them to the proxy as
+  # ATYP DOMAIN. Keeping the kind here lets the dialer make that decision once.
+  # `https://` keeps its historical meaning (a plaintext HTTP CONNECT proxy) for compatibility;
+  # TLS-to-proxy is not implemented.
+  def self.parse_upstream_proxy(value : String) : UpstreamRoute
+    raw = value.strip
+    return UpstreamRoute::DIRECT if raw.empty?
+    return legacy_upstream_route(raw, value) unless raw.includes?("://")
+    uri_upstream_route(URI.parse(raw), raw, value)
+  rescue URI::Error | ArgumentError | OverflowError
+    invalid_upstream_route("settings: invalid upstream proxy #{value.inspect}")
   end
 
-  # Tolerant parse: entries missing host/kind are dropped, an unknown kind is dropped (rather
-  # than silently treated as "direct", which would quietly disable an intended proxy), and a
-  # non-array node keeps the current value. Mirrors parse_oast_providers' robustness.
-  private def self.parse_upstream_rules(node : JSON::Any?) : Array(UpstreamRule)
-    arr = node.try(&.as_a?)
-    return upstream_rules unless arr
+  private def self.legacy_upstream_route(raw : String, original : String) : UpstreamRoute
+    addr = proxy_addr(raw, default_port: DEFAULT_HTTP_PROXY_PORT)
+    return UpstreamRoute.new("http", addr[0], addr[1]) if addr
+    invalid_upstream_route("settings: invalid upstream proxy #{original.inspect}")
+  end
+
+  private def self.uri_upstream_route(uri : URI, raw : String,
+                                      original : String) : UpstreamRoute
+    route_kind = upstream_route_kind(uri.scheme.try(&.downcase) || "")
+    return route_kind if route_kind.is_a?(UpstreamRoute)
+    kind, default_port = route_kind
+    if uri.user || uri.password
+      return invalid_upstream_route(
+        "settings: upstream proxy URI credentials are not stored here; use an upstream rule with username + password_env"
+      )
+    end
+    unless uri.query.nil? && uri.fragment.nil? && (uri.path.empty? || uri.path == "/")
+      return invalid_upstream_route("settings: upstream proxy must be an authority without a path, query, or fragment")
+    end
+    authority_route(raw, original, kind, default_port)
+  end
+
+  private def self.upstream_route_kind(scheme : String) : {String, Int32} | UpstreamRoute
+    case scheme
+    when "http", "https" then {"http", DEFAULT_HTTP_PROXY_PORT}
+    when "socks5"        then {"socks5", DEFAULT_SOCKS_PORT}
+    when "socks5h"       then {"socks5h", DEFAULT_SOCKS_PORT}
+    else
+      invalid_upstream_route(
+        "settings: unsupported upstream proxy scheme #{scheme.inspect}; use http, socks5, or socks5h"
+      )
+    end
+  end
+
+  private def self.authority_route(raw : String, original : String, kind : String,
+                                   default_port : Int32) : UpstreamRoute
+    authority = raw[(raw.index!("://") + 3)..]
+    authority = authority[...-1] if authority.ends_with?('/')
+    addr = proxy_addr(authority, default_port: default_port)
+    return UpstreamRoute.new(kind, addr[0], addr[1]) if addr
+    invalid_upstream_route("settings: invalid upstream proxy #{original.inspect}")
+  end
+
+  def self.upstream_proxy_error(value : String) : String?
+    parse_upstream_proxy(value).configuration_error
+  end
+
+  # Validate the single project Destination host pattern. This intentionally uses the shared
+  # HostPattern `*` dialect but accepts only host-shaped input: a URL/port can never match the
+  # bare destination name Upstream passes to #upstream_route. IPv6 may be bare or bracketed;
+  # wildcard labels support domain and IPv4 patterns such as `*.corp.test` / `10.*`.
+  def self.upstream_destination_error(value : String) : String?
+    pattern = value.strip
+    return "settings: destination host is required (use * for all traffic)" if pattern.empty?
+    return "settings: destination host must not include a scheme" if pattern.includes?("://")
+    return "settings: destination host must not include a path" if pattern.includes?('/')
+
+    literal, literal_error = upstream_destination_literal(pattern)
+    return literal_error if literal
+    return "settings: destination host must not include a :port" if pattern.includes?(':')
+    return nil if pattern == "*"
+
+    return nil if upstream_destination_pattern?(pattern)
+    "settings: invalid destination host pattern #{pattern.inspect}"
+  end
+
+  # `{handled, error}` distinguishes "not an IP literal" from "a valid literal" (both have no
+  # error). A bracket declares IPv6 intent, so a malformed bracketed value is handled+invalid
+  # rather than falling through to the hostname wildcard grammar.
+  private def self.upstream_destination_literal(pattern : String) : {Bool, String?}
+    if pattern.starts_with?('[')
+      return {true, nil} if pattern.ends_with?(']') && Socket::IPAddress.valid_v6?(pattern[1...-1])
+      return {true, "settings: invalid destination host #{pattern.inspect}"}
+    end
+    return {true, nil} if Socket::IPAddress.valid_v4?(pattern) || Socket::IPAddress.valid_v6?(pattern)
+    {false, nil}
+  end
+
+  private def self.upstream_destination_pattern?(pattern : String) : Bool
+    pattern.split('.').all? do |label|
+      !label.empty? && label.matches?(/\A[A-Za-z0-9*](?:[A-Za-z0-9*\-]*[A-Za-z0-9*])?\z/)
+    end
+  end
+
+  # The three editable values used by both settings surfaces. nil preserves an invalid raw
+  # declaration as something the UI can show and refuse, rather than laundering it into
+  # direct access merely because it could not be projected into fields.
+  def self.upstream_proxy_fields(value : String) : {String, String, String}?
+    route = parse_upstream_proxy(value)
+    return nil if route.invalid?
+    return {"none", "", ""} if route.direct?
+    {route.kind, route.host, route.port.to_s}
+  end
+
+  # Compose the split UI fields back into the existing scalar storage format. The setting
+  # remains one string for compatibility; this is the single validation seam shared by the
+  # global and project editors. An IPv6 authority is bracketed only at serialization time.
+  def self.build_upstream_proxy(protocol : String, host : String,
+                                port : String) : {String, String?}
+    kind = protocol.strip.downcase
+    return {"", nil} if kind == "none"
+    unless UPSTREAM_PROTOCOLS.includes?(kind)
+      return {"", "settings: proxy protocol must be one of none, http, socks5, socks5h"}
+    end
+    bare = host.strip
+    bare = bare[1...-1] if bare.starts_with?('[') && bare.ends_with?(']')
+    return {"", "settings: proxy host is required"} if bare.empty?
+    parsed_port = port.strip.to_i?
+    unless parsed_port && parsed_port.in?(1..65535)
+      return {"", "settings: proxy port must be between 1 and 65535"}
+    end
+    authority_host = bare.includes?(':') ? "[#{bare}]" : bare
+    value = "#{kind}://#{authority_host}:#{parsed_port}"
+    if err = upstream_proxy_error(value)
+      {"", err}
+    else
+      {value, nil}
+    end
+  end
+
+  # Build and validate the credential value the Project Settings card persists. HTTP Basic
+  # and SOCKS5 RFC 1929 are the only methods offered, and the proxy URI chooses between them;
+  # there is no second method selector that can disagree with the actual transport.
+  def self.build_project_proxy_auth(upstream : String, enabled : Bool,
+                                    username : String, password : String) : {ProjectProxyAuth?, String?}
+    return {nil, nil} unless enabled
+    route = parse_upstream_proxy(upstream)
+    if err = route.configuration_error
+      return {nil, err}
+    end
+    if route.direct?
+      return {nil, "project proxy authentication requires an upstream proxy"}
+    end
+    method = route.socks5? ? "socks5" : "basic"
+    auth = ProjectProxyAuth.new(method, username, password)
+    {auth, project_proxy_auth_error(auth, route)}
+  end
+
+  # Apply a scalar node without allowing a present-but-non-string value to disappear into the
+  # previous blank default. Absent means "leave this layer alone", as profile imports require.
+  protected def self.apply_upstream_proxy(node : JSON::Any?) : Nil
+    return unless node
+    if value = node.as_s?
+      self.upstream_proxy = value
+      @@upstream_proxy_load_error = nil
+    else
+      @@upstream_proxy_load_error = "settings: network.upstream_proxy must be a string"
+    end
+  end
+
+  # Apply the rule table and retain any malformed declaration as a global configuration error.
+  # Without a trustworthy host pattern there is no safe destination to scope the refusal to.
+  protected def self.apply_upstream_rules(node : JSON::Any?) : Nil
+    return unless node
+    arr = node.as_a?
+    unless arr
+      @@upstream_rules_load_error = "settings: upstream_rules must be an array"
+      return
+    end
     out = [] of UpstreamRule
-    arr.each do |e|
-      next unless o = e.as_h?
-      host = o["host"]?.try(&.as_s?).try(&.strip)
+    error = nil.as(String?)
+    arr.each_with_index do |e, index|
+      unless o = e.as_h?
+        error ||= "settings: upstream_rules[#{index}] must be an object"
+        next
+      end
+      host = o["host"]?.try(&.as_s?).try(&.strip).try(&.presence)
       kind = o["kind"]?.try(&.as_s?).try(&.strip.downcase)
-      next if host.nil? || host.empty? || kind.nil? || !UPSTREAM_KINDS.includes?(kind)
-      out << UpstreamRule.new(
+      unless host && kind && UPSTREAM_KINDS.includes?(kind)
+        error ||= "settings: upstream_rules[#{index}] needs a host and kind #{UPSTREAM_KINDS.join("/")}"
+        next
+      end
+      rule = UpstreamRule.new(
         host, kind,
         o["addr"]?.try(&.as_s?).try(&.strip) || "",
         o["username"]?.try(&.as_s?) || "",
         o["password_env"]?.try(&.as_s?).try(&.strip) || "",
       )
+      error ||= upstream_rule_error(rule)
+      out << rule
     end
-    out
+    self.upstream_rules = out
+    @@upstream_rules_load_error = error
+  end
+
+  # A fresh disk load means a removed/fixed declaration must release the old refusal. Imports
+  # do not call this, so omitted sections keep their current state.
+  protected def self.reset_upstream_route_errors : Nil
+    @@upstream_rules_load_error = nil
+    @@upstream_proxy_load_error = nil
   end
 
   # Factory reset for this section (dispatched by Settings.reset_to_factory). Through the
   # SETTER, so the compiled host patterns are dropped with the rules.
   private def self.reset_upstream_rules : Nil
     self.upstream_rules = [] of UpstreamRule
+    @@upstream_proxy_load_error = nil
   end
 
   # Omit when empty so an untouched install never writes "upstream_rules": [].
@@ -196,11 +428,13 @@ module Gori::Settings
   end
 
   # nil if `rule` is usable; an error message otherwise. A non-direct rule needs an address,
-  # and its port must parse — a typo there would otherwise resolve to the default port and
-  # fail every dial for the host, far from the mistake (same reasoning as
-  # upstream_proxy_port_error, which this reuses for the port check).
+  # and its authority must parse — a typo there would otherwise fail every dial for the host,
+  # far from the mistake. Rule addresses remain bare authorities; the kind column owns the
+  # transport, unlike the catch-all scalar whose URI scheme selects it.
   def self.upstream_rule_error(rule : UpstreamRule) : String?
-    return "settings: upstream rule needs a host pattern" if rule.host.strip.empty?
+    if err = upstream_rule_host_error(rule.host)
+      return err
+    end
     return "settings: upstream rule kind must be one of #{UPSTREAM_KINDS.join(", ")}" unless UPSTREAM_KINDS.includes?(rule.kind)
     if rule.direct?
       # A direct rule carrying an address/credentials is a sign the operator meant http/socks5;
@@ -212,7 +446,73 @@ module Gori::Settings
     if err = upstream_proxy_port_error(rule.addr)
       return err
     end
+    default_port = rule.socks5? ? DEFAULT_SOCKS_PORT : DEFAULT_HTTP_PROXY_PORT
+    unless proxy_addr(rule.addr, default_port: default_port)
+      return "settings: invalid #{rule.kind} upstream proxy #{rule.addr.inspect}"
+    end
     return "settings: upstream rule password_env is an environment variable NAME, not a value" if rule.password_env.includes?('$')
+    nil
+  end
+
+  # Upstream rules and the project Destination host use the same host-only pattern dialect.
+  # Reuse that validator so a malformed glob cannot compile as a permanently non-matching rule
+  # and leak its intended destinations through the next routing layer.
+  private def self.upstream_rule_host_error(value : String) : String?
+    pattern = value.strip
+    return "settings: upstream rule needs a host pattern" if pattern.empty?
+    return nil unless upstream_destination_error(pattern)
+    "settings: invalid upstream rule host pattern #{pattern.inspect}"
+  end
+
+  private def self.invalid_upstream_route(message : String) : UpstreamRoute
+    UpstreamRoute.new("invalid", configuration_error: message)
+  end
+
+  private def self.project_upstream_route(value : String) : UpstreamRoute
+    if err = project_upstream_auth_error
+      return invalid_upstream_route(err)
+    end
+    route = parse_upstream_proxy(value)
+    return route if route.invalid?
+    auth = project_upstream_auth
+    return route unless auth
+    if err = project_proxy_auth_error(auth, route)
+      return invalid_upstream_route(err)
+    end
+    UpstreamRoute.new(route.kind, route.host, route.port, auth.username, auth.password)
+  end
+
+  private def self.project_proxy_auth_error(auth : ProjectProxyAuth,
+                                            route : UpstreamRoute) : String?
+    return "project proxy authentication requires an upstream proxy" if route.direct?
+    method_error = project_proxy_auth_method_error(auth, route)
+    return method_error unless method_error.nil?
+    project_proxy_auth_value_error(auth)
+  end
+
+  private def self.project_proxy_auth_method_error(auth : ProjectProxyAuth,
+                                                   route : UpstreamRoute) : String?
+    unless ProjectProxyAuth::METHODS.includes?(auth.method)
+      return "project proxy authentication method must be basic or socks5"
+    end
+    expected = route.socks5? ? "socks5" : "basic"
+    unless auth.method == expected
+      return "project proxy authentication method #{auth.method.inspect} does not match the #{route.kind} proxy"
+    end
+    nil
+  end
+
+  private def self.project_proxy_auth_value_error(auth : ProjectProxyAuth) : String?
+    return "project proxy authentication requires a username" if auth.username.empty?
+    if auth.username.includes?('\r') || auth.username.includes?('\n') ||
+       auth.password.includes?('\r') || auth.password.includes?('\n')
+      return "project proxy credentials cannot contain CR or LF"
+    end
+    if auth.method == "basic"
+      return "HTTP Basic proxy usernames cannot contain ':'" if auth.username.includes?(':')
+    elsif auth.username.bytesize > 255 || auth.password.empty? || auth.password.bytesize > 255
+      return "SOCKS5 proxy username and password must each be 1-255 bytes"
+    end
     nil
   end
 end

--- a/src/gori/settings/upstream_rules.cr
+++ b/src/gori/settings/upstream_rules.cr
@@ -223,7 +223,8 @@ module Gori::Settings
     kind, default_port = route_kind
     if uri.user || uri.password
       return invalid_upstream_route(
-        "settings: upstream proxy URI credentials are not stored here; use an upstream rule with username + password_env"
+        "settings: upstream proxy URI credentials are not stored here; use Project settings proxy auth, " \
+        "or an upstream rule with username + password_env"
       )
     end
     unless uri.query.nil? && uri.fragment.nil? && (uri.path.empty? || uri.path == "/")
@@ -288,9 +289,14 @@ module Gori::Settings
     {false, nil}
   end
 
+  # `_` is accepted even though DNS hostnames disallow it. This grammar is applied to EXISTING
+  # `upstream_rules` at load, and one rejected rule refuses every route (apply_upstream_rules);
+  # the scope editor this dialect is shared with has always taken underscore names, which
+  # internal networks and `_service._tcp` labels do use. Rejecting them here would brick egress
+  # on upgrade for a pattern gori itself taught the operator to write.
   private def self.upstream_destination_pattern?(pattern : String) : Bool
     pattern.split('.').all? do |label|
-      !label.empty? && label.matches?(/\A[A-Za-z0-9*](?:[A-Za-z0-9*\-]*[A-Za-z0-9*])?\z/)
+      !label.empty? && label.matches?(/\A[A-Za-z0-9*_](?:[A-Za-z0-9*_\-]*[A-Za-z0-9*_])?\z/)
     end
   end
 
@@ -353,8 +359,7 @@ module Gori::Settings
   protected def self.apply_upstream_proxy(node : JSON::Any?) : Nil
     return unless node
     if value = node.as_s?
-      self.upstream_proxy = value
-      @@upstream_proxy_load_error = nil
+      self.upstream_proxy = value # the setter retires any error a previous load retained
     else
       @@upstream_proxy_load_error = "settings: network.upstream_proxy must be a string"
     end

--- a/src/gori/store/settings_kv.cr
+++ b/src/gori/store/settings_kv.cr
@@ -55,5 +55,24 @@ module Gori
         nil
       }
     end
+
+    # Several rows in ONE writer task, so they commit or roll back together. A nil value
+    # deletes its key. For rows that are only meaningful as a set — a proxy address and the
+    # credentials pinned to it — per-key writes can land one half and lose the other, leaving
+    # the project pointing a live secret at the address it used to have. Returns whether the
+    # batch COMMITTED, like the single-key calls above.
+    def set_settings(entries : Array({String, String?})) : Bool
+      return true if entries.empty?
+      exec_task_ok ->(c : DB::Connection) {
+        entries.each do |(key, value)|
+          if value
+            c.exec("INSERT INTO settings (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = ?", key, value, value)
+          else
+            c.exec("DELETE FROM settings WHERE key = ?", key)
+          end
+        end
+        nil
+      }
+    end
   end
 end

--- a/src/gori/tui/controllers/project_controller.cr
+++ b/src/gori/tui/controllers/project_controller.cr
@@ -64,6 +64,8 @@ module Gori::Tui
       when :settings
         if @project_view.settings_text_row?
           "type to edit · ↵ apply · ←/→ cursor · ↑/↓ move · esc sub-tabs"
+        elsif @project_view.settings_protocol_row?
+          "←/→/space protocol · SOCKS5 local DNS · SOCKS5H proxy DNS · ↑/↓ move · esc sub-tabs"
         elsif @project_view.settings_sandbox_row?
           "space/↵ sandbox — ON blocks ALL out-of-scope traffic · ↑/↓ move · esc sub-tabs"
         else
@@ -209,17 +211,22 @@ module Gori::Tui
         end
         @project_view.desc_click_to_cursor(rect, mx, my)
       when :settings
-        @project_view.focus_pane(:settings)
-        if idx = @project_view.set_row_at(rect, mx, my)
-          @project_view.select_setting(idx)
-          case idx
-          when ProjectView::SETTINGS_SCOPE_ROW   then @host.toggle_scope_lens
-          when ProjectView::SETTINGS_SANDBOX_ROW then @host.toggle_sandbox
-          else                                        @project_view.setting_click_to_cursor(rect, mx, my)
-          end
-        end
+        handle_project_settings_click(rect, mx, my)
       end # :overview band → just take body focus
       true
+    end
+
+    private def handle_project_settings_click(rect : Rect, mx : Int32, my : Int32) : Nil
+      @project_view.focus_pane(:settings)
+      return unless idx = @project_view.set_row_at(rect, mx, my)
+      @project_view.select_setting(idx)
+      case idx
+      when ProjectView::SETTINGS_SCOPE_ROW    then @host.toggle_scope_lens
+      when ProjectView::SETTINGS_SANDBOX_ROW  then @host.toggle_sandbox
+      when ProjectView::SETTINGS_PROTOCOL_ROW then @project_view.cycle_settings_protocol
+      when ProjectView::SETTINGS_AUTH_ROW     then @project_view.toggle_settings_auth
+      else                                         @project_view.setting_click_to_cursor(rect, mx, my)
+      end
     end
 
     # --- mouse drag + double-click (see TabController#supports_drag?) ---
@@ -937,12 +944,29 @@ module Gori::Tui
     private def commit_project_protos : String?
       return nil unless @project_view.protos_dirty?
       line = @host.apply_project_protos(@project_view.protos_value)
-      @project_view.refresh_protos # NOT refresh_settings — that would reset the six network fields
+      @project_view.refresh_protos # NOT refresh_settings — that would reset the network fields
       line
     end
 
     private def handle_project_settings_action(ev : Termisu::Event::Key) : Nil
-      @project_view.settings_text_row? ? handle_project_settings_field_key(ev) : handle_project_settings_toggle_key(ev)
+      if @project_view.settings_protocol_row?
+        handle_project_settings_protocol_key(ev)
+      elsif @project_view.settings_auth_row?
+        handle_project_settings_auth_key(ev)
+      elsif @project_view.settings_toggle_row?
+        handle_project_settings_toggle_key(ev)
+      elsif @project_view.settings_text_row?
+        handle_project_settings_field_key(ev)
+      end
+    end
+
+    private def handle_project_settings_protocol_key(ev : Termisu::Event::Key) : Nil
+      key = ev.key
+      if key.left?
+        @project_view.cycle_settings_protocol(-1)
+      elsif key.right? || key.enter? || key.space?
+        @project_view.cycle_settings_protocol(1)
+      end
     end
 
     # The two toggle rows (scope lens, sandbox): space/↵ flips whichever is selected. ↑/↓ are
@@ -954,7 +978,14 @@ module Gori::Tui
       end
     end
 
-    # Rows 2-8 (bind IP / port / upstream / timeouts / capture cap / proto schema): type to
+    private def handle_project_settings_auth_key(ev : Termisu::Event::Key) : Nil
+      key = ev.key
+      if key.enter? || key.space? || key.left? || key.right?
+        @project_view.toggle_settings_auth
+      end
+    end
+
+    # Text rows (bind / proxy / credentials / timeouts / capture cap / proto schema): type to
     # edit, ↵ applies,
     # ←/→ move the caret (clamped — they no longer escape the card sideways).
     private def handle_project_settings_field_key(ev : Termisu::Event::Key) : Nil
@@ -980,14 +1011,26 @@ module Gori::Tui
     # ↵ keeps it so the user can fix it. Dirty-guarded so an unchanged pane never re-applies.
     private def commit_project_network(on_leave : Bool = false) : String?
       return nil unless @project_view.settings_dirty?
-      host, port_s, upstream, connect_s, idle_s, cap_s = @project_view.settings_values
+      host, port_s, _protocol, _proxy_host, _proxy_port, destination, auth_s, username, password, connect_s, idle_s, cap_s =
+        @project_view.settings_values
       return settings_invalid("bind IP is required", on_leave) if host.empty?
       port = port_s.to_i?
       unless port && 0 <= port <= 65535
         return settings_invalid("invalid bind port #{port_s.inspect}", on_leave)
       end
-      if err = Settings.upstream_proxy_port_error(upstream)
+      upstream, proxy_error = @project_view.settings_upstream_proxy
+      if proxy_error
+        return settings_invalid(proxy_error, on_leave)
+      end
+      if err = Settings.upstream_proxy_error(upstream)
         return settings_invalid(err, on_leave)
+      end
+      if err = Settings.upstream_destination_error(destination)
+        return settings_invalid(err, on_leave)
+      end
+      auth, auth_error = Settings.build_project_proxy_auth(upstream, auth_s == "on", username, password)
+      if auth_error
+        return settings_invalid(auth_error, on_leave)
       end
       connect = positive_secs(connect_s)
       return settings_invalid("invalid connect timeout #{connect_s.inspect} (seconds, min 1)", on_leave) unless connect
@@ -996,7 +1039,8 @@ module Gori::Tui
       cap = positive_secs(cap_s)
       return settings_invalid("invalid capture limit #{cap_s.inspect} (MiB, min 1)", on_leave) unless cap
       cap = cap.clamp(1, Settings::MAX_CAPTURE_MAX_MIB) # keep cap*1024*1024 inside Int32
-      line = @host.apply_project_network(host, port, upstream, connect, idle, cap)
+      config = Settings::ProjectNetworkConfig.new(host, port, upstream, auth, connect, idle, cap, destination)
+      line = @host.apply_project_network(config)
       @project_view.refresh_settings
       line
     end

--- a/src/gori/tui/project_view.cr
+++ b/src/gori/tui/project_view.cr
@@ -198,7 +198,7 @@ module Gori::Tui
     # (Re)load the PROJECT SETTINGS network fields from the effective config — the project
     # override when pinned, else the global default (Session.open populated Settings.project_*
     # from this project's DB on open). @set_overridden drives the "· project/global" marker
-    # (Destination host uses "· default" because it has no global counterpart).
+    # (the project-only fields use "· default" — see SETTINGS_PROJECT_ONLY_INDICES).
     #
     # The bind pair uses `configured_bind_*`, NOT `effective_bind_*`: those two differ only by
     # the process-only `-l`/`-p` layer, which is neither a project pin nor the global — so it
@@ -442,10 +442,15 @@ module Gori::Tui
     SETTINGS_PROXY_PORT_INDEX  = SETTINGS_PROXY_PORT_ROW - SETTINGS_FIELD_BASE
     SETTINGS_DESTINATION_INDEX = SETTINGS_DESTINATION_ROW - SETTINGS_FIELD_BASE
     SETTINGS_AUTH_INDEX        = SETTINGS_AUTH_ROW - SETTINGS_FIELD_BASE
+    SETTINGS_USERNAME_INDEX    = SETTINGS_USERNAME_ROW - SETTINGS_FIELD_BASE
     SETTINGS_PASSWORD_INDEX    = SETTINGS_PASSWORD_ROW - SETTINGS_FIELD_BASE
     SETTINGS_PROTOS_FIELD      = 12
     SETTINGS_LABEL_W           = 16 # value column starts past the widest label ("Connect timeout")
     SETTINGS_PROTOCOL_CHOICES  = ["None", "HTTP", "SOCKS5", "SOCKS5H"]
+    # Fields with no global counterpart to inherit — their unset marker is "· default", not
+    # "· global" (see render_settings_field).
+    SETTINGS_PROJECT_ONLY_INDICES = [SETTINGS_DESTINATION_INDEX, SETTINGS_USERNAME_INDEX,
+                                     SETTINGS_PASSWORD_INDEX]
 
     # The 's' / scope.edit jump target: focus the SCOPE pane fresh (no half-open row in
     # either list).
@@ -2145,7 +2150,11 @@ module Gori::Tui
                                       fi : Int32, selected : Bool, bg : Color) : Nil
       return render_protos_field(screen, inner, y, vx, selected, bg) if fi == SETTINGS_PROTOS_FIELD
       overridden = @set_overridden[fi]
-      marker = if fi == SETTINGS_DESTINATION_INDEX
+      # "· global" claims settings.json supplied the inherited value. The destination gate and
+      # the two credentials have no global counterpart at all — a project-only field that is
+      # unset is at its DEFAULT, and naming a source that cannot exist would send an operator
+      # looking for the credential in the global editor.
+      marker = if SETTINGS_PROJECT_ONLY_INDICES.includes?(fi)
                  overridden ? "· project" : "· default"
                else
                  overridden ? "· project" : "· global"

--- a/src/gori/tui/project_view.cr
+++ b/src/gori/tui/project_view.cr
@@ -103,14 +103,16 @@ module Gori::Tui
       @env_icx = 0
       @env_preedit = ""
 
-      # NETWORK pane: two toggle rows (scope lens, sandbox) + inline-editable network fields
-      # (bind IP / bind port / upstream proxy). @set_values holds the three text
-      # fields; @set_overridden tracks whether each is a project override (vs inheriting global).
+      # PROJECT SETTINGS pane: two policy toggles plus project network/proxy fields and the
+      # target's protobuf schema. Authentication belongs to the project proxy pin, not global
+      # settings.json; the schema has its own baseline and commit path.
       @set_sel = 0
-      @set_values = ["", "", ""]
-      @set_overridden = [false, false, false]
-      @set_baseline = {"", "", "", "", "", ""} # the six NETWORK fields as last loaded; drives settings_dirty?
-      @protos_baseline = ""                    # …and the proto-schema field's own, per its own commit
+      @set_values = ["", "", "", "", "", "", "", "", "", "", "", "", ""]
+      @set_overridden = [false, false, false, false, false, false,
+                         false, false, false, false, false, false]
+      @set_baseline = {"", "", "", "", "", "", "", "", "", "", "", ""}
+      @set_upstream_raw = ""
+      @protos_baseline = ""
       @set_cursor = 0
       @set_preedit = ""
       load_settings_values
@@ -195,7 +197,8 @@ module Gori::Tui
 
     # (Re)load the PROJECT SETTINGS network fields from the effective config — the project
     # override when pinned, else the global default (Session.open populated Settings.project_*
-    # from this project's DB on open). @set_overridden drives the "· project/global" marker.
+    # from this project's DB on open). @set_overridden drives the "· project/global" marker
+    # (Destination host uses "· default" because it has no global counterpart).
     #
     # The bind pair uses `configured_bind_*`, NOT `effective_bind_*`: those two differ only by
     # the process-only `-l`/`-p` layer, which is neither a project pin nor the global — so it
@@ -208,7 +211,7 @@ module Gori::Tui
       load_protos_value
     end
 
-    # The six NETWORK fields only, written in place so the proto-schema slot beside them
+    # The twelve NETWORK fields only, written in place so the proto-schema slot beside them
     # survives. Partial ON PURPOSE: the two halves commit separately, so each half's refresh
     # must leave the other's pending edit alone — see `refresh_settings` / `refresh_protos`.
     private def load_network_values : Nil
@@ -217,6 +220,12 @@ module Gori::Tui
         !Settings.project_bind_host.nil?,
         !Settings.project_bind_port.nil?,
         !Settings.project_upstream_proxy.nil?,
+        !Settings.project_upstream_proxy.nil?,
+        !Settings.project_upstream_proxy.nil?,
+        !Settings.project_upstream_destination.nil?,
+        !Settings.project_upstream_auth.nil?,
+        !Settings.project_upstream_auth.nil?,
+        !Settings.project_upstream_auth.nil?,
         !Settings.project_connect_timeout_secs.nil?,
         !Settings.project_io_timeout_secs.nil?,
         !Settings.project_capture_max_mib.nil?,
@@ -234,14 +243,39 @@ module Gori::Tui
     end
 
     private def network_values : Array(String)
+      @set_upstream_raw = Settings.effective_upstream_proxy
+      proxy = project_proxy_field_values(@set_upstream_raw)
       [
         Settings.configured_bind_host,
         Settings.configured_bind_port.to_s,
-        Settings.effective_upstream_proxy,
+        proxy[0],
+        proxy[1],
+        proxy[2],
+        Settings.effective_project_upstream_destination,
+        Settings.project_upstream_auth ? "on" : "off",
+        Settings.project_upstream_auth.try(&.username) || "",
+        Settings.project_upstream_auth.try(&.password) || "",
         Settings.effective_connect_timeout_secs.to_s,
         Settings.effective_io_timeout_secs.to_s,
         Settings.effective_capture_max_mib.to_s,
       ]
+    end
+
+    private def project_proxy_field_values(raw : String) : {String, String, String}
+      if fields = Settings.upstream_proxy_fields(raw)
+        {project_proxy_protocol_label(fields[0]), fields[1], fields[2]}
+      else
+        {"Invalid · #{raw}", "", ""}
+      end
+    end
+
+    private def project_proxy_protocol_label(kind : String) : String
+      case kind
+      when "http"    then "HTTP"
+      when "socks5"  then "SOCKS5"
+      when "socks5h" then "SOCKS5H"
+      else                "None"
+      end
     end
 
     private def current_set_value : String
@@ -382,26 +416,36 @@ module Gori::Tui
     # One row for the sub-tab chips.
     STRIP_H = 1
 
-    # PROJECT SETTINGS pane rows: two toggles (scope-lens, sandbox) over the inline text
-    # fields. The toggle/field boundary is FIELD_BASE — every field access is @set_sel minus
-    # it (the fields live in @set_values, indexed @set_sel - FIELD_BASE).
-    # Row order is the tuple order everywhere (settings_values, @set_overridden, the controller's
-    # commit). The three timeout/capture fields were global-only until #440; they are ENGAGEMENT
-    # properties, so a slow appliance or a fat-response target no longer taxes every project.
+    # PROJECT SETTINGS pane rows: two toggles (scope-lens, sandbox) over the inline project
+    # fields. The auth method is inferred from the proxy kind, so its row is only off/on: HTTP
+    # means Basic and SOCKS5 means RFC 1929. This prevents a method selector disagreeing with
+    # the transport it is supposed to authenticate.
     #
     # "Proto schema" (#823) sits LAST and is deliberately not part of the network tuple: it is
-    # committed on its own baseline, so editing it never re-applies (and re-BINDS) six network
-    # values that did not change. It is an engagement property for the same reason the timeouts
-    # are — a `.proto` describes THIS target's API and must not follow the operator to the next.
-    SETTINGS_LABELS = ["Scope lens", "Sandbox", "Bind IP", "Bind Port", "Upstream proxy",
-                       "Connect timeout", "Idle timeout", "Capture limit", "Proto schema"]
-    SETTINGS_SCOPE_ROW   =  0
-    SETTINGS_SANDBOX_ROW =  1
-    SETTINGS_FIELD_BASE  =  2 # first inline-editable text-field row
-    SETTINGS_LABEL_W     = 16 # value column starts past the widest label ("Connect timeout")
-    # Index into @set_values / @set_overridden of the "Proto schema" field (its row is
-    # SETTINGS_FIELD_BASE + this). Named because three places have to agree on it.
-    SETTINGS_PROTOS_FIELD = 6
+    # committed on its own baseline, so editing it never re-applies (and re-BINDS) unchanged
+    # network values. It is an engagement property for the same reason the timeouts are.
+    SETTINGS_LABELS = ["Scope lens", "Sandbox", "Bind IP", "Bind Port", "Proxy protocol",
+                       "Proxy host", "Proxy port", "Destination host", "Proxy auth", "Username",
+                       "Password", "Connect timeout", "Idle timeout", "Capture limit", "Proto schema"]
+    SETTINGS_SCOPE_ROW         =  0
+    SETTINGS_SANDBOX_ROW       =  1
+    SETTINGS_FIELD_BASE        =  2 # first inline-editable network-field row
+    SETTINGS_PROTOCOL_ROW      =  4
+    SETTINGS_PROXY_HOST_ROW    =  5
+    SETTINGS_PROXY_PORT_ROW    =  6
+    SETTINGS_DESTINATION_ROW   =  7
+    SETTINGS_AUTH_ROW          =  8
+    SETTINGS_USERNAME_ROW      =  9
+    SETTINGS_PASSWORD_ROW      = 10
+    SETTINGS_PROTOCOL_INDEX    = SETTINGS_PROTOCOL_ROW - SETTINGS_FIELD_BASE
+    SETTINGS_PROXY_HOST_INDEX  = SETTINGS_PROXY_HOST_ROW - SETTINGS_FIELD_BASE
+    SETTINGS_PROXY_PORT_INDEX  = SETTINGS_PROXY_PORT_ROW - SETTINGS_FIELD_BASE
+    SETTINGS_DESTINATION_INDEX = SETTINGS_DESTINATION_ROW - SETTINGS_FIELD_BASE
+    SETTINGS_AUTH_INDEX        = SETTINGS_AUTH_ROW - SETTINGS_FIELD_BASE
+    SETTINGS_PASSWORD_INDEX    = SETTINGS_PASSWORD_ROW - SETTINGS_FIELD_BASE
+    SETTINGS_PROTOS_FIELD      = 12
+    SETTINGS_LABEL_W           = 16 # value column starts past the widest label ("Connect timeout")
+    SETTINGS_PROTOCOL_CHOICES  = ["None", "HTTP", "SOCKS5", "SOCKS5H"]
 
     # The 's' / scope.edit jump target: focus the SCOPE pane fresh (no half-open row in
     # either list).
@@ -643,7 +687,62 @@ module Gori::Tui
     end
 
     def settings_text_row? : Bool
+      return false if settings_protocol_row?
+      return false if settings_auth_row?
+      return false if settings_credential_row? && !settings_auth_enabled?
+      return false if settings_proxy_field_disabled?
       @set_sel >= SETTINGS_FIELD_BASE
+    end
+
+    def settings_protocol_row? : Bool
+      @set_sel == SETTINGS_PROTOCOL_ROW
+    end
+
+    def settings_auth_row? : Bool
+      @set_sel == SETTINGS_AUTH_ROW
+    end
+
+    private def settings_credential_row? : Bool
+      @set_sel == SETTINGS_USERNAME_ROW || @set_sel == SETTINGS_PASSWORD_ROW
+    end
+
+    def settings_auth_enabled? : Bool
+      @set_values[SETTINGS_AUTH_INDEX] == "on"
+    end
+
+    def toggle_settings_auth : Nil
+      @set_values[SETTINGS_AUTH_INDEX] = settings_auth_enabled? ? "off" : "on"
+      @set_cursor = 0
+      @set_preedit = ""
+    end
+
+    def cycle_settings_protocol(delta : Int32 = 1) : Nil
+      choices = SETTINGS_PROTOCOL_CHOICES
+      previous = @set_values[SETTINGS_PROTOCOL_INDEX]
+      index = choices.index(previous) || 0
+      current = choices[(index + delta) % choices.size]
+      @set_values[SETTINGS_PROTOCOL_INDEX] = current
+      port = @set_values[SETTINGS_PROXY_PORT_INDEX].strip
+      previous_default = project_proxy_default_port(previous)
+      if port.empty? || port == previous_default
+        @set_values[SETTINGS_PROXY_PORT_INDEX] = project_proxy_default_port(current)
+      end
+      @set_cursor = 0
+      @set_preedit = ""
+    end
+
+    private def project_proxy_default_port(label : String) : String
+      case label
+      when "HTTP"              then Settings::DEFAULT_HTTP_PROXY_PORT.to_s
+      when "SOCKS5", "SOCKS5H" then Settings::DEFAULT_SOCKS_PORT.to_s
+      else                          ""
+      end
+    end
+
+    private def settings_proxy_field_disabled? : Bool
+      return false unless @set_sel == SETTINGS_PROXY_HOST_ROW || @set_sel == SETTINGS_PROXY_PORT_ROW
+      protocol = @set_values[SETTINGS_PROTOCOL_INDEX]
+      protocol == "None" || protocol.starts_with?("Invalid ·")
     end
 
     # On row 0 → ↑ pops up to the sub-tab strip. There's no matching at_bottom? / at_cursor_start?
@@ -652,12 +751,23 @@ module Gori::Tui
       @set_sel <= 0
     end
 
-    # The six NETWORK fields, trimmed, for commit: {bind IP, bind port, upstream proxy,
-    # connect timeout, idle timeout, capture limit}. Deliberately NOT including the proto
-    # schema path — see SETTINGS_PROTOS_FIELD.
-    def settings_values : {String, String, String, String, String, String}
-      {@set_values[0].strip, @set_values[1].strip, @set_values[2].strip,
-       @set_values[3].strip, @set_values[4].strip, @set_values[5].strip}
+    # All persisted network fields, in the same order as the rows after the two toggles.
+    # Deliberately excludes the proto schema path, which has its own baseline and commit.
+    def settings_values : {String, String, String, String, String, String, String, String, String, String, String, String}
+      {@set_values[0].strip, @set_values[1].strip,
+       @set_values[2], @set_values[3].strip, @set_values[4].strip,
+       @set_values[5].strip, @set_values[6], @set_values[7], @set_values[8],
+       @set_values[9].strip, @set_values[10].strip, @set_values[11].strip}
+    end
+
+    # Preserve the exact inherited/project scalar while its three-field projection is
+    # untouched (including legacy host:port spelling). Once edited, serialize canonically.
+    def settings_upstream_proxy : {String, String?}
+      unchanged = @set_values[2] == @set_baseline[2] &&
+                  @set_values[3] == @set_baseline[3] &&
+                  @set_values[4] == @set_baseline[4]
+      return {@set_upstream_raw, nil} if unchanged
+      Settings.build_upstream_proxy(@set_values[2].downcase, @set_values[3], @set_values[4])
     end
 
     # The "Proto schema" field, trimmed: a `.desc` file, a directory of them, or blank for
@@ -1920,25 +2030,22 @@ module Gori::Tui
       @desc_read.paint_chrome(screen, rect, @desc_area, active)
     end
 
-    # PROJECT SETTINGS card: the scope-lens + sandbox toggles over the inline-editable text
-    # fields. Each network row carries a "· project" / "· global" marker so a pinned override
-    # reads distinct from an inherited global value; the proto-schema row shows what actually
-    # LOADED instead, because a path with nothing behind it is the failure that matters there.
+    # PROJECT SETTINGS card: policy toggles plus project network, proxy-auth, and protobuf
+    # fields. It is windowed so keyboard and pointer hit-tests can keep every selected row
+    # visible. Network rows show their project/global source; the schema row shows what loaded.
     private def render_settings_card(screen : Screen, rect : Rect, focused : Bool) : Nil
       return if rect.w < 2 || rect.h < 2
       Frame.card(screen, rect, "PROJECT SETTINGS", bg: Theme.bg, border: Frame.pane_border(focused))
       inner = rect.inset(1, 1)
       return if inner.h <= 0 || inner.w <= 0
-      # Scrolled, not clipped. The card takes whatever height is left under the OVERVIEW band,
-      # so on a short terminal the LAST rows fall off — and `set_select` clamps to the full
-      # label count regardless, which let the selection (and typing, and a commit that toasts)
-      # land on a row nothing had drawn.
-      off = settings_scroll(inner.h)
-      SETTINGS_LABELS.each_with_index do |label, i|
-        next if i < off
-        break if i - off >= inner.h
-        render_settings_row(screen, inner, inner.y + (i - off), i, label, focused && @set_sel == i)
+      # Scrolled, not clipped: every selected row remains visible on a short terminal.
+      start = settings_scroll(inner.h)
+      inner.h.times do |row|
+        i = start + row
+        break if i >= SETTINGS_LABELS.size
+        render_settings_row(screen, inner, inner.y + row, i, SETTINGS_LABELS[i], focused && @set_sel == i)
       end
+      Frame.scroll_gauge(screen, inner, SETTINGS_LABELS.size, start, focused, Theme.bg)
     end
 
     # Rows scrolled off the TOP of the settings card, so render and hit-test agree.
@@ -1964,9 +2071,53 @@ module Gori::Tui
         screen.text(vx, y, on ? "ON" : "OFF", on ? Theme.accent : Theme.muted, bg, Attribute::Bold)
       when SETTINGS_SANDBOX_ROW
         render_sandbox_toggle(screen, inner, y, vx, bg)
+      when SETTINGS_PROTOCOL_ROW
+        render_proxy_protocol(screen, inner, y, vx, selected, bg)
+      when SETTINGS_AUTH_ROW
+        render_proxy_auth(screen, inner, y, vx, selected, bg)
       else
-        render_settings_field(screen, inner, y, vx, i - SETTINGS_FIELD_BASE, selected, bg)
+        render_settings_value(screen, inner, y, vx, i, selected, bg)
       end
+    end
+
+    private def render_settings_value(screen : Screen, inner : Rect, y : Int32, vx : Int32,
+                                      row : Int32, selected : Bool, bg : Color) : Nil
+      proxy_disabled = (row == SETTINGS_PROXY_HOST_ROW || row == SETTINGS_PROXY_PORT_ROW) &&
+                       (@set_values[SETTINGS_PROTOCOL_INDEX] == "None" ||
+                        @set_values[SETTINGS_PROTOCOL_INDEX].starts_with?("Invalid ·"))
+      if proxy_disabled || ((row == SETTINGS_USERNAME_ROW || row == SETTINGS_PASSWORD_ROW) && !settings_auth_enabled?)
+        screen.text(vx, y, "—", Theme.muted, bg)
+      else
+        render_settings_field(screen, inner, y, vx, row - SETTINGS_FIELD_BASE, selected, bg)
+      end
+    end
+
+    private def render_proxy_protocol(screen : Screen, inner : Rect, y : Int32, vx : Int32,
+                                      selected : Bool, bg : Color) : Nil
+      value = @set_values[SETTINGS_PROTOCOL_INDEX]
+      overridden = @set_overridden[SETTINGS_PROTOCOL_INDEX]
+      marker = overridden ? "· project" : "· global"
+      mx = inner.right - marker.size
+      width = {mx - vx - 1, 3}.max
+      shown = SETTINGS_PROTOCOL_CHOICES.includes?(value) && selected ? "‹ #{value} ›" : value
+      color = SETTINGS_PROTOCOL_CHOICES.includes?(value) ? (selected ? Theme.text_bright : Theme.text) : Theme.yellow
+      screen.text(vx, y, shown, color, bg, width: width)
+      screen.text(mx, y, marker, overridden ? Theme.accent : Theme.muted, bg) if mx > vx + 3
+    end
+
+    private def render_proxy_auth(screen : Screen, inner : Rect, y : Int32, vx : Int32,
+                                  selected : Bool, bg : Color) : Nil
+      label = if !settings_auth_enabled?
+                "None"
+              elsif @set_values[SETTINGS_PROTOCOL_INDEX] == "SOCKS5" ||
+                    @set_values[SETTINGS_PROTOCOL_INDEX] == "SOCKS5H"
+                "SOCKS5 username/password"
+              else
+                "Basic"
+              end
+      label = "‹ #{label} ›" if selected
+      screen.text(vx, y, label, settings_auth_enabled? ? Theme.accent : Theme.muted, bg,
+        width: {inner.right - vx, 1}.max)
     end
 
     # The Sandbox toggle value + an ALWAYS-VISIBLE, state-aware guidance note. This is a
@@ -1989,18 +2140,26 @@ module Gori::Tui
     end
 
     # One network text field: the value (editable input_line when the row is focused) plus a
-    # right-aligned "· project" / "· global" override marker.
+    # right-aligned override marker ("· project" versus "· global" / "· default").
     private def render_settings_field(screen : Screen, inner : Rect, y : Int32, vx : Int32,
                                       fi : Int32, selected : Bool, bg : Color) : Nil
       return render_protos_field(screen, inner, y, vx, selected, bg) if fi == SETTINGS_PROTOS_FIELD
       overridden = @set_overridden[fi]
-      marker = overridden ? "· project" : "· global"
+      marker = if fi == SETTINGS_DESTINATION_INDEX
+                 overridden ? "· project" : "· default"
+               else
+                 overridden ? "· project" : "· global"
+               end
       mx = inner.right - marker.size
       fw = {mx - vx - 1, 3}.max
+      value = @set_values[fi]
+      masked = fi == SETTINGS_PASSWORD_INDEX && !selected
+      shown = masked ? "•" * value.size : value
+      preedit = masked ? "•" * @set_preedit.size : @set_preedit
       if selected
-        screen.input_line(vx, y, @set_values[fi], @set_cursor, @set_preedit, Theme.text_bright, bg, width: fw)
+        screen.input_line(vx, y, shown, @set_cursor, preedit, Theme.text_bright, bg, width: fw)
       else
-        screen.text(vx, y, @set_values[fi], Theme.text, bg, width: fw)
+        screen.text(vx, y, shown, Theme.text, bg, width: fw)
       end
       screen.text(mx, y, marker, overridden ? Theme.accent : Theme.muted, bg) if mx > vx + 3
     end

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -457,7 +457,7 @@ module Gori::Tui
       end
       # The Project SETTINGS pane is an editor for the PINNED config, so its snapshot (and the
       # dirty baseline `load_settings_values` takes from it) must read the pin, not the port
-      # the environment forced us onto. `commit_project_network` writes all six fields
+      # the environment forced us onto. `commit_project_network` writes every network field
       # whenever ANY one of them is dirty, so a baseline seeded from the fallback turns an edit
       # to the idle timeout into a silent re-pin of the wrong port. The LIVE port is shown by
       # every surface that answers "where am I listening": the top-bar chip
@@ -4738,8 +4738,8 @@ module Gori::Tui
     # global that any later `Settings.save` flushes to settings.json and every future project
     # then inherits; and not `Settings.project_bind_port`, which `apply_project_network`
     # persists into THIS project's DB and which `ProjectView#load_settings_values` seeds its
-    # dirty baseline from, so that a subsequent edit to ANY of the six network fields re-pins
-    # the port along with it (`commit_project_network` passes all six). Config records what the
+    # dirty baseline from, so that a subsequent edit to ANY network field re-pins the port
+    # along with it (`commit_project_network` passes every field). Config records what the
     # operator asked for; the proxy object records what the OS gave us. Keeping the two
     # separate is the whole point — see `Runner#run` and `.port_fallback_stands?`.
     def self.port_fallback(requested : Int32, actual : Int32) : Tuple(Int32, Int32)?
@@ -4809,41 +4809,33 @@ module Gori::Tui
       end
     end
 
-    # Persist + apply the Project settings pane's per-project network config. Each field is
-    # stored only when it DIFFERS from the current global (else the KV key is dropped, so the
-    # project inherits — and later global edits propagate). Refreshes the Settings runtime
-    # override layer, then rebinds the live proxy (the upstream is already live via effective_*).
+    # Persist + apply the Project settings pane's per-project network config. Non-auth fields
+    # are stored only when they differ from the current global; auth pins its proxy address as
+    # well. Refreshes the Settings runtime layer, then rebinds the live proxy (the upstream is
+    # already live via upstream_route).
     def apply_project_network(bind_host : String, bind_port : Int32, upstream : String,
                               connect_secs : Int32, io_secs : Int32, capture_mib : Int32) : String
+      apply_project_network(Settings::ProjectNetworkConfig.new(
+        bind_host, bind_port, upstream, Settings.project_upstream_auth,
+        connect_secs, io_secs, capture_mib, Settings.effective_project_upstream_destination
+      ))
+    end
+
+    def apply_project_network(config : Settings::ProjectNetworkConfig) : String
       # The bind pair compares against the bare GLOBAL, which is exactly what ProjectView seeded
       # the pane with for an unpinned project (`Settings.configured_bind_*`) — so "unchanged
       # means inherit" tracks what the operator was shown. A `-l`/`-p` override is in neither
       # value, which is what keeps a one-run flag from being pinned into this project's DB the
       # next time someone saves this pane for an unrelated reason: the mistake
       # `Runner.port_fallback` describes, one layer down.
-      # Both store writes report whether they COMMITTED, and all six are collected: a project
+      # Every store write reports whether it COMMITTED, and all eight are collected: a project
       # whose writer is held by another instance rolls them back, and this pane used to answer
       # "project network saved" anyway. The pin then existed only in the process globals set
       # below — so the operator saw it applied, the proxy really did rebind, and reopening the
       # project silently reverted every field. That is the same failure `gori run project
       # sandbox on` refuses to have, in its own words: "the in-memory flag flips either way,
       # and the next reload reverts it to the disk value".
-      persisted = [
-        set_or_clear(Settings::PROJECT_BIND_HOST_KEY, bind_host, Settings.bind_host),
-        set_or_clear(Settings::PROJECT_BIND_PORT_KEY, bind_port.to_s, Settings.bind_port.to_s),
-        set_or_clear(Settings::PROJECT_UPSTREAM_KEY, upstream, Settings.upstream_proxy),
-        set_or_clear(Settings::PROJECT_CONNECT_TIMEOUT_KEY, connect_secs.to_s, Settings.connect_timeout_secs.to_s),
-        set_or_clear(Settings::PROJECT_IO_TIMEOUT_KEY, io_secs.to_s, Settings.io_timeout_secs.to_s),
-        set_or_clear(Settings::PROJECT_CAPTURE_MAX_KEY, capture_mib.to_s, Settings.capture_max_mib.to_s),
-      ].all?
-      Settings.project_bind_host = bind_host == Settings.bind_host ? nil : bind_host
-      Settings.project_bind_port = bind_port == Settings.bind_port ? nil : bind_port
-      Settings.project_upstream_proxy = upstream == Settings.upstream_proxy ? nil : upstream
-      # Same equals-global-means-inherit rule as the three above: storing a duplicate would
-      # freeze the project against later global edits.
-      Settings.project_connect_timeout_secs = connect_secs == Settings.connect_timeout_secs ? nil : connect_secs
-      Settings.project_io_timeout_secs = io_secs == Settings.io_timeout_secs ? nil : io_secs
-      Settings.project_capture_max_mib = capture_mib == Settings.capture_max_mib ? nil : capture_mib
+      persisted = Settings.save_project_network(@session.store, config)
       # The globals above are still assigned and the rebind below still happens even when the
       # write did not land: the operator asked for this address, and refusing to apply it would
       # be the worse half of the trade. What must not happen is calling it saved. `apply_settings`
@@ -4871,13 +4863,6 @@ module Gori::Tui
       # did (a missing path, or the `.proto` SOURCE file mistaken for a descriptor set).
       line = "proto schema: #{Gori::Protobuf::Schemas.status}"
       persisted ? line : "#{line} — but NOT saved (project busy); it reverts when you reopen this project"
-    end
-
-    # Store the per-project value, or drop the key so the project inherits the global.
-    # Returns whether that write COMMITTED (both store calls are `exec_task_ok`).
-    private def set_or_clear(key : String, value : String, global : String) : Bool
-      store = @session.store
-      value == global ? store.delete_setting(key) : store.set_setting(key, value)
     end
 
     # Open the settings editor for `section` (palette → settings:network/editor/theme/

--- a/src/gori/tui/settings_view.cr
+++ b/src/gori/tui/settings_view.cr
@@ -27,10 +27,18 @@ module Gori::Tui
     record Field, label : String, hint : String, bool : Bool = false, choices : Array(String)? = nil,
       opener : Symbol? = nil, readonly : Bool = false
 
+    PROXY_PROTOCOL_CHOICES = ["None", "HTTP", "SOCKS5", "SOCKS5H"]
+    NETWORK_PROXY_PROTOCOL = 2
+    NETWORK_PROXY_HOST     = 3
+    NETWORK_PROXY_PORT     = 4
+
     NETWORK_FIELDS = [
       Field.new("Bind IP", "global default listen address — projects may pin their own"),
       Field.new("Bind Port", "global default port (0-65535) — project overrides win when set"),
-      Field.new("Upstream proxy", "host:port — blank = connect directly; projects may override"),
+      Field.new("Proxy protocol", "None = direct · SOCKS5 resolves names locally · SOCKS5H resolves at the proxy — ←/→ cycles",
+        choices: PROXY_PROTOCOL_CHOICES),
+      Field.new("Proxy host", "upstream proxy hostname or IP — disabled when protocol is None"),
+      Field.new("Proxy port", "upstream proxy port (1-65535) — disabled when protocol is None"),
       Field.new("Verify upstream TLS", "check the upstream server's certificate — off accepts any cert (MITM/testing); ←/→/space toggles", bool: true),
       Field.new("Info page and CA download", "serve a gori welcome + CA-download page to browsers that hit the listen address, or http://gori.proxy/ when already proxied — ←/→/space toggles", bool: true),
       Field.new("Connect timeout (s)", "how long an upstream TCP/proxy connect may take before giving up — seconds (min 1)"),
@@ -41,7 +49,7 @@ module Gori::Tui
       Field.new("Strip HTTP/3 Alt-Svc", "remove Alt-Svc alternatives advertising h3 from the response the client gets, so a browser cannot switch to QUIC/UDP where gori sees nothing — Alt-Svc: clear and non-h3 alternatives are left alone; ←/→/space toggles", bool: true),
       Field.new("TLS passthrough", "comma-separated hosts to relay WITHOUT decrypting (for certificate-pinned apps) — acme.test covers subdomains, *.acme.test globs; nothing is captured for them"),
       Field.new("Upstream rules",
-        "per-host routing / SOCKS5 / proxy auth — edit with `gori settings --edit` (network.upstream_rules)",
+        "per-host routing / proxy auth — edit with `gori settings --edit` (network.upstream_rules)",
         readonly: true),
       Field.new("Outbound TLS",
         "per-host client certificates, protocol range and TLS fingerprint (groups/sigalgs/ALPN, or a chrome/firefox/safari/curl preset) — edit with `gori settings --edit` (outbound_tls); check what actually goes on the wire with `gori settings tls-fingerprint`",
@@ -199,6 +207,7 @@ module Gori::Tui
     def initialize
       @values = ["", "", ""]
       @baseline = [] of String # last persisted/loaded values — @values != @baseline means unsaved
+      @network_upstream_raw = ""
       @focused = 0
       @cursor = 0
       @preedit = ""
@@ -298,7 +307,19 @@ module Gori::Tui
                   Settings::DEFAULT_RETENTION_FLOWS.to_s,
                   Settings::DEFAULT_REPEATER_RECORD_HISTORY ? "on" : "off",
                 ]
-                else [Settings::DEFAULT_BIND_HOST, Settings::DEFAULT_BIND_PORT.to_s, Settings::DEFAULT_UPSTREAM_PROXY, Settings::DEFAULT_VERIFY_UPSTREAM ? "on" : "off", Settings::DEFAULT_SERVE_LANDING ? "on" : "off", Settings::DEFAULT_CONNECT_TIMEOUT_SECS.to_s, Settings::DEFAULT_IO_TIMEOUT_SECS.to_s, Settings::DEFAULT_CAPTURE_MAX_MIB.to_s, Settings::DEFAULT_HTTP2, Settings::DEFAULT_STRIP_ALT_SVC ? "on" : "off", passthrough_label(Settings::DEFAULT_TLS_PASSTHROUGH), rule_count_label(Settings.upstream_rules.size, "rule"), outbound_tls_summary, hostnames_summary]
+                else [Settings::DEFAULT_BIND_HOST, Settings::DEFAULT_BIND_PORT.to_s,
+                      proxy_protocol_label("none"), "", "",
+                      Settings::DEFAULT_VERIFY_UPSTREAM ? "on" : "off",
+                      Settings::DEFAULT_SERVE_LANDING ? "on" : "off",
+                      Settings::DEFAULT_CONNECT_TIMEOUT_SECS.to_s,
+                      Settings::DEFAULT_IO_TIMEOUT_SECS.to_s,
+                      Settings::DEFAULT_CAPTURE_MAX_MIB.to_s,
+                      Settings::DEFAULT_HTTP2,
+                      Settings::DEFAULT_STRIP_ALT_SVC ? "on" : "off",
+                      passthrough_label(Settings::DEFAULT_TLS_PASSTHROUGH),
+                      rule_count_label(Settings.upstream_rules.size, "rule"),
+                      outbound_tls_summary,
+                      hostnames_summary]
                 end
       @focused = 0
       @cursor = @values[0].size
@@ -311,10 +332,14 @@ module Gori::Tui
     # NETWORK_FIELDS — the values are positional, so an inserted field would otherwise have to
     # be mirrored in three separate literals.
     private def network_values : Array(String)
+      @network_upstream_raw = Settings.upstream_proxy
+      proxy = upstream_proxy_field_values(@network_upstream_raw)
       [
         Settings.bind_host,
         Settings.bind_port.to_s,
-        Settings.upstream_proxy,
+        proxy[0],
+        proxy[1],
+        proxy[2],
         Settings.verify_upstream? ? "on" : "off",
         Settings.serve_landing? ? "on" : "off",
         Settings.connect_timeout_secs.to_s,
@@ -327,6 +352,27 @@ module Gori::Tui
         outbound_tls_summary,
         hostnames_summary,
       ]
+    end
+
+    private def upstream_proxy_field_values(raw : String) : {String, String, String}
+      if fields = Settings.upstream_proxy_fields(raw)
+        {proxy_protocol_label(fields[0]), fields[1], fields[2]}
+      else
+        {"Invalid · #{raw}", "", ""}
+      end
+    end
+
+    private def proxy_protocol_label(kind : String) : String
+      case kind
+      when "http"    then "HTTP"
+      when "socks5"  then "SOCKS5"
+      when "socks5h" then "SOCKS5H"
+      else                "None"
+      end
+    end
+
+    private def proxy_protocol_kind(label : String) : String
+      label.downcase
     end
 
     # The EDITOR row values, read from the live Settings — same reason as #network_values:
@@ -483,7 +529,8 @@ module Gori::Tui
     def insert(ch : Char) : Nil
       return if readonly_field? # a display row — nothing to type into
       return if opener_field?   # an action row — typing does nothing (↵ opens its overlay)
-      if bool_field?            # a toggle field swallows typing; space flips it
+      return if disabled_field?
+      if bool_field? # a toggle field swallows typing; space flips it
         toggle if ch == ' '
         return
       end
@@ -500,7 +547,7 @@ module Gori::Tui
     end
 
     def backspace : Nil
-      return if bool_field? || choice_field? || opener_field? || readonly_field? || @cursor == 0
+      return if bool_field? || choice_field? || opener_field? || readonly_field? || disabled_field? || @cursor == 0
       v = @values[@focused]
       c = @cursor.clamp(0, v.size)
       @values[@focused] = "#{v[0, c - 1]}#{v[c..]}"
@@ -517,7 +564,7 @@ module Gori::Tui
     # the `c >= v.size` brake below — so Del would chew up the live summary and flip
     # `dirty?`, painting a spurious "● unsaved" for an edit the operator never made.
     def delete : Nil
-      return if bool_field? || choice_field? || opener_field? || readonly_field?
+      return if bool_field? || choice_field? || opener_field? || readonly_field? || disabled_field?
       v = @values[@focused]
       c = @cursor.clamp(0, v.size)
       return if c >= v.size
@@ -537,6 +584,7 @@ module Gori::Tui
     end
 
     def move_cursor(delta : Int32) : Nil
+      return if disabled_field?
       @cursor = (@cursor + delta).clamp(0, @values[@focused].size)
     end
 
@@ -554,6 +602,13 @@ module Gori::Tui
 
     private def readonly_field? : Bool
       fields[@focused].readonly
+    end
+
+    private def disabled_field?(index : Int32 = @focused) : Bool
+      return false unless @section == :network
+      return false unless index == NETWORK_PROXY_HOST || index == NETWORK_PROXY_PORT
+      protocol = @values[NETWORK_PROXY_PROTOCOL]
+      protocol == "None" || protocol.starts_with?("Invalid ·")
     end
 
     # The sub-overlay the focused action row opens (↵), or nil for an ordinary field. The
@@ -588,9 +643,28 @@ module Gori::Tui
       end
       choices = fields[@focused].choices
       return unless choices
+      previous = @values[@focused]
       i = choices.index(@values[@focused]) || 0
       @values[@focused] = choices[(i + delta) % choices.size]
+      update_proxy_default_port(previous, @values[@focused]) if @section == :network && @focused == NETWORK_PROXY_PROTOCOL
       @status = nil
+    end
+
+    # Change 8080↔1080 only while the port still looks automatic. A custom port is operator
+    # intent and survives protocol cycling; None clears the automatic value and disables it.
+    private def update_proxy_default_port(previous : String, current : String) : Nil
+      port = @values[NETWORK_PROXY_PORT].strip
+      previous_default = proxy_default_port(previous)
+      return unless port.empty? || port == previous_default
+      @values[NETWORK_PROXY_PORT] = proxy_default_port(current)
+    end
+
+    private def proxy_default_port(label : String) : String
+      case label
+      when "HTTP"              then Settings::DEFAULT_HTTP_PROXY_PORT.to_s
+      when "SOCKS5", "SOCKS5H" then Settings::DEFAULT_SOCKS_PORT.to_s
+      else                          ""
+      end
     end
 
     # The currently-selected theme name (for live preview as the user cycles) — only
@@ -705,28 +779,39 @@ module Gori::Tui
         @status = "invalid port"
         return "settings: invalid bind port #{@values[1].inspect}"
       end
-      up = @values[2].strip
-      if err = Settings.upstream_proxy_port_error(up)
-        @status = "invalid upstream port"
+      proxy_fields_unchanged = @values[NETWORK_PROXY_PROTOCOL, 3] == @baseline[NETWORK_PROXY_PROTOCOL, 3]
+      if proxy_fields_unchanged
+        up = @network_upstream_raw
+      else
+        up, proxy_error = Settings.build_upstream_proxy(
+          proxy_protocol_kind(@values[NETWORK_PROXY_PROTOCOL]),
+          @values[NETWORK_PROXY_HOST], @values[NETWORK_PROXY_PORT])
+        if proxy_error
+          @status = "invalid upstream proxy"
+          return proxy_error
+        end
+      end
+      if err = Settings.upstream_proxy_error(up)
+        @status = "invalid upstream proxy"
         return err
       end
-      ct = @values[5].strip.to_i?
+      ct = @values[7].strip.to_i?
       unless ct && ct >= 1
         @status = "invalid connect timeout"
-        return "settings: invalid connect timeout #{@values[5].inspect} (seconds, min 1)"
+        return "settings: invalid connect timeout #{@values[7].inspect} (seconds, min 1)"
       end
-      it = @values[6].strip.to_i?
+      it = @values[8].strip.to_i?
       unless it && it >= 1
         @status = "invalid idle timeout"
-        return "settings: invalid idle timeout #{@values[6].inspect} (seconds, min 1)"
+        return "settings: invalid idle timeout #{@values[8].inspect} (seconds, min 1)"
       end
-      cap = @values[7].strip.to_i?
+      cap = @values[9].strip.to_i?
       unless cap && cap >= 1
         @status = "invalid capture limit"
-        return "settings: invalid capture limit #{@values[7].inspect} (MiB, min 1)"
+        return "settings: invalid capture limit #{@values[9].inspect} (MiB, min 1)"
       end
       cap = cap.clamp(1, Settings::MAX_CAPTURE_MAX_MIB) # keep cap*1024*1024 within Int32 (never break the proxy)
-      passthrough = passthrough_from_label(@values[10]) # index 9 is the Strip HTTP/3 Alt-Svc bool inserted above it
+      passthrough = passthrough_from_label(@values[12])
       if err = Settings.tls_passthrough_error(passthrough)
         @status = "invalid TLS passthrough host"
         return err
@@ -745,13 +830,13 @@ module Gori::Tui
       Settings.bind_host = @values[0].strip
       Settings.bind_port = port
       Settings.upstream_proxy = up
-      Settings.verify_upstream = @values[3] == "on"
-      Settings.serve_landing = @values[4] == "on"
+      Settings.verify_upstream = @values[5] == "on"
+      Settings.serve_landing = @values[6] == "on"
       Settings.connect_timeout_secs = ct
       Settings.io_timeout_secs = it
       Settings.capture_max_mib = cap
-      Settings.http2 = @values[8]
-      Settings.strip_alt_svc = @values[9] == "on"
+      Settings.http2 = @values[10]
+      Settings.strip_alt_svc = @values[11] == "on"
       Settings.tls_passthrough = passthrough
       @values = network_values
       persist
@@ -863,17 +948,25 @@ module Gori::Tui
         screen.text(rect.x + 2 + label_w + 1, ry, "›", focused ? Theme.accent : Theme.muted, bg)
         vx = rect.x + 2 + label_w + 3
         vw = {rect.right - vx, 1}.max
-        render_field_value(screen, field, @values[i], vx, ry, vw, focused, bg)
+        render_field_value(screen, field, @values[i], vx, ry, vw, focused, bg,
+          disabled: disabled_field?(i))
       end
     end
 
     # The value column of one field: a choice cycle, a bool toggle, the editable line
     # (focused), the hint (empty + unfocused), or the plain value.
     private def render_field_value(screen : Screen, field : Field, value : String,
-                                   vx : Int32, ry : Int32, vw : Int32, focused : Bool, bg : Color) : Nil
-      if field.opener # an action row: show its summary (display-only), accent to signal ↵ opens it
+                                   vx : Int32, ry : Int32, vw : Int32, focused : Bool, bg : Color,
+                                   *, disabled : Bool = false) : Nil
+      if disabled
+        screen.text(vx, ry, "—", Theme.muted, bg, width: vw)
+      elsif field.opener # an action row: show its summary (display-only), accent to signal ↵ opens it
         screen.text(vx, ry, value, focused ? Theme.text_bright : Theme.accent, bg, width: vw)
       elsif choices = field.choices
+        unless choices.includes?(value)
+          screen.text(vx, ry, value, Theme.yellow, bg, width: vw)
+          return
+        end
         # List the options left-to-right; the active one is emphasised (◉ + bright).
         cx = vx
         left = vw

--- a/src/gori/tui/tab_controller.cr
+++ b/src/gori/tui/tab_controller.cr
@@ -107,6 +107,15 @@ module Gori::Tui
     # Persist + apply the Project settings pane's per-project network config; returns a toast.
     abstract def apply_project_network(bind_host : String, bind_port : Int32, upstream : String,
                                        connect_secs : Int32, io_secs : Int32, capture_mib : Int32) : String
+
+    # Secret-bearing extension used by the real Runner. The positional overload stays as the
+    # compatibility contract for the small controller Host doubles; their tests do not own a
+    # project DB and deliberately exercise controller routing rather than persistence.
+    def apply_project_network(config : Settings::ProjectNetworkConfig) : String
+      apply_project_network(config.bind_host, config.bind_port, config.upstream,
+        config.connect_secs, config.io_secs, config.capture_mib)
+    end
+
     # Persist + load this project's gRPC `.proto` descriptor set path (#823); returns a toast
     # naming what loaded (or why nothing did). Blank = the `~/.gori/protos` convention dir.
     abstract def apply_project_protos(spec : String) : String

--- a/src/gori/update.cr
+++ b/src/gori/update.cr
@@ -5,6 +5,7 @@ require "file_utils"
 require "random/secure"
 require "digest/sha256"
 
+require "./http_transport"
 require "./update/asset"
 require "./update/channel"
 require "./update/verify"
@@ -98,7 +99,7 @@ module Gori
     # by type) pass through untouched.
     private def self.io_guard(what : String, &)
       yield
-    rescue ex : IO::Error | OpenSSL::Error
+    rescue ex : IO::Error | OpenSSL::Error | HttpTransport::Error
       raise Error.new("#{what}: #{ex.message.presence || ex.class}")
     end
 
@@ -137,25 +138,6 @@ module Gori
         "could not resolve the running gori executable: #{ex.message.presence || ex.class} " \
         "(it may have been moved or deleted while running)"
       )
-    end
-
-    private def self.http_client(host : String, port : Int32, tls : Bool,
-                                 timeout : Time::Span = HTTP_TIMEOUT) : HTTP::Client
-      # When tls is a bare `true`, HTTP::Client builds OpenSSL::SSL::Context::Client.new
-      # with only the compiled-in OPENSSLDIR store. A static-musl release binary's store
-      # is often empty (#323/#333) — exactly the environment `gori update` exists to
-      # serve (Channel::Binary). Apply the same system-trust repair the proxy uses so
-      # GitHub HTTPS verification works out of the box; additive and rescue-guarded.
-      client = if tls
-                 ctx = OpenSSL::SSL::Context::Client.new
-                 Proxy::Upstream.apply_system_trust(ctx)
-                 HTTP::Client.new(host, port, ctx)
-               else
-                 HTTP::Client.new(host, port, false)
-               end
-      client.connect_timeout = timeout
-      client.read_timeout = timeout
-      client
     end
 
     # Best-effort latest published release version (normalized, no leading `v`), or
@@ -213,8 +195,7 @@ module Gori
       uri = URI.parse(RELEASES_LATEST_URL)
       host = uri.host
       return nil unless host
-      port = uri.port || (uri.scheme == "https" ? 443 : 80)
-      client = http_client(host, port, uri.scheme == "https", timeout)
+      client = HttpTransport.client(uri, connect_timeout: timeout, read_timeout: timeout)
       begin
         response = client.head(uri.request_target,
           headers: HTTP::Headers{"User-Agent" => USER_AGENT})
@@ -344,9 +325,9 @@ module Gori
       if host == "api.github.com" && (token = github_token)
         headers["Authorization"] = "Bearer #{token}"
       end
-      port = uri.port || (uri.scheme == "https" ? 443 : 80)
-      tls = uri.scheme == "https"
-      client = http_client(host, port, tls, timeout)
+      client = io_guard("could not reach #{host}") do
+        HttpTransport.client(uri, connect_timeout: timeout, read_timeout: timeout)
+      end
       begin
         response = io_guard("could not reach #{host}") do
           client.get(uri.request_target, headers: headers)
@@ -366,12 +347,12 @@ module Gori
       raise Error.new("too many redirects downloading #{url}") if redirects_left < 0
 
       uri = parse_url(url, "invalid download URL: #{url}")
-      host = uri.host || raise Error.new("invalid download URL: #{url}")
-      port = uri.port || (uri.scheme == "https" ? 443 : 80)
-      tls = uri.scheme == "https"
+      uri.host || raise Error.new("invalid download URL: #{url}")
       headers = HTTP::Headers{"User-Agent" => USER_AGENT}
 
-      client = http_client(host, port, tls)
+      client = io_guard("could not download #{url}") do
+        HttpTransport.client(uri, connect_timeout: HTTP_TIMEOUT, read_timeout: HTTP_TIMEOUT)
+      end
       begin
         # Capture result outside the HTTP block (block return is not always the method return).
         result = 0_i64


### PR DESCRIPTION
## Summary

- Route updater and OAST HTTP traffic through the same upstream decision and dial path as the proxy/send engines, with no direct retry after a configured route fails.
- Distinguish `socks5` local DNS from `socks5h` proxy DNS across scalar settings, ordered rules, and both settings editors.
- Add project-scoped proxy authentication and a destination-host gate, keeping credentials attached to an explicit project proxy pin and failing closed on malformed/orphaned state.
- Add egress seam coverage so new direct socket or `HTTP::Client` construction cannot bypass the reviewed routing owners.

## Behavior changes

- Existing `upstream_rules` entries using `kind: "socks5"` now resolve destination names locally. Use `socks5h` to preserve the previous proxy-side DNS behavior.
- Malformed proxy declarations and failed HTTP CONNECT/SOCKS handshakes no longer degrade to a direct origin connection.
- A project destination non-match is explicitly direct and does not fall through to global rules or the scalar proxy.
- Project proxy passwords are stored in the owner-only project database and are masked in the TUI except while the password row is focused.
- Updater/OAST traffic follows the effective upstream route while continuing to skip target host overrides and the active-testing scope gate.

## Why

`network.upstream_proxy` looked like a catch-all, but updater and OAST stdlib clients could still open direct sockets. The new `HttpTransport` keeps those service clients on `Proxy::Upstream`, while `Settings.upstream_route(host)` remains the single place that chooses direct, HTTP CONNECT, SOCKS5, SOCKS5H, or an invalid fail-closed route. Project credentials pin the proxy address they were entered for so later global/rule edits cannot redirect the secret to a different proxy.

## Validation

- `crystal build --no-codegen src/main.cr` — passed
- `crystal tool format --check src spec` — passed
- `crystal spec` — 11,673 examples passed
- `./scripts/bench_check.sh` — all 48 harnesses build

Refs #434.
