### PR TITLE
perf(probe): cut passive-scan cost; fix open-redirect FN and SRI FP

### DIFF
--- a/spec/probe/passive/prototype_pollution_spec.cr
+++ b/spec/probe/passive/prototype_pollution_spec.cr
@@ -1,4 +1,5 @@
 require "../../spec_helper"
+require "compress/gzip"
 
 # --- file-local harness (mirrors spec/probe_spec.cr) -----------------------------------
 private def with_store(&)
@@ -309,6 +310,33 @@ describe Gori::Probe::Passive::PrototypePollution do
           req_headers: "Content-Type: application/json\r\n",
           req_body: %({"__proto__":{"polluted":true}}))
         codes_of(dets).should contain("prototype_pollution_param")
+      end
+    end
+
+    it "still sees a GZIPPED request body (the raw-bytes prefilter must not gate it out)" do
+      with_store do |store|
+        # `check_request` prefilters the RAW body for `__proto__`/`constructor` before letting
+        # Context materialise the decoded text. Those literals are NOT in the compressed bytes,
+        # so a body declaring a Content-Encoding has to skip the prefilter and decode — otherwise
+        # this rule would go silently blind on every compressed upload.
+        plain = %({"__proto__":{"polluted":true}})
+        gz = IO::Memory.new
+        Compress::Gzip::Writer.open(gz, &.print(plain))
+        dets = analyze(store, resp_head: "HTTP/1.1 200 OK\r\n\r\n", method: "POST",
+          target: "/submit", content_type: nil,
+          req_headers: "Content-Type: application/json\r\nContent-Encoding: gzip\r\n",
+          req_body: String.new(gz.to_slice))
+        codes_of(dets).should contain("prototype_pollution_param")
+      end
+    end
+
+    it "does not flag an ordinary JSON body (the prefilter's common case)" do
+      with_store do |store|
+        dets = analyze(store, resp_head: "HTTP/1.1 200 OK\r\n\r\n", method: "POST",
+          target: "/submit", content_type: nil,
+          req_headers: "Content-Type: application/json\r\n",
+          req_body: %({"filters":{"status":"active"},"items":[1,2,3]}))
+        codes_of(dets).should_not contain("prototype_pollution_param")
       end
     end
 

--- a/spec/probe/passive/sri_spec.cr
+++ b/spec/probe/passive/sri_spec.cr
@@ -152,4 +152,22 @@ describe Gori::Probe::Passive::Sri do
       sri(store, body).map(&.evidence).should eq(["a.example.com", "b.example.com"])
     end
   end
+  it "ignores a commented-out third-party <script src> (the browser never fetches it)" do
+    with_store do |store|
+      body = <<-HTML
+        <html><head>
+        <!-- disabled for now: <script src="https://old-analytics.example/t.js"></script> -->
+        <script src="https://cdn.example/app.js"></script>
+        </head><body>hi</body></html>
+        HTML
+      sri(store, body).map(&.evidence).should eq(["cdn.example"])
+    end
+  end
+
+  it "still reports a tag that follows the comment's close" do
+    with_store do |store|
+      body = %(<html><head><!-- note --><script src="https://cdn.example/app.js"></script></head></html>)
+      sri(store, body).map(&.evidence).should eq(["cdn.example"])
+    end
+  end
 end

--- a/spec/probe_spec.cr
+++ b/spec/probe_spec.cr
@@ -3745,12 +3745,59 @@ describe "Gori::Probe::Active::OpenRedirect" do
       # Captured 200 → not a redirect.
       probe.plan(capture_flow(store, "HTTP/1.1 200 OK\r\n\r\n",
         target: "/login?next=https%3A%2F%2Facme.test%2Fcb")).should be_nil
-      # Redirect to a relative Location → no absolute target for a param to drive.
+      # Relative Location that NO parameter accounts for: the only param carries an absolute
+      # value, so it cannot be what produced `/home`.
       probe.plan(capture_flow(store, "HTTP/1.1 302 F\r\nLocation: /home\r\n\r\n",
         target: "/login?next=https%3A%2F%2Facme.test%2Fcb", status: 302)).should be_nil
+      # A bare "/" must not nominate a parameter: it prefixes every relative Location there is.
+      probe.plan(capture_flow(store, "HTTP/1.1 302 F\r\nLocation: /home\r\n\r\n",
+        target: "/login?next=%2F", status: 302)).should be_nil
       # Redirect present but no parameter matches its authority.
       probe.plan(capture_flow(store, "HTTP/1.1 302 F\r\nLocation: https://acme.test/cb\r\n\r\n",
         target: "/login?foo=bar", status: 302)).should be_nil
+    end
+  end
+
+  it "gates on a RELATIVE Location a parameter drives, and probes it unencoded" do
+    with_store do |store|
+      # `/login?next=/dashboard` → `Location: /dashboard` is the dominant open-redirect shape;
+      # the rule used to skip it entirely because the captured Location named no authority.
+      detail = capture_flow(store, "HTTP/1.1 302 F\r\nLocation: /dashboard\r\n\r\n",
+        target: "/login?next=%2Fdashboard", status: 302)
+      plan = probe.plan(detail).not_nil!
+      plan.params.first.name.should eq("next")
+      # This capture arrived percent-encoded, so the app decodes: send the ENCODED probe.
+      String.new(plan.request).should contain(Gori::Probe::Active::OpenRedirect::PROBE_VALUE)
+      probe.detections(plan, resp.call(302, "https://gori-redir-probe.example/x"), detail)
+        .map(&.code).should eq(["open_redirect"])
+      # Confirmation is unchanged: only the probe response's OWN authority counts.
+      probe.detections(plan, resp.call(302, "/dashboard"), detail).should be_empty
+      probe.detections(plan, resp.call(302, "https://gori-redir-probe.example@evil.test/"), detail).should be_empty
+    end
+  end
+
+  it "sends the LITERAL probe when the relative driver arrived undecoded" do
+    with_store do |store|
+      # A raw `/dashboard` in the query is the app telling us it does not url-decode this
+      # parameter. Sending the percent-encoded probe to it would put a literal
+      # `https%3A%2F%2F…` in Location — no authority to parse — and the rule would report
+      # clean on an endpoint it never actually asked.
+      detail = capture_flow(store, "HTTP/1.1 302 F\r\nLocation: /dashboard\r\n\r\n",
+        target: "/login?next=/dashboard", status: 302)
+      req = String.new(probe.plan(detail).not_nil!.request)
+      req.should contain(Gori::Probe::Active::OpenRedirect::PROBE_LITERAL)
+      req.should_not contain(Gori::Probe::Active::OpenRedirect::PROBE_VALUE)
+    end
+  end
+
+  it "accepts a relative driver whose Location gained the app's own query" do
+    with_store do |store|
+      detail = capture_flow(store, "HTTP/1.1 302 F\r\nLocation: /dashboard?welcome=1\r\n\r\n",
+        target: "/login?next=%2Fdashboard", status: 302)
+      probe.plan(detail).not_nil!.params.first.name.should eq("next")
+      # …but not one that merely shares a path PREFIX — /dash is a different endpoint.
+      probe.plan(capture_flow(store, "HTTP/1.1 302 F\r\nLocation: /dashboard\r\n\r\n",
+        target: "/login?next=%2Fdash", status: 302)).should be_nil
     end
   end
 

--- a/src/gori/probe/active/open_redirect.cr
+++ b/src/gori/probe/active/open_redirect.cr
@@ -13,13 +13,14 @@ module Gori
       # arbitrary redirect (phishing, OAuth token theft). Passive analysis cannot prove the parameter
       # *controls* the target.
       #
-      # For one in-scope flow whose captured response was a 3xx AND whose `Location` authority matches
-      # one of the request's query-parameter values (i.e. that parameter demonstrably DROVE the
-      # redirect), it re-sends ONE request with that parameter replaced by a synthetic external host,
-      # and flags High only when the response `Location` redirects to OUR probe host.
+      # For one in-scope flow whose captured response was a 3xx AND whose `Location` a query
+      # parameter demonstrably DROVE — the param's value carries the same authority as an absolute
+      # `Location`, or IS the path of a relative one — it re-sends ONE request with that parameter
+      # replaced by a synthetic external host, and flags High only when the response `Location`
+      # redirects to OUR probe host.
       #
       # Low-FP by construction:
-      #   * gated to a parameter whose value already equals the captured redirect's authority — a
+      #   * gated to a parameter whose value already accounts for the captured redirect target — a
       #     stray reflected value that doesn't drive the redirect is never probed;
       #   * confirmation parses the response `Location`'s OWN authority (Active.url_authority), so a
       #     relative `Location: /go?next=…probe…` (probe host only in a sub-param) and the
@@ -55,12 +56,21 @@ module Gori
           Plan.new(request, [Param.new("query", name, "")], key_string(detail, method_up, path, name))
         end
 
-        # Mirror the captured value's encoding: a literal `://` in the driving value means the app does
-        # not url-decode it, so send the literal probe URL; otherwise send the percent-encoded form.
+        # Mirror the captured value's encoding: an unencoded delimiter in the driving value means
+        # the app reads the parameter without url-decoding it, so send the literal probe URL;
+        # otherwise send the percent-encoded form.
+        #
+        # The test is a bare `/`, not `://`. Both are unencoded-delimiter evidence and the absolute
+        # driving values this rule used to be limited to always carried both (`https://acme.test/cb`
+        # has a `/` too, so those keep choosing the literal exactly as before). But a RELATIVE
+        # driving value — `next=/dashboard`, now that those are gated in — has a `/` and no `://`,
+        # and would have been sent percent-encoded to an app that just proved it does not decode:
+        # the probe would land in `Location` as a literal `https%3A%2F%2F…`, which parses to no
+        # authority at all, and the rule would report clean on an endpoint it never really asked.
         private def probe_value_for(pair : String) : String
           eq = pair.index('=')
           raw = eq ? pair[(eq + 1)..] : ""
-          raw.includes?("://") ? PROBE_LITERAL : PROBE_VALUE
+          raw.includes?('/') ? PROBE_LITERAL : PROBE_VALUE
         end
 
         def detections(plan : Plan, result : Repeater::Result, detail : Store::FlowDetail) : Array(Detection)
@@ -89,17 +99,30 @@ module Gori
           return nil unless REDIRECT_STATUSES.includes?(detail.row.status)
           rhead = detail.response_head || return nil
           loc = Proxy::Codec::Http1.parse_response_head(rhead).headers.get?("Location") || return nil
-          loc_auth = Active.url_authority(loc) || return nil # captured redirect must be to an absolute host
           path, query = split_target(Active.origin_form(target))
           return nil if query.empty?
           pairs = query.split('&')
-          found = first_driving_param(pairs, loc_auth[0]) || return nil
+          found = first_driving_param(pairs, loc) || return nil
           {method_up, path, pairs, found[0], found[1]}
         end
 
-        # {index, decoded name} of the first query param whose value's authority host == `loc_host`
-        # (i.e. that param drove the captured redirect), or nil.
-        private def first_driving_param(pairs : Array(String), loc_host : String) : {Int32, String}?
+        # {index, decoded name} of the first query param that demonstrably DROVE the captured
+        # redirect, or nil. Two shapes, because a redirect target is written both ways:
+        #
+        #   * `Location` is ABSOLUTE — the param whose value carries the same authority host.
+        #   * `Location` is RELATIVE — the param whose value IS that path. This is the shape the
+        #     rule used to skip entirely (the gate demanded `url_authority(loc)`), and it is the
+        #     COMMON one: `/login?next=/dashboard` → `Location: /dashboard` is how nearly every
+        #     framework's post-login return works, and it is exactly the endpoint worth asking
+        #     whether it will also follow an absolute host. Requiring the captured redirect to
+        #     already point off-site meant the rule mostly confirmed redirects that were external
+        #     before we touched them.
+        #
+        # Widening this widens only WHAT IS PROBED, never what is reported: `detections` still
+        # fires solely when the probe response's `Location` parses to PROBE_HOST as its own
+        # authority. So a wrong guess here costs one request, not a false finding.
+        private def first_driving_param(pairs : Array(String), loc : String) : {Int32, String}?
+          loc_auth = Active.url_authority(loc)
           pairs.each_with_index do |pair, i|
             next if pair.empty?
             eq = pair.index('=')
@@ -108,10 +131,31 @@ module Gori
             next if raw_name.empty?
             raw_value = pair[(eq + 1)..]
             next if raw_value.empty?
-            pa = Active.url_authority(decode(raw_value))
-            return {i, decode(raw_name)} if pa && pa[0] == loc_host
+            value = decode(raw_value)
+            drives =
+              if host = loc_auth
+                Active.url_authority(value).try { |pa| pa[0] == host[0] } || false
+              else
+                relative_driver?(loc, value)
+              end
+            return {i, decode(raw_name)} if drives
           end
           nil
+        end
+
+        # Does this DECODED parameter value account for a RELATIVE `Location`? Only a path-shaped
+        # value counts, and it must be the whole target or its path part:
+        #   `next=/dashboard` → `Location: /dashboard`        (equal)
+        #   `next=/dashboard` → `Location: /dashboard?ok=1`   (app appended its own query)
+        # The `size >= 2` floor keeps a bare `/` — which prefixes every relative Location there is
+        # — from nominating whichever parameter happens to come first.
+        private def relative_driver?(loc : String, value : String) : Bool
+          return false unless value.size >= 2 && value.starts_with?('/')
+          target = loc.strip
+          return true if target == value
+          return false unless target.starts_with?(value)
+          nxt = target[value.size]?
+          nxt == '?' || nxt == '#'
         end
 
         private def key_string(detail : Store::FlowDetail, method_upcase : String, path : String, name : String) : String

--- a/src/gori/probe/passive/js_scan.cr
+++ b/src/gori/probe/passive/js_scan.cr
@@ -147,12 +147,24 @@ module Gori
             String.build(js.bytesize) do |io|
               i = 0
               while i < n
-                if j = blank_token_at(chars, i, n, io, 0)
-                  i = j
-                else
-                  io << chars[i]
-                  i += 1
-                end
+                # The token dispatch is spelled out here rather than delegated to
+                # `blank_token_at` (which `emit_interpolation` still uses), and the shape mirrors
+                # `strip_comments`' loop deliberately. That helper returns `Int32?` — nil meaning
+                # "no token starts here" — so the OVERWHELMINGLY common case, an ordinary code
+                # character, paid a nilable-union result on every char of the script. Deciding it
+                # from the char in the loop keeps this hot path on a plain Int32; the branch order
+                # (comment, then string) is the helper's, so what gets blanked is unchanged.
+                c = chars[i]
+                i = if c == '/' && i + 1 < n && chars[i + 1] == '/'
+                      blank_line_comment(chars, i, n, io)
+                    elsif c == '/' && i + 1 < n && chars[i + 1] == '*'
+                      blank_block_comment(chars, i, n, io)
+                    elsif c == '\'' || c == '"' || c == '`'
+                      blank_string(chars, i, n, io, 0)
+                    else
+                      io << c
+                      i + 1
+                    end
               end
             end
           end
@@ -399,13 +411,21 @@ module Gori
         # within WINDOW chars each side). Empty when no sink co-occurs with a source.
         def self.source_sink_pairs(code : String) : Array({String, String})
           pairs = [] of {String, String}
-          # Whole-script source prefilter. A sink can only pair with a source that exists SOMEWHERE
-          # in the script, so a bundle with no source at all cannot produce a pair no matter how
-          # many sinks it carries — and a minified SPA/jQuery bundle carries thousands (`.html(`,
-          # `.innerHTML=`, `setTimeout(`). Without this, that bundle paid the full sink walk to
-          # return []: measured 230ms per flow, on the fiber the passive scan shares with the proxy.
-          # 14 whole-body `matches?` passes instead ⇒ 1.0ms (228× — bench/probe_passive_bench).
-          return pairs unless SOURCES.any? { |(re, _)| re.matches?(code) }
+          # Whole-script source INDEX, which is also the prefilter. A sink can only pair with a
+          # source that exists SOMEWHERE in the script, so a bundle with no source at all cannot
+          # produce a pair no matter how many sinks it carries — and a minified SPA/jQuery bundle
+          # carries thousands (`.html(`, `.innerHTML=`, `setTimeout(`). Without this, that bundle
+          # paid the full sink walk to return []: measured 230ms per flow, on the fiber the passive
+          # scan shares with the proxy. 14 whole-body passes instead ⇒ 1.0ms (228×).
+          #
+          # This used to be a bare `SOURCES.any?(&.matches?(code))` and the per-sink window test
+          # then re-ran all 14 SOURCE regexes over two freshly-allocated window strings. On a
+          # bundle with thousands of sink hits that is the dominant cost of the whole passive
+          # scan: 14 patterns × 2 sides × N hits PCRE calls, plus 2N transient strings. Scanning
+          # each source ONCE up front for its match POSITIONS turns every one of those into an
+          # allocation-free binary search (see `source_in_window`).
+          sources = source_spans(code)
+          return pairs if sources.empty?
           SINKS.each do |(sink_re, sink_label)|
             # `scan`, NOT a `while m = sink_re.match(code, pos)` loop: re-entering `match` with a
             # start offset is ~515× slower than one `scan` walk for the SAME matches and the SAME
@@ -413,7 +433,7 @@ module Gori
             # the match call; `match_at_byte_index` is just as slow, so it is not char↔byte
             # conversion). `scan` yields the same MatchData, so begin/end are unchanged.
             code.scan(sink_re) do |m|
-              if src = source_in_window(code, m.byte_begin(0), m.byte_end(0))
+              if src = source_in_window(code, sources, m.byte_begin(0), m.byte_end(0))
                 pairs << {src, sink_label}
               end
             end
@@ -430,13 +450,53 @@ module Gori
         # WINDOW bytes per side and allocates nothing — and this runs once per sink occurrence.
         BOUNDS = {0x3Bu8, 0x7Bu8, 0x7Du8, 0x0Au8}
 
+        # Every taint SOURCE occurrence in the script, as BYTE spans, in SOURCES order. One
+        # `scan` per source pattern, once per script — the index `source_in_window` binary-searches
+        # instead of re-running the 14 patterns per sink occurrence. Sources with no occurrence are
+        # dropped, so a script carrying one source pays one entry, not fourteen; an empty result is
+        # exactly the old `SOURCES.any?` prefilter's "no source anywhere" verdict.
+        #
+        # `scan` yields NON-OVERLAPPING matches left to right, so within one entry both `begin` and
+        # `end` are strictly increasing — the property `span_within?` binary-searches on.
+        private def self.source_spans(code : String) : Array({Array({Int32, Int32}), String})
+          index = [] of {Array({Int32, Int32}), String}
+          SOURCES.each do |(re, label)|
+            spans = [] of {Int32, Int32}
+            code.scan(re) { |m| spans << {m.byte_begin(0), m.byte_end(0)} }
+            index << {spans, label} unless spans.empty?
+          end
+          index
+        end
+
+        # Does `spans` hold an occurrence lying ENTIRELY within [a, b)? Binary-searches for the
+        # first span beginning at/after `a`; because the spans are non-overlapping and ordered,
+        # that one also has the SMALLEST end among the candidates, so it alone decides.
+        #
+        # Full containment is what the old two-slice test meant: a source straddling the window
+        # edge was cut by the slice and could not match there either.
+        private def self.span_within?(spans : Array({Int32, Int32}), a : Int32, b : Int32) : Bool
+          lo = 0
+          hi = spans.size
+          while lo < hi
+            mid = (lo + hi) // 2
+            if spans[mid][0] < a
+              lo = mid + 1
+            else
+              hi = mid
+            end
+          end
+          return false if lo >= spans.size
+          spans[lo][1] <= b
+        end
+
         # The first taint source inside the statement window around [from, to), or nil.
         # Offsets are BYTE offsets. Char-index slicing (`code[floor...from]`) is O(1) only while
         # the script is all-ASCII; one non-ASCII byte anywhere makes every `String#[]` walk from
         # the start, and this runs per sink occurrence — thousands of times in a minified bundle.
         # A single accented char in a regex literal (kept intact by `strip`, by design) is enough:
         # measured 9ms → 1765ms per flow, on the fiber the passive scan shares with the proxy.
-        private def self.source_in_window(code : String, from : Int32, to : Int32) : String?
+        private def self.source_in_window(code : String, sources : Array({Array({Int32, Int32}), String}),
+                                          from : Int32, to : Int32) : String?
           bytes = code.to_slice
           floor = from - WINDOW
           floor = 0 if floor < 0
@@ -474,11 +534,21 @@ module Gori
           # source really inside the sink's arguments still sits in the POST side, which is where
           # `document.write(document.URL)` has always been read from.
           #
-          # A window edge can land mid-char, so scrub before handing a slice to PCRE (invalid
-          # UTF-8 makes the match raise). Both slices are bounded by WINDOW, so this costs nothing.
-          pre = String.new(bytes[lo, from - lo]).scrub
-          post = String.new(bytes[to, hi - to]).scrub
-          SOURCES.each { |(re, label)| return label if re.matches?(pre) || re.matches?(post) }
+          # Answered against the precomputed span index (`source_spans`) rather than by slicing the
+          # two sides out and re-running the SOURCE patterns on them. Same verdict — a source
+          # matches a side exactly when one of its occurrences lies entirely within that side's
+          # byte range — and it keeps SOURCES order, so the label reported for a window holding
+          # several sources is the one the slice-and-match version reported. What it drops is the
+          # per-occurrence cost: two String allocations and up to 28 PCRE calls per sink hit, on
+          # the fiber the passive scan shares with the proxy.
+          #
+          # (The slices also had to be `scrub`bed, because a window edge can land mid-char and
+          # invalid UTF-8 makes PCRE raise. Nothing is handed to PCRE here, so that is moot —
+          # and it was never a correctness dimension: every SOURCE pattern is pure ASCII, so a
+          # replacement char at an edge can neither create nor destroy a match.)
+          sources.each do |(spans, label)|
+            return label if span_within?(spans, lo, from) || span_within?(spans, to, hi)
+          end
           nil
         end
       end

--- a/src/gori/probe/passive/prototype_pollution.cr
+++ b/src/gori/probe/passive/prototype_pollution.cr
@@ -1,4 +1,6 @@
 require "./rule"
+require "../../ascii_bytes"
+require "../../proxy/codec/content_decode"
 
 module Gori
   module Probe
@@ -34,6 +36,13 @@ module Gori
         # A prototype key inside a request body region (urlencoded / JSON / bracketed).
         REQ_BODY_PROTO = /(?:["'\[]\s*__proto__|__proto__\s*[\]"':=]|constructor(?:\[|%5[Bb]).{0,12}prototype)/i
 
+        # Every alternative of REQ_BODY_PROTO needs one of these two literals, so their absence
+        # from the body is proof the pattern cannot match. Lowercase because the pattern is /i and
+        # `AsciiBytes.contains_ci?` wants an already-lowercase needle. Held as constants so the
+        # slices are built once for the process, not per flow.
+        private PROTO_NEEDLE       = "__proto__".to_slice
+        private CONSTRUCTOR_NEEDLE = "constructor".to_slice
+
         def check(ctx : Context, acc : Array(Detection)) : Nil
           check_request(ctx, acc)
           seen = Set(String).new
@@ -53,14 +62,41 @@ module Gori
           target = ctx.req.target
           hit = target.includes?("__proto__") ||
                 (target.includes?("constructor") && target.includes?("prototype"))
-          unless hit
-            body = ctx.request_body_text
-            hit = !body.nil? && REQ_BODY_PROTO.matches?(body)
-          end
+          hit ||= body_has_proto_key?(ctx)
           return unless hit
           acc << Detection.new("prototype_pollution_param", Category::CLIENT, ctx.host, ctx.url,
             "Prototype-pollution parameter in request", Store::Severity::Low,
             "__proto__/constructor.prototype in request", ctx.fid)
+        end
+
+        # Does the request body carry a prototype key?
+        #
+        # `Context#request_body_text` is what actually answers this, but materialising it means
+        # content-decoding, capping, copying and UTF-8-scrubbing up to 64 KiB — and this rule is
+        # not response-gated, so an ordinary JSON API POST paid that full copy on EVERY captured
+        # flow just to be told "no". (No other built-in rule asks for the request body; only a
+        # user's custom rule does, and it has its own memoised getter.)
+        #
+        # So the RAW bytes are scanned first for a necessary literal. That is exact whenever the
+        # body is not compressed: `decode` returns the same bytes and `scrub` only ever maps an
+        # invalid sequence to U+FFFD, which can neither create nor destroy an ASCII `__proto__`.
+        # A body that IS compressed skips the prefilter and takes the old path — the plaintext
+        # literal is not in the compressed bytes, so gating on it there would be a false negative.
+        # `content_encoded?` is the codebase's fail-closed predicate for that question, so an
+        # obs-folded or otherwise unreadable head lands on the safe side by construction.
+        #
+        # The prefilter scans the WHOLE body while the regex sees only the first 64 KiB, so it is
+        # a strict superset of what can match — it can wave through a body the regex then rejects
+        # (exactly as before), never the reverse.
+        private def body_has_proto_key?(ctx : Context) : Bool
+          body = ctx.detail.request_body
+          return false if body.nil? || body.empty?
+          unless Proxy::Codec::ContentDecode.content_encoded?(ctx.detail.request_head)
+            return false unless AsciiBytes.contains_ci?(body, PROTO_NEEDLE) ||
+                                AsciiBytes.contains_ci?(body, CONSTRUCTOR_NEEDLE)
+          end
+          text = ctx.request_body_text
+          !text.nil? && REQ_BODY_PROTO.matches?(text)
         end
       end
     end

--- a/src/gori/probe/passive/sri.cr
+++ b/src/gori/probe/passive/sri.cr
@@ -39,14 +39,31 @@ module Gori
 
         MAX_HOSTS = 5 # distinct third-party hosts reported per flow
 
+        # An HTML comment. `TAG` happily matches a `<script src>` INSIDE one, and a commented-out
+        # third-party snippet — a disabled analytics tag, an A/B script kept "for later", a
+        # provider swapped out but not deleted — is ordinary in real markup. The browser never
+        # fetches it, so it is not a subresource and carries no supply-chain exposure: reporting
+        # it names a third party the page does not actually load. That FP also STICKS, because
+        # `missing_sri` accumulates its evidence hosts across every flow of the host group
+        # (Store::ACCUMULATING_EVIDENCE_CODES), so one commented-out tag permanently joins the
+        # issue's list of the site's third parties.
+        #
+        # Non-greedy, so nested-looking `--` inside a comment does not over-extend it. An
+        # UNTERMINATED comment matches nothing and its tags stay reported — the previous
+        # behaviour, and the safe direction (a lead, not a silence) when the 256 KiB body prefix
+        # cut the closing `-->` off.
+        COMMENT = /<!--[\s\S]*?-->/
+
         def check(ctx : Context, acc : Array(Detection)) : Nil
           return unless ctx.response
           return unless ctx.html?
           text = ctx.client_body_text
           return if text.nil? || text.empty?
+          comments = comment_spans(text)
           hosts = [] of String
           text.scan(TAG) do |m|
             break if hosts.size >= MAX_HOSTS
+            next if in_comment?(comments, m.byte_begin(0))
             next unless h = external_ref(m[0], ctx)
             hosts << h unless hosts.includes?(h)
           end
@@ -55,6 +72,41 @@ module Gori
               "Cross-origin subresource without Subresource Integrity", Store::Severity::Low,
               h, ctx.fid)
           end
+        end
+
+        # Byte spans of every HTML comment in the document, in order. One `scan` for the whole
+        # document rather than a per-tag backward search (which would be quadratic in the number
+        # of external tags).
+        #
+        # NO literal prefilter, and that is measured, not assumed. The obvious
+        # `return spans unless text.includes?("<!--")` guard costs 238µs on a 200 KiB document
+        # while the `scan` it was meant to avoid costs 50µs — Crystal's `String#includes?` is a
+        # naive byte search, where PCRE2 gets to use its start optimization on the same literal.
+        # The guard made a comment-free page 4× more expensive than just asking. Same shape as
+        # the `includes?`-before-`gsub` guard removed from the Match&Replace body path: do not
+        # hand-roll a prefilter in front of something that already prefilters itself.
+        private def comment_spans(text : String) : Array({Int32, Int32})
+          spans = [] of {Int32, Int32}
+          text.scan(COMMENT) { |m| spans << {m.byte_begin(0), m.byte_end(0)} }
+          spans
+        end
+
+        # Is byte offset `pos` inside one of those spans? `scan` yields non-overlapping matches
+        # left to right, so the spans are ordered and disjoint: binary-search for the last one
+        # starting at/before `pos` and ask whether it also ends after it.
+        private def in_comment?(spans : Array({Int32, Int32}), pos : Int32) : Bool
+          return false if spans.empty?
+          lo = 0
+          hi = spans.size
+          while lo < hi
+            mid = (lo + hi) // 2
+            if spans[mid][0] <= pos
+              lo = mid + 1
+            else
+              hi = mid
+            end
+          end
+          lo > 0 && pos < spans[lo - 1][1]
         end
 
         # The third-party host this tag pulls a subresource from with no integrity guard; nil


### PR DESCRIPTION
A pass over the Probe rule set on the three axes it is judged by: false positives, false negatives, and per-flow cost. Four independent commits, each self-contained and bisectable.

## Speed

Measured with `bench/probe_passive_bench`, same tree, control build via `git checkout origin/main -- <the three passive files>` so the numbers are not confounded by the rules #866 just added. Alternating runs on a quiet machine.

| flow | before | after | |
|---|---|---|---|
| JSON API POST | 150µs / 35.4kB | **52µs / 8.3kB** | **2.9× · alloc 4.3×↓** |
| JS bundle, 256 KiB | 10.49ms / 1.31MB | **7.87ms / 1.06MB** | **1.33× · alloc 19%↓** |
| JS bundle, non-ASCII | 11.11ms / 3.31MB | **8.79ms / 3.06MB** | **1.26×** |
| HTML document, 30 KB | 1.43ms | 1.46ms | flat |
| HTML document, 200 KiB | 3.60ms | 3.65ms | flat (see below) |

Detection counts are unchanged on every fixture.

**`JsScan.source_in_window` re-ran 14 regexes per sink occurrence.** A minified SPA/jQuery bundle carries thousands of sink hits, and each one allocated two window strings and ran up to 28 PCRE calls against them. The sources are now scanned once per script for their byte spans, and the window test is a binary search. `scan` yields non-overlapping matches left to right, so both `begin` and `end` are increasing and the first span beginning at/after the window start also has the smallest end — that one span decides. SOURCES order is preserved, so the label reported for a window holding several sources is the one the slice-and-match version reported.

**`JsScan.strip` paid a nilable union per character.** It called `blank_token_at`, which returns `Int32?`, for every char of the script. `strip_comments` does the same walk with the dispatch inlined and was 2.17× faster for it (0.72ms vs 1.55ms on the same fixture). The dispatch is spelled out in both now.

**`PrototypePollution#check_request` decoded every request body.** The rule is not response-gated, and no other built-in asks for the request body, so an ordinary JSON API POST paid a full content-decode + cap + copy + UTF-8 scrub of up to 64 KiB just to be told "no". It now prefilters the raw bytes for a necessary literal. A compressed body skips the prefilter and takes the old path, because the plaintext literal is not in the compressed bytes — `ContentDecode.content_encoded?` is the fail-closed predicate for that, and a spec pins the gzip case.

## False negative: open redirect only probed already-external redirects

The gate required `Active.url_authority(loc)` to parse, so it only ever probed an endpoint whose captured redirect **already** pointed at an absolute external host — largely confirming redirects that were off-site before we touched them. The dominant shape was skipped outright: `/login?next=/dashboard` → `Location: /dashboard`, which is how nearly every framework's post-login return works, and exactly the endpoint worth asking whether it will also follow an absolute host.

A relative `Location` now counts as driven by a parameter when the decoded value **is** that path — equal, or the prefix the app appended its own query/fragment to. A bare `/` is refused, since it prefixes every relative Location there is and would nominate whichever parameter came first.

This widens only *what is probed*, never what is reported: `detections` still fires solely when the probe response's `Location` parses to `PROBE_HOST` as its own authority, so a wrong guess in the gate costs one request, not a false finding.

The widening also exposed a latent bug in the encoding mirror. `probe_value_for` chose the literal probe URL on `://`; a relative driving value has none, so it would have been sent percent-encoded to an app that had just demonstrated it does not url-decode. The probe would land in `Location` as a literal `https%3A%2F%2F…`, which parses to no authority — and the rule would report clean on an endpoint it never really asked. The test is a bare `/` instead; absolute values carry one too, so those keep choosing the literal exactly as before.

## False positive: SRI reported commented-out tags

`Sri`'s `TAG` pattern matched a `<script src>` inside an HTML comment, and a commented-out third-party snippet — a disabled analytics tag, a provider swapped out but not deleted — is ordinary in real markup. The browser never fetches it, so it is not a subresource and carries no supply-chain exposure.

That false positive also **sticks**: `missing_sri` accumulates its evidence hosts across the whole `(code, host)` group via `Store::ACCUMULATING_EVIDENCE_CODES`, so one commented-out tag permanently joins the issue's list of the site's third parties. Comment spans are collected in one scan and tested by binary search; an unterminated comment matches nothing and its tags stay reported, which is the previous behaviour and the safe direction when the body prefix cut the closing `-->` off.

## Two measured negative results, recorded in the code

Both contradict an instinct this tree uses elsewhere, so they are written down next to the code rather than left to be rediscovered:

- **A `String#includes?` prefilter in front of a regex can be a pessimization.** `text.includes?("<!--")` costs **238µs** on a 200 KiB document while the `scan` it was meant to avoid costs **50µs** — Crystal's `String#includes?` is a naive byte search where PCRE2 gets to use its start optimization on the same literal. Added as an "obvious" guard, it made a comment-free page 4× more expensive than just asking, and showed up as a real regression on the 200 KiB fixture before being removed. Same shape as the `includes?`-before-`gsub` guard dropped from the Match&Replace body path. (A literal that guards *several* regexes, as in `body_leaks`, is still a win — it is the count that decides.)
- **Collapsing the 14 source patterns into one named-group alternation is slower**, 0.96ms → 1.40ms, the same way `Regex.union` lost to `body_leaks`' per-pattern loop. It defeats PCRE's per-pattern start optimization.

The residual ~50µs of the SRI comment scan is the measured price of that FP fix and is what the 200 KiB HTML row above absorbs (~1.4%, inside the run-to-run band).

## Verification

Rebased onto `origin/main` (which had moved by two PRs, including #866's new passive rules) and re-verified **after** the rebase, since CI builds the branch and never the merge result:

- `crystal build --no-codegen src/main.cr`
- `crystal tool format --check src/ spec/`
- `scripts/bench_check.sh` — 48 harnesses
- `crystal spec` — **11722 examples, 0 failures, 0 errors**

New specs pin each behaviour change, and the SRI one was confirmed to fail with the fix reverted.

## Deliberately not done

`Secrets::PATTERNS` scans only the 64 KiB `body_text` on JS bundles while `client_body_text` (256 KiB) is already materialised, which is a real false negative for hard-coded keys past the cap. Widening it costs ~2.2ms/flow (25 patterns × 192 KiB more) and would erase this pass's speed win. #612 already recorded that decision — widening a tag scan and widening a content scan are different trades — so it is left alone; the right shape would be JS-only with a reduced pattern set.
