### PR TITLE
docs: single-tier footer, sticky sidebar, faded rail edges

### DIFF
--- a/docs/i18n/en.toml
+++ b/docs/i18n/en.toml
@@ -47,14 +47,6 @@ overview = "Overview"
 [section]
 in_this_section = "In This Section"
 
-[footer]
-tagline = "Sit in the loop."
-docs = "Documentation"
-project = "Project"
-releases = "Releases"
-issues = "Issues"
-built_with = "Built with"
-
 [notfound]
 title = "Page not found"
 body = "The page you are looking for does not exist."

--- a/docs/i18n/ko.toml
+++ b/docs/i18n/ko.toml
@@ -47,14 +47,6 @@ overview = "개요"
 [section]
 in_this_section = "이 섹션의 문서"
 
-[footer]
-tagline = "루프 안에 앉으세요."
-docs = "문서"
-project = "프로젝트"
-releases = "릴리스"
-issues = "이슈"
-built_with = "만든 도구:"
-
 [notfound]
 title = "페이지를 찾을 수 없음"
 body = "찾으시는 페이지가 존재하지 않습니다."

--- a/docs/static/css/style.css
+++ b/docs/static/css/style.css
@@ -1593,16 +1593,6 @@ kbd {
 
 /* Narrow: stack the seam vertically and turn the wire on its end. */
 @media (max-width: 720px) {
-  .footer-grid {
-    grid-template-columns: 1fr;
-    gap: var(--space-5);
-  }
-
-  .footer-bottom {
-    flex-direction: column;
-    gap: var(--space-1);
-  }
-
   .agent-seam {
     flex-direction: column;
     max-width: 26rem;
@@ -1878,35 +1868,50 @@ kbd {
   position: relative;
   z-index: 1;
   display: flex;
-  gap: 3rem;
   min-height: 100dvh;
   padding-top: var(--header-h);
-  padding-left: var(--sidebar-w);
 }
 
+/* Sticky, not fixed: a fixed rail never ends, which forced the footer to
+   start after it and centre on the content column instead of the page —
+   visibly off-axis on wide screens. In flow the rail stops with the article,
+   its border-right meets the footer's border-top in a clean T, and the
+   footer spans the real page width. Sticky keeps it parked under the header
+   while the article scrolls, so nothing about the reading experience moves. */
 .docs-sidebar {
-  position: fixed;
+  position: sticky;
   top: var(--header-h);
-  left: 0;
-  width: var(--sidebar-w);
+  align-self: flex-start;
+  flex: 0 0 var(--sidebar-w);
   height: calc(100dvh - var(--header-h));
-  padding: 1.2rem 0.85rem 1.5rem;
-  overflow-y: auto;
   border-right: 1px solid var(--line);
   background:
     linear-gradient(180deg, rgb(var(--ink-rgb) / 0.045), transparent 18rem),
     var(--sidebar-bg);
   backdrop-filter: blur(14px);
   -webkit-backdrop-filter: blur(14px);
+}
+
+/* The rail now stops at the footer's rule, so its scroll edge lands on that
+   line and used to slice the last link mid-glyph. Fade the last 2rem instead.
+   The fade is exactly the scroller's own padding-bottom, so at the end of the
+   scroll the final link sits clear of it and reads at full strength — the
+   fade only ever touches content that is already leaving the viewport. */
+.sidebar-scroll {
+  height: 100%;
+  padding: 1.2rem 0.85rem 2rem;
+  overflow-y: auto;
+  -webkit-mask-image: linear-gradient(to bottom, #000 calc(100% - 2rem), transparent);
+  mask-image: linear-gradient(to bottom, #000 calc(100% - 2rem), transparent);
   scrollbar-width: thin;
   scrollbar-color: var(--line-strong) transparent;
 }
 
-.docs-sidebar::-webkit-scrollbar {
+.sidebar-scroll::-webkit-scrollbar {
   width: 6px;
 }
 
-.docs-sidebar::-webkit-scrollbar-thumb {
+.sidebar-scroll::-webkit-scrollbar-thumb {
   background: var(--line-strong);
   border-radius: var(--radius-pill);
 }
@@ -2070,15 +2075,22 @@ kbd {
   color: var(--accent-strong);
 }
 
+/* Same fade as .sidebar-scroll, and for the same reason — a long page's TOC
+   outruns its max-height and used to end on a sliced line. The rail carries
+   no panel of its own, so the mask goes straight on it. Keep the fade equal
+   to padding-bottom: at the end of the scroll the last heading clears it. */
 .docs-toc-rail {
   display: none;
   flex: 0 0 var(--toc-w);
+  margin-left: 3rem;
   align-self: flex-start;
   position: sticky;
   top: calc(var(--header-h) + 2.2rem);
   max-height: calc(100dvh - var(--header-h) - 4rem);
-  padding: 0.1rem 0 1.5rem;
+  padding: 0.1rem 0 2rem;
   overflow-y: auto;
+  -webkit-mask-image: linear-gradient(to bottom, #000 calc(100% - 2rem), transparent);
+  mask-image: linear-gradient(to bottom, #000 calc(100% - 2rem), transparent);
   scrollbar-width: thin;
   scrollbar-color: var(--line-strong) transparent;
 }
@@ -2757,20 +2769,20 @@ nav.pagination a:hover,
   z-index: 1;
   width: min(100%, 1380px);
   margin: 0 auto;
-  padding: 2rem 1.25rem 2.4rem;
+  padding: var(--space-6) 1.25rem;
   border-top: 1px solid var(--line);
-  color: var(--quiet);
+  /* --muted, not --quiet: the meta line runs at 0.82rem and --quiet is
+     3.9:1 there, under AA (same call as the Meaning block above). */
+  color: var(--muted);
   font-size: 0.9rem;
+  text-align: center;
 }
 
-/* Doc pages keep the sidebar fixed for the full viewport height, so the
-   footer (a flow sibling after .docs-container closes) starts AFTER the
-   sidebar — margin, not padding, so its border-top never runs underneath
-   the translucent sidebar and crosses its border-right. */
+/* Doc pages are full-bleed — the rail starts at x:0 and the TOC runs to the
+   right edge — so the 1380px cap would leave the rule floating inside the
+   sidebar column on wide screens. Only the home page's content is capped. */
 .is-doc .docs-footer {
-  width: auto;
-  margin: 0 0 0 var(--sidebar-w);
-  padding-left: 3rem;
+  width: 100%;
 }
 
 .docs-footer p {
@@ -2785,82 +2797,68 @@ nav.pagination a:hover,
   color: var(--accent-strong);
 }
 
-/* Link columns: brand + two quiet nav stacks, closed by a hairline bottom
-   bar. Column heads borrow the TOC rail's mono uppercase voice. */
-.footer-grid {
-  display: grid;
-  grid-template-columns: 1.4fr 1fr 1fr;
-  gap: var(--space-6);
-  padding-bottom: var(--space-6);
+/* One centered tier: three outbound links over a single meta line. The old
+   brand + two-column grid, its mono column heads, and the hairline bottom
+   bar were more scaffolding than three links and a copyright ever needed,
+   and wrapping keeps them upright without a breakpoint. */
+.footer-links {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: var(--space-1) var(--space-2);
 }
 
-.footer-brand .logo-word {
-  font-size: 1.3rem;
+/* Borrows .top-nav a's quiet pill so the row reads as the header's echo
+   rather than a second link idiom. */
+.footer-links a {
+  padding: 0.3rem 0.7rem;
+  border-radius: var(--radius-pill);
+  text-decoration: none;
+  transition: color var(--transition), background var(--transition);
 }
 
-.footer-brand .footer-tagline {
-  margin-top: var(--space-2);
-  max-width: 26rem;
-  color: var(--quiet);
+.footer-links a:hover {
+  background: rgb(var(--ink-rgb) / 0.06);
+  color: var(--heading);
 }
 
-.footer-col h2 {
-  margin: 0 0 var(--space-3);
-  color: var(--quiet);
-  font-family: var(--font-mono);
-  font-size: 0.7rem;
-  font-weight: 600;
-  letter-spacing: 0.09em;
-  text-transform: uppercase;
+.footer-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem 0.6rem;
+  margin-top: var(--space-4);
+  font-size: 0.82rem;
 }
 
-.footer-col a {
-  display: block;
-  width: fit-content;
-  padding: var(--space-1) 0;
+/* hahwul mark — Built with Love (matches dalfox docs footer), folded into
+   the meta line so the signature costs a glyph instead of its own block. */
+.footer-sig {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
   text-decoration: none;
 }
 
-.footer-bottom {
-  display: flex;
-  justify-content: space-between;
-  gap: var(--space-4);
-  padding-top: var(--space-5);
-  border-top: 1px solid var(--line-soft);
-}
-
-/* hahwul mark — Built with Love (matches dalfox docs footer) */
-.footer-mark {
-  text-align: center;
-  margin-top: 1.5rem;
-}
-
-.footer-mark a {
-  display: inline-block;
-  line-height: 0;
-}
-
-.footer-mark .hahwul-img {
-  display: inline-block;
-  width: 80px;
-  height: 80px;
+.footer-sig .hahwul-img {
+  width: 22px;
+  height: 22px;
   /* Recolor the logo to the footer text tone by using its alpha as a mask
      and filling with the muted token (the raster itself is white). */
   background-color: var(--muted);
   -webkit-mask: url("../images/hahwul.webp") center / contain no-repeat;
   mask: url("../images/hahwul.webp") center / contain no-repeat;
-  transition: background-color 0.3s ease;
+  transition: background-color var(--transition);
 }
 
-.footer-mark .hahwul-img:hover {
+.footer-sig:hover .hahwul-img {
   background-color: var(--text);
 }
 
 .footer-love {
-  margin-top: 0.85rem;
-  color: var(--muted);
   font-family: "Bradley Hand", "Snell Roundhand", "Apple Chancery", cursive;
-  font-size: 0.95rem;
+  font-size: 0.9rem;
   letter-spacing: 0.02em;
 }
 
@@ -3480,13 +3478,6 @@ html.search-lock body {
 
   .docs-container {
     display: block;
-    padding-left: 0;
-  }
-
-  .is-doc .docs-footer {
-    width: min(100%, 1380px);
-    margin: 0 auto;
-    padding-left: 1.25rem;
   }
 
   .docs-main {

--- a/docs/templates/footer.html
+++ b/docs/templates/footer.html
@@ -1,33 +1,22 @@
+{# One centered tier: three outbound links over a single meta line that
+   carries the hahwul signature inline. The doc sections are already the
+   whole of .top-nav, so repeating them here bought nothing but a grid.
+   Deliberately untranslated — this strip is frame, not content, and the
+   handwriting stack under "Built with Love" carries no Hangul anyway. #}
 <footer class="docs-footer">
-  <div class="footer-grid">
-    <div class="footer-brand">
-      <span class="logo-word" aria-hidden="true">𝓰𝓸𝓻𝓲</span>
-      <p class="footer-tagline">{{ "footer.tagline" | t }}</p>
-    </div>
-    <nav class="footer-col" aria-label="{{ "footer.docs" | t }}">
-      <h2>{{ "footer.docs" | t }}</h2>
-      <a href="{{ base_url }}{{ lang_prefix }}/getting-started/">{{ "nav.start" | t }}</a>
-      <a href="{{ base_url }}{{ lang_prefix }}/playbooks/">{{ "nav.playbooks" | t }}</a>
-      <a href="{{ base_url }}{{ lang_prefix }}/guide/">{{ "nav.guide" | t }}</a>
-      <a href="{{ base_url }}{{ lang_prefix }}/reference/">{{ "nav.reference" | t }}</a>
-    </nav>
-    <nav class="footer-col" aria-label="{{ "footer.project" | t }}">
-      <h2>{{ "footer.project" | t }}</h2>
-      <a href="https://github.com/hahwul/gori" target="_blank" rel="noopener noreferrer">GitHub</a>
-      <a href="https://github.com/hahwul/gori/releases" target="_blank" rel="noopener noreferrer">{{ "footer.releases" | t }}</a>
-      <a href="https://github.com/hahwul/gori/issues" target="_blank" rel="noopener noreferrer">{{ "footer.issues" | t }}</a>
-    </nav>
-  </div>
-  <div class="footer-bottom">
-    <p>Apache-2.0 · © hahwul</p>
-    <p>{{ "footer.built_with" | t }} <a href="https://github.com/hahwul/hwaro" target="_blank" rel="noopener noreferrer">Hwaro</a></p>
-  </div>
-  <div class="footer-mark">
-    <a href="https://www.hahwul.com" target="_blank" rel="noopener" aria-label="hahwul">
-      <span class="hahwul-img" role="img" aria-label="hahwul"></span>
+  <nav class="footer-links" aria-label="Project">
+    <a href="https://github.com/hahwul/gori" target="_blank" rel="noopener noreferrer">GitHub</a>
+    <a href="https://github.com/hahwul/gori/releases" target="_blank" rel="noopener noreferrer">Releases</a>
+    <a href="https://github.com/hahwul/gori/issues" target="_blank" rel="noopener noreferrer">Issues</a>
+  </nav>
+  <p class="footer-meta">
+    <a class="footer-sig" href="https://www.hahwul.com" target="_blank" rel="noopener" aria-label="hahwul">
+      <span class="hahwul-img" aria-hidden="true"></span>
+      <span class="footer-love">Built with Love</span>
     </a>
-    <p class="footer-love">Built with Love</p>
-  </div>
+    <span aria-hidden="true">·</span>
+    <span>Apache-2.0 · © hahwul · Built with <a href="https://github.com/hahwul/hwaro" target="_blank" rel="noopener noreferrer">Hwaro</a></span>
+  </p>
 </footer>
 <script>
   /* Theme toggle: flip data-theme, remember the choice, and swap the TUI

--- a/docs/templates/partials/sidebar.html
+++ b/docs/templates/partials/sidebar.html
@@ -1,4 +1,8 @@
+{# The panel (background, border-right, backdrop blur) stays on the <aside>;
+   only this inner scroller carries the fade mask, which would otherwise eat
+   the panel itself and break its seam with the footer. #}
 <aside class="docs-sidebar">
+  <div class="sidebar-scroll">
   {% for sec in site.sections | sort(attribute="weight") %}{% if sec.name != "" and sec.language == page_language %}
   <details class="sidebar-section"{% if page.section == sec.name %} open{% endif %}>
     <summary class="sidebar-title">
@@ -17,4 +21,5 @@
     </ul>
   </details>
   {% endif %}{% endfor %}
+  </div>
 </aside>


### PR DESCRIPTION
## Footer

The footer had accreted four structural zones across three separate passes:

1. `.footer-grid` — brand + two link columns (`1.4fr 1fr 1fr`)
2. `.footer-col h2` — `DOCUMENTATION` / `PROJECT` mono-caps column heads
3. `.footer-bottom` — a hairline bar with the licence and "Built with Hwaro"
4. `.footer-mark` — an 80px hahwul mark and a cursive "Built with Love"

That is a grid, two headings, a divider and a signature block to hold seven
links — four of which (Start / Playbooks / Guide / Reference) were an exact
copy of `.top-nav`.

It is now one centred tier: three outbound links over a single meta line
carrying the hahwul mark inline at 22px.

```
──────────────────────────────────────────────────────────
              GitHub    Releases    Issues
  ♥ Built with Love · Apache-2.0 · © hahwul · Built with Hwaro
```

The footer is frame, not content, so it drops its `[footer]` i18n keys and
stays English on every locale — "Built with Love" in particular has no
Hangul glyphs in its handwriting stack, so translating it would fall back to
sans and lose the signature it exists for.

## Sticky sidebar

Centring the footer exposed an older problem: `.docs-sidebar` was
`position: fixed`, so the rail **never ended**. The footer had to start after
it (`margin-left: var(--sidebar-w)`), which meant `text-align: center`
centred on the content column rather than the page — footer centre 828 vs
page centre 686 at 1372px.

The rail is now `position: sticky` in the flex flow. It stops with the
article, its `border-right` meets the footer's `border-top` in a clean T, and
the footer spans the real page width. Sticky keeps it parked under the header
while the article scrolls, so nothing about reading changes.

Two knock-ons handled: the container `gap` moved to `.docs-toc-rail`
(a sidebar in flow would otherwise take a 3rem gap it never had), and the
footer's `min(100%, 1380px)` cap is lifted on doc pages — those are full
bleed, so at 1700px the cap left the rule starting at x:160, cutting across
under the sidebar column.

## Faded rail edges

Both scrolling rails now end on the footer's rule, which sliced the last link
mid-glyph. Each fades its final 2rem instead. The fade is exactly each rail's
`padding-bottom`, so at the end of the scroll the last item sits clear of it
and reads at full strength — the fade only ever touches content already
leaving the viewport.

The sidebar needed an inner `.sidebar-scroll` wrapper for this: masking the
`<aside>` directly would fade its panel background, border and backdrop blur,
breaking the seam with the footer. The TOC rail carries no panel, so the mask
goes straight on it.

## Verification

Driven through the Chrome DevTools Protocol headless, dark and light:

| vw | footer | centre | sidebarBottom / footerTop | scrollWidth |
|---|---|---|---|---|
| 1700 | 0..1700 | 850 | — | 1700 |
| 1372 | 0..1372 | 686 | 684 / 684 | 1372 |
| 1200 | 0..1200 | 600 | 685 / 685 | 1200 |
| 900 | 0..900 | 450 | 685 / 685 | 900 |
| 760 | 0..760 | 380 | sidebar hidden | 760 |
| 500 | 0..500 | 250 | sidebar hidden | 500 |

`centre == vw / 2` everywhere, `sidebarBottom == footerTop` exactly, and no
horizontal overflow at any width. Checked home, `/guide/`, `/reference/cli/`
(42 headings, the longest TOC), `/ko/guide/` and 404, in both themes, with
the rails at mid-scroll and at their end.