### PR TITLE
docs: simplify footer and uppercase copyright author

### DIFF
--- a/docs/static/css/style.css
+++ b/docs/static/css/style.css
@@ -2828,7 +2828,6 @@ nav.pagination a:hover,
   align-items: center;
   justify-content: center;
   gap: 0.35rem 0.6rem;
-  margin-top: var(--space-4);
   font-size: 0.82rem;
 }
 

--- a/docs/templates/footer.html
+++ b/docs/templates/footer.html
@@ -1,21 +1,14 @@
-{# One centered tier: three outbound links over a single meta line that
-   carries the hahwul signature inline. The doc sections are already the
-   whole of .top-nav, so repeating them here bought nothing but a grid.
+{# One centered tier: meta line carrying the hahwul signature and copyright.
    Deliberately untranslated — this strip is frame, not content, and the
    handwriting stack under "Built with Love" carries no Hangul anyway. #}
 <footer class="docs-footer">
-  <nav class="footer-links" aria-label="Project">
-    <a href="https://github.com/hahwul/gori" target="_blank" rel="noopener noreferrer">GitHub</a>
-    <a href="https://github.com/hahwul/gori/releases" target="_blank" rel="noopener noreferrer">Releases</a>
-    <a href="https://github.com/hahwul/gori/issues" target="_blank" rel="noopener noreferrer">Issues</a>
-  </nav>
   <p class="footer-meta">
     <a class="footer-sig" href="https://www.hahwul.com" target="_blank" rel="noopener" aria-label="hahwul">
       <span class="hahwul-img" aria-hidden="true"></span>
       <span class="footer-love">Built with Love</span>
     </a>
     <span aria-hidden="true">·</span>
-    <span>Apache-2.0 · © hahwul · Built with <a href="https://github.com/hahwul/hwaro" target="_blank" rel="noopener noreferrer">Hwaro</a></span>
+    <span>Apache-2.0 · © HAHWUL</span>
   </p>
 </footer>
 <script>


### PR DESCRIPTION
Simplify the documentation footer by removing footer links and 'Built with Hwaro', and update the copyright author text to uppercase 'HAHWUL'.