### PR TITLE
docs(contributors): rank the wall by commits, and let it pick its own width

### DIFF
--- a/.github/contributor-mural.yml
+++ b/.github/contributor-mural.yml
@@ -19,6 +19,15 @@
 # Roles name a kind of contribution, not an amount of it — one word or two, the
 # same weight for everyone. Spelling out what a report contained while a commit
 # stays "Code" ranks the wall by how much was written here, which is backwards.
+#
+# `weight: 0` marks the entries with no commits. The wall ranks by weight, and
+# the contributors API counts from one commit up — so an entry left at the
+# default weighed exactly as much as whoever has a single commit, and the two
+# were separated by nothing but the alphabet. That is how someone who wrote
+# code ended up standing in the middle of the people thanked for reports. 0 is
+# the rung the API can never report, so it holds the thanks behind everyone
+# with a commit without titling either half of the wall. Every new entry here
+# that arrives without a commit wants it.
 style: grid
 
 output: docs/static/CONTRIBUTORS.svg
@@ -33,8 +42,10 @@ users:
     role: Code, Bug Reports
   - login: bash-bunny
     role: Bug Reports
+    weight: 0
   - login: pwnxpl0it
     role: Bug Reports
+    weight: 0
 
 exclude:
   - dependabot[bot]
@@ -43,7 +54,12 @@ exclude:
   - imgbot[bot]
 
 grid:
-  columns: 8
+  # The headcount picks the width: one row until `max_columns`, then the fewest
+  # even rows that hold everyone. A number here is a count of today's people,
+  # and it goes stale the moment someone lands their first commit — this wall
+  # was 3 columns, then 8, and would need editing again at nine faces.
+  columns: auto
+  max_columns: 10
   avatar_size: 96
   shape: circle
   margin: 16


### PR DESCRIPTION
The contributor wall put d0kk2bi — who wrote code — between two people thanked for bug reports.

The cause was a default, not the sort. A `users:` entry defaults to a weight of 1, and the contributors API reports 1 for a single commit, so an entry for someone with **no** commits weighed exactly as much as whoever has **one**, and `sort: weight` separated the two by nothing but the alphabet.

## What changed

- `weight: 0` on the two entries with no commits. It is the rung the API can never report from — GitHub counts a contributor from one commit up — so the thanks hold behind everyone with a commit, and neither half of the wall has to be titled to say so. Every future entry that arrives without a commit wants it; the file's comments say so.
- `columns: auto` with `max_columns: 10`. The column count was 3, then 8, and would want editing again at nine faces. Auto keeps the wall on one row until `max_columns`, then splits it into the fewest even rows that hold everyone (eleven people are 6 and 5, not 10 and a lone face underneath).

Both keys landed in contributor-mural v1.5.0 ([crystal-actions/contributor-mural#…](https://github.com/crystal-actions/contributor-mural/releases/tag/v1.5.0)), which `@v1` now resolves to — verified by rendering this exact config through the released `ghcr.io/crystal-actions/contributor-mural:v1` image.

## Result

Order becomes `hahwul · chei-l · sebastianosrt · d0kk2bi · bash-bunny · pwnxpl0it`. The picture is otherwise unchanged today: 688×160, one row of six.

`docs/static/CONTRIBUTORS.svg` is left alone — the mural workflow redraws and commits it on the next push to `main`, the way it always has.