### PR TITLE
fix(tui): Activity pane — a refused step, a gauge that pages, a list that stops growing

### DIFF
--- a/spec/tui/project_activity_pane_spec.cr
+++ b/spec/tui/project_activity_pane_spec.cr
@@ -610,4 +610,68 @@ describe "ProjectView ACTIVITY refresh (the data_version poll)" do
       view.activity_rows.first.message.should eq("flood #{flood - 1}")
     end
   end
+
+  # The catch-up above is what makes this necessary. `prepend_activity` runs on every poll for
+  # as long as the pane is open — and the capture-lock holder moves `data_version` every 3 s on
+  # an idle project — so the loaded list only ever GREW: a session left on this card while an
+  # agent worked retained every event that agent had ever written, and copied the whole array
+  # on the render fiber each time. Nothing is lost by capping it: the resume point moves up to
+  # the last row kept, so the trimmed tail pages straight back in.
+  it "caps the rows it keeps at the head, and pages the trimmed tail back in" do
+    tmp_store do |store, project|
+      200.times { |i| store.insert_event("agent", "agent_action", "info", "old #{i}") }
+      store.flush
+      view = activity_view(store, project)
+      view.reload_activity(store)
+
+      total = 200
+      # Bursts inside ACT_CATCHUP_PAGES, so every round folds in rather than reloading.
+      8.times do |t|
+        800.times { |i| store.insert_event("agent", "agent_action", "info", "burst #{t}-#{i}") }
+        total += 800
+        store.flush
+        view.refresh_activity(store)
+      end
+      total.should be > ProjectView::ACT_MAX_ROWS
+      view.activity_rows.size.should eq(ProjectView::ACT_MAX_ROWS)
+      # Newest-first still: the cap cut the TAIL, not the head the operator is watching.
+      view.activity_rows.first.message.should eq("burst 7-799")
+
+      # And the tail is only unloaded, not skipped: walking back down returns every event
+      # exactly once, in order.
+      while view.activity_more?
+        view.activity_select(view.activity_rows.size) # park at the end so nothing trims
+        view.activity_load_more(store)
+      end
+      ids = view.activity_rows.map(&.id)
+      ids.size.should eq(total)
+      ids.uniq.size.should eq(total)
+      ids.should eq(ids.sort.reverse)
+    end
+  end
+
+  # The cut is below the CURSOR, never at it. Trimming the row an operator parked on would do
+  # to the selection exactly what a reload does — hand `↵` a different event — which is the one
+  # thing the id anchor exists to prevent.
+  it "never trims the row the cursor is parked on" do
+    tmp_store do |store, project|
+      200.times { |i| store.insert_event("agent", "agent_action", "info", "old #{i}") }
+      store.flush
+      view = activity_view(store, project)
+      view.reload_activity(store)
+      view.activity_select(3)
+      parked = view.activity_selected_row.not_nil!
+
+      8.times do |t|
+        800.times { |i| store.insert_event("agent", "agent_action", "info", "burst #{t}-#{i}") }
+        store.flush
+        view.refresh_activity(store)
+      end
+
+      view.activity_selected_row.not_nil!.id.should eq(parked.id)
+      # Everything above it is still there — that growth is the operator's own parking, and
+      # cutting into it is what would move the cursor.
+      view.activity_rows.size.should be > ProjectView::ACT_MAX_ROWS
+    end
+  end
 end

--- a/spec/tui/project_activity_wiring_spec.cr
+++ b/spec/tui/project_activity_wiring_spec.cr
@@ -110,4 +110,77 @@ describe "ACTIVITY pane controller wiring" do
       ctl.view.activity_rows.size.should eq(3)
     end
   end
+
+  # …and the mirror image: a step the strip REFUSES must settle nothing. ACTIVITY is the last
+  # chip, so `→` there moves nowhere, yet it still ran `settle_subtab` + `settle_activity_entry`
+  # — dropping a committed filter, throwing away every page walked in, and re-seating the
+  # cursor (via `clamp_act_sel`) on a different event. An arrow key that moves nothing must not
+  # change what the pane is showing.
+  it "leaves the pane alone when the strip refuses the step" do
+    with_activity do |ctl, store|
+      500.times { |i| store.insert_event("agent", "agent_action", "info", "e#{i}") }
+      store.flush
+      ctl.view.focus_pane(:activity)
+      ctl.reload_activity
+      ctl.body_scroll(400)
+      ctl.body_scroll(400)
+      loaded = ctl.view.activity_rows.size
+      loaded.should eq(500)
+      parked = ctl.view.activity_selected_row.not_nil!.id
+
+      ctl.move_subtab(1) # ACTIVITY is PANES.last — refused
+
+      ctl.view.pane.should eq(:activity)
+      ctl.view.activity_rows.size.should eq(loaded)
+      ctl.view.activity_selected_row.not_nil!.id.should eq(parked)
+    end
+  end
+
+  it "keeps a committed text filter through a refused step" do
+    with_activity do |ctl, store|
+      seed(store)
+      ctl.view.focus_pane(:activity)
+      ctl.view.activity_filter_field.set("extract")
+      ctl.reload_activity
+      ctl.view.activity_rows.size.should eq(1)
+
+      ctl.move_subtab(1)
+
+      ctl.view.activity_filtered?.should be_true
+      ctl.view.activity_rows.size.should eq(1)
+    end
+  end
+
+  # This is the one Project list whose rows are a PAGE rather than the whole set, so the gauge
+  # has to pull the next one exactly as `↓` does. It did not: the keyboard walked past the end
+  # of page one and the gauge stopped dead there.
+  it "pages from a scroll-gauge grab, not only from the keyboard" do
+    with_activity do |ctl, store|
+      500.times { |i| store.insert_event("agent", "agent_action", "info", "e#{i}") }
+      store.flush
+      ctl.view.focus_pane(:activity)
+      ctl.reload_activity
+      ctl.view.activity_rows.size.should eq(Gori::Tui::ProjectView::ACT_PAGE)
+
+      # Located through the view's OWN hit-test rather than re-derived here, so the spec cannot
+      # drift from the card geometry (`act_list_inner` is the single offset source).
+      rect = Gori::Tui::Rect.new(0, 0, 120, 40)
+      last = ctl.view.activity_rows.size - 1
+      hit = nil.as({Int32, Int32}?)
+      (0...rect.h).each do |y|
+        (0...rect.w).each do |x|
+          if ctl.view.activity_gauge_row(rect, x, y) == last
+            hit = {x, y}
+            break
+          end
+        end
+        break if hit
+      end
+      x, y = hit.not_nil!
+
+      ctl.handle_click(rect, x, y)
+
+      ctl.view.activity_rows.size.should eq(Gori::Tui::ProjectView::ACT_PAGE * 2)
+    end
+  end
 end

--- a/src/gori/tui/controllers/project_controller.cr
+++ b/src/gori/tui/controllers/project_controller.cr
@@ -123,7 +123,14 @@ module Gori::Tui
       true
     end
 
+    # A REFUSED step is inert; SETTLING one is not. `settle_subtab` drops the ACTIVITY text
+    # filter and `settle_activity_entry` re-reads page one, so `→` on the last chip used to
+    # throw away every page the operator had walked in (500 rows back to 200) and re-seat the
+    # cursor, by `clamp_act_sel`, on a different event — the exact "stale but in range" failure
+    # the id anchor exists to prevent, triggered by an arrow key that moves nothing. Peek
+    # first, so the strip's clamp costs nothing beyond not moving.
     def move_subtab(dir : Int32) : Nil
+      return unless @project_view.pane_can_advance?(dir)
       settle_subtab
       @project_view.pane_advance(dir) # clamps at both ends, like the chips read
       settle_activity_entry
@@ -229,8 +236,13 @@ module Gori::Tui
       when :activity
         @project_view.focus_pane(:activity)
         # The card's scroll gauge rides its right hairline, which `activity_row_at` excludes.
+        # BOTH branches page. This is the one Project list whose rows are a PAGE rather than
+        # the whole set, so a gauge grab that lands on the last loaded row has to pull the next
+        # one exactly as `↓` does — without it the gauge stopped dead at the end of page one
+        # while the keyboard walked straight past it.
         if row = @project_view.activity_gauge_row(rect, mx, my)
           @project_view.activity_select_at(row)
+          page_activity
         elsif idx = @project_view.activity_row_at(rect, mx, my)
           @project_view.activity_select_at(idx)
           page_activity

--- a/src/gori/tui/project_view.cr
+++ b/src/gori/tui/project_view.cr
@@ -495,12 +495,19 @@ module Gori::Tui
       cancel_env_prefix_edit
     end
 
+    # Whether `pane_advance` would land on a pane at all. Peeked SEPARATELY because the
+    # controller has to decide before it settles: settling a step that then gets refused is a
+    # side effect with no navigation attached to it (see `ProjectController#move_subtab`).
+    def pane_can_advance?(dir : Int32) : Bool
+      i = pane_index + dir
+      i >= 0 && i < PANES.size
+    end
+
     # Step to the neighbouring sub-tab; false at either end (the strip clamps, it does not
     # wrap — same as the chips read). Driven by the strip's ←/→ via move_subtab.
     def pane_advance(dir : Int32) : Bool
-      i = pane_index + dir
-      return false if i < 0 || i >= PANES.size
-      @pane = PANES[i]
+      return false unless pane_can_advance?(dir)
+      @pane = PANES[pane_index + dir]
       true
     end
 
@@ -1013,6 +1020,18 @@ module Gori::Tui
     # One page. Big enough that the ordinary feed arrives whole, small enough that the first
     # paint of a busy project is not waiting on 50k rows.
     ACT_PAGE = 200
+    # Ceiling on the rows this pane KEEPS. The loaded list only ever grew: `prepend_activity`
+    # runs on every `data_version` poll for as long as the pane is open — and the capture-lock
+    # holder moves `data_version` every 3 s on an idle project — so a session left on this card
+    # while an agent worked accumulated every event that agent ever wrote, and paid for it
+    # twice, because each prepend reallocates and copies the whole array on the render fiber.
+    # (Measured: 2 050 events written under an open pane, 2 050 rows retained.)
+    #
+    # 25 pages is more scrollback than anyone reads in one sitting, and nothing is LOST by
+    # trimming: `@act_next_before` moves up to the last row kept, so the dropped tail pages
+    # straight back in on the next `↓`. Rows at or above the cursor are never trimmed — the
+    # selected event has to stay selected — so a cursor parked deep still holds its whole list.
+    ACT_MAX_ROWS = 5_000
     # Divider + wrapped message rows. The feed's messages are PROSE, not labels — a binding
     # miss explains which descriptor read what and why nothing bound — so a list that only
     # truncates would show the token and drop every word of the reason.
@@ -1252,15 +1271,49 @@ module Gori::Tui
     # the same failure in a slower form.
     private def prepend_activity(fresh : Array(Store::EventRow)) : Nil
       following = @act_sel == 0
-      @act_rows = fresh + @act_rows
+      # Read BEFORE the concat below, which grows `fresh` into the whole list — taking it
+      # afterwards credited the border's "↑N new" with every row on screen (`↑8 new` over five
+      # arrivals). The count is what ARRIVED, and after the concat `fresh` no longer means that.
+      arrived = fresh.size
+      # `fresh.concat`, not `fresh + @act_rows`: the sum allocates a THIRD array and copies
+      # both halves into it, and this runs on the render fiber on every poll. `fresh` is the
+      # walk's own scratch list and is dropped by its caller, so growing it in place is free.
+      @act_rows = fresh.concat(@act_rows)
       if following
         @act_sel = 0
         @act_anchor = @act_rows.first.id
         @act_new_above = 0
       else
-        @act_new_above += fresh.size
+        @act_new_above += arrived
         resolve_activity_anchor
       end
+      trim_activity_tail
+    end
+
+    # Drop the oldest loaded rows once the list passes `ACT_MAX_ROWS`, and move the resume
+    # point up to match.
+    #
+    # THE cut is below the cursor, never at it: the selected row must still be selected
+    # afterwards, and the rows within a `↓` of it must still be there, or trimming would do to
+    # the cursor exactly what a full reload does (`ProjectController#move_subtab`'s post-mortem).
+    # So a cursor parked deep in the list keeps everything above it — that growth is the
+    # operator's own doing and is bounded by their scrolling; what this bounds is the growth
+    # NOTHING asked for, the head-following list that the poll extends by itself.
+    #
+    # `@act_next_before` becomes the last row KEPT, so the tail is re-read rather than skipped,
+    # and `@act_walked` goes with it: the resume point is now a hand-set place further down the
+    # feed, which is precisely the state a page-one refresh must not rewind.
+    #
+    # `@act_scanned` is deliberately left alone. It only reaches the screen through
+    # `activity_no_match_line`, which is drawn only for an EMPTY list, and every route from a
+    # trimmed list (5 000+ rows) back to an empty one — a chip, the query bar, a clear, a lost
+    # head — goes through `reload_activity`, which re-seeds it from a fresh page one.
+    private def trim_activity_tail : Nil
+      keep = {ACT_MAX_ROWS, @act_sel + 1 + ACT_PAGE}.max
+      return if @act_rows.size <= keep
+      @act_next_before = @act_rows[keep - 1].id
+      @act_rows = @act_rows[0, keep]
+      @act_walked = true
     end
 
     # Append the next page. Called when the cursor reaches the end of what is loaded — the page


### PR DESCRIPTION
Three defects in the Project tab's ACTIVITY pane, found auditing it after #875.

## A refused sub-tab step still settled

ACTIVITY is `PANES.last`, so `→` there moves nowhere — but `move_subtab` had
already run `settle_subtab` (which drops the text filter) and
`settle_activity_entry` (which re-reads page one). Reproduced:

```
before: loaded=500 sel=e100
after : loaded=200 sel=e300   ← from a key that moved nothing
```

An arrow key that navigates nowhere threw away every page the operator had walked
in and re-seated the cursor, via `clamp_act_sel`, on a **different event** — the
exact "stale but in range" failure the id anchor exists to prevent, where `↵` then
acts on a row nobody chose. A committed `/` filter went with it.

`move_subtab` now peeks with `pane_can_advance?` and settles only when the step
lands.

## The scroll gauge did not page

`handle_click`'s row branch pulled the next page; its gauge branch did not. A gauge
grab stopped dead at the end of page one while the keyboard walked straight past
it. This is the one Project list whose rows are a PAGE rather than the whole set —
its three siblings (scope / overrides / env) load everything, so the copied shape
looked right.

## The loaded list only ever grew

`prepend_activity` runs on every `data_version` poll for as long as the pane is
open, and the capture-lock holder moves `data_version` every 3 s on an idle project
(#875). `@act_rows` had no shrinking path at all, so a session left on this card
while an agent worked retained every event that agent ever wrote — measured, 2 050
written under an open pane, 2 050 rows held — and copied the whole array on the
render fiber each time.

`ACT_MAX_ROWS = 5_000` caps it, cutting **below the cursor only** (the selected
event has to stay selected, or trimming would do to it what a reload does) and
moving `@act_next_before` up to the last row kept, so the trimmed tail pages
straight back in on the next `↓` rather than being skipped. Verified over 8 050
events: full re-walk returns every row exactly once, still descending.

While tightening `fresh + @act_rows` into `fresh.concat(@act_rows)`, the aliased
argument made `@act_new_above += fresh.size` read the size *after* the concat — the
border rendered `↑8 new` for five arrivals. Existing specs caught it; the count is
now read before the list is grown.

## Left alone, deliberately

* `r` (`activity.refresh`) still discards a walked scan — `activity_no_match_line`
  already steers away from it ("NOT `r`").
* `refresh_activity_head` still falls back to a full reload past
  `ACT_CATCHUP_PAGES = 5`; chasing an agent mid-fuzz further on the render fiber is
  the worse trade.

## Verification

Full suite 11 808 green (4 new specs), `--no-codegen` on `src/main.cr` and
`scripts/seed_demo.cr`, `bench_check.sh` (48 harnesses), `crystal tool format
--check`. Re-run after rebasing onto `main`.

Also audited and found clean: `events_recent`'s paging arithmetic across sparse
ids, filters and a feed grown past retention; control characters in event messages
(neutralised by `Screen#cell`, no terminal-escape injection); `ACT_SOURCES` /
`ACT_LEVELS` against every `insert_event` call site.
