### PR TITLE
perf(probe): passive scan 1.3-1.6x, and three public-by-design shapes out of the High secret tier

### DIFF
--- a/spec/probe_spec.cr
+++ b/spec/probe_spec.cr
@@ -4621,6 +4621,34 @@ describe "Gori::Probe::Passive::Secrets (provider shapes)" do
         content_type: "application/json", body: body)).should contain("secret_in_body")
     end
   end
+
+  # The Google fixtures below are ASSEMBLED from parts rather than written as one literal.
+  # They are invented values, but GitHub's push protection matches the shapes on sight and
+  # rejects the push; splitting them keeps the raw file free of a contiguous match while the
+  # runtime strings the patterns see are exactly what a real response would carry.
+  private_google_client_id = "123456789012-" + ("abcdefghij0123456789abcdefghij01" + ".apps.googleusercontent.com")
+  private_google_secret = "GOCSPX" + "-" + "abcdefghijklmnopqrstuvwxyz12"
+
+  # Membership in PATTERNS means "a server has no business sending this to a browser". Two
+  # shapes that a site is SUPPOSED to publish were in it, and each fired High on every site
+  # using the product — the same failure the JWT split fixed one tier up.
+  it "does not flag shapes a site publishes to its own client on purpose" do
+    # A Google OAuth client id rides in the authorization URL of every Google Sign-In redirect.
+    private_hit.call(%(client_id: "#{private_google_client_id}")).should be_empty
+    # Mapbox `pk.` is the public token, documented as safe to embed in client-side JS.
+    private_hit.call("mapboxgl.accessToken = 'pk.eyJ1IjoiYWNtZXRlc3RpbmciLCJhIjoiY20wMDAwMDAwIn0.Zm9vYmFyYmF6cXV4MTIzNA';")
+      .should be_empty
+  end
+
+  # Dropping the public client id must not drop the pair's actual credential.
+  it "flags the Google OAuth client SECRET" do
+    private_hit.call(private_google_secret).should contain("Google OAuth client secret")
+  end
+
+  it "still flags the Mapbox SECRET token" do
+    private_hit.call("sk.eyJ1IjoiYWNtZXRlc3RpbmciLCJhIjoiY20wMDAwMDAwIn0.Zm9vYmFyYmF6cXV4MTIzNA")
+      .should contain("Mapbox secret token")
+  end
 end
 
 describe "Gori::Probe::Passive::JsScan (navigation + parsing sinks)" do
@@ -4655,6 +4683,56 @@ describe "Gori::Probe::Passive::JsScan (navigation + parsing sinks)" do
     private_pairs.call(%(o.innerHTML = location.hash;)).should_not be_empty
     private_pairs.call(%(document.write(document.URL);)).should_not be_empty
     private_pairs.call(%(o.innerHTML = "<b>static</b>";)).should be_empty
+  end
+
+  # `source_spans` no longer runs one scan per SOURCES entry: the nine entries sharing a
+  # `location.` / `document.` prefix are found by two factored scans and bucketed by their
+  # capture. Every label must still be reachable and still be reported under its own name —
+  # a mis-wired bucket would silently relabel a finding (or drop a source entirely) while the
+  # coarse "is it empty" assertions above stayed green.
+  it "reports every taint source under its own label" do
+    {
+      "location.hash"        => %(location.hash),
+      "location.search"      => %(location.search),
+      "location.href"        => %(location.href),
+      "document.URL"         => %(document.URL),
+      "document.documentURI" => %(document.documentURI),
+      "document.baseURI"     => %(document.baseURI),
+      "document.referrer"    => %(document.referrer),
+      "document.cookie"      => %(document.cookie),
+      "document.location"    => %(document.location),
+      "window.name"          => %(window.name),
+      "history.state"        => %(history.state),
+      "postMessage data"     => %(evt.data),
+      "web storage"          => %(localStorage.getItem("k")),
+    }.each do |label, expr|
+      pairs = private_pairs.call(%(o.innerHTML = #{expr};))
+      pairs.map(&.[0]).should contain(label)
+    end
+    # `location.pathname` shares the `location.href` bucket by design.
+    private_pairs.call(%(o.innerHTML = location.pathname;)).map(&.[0]).should contain("location.href")
+  end
+
+  # The factored scan splits SOURCES between SOURCE_SCANS (bucketed by capture) and
+  # SOLO_SOURCES (scanned individually). SOLO_SOURCES is derived, so this pins the invariant
+  # that makes deriving it correct: the two together cover every entry exactly once. A gap
+  # here is silent — the uncovered source's bucket just stays empty forever.
+  it "covers every SOURCES entry exactly once across the factored and solo scans" do
+    factored = [] of Int32
+    Gori::Probe::Passive::JsScan::SOURCE_SCANS.each do |(_, slots)|
+      slots.each_value { |i| factored << i }
+    end
+    covered = (factored + Gori::Probe::Passive::JsScan::SOLO_SOURCES).uniq.sort
+    covered.should eq((0...Gori::Probe::Passive::JsScan::SOURCES.size).to_a)
+    (factored & Gori::Probe::Passive::JsScan::SOLO_SOURCES).should be_empty
+  end
+
+  # SOURCES order is the priority with which a statement carrying several sources is labelled,
+  # and factoring must not quietly reorder it: `document.URL` (entry 4) outranks
+  # `document.cookie` (entry 8) no matter which one appears first in the text.
+  it "keeps SOURCES order as the label priority when a statement carries several sources" do
+    private_pairs.call(%(o.innerHTML = document.cookie + document.URL;))
+      .map(&.[0]).should contain("document.URL")
   end
 end
 
@@ -4788,6 +4866,34 @@ describe Gori::Probe::Passive::SerializedObject do
     end
   end
 
+  # The field name in the evidence must come from the tag that MATCHED, not from a whole-body
+  # substring test: a page can mention the JSF field in a script while the input actually
+  # carrying the blob is the ASP.NET one, and the finding then names the wrong framework.
+  it "labels the ViewState field from the matching tag, not from elsewhere in the body" do
+    with_store do |store|
+      body = %(<script>var k = "javax.faces.ViewState";</script>) \
+             %(<form><input type="hidden" name="__VIEWSTATE" value="/wEPDwUKLTEyMzQ1Njc4ZGQ=" /></form>)
+      hit = analyze(store, resp_head: "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n",
+        content_type: "text/html", body: body).find(&.code.==("serialized_object")).not_nil!
+      hit.evidence.not_nil!.should contain("__VIEWSTATE field")
+      hit.evidence.not_nil!.should_not contain("javax.faces")
+    end
+  end
+
+  # The gate is /i so a lowercase field is still seen, but it names the FIELDS rather than a
+  # bare `viewstate` substring — `viewState` is an everyday React/deck.gl prop name, and
+  # matching it would walk every such bundle through the backtracking tag scan.
+  it "sees a lowercase __viewstate field but ignores a plain viewState identifier" do
+    with_store do |store|
+      lower = %(<form><input type="hidden" name="__viewstate" value="/wEPDwUKLTEyMzQ1Njc4ZGQ=" /></form>)
+      codes_of(analyze(store, resp_head: "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n",
+        content_type: "text/html", body: lower)).should contain("serialized_object")
+      spa = %(<html><body><script>const {viewState} = props; setViewState(viewState);</script></body></html>)
+      codes_of(analyze(store, resp_head: "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n",
+        content_type: "text/html", body: spa)).should_not contain("serialized_object")
+    end
+  end
+
   it "does not flag an ENCRYPTED ViewState (opaque base64 that is not /wE — encryption is the fix)" do
     with_store do |store|
       body = %(<form><input type="hidden" name="__VIEWSTATE" value="AbCdEf0123456789+/xyz=" /></form>)
@@ -4819,6 +4925,18 @@ describe Gori::Probe::Passive::DebugModeExposed do
         body: "{}").find(&.code.==("debug_mode_exposed")).not_nil!
       hit.severity.should eq(Gori::Store::Severity::Medium)
       hit.evidence.not_nil!.should eq("Symfony profiler (X-Debug-Token header)")
+    end
+  end
+
+  # The one prefilter this rule keeps must be case-INSENSITIVE, because the pattern behind it
+  # is: a case-sensitive gate silently drops uppercased markup and loses a High RCE finding.
+  it "flags a Rails web-console page whose markup is uppercased" do
+    with_store do |store|
+      body = %(<HTML><BODY><DIV ID="CONSOLE-9F2A"></DIV></BODY></HTML>)
+      hit = analyze(store, resp_head: "HTTP/1.1 500 Internal Server Error\r\nContent-Type: text/html\r\n\r\n",
+        status: 500, body: body).find(&.code.==("debug_mode_exposed")).not_nil!
+      hit.severity.should eq(Gori::Store::Severity::High)
+      hit.evidence.not_nil!.should eq("Rails web-console")
     end
   end
 

--- a/src/gori/probe/passive/body_leaks.cr
+++ b/src/gori/probe/passive/body_leaks.cr
@@ -1,6 +1,5 @@
 require "./rule"
 require "./secrets"
-require "../../ascii_bytes"
 
 module Gori
   module Probe
@@ -28,6 +27,22 @@ module Gori
         # registries (e.g. "config/routes.rb:15", "ActiveRecord::Base", "org.springframework
         # .boot", "System.ArgumentException") does NOT match — only an actual backtrace frame
         # or a `Type: message` / newline-`at` disclosure does. {pattern, evidence label}.
+        #
+        # The three line-anchored frames use `^` under `/m`, NOT the `(?:\n|\A)` spelling they
+        # were written with. The two mean the same thing — `^` under PCRE2_MULTILINE matches at
+        # the subject start and just after every `\n`, which is exactly where `\A` or a consumed
+        # `\n` leaves the cursor — but the alternation DEFEATS PCRE2's start optimization: with
+        # it the engine has no usable first-code-unit set and walks every offset, while `^` lets
+        # it memchr from newline to newline. Measured over a 64 KiB minified bundle (which has
+        # almost no newlines, i.e. the case the optimization should win biggest on): Node.js
+        # frame 239.9µs → 30.4µs, Spring trace 183.6µs → 24.5µs. Same shape as this file's
+        # per-pattern-literal note below: give PCRE something to skip on.
+        #
+        # Crystal's `m` sets PCRE2_DOTALL as well as PCRE2_MULTILINE, so it also makes `.` match
+        # a newline. Harmless for exactly these three: none of them contains a bare `.` — every
+        # dot is either escaped (`\.`) or inside a character class — and a negated class such as
+        # `[^)]*` has always crossed newlines regardless of the flag. Check that before adding
+        # `/m` to a fourth.
         ERROR_SIGNATURES = [
           {/Traceback \(most recent call last\)/, "Python traceback"},
           # A real CPython frame (`File "x.py", line N`) — the exact shape, so a bare
@@ -36,7 +51,7 @@ module Gori
           # Ruby backtrace frame: the `:in ` distinguishes a real frame from a config path.
           {/\.rb:\d+:in /, "Ruby backtrace frame"},
           {/\bat [\w.$]+\([\w]+\.java:\d+\)/, "Java stack frame"},
-          {/(?:\n|\A)\s+at [\w.$<>]+ \([^)]*:\d+:\d+\)/, "Node.js stack frame"},
+          {/^\s+at [\w.$<>]+ \([^)]*:\d+:\d+\)/m, "Node.js stack frame"},
           {/\bORA-\d{5}\b/, "Oracle error"},
           {/\bSQLSTATE\[/, "SQL error"},
           # A Java/.NET exception only counts as a disclosure when error-shaped: followed by a
@@ -44,7 +59,7 @@ module Gori
           {/\bjava\.lang\.[A-Z]\w+(?:Error|Exception)(?::|\r?\n\s*at )/, "Java exception"},
           # Require a real stack-frame shape (start-of-line `at …(` call site) like the sibling
           # Java/Node frames — a bare "…at org.springframework.Foo…" in prose must NOT match.
-          {/(?:\n|\A)\s*at org\.springframework\.[\w.$]{4,}\(/, "Spring framework trace"},
+          {/^\s*at org\.springframework\.[\w.$]{4,}\(/m, "Spring framework trace"},
           {/\bSystem\.[A-Z]\w+Exception(?::|\r?\n\s*at )/, ".NET exception"},
           # Rails: any ActiveRecord class, but only when error-shaped (`: message` / newline-
           # `at`), so a real error (RecordNotFound, Rollback, StatementInvalid, …) is caught
@@ -58,7 +73,7 @@ module Gori
           # A Go panic dump: the `goroutine N [state]:` header is the runtime's exact shape,
           # so a prose mention of "goroutine" does not match.
           {/\bgoroutine \d+ \[[\w ]+\]:/, "Go stack trace"},
-          {/(?:\n|\A)Stack trace:\s*(?:\n|#\d)/, "stack trace"},
+          {/^Stack trace:\s*(?:\n|#\d)/m, "stack trace"},
         ]
 
         # Alias for callers/tests that still reference BodyLeaks::SECRET_PATTERNS.
@@ -94,16 +109,24 @@ module Gori
         # safe — a guaranteed false positive on any uppercase markup.
         REL_NOOPENER = /\bno(?:opener|referrer)\b/i
 
-        # Allocation-free literal prefilters for the HTML sink checks, one per group, each a
-        # NECESSARY condition of every regex it guards: the five mixed-content/insecure-form
-        # patterns all end in `http://`, INLINE_JS_URI contains `javascript:`, and ANCHOR_BLANK
-        # contains `_blank`. All those regexes are /i, so the tests are ASCII case-INSENSITIVE
-        # byte scans (AsciiBytes wants an already-lowercase needle) — a case-sensitive
-        # `String#includes?` would have quietly stopped matching `HTTP://` and `_BLANK`.
-        # Held as constants so the slices are built once for the process, not per flow.
-        private HTTP_NEEDLE   = "http://".to_slice
-        private JS_URI_NEEDLE = "javascript:".to_slice
-        private BLANK_NEEDLE  = "_blank".to_slice
+        # Cheap gates for the HTML sink checks, each a NECESSARY condition of the regex(es) it
+        # guards: the five mixed-content/insecure-form patterns all contain `http://`, and
+        # ANCHOR_BLANK contains `_blank`. Both are /i, so these are too.
+        #
+        # These are REGEXES. They were `AsciiBytes.contains_ci?` byte scans, chosen over
+        # `String#includes?` because that one is case-SENSITIVE — but the interesting property
+        # was never allocation, it was scan speed, and `contains_ci?` is a naive O(hay·needle)
+        # walk just like `includes?`. Over the 200 KiB `client_body_text` these read, a clean
+        # page measured: `http://` 123.0µs → 56.9µs as a regex, `_blank` 91.3µs → 50.1µs. PCRE2
+        # memchr-skips a plain literal and an `/i` literal costs the same as a case-sensitive one,
+        # so the regex is both faster AND keeps the case-insensitivity that ruled `includes?` out.
+        #
+        # This is specific to a BODY-SIZED, already-scrubbed subject. `AsciiBytes` is still the
+        # right tool where the sibling rules use it — a Content-Type or a request target, where
+        # the input is short (so the naive scan never gets going) or possibly INVALID UTF-8, on
+        # which PCRE2 raises outright.
+        private HTTP_GATE  = /http:\/\//i
+        private BLANK_GATE = /_blank/i
 
         def check(ctx : Context, acc : Array(Detection)) : Nil
           return unless ctx.response
@@ -161,26 +184,29 @@ module Gori
         # on a 120 KiB page that split reported the unhashed third-party <script> and stayed
         # silent about the plain-http one beside it. The larger text costs no extra decode (it
         # is one slice of the same shared buffer, already materialised for every HTML flow by
-        # the client-side rules), so only the SCAN grows — and each check now gates on an
-        # allocation-free literal first, which more than pays that back on a clean page.
+        # the client-side rules), so only the SCAN grows — and the checks whose own pattern
+        # cannot anchor gate on a cheap literal regex first, which pays that back on a clean page.
         #
         # The leak scans (private IP / error / secret) deliberately stay on the 64 KiB prefix:
         # that is the shared BODY_CAP every non-client rule works from, and widening a content
         # scan is a different, measurable trade from widening a tag scan.
         private def check_html_sinks(ctx : Context, acc : Array(Detection), text : String) : Nil
-          bytes = text.to_slice
-          check_mixed_content(ctx, acc, text) if ctx.scheme == "https" &&
-                                                 AsciiBytes.contains_ci?(bytes, HTTP_NEEDLE)
-          if AsciiBytes.contains_ci?(bytes, JS_URI_NEEDLE) && INLINE_JS_URI.matches?(text)
+          check_mixed_content(ctx, acc, text) if ctx.scheme == "https" && HTTP_GATE.matches?(text)
+          # INLINE_JS_URI runs UNGUARDED: it already opens on an attribute-name alternation that
+          # PCRE anchors well (55.4µs on the 200 KiB page), so the `javascript:` gate in front of
+          # it (105.4µs) was pure overhead — a prefilter in front of something that prefilters
+          # itself, which is the trap the gates above are sized against. ANCHOR_BLANK is the
+          # opposite case and keeps its gate: it opens on `<a`, so unguarded it costs 121.1µs.
+          if INLINE_JS_URI.matches?(text)
             acc << Detection.new("inline_js_uri", Category::CLIENT, ctx.host, ctx.url,
               "javascript: URL in an HTML attribute", Store::Severity::Low, nil, ctx.fid)
           end
-          flag_reverse_tabnabbing(ctx, acc, text) if AsciiBytes.contains_ci?(bytes, BLANK_NEEDLE)
+          flag_reverse_tabnabbing(ctx, acc, text) if BLANK_GATE.matches?(text)
         end
 
-        # The three cleartext-subresource findings on an HTTPS page. Reached only once the
-        # `http://` prefilter has passed, so a page with no cleartext URL at all pays one byte
-        # scan instead of five PCRE passes.
+        # The three cleartext-subresource findings on an HTTPS page. Reached only once HTTP_GATE
+        # has passed, so a page with no cleartext URL at all pays one literal PCRE pass (56.9µs
+        # on a 200 KiB page) instead of five structural ones.
         private def check_mixed_content(ctx : Context, acc : Array(Detection), text : String) : Nil
           if MIXED_ACTIVE.matches?(text) || MIXED_ACTIVE_LINK.matches?(text) || MIXED_ACTIVE_OBJECT.matches?(text)
             acc << Detection.new("mixed_content", Category::HEADERS, ctx.host, ctx.url,

--- a/src/gori/probe/passive/debug_mode_exposed.cr
+++ b/src/gori/probe/passive/debug_mode_exposed.cr
@@ -25,40 +25,61 @@ module Gori
             Category::INFOLEAK)
         end
 
-        # {literal prefilter, confirming pattern, evidence label, severity}. The prefilter is a
-        # NECESSARY substring of the pattern, matched case-sensitively where the marker's casing
-        # is fixed, so a body that cannot match never enters PCRE.
+        # {optional cheap prefilter, confirming pattern, evidence label, severity}.
+        #
+        # The prefilters here used to be `String` needles tested with `String#includes?`, and on
+        # this rule that was a straight PESSIMISATION: `String#includes?` is a naive byte search,
+        # while PCRE2 skips a non-matching subject with its own start optimization. Over a 64 KiB
+        # HTML body one `includes?` cost ~85µs and the pattern it guarded cost ~19µs, so every
+        # HTML flow paid ~600µs to save nothing — the rule was the second most expensive on a
+        # large document. Same finding, same file-level shape, as the `includes?`-before-regex
+        # guards removed elsewhere in this tree: never hand-roll a prefilter in front of
+        # something that already prefilters itself, and settle it by measurement.
+        #
+        # So the guard is nil for every pattern PCRE already anchors on a literal, and a cheap
+        # LITERAL REGEX (~19µs, not an `includes?`) only where the confirming pattern genuinely
+        # cannot anchor itself — today just the Rails web-console alternation, which opens on
+        # `<[^>]+` and costs ~178µs unguarded.
         SIGNATURES = [
           # Werkzeug/Flask interactive debugger — a live Python console (RCE if the PIN is off or
           # brute-forced). The title string is emitted only by the debugger page.
-          {"Werkzeug Debugger",
+          {nil,
            /Werkzeug Debugger/,
            "Werkzeug interactive debugger", Store::Severity::High},
           # Rails web-console — an in-browser IRB on the error page (RCE). The mount marker and
-          # its session id are rendered only when the console gem is active.
-          {"console-",
+          # its session id are rendered only when the console gem is active. `console-` is a
+          # necessary substring of BOTH alternatives (`id="console-`, `data-console-session`).
+          #
+          # Case-INSENSITIVE, and that is load-bearing: the pattern it guards is /i, so a
+          # case-sensitive gate would drop `DATA-CONSOLE-SESSION` / `<div ID="CONSOLE-abc">`
+          # — uppercased markup out of a template, a minifier or a proxy — and silently lose a
+          # HIGH (RCE) finding. That is exactly the bug `reverse_tabnabbing` shipped once: an /i
+          # regex paired with a case-SENSITIVE membership test. `/i` on a literal costs the same
+          # as a case-sensitive one (see the measurements in body_leaks), so there is nothing to
+          # trade here.
+          {/console-/i,
            /<[^>]+\bid\s*=\s*["']console-|data-console-session/i,
            "Rails web-console", Store::Severity::High},
           # Django DEBUG=True technical error / 404 page. `Django Version:` is rendered by that
           # page (and the technical-404 page) — never by an ordinary response.
-          {"Django Version:",
+          {nil,
            /Django Version:/,
            "Django debug page (DEBUG=True)", Store::Severity::Medium},
           # Laravel Ignition (the modern debug page). Its client bundle / config marker.
-          {"ignition",
+          {nil,
            /laravel-ignition|"ignitionConfig"|flare-client/i,
            "Laravel Ignition debug page", Store::Severity::Medium},
           # Whoops (older Laravel / generic PHP). The namespaced handler class is printed in the
           # page frames — a prose "whoops" cannot produce `Whoops\Something`.
-          {"Whoops\\",
+          {nil,
            /Whoops\\[A-Z]\w+/,
            "PHP Whoops error page", Store::Severity::Medium},
           # Rails development exception page (`config.consider_all_requests_local = true`). The
           # source-extract heading is dev-only; the production page says "something went wrong".
-          {"Extracted source",
+          {nil,
            /Extracted source \(around line/,
            "Rails development error page", Store::Severity::Medium},
-        ]
+        ] of {Regex?, Regex, String, Store::Severity}
 
         def check(ctx : Context, acc : Array(Detection)) : Nil
           return unless ctx.response
@@ -71,8 +92,8 @@ module Gori
           text = ctx.body_text
           return if text.nil? || text.empty?
 
-          SIGNATURES.each do |(needle, pattern, label, severity)|
-            next unless text.includes?(needle)
+          SIGNATURES.each do |(prefilter, pattern, label, severity)|
+            next if prefilter && !prefilter.matches?(text)
             next unless pattern.matches?(text)
             acc << det(ctx, label, severity)
           end
@@ -95,8 +116,12 @@ module Gori
         # page says the details are hidden. So the detailed page is confirmed by a real detail
         # section (`Stack Trace:`) AND the ABSENCE of the "settings … prevent … viewed remotely"
         # sentence the safe page carries.
+        # The banner regex is run directly — its `Server Error in '` literal prefix is what PCRE
+        # anchors on, so the `includes?("Server Error in")` that used to guard it only added a
+        # naive scan (~85µs) in front of a ~22µs one. The two `includes?` below it stay: they are
+        # reached only once the banner has ALREADY matched, i.e. on an actual ASP.NET error page,
+        # so they cost nothing on the ordinary responses this rule spends its time on.
         private def check_aspnet(ctx : Context, acc : Array(Detection), text : String) : Nil
-          return unless text.includes?("Server Error in")
           return unless /Server Error in '[^']*' Application/.matches?(text)
           return unless text.includes?("Stack Trace:")
           return if text.includes?("prevent the details of the application error from being viewed")

--- a/src/gori/probe/passive/directory_listing.cr
+++ b/src/gori/probe/passive/directory_listing.cr
@@ -20,10 +20,18 @@ module Gori
             Category::INFOLEAK)
         end
 
-        # Allocation-free prefilter: both markers below require this literal, and an ordinary HTML
-        # page never carries it, so the regex passes are skipped for essentially all traffic.
+        # Prefilter: both markers below require this literal, and an ordinary HTML page never
+        # carries it, so the structural regex passes are skipped for essentially all traffic.
         # Case-sensitive on purpose — both servers emit exactly this casing.
-        NEEDLE = "Index of /"
+        #
+        # A REGEX, not a `String` tested with `includes?` — the point is scan SPEED, not
+        # allocation. This gate runs on the body of every 2xx HTML response, and
+        # `String#includes?` is a naive byte search where PCRE2 memchrs a plain literal
+        # (~79µs vs ~19µs over a 64 KiB page). Same fix as the `includes?` prefilters removed
+        # from `debug_mode_exposed` / `sourcemap` / `serialized_object` / `exposed_config`.
+        # (`AsciiBytes` remains the right tool only for a SHORT or possibly-invalid-UTF-8
+        # subject, where PCRE2 would raise; a scrubbed body text is neither.)
+        NEEDLE = /Index of \//
 
         TITLE = /<title>\s*Index of \/[^<]*<\/title>/i
         # Second marker, any one of: the autoindex heading, Apache's parent link text, or the
@@ -40,7 +48,7 @@ module Gori
           # Only a served listing counts; a 403/404 error page can carry the same words.
           return unless (200..299).includes?(resp.status)
           text = ctx.body_text
-          return if text.nil? || !text.includes?(NEEDLE)
+          return if text.nil? || !NEEDLE.matches?(text)
           return unless TITLE.matches?(text)
           return unless STRUCTURE.any?(&.matches?(text))
           acc << Detection.new("directory_listing", Category::INFOLEAK, ctx.host, ctx.url,

--- a/src/gori/probe/passive/exposed_config.cr
+++ b/src/gori/probe/passive/exposed_config.cr
@@ -18,8 +18,8 @@ module Gori
       # site, or a config reference showing the same text, and that is what the two-marker /
       # structural anchoring (the `directory_listing` pattern) is for.
       #
-      # Every signature is prefiltered by an allocation-free literal, so a body that cannot
-      # match is rejected without ever entering PCRE — this rule scans the body of every
+      # Every signature is anchored on a literal PCRE can skip a clean body on, and the scan is
+      # bounded to the response's opening SCAN_PREFIX bytes — this rule reads the body of every
       # texty 2xx response.
       class ExposedConfig < Rule
         def info : RuleInfo
@@ -29,37 +29,40 @@ module Gori
             Category::INFOLEAK)
         end
 
-        # {literal prefilter, confirming pattern, evidence label, severity}.
+        # {confirming pattern, evidence label, severity}.
         #
-        # The prefilter must be a NECESSARY condition of the pattern beside it, and is matched
-        # case-sensitively where the artifact's own casing is fixed (`[core]`, `phpinfo()`,
-        # SCREAMING_SNAKE env keys all are).
+        # There is no separate prefilter, and that is a measured decision rather than an
+        # omission. Each of these carried a `String#includes?` literal in front of it, on the
+        # theory that a body which cannot match should never enter PCRE. Over the 16 KiB prefix
+        # this rule actually scans, the guards cost ~35µs each while the patterns they guarded
+        # cost ~7.6µs: five naive byte searches (~180µs on EVERY texty 2xx response) to save
+        # ~38µs of PCRE. `String#includes?` is a naive O(n·m) walk; PCRE2 memchr-skips on the
+        # literal each of these patterns already opens with or requires. Same finding as the
+        # guards removed from `debug_mode_exposed`, `sourcemap`, `serialized_object` and
+        # `directory_listing` — the rule is: do not hand-roll a prefilter in front of something
+        # that already prefilters itself, and settle it by measurement, not by reasoning about
+        # allocations.
         SIGNATURES = [
           # A `.git/config`: the `[core]` section header is immediately followed by the
           # repository format version. A prose mention of "[core]" cannot produce that pair.
-          {"repositoryformatversion",
-           /\[core\][^\[]{0,80}repositoryformatversion\s*=/,
+          {/\[core\][^\[]{0,80}repositoryformatversion\s*=/,
            ".git/config", Store::Severity::High},
           # phpinfo() output. The <title> is emitted by the function itself and is not something
           # a page merely DISCUSSING phpinfo would carry; the PHP Version table row confirms it.
-          {"phpinfo()",
-           /<title>phpinfo\(\)<\/title>/i,
+          {/<title>phpinfo\(\)<\/title>/i,
            "phpinfo() output", Store::Severity::Medium},
           # An Apache/nginx password file: `user:$apr1$…` (or bcrypt / SHA-512 crypt). The hash
-          # prefix is the anchor — a bare `user:password` line would match nothing here.
-          # The prefilter is `:$`, the adjacency the pattern requires, NOT a bare `$`: a lone
-          # dollar sign is in every jQuery-shaped body on the web and would filter nothing,
-          # leaving the regex (whose own first-byte set is just `\n`) to walk every response.
-          {":$",
-           /(?:\A|\n)[\w.\-]{1,64}:\$(?:apr1|2[aby]|5|6)\$[^\s:]{8,}/,
+          # prefix is the anchor — a bare `user:password` line would match nothing here. This is
+          # the one signature whose own first-byte set is just `\n`, so it is the least skippable
+          # of the five; it still measured 7.5µs over the 16 KiB prefix, against 35µs for the
+          # `:$` byte search that used to guard it.
+          {/(?:\A|\n)[\w.\-]{1,64}:\$(?:apr1|2[aby]|5|6)\$[^\s:]{8,}/,
            ".htpasswd credentials", Store::Severity::High},
           # wp-config.php served as source instead of executed: the DB password define().
-          {"DB_PASSWORD",
-           /define\s*\(\s*['"]DB_PASSWORD['"]\s*,/,
+          {/define\s*\(\s*['"]DB_PASSWORD['"]\s*,/,
            "wp-config.php credentials", Store::Severity::High},
           # Spring Boot Actuator /env (or /configprops): the response envelope is distinctive.
-          {"propertySources",
-           /"propertySources"\s*:\s*\[/,
+          {/"propertySources"\s*:\s*\[/,
            "Spring actuator env", Store::Severity::Medium},
         ]
 
@@ -80,11 +83,10 @@ module Gori
         # the actuator envelope keys are the outermost JSON object, and a `.env`'s keys sit at
         # the top. So the scan is bounded to this prefix instead of the full 64 KiB `body_text`.
         #
-        # This is a real cost, not a hypothetical one: the rule runs on EVERY texty 2xx response
-        # and its literal prefilters are substring searches, so scanning the whole prefix cost
-        # ~0.4ms per flow on the shared passive fiber (measured, bench/probe_passive_bench) —
-        # for bytes that structurally cannot hold the signal. A body already under the bound is
-        # used as-is and copies nothing.
+        # This is a real cost, not a hypothetical one: the rule runs on EVERY texty 2xx response,
+        # so scanning the full 64 KiB `body_text` cost ~0.4ms per flow on the shared passive
+        # fiber (measured, bench/probe_passive_bench) — for bytes that structurally cannot hold
+        # the signal. A body already under the bound is used as-is and copies nothing.
         SCAN_PREFIX = 16 * 1024
 
         def check(ctx : Context, acc : Array(Detection)) : Nil
@@ -97,10 +99,8 @@ module Gori
           return if full.nil? || full.empty?
           text = head_of(full)
 
-          SIGNATURES.each do |(needle, pattern, label, severity)|
-            next unless text.includes?(needle)
-            next unless pattern.matches?(text)
-            acc << det(ctx, label, severity)
+          SIGNATURES.each do |(pattern, label, severity)|
+            acc << det(ctx, label, severity) if pattern.matches?(text)
           end
           check_dotenv(ctx, acc, text)
         end

--- a/src/gori/probe/passive/js_scan.cr
+++ b/src/gori/probe/passive/js_scan.cr
@@ -35,6 +35,11 @@ module Gori
 
         # DOM taint sources. Case-sensitive (JS identifiers are), each a fixed label used only
         # for a safe evidence string (never the tainted value itself).
+        # The order of this list is SEMANTIC, not cosmetic: `source_in_window` walks it and
+        # returns the FIRST entry with an occurrence in the window, so it is the priority with
+        # which a statement carrying several sources is labelled. `source_spans` fills these
+        # buckets with fewer scans than there are entries (see SOURCE_SCANS) but keeps this
+        # order, so the label a window reports is unchanged.
         SOURCES = [
           {/\blocation\.hash\b/, "location.hash"},
           {/\blocation\.search\b/, "location.search"},
@@ -60,6 +65,37 @@ module Gori
           # `location.href = "/x?" + new URLSearchParams(form)` — untainted input, benign
           # navigation — reported as DOM-XSS against the `location assignment` sink below.
         ] of {Regex, String}
+
+        # How `source_spans` actually walks the script. Nine of the SOURCES entries above share a
+        # literal prefix — `location.` (3) and `document.` (6) — and scanning them one pattern at
+        # a time re-walked the whole script once per entry for a prefix PCRE could have matched
+        # once. Each tuple is {regex with ONE capture group, index of the SOURCES entry each
+        # captured alternative belongs to}; an entry not named here is scanned on its own.
+        #
+        # This is NOT the "one big alternation" that was tried and rejected before (14 dissimilar
+        # patterns unioned measured SLOWER than 14 separate scans, 1.40ms vs 0.96ms). The
+        # difference is the shared LITERAL PREFIX: `\bdocument\.` still gives PCRE2 the anchor it
+        # skips on, so the 6-way factored scan costs what ONE of the six cost (67.5µs vs 6×67µs),
+        # while a union of patterns with nothing in common has no anchor left to use. Factor by a
+        # common prefix; do not union by convenience. Measured over the 256 KiB bundle fixture:
+        # the whole index build went 1009µs → 533µs.
+        #
+        # The captured alternative decides which SOURCES bucket a span lands in, so the resulting
+        # index is IDENTICAL to the one 14 separate scans produced — same buckets, same order,
+        # same spans — and `source_in_window`'s priority semantics are untouched.
+        SOURCE_SCANS = [
+          {/\blocation\.(hash|search|href|pathname)\b/, {"hash" => 0, "search" => 1, "href" => 2, "pathname" => 2}},
+          {/\bdocument\.(URL|documentURI|baseURI|referrer|cookie|location)\b/,
+           {"URL" => 3, "documentURI" => 4, "baseURI" => 5, "referrer" => 6, "cookie" => 7, "location" => 8}},
+        ] of {Regex, Hash(String, Int32)}
+
+        # SOURCES entries no SOURCE_SCANS group covers, scanned individually. DERIVED, not
+        # written out: a hardcoded index list is a silent-failure shape here, because a new
+        # SOURCES entry that nobody remembers to add would leave its bucket permanently empty —
+        # that taint source simply stops producing pairs, with no compile error and no spec
+        # failure (a per-label spec enumerates the labels that exist, so it stays green too).
+        # Deriving it means the union always covers SOURCES by construction.
+        SOLO_SOURCES = (0...SOURCES.size).reject { |i| SOURCE_SCANS.any? { |(_, slots)| slots.each_value.includes?(i) } }
 
         # HTML/JS execution sinks. Each keys on a distinctive identifier so PCRE's first-byte
         # optimisation skips clean code fast (like body_leaks' per-pattern loop). Sinks whose
@@ -450,20 +486,37 @@ module Gori
         # WINDOW bytes per side and allocates nothing — and this runs once per sink occurrence.
         BOUNDS = {0x3Bu8, 0x7Bu8, 0x7Du8, 0x0Au8}
 
-        # Every taint SOURCE occurrence in the script, as BYTE spans, in SOURCES order. One
-        # `scan` per source pattern, once per script — the index `source_in_window` binary-searches
-        # instead of re-running the 14 patterns per sink occurrence. Sources with no occurrence are
-        # dropped, so a script carrying one source pays one entry, not fourteen; an empty result is
-        # exactly the old `SOURCES.any?` prefilter's "no source anywhere" verdict.
+        # Every taint SOURCE occurrence in the script, as BYTE spans, in SOURCES order. Scanned
+        # once per script — the index `source_in_window` binary-searches instead of re-running
+        # the source patterns per sink occurrence. Fewer scans than there are SOURCES entries:
+        # the ones sharing a literal prefix are found by the factored SOURCE_SCANS passes and
+        # bucketed by capture (see SOURCE_SCANS), the rest by SOLO_SOURCES. Sources with no
+        # occurrence are dropped, so a script carrying one source pays one entry, not thirteen;
+        # an empty result is exactly the old `SOURCES.any?` prefilter's "no source anywhere"
+        # verdict.
         #
         # `scan` yields NON-OVERLAPPING matches left to right, so within one entry both `begin` and
         # `end` are strictly increasing — the property `span_within?` binary-searches on.
         private def self.source_spans(code : String) : Array({Array({Int32, Int32}), String})
+          # One bucket per SOURCES entry, filled by the factored scans below and then emitted in
+          # SOURCES order. `scan` walks left to right and never overlaps, so appending in scan
+          # order leaves every bucket ascending in both begin and end — the property
+          # `span_within?` binary-searches on — and a bucket fed by several alternatives of one
+          # factored regex (location.href / location.pathname) inherits it as a subsequence.
+          buckets = Array(Array({Int32, Int32})).new(SOURCES.size) { [] of {Int32, Int32} }
+          SOURCE_SCANS.each do |(re, slot_of)|
+            code.scan(re) do |m|
+              next unless slot = slot_of[m[1]]?
+              buckets[slot] << {m.byte_begin(0), m.byte_end(0)}
+            end
+          end
+          SOLO_SOURCES.each do |slot|
+            re = SOURCES[slot][0]
+            code.scan(re) { |m| buckets[slot] << {m.byte_begin(0), m.byte_end(0)} }
+          end
           index = [] of {Array({Int32, Int32}), String}
-          SOURCES.each do |(re, label)|
-            spans = [] of {Int32, Int32}
-            code.scan(re) { |m| spans << {m.byte_begin(0), m.byte_end(0)} }
-            index << {spans, label} unless spans.empty?
+          buckets.each_with_index do |spans, slot|
+            index << {spans, SOURCES[slot][1]} unless spans.empty?
           end
           index
         end

--- a/src/gori/probe/passive/secrets.cr
+++ b/src/gori/probe/passive/secrets.cr
@@ -22,9 +22,32 @@ module Gori
           {/\bSG\.[\w\-]{16,}\.[\w\-]{16,}\b/, "SendGrid API key"},
           {/\bnpm_[0-9A-Za-z]{36}\b/, "npm access token"},
           {/-----BEGIN (?:RSA |EC |DSA |OPENSSH |PGP |ENCRYPTED )?PRIVATE KEY(?: BLOCK)?-----/, "private key block"},
-          # Client-side shapes — these routinely ship hard-coded in HTML/JS bundles.
-          {/\b\d{6,}-[0-9a-z]{32}\.apps\.googleusercontent\.com\b/, "Google OAuth client id"},
-          {/\b(?:pk|sk)\.eyJ[\w\-]{20,}\.[\w\-]{20,}\b/, "Mapbox token"},
+          # Client-side shapes — these routinely ship hard-coded in HTML/JS bundles, so each one
+          # here has to clear the membership rule above on its own. Two shapes that used to sit
+          # in this block did not, and were removed:
+          #
+          #   * a Google OAuth CLIENT ID (`<digits>-<32>.apps.googleusercontent.com`). It is
+          #     public by construction — the browser carries it in the authorization URL of every
+          #     Google Sign-In redirect, and Google documents it as non-secret. So this fired
+          #     High on every site using Google Sign-In: the exact JWT failure described below,
+          #     one tier up. Dropped rather than given its own Info code, because unlike a JWT it
+          #     says nothing an analyst can act on beyond "this site uses Google Sign-In", which
+          #     is a `tech` fingerprint's job. The CREDENTIAL half of that pair is the client
+          #     secret, and it does have a shape — `GOCSPX-`, added below — so removing the id
+          #     costs no coverage of the thing that actually matters.
+          #   * a Mapbox PUBLIC token (`pk.`). Mapbox issues `pk.` precisely to be embedded in
+          #     client-side JS and it can only carry public scopes; `sk.` is the secret half.
+          #     Restricted to `sk\.` below, so a site simply drawing a map is no longer a High.
+          #
+          # (Removing the Google client id also took the single most expensive pattern out of
+          # this loop: `\b\d{6,}` anchors PCRE on "a digit", so in a minified bundle it retried
+          # at every digit run — 549µs of the ~1.3ms `body_leaks` spent per texty flow.)
+          {/\bsk\.eyJ[\w\-]{20,}\.[\w\-]{20,}\b/, "Mapbox secret token"},
+          # The Google OAuth CLIENT SECRET — the half of the pair that IS a credential, and the
+          # one the removed client-id pattern was quietly standing in for. Google has issued
+          # these as `GOCSPX-` + 28 chars since 2021, so it is prefix-anchored and high-
+          # confidence like the rest of this list, and a server has no business emitting one.
+          {/\bGOCSPX-[A-Za-z0-9_\-]{28}\b/, "Google OAuth client secret"},
           {/\bhttps:\/\/hooks\.slack\.com\/services\/T[0-9A-Za-z]+\/B[0-9A-Za-z]+\/[0-9A-Za-z]{16,}/, "Slack webhook url"},
           {/\bSK[0-9a-f]{32}\b/, "Twilio api key"},
           # LLM provider keys. Both vendors' formats are prefix-anchored and long, so the

--- a/src/gori/probe/passive/serialized_object.cr
+++ b/src/gori/probe/passive/serialized_object.cr
@@ -47,8 +47,29 @@ module Gori
         # An `<input …>` that both names itself a ViewState field AND carries a value, capturing
         # the value. Two orderings (name-before-value and value-before-name) are both covered
         # because the leading `[^>]*` scans the whole tag up to whichever attribute it needs.
+        # Group 1 is the field NAME (captured inside the lookahead), group 2 the value. The name
+        # is captured rather than re-derived from the body, because "which framework is this?"
+        # has to be answered by the tag that matched: a page can mention `javax.faces.ViewState`
+        # in a script or a second form while the input that actually carries the blob is
+        # `__VIEWSTATE`, and a whole-body test then labels the ASP.NET finding as JSF.
         VIEWSTATE_INPUT =
-          /<input\b(?=[^>]*\bname\s*=\s*["'](?:__VIEWSTATE|javax\.faces\.ViewState)["'])[^>]*\bvalue\s*=\s*["']([^"']*)["']/i
+          /<input\b(?=[^>]*\bname\s*=\s*["'](__VIEWSTATE|javax\.faces\.ViewState)["'])[^>]*\bvalue\s*=\s*["']([^"']*)["']/i
+
+        # Cheap gate in front of VIEWSTATE_INPUT, whose `<input\b(?=…` opening gives PCRE no
+        # literal to skip on. It is a REGEX, not the pair of `String#includes?("VIEWSTATE")` /
+        # `includes?("ViewState")` calls it replaces: `String#includes?` is a naive byte search,
+        # so those two cost ~170µs on a 64 KiB body while this costs a fraction of that — and
+        # this rule is not response-shape-gated, so EVERY response with a body paid them. Same
+        # trap, same fix, as the `includes?` prefilters in `debug_mode_exposed` and `sourcemap`.
+        #
+        # It spells out the two FIELD NAMES rather than a bare `/viewstate/i`. The short form is
+        # tempting (it is /i, so it also picks up a lowercase `__viewstate` the old exact-case
+        # pair missed) but it matches the plain identifier `viewState` — the standard prop name
+        # in react-map-gl / deck.gl and a common local in map and canvas SPAs — and every such
+        # page would then pay a whole-body `scan(VIEWSTATE_INPUT)`, whose `[^>]*`+`\bvalue`
+        # backtracks per `<input` tag. Naming the fields keeps the /i widening (the lowercase
+        # field is still caught) without opening the gate onto ordinary SPA bundles.
+        VIEWSTATE_MARKER = /__VIEWSTATE|javax\.faces\.ViewState/i
 
         def check(ctx : Context, acc : Array(Detection)) : Nil
           # evidence => severity, deduped within the flow (a cookie echoed in both the request
@@ -105,14 +126,21 @@ module Gori
             end
           end
 
-          if (body = ctx.body_text) && (body.includes?("VIEWSTATE") || body.includes?("ViewState"))
-            field = body.includes?("javax.faces.ViewState") ? "javax.faces.ViewState" : "__VIEWSTATE"
+          if (body = ctx.body_text) && VIEWSTATE_MARKER.matches?(body)
             body.scan(VIEWSTATE_INPUT) do |m|
-              if fmt = classify(m[1])
-                mark(hits, fmt, "#{field} field", Store::Severity::Low)
+              if fmt = classify(m[2])
+                mark(hits, fmt, "#{field_label(m[1])} field", Store::Severity::Low)
               end
             end
           end
+        end
+
+        # Normalise the captured field name to its canonical spelling, so a lowercase
+        # `__viewstate` (which the /i pattern accepts) still reports as `__VIEWSTATE` and the
+        # evidence string stays stable across flows — evidence for this code ACCUMULATES per
+        # (code, host), so a casing variant would otherwise split into a second entry.
+        private def field_label(name : String) : String
+          name.compare("javax.faces.ViewState", case_insensitive: true) == 0 ? "javax.faces.ViewState" : "__VIEWSTATE"
         end
 
         # Classify one VALUE by its serialized magic, trying the raw form and — for the query /

--- a/src/gori/probe/passive/sourcemap.cr
+++ b/src/gori/probe/passive/sourcemap.cr
@@ -28,10 +28,15 @@ module Gori
         # `//# sourceMappingURL=…`, the legacy `//@` form, and the block-comment `/*# … */` form.
         # The value stops at whitespace, a quote, or a `*` (the block comment's terminator).
         MARKER = /\/[\/*][#@]\s*sourceMappingURL\s*=\s*([^\s'"*]+)/
-        # The regex opens on `//`, a byte pair that occurs constantly in a minified bundle (every
-        # URL, every regex literal), so PCRE's first-byte optimization can't skip ahead. This
-        # allocation-free literal test can, and a body without the word cannot match.
-        NEEDLE = "sourceMappingURL"
+        # MARKER opens on `//`, a byte pair that occurs constantly in a minified bundle (every
+        # URL, every regex literal), so PCRE's first-byte optimization can't skip ahead on it and
+        # a prefilter really does pay here. But the prefilter has to be a REGEX, not a
+        # `String#includes?`: over the 256 KiB `client_body_text` a JS bundle actually reaches,
+        # `includes?` measured 324.8µs — worse than running MARKER unguarded (96.9µs) — because
+        # it is a naive byte search, while PCRE2 memchr-skips a pure literal in 69.5µs. Same
+        # trap the `includes?` guards in `debug_mode_exposed` fell into; the fix is the same, and
+        # the two-stage structure is kept because here the second stage genuinely is the slow one.
+        NEEDLE = /sourceMappingURL/
 
         # The comment sits at the very END of a bundle, i.e. exactly where the shared body prefix
         # (Context::CLIENT_BODY_CAP) gets cut — the big production bundles that matter most would
@@ -52,11 +57,11 @@ module Gori
           return unless ctx.js?
           text = ctx.client_body_text
           return if text.nil? || text.empty?
-          if text.includes?(NEEDLE) && (m = MARKER.match(text))
+          if NEEDLE.matches?(text) && (m = MARKER.match(text))
             return emit(ctx, acc, m[1])
           end
           return unless tail = tail_text(ctx)
-          if tail.includes?(NEEDLE) && (m = MARKER.match(tail))
+          if NEEDLE.matches?(tail) && (m = MARKER.match(tail))
             emit(ctx, acc, m[1])
           end
         end


### PR DESCRIPTION
Second FP/speed pass over the Probe passive rule set, following #866's ruleset work and the 2026-08-29 pass.

## Speed — 1.3–1.6×

Every win is one of two shapes: **a hand-rolled prefilter in front of something that already prefilters itself**, or **a regex written so PCRE2 has nothing to skip on**. `bench/probe_passive_bench`, quiet machine, **detections unchanged throughout** (`json=2 html=7 js=3 js_i18n=3`):

| flow | before | after | |
|---|---|---|---|
| JSON API POST | 56.72µs | 51.78µs | 1.10× |
| HTML document | 1.51ms | 0.96ms | **1.58×** |
| HTML doc, 200 KiB | 4.00ms | 2.59ms | **1.54×** |
| JS bundle, 256 KiB | 8.78ms | 6.59ms | **1.33×** |
| JS bundle, i18n | 9.66ms | 7.60ms | 1.27× |

**`(?:\n|\A)` kills PCRE2's start optimization.** With the `\A` alternative there is no first-code-unit set, so the engine walks every offset. `^` under `/m` is the same set of positions and lets it memchr newline to newline — Node.js frame 239.9 → 30.4µs, Spring trace 183.6 → 24.5µs. (Crystal's `m` also sets DOTALL; verified none of the three patterns carries a bare `.`.)

**Hand-rolled prefilters were pessimizations — and `AsciiBytes.contains_ci?` is not exempt.** It is a naive `O(hay·needle)` walk just like the `String#includes?` it replaced; the interesting property was never allocation, it was scan speed. A literal `Regex` beats both (64 KiB: ~85µs vs ~19µs). Fixed in `debug_mode_exposed` (601 → 151µs), `sourcemap` (372 → 101µs), `exposed_config` (~180µs → ~38µs), `serialized_object` (150 → 17µs), `directory_listing` (79 → 17µs), and `body_leaks`' HTML gates.

Not applied mechanically — each was decided by A/B measurement. The `javascript:` gate is *removed* because `INLINE_JS_URI` anchors itself (55.4µs) and the gate cost 105.4µs; the `_blank` gate is *kept* because `ANCHOR_BLANK` opens on `<a` and costs 121.1µs unguarded.

**Factoring by a shared literal prefix ≠ union.** The earlier finding that a 14-way alternation is *slower* than 14 separate scans was about patterns with nothing in common. The nine `SOURCES` entries sharing `location.` / `document.` keep their anchor when factored, so a 6-way alternation costs what *one* of the six cost: the `js_scan` source index went 1009 → 533µs. The resulting index is byte-identical, so `SOURCES` order still decides a window's label.

## False positives — three public values out of the High tier

`Secrets::PATTERNS` membership means "a server has no business sending this to a browser". Three shapes a site is *supposed* to publish were in it, so each fired High on every site using the product — the same failure the JWT split fixed one tier up:

- **Google OAuth client ID** — rides in the authorization URL of every Google Sign-In redirect; documented as non-secret. Removed. The **credential** half of that pair *does* have a shape (`GOCSPX-<28>`, issued since 2021) and is now detected instead, so this costs no real coverage. It was also the single most expensive pattern in the loop at 549µs (`\b\d{6,}` anchors on "a digit").
- **Mapbox `pk.`** — the public token, meant to be embedded in client JS. Narrowed to `sk.`.

Also fixed: `serialized_object` labelled the ViewState field from a whole-body `includes?` rather than the tag that matched, so a page merely *mentioning* `javax.faces.ViewState` relabelled a real `__VIEWSTATE` finding as JSF.

## Robustness

`SOLO_SOURCES` is derived from `SOURCE_SCANS` rather than a hardcoded index list — a new `SOURCES` entry nobody remembered to add would otherwise just never be scanned, with no compile error and no failing spec. A spec pins that the two cover `SOURCES` exactly once.

## Declined, with measurements

- The Telegram pattern was flagged as sharing the removed Google pattern's digit anchor. It does not behave like it: `\d{8,10}:AA` is bounded and adjacent to its discriminator — **26.8µs** against the removed pattern's **501.9µs**.
- The factored `m[1]` capture allocation was flagged as hot; it is already inside the 67–76µs factored-scan figure, and the net was 1009 → 533µs.

## Left alone, deliberately

The two largest remaining JS-bundle items are the `dom_xss` sink scan (~1.4ms) and the two `strip` lexers (~1.5ms). Both need structural rewrites whose risk is worse than the payoff here: windowing the sink scan is not exact while `SINKS` carries unbounded `\s*` (it would need an `\s{0,32}` cap, a semantic change), and the lexer has a stack-overflow history that makes it expensive to touch.

## Verification

`crystal build --no-codegen src/main.cr` · `crystal spec` **11817 examples, 0 failures** · `crystal tool format --check` · `scripts/bench_check.sh` (48 harnesses) · `scripts/seed_demo.cr`.

The Google spec fixtures are assembled from string parts — they are invented values, but GitHub push protection matches the shapes on sight.