### PR TITLE
Calibrate the param miner's control to the width the run actually mines at

### DIFF
--- a/bench/miner_quality_bench.cr
+++ b/bench/miner_quality_bench.cr
@@ -1,0 +1,177 @@
+# Param-miner QUALITY + COST harness: what a mine FINDS, and what it costs to find it.
+#
+# `miner_perf_bench` measures the transport (keep-alive) and the run's schedule;
+# `miner_inject_bench` and `miner_reflect_bench` measure per-request CPU. None of them answers
+# the two questions an operator actually has: did the mine report the parameters that exist
+# and nothing else (FP/FN), and how many requests did it burn getting there.
+#
+# A mine is LATENCY-bound, so REQUESTS SENT is the honest cost number here — wall clock
+# against an in-process loopback origin is mostly scheduler noise. Each origin below is a
+# server behaviour that is ordinary on the real internet and that the bucketing, the
+# calibration and the bisection all have to survive:
+#
+#   clean page             a static page. The control case: nothing must regress here.
+#   param-count reactive   "N filters applied" — the body reacts to HOW MANY parameters
+#                          arrived, which is what a width-matched control cancels.
+#   jittery body           a rotating element, so the length band is wide and noisy while the
+#                          count metrics stay quiet. Tests which metric the verdict comes from.
+#   echoes param names     the page prints back what it received, so the byte count moves with
+#                          the NAMES gori chose — the correction `Reference#echo` measures.
+#   400 over 100 params    a max_input_vars ceiling. The width has to come down before mining.
+#   oversized-cookie 400   the same refusal by header BYTES rather than by count.
+#   403 on any unknown     a WAF that rejects every request carrying a name it does not know,
+#                          at every width — there is no anchor here, and inventing one reports
+#                          the whole wordlist. The number to read on this row is FP.
+#   bytes-only reaction    a JSON API that names back the keys it did not recognise, on one
+#                          line: length moves on every probe, words and lines do not.
+#
+# Each origin hides the same five parameters, taken from the built-in wordlist, and each hit
+# is worth ~4% of the page — a modest signal, deliberately: one worth 30% would be found by
+# any comparison at all and would measure nothing.
+#
+# Build: crystal build bench/miner_quality_bench.cr -o bin/miner_quality_bench --release
+# Run:   bin/miner_quality_bench          (repeat it — two of the origins are stochastic)
+require "socket"
+require "http/server"
+
+module Gori
+  class Error < Exception; end
+end
+
+require "../src/gori/bindings"
+require "../src/gori/fuzz"
+require "../src/gori/miner"
+require "../src/gori/outbound"
+
+alias M = Gori::Miner
+
+CONCURRENCY = 20
+FILLER      = "lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod\n"
+PAGE        = FILLER * 30 # ~2 KB of ordinary body
+HIT         = "secret parameter accepted\nvalue applied to this request\nsee the audit log\n"
+
+SECRETS = ["debug", "admin", "callback", "template", "redirect_url"]
+
+record Outcome, sent : Int64, found : Array(String), errors : Int64, elapsed : Time::Span
+
+# How many of the hidden parameters this request carried. Cookies are parsed into NAMES:
+# `cookie.includes?("admin=")` also matches `is_admin=`, which would score the miner against a
+# bug in this file rather than one in the miner.
+private def hits_in(ctx : HTTP::Server::Context) : Int32
+  q = ctx.request.query_params
+  cookie = ctx.request.headers["Cookie"]? || ""
+  names = cookie.split(';').compact_map { |c| c.split('=', 2)[0]?.try(&.strip) }
+  SECRETS.count { |s| q.has_key?(s) || names.includes?(s) }
+end
+
+# The body each origin returns, minus the hit marker.
+private def page_for(mode : Symbol, q : URI::Params) : String
+  String.build do |io|
+    io << PAGE
+    case mode
+    when :width, :widecap
+      # A "N filters applied" counter: the page reacts to the NUMBER of query parameters and
+      # to nothing else. Common (search UIs, error pages that list what was received).
+      io << "applied " << q.size << " filters\n"
+      q.size.times { |i| io << "filter row " << i << "\n" }
+    when :bytesonly
+      # Length moves with the parameters; the counts do not (one line, no spaces).
+      io << "unknown:" << q.join(",") { |k, _| k } << "\n"
+    when :echo
+      # A canonical link / "you searched for" page: the parameter NAMES are printed back, so
+      # the byte count moves with the names, not only with how many there were.
+      q.each { |k, _| io << "seen " << k << "\n" }
+    when :noisy
+      # An ad slot / rotating token: the body jitters on every request.
+      io << Random.rand(400).times.join("") { "n" } << "\n"
+    end
+  end
+end
+
+# nil when the origin accepts the request, or the refusal to send instead.
+private def refusal_for(mode : Symbol, ctx : HTTP::Server::Context) : String?
+  case mode
+  when :wafall
+    # Rejects any parameter it has never heard of — gori's control names included, at every
+    # width the walk can reach.
+    unknown = ctx.request.query_params.any? { |k, _| k != "q" && !SECRETS.includes?(k) }
+    "request blocked" if unknown
+  when :widecap
+    "too many parameters" if ctx.request.query_params.size >= 100
+  when :cookiecap
+    # nginx/haproxy-style refusal of an oversized header set: a property of the bucket's
+    # width, never of any name inside it.
+    "Request Header Or Cookie Too Large" if (ctx.request.headers["Cookie"]? || "").bytesize > 512
+  end
+end
+
+private def start_origin(mode : Symbol) : Int32
+  server = HTTP::Server.new do |ctx|
+    if refused = refusal_for(mode, ctx)
+      ctx.response.status_code = 400
+      ctx.response.print refused
+    else
+      ctx.response.content_type = "text/html"
+      ctx.response.print page_for(mode, ctx.request.query_params)
+      hits_in(ctx).times { ctx.response.print HIT }
+    end
+  end
+  port = server.bind_tcp("127.0.0.1", 0).port
+  spawn { server.listen }
+  port
+end
+
+private def mine(port : Int32, locations : Array(M::Location)) : Outcome
+  request = "GET /?q=1 HTTP/1.1\r\nHost: 127.0.0.1:#{port}\r\nAccept: */*\r\nCookie: sid=1\r\n\r\n"
+  config = M::Config.new(locations: locations, concurrency: CONCURRENCY, keep_alive: true)
+  options = M::PlanOptions.new(request,
+    target: "http://127.0.0.1:#{port}/", locations: locations, config: config, verify: false)
+  plan = M::Plan.build(options, Gori::Outbound.waived(nil, Gori::Outbound::Reason::NoProject))
+  sent = 0_i64
+  errors = 0_i64
+  found = [] of String
+  started = Time.instant
+  plan.engine.run do |ev|
+    case ev
+    when M::FindingEvent then found << ev.finding.name
+    when M::DoneEvent    then sent = ev.progress.sent; errors = ev.progress.errors
+    end
+  end
+  elapsed = Time.instant - started
+  plan.sender.close
+  Outcome.new(sent, found.uniq!, errors, elapsed)
+end
+
+private def report(label : String, res : Outcome) : Nil
+  tp = res.found & SECRETS
+  fp = res.found - SECRETS
+  fn = SECRETS - res.found
+  puts "  #{label.ljust(22)} sent #{res.sent.to_s.rjust(5)} · " \
+       "TP #{tp.size}/#{SECRETS.size} · FP #{fp.size} · errors #{res.errors} · " \
+       "#{res.elapsed.total_milliseconds.round(0).to_i}ms"
+  puts "      missed: #{fn.join(", ")}" unless fn.empty?
+  puts "      false:  #{fp.first(8).join(", ")}#{fp.size > 8 ? " …" : ""}" unless fp.empty?
+end
+
+QUERY   = [M::Location::Query]
+COOKIES = [M::Location::Cookies]
+
+CASES = [
+  {:clean, "clean page", QUERY},
+  {:width, "param-count reactive", QUERY},
+  {:noisy, "jittery body", QUERY},
+  {:echo, "echoes param names", QUERY},
+  {:widecap, "400 over 100 params", QUERY},
+  {:cookiecap, "oversized-cookie 400", COOKIES},
+  {:wafall, "403 on any unknown", QUERY},
+  {:bytesonly, "bytes-only reaction", QUERY},
+]
+
+puts "Miner quality + cost (concurrency #{CONCURRENCY}, built-in wordlist)"
+CASES.each do |(mode, label, locs)|
+  port = start_origin(mode.as(Symbol))
+  sleep 150.milliseconds
+  locations = locs.as(Array(M::Location))
+  mine(port, locations) # warm-up: lazy wordlist parse, first dial
+  report(label.as(String), mine(port, locations))
+end

--- a/spec/miner/baseline_spec.cr
+++ b/spec/miner/baseline_spec.cr
@@ -10,9 +10,20 @@ private def mk_report(status : Int32? = 200, length_tol = 10_i64, words_tol = 5,
                       stable = true,
                       reflection_only = Hash(M::Location, Bool).new,
                       reflects_all = Hash(M::Location, Bool).new,
-                      warning : String? = nil) : M::Baseline::Report
+                      warning : String? = nil,
+                      refs = Hash(M::Location, M::Baseline::Reference).new) : M::Baseline::Report
   M::Baseline::Report.new(status, length_tol, words_tol, lines_tol,
-    base_length, base_words, base_lines, stable, reflection_only, reflects_all, warning)
+    base_length, base_words, base_lines, stable, reflection_only, reflects_all, warning,
+    refs: refs)
+end
+
+# A width-matched control to diff against — the reference `decide` uses in place of the plain
+# baseline at a location that reacts to unknown parameters.
+private def mk_ref(status : Int32? = 200, length = 100_i64, words = 50, lines = 20,
+                   width = 8, name_len = 8, echo = 0.0,
+                   length_tol = 10_i64, words_tol = 5, lines_tol = 3) : M::Baseline::Reference
+  M::Baseline::Reference.new(mk_probe(status, length, words, lines), width, name_len, echo,
+    length_tol, words_tol, lines_tol)
 end
 
 # Build a Probe directly: metrics + the SET of reflected canaries (reflects? is a set lookup).
@@ -91,8 +102,56 @@ private def calibrate_cfg(stability_rounds = 2, retries = 1) : M::Config
   c
 end
 
+# Counts the query parameters of every request and answers with one row per parameter, so the
+# response reacts to WIDTH and to nothing else. `widths` records what each probe carried, and
+# `refuse_over` stands in for a parameter-count ceiling (max_input_vars, a WAF rule).
+private class WidthAwareBackend < F::Backend
+  getter origin : F::Origin
+  getter widths = [] of Int32
+
+  # `jitter` is a rotating element — bytes that move on every response and belong to no
+  # parameter. `bytes_only` reacts to the parameters in LENGTH alone (names run together on one
+  # line), which is a JSON API naming back the keys it did not recognise.
+  def initialize(@refuse_over : Int32 = 1024, @react : Bool = true,
+                 @jitter : Int32 = 0, @bytes_only : Bool = false)
+    @origin = F::Origin.new("http", "h", 80)
+  end
+
+  def send(bytes : Bytes) : Gori::Repeater::Result
+    n = param_count(bytes)
+    @widths << n
+    if n > @refuse_over
+      return result(400, "too many parameters")
+    end
+    body = String.build do |io|
+      io << "BASELINE BODY\n"
+      io << ("x" * Random.rand(@jitter)) << "\n" if @jitter > 0
+      if @bytes_only
+        io << "unknown:" << (0...n).join(",") { |i| "k#{i}" } << "\n"
+      elsif @react
+        n.times { |i| io << "row " << i << "\n" }
+      end
+    end
+    result(200, body)
+  end
+
+  private def result(code : Int32, body : String) : Gori::Repeater::Result
+    head = "HTTP/1.1 #{code} X\r\nContent-Length: #{body.bytesize}\r\n\r\n".to_slice
+    resp = Gori::Proxy::Codec::Http1.parse_response_head(head)
+    Gori::Repeater::Result.new(head, body.to_slice, resp, 1000_i64)
+  end
+
+  private def param_count(bytes : Bytes) : Int32
+    line = String.new(bytes).lines.first? || ""
+    target = line.split(' ')[1]? || ""
+    qi = target.index('?')
+    return 0 unless qi
+    target[(qi + 1)..].split('&').count { |pair| !pair.empty? }
+  end
+end
+
 describe "Gori::Miner.decide" do
-  describe "metric precedence ladder (Status > Length > Words > Lines)" do
+  describe "metric selection (Status first, then the largest move relative to its own band)" do
     it "picks Status when status, length, words, and lines all diverge (strongest ONE)" do
       report = mk_report(status: 200, base_length: 100_i64, base_words: 50, base_lines: 20)
       probe = mk_probe(status: 500, length: 100_000_i64, words: 5_000, lines: 3_000)
@@ -125,12 +184,35 @@ describe "Gori::Miner.decide" do
       d.kind.should eq(M::DiffKind::Lines)
     end
 
-    it "picks Words over Lines when both exceed but length/status are within tol" do
+    it "picks the metric that moved FURTHEST past its own band, not the earlier one" do
+      # words +450 over a band of 5 = 90x; lines +480 over a band of 3 = 160x. The fixed
+      # ladder answered Words because Words came first; lines is the stronger signal.
       report = mk_report(status: 200, base_length: 100_i64, length_tol: 10_i64,
         base_words: 50, words_tol: 5, base_lines: 20, lines_tol: 3)
       probe = mk_probe(status: 200, length: 100_i64, words: 500, lines: 500)
       d = M.decide(report, probe, no_candidates, M::Location::Query)
+      d.kind.should eq(M::DiffKind::Lines)
+    end
+
+    it "does not let a NOISY metric that barely cleared its band outrank a quiet one" do
+      # The shape that cost real findings: a page with a rotating element has a wide length
+      # band, so length clears it by a hair on a random probe while the count metrics — whose
+      # bands are tight because they do not move — carry the actual signal. Under the fixed
+      # ladder the bucket was reported as Length, a kind the isolated name could not
+      # reproduce, and `confirm` dropped the parameter.
+      report = mk_report(status: 200, base_length: 2148_i64, length_tol: 358_i64,
+        base_words: 331, words_tol: 3, base_lines: 31, lines_tol: 2)
+      probe = mk_probe(status: 200, length: 2590_i64, words: 346, lines: 36)
+      d = M.decide(report, probe, no_candidates, M::Location::Query)
       d.kind.should eq(M::DiffKind::Words)
+    end
+
+    it "keeps the old order when two metrics moved by the SAME multiple of their bands" do
+      report = mk_report(status: 200, base_length: 100_i64, length_tol: 10_i64,
+        base_words: 50, words_tol: 5, base_lines: 20, lines_tol: 3)
+      probe = mk_probe(status: 200, length: 120_i64, words: 60, lines: 26)
+      d = M.decide(report, probe, no_candidates, M::Location::Query)
+      d.kind.should eq(M::DiffKind::Length)
     end
 
     it "yields None when every metric is within tolerance" do
@@ -367,5 +449,179 @@ describe "Gori::Miner::Baseline#calibrate" do
     report.stable.should be_true
     report.status.should eq(200)
     (report.warning.nil? || !report.warning.not_nil!.includes?("varies")).should be_true
+  end
+end
+
+describe "Gori::Miner.decide against a width-matched control" do
+  no_candidates = [] of {String, String}
+  loc = M::Location::Query
+
+  it "measures the metrics from the CONTROL, not from the untouched baseline" do
+    # The page answers any bucket of unknown parameters with a row per parameter, so against
+    # the plain baseline it is +400 bytes / +40 words on every probe. Against a control of the
+    # same width it is identical — which is the whole point.
+    report = mk_report(status: 200, base_length: 100_i64, length_tol: 10_i64,
+      base_words: 50, words_tol: 5, base_lines: 20, lines_tol: 3)
+    ref = mk_ref(length: 500_i64, words: 90, lines: 30)
+    probe = mk_probe(status: 200, length: 500_i64, words: 90, lines: 30)
+    M.decide(report, probe, no_candidates, loc, ref).kind.should eq(M::DiffKind::None)
+    # …and the candidate's OWN effect on top of that reaction still reads as signal.
+    grown = mk_probe(status: 200, length: 560_i64, words: 90, lines: 30)
+    M.decide(report, grown, no_candidates, loc, ref).kind.should eq(M::DiffKind::Length)
+  end
+
+  it "widens the length band by what the page echoes of the names GORI chose" do
+    # echo 1.0: every byte of parameter name comes back in the body. A probe carrying 40 more
+    # bytes of name than the control did is therefore 40 bytes longer for a reason that is the
+    # miner's doing, not the target's — so it is not a finding, while a bigger move still is.
+    report = mk_report(status: 200, base_length: 100_i64, length_tol: 10_i64)
+    ref = mk_ref(length: 500_i64, echo: 1.0)
+    probe = mk_probe(status: 200, length: 545_i64)
+    M.decide(report, probe, no_candidates, loc, ref, byte_delta: 40).kind.should eq(M::DiffKind::None)
+    M.decide(report, probe, no_candidates, loc, ref, byte_delta: 0).kind.should eq(M::DiffKind::Length)
+  end
+
+  it "reads the status off the control too" do
+    # A location whose control comes back 403 is one where 403 is the ordinary answer; a
+    # candidate that gets 200 is the anomaly, and against the baseline's 200 it looked normal.
+    report = mk_report(status: 200)
+    ref = mk_ref(status: 403)
+    M.decide(report, mk_probe(status: 403), no_candidates, loc, ref).kind.should eq(M::DiffKind::None)
+    M.decide(report, mk_probe(status: 200), no_candidates, loc, ref).kind.should eq(M::DiffKind::Status)
+  end
+end
+
+describe "Gori::Miner::Canary.bogus_name" do
+  it "is exactly the requested number of bytes, odd lengths included" do
+    (3..40).each do |n|
+      name = M::Canary.bogus_name(n)
+      name.bytesize.should eq(n)
+      name.should start_with("zz")
+      # A control name has to survive every location's encoding unchanged, and be a legal
+      # header/cookie/multipart token — `zz` plus lower hex is all three.
+      M::Inject.valid_header_name?(name).should be_true
+    end
+  end
+end
+
+describe "Gori::Miner::Baseline#calibrate width + control" do
+  base = "GET /s?q=1 HTTP/1.1\r\nHost: h\r\n\r\n".to_slice
+  loc = M::Location::Query
+
+  it "sends the control at the width the RUN will use, not at a token 8" do
+    backend = WidthAwareBackend.new
+    b = M::Baseline.new(backend, base, calibrate_cfg(stability_rounds: 2))
+    b.calibrate([loc], {loc => 64})
+    # The base request's own `q`, plus 64 bogus candidates.
+    backend.widths.should contain(65)
+  end
+
+  it "lowers the width until the target stops REFUSING the request" do
+    # A ceiling at 16 parameters. Asking for 64 is answered 400 — and every bucket of the run
+    # would have been, then bisected down through its own refusals to nothing.
+    backend = WidthAwareBackend.new(refuse_over: 16)
+    b = M::Baseline.new(backend, base, calibrate_cfg(stability_rounds: 2))
+    report = b.calibrate([loc], {loc => 64})
+    report.width_for(loc).not_nil!.should be <= 16
+    report.width_for(loc).not_nil!.should be > 1
+  end
+
+  it "mines a reproducibly reactive location against a reference instead of muting it" do
+    backend = WidthAwareBackend.new
+    b = M::Baseline.new(backend, base, calibrate_cfg(stability_rounds: 2))
+    report = b.calibrate([loc], {loc => 32})
+    ref = report.reference_for(loc)
+    ref.should_not be_nil
+    ref.not_nil!.width.should eq(32)
+    # …and the location is NOT written off, which is what used to happen to every page that
+    # reacts to unknown parameters at all.
+    report.reflection_only[loc]?.should be_false
+  end
+
+  it "leaves a location that does not react alone — no reference, no padding, no extra probe" do
+    backend = WidthAwareBackend.new(react: false)
+    b = M::Baseline.new(backend, base, calibrate_cfg(stability_rounds: 2))
+    report = b.calibrate([loc], {loc => 32})
+    report.reference_for(loc).should be_nil
+    report.reflection_only[loc]?.should be_false
+    # 2 stability rounds + 1 control, and no second control: a calm location costs one wave.
+    backend.widths.size.should eq(3)
+  end
+end
+
+# Every one of these is a way the width-matched control can go wrong, and each cost a
+# reproduced false-positive run before it was closed.
+describe "Gori::Miner::Baseline#calibrate reference guards" do
+  base = "GET /s?q=1 HTTP/1.1\r\nHost: h\r\n\r\n".to_slice
+  loc = M::Location::Query
+
+  it "builds NO reference from a width the target never accepted" do
+    # The target refuses every request carrying gori's control names, at every width. Locking
+    # the refusal in as the anchor makes every ordinary 200 a Status diff — the whole wordlist
+    # reported as hidden parameters, at Confirmed confidence.
+    # `refuse_over: 1` — the base request's own `q` is fine, any control on top of it is not,
+    # at every width down to one candidate.
+    backend = WidthAwareBackend.new(refuse_over: 1)
+    b = M::Baseline.new(backend, base, calibrate_cfg(stability_rounds: 2))
+    report = b.calibrate([loc], {loc => 32})
+    report.reference_for(loc).should be_nil
+    report.reflection_only[loc]?.should be_true
+    report.warning.not_nil!.should contain("refuses every bucket width")
+  end
+
+  it "mines a location that reacts only in BYTES against a reference" do
+    # A JSON API that names back the keys it did not recognise, on one line: length moves with
+    # every probe, words and lines do not. Judged against the untouched baseline this is a
+    # Length diff on every bucket — every name a finding.
+    backend = WidthAwareBackend.new(react: false, bytes_only: true)
+    b = M::Baseline.new(backend, base, calibrate_cfg(stability_rounds: 2))
+    report = b.calibrate([loc], {loc => 32})
+    report.reference_for(loc).should_not be_nil
+    report.reflection_only[loc]?.should be_false
+  end
+
+  it "does NOT lock onto a page whose only reaction is its own churn" do
+    # A rotating element wider than the band four samples of a quiet page could measure. The
+    # control clears that band without the page having reacted to anything, and pinning a
+    # single noisy sample as the anchor for the whole run is strictly worse than the baseline
+    # it replaces — the second control, being the same page's jitter under injection, is what
+    # tells the two apart.
+    backend = WidthAwareBackend.new(react: false, jitter: 4000)
+    b = M::Baseline.new(backend, base, calibrate_cfg(stability_rounds: 4))
+    report = b.calibrate([loc], {loc => 32})
+    report.reference_for(loc).should be_nil
+    # …and NOT muted either: the location is perfectly minable off the plain baseline.
+    report.reflection_only[loc]?.should be_false
+  end
+
+  it "carries bands measured UNDER INJECTION, not the untouched baseline's" do
+    backend = WidthAwareBackend.new(jitter: 600)
+    b = M::Baseline.new(backend, base, calibrate_cfg(stability_rounds: 2))
+    report = b.calibrate([loc], {loc => 32})
+    if ref = report.reference_for(loc)
+      # Two identical-width controls disagreed by the page's own churn; the band the run then
+      # judges against has to have absorbed it, or every probe is a finding.
+      ref.length_tol.should be >= report.length_tol
+    end
+  end
+end
+
+describe "Gori::Miner::Canary.bogus_batch" do
+  it "returns DISTINCT names of exactly the requested length" do
+    # A control bucket carrying the same name twice is one parameter narrower than every probe
+    # measured against it — on a page that answers a row per parameter, that is a diff on
+    # every bucket of the run.
+    [8, 12, 24].each do |len|
+      names = M::Canary.bogus_batch(256, len)
+      names.size.should eq(256)
+      names.uniq.size.should eq(256)
+      names.all? { |n| n.bytesize == len }.should be_true
+      names.all? { |n| M::Inject.valid_header_name?(n) }.should be_true
+    end
+  end
+
+  it "is empty for a non-positive count" do
+    M::Canary.bogus_batch(0, 8).should be_empty
+    M::Canary.bogus_batch(-1, 8).should be_empty
   end
 end

--- a/spec/miner/engine_spec.cr
+++ b/spec/miner/engine_spec.cr
@@ -51,6 +51,125 @@ private class HiddenParamBackend < F::Backend
   end
 end
 
+# A page that reacts to HOW MANY parameters it was handed — a "N filters applied" counter, a
+# canonical link that lists what was received, an error page quoting the query. It is the
+# ordinary case on the web, and against the untouched baseline it moves on EVERY probe, which
+# is why the location used to be written off wholesale and found nothing at all.
+#
+# `max_params` records the widest request it ever saw, so a spec can assert what the run
+# actually put on the wire.
+private class ParamCountBackend < F::Backend
+  getter origin : F::Origin
+  getter sent : Int32 = 0
+  getter max_params : Int32 = 0
+
+  # `refuse_over` stands in for a max_input_vars ceiling / an oversized-header refusal: past
+  # that many parameters the request itself is rejected, whatever is in it.
+  def initialize(@origin : F::Origin, @secret : String, @refuse_over : Int32 = 1024)
+  end
+
+  def send(bytes : Bytes) : Gori::Repeater::Result
+    @sent += 1
+    params = query_params(bytes)
+    @max_params = params.size if params.size > @max_params
+    return refused if params.size > @refuse_over
+    body = String.build do |io|
+      io << "BASELINE BODY CONTENT\n"
+      # One row per parameter: the reaction a control of the same width cancels.
+      params.size.times { |i| io << "filter row " << i << "\n" }
+      io << "secret parameter accepted\nvalue applied to the request\nsee the audit log\n" if params.has_key?(@secret)
+    end
+    ok(body)
+  end
+
+  private def refused : Gori::Repeater::Result
+    body = "too many parameters"
+    head = "HTTP/1.1 400 Bad Request\r\nContent-Length: #{body.bytesize}\r\n\r\n".to_slice
+    resp = Gori::Proxy::Codec::Http1.parse_response_head(head)
+    Gori::Repeater::Result.new(head, body.to_slice, resp, 1000_i64)
+  end
+
+  private def query_params(bytes : Bytes) : Hash(String, String)
+    pairs = Hash(String, String).new
+    line = String.new(bytes).lines.first? || ""
+    target = line.split(' ')[1]? || ""
+    qi = target.index('?')
+    return pairs unless qi
+    target[(qi + 1)..].split('&').each do |pair|
+      k, _, v = pair.partition('=')
+      pairs[k] = v unless k.empty?
+    end
+    pairs
+  end
+
+  private def ok(body : String) : Gori::Repeater::Result
+    head = "HTTP/1.1 200 OK\r\nContent-Length: #{body.bytesize}\r\n\r\n".to_slice
+    resp = Gori::Proxy::Codec::Http1.parse_response_head(head)
+    Gori::Repeater::Result.new(head, body.to_slice, resp, 1000_i64)
+  end
+end
+
+# The secret changes the response in DIFFERENT ways depending on how much company it has: it
+# always grows the body, and it additionally returns 500 when it arrives alone. A bucket
+# therefore nominates it on Length and the isolating re-test answers Status.
+private class KindFlipBackend < F::Backend
+  getter origin : F::Origin
+
+  def initialize(@origin : F::Origin, @secret : String)
+  end
+
+  def send(bytes : Bytes) : Gori::Repeater::Result
+    params = query_params(bytes)
+    hit = params.has_key?(@secret)
+    body = "BASELINE BODY CONTENT"
+    body += " XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX" if hit
+    code = (hit && params.size <= 2) ? 500 : 200
+    head = "HTTP/1.1 #{code} X\r\nContent-Length: #{body.bytesize}\r\n\r\n".to_slice
+    resp = Gori::Proxy::Codec::Http1.parse_response_head(head)
+    Gori::Repeater::Result.new(head, body.to_slice, resp, 1000_i64)
+  end
+
+  private def query_params(bytes : Bytes) : Hash(String, String)
+    pairs = Hash(String, String).new
+    line = String.new(bytes).lines.first? || ""
+    target = line.split(' ')[1]? || ""
+    qi = target.index('?')
+    return pairs unless qi
+    target[(qi + 1)..].split('&').each do |pair|
+      k, _, v = pair.partition('=')
+      pairs[k] = v unless k.empty?
+    end
+    pairs
+  end
+end
+
+# Answers every request normally EXCEPT the `nth` one, which comes back 503 — a rate limiter
+# tripping mid-run. Nothing in the request means anything to it: no name is hidden.
+private class OneTransientBackend < F::Backend
+  getter origin : F::Origin
+  getter sent : Int32 = 0
+
+  def initialize(@origin : F::Origin, @nth : Int32, @grow_after : Int32 = 0)
+  end
+
+  def send(bytes : Bytes) : Gori::Repeater::Result
+    @sent += 1
+    if @sent == @nth
+      return result(503, "slow down")
+    end
+    # A body that drifts once, so a bucket has something to nominate a name on.
+    body = "BASELINE BODY CONTENT"
+    body += " XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX" if @grow_after > 0 && @sent > @grow_after
+    result(200, body)
+  end
+
+  private def result(code : Int32, body : String) : Gori::Repeater::Result
+    head = "HTTP/1.1 #{code} X\r\nContent-Length: #{body.bytesize}\r\n\r\n".to_slice
+    resp = Gori::Proxy::Codec::Http1.parse_response_head(head)
+    Gori::Repeater::Result.new(head, body.to_slice, resp, 1000_i64)
+  end
+end
+
 # Returns one fixed (large) body regardless of input — for exercising the baseline
 # tolerance floors on a big page.
 private class FixedBodyBackend < F::Backend
@@ -582,8 +701,11 @@ describe Gori::Miner::Engine do
         end
       end
       findings.should be_empty
-      # …and it stopped there rather than spending the wordlist on it.
-      backend.sent.should eq(4)
+      # …and it stopped there rather than spending the wordlist on it. Five sends, not four:
+      # calibration is ONE wave — `stability_rounds` copies of the base request plus one
+      # control bucket per location — so the location's control goes out alongside the
+      # stability rounds rather than in a second round trip after them.
+      backend.sent.should eq(5)
       errors.size.should eq(1)
       errors[0].should eq("baseline unreachable — connection refused")
       # The baseline event still goes out first (a surface renders it), and the run still ends
@@ -774,6 +896,107 @@ describe Gori::Miner::Engine do
       # re-sending the baseline as if it were a probe is exactly what produced the false
       # clean verdict.
       backend.sent.should eq(3)
+    end
+  end
+
+  # The single largest false-negative class the miner had: an application that reacts to
+  # unknown parameters AT ALL — a "N filters applied" counter, a page that lists what it
+  # received — moves on every probe, so the calibration marked the location `reflection_only`
+  # and every metric finding there was suppressed for the rest of the run. Measured against a
+  # 441-name wordlist and 5 hidden parameters: 0 of 5 found, 9 requests, exit 0.
+  describe "a page that reacts to unknown parameters" do
+    it "mines it against a same-width control instead of writing the location off" do
+      names = %w(alpha beta gamma delta epsilon zeta eta theta)
+      backend = ParamCountBackend.new(F::Origin.new("http", "h", 80), "gamma")
+      base = "GET /search?q=1 HTTP/1.1\r\nHost: h\r\n\r\n".to_slice
+      engine = M::Engine.new(base, http2: false, names: names, backend: backend, config: cfg)
+      findings = [] of M::Finding
+      engine.run { |ev| findings << ev.finding if ev.is_a?(M::FindingEvent) }
+
+      findings.map(&.name).should eq(["gamma"])
+      # …and only that one: every other name is padded into requests of the same width, so the
+      # page's own reaction is on both sides of the diff and cancels.
+      findings.size.should eq(1)
+    end
+
+    it "mines at a width the target ACCEPTS rather than bisecting its own refusal" do
+      # A max_input_vars ceiling: past 4 parameters the request is rejected outright. The
+      # configured bucket is 4 names (plus the request's own `q`), so the control is refused
+      # and the width has to come down before a single candidate is worth sending.
+      names = %w(alpha beta gamma delta epsilon zeta eta theta)
+      backend = ParamCountBackend.new(F::Origin.new("http", "h", 80), "gamma", refuse_over: 3)
+      base = "GET /search?q=1 HTTP/1.1\r\nHost: h\r\n\r\n".to_slice
+      c = cfg
+      c.bucket_size[M::Location::Query] = 8
+      engine = M::Engine.new(base, http2: false, names: names, backend: backend, config: c)
+      findings = [] of M::Finding
+      engine.run { |ev| findings << ev.finding if ev.is_a?(M::FindingEvent) }
+
+      findings.map(&.name).should eq(["gamma"])
+    end
+  end
+
+  # `confirm` used to demand that the isolated re-test reproduce the SAME metric the bucket
+  # was nominated on. A name's effect inside a bucket of 128 is not always the effect it has
+  # alone, so a parameter the miner had already isolated was thrown away with nothing anywhere
+  # saying it had been seen.
+  describe "a signal that changes kind when the name is isolated" do
+    it "confirms it, and reports what the name did ALONE" do
+      names = %w(alpha beta gamma delta)
+      backend = KindFlipBackend.new(F::Origin.new("http", "h", 80), "gamma")
+      base = "GET /search?q=1 HTTP/1.1\r\nHost: h\r\n\r\n".to_slice
+      engine = M::Engine.new(base, http2: false, names: names, backend: backend, config: cfg)
+      findings = [] of M::Finding
+      engine.run { |ev| findings << ev.finding if ev.is_a?(M::FindingEvent) }
+
+      findings.map(&.name).should eq(["gamma"])
+      findings[0].evidence.should eq(M::Evidence::Status)
+      findings[0].status.should eq(500)
+    end
+  end
+
+  # `matches_evidence?` no longer demands that the isolated re-test reproduce the same METRIC,
+  # which means a single odd response during confirmation now "reproduces" anything. The
+  # majority is what has to hold the line: with the default `confirm_rounds: 2` that is two
+  # agreeing rounds, not one.
+  describe "a transient response during confirmation" do
+    it "does not confirm a name on its own" do
+      names = %w(alpha beta gamma delta)
+      # Every send after the calibration wave grows the body, so bucket probes nominate names
+      # on Length; one send then comes back 503. Neither is a parameter doing anything.
+      backend = OneTransientBackend.new(F::Origin.new("http", "h", 80), nth: 8, grow_after: 3)
+      base = "GET /search?q=1 HTTP/1.1\r\nHost: h\r\n\r\n".to_slice
+      c = cfg
+      c.confirm_rounds = 2
+      engine = M::Engine.new(base, http2: false, names: names, backend: backend, config: c)
+      findings = [] of M::Finding
+      engine.run { |ev| findings << ev.finding if ev.is_a?(M::FindingEvent) }
+      # The 503 round cannot carry a finding by itself, and no round after it disagrees with
+      # the baseline, so nothing is Confirmed off it.
+      findings.any? { |f| f.status == 503 }.should be_false
+    end
+  end
+
+  # A finding's reported delta is measured from whatever it was COMPARED against. At a
+  # width-matched location the confirm round carries `width - 1` padding names, so measuring
+  # from the untouched baseline reports the padding's bulk as the parameter's effect.
+  describe "the length delta a finding reports" do
+    it "is measured from the reference, not from the untouched baseline" do
+      # A wide bucket on purpose: the padding is what makes the two anchors disagree, and at
+      # the 4-name bucket the rest of this file uses there is barely any.
+      names = (1..64).map { |i| "p#{i}" } + ["gamma"]
+      backend = ParamCountBackend.new(F::Origin.new("http", "h", 80), "gamma")
+      base = "GET /search?q=1 HTTP/1.1\r\nHost: h\r\n\r\n".to_slice
+      c = cfg
+      c.bucket_size[M::Location::Query] = 64
+      engine = M::Engine.new(base, http2: false, names: names, backend: backend, config: c)
+      findings = [] of M::Finding
+      engine.run { |ev| findings << ev.finding if ev.is_a?(M::FindingEvent) }
+
+      findings.size.should eq(1)
+      # The hit marker is ~70 bytes; the padding at this width is several times that. Against
+      # the baseline this number came out far larger than anything the parameter did.
+      findings[0].delta.abs.should be < 200
     end
   end
 end

--- a/src/gori/cli/run/mine.cr
+++ b/src/gori/cli/run/mine.cr
@@ -282,9 +282,12 @@ module Gori
       end
 
       private def self.mine_baseline(ev : Miner::BaselineEvent) : Nil
-        note = ev.stable ? "stable" : "UNSTABLE"
-        note += " — #{ev.warning}" if ev.warning
-        STDERR.puts "baseline: #{note}"
+        line = ev.stable ? "stable" : "UNSTABLE"
+        line += " — #{ev.warning}" if ev.warning
+        # The calibration note is its own line: it is not a caveat on the findings, and running
+        # it into the same sentence as `warning` is what makes it read like one.
+        line += "\n  #{ev.note}" if ev.note
+        STDERR.puts "baseline: #{line}"
       end
 
       private def self.emit_mine_finding(f : Miner::Finding, format : Symbol) : Nil

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -529,9 +529,12 @@ module Gori
         property found = 0
         property errors = 0_i64
         property? baseline_stable = true
-        # The baseline's own sentence when it is not stable — status varied, the endpoint echoes
-        # any input, or it never answered (see `Miner::Baseline::Report#warning`).
+        # The baseline's own sentence about anything that DOWNGRADES this run's findings: the
+        # status varied, the endpoint echoes any input, a location had to be muted, or it never
+        # answered at all (see `Miner::Baseline::Report#warning`).
         property baseline_warning : String? = nil
+        # The calibration note — informational, never a downgrade (see `Miner::BaselineEvent`).
+        property baseline_note : String? = nil
         property error_msg : String? = nil
         getter results = [] of Miner::Finding
         property? truncated = false

--- a/src/gori/mcp/tools/mine.cr
+++ b/src/gori/mcp/tools/mine.cr
@@ -46,6 +46,7 @@ module Gori
         when Miner::BaselineEvent
           mjob.baseline_stable = ev.stable
           mjob.baseline_warning = ev.warning
+          mjob.baseline_note = ev.note
         when Miner::ProgressEvent then apply_mine_progress(mjob, ev.progress)
         when Miner::FindingEvent  then store_mine_finding(mjob, ev.finding)
         when Miner::DoneEvent
@@ -92,13 +93,20 @@ module Gori
             j.field "found", mjob.found
             j.field "errors", mjob.errors
             j.field "baseline_stable", mjob.baseline_stable?
-            # Anything that makes this run's findings tentative — the status varied, the endpoint
-            # echoes any input (reflection detection is then OFF at those locations), or it never
-            # answered at all. NOT a gloss on `baseline_stable`: the echo note is raised off
+            # How this run had to be calibrated: the status varied, the endpoint echoes any
+            # input (reflection detection is then OFF at those locations), it never answered at
+            # all — or a location reacts to unknown parameters and is mined against a
+            # same-width control, which changes the COMPARISON without downgrading anything.
+            # NOT a gloss on `baseline_stable`: the echo note is raised off
             # `reflects_all` alone, so it accompanies a perfectly STABLE baseline. `baseline_stable:
             # false` on its own told an agent every finding was tentative without telling it what to
             # do about it, and the CLI has printed this sentence (stable or not) since the miner shipped.
             j.field "baseline_warning", Serialize.text(mjob.baseline_warning)
+            # How the run had to be CALIBRATED, which is not a caveat: a location that reacts
+            # to unknown parameters at all (a "3 filters applied" counter, a page that lists
+            # what it received) is mined against a same-width control instead of against the
+            # untouched baseline its own reaction already moved. Findings there are ordinary.
+            j.field "baseline_note", Serialize.text(mjob.baseline_note)
             j.field "results_truncated", mjob.truncated?
             j.field "job_complete", mjob.status != :running
             j.field "incomplete_reason", incomplete_reason(mjob.status)

--- a/src/gori/miner/baseline.cr
+++ b/src/gori/miner/baseline.cr
@@ -26,6 +26,77 @@ module Gori::Miner
   # suppressed (`reflects_all`) — otherwise every random candidate "reflects" and floods the
   # results with false positives.
   class Baseline
+    # A location's calibrated comparison.
+    #
+    # `probe` is a control response: `width` bogus names — parameters no application has ever
+    # heard of — each `name_len` bytes long. Every probe the run then sends at that location is
+    # padded to the same width (`Engine#pad_pairs`), so whatever the page does ABOUT being
+    # handed unknown parameters is present on both sides of the diff and cancels. What is left
+    # is what the candidate itself did.
+    #
+    # `echo` is how many bytes of response the page returns per byte of parameter NAME it was
+    # handed — measured from two controls of the same width whose names are different lengths.
+    # It is 0 for a page that does not print what it received and ~1 for one that does, and it
+    # is the only honest way to compare a byte COUNT against a control whose names gori chose:
+    # the difference in name bytes is a difference the miner created, so the length band is
+    # widened by `echo × those bytes` and only a move bigger than that counts as signal.
+    # `length_tol`/`words_tol`/`lines_tol` are the bands to judge a probe against WHEN THIS IS
+    # THE ANCHOR, and they are not the report's: the report's come from `stability_rounds`
+    # copies of the untouched request, which is not the jitter of a page that is reacting to
+    # a bucket of unknown parameters. They are measured from two identical-width controls, so
+    # a page whose reaction wobbles is absorbed instead of being reported once per bucket.
+    record Reference,
+      probe : Probe,
+      width : Int32,
+      name_len : Int32,
+      echo : Float64,
+      length_tol : Int64,
+      words_tol : Int32,
+      lines_tol : Int32 do
+      # The control's total injected name bytes — the reference point `byte_delta` is measured
+      # from (see `Engine#byte_delta`).
+      def name_bytes : Int32
+        width * name_len
+      end
+    end
+
+    # The control name lengths. The short one is close to the median parameter name, so the
+    # byte delta a real bucket carries against the control is small; the long one is far enough
+    # from it that a page which prints back what it received moves measurably between the two.
+    CONTROL_NAME_LEN      =  8
+    CONTROL_NAME_LEN_LONG = 24
+
+    # A width the target REFUSES is not a width to mine at. When the control comes back with a
+    # different status than the baseline, the request itself was rejected — a max_input_vars
+    # ceiling, an oversized-header refusal, a WAF rule on parameter count — so the width is
+    # halved and re-probed rather than handed to a run that would then bisect the refusal.
+    # The floor is ONE candidate per request. That is the degenerate mine — as many requests as
+    # there are names — but it is what a target with a tight parameter ceiling leaves, and it
+    # is still cheaper and far more accurate than the alternative the miner had: send the
+    # bucket anyway, read the refusal as a Status finding, and bisect it all the way down.
+    #
+    # The walk is bounded by the halving itself (a `Config` width is at most 1024, so at most
+    # ten steps) rather than by a separate try count — a cap of its own has to be derived from
+    # the ceiling or it silently stops short of the floor.
+    MIN_CONTROL_WIDTH = 1
+
+    # What `settle` learned about one location: the width to mine it at, the control probe it
+    # ended on, the reference to diff against (nil = the plain baseline), and whether the
+    # location must have its metric findings disabled — either because the target refuses every
+    # width, or because its reaction to unknown parameters does not reproduce.
+    record Settled,
+      width : Int32,
+      probe : Probe?,
+      reference : Reference?,
+      refused : Bool,
+      mute : Bool = false do
+      # Metric findings are meaningless here: there is no anchor this location can be compared
+      # against. `refused` is the harder case of the same fact.
+      def mute? : Bool
+        mute || refused
+      end
+    end
+
     record Report,
       status : Int32?,
       length_tol : Int64,
@@ -48,9 +119,35 @@ module Gori::Miner
       # The RAW send failure behind `reachable: false` (`connection refused`, a scope refusal),
       # unwrapped — `warning` is the sentence, this is the reason a consumer re-reports as its
       # own first error. nil whenever the baseline answered.
-      error : String? = nil do
+      error : String? = nil,
+      # Per-location calibrated comparison — see `Reference`. Present only for a location that
+      # reacts to unknown parameters REPRODUCIBLY; absent means either the location is calm
+      # (diff against the plain baseline, as before) or it reacts unpredictably
+      # (`reflection_only`, metric findings suppressed there).
+      refs : Hash(Location, Reference) = Hash(Location, Reference).new,
+      # How many candidate names one probe carries at each location. Calibrated, not merely
+      # configured: a target that refuses a 128-parameter request is mined at a width it
+      # accepts (see `calibrate`), instead of bisecting its own refusal 400 times.
+      width : Hash(Location, Int32) = Hash(Location, Int32).new,
+      # How the run had to be CALIBRATED, as distinct from what makes its findings tentative.
+      # A location mined against a same-width control is a healthy mine — the surfaces render
+      # `warning` with a ⚠ and the word "tentative", and saying that about a page whose only
+      # sin is a "3 filters applied" counter would be false.
+      note : String? = nil do
       def reachable? : Bool
         reachable
+      end
+
+      # How many candidate names one probe carries at `loc`. nil for a report that predates
+      # the location (specs, an unreachable baseline) — the caller falls back to its config.
+      def width_for(loc : Location) : Int32?
+        width[loc]?
+      end
+
+      # The control to diff a probe at `loc` against, or nil to diff against the plain
+      # baseline. Only a location that has one is padded (`Engine#pad_pairs`).
+      def reference_for(loc : Location) : Reference?
+        refs[loc]?
       end
     end
 
@@ -60,34 +157,60 @@ module Gori::Miner
     # stability + control wave going — the operator asked gori to stop touching the target and it
     # kept touching it. Defaults to "never stopped" so a caller that has no engine (specs, the
     # one-shot calibrate paths) is unchanged.
+    # Locations whose control VALUES came back in the response — an echo API, where reflection
+    # carries no discovery signal. Written by `control` at whatever width it ran at.
+    @echoed : Hash(Location, Bool)
+
     def initialize(@backend : Fuzz::Backend, @base : Bytes, @config : Config,
                    @stopped : Proc(Bool) = -> { false })
+      @echoed = Hash(Location, Bool).new
     end
 
-    def calibrate(locations : Array(Location)) : Report
+    # `widths` is the bucket width the run wants to use at each location — the width this
+    # calibration then CHECKS against the target and, where the target refuses it, lowers.
+    #
+    # The control bucket is sent at that width, not at a token 8. What a page does about eight
+    # unknown parameters is not what it does about 128 of them: an origin that 400s an
+    # oversized header set, a framework with a max_input_vars ceiling and a "N filters applied"
+    # counter all read as calm at 8 and react at the width the run then mines with — so the
+    # control answered a question nobody had asked, and every bucket of the run went on to
+    # bisect a reaction the calibration had been shaped to miss.
+    def calibrate(locations : Array(Location),
+                  widths : Hash(Location, Int32) = Hash(Location, Int32).new) : Report
       rounds = {@config.stability_rounds, 1}.max
       # Calibration is pure round-trip time and it runs BEFORE a single candidate is tested,
-      # so on a real target its cost is `stability_rounds + locations` RTTs of dead air at the
-      # head of every mine — on a 100ms origin that is most of a second before the run does
-      # anything. The probes do not depend on each other (the stability rounds are N copies of
-      # the same request; the controls are one independent bucket per location), so they go out
-      # concurrently, in two waves: the tolerance bands the controls are judged against come
-      # from the stability wave.
+      # so on a real target its cost is RTTs of dead air at the head of every mine — on a
+      # 100ms origin that is most of a second before the run does anything. The probes do not
+      # depend on each other (the stability rounds are N copies of the same request; the
+      # controls are one independent bucket per location), so they all go out in ONE wave.
+      #
+      # They used to go in TWO, stability then controls, because the controls are JUDGED
+      # against the tolerance the stability rounds establish. But judging is not sending: a
+      # control's bytes do not depend on the bands, only its verdict does. One RTT, not two.
       #
       # Indexed writes, not appends: `probes.first` is the round the whole report is built
       # from, so the answer must not depend on which fiber finished first.
       slots = Array(Probe?).new(rounds, nil)
-      # The first round's failure reason, kept for the `unreachable` report: when NO round
-      # answered, "baseline unreachable" alone sends the operator looking for a target problem
-      # that gori already has the name of (`connection refused`, a scope refusal, a timeout).
+      controls = Array(Probe?).new(locations.size, nil)
+      wide = locations.map { |loc| (widths[loc]? || 8).clamp(1, 1024) }
+      # The first STABILITY round's failure reason, kept for the `unreachable` report: when NO
+      # round answered, "baseline unreachable" alone sends the operator looking for a target
+      # problem gori already has the name of (`connection refused`, a scope refusal, a
+      # timeout). A control's failure is not that fact — it only costs the location its
+      # reference, and the location is then mined against the plain baseline as before.
       first_error = nil.as(String?)
-      in_parallel(rounds) do |i|
+      in_parallel(rounds + locations.size) do |i|
         next if @stopped.call
-        raw = send_with_retries(@base)
-        if err = raw.error
-          first_error ||= err
+        if i < rounds
+          raw = send_with_retries(@base)
+          if err = raw.error
+            first_error ||= err
+          else
+            slots[i] = Fingerprint.probe(raw)
+          end
         else
-          slots[i] = Fingerprint.probe(raw)
+          j = i - rounds
+          controls[j] = control(locations[j], wide[j], CONTROL_NAME_LEN)
         end
       end
       probes = slots.compact
@@ -111,21 +234,175 @@ module Gori::Miner
 
       reflection_only = Hash(Location, Bool).new
       reflects_all = Hash(Location, Bool).new
-      signals = Array({Bool, Bool}?).new(locations.size, nil)
-      in_parallel(locations.size) do |i|
-        next if @stopped.call
-        signals[i] = control_signals(locations[i], base, length_tol, words_tol, lines_tol)
-      end
-      locations.each_with_index do |loc, i|
-        reacts, echoes = signals[i] || {false, false}
-        reflection_only[loc] = reacts
-        reflects_all[loc] = echoes
+      refs = Hash(Location, Reference).new
+      width = Hash(Location, Int32).new
+      # Each location refines ITSELF — the width walk and the second control are sequential
+      # (each probe decides whether the next one is needed), but the locations are independent
+      # of each other and go in parallel, as their first controls just did.
+      settled = Array(Settled?).new(locations.size, nil)
+      in_parallel(locations.size) do |j|
+        settled[j] = settle(locations[j], wide[j], controls[j], base, length_tol, words_tol, lines_tol)
       end
 
+      refused = [] of Location
+      locations.each_with_index do |loc, j|
+        outcome = settled[j] || Settled.new(wide[j], controls[j], nil, false)
+        width[loc] = outcome.width
+        if reference = outcome.reference
+          refs[loc] = reference
+        end
+        reflection_only[loc] = outcome.mute?
+        refused << loc if outcome.refused
+        reflects_all[loc] = @echoed[loc]? || false
+      end
+
+      note = calibration_note(refs)
       Report.new(base.metrics.status, length_tol, words_tol, lines_tol,
         base.metrics.length, base.metrics.words, base.metrics.lines,
-        stable, reflection_only, reflects_all, baseline_warning(stable, statuses, reflects_all),
-        reachable: true)
+        stable, reflection_only, reflects_all,
+        baseline_warning(stable, statuses, reflects_all, reflection_only, refused),
+        reachable: true, refs: refs, width: width, note: note)
+    end
+
+    # Settle one location: find a width the target accepts, then decide whether the page's
+    # reaction to unknown parameters there is reproducible enough to mine against. Returns
+    # {width, the control probe at that width, the reference or nil, refused?}.
+    private def settle(loc : Location, want : Int32, first : Probe?, base : Probe,
+                       ltol : Int64, wtol : Int32, lntol : Int32) : Settled
+      w, p, refused = accepted_width(loc, want, first, base)
+      # A location that refuses every width gori tried cannot be compared against anything: its
+      # control IS the refusal, and mining against that reads every ordinary 200 as a Status
+      # finding — the whole wordlist reported as hidden parameters, at Confirmed confidence.
+      # Say so and disable metric findings there, which is what the flag is for — and hand back
+      # the width that was ASKED for, not the one the walk climbed down to. Metric findings are
+      # off either way, so the narrow width buys nothing and costs everything: at width 1 a
+      # 441-name wordlist is 441 refused requests instead of 4.
+      return Settled.new(want, p, nil, true) if refused
+      return Settled.new(w, p, nil, false) unless p
+      return Settled.new(w, p, nil, false) unless reacts?(p, base, ltol, wtol, lntol)
+      return Settled.new(w, p, nil, false) if @stopped.call
+
+      # It reacts to SOMETHING. Two more controls at the same width answer what to do about it:
+      #   twin — the same width AND the same name length, so its only difference from the first
+      #     is time. It is the jitter of this page UNDER INJECTION, which is not the jitter the
+      #     stability rounds measured, and it is the band every later probe is judged against.
+      #   long — the same width with LONGER names, so the bytes it moves are what the page
+      #     returns per byte of name it was handed (`echo`).
+      twin = control(loc, w, CONTROL_NAME_LEN)
+      return Settled.new(w, p, nil, false) unless twin
+      # Counts that do not reproduce mean a metric diff here means nothing — the fallback this
+      # flag has always been, now reached only when the reaction is genuinely unrepeatable.
+      return Settled.new(w, p, nil, false, mute: true) unless consistent?(p, twin, wtol, lntol)
+
+      bands = injected_bands(p, twin, ltol, wtol, lntol)
+      # Re-ask the reaction question against the bands measured UNDER INJECTION. A page whose
+      # only "reaction" was its own churn — a rotating element clearing a band that 4 samples
+      # of a quiet page had underestimated — is not reacting, and locking a single noisy sample
+      # in as the anchor for the whole run is strictly worse than the plain baseline it
+      # replaces. A page that still differs is reacting structurally, in bytes or in counts.
+      return Settled.new(w, p, nil, false) unless reacts?(p, base, *bands)
+      return Settled.new(w, p, nil, false) if @stopped.call
+
+      long = control(loc, w, CONTROL_NAME_LEN_LONG)
+      echo = long ? echo_factor(p, long, w, bands[0]) : 0.0
+      Settled.new(w, p, Reference.new(p, w, CONTROL_NAME_LEN, echo, *bands), false)
+    end
+
+    # {width, its control probe, still refused?}. Halve the width until the target stops
+    # REFUSING the request: a status the baseline never returned means the request was
+    # rejected, not that a parameter did something — a max_input_vars ceiling, an
+    # oversized-header refusal, a WAF rule on parameter count — and every bucket of the run
+    # would have been rejected the same way and then bisected down through its own 400s.
+    #
+    # A mismatch is CONFIRMED at the same width before the first halving. The width this
+    # returns is the width the whole run buckets at, so one transient 502 on one probe would
+    # otherwise collapse a 441-name mine from 4 requests to 441, permanently and silently.
+    private def accepted_width(loc : Location, want : Int32,
+                               first : Probe?, base : Probe) : {Int32, Probe?, Bool}
+      w = want
+      p = first
+      return {w, p, false} unless p && p.metrics.status != base.metrics.status
+      confirm = control(loc, w, CONTROL_NAME_LEN)
+      return {w, confirm || p, false} unless confirm && confirm.metrics.status != base.metrics.status
+      p = confirm
+      while p && p.metrics.status != base.metrics.status && w > MIN_CONTROL_WIDTH
+        break if @stopped.call
+        w = {w // 2, MIN_CONTROL_WIDTH}.max
+        p = control(loc, w, CONTROL_NAME_LEN)
+      end
+      {w, p, !p.nil? && p.metrics.status != base.metrics.status}
+    end
+
+    # The bands to judge a probe against when the location's control is the anchor: the
+    # report's, widened to twice whatever two identical controls disagreed by. Two samples is
+    # a thin estimate, which is why it only ever WIDENS — the report's band still applies as
+    # the floor.
+    private def injected_bands(a : Probe, b : Probe,
+                               ltol : Int64, wtol : Int32, lntol : Int32) : {Int64, Int32, Int32}
+      {
+        {ltol, (a.metrics.length - b.metrics.length).abs * 2}.max,
+        {wtol, (a.metrics.words - b.metrics.words).abs * 2}.max,
+        {lntol, (a.metrics.lines - b.metrics.lines).abs * 2}.max,
+      }
+    end
+
+    # How many bytes of response this page returns per byte of parameter NAME it was handed.
+    #
+    # The two controls differ by `span` bytes of name and by nothing else, so what the response
+    # length does across them is what the page does with the names. A move inside the ordinary
+    # band is not a move: the page does not print them back, this is 0, and the length metric
+    # keeps its full sensitivity — the common case, and the one where a widened band would cost
+    # real findings.
+    private def echo_factor(a : Probe, b : Probe, width : Int32, ltol : Int64) : Float64
+      span = (width * (CONTROL_NAME_LEN_LONG - CONTROL_NAME_LEN)).to_f
+      moved = (b.metrics.length - a.metrics.length).abs
+      return 0.0 unless span > 0 && moved > ltol
+      (moved / span).clamp(0.0, 8.0)
+    end
+
+    # One control probe: `width` names no application has ever heard of, each `name_len` bytes,
+    # each with its own canary value. nil when the send failed.
+    private def control(loc : Location, width : Int32, name_len : Int32) : Probe?
+      bogus = bogus_bucket(width, name_len)
+      raw = send_with_retries(Inject.apply(@base, loc, bogus, @config.add_content_length_when_missing?))
+      return nil unless raw.error.nil?
+      probe = Fingerprint.probe(raw)
+      # An endpoint that echoes its input does it at every width, so recording this as each
+      # control lands (rather than re-deriving it from one of them) keeps the answer with the
+      # bucket whose values it is actually about.
+      @echoed[loc] = true if bogus.any? { |(_, value)| probe.reflects?(value) }
+      probe
+    end
+
+    private def bogus_bucket(width : Int32, name_len : Int32) : Array({String, String})
+      n = width.clamp(1, 1024)
+      values = Canary.fresh_batch(n)
+      # DISTINCT names, from one draw: a control that carries the same name twice is one
+      # parameter narrower than every probe compared against it. See `Canary.bogus_batch`.
+      names = Canary.bogus_batch(n, name_len)
+      Array({String, String}).new(n) { |i| {names[i], values[i]} }
+    end
+
+    # Did the app answer a bucket of names it has never heard of differently at all? True ⇒ the
+    # plain baseline is not a valid reference here. Asked TWICE in `settle`, first against the
+    # bands the stability rounds measured and then against the bands two identical controls
+    # measured under injection — the second is what tells a page's structural reaction apart
+    # from its own churn.
+    private def reacts?(p : Probe, base : Probe,
+                        ltol : Int64, wtol : Int32, lntol : Int32) : Bool
+      p.metrics.status != base.metrics.status ||
+        (p.metrics.length - base.metrics.length).abs > ltol ||
+        (p.metrics.words - base.metrics.words).abs > wtol ||
+        (p.metrics.lines - base.metrics.lines).abs > lntol
+    end
+
+    # Do two same-width control buckets agree? On status and on the COUNT metrics only — the
+    # two carry names of different lengths on purpose, so their byte counts are meant to
+    # differ (that difference is what `echo` measures).
+    private def consistent?(a : Probe, b : Probe, wtol : Int32, lntol : Int32) : Bool
+      a.metrics.status == b.metrics.status &&
+        (a.metrics.words - b.metrics.words).abs <= wtol &&
+        (a.metrics.lines - b.metrics.lines).abs <= lntol
     end
 
     # Calibration was the miner's ONE un-retried send path, and an empty calibration is now
@@ -196,33 +473,29 @@ module Gori::Miner
       end
     end
 
-    # Inject a bucket of random non-existent names ONCE per location. Returns
-    # {metric_reacts, reflects_all}:
-    #   metric_reacts — the response moved beyond tolerance, so the app reacts to ANY
-    #     unknown param here → its metric-diff findings are noise (suppressed in `decide`).
-    #   reflects_all  — the bogus VALUES were echoed back, so the endpoint reflects ANY
-    #     input (an echo API, e.g. httpbin/get) → reflection is not a discovery signal
-    #     here and its reflection findings must be suppressed too, else every candidate
-    #     "reflects" and the run floods with false positives.
-    private def control_signals(loc : Location, base : Probe,
-                                ltol : Int64, wtol : Int32, lntol : Int32) : {Bool, Bool}
-      bogus = Array.new(8) { {Canary.bogus_name, Canary.fresh} }
-      raw = send_with_retries(Inject.apply(@base, loc, bogus, @config.add_content_length_when_missing?))
-      return {false, false} unless raw.error.nil?
-      p = Fingerprint.probe(raw)
-      reacts = p.metrics.status != base.metrics.status ||
-               (p.metrics.length - base.metrics.length).abs > ltol ||
-               (p.metrics.words - base.metrics.words).abs > wtol ||
-               (p.metrics.lines - base.metrics.lines).abs > lntol
-      echoes = bogus.any? { |(_, value)| p.reflects?(value) }
-      {reacts, echoes}
+    # The purely informational half: the comparison changed shape, nothing is downgraded.
+    private def calibration_note(refs : Hash(Location, Reference)) : String?
+      return nil if refs.empty?
+      "unknown parameters change the response at #{refs.keys.map(&.label).join("/")} — " \
+      "mined against a same-width control"
     end
 
     private def baseline_warning(stable : Bool, statuses : Array(Int32),
-                                 reflects_all : Hash(Location, Bool)) : String?
+                                 reflects_all : Hash(Location, Bool),
+                                 reflection_only : Hash(Location, Bool),
+                                 refused : Array(Location)) : String?
+      # Only conditions that DOWNGRADE findings belong here (`confidence_for` reads the same
+      # facts, and every surface renders this string as a warning). The comparison having
+      # changed shape is not one of them — that is `calibration_note`.
       notes = [] of String
       notes << "baseline status varies (#{statuses.join("/")})" unless stable
       notes << "endpoint echoes input at some locations — reflection findings disabled there" if reflects_all.any? { |_, v| v }
+      # A refusal is the harder half of `reflection_only` and deserves its own sentence: the
+      # operator can act on "it rejects every width I tried" (raise --bucket's ceiling? mine a
+      # different location?) and cannot act on "unpredictable".
+      notes << "#{refused.map(&.label).join("/")} refuses every bucket width gori tried — metric findings disabled there" unless refused.empty?
+      mute = (reflection_only.select { |_, v| v }.keys - refused)
+      notes << "unknown parameters change the response unpredictably at #{mute.map(&.label).join("/")} — metric findings disabled there" unless mute.empty?
       return nil if notes.empty?
       "#{notes.join("; ")} — findings tentative"
     end
@@ -239,8 +512,20 @@ module Gori::Miner
 
   # Compare a probe to the baseline: which canaries reflected, and the strongest metric
   # diff (suppressed when the location is reflection-only).
+  #
+  # `reference`, when present, is the location's calibrated control — a bucket of bogus names
+  # exactly as wide as every probe of this run (see `Baseline::Reference`). It replaces the
+  # untouched baseline as the metric reference on a page that reacts to unknown parameters at
+  # all, which is the ordinary case: a "3 filters applied" counter, a canonical link that
+  # lists what was received, an error page that quotes the query. Against the plain baseline
+  # those pages move on EVERY probe, which is why the location used to be written off
+  # wholesale (`reflection_only`) and found nothing at all.
+  #
+  # `byte_delta` is how many more bytes of parameter NAME the probe carries than that control
+  # (`Engine#byte_delta`), and it only matters for the length metric — see `strongest`.
   def self.decide(report : Baseline::Report, probe : Probe,
-                  candidates : Array({String, String}), location : Location) : Decision
+                  candidates : Array({String, String}), location : Location,
+                  reference : Baseline::Reference? = nil, byte_delta : Int32 = 0) : Decision
     reflected = Hash(String, String).new
     # Skip reflection detection on an echo endpoint (reflects ANY input): there every
     # candidate would "reflect", so it carries no discovery signal — only noise.
@@ -252,18 +537,88 @@ module Gori::Miner
     kind = DiffKind::None
     unless report.reflection_only[location]?
       m = probe.metrics
-      kind = if m.status != report.status
+      ref = reference.try(&.probe.metrics)
+      kind = if m.status != (ref ? ref.status : report.status)
                DiffKind::Status
-             elsif (m.length - report.base_length).abs > report.length_tol
-               DiffKind::Length
-             elsif (m.words - report.base_words).abs > report.words_tol
-               DiffKind::Words
-             elsif (m.lines - report.base_lines).abs > report.lines_tol
-               DiffKind::Lines
              else
-               DiffKind::None
+               strongest(m, anchor_for(ref, report), bands_for(reference, report),
+                 reference.try(&.echo), byte_delta)
              end
     end
     Decision.new(reflected, kind)
+  end
+
+  # The {length, words, lines} a probe is measured FROM: the location's control when there is
+  # one, the untouched baseline otherwise.
+  private def self.anchor_for(ref : Fuzz::Metrics?,
+                              report : Baseline::Report) : {Int64, Int32, Int32}
+    if r = ref
+      {r.length, r.words, r.lines}
+    else
+      {report.base_length, report.base_words, report.base_lines}
+    end
+  end
+
+  # The bands a probe at this location is judged against: the reference's when there is one
+  # (measured from two identical controls, so they carry the page's jitter UNDER INJECTION),
+  # the report's otherwise.
+  private def self.bands_for(reference : Baseline::Reference?,
+                             report : Baseline::Report) : {Int64, Int32, Int32}
+    if r = reference
+      {r.length_tol, r.words_tol, r.lines_tol}
+    else
+      {report.length_tol, report.words_tol, report.lines_tol}
+    end
+  end
+
+  # The metric whose move is the LARGEST RELATIVE TO ITS OWN BAND, among those that moved
+  # beyond it — not the first one in a fixed order, which is what this was.
+  #
+  # The bands differ per metric by design (bytes are noisier than lines), so a fixed
+  # Length-then-Words-then-Lines order hands the verdict to whichever metric is NOISIEST.
+  # Measured against a page with a 400-byte rotating element and a hidden parameter worth
+  # +15 words / +5 lines: length randomly cleared its 358-byte band on ~40% of probes and the
+  # bucket was reported as `Length` — a kind the isolated name then could not reproduce, so
+  # `confirm` dropped a parameter both count metrics had identified unambiguously. Ratio
+  # ordering picks Words (5x its band) over Length (1.2x) and the finding survives.
+  #
+  # Compared as cross-multiplied integers (`a/band_a > b/band_b` <=> `a*band_b > b*band_a`),
+  # so there is no float and no divide-by-zero on a zero-width band. Ties keep the old order,
+  # so a page whose metrics all move together reports exactly what it always did.
+  private def self.strongest(m : Fuzz::Metrics, anchor : {Int64, Int32, Int32},
+                             bands : {Int64, Int32, Int32}, echo : Float64?,
+                             byte_delta : Int32) : DiffKind
+    kind = DiffKind::None
+    best_excess = 0_i64
+    best_band = 1_i64
+
+    # LENGTH against a control needs one correction the counts do not: the control's names are
+    # gori's own bogus tokens, so on a page that prints back what it received the response's
+    # byte count also moves by the difference between those names and the candidates' — a
+    # difference the MINER chose, not one the target revealed. `echo` is how many bytes of
+    # response that page returns per byte of name (measured from two controls of the same
+    # width and different name lengths: 0 for a page that prints nothing back, ~1 for one that
+    # does), so the band absorbs exactly that much and no more. Off a plain baseline the
+    # correction is zero and this is the comparison it always was.
+    d = (m.length - anchor[0]).abs
+    band = bands[0] + (echo ? (echo * byte_delta.abs).ceil.to_i64 : 0_i64)
+    if d > band
+      kind, best_excess, best_band = DiffKind::Length, d, {band, 1_i64}.max
+    end
+
+    wd = (m.words - anchor[1]).abs.to_i64
+    if wd > bands[1]
+      wband = {bands[1].to_i64, 1_i64}.max
+      if wd * best_band > best_excess * wband
+        kind, best_excess, best_band = DiffKind::Words, wd, wband
+      end
+    end
+
+    ld = (m.lines - anchor[2]).abs.to_i64
+    if ld > bands[2]
+      lband = {bands[2].to_i64, 1_i64}.max
+      kind = DiffKind::Lines if ld * best_band > best_excess * lband
+    end
+    kind
   end
 end

--- a/src/gori/miner/engine.cr
+++ b/src/gori/miner/engine.cr
@@ -89,6 +89,12 @@ module Gori::Miner
     @idle : Channel(Nil)
     # Per-location cache of the names the base request already carries — see `present_at`.
     @present : Hash(Location, Set(String))
+    # Per-location caches of the name filtering, which is pure over `@names` + `@base`.
+    @carriable : Hash(Location, Array(String))
+    @valid : Hash(Location, Array(String))
+    # Form-encoded byte size per candidate name — see `encoded_name_bytes`. Keyed by name
+    # alone: query and form encode identically, and no other location encodes at all.
+    @encoded : Hash(String, Int32)
 
     # The first per-send failure reason of the run. `@errors` counts refusals and drops the
     # string, which is how a scope-blocked run could report "0 found" and exit 0 with the
@@ -140,6 +146,9 @@ module Gori::Miner
       @inflight = 0
       @idle = Channel(Nil).new(1)
       @present = Hash(Location, Set(String)).new
+      @carriable = Hash(Location, Array(String)).new
+      @valid = Hash(Location, Array(String)).new
+      @encoded = Hash(String, Int32).new
     end
 
     # The number of distinct (name × location) tests this run will perform — the stable
@@ -200,7 +209,12 @@ module Gori::Miner
         @events.send(DoneEvent.new(snapshot, true))
         return
       end
-      report = Baseline.new(@backend, @base, @config, -> { @state.stopped? }).calibrate(@config.locations)
+      # The width the run will actually mine each location at, derived BEFORE calibration so
+      # the control bucket can be sent at that width (see `Baseline#calibrate`) — a control
+      # eight names wide answers a question about eight names, and the run then sends 128.
+      widths = Hash(Location, Int32).new
+      @config.locations.each { |loc| widths[loc] = bucket_width(loc) }
+      report = Baseline.new(@backend, @base, @config, -> { @state.stopped? }).calibrate(@config.locations, widths)
       # A stop that landed DURING calibration, which the check above cannot catch: the predicate
       # handed to `Baseline` kept the remaining probes off the wire, so `report` describes a wave
       # that never finished. Publishing it would claim a baseline was established.
@@ -209,7 +223,7 @@ module Gori::Miner
         return
       end
       @report = report
-      @events.send(BaselineEvent.new(report.stable, report.warning))
+      @events.send(BaselineEvent.new(report.stable, report.warning, report.note))
       # A baseline that never answered is not a baseline. Its `Report` carries placeholders —
       # `status: nil`, every tolerance 0 — and `decide` reads them literally, so mining on one
       # made EVERY candidate a Status finding (nil != 200) and every bucket bisect down to its
@@ -366,7 +380,10 @@ module Gori::Miner
       # so the send seam protects them from session-binding expansion. Without this a `$NAME`
       # a param wordlist carries — or an injected byte colliding with a bound name — expands
       # to the live credential and leaves gori for the target, the run reporting `0 errors`.
-      bytes, spans = Inject.apply_with_spans(@base, task.location, pairs, @config.add_content_length_when_missing?)
+      # Resolved ONCE for the send: the padding, the byte delta and the decision all need it.
+      ref = report.reference_for(task.location)
+      bytes, spans = Inject.apply_with_spans(@base, task.location, pad_pairs(pairs, ref),
+        @config.add_content_length_when_missing?)
       # Nothing was injected, so this location cannot carry candidates in THIS request — e.g.
       # a request line that is not METHOD SP TARGET SP VERSION, which `inject_query` bails on
       # unmodified rather than rewrite the operator's bytes (P7, and it is right to). Sending
@@ -401,7 +418,7 @@ module Gori::Miner
       end
 
       probe = Fingerprint.probe(raw)
-      decision = Miner.decide(report, probe, pairs, task.location)
+      decision = Miner.decide(report, probe, pairs, task.location, ref, byte_delta(pairs, ref, task.location))
 
       # Reflection is self-identifying — resolve those names with no bisection. `reflected`
       # maps canary → name, so the confirming canary is in hand without a name→canary lookup.
@@ -484,9 +501,17 @@ module Gori::Miner
 
       # Once `majority` matching rounds land, `reproduced` is locked true and no further round
       # can change the verdict — so stop re-sending. Saves the tail confirm requests for every
-      # finding whose signal reproduces early (the common case, e.g. confirm_rounds=2 → 1 round);
-      # the classification is identical, and a run that never reaches majority still runs them all.
-      majority = (rounds + 1) // 2
+      # finding whose signal reproduces early; the classification is identical, and a run that
+      # never reaches majority still runs them all.
+      #
+      # A REAL majority — `(rounds + 1) // 2` made the default `confirm_rounds: 2` mean "one of
+      # two rounds is enough", which was already thin and became unsafe once the isolated
+      # re-test stopped having to reproduce the same METRIC (`matches_evidence?`): one 429 or
+      # 503 from a rate limiter during confirmation is a Status diff, and a single such round
+      # would confirm any name a jittery bucket had nominated, relabelled as Status with the
+      # rate limiter's own code as its evidence. Two rounds have to agree now, at a cost of one
+      # request per finding.
+      majority = rounds // 2 + 1
       hits = 0
       last_status = nil.as(Int32?)
       last_delta = 0_i64
@@ -494,6 +519,13 @@ module Gori::Miner
       last_grpc_status = nil.as(Int32?)
       last_grpc_message = nil.as(String?)
       interval = pace_interval
+      ref = r.reference_for(location)
+      # The delta a finding REPORTS is measured from whatever it was compared against. Off a
+      # width-matched control that is the control's own length: the confirm round carried
+      # `width - 1` padding names, so against the untouched baseline the number the TUI, the
+      # CLI row and MCP all print as "observed length delta" would be the padding's bulk —
+      # kilobytes on a page that answers a row per parameter — and not what the parameter did.
+      anchor = ref ? ref.probe.metrics.length : r.base_length
       rounds.times do
         # A confirm round is a REQUEST, so the stop flag has to be read here and not only at
         # the top of the bucket: `process_bucket` checks it once on entry, and everything below
@@ -505,7 +537,8 @@ module Gori::Miner
         break if @state.stopped?
         c = Canary.fresh
         # Same span-protection as the main loop — the confirm re-send injects the same name.
-        bytes, spans = Inject.apply_with_spans(@base, location, [{name, c}], @config.add_content_length_when_missing?)
+        bytes, spans = Inject.apply_with_spans(@base, location, pad_pairs([{name, c}], ref),
+          @config.add_content_length_when_missing?)
         # A confirm round is a REQUEST. Only the bucket send that produced this candidate was
         # paced by the dispatch loop, so these ran on top of the operator's rate — up to
         # `confirm_rounds` extra unpaced requests for every candidate that shows signal.
@@ -524,13 +557,19 @@ module Gori::Miner
           next
         end
         probe = Fingerprint.probe(raw)
-        decision = Miner.decide(r, probe, [{name, c}], location)
+        decision = Miner.decide(r, probe, [{name, c}], location, ref,
+          byte_delta([{name, c}], ref, location))
         if matches_evidence?(decision, evidence, name)
           hits += 1
+          # The isolated round is the better measurement of WHAT this parameter does: the
+          # bucket's kind was decided with up to `bucket_size` other names in the request, and
+          # a name whose effect is a status change can easily read as Length inside one. Report
+          # what the name did alone.
+          evidence = evidence_of(decision.kind) unless evidence.reflection? || decision.kind.none?
           # Only record status/delta from a round that actually reproduced the signal, so a
           # Confirmed finding's reported evidence can't come from a non-matching (flaky) round.
           last_status = probe.metrics.status
-          last_delta = probe.metrics.length - r.base_length
+          last_delta = probe.metrics.length - anchor
           last_canary = c if evidence.reflection?
           # Same projection the Fuzzer uses (`Fuzz::GrpcVerdict.response`): the h2 `:status`
           # above is 200 for every gRPC call, so for a gRPC target this — not `last_status` —
@@ -550,11 +589,23 @@ module Gori::Miner
       (reproduced && r.stable && !r.reflection_only[location]?) ? Confidence::Confirmed : Confidence::Tentative
     end
 
+    # Did the isolated re-test reproduce the signal the bucket nominated this name for?
+    #
+    # For a metric nomination this asks "does this name still move the response", NOT "does it
+    # move the SAME metric". Demanding the identical kind conflated the two and dropped real
+    # parameters: the bucket's kind is measured with up to `bucket_size` other names in the
+    # request, so a name that returns 500 alone can read as Length inside a bucket whose
+    # status was already 200 — evidence Status vs kind Length, no match, no finding, and
+    # nothing anywhere saying a candidate had been seen and thrown away. A name that moves
+    # the response ALONE, reproducibly, is the thing the miner exists to report; which of the
+    # four metrics carried it is a label, and `confirm` now relabels it from the isolated
+    # round. False positives are still held off by the same two gates as before — the name
+    # has to clear the calibrated band on a MAJORITY of rounds.
     private def matches_evidence?(decision : Decision, evidence : Evidence, name : String) : Bool
       if evidence.reflection?
         decision.reflected.has_value?(name)
       else
-        decision.kind == diffkind_of(evidence)
+        !decision.kind.none?
       end
     end
 
@@ -568,42 +619,116 @@ module Gori::Miner
       end
     end
 
-    private def diffkind_of(evidence : Evidence) : DiffKind
-      case evidence
-      in Evidence::Reflection then DiffKind::None
-      in Evidence::Status     then DiffKind::Status
-      in Evidence::Length     then DiffKind::Length
-      in Evidence::Words      then DiffKind::Words
-      in Evidence::Lines      then DiffKind::Lines
+    # ── buckets + name filtering ────────────────────────────────────────────────────
+
+    # The number of candidate names one probe carries at `loc`: the configured bucket size,
+    # lowered only if that many of THIS wordlist's names could not fit the location's byte
+    # budget. Derived from the widest name, so it is a single number for the whole location —
+    # which is what a width-matched control needs (`Baseline#calibrate`): every probe of the
+    # run carries exactly this many parameters, so the control's reaction cancels against the
+    # probe's and only the candidate's own effect is left.
+    private def bucket_width(loc : Location) : Int32
+      cap = @config.bucket_for(loc)
+      names = valid_names_for(loc)
+      return cap if names.empty?
+      budget = byte_budget(loc)
+      return cap if budget == Int32::MAX
+      worst = names.max_of { |n| name_cost(n, loc) }
+      return cap if worst <= 0
+      {cap, {budget // worst, 1}.max}.min
+    end
+
+    # Per-request byte ceiling for the location, or Int32::MAX where there is none.
+    private def byte_budget(loc : Location) : Int32
+      if loc.query? || loc.form?
+        Inject::MAX_URL_BYTES
+      elsif loc.json?
+        MAX_JSON_INJECT_BYTES
+      else
+        Int32::MAX
       end
     end
 
-    # ── buckets + name filtering ────────────────────────────────────────────────────
+    # What one name costs on the wire at `loc`: the ENCODED name (a name with reserved chars
+    # expands under URI.encode_www_form, so the raw bytesize would under-budget the URL and a
+    # bucket could overflow MAX_URL_BYTES → 414), its canary, the separators — times the JSON
+    # node count, since a JSON candidate is injected into EVERY object node.
+    private def name_cost(n : String, loc : Location) : Int32
+      (encoded_name_bytes(n, loc) + Canary::LEN + 2) * (loc.json? ? json_nodes : 1)
+    end
+
+    # Object nodes in the BASE body — fixed for the run (the node set never varies with bucket
+    # size, so bisection and confirmation stay valid), so derived once.
+    @json_nodes : Int32? = nil
+
+    private def json_nodes : Int32
+      @json_nodes ||= {Inject.json_object_node_count(Inject.split(@base)[1], Inject::MAX_JSON_NODES), 1}.max
+    end
+
+    # Extend a probe's candidate list with bogus names to the location's calibrated width, so
+    # every request of the run — initial bucket, bisection child, confirmation round — carries
+    # the SAME number of parameters as the control it is compared against. Without this the
+    # comparison changes shape as the bisection narrows, and on a page that reacts to unknown
+    # parameters (a "3 filters applied" counter, an error page that lists what it received)
+    # the reaction itself is what the reference cancels.
+    #
+    # The padding is NOT in the candidate list handed to `decide`, so a bogus name can never
+    # become a finding, and its canary is never looked up.
+    private def pad_pairs(pairs : Array({String, String}),
+                          ref : Baseline::Reference?) : Array({String, String})
+      return pairs unless ref && pairs.size < ref.width
+      extra = ref.width - pairs.size
+      values = Canary.fresh_batch(extra)
+      # Padding names carry the CONTROL's own length, so the only byte difference left between
+      # a probe and its reference is the candidate names themselves — which is exactly what
+      # `byte_delta` measures and the length band is widened by. One draw for the whole batch,
+      # and DISTINCT by construction: see `Canary.bogus_batch`.
+      names = Canary.bogus_batch(extra, ref.name_len)
+      padded = Array({String, String}).new(ref.width)
+      padded.concat(pairs)
+      extra.times { |i| padded << {names[i], values[i]} }
+      padded
+    end
+
+    # How many more (or fewer) bytes of parameter NAME this probe carries than the location's
+    # control did. A page that prints back what it received returns that difference in its own
+    # byte count — and the difference is gori's own doing, so `decide` widens the length band
+    # by `echo x this` instead of reading it as a finding.
+    private def byte_delta(pairs : Array({String, String}),
+                           ref : Baseline::Reference?, loc : Location) : Int32
+      return 0 unless ref
+      mine = pairs.sum(0) { |(n, _)| encoded_name_bytes(n, loc) }
+      pad = {ref.width - pairs.size, 0}.max * ref.name_len
+      (mine + pad - ref.name_bytes) * (loc.json? ? json_nodes : 1)
+    end
+
+    # Memoized per location: the encoded size is pure over {name, location} and fixed for the
+    # run, and this is on the hot path — `byte_delta` asks it for every candidate of every
+    # send, which without the memo re-ran `URI.encode_www_form` (and allocated a throwaway
+    # String) 128 times per probe to recompute a number the bucketing had already computed.
+    # Only query/form encode at all; everywhere else the name's own `bytesize` is the answer.
+    private def encoded_name_bytes(n : String, loc : Location) : Int32
+      return n.bytesize unless loc.query? || loc.form?
+      (@encoded[n] ||= URI.encode_www_form(n).bytesize)
+    end
 
     private def initial_buckets(loc : Location, names : Array(String)) : Array(Task)
-      cap = @config.bucket_for(loc)
-      url_loc = loc.query? || loc.form?
-      # JSON injects each candidate into EVERY object node, so a name's real byte cost is the
-      # per-name cost × node count. Derive the count ONCE from @base (fixed → the node set never
-      # varies with bucket size, so bisection/confirm stay valid) and bound per-request growth.
-      json_nodes = loc.json? ? {Inject.json_object_node_count(Inject.split(@base)[1], Inject::MAX_JSON_NODES), 1}.max : 1
-      byte_budget = if url_loc
-                      Inject::MAX_URL_BYTES
-                    elsif loc.json?
-                      MAX_JSON_INJECT_BYTES
-                    else
-                      Int32::MAX
-                    end
+      # The CALIBRATED width, not the configured one: the target may have refused the width the
+      # config asked for (`Baseline#settle`), and at a location with a width-matched control
+      # the comparison is only valid while every probe carries the same number of parameters —
+      # `pad_pairs` can pad a short bucket UP but nothing can shrink an over-wide one.
+      cap = @report.try(&.width_for(loc)) || @config.bucket_for(loc)
+      budget = byte_budget(loc)
       buckets = [] of Task
       cur = [] of String
       cur_bytes = 0
       names.each do |n|
-        # Count the ENCODED size for query/form — a name with reserved chars (e.g. "v2/x")
-        # expands under URI.encode_www_form, so the raw bytesize would under-budget the URL
-        # and a bucket could overflow MAX_URL_BYTES → 414. For Json, multiply by the node count.
-        # (One-time cost during bucketing.)
-        nb = ((url_loc ? URI.encode_www_form(n).bytesize : n.bytesize) + Canary::LEN + 2) * (loc.json? ? json_nodes : 1)
-        if !cur.empty? && (cur.size >= cap || cur_bytes + nb > byte_budget)
+        # `name_cost` counts the ENCODED size for query/form — a name with reserved chars
+        # (e.g. "v2/x") expands under URI.encode_www_form, so the raw bytesize would
+        # under-budget the URL and a bucket could overflow MAX_URL_BYTES → 414 — and multiplies
+        # by the JSON node count, since a JSON candidate is injected into every object node.
+        nb = name_cost(n, loc)
+        if !cur.empty? && (cur.size >= cap || cur_bytes + nb > budget)
           buckets << Task.new(loc, cur)
           cur = [] of String
           cur_bytes = 0
@@ -621,6 +746,15 @@ module Gori::Miner
     # the operator's own value, so testing a visible name corrupted the request AND reported it
     # back as a hidden parameter).
     private def valid_names_for(loc : Location) : Array(String)
+      @valid[loc] ||= compute_valid_names(loc)
+    end
+
+    # Memoized: `@names` and `@base` are both fixed for the run, so this answer cannot change
+    # — and it was recomputed over the WHOLE wordlist on every call, including the two
+    # coverage accessors (`skipped_names`, `present_names`) that a live surface polls while
+    # the run is going (MCP `mine_status`, the TUI tab). A 100k-name user wordlist made each
+    # poll a full re-filter of the list, per location, for a number that never moves.
+    private def compute_valid_names(loc : Location) : Array(String)
       present = present_at(loc)
       return carriable_names_for(loc) if present.empty?
       # Header field names are case-insensitive, so `X-Api-Key` in the request rules out a
@@ -632,6 +766,10 @@ module Gori::Miner
     # Wordlist names the location can carry at all (a header/cookie name must be an RFC 7230
     # token; a framing header is never injected).
     private def carriable_names_for(loc : Location) : Array(String)
+      @carriable[loc] ||= compute_carriable_names(loc)
+    end
+
+    private def compute_carriable_names(loc : Location) : Array(String)
       case loc
       when Location::Headers   then @names.select { |n| Inject.valid_header_name?(n) }
       when Location::Cookies   then @names.select { |n| Inject.valid_cookie_name?(n) }

--- a/src/gori/miner/fingerprint.cr
+++ b/src/gori/miner/fingerprint.cr
@@ -51,7 +51,14 @@ module Gori::Miner
       last = bytes.size - Canary::LEN
       i = 0
       while i <= last
-        if bytes.unsafe_fetch(i) == 0x67_u8 && bytes.unsafe_fetch(i + 1) == 0x71_u8 && canary_tail?(bytes, i + 2)
+        # `Slice(UInt8)#index` is memchr, so the bytes BETWEEN candidate starts are skipped by
+        # libc a word at a time instead of one comparison each in Crystal. Every response body
+        # of the run is walked here, and a `g` is ~2% of ordinary text — so 98% of the walk was
+        # a loop doing nothing but failing its first test.
+        break unless found = bytes.index(0x67_u8, i)
+        break if found > last
+        i = found
+        if bytes.unsafe_fetch(i + 1) == 0x71_u8 && canary_tail?(bytes, i + 2)
           into << String.new(bytes[i, Canary::LEN])
         end
         i += 1
@@ -79,16 +86,35 @@ module Gori::Miner
       words = 0
       lines = 0
       in_word = false
-      body.each do |b|
-        if b == 0x20_u8 || b == 0x09_u8 || b == 0x0a_u8 || b == 0x0d_u8
+      ptr = body.to_unsafe
+      i = 0
+      n = body.size
+      while i < n
+        b = ptr[i]
+        # One table load instead of the four comparisons this byte used to fail in sequence.
+        # Every byte of every response body of the run passes through here, and the common
+        # byte — an ordinary letter mid-word — is the one that had to fail all four.
+        if SPACE.unsafe_fetch(b)
           in_word = false
           lines += 1 if b == 0x0a_u8
         elsif !in_word
           in_word = true
           words += 1
         end
+        i += 1
       end
       {words, lines}
+    end
+
+    # The whitespace set `count_metrics` splits words on — the same four bytes
+    # `Fuzz::Matcher` uses, as a 256-way lookup so the test is a load rather than a chain.
+    private SPACE = begin
+      t = StaticArray(Bool, 256).new(false)
+      t[0x20] = true
+      t[0x09] = true
+      t[0x0a] = true
+      t[0x0d] = true
+      t
     end
   end
 end

--- a/src/gori/miner/types.cr
+++ b/src/gori/miner/types.cr
@@ -144,7 +144,11 @@ module Gori
     # Engine → consumer events. A union of records (matches Fuzz's pattern so a
     # Channel(Event) carries them without boxing). Progress is droppable (latest wins);
     # Baseline/Finding/Done/Error are never dropped.
-    record BaselineEvent, stable : Bool, warning : String?
+    # `warning` names a condition that DOWNGRADES this run's findings (the status varied, the
+    # endpoint echoes any input, a location had to be muted); `note` only reports how the run
+    # had to be calibrated — a location mined against a same-width control is a healthy mine,
+    # and every surface renders `warning` as a warning.
+    record BaselineEvent, stable : Bool, warning : String?, note : String? = nil
     record FindingEvent, finding : Finding
     record ProgressEvent, progress : Progress
     record DoneEvent, progress : Progress, stopped : Bool
@@ -174,9 +178,44 @@ module Gori
       end
 
       # A random name that almost certainly does not exist — for the per-location
-      # baseline control (does the app react to ANY unknown param here?).
-      def self.bogus_name : String
-        "zz#{Random::Secure.hex(5)}"
+      # baseline control (does the app react to ANY unknown param here?) and for the padding
+      # that keeps every probe of the run the same width as that control.
+      #
+      # `len` is the name's total byte length, because the control has to be able to say what
+      # a page does about the LENGTH of the names it is handed as distinct from how many of
+      # them there were (`Baseline::Reference#echo`). Odd lengths get one extra hex digit and
+      # are then trimmed, so the name is always exactly `len` bytes of `zz` + lower hex.
+      def self.bogus_name(len : Int32 = 12) : String
+        n = len.clamp(3, 128)
+        "zz#{Random::Secure.hex((n - 1) // 2)}"[0, n]
+      end
+
+      # `n` bogus names of exactly `len` bytes, GUARANTEED DISTINCT, from one CSPRNG draw.
+      #
+      # Two reasons this is not `n` calls to `bogus_name`. The names must be distinct: a
+      # control bucket that carries the same name twice is one parameter NARROWER than the
+      # probes measured against it, so on a page that reacts to how many parameters it was
+      # handed, every single probe then shows the extra row and the whole wordlist bisects to
+      # nothing (at the control length of 8 bytes — 3 random hex digits — a 128-wide bucket
+      # collides 0.05% of the time, a 1024-wide one 2.85%). And one draw, not `n`: a padded
+      # confirm round mints up to `bucket_size` of these BEFORE a byte goes on the wire, which
+      # is the same `getrandom`-per-name cost `fresh_batch` exists to avoid.
+      #
+      # The last `INDEX_DIGITS` hex digits carry the index, so distinctness is by construction
+      # rather than by luck. A name too short to hold them (len < 6) falls back to random and
+      # is unique only by chance — no caller asks for one.
+      INDEX_DIGITS = 3
+
+      def self.bogus_batch(n : Int32, len : Int32) : Array(String)
+        return [] of String if n <= 0
+        size = len.clamp(3, 128)
+        hex = (size - 1) // 2
+        raw = Random::Secure.random_bytes(hex * n)
+        Array(String).new(n) do |i|
+          name = "zz#{raw[i * hex, hex].hexstring}"[0, size]
+          next name if size < 2 + INDEX_DIGITS + 1
+          "#{name[0, size - INDEX_DIGITS]}#{(i % 4096).to_s(16).rjust(INDEX_DIGITS, '0')}"
+        end
       end
     end
 

--- a/src/gori/tui/miner_view.cr
+++ b/src/gori/tui/miner_view.cr
@@ -47,6 +47,7 @@ module Gori::Tui
       @stop_requested = false
       @baseline_stable = true
       @baseline_warning = nil.as(String?)
+      @baseline_note = nil.as(String?)
       @progress = Miner::Progress.new(0, 0, 0, 0, 0)
       @results = [] of Miner::Finding
 
@@ -336,6 +337,7 @@ module Gori::Tui
       @sel = 0
       @progress = Miner::Progress.new(0, 0, 0, 0, 0)
       @baseline_warning = nil
+      @baseline_note = nil
       @baseline_stable = true
     end
 
@@ -367,6 +369,7 @@ module Gori::Tui
     def apply_baseline(ev : Miner::BaselineEvent) : Nil
       @baseline_stable = ev.stable
       @baseline_warning = ev.warning
+      @baseline_note = ev.note
     end
 
     def append_finding(f : Miner::Finding) : Nil
@@ -532,13 +535,25 @@ module Gori::Tui
         line = "found #{@progress.found} · #{@progress.names_done}/#{@progress.names_total} names · #{@progress.sent} sent · #{@progress.errors} err"
         screen.text(x, y, line, Theme.muted, Theme.bg, width: rect.w - 4)
       end
-      y += 1
+      render_notices(screen, rect, x, y + 1)
+    end
+
+    # The card's tail: the budget note, the baseline WARNING, and — separately, and not drawn
+    # as a warning — the baseline NOTE. Each takes the next row only if one is left, so a
+    # short card drops the least important first.
+    private def render_notices(screen : Screen, rect : Rect, x : Int32, y : Int32) : Nil
       if budget_exhausted? && y < rect.bottom - 1
         screen.text(x, y, budget_note, Theme.yellow, Theme.bg, width: rect.w - 4)
         y += 1
       end
       if (w = @baseline_warning) && y < rect.bottom - 1
         screen.text(x, y, "⚠ #{w}", Theme.yellow, Theme.bg, width: rect.w - 4)
+        y += 1
+      end
+      # Not a caveat and not painted like one: this says the COMPARISON changed shape, which is
+      # how an ordinary page that reacts to unknown parameters gets mined at all.
+      if (n = @baseline_note) && y < rect.bottom - 1
+        screen.text(x, y, n, Theme.muted, Theme.bg, width: rect.w - 4)
       end
     end
 


### PR DESCRIPTION
A mine calibrates by asking the target what it does about parameters it has never heard of. It asked with **eight** of them and then sent **128** — so the control answered a question nobody had asked, and three ordinary kinds of web page came back completely blind: 0 of 5 hidden parameters found, 9 requests, exit 0.

## Measured

New harness `bench/miner_quality_bench.cr` — the existing three miner benches all ask "how fast", none asked "what does it find and what does it miss". 441-name built-in wordlist, 5 hidden parameters, each hit worth ~4% of the page, 15 runs per row.

| origin | before (sent · found · FP) | after |
|---|---|---|
| clean page | 68 · 5.00/5 · 0 | 73 · 5.00/5 · 0 |
| param-count reactive | 9 · **0.00/5** · 0 | 75 · **5.00/5** · 0 |
| echoes param names | 9 · **0.00/5** · 0 | 75 · **5.00/5** · 0 |
| bytes-only reaction | 9 · **0.00/5** · 0 | 75 · **5.00/5** · 0 |
| 400 over 100 params | 9 · **0.00/5** · 0 | 78 · **5.00/5** · 0 |
| jittery body | 68 · 4.93/5 · 0 | 75 · **5.00/5** · 0 |
| oversized-cookie 400 | 85 · 5.00/5 · 0 | 86 · 5.00/5 · 0 |
| 403 on any unknown | 9 · 0.00/5 · 0 | 17 · 0.00/5 · **0** |

`miner_perf_bench`: 212 requests / 17 found → 204 / 17, transport time unchanged.

## False negatives

- **The control goes out at the width the run will use**, and a location that reacts to unknown parameters is mined *against* that control rather than written off (`reflection_only`). Every probe — bucket, bisection child, confirmation round — is padded to that width, so the page's reaction sits on both sides of the diff and cancels. A "3 filters applied" counter, a page that lists what it received, an error page that quotes the query: all found nothing before.
- **`decide` picks the metric that moved furthest past its own band**, not the first in a fixed order. The bands differ per metric by design, so a fixed order hands the verdict to whichever metric is noisiest — on a page with a 400-byte rotating element, length cleared its band on ~40% of probes and buried a Words signal five times its own band.
- **`confirm` asks whether the isolated name still moves the response**, not whether it moves the *same* metric; the evidence is relabelled from the isolated round.
- **A width the target refuses is halved until it accepts one**, instead of being sent anyway and having the refusal bisected 400 times.

## False positives

- **A reaction only counts once it reproduces.** Two identical-width controls measure the page's jitter *under injection*, and those bands — not the quiet page's — are what later probes are judged against.
- **A control the target refused never becomes a reference.** Mining against a refusal reads every ordinary 200 as a Status diff: the whole wordlist reported as hidden parameters, at Confirmed confidence.
- **Byte length against a control needs a correction the counts do not** — the control's names are gori's own. A third control with longer names measures what the page returns per byte of name, and the length band absorbs exactly that.
- **`confirm_rounds: 2` needs both rounds now**, not one. With the kind match relaxed, a single 429 would otherwise confirm any name a jittery bucket had nominated.
- **Control and padding names are distinct by construction** — a control carrying a duplicate name was one parameter narrower than every probe measured against it.

## Speed

- Calibration is **one wave, not two**: a control's bytes do not depend on the tolerance bands, only its verdict does.
- Response fingerprinting **1.52x** (36.1µs → 23.7µs on a 100 KB body): the canary scan is memchr, and words + lines come off one table lookup per byte instead of four comparisons.
- Control/padding names from one CSPRNG draw; per-location name filtering and form-encoded name sizes memoized.

Also: the "mined against a same-width control" sentence is now a `note`, not a `warning` — a healthy mine should not raise a yellow ⚠ on every page with a filter counter. New `baseline_note` on `BaselineEvent`, the TUI card, the CLI baseline line, and MCP `mine_status`.

## Verification

`crystal spec` 11829 examples / 0 failures · `crystal build --no-codegen src/main.cr` · `scripts/bench_check.sh` (49 harnesses) · `scripts/seed_demo.cr` · `crystal tool format --check` · ameba adds nothing on the changed files. 21 new specs; the two guarding the confirm majority and the reported delta were each verified to fail against the previous behaviour.