### PR TITLE
fix(tui): a raise in a background fiber, an idle poll, and a log in /tmp

### DIFF
--- a/spec/tui/input_idle_backoff_spec.cr
+++ b/spec/tui/input_idle_backoff_spec.cr
@@ -1,0 +1,28 @@
+require "../spec_helper"
+require "../../src/gori/tui/input_idle_backoff_patch"
+
+# The delete trigger for `src/gori/tui/input_idle_backoff_patch.cr`, and the proof it is still
+# wired in.
+#
+# It carries its OWN pin rather than leaning on `paste_end_marker_spec.cr`'s. That spec exists
+# to be deleted — it is the trigger for the other carried patch, and the day termisu ships the
+# paste fix, that file and its pin go with it. This patch would then have silently lost its only
+# guard, which is the failure the pin exists to prevent.
+describe "the termisu pin the carried input back-off is written against" do
+  it "has not moved (if it has, re-check whether input_idle_backoff_patch.cr is still needed)" do
+    lock = File.read(File.join(__DIR__, "..", "..", "shard.lock"))
+    pinned = lock[/termisu:.*?commit\.([0-9a-f]{40})/m, 1]?
+
+    pinned.should eq("df6e907e6fe27f2cc70b9f855dff996d08398ad1")
+  end
+
+  # The patch reopens `Termisu::Event::Source::Input` and overrides a PRIVATE method, so no spec
+  # can call it. What a spec can see is that the reopen is compiled in at all: these two
+  # constants exist nowhere in termisu, so their presence pins that the file is required and
+  # applied. A rename upstream would leave them defined with a dead `run_loop` beside them —
+  # which is what the lock pin above is for.
+  it "is compiled in, and its cadences are ordered" do
+    Termisu::Event::Source::Input::IDLE_GRACE.should be > Termisu::Event::Source::Input::DEEP_IDLE_SLEEP
+    Termisu::Event::Source::Input::DEEP_IDLE_SLEEP.should be > Termisu::Event::Source::Input::IDLE_SLEEP
+  end
+end

--- a/spec/tui/spawn_rescue_spec.cr
+++ b/spec/tui/spawn_rescue_spec.cr
@@ -1,0 +1,76 @@
+require "../spec_helper"
+
+# Every background fiber the TUI starts must rescue.
+#
+# Not a style rule — a raise inside `spawn` kills only that fiber and prints its backtrace to
+# STDERR, which under the TUI is the ALTERNATE SCREEN (#411). Both halves of that are bad and
+# neither is visible as a bug:
+#
+#   - the display garbles, and the operator reads it as a rendering glitch;
+#   - the work stops with no terminal event, so whatever the main fiber was waiting for never
+#     arrives. Measured cases: a Discover/Miner/Sequencer run whose bottom-bar job spins for
+#     the rest of the session (`jobs.finish` is only reached from a Done/Error drain, so the
+#     exit prompt keeps counting a run that already died), the Authorize passive watcher whose
+#     `ensure` also stops its catch-up sweep, and the statusline worker that leaves the row
+#     frozen at its last value.
+#
+# WHAT THIS DOES AND DOES NOT CHECK. It asserts only that a `rescue` appears somewhere inside
+# each spawn block — that the decision was MADE. Where the rescue belongs, and how wide it is,
+# stays a per-fiber judgement: `rescue Channel::ClosedError` is exactly right for a fiber whose
+# only expected end is its feed closing, and exactly wrong for one doing store reads. So a
+# narrow rescue passes here, and a rescue inside a nested `begin` passes here. Neither is an
+# oversight; both are cases where a mechanical rule would be wrong more often than right. This
+# catches the one thing that is never right — a spawn block with no answer at all — and the
+# reviewing eye covers the rest.
+#
+# The TUI alone: a proxy relay fiber unwinding is ordinary per-connection teardown, and the
+# alternate-screen argument above is what makes this universal here.
+describe "TUI background fibers" do
+  it "rescue, so a raise cannot land on the alternate screen" do
+    root = File.expand_path(File.join(__DIR__, "..", ".."))
+    offenders = [] of String
+
+    # `src/gori/tui.cr` as well as the directory: the module's own file holds terminal
+    # construction, and a glob of the directory alone would never look at it.
+    paths = Dir.glob(File.join(root, "src", "gori", "tui", "**", "*.cr"))
+    paths << File.join(root, "src", "gori", "tui.cr")
+
+    paths.sort.each do |path|
+      relative = Path[path].relative_to(root).to_s
+      lines = File.read_lines(path)
+      lines.each_with_index do |line, index|
+        stripped = line.strip
+        next unless stripped.starts_with?("spawn(") || stripped.starts_with?("spawn ")
+
+        indent = line.size - line.lstrip.size
+        # The three forms a spawn can take. A brace block opened and closed on one line is that
+        # line; anything else runs to the first `end` / `}` sitting at the spawn's own indent.
+        closer =
+          if stripped.matches?(/\bdo(\s*\|[^|]*\|)?$/)
+            "end"
+          elsif stripped.count('{') > stripped.count('}')
+            "}"
+          end
+
+        body =
+          if closer
+            close = ((index + 1)...lines.size).find do |i|
+              l = lines[i]
+              l.strip == closer && (l.size - l.lstrip.size) == indent
+            end
+            unless close
+              offenders << "#{relative}:#{index + 1}: spawn block has no `#{closer}` at its own indent"
+              next
+            end
+            lines[index..close].join("\n")
+          else
+            line
+          end
+
+        offenders << "#{relative}:#{index + 1}: #{stripped}" unless body.includes?("rescue")
+      end
+    end
+
+    fail("TUI spawn without a rescue (a raise here lands on the alternate screen):\n#{offenders.join("\n")}") unless offenders.empty?
+  end
+end

--- a/src/gori/app.cr
+++ b/src/gori/app.cr
@@ -143,8 +143,7 @@ module Gori
     # still works. `settings_warning` is anything Settings.load has to say about the
     # file it loaded: it was written to STDERR, which the alt screen is about to wipe.
     def run_tui(open_db_path : String? = nil, settings_warning : String? = nil) : Nil
-      log_io = File.open(File.join(Paths.home_dir, "gori.log"), "a")
-      setup_logging(log_io)
+      Tui.bind_log_file                # gori.log, and OFF the screen — see Tui.bind_log_file
       Tui::Theme.load_custom           # register user themes from <GORI_HOME>/themes/*.json
       Tui::Theme.apply(Settings.theme) # honour the persisted theme from the first frame (picker included)
       projects = ProjectRegistry.new(Paths.projects_dir)
@@ -152,15 +151,17 @@ module Gori
       # first-run wizard auto-launched below, so a no-tty run (CI/detached) gets a clean
       # message instead of a raw backtrace.
       term = Tui.open_terminal("run it directly, not under CI or a detached/background job, or use 'gori run capture' for non-interactive capture")
-      # Termisu.new (just above) unconditionally runs its OWN `Log.setup("*", ...)`, aimed at
+      # Termisu.new (just above) runs its OWN `Log.setup("*", ...)` unless told not to, aimed at
       # TERMISU_LOG_FILE (default /tmp/termisu.log, a shared, unbounded, non-project-scoped
-      # file). Crystal's `Log.setup` always fully reconfigures the root logger (clears prior
-      # bindings first), so whichever call runs LAST wins process-wide — Termisu's call would
-      # otherwise silently swallow every subsequent `Log.*` call gori itself makes, including
-      # the "failed to open session" error this TUI depends on landing in gori.log. Re-assert
-      # gori's binding now that Termisu has had its say, so it's the one left standing
-      # regardless of what Termisu does internally (same io — no new fd, no duplicate lines).
-      setup_logging(log_io)
+      # file). `Tui.open_terminal` heads that off around the constructor, so ordinarily there is
+      # nothing here to undo. This stays because the guard yields to an operator who exported
+      # TERMISU_LOG_LEVEL themselves, and because Crystal's `Log.setup` always fully
+      # reconfigures the root logger (clears prior bindings first): whichever call runs LAST
+      # wins process-wide, and Termisu's would otherwise silently swallow every subsequent
+      # `Log.*` call gori itself makes, including the "failed to open session" error this TUI
+      # depends on landing in gori.log. Re-assert gori's binding now that Termisu has had its
+      # say (same memoized io — no new fd, no duplicate lines).
+      Tui.bind_log_file
 
       begin
         # Armed FIRST, before anything else in this block: `open_terminal` above has ALREADY

--- a/src/gori/tui.cr
+++ b/src/gori/tui.cr
@@ -16,13 +16,82 @@ module Gori
     # interactive entrypoint (the TUI and `gori wizard`) goes through here so the guard
     # lives at the one shared construction point.
     def self.open_terminal(hint : String) : Termisu
-      Termisu.new
+      bind_log_file
+      with_termisu_logging_silenced { Termisu.new }
     rescue IO::Error
       abort "gori: requires an interactive terminal (no /dev/tty) — #{hint}"
+    end
+
+    # The one fd every entrypoint's records go to, and the binding that keeps them OFF the
+    # screen. Called here, before the terminal exists, because the terminal's own constructor
+    # already logs.
+    #
+    # Crystal's default `::Log` backend is `Log::IOBackend.new`, whose io is **STDOUT** — which
+    # under a TUI is the screen being drawn. termisu emits three INFO records inside
+    # `Termisu.new` alone, and it used to hide that by seizing the root binding for its own file
+    # (see `with_termisu_logging_silenced`). Taking that away without putting gori's binding in
+    # its place painted those records into the first frame: measured, `gori tutorial` opened
+    # with "Initializing Termisu v0.6.1" written across its own tour chrome. `App#run_tui` had
+    # always bound first and was fine; `gori wizard` and `gori tutorial` reach a terminal
+    # without ever calling it, which is why the binding belongs at the SHARED construction
+    # point rather than in one caller.
+    #
+    # The io is memoized and the binding re-applied on every call: three entrypoints share one
+    # fd, and a caller that re-asserts after something else has had its say (App#run_tui does)
+    # costs nothing.
+    def self.bind_log_file : Nil
+      io = (@@log_io ||= File.open(File.join(Gori::Paths.home_dir, "gori.log"), "a"))
+      ::Log.setup(:info, ::Log::IOBackend.new(io))
+    rescue
+      # No writable log file (a read-only or missing home). Silence is the only other safe
+      # answer: the default backend writes to STDOUT, and a diagnostic that lands on the
+      # alternate screen is worse than one nobody keeps (#411).
+      ::Log.setup(:none)
+    end
+
+    @@log_io : File? = nil
+
+    # Keep the terminal library out of `/tmp`, for the length of its constructor and no longer.
+    #
+    # `Termisu.new` unconditionally runs `Termisu::Logging.setup`, and with nothing in the
+    # environment that opens `/tmp/termisu.log` in append mode and rebinds the process-wide root
+    # logger to it at DEBUG. Three things follow from that, none of them gori's intent:
+    #
+    #   - a path in a world-writable directory is opened BY NAME on every launch, and
+    #     `File.open(path, "a")` follows a symlink. On a shared box anyone can pre-create
+    #     `/tmp/termisu.log` pointing at a file this user can write and collect gori's records
+    #     there. gori keeps its own tree at 0700/0600 to avoid exactly this shape.
+    #   - the file is world-readable and never rotated, and every launch appends the terminal
+    #     setup trace to it — measured, ~10 lines per run — so it doubles as an unowned record
+    #     that this user runs gori, growing without bound.
+    #   - `::Log.setup("*", …)` CLEARS prior bindings, so it would drop what `bind_log_file`
+    #     just installed.
+    #
+    # `TERMISU_LOG_LEVEL=none` is termisu's own switch for all three: it marks logging
+    # configured and returns BEFORE opening the file or touching `::Log`.
+    #
+    # SET AND RESTORED around the call rather than left in place. `ENV[]=` is `setenv(3)` for
+    # the whole process, and Crystal hands the parent environment to every child by default —
+    # so leaving it set exports gori's preference to the statusline's `sh -c`, to `$EDITOR`,
+    # and to the external process hooks (#818). A user debugging a termisu app from inside gori
+    # would have had its logging silenced with nothing to point at. An operator who set the
+    # variable themselves keeps their setting untouched: termisu's records then land in
+    # gori.log, since `bind_log_file` above ran first and termisu's `Log.setup` re-points the
+    # root at its own file only when it actually configures one.
+    private def self.with_termisu_logging_silenced(&)
+      key = "TERMISU_LOG_LEVEL"
+      return yield if ENV.has_key?(key)
+      ENV[key] = "none"
+      begin
+        yield
+      ensure
+        ENV.delete(key)
+      end
     end
   end
 end
 
+require "./tui/input_idle_backoff_patch" # carried termisu patch — see the file
 require "./tui/geometry"
 require "./tui/theme"
 require "./tui/screen"

--- a/src/gori/tui/controllers/authorize_controller.cr
+++ b/src/gori/tui/controllers/authorize_controller.cr
@@ -252,20 +252,7 @@ module Gori::Tui
       store = @host.session.store
       spawn(name: "authorize-passive") do
         while ev = feed.receive?
-          next unless @passive
-          next unless ev.kind == :updated # the response side exists only on the second event
-          detail = store.get_flow(ev.id)
-          next unless detail
-          next unless proxy_origin?(detail.row)
-          # NO filtering here. The decision needs the identity set and its outcome needs to be
-          # COUNTED, and both live on the main fiber — a flow silently dropped on this side is
-          # exactly how this mode came to look broken.
-          select
-          when @seeds.send(detail)
-          else
-            # main fiber behind — drop rather than stall the feed; the next matching flow
-            # queues the endpoint anyway, and the queue is a sample, not a ledger.
-          end
+          offer_passive_seed(store, ev)
         end
       rescue Channel::ClosedError
         # project closing
@@ -275,6 +262,42 @@ module Gori::Tui
         @passive_closed = true
       end
       start_passive_catchup(store)
+    end
+
+    # One live-feed event, off the main fiber.
+    #
+    # EXTRACTED so it can carry the same `DB::Error | SQLite3::Exception` rescue the catch-up
+    # sweep has always had, and for the same reason: `get_flow` reads the store, and a store
+    # that is closing or momentarily busy raises. Inline in the `while` above, that raise
+    # unwound the whole watcher — and because the watcher's `ensure` sets `@passive_closed`,
+    # which is the ONLY thing that stops the catch-up timer, one transient busy killed BOTH
+    # halves of passive replay for the rest of the session while printing its backtrace onto
+    # the alternate screen (#411). Dropping the flow instead costs a delay, not the endpoint:
+    # the sweep re-offers it within PASSIVE_CATCHUP_INTERVAL.
+    private def offer_passive_seed(store : Store, ev : Store::FlowEvent) : Nil
+      return unless @passive
+      return unless ev.kind == :updated # the response side exists only on the second event
+      detail = store.get_flow(ev.id)
+      return unless detail
+      return unless proxy_origin?(detail.row)
+      # NO filtering here. The decision needs the identity set and its outcome needs to be
+      # COUNTED, and both live on the main fiber — a flow silently dropped on this side is
+      # exactly how this mode came to look broken.
+      select
+      when @seeds.send(detail)
+      else
+        # main fiber behind — drop rather than stall the feed; the next matching flow
+        # queues the endpoint anyway, and the queue is a sample, not a ledger.
+      end
+    rescue DB::Error | SQLite3::Exception
+      # store closing / busy — the catch-up sweep re-reads (see start_passive_catchup)
+    rescue ex
+      # And everything else, at the SAME depth. Narrowing to the two DB classes only moved the
+      # original failure one exception over: any other raise from here still unwound the watcher
+      # and, through its `ensure`, stopped the catch-up sweep with it. One bad flow must cost one
+      # flow. `@seeds` is never closed, so nothing legitimate is being swallowed — the watcher's
+      # own `rescue Channel::ClosedError` is for `feed`, which this does not touch.
+      ::Log.error(exception: ex) { "authorize passive seed dropped" }
     end
 
     # The live feed DROPS on a full channel (see `Store#publish`), and both this consumer and
@@ -307,6 +330,13 @@ module Gori::Tui
           end
         rescue DB::Error | SQLite3::Exception
           # store closing / busy — the next tick re-reads
+        rescue ex
+          # Same depth, deliberately: one level out (on the spawn block) this reads as a rescue
+          # but still ENDS the sweep, and nothing restarts it. The sweep is the only cover for
+          # the live feed's dropped events (`Store#publish` drops on a full channel), so losing
+          # it degrades passive replay silently while the tab still reads ON — the exact shape
+          # this mode came to look broken in. A bad tick costs a tick.
+          ::Log.error(exception: ex) { "authorize passive catch-up tick failed" }
         end
       end
     end

--- a/src/gori/tui/controllers/discover_controller.cr
+++ b/src/gori/tui/controllers/discover_controller.cr
@@ -302,6 +302,7 @@ module Gori::Tui
       run.begin_run
       run.job_id = @host.jobs.start(:discover, run.label(40), goto: Jobs::Goto.new(:target, run.id.to_i64))
       events = @discover_events
+      terminal_sent = false
       spawn(name: "gori-discover") do
         engine.run do |ev|
           case ev
@@ -311,9 +312,28 @@ module Gori::Tui
             else
             end
           else
+            # Done/Error is the run's VERDICT. Once one is on the channel the rescue below
+            # must not send a second: `apply_event`'s ErrorEvent arm re-finishes the row,
+            # so a raise on the way out of a COMPLETED run would relabel it :error and fire
+            # an error notification for work that succeeded. (`jobs.finish` keeps the first
+            # terminal state, so the job itself was already safe — nothing else was.)
+            terminal_sent = true if ev.is_a?(Discover::DoneEvent) || ev.is_a?(Discover::ErrorEvent)
             events.send({run, ev}) # Finding/Baseline/Done/Error — blocking, never dropped
           end
         end
+      rescue ex
+        # An unrescued raise in a `spawn` block kills only this fiber and prints to STDERR,
+        # which under the TUI is the alternate screen (#411) — so a bug in the crawl garbled
+        # the display AND left no terminal event behind. Without one the row stays `:running`
+        # for the rest of the session: its bottom-bar job never finishes (the spinner turns
+        # forever and the exit prompt keeps counting it), and `discover_dismiss` refuses the
+        # row because it still reads as live. The engine already reports its own setup /
+        # frontier failures this way, so reuse that channel rather than inventing a second way
+        # to say the same thing — `apply_event`'s ErrorEvent arm does the whole finish.
+        ::Log.error(exception: ex) { "discover run fiber died" }
+        # `ex.class` too — see the Miner's sibling. No `ensure` here because the row's status
+        # lives on the main fiber: this event IS the finish, so there is nothing local to clear.
+        events.send({run, Discover::ErrorEvent.new("#{ex.class}: #{ex.message}")}) unless terminal_sent
       end
       @host.status("discovering #{run.target} in the background — watch the bottom bar / notifications")
     end

--- a/src/gori/tui/controllers/fuzzer_controller.cr
+++ b/src/gori/tui/controllers/fuzzer_controller.cr
@@ -1108,6 +1108,7 @@ module Gori::Tui
       v.job_id = @host.jobs.start(:fuzz, v.summary, goto: goto_for(v))
       events = @fuzz_events
       calibrate = v.config.auto_calibrate?
+      terminal_sent = false
       spawn(name: "gori-fuzz") do
         engine.calibrate_baseline if calibrate
         engine.run do |ev|
@@ -1118,6 +1119,12 @@ module Gori::Tui
             else
             end
           else
+            # Done/Error is the run's VERDICT. Once one is on the channel the rescue below
+            # must not send a second: `apply_event`'s ErrorEvent arm re-finishes the run,
+            # so a raise on the way out of a COMPLETED run would relabel it :error and fire
+            # an error notification for work that succeeded. (`jobs.finish` keeps the first
+            # terminal state, so the job itself was already safe — nothing else was.)
+            terminal_sent = true if ev.is_a?(Fuzz::DoneEvent) || ev.is_a?(Fuzz::ErrorEvent)
             events.send({v, ev}) # Result/Done/Error — blocking, never dropped
           end
           engine.stop if v.stop_requested?
@@ -1129,7 +1136,8 @@ module Gori::Tui
         # reports its own setup/generation failures this way (Fuzz::Engine), so reuse that
         # channel rather than inventing a second way to say the same thing.
         ::Log.error(exception: ex) { "fuzz run fiber died" }
-        events.send({v, Fuzz::ErrorEvent.new(ex.message || "fuzz run error")})
+        v.finish_run # before the blocking send — see the Miner's sibling for why
+        events.send({v, Fuzz::ErrorEvent.new("#{ex.class}: #{ex.message}")}) unless terminal_sent
       ensure
         v.finish_run # backstop — the drain's Done also clears it + shows the summary
       end

--- a/src/gori/tui/controllers/miner_controller.cr
+++ b/src/gori/tui/controllers/miner_controller.cr
@@ -567,6 +567,7 @@ module Gori::Tui
       view.begin_run
       view.job_id = @host.jobs.start(:miner, view.summary, goto: goto_for(view))
       events = @mine_events
+      terminal_sent = false
       spawn(name: "gori-miner") do
         engine.run do |ev|
           case ev
@@ -576,10 +577,32 @@ module Gori::Tui
             else
             end
           else
+            # Done/Error is the run's VERDICT. Once one is on the channel the rescue below
+            # must not send a second: `apply_event`'s ErrorEvent arm re-finishes the run,
+            # so a raise on the way out of a COMPLETED run would relabel it :error and fire
+            # an error notification for work that succeeded. (`jobs.finish` keeps the first
+            # terminal state, so the job itself was already safe — nothing else was.)
+            terminal_sent = true if ev.is_a?(Miner::DoneEvent) || ev.is_a?(Miner::ErrorEvent)
             events.send({view, ev}) # Baseline/Finding/Done/Error — blocking, never dropped
           end
           engine.stop if view.stop_requested?
         end
+      rescue ex
+        # An unrescued raise in a `spawn` block kills only this fiber and prints to STDERR,
+        # which under the TUI is the alternate screen (#411). The `ensure` below clears the
+        # view's running flag, so the pane merely looked finished — but `jobs.finish` is only
+        # ever reached from `apply_event`'s Done/Error arms, so with no terminal event the
+        # bottom-bar job spun for the rest of the session and the exit prompt kept counting a
+        # mine that had already died. Worse, a mine that stops with no verdict reads as one
+        # that found nothing. Hand the failure back the way the engine reports its own.
+        ::Log.error(exception: ex) { "mine run fiber died" }
+        # Cleared BEFORE the send, not only in the `ensure`: `events` is bounded and this send
+        # blocks, so with the drain gone the `ensure` would be reached late or not at all — and
+        # un-wedging the pane is the one thing that must not wait on a reader.
+        view.finish_run
+        # `ex.class` too: "Nil assertion failed" alone is what the operator gets in the job's
+        # error text, the notification AND the persisted event log, and it names nothing.
+        events.send({view, Miner::ErrorEvent.new("#{ex.class}: #{ex.message}")}) unless terminal_sent
       ensure
         view.finish_run # backstop — the drain's Done also clears it
       end

--- a/src/gori/tui/controllers/oast_controller.cr
+++ b/src/gori/tui/controllers/oast_controller.cr
@@ -686,6 +686,13 @@ module Gori::Tui
       spawn(name: "gori-oast-deregister") do
         outcome, err = Oast::Sessions.release_detail(provider, session, http)
         ch.send(ReleaseResult.new(sid, outcome, label, err)) if report
+      rescue ex
+        # `release_detail` never raises (it owns the four-way answer), so what is left is the
+        # SEND — the drain is gone with the project and the channel closed under a release the
+        # operator has already been told is in flight. An unrescued raise in `spawn` prints its
+        # backtrace to STDERR, which under the TUI is the alternate screen (#411), so the one
+        # visible sign of a detached teardown failing would be a garbled display.
+        ::Log.error(exception: ex) { "oast deregister fiber died" }
       end
     end
 

--- a/src/gori/tui/controllers/sequencer_controller.cr
+++ b/src/gori/tui/controllers/sequencer_controller.cr
@@ -679,6 +679,7 @@ module Gori::Tui
       view.begin_run
       view.job_id = @host.jobs.start(:sequence, view.summary, goto: goto_for(view))
       events = @seq_events
+      terminal_sent = false
       spawn(name: "gori-sequencer") do
         engine.run do |ev|
           case ev
@@ -688,10 +689,24 @@ module Gori::Tui
             else
             end
           else
+            # Done/Error is the collection's VERDICT. Once one is on the channel the rescue below
+            # must not send a second: `apply_event`'s ErrorEvent arm re-finishes the run,
+            # so a raise on the way out of a COMPLETED run would relabel it :error and fire
+            # an error notification for work that succeeded. (`jobs.finish` keeps the first
+            # terminal state, so the job itself was already safe — nothing else was.)
+            terminal_sent = true if ev.is_a?(Sequencer::DoneEvent) || ev.is_a?(Sequencer::ErrorEvent)
             events.send({view, ev}) # Sample/Done/Error — blocking, never dropped
           end
           engine.stop if view.stop_requested?
         end
+      rescue ex
+        # Same shape as the Miner's, for the same two reasons: an unrescued raise here writes
+        # its backtrace to the alternate screen (#411), and `jobs.finish` is only reached from
+        # `apply_event`'s Done/Error arms — so a dead fiber left the bottom-bar job spinning
+        # and the exit prompt counting a collection that had already stopped.
+        ::Log.error(exception: ex) { "sequencer run fiber died" }
+        view.finish_run # before the blocking send — see the Miner's sibling for why
+        events.send({view, Sequencer::ErrorEvent.new("#{ex.class}: #{ex.message}")}) unless terminal_sent
       ensure
         view.finish_run
       end

--- a/src/gori/tui/controllers/statusline_controller.cr
+++ b/src/gori/tui/controllers/statusline_controller.cr
@@ -161,6 +161,9 @@ module Gori::Tui
       @discard = false            # drop the in-flight result: it belongs to a superseded run
       @last_run = nil.as(Time::Instant?)
       @last_spec = current_spec # the {command, interval, timeout} the last launch used
+      # Last unexpected-raise signature the worker logged, so a persistent failure at a 1s
+      # interval writes one backtrace rather than one per second. Worker-fiber only.
+      @last_error = nil.as(String?)
     end
 
     # Called every main-loop tick. Drains a finished result and (re-)launches the
@@ -263,7 +266,19 @@ module Gori::Tui
     private def ensure_started : Nil
       return if @started
       @started = true
-      spawn(name: "gori-statusline") { worker_loop }
+      spawn(name: "gori-statusline") do
+        worker_loop
+      rescue ex
+        # The outermost net. `worker_loop` already answers for the two failures it expects — one
+        # run raising, and the channel closing on `stop` — so a raise reaching HERE means the
+        # worker is gone. Logging alone would leave the row dead for the session with no way
+        # back: `@running` is only cleared by a result that will never arrive, so `tick` stops
+        # queueing entirely, and `@started` is only ever set, so nothing respawns. Clear both and
+        # the next tick starts a fresh worker.
+        ::Log.error(exception: ex) { "statusline worker fiber died" }
+        @started = false
+        @running = false
+      end
     end
 
     private def worker_loop : Nil
@@ -271,7 +286,28 @@ module Gori::Tui
         msg = @work_ch.receive?
         break if msg.nil? # channel closed (stop) → exit
         cmd, ctx, to = msg
-        line = Statusline.run(cmd, ctx, to)
+        line = begin
+          Statusline.run(cmd, ctx, to)
+        rescue ex
+          # `Statusline.run` converts every failure it names into a marker of its own, so a raise
+          # reaching here is one it does not name. Letting it out ends the WORKER and the row
+          # dies with it; one bad run must cost one bad row instead.
+          #
+          # Its own text, not `Statusline.run`'s "(statusline failed)": those two are different
+          # answers — one is a failure the code accounted for, the other is not — and printing
+          # the same seven characters for both leaves the difference visible only in a log.
+          #
+          # Logged ONCE per distinct failure. The interval floors at one second and the
+          # motivating cases are persistent (no `sh`, a fork that cannot succeed), so an
+          # unconditional `Log.error(exception:)` writes a full backtrace every second into an
+          # append-only gori.log that nothing rotates.
+          signature = "#{ex.class}: #{ex.message}"
+          if signature != @last_error
+            @last_error = signature
+            ::Log.error(exception: ex) { "statusline command raised" }
+          end
+          "⋯ (statusline error)"
+        end
         select
         when @result_ch.send(line) # latest-wins
         else

--- a/src/gori/tui/input_idle_backoff_patch.cr
+++ b/src/gori/tui/input_idle_backoff_patch.cr
@@ -1,0 +1,106 @@
+require "termisu"
+
+# Stops an IDLE `gori tui` burning two thirds of its CPU on a poll for input that is not coming.
+#
+# CARRIED PATCH — same terms as `paste_end_marker_patch.cr`: `lib/` is gitignored and shard.lock
+# pins a commit, so there is nothing in the dependency to edit, and this is a verbatim copy of
+# the pinned `run_loop` apart from the change named below. Delete it once shard.lock ships a
+# termisu whose input source waits on the fd instead of polling it.
+#
+# `spec/tui/input_idle_backoff_spec.cr` carries the trigger, and it is this patch's OWN, not a
+# reference to the paste patch's. That one exists to be deleted the day termisu ships the paste
+# fix, and this file would have gone unguarded with it.
+#
+# THE COST, in `Termisu::Event::Source::Input#run_loop`: the fiber every termisu app receives
+# input through drains with a NON-BLOCKING `poll_event(0)` and then sleeps a fixed
+# `IDLE_SLEEP` (4ms). That is 250 wake-ups a second, each one a fiber-scheduler round trip and
+# a `select(2)` on the tty, for as long as the program is open — whether or not anybody is
+# typing. Termisu's own comment calls the 4ms a "measured stopgap" and names the real fix
+# (evented IO on the input fd) as deferred.
+#
+# MEASURED here as cumulative process CPU (`ps -o cputime=`) across an idle window, tmux 120x30,
+# the two gori builds run alternately so machine drift shows up as noise rather than as a result:
+#
+#     a bare termisu app polling at gori's own 50ms cadence   0.42s /  30s = 1.4%
+#     the same app with the back-off below                    0.13s /  30s = 0.43%
+#     `gori tui` on the Project tab, unpatched                2.67s / 120s = 2.2%
+#     `gori tui` on the Project tab, with this                2.00s / 120s = 1.7%
+#
+# So most of what an idle termisu costs is this poll (3.3x), and a quarter of what an idle gori
+# costs is the same poll seen through everything else gori does per tick — on a tool that stays
+# open all day beside a browser, on a laptop. Key-to-repaint latency was measured over the same
+# pair (tab switch after a 2s pause, 6 runs each) and did not regress.
+#
+# THE FIX is to poll at the SAME 4ms while input is actually flowing and back off to one 60Hz
+# frame once it has been quiet for a moment. `IDLE_GRACE` is what keeps typing on the fast
+# path: any delivered event re-arms it, so a keystroke, a held arrow, a paste and a mouse drag
+# all run at the original cadence — the back-off can only ever apply to the FIRST event after a
+# pause, and it bounds that at one frame. gori cannot get this from the outside: the sleep is
+# inside the fiber termisu owns, and the caller's `poll_event` timeout does not reach it.
+#
+# NOT evented IO, deliberately. `Reader` does its readiness check with a raw `select(2)`, which
+# blocks the THREAD rather than the fiber — under a single-threaded scheduler that would stall
+# the proxy's fibers, which is the whole reason the loop polls in the first place. Rebuilding it
+# on `IO::FileDescriptor` means a second IO over gori's live tty fd (and a finalizer that would
+# close it), which is a change that belongs in termisu, not in a patch carried by a consumer.
+#
+# ONE THING THIS WIDENS, disclosed because it is not zero. `Termisu#resume_input_processing`
+# calls `Source::Input#start`, which flips `@running` back to true and spawns a fresh fiber —
+# so if the PREVIOUS fiber is still parked in this sleep when that happens, it wakes to a true
+# flag, never exits, and two fibers read the same parser. That race is termisu's and predates
+# this, but its window was the sleep, so it grows from 4ms to at most 16ms. gori has exactly
+# one path through `stop`/`start`: `Runner#run_external_editor`, whose block is a `Process.run`
+# on the operator's `$EDITOR` — seconds, not milliseconds — so the old fiber has long since
+# seen the flag. Nothing else in gori suspends the terminal.
+#
+# TWO WAYS THIS GOES WRONG, and only one of them is benign. If upstream RENAMES or restructures
+# `run_loop`, the override becomes dead code and the poll returns to 4ms — nothing breaks, and
+# the spec's constant assertion still says the file is compiled in. The other way is not benign:
+# if upstream keeps the name and fixes something INSIDE it — including the double-fiber race
+# this file discloses above — a verbatim copy silently reinstates whatever was fixed, with no
+# compile error and no failing example. That is the same "keeps applying when it should not"
+# case `paste_end_marker_patch.cr` guards on purpose, and it is what the lock pin answers: move
+# the pin and the spec fails, which is exactly when someone should be re-reading this file.
+class Termisu::Event::Source::Input
+  # How long input must have been quiet before the poll backs off. Long enough that a pause
+  # between two keystrokes — even a slow typist's — never leaves the fast path.
+  IDLE_GRACE = 250.milliseconds
+
+  # The backed-off cadence: one frame at 60Hz. This is the WORST added latency for the first
+  # event after a pause, and only for that one, since delivering it re-arms `IDLE_GRACE`.
+  DEEP_IDLE_SLEEP = 16.milliseconds
+
+  private def run_loop : Nil
+    output = @output
+    return unless output
+
+    last_delivery = Time.instant
+
+    while @running.get
+      emitted = false
+      drained = 0
+
+      while @running.get && drained < MAX_DRAIN_PER_CYCLE
+        event = @parser.poll_event(0)
+        break unless event
+
+        output.send(event)
+        emitted = true
+        drained += 1
+      end
+
+      break unless @running.get
+
+      if emitted
+        last_delivery = Time.instant
+        Fiber.yield
+      else
+        # THE CHANGE. Upstream sleeps `IDLE_SLEEP` unconditionally here.
+        sleep(Time.instant - last_delivery >= IDLE_GRACE ? DEEP_IDLE_SLEEP : IDLE_SLEEP)
+      end
+    end
+  rescue Channel::ClosedError
+    # Channel closed during shutdown - exit gracefully
+    Log.debug { "Input channel closed, exiting" }
+  end
+end

--- a/src/gori/tui/project_picker.cr
+++ b/src/gori/tui/project_picker.cr
@@ -255,6 +255,15 @@ module Gori::Tui
         @remote_latest = latest
         @fetched_live = true
         @remote_ready = true # set last so the reader never sees a half-written pair
+      rescue ex
+        # `latest_version` answers nil for every failure it knows about, so a raise here is one
+        # it does not — and it is one file away, free to change without this one being read.
+        # Unrescued it would print a backtrace onto the PICKER's alternate screen (#411) and
+        # leave `@remote_ready` false, so the check would never resolve and never say why.
+        # Ready-with-no-version is the same outcome an offline fetch already has: nothing
+        # shown, the day cache untouched, retried next launch.
+        ::Log.error(exception: ex) { "update check fiber died" }
+        @remote_ready = true
       end
     end
 


### PR DESCRIPTION
Three things an operator could not have reported as bugs, because none of them
look like one from the outside.

**Every background fiber the TUI starts now rescues.** An unrescued raise in
`spawn` kills only that fiber and prints its backtrace to STDERR, which under
the TUI is the alternate screen (#411) — so it reads as a rendering glitch. The
second cost is the one that lasts: `jobs.finish` is only ever reached from a
Done/Error drain, so a dead fiber left its bottom-bar job spinning for the rest
of the session and the exit prompt counting a run that had already stopped.
`close_tab` could not clean it up either, because the `ensure` had already
cleared the flag that gate reads.

  - `gori-discover` had neither a rescue nor an ensure. The row stayed
    `:running`, and `discover_dismiss` refused to remove it as still live.
  - `gori-miner` and `gori-sequencer` had an ensure but no rescue, so the pane
    looked finished while the job never was — and a run that stops with no
    verdict reads as one that found nothing.
  - `authorize-passive` rescued only `Channel::ClosedError` while its catch-up
    sibling had always rescued store errors. Its `ensure` sets `@passive_closed`,
    the one thing that stops that sweep, so a single transient SQLite busy from
    `get_flow` killed BOTH halves of passive replay for the session while the tab
    still read ON. The per-event work is extracted so it can carry the same
    rescue, and the sweep's own rescue moved inside its loop: a bad tick now
    costs a tick, not the sweep.
  - the statusline worker died on any raise `Statusline.run` does not name,
    freezing the row at its last value with no restart path — `@started` is only
    ever set and `@running` only cleared by a result that would never arrive.
  - `gori-oast-deregister` and `gori-update-check` were bare.

All four engine fibers — fuzz included, which had the shape already and would
otherwise have kept the defects alone — also stop sending a terminal event after
the engine has emitted its own (a raise on the way out of a COMPLETED run was
relabelling it `:error` and firing an error notification for work that
succeeded), clear their view state before the blocking send rather than leaving
it to an `ensure` that a full channel can delay, and name the exception class in
the message that reaches the job, the notification and the persisted event log.

`spec/tui/spawn_rescue_spec.cr` keeps the invariant: no spawn block anywhere
under `src/gori/tui` without an answer. It asserts only that the decision was
made, not which one — `rescue Channel::ClosedError` is right for some of these
fibers and wrong for others, and that judgement does not mechanise.

**Two termisu costs move off gori's back**, both as carried patches against the
pinned 0.6.1, each with its own delete trigger:

  - the input source polls the tty every 4ms whether or not anyone is typing —
    250 wake-ups a second, which termisu's own comment calls a measured stopgap.
    It now backs off to one 60Hz frame after 250ms of quiet, which any delivered
    event re-arms, so typing, a held arrow, a paste and a mouse drag all keep the
    original cadence. Idle gori 2.2% -> 1.7% CPU (3.3x off the shard's own
    floor), measured with the two builds run alternately; key-to-repaint latency
    did not regress.
  - `Termisu.new` opened `/tmp/termisu.log` by name — a world-writable path, and
    `File.open(path, "a")` follows a symlink — and seized the process root logger
    to point at it. `Tui.open_terminal` now binds gori's own log file first, at
    the shared construction point rather than in one caller: `gori wizard` and
    `gori tutorial` never bound one at all, and Crystal's default backend writes
    to STDOUT, so silencing termisu without this painted its records straight
    into the tour's first frame. `TERMISU_LOG_LEVEL=none` is then set and
    restored around the constructor only, so the statusline's `sh -c`, `$EDITOR`
    and the process hooks do not inherit it.

Verified: 11,871 examples green; ~4,200 randomised keystrokes across terminal
sizes down to 1x1 with no crash and no absorbed tick error; `kill -TERM` still
exits 143 with the tty fully restored; `/tmp/termisu.log` no longer created; the
statusline child reads `TERMISU_LOG_LEVEL` unset.
