### PR TITLE
fix(mcp): put the closed argument sets in the schema, and stop two readers defaulting silently

### DIFF
--- a/spec/mcp/enum_schema_spec.cr
+++ b/spec/mcp/enum_schema_spec.cr
@@ -1,0 +1,211 @@
+require "../spec_helper"
+
+# An MCP client hands the MODEL the tool's JSON Schema, never the reader. So for every
+# argument with a CLOSED set of legal strings, the set has to be in the schema as `enum` —
+# otherwise the model infers it from the description's prose, and when it infers wrong the
+# call comes back refused and it guesses again. That loop costs a round trip per guess and
+# reads, from outside the process, as a flaky server.
+#
+# Declaring the set is only half of it; the other half is that the declaration and the
+# reader must AGREE. They drifted before this file existed: `update_rule` and `preview_rule`
+# each described `op` without `pipe` while their reader had accepted `pipe` all along, and
+# `list_events` offered a `source` its filter would answer with an empty feed.
+#
+# So these specs drive the real `tools/list` output back through the real `Tools#call`, both
+# directions:
+#
+#   * every value a tool ADVERTISES is one its reader ACCEPTS, and
+#   * a value it does not advertise is REFUSED, by name — never silently defaulted, which is
+#     how `body_mode` used to inline a whole response body for a caller that mistyped "none".
+#
+# Generic on purpose. A new `enumprop` is covered the day it is added, and a hand-written
+# list that drifts from its reader fails here rather than in an agent's retry loop.
+
+private def with_store(&)
+  path = File.tempname("gori-mcpenum", ".db")
+  store = Gori::Store.open(path)
+  begin
+    with_globals { yield store }
+  ensure
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+# Driving `scope:"global"` through create_rule / create_color_rule / create_view is the point
+# of the acceptance sweep below — and every one of those writes PROCESS-WIDE `Settings` state
+# plus a settings.json under `$GORI_HOME`, which the whole suite otherwise shares. Left
+# unwound, this file's rules are merged into every later example's rule list: `spec/rules_spec`
+# counted three rows where it had created two, and `crystal spec` failed ten examples in files
+# this change never touched while each of them passed alone. Same shape (and the same remedy)
+# as `spec/rules_spec.cr`'s own `with_globals` — its comment explains why the HOME has to move
+# too, not just the arrays.
+private def with_globals(&)
+  prev_home = ENV["GORI_HOME"]?
+  rules = Gori::Settings.rewriter_rules
+  rule_id = Gori::Settings.rewriter_next_rule_id
+  colors = Gori::Settings.colormarker_colors
+  color_rules = Gori::Settings.colormarker_rules
+  color_id = Gori::Settings.colormarker_next_rule_id
+  views = Gori::Settings.saved_views
+  view_id = Gori::Settings.saved_views_next_id
+  providers = Gori::Settings.oast_providers
+  dir = File.tempname("gori-mcpenum-globals")
+  Dir.mkdir_p(dir)
+  begin
+    ENV["GORI_HOME"] = dir
+    # Cleared AND re-based: `rules_spec.cr` resets its counter inside the block for the same
+    # reason, and leaving one at whatever an earlier file left behind makes the ids this file
+    # mints depend on suite ordering. Everything saved above is cleared here, so the restore
+    # has nothing to put back that this file did not itself create.
+    Gori::Settings.rewriter_rules = [] of Gori::Settings::RewriterRule
+    Gori::Settings.rewriter_next_rule_id = 1_i64
+    Gori::Settings.colormarker_colors = [] of Gori::Settings::ColormarkerColor
+    Gori::Settings.colormarker_rules = [] of Gori::Settings::ColormarkerRule
+    Gori::Settings.colormarker_next_rule_id = 1_i64
+    Gori::Settings.saved_views = [] of Gori::Settings::SavedView
+    Gori::Settings.saved_views_next_id = 1_i64
+    Gori::Settings.oast_providers = [] of Gori::Settings::OastProvider
+    yield
+  ensure
+    prev_home ? (ENV["GORI_HOME"] = prev_home) : ENV.delete("GORI_HOME")
+    Gori::Settings.rewriter_rules = rules
+    Gori::Settings.rewriter_next_rule_id = rule_id
+    Gori::Settings.colormarker_colors = colors
+    Gori::Settings.colormarker_rules = color_rules
+    Gori::Settings.colormarker_next_rule_id = color_id
+    Gori::Settings.saved_views = views
+    Gori::Settings.saved_views_next_id = view_id
+    Gori::Settings.oast_providers = providers
+    FileUtils.rm_rf(dir)
+  end
+end
+
+private def tools_for(store) : Gori::MCP::Tools
+  Gori::MCP::Tools.new(store, allow_actions: true, verify_upstream: false)
+end
+
+private record EnumArg, tool : String, arg : String, values : Array(String),
+  required : Hash(String, JSON::Any)
+
+# Every {tool, argument, enum values} the live schema declares, with the tool's OTHER
+# required arguments filled in so the call reaches the reader under test instead of stopping
+# at a missing-argument check. Placeholders only — every case below asserts on whether the
+# error names THIS argument, so whatever the filler arguments do is irrelevant.
+private def enum_args(tools) : Array(EnumArg)
+  listing = JSON.parse(JSON.build { |j| tools.list(j) }).as_a
+  out = [] of EnumArg
+  listing.each do |t|
+    name = t["name"].as_s
+    # These dial a real origin (or register with a public OAST host) before the reader they
+    # would exercise here can be reached. Their enums come from the same constants as the
+    # tools that ARE driven below.
+    next if name.in?("oast_start", "probe_scan", "send_request", "send_websocket", "grpc_reflect")
+    schema = t["inputSchema"]
+    props = schema["properties"].as_h
+    required = schema["required"].as_a.map(&.as_s)
+    props.each do |arg, spec|
+      values = spec.as_h["enum"]?.try(&.as_a.map(&.as_s))
+      next unless values
+      fillers = {} of String => JSON::Any
+      required.each do |r|
+        next if r == arg
+        fillers[r] = case props[r]["type"]?.try(&.as_s)
+                     when "integer" then JSON::Any.new(1_i64)
+                     when "boolean" then JSON::Any.new(true)
+                     else                JSON::Any.new("placeholder")
+                     end
+      end
+      out << EnumArg.new(name, arg, values, fillers)
+    end
+  end
+  out
+end
+
+# Whether `text` is the reader refusing THIS argument (as opposed to erroring on one of the
+# placeholder fillers, or on a row id that does not exist — both expected and both fine).
+private def refuses_arg?(text : String, arg : String) : Bool
+  !!text.matches?(/(invalid|unknown|unsupported)\s+'?"?#{Regex.escape(arg)}'?"?/i)
+end
+
+private def call_with(tools, e : EnumArg, value : JSON::Any) : {String, Bool}
+  args = e.required.dup
+  args[e.arg] = value
+  r = tools.call(e.tool, JSON::Any.new(args))
+  {r.text, r.is_error}
+end
+
+describe "MCP closed-set arguments" do
+  it "declares at least one enum on every tool family that has a closed set" do
+    with_store do |store|
+      args = enum_args(tools_for(store))
+      # A floor, not a target: it exists so a refactor that drops `enumprop` from a whole
+      # file fails here instead of quietly shipping prose-only schemas again.
+      args.size.should be > 50
+      args.each(&.values.should_not(be_empty))
+    end
+  end
+
+  it "accepts every value it advertises" do
+    with_store do |store|
+      tools = tools_for(store)
+      offenders = [] of String
+      enum_args(tools).each do |e|
+        e.values.each do |v|
+          text, is_error = call_with(tools, e, JSON::Any.new(v))
+          next unless is_error && refuses_arg?(text, e.arg)
+          offenders << "#{e.tool}.#{e.arg}=#{v}: #{text}"
+        end
+      end
+      offenders.should eq([] of String)
+    end
+  end
+
+  it "refuses a value it does not advertise, by name" do
+    with_store do |store|
+      tools = tools_for(store)
+      offenders = [] of String
+      enum_args(tools).each do |e|
+        bogus = "zzz-not-a-#{e.arg}"
+        next if e.values.includes?(bogus)
+        text, is_error = call_with(tools, e, JSON::Any.new(bogus))
+        # Silence is the failure mode this catches: a reader whose `else` branch falls back
+        # to a default answers `isError:false` for a call that did something other than what
+        # it was asked to do, and the caller never learns.
+        offenders << "#{e.tool}.#{e.arg}: accepted #{bogus.inspect} — #{text[0, 120]}" unless is_error
+      end
+      offenders.should eq([] of String)
+    end
+  end
+
+  it "does not re-list the enum values as prose in the description" do
+    with_store do |store|
+      # Specifically the LIST form — `head|body|ws`, `flask / rack / django` — and not a
+      # description that names a value to explain it ("none returns body shape only";
+      # "a global rule lives in settings.json"). Naming one is what a good description does;
+      # spelling the whole set out a second time is what went stale, because nothing reads
+      # the prose copy and so nothing notices when the reader moves on without it.
+      offenders = [] of String
+      listing = JSON.parse(JSON.build { |j| tools_for(store).list(j) }).as_a
+      listing.each do |t|
+        t["inputSchema"]["properties"].as_h.each do |arg, spec|
+          h = spec.as_h
+          values = h["enum"]?.try(&.as_a.map(&.as_s))
+          next unless values && values.size > 1
+          desc = h["description"].as_s
+          # Two of the set's own values, adjacent, joined by a list separator. The
+          # lookarounds stand in for `\b`, which misreads a value carrying `.`, `+` or `-`
+          # (`webhook.site`, `host+subdomains`, `cluster-bomb`) and would also let `head`
+          # match inside `headers`.
+          pairs = values.each_permutation(2).select do |(a, b)|
+            desc.matches?(/(?<![A-Za-z0-9_.+-])#{Regex.escape(a)}(?![A-Za-z0-9_.+-])\s*[|\/]\s*#{Regex.escape(b)}(?![A-Za-z0-9_.+-])/)
+          end
+          offenders << "#{t["name"]}.#{arg}: description re-lists #{pairs.first} — the enum is the one copy" unless pairs.empty?
+        end
+      end
+      offenders.should eq([] of String)
+    end
+  end
+end

--- a/src/gori/cli/run/fuzz.cr
+++ b/src/gori/cli/run/fuzz.cr
@@ -101,7 +101,7 @@ module Gori
           p.on("--idle-ms=N", "WebSocket: per-session server-silence timeout after the first inbound frame (100-60000, default 3000)") { |v| ws_idle_ms = parse_count(v, "--idle-ms").to_i64 }
           p.on("--ws-keep-key", "WebSocket: send the template's own Sec-WebSocket-Key instead of a fresh one per session (lets an absent/short/duplicate/non-base64 key be the thing under test)") { ws_keep_key = true }
           p.on("--ws-http-only", "Sweep a WebSocket template as plain HTTP: the upgrade handshake goes out as an ordinary request and the 101 is read as a response, instead of the framed exchange. The bytes are unchanged — this selects the engine, not a rewrite") { ws_http_only = true }
-          p.on("--mode=MODE", "sniper (default) | batteringram | pitchfork | clusterbomb") { |v| mode = parse_mode(v) }
+          p.on("--mode=MODE", "#{Fuzz::Mode.names.join(" | ")} (default sniper)") { |v| mode = parse_mode(v) }
           p.on("-wPATH", "--wordlist=PATH", "Payload set: a wordlist file (repeatable; order → positions)") { |v| sources << Fuzz::WordlistFile.new(v) }
           p.on("--preset=NAME", "Payload set: a built-in preset (#{Fuzz::Presets.names.join("|")}); NAME:FILE merges a user file into it") { |v| sources << parse_preset(v) }
           p.on("--payloads=LIST", "Payload set: inline comma list (a,b,c)") { |v| sources << Fuzz::InlineList.new(v.split(',')) }
@@ -951,7 +951,7 @@ module Gori
       end
 
       private def self.parse_mode(v : String) : Fuzz::Mode
-        Fuzz::Mode.parse?(v) || abort "gori run fuzz: invalid --mode '#{v}' (sniper|batteringram|pitchfork|clusterbomb)"
+        Fuzz::Mode.parse?(v) || abort "gori run fuzz: invalid --mode '#{v}' (#{Fuzz::Mode.names.join("|")})"
       end
 
       private def self.hydrate_project_env(project_name : String?, db_path : String?) : Nil

--- a/src/gori/fuzz/types.cr
+++ b/src/gori/fuzz/types.cr
@@ -33,6 +33,18 @@ module Gori
         pitchfork? || cluster_bomb?
       end
 
+      # The spelling every gori surface TEACHES for this argument: the `--mode` flag's help and
+      # its refusal, the docs' mode tables (EN and KO), and MCP's `fuzz_start` schema `enum`.
+      #
+      # Deliberately not `label`. `label` is the OUTPUT form — hyphenated, and what
+      # `fuzz_results` echoes back — while the docs have spelled the input `batteringram` since
+      # before it existed. `parse?` takes either, so the two forms cost a reader nothing; an
+      # `enum`, though, is a constraint an MCP client can apply BEFORE the call, so advertising
+      # the form nothing documents would block the one an agent learned from the docs.
+      def self.names : Array(String)
+        %w[sniper batteringram pitchfork clusterbomb]
+      end
+
       # Lenient parse of a CLI/MCP token — ignores case and -/_/space so
       # "cluster-bomb", "ClusterBomb", "clusterbomb" all resolve.
       def self.parse?(token : String) : Mode?

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -383,6 +383,68 @@ module Gori
         @presence = nil
       end
 
+      # --- Closed argument value sets ------------------------------------------
+      #
+      # One list per argument whose reader accepts a FIXED set of strings. Each is read
+      # twice: by `enumprop`, which puts it in the tool's JSON Schema as `enum`, and by the
+      # reader's own refusal message. Two readers, one list, so the two can never disagree.
+      #
+      # Why the schema needs them at all: an MCP client hands the MODEL the schema, not the
+      # reader. With the values spelled out only in the description's prose the model had to
+      # infer the set from a sentence, and when it inferred wrong the call came back refused
+      # and it guessed again — a retry loop that costs a round trip per guess and reads, from
+      # the outside, as a flaky server. `enum` is the one field a client can both show and
+      # validate against before the call is ever made.
+      #
+      # Derived from the domain type wherever one exists (`Store::RuleOp.values.map(&.label)`
+      # rather than a copy of its labels), so a member added there reaches the agent with no
+      # second edit. That drift is not hypothetical: `update_rule` and `preview_rule` both
+      # described `op` without `pipe` while their reader had accepted `pipe` all along.
+      #
+      # Deliberately NOT here: `create_color_rule`'s `color`, whose set grows with the
+      # project's custom colours, and `tls_preset`, which also takes `""` to clear. An `enum`
+      # is a promise about every future call; a set that moves under the client belongs in
+      # prose. `payload set` / `processor` specs are mini-DSLs, not values.
+      RULE_SCOPES    = Store::RuleScope.values.map(&.label)
+      RULE_TARGETS   = Store::RuleTarget.values.map(&.label)
+      RULE_PARTS     = Store::RulePart.values.map(&.label)
+      RULE_OPS       = Store::RuleOp.values.map(&.label)
+      RULE_MATCHES   = Store::MatchKind.values.map(&.label)
+      SEVERITIES     = Store::Severity.values.map(&.label)
+      ISSUE_STATUSES = Store::Status.values.map(&.label)
+      LINK_OWNERS    = Store::LinkOwnerKind.values.map(&.label)
+      LINK_REFS      = Store::LinkRefKind.values.map(&.label)
+      EXTRACT_KINDS  = Gori::ExtractKind.values.map(&.label)
+      # request/response as the two HALVES of one exchange — which pane to diff, which side a
+      # probe rule reads, which stored blob to page. Its own list rather than a reuse of
+      # `RULE_TARGETS`: those happen to be the same two words today, and a member added to the
+      # rewriter's target enum has nothing to say about which half of a flow to read.
+      MESSAGE_SIDES = %w[request response]
+      # How much of a response body `get_flow`/`send_request` inline. `full` is the default
+      # and is also spellable, so a caller can say it rather than omit the argument.
+      BODY_MODES = %w[none preview full]
+      MOVE_DIRS  = %w[up down]
+      # `list_*` and `create_view` differ: a saved view can also be a BUILTIN, which is
+      # readable but not writable, so only the read side offers it.
+      VIEW_SCOPES_R = %w[builtin project global]
+      # The event feed's `source` column, as written by every producer.
+      EVENT_SOURCES = Store::EVENT_SOURCES
+      # …and its `actor` column: the surface that acted, or nothing. Written only by the two
+      # producers that can name one (`log_agent_action`, `ConfigLog.record`), both from
+      # `FlowSource.surface`.
+      EVENT_ACTORS          = Gori::FlowSource::Surface.values.map(&.token)
+      FUZZ_MODES            = Fuzz::Mode.names
+      MINE_LOCATIONS        = Miner::Location.values.map(&.label)
+      DISCOVER_CONTAINMENTS = Discover::Containment.values.map(&.label)
+      # The string spellings of `record_history`. It also takes the booleans send_request
+      # spells this argument with (true = all, false = none), which `"type":"string"` never
+      # advertised either way — the enum makes the three real values precise without
+      # narrowing anything the schema had promised.
+      RECORD_HISTORY_MODES = %w[none matched all]
+      # both/request/response — the intercept direction, and (minus `both`) the two sides a
+      # probe rule and a diff pane name.
+      INTERCEPT_DIRECTIONS = %w[both request response]
+
       # Tools that work with no project store open.
       UNBOUND_SAFE = Set{
         "list_projects", "create_project", "switch_project", "delete_project",
@@ -1108,16 +1170,31 @@ module Gori
       # {cap_bytes, omit} pair. none → metadata only; preview → small cap; full
       # (default) → the full MAX_TEXT cap. max_body_bytes tunes the cap (clamped to
       # MAX_TEXT — larger bodies are paged with get_response_body_chunk).
-      private def body_return_opts(h) : {Int32, Bool}
+      private def body_return_opts(h) : {Int32, Bool} | Result
         # Only a POSITIVE max_body_bytes overrides the cap; 0/negative falls back to
         # the mode default (Crystal treats 0 as truthy, so `max || default` alone
         # wouldn't). Use body_mode:none for a zero-byte, shape-only body.
         raw = optional_int_arg(h, "max_body_bytes").try(&.clamp(0_i64, Serialize::MAX_TEXT.to_i64).to_i)
         max = (raw && raw > 0) ? raw : nil
-        case str(h, "body_mode").try(&.strip.downcase)
-        when "none"    then {0, true}
-        when "preview" then {max || BODY_PREVIEW_BYTES, false}
-        else                {max || Serialize::MAX_TEXT, false}
+        mode = str(h, "body_mode").try(&.strip.downcase).presence
+        case mode
+        when nil, "full" then {max || Serialize::MAX_TEXT, false}
+        when "none"      then {0, true}
+        when "preview"   then {max || BODY_PREVIEW_BYTES, false}
+        else
+          # Refused by name, not defaulted. The `else` used to fold every unrecognised value
+          # into `full`, which is the WORST of the three to land on by accident: a caller that
+          # asked for `none` or a preview and mistyped it got the whole body inlined instead —
+          # on this transport, a megabyte into the agent's context for a call whose entire
+          # purpose was to keep it out. The sibling `max_body_bytes` on this same line already
+          # refuses an unreadable value (see send_request, which hoists this read ABOVE the send
+          # for exactly that reason); this is the other half of it.
+          # A Result rather than a `raise`: the blanket `Gori::Error` rescue in `call` can only
+          # produce `INVALID_ARGUMENT` with NO `field`, and every other refusal added alongside
+          # this one names the argument it is about — which is what a machine consumer reads to
+          # know what to fix. Both call sites already have to branch on a Result.
+          err("invalid 'body_mode' #{mode.inspect} (expected #{BODY_MODES.join(" | ")})",
+            "INVALID_ARGUMENT", field: "body_mode")
         end
       end
 
@@ -1270,7 +1347,7 @@ module Gori
       private def bad_severity(s : String?) : Result?
         return nil if s.nil? || s.strip.empty?
         return nil if severity_from(s)
-        Result.new("invalid severity: #{s} (info|low|medium|high|critical)", is_error: true)
+        Result.new("invalid severity: #{s} (#{SEVERITIES.join("|")})", is_error: true)
       end
 
       # The optional `cvss` argument as {value, clear}. THREE readings, because an agent has
@@ -1299,7 +1376,7 @@ module Gori
       private def bad_status(s : String?) : Result?
         return nil if s.nil? || s.strip.empty?
         return nil if status_from(s)
-        Result.new("invalid status: #{s} (open|confirmed|false-positive|resolved)", is_error: true)
+        Result.new("invalid status: #{s} (#{ISSUE_STATUSES.join("|")})", is_error: true)
       end
 
       # --- helpers ------------------------------------------------------------
@@ -1659,6 +1736,19 @@ module Gori
         value
       end
 
+      # A filter argument whose column holds a CLOSED set of strings: the value, nil when the
+      # caller did not narrow, or the refusal. Blank reads as absent, and the match is on the
+      # normalised form — every sibling reader on this surface strips and downcases, and a
+      # filter that refuses `"Agent"` while accepting `"agent"` would be the strictest reader
+      # in the file for no reason anyone could infer from the schema.
+      private def closed_filter(h, key : String, values : Array(String)) : (String | Result)?
+        raw = str(h, key).try(&.strip.downcase).presence
+        return nil unless raw
+        return raw if values.includes?(raw)
+        err("invalid #{key.inspect} #{raw.inspect} (expected #{values.join(" | ")})",
+          "INVALID_ARGUMENT", field: key)
+      end
+
       private def clamp(n : Int64?, default : Int32, max : Int32) : Int32
         return default unless n
         n.clamp(1_i64, max.to_i64).to_i
@@ -1671,13 +1761,13 @@ module Gori
 
       private def status_from(s : String?) : Store::Status?
         return nil unless s
-        case s.strip.downcase
-        when "open"                                              then Store::Status::Open
-        when "confirmed"                                         then Store::Status::Confirmed
-        when "false-positive", "false_positive", "falsepositive" then Store::Status::FalsePositive
-        when "resolved"                                          then Store::Status::Resolved
-        else                                                          nil
-        end
+        # `false_positive` / `falsepositive` stay accepted — they predate the schema's `enum`
+        # and an agent that learned them must not start failing — but the LABEL is what the
+        # enum advertises and what `Status#label` round-trips, so it is matched from the one
+        # list rather than spelled out beside its own aliases.
+        down = s.strip.downcase
+        Store::Status.values.find { |v| v.label == down } ||
+          (down.in?("false_positive", "falsepositive") ? Store::Status::FalsePositive : nil)
       end
 
       # --- tools/list schema builders -----------------------------------------
@@ -1706,6 +1796,17 @@ module Gori
 
       private def strprop(desc : String) : JSON::Any
         prop("string", desc)
+      end
+
+      # A string argument with a CLOSED value set (see the value-set constants above).
+      # Emits JSON Schema `enum` alongside the description, which is what lets an MCP client
+      # both SHOW the model the legal values and reject an illegal one before the call is
+      # made — the difference between one correct call and a guess-refuse-guess loop.
+      #
+      # `desc` should carry the MEANING and the default; it no longer has to repeat the list,
+      # and repeating it is how the list came to drift in the first place.
+      private def enumprop(desc : String, values : Enumerable(String)) : JSON::Any
+        JSON.parse(%({"type":"string","description":#{desc.to_json},"enum":#{values.to_a.to_json}}))
       end
 
       # For an argument that is genuinely fractional (`rate` — see `optional_float_arg`).

--- a/src/gori/mcp/tools/color_rules.cr
+++ b/src/gori/mcp/tools/color_rules.cr
@@ -60,11 +60,8 @@ module Gori
       private def color_rule_scope(h) : Store::RuleScope | Result
         s = str(h, "scope")
         return Store::RuleScope::Project if s.nil? || s.empty?
-        case s.downcase
-        when "project" then Store::RuleScope::Project
-        when "global"  then Store::RuleScope::Global
-        else                err("invalid 'scope' (expected project|global)", "INVALID_ARGUMENT", field: "scope")
-        end
+        Store::RuleScope.values.find { |v| v.label == s.downcase } ||
+          err("invalid 'scope' (expected #{RULE_SCOPES.join("|")})", "INVALID_ARGUMENT", field: "scope")
       end
 
       # A colour LABEL: one of the six built-in words, or the name of a user-defined custom
@@ -84,7 +81,7 @@ module Gori
       private def marker_style(h, dft : Store::MarkerStyle) : Store::MarkerStyle | Result
         s = str(h, "style")
         return dft if s.nil? || s.empty?
-        return err("invalid 'style' (expected full|strip)",
+        return err("invalid 'style' (expected #{Settings::COLORMARKER_STYLES.join("|")})",
           "INVALID_ARGUMENT", field: "style") unless Settings::COLORMARKER_STYLES.includes?(s.downcase)
         Store::MarkerStyle.from_label(s)
       end
@@ -248,7 +245,7 @@ module Gori
           case dir_s.try(&.downcase)
           when "up"   then -1
           when "down" then 1
-          else             return err("invalid 'direction' (expected up|down)", "INVALID_ARGUMENT", field: "direction")
+          else             return err("invalid 'direction' (expected #{MOVE_DIRS.join("|")})", "INVALID_ARGUMENT", field: "direction")
           end
         return not_found("no #{scope.label} colour rule with id #{id}") unless color_rule_exists?(id, scope)
         scoped = Gori::Colormarker.merged(store).select { |r| r.scope == scope }
@@ -404,7 +401,7 @@ module Gori
           "changes it. `id` is unique only within a scope, so pass both to the mutation tools. " \
           "For a global rule, `enabled` is the state in THIS project and `default_enabled` the " \
           "library's own." do |s|
-          s.field "scope", strprop("show only project | global rules (default: both)")
+          s.field "scope", enumprop("show only rules from this store (default: both)", RULE_SCOPES)
         end
 
         tool j, "preview_color_rule",
@@ -433,9 +430,9 @@ module Gori
           "it. Display only — a colour rule never modifies traffic." do |s|
           s.field "when", strprop("the condition, in History QL — the SAME query language and the same fields list_history takes: host: path: url: method: scheme: proto: status: size: reqsize: respsize: dur: header: body: stub: scope:, ~regex on host/path/url/header/body, plus AND/OR/NOT, -negation and (grouping). Matched against the captured flow. CAVEATS, each of which otherwise fails silently: `host:` is a SUBSTRING, not a DNS-label glob, so host:alpha.test also matches xalpha.test; a flow with no response yet has no status, and is painted once the response lands; `scope:in`/`scope:out` follows the project's scope rules as they change and ignores the ⇧S display lens, so with NO scope rules configured nothing is in scope and both spellings paint nothing; and `body:` here SCANS rather than reading the trigram index list_history uses, so it reaches binary bodies that index skips, but it reads only the first 64 KiB of each side and reads the bytes AS CAPTURED, so a match past that bound — or inside a gzipped body — is not painted"), required: true
           s.field "color", strprop("red | orange | yellow | green | blue | purple (default yellow) — resolved through the active theme, so it reads correctly on light and dark alike — OR the name of a custom colour (list_custom_colors / create_custom_color), which carries an absolute hex")
-          s.field "style", strprop("full (tint the whole History row) | strip (one colour cell in a narrow column ahead of TIME) — default full")
+          s.field "style", enumprop("full tints the whole History row; strip paints one colour cell in a narrow column ahead of TIME (default full)", Settings::COLORMARKER_STYLES)
           s.field "name", strprop("optional label for the rule")
-          s.field "scope", strprop("project (default) | global — a global rule lives in settings.json and applies in EVERY project")
+          s.field "scope", enumprop("which store the rule lives in (default project). A global rule lives in settings.json and applies in EVERY project", RULE_SCOPES)
           s.field "enabled", boolprop("create the rule already enabled (default true)")
         end
 
@@ -445,10 +442,10 @@ module Gori
           "only this project's on/off answer use set_color_rule_enabled. Display only — a " \
           "colour rule never modifies traffic." do |s|
           s.field "id", intprop("rule id from list_color_rules"), required: true
-          s.field "scope", strprop("which id: project (default) | global")
+          s.field "scope", enumprop("which store `id` is in (default project)", RULE_SCOPES)
           s.field "when", strprop("new condition (see create_color_rule for the grammar and its caveats)")
           s.field "color", strprop("a built-in (red | orange | yellow | green | blue | purple) or a custom colour's name")
-          s.field "style", strprop("full | strip")
+          s.field "style", enumprop("full tints the whole row; strip paints one colour cell", Settings::COLORMARKER_STYLES)
           s.field "name", strprop("rule label")
         end
 
@@ -460,7 +457,7 @@ module Gori
           "following later changes to that default." do |s|
           s.field "id", intprop("rule id from list_color_rules"), required: true
           s.field "enabled", boolprop("true to enable, false to disable"), required: true
-          s.field "scope", strprop("which id: project (default) | global")
+          s.field "scope", enumprop("which store `id` is in (default project)", RULE_SCOPES)
           s.field "everywhere", boolprop("global rules only: change the default for every project instead of this one")
         end
 
@@ -470,15 +467,15 @@ module Gori
           "cosmetics. Moves within the rule's own scope only: every global rule resolves " \
           "before every project one, so the boundary is not a position." do |s|
           s.field "id", intprop("rule id from list_color_rules"), required: true
-          s.field "direction", strprop("up (higher precedence) | down (lower)"), required: true
-          s.field "scope", strprop("which id: project (default) | global")
+          s.field "direction", enumprop("up raises the rule's precedence, down lowers it", MOVE_DIRS), required: true
+          s.field "scope", enumprop("which store `id` is in (default project)", RULE_SCOPES)
         end
 
         tool j, "delete_color_rule",
           "Delete a Colormarker rule by id. Deleting a GLOBAL rule removes it from every " \
           "project, and takes this project's override of it along." do |s|
           s.field "id", intprop("rule id from list_color_rules"), required: true
-          s.field "scope", strprop("which id: project (default) | global")
+          s.field "scope", enumprop("which store `id` is in (default project)", RULE_SCOPES)
         end
 
         tool j, "create_custom_color",

--- a/src/gori/mcp/tools/compare.cr
+++ b/src/gori/mcp/tools/compare.cr
@@ -23,8 +23,8 @@ module Gori
         return not_found("no flow with id #{id_b}") unless detail_b
 
         pane_s = str(h, "pane").try(&.strip.downcase)
-        if pane_s && !pane_s.in?("request", "response")
-          return err("invalid 'pane' (expected request|response)", "INVALID_ARGUMENT", field: "pane")
+        if pane_s && !MESSAGE_SIDES.includes?(pane_s)
+          return err("invalid 'pane' (expected #{MESSAGE_SIDES.join("|")})", "INVALID_ARGUMENT", field: "pane")
         end
         pane = pane_s == "request" ? :request : :response
         changes_only = bool_arg(h, "changes_only", false)
@@ -186,7 +186,7 @@ module Gori
           "text unless include_sensitive=true. Pure read: no network, nothing written." do |s|
           s.field "flow_id_a", intprop("first flow id (the 'original' side)"), required: true
           s.field "flow_id_b", intprop("second flow id (the 'new' side)"), required: true
-          s.field "pane", strprop("request | response (default response)")
+          s.field "pane", enumprop("which half of the two flows to diff (default response)", MESSAGE_SIDES)
           s.field "changes_only", boolprop("omit unchanged (same) lines from the diff (default false)")
           s.field "context", intprop("collapse unchanged runs to {kind:fold,hidden} markers, keeping N lines around each change — the readable form for a long response (mutually exclusive with changes_only)")
           s.field "include_sensitive", boolprop("return Authorization/Cookie/Set-Cookie/API-key header values instead of [REDACTED] (default false)")

--- a/src/gori/mcp/tools/cookie.cr
+++ b/src/gori/mcp/tools/cookie.cr
@@ -83,7 +83,7 @@ module Gori
         when "django"
           Cookie::Django.forge(forge_payload(h), secret, ts,
             salt: str(h, "salt") || Cookie::Django::DEFAULT_SALT,
-            algorithm: str(h, "algorithm") || Cookie::Django::DEFAULT_ALGO)
+            algorithm: django_algorithm(h))
         when "rack"
           data = (str(h, "value") || str(h, "payload")).try(&.presence) ||
                  raise Cookie::CookieError.new("rack forge needs 'value' (the base64 Marshal cookie value)")
@@ -100,12 +100,28 @@ module Gori
 
       # --- shared cookie helpers ----------------------------------------------
 
-      # An optional 'format' pin (flask/rack/django), validated. nil = auto-detect.
+      # An optional 'format' pin, validated. nil = auto-detect. The list is `Cookie::FORMATS`
+      # in both halves — the check and the sentence — so the schema's `enum`, built from the
+      # same constant, cannot come to advertise a format this refuses.
       private def cookie_format(h) : String?
         f = str(h, "format").try(&.presence.try(&.downcase))
         return nil if f.nil?
-        raise Cookie::CookieError.new("unknown format #{f.inspect} (use flask/rack/django)") unless Cookie::FORMATS.includes?(f)
+        raise Cookie::CookieError.new("unknown format #{f.inspect} (use #{Cookie::FORMATS.join("/")})") unless Cookie::FORMATS.includes?(f)
         f
+      end
+
+      # The Django HMAC algorithm, validated the same way — it was read with NO check at all
+      # (`str(h, "algorithm") || DEFAULT_ALGO`), so `algorithm:"SHA256"` (a plausible casing)
+      # or `"sha512"` travelled down to `Django.hmac_algo` and surfaced as a raise from deep in
+      # the crypto path rather than a refusal naming the argument. Its sibling `format` on
+      # these same three tools has been validated all along.
+      private def django_algorithm(h) : String
+        a = str(h, "algorithm").try(&.strip.downcase.presence)
+        return Cookie::Django::DEFAULT_ALGO if a.nil?
+        unless Cookie::Django::SUPPORTED_ALGOS.includes?(a)
+          raise Cookie::CookieError.new("unknown algorithm #{a.inspect} (use #{Cookie::Django::SUPPORTED_ALGOS.join("/")})")
+        end
+        a
       end
 
       private def cookie_resolved_format(cookie : String, h) : String?
@@ -119,7 +135,7 @@ module Gori
         when "rack"  then Cookie::Rack.verify(cookie, secret)
         when "django" then Cookie::Django.verify(cookie, secret,
           salt: str(h, "salt") || Cookie::Django::DEFAULT_SALT,
-          algorithm: str(h, "algorithm") || Cookie::Django::DEFAULT_ALGO)
+          algorithm: django_algorithm(h))
         else raise Cookie::CookieError.new("unrecognized cookie format")
         end
       end
@@ -130,7 +146,7 @@ module Gori
         when "rack"  then Cookie::Rack.crack(cookie, secrets)
         when "django" then Cookie::Django.crack(cookie, secrets,
           salt: str(h, "salt") || Cookie::Django::DEFAULT_SALT,
-          algorithm: str(h, "algorithm") || Cookie::Django::DEFAULT_ALGO)
+          algorithm: django_algorithm(h))
         else raise Cookie::CookieError.new("unrecognized cookie format")
         end
       end
@@ -146,7 +162,7 @@ module Gori
           "signature). Auto-detects the format from the cookie's punctuation. Pure transform: " \
           "no network, no signature verification. Returns {format, payload, timestamp, signature, …}." do |s|
           s.field "cookie", strprop("the raw cookie value (URL-decoded)"), required: true
-          s.field "format", strprop("force a format instead of auto-detect: flask | rack | django")
+          s.field "format", enumprop("force a format instead of auto-detect", Cookie::FORMATS)
         end
 
         tool j, "cookie_verify",
@@ -154,9 +170,9 @@ module Gori
           "confirms a guessed/cracked signing key. Returns {valid, format}." do |s|
           s.field "cookie", strprop("the raw cookie value"), required: true
           s.field "secret", strprop("the candidate signing secret"), required: true
-          s.field "format", strprop("force a format: flask | rack | django (default auto-detect)")
+          s.field "format", enumprop("force a format (default auto-detect)", Cookie::FORMATS)
           s.field "salt", strprop("Flask/Django signing salt (Flask default 'cookie-session', Django 'django.core.signing')")
-          s.field "algorithm", strprop("Django HMAC algorithm: sha256 (default) | sha1")
+          s.field "algorithm", enumprop("Django HMAC algorithm (default #{Cookie::Django::DEFAULT_ALGO})", Cookie::Django::SUPPORTED_ALGOS)
         end
 
         tool j, "cookie_crack",
@@ -166,22 +182,22 @@ module Gori
           s.field "cookie", strprop("the raw cookie value"), required: true
           s.field "secrets", strarrprop("inline candidate secrets to try (in order)")
           s.field "wordlist", strprop("path to a newline-delimited wordlist file")
-          s.field "format", strprop("force a format: flask | rack | django (default auto-detect)")
+          s.field "format", enumprop("force a format (default auto-detect)", Cookie::FORMATS)
           s.field "salt", strprop("Flask/Django signing salt")
-          s.field "algorithm", strprop("Django HMAC algorithm: sha256 (default) | sha1")
+          s.field "algorithm", enumprop("Django HMAC algorithm (default #{Cookie::Django::DEFAULT_ALGO})", Cookie::Django::SUPPORTED_ALGOS)
         end
 
         tool j, "cookie_forge",
           "Re-sign a (possibly edited) payload with a known/cracked secret and emit a valid " \
           "session cookie — forge an admin session once the key is known. Flask/Django take a " \
           "'payload' JSON; Rack takes the opaque base64 'value'. Returns {cookie, format}." do |s|
-          s.field "format", strprop("flask | rack | django"), required: true
+          s.field "format", enumprop("which framework's cookie to forge", Cookie::FORMATS), required: true
           s.field "secret", strprop("the signing secret"), required: true
           s.field "payload", strprop("session JSON to sign (Flask/Django)")
           s.field "value", strprop("the base64 Marshal cookie value (Rack — opaque bytes)")
           s.field "timestamp", intprop("unix second to stamp (Flask/Django; defaults to now)")
           s.field "salt", strprop("Flask/Django signing salt")
-          s.field "algorithm", strprop("Django HMAC algorithm: sha256 (default) | sha1")
+          s.field "algorithm", enumprop("Django HMAC algorithm (default #{Cookie::Django::DEFAULT_ALGO})", Cookie::Django::SUPPORTED_ALGOS)
         end
       end
 

--- a/src/gori/mcp/tools/decode.cr
+++ b/src/gori/mcp/tools/decode.cr
@@ -188,7 +188,7 @@ module Gori
           s.field "header", strprop("header JSON object (overrides the token's header)")
           s.field "payload", strprop("payload JSON (overrides the token's payload wholesale; mutually exclusive with 'set')")
           s.field "set", strarrprop("patch individual claims before signing, each \"key=value\" (e.g. \"role=admin\"); value is JSON if it parses (true/3), else a string. Mutually exclusive with 'payload'")
-          s.field "alg", strprop("HS256 (default) | HS384 | HS512 | none")
+          s.field "alg", enumprop("signing algorithm (default HS256; none emits an unsigned token)", Gori::Jwt::ALGS)
           s.field "secret", strprop("HMAC secret for an HS algorithm")
         end
 

--- a/src/gori/mcp/tools/discover.cr
+++ b/src/gori/mcp/tools/discover.cr
@@ -118,7 +118,7 @@ module Gori
         c = str(h, "containment").presence
         return Discover::Containment::ScopeAware unless c
         Discover::Containment.parse?(c) ||
-          raise FuzzArgError.new("invalid containment '#{c}' (same-origin|scope-aware|host+subdomains)")
+          raise FuzzArgError.new("invalid containment '#{c}' (#{DISCOVER_CONTAINMENTS.join("|")})")
       end
 
       private def discover_extensions(h) : Array(String)
@@ -386,7 +386,7 @@ module Gori
           s.field "wordlist", strprop("path to an extra path wordlist (merged with the built-in list)")
           s.field "extensions", strprop("comma list of extensions to also probe (e.g. php,json,bak)")
           s.field "headers", objprop("custom request-header name->value map added to every probe (e.g. Authorization/Cookie); overrides Accept/User-Agent, Host/Connection are ignored")
-          s.field "containment", strprop("boundary: same-origin | scope-aware (default) | host+subdomains")
+          s.field "containment", enumprop("how far off the seed the crawl may wander (default scope-aware)", DISCOVER_CONTAINMENTS)
           s.field "concurrency", intprop("parallel requests (default 20, max #{DISCOVER_MAX_CONCURRENCY})")
           s.field "rate", numprop("requests/sec cap, fractional allowed (0 = unlimited; 0.5 = one request every two seconds)")
           s.field "timeout_ms", intprop("per-request connect + idle timeout in milliseconds")

--- a/src/gori/mcp/tools/flows.cr
+++ b/src/gori/mcp/tools/flows.cr
@@ -116,15 +116,29 @@ module Gori
       private def list_events(h) : Result
         since = optional_int_arg(h, "since") || 0_i64
         limit = clamp(optional_int_arg(h, "limit"), 100, 500)
-        source = str(h, "source")
+        # Refused, not filtered. `source` and `actor` are the two CLOSED filters on this tool,
+        # and a value nothing writes narrows the feed to nothing — which comes back
+        # `events: []`, `isError:false`, and reads as "the project has no such activity" rather
+        # than "that is not a source". A wrong answer with no error on it is the worst shape a
+        # read tool has. `kind` stays open: it is a free string each producer coins
+        # (`job_done`, `agent_action`, `scope_add`, …) with no registry to check against.
+        #
+        # `actor` is the likelier trap of the two, because the Activity pane PRINTS `agent` for
+        # the `mcp` token (project_view's `act_actor_label` — the pane's filter is cycled, not
+        # typed, so it can afford the nicer word). An agent reading that label off a screenshot
+        # and calling `list_events{actor:"agent"}` used to get an empty feed for a project full
+        # of its own actions.
+        source = closed_filter(h, "source", EVENT_SOURCES)
+        return source if source.is_a?(Result)
+        actor = closed_filter(h, "actor", EVENT_ACTORS)
+        return actor if actor.is_a?(Result)
         kind = str(h, "kind")
-        actor = str(h, "actor")
         scanned = store.events_after(since, limit)
         next_cursor = scanned.empty? ? since : scanned.last.id
         rows = scanned
-        rows = rows.select { |r| r.source == source } if source && !source.empty?
+        rows = rows.select { |r| r.source == source } if source
         rows = rows.select { |r| r.kind == kind } if kind && !kind.empty?
-        rows = rows.select { |r| r.actor == actor } if actor && !actor.empty?
+        rows = rows.select { |r| r.actor == actor } if actor
         Result.new(JSON.build do |j|
           j.object do
             j.field("events") { j.array { rows.each { |r| Serialize.event_row(j, r) } } }
@@ -150,7 +164,9 @@ module Gori
         # feature on h2 ones.
         ws_msgs = store.ws_messages(id)
         include_sensitive = bool_arg(h, "include_sensitive", false)
-        cap, omit = body_return_opts(h)
+        opts = body_return_opts(h)
+        return opts if opts.is_a?(Result)
+        cap, omit = opts
         Result.new(Serialize.flow_detail_json(detail, ws_msgs, include_sensitive, cap, omit))
       end
 
@@ -221,8 +237,8 @@ module Gori
           raise Gori::Error.new("pass exactly one of flow_id or repeater_id")
         end
         part = str(h, "part") || "response"
-        unless part == "response" || part == "request"
-          raise Gori::Error.new("invalid 'part' #{part.inspect} (expected \"response\" or \"request\")")
+        unless MESSAGE_SIDES.includes?(part)
+          raise Gori::Error.new("invalid 'part' #{part.inspect} (expected #{MESSAGE_SIDES.join(" or ")})")
         end
         offset = bounded_int_arg(h, "offset", 0_i64, min: 0_i64)
         limit = bounded_int_arg(h, "limit", 65_536_i64, min: 1_i64, max: 262_144_i64).to_i
@@ -331,9 +347,9 @@ module Gori
           "Activity pane." do |s|
           s.field "since", intprop("forward cursor: only events with id > this (default 0 = from oldest). Pass back the response's next_cursor to tail.")
           s.field "limit", intprop("max events scanned (default 100, max 500)")
-          s.field "source", strprop("filter to one source: config | agent | miner | fuzzer | probe | bindings | rewriter | discover | sequencer")
+          s.field "source", enumprop("filter to one producer of feed rows", EVENT_SOURCES)
+          s.field "actor", enumprop("filter to the surface that acted; rows written by a background engine name none", EVENT_ACTORS)
           s.field "kind", strprop("filter to one kind (e.g. job_done, agent_action, scope_add)")
-          s.field "actor", strprop("filter to one surface: tui | cli | mcp")
         end
 
         tool j, "get_flow",
@@ -345,7 +361,7 @@ module Gori
           "unless include_sensitive=true." do |s|
           s.field "id", intprop("flow id from list_history"), required: true
           s.field "include_sensitive", boolprop("return Authorization/Cookie/Set-Cookie/API-key header values instead of [REDACTED] (default false)")
-          s.field "body_mode", strprop("none | preview | full (default full) — none returns body shape only (encoding/size, omitted:true); preview inlines a small head; page more with get_response_body_chunk")
+          s.field "body_mode", enumprop("how much response body to inline (default full). none returns body shape only (encoding/size, omitted:true); preview inlines a small head; page more with get_response_body_chunk", BODY_MODES)
           s.field "max_body_bytes", intprop("cap inlined body bytes (clamped to 65536; page the rest with get_response_body_chunk)")
         end
 
@@ -359,7 +375,7 @@ module Gori
           "(requested_offset, offset_out_of_range, warning) rather than silently returning empty." do |s|
           s.field "flow_id", intprop("History flow id")
           s.field "repeater_id", intprop("Repeater workbench database id")
-          s.field "part", strprop("response (default) | request — \"request\" pages the stored REQUEST bytes: for a repeater that is the exact head+body blob send_request(repeater_id) replays, which is the only way to read past get_repeater_context's inline cap")
+          s.field "part", enumprop("which stored blob to page (default response). \"request\" pages the stored REQUEST bytes: for a repeater that is the exact head+body blob send_request(repeater_id) replays, which is the only way to read past get_repeater_context's inline cap", MESSAGE_SIDES)
           s.field "offset", intprop("zero-based byte offset (default 0)")
           s.field "limit", intprop("bytes to return (default 65536, max 262144)")
           s.field "raw", boolprop("page stored response bytes without content decoding (default false)")

--- a/src/gori/mcp/tools/fuzz.cr
+++ b/src/gori/mcp/tools/fuzz.cr
@@ -543,14 +543,12 @@ module Gori
         when true  then return :all
         when false then return :none
         end
-        case raw.as_s?.try(&.strip.downcase)
-        when "none"    then :none
-        when "matched" then :matched
-        when "all"     then :all
-        else
+        spelled = raw.as_s?.try(&.strip.downcase)
+        unless spelled && RECORD_HISTORY_MODES.includes?(spelled)
           raise FuzzArgError.new("invalid 'record_history' #{raw.to_json} " \
-                                 "(expected none | matched | all; true = all, false = none)")
+                                 "(expected #{RECORD_HISTORY_MODES.join(" | ")}; true = all, false = none)")
         end
+        spelled.to_s == "matched" ? :matched : (spelled.to_s == "all" ? :all : :none)
       end
 
       # {template text, the seeding flow's target, http2, EVIDENCE?}. The last element is the
@@ -722,7 +720,7 @@ module Gori
       private def fuzz_mode(h) : Fuzz::Mode
         s = str(h, "mode")
         return Fuzz::Mode::Sniper if s.nil? || s.strip.empty?
-        Fuzz::Mode.parse?(s) || raise FuzzArgError.new("invalid mode '#{s}' (sniper|batteringram|pitchfork|clusterbomb)")
+        Fuzz::Mode.parse?(s) || raise FuzzArgError.new("invalid mode '#{s}' (#{FUZZ_MODES.join("|")})")
       end
 
       # Mirrors `fuzz_sets`'s array-pulling pattern (bare array, or a JSON-encoded
@@ -1186,7 +1184,7 @@ module Gori
           s.field "auto", boolprop("auto-mark every query/cookie/body param when the template has no § markers")
           s.field "marks", strarrprop("literal tokens to mark as §…§ positions (each occurrence, mirrors CLI --mark); alternative to embedding §…§ in template. An occurrence already inside a §…§ (or flush against one) is skipped — re-wrapping it would merge the two positions — and a token left with none of its own is named in `marks_warning`")
           s.field "fields", strarrprop("schema-known gRPC fields of a UNARY request to sweep, each a field name, a path into a nested message ('profile.age'), or a field number, with [i] for one occurrence of a repeated field ('tags[1]'); append ¦chain to run a Decoder chain over the payload BEFORE the declared type encodes it. Each payload goes through the field's DECLARATION on its way to bytes (-3 is a different set of octets as int32, sint32, bool or an enum), every other byte of the message is copied from the capture, and the 5-byte gRPC length prefix is recomputed. Needs a descriptor set that resolves the rpc (see grpc_schema / grpc_reflect). These positions follow the template's own §…§ positions in the run's index space, so 'mode' and 'payloads' keep their meaning. A field the schema does not declare, one whose wire type the declaration contradicts, and a payload the declared type cannot hold are all refused before the first request. The field must be PRESENT on the captured message — gori replaces an occurrence, it never adds one, so a proto3 field left at its default is not a position. Payloads for a `bytes` field are read as HEX ('de ad be ef').")
-          s.field "mode", strprop("sniper (default) | batteringram | pitchfork | clusterbomb")
+          s.field "mode", enumprop("how payload sets are combined across marks (default sniper)", FUZZ_MODES)
           s.field "payloads", arrprop(%(array of payload sets, e.g. [{"list":["a","b"]},{"list_base64":["gA==","/w=="]},{"preset":"sqli"},{"numbers":"1-100"},{"wordlist":"/p.txt"},{"null":5},{"brute":"abc:1-3"}] — JSON array, NOT a string. "preset" is a built-in curated set — one of #{Fuzz::Presets.names.join(", ")} — for a fast start with no file; add "file":"/extra.txt" to merge a user file into it (built-in first, de-duped). "list_base64" is the byte-exact list: use it for payloads a JSON string cannot carry (0x00, 0x80-0xFF, invalid/overlong UTF-8), since "list" entries go on the wire as their UTF-8 encoding. numbers/brute also accept a structured object: {"numbers":{"from":1,"to":100,"step":2}}, {"brute":{"charset":"abc","min":1,"max":3}}. Brute lengths are capped at #{BRUTE_MAX_LEN}.))
           s.field "processors", arrprop(%(ordered pipeline applied to EVERY payload before it's spliced in (mirrors CLI --prefix/--suffix/--encode/--case/--hash/--regex-replace) — e.g. [{"type":"encode","kind":"url"}]. Query-string and form-urlencoded body positions are ALREADY percent-encoded by default (see "no_encode"), so this is for the other positions — a path segment, a JSON body, a header or a cookie value — where a payload carrying a raw space, CRLF or quote would otherwise corrupt the request line/framing instead of reaching the app. Giving this pipeline REPLACES the default encoding (it applies to every position, so it is not stacked on top). Entries: {"type":"prefix","text":".."} {"type":"suffix","text":".."} {"type":"encode","kind":"url|urlall|base64|hex"} {"type":"case","kind":"upper|lower"} {"type":"hash","algo":"md5|sha1|sha256"} {"type":"regex_replace","pattern":"..","replacement":".."}))
           s.field "no_encode", boolprop("send payloads into query-string / form-body positions RAW — turns off the default percent-encoding for those positions (path, JSON body, header and cookie positions are raw either way). For a payload that IS the raw byte: parameter pollution with a bare &, a request-line CRLF probe. Also for a payload that is ALREADY a percent-escape and aims at the origin's own decoder — %00, %c0%af, %2e%2e%2f — which the default encodes again (%00 -> %2500) so it arrives as text, testing something else. An explicit 'processors' pipeline already replaces the default.")
@@ -1208,7 +1206,7 @@ module Gori
           s.field "insecure", boolprop("skip upstream TLS verification (default false)")
           s.field "max_requests", intprop("caller cap on total requests")
           s.field "allow_unscoped", boolprop("run even when the target host is outside the project's configured scope — REQUIRED to run against an out-of-scope target, or when no scope is configured at all (active requests are refused by default without a matching scope)")
-          s.field "record_history", strprop("none (default) | matched | all — record each sent request+response as a History flow for audit/evidence; matched results carry the flow_id in fuzz_results (fetch full detail with get_flow). 'all' is capped at #{FUZZ_HISTORY_MAX} flows. Booleans are accepted as aliases (true = all, false = none) because send_request spells this argument as a boolean; any OTHER value is refused by name rather than silently recording nothing.")
+          s.field "record_history", enumprop("record each sent request+response as a History flow for audit/evidence (default none); matched results carry the flow_id in fuzz_results (fetch full detail with get_flow). 'all' is capped at #{FUZZ_HISTORY_MAX} flows. Booleans are accepted as aliases (true = all, false = none) because send_request spells this argument as a boolean; any OTHER value is refused by name rather than silently recording nothing.", RECORD_HISTORY_MODES)
           s.field "update_content_length", boolprop("recompute Content-Length after each payload is spliced into the body (default true). Set FALSE to send your template's declared value verbatim — a Content-Length shorter or longer than the body, or Content-Length alongside Transfer-Encoding, is the canonical request-smuggling primitive, and with the default on every payload is silently re-framed to fit before it leaves. Mirrors CLI `gori run fuzz --verbatim` and intercept_forward_edit{update_content_length:false}.")
           s.field "reframe_grpc", boolprop("recompute the gRPC 5-byte length prefix after each payload is spliced into a gRPC message body (default FALSE). With the default, a payload that changes the message length leaves the prefix declaring the old one — a real gRPC server rejects those, and fuzz_status reports it as grpc_stale_prefix rather than silently repairing the operator's bytes (a deliberately-wrong length prefix is a standard parser test). Set TRUE for an ordinary unary sweep where framing rejections are noise rather than the test. Applies to unary messages only; a client-streaming body is left alone and still reported. Mirrors CLI `gori run fuzz --reframe-grpc`.")
           s.field "race_count", intprop("Race condition (last-byte-sync) mode: dial this many DEDICATED connections, hold back the request's final byte on each, then release every held-back byte in one tight write loop so the target receives all of them as close to simultaneously as this process can manage — for finding TOCTOU bugs (double-spend, coupon reuse, limit bypass). BYPASSES mode/payloads/marks entirely: the template is sent byte-identical on every connection (no §…§ substitution), so `template`/`flow_id` alone is enough — set match:{status:...} so 'matched' in fuzz_results marks the success response (a correctly-guarded endpoint should show at most one). Max #{Fuzz::Engine::MAX_RACE_SIZE}. This is HTTP/1.1-only (h2 degrades to independent per-connection sends — true single-packet HTTP/2 racing is not yet implemented).")

--- a/src/gori/mcp/tools/import.cr
+++ b/src/gori/mcp/tools/import.cr
@@ -65,7 +65,7 @@ module Gori
           "of `gori run import`. `path` is read from the MCP SERVER's local filesystem (this " \
           "process runs locally, same trust boundary as send_request). Only `har` and `burp` " \
           "carry responses; the rest import request templates with no response." do |s|
-          s.field "kind", strprop("har | urls | oas | postman | insomnia | burp | wsdl"), required: true
+          s.field "kind", enumprop("the source format to read", KINDS.keys), required: true
           s.field "path", strprop("filesystem path to the source file"), required: true
         end
       end

--- a/src/gori/mcp/tools/intercept.cr
+++ b/src/gori/mcp/tools/intercept.cr
@@ -228,8 +228,8 @@ module Gori
 
       private def intercept_set_direction(h) : Result
         dir = str(h, "direction").try(&.downcase)
-        unless dir && {"both", "request", "response"}.includes?(dir)
-          return err("invalid 'direction' (expected both | request | response)", "INVALID_ARGUMENT", field: "direction")
+        unless dir && INTERCEPT_DIRECTIONS.includes?(dir)
+          return err("invalid 'direction' (expected #{INTERCEPT_DIRECTIONS.join(" | ")})", "INVALID_ARGUMENT", field: "direction")
         end
         enqueue_intercept("set_direction", arg: dir)
       end
@@ -373,7 +373,7 @@ module Gori
         tool j, "intercept_set_direction",
           "Set which leg(s) intercept holds: both | request | response. Applied by the " \
           "capturing instance." do |s|
-          s.field "direction", strprop("both | request | response"), required: true
+          s.field "direction", enumprop("which side of a flow the proxy holds", INTERCEPT_DIRECTIONS), required: true
         end
       end
     end

--- a/src/gori/mcp/tools/issues.cr
+++ b/src/gori/mcp/tools/issues.cr
@@ -174,7 +174,7 @@ module Gori
 
         tool j, "create_issue", "Record a new issue in the project." do |s|
           s.field "title", strprop("issue title"), required: true
-          s.field "severity", strprop("info|low|medium|high|critical (default auto from cvss, else info)")
+          s.field "severity", enumprop("issue severity (default: derived from cvss, else info)", SEVERITIES)
           s.field "cvss", strprop("optional CVSS vector or numeric score (e.g. 9.8 or CVSS:3.1/...)")
           s.field "host", strprop("optional host the issue concerns")
           s.field "flow_id", intprop("optional flow id this issue links to")
@@ -184,10 +184,10 @@ module Gori
         tool j, "update_issue", "Update an existing issue's fields." do |s|
           s.field "id", intprop("issue id"), required: true
           s.field "title", strprop("new title")
-          s.field "severity", strprop("info|low|medium|high|critical")
+          s.field "severity", enumprop("new severity", SEVERITIES)
           s.field "cvss", strprop("optional CVSS vector or score (empty to clear)")
           s.field "notes", strprop("free-form notes (replaces existing)")
-          s.field "status", strprop("open|confirmed|false-positive|resolved")
+          s.field "status", enumprop("new triage state", ISSUE_STATUSES)
           s.field "repeater_id", intprop("optional repeater id to link to the issue")
         end
 

--- a/src/gori/mcp/tools/links.cr
+++ b/src/gori/mcp/tools/links.cr
@@ -132,7 +132,7 @@ module Gori
           "Repeater tab, or a Fuzz/Miner run — each resolved to a human label and URL. " \
           "A pointer whose target was pruned comes back with stale:true rather than being " \
           "dropped, so you can tell \"no evidence\" from \"evidence that is gone\"." do |s|
-          s.field "owner_kind", strprop("issue|note"), required: true
+          s.field "owner_kind", enumprop("which kind of record owns the link", LINK_OWNERS), required: true
           s.field "owner_id", intprop("the issue or note id"), required: true
         end
 
@@ -142,18 +142,18 @@ module Gori
           "Attach an evidence pointer from an Issue or Note to a Flow / Repeater tab / " \
           "Fuzz or Miner run. Idempotent — re-linking the same pair returns " \
           "already_linked:true rather than erroring or duplicating." do |s|
-          s.field "owner_kind", strprop("issue|note"), required: true
+          s.field "owner_kind", enumprop("which kind of record owns the link", LINK_OWNERS), required: true
           s.field "owner_id", intprop("the issue or note id"), required: true
-          s.field "ref_kind", strprop("flow|repeater|fuzz|miner"), required: true
+          s.field "ref_kind", enumprop("which workbench entity the link points at", LINK_REFS), required: true
           s.field "ref_id", intprop("id of the linked flow/repeater/fuzz/miner"), required: true
         end
 
         tool j, "remove_link",
           "Detach an evidence pointer, addressed by the same (owner, ref) pair add_link " \
           "takes — no need to look up the link row's own id first." do |s|
-          s.field "owner_kind", strprop("issue|note"), required: true
+          s.field "owner_kind", enumprop("which kind of record owns the link", LINK_OWNERS), required: true
           s.field "owner_id", intprop("the issue or note id"), required: true
-          s.field "ref_kind", strprop("flow|repeater|fuzz|miner"), required: true
+          s.field "ref_kind", enumprop("which workbench entity the link points at", LINK_REFS), required: true
           s.field "ref_id", intprop("id of the linked flow/repeater/fuzz/miner"), required: true
         end
       end

--- a/src/gori/mcp/tools/mine.cr
+++ b/src/gori/mcp/tools/mine.cr
@@ -291,7 +291,7 @@ module Gori
         return nil if raw.nil? || raw.strip.empty?
         raw.split(',').compact_map do |tok|
           next if tok.strip.empty?
-          Miner::Location.parse?(tok) || raise FuzzArgError.new("unknown location '#{tok}' (query|form|multipart|json|headers|cookies)")
+          Miner::Location.parse?(tok) || raise FuzzArgError.new("unknown location '#{tok}' (#{MINE_LOCATIONS.join("|")})")
         end
       end
 
@@ -315,7 +315,7 @@ module Gori
           s.field "template", strprop("raw HTTP request to mine")
           s.field "flow_id", intprop("seed the request from a captured flow id (instead of template)")
           s.field "url", strprop("absolute target URL (scheme+host) that sets the origin — a 'template' or 'flow_id' is still REQUIRED; url alone does NOT define the request (unlike send_request)")
-          s.field "locations", strprop("comma list of where to mine: query,form,multipart,json,headers,cookies (default: auto-detect; multipart is applicable but off by default — pass it explicitly)")
+          s.field "locations", strprop("comma list of where to mine: #{MINE_LOCATIONS.join(",")} (default: auto-detect; multipart is applicable but off by default — pass it explicitly)")
           s.field "wordlist", strprop("path to an extra param-name wordlist (merged with the built-in list)")
           s.field "bucket", intprop("names stuffed per request before bisection (per location)")
           s.field "concurrency", intprop("parallel requests (default 10, max #{MINE_MAX_CONCURRENCY})")

--- a/src/gori/mcp/tools/oast_providers.cr
+++ b/src/gori/mcp/tools/oast_providers.cr
@@ -160,7 +160,7 @@ module Gori
         tool j, "oast_start",
           "Register an OAST listener and return {session_id, payload_url}. Default provider is " \
           "interactsh on a public server. Put payload_url in a target, then oast_poll for hits." do |s|
-          s.field "provider", strprop("interactsh (default) | custom-http | webhook.site | BOAST | postbin")
+          s.field "provider", enumprop("out-of-band provider to register with (default interactsh)", Oast::ProviderKind.values.map(&.label))
           s.field "server", strprop("provider server/base URL (default: the provider's public preset)")
           s.field "token", strprop("optional provider auth token")
         end

--- a/src/gori/mcp/tools/probe.cr
+++ b/src/gori/mcp/tools/probe.cr
@@ -10,6 +10,11 @@ module Gori
       # so cap how many flows an active scan touches. Passive mode is request-free and uncapped.
       PROBE_ACTIVE_MAX_FLOWS = 500
 
+      # How `list_probe_rules{kind}` narrows the catalog: the two built-in families plus the
+      # operator's own. Not a Probe enum — `RuleCatalog` stores this as a plain string per
+      # entry — so the list lives here, read by the reader's refusal AND by the schema.
+      PROBE_RULE_KINDS = %w[passive active custom]
+
       # probe_scan — the MCP surface for the Prism scanner (parity with `gori run probe`).
       # PASSIVE by default (zero outbound requests): scans captured History flows (optional
       # QL filter) + Repeater tabs and returns grouped issues. active:true also runs the
@@ -211,8 +216,8 @@ module Gori
       # state. The ids here are what set_probe_rule_enabled / delete_probe_rule take.
       private def list_probe_rules(h) : Result
         kind = str(h, "kind").try(&.strip.downcase).presence
-        if kind && !%w[passive active custom].includes?(kind)
-          return err("invalid kind '#{kind}' (passive|active|custom)", "INVALID_ARGUMENT", field: "kind")
+        if kind && !PROBE_RULE_KINDS.includes?(kind)
+          return err("invalid kind '#{kind}' (#{PROBE_RULE_KINDS.join("|")})", "INVALID_ARGUMENT", field: "kind")
         end
         entries = Probe::RuleCatalog.load(store)
         entries = entries.select { |e| e.kind == kind } if kind
@@ -473,8 +478,8 @@ module Gori
           "fingerprint, an informational jwt_in_* note, or a custom rule. Writes nothing." do |s|
           s.field "query", strprop("gori QL filter applied to History flows only; empty scans all (Repeater tabs are always scanned)")
           s.field "active", boolprop("also run active checks that SEND probe requests (default false = passive, request-free); requires write access + a configured scope")
-          s.field "severity", strprop("only return issues at/above this level (info|low|medium|high|critical)")
-          s.field "category", strprop("only return issues in this category (#{Probe::FILTER_CATEGORIES.join("|")})")
+          s.field "severity", enumprop("only return issues at/above this level", SEVERITIES)
+          s.field "category", enumprop("only return issues in this category", Probe::FILTER_CATEGORIES)
           s.field "in_scope", boolprop("only return issues on hosts in the project's configured scope (the TUI ⇧S lens; ALL flows are still scanned). Empty result when no scope rules exist. Independent of active/allow_unscoped. Default false")
           s.field "allow_unscoped", boolprop("with active:true, run even when a target host is outside — or without — a configured scope (default false)")
           s.field "unsafe", boolprop("with active:true, ALSO probe unsafe methods (POST/PUT/PATCH/DELETE) — re-sends may mutate server data (default false)")
@@ -490,8 +495,8 @@ module Gori
           "OPEN findings only, mirroring the TUI's default lens. Returns " \
           "{issues, returned, offset, total, has_more} — not a bare array." do |s|
           s.field "include_closed", boolprop("also return dismissed/confirmed/resolved findings (default false = open only)")
-          s.field "severity", strprop("only return findings at/above this level (info|low|medium|high|critical)")
-          s.field "category", strprop("only return findings in this category (#{Probe::FILTER_CATEGORIES.join("|")})")
+          s.field "severity", enumprop("only return findings at/above this level", SEVERITIES)
+          s.field "category", enumprop("only return findings in this category", Probe::FILTER_CATEGORIES)
           s.field "host", strprop("only return findings for this exact host")
           s.field "limit", intprop("max rows (default 100, max 500)")
           s.field "offset", intprop("start row (default 0)")
@@ -502,7 +507,7 @@ module Gori
           "with whether the operator has each enabled, plus the project's current scan `mode`. " \
           "The `id` of each row is what set_probe_rule_enabled / update_probe_rule / " \
           "delete_probe_rule take. Both a scan here and one in the TUI honour this config." do |s|
-          s.field "kind", strprop("only list rules of this kind (passive|active|custom)")
+          s.field "kind", enumprop("only list rules of this kind", PROBE_RULE_KINDS)
         end
 
         return unless @allow_actions
@@ -551,10 +556,10 @@ module Gori
           s.field "title", strprop("short rule name (shown as the finding title)"), required: true
           s.field "pattern", strprop("the string to look for, a regex when match_kind=regex, or the COMMAND as an argv when match_kind=exec"), required: true
           s.field "description", strprop("what the rule is for (default empty)")
-          s.field "side", strprop("request|response (default response)")
-          s.field "region", strprop("whole|header|body (default body)")
-          s.field "match_kind", strprop("string|regex|exec (default string). exec RUNS A LOCAL COMMAND with the operator's own privileges: the selected region goes to it on stdin, exit 0 raises the finding, its first stdout line becomes the evidence. No shell; a spawn failure or timeout raises nothing and writes a warn event")
-          s.field "severity", strprop("info|low|medium|high|critical (default info)")
+          s.field "side", enumprop("which half of the exchange the rule reads (default response)", Probe::CustomRule::SIDES)
+          s.field "region", enumprop("which part of that half the pattern is matched against (default body)", Probe::CustomRule::REGIONS)
+          s.field "match_kind", enumprop("how `pattern` is read (default string). exec RUNS A LOCAL COMMAND with the operator's own privileges: the selected region goes to it on stdin, exit 0 raises the finding, its first stdout line becomes the evidence. No shell; a spawn failure or timeout raises nothing and writes a warn event", Probe::CustomRule::KINDS)
+          s.field "severity", enumprop("severity the raised finding carries (default info)", SEVERITIES)
         end
 
         tool j, "update_probe_rule",
@@ -564,10 +569,10 @@ module Gori
           s.field "title", strprop("short rule name"), required: true
           s.field "pattern", strprop("the string or regex to match, or the COMMAND as an argv when match_kind=exec"), required: true
           s.field "description", strprop("what the rule is for")
-          s.field "side", strprop("request|response (default response)")
-          s.field "region", strprop("whole|header|body (default body)")
-          s.field "match_kind", strprop("string|regex|exec (default string). exec RUNS A LOCAL COMMAND with the operator's own privileges: the selected region goes to it on stdin, exit 0 raises the finding, its first stdout line becomes the evidence. No shell; a spawn failure or timeout raises nothing and writes a warn event")
-          s.field "severity", strprop("info|low|medium|high|critical (default info)")
+          s.field "side", enumprop("which half of the exchange the rule reads (default response)", Probe::CustomRule::SIDES)
+          s.field "region", enumprop("which part of that half the pattern is matched against (default body)", Probe::CustomRule::REGIONS)
+          s.field "match_kind", enumprop("how `pattern` is read (default string). exec RUNS A LOCAL COMMAND with the operator's own privileges: the selected region goes to it on stdin, exit 0 raises the finding, its first stdout line becomes the evidence. No shell; a spawn failure or timeout raises nothing and writes a warn event", Probe::CustomRule::KINDS)
+          s.field "severity", enumprop("severity the raised finding carries (default info)", SEVERITIES)
         end
 
         tool j, "delete_probe_rule",
@@ -581,7 +586,7 @@ module Gori
           "requests to scope-included targets; aggressive = active with raised caps, wider " \
           "bypass sets, and UNSAFE methods (POST/PUT/PATCH/DELETE) — authorized targets only. " \
           "This arms the AUTOMATIC pipeline for live captures, not just one scan." do |s|
-          s.field "mode", strprop("off|passive|active|aggressive"), required: true
+          s.field "mode", enumprop("how much scanning the project does", Probe::Mode.values.map(&.label)), required: true
         end
       end
     end

--- a/src/gori/mcp/tools/rules.cr
+++ b/src/gori/mcp/tools/rules.cr
@@ -57,11 +57,12 @@ module Gori
       private def rule_scope(h) : Store::RuleScope | Result
         s = str(h, "scope")
         return Store::RuleScope::Project if s.nil? || s.empty?
-        case s.downcase
-        when "project" then Store::RuleScope::Project
-        when "global"  then Store::RuleScope::Global
-        else                err("invalid 'scope' (expected project|global)", "INVALID_ARGUMENT", field: "scope")
-        end
+        # One list — `RuleScope.values` — behind the match, the refusal sentence and the
+        # schema's `enum`, so they cannot come to disagree. Matched on `label` rather than
+        # through `parse?`, which folds separators and so accepts spellings the enum never
+        # advertises; case is folded, as it is in every sibling reader here.
+        Store::RuleScope.values.find { |v| v.label == s.downcase } ||
+          err("invalid 'scope' (expected #{RULE_SCOPES.join("|")})", "INVALID_ARGUMENT", field: "scope")
       end
 
       # Whether a rule's pattern is acceptable: only a Replace+Regex rule must compile; a
@@ -336,11 +337,16 @@ module Gori
       # pair or an error Result. Shared by create/update/preview_rule.
       private def rule_target_part(h, dft_target : Store::RuleTarget, dft_part : Store::RulePart) : {Store::RuleTarget, Store::RulePart} | Result
         tgt_s = str(h, "target").try(&.strip)
-        target = tgt_s.nil? || tgt_s.empty? ? dft_target : Store::RuleTarget.parse?(tgt_s)
-        return err("invalid 'target' (expected request|response)", "INVALID_ARGUMENT", field: "target") unless target
+        # Matched against the LABEL rather than through `parse?`, so ONE list — the enum's own
+        # members — backs the match, the refusal sentence and the schema's `enum` alike; add a
+        # member and all three follow. (`parse?` is also looser than the advertised set: it
+        # folds separators, so it answers for `shortcircuit` where `RuleOp` offers only
+        # `short_circuit`.) Case is still folded, as every sibling reader here folds it.
+        target = tgt_s.nil? || tgt_s.empty? ? dft_target : Store::RuleTarget.values.find { |v| v.label == tgt_s.downcase }
+        return err("invalid 'target' (expected #{RULE_TARGETS.join("|")})", "INVALID_ARGUMENT", field: "target") unless target
         part_s = str(h, "part").try(&.strip)
-        part = part_s.nil? || part_s.empty? ? dft_part : Store::RulePart.parse?(part_s)
-        return err("invalid 'part' (expected head|body|ws)", "INVALID_ARGUMENT", field: "part") unless part
+        part = part_s.nil? || part_s.empty? ? dft_part : Store::RulePart.values.find { |v| v.label == part_s.downcase }
+        return err("invalid 'part' (expected #{RULE_PARTS.join("|")})", "INVALID_ARGUMENT", field: "part") unless part
         {target, part}
       end
 
@@ -375,17 +381,9 @@ module Gori
         op = if op_s.nil? || op_s.empty?
                dft_op
              else
-               case op_s.downcase
-               when "replace"       then Store::RuleOp::Replace
-               when "add_header"    then Store::RuleOp::AddHeader
-               when "set_header"    then Store::RuleOp::SetHeader
-               when "remove_header" then Store::RuleOp::RemoveHeader
-               when "short_circuit" then Store::RuleOp::ShortCircuit
-               when "pipe"          then Store::RuleOp::Pipe
-               else                      nil
-               end
+               Store::RuleOp.values.find { |v| v.label == op_s.downcase }
              end
-        return err("invalid 'op' (expected replace|add_header|set_header|remove_header|short_circuit|pipe)", "INVALID_ARGUMENT", field: "op") unless op
+        return err("invalid 'op' (expected #{RULE_OPS.join("|")})", "INVALID_ARGUMENT", field: "op") unless op
         # Validate `match` explicitly instead of leaning on MatchKind.from_label
         # (which coerces any unknown label to Literal). A silent literal fallback
         # would mislead a caller into thinking a `regex` rule was applied while the
@@ -394,13 +392,9 @@ module Gori
         kind = if kind_s.nil? || kind_s.empty?
                  dft_kind
                else
-                 case kind_s.downcase
-                 when "literal" then Store::MatchKind::Literal
-                 when "regex"   then Store::MatchKind::Regex
-                 else                nil
-                 end
+                 Store::MatchKind.values.find { |v| v.label == kind_s.downcase }
                end
-        return err("invalid 'match' (expected literal|regex)", "INVALID_ARGUMENT", field: "match") unless kind
+        return err("invalid 'match' (expected #{RULE_MATCHES.join("|")})", "INVALID_ARGUMENT", field: "match") unless kind
         {op, kind}
       end
 
@@ -521,8 +515,8 @@ module Gori
       private def extract_kind_arg(h, dft : Gori::ExtractKind) : Gori::ExtractKind | Result
         raw = str(h, "kind").try(&.strip)
         return dft if raw.nil? || raw.empty?
-        Gori::ExtractKind.parse?(raw) ||
-          err("invalid 'kind' (expected cookie|header|regex|position|jsonpath)", "INVALID_ARGUMENT", field: "kind")
+        Gori::ExtractKind.values.find { |v| v.label == raw.downcase } ||
+          err("invalid 'kind' (expected #{EXTRACT_KINDS.join("|")})", "INVALID_ARGUMENT", field: "kind")
       end
 
       # The `$` is stripped so an agent may pass the token the way an operator reads it.
@@ -700,7 +694,7 @@ module Gori
           "project's own. `id` is unique only within a scope, so pass both to the mutation tools. " \
           "For a global rule, `enabled` is the state in THIS project and `default_enabled` the " \
           "library's own; `overridden` says the two were made to differ here." do |s|
-          s.field "scope", strprop("show only project | global rules (default: both)")
+          s.field "scope", enumprop("show only rules from this store (default: both)", RULE_SCOPES)
         end
 
         tool j, "list_rule_presets",
@@ -724,14 +718,14 @@ module Gori
           "scope=global. Note: a gori TUI already running applies it only after its " \
           "rules reload (reopen the Rewriter tab or restart); `gori run` and newly opened TUIs " \
           "pick it up immediately." do |s|
-          s.field "scope", strprop("project (default) | global — a global rule lives in settings.json and applies in EVERY project")
+          s.field "scope", enumprop("which store the rule lives in (default project). A global rule lives in settings.json and applies in EVERY project", RULE_SCOPES)
           s.field "pattern", strprop("for replace: the substring/regex to match; for a header op: the HEADER NAME; for short_circuit: the substring/regex matched against the REQUEST head"), required: true
           s.field "replacement", strprop("for replace: the replacement (empty = delete; supports $1 capture refs when match=regex); for add/set header: the header VALUE (default empty); for short_circuit: the canned RESPONSE — a status line such as '200 OK', then header lines, then a blank line and the body; for pipe: the COMMAND as an argv ('./sign --key k'), tokenized with quote/backslash rules but NEVER interpreted by a shell")
-          s.field "target", strprop("request|response (default request; short_circuit is always request)")
-          s.field "part", strprop("head|body|ws — head = request/status line + headers, body = entity body, ws = a WebSocket MESSAGE on an upgraded (101) flow with target picking the direction (request = client→server, response = server→client). Default head; ignored by header ops and short_circuit, which are head-only, and rejected for those ops when set to ws (replace and pipe are the two ops that can target ws)")
-          s.field "op", strprop("short_circuit | replace | add_header | set_header | remove_header | pipe (default replace). short_circuit ANSWERS the request from the rule and never dials the origin — nothing is sent upstream; use it to stub a response that does not exist. pipe RUNS A LOCAL COMMAND: 'replacement' is an argv, exec'd with no shell and with the operator's own privileges, fed the matched bytes on stdin, its stdout spliced back in — on timeout, non-zero exit or a failed spawn the bytes pass through unchanged and a notice is written (P6)")
+          s.field "target", enumprop("which message the rule rewrites (default request; short_circuit is always request)", RULE_TARGETS)
+          s.field "part", enumprop("head = request/status line + headers, body = entity body, ws = a WebSocket MESSAGE on an upgraded (101) flow with target picking the direction (request = client→server, response = server→client). Default head; ignored by header ops and short_circuit, which are head-only, and rejected for those ops when set to ws (replace and pipe are the two ops that can target ws)", RULE_PARTS)
+          s.field "op", enumprop("what the rule does (default replace). short_circuit ANSWERS the request from the rule and never dials the origin — nothing is sent upstream; use it to stub a response that does not exist. pipe RUNS A LOCAL COMMAND: 'replacement' is an argv, exec'd with no shell and with the operator's own privileges, fed the matched bytes on stdin, its stdout spliced back in — on timeout, non-zero exit or a failed spawn the bytes pass through unchanged and a notice is written (P6)", RULE_OPS)
           s.field "body_file", strprop("short_circuit only: serve this file's bytes as the response BODY instead of the inline one (re-read when the file changes). Empty = inline")
-          s.field "match", strprop("for replace: literal | regex (default literal). Regex supports $1/\\1 capture groups")
+          s.field "match", enumprop("for replace: how `pattern` is read (default literal). Regex supports $1/\\1 capture groups", RULE_MATCHES)
           s.field "name", strprop("optional label for the rule")
           s.field "host", strprop("optional host glob scoping the rule (e.g. 'example.com' substring, '*.example.com' wildcard; empty = all hosts)")
           s.field "enabled", boolprop("create the rule already enabled (default true); pass false for an atomic disabled creation (no live window before you can preview/adjust it)")
@@ -742,8 +736,8 @@ module Gori
           "Replace rules — the same result as create_rule called once per rule, so they are " \
           "visible, editable and disable-able afterwards. Returns the ids created. Note: a gori " \
           "TUI already running applies them only after its rules reload." do |s|
-          s.field "preset", strprop("the preset key from list_rule_presets (e.g. 'unhide-hidden-fields', 'remove-csp')"), required: true
-          s.field "scope", strprop("project (default) | global — global rules live in settings.json and apply in EVERY project")
+          s.field "preset", enumprop("the preset to install; list_rule_presets describes each one", Gori::RulePresets.keys), required: true
+          s.field "scope", enumprop("which store the rules live in (default project). Global rules live in settings.json and apply in EVERY project", RULE_SCOPES)
           s.field "enabled", boolprop("install the rules already enabled (default true); pass false to install them disabled for review before they touch traffic")
         end
 
@@ -752,14 +746,14 @@ module Gori
           "For a global rule, `enabled` changes the state in THIS project (an override), not " \
           "the library's default — use set_rule_enabled with everywhere=true for that." do |s|
           s.field "id", intprop("rule id from list_rules"), required: true
-          s.field "scope", strprop("which id: project (default) | global")
+          s.field "scope", enumprop("which store `id` is in (default project)", RULE_SCOPES)
           s.field "pattern", strprop("new match substring/regex, or header name")
           s.field "replacement", strprop("new replacement / header value / canned response")
-          s.field "target", strprop("request|response")
-          s.field "part", strprop("head|body|ws (ws = a WebSocket message; replace only)")
-          s.field "op", strprop("short_circuit | replace | add_header | set_header | remove_header")
+          s.field "target", enumprop("which message the rule rewrites", RULE_TARGETS)
+          s.field "part", enumprop("which part of the message (ws = a WebSocket message; replace only)", RULE_PARTS)
+          s.field "op", enumprop("what the rule does", RULE_OPS)
           s.field "body_file", strprop("short_circuit only: file served as the response body ('' = inline)")
-          s.field "match", strprop("literal | regex")
+          s.field "match", enumprop("how `pattern` is read", RULE_MATCHES)
           s.field "name", strprop("rule label")
           s.field "host", strprop("host glob ('' = all hosts)")
           s.field "enabled", boolprop("enable/disable the rule")
@@ -771,10 +765,10 @@ module Gori
           "Approximate: response bodies are scanned as stored wire bytes." do |s|
           s.field "pattern", strprop("the substring/regex to match, or header name"), required: true
           s.field "replacement", strprop("replacement / header value (matters for header ops, which change the head regardless of match)")
-          s.field "target", strprop("request|response (default request)")
-          s.field "part", strprop("head|body|ws (default head; ws counts captured WebSocket messages, replace only)")
-          s.field "op", strprop("short_circuit | replace | add_header | set_header | remove_header (default replace). For short_circuit this counts the flows the rule WOULD have answered instead of sending")
-          s.field "match", strprop("literal | regex (default literal)")
+          s.field "target", enumprop("which message the rule rewrites (default request)", RULE_TARGETS)
+          s.field "part", enumprop("which part of the message (default head; ws counts captured WebSocket messages, replace only)", RULE_PARTS)
+          s.field "op", enumprop("what the rule does (default replace). For short_circuit this counts the flows the rule WOULD have answered instead of sending", RULE_OPS)
+          s.field "match", enumprop("how `pattern` is read (default literal)", RULE_MATCHES)
           s.field "host", strprop("host glob ('' = all hosts)")
         end
 
@@ -784,7 +778,7 @@ module Gori
           "every project that has not overridden it follows." do |s|
           s.field "id", intprop("rule id from list_rules"), required: true
           s.field "enabled", boolprop("true to enable, false to disable"), required: true
-          s.field "scope", strprop("which id: project (default) | global")
+          s.field "scope", enumprop("which store `id` is in (default project)", RULE_SCOPES)
           s.field "everywhere", boolprop("global rules only: change the default for every project instead of this one")
         end
 
@@ -792,7 +786,7 @@ module Gori
           "Delete a Match & Replace rule by id. Deleting a GLOBAL rule removes it from every " \
           "project." do |s|
           s.field "id", intprop("rule id from list_rules"), required: true
-          s.field "scope", strprop("which id: project (default) | global")
+          s.field "scope", enumprop("which store `id` is in (default project)", RULE_SCOPES)
         end
 
         tool j, "create_extract_rule",
@@ -802,7 +796,7 @@ module Gori
           "because a response echoing an attacker-shaped payload back could otherwise rebind the " \
           "operator's session to it. One name, one writer: a duplicate name is refused." do |s|
           s.field "name", strprop("the binding name, without the $ (letters, digits and _, not starting with a digit)"), required: true
-          s.field "kind", strprop("cookie | header | regex | position | jsonpath (default cookie). regex/position/jsonpath read the DECODED body; cookie/header read the parsed head")
+          s.field "kind", enumprop("where the token is read from (default cookie). cookie and header read the parsed head; the rest read the DECODED body", EXTRACT_KINDS)
           s.field "selector", strprop("cookie name, header name, regex source, or JSON path ($.a.b[0]) — required for every kind except position")
           s.field "when", strprop("which messages to read, in intercept-filter syntax (host:/path:/method:/scheme:/status:, AND/OR/NOT, '' = any). status: matches responses only")
           s.field "host", strprop("optional host glob scoping the rule ('example.com' substring, '*.example.com' wildcard; empty = all hosts)")
@@ -816,7 +810,7 @@ module Gori
           "drops the old name's bound value rather than re-labelling it." do |s|
           s.field "id", intprop("extract rule id from list_extract_rules"), required: true
           s.field "name", strprop("new binding name (without the $)")
-          s.field "kind", strprop("cookie | header | regex | position | jsonpath")
+          s.field "kind", enumprop("where the token is read from", EXTRACT_KINDS)
           s.field "selector", strprop("cookie/header name, regex source, or JSON path")
           s.field "when", strprop("intercept-filter condition ('' = any message)")
           s.field "host", strprop("host glob ('' = all hosts)")

--- a/src/gori/mcp/tools/saved_views.cr
+++ b/src/gori/mcp/tools/saved_views.cr
@@ -244,7 +244,7 @@ module Gori
           "view the TUI is showing this project through — it does NOT apply to list_history, " \
           "which filters only by the `view` you pass it, so a stored UI preference can never " \
           "silently drop rows from your answer. Names are unique only WITHIN a scope." do |s|
-          s.field "scope", strprop("show only builtin | project | global views (default: all three)")
+          s.field "scope", enumprop("show only views from this store (default: all three)", VIEW_SCOPES_R)
         end
 
         return unless @allow_actions
@@ -257,7 +257,7 @@ module Gori
           "chip claims it does, so it is refused." do |s|
           s.field "name", strprop("the view's name — how list_history{view} and `gori run history --view` address it; unique within its scope, and not one of the built-in names"), required: true
           s.field "query", strprop("the view's query, in History QL — the SAME language and fields list_history's `query` takes (host: path: url: method: status: src: size: dur: header: body: scope: …, ~regex, AND/OR/NOT, -negation, grouping)"), required: true
-          s.field "scope", strprop("project (default) | global — a global view appears in EVERY project")
+          s.field "scope", enumprop("which store the view lives in (default project). A global view appears in EVERY project", RULE_SCOPES)
         end
 
         tool j, "update_view",
@@ -265,17 +265,17 @@ module Gori
           "the project and global stores (new_scope), or any combination. Omitted fields are " \
           "left unchanged. Built-in views cannot be edited." do |s|
           s.field "name", strprop("the view to update, as listed by list_views"), required: true
-          s.field "scope", strprop("which store `name` is in: project (default) | global")
+          s.field "scope", enumprop("which store `name` is in (default project)", RULE_SCOPES)
           s.field "new_name", strprop("rename the view")
           s.field "query", strprop("replace the view's query (see create_view for the grammar)")
-          s.field "new_scope", strprop("move the view to the other store: project | global")
+          s.field "new_scope", enumprop("move the view to the other store", RULE_SCOPES)
         end
 
         tool j, "delete_view",
           "Delete a saved view. Built-in views cannot be deleted. If this project was looking " \
           "through the deleted view it falls back to All." do |s|
           s.field "name", strprop("the view to delete, as listed by list_views"), required: true
-          s.field "scope", strprop("which store `name` is in: project (default) | global")
+          s.field "scope", enumprop("which store `name` is in (default project)", RULE_SCOPES)
         end
       end
     end

--- a/src/gori/mcp/tools/scope.cr
+++ b/src/gori/mcp/tools/scope.cr
@@ -8,9 +8,9 @@ module Gori
       # Add a scope rule (validates + dedupes, like `gori run project scope add`).
       private def add_scope_rule(h) : Result
         kind = str(h, "kind").try(&.strip.downcase) || "include"
-        return err("invalid 'kind' (expected include|exclude)", "INVALID_ARGUMENT", field: "kind") unless kind.in?(Scope::KINDS)
+        return err("invalid 'kind' (expected #{Scope::KINDS.join("|")})", "INVALID_ARGUMENT", field: "kind") unless kind.in?(Scope::KINDS)
         match_type = str(h, "match_type").try(&.strip.downcase) || "host"
-        return err("invalid 'match_type' (expected host|string|regex)", "INVALID_ARGUMENT", field: "match_type") unless match_type.in?(Scope::TYPES)
+        return err("invalid 'match_type' (expected #{Scope::TYPES.join("|")})", "INVALID_ARGUMENT", field: "match_type") unless match_type.in?(Scope::TYPES)
         pattern = str(h, "pattern").try(&.strip)
         return err("missing required 'pattern'", "INVALID_ARGUMENT", field: "pattern") if pattern.nil? || pattern.empty?
         if e = Scope.validation_error(match_type, pattern)
@@ -60,9 +60,9 @@ module Gori
         # Every field defaults to the rule's CURRENT value, so a caller can change just the
         # pattern without restating kind/match_type.
         kind = str(h, "kind").try(&.strip.downcase) || existing.kind
-        return err("invalid 'kind' (expected include|exclude)", "INVALID_ARGUMENT", field: "kind") unless kind.in?(Scope::KINDS)
+        return err("invalid 'kind' (expected #{Scope::KINDS.join("|")})", "INVALID_ARGUMENT", field: "kind") unless kind.in?(Scope::KINDS)
         match_type = str(h, "match_type").try(&.strip.downcase) || existing.match_type
-        return err("invalid 'match_type' (expected host|string|regex)", "INVALID_ARGUMENT", field: "match_type") unless match_type.in?(Scope::TYPES)
+        return err("invalid 'match_type' (expected #{Scope::TYPES.join("|")})", "INVALID_ARGUMENT", field: "match_type") unless match_type.in?(Scope::TYPES)
         # An ABSENT pattern keeps the current one; a SUPPLIED blank one is a mistake, not a
         # no-op — silently keeping the old pattern would report success for an edit that
         # never happened, on the rule that gates outbound traffic.
@@ -158,8 +158,8 @@ module Gori
         tool j, "add_scope_rule",
           "Add a scope include/exclude rule (the Target/Sitemap ⇧S lens, and the intercept " \
           "gate). Deduped on the kind/match_type/pattern triple." do |s|
-          s.field "kind", strprop("include | exclude (default include)")
-          s.field "match_type", strprop("host | string | regex (default host)")
+          s.field "kind", enumprop("whether the rule brings hosts INTO scope or carves them out (default include)", Scope::KINDS)
+          s.field "match_type", enumprop("how `pattern` is matched against a request (default host)", Scope::TYPES)
           s.field "pattern", strprop("host: exact/subdomain/'*' glob; string: substring of scheme://host/target; regex: over the same (case-sensitive; use (?i) to opt out)"), required: true
         end
 
@@ -186,8 +186,8 @@ module Gori
           "to the rule's current value, so you can change just the pattern. Prefer this over " \
           "delete + re-add, which changes the id and briefly drops the rule from the gate." do |s|
           s.field "id", intprop("scope rule id"), required: true
-          s.field "kind", strprop("include|exclude (default: unchanged)")
-          s.field "match_type", strprop("host|string|regex (default: unchanged)")
+          s.field "kind", enumprop("whether the rule includes or excludes (default: unchanged)", Scope::KINDS)
+          s.field "match_type", enumprop("how `pattern` is matched (default: unchanged)", Scope::TYPES)
           s.field "pattern", strprop("new pattern (default: unchanged)")
         end
       end

--- a/src/gori/mcp/tools/send.cr
+++ b/src/gori/mcp/tools/send.cr
@@ -32,7 +32,9 @@ module Gori
         # as "nothing was sent", so it fixes the argument and sends a second real request with
         # a second repeater row behind it. Same rule `minimize_repeater` states for `apply`:
         # every argument is validated before the sends are spent.
-        body_cap, body_omit = body_return_opts(h)
+        body_opts = body_return_opts(h)
+        return body_opts if body_opts.is_a?(Result)
+        body_cap, body_omit = body_opts
         issue_id = send_issue_id(h, save)
         return issue_id if issue_id.is_a?(Result)
 
@@ -1370,7 +1372,7 @@ module Gori
           s.field "record_history", boolprop("record the outbound request and response in History for audit/evidence (default true)")
           s.field "save_as_repeater", boolprop("save this request and its response to the Repeater workbench (default false)")
           s.field "include_sensitive_headers", boolprop("return Cookie/Set-Cookie/Authorization/API-key response values instead of [REDACTED] (default false)")
-          s.field "body_mode", strprop("none | preview | full (default full) — control how much response body is inlined")
+          s.field "body_mode", enumprop("how much response body to inline (default full)", BODY_MODES)
           s.field "max_body_bytes", intprop("cap inlined response-body bytes (clamped to 65536)")
           s.field "allow_unscoped", boolprop("send even when the target host is outside the project's configured scope — REQUIRED to run against an out-of-scope target, or when no scope is configured at all (active requests are refused by default without a matching scope)")
           s.field "name", strprop("optional custom name for the saved repeater tab (only when save_as_repeater=true)")

--- a/src/gori/store/event_log.cr
+++ b/src/gori/store/event_log.cr
@@ -2,6 +2,18 @@ require "db"
 
 module Gori
   class Store
+    # Every `source` the #124 feed carries, as the producers spell it. The column is a free
+    # string — `insert_event` takes whatever it is handed — so this is the list of what is
+    # actually WRITTEN, and it exists because three surfaces had each grown their own copy of
+    # it: the Activity pane's filter cycle (`ACT_SOURCES`), that filter's keybinding help in
+    # `verbs/activity.cr` (which had already lost `config`), and the MCP `list_events{source}`
+    # schema. All three read this now. A filter offering a source nothing writes returns an
+    # empty feed that reads as "nothing happened".
+    #
+    # Ordered the way a reader wants them: who acted first (`agent`, `config`), then the
+    # background producers.
+    EVENT_SOURCES = %w[agent config bindings rewriter probe discover fuzzer miner sequencer]
+
     # Append one row to the #124 event feed (the AI firehose). Goes through the writer
     # fiber like every other insert; returns last_insert_rowid (0 on a dropped/closed-store
     # write — the caller decides whether a lost event matters). NEVER used for flow rows

--- a/src/gori/tui/project_view.cr
+++ b/src/gori/tui/project_view.cr
@@ -1040,10 +1040,10 @@ module Gori::Tui
     # events and two lines of one message is worse at both jobs than a short list.
     ACT_DETAIL_MIN_H = 8
 
-    # Cycle order for the `s` chip, `nil` = no narrowing. These are the sources the feed
-    # actually carries (every `insert_event` call site), listed with the two an operator reaches
-    # for first — the agent audit trail and the silent binding failures — at the front.
-    ACT_SOURCES = [nil, "agent", "config", "bindings", "rewriter", "probe", "discover", "fuzzer", "miner", "sequencer"]
+    # Cycle order for the `s` chip, `nil` = no narrowing. The sources themselves come from
+    # `Store::EVENT_SOURCES` — the list next to the writer — rather than a copy here: this used
+    # to be its own literal, and the keybinding help beside it had already lost `config`.
+    ACT_SOURCES = [nil] + Gori::Store::EVENT_SOURCES
 
     # Cycle order for the `a` chip: WHICH SURFACE acted. `nil` = every actor, including the
     # events no surface produced (a background engine's own finding).

--- a/src/gori/verbs/activity.cr
+++ b/src/gori/verbs/activity.cr
@@ -20,7 +20,7 @@ module Gori
 
       r.register Verb::Definition.new(
         "activity.filter-source", "Filter by source",
-        "Cycle the source narrowing: all, agent, bindings, rewriter, probe, discover, fuzzer, miner, sequencer",
+        "Cycle the source narrowing: all, #{Gori::Store::EVENT_SOURCES.join(", ")}",
         Verb::Scope::ProjectActivity, [Verb::Chord.new("s")]) { |ctx| ctx.activity_filter_source; nil }
 
       r.register Verb::Definition.new(


### PR DESCRIPTION
An MCP client hands the **model** the tool's JSON Schema, never the reader. None of gori's 153 tools declared a single `enum`, so for every argument with a fixed set of legal strings the model had to infer that set from the description's prose — and when it inferred wrong the call came back refused and it guessed again. A round trip per guess, which from outside the process reads as a flaky server.

I went looking for crashes first and did not find any: twenty protocol-robustness cases (100k-deep JSON, an 8 MB argument, a 1000-member batch, raw invalid UTF-8, unpaired surrogates, empty/nested batches, truncated lines) all survive with the following `ping` answered, empty-argument calls across every tool produce no `INTERNAL`, nonexistent ids never come back `retryable`, and read-only/unbound gating is exact in both directions. The transport hardening rounds closed that axis. What was left was this.

## What changed

**81 properties now carry `enum`**, sourced from the same list the reader validates against (`Store::RuleOp.values.map(&.label)`, `Scope::TYPES`, `Cookie::FORMATS`, `Probe::CustomRule::REGIONS`, …) rather than a second copy. The prose lists are gone, because the prose copy is what went stale: `update_rule` and `preview_rule` both described `op` **without `pipe`** while their reader had accepted `pipe` all along.

Where a reader had its own hand-written `case`, it now matches the same `label` list the schema publishes — so the gate and the sentence above it cannot drift apart either. That was the substantive fix on review: converting only the message would have created exactly the disagreement the constants exist to remove.

**Two silent-default bugs**, both the shape this surface refuses everywhere else:

- `body_mode`'s `else` folded every unrecognised value into `full` — the worst of the three to land on by accident, since a caller that asked for `none` and mistyped it got a whole response body inlined, on a transport where that is a megabyte into the agent's context. Its sibling `max_body_bytes` on the same line already refused an unreadable value; this is the other half. It now returns a `Result` carrying `field: "body_mode"` rather than raising, so the refusal names its argument like every other one here.
- `list_events` answered an unknown `source` (and `actor`) with `events: []`, `isError:false` — "the project has no such activity" for a value nothing ever writes. `actor` was the likelier trap: the Activity pane prints `agent` for the `mcp` token, so an agent reading that label back got an empty feed for a project full of its own work.

`Cookie` gained the same treatment for `algorithm`, which was read with **no check at all** and surfaced a typo as a raise from inside the crypto path.

**Single sources for two lists that had grown copies.** The event feed's `source` list moves next to its writer as `Store::EVENT_SOURCES`; the Activity pane's filter cycle and that filter's keybinding help — which had already lost `config` — now read it instead of each holding a copy. `Fuzz::Mode.names` does the same for the `--mode` spelling the docs and the CLI teach (`batteringram`), which is *not* the hyphenated `label` the results echo; the schema advertises the documented form so a validating client cannot block what the docs taught.

## Not converted, on purpose

`create_color_rule`'s `color` (the set grows with the project's custom colours) and `tls_preset` (also takes `""` to clear). An `enum` is a promise about every future call; a set that moves under the client belongs in prose. Payload-set and processor specs are mini-DSLs, not values.

## The guard

`spec/mcp/enum_schema_spec.cr` drives the live `tools/list` back through the live `Tools#call`: every advertised value is accepted, every unadvertised one is refused **by name**, and no description re-lists a set the `enum` already carries. Generic, so a new `enumprop` is covered the day it lands.

One trap worth naming for the next person: driving `scope:"global"` through these tools writes **process-wide** `Settings` state, so the spec has to unwind it the way `spec/rules_spec.cr` does. Without that, ten examples in files this change never touched failed under `crystal spec` while each passed alone.

## Verification

`crystal spec` (11872 examples, 0 failures) · `crystal build --no-codegen src/main.cr` · `scripts/bench_check.sh` (49 harnesses) · `scripts/seed_demo.cr` · `crystal tool format --check` · ameba unchanged from baseline (net −3).
