### PR TITLE
fix(outbound): gate a `--bind-from` seed as a sweep, so an EXCLUDE rule holds

### DIFF
--- a/spec/outbound_spec.cr
+++ b/spec/outbound_spec.cr
@@ -593,3 +593,64 @@ describe Gori::Outbound do
     end
   end
 end
+
+# The Layer-2 decision `CLI::Run.seed_bindings` makes for a `--bind-from FLOW-ID` seed, reached
+# the way `repeater_out_of_scope_for_spec` reaches its Layer-1 sibling.
+module Gori::CLI::Run
+  def self.bind_from_scope_triple_for_spec(built : Gori::Repeater::FlowRequest::Built)
+    bind_from_scope_triple(built)
+  end
+
+  def self.bind_from_seed_block_for_spec(ob : Gori::Outbound,
+                                         built : Gori::Repeater::FlowRequest::Built) : String?
+    bind_from_seed_block(ob, *bind_from_scope_triple(built))
+  end
+end
+
+private def built_for(target : String, path : String) : Gori::Repeater::FlowRequest::Built
+  host = URI.parse(target).host || ""
+  Gori::Repeater::FlowRequest::Built.new(
+    target: target,
+    bytes: "GET #{path} HTTP/1.1\r\nHost: #{host}\r\nCookie: sid=secret\r\n\r\n".to_slice,
+    http2: false, sni: nil)
+end
+
+describe "gori run --bind-from — the seed replay's Layer-2 gate" do
+  # The seed goes out through `Repeater::Sender`, whose gate is `send_block` — Sandbox only,
+  # because an EXCLUDE deliberately does not stop one HAND-AUTHORED Repeater send. A seed is
+  # not hand-authored: it is the first send of an automated sweep, and it carries the whole
+  # captured request (cookies, Authorization) to the capture's own host. With
+  # --allow-unscoped waiving Layer 1, `discover --bind-from 1 --allow-unscoped` therefore hit
+  # a path an exclude rule had carved out, contradicting both `--allow-unscoped`'s help text
+  # and `EXCLUDE_SWEEP_ERROR`'s own sentence.
+  it "refuses a seed whose host an EXCLUDE rule matches, even under --allow-unscoped" do
+    with_scope do |scope, _store|
+      scope.add("include", "host", "acme.test")
+      scope.add("exclude", "string", "DANGER-LOGOUT")
+      ob = Gori::Outbound.cli(scope, true)
+      # Layer 1 is waived by the flag — which is what made the leak reachable.
+      gs, gh, gt = Gori::CLI::Run.bind_from_scope_triple_for_spec(
+        built_for("http://acme.test/", "/DANGER-LOGOUT"))
+      ob.check_request(gs, gh, gt).blocked?.should be_false
+      # Layer 2 is what has to hold, and the Repeater's own gate does not.
+      ob.send_block(gs, gh, gt).should be_nil
+      Gori::CLI::Run.bind_from_seed_block_for_spec(ob,
+        built_for("http://acme.test/", "/DANGER-LOGOUT"))
+        .should eq(Gori::Outbound::EXCLUDE_SWEEP_ERROR)
+      # An unrelated in-scope flow still seeds.
+      Gori::CLI::Run.bind_from_seed_block_for_spec(ob,
+        built_for("http://acme.test/", "/login")).should be_nil
+    end
+  end
+
+  it "stops a seed to a SANDBOXed host before the captured request goes out" do
+    with_scope do |scope, _store|
+      scope.add("include", "host", "in.test")
+      scope.enable_sandbox
+      ob = Gori::Outbound.cli(scope, true)
+      Gori::CLI::Run.bind_from_seed_block_for_spec(ob, built_for("http://other.test/", "/a"))
+        .should eq(Gori::Outbound::SANDBOX_SWEEP_ERROR)
+      Gori::CLI::Run.bind_from_seed_block_for_spec(ob, built_for("http://in.test/", "/a")).should be_nil
+    end
+  end
+end

--- a/src/gori/cli/run.cr
+++ b/src/gori/cli/run.cr
@@ -815,6 +815,27 @@ module Gori
         {scheme, host, Gori::Outbound.request_target(built.bytes)}
       end
 
+      # WHY a `--bind-from` seed replay may not go out, or nil to proceed — Layer 2, judged on
+      # the SWEEP's terms rather than the Repeater's.
+      #
+      # The replay travels through `Repeater::Sender`, whose per-send gate is
+      # `Outbound#send_block`: Sandbox ALONE, because an EXCLUDE rule deliberately does not stop
+      # ONE hand-authored Repeater send — a human replaying a single request has already decided.
+      # A `--bind-from` seed is not that request. It is the first send of an automated sweep,
+      # issued by the sweep's own invocation, so it takes the sweep's gate — `sweep_block`, which
+      # is exactly what `EXCLUDE_SWEEP_ERROR` promises when it says "excludes hold even under
+      # --allow-unscoped". Without this, `--allow-unscoped` waived Layer 1 and `send_block`
+      # skipped the exclude, so `discover --bind-from N --allow-unscoped` (and `fuzz`/`mine`/
+      # `sequence`, which share this helper) replayed the FULL captured request — cookies and
+      # Authorization included — to a host the operator had explicitly carved out.
+      #
+      # Named rather than inlined for the same reason `bind_from_scope_triple` is: the decision
+      # is spec-able without a live send.
+      private def self.bind_from_seed_block(outbound : Gori::Outbound, scheme : String,
+                                            host : String, target : String) : String?
+        outbound.sweep_block(scheme, host, target)
+      end
+
       # Replay flow `flow_id` through `Repeater::Sender` — the one extraction source — so its
       # response can fill the binding table before the sweep starts. Aborts on anything that
       # leaves the table unfilled: a seed that silently did nothing would hand the operator
@@ -845,12 +866,18 @@ module Gori
         # a second, unrelated destination: whatever host that capture was taken from. Without
         # this the seed replayed a full captured request — cookies and all — to an out-of-scope
         # host that the very same invocation would have refused as a `--target`, and only
-        # Sandbox/excludes (Layer 2, inside `Repeater::Sender`) could stop it. `Outbound` exists
-        # so no active request leaves gori without a scope decision; a replay is an active
-        # request. `--allow-unscoped` still waives it, exactly as it does for the sweep.
+        # Sandbox (Layer 2, inside `Repeater::Sender`) could stop it. `Outbound` exists so no
+        # active request leaves gori without a scope decision; a replay is an active request.
+        # `--allow-unscoped` still waives it, exactly as it does for the sweep.
         # Same gap, same shape, and the same fix as #406 gave `gori run repeater`.
         gs, gh, gt = bind_from_scope_triple(built)
         guard_outbound(outbound, gs, gh, gt, "#{cmd}: --bind-from")
+        # Layer 2, BEFORE the send rather than leaving it to `Repeater::Sender` — see
+        # `bind_from_seed_block` for the exclude this closes.
+        if err = bind_from_seed_block(outbound, gs, gh, gt)
+          outbound.close
+          abort "#{cmd}: --bind-from: #{err}"
+        end
         # `evidence: true` is not conditional here and cannot be: `built` is
         # `Repeater::FlowRequest.build(detail)`, which reads `request_head`/`request_body` and
         # nothing else, and the operator supplied one integer. There is no draft on this path


### PR DESCRIPTION
`CLI::Run.seed_bindings` sends the `--bind-from FLOW-ID` replay through `Repeater::Sender`, whose Layer-2 gate is `Outbound#send_block` — Sandbox **alone**, because an EXCLUDE rule deliberately does not stop one *hand-authored* Repeater send (a human replaying a single request has already decided).

A `--bind-from` seed is not that send. It is the first request of an automated sweep, issued by the sweep's own invocation, so it belongs on the sweep's gate `Outbound#sweep_block` — which is exactly what `EXCLUDE_SWEEP_ERROR` promises when it says *"excludes hold even under --allow-unscoped"*.

## Repro

A project with `exclude string DANGER-LOGOUT` and a captured flow #1 = `GET /DANGER-LOGOUT` carrying `Cookie: sid=…` and `Authorization: Bearer …`:

```
gori run discover --db X --target http://127.0.0.1:PORT/ --bind-from 1 --allow-unscoped
```

**Before** — the origin logged the hit:

```
bind-from: flow #1 replayed → bound $TOK
...
--- origin hits ---
/DANGER-LOGOUT      ← the excluded path
/robots.txt
...
```

`--allow-unscoped` waived Layer 1, `send_block` skipped the exclude, and the **full captured request — cookies and Authorization included — went to a host the operator had explicitly carved out.** Same on `fuzz`, and therefore on `mine`/`sequence`, which share the helper.

**After** — refused before a byte goes out, zero origin hits:

```
gori run discover: --bind-from: blocked by a scope exclude rule — excludes hold even under --allow-unscoped
```

Scope of the leak: without `--allow-unscoped` Layer 1 already refused, Sandbox-on already refused, and `probe --active --allow-unscoped` honours excludes correctly (0 hits). Only this seed path leaked.

## Fix

* New private decision `bind_from_seed_block`, applied in `seed_bindings` right after the Layer-1 `guard_outbound` and **before** the send.
* The interactive Repeater path is untouched — its exclude-skip is intentional.
* The comment at the Layer-1 guard claimed excludes could stop the replay, which `send_block` never did; corrected to name Sandbox alone.

Verified not to over-block: a seed from an *unrelated, included* flow still binds (`bind-from: flow #2 replayed → bound $TOK`), and `fuzz --bind-from <excluded>` exits 1 with 0 origin hits.

## Regression specs

`spec/outbound_spec.cr`

* *refuses a seed whose host an EXCLUDE rule matches, even under --allow-unscoped*
* *stops a seed to a SANDBOXed host before the captured request goes out*

Confirmed red on the old gate (`got: nil` for the exclude case), green after.

Full suite: **11,895 examples, 0 failures, 0 errors.**
