### PR TITLE
fix(discover): the slot that was never sent, the calibration --no-bruteforce switched off, and the scope-refused sweep that reported clean

### DIFF
--- a/spec/discover/engine_spec.cr
+++ b/spec/discover/engine_spec.cr
@@ -149,6 +149,26 @@ private class DenyAfterFirstAsk < D::ScopePolicy
   end
 end
 
+# A scope that changes its mind MID-RUN — the shape `StoreScope#refresh` reaches when an
+# operator runs `gori run project scope add exclude …` in a second terminal while the sweep is
+# in flight (#396). The enqueue gates already said yes; `send_with_retries` is where the new
+# answer lands, and every candidate behind it is dropped.
+private class FlippableScope < Gori::Discover::ScopePolicy
+  property? denying : Bool = false
+
+  def allowed?(url : String, host : String) : Bool
+    !@denying
+  end
+
+  def boundary?(url : String, host : String) : Bool
+    true
+  end
+
+  def configured? : Bool
+    false
+  end
+end
+
 # The three sources `Engine#well_known?` routes through the soft-404 baseline — a document the
 # run GUESSED at a fixed origin path, as opposed to a link the target published.
 private def well_known_source?(f : Gori::Discover::Finding) : Bool
@@ -339,6 +359,53 @@ describe Gori::Discover::Engine do
         done.not_nil!.budget_exhausted.should be_false
         done.not_nil!.progress.queued.should eq(0)
       end
+    end
+  end
+
+  # The OTHER way a discover run stops short, and the one that had no number at all. #396 made
+  # the Layer-2 gate re-read the scope mid-run, which correctly cuts the traffic off within a
+  # second — but `StoreScope#allowed?` returning false makes `send_with_retries` return a
+  # BENIGN error, so the candidate inflated neither `errors` nor `sent` and was counted
+  # nowhere. A crawl entirely refused after its first probe reported
+  # `done · 1 found · 105 sent · 0 errors`, exit 0, with ~1000 wordlist candidates dropped and
+  # nothing saying the sweep had been cut short — while `budget_exhausted`, the precedent for
+  # exactly this, sat two lines away in the same summary.
+  describe "candidates refused by a mid-run scope change" do
+    it "counts every one of them" do
+      cfg = D::Config.new(spider: false, bruteforce: true, calibrate_probes: 1,
+        concurrency: 1, retries: 0)
+      words = (1..20).map { |i| "w#{i}" }
+      scope = FlippableScope.new
+      served = 0
+      backend = RouteBackend.new(->(_t : String) do
+        served += 1
+        # After the calibration probe and the first real candidate: the exclude rule lands.
+        scope.denying = true if served >= 2
+        notfound
+      end)
+      engine = D::Engine.new("http://t/", words, backend, cfg, scope)
+      done = nil.as(D::DoneEvent?)
+      engine.run { |ev| done = ev if ev.is_a?(D::DoneEvent) }
+      d = done.not_nil!
+      # Every candidate but the one that got through, and each counted ONCE — the refusal
+      # returns before the retry loop.
+      engine.scope_refused.should eq(words.size - 1)
+      # …and the reason the counter had to exist: nothing else in the report moves. Without it
+      # this run is indistinguishable from a complete sweep of a target that held nothing.
+      d.progress.errors.should eq(0)
+      d.stats.sent.should eq(2)
+      d.budget_exhausted.should be_false
+    end
+
+    # The control: a run nothing refuses reports zero, so the CLI's line stays silent on every
+    # ordinary sweep.
+    it "is zero when the scope refuses nothing" do
+      cfg = D::Config.new(spider: false, bruteforce: true, calibrate_probes: 1,
+        concurrency: 1, retries: 0)
+      engine = D::Engine.new("http://t/", ["admin", "login"],
+        RouteBackend.new(->(_t : String) { notfound }), cfg, FlippableScope.new)
+      engine.run { |_ev| }
+      engine.scope_refused.should eq(0)
     end
   end
 

--- a/spec/discover/engine_spec.cr
+++ b/spec/discover/engine_spec.cr
@@ -149,6 +149,12 @@ private class DenyAfterFirstAsk < D::ScopePolicy
   end
 end
 
+# The three sources `Engine#well_known?` routes through the soft-404 baseline — a document the
+# run GUESSED at a fixed origin path, as opposed to a link the target published.
+private def well_known_source?(f : Gori::Discover::Finding) : Bool
+  f.source.robots? || f.source.sitemap? || f.source.well_known?
+end
+
 # Every path `seed_frontier` queues by name at the origin, in order.
 private WELL_KNOWN_PATHS = Gori::Discover::Engine::WELL_KNOWN.map { |path, _| path }.to_a
 
@@ -416,6 +422,37 @@ describe Gori::Discover::Engine do
     findings.select { |f| f.source.robots? || f.source.sitemap? }.should be_empty
     findings.select(&.source.bruteforced?).should be_empty
     stats.calibrated_out.should be > 0
+  end
+
+  # The same gate on a SPIDER-ONLY run. `--no-bruteforce` used to switch the calibration off
+  # with it — `seed_frontier` set `@seed_calibration_dir` only when both techniques were on, so
+  # a well-known outcome fell through to `record_page`'s raw-status trust. Measured on a
+  # wildcard-200 origin: `--max-depth=1` reported `5 found · calibrated-out 485`, and the same
+  # run with `--no-bruteforce` reported `16 found · calibrated-out 0` — eleven nonexistent
+  # endpoints at confidence 0.9, written into the Sitemap as real without `--no-store`. The
+  # GENTLER flag produced the WORSE data. The calibration is `calibrate_probes` bogus paths at
+  # the origin and owes nothing to the wordlist, so there was never a reason to tie it to one.
+  it "calibrates the well-known guesses on a spider-only run too (--no-bruteforce)" do
+    cfg = D::Config.new(spider: true, bruteforce: false, calibrate_probes: 3, concurrency: 2, retries: 0)
+    findings, stats = run_discover("http://t/", %w(), cfg) do |_t|
+      html("THE SAME SOFT-404 PAGE FOR EVERY SINGLE PATH ON THIS SERVER")
+    end
+    findings.select { |f| well_known_source?(f) }.should be_empty
+    stats.calibrated_out.should be > 0
+  end
+
+  # …and the control: turning brute-force off must not cost a spider-only run the well-known
+  # documents that ARE there. A real 404 baseline means every one of these diverges.
+  it "still records genuine well-known documents on a spider-only run" do
+    cfg = D::Config.new(spider: true, bruteforce: false, calibrate_probes: 3, concurrency: 2, retries: 0)
+    findings, _ = run_discover("http://t/", %w(), cfg) do |t|
+      case t
+      when "/robots.txt" then make(200, "User-agent: *\nDisallow: /admin\n", "text/plain")
+      when "/"           then html("home")
+      else                    notfound
+      end
+    end
+    findings.map(&.url).should contain("http://t/robots.txt")
   end
 
   it "still records a genuine robots.txt/sitemap.xml on a server with a real 404 baseline" do
@@ -887,7 +924,11 @@ describe Gori::Discover::Engine do
       # not fire) and then every send is refused per-URL in `send_with_retries`. This is
       # exactly the shape a mid-run EXCLUDE now produces. `SCOPE_REFUSED` is a benign error, so
       # `errors` stays 0 too — without the send-counter condition the run is completely silent.
-      cfg = D::Config.new(spider: true, bruteforce: false, concurrency: 1, retries: 0)
+      # `calibrate_probes: 0` so the origin-root calibration every spider run queues sends
+      # nothing: its bogus paths are a fresh URL each time, which `DenyAfterFirstAsk` allows
+      # once by construction. What is under test is the per-URL refusal, not the measurement.
+      cfg = D::Config.new(spider: true, bruteforce: false, concurrency: 1, retries: 0,
+        calibrate_probes: 0)
       sent = [] of String
       backend = RouteBackend.new(->(t : String) { sent << t; notfound })
       engine = D::Engine.new("http://t/api", [] of String, backend, cfg, DenyAfterFirstAsk.new)
@@ -966,7 +1007,10 @@ describe Gori::Discover::Engine do
         sent << t
         t == "/" ? html("home, no links") : notfound
       end
-      sent.should eq(["/"])
+      # The deny set is the well-known paths and nothing else, so the origin-root soft-404
+      # calibration every spider run queues still goes out — it is the gate that grades those
+      # paths, not one of them. Apart from it, only the seed reached the wire.
+      (sent - root_calibration_probes(sent)).should eq(["/"])
     end
 
     it "still fetches them all when nothing denies them (the control for the case above)" do
@@ -976,7 +1020,7 @@ describe Gori::Discover::Engine do
         sent << t
         t == "/" ? html("home, no links") : notfound
       end
-      sent.sort.should eq((["/"] + WELL_KNOWN_PATHS).sort)
+      (sent - root_calibration_probes(sent)).sort.should eq((["/"] + WELL_KNOWN_PATHS).sort)
     end
 
     it "gates the origin calibration a path-scoped run queues to grade those paths" do

--- a/spec/discover/plan_spec.cr
+++ b/spec/discover/plan_spec.cr
@@ -68,13 +68,19 @@ end
 # vacuously — `CappedBackend` refuses over budget without touching the network, so the origin
 # simply never saw the hop the test is about, and `seen` was empty for the right reason and
 # the wrong one at once.
-private WELL_KNOWN_PATHS     = D::Engine::WELL_KNOWN.map { |path, _| path }.to_a
-private SEED_PLUS_WELL_KNOWN = (1 + WELL_KNOWN_PATHS.size).to_i64
+private WELL_KNOWN_PATHS = D::Engine::WELL_KNOWN.map { |path, _| path }.to_a
+# The origin-root soft-404 calibration `seed_frontier` queues for every SPIDER run — the gate
+# that stops a wildcard-200 origin minting well-known findings — costs `calibrate_probes`
+# sends of its own. Read off the default Config for the same reason the set above is derived
+# from the constant: it is part of what the seed frontier spends before a crawled link can
+# reach the wire.
+private SEED_CALIBRATION_PROBES = D::Config.new.calibrate_probes
+private SEED_FRONTIER_COST      = (1 + WELL_KNOWN_PATHS.size + SEED_CALIBRATION_PROBES).to_i64
 
-# Room for the seed plus its derived well-known probes plus ONE crawled link, so a
-# depth-1 hop is observable. Used by the policy A/B, which asserts on that hop.
+# Room for everything `seed_frontier` queues plus ONE crawled link, so a depth-1 hop is
+# observable. Used by the policy A/B, which asserts on that hop.
 private def crawl_config : D::Config
-  D::Config.new(concurrency: 1, retries: 0, max_requests: SEED_PLUS_WELL_KNOWN + 1, spider: true,
+  D::Config.new(concurrency: 1, retries: 0, max_requests: SEED_FRONTIER_COST + 1, spider: true,
     bruteforce: false, max_depth: 1, timeout: 3.seconds)
 end
 
@@ -82,13 +88,20 @@ end
 # a further request, and headroom on `max_requests` so one would still be visible on the
 # wire rather than swallowed by CappedBackend. Used by the Layer-2 tests on the seed set.
 private def seed_trio_config : D::Config
-  D::Config.new(concurrency: 1, retries: 0, max_requests: SEED_PLUS_WELL_KNOWN + 4, spider: true,
+  D::Config.new(concurrency: 1, retries: 0, max_requests: SEED_FRONTIER_COST + 4, spider: true,
     bruteforce: false, max_depth: 0, timeout: 3.seconds)
 end
 
 # The request targets an origin actually saw, in the order it saw them.
 private def targets_of(heads : Array(String)) : Array(String)
   heads.compact_map { |h| h.lines.first?.try(&.split(' ')[1]?) }
+end
+
+# The origin-root calibration's bogus paths — `Engine#bogus_name` is `Random::Secure.hex(8)`,
+# so 16 hex characters directly under "/". Subtracted where a test asserts on the exact set of
+# paths a gate let through: the calibration is a soft-404 measurement, not a guess under test.
+private def calibration_probes(targets : Array(String)) : Array(String)
+  targets.select(&.matches?(%r{\A/[0-9a-f]{16}\z}))
 end
 
 # Run one plan against a throwaway origin. Yields the listener's port so the caller can
@@ -357,7 +370,8 @@ describe Gori::Discover::Plan do
         _findings, seen = run_one(Gori::Outbound.interactive(scope)) do |port|
           D::PlanOptions.new("http://127.0.0.1:#{port}/", config: seed_trio_config, verify: false)
         end
-        targets_of(seen).sort.should eq((["/"] + WELL_KNOWN_PATHS).sort)
+        got = targets_of(seen)
+        (got - calibration_probes(got)).sort.should eq((["/"] + WELL_KNOWN_PATHS).sort)
       end
     end
 

--- a/spec/discover/sender_spec.cr
+++ b/spec/discover/sender_spec.cr
@@ -198,3 +198,65 @@ describe Gori::Discover::Sender do
     result.not_nil!.error.should eq(D::Sender::UNSAFE_URL)
   end
 end
+
+# ── the active session slot ─────────────────────────────────────────────────────────────
+#
+# A store + registry with one slot active, the state `gori run discover --slot admin` reaches
+# through `CLI::Run.activate_slot`. `Env.layer` is process-wide, so it is restored.
+private def with_active_slot(headers : Array({String, String}), &)
+  path = File.tempname("gori-discover-slot", ".db")
+  store = Gori::Store.open(path)
+  previous = Gori::Env.layer
+  begin
+    slots = Gori::SessionSlots.new(store, [Gori::SessionSlot.new("admin", set_headers: headers)])
+    Gori::Env.layer = Gori::Bindings.load(store, slots)
+    slots.activate("admin").should be_true
+    yield
+  ensure
+    Gori::Env.layer = previous
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+describe Gori::Discover::Sender do
+  describe "with a session slot active" do
+    # `--slot admin` printed "slot: sending as admin" and then crawled ANONYMOUSLY: activation
+    # flipped the registry pointer and nothing downstream read it, because this backend BUILDS
+    # its request from (scheme, host, port, target) and `Config#headers` (`-H`) was the only
+    # header source it had. `fuzz --slot` and `mine --slot` both reached the wire; discover was
+    # the sole outlier, on the one sweep whose result IS "what surface exists" — so the
+    # authenticated half came back reported as absent.
+    it "puts the slot's headers on the wire" do
+      wire = with_active_slot([{"X-Slot", "v"}, {"Cookie", "s=abc"}]) do
+        wire_bytes do |port|
+          D::Sender.new(verify: false, timeout: 2.seconds).fetch("http", "127.0.0.1", port, "/a")
+        end
+      end
+      request_lines(wire).should eq(["GET /a HTTP/1.1"])
+      wire.should contain("X-Slot: v\r\n")
+      wire.should contain("Cookie: s=abc\r\n")
+    end
+
+    # The stored half: `Engine#capture_exchange` keeps `request_head` as the request bytes a
+    # finding is persisted with, so a head without the overlay would describe a request nobody
+    # made — the `Repeater::Sender#wire` failure, one seam over.
+    it "keeps the overlay on the head a finding is stored with" do
+      head = with_active_slot([{"X-Slot", "v"}]) do
+        String.new(D::Sender.new(verify: false).request_head("http", "acme.test", 80, "/a"))
+      end
+      head.should contain("X-Slot: v\r\n")
+    end
+
+    # The control: an overlay that sets nothing changes no byte (`SessionSlots#overlay` returns
+    # the same slice), so a project that never selects a slot is unaffected.
+    it "changes nothing when no slot is active" do
+      wire = wire_bytes do |port|
+        D::Sender.new(verify: false, timeout: 2.seconds).fetch("http", "127.0.0.1", port, "/a")
+      end
+      wire.should_not contain("X-Slot")
+    end
+  end
+end

--- a/src/gori/cli/run/discover.cr
+++ b/src/gori/cli/run/discover.cr
@@ -248,7 +248,7 @@ module Gori
               flush_discover(store, pending) if pending.size >= 200
             end
           when Discover::ProgressEvent then discover_progress(ev)
-          when Discover::DoneEvent     then discover_done(ev, pool_stats)
+          when Discover::DoneEvent     then discover_done(ev, engine, pool_stats)
           when Discover::ErrorEvent    then had_error = true; STDERR.puts "discover error: #{ev.message}"
           end
         end
@@ -296,7 +296,8 @@ module Gori
         STDERR.flush
       end
 
-      private def self.discover_done(ev : Discover::DoneEvent, pool_stats : Proc(Discover::PoolStats?)) : Nil
+      private def self.discover_done(ev : Discover::DoneEvent, engine : Discover::Engine,
+                                     pool_stats : Proc(Discover::PoolStats?)) : Nil
         STDERR.print "\r" if STDERR.tty?
         s = ev.stats
         STDERR.puts "done · #{s.found} found · #{s.sent} sent · #{ev.progress.errors} errors" \
@@ -310,6 +311,17 @@ module Gori
         if ev.budget_exhausted
           STDERR.puts "budget exhausted · #{ev.progress.queued} queued unexplored " \
                       "— raise or drop --max-requests to finish the sweep"
+        end
+        # The OTHER way a sweep stops short, and the one that had no line at all: the Layer-2
+        # gate re-reads the project scope mid-run, so a `scope add exclude …` in a second
+        # terminal cuts the traffic off within a second (#396) — correctly — and every
+        # candidate after it is dropped as a benign refusal, counted in neither `errors` nor
+        # `sent`. The run then read `done · 1 found · 105 sent · 0 errors`, exit 0, over a
+        # target it had barely touched. Read off the engine rather than the event for the
+        # reason `pool_stats` is: the counter is final exactly when this event arrives.
+        if (refused = engine.scope_refused) > 0
+          STDERR.puts "#{refused} candidate#{refused == 1 ? "" : "s"} refused by scope " \
+                      "— the sweep stopped early; this is not a clean result over the whole target"
         end
         # Handshakes actually paid for — the one thing the request counts above cannot show.
         # `dialed ≈ sent` means the origin closed after every response, which is the usual

--- a/src/gori/cli/run/discover.cr
+++ b/src/gori/cli/run/discover.cr
@@ -258,6 +258,12 @@ module Gori
         # like any other — so this one flush covers the normal, error, AND interrupted paths.
         flush_discover(store, pending) unless no_store
         puts CLI::Output.discover_array_json(findings) if format == :json
+        # LAST, after the summary: `--slot NAME` whose overlay resolved to nothing means every
+        # probe in the sweep carried `$SESSION` itself instead of a session, so the whole crawl
+        # ran UNAUTHENTICATED while announcing "slot: sending as NAME" — and a crawl is the one
+        # sweep whose result IS "what surface exists", so an anonymous one reports the
+        # authenticated half as absent. Same drain, same sentence, as fuzz/repeater/authorize.
+        report_unbound_slot_overlay("gori run discover")
         # `Run.report_interrupted` (exit 130) rather than the local reporter this used to call:
         # that one only wrote to STDERR and returned, so a Ctrl-C'd crawl fell through to a
         # plain exit 0 and a scripted `gori run discover … && ./triage.sh` treated a truncated

--- a/src/gori/discover/engine.cr
+++ b/src/gori/discover/engine.cr
@@ -811,8 +811,16 @@ module Gori::Discover
       enqueue_dir(bf_dir, 0) if @config.bruteforce?
       # WELL_KNOWN paths are GUESSED, not organically-linked — they deserve the same soft-404
       # gate a brute-forced wordlist hit gets, not the "exists by
-      # construction" trust record_page gives a crawled <a href>. Only wire this up when
-      # bruteforce is on: that's the only mode with a calibration baseline to gate against.
+      # construction" trust record_page gives a crawled <a href>. Wired up for every SPIDER
+      # run, and deliberately NOT conditioned on bruteforce: the seed-only calibration below
+      # is `calibrate_probes + extensions` bogus paths at the ORIGIN and owes nothing to the
+      # wordlist, so `--no-bruteforce` was switching off a gate it does not pay for. It did so
+      # silently, and in the direction that mints findings: on a wildcard-200 origin the same
+      # seed answered `16 found · calibrated-out 0` with `--no-bruteforce` against
+      # `5 found · calibrated-out 485` without it, the extra eleven being sitemap.xml,
+      # robots.txt and the `.well-known/` registry at confidence 0.9 — and, without
+      # `--no-store`, written into the Sitemap as real endpoints. The GENTLER flag produced
+      # the WORSE data.
       # The origin is calibrated separately — a well-known path always lives there even on
       # a path-scoped run confined elsewhere — and `enqueue_seed_only_calibration`'s own @dirs
       # check reuses the bf_dir calibration when that dir IS the origin. Asking @dirs rather
@@ -824,7 +832,7 @@ module Gori::Discover
       # findings recorded, not even counted in calibrated_out. (The shape that first exposed
       # it — a file-shaped seed whose bf_dir fell outside its own confine — is gone with #395,
       # but the assumption it broke was never safe.)
-      if @config.spider? && @config.bruteforce?
+      if @config.spider?
         root_dir = "#{Url.origin(@seed_parts)}/"
         # @seed_calibration_dir is set even when the Calibrate task below is refused, and that
         # is deliberate: it is what routes a robots/sitemap outcome to resolve_seed_finding

--- a/src/gori/discover/engine.cr
+++ b/src/gori/discover/engine.cr
@@ -578,6 +578,18 @@ module Gori::Discover
     # whose every send failed still has `sent > 0`. Same counter, same name and same purpose
     # as `Miner::Engine#successful_sends`; see `wholly_refused_reason`.
     getter successful_sends : Int64 = 0_i64
+    # Candidates the per-URL Layer-2 gate refused in `send_with_retries` — a sweep CUT SHORT,
+    # in the shape `CappedBackend#refused` already carries for the request cap.
+    #
+    # A scope refusal is deliberately benign (`benign_error?`): it is a decision the operator
+    # asked for, not a failure of the run, so it inflates neither `errors` nor `sent`. That is
+    # right for the error count and wrong for the report, because it left the refusal counted
+    # NOWHERE. A mid-run `scope add exclude …` in a second terminal stops the traffic within
+    # `Outbound::RELOAD_INTERVAL` (#396, and it works) — and the run then ended
+    # `done · 1 found · 105 sent · 0 errors`, exit 0, with ~1000 wordlist candidates refused
+    # and nothing saying so. `budget_exhausted` already exists to stop a truncated sweep
+    # reading as a complete one; this is the same fact arriving by the other door.
+    getter scope_refused : Int32 = 0
     @pages : Int32
     @crawl_enqueued : Int32
     @calibrated_out : Int32
@@ -1688,6 +1700,12 @@ module Gori::Discover
       # while the run is in flight stops it here within that window — on every surface, not
       # only in the TUI where the `Scope` object happens to be shared live (#396).
       unless @scope.allowed?(Url.gate_url(p), p.host)
+        # Booked here rather than at the enqueue gates, and for the same reason the error
+        # facts above are: this is the one line every send passes, so one candidate is one
+        # count — no retry doubles it (the refusal returns before the loop) and no
+        # containment or path-confine drop, which are the run's own bounds and not a
+        # refusal, can be mistaken for one. See `scope_refused`.
+        @scope_refused += 1
         return Repeater::Result.new(Bytes.new(0), nil, nil, 0_i64, SCOPE_REFUSED)
       end
       target = p.query ? "#{p.path}?#{p.query}" : p.path

--- a/src/gori/discover/engine.cr
+++ b/src/gori/discover/engine.cr
@@ -203,8 +203,20 @@ module Gori::Discover
 
     # The real thing, not an approximation of it: `fetch` sends exactly these bytes (it calls
     # this method), so the request a finding is stored with is the request that was made.
+    #
+    # The ACTIVE SESSION SLOT's header overlay is written over the built head, after the
+    # `$NAME` pass and in the order `Repeater::Sender#wire` and `Fuzz::Sender#send` already
+    # use: the message's own references resolve against the active slot's table first, the
+    # identity's headers go over the result. Discover was the ONE send seam without it — the
+    # asymmetry `binding_headers` above names, made real. `--slot admin` flipped
+    # `SessionSlots#activate`, printed "slot: sending as admin", and then crawled anonymously,
+    # because the slot's headers had nothing to be written onto until this line existed and
+    # `Config#headers` (`-H`) was the crawler's only header source. A sweep that reports
+    # "found nothing" over an authenticated surface it never reached is the failure this file
+    # already warns about; announcing the identity while sending none is that failure with a
+    # receipt on top.
     def request_head(scheme : String, host : String, port : Int32, target : String) : Bytes
-      build_get(scheme, host, port, target, binding_headers)
+      Gori::Env.overlay_slot(build_get(scheme, host, port, target, binding_headers))
     end
 
     def close : Nil


### PR DESCRIPTION
Three defects in the Discover engine + CLI, each with a runtime A/B against the same
wildcard-200 origin (old binary built from `a76a9659`) and a regression spec verified red on
the old code.

## 1. `discover --slot NAME` announced an identity it never sent (P1)

The authenticated crawl ran **anonymous** while printing `slot: sending as admin`.

```
gori run session add --name admin --set 'X-Slot: v' --set 'Cookie: s=abc' --project p
gori run discover --target http://origin/ --project p --slot admin --no-bruteforce --max-depth=1
```

| | stderr | requests carrying `X-Slot` |
|---|---|---|
| before | `slot: sending as admin` | **0 / 12** |
| after | `slot: sending as admin` | **15 / 15** (`Cookie` likewise) |

`activate_slot` only flipped `SessionSlots#activate` and printed the line; the engine had no
session-slot seam at all (`grep -rn "slots" src/gori/discover/*.cr` returned nothing), so
`--slot` reached only `$NAME` resolution inside `-H` values. `-H 'X-Slot: v'` DID reach the
wire, and `fuzz --slot` (1/1) and `mine --slot` (9/9) both carried it — discover was the sole
outlier, and a bogus slot name IS rejected, which made the flag look wired up.

`Discover::Sender#request_head` — the one line `fetch` and `capture_exchange` both pass — now
runs `Env.overlay_slot` over the built head, after the `$NAME` pass and in the order
`Repeater::Sender#wire` and `Fuzz::Sender#send` already use. The CLI drains
`report_unbound_slot_overlay` alongside its summary, as the other slot-aware `gori run`
surfaces do.

## 2. `--no-bruteforce` silently disabled soft-404 calibration for the well-known guesses (P2)

On a wildcard-200 origin, the **gentler** flag produced the **worse** data:

| | result |
|---|---|
| before | `done · 12 found · 12 sent · calibrated-out 0` — sitemap.xml, robots.txt and the whole `.well-known/` registry reported at confidence 0.9, and without `--no-store` written into the Sitemap as real endpoints |
| after | `done · 1 found · 15 sent · calibrated-out 11` |

`seed_frontier` set `@seed_calibration_dir` only when spider AND bruteforce were both on, and
`handle_crawl` routes a well-known outcome to `resolve_seed_finding` only when that is set —
otherwise to `record_page`'s raw-status trust. The seed-only calibration is `calibrate_probes`
bogus paths at the ORIGIN and owes nothing to the wordlist, so it is now queued for every
spider run.

The plan/engine specs that budget `max_requests` off the seed frontier derive that calibration
cost from `Config#calibrate_probes` rather than hard-coding it — the reason their own comment
already gives.

## 3. A sweep cut short by a mid-run scope change reported as a clean, complete run (P2)

Adding `scope add exclude string 127.0.0.1` in a second terminal 3s into a run:

| | stderr |
|---|---|
| before | `done · 1 found · 221 sent · 0 errors · calibrated-out 214` — exit 0, nothing indicating the sweep was cut short |
| after | same summary, plus `476 candidates refused by scope — the sweep stopped early; this is not a clean result over the whole target` |

The mid-run reload (#396) correctly stops the traffic within a second. But a scope refusal is
deliberately benign (`benign_error?`), so it inflated neither `errors` nor `sent` — and was
counted nowhere at all. `Engine#scope_refused` books each refusal at `send_with_retries`, so
one candidate is one count: no retry doubles it (the refusal returns before the loop) and no
containment or path-confine drop, which are the run's own bounds rather than a refusal, can be
mistaken for one. `gori run discover` prints it beside the `budget_exhausted` line that is the
precedent for reporting a truncated sweep.

## Verification

- `crystal spec` — **11900 examples, 0 failures, 0 errors, 0 pending**
- `crystal build --no-codegen src/main.cr`, `crystal build --no-codegen scripts/seed_demo.cr`,
  `./scripts/bench_check.sh` (49 harnesses), `crystal tool format --check src spec`
- each regression spec confirmed failing on the pre-fix source
