### PR TITLE
fix(cookie): reject a Flask timestamp past Int64::MAX instead of wrapping it negative

### DIFF
--- a/spec/cookie_spec.cr
+++ b/spec/cookie_spec.cr
@@ -84,6 +84,25 @@ describe Gori::Cookie do
       Gori::Cookie.b64_to_int?("AAAAAAAAAAAAAAAA").should be_nil            # decodes to > 8 bytes
     end
 
+    it "b64_to_int? answers nil (not a wrapped-negative) on an 8-byte value past Int64::MAX" do
+      # itsdangerous timestamps are UNSIGNED big-endian: an 8-byte segment with the top bit
+      # set is a value > Int64::MAX. `n << 8 | byte` is a bitwise op (not overflow-checked),
+      # so it used to WRAP to a negative Int64 and render a bogus pre-1970 timestamp for what
+      # is really a far-future one. Refuse it — the same contract base62_decode gives Django.
+      over = Gori::Cookie.b64url(Bytes[0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]) # 2**64-1
+      Gori::Cookie.b64_to_int?(over).should be_nil
+      # But an 8-byte value that IS representable (Int64::MAX, top bit clear) still decodes.
+      max = Gori::Cookie.b64url(Bytes[0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff])
+      Gori::Cookie.b64_to_int?(max).should eq(Int64::MAX)
+    end
+
+    it "decodes a Flask cookie carrying an oversized (past-Int64) timestamp instead of a negative one" do
+      over = Gori::Cookie.b64url(Bytes[0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff])
+      cookie = "Zm9v.#{over}.c2ln"
+      Gori::Cookie.decode(cookie, "flask").should contain("invalid timestamp")
+      JSON.parse(Gori::Cookie.decode_json(cookie, "flask"))["timestamp"].raw.should be_nil
+    end
+
     it "secure_compare is length- and content-exact" do
       Gori::Cookie.secure_compare("abc", "abc").should be_true
       Gori::Cookie.secure_compare("abc", "abd").should be_false

--- a/src/gori/cookie.cr
+++ b/src/gori/cookie.cr
@@ -157,7 +157,16 @@ module Gori
       bytes = b64decode(seg)
       return nil if bytes.size > 8
       n = 0_i64
-      bytes.each { |byte| n = n << 8 | byte }
+      bytes.each do |byte|
+        # itsdangerous timestamps are UNSIGNED big-endian, so an exactly-8-byte segment with
+        # the top bit set is a value past Int64::MAX. Left unguarded, `n << 8 | byte` (a
+        # bitwise op, NOT overflow-checked) wraps to a NEGATIVE Int64 and renders a bogus
+        # pre-1970 timestamp for what is really a far-future one — the same silent-wrap
+        # `base62_decode` already guards for Django. Checked before the shift so a value that
+        # wraps is refused rather than surfaced (Int64::MAX itself still decodes cleanly).
+        return nil if n > (Int64::MAX - byte) >> 8
+        n = n << 8 | byte
+      end
       n
     rescue CookieError
       nil


### PR DESCRIPTION
## What

`Cookie.b64_to_int?` (the tolerant Flask-timestamp decoder) built its accumulator with `n << 8 | byte` — a bitwise op that Crystal does **not** overflow-check. itsdangerous timestamps are **unsigned** big-endian integers, so an exactly-8-byte segment with the top bit set is a value past `Int64::MAX`. Left unguarded, it silently wrapped to a **negative** Int64, and the decode surfaces rendered a bogus pre-1970 timestamp for what is really a far-future one.

### Repro (before)

```
$ gori run cookie "Zm9v.__________8.c2ln" --format json
{"format":"flask",...,"timestamp":-1,...}      # text: "timestamp: 1969-12-31 23:59:59Z (unix -1)"
```

`__________8` is 8 bytes of `0xFF` = 2**64-1 (a far-future unsigned unix second). A security tester decoding an attacker-supplied cookie would see a plausible-looking 1969 date instead of the honest "invalid".

### After

```
$ gori run cookie "Zm9v.__________8.c2ln" --format json   → "timestamp":null   # "(invalid timestamp …)"
$ gori run cookie "Zm9v.f_________8.c2ln"  --format json   → "timestamp":9223372036854775807   # Int64::MAX still decodes
```

## Fix

Guard the shift the same way `base62_decode` already guards Django's timestamp: refuse (return `nil`) a value that would overflow, while `Int64::MAX` itself still decodes cleanly. This closes the parity gap where Flask was the odd sibling out.

## Tests

Two regression specs in `spec/cookie_spec.cr` (both RED on old code, GREEN on the fix):
- `b64_to_int? answers nil (not a wrapped-negative) on an 8-byte value past Int64::MAX`
- `decodes a Flask cookie carrying an oversized (past-Int64) timestamp instead of a negative one`

Full suite: **11895 examples, 0 failures, 0 errors**.
