### PR TITLE
fix(import): six defects in HAR / URL-list ingestion, found by round-tripping gori's own export

### DIFF
--- a/spec/har_fixed_point_spec.cr
+++ b/spec/har_fixed_point_spec.cr
@@ -78,6 +78,34 @@ describe "HAR round-trip fixed point" do
     req.should start_with("GET /x HTTP/1.0\r\n")
   end
 
+  # `Export::Har` writes the RESPONSE's own `httpVersion` (`resp.version`) precisely because an
+  # origin may answer HTTP/1.0 to an HTTP/1.1 request, and 1.0 vs 1.1 is semantically
+  # load-bearing (no default keep-alive). Only half that round trip existed: the reader rebuilt
+  # the status line from the REQUEST version, so gori read its own export back with the
+  # response head rewritten.
+  it "keeps the response's own version rather than restating the request's" do
+    _, resp = import_heads("HTTP/1.1", "HTTP/1.0")
+    resp.should start_with("HTTP/1.0 200 OK\r\n")
+
+    _, resp = import_heads("HTTP/2", "HTTP/1.1")
+    resp.should start_with("HTTP/1.1 200 OK\r\n")
+  end
+
+  # The same drop split the status line against the phrase beside it: the "h2 carries no reason
+  # phrase" decision already reads the RESPONSE's version, so an HTTP/1.1 request answered over
+  # h2 came back as `HTTP/1.1 200` — the reason-less status line that is supposed to mean the
+  # origin really sent one.
+  it "does not fabricate a reason-less HTTP/1.1 status line for an h2 response" do
+    _, resp = import_heads("HTTP/1.1", "HTTP/2", status_text: nil)
+    resp.should start_with("HTTP/2 200\r\n")
+  end
+
+  # A HAR that states no response httpVersion at all still falls back to the request's.
+  it "falls back to the request version when the response states none" do
+    _, resp = import_heads("HTTP/1.0", "")
+    resp.should start_with("HTTP/1.0 200 OK\r\n")
+  end
+
   # `parse_response_head` yields reason == "" for a reason-less status line
   # (`HTTP/1.1 200\r\n`) — a real server fingerprint and a deliberate probe target. Export
   # writes `"statusText": ""`; importing that used to invent "OK", putting three bytes on the

--- a/spec/import/import_spec.cr
+++ b/spec/import/import_spec.cr
@@ -1274,9 +1274,37 @@ describe Gori::Import::Builder do
       String.new(pair.request.head).should start_with("get /admin HTTP/1.1\r\n")
     end
 
-    it "is still UPCASED in the projection column History and QL match on" do
+    # The projection COLUMN keeps the case too, matching live capture: `FlowMapper.request`
+    # passes `req.method` straight through, and the consumers that need a canonical form
+    # upcase at the comparison (`Authorize::Passive`, QL's `upper(method) = ?`). Upcasing on
+    # import made the two ingest paths disagree about the same message, and folded a
+    # method-case ACL bypass into the GET rows of every list view — the finding itself. The
+    # demo project's `get /admin/dashboard` came back from gori's own HAR round trip as `GET`.
+    it "reaches the projection column History renders with its case intact" do
       pair = Gori::Import::Builder.pending_request(0_i64, "http://h.test/admin", "get")
-      pair.request.method.should eq("GET")
+      pair.request.method.should eq("get")
+    end
+
+    it "survives a whole HAR import into the column, not just the start line" do
+      har = File.tempname("gori", ".har")
+      begin
+        File.write(har, {"log" => {"entries" => [{
+          "startedDateTime" => "2026-06-01T12:00:00.000Z", "time" => 1,
+          "request" => {"method" => "get", "url" => "https://shop.test/admin/dashboard",
+                        "httpVersion" => "HTTP/1.1", "headers" => [] of String},
+          "response" => {"status" => 200, "statusText" => "OK", "httpVersion" => "HTTP/1.1",
+                         "headers" => [] of String, "content" => {"mimeType" => "text/html", "text" => "ok"}},
+        }]}}.to_json)
+        with_store do |store|
+          Gori::Import.import_file(store, :har, har)
+          store.search(Gori::QL::EMPTY, 10).first.method.should eq("get")
+          # QL is unaffected either way — it upcases both sides — which is why the column was
+          # free to keep the wire case all along.
+          store.search(Gori::QL.parse("method:GET"), 10).size.should eq(1)
+        end
+      ensure
+        File.delete?(har)
+      end
     end
 
     it "keeps a non-standard method verbatim on both sides of complete_flow" do
@@ -1284,7 +1312,7 @@ describe Gori::Import::Builder do
       pair = Gori::Import::Builder.complete_flow(
         0_i64, "http://h.test/x", "PaTcH", empty, nil, "HTTP/1.1", 200, "OK", empty, nil, nil, nil)
       String.new(pair.request.head).should start_with("PaTcH /x HTTP/1.1\r\n")
-      pair.request.method.should eq("PATCH")
+      pair.request.method.should eq("PaTcH")
     end
 
     it "still refuses a method that would forge a start line" do

--- a/spec/import/import_spec.cr
+++ b/spec/import/import_spec.cr
@@ -565,6 +565,27 @@ describe Gori::Import do
     end
   end
 
+  # `ParseResult` carries a skipped tally so `Import.import_file` can say WHY nothing landed
+  # instead of the opaque "no flows found". `Har.parse_file` raised its own message first, which
+  # made that branch dead for the format it matters most for: an all-malformed OpenAPI spec
+  # reported its count (the spec above) and an all-malformed HAR did not.
+  it "reports the skipped count when every HAR entry is malformed" do
+    har = File.tempname("gori", ".har")
+    begin
+      File.write(har, {"log" => {"entries" => [
+        {"request" => {"method" => "GET", "url" => "", "headers" => [] of String}},
+        {"request" => {"method" => "GET", "url" => "not a url at all", "headers" => [] of String}},
+      ]}}.to_json)
+      with_store do |store|
+        expect_raises(Gori::Error, /all 2 entries were skipped as malformed/) do
+          Gori::Import.import_file(store, :har, har)
+        end
+      end
+    ensure
+      File.delete?(har)
+    end
+  end
+
   it "skips a malformed HAR entry (invalid base64 body) instead of aborting the whole import" do
     har = File.tempname("gori", ".har")
     begin

--- a/spec/import/import_spec.cr
+++ b/spec/import/import_spec.cr
@@ -201,6 +201,61 @@ describe Gori::Import do
     end
   end
 
+  # Chrome and Firefox list an h2 request's pseudo-headers in `headers`, so this is the
+  # ORDINARY shape of a HAR of h2 traffic. Writing them out as header LINES did not preserve
+  # them: gori's own `parse_request_head` reads `:method: GET` back as a field NAMED "" with
+  # the value `method: GET`. `HeadCodec.synth_request` drops the same fields when gori captures
+  # h2 itself, so the import now agrees with the capture.
+  it "drops HTTP/2 pseudo-headers rather than storing them as garbled header lines" do
+    har = File.tempname("gori", ".har")
+    begin
+      File.write(har, <<-JSON)
+        {
+          "log": {
+            "entries": [
+              {
+                "startedDateTime": "2026-06-01T12:00:00.000Z", "time": 1,
+                "request": {
+                  "method": "GET", "url": "https://acme.test/x", "httpVersion": "http/2.0",
+                  "headers": [
+                    {"name": ":method", "value": "GET"},
+                    {"name": ":authority", "value": "acme.test"},
+                    {"name": ":scheme", "value": "https"},
+                    {"name": ":path", "value": "/x"},
+                    {"name": "user-agent", "value": "Chrome"}
+                  ]
+                },
+                "response": {
+                  "status": 200, "statusText": "", "httpVersion": "http/2.0",
+                  "headers": [
+                    {"name": ":status", "value": "200"},
+                    {"name": "content-type", "value": "text/html"}
+                  ],
+                  "content": {"mimeType": "text/html", "text": "ok"}
+                }
+              }
+            ]
+          }
+        }
+        JSON
+
+      with_store do |store|
+        Gori::Import.import_file(store, :har, har)
+        detail = store.get_flow(store.search(Gori::QL::EMPTY, 10).first.id).not_nil!
+        req = String.new(detail.request_head)
+        req.should eq("GET /x HTTP/2\r\nHost: acme.test\r\nuser-agent: Chrome\r\n\r\n")
+        String.new(detail.response_head.not_nil!)
+          .should eq("HTTP/2 200\r\ncontent-type: text/html\r\n\r\n")
+        # The point of dropping them: what is stored re-parses as the fields it was written as,
+        # with no ""-named field carrying a mangled value.
+        parsed = Gori::Proxy::Codec::Http1.parse_request_head(detail.request_head)
+        parsed.headers.to_a.map(&.name).should eq(["Host", "user-agent"])
+      end
+    ensure
+      File.delete?(har)
+    end
+  end
+
   it "imports pending flows from a URL list file" do
     urls = File.tempname("gori", ".txt")
     begin

--- a/spec/import/import_spec.cr
+++ b/spec/import/import_spec.cr
@@ -1427,6 +1427,22 @@ describe Gori::Import::Builder do
       end
     end
 
+    # A host is not an ASCII thing. `URI.parse` copies an IDN authority through in whatever
+    # form the source wrote it and gori CAPTURES and stores the Unicode form, so an ASCII-only
+    # whitelist meant gori could not read its own HAR export back: the demo project's own
+    # U-label host exported fine and re-imported as a skipped malformed entry, against
+    # `Export::Har`'s stated export→import→export fixed point. The homograph host is the
+    # same bug, and it is evidence an operator imports a capture specifically to keep.
+    it "accepts a U-label IDN host and a homograph one, not just punycode" do
+      {
+        "https://쇼핑몰.한국/api/주문/9"      => "쇼핑몰.한국",
+        "https://ѕhop.demo.test/login" => "ѕhop.demo.test",
+        "https://münchen.de/x"         => "münchen.de",
+      }.each do |url, host|
+        Gori::Import::Builder.endpoint(url)[1].should eq(host)
+      end
+    end
+
     it "makes a file that is not a URL list fail AS one, rather than importing its punctuation" do
       urls = File.tempname("gori", ".txt")
       begin

--- a/spec/import/import_spec.cr
+++ b/spec/import/import_spec.cr
@@ -584,6 +584,44 @@ describe Gori::Import do
     end
   end
 
+  # `Import::Urls` names `mailto:` and `tel:` among the lines it skips, and they were not
+  # skipped: LEADING_SCHEME requires the `://`, so a `scheme:path` URI with no authority fell
+  # through to the `"https://" + u` branch. `mailto:bob@example.com` imported as a real
+  # `GET https://example.com/` — the userinfo swallowing `mailto:bob` — counted as a successful
+  # import and offered to History, the Sitemap and Scope as a target nobody listed.
+  it "skips an authority-less non-http URI instead of importing its tail as a host" do
+    urls = File.tempname("gori", ".txt")
+    begin
+      File.write(urls, "https://a.test/1\nmailto:bob@example.com\ndata:text/html,x\nabout:blank\n")
+      with_store do |store|
+        result = Gori::Import.import_file(store, :urls, urls)
+        result.count.should eq(1)
+        result.skipped.should eq(3)
+        store.search(Gori::QL::EMPTY, 10).map(&.host).should eq(["a.test"])
+      end
+    ensure
+      File.delete?(urls)
+    end
+  end
+
+  # The `://` in LEADING_SCHEME is load-bearing and the fix above must not relax it:
+  # `example.com:8080/p` is a scheme-LESS line with a leading `token:` too, told apart by the
+  # PORT after the colon.
+  it "still imports a scheme-less host:port line" do
+    urls = File.tempname("gori", ".txt")
+    begin
+      File.write(urls, "example.com:8080/p?x=1\nlocalhost:3000/x\n")
+      with_store do |store|
+        result = Gori::Import.import_file(store, :urls, urls)
+        result.skipped.should eq(0)
+        rows = store.search(Gori::QL::EMPTY, 10).map { |r| {r.host, r.port} }.to_set
+        rows.should eq({ {"example.com", 8080}, {"localhost", 3000} }.to_set)
+      end
+    ensure
+      File.delete?(urls)
+    end
+  end
+
   it "skips a non-http(s) URL line instead of discarding the whole list" do
     urls = File.tempname("gori", ".txt")
     begin

--- a/src/gori/import/builder.cr
+++ b/src/gori/import/builder.cr
@@ -461,6 +461,7 @@ module Gori
                              declared_req_body_size : Int64? = nil,
                              declared_resp_body_size : Int64? = nil,
                              connect_protocol : String? = nil,
+                             resp_http_version : String? = nil,
                              source : FlowSource::Kind = FlowSource::Kind::Import,
                              source_surface : FlowSource::Surface? = nil,
                              source_ref : String? = nil) : FlowPair
@@ -482,7 +483,18 @@ module Gori
         # It does need to KNOW the body was cut short, though, or a capped chunked response
         # loses its Transfer-Encoding (`wire_chunked?`), so cap first and tell it.
         resp_stored, resp_trunc, resp_size = capped(resp_body, declared_resp_body_size)
-        resp_head = response_head(http_version, status, reason, resp_headers, resp_body, resp_trunc)
+        # The RESPONSE's own version when the source recorded one, falling back to the
+        # request's. `Export::Har` writes `resp.version` for exactly this reason — an origin
+        # answering HTTP/1.0 to an HTTP/1.1 request — and only half that round trip existed:
+        # the reader reconstructed the status line from the REQUEST version, so gori read its
+        # own export back with the response head rewritten, and 1.0 vs 1.1 is semantically
+        # load-bearing (no default keep-alive). It also split the status line against the
+        # phrase beside it, since `Import::Har` already decides "h2 has no reason phrase" off
+        # the response's version: a HTTP/1.1 request answered over h2 came back as
+        # `HTTP/1.1 200` with no phrase — the reason-less status line that is supposed to mean
+        # the origin really sent one.
+        resp_head = response_head(resp_http_version || http_version, status, reason,
+          resp_headers, resp_body, resp_trunc)
         content_encoding = resp_headers.find { |(k, _)| k.compare("content-encoding", case_insensitive: true) == 0 }.try(&.[1])
         resp = Store::CapturedResponse.new(
           flow_id: 0, status: status, reason: reason.presence, content_type: content_type,

--- a/src/gori/import/builder.cr
+++ b/src/gori/import/builder.cr
@@ -98,7 +98,16 @@ module Gori
       # underscore label. Callers that want a BETTER message for a specific shape still check
       # first (`Vars.unresolved` for `{{baseUrl}}`, `Oas`/`Postman`/`Insomnia`); this is the
       # backstop, not their replacement.
-      HOST_VALID = /\A(?:\[[A-Za-z0-9:.%_-]+\]|[A-Za-z0-9._~%-]+)\z/
+      #
+      # The reg-name half is `\p{L}\p{N}`, not `A-Za-z0-9`, because a host is not an ASCII
+      # thing: `URI.parse` copies an IDN authority through in whatever form the source wrote
+      # it, and gori CAPTURES and stores the Unicode form. An ASCII-only whitelist meant gori
+      # could not read its own HAR export back — `https://쇼핑몰.한국/…` exported fine and
+      # re-imported as a skipped, malformed entry, against `Export::Har`'s stated fixed point.
+      # It cost the homograph cases too (`ѕhop.demo.test`, a Cyrillic dze), which are evidence
+      # an operator imports a capture specifically to keep. The exclusions above are unchanged
+      # and still do the work: `{`, `}`, `,`, `;` and space are neither a letter nor a digit.
+      HOST_VALID = /\A(?:\[[A-Za-z0-9:.%_-]+\]|[\p{L}\p{N}._~%-]+)\z/
 
       def self.normalize_url(url : String) : String
         u = url.strip

--- a/src/gori/import/builder.cr
+++ b/src/gori/import/builder.cr
@@ -249,9 +249,8 @@ module Gori
           # non-standard method is the operator's" — and upcasing it here destroyed a
           # method-case bypass probe (`get /admin`) on the way back in, so gori's own HAR
           # round-trip could not carry the test case it had captured. `reject_inject!` above
-          # already refuses the CR/LF/NUL that would forge a start line. The UPCASED form is
-          # not lost: it is what the `flows.method` projection column stores, which is what
-          # `pending_request`/`complete_flow` pass to the DTO and what History/QL match on.
+          # already refuses the CR/LF/NUL that would forge a start line. The `flows.method`
+          # projection column carries the same case, for the reason `pending_request` states.
           b << method << ' ' << target << ' ' << http_version << "\r\n"
           b << "Host: " << host_header(scheme, host, port) << "\r\n" unless has_host
           # One pass, allocation-free case-insensitive compares. Skip any incoming
@@ -470,9 +469,17 @@ module Gori
         stored, trunc, size = capped(body, declared_body_size)
         head = request_head(method, target, http_version, scheme, host, port, headers, body,
           trunc ? size : nil, trunc)
+        # The `flows.method` COLUMN keeps the source's case too, matching live capture:
+        # `FlowMapper.request` passes `req.method` straight through, and the consumers that
+        # need a canonical form upcase at the comparison (`Authorize::Passive`, QL's
+        # `upper(method) = ?`). Upcasing here made the two ingest paths disagree about the
+        # same message and folded a method-case ACL bypass — `get /admin`, RFC 9110 §9.1
+        # makes the method case-SENSITIVE — into the GET rows of every list view, which is
+        # the finding itself. The start line already carried the case; the column, which is
+        # what History renders, did not.
         req = Store::CapturedRequest.new(
           created_at: created_at, scheme: scheme, host: host, port: port,
-          method: method.upcase, target: target, http_version: http_version,
+          method: method, target: target, http_version: http_version,
           head: head, body: stored, body_truncated: trunc, body_size: size,
           source: source, source_surface: source_surface, source_ref: source_ref)
         FlowPair.new(req, nil)
@@ -501,7 +508,7 @@ module Gori
         # may be believed stays with the importer that read them — see `Import::Har`.
         req = Store::CapturedRequest.new(
           created_at: created_at, scheme: scheme, host: host, port: port,
-          method: method.upcase, target: target, http_version: http_version,
+          method: method, target: target, http_version: http_version,
           head: req_head, body: req_stored, body_truncated: req_trunc, body_size: req_size,
           connect_protocol: connect_protocol,
           source: source, source_surface: source_surface, source_ref: source_ref)

--- a/src/gori/import/builder.cr
+++ b/src/gori/import/builder.cr
@@ -43,6 +43,22 @@ module Gori
       LEADING_SCHEME = /\A[a-z][a-z0-9+.-]*:\/\//i
       HTTP_SCHEME    = /\Ahttps?:\/\//i
 
+      # The OTHER shape of a non-http scheme: `scheme ":" path` with no `//` authority at all
+      # (RFC 3986 §3) — `mailto:`, `tel:`, `data:`, `urn:`, `about:`. `Import::Urls` names
+      # `mailto:` and `tel:` among the lines it skips and they were NOT skipped: LEADING_SCHEME
+      # requires the `://`, so these fell through to the `"https://#{u}"` branch and became real
+      # requests. `mailto:bob@example.com` imported as a `GET https://example.com/` — the
+      # userinfo swallowing `mailto:bob` — counted as a successful import and offered to
+      # History, the Sitemap and Scope as a target the operator never listed. A scraped URL
+      # list is full of `mailto:` links, so this was the everyday case, not a corner.
+      #
+      # The `://` in LEADING_SCHEME is not gratuitous, which is why this is a second pattern
+      # and not a relaxation of that one: `example.com:8080/p` is a scheme-LESS line every URL
+      # list carries and it has a leading `token:` too. What tells them apart is what follows
+      # the colon — a PORT (digits, then a path/query/fragment delimiter or the end) and
+      # nothing else.
+      SCHEME_NO_AUTHORITY = /\A[a-z][a-z0-9+.-]*:(?!\/\/)(?!\d*(?:[\/?#]|\z))/i
+
       # A raw control byte (CR, LF, other C0 or DEL) in the PATH or QUERY of an imported
       # URL is NOT rejected: it is the operator's own payload. Importing a HAR of a deliberately
       # CRLF-bearing request — a smuggling case — is exactly what a security-testing proxy is
@@ -87,7 +103,9 @@ module Gori
       def self.normalize_url(url : String) : String
         u = url.strip
         return u if u.starts_with?(HTTP_SCHEME)
-        raise Gori::Error.new("invalid URL (missing scheme): #{url}") if u.matches?(LEADING_SCHEME)
+        if u.matches?(LEADING_SCHEME) || u.matches?(SCHEME_NO_AUTHORITY)
+          raise Gori::Error.new("invalid URL (missing scheme): #{url}")
+        end
         "https://#{u}"
       end
 

--- a/src/gori/import/har.cr
+++ b/src/gori/import/har.cr
@@ -253,6 +253,17 @@ module Gori
 
       # An ORDERED list of {name, value} — a HAR response commonly has several Set-Cookie
       # entries (and Via/etc.); a Hash would keep only the last, dropping the rest.
+      #
+      # PSEUDO-HEADERS are dropped, which is what `Proxy::H2::HeadCodec.synth_request` does
+      # with the very same fields when gori captures h2 itself: `:method`/`:path`/`:scheme`/
+      # `:authority`/`:status` are the h2 spelling of the start line, and the h1 text form the
+      # store keeps carries them there already (the method and target off the entry's `url`,
+      # the authority via the synthesized `Host:`). Chrome and Firefox list them in `headers`,
+      # so this is the ORDINARY shape of a HAR of h2 traffic, and writing them out as header
+      # LINES did not preserve them — `:method: GET` reads back through gori's own
+      # `parse_request_head` as a field NAMED "" with the value `method: GET`, which is what
+      # History shows, what `Export::Har` then re-exports, and what a Repeater replay would
+      # put on the wire. A colon is not a tchar, so a leading one is unambiguous.
       private def self.headers_list(node : JSON::Any?) : Builder::Headers
         list = Builder::Headers.new
         arr = node.try(&.as_a?)
@@ -260,7 +271,7 @@ module Gori
         arr.each do |item|
           name = item["name"]?.to_s
           value = item["value"]?.to_s
-          next if name.empty?
+          next if name.empty? || name.starts_with?(':')
           list << {name, value}
         end
         list

--- a/src/gori/import/har.cr
+++ b/src/gori/import/har.cr
@@ -110,6 +110,7 @@ module Gori
           created_at, url, method, req_headers, req_body, http_version,
           status, reason, resp_headers, resp_body, content_type, duration_us,
           req_declared, resp_declared, connect_protocol(req_headers),
+          resp_http_version: resp_version,
           source_surface: prov.surface, source_ref: prov.ref)
         msgs = ws_messages(entry, created_at)
         msgs.empty? ? pair : Builder::FlowPair.new(pair.request, pair.response, msgs)

--- a/src/gori/import/har.cr
+++ b/src/gori/import/har.cr
@@ -40,7 +40,12 @@ module Gori
             skipped += 1
           end
         end
-        raise Gori::Error.new("no valid HAR entries in #{path}") if flows.empty?
+        # No raise on an empty result, deliberately. `Import.import_file` owns that message and
+        # says WHY nothing landed — "all N entries were skipped as malformed" — which is the
+        # whole reason `ParseResult` carries a tally. Raising here first made that branch dead
+        # for HAR, the format it matters most for: an operator with a 4000-entry file got "no
+        # valid HAR entries in <path>" and no count, while the same all-malformed OpenAPI spec
+        # got the tally. Every other parser already returns and lets `import_file` speak.
         ParseResult.new(flows, skipped)
       end
 


### PR DESCRIPTION
Six defects in the import path, found by auditing `Import` against the round trip `Export::Har` says it has: export the demo project's history to HAR and read it straight back. Of 118 entries gori wrote, its own importer took 115 — and two of the three it refused were hosts gori had just captured, stored and exported itself.

Each fix is its own commit with a regression spec verified red on the old code.

## 1. A HAR response's own `httpVersion` was dropped (`3045752c`)

`Export::Har` writes `resp.version` separately, on purpose — its comment names the case: an origin answering `HTTP/1.0` to an `HTTP/1.1` request, where 1.0 vs 1.1 is semantically load-bearing (no default keep-alive). Only half that round trip existed. `Builder.complete_flow` rebuilt the status line from the REQUEST version, so gori read its own export back with the response head rewritten.

The drop also split the status line against the phrase beside it. `Import::Har` already decides "h2 carries no reason phrase" off the response's version, so an HTTP/1.1 request answered over h2 imported as `HTTP/1.1 200` with no phrase — fabricating the reason-less status line that is supposed to mean the origin really sent one.

## 2. HTTP/2 pseudo-headers stored as garbled header lines (`42ad479b`)

Chrome and Firefox list `:method` / `:authority` / `:scheme` / `:path` (and the response's `:status`) in `headers`, so this is the ordinary shape of a HAR of h2 traffic. `headers_list` wrote them out as header LINES, which did not preserve them: gori's own `Codec::Http1.parse_request_head` reads `:method: GET` back as a field NAMED `""` carrying the value `method: GET`. That is what History showed, what `Export::Har` re-exported, and what a Repeater replay would have put on the wire.

`Proxy::H2::HeadCodec.synth_request` drops the same fields when gori captures h2 itself, so the import now agrees with the capture instead of producing a head no gori capture could.

## 3. `mailto:` and friends imported as fabricated hosts (`4340bd84`)

`Import::Urls` names `mailto:` and `tel:` among the lines it skips, and they were not skipped. `LEADING_SCHEME` requires the `://`, so `scheme:path` with no authority (RFC 3986 §3) fell through to the `"https://" + u` branch: `mailto:bob@example.com` imported as a real `GET https://example.com/` — the userinfo swallowing `mailto:bob` — counted as a successful import, and offered to History, the Sitemap and Scope as a target nobody listed. A scraped URL list is full of `mailto:` links, so this was the everyday case.

The `://` in `LEADING_SCHEME` is load-bearing and stays: `example.com:8080/p` is a scheme-LESS line with a leading `token:` too. `SCHEME_NO_AUTHORITY` tells them apart by what follows the colon — a PORT, or anything else.

## 4. A U-label IDN host could not be re-imported (`520009fb`)

`HOST_VALID`'s reg-name half was `A-Za-z0-9`, but a host is not an ASCII thing: `URI.parse` copies an IDN authority through in whatever form the source wrote it, and gori CAPTURES and stores the Unicode form. So gori could not read its own HAR export back — the demo's `쇼핑몰.한국` and the homograph `ѕhop.demo.test` (a Cyrillic dze) came back as skipped, malformed entries. The homograph host is the one an operator imports a capture specifically to keep.

`\p{L}\p{N}` instead. The exclusions the whitelist was written for are unchanged and still do the work: `{`, `}`, `,`, `;` and space are neither a letter nor a digit.

## 5. The method's case was lost in the projection column (`ae86f52a`)

`FlowMapper.request` passes `req.method` straight through, so a live capture's `flows.method` holds the case the client sent; the consumers that need a canonical form upcase at the comparison (`Authorize::Passive`, QL's `upper(method) = ?`). Import upcased the column instead, so the two ingest paths disagreed about the same message. The comment defending the upcase — "what History/QL match on" — was not accurate: QL upcases both sides, so the column was free to keep the wire case all along.

What that costs is the finding itself. RFC 9110 §9.1 makes the method case-SENSITIVE, and `get /admin` answered anyway is the classic way past an access rule written as `if (method == "GET")`. `scripts/seed_demo.cr` seeds exactly that flow with the note that it "has to draw as its own row with the case the client sent, not folded into the GETs above, or the demo would be hiding the finding" — and a HAR round trip folded it into the GETs.

## 6. An all-malformed HAR lost its skipped tally (`9f8cdd8d`)

`ParseResult` carries a skipped count so `Import.import_file` can say WHY nothing landed. `Har.parse_file` raised its own "no valid HAR entries in <path>" first, which made that branch dead for the format it matters most for: an all-malformed OpenAPI spec reported its count and an operator's 4000-entry HAR reported nothing.

## Verification

- `crystal build --no-codegen src/main.cr`, `scripts/seed_demo.cr` typecheck, `./scripts/bench_check.sh` (49 harnesses)
- `crystal spec` — **11902 examples, 0 failures, 0 errors, 0 pending**
- End to end, demo project HAR round trip: **115 → 117 of 118 entries**, with the IDN and homograph hosts back and `get /admin/dashboard` keeping its case.

## Known gaps, deliberately not touched here

- **`OPTIONS *`** is the one remaining entry the round trip drops. `FlowRow.url_of` builds `https://api.demo.test*` for an asterisk-form target and `Builder.endpoint` cannot read it back. The fix belongs in `store/models.cr` plus the fixed-point exception list `Export::Har` already keeps for absolute-form request lines — both outside this PR's files.
- **A NUL in the target** is still truncated by `URI.parse`. `Builder` documents this as a KNOWN GAP and points at the proxy's `resolve_forward` → `origin_form`, which truncates identically; fixing import alone would make the two paths disagree.
