### PR TITLE
fix(cli): what the listings got wrong — a silent scan cap, two glued columns, a dropped port, and a dangling flow id

### DIFF
--- a/spec/cli/run/authorize_spec.cr
+++ b/spec/cli/run/authorize_spec.cr
@@ -201,6 +201,16 @@ describe "gori run authorize — output" do
     lines[3].should contain("different")
   end
 
+  # Same `ljust(7)` shape as the history row: `OPTIONS` (a CORS preflight is exactly the kind
+  # of request an authz sweep is pointed at) ran flush into the URL, printing
+  # `#7     OPTIONShttps://acme.test/admin`.
+  it "text: keeps a space between a 7+-character METHOD and the URL" do
+    t = A::Target.new(7_i64, "OPTIONS", "https://acme.test/admin", [
+      trial("as-captured", A::Verdict::Baseline, 200, 10_i64, baseline: true),
+    ])
+    Gori::CLI::Output.authorize_target_text(t).lines[0].should contain("OPTIONS https://acme.test/admin")
+  end
+
   it "text: an enforced request is quiet, and an all-errored one says error" do
     enforced = A::Target.new(8_i64, "GET", "https://acme.test/me", [
       trial("as-captured", A::Verdict::Baseline, 200, 10_i64, baseline: true),

--- a/spec/cli/run/history_spec.cr
+++ b/spec/cli/run/history_spec.cr
@@ -67,6 +67,37 @@ describe "gori run history — CLI::Output rows" do
     rel.should contain("api.test/a")
   end
 
+  # The location cell was `Url.location(row.host, row.target)` — host + target, no PORT — so
+  # every origin-form (HTTPS/CONNECT) capture printed its host bare and two services on one
+  # host were the SAME cell. `--format json` told them apart the whole time (it emits `port`,
+  # and its `url` goes through `FlowRow#url`), which is exactly what makes the text list
+  # misleading rather than merely terse.
+  it "keeps the non-default port of an origin-form flow, so two services on one host differ" do
+    a = Gori::Store::FlowRow.new(
+      id: 1_i64, created_at: 0_i64, scheme: "https", method: "GET", host: "127.0.0.1",
+      port: 19315, target: "/service-A", status: 200, size: 0_i64, state: Gori::Store::FlowState::Complete)
+    b = Gori::Store::FlowRow.new(
+      id: 2_i64, created_at: 0_i64, scheme: "https", method: "GET", host: "127.0.0.1",
+      port: 19316, target: "/service-B", status: 200, size: 0_i64, state: Gori::Store::FlowState::Complete)
+    Gori::CLI::Output.flow_row_text(a).should contain("127.0.0.1:19315/service-A")
+    Gori::CLI::Output.flow_row_text(b).should contain("127.0.0.1:19316/service-B")
+    # The SCHEME column already says https; the cell must not repeat it.
+    Gori::CLI::Output.flow_row_text(a).should_not contain("https://")
+  end
+
+  it "leaves a default-port flow and an IPv6 literal spelled the way FlowRow#url spells them" do
+    plain = Gori::Store::FlowRow.new(
+      id: 3_i64, created_at: 0_i64, scheme: "https", method: "GET", host: "api.test",
+      port: 443, target: "/a", status: 200, size: 0_i64, state: Gori::Store::FlowState::Complete)
+    Gori::CLI::Output.flow_row_text(plain).should contain("api.test/a")
+    Gori::CLI::Output.flow_row_text(plain).should_not contain(":443")
+
+    v6 = Gori::Store::FlowRow.new(
+      id: 4_i64, created_at: 0_i64, scheme: "http", method: "GET", host: "::1",
+      port: 8080, target: "/a", status: 200, size: 0_i64, state: Gori::Store::FlowState::Complete)
+    Gori::CLI::Output.flow_row_text(v6).should contain("[::1]:8080/a")
+  end
+
   # R4. `target.starts_with?("http")` is not the absolute-form test — RFC 3986 §3.1 makes a
   # URI scheme case-insensitive, and gori captures the request line the client wrote. Driven
   # live through the proxy: `GET HTTP://127.0.0.1:19594/upper HTTP/1.1` printed as

--- a/spec/cli/run/history_spec.cr
+++ b/spec/cli/run/history_spec.cr
@@ -120,6 +120,27 @@ describe "gori run history — CLI::Output rows" do
     txt.should contain("G·ET")
   end
 
+  # `ljust(7)` guarantees a separator only while the method is SHORTER than 7 — so the two
+  # most ordinary long methods in the registry ran flush into SCHEME and the row printed
+  # `#87    OPTIONShttps  api.demo.test …`, which nothing can split back apart.
+  it "keeps a space between a 7+-character METHOD and the SCHEME column" do
+    {"OPTIONS", "CONNECT", "PROPFIND", "VERSION-CONTROL", "M" * 40}.each do |method|
+      row = Gori::Store::FlowRow.new(
+        id: 87_i64, created_at: 0_i64, scheme: "https", method: method, host: "api.demo.test",
+        port: 443, target: "/", status: 204, size: 0_i64, state: Gori::Store::FlowState::Complete)
+      txt = Gori::CLI::Output.flow_row_text(row)
+      txt.should contain("#{method} https") # the method survives WHOLE, with a separator
+      txt.should_not contain("#{method}https")
+    end
+  end
+
+  it "still pads a short METHOD to its column, so the rows stay aligned" do
+    row = Gori::Store::FlowRow.new(
+      id: 1_i64, created_at: 0_i64, scheme: "https", method: "GET", host: "h", port: 443,
+      target: "/", status: 200, size: 0_i64, state: Gori::Store::FlowState::Complete)
+    Gori::CLI::Output.flow_row_text(row).should contain("GET    https")
+  end
+
   it "term_safe leaves ordinary UTF-8 untouched but replaces control bytes" do
     Gori::CLI::Output.term_safe("api.test/π/데이터").should eq("api.test/π/데이터")
     Gori::CLI::Output.term_safe("a\tb\nc").should eq("a·b·c")

--- a/spec/cli/run/issues_spec.cr
+++ b/spec/cli/run/issues_spec.cr
@@ -29,6 +29,53 @@ module Gori::CLI::Run
   def self.issues_text_for_spec(issues : Array(Gori::Store::Issue)) : String
     issues_text(issues)
   end
+
+  def self.issue_flow_error_for_spec(store : Gori::Store, flow_id : Int64?) : String?
+    issue_flow_error(store, flow_id)
+  end
+end
+
+private def captured_flow(store : Gori::Store) : Int64
+  id = store.insert_flow(Gori::Store::CapturedRequest.new(
+    created_at: 1_000_i64, scheme: "https", host: "acme.test", port: 443,
+    method: "GET", target: "/admin", http_version: "HTTP/1.1",
+    head: "GET /admin HTTP/1.1\r\nHost: acme.test\r\n\r\n".to_slice, body: nil,
+    source: Gori::FlowSource::Kind::Proxy))
+  store.flush
+  id
+end
+
+describe "gori run issues create --flow" do
+  # `--flow` went through `parse_flow_id`, which is only `to_i64? || abort` — so
+  # `issues create --flow 424242` reported "Issue #4 created" and persisted a reference the
+  # listing, the markdown report and the SARIF location then advertise as `flow#424242`
+  # evidence that cannot be opened. The sibling `links add --ref flow --ref-id 999999`
+  # refuses the identical id.
+  it "refuses a flow id no captured flow has" do
+    with_store do |store|
+      captured_flow(store)
+      Gori::CLI::Run.issue_flow_error_for_spec(store, 424_242_i64).should eq("no flow with id 424242")
+    end
+  end
+
+  # A separate arm: the store has no row at 0 or -5 to disagree with, and "no flow with id -5"
+  # would send the reader looking for a capture instead of at their own argument.
+  it "refuses a zero or negative flow id as invalid rather than as missing" do
+    with_store do |store|
+      Gori::CLI::Run.issue_flow_error_for_spec(store, 0_i64)
+        .should eq("invalid --flow 0 (expected a positive flow id)")
+      Gori::CLI::Run.issue_flow_error_for_spec(store, -5_i64)
+        .should eq("invalid --flow -5 (expected a positive flow id)")
+    end
+  end
+
+  it "accepts a real flow id, and says nothing when --flow was not given" do
+    with_store do |store|
+      id = captured_flow(store)
+      Gori::CLI::Run.issue_flow_error_for_spec(store, id).should be_nil
+      Gori::CLI::Run.issue_flow_error_for_spec(store, nil).should be_nil
+    end
+  end
 end
 
 describe "gori run issues — the text listing" do

--- a/spec/cli/run/sitemap_spec.cr
+++ b/spec/cli/run/sitemap_spec.cr
@@ -18,6 +18,10 @@ module Gori::CLI::Run
   def self.sitemap_truncation_notice_for_spec(truncated : Bool, limit : Int32) : String?
     sitemap_truncation_notice(truncated, limit)
   end
+
+  def self.sitemap_tag_row_for_spec(host : String, path : String, tag : String) : String
+    sitemap_tag_row(host, path, tag)
+  end
 end
 
 private def sitemap_store(&)
@@ -386,5 +390,22 @@ describe "gori run sitemap tag — the key a tag is filed under" do
     # Sitemap.build normalizes before stamping — so the key is "/a", not the whole URL.
     Gori::CLI::Run.sitemap_tag_path_for_spec("http://h/a").should eq("/a")
     Gori::CLI::Run.sitemap_tag_path_for_spec("https://h/a?b=1").should eq("/a?b=1")
+  end
+end
+
+describe "gori run sitemap tag --list — the TSV line" do
+  it "folds a newline and a tab in the tag, so one tag is one line with three fields" do
+    # A tag is free text and can be set from the TUI or MCP too. Printed raw it broke the TSV
+    # two ways at once: the newline split one tag across two physical lines, and the tab
+    # invented a fourth column. The tree view already folds the same tag to `# multi·line`.
+    row = Gori::CLI::Run.sitemap_tag_row_for_spec("acme.test", "/api", "multi\nline\tcol 한글 <b>")
+    row.lines.size.should eq(1)
+    row.split('\t').size.should eq(2)
+    row.should eq("acme.test/api\tmulti·line·col 한글 <b>")
+  end
+
+  it "folds the host and path halves too, and leaves an ordinary tag untouched" do
+    Gori::CLI::Run.sitemap_tag_row_for_spec("acme.test", "/a\nb", "ok").should eq("acme.test/a·b\tok")
+    Gori::CLI::Run.sitemap_tag_row_for_spec("acme.test", "/api", "payment flow").should eq("acme.test/api\tpayment flow")
   end
 end

--- a/spec/cli/run/sitemap_spec.cr
+++ b/spec/cli/run/sitemap_spec.cr
@@ -10,6 +10,78 @@ module Gori::CLI::Run
   def self.sitemap_tag_path_for_spec(target : String) : String
     sitemap_tag_path(target)
   end
+
+  def self.collect_sitemap_for_spec(store : Gori::Store, limit : Int32) : {Array(Gori::Sitemap::Node), Bool}
+    collect_sitemap(store, Gori::QL::EMPTY, limit, false, true, true)
+  end
+
+  def self.sitemap_truncation_notice_for_spec(truncated : Bool, limit : Int32) : String?
+    sitemap_truncation_notice(truncated, limit)
+  end
+end
+
+private def sitemap_store(&)
+  path = File.tempname("gori-clisitemap", ".db")
+  db = DB.open("sqlite3:#{path}?journal_mode=wal&busy_timeout=5000")
+  Gori::Store::Schema.migrate!(db)
+  store = Gori::Store.new(db, nil)
+  begin
+    yield store
+  ensure
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+private def sitemap_captured(host : String, target : String) : Gori::Store::CapturedRequest
+  Gori::Store::CapturedRequest.new(
+    created_at: 1_000_i64, scheme: "https", host: host, port: 443,
+    method: "GET", target: target, http_version: "HTTP/1.1",
+    head: "GET #{target} HTTP/1.1\r\nHost: #{host}\r\n\r\n".to_slice, body: nil,
+    source: Gori::FlowSource::Kind::Proxy)
+end
+
+describe "gori run sitemap — a capped scan" do
+  # The tree used to be built off `store.sitemap_entries(filter, limit)` with nothing ever
+  # comparing the returned size to `limit`, so `sitemap -n 5` on a project with more endpoints
+  # printed a short host list AND a per-host `(N paths)` header counted off the surviving
+  # rows — a positive, wrong claim about the project, with nothing on STDERR in text, json OR
+  # paths. The cut is invisible by the time the tree exists (every fold below collapses rows),
+  # so it has to be measured on the raw read.
+  it "reports the cut when the read comes back at the limit" do
+    sitemap_store do |store|
+      8.times { |i| store.insert_flow(sitemap_captured("acme.test", "/p#{i}")) }
+      store.flush
+
+      hosts, truncated = Gori::CLI::Run.collect_sitemap_for_spec(store, 5)
+      truncated.should be_true
+      # The counts the header prints ARE the truncated ones — which is exactly why the notice
+      # has to fire rather than the number being quietly trusted.
+      hosts.sum(&.endpoints).should eq(5)
+      Gori::CLI::Output.sitemap_text(hosts).should contain("(5 paths)")
+    end
+  end
+
+  it "reports no cut when the whole set fits under the limit" do
+    sitemap_store do |store|
+      3.times { |i| store.insert_flow(sitemap_captured("acme.test", "/p#{i}")) }
+      store.flush
+
+      hosts, truncated = Gori::CLI::Run.collect_sitemap_for_spec(store, 5)
+      truncated.should be_false
+      hosts.sum(&.endpoints).should eq(3)
+    end
+  end
+
+  it "names the limit and disowns the counts in the notice, and stays silent otherwise" do
+    note = Gori::CLI::Run.sitemap_truncation_notice_for_spec(true, 5).should_not be_nil
+    note.should contain("TRUNCATED")
+    note.should contain("5")
+    note.should contain("(N paths)")
+    Gori::CLI::Run.sitemap_truncation_notice_for_spec(false, 5).should be_nil
+  end
 end
 
 describe "gori run sitemap — text tree" do

--- a/src/gori/cli/output.cr
+++ b/src/gori/cli/output.cr
@@ -224,6 +224,18 @@ module Gori
         String.build { |io| s.each_char { |c| io << ((c.control? && c != '\n' && c != '\t') ? '·' : c) } }
       end
 
+      # A padded cell that is never flush against the one after it. `ljust(n)` alone guarantees
+      # a separator only while the value is SHORTER than the column: an HTTP method is an RFC
+      # 9110 token of any length, and at exactly 7 characters — `OPTIONS` and `CONNECT`, both
+      # registered and both routine (CORS preflight, tunnels) — the pad produced zero spaces
+      # and the row read `OPTIONShttps`, which neither an operator nor a script can split.
+      # The value stays WHOLE and the column grows by the one space it owes: unlike the TUI's
+      # fixed 8-cell clamp, a CLI listing has no geometry to defend, and truncating `PROPFIND`
+      # to buy a gap would lose information a script is reading this line for.
+      def self.pad_cell(s : String, width : Int32) : String
+        s.size < width ? s.ljust(width) : "#{s} "
+      end
+
       # "#42  GET   https  example.com:443/users  200  1.2kB  3ms  [Complete]"
       # Columns are padded for scannability; status/state make capture progress legible.
       def self.flow_row_text(row : Store::FlowRow, columns : Array({String, String})? = nil) : String
@@ -237,7 +249,7 @@ module Gori
         dur = row.duration_us.try { |us| " #{human_us(us)}" } || ""
         String.build do |io|
           io << '#' << row.id.to_s.ljust(6)
-          io << term_safe(row.method).ljust(7)
+          io << pad_cell(term_safe(row.method), 7)
           io << term_safe(row.scheme).ljust(6)
           io << loc
           io << "  -> " << status
@@ -713,7 +725,7 @@ module Gori
         String.build do |io|
           io << authorize_verdict_label(v)
           io << "  #" << (t.flow_id.try(&.to_s) || "-").ljust(6)
-          io << term_safe(t.method).ljust(7)
+          io << pad_cell(term_safe(t.method), 7)
           io << term_safe(t.url)
           # The count is the whole reason the headline is worth reading twice: which identities,
           # and how many of them, were served what the baseline was served.

--- a/src/gori/cli/output.cr
+++ b/src/gori/cli/output.cr
@@ -224,6 +224,29 @@ module Gori
         String.build { |io| s.each_char { |c| io << ((c.control? && c != '\n' && c != '\t') ? '·' : c) } }
       end
 
+      # The listing's location cell: the flow's absolute URL minus the scheme the SCHEME column
+      # beside it already printed.
+      #
+      # `row.url`, not the `Gori::Url.location(row.host, row.target)` this used to be: that
+      # spelling is host + target and carries no PORT, so every origin-form capture (the
+      # HTTPS/CONNECT case — the target is a bare "/path") printed its host bare and two
+      # services on one host, 127.0.0.1:19315/a and 127.0.0.1:19316/a, came out as the same
+      # cell. `--format json` told them apart the whole time — it emits `port`, and its `url`
+      # goes through `FlowRow#url`. That is also the reason the fix routes through `row.url`
+      # rather than pasting `:#{port}` in here: `FlowRow.url_of` is the single definition of a
+      # flow's absolute URL, non-default-port and IPv6-bracket rules included, and a second
+      # copy of it on this line is a copy that drifts.
+      #
+      # An absolute-form target keeps its scheme, exactly as before: it is the request line the
+      # client wrote (`GET HTTP://host/x` — RFC 3986 §3.1 makes the scheme case-insensitive, so
+      # the old `target.starts_with?("http")` test let it double into
+      # `127.0.0.1HTTP://127.0.0.1:19594/upper`), and rewriting the operator's own bytes to
+      # match the column beside them would be a different lie.
+      private def self.flow_location(row : Store::FlowRow) : String
+        url = row.url
+        Store::FlowRow.absolute_form?(row.target) ? url : url.lchop("#{row.scheme}://")
+      end
+
       # A padded cell that is never flush against the one after it. `ljust(n)` alone guarantees
       # a separator only while the value is SHORTER than the column: an HTTP method is an RFC
       # 9110 token of any length, and at exactly 7 characters — `OPTIONS` and `CONNECT`, both
@@ -240,12 +263,7 @@ module Gori
       # Columns are padded for scannability; status/state make capture progress legible.
       def self.flow_row_text(row : Store::FlowRow, columns : Array({String, String})? = nil) : String
         status = row.status.try(&.to_s) || "—"
-        # HTTP proxied requests store an absolute-form target ("http://host/path") that
-        # already carries the host; only origin-form targets need the host prefixed.
-        # `Gori::Url.location`, not the `target.starts_with?("http")` spelled out here before:
-        # that is not the absolute-form test (RFC 3986 §3.1 — schemes are case-insensitive),
-        # so a captured `GET HTTP://host/x` printed as `127.0.0.1HTTP://127.0.0.1:19594/upper`.
-        loc = term_safe(Gori::Url.location(row.host, row.target))
+        loc = term_safe(flow_location(row))
         dur = row.duration_us.try { |us| " #{human_us(us)}" } || ""
         String.build do |io|
           io << '#' << row.id.to_s.ljust(6)

--- a/src/gori/cli/run/issues.cr
+++ b/src/gori/cli/run/issues.cr
@@ -121,7 +121,8 @@ module Gori
         # Refuse a cvss nothing can score, BEFORE the insert. Stored as-is it would sit in a
         # column the Issues list, `cvss:` queries and every export read through a parser that
         # answers nil for it — a field only its own raw string can see, written on a command
-        # that reported success. Same rule --severity and --flow already follow.
+        # that reported success. Same rule --severity follows; --flow is checked against the
+        # store below, where the answer lives.
         cvss = cvss.try(&.strip).presence
         cvss.try do |c|
           abort "gori run issues create: invalid --cvss '#{c}' (a vector like CVSS:3.1/AV:N/... or a score 0.0-10.0)" unless Gori::Cvss.valid?(c)
@@ -138,6 +139,9 @@ module Gori
         project = resolve_read_project(project_name, db_path)
         store = open_store(project)
         begin
+          if err = issue_flow_error(store, flow_id)
+            abort "gori run issues create: #{err}"
+          end
           masked_title = Env.mask_secrets(t)
           masked_host = host.try { |h| Env.mask_secrets(h) }
           id = store.insert_issue(masked_title, severity, masked_host, flow_id, cvss: cvss)
@@ -146,6 +150,21 @@ module Gori
         ensure
           store.close
         end
+      end
+
+      # The refusal for a `--flow` that names no captured flow, or nil when it names one (or
+      # was not given). The same existence check `links add --ref flow` makes, and for the same
+      # reason: a dangling flow id is not caught later, it is ADVERTISED — the listing row, the
+      # markdown report and the SARIF location all print `flow#N` as evidence a reader is then
+      # told to open. `flow_row`, not `get_flow`: the row-only read answers "does this exist?"
+      # without materializing both BLOBs. The `<= 0` half is separate because the store has no
+      # row there to disagree with — `--flow 0` and `--flow -5` parsed fine and persisted a
+      # reference no id can ever be. Pure and returning the sentence (not aborting in place) so
+      # the decision is spec-able; `abort` is `exit`, which a spec process cannot survive.
+      private def self.issue_flow_error(store : Store, flow_id : Int64?) : String?
+        return nil unless fid = flow_id
+        return "invalid --flow #{fid} (expected a positive flow id)" if fid <= 0
+        store.flow_row(fid) ? nil : "no flow with id #{fid}"
       end
 
       # Remove an issue outright. Distinct from `update --status=resolved|false-positive`,

--- a/src/gori/cli/run/sitemap.cr
+++ b/src/gori/cli/run/sitemap.cr
@@ -203,7 +203,7 @@ module Gori
           store.close
           abort "gori run sitemap: #{err}"
         end
-        hosts = begin
+        hosts, truncated = begin
           collect_sitemap(store, filter, limit, in_scope, group, fold_query)
         rescue ex
           abort "gori run sitemap: query #{query.inspect} failed: #{ex.message}"
@@ -211,7 +211,7 @@ module Gori
           store.close
         end
 
-        emit_sitemap(hosts, format)
+        emit_sitemap(hosts, format, truncated, limit)
       end
 
       # QL.parse + the same un-compilable-query rejection as history (a non-blank query
@@ -240,12 +240,18 @@ module Gori
       # the TUI lens's per-flow SQL filter and conservative on url-level includes.
       private def self.collect_sitemap(store : Store, filter : QL::Filter, limit : Int32,
                                        in_scope : Bool, group : Bool,
-                                       fold_query : Bool) : Array(Sitemap::Node)
+                                       fold_query : Bool) : {Array(Sitemap::Node), Bool}
         # A `--query body:…` filter arrives here already drained and CHECKED — see
         # `cmd_sitemap_tree`, which refuses outright when the off-commit trigram index (Store V4)
         # is still behind.
         # The drain used to sit on this line, where a leftover backlog had no way to be reported.
-        hosts = Sitemap.build(store.sitemap_entries(filter, limit, raise_on_error: true))
+        entries = store.sitemap_entries(filter, limit, raise_on_error: true)
+        # Measured HERE, on the raw read, and not after the folds: every step below collapses
+        # rows, so by the time the tree exists the cut is invisible. Same test as
+        # `Diff::Snapshot` (`rows.size >= limit`) — the read is capped, not cursored, so a
+        # group that lost the cut is not on a later page, it is simply absent.
+        truncated = entries.size >= limit
+        hosts = Sitemap.build(entries)
         Sitemap.stamp_tags!(hosts, store.sitemap_tags)
         if in_scope
           scope = Scope.load(store)
@@ -261,12 +267,30 @@ module Gori
         # children they always did (/items/7?ref=home still joins the /items/7 numeric run).
         hosts.each { |h| Sitemap.fold_queries!(h) } if fold_query
         hosts.each { |h| h.endpoints = Sitemap.endpoint_count(h) }
-        hosts
+        {hosts, truncated}
       end
 
-      # Results → STDOUT; the empty-state note → STDERR (STDOUT-purity). JSON always
-      # emits a (possibly empty) array so scripts get valid JSON either way.
-      private def self.emit_sitemap(hosts : Array(Sitemap::Node), format : Symbol) : Nil
+      # The sentence for a tree built off a capped read, or nil when the read was complete.
+      # Pure and separate for the same reason `tag_match_warning` is: a capped read is the one
+      # thing this tree must not be silent about, because the per-host `(N paths)` header is
+      # counted off whatever survived the cut — so a truncated run makes a POSITIVE and wrong
+      # claim about the project's endpoints. The cap counts 6-column transport keys (see
+      # `sitemap_node_exists?`), which multiply past the default long before the collapsed row
+      # count suggests, so this fires on real engagements rather than on a pathological one.
+      private def self.sitemap_truncation_notice(truncated : Bool, limit : Int32) : String?
+        return nil unless truncated
+        "TRUNCATED — the scan stopped at the --limit of #{limit} endpoint keys, so hosts are " \
+        "missing and every '(N paths)' count is a count of the partial read, not of the " \
+        "project. Raise -n/--limit or narrow the query."
+      end
+
+      # Results → STDOUT; the empty-state and truncation notes → STDERR (STDOUT-purity). JSON
+      # always emits a (possibly empty) array so scripts get valid JSON either way.
+      private def self.emit_sitemap(hosts : Array(Sitemap::Node), format : Symbol,
+                                    truncated : Bool, limit : Int32) : Nil
+        if note = sitemap_truncation_notice(truncated, limit)
+          STDERR.puts "gori run sitemap: #{note}"
+        end
         if format == :json
           puts CLI::Output.sitemap_json(hosts)
         elsif hosts.empty?

--- a/src/gori/cli/run/sitemap.cr
+++ b/src/gori/cli/run/sitemap.cr
@@ -60,6 +60,16 @@ module Gori
         end
       end
 
+      # One tag as one TSV line. The memo is folded the way the TREE view already folds it
+      # (`term_safe`, which is why a multi-line tag reads there as `# multi·line`): a tag is
+      # free text — typed here, or set from the TUI or MCP — and printed raw, a newline in it
+      # split one tag across two physical lines while a tab invented a fourth column, either
+      # of which desyncs host+path from the memo for anything reading this output. There is no
+      # `--format json` on --list to fall back to.
+      private def self.sitemap_tag_row(host : String, path : String, tag : String) : String
+        "#{CLI::Output.term_safe(host)}#{CLI::Output.term_safe(path)}\t#{CLI::Output.term_safe(tag)}"
+      end
+
       # Validate the write-side flags and set (or clear) the tag. Split out of cmd_sitemap_tag
       # to keep it under the cyclomatic-complexity bar. Takes the parsed values as ARGUMENTS:
       # in place they are assigned inside OptionParser blocks, so Crystal keeps them nilable


### PR DESCRIPTION
Five defects on the CLI's read surfaces. None of them crashes; every one of them
prints something an operator or a script then believes. Each commit is one fix
plus a regression spec that was confirmed red against the old code.

### 1. `sitemap` hit its scan cap silently — and then counted off the truncated set

`collect_sitemap` called `store.sitemap_entries(filter, limit, …)` and never
compared the returned size to `limit`.

```
$ gori run sitemap --project demo -n 5
acme-corporation-staging-….demo.test  (1 path)
…
# nothing on stderr, in text, json OR paths
```

The short host list is bad enough; the per-host `(N paths)` header is counted off
whatever survived the cut, so a capped run makes a *positive, wrong* claim about
the project. The cap counts 6-column transport keys — the same multiplication
`sitemap_node_exists?` already documents — so the 10k default is reachable on a
real engagement, not just with `-n 5`.

The cut is measured on the raw read (`entries.size >= limit`, the test
`Diff::Snapshot` uses) *before* any fold makes it invisible, and the notice goes
to STDERR so json/paths keep a pure STDOUT. `sitemap_truncation_notice` is a pure
`String?` helper for the same reason `tag_match_warning` is one.

### 2. The METHOD column ran into the one beside it

```
$ gori run history -q 'method:OPTIONS'
#87    OPTIONShttps api.demo.test*  -> 204
```

`ljust(7)` guarantees a separator only while the value is *shorter* than the
column. `OPTIONS` and `CONNECT` are exactly 7 and both are RFC 9110 registered and
routine (CORS preflight, tunnels), so the row is unsplittable on ordinary traffic;
`PROPFIND`, `CHECKOUT` and `VERSION-CONTROL` follow.

`pad_cell` keeps the value whole and grows the column by the one space it owes.
Not a clamp: the TUI's fixed 8-cell version is right for a screen (its own comment
says truncating `PROPFIND` would *be* the regression), but a CLI listing has no
geometry to defend and a script is reading that token. Both sites — the history
row and `authorize_target_text`.

### 3. The history row dropped the port, while `--format json` kept it

The location cell was `Url.location(row.host, row.target)` — host + target, which
carries no port — so every origin-form (HTTPS/CONNECT) capture printed its host
bare and two services on one host became the same cell:

```
https 127.0.0.1/service-A     # :19315
https 127.0.0.1/service-B     # :19316
```

json told them apart the whole time (it emits `port`, and its `url` goes through
`FlowRow#url`), so the two formats disagreed about the same flow. Visible on the
seeded demo as well: `legacy.demo.test:8080/` printed as `legacy.demo.test/`.

The cell now routes through `row.url` and chops the scheme the SCHEME column
beside it already printed. Deliberately not `:#{port}` pasted in here:
`FlowRow.url_of` is the single definition of a flow's absolute URL, non-default
port and IPv6 brackets included, and a second copy on that line is a copy that
drifts. An absolute-form target keeps its scheme, unchanged — those bytes are the
request line the client wrote.

### 4. `issues create --flow` accepted a flow id that does not exist

```
$ gori run issues create --db X -t t --flow 424242
Issue #21 created successfully.          # exit 0
```

`--flow 0` and `--flow -5` were accepted too. The listing, the markdown report and
the SARIF location then advertise `flow#424242` as evidence a reader is told to
open. The sibling refuses the identical id: `links add --ref flow --ref-id 999999`
→ `no flow with id 999999`, exit 1.

Checked against the store before the insert, with the sibling's wording and exit
code. `flow_row`, not `get_flow` — the row-only read answers "does this exist?"
without materializing both BLOBs. `<= 0` is a separate arm because the store has
no row there to disagree with, and `no flow with id -5` would send the reader
hunting for a capture instead of at their own argument. `parse_flow_id` itself is
left alone on purpose: fuzz/mine/sequence load the flow and already fail.

The comment at `issues.cr:124` claimed "Same rule --severity and --flow already
follow". Only `--cvss`/`--severity` did; that sentence is corrected.

### 5. `sitemap tag --list` wrote a raw tag into a TSV line

A tag is free text and can be set from the TUI or MCP as well as `--tag`, so a
newline in one split a single tag across two physical lines and a tab invented a
fourth column. The tree view already folds the same tag to `# multi·line`; the
TSV line goes through the same `term_safe`, and `--list` has no `--format json`
to fall back to.

---

**Verification.** Each spec was confirmed red against the pre-fix behavior first
(new helpers neutered to their old semantics, then restored — no canaries left in
the tree). `crystal tool format src spec`, `crystal build --no-codegen
src/main.cr`, and the full suite: **11906 examples, 0 failures, 0 errors**.

Dogfooded end-to-end against a seeded `demo` project in an isolated `GORI_HOME`,
including the `links add` wording comparison and the text-vs-json port disagreement.
