### PR TITLE
fix(decoder): three answers the engine gives that were wrong at the edges

### DIFF
--- a/spec/cli/run/decoder_spec.cr
+++ b/spec/cli/run/decoder_spec.cr
@@ -88,3 +88,24 @@ describe "gori run decoder --format json" do
     json["output"].as_s.valid_encoding?.should be_true
   end
 end
+
+# `gori run decoder <chain>` where the chain is only separators. The DECISION and the
+# MESSAGE are split out of the abort for the same reason `list_leftover_error` is —
+# `abort` calls `exit` and cannot run in-process.
+describe "gori run decoder <chain>" do
+  it "proceeds for a chain that has converter tokens" do
+    Gori::CLI::Run.decoder_empty_chain_error("base64-decode").should be_nil
+    Gori::CLI::Run.decoder_empty_chain_error(" hex , url-encode ").should be_nil
+  end
+
+  it "refuses a chain that is only separators, which would echo the input back as a success" do
+    # `Chain.run` treats a zero-token spec as the IDENTITY, so `gori run decoder '>' hello`
+    # printed `hello` and exited 0 — a chain the operator typed wrong reported as a decode
+    # that worked. The MCP `decode` tool already refuses exactly this shape by name.
+    ["", ">", ",", "|", " > | , ", ">>"].each do |chain|
+      msg = Gori::CLI::Run.decoder_empty_chain_error(chain)
+      msg.should_not be_nil
+      msg.not_nil!.should contain("no converter tokens")
+    end
+  end
+end

--- a/spec/cli/run/decoder_spec.cr
+++ b/spec/cli/run/decoder_spec.cr
@@ -109,3 +109,15 @@ describe "gori run decoder <chain>" do
     end
   end
 end
+
+describe "gori run decoder --format json with --output text" do
+  it "keeps the document parseable when text is forced over binary bytes" do
+    binary = Base64.strict_encode(Bytes[0x00, 0xFF, 0xFE, 0x80])
+    json_str = Gori::CLI::Run.decoder_json_for_spec(
+      run_chain(binary, "base64-decode"), Gori::Decoder::RenderAs::Text)
+    json_str.valid_encoding?.should be_true
+    json = JSON.parse(json_str)
+    json["render"].as_s.should_not eq("text")
+    json["output"].as_s.valid_encoding?.should be_true
+  end
+end

--- a/spec/decoder_spec.cr
+++ b/spec/decoder_spec.cr
@@ -953,6 +953,33 @@ describe Gori::Decoder do
       end
     end
 
+    # A saved chain is only as runnable as its steps. `brotli-decompress` / `zstd-decompress`
+    # are registered CARRYING a reason on a `-Dwithout_native_codecs` build (the catalog's
+    # `native_codec_reason`) so their names still resolve; a saved chain wrapping one inherited
+    # `unusable: nil`, so `Fuzz::Plan.refuse_unrunnable_chains` — which reads that flag off the
+    # ONE token the spec names — waved the run through and every payload failed at send instead.
+    # Same defect as the unknown-token case above, one arm over. Built by hand rather than off
+    # the shared registry because this build links the native codecs.
+    it "inherits a built-in's `unusable` into a saved chain that wraps it" do
+      r = Gori::Decoder::Registry.new
+      r.register Gori::Decoder.bytes("no-native",
+        category: Gori::Decoder::Category::Compression,
+        direction: Gori::Decoder::Direction::Decode,
+        description: "stand-in for a codec this build dropped",
+        unusable: "no-native: this gori was built without it") { |b| b }
+      r.register Gori::Decoder.text("upcase-it", category: Gori::Decoder::Category::Text,
+        direction: Gori::Decoder::Direction::Transform, description: "x", &.upcase)
+
+      Gori::Decoder::Library.register_all(r, [
+        {"wrapper", "upcase-it > no-native"},
+        {"clean", "upcase-it"},
+      ])
+      r["wrapper"].unusable.not_nil!.should contain "no-native"
+      r["wrapper"].unusable.not_nil!.should contain "built without it"
+      # The complement: a saved chain over runnable steps stays runnable.
+      r["clean"].unusable.should be_nil
+    end
+
     it "publishes through the Settings setter, so every surface sees the same library" do
       before = Gori::Settings.decoder_chains
       begin

--- a/src/gori/cli/run/decoder.cr
+++ b/src/gori/cli/run/decoder.cr
@@ -117,7 +117,9 @@ module Gori
               end
             end
             if final_bytes = result.output
-              rendered, render = Decoder.display(final_bytes, mode)
+              # `display_utf8`, not `display`: this rendering goes inside a JSON string, and
+              # `--output text` over binary would put raw bytes there — see its comment.
+              rendered, render = Decoder.display_utf8(final_bytes, mode)
               j.field "render", render.to_s.downcase
               j.field "output", rendered
             end

--- a/src/gori/cli/run/decoder.cr
+++ b/src/gori/cli/run/decoder.cr
@@ -39,6 +39,7 @@ module Gori
         abort "gori run decoder: missing <chain> (e.g. 'base64-decode'; see 'gori run decoder list')" if positional.empty?
         abort "gori run decoder: too many arguments (expected <chain> [input])" if positional.size > 2
         chain = positional[0]
+        (msg = decoder_empty_chain_error(chain)) && abort(msg)
 
         input_str = input_flag || positional[1]?
         input_str ||= STDIN.gets_to_end unless STDIN.tty?
@@ -65,6 +66,21 @@ module Gori
         # A broken chain exits non-zero in BOTH formats — the json branch previously always
         # exited 0, burying "ok":false (inconsistent with the text view + intercept acks).
         exit 1 unless result.ok?
+      end
+
+      # The sentence `cmd_decoder` aborts with when `<chain>` holds no converter at all, or nil
+      # to proceed. Split from the abort so the decision AND the message are spec-able, the same
+      # split `list_leftover_error` documents.
+      #
+      # `Chain.run` treats a zero-token spec as the IDENTITY (which is right for it — the TUI's
+      # empty chain box shows the input), so `gori run decoder '>' hello` printed `hello` and
+      # exited 0: a chain the operator mistyped, reported as a decode that worked. The MCP
+      # `decode` tool already refuses this exact shape rather than "reporting a phantom
+      # 'success' that echoes the input back unchanged"; the CLI was the surface that did not.
+      def self.decoder_empty_chain_error(chain : String) : String?
+        return nil unless Decoder.parse_spec(chain).empty?
+        "gori run decoder: <chain> has no converter tokens (separators are > | ,; " \
+        "e.g. 'base64-decode > gunzip'; see 'gori run decoder list')"
       end
 
       # STDERR line for the first non-Ok step, so a failing chain is diagnosable in

--- a/src/gori/decoder.cr
+++ b/src/gori/decoder.cr
@@ -100,6 +100,20 @@ module Gori::Decoder
     end
   end
 
+  # `display`, guaranteed to be valid UTF-8 — for a caller that puts the rendering INSIDE a
+  # JSON string, where raw bytes are not a thing the format can carry.
+  #
+  # Only `RenderAs::Text` can hand back invalid UTF-8, and only over binary. `gori run decoder
+  # --output text --format json` did exactly that with a base64 blob that decodes to arbitrary
+  # bytes: the bytes went into the document verbatim and no JSON parser would read it back,
+  # with `ok: true` and exit 0 — the CLI's own answer to a documented flag combination. The
+  # fall-back is the AUTO choice rather than an error because the returned mode is what the
+  # `render` field reports, so the document still names the rendering it actually used.
+  def self.display_utf8(data : Bytes, prefer : RenderAs? = nil) : {String, RenderAs}
+    out = display(data, prefer)
+    out[0].valid_encoding? ? out : display(data, nil)
+  end
+
   def self.binary?(data : Bytes) : Bool
     !String.new(data).valid_encoding?
   end

--- a/src/gori/decoder/library.cr
+++ b/src/gori/decoder/library.cr
@@ -110,7 +110,20 @@ module Gori::Decoder
             break
           end
           out << tok
-        elsif r[tok]?
+        elsif conv = r[tok]?
+          # A built-in that CANNOT RUN on this build fails the chain here, exactly as an
+          # unknown token does. `brotli-decompress` / `zstd-decompress` are registered carrying
+          # `native_codec_reason` on a `-Dwithout_native_codecs` build so their names still
+          # resolve — but a saved chain wrapping one was spliced as if it were ordinary and
+          # inherited `unusable: nil`, which is the same blindness the comment above describes:
+          # `Fuzz::Plan.refuse_unrunnable_chains` reads the flag off the one token the spec
+          # names, so it waved the run through and every payload failed at send instead of the
+          # plan being refused before the first dial.
+          if reason = conv.unusable
+            failed = true
+            why[nk] = reason # already prefixed with the built-in's own name
+            break
+          end
           out << tok
         elsif !specs.has_key?(tk)
           failed = true


### PR DESCRIPTION
I went at the Decoder engine adversarially and did **not** find a defect in the codecs themselves. That is the headline, and the evidence for it is below — the three fixes here are all one layer out, where the engine's answer is handed to somebody: the CLI's JSON document, the CLI's chain argument, and the saved-chain library's runnability flag.

## The three

**A JSON document `--output text` made unparseable.** `gori run decoder --output text --format json` rendered the final value through `Decoder.display(bytes, RenderAs::Text)`, which is `String.new(data)` — raw octets. Over any chain that produces binary (a base64 blob that decodes to arbitrary bytes, a hash, a gzip) those octets went straight into a JSON string:

```
$ gori run decoder hex-decode fffe80 --output text --format json | python3 -c 'import json,sys; json.load(sys.stdin)'
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 137
```

…with `"ok":true` and exit 0. The file's own spec already stated the invariant — *"a base64 blob that decodes to arbitrary bytes must not put invalid UTF-8 into the JSON document"* — it just never exercised the forced-text arm, only `auto`. `Decoder.display_utf8` is `display` with that guarantee; only the Text arm can produce invalid UTF-8 and only over binary, so that case falls back to the AUTO choice. Nothing is lost and nothing is silent: the mode it returns is what the document's `render` field reports, so the JSON names the rendering it used. The **text** format is untouched — `--output text` there is the byte-exact path and stays byte-exact (verified: `ff fe 80` out, unchanged).

**`run decoder` echoed the input back for a chain with no converters.** `Chain.run` treats a zero-token spec as the IDENTITY, which is right for the engine — the TUI's empty chain box shows the input. At the CLI it meant a `<chain>` of only separators ran nothing and reported the input as the result:

```
$ gori run decoder ">" hello
hello                                    # exit 0
$ gori run decoder "," hello --format json
{"ok":true,"steps":[],"render":"text","output":"hello","failed_at":null}
```

A mistyped or shell-mangled chain therefore reads exactly like a decode that worked, and a script cannot see the difference. The MCP `decode` tool already refuses this, by name and for this reason ("reporting a phantom 'success' that echoes the input back unchanged"); the CLI was the surface that did not. Same refusal, with the DECISION and the MESSAGE split out of the `abort` so both are spec-able — the split `list_leftover_error` documents.

**A saved chain wrapping an unrunnable built-in reported itself runnable.** `Library.flatten` spliced any token the built-in registry answered for, without asking whether that built-in can run on *this* build. `brotli-decompress` / `zstd-decompress` are registered carrying `native_codec_reason` on a `-Dwithout_native_codecs` build — deliberately, so their names still resolve instead of reading as typos — so a saved chain over one flattened cleanly and registered with `unusable: nil`.

That is the blindness `flatten`'s own comment describes one arm over, for an unknown token: `Fuzz::Plan.refuse_unrunnable_chains` reads `unusable` off the ONE token a `§value¦chain§` marker names, and a saved chain is callable BY NAME, so the plan gate saw nothing to refuse. The run started and every payload failed at send instead of the plan being refused before the first dial. It now fails the entry with the built-in's own reason, which is already prefixed with its name — the same answer the unknown-token arm gives.

## What I could not break

The engine is in good shape and I want the negative result on the record, because "we looked" is worth more than the absence of a diff:

- **800,000 converter applications** over chained, mutating input across the whole catalog: zero raises that were not `DecoderError` (or `CookieError`, which the chain catches). A raw `OverflowError` or `Index out of bounds` escaping a converter is the failure class `puny_decode_label`'s overflow guards were written for; there are none left.
- **CBOR / MessagePack**: exhaustive 1-byte and 2-byte inputs (65,536), 30k random, 300k random 6-byte, and every prefix of a dozen rich documents. Never raises; the rendering is **always** valid UTF-8 and always re-parses as JSON; `consumed ≤ size` and `complete ⇒ consumed == size` hold throughout.
- **RFC 8949 Appendix A**, every published vector: all correct, bignums / half floats / indefinite forms / tags / non-string keys included. Separately: 3,000 random bignums checked against `BigInt` (0 diffs), **all 65,536 half floats** against a hand-expanded reference (0 diffs), and the int64/uint64 boundary set including `3b ff…ff` = −2^64.
- **20,000 random value trees** encoded by an independent CBOR *and* MessagePack encoder: both readers parse every one to `complete`, and agree with each other modulo the one marker name they spell differently.
- **Python reference cross-check**: base32 / base64 / ascii85 encode over 1,230 vectors and decode over 2,000 (stripped padding, the Adobe `<~ ~>` wrapper, `wrapcol`, lowercase, url-safe) — byte-identical. punycode over 20 labels including the error cases — identical to `codecs.encode(…, 'punycode')` plus the RFC 3490 map, refusal messages and all. `html.unescape` over 37 entity shapes — identical but for `&#x10FFFF;`, which is Crystal's `HTML.unescape` and a noncharacter.
- **Every encode/decode pair round-trips byte-exactly** on empty input, one byte, NUL, invalid UTF-8, a 4-byte emoji, all 256 byte values, trailing whitespace and CR/LF. The `base36`/`base62` "leading NULs kept as '0'" claim holds.
- **The 32 MiB decompress caps are real** for gzip / zlib / raw-inflate, and the boundary is where the comment says it is: exactly `MAX_OUT` succeeds, one byte past it fails.
- `AsciiBytes` against a downcased-`String` reference over 200,000 cases (0 diffs); `Entity.of` over 80 head/body combinations including truncated gzip and malformed chunk framing (no raises, no false projection flag); and the decoder guide + playbook's backticked names all still resolve in the registry.

**On the `gzip-decode` lead**: not a defect. The catalog is consistent *per category* — Encoding uses `-encode`/`-decode`, Compression uses `-compress`/`-decompress` — and the one real asymmetry (`br`, `zstd` meaning decompress bare, where every other bare alias means encode) is deliberate and says so: gori links the brotli *decoder* library because what a proxy needs is to read what an origin sent. `gzip-decode` gets a clean refusal pointing at `decoder list`.

## Two things I found and deliberately did not fix

- **A saved chain named `exec:…` can never be reached.** `save_chain` refuses a name containing a separator or shadowing a built-in, for the stated reason that "a name that no spec could ever reach would save a library entry that silently does nothing" — but `Chain.run` consults `exec_step?` *before* the registry, so `exec:foo` saves fine, lists fine, autocompletes fine, and then runs the external command `foo` instead of the chain. #818 landed after that guard. Contrived enough that I left it; worth a line in the guard if anyone is in there.
- `gori run decoder list`'s text columns are `ljust(22)` against two 23-character names, so those two rows shift the rest by one. Cosmetic, and adjacent enough to the `ljust` column work in #890 (which does not touch this file) that I left it to whoever is already in that territory.

## Verification

`crystal spec` (11897 examples, 0 failures, 0 errors) · `crystal build --no-codegen src/main.cr` · `scripts/bench_check.sh` (49 harnesses) · `scripts/seed_demo.cr` · `crystal tool format --check src spec`. Ameba on the three changed files is unchanged in kind — the two warnings there are both pre-existing; `flatten`'s cyclomatic complexity, already over the threshold at 13, goes to 14 with the new guard clause.

Each fix ships a regression spec that fails on the old code: the JSON one red on `valid_encoding?`, the library one red on the `unusable` nil assertion. The empty-chain spec targets a newly extracted function (the `abort` itself is not spec-able, the same limit `list_leftover_error` documents), so its red/green was taken against the built binary — before: `hello` / exit 0, after: a refusal / exit 1.
