### PR TITLE
fix(scope): close an h2 sandbox bypass, and the surfaces that wrote past the model

### DIFF
--- a/spec/mcp_spec.cr
+++ b/spec/mcp_spec.cr
@@ -3758,6 +3758,44 @@ describe "MCP update_scope_rule" do
       Gori::Scope.load(store).rules.first.pattern.should eq("a.test")
     end
   end
+
+  # `ConfigLog` is recorded at the MODEL so that one site covers TUI, CLI and MCP (see its
+  # header). These two tools wrote straight at the store instead, so an agent could rewrite or
+  # delete the include rule that gates every active send and the config feed said nothing —
+  # `scope_update` was an event no headless surface emitted at all.
+  it "records the VALUE of an edit and a delete in the config feed, like every other surface" do
+    with_store do |store|
+      scope = Gori::Scope.load(store)
+      scope.add("include", "host", "old.test")
+      id = Gori::Scope.load(store).rules.first.id
+      tools = tools_for(store)
+
+      ok_json(tools, "update_scope_rule", %({"id":#{id},"pattern":"new.test"}))
+      ok_json(tools, "delete_scope_rule", %({"id":#{id}}))
+
+      store.flush
+      rows = store.events_recent(100, source: Gori::ConfigLog::SOURCE).rows.reverse
+      rows.map(&.kind).should eq(["scope_add", "scope_update", "scope_remove"])
+      rows[1].message.should contain("new.test")
+      rows[2].message.should contain("new.test") # the rule that GOES, named before it is gone
+    end
+  end
+
+  # An edit can black-hole the proxy exactly as a delete can: flip the last include to an
+  # exclude and the sandbox holds an empty allowlist. `delete_scope_rule` reported that; the
+  # edit changed it silently.
+  it "reports blocks_all when an edit leaves the sandbox holding an empty allowlist" do
+    with_store do |store|
+      scope = Gori::Scope.load(store)
+      scope.add("include", "host", "acme.test")
+      scope.enable_sandbox
+      id = Gori::Scope.load(store).rules.first.id
+      tools = tools_for(store)
+
+      ok_json(tools, "update_scope_rule", %({"id":#{id},"kind":"exclude"}))["blocks_all"].as_bool.should be_true
+      ok_json(tools, "list_scope", "{}")["blocks_all"].as_bool.should be_true
+    end
+  end
 end
 
 describe "MCP sitemap tags" do

--- a/spec/proxy/h2/stream_gate_spec.cr
+++ b/spec/proxy/h2/stream_gate_spec.cr
@@ -1514,4 +1514,36 @@ describe Gori::Proxy::H2::StreamGate do
       rig.to_origin.should be_empty
     end
   end
+
+  it "refuses a stream whose :path is an ABSOLUTE URI naming an in-scope host on an out-of-scope connection" do
+    with_ic(intercept: false) do |ic, scope|
+      # `Scope.request_url` returns an absolute-form target VERBATIM, so a client that spells
+      # its `:path` as a full URL chooses the string the sandbox evaluates. h1 cannot reach
+      # this (`pinned_origin_head`/`resolve_forward` reduce an absolute-form request line to
+      # origin-form before the gate sees it); h2 relays `:path` untouched.
+      scope.add("include", "string", "https://acme.test/")
+      scope.enable_sandbox
+      rig = Rig.new(ic, host: "evil.example.com")
+
+      rig.c2s.accept(headers(1_u32, rig.enc_out.encode(request("https://acme.test/x", authority: "evil.example.com"))))
+      rig.to_origin.should be_empty
+      rig.to_client.map(&.frame_type).should eq([Frame::Type::RstStream])
+    end
+  end
+
+  it "judges an absolute-form :path by the host it will DIAL, not the one the path names" do
+    with_ic(intercept: false) do |ic, scope|
+      # The mirror of the case above, so the reduction is anchoring the decision rather than
+      # blanket-refusing every absolute-form path: the connection IS in scope, the URL spelled
+      # into `:path` is not, and gori dials the connection's host — so this one goes through.
+      scope.add("include", "string", "https://api.example.com/")
+      scope.enable_sandbox
+      rig = Rig.new(ic, host: "api.example.com")
+
+      rig.c2s.accept(headers(1_u32, rig.enc_out.encode(request("https://evil.example.com/x"))))
+      rig.to_origin.map(&.frame_type).should eq([Frame::Type::Headers])
+      # The head goes on the wire byte-exact (P7) — only the gate's url was reduced.
+      head_of(rig.to_origin, 1_u32).should eq(request("https://evil.example.com/x"))
+    end
+  end
 end

--- a/src/gori/cli/run/project.cr
+++ b/src/gori/cli/run/project.cr
@@ -525,24 +525,29 @@ module Gori
           if err = Scope.validation_error(new_type, new_pattern)
             abort "gori run project scope update: #{err}"
           end
-          # `scope_rules` carries UNIQUE(kind, match_type, pattern) (store/schema.cr), and this
-          # command writes straight through the store rather than via `Scope#update`, which
-          # dedupes. Without this pre-check the constraint violation rolled the writer batch
-          # back, `update_scope_rule` returned false, and the busy-store abort below reported a
-          # duplicate as "store busy or unwritable" — sending the operator to hunt for a lock.
-          # `scope add` already names the duplicate; this makes the two agree.
+          # `scope_rules` carries UNIQUE(kind, match_type, pattern) (store/schema.cr), and
+          # `Scope#update` collapses a collision and a rolled-back write into ONE false.
+          # Without this pre-check the busy-store abort below reported a duplicate as "store
+          # busy or unwritable" — sending the operator to hunt for a lock. `scope add` already
+          # names the duplicate; this makes the two agree, and leaves whatever false survives
+          # it meaning the store, exactly as MCP's `update_scope_rule` splits the same pair.
           if scope.rules.any? { |r| r.id != id && r.kind == new_kind && r.match_type == new_type && r.pattern == new_pattern }
             store.close
             abort "gori run project scope update: rule ##{id} NOT updated — #{new_kind} #{new_type} #{new_pattern} " \
                   "already exists as another rule; the scope is unchanged"
           end
-          unless store.update_scope_rule(id, new_kind, new_type, new_pattern)
+          # Through `Scope#update`, like `scope add`/`scope delete` beside it. Going straight at
+          # the store skipped `ConfigLog`, which is recorded at the MODEL (see its header, which
+          # names the CLI as the surface that gets forgotten) — so `scope_update` was an event
+          # NO surface but the TUI ever emitted, and narrowing the include rule that gates every
+          # active send left the project's config feed with nothing to show for it.
+          unless scope.update(id, new_kind, new_type, new_pattern)
             abort "gori run project scope update: rule NOT updated (store busy or unwritable); it is unchanged and still gates traffic"
           end
           puts "Scope rule ##{id} updated: #{new_kind} #{new_type} #{new_pattern}"
-          # Re-read: the write went through the store, not this Scope instance, so the
-          # in-memory rule list is one edit stale.
-          warn_scope_blackhole(Scope.load(store), "gori run project scope update")
+          # `Scope#update` reloads its own rule list, so this reads the edit rather than the
+          # list as it stood one write ago.
+          warn_scope_blackhole(scope, "gori run project scope update")
         ensure
           store.close
         end

--- a/src/gori/mcp/tools/context.cr
+++ b/src/gori/mcp/tools/context.cr
@@ -13,6 +13,12 @@ module Gori
           j.object do
             j.field "enabled", scope.enabled?
             j.field "sandbox", scope.sandbox?
+            # The state `set_sandbox` and `delete_scope_rule` both report on the WRITE that
+            # causes it. Reading it back was the one place it disappeared: `sandbox: true` beside
+            # three exclude rules is a proxy refusing every captured request, and nothing in this
+            # payload said so — a caller would have to know that the allowlist deliberately reads
+            # an empty include set as "block all" rather than "allow all" to derive it.
+            j.field "blocks_all", scope.sandbox? && scope.include_count.zero?
             j.field "rules" do
               j.array do
                 store.scope_rules.each do |(id, kind, match_type, pattern)|

--- a/src/gori/mcp/tools/scope.cr
+++ b/src/gori/mcp/tools/scope.cr
@@ -85,7 +85,15 @@ module Gori
           return err("another scope rule already matches #{kind} #{match_type} #{pattern}",
             "INVALID_ARGUMENT", field: "pattern")
         end
-        unless store.update_scope_rule(id, kind, match_type, pattern)
+        # Through `Scope#update`, not straight at the store: `ConfigLog` is recorded at the
+        # MODEL on purpose (see its header — "a per-surface producer would be three copies, and
+        # the CLI is the one that gets forgotten"), and this surface plus `gori run project
+        # scope update` were both writing past it. `scope_update` was therefore an event NO
+        # headless surface ever emitted: an agent could rewrite the include rule that gates
+        # every active send and the feed carried only `agent | "update_scope_rule ok"`, which
+        # by that header's own argument cannot carry the VALUE. The in-place reload it also
+        # does is one SELECT on a throwaway Scope, and `blocks_all` below now reads it.
+        unless scope.update(id, kind, match_type, pattern)
           return busy("scope rule NOT updated (store busy or unwritable); it is unchanged and still gates traffic")
         end
         Result.new(JSON.build do |j|
@@ -94,6 +102,11 @@ module Gori
             j.field "kind", kind
             j.field "match_type", match_type
             j.field "pattern", pattern
+            # An EDIT can black-hole the proxy exactly as a delete can — flip the last include
+            # to an exclude and the sandbox holds an empty allowlist. `delete_scope_rule`
+            # reports that state and the TUI/CLI both re-ask on this edge; MCP's edit was the
+            # one write that changed it silently.
+            j.field "blocks_all", scope.sandbox? && scope.include_count.zero?
           end
         end)
       end
@@ -103,16 +116,19 @@ module Gori
         return err(id_error(h, "id"), "INVALID_ARGUMENT", field: "id") unless id
         scope = Scope.load(store)
         return not_found("no scope rule with id #{id}") unless scope.rules.any? { |r| r.id == id }
-        # Write straight to the store (this Scope is a throwaway load, so scope.remove's
-        # in-place reload buys nothing here) and confirm it committed — a busy/locked
-        # rollback must not report the rule deleted while it still gates active requests.
-        return busy("scope rule NOT deleted (store busy or unwritable); it is unchanged and still gates traffic") unless store.remove_scope_rule(id)
+        # Through `Scope#remove`, not straight at the store, and confirm it committed — a
+        # busy/locked rollback must not report the rule deleted while it still gates active
+        # requests. It used to take the store directly on the argument that the in-place reload
+        # buys nothing on a throwaway Scope; what it actually skipped was `ConfigLog`, which is
+        # recorded at the MODEL (see its header) and which alone can name WHICH rule went. The
+        # TUI and `gori run project scope delete` both go through here, so MCP was the surface
+        # that could delete the include rule gating every active send and leave the config feed
+        # silent. The reload is also what makes `include_count` below current.
+        return busy("scope rule NOT deleted (store busy or unwritable); it is unchanged and still gates traffic") unless scope.remove(id)
         # `set_sandbox` reports `blocks_all` for exactly this state; a delete that CAUSES
         # it used to return a bare {id, deleted:true}, so an agent could black-hole the
-        # proxy and read the write as ordinary success. Re-load — the removal went through
-        # the store, not this throwaway Scope.
-        after = Scope.load(store)
-        blocks_all = after.sandbox? && after.include_count.zero?
+        # proxy and read the write as ordinary success.
+        blocks_all = scope.sandbox? && scope.include_count.zero?
         Result.new(JSON.build { |j| j.object { j.field "id", id; j.field "deleted", true; j.field "blocks_all", blocks_all } })
       end
 

--- a/src/gori/proxy/h2/stream_gate/sandbox.cr
+++ b/src/gori/proxy/h2/stream_gate/sandbox.cr
@@ -47,7 +47,19 @@ class Gori::Proxy::H2::StreamGate
     authority = HeadCodec.pseudo_of(fields, ":authority") || @host
     host, port = Upstream.split_host_port(authority, @port)
     scheme = HeadCodec.pseudo_of(fields, ":scheme") || "https"
-    target = HeadCodec.pseudo_of(fields, ":path") || "/"
+    # `:path` reduced to its origin form BEFORE either test, because `Url.request_url` returns
+    # an ABSOLUTE-form target VERBATIM — so a peer that spells `:path` as a full URL picks the
+    # string this gate evaluates, and both tests below then read the authority IT chose instead
+    # of either name gori knows. A stream on a connection to `evil.test` carrying
+    # `:path: https://acme.test/x` was allowed through by an `include string "https://acme.test/"`
+    # (and an `exclude` naming a port stopped matching, since `Interceptor#port_excluded?` skips
+    # an absolute-form target as already-authoritative). §8.3.1 wants a path-absolute here, but
+    # nothing rejects the other spelling and gori relays the head untouched, so the GATE is what
+    # has to be anchored. h1 cannot reach this: `resolve_forward`/`pinned_origin_head` rewrite an
+    # absolute-form request line to origin-form before `gate_target` is taken — see the second
+    # bullet of `pinned_origin_head`, which is this same finding on the other protocol. The wire
+    # bytes are untouched (P7); only the url the decision is made on changes.
+    target = Gori::Url.origin_path(HeadCodec.pseudo_of(fields, ":path") || "/")
     blocked = @interceptor.sandbox_blocks?(scheme, host, target, port) ||
               (host != @host && @interceptor.sandbox_blocks?(scheme, @host, target, @port))
     blocked ? {scheme, host, target} : nil

--- a/src/gori/scope.cr
+++ b/src/gori/scope.cr
@@ -534,7 +534,15 @@ module Gori
       ok
     end
 
-    def toggle : Nil
+    # Returns whether the persisted enabled flag committed, exactly as `enable`/`disable`
+    # below and `toggle_sandbox` above already do. It used to answer `Nil`, so its one caller
+    # (`Runner#scope_toggle_lens`) had nothing to check and announced the new lens state over a
+    # write the store had refused — the in-memory flag flips either way, and the next `reload`
+    # (the TUI's data_version poll, which moves every few seconds even on an idle project)
+    # reverts it to the disk value it never reached. That is the same failure
+    # `report_sandbox_write` was written for one gate over, and MCP's `set_scope_enabled` and
+    # `gori run project scope enable` both already confirm this write before reporting it.
+    def toggle : Bool
       @write_mutex.synchronize { set_enabled(!@mutex.synchronize { @enabled }) }
     end
 

--- a/src/gori/tui/runner/scope.cr
+++ b/src/gori/tui/runner/scope.cr
@@ -66,10 +66,16 @@ class Gori::Tui::Runner < Gori::Verb::ExecContext
   # Toggle the scope display lens (in-scope-only ⇄ all flows) right from History —
   # the lens filters History/Sitemap, so reload the active list and confirm the state.
   def scope_toggle_lens : Nil
-    @scope.toggle
+    committed = @scope.toggle
+    # The reloads run either way: `Scope#toggle` flips the in-memory flag whether or not the
+    # write landed, and these lists render off that flag — leaving them stale would put a
+    # SECOND disagreement on screen. What changes is the report. Same shape, and the same
+    # reason, as `report_sandbox_write` for the gate next door: announcing a lens the store
+    # refused is a claim the next data_version poll silently takes back.
     history_controller.view.reload(@session.store)
     sitemap_controller.reload if @active_tab == :target && target_controller.sitemap_active?
     probe_controller.view.reload(@session.store) if @active_tab == :probe
+    return (@toast = "scope lens NOT changed — the project store is busy or unwritable") unless committed
     project_controller.toast_scope_state
   end
 


### PR DESCRIPTION
A focused pass over Project scope + sandbox. The core is clean — `Scope`, `Outbound` and
`Interceptor` all hold: the port include/exclude split (#884), the h2 gate's two-URL test,
and the SQL/Crystal matching parity. The four defects are all at the EDGES: the point that
picks the url a gate reads, and the surfaces that wrote past the model.

### 1. fail-OPEN: an absolute-form `:path` chose the string the h2 sandbox evaluated

`Url.request_url` returns an absolute-form target verbatim, and `sandbox_blocked_url` handed
it `:path` untouched. On a connection to `evil.test`, a stream carrying
`:path: https://acme.test/x` was let through by an `include string "https://acme.test/"`.
Testing both the stream's `:authority` and the connection's host does not help: both read
the same spoofed string, so neither name gori knows is consulted. An exclude naming a port
also stopped matching on that head, since `port_excluded?` skips an absolute-form target as
already-authoritative.

h1 cannot reach this, and that is the fix: `resolve_forward` / `pinned_origin_head` reduce
an absolute-form request line to origin-form before `gate_target` is taken — the second
bullet of `pinned_origin_head` is this same finding on the other protocol. `:path` is now
reduced with `Url.origin_path` before either test. Wire bytes are untouched (P7; rewriting
`:path` means re-encoding HPACK, the trade step 3 already declined) — only the url the
decision is made on changes.

Both directions are pinned by spec: the refusal, and an absolute-form path naming an
out-of-scope host on an in-scope connection, which still goes through because that is the
host gori dials.

### 2. MCP and CLI scope edits wrote past the model, so the config feed never saw them

`ConfigLog` is recorded at the MODEL on purpose — its header says a per-surface producer
would be three copies "and the CLI is the one that gets forgotten". Three writes went
straight at the store: MCP `update_scope_rule` / `delete_scope_rule`, and `gori run project
scope update`. `scope_update` was therefore an event no headless surface emitted at all,
and MCP could delete the include rule gating every active send with nothing in the feed to
show for it. `log_agent_action` does not cover this — by that header's own argument it
carries the call, never the VALUE that names which rule moved.

### 3. `Scope#toggle` did not report whether the lens write committed

It answered `Nil` while `enable` / `disable` / `toggle_sandbox` beside it all return the
commit flag, so `Runner#scope_toggle_lens` announced a lens state a busy store had rolled
back — and the next data_version poll (seconds, even on an idle project) reverted it. Same
failure `report_sandbox_write` exists for one gate over; both headless surfaces already
confirmed this write.

### 4. `blocks_all` was missing from an edit and from the read

An edit black-holes the proxy exactly as a delete does (flip the last include to an exclude
and the sandbox holds an empty allowlist). The TUI and CLI re-ask on that edge; MCP's edit
did not. And `list_scope` reported the state on every write but not on the read, so
`sandbox: true` beside three exclude rules was a proxy refusing everything with nothing
saying so.

### Verification

`crystal spec` 12021 examples green, `crystal build --no-codegen src/main.cr`,
`scripts/bench_check.sh` (49 harnesses), `scripts/seed_demo.cr`, `crystal tool format
--check`. ameba compared per file against a HEAD copy: 13 findings before, 13 after, no new
violations.

The new specs were checked as real canaries, not decoration: reverting the MCP change makes
three of them fail. The CLI half has no spec surface (private `self.` methods), so it was
driven end to end against a built binary with `GORI_HOME` pointed at a scratch dir, and the
`scope_update | scope rule changed — include host "api.acme.test" | cli` row read back out
of the events table; the black-hole warning and the duplicate-vs-busy split still behave.
