### PR TITLE
fix(repeater): the fingerprint a copy dropped, the transcript a rescue threw away, and four more

### DIFF
--- a/spec/cli/run/repeater_positional_spec.cr
+++ b/spec/cli/run/repeater_positional_spec.cr
@@ -1,0 +1,85 @@
+require "../../spec_helper"
+
+# `CLI::Run.no_positional_error` — the ZERO-positional half of the rule
+# `list_leftover_error` / `extra_positional_error` already state for the other two shapes.
+#
+# `OptionParser`'s default `unknown_args` handler is SILENT, so a command that installs none
+# discards every leftover word without a sound. Three `repeater` subcommands did:
+#
+#     $ gori run repeater create -t http://h -r 'GET / HTTP/1.1' STRAYARG
+#     Repeater session #8 created successfully.        ← STRAYARG never mentioned
+#     $ gori run repeater h2 --target http://h --fields f.json STRAY
+#     → 200 in 3.1ms                                   ← request sent, STRAY never mentioned
+#     $ gori run repeater list STRAY
+#     #1  [H1]  t1  → http://h                         ← listed, STRAY never mentioned
+#
+# `create` is the one that costs: a bare word there is almost always the request file or the
+# target the operator meant to pass through a flag, so the row that gets written holds a
+# request they did not type — reported as a clean "session #N created successfully."
+#
+# `abort` is not spec-able, which is why the decision and the message are a function.
+describe Gori::CLI::Run do
+  describe ".no_positional_error" do
+    it "proceeds when the command was handed no positionals at all" do
+      Gori::CLI::Run.no_positional_error([] of String, "gori run repeater list", "hint").should be_nil
+    end
+
+    it "refuses ONE — unlike the one-positional sites, a single token here is already a drop" do
+      Gori::CLI::Run.no_positional_error(["STRAY"], "gori run repeater create", "pass it via --request-file")
+        .should eq("gori run repeater create: unexpected argument \"STRAY\" — pass it via --request-file")
+    end
+
+    it "pluralises, and prints every token so the operator can spot which flag went missing" do
+      Gori::CLI::Run.no_positional_error(["a.txt", "b.txt"], "gori run repeater create", "use --request-file")
+        .should eq("gori run repeater create: unexpected arguments \"a.txt b.txt\" — use --request-file")
+    end
+  end
+
+  # A source check, the same shape (and for the same reason) as `list_leftovers_spec`'s: the
+  # defect is an ABSENCE, and an absence cannot be caught by grepping for a spelling. Every
+  # `OptionParser` in the repeater CLI must reach an `unknown_args` handler, whether it
+  # installs one itself (the sites that take a positional) or hands the parser to
+  # `parse_no_positionals` (the sites that take none) — without either, the leftovers never
+  # reach any guard at all.
+  #
+  # Scoped to these two files rather than all of `cli/run`: 30-odd parsers elsewhere are still
+  # missing theirs (`project scope add -p zzz.test STRAY` adds the rule and says nothing), and
+  # a repo-wide gate here would be a red suite standing in for a sweep nobody has done.
+  it "routes every repeater OptionParser through an unknown_args guard" do
+    dir = File.join(__DIR__, "..", "..", "..", "src", "gori", "cli", "run")
+    offenders = [] of String
+    {"repeater.cr", "repeater_minimize.cr"}.each do |name|
+      src = File.read(File.join(dir, name))
+      # Window each block from its `OptionParser.new` to the NEXT one — anchoring on the
+      # `parse(` call instead let a block that spells its parse differently (or returns early)
+      # swallow the rest of the file, so a LATER block's handler satisfied the check for one
+      # that had none: the gate going green on exactly the drift it exists to catch.
+      starts = [] of Int32
+      pos = 0
+      while at = src.index("OptionParser.new do |", pos)
+        starts << at
+        pos = at + 1
+      end
+      starts.each_with_index do |at, i|
+        window = src[at...(starts[i + 1]? || src.size)]
+        next if window.includes?(".unknown_args") || window.includes?("parse_no_positionals(")
+        offenders << "#{name}@#{src[0, at].count('\n') + 1}"
+      end
+    end
+    offenders.should be_empty
+  end
+
+  # …and the gate has to actually select things, or it is a check that never looked: strip the
+  # guard from one window and it must fail. Pinned on the shape rather than on a count, so a
+  # new parser in either file does not have to update a magic number.
+  it "would catch a parser with neither guard" do
+    src = <<-CR
+      parser = OptionParser.new do |p|
+        p.on("--a", "") { }
+      end
+      parser.parse(args)
+      CR
+    src.includes?(".unknown_args").should be_false
+    src.includes?("parse_no_positionals(").should be_false
+  end
+end

--- a/spec/mcp_spec.cr
+++ b/spec/mcp_spec.cr
@@ -88,6 +88,29 @@ private def start_mcp_ws_origin : Int32
   port
 end
 
+# An origin that reads the upgrade and REFUSES it with a real HTTP response. The handshake
+# failed, but the origin answered — the distinction `WsEngine::Result#answered?` draws, and
+# the one that decides whether a session's stored last response is replaced.
+private def start_refusing_ws_origin(status : Int32) : Int32
+  origin = TCPServer.new("127.0.0.1", 0)
+  port = origin.local_address.port
+  spawn do
+    conn = origin.accept?
+    origin.close rescue nil
+    next unless conn
+    begin
+      conn.read_timeout = 5.seconds
+      Gori::Proxy::Codec::Http1.read_head(conn)
+      conn << "HTTP/1.1 #{status} Forbidden\r\nContent-Length: 0\r\n\r\n"
+      conn.flush
+    rescue
+    ensure
+      conn.close rescue nil
+    end
+  end
+  port
+end
+
 # An origin that completes the TCP handshake and then says nothing, so a send_request
 # against it occupies the tools worker until its own idle timeout fires. The socket is held
 # by the fiber for the life of the example (the spec's timeout, not the origin's, ends it).
@@ -2494,6 +2517,55 @@ describe Gori::MCP::Server do
         payload["repeater_id"].as_i64.should eq(repeater_id)
         payload["upgraded"].as_bool.should be_false
         payload["error"].as_s.should contain("connect failed")
+      end
+    end
+
+    # `gori run repeater send`'s WS path and the TUI's `drain_results` both persist the last
+    # response ONLY on success, and both say why: a later FAILED re-send must not wipe a good
+    # stored handshake. This surface wrote unconditionally, so one send at a session whose
+    # origin was momentarily down (or whose target had been retargeted) replaced a stored 101
+    # with an empty head — measured through the MCP stdio server, `length(response_head)`
+    # 129 → 0 — taking the TUI tab's handshake card and `repeater send --diff`'s baseline with
+    # it. Three surfaces, one row; the failure belongs in the RESULT, which carries it in full.
+    it "keeps a good stored handshake when a later send fails" do
+      with_store do |store|
+        rid = store.insert_repeater("ws://127.0.0.1:1",
+          "GET /ws HTTP/1.1\r\nHost: 127.0.0.1\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n".to_slice,
+          false, true, nil, 0)
+        good = "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\n\r\n"
+        store.update_repeater_response(rid, good.to_slice, Bytes.empty, nil, 42_i64)
+
+        call = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"send_websocket","arguments":{"repeater_id":#{rid},"messages":["ping"],"idle_ms":100,"allow_unscoped":true}}})
+        resp = drive(store, call, verify_upstream: false)[0]
+        resp["result"]["isError"].as_bool.should be_true
+
+        row = store.get_repeater_full(rid).not_nil!
+        String.new(row.response_head.not_nil!).should eq(good)
+        row.response_error.should be_nil
+      end
+    end
+
+    # The other half of the same gate. `ok?` alone would keep the stale 101 forever at an
+    # origin that has started answering 403 — the TUI handshake card, `repeater list` and
+    # `repeater send --diff`'s baseline all going on showing a handshake the origin no longer
+    # performs, with `--diff` silently comparing each new run against it. The origin ANSWERED;
+    # that answer is the news, and it is what the row now holds.
+    it "replaces the stored handshake when the origin answers, but does not upgrade" do
+      with_store do |store|
+        port = start_refusing_ws_origin(403)
+        rid = store.insert_repeater("ws://127.0.0.1:#{port}",
+          "GET /ws HTTP/1.1\r\nHost: 127.0.0.1\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n".to_slice,
+          false, true, nil, 0)
+        store.update_repeater_response(rid,
+          "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\n\r\n".to_slice, Bytes.empty, nil, 42_i64)
+
+        call = %({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"send_websocket","arguments":{"repeater_id":#{rid},"messages":["ping"],"idle_ms":100,"allow_unscoped":true}}})
+        resp = drive(store, call, verify_upstream: false)[0]
+        resp["result"]["isError"].as_bool.should be_true
+
+        row = store.get_repeater_full(rid).not_nil!
+        String.new(row.response_head.not_nil!).should contain("403")
+        row.response_error.not_nil!.should contain("did not upgrade")
       end
     end
 

--- a/spec/repeater/flow_request_spec.cr
+++ b/spec/repeater/flow_request_spec.cr
@@ -116,6 +116,73 @@ describe Gori::Repeater::FlowRequest do
       wire = "POST /x HTTP/1.1\r\n transfer-encoding: chunked\r\nContent-Length: 3\r\n\r\nABCDEFGHIJ".to_slice
       Gori::Repeater::FlowRequest.resync_content_length(wire).should eq(wire)
     end
+
+    # The TUI editor has always refused to rewrite these (`RepeaterView#rewritable_length_header?`,
+    # whose comment states the rule as "the test on screen must be the test on the wire") — and
+    # the wire did it anyway, so one request had two Content-Lengths depending on where you
+    # read it. Measured through `gori run repeater create -f req.txt` + `repeater send` against
+    # a raw-socket origin: the stored/pane value `0abc`, the bytes the origin logged
+    # `Content-Length: 2`. A malformed length is a desync primitive, so the repair also defused
+    # the probe.
+    it "leaves a deliberately malformed Content-Length alone (the editor guard's other half)" do
+      %w[0abc +5 -1].each do |bad|
+        wire = "POST /x HTTP/1.1\r\nHost: h\r\nContent-Length: #{bad}\r\n\r\nhi".to_slice
+        Gori::Repeater::FlowRequest.resync_content_length(wire).should eq(wire)
+      end
+    end
+
+    # `-H "Content-Length:"` sends the header with an EMPTY value, which is a different test
+    # from omitting it — and inventing a number for it would make the flag read as a no-op.
+    it "leaves an EMPTY Content-Length alone" do
+      wire = "POST /x HTTP/1.1\r\nHost: h\r\nContent-Length:\r\n\r\nhi".to_slice
+      Gori::Repeater::FlowRequest.resync_content_length(wire).should eq(wire)
+    end
+
+    # …and the guard is about the VALUE's shape, not about tidiness: leading zeros and OWS
+    # around the digits are still an ordinary length auto-CL may keep honest, exactly as the
+    # editor reads them (both strip before the digit test).
+    it "still rewrites a padded / zero-padded decimal" do
+      wire = "POST /x HTTP/1.1\r\nHost: h\r\nContent-Length:  0005  \r\n\r\nhi".to_slice
+      String.new(Gori::Repeater::FlowRequest.resync_content_length(wire))
+        .should contain("Content-Length: 2\r\n")
+    end
+
+    # A CL.CL desync probe: the disagreement IS the test, exactly as it is for the CL+TE pair.
+    # Rewriting only the first (the sole one this rewrite can reach) turned `5`/`7` into
+    # `2`/`7` — the operator's probe replaced by a different one, silently.
+    it "leaves a message carrying TWO Content-Lengths alone" do
+      wire = "POST /x HTTP/1.1\r\nHost: h\r\nContent-Length: 5\r\nContent-Length: 7\r\n\r\nhi".to_slice
+      Gori::Repeater::FlowRequest.resync_content_length(wire).should eq(wire)
+    end
+
+    # The matcher that FINDS the line `lstrip`s, so a guard cannot be dodged by indenting —
+    # right for a refusal, destructive for a rewrite, which replaces the WHOLE line. An
+    # obs-fold continuation (RFC 9112 §5.2) came back unindented as a second real header.
+    it "leaves an obs-fold continuation line alone" do
+      wire = "POST /x HTTP/1.1\r\nHost: h\r\nX-Foo: bar\r\n Content-Length: 5\r\n\r\nhi".to_slice
+      Gori::Repeater::FlowRequest.resync_content_length(wire).should eq(wire)
+    end
+  end
+
+  # ONE predicate, because the editor and the wire were reading two.
+  describe ".rewritable_length_header?" do
+    it "accepts a decimal, with or without padding and leading zeros" do
+      Gori::Repeater::FlowRequest.rewritable_length_header?("Content-Length: 5").should be_true
+      Gori::Repeater::FlowRequest.rewritable_length_header?("Content-Length:  0005  ").should be_true
+    end
+
+    it "refuses anything else — those are the operator's deliberate bytes" do
+      Gori::Repeater::FlowRequest.rewritable_length_header?("Content-Length: 0abc").should be_false
+      Gori::Repeater::FlowRequest.rewritable_length_header?("Content-Length: +5").should be_false
+      Gori::Repeater::FlowRequest.rewritable_length_header?("Content-Length:").should be_false
+      # The mid-edit clobber shape the editor guard was written for: the next header still
+      # glued to this line's tail. Rewriting replaces the WHOLE line, taking it with it.
+      Gori::Repeater::FlowRequest.rewritable_length_header?("Content-Length: 4GET / HTTP/1.1").should be_false
+      Gori::Repeater::FlowRequest.rewritable_length_header?("Content-Length").should be_false
+      # An indented field name is an obs-fold continuation, not a header this may replace.
+      Gori::Repeater::FlowRequest.rewritable_length_header?(" Content-Length: 5").should be_false
+      Gori::Repeater::FlowRequest.rewritable_length_header?("\tContent-Length: 5").should be_false
+    end
   end
 
   # The REQUEST-side fact behind the "captured incomplete" replay warning. It used to key on

--- a/spec/repeater/minimize_spec.cr
+++ b/spec/repeater/minimize_spec.cr
@@ -422,6 +422,12 @@ describe Gori::Repeater::Minimize do
     report = Min.run(text, auto_cl: false, resolve: RESOLVE, backend: capped) { |_| }
     report.note.should contain("cap")
     capped.sent.should eq(3)
+    # …and the run REPORTS the three it spent, not four. `CappedBackend#send` returns
+    # `CAP_ERROR` ahead of its own `@sent += 1`, so the refused call put nothing on the wire;
+    # counting it made `sends` (the note, the CLI/MCP `sends` field) read SEND_CAP + 1 for
+    # every capped run there has ever been.
+    report.sends.should eq(3)
+    report.note.should contain("3 sends")
   end
 end
 
@@ -541,5 +547,54 @@ describe "Gori::Repeater::Minimize — body bytes on the round trip" do
     # An LF head stays an LF head even though the body carries a CRLF pair.
     report.minimized_text.split("\n\n", 2)[0].should_not contain('\r')
     report.minimized_text.should end_with("line1\r\nline2")
+  end
+end
+
+# The auto-CL resolver every surface uses, so this gate is measured against the bytes a real
+# run would send.
+private def cl_resolve(text : String) : Bytes
+  Gori::Repeater::FlowRequest.resync_content_length(Gori::Env.expand_wire(text))
+end
+
+# The body-param candidate gate's premise is "resolve re-lengths the body" — and `auto_cl`
+# alone stopped being that test once `FlowRequest.resync_content_length` learned to leave a
+# deliberately malformed length alone. With the flag on and a `Content-Length: 0abc` in the
+# head, every variant would go out one param shorter under an unchanged, unparseable length:
+# the origin mis-frames all of them identically, `unchanged?` says so, and the minimizer
+# strips every body param it has — which `--apply` then writes back over the operator's
+# request. `StaticOrigin` answers identically to everything, so anything OFFERED is removed
+# and the removal list is exactly the candidate set.
+describe Gori::Repeater::Minimize do
+  describe "a head whose Content-Length cannot be re-synced" do
+    it "offers no BODY params — their framing could not be kept honest" do
+      text = "POST /x HTTP/1.1\nHost: h\nContent-Type: application/json\nContent-Length: 0abc\n\n" +
+             %({"a":1,"b":2})
+      report = Min.run(text, auto_cl: true, resolve: ->cl_resolve(String),
+        backend: StaticOrigin.new) { }
+      report.removed.any?(&.kind.param?).should be_false
+    end
+
+    # …and the gate is scoped to the BODY: a header, a cookie crumb and a query param do not
+    # change the body's length, so refusing them would be a second bug in the other direction.
+    it "still offers header / cookie / query candidates" do
+      text = "POST /x?keep=1 HTTP/1.1\nHost: h\nUser-Agent: gori\nCookie: theme=dark\n" \
+             "Content-Type: application/json\nContent-Length: 0abc\n\n" + %({"a":1})
+      report = Min.run(text, auto_cl: true, resolve: ->cl_resolve(String),
+        backend: StaticOrigin.new) { }
+      kinds = report.removed.map(&.kind)
+      kinds.should contain(Min::Kind::Header)
+      kinds.should contain(Min::Kind::Cookie)
+      kinds.should contain(Min::Kind::Query)
+    end
+
+    # The control: the identical request with an ORDINARY length does offer them, so the two
+    # examples above are about the malformed header and not about JSON candidates at large.
+    it "offers them again once the length is an ordinary number" do
+      text = "POST /x HTTP/1.1\nHost: h\nContent-Type: application/json\nContent-Length: 13\n\n" +
+             %({"a":1,"b":2})
+      report = Min.run(text, auto_cl: true, resolve: ->cl_resolve(String),
+        backend: StaticOrigin.new) { }
+      report.removed.count(&.kind.param?).should eq(2)
+    end
   end
 end

--- a/spec/repeater/plan_spec.cr
+++ b/spec/repeater/plan_spec.cr
@@ -444,6 +444,32 @@ describe Gori::Repeater::Plan do
       rewritten.sni.should eq(plan.sni)
       rewritten.sender.should be(plan.sender) # the SAME gated dialer, not a second one
     end
+
+    # The rewrite reuses the SENDER, so the fingerprint kept reaching the socket while the
+    # PLAN forgot it — and every surface that reports or persists reads the plan. Measured
+    # through MCP against a raw-socket origin: `send_request` with `apply_rules:true`,
+    # `tls_preset:"chrome"` and `save_as_repeater:true` wrote `repeaters.tls_preset = NULL`
+    # whenever a rule actually fired, and `chrome` whenever none did — so a later
+    # `repeater send` on the saved session dialed a different handshake from the one that
+    # produced the response it was saved with, and the tool result denied an override it had
+    # applied.
+    it "carries the per-send TLS fingerprint (#844) across the rewrite" do
+      plan = R::Plan.build(R::PlanOptions.new([SESSION_RAW.to_slice],
+        target: "https://t.test:8443", tls_preset: "chrome"), ungated)
+      plan.tls_preset.should eq("chrome")
+      plan.with_requests(["GET /rewritten HTTP/1.1\r\n\r\n".to_slice]).tls_preset.should eq("chrome")
+    end
+
+    # A field-native plan's `requests` is only the synthetic scope line, so dropping the
+    # field list here would make `send` encode THAT instead of the operator's fields — the
+    # rewrite sent in place of the message. MCP declines Match&Replace on such a plan, which
+    # is why nothing exercises it today; carrying the fields is what keeps the next caller
+    # from having to know.
+    it "keeps a field-native plan field-native" do
+      plan = R::Plan.build(R::PlanOptions.new(h2_fields: FN_FIELDS, target: "http://t.test"), ungated)
+      rewritten = plan.with_requests(["GET /rewritten HTTP/1.1\r\n\r\n".to_slice])
+      rewritten.h2_fields.should eq(FN_FIELDS)
+    end
   end
   # `downgrade_version_line` documents itself as running "unasked on every send", but the TUI
   # was its only caller — so the SAME session sent `HTTP/2` down an h1 socket from

--- a/spec/repeater/ws_transport_failure_spec.cr
+++ b/spec/repeater/ws_transport_failure_spec.cr
@@ -1,0 +1,122 @@
+require "../spec_helper"
+require "socket"
+require "openssl"
+require "digest/sha1"
+require "base64"
+
+private alias WS = Gori::Proxy::WS
+private alias WsEngine = Gori::Repeater::WsEngine
+
+private WSTF_UPGRADE = ("GET /ws HTTP/1.1\r\nHost: 127.0.0.1\r\n" \
+                        "Upgrade: websocket\r\nConnection: Upgrade\r\n" \
+                        "Sec-WebSocket-Key: dGhlIHNhbXBsZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n").to_slice
+
+# The 101, with the Accept derived from whatever key the engine actually sent.
+private def wstf_upgrade(io : IO) : Nil
+  head = Gori::Proxy::Codec::Http1.read_head(io).not_nil!
+  key = String.new(head).each_line
+    .find(&.downcase.starts_with?("sec-websocket-key:"))
+    .try(&.split(':', 2)[1].strip) || ""
+  accept = Base64.strict_encode(Digest::SHA1.digest(key + WsEngine::GUID))
+  io << "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\n" \
+        "Connection: Upgrade\r\nSec-WebSocket-Accept: #{accept}\r\n\r\n"
+  io.flush
+end
+
+# A TLS origin that upgrades, echoes ONE frame, and then writes a bogus TLS record straight
+# onto the underlying TCP socket — bypassing its own SSL layer, so the client's next
+# `SSL_read` fails to decrypt.
+#
+# That failure is `OpenSSL::SSL::Error`, which is NOT an `IO::Error`, and the two rescues in
+# `WsEngine` that turn a dead socket into `peer_gone` used to catch only the latter. So the
+# raise unwound out of `drain` → `exchange` → into `send`'s rescue, whose comment reads
+# "reaching here means the handshake failed". It had not: measured against this exact origin,
+# gori answered `upgraded:false, messages:[], error:"SSL_read: … bad record mac"` — the
+# upgrade denied and the frame the origin really sent deleted. The IDENTICAL event on a `ws://`
+# socket raises `IO::Error` and has always been a NOTE with the transcript intact, so one
+# protocol's findings were being thrown away by the other's exception type.
+private def start_garbling_tls_ws_origin(echo_first : Bool = true) : Int32
+  # In-memory root + server context, the pattern every other TLS origin in this suite uses
+  # (spec/proxy/tls/non_tls_connect_spec.cr, reverse_spec.cr, transparent_spec.cr): no CA on
+  # disk, no tempdir, and nothing for an aborted example to leak.
+  cert, key = Gori::Proxy::Tls::CertBuilder.build_root("origin.test")
+  ctx = Gori::Proxy::Tls::ContextFactory.server_context(cert, key, advertise_h2: false)
+  origin = TCPServer.new("127.0.0.1", 0)
+  port = origin.local_address.port
+  spawn do
+    conn = origin.accept?
+    origin.close rescue nil # one connection is all this origin serves — do not leave it bound
+    next unless conn
+    begin
+      conn.read_timeout = 5.seconds
+      ssl = OpenSSL::SSL::Socket::Server.new(conn, ctx, sync_close: false)
+      wstf_upgrade(ssl)
+      # `echo_first: false` garbles straight after the 101 without waiting for a client frame —
+      # the shape a script with NO messages produces, where the engine's only drain is its one
+      # generous first-reply pass.
+      if echo_first && (frame = WS.read_frame(ssl)) && frame.data?
+        ssl.write(WS.encode(frame.opcode, "echo:#{String.new(frame.payload)}".to_slice, mask: false))
+        ssl.flush
+      end
+      # A TLS application-data record header over 0x40 bytes of noise: well-formed framing,
+      # undecryptable content. Written straight onto the TCP socket, under its own SSL layer.
+      conn.write(Bytes[0x17, 0x03, 0x03, 0x00, 0x40])
+      conn.write(Random::Secure.random_bytes(0x40))
+      conn.flush
+      sleep 300.milliseconds # let the client read the garbage rather than an EOF
+    rescue
+    ensure
+      conn.close rescue nil
+    end
+  end
+  port
+end
+
+describe Gori::Repeater::WsEngine do
+  describe "a transport failure AFTER the upgrade" do
+    it "keeps the transcript and reports it as a note, not as a failed handshake" do
+      port = start_garbling_tls_ws_origin
+      result = WsEngine.send(WSTF_UPGRADE, [
+        WsEngine::OutMsg.new(1, "first".to_slice),
+        WsEngine::OutMsg.new(1, "second".to_slice),
+      ], scheme: "https", host: "127.0.0.1", port: port,
+        verify_upstream: false, idle: 500.milliseconds)
+
+      # The upgrade HAPPENED. Reporting `upgraded: false` for a socket that answered 101 is
+      # the half of this that misdescribes the origin.
+      result.upgraded?.should be_true
+      result.ok?.should be_true
+      result.error.should be_nil
+
+      # …and the frame the origin actually sent is still in the transcript. This is the half
+      # that DESTROYS evidence: `err` builds an empty message list.
+      result.messages.map(&.direction).should contain("in")
+      result.messages.any? { |m| String.new(m.payload) == "echo:first" }.should be_true
+
+      # Not silent about it either: the reason the exchange stopped is named, with the
+      # underlying failure quoted, so an operator is not left wondering why the second
+      # message never went out.
+      note = result.note.not_nil!
+      note.should contain("the connection failed")
+      note.downcase.should contain("ssl")
+    end
+
+    # A session with NO outbound messages — `send_websocket{messages: []}`, or a seed whose
+    # every stored row was a `[gori]` advisory `ws_seed_rows` drops — has `sent == total == 0`,
+    # which slips past `with_unsent_note`'s `sent < total` guard. Without its own sentence the
+    # run was told the connection failed "after the last message was written" for an exchange
+    # in which nothing was ever written.
+    it "does not claim a message was written when the script had none" do
+      port = start_garbling_tls_ws_origin(echo_first: false)
+      result = WsEngine.send(WSTF_UPGRADE, [] of WsEngine::OutMsg,
+        scheme: "https", host: "127.0.0.1", port: port,
+        verify_upstream: false, idle: 500.milliseconds)
+
+      result.upgraded?.should be_true
+      result.ok?.should be_true
+      note = result.note.not_nil!
+      note.should contain("while waiting for the origin")
+      note.should_not contain("after the last message was written")
+    end
+  end
+end

--- a/src/gori/cli/run.cr
+++ b/src/gori/cli/run.cr
@@ -316,6 +316,41 @@ module Gori
         "#{prefix}: too many arguments (expected one #{what}, got: #{all.join(" ")})"
       end
 
+      # ZERO positionals: the same decision for a command whose every argument is a flag.
+      #
+      # `one_positional*` above covers the sites that KEEP the first token and drop the rest.
+      # This is one step further down the same slope: three `repeater` subcommands installed
+      # no `unknown_args` handler at all, and `OptionParser`'s default one is silent — so
+      # `gori run repeater create -t URL -f req.txt extra.txt` built the session from
+      # `req.txt`, discarded `extra.txt` and printed `Repeater session #N created
+      # successfully.`, and `repeater h2 --target U --fields F stray` put the request on the
+      # wire without a word. A dropped argument under a SUCCESS status is what a scripted
+      # surface can least afford, which is the whole argument the twelve sites above make.
+      #
+      # `hint` names the flag the value belongs to, because a bare token here is almost always
+      # something the operator meant to pass through one.
+      def self.no_positional_error(all : Array(String), prefix : String, hint : String) : String?
+        return nil if all.empty?
+        "#{prefix}: unexpected argument#{all.size == 1 ? "" : "s"} #{all.join(" ").inspect} — #{hint}"
+      end
+
+      # Parse a command whose every argument is a flag, refusing any leftover word.
+      #
+      # A method rather than three copies of the idiom, because the subtle half is
+      # `before + after`: a copy that keeps only `before` lets a bare word after `--` through
+      # in silence, which is the same footgun `optionparser-unknown-args` was written about.
+      # Installing the handler HERE makes the correct form the only form, and the call site
+      # reads as what it means.
+      private def self.parse_no_positionals(parser : OptionParser, args : Array(String),
+                                            prefix : String, hint : String) : Nil
+        positional = [] of String
+        parser.unknown_args { |before, after| positional = before + after }
+        parser.parse(args)
+        if msg = no_positional_error(positional, prefix, hint)
+          abort msg
+        end
+      end
+
       # `--db` and `--project` both name the target, so BOTH is not a preference to resolve —
       # it is two answers to one question, and silently keeping one is the failure this
       # surface is least able to survive.

--- a/src/gori/cli/run/repeater.cr
+++ b/src/gori/cli/run/repeater.cr
@@ -75,7 +75,9 @@ module Gori
           p.invalid_option { |f| abort "gori run repeater h2: unknown option: #{f}\n#{p}" }
           p.missing_option { |f| abort "gori run repeater h2: missing value for #{f}" }
         end
-        parser.parse(args)
+        # A stray word here is refused, not dropped — see `Run.parse_no_positionals`.
+        parse_no_positionals(parser, args, "gori run repeater h2",
+          "pass the origin as --target URL and the field list as --fields FILE")
 
         tgt = target
         abort "gori run repeater h2: --target is required" if tgt.nil? || tgt.empty?
@@ -164,7 +166,9 @@ module Gori
           p.invalid_option { |f| abort "gori run repeater list: unknown option: #{f}\n#{p}" }
           p.missing_option { |f| abort "gori run repeater list: missing value for #{f}" }
         end
-        parser.parse(args)
+        parse_no_positionals(parser, args, "gori run repeater list",
+          "`repeater list` takes no positional arguments; to act on one session use " \
+          "`gori run repeater send <id>`")
 
         project = resolve_read_project(project_name, db_path)
         store = open_store(project, read_only: true)
@@ -278,7 +282,11 @@ module Gori
           p.invalid_option { |f| abort "gori run repeater create: unknown option: #{f}\n#{p}" }
           p.missing_option { |f| abort "gori run repeater create: missing value for #{f}" }
         end
-        parser.parse(args)
+        # A bare word here is almost always the request or the target the operator meant to
+        # pass through a flag, and creating the session WITHOUT it left a row whose request
+        # was not the one they typed — reported as a clean "session #N created".
+        parse_no_positionals(parser, args, "gori run repeater create",
+          "pass the request via --request-file/--request-raw/--flow and the origin via --target")
 
         req_content = ""
         if file = request_file
@@ -728,9 +736,12 @@ module Gori
         result = plan.send_ws(out_messages, idle, keep_key)
         outbound.close
 
-        # Persist ONLY on success — parity with the TUI (repeater_controller#drain_results):
-        # a later failed resend must not wipe a good stored handshake/response.
-        if result.ok?
+        # Persist ONLY when the ORIGIN ANSWERED — parity with the TUI
+        # (repeater_controller#drain_results) and MCP `send_websocket`: a failed re-send must
+        # not wipe a good stored handshake, and `ok?` alone was the other half of that mistake
+        # (a 403/426 where the stored row holds a 101 IS the news, and it was being dropped).
+        # See `WsEngine::Result#answered?`.
+        if result.answered?
           store2 = open_store(resolve_read_project(project_name, db_path))
           begin
             store2.update_repeater_response(id, result.handshake_head, Bytes.empty, result.error, result.duration_us)

--- a/src/gori/cli/run/repeater_minimize.cr
+++ b/src/gori/cli/run/repeater_minimize.cr
@@ -375,7 +375,11 @@ module Gori
           end)
           return
         end
-        STDERR.puts "#{report.note} · #{report.sends} send#{report.sends == 1 ? "" : "s"}"
+        # `report.note` already ends in the send count (every one of `Minimize`'s three notes
+        # states it, because that note is the whole sentence the TUI notification prints), so
+        # appending it here read `minimized: removed 2 cookies, 3 params (8 sends) · 8 sends`.
+        # The JSON form keeps its own `sends` field — a script should not have to parse prose.
+        STDERR.puts report.note
         report.removed.each { |r| STDERR.puts "  - [#{r.kind.to_s.downcase}] #{r.label}" }
         STDERR.puts "saved back to session ##{id}" if applied
         STDOUT.write(wire)

--- a/src/gori/mcp/tools/send.cr
+++ b/src/gori/mcp/tools/send.cr
@@ -926,8 +926,14 @@ module Gori
         end
         result = plan.send_ws(out_messages, idle, keep_key)
 
+        # ONLY when the origin ANSWERED (see `WsEngine::Result#answered?`). This surface wrote
+        # unconditionally, so one `send_websocket` at a session whose target had moved (or an
+        # origin that was momentarily down) replaced the stored 101 with an empty head —
+        # measured: `length(response_head)` 129 → 0, and with it the TUI tab's handshake card
+        # and `repeater send --diff`'s baseline. The row is not this call's report; the result
+        # below is, and it carries the failure in full.
         store.update_repeater_response(repeater_id, result.handshake_head, Bytes.empty,
-          result.error, result.duration_us)
+          result.error, result.duration_us) if result.answered?
         Log.info { "send_websocket #{plan.scheme}://#{host}:#{plan.port} repeater_id=#{repeater_id} -> #{result.ok? ? "ok" : result.error}" }
 
         payload = JSON.build do |j|

--- a/src/gori/repeater/flow_request.cr
+++ b/src/gori/repeater/flow_request.cr
@@ -134,8 +134,29 @@ module Gori
         body = text[(sep + 4)..]
         lines = head.split("\r\n")
         return bytes if lines.any? { |l| l.lstrip[0, 18]?.try(&.downcase) == "transfer-encoding:" }
-        idx = lines.index { |l| l.lstrip.downcase.starts_with?("content-length:") }
-        if idx
+        cl_at = [] of Int32
+        lines.each_with_index { |l, i| cl_at << i if l.lstrip.downcase.starts_with?("content-length:") }
+        if idx = cl_at.first?
+          # TWO of them is a CL.CL desync probe: the disagreement IS the test, exactly as it
+          # is for the CL+TE pair guarded above. Rewriting only the first (the sole one this
+          # rewrite can reach) turns `5`/`7` into `2`/`7` — the operator's probe replaced by a
+          # different one, silently. Refuse the whole message instead.
+          return bytes if cl_at.size > 1
+          # …and one of them only when it is REWRITABLE: a `Content-Length: 0abc`, a `+5`, an
+          # empty one, a mid-edit line with the next header glued to its tail, or a line whose
+          # field name is indented (an obs-fold continuation, itself a smuggling primitive —
+          # and rewriting REPLACES the whole line, so it would come back unindented as a
+          # second real header). Every one of those is a deliberately malformed length, which
+          # is one of the things this tool exists to send, so auto-CL "correcting" it turns the
+          # operator's probe into an ordinary request.
+          #
+          # The TUI editor has long refused to rewrite these (`RepeaterView#plain_numeric_header?`,
+          # whose own comment states the rule as "the test on screen must be the test on the
+          # wire") — but the WIRE did not, so the two disagreed about one request: the pane went
+          # on showing `Content-Length: 0abc` while the socket got `Content-Length: 2`. Measured
+          # through `gori run repeater create` + `repeater send` against a raw-socket origin.
+          # One predicate now, read by both.
+          return bytes unless rewritable_length_header?(lines[idx])
           lines[idx] = "Content-Length: #{body.bytesize}"
         elsif add_if_missing && body.bytesize > 0
           # ADD only into a head this function actually parsed. `split("\r\n")` collapses a
@@ -155,6 +176,32 @@ module Gori
           return bytes
         end
         "#{lines.join("\r\n")}\r\n\r\n#{body}".to_slice
+      end
+
+      # May auto-Content-Length rewrite THIS line? Two things have to hold, and the rewrite
+      # replacing the WHOLE line is why both do.
+      #
+      #   * the FIELD NAME starts at column 0. A leading space makes the line an obs-fold
+      #     continuation of the header above it (RFC 9112 §5.2 — a smuggling primitive gori
+      #     stores byte-exact), and the matcher that finds this line deliberately `lstrip`s so
+      #     a bail-out guard cannot be dodged by indenting. Liberal matching is right for a
+      #     REFUSAL and destructive for a REWRITE: `X-Foo: bar\r\n Content-Length: 5` came back
+      #     as an unindented `Content-Length: 2`, i.e. gori un-folding the operator's fold and
+      #     minting a second real header.
+      #   * the VALUE is a plain decimal count and nothing else. Leading zeros and surrounding
+      #     OWS still count as plain — `  0005  ` is an ordinary length gori may keep honest,
+      #     because `strip` runs before the digit test; what is refused is a value with a
+      #     non-digit in it (`0abc`, `+5`, `4GET / HTTP/1.1`) or none at all.
+      #
+      # THE home for that rule: `resync_content_length` above (the wire) and the TUI's
+      # `RepeaterView#plain_numeric_header?` (the visible header) both read it, and they used
+      # to answer differently for the same line.
+      def self.rewritable_length_header?(line : String) : Bool
+        return false if line.starts_with?(' ') || line.starts_with?('\t')
+        value = line.split(':', 2)[1]?
+        return false unless value
+        digits = value.strip
+        !digits.empty? && digits.each_char.all?(&.ascii_number?)
       end
 
       # The CAPTURED-FLOW replay policy, as opposed to the repeater's auto-CL toggle above.

--- a/src/gori/repeater/minimize.cr
+++ b/src/gori/repeater/minimize.cr
@@ -1,5 +1,6 @@
 require "json"
 require "./engine"
+require "./flow_request"
 require "../media_type"
 require "../tolerance"
 require "../env"
@@ -188,7 +189,7 @@ module Gori::Repeater
       crlf = head_crlf?(base_text)
       base_text = normalize_head_lf(base_text) if crlf
       candidates = candidates_for(base_text, auto_cl: auto_cl)
-      return Report.new(restore_eol(base_text, crlf), [] of Removed, 0, false, "already minimal — nothing removable") if candidates.empty?
+      return Report.new(restore_eol(base_text, crlf), [] of Removed, 0, false, "already minimal — nothing removable (0 sends)") if candidates.empty?
 
       sends = 0
       # --- calibrate a FROZEN baseline from the original request ---
@@ -209,13 +210,13 @@ module Gori::Repeater
       # and `aborted` says so (same shape as an unreachable baseline, different sentence).
       if stop.try(&.stopped?)
         return Report.new(restore_eol(base_text, crlf), [] of Removed, sends, true,
-          "stopped before the baseline was calibrated — request left unchanged")
+          "stopped before the baseline was calibrated — request left unchanged (#{sends} sends)")
       end
-      return Report.new(restore_eol(base_text, crlf), [] of Removed, sends, true, "baseline unreachable — request left unchanged") if metrics.empty?
+      return Report.new(restore_eol(base_text, crlf), [] of Removed, sends, true, "baseline unreachable — request left unchanged (#{sends} sends)") if metrics.empty?
       statuses = metrics.compact_map(&.status).uniq!
       unless statuses.size <= 1
         return Report.new(restore_eol(base_text, crlf), [] of Removed, sends, true,
-          "baseline response unstable (status #{statuses.join("/")}) — request left unchanged")
+          "baseline response unstable (status #{statuses.join("/")}) — request left unchanged (#{sends} sends)")
       end
       baseline = calibrate(metrics, sigs)
 
@@ -233,8 +234,12 @@ module Gori::Repeater
         # baseline, so keeping them (aborted: false) is as sound as the capped partial.
         return Report.new(restore_eol(working, crlf), removed, sends, false, stop_note(removed, sends)) if stop.try(&.stopped?)
         r = backend.send(resolve.call(variant))
+        # The cap REFUSES before it charges (`CappedBackend#send` returns CAP_ERROR ahead of
+        # its own `@sent += 1`), so a refused call put nothing on the wire and must not be
+        # counted here either — counting it made `sends` report SEND_CAP + 1, in the note and
+        # in every surface's `sends` field.
+        return Report.new(restore_eol(working, crlf), removed, sends, false, cap_note(removed, sends)) if r.error == Fuzz::CappedBackend::CAP_ERROR
         sends += 1
-        return Report.new(restore_eol(working, crlf), removed, sends, false, cap_note(removed)) if r.error == Fuzz::CappedBackend::CAP_ERROR
         if unchanged?(r, baseline)
           working = variant
           removed << Removed.new(cand.kind, cand.label)
@@ -307,9 +312,17 @@ module Gori::Repeater
 
       query_segments(head_lines[0]?).each { |seg| out << query_candidate(seg) }
 
-      # Body params only when Auto-Content-Length is on (so resolve re-lengths the body) —
-      # otherwise a deliberately-wrong CL (a smuggling/CL.TE probe) would be clobbered.
-      if has_body && auto_cl && !body.empty?
+      # Body params only when the resolver will actually RE-LENGTH the body — otherwise a
+      # deliberately-wrong CL (a smuggling/CL.TE probe) would be clobbered.
+      #
+      # `auto_cl` alone was the whole test, and it stopped being sufficient the moment
+      # `FlowRequest.resync_content_length` learned to leave a deliberately malformed length
+      # alone: the flag was on, the re-length was not happening, and this gate's own premise
+      # was false. Every variant then went out with a body one param shorter under an
+      # unchanged (and unparseable) Content-Length — the origin mis-framed all of them
+      # identically, `unchanged?` said so, and the minimizer stripped every body param it had.
+      # `--apply` then wrote that back over the operator's request.
+      if has_body && auto_cl && body_reframable?(head_lines) && !body.empty?
         ct = (header_value(head_lines, "content-type") || "").downcase
         # `MediaType.json?`, not `includes?("application/json")`: that substring is absent from
         # every `+json` structured-syntax type — `application/graphql+json`,
@@ -323,6 +336,18 @@ module Gori::Repeater
         end
       end
       out
+    end
+
+    # Would `resolve` actually re-length this head's body? The two shapes that stop it are
+    # exactly the two `FlowRequest.resync_content_length` refuses: a `Transfer-Encoding` (the
+    # message is chunked, and the CL+TE pair is itself the probe) and a Content-Length that is
+    # not gori's to rewrite — malformed, duplicated, or obs-folded. A head with NO
+    # Content-Length is fine: `resolve` adds one (`add_if_missing` is on for this caller).
+    private def self.body_reframable?(head_lines : Array(String)) : Bool
+      return false if head_lines.any? { |l| l.lstrip[0, 18]?.try(&.downcase) == "transfer-encoding:" }
+      cl = head_lines.select { |l| l.lstrip.downcase.starts_with?("content-length:") }
+      return true if cl.empty?
+      cl.size == 1 && FlowRequest.rewritable_length_header?(cl[0])
     end
 
     private def self.header_candidate(line : String) : Candidate
@@ -709,13 +734,19 @@ module Gori::Repeater
       "minimized: removed #{parts.join(", ")} (#{sends} sends)"
     end
 
-    private def self.cap_note(removed : Array(Removed)) : String
-      "send cap reached — kept #{removed.size} removal#{removed.size == 1 ? "" : "s"} so far (partial)"
+    # `sends` for the same reason the other two notes carry it: `report.note` is the ONE
+    # sentence the TUI notification and the `gori run` status line both print, so a note that
+    # omits the count is a surface that cannot state it. It IS redundant here (a capped run
+    # spent exactly `SEND_CAP`) and is stated anyway, because the alternative — the CLI
+    # appending the count itself — made the other two read `… (11 sends) · 11 sends`.
+    private def self.cap_note(removed : Array(Removed), sends : Int32) : String
+      "send cap reached — kept #{removed.size} removal#{removed.size == 1 ? "" : "s"} " \
+      "so far (partial, #{sends} sends)"
     end
 
-    # A stop reports the SENDS as well as the removals, unlike `cap_note`: the cap's count is
-    # already known (it is the cap), while "how many requests did the origin actually get
-    # before it stopped" is the whole question the operator pressed stop to ask.
+    # The send count matters most here: a capped run spent `SEND_CAP` by definition and a
+    # finished one ran to the end, but "how many requests did the origin actually get before
+    # it stopped" is the whole question the operator pressed stop to ask.
     private def self.stop_note(removed : Array(Removed), sends : Int32) : String
       "stopped — kept #{removed.size} removal#{removed.size == 1 ? "" : "s"} (#{sends} sends)"
     end

--- a/src/gori/repeater/plan.cr
+++ b/src/gori/repeater/plan.cr
@@ -334,12 +334,28 @@ module Gori::Repeater
     # origin, and a rewrite must not be able to move the dial target out from under it.
     # `websocket?` IS re-derived, because a rule that adds or strips `Upgrade: websocket`
     # would otherwise leave the plan classified against bytes it no longer carries.
+    #
+    # EVERY OTHER FIELD IS COPIED, and that is a rule rather than a list: this is a
+    # copy-with-new-bytes, so a field the copy forgets is one the SEND still applies (it
+    # lives on the reused `Sender`) while the plan REPORTS it gone. `tls_preset` was
+    # forgotten for exactly that reason — the send presented the chrome hello it was told
+    # to, and `send_request`'s `tls_preset` field and the repeater row it saves both came
+    # back empty, so a later `repeater send` on that saved session dialed a different
+    # handshake from the one that produced the answer it was saved with. Reproduced against
+    # a raw-socket origin: `apply_rules:true` + `tls_preset:"chrome"` + `save_as_repeater`
+    # wrote `tls_preset = NULL`, while the identical call whose rules did not fire wrote
+    # `chrome`. `h2_fields`/`h2_body` ride along for the same reason: dropping them would
+    # turn a field-native plan into a byte plan whose `requests` is only the synthetic scope
+    # line — the rewrite would be sent INSTEAD of the operator's field list. (MCP declines
+    # to offer Match&Replace on a field-native plan at all, so nothing exercises that today;
+    # carrying them is what keeps the next caller from having to know.)
     def with_requests(requests : Array(Bytes)) : Plan
       raise PlanError.new(PlanError::Reason::NoRequest, "no request to send") if requests.empty?
       Plan.new(sender: @sender, requests: requests, scheme: @scheme, host: @host,
         port: @port, http2: @http2,
         websocket: WsEngine.upgrade_request?(String.new(requests.first)), sni: @sni,
-        preserve_field_case: @preserve_field_case, reframe_grpc: @reframe_grpc)
+        preserve_field_case: @preserve_field_case, h2_fields: @h2_fields, h2_body: @h2_body,
+        reframe_grpc: @reframe_grpc, tls_preset: @tls_preset)
     end
 
     def self.build(options : PlanOptions, outbound : Gori::Outbound) : Plan

--- a/src/gori/repeater/ws_engine.cr
+++ b/src/gori/repeater/ws_engine.cr
@@ -139,6 +139,20 @@ module Gori
         def ok? : Bool
           @error.nil?
         end
+
+        # Did the origin ANSWER the handshake — with anything at all? True for a 101 and for
+        # the 403/401/426 that `ok?` calls a failure, false only when there was no response to
+        # read (a refused dial, a TLS handshake that never completed, a silent origin).
+        #
+        # It is the predicate the three surfaces persist a repeater's last response on.
+        # `ok?` alone was too narrow in one direction and absent in the other: writing
+        # unconditionally let a failed re-send replace a good stored 101 with an empty head,
+        # and writing only on `ok?` would keep that stale 101 forever at an origin that has
+        # started answering 403 — the TUI handshake card, `repeater list` and `repeater send
+        # --diff`'s baseline all going on showing a handshake the origin no longer performs.
+        def answered? : Bool
+          !@handshake_head.empty?
+        end
       end
 
       def self.send(upgrade_request : Bytes, out_messages : Array(OutMsg), *,
@@ -243,6 +257,7 @@ module Gori
           # delivery is unconfirmed.
           note = with_delivery_note(note, sent, messages.size, st.close_code)
           note = with_unsent_note(note, sent, out_messages.size, st)
+          note = with_transport_note(note, sent, out_messages.size, st)
           Result.new(head, messages, elapsed(started), note: note,
             close_code: st.close_code, upgraded: true, truncated: st.truncated)
         rescue ex
@@ -280,11 +295,19 @@ module Gori
           # A CLOSE the OPERATOR wrote does NOT stop the loop: "data frames after a CLOSE" is
           # a §5.5.1 test this engine deliberately lets them run, exactly as it lets them send
           # a lone CONT or an unmasked frame. Only the SERVER's close stops it.
+          # Framed OUTSIDE the rescue below: that rescue means "the peer is gone", and a frame
+          # the encoder could not build is not that.
+          bytes = Proxy::WS.encode(op, m.payload, m.shape, mask: true)
           begin
-            upstream.write(Proxy::WS.encode(op, m.payload, m.shape, mask: true))
+            upstream.write(bytes)
             upstream.flush
-          rescue IO::Error
+          rescue ex : IO::Error | OpenSSL::Error
+            # BOTH hierarchies, not `IO::Error` alone — see `DrainState#gone_reason`. Kept to
+            # the two the transport can actually raise rather than a bare `rescue`: anything
+            # else reaching here is a gori bug, and folding one into `peer_gone` would report
+            # it as an exchange that merely lost its socket — `ok? == true`, exit 0.
             st.peer_gone = true
+            st.gone_reason ||= transport_reason(ex)
             break
           end
           messages << Message.new("out", op.to_i, m.payload, m.shape)
@@ -320,7 +343,7 @@ module Gori
         why = if st.close_code
                 "the server sent CLOSE (§5.5.1: no data frames may follow it)"
               elsif st.peer_gone?
-                "the connection ended"
+                (r = st.gone_reason) ? failed_clause(r) : "the connection ended"
               elsif st.deadline_reached?
                 # NOT "a capture cap": the deadline is a bound on how long the engine spent
                 # reading, and saying "cap" sent operators looking at MAX_RECV_* — the wrong
@@ -331,6 +354,41 @@ module Gori
               end
         unsent = "stopped after #{sent} of #{total} message(s): #{why}"
         note ? "#{note}; #{unsent}" : unsent
+      end
+
+      # The same fact for a run in which every recorded message DID go out: `with_unsent_note`
+      # is silent there (nothing was left unsent), so a transport failure during the LAST
+      # drain — the commonest shape, since that drain is where the exchange spends its time —
+      # had nothing at all to report it. Guarded on `sent >= total` so the two never say it
+      # twice.
+      #
+      # `total == 0` gets its own sentence rather than the tail: a session with no messages at
+      # all (`messages: []`, or a seed whose every stored row was a `[gori]` advisory
+      # `ws_seed_rows` dropped) passes `sent < total` — 0 < 0 is false — and would otherwise
+      # be told the connection failed "after the last message was written" when nothing was
+      # ever written. Its one drain is the generous first-reply pass, so that is what failed.
+      private def self.with_transport_note(note : String?, sent : Int32, total : Int32,
+                                           st : DrainState) : String?
+        return note if sent < total # `with_unsent_note` already named it
+        reason = st.gone_reason || return note
+        line = total == 0 ? "#{failed_clause(reason)} while waiting for the origin; no message was sent" : "#{failed_clause(reason)} after the last message was written; the transcript ends there"
+        note ? "#{note}; #{line}" : line
+      end
+
+      # The clause both notes are built from, in ONE place: they describe a single fact from
+      # two vantage points and were written in the same round, so a later edit to the wording
+      # would otherwise reach one and not the other — and which one an operator sees depends
+      # on whether the script ran out of messages first.
+      private def self.failed_clause(reason : String) : String
+        "the connection failed (#{reason})"
+      end
+
+      # A raised transport failure as one short clause. `ex.message` is the useful half
+      # (`SSL_read: error:0A000119:… bad record mac`, `Broken pipe`); the class name is the
+      # fallback for the exceptions that carry none, because "the connection failed ()" names
+      # nothing at all.
+      private def self.transport_reason(ex : Exception) : String
+        ex.message.presence || ex.class.name
       end
 
       # Everything the drain accumulates, carried ACROSS the per-message drains an interleaved
@@ -360,6 +418,25 @@ module Gori
         property? peer_gone = false                      # EOF / IO error / failed write — nothing more can be sent
         property? capped = false                         # a HARD cap ended the drain (the control cap does not)
         property? deadline_reached = false               # ...and that cap was DRAIN_DEADLINE, not a capture cap
+
+        # WHY the socket ended, when it ended in a RAISE rather than a clean EOF. nil for an
+        # ordinary EOF (the peer closed; "the connection ended" is the whole story) and for a
+        # run that never lost the socket.
+        #
+        # It exists because the two rescues that set `peer_gone` used to catch `IO::Error`
+        # ALONE, and a `wss://` origin does not fail that way: Crystal raises
+        # `OpenSSL::SSL::Error`, which is not an `IO::Error`, so a bad record mac / decryption
+        # failure / a write into a torn-down TLS session unwound past BOTH of them and out of
+        # `exchange` into `send`'s rescue — the one whose comment says "reaching here means the
+        # handshake failed". It had not: measured against a TLS origin that answered the 101,
+        # echoed a frame and then wrote a bogus TLS record, gori reported
+        # `upgraded:false, messages:[], error:"SSL_read: … bad record mac"` — the upgrade
+        # denied, and the frame the origin really sent thrown away. The IDENTICAL event on a
+        # `ws://` socket was (and is) a note with the transcript intact, so one protocol's
+        # findings were being deleted by the other's exception type. Keeping the reason is what
+        # lets that stay a NOTE without going silent about the failure.
+        property gone_reason : String? = nil
+
         # DRAIN_DEADLINE runs from here, over the whole exchange — but ADVANCED past every idle
         # gap by `credit_idle`, so what it measures is active drain time and not wall clock.
         getter started : Time::Instant = Time.instant
@@ -449,8 +526,15 @@ module Gori
             # the engine's turn, so it is credited back rather than charged to DRAIN_DEADLINE.
             st.credit_idle(Time.instant - read_started)
             break
-          rescue IO::Error
-            st.peer_gone = true # RST or broken pipe — end the exchange, keep what we have
+          rescue ex : IO::Error | OpenSSL::Error
+            # RST, broken pipe, or a TLS-layer failure — end the exchange, keep what we have.
+            # BOTH hierarchies and no more: `OpenSSL::Error` is not an `IO::Error` (which is
+            # the whole gap — see `DrainState#gone_reason`), while a parse bug raising
+            # `IndexError` out of `read_frame` must stay LOUD. Swallowed here it would come
+            # back as `ok? == true` with a note blaming the peer, and (once the repeater row
+            # is written from it) overwrite the session's stored handshake with the wreckage.
+            st.peer_gone = true
+            st.gone_reason ||= transport_reason(ex)
             break
           end
           if frame.nil? # EOF / truncated

--- a/src/gori/tui/controllers/repeater_controller.cr
+++ b/src/gori/tui/controllers/repeater_controller.cr
@@ -1230,14 +1230,19 @@ module Gori::Tui
         view, result = pair
         next unless tab = @repeaters.find(&.view.same?(view)) # sub-tab closed mid-flight
         view.apply_ws(result)
+        # The stored last response follows `answered?`, not `ok?`: a failed re-send must not
+        # wipe a good stored handshake, and a 403/426 where the row holds a 101 is exactly the
+        # news the row should carry. The PROBE scan stays on `ok?` — it wants a completed
+        # exchange. See `WsEngine::Result#answered?`.
+        id = tab.db_id
+        if id && result.answered?
+          @host.session.store.update_repeater_response(id, result.handshake_head, Bytes.empty, result.error, result.duration_us)
+        end
         if result.ok?
           recv = result.messages.count(&.direction.==("in"))
           @host.status("ws sent: #{recv} received#{result.close_code ? " · closed #{result.close_code}" : ""}")
           # Feed the handshake + captured frames into Probe (WS payload secrets, tech).
-          if id = tab.db_id
-            @host.session.store.update_repeater_response(id, result.handshake_head, Bytes.empty, result.error, result.duration_us)
-            probe_scan_ws_repeater(id, result, tab.flow_id, view)
-          end
+          probe_scan_ws_repeater(id, result, tab.flow_id, view) if id
         else
           @host.status("ws repeater error: #{result.error}")
         end

--- a/src/gori/tui/repeater_view/reflect.cr
+++ b/src/gori/tui/repeater_view/reflect.cr
@@ -125,16 +125,26 @@ class Gori::Tui::RepeaterView
   # whatever followed the caret.
   #
   # The second is that gori is a tool for sending requests an origin should not accept. A
-  # `Content-Length: 0abc`, a `Content-Length: +5`, a duplicated or space-padded value are
-  # request-smuggling and desync primitives an operator types ON PURPOSE, and auto-CL
-  # quietly correcting them means the test on screen is not the test on the wire. Auto-CL's
-  # job is keeping an ordinary length honest while the body is edited; a value that is not a
-  # bare number is a deliberate one, so it is left exactly as typed.
+  # `Content-Length: 0abc`, a `Content-Length: +5`, an empty one, an indented (obs-fold) one —
+  # request-smuggling and desync primitives an operator types ON PURPOSE — and auto-CL quietly
+  # correcting them means the test on screen is not the test on the wire. Auto-CL's job is
+  # keeping an ordinary length honest while the body is edited; a value that is not a bare
+  # number is a deliberate one, so it is left exactly as typed. (Surrounding OWS and leading
+  # zeros are NOT in that set: `strip` runs before the digit test, so `  0005  ` is an ordinary
+  # length and is kept honest. The rule is about the value's SHAPE, not its spelling.)
+  #
+  # A DUPLICATED Content-Length is deliberate too, and it is guarded one level down rather
+  # than here: `resync_content_length` refuses the whole message when it finds two, so
+  # `reflect_chunk_content_length`'s `synced == source` early return means this predicate is
+  # never even reached for one.
+  #
+  # THE predicate lives in `Repeater::FlowRequest`, because the WIRE has to apply the same
+  # rule and did not: `resync_content_length` rewrote a `Content-Length: 0abc` that this
+  # guard deliberately preserved, so the pane went on showing `0abc` while the socket got
+  # `Content-Length: 2` — the display-vs-wire lie the paragraph above is entirely about,
+  # told by the half nobody was looking at.
   private def plain_numeric_header?(line : String) : Bool
-    value = line.split(':', 2)[1]?
-    return false unless value
-    digits = value.strip
-    !digits.empty? && digits.each_char.all?(&.ascii_number?)
+    Repeater::FlowRequest.rewritable_length_header?(line)
   end
 
   # See @link_host_to_target: on the FIRST target edit of a fresh ^N tab, mirror the new


### PR DESCRIPTION
A focused pass over the Repeater — core, TUI, CLI and MCP, about 19k lines. The engines are
clean: h1 exchange and its interim-1xx handling, `Plan.build`'s evidence and Content-Length
policy, the absolute-form and TE guards, the minimize search itself, the sub-tab filter, the
diff/side-by-side/message-lines trio, and `update_repeater`'s column preservation all hold.

Every defect below was reproduced against a live origin before it was touched — a raw-socket
HTTP server, a WebSocket server, a TLS WebSocket server, and the MCP stdio server.

### 1. `Plan#with_requests` dropped the per-send TLS fingerprint

It is a copy-with-new-bytes that deliberately reuses the SENDER, so `tls_preset` kept
reaching the socket while the PLAN reported it gone — and every surface that reports or
persists reads the plan. Measured through MCP:

```
send_request{url, apply_rules:true, tls_preset:"chrome", save_as_repeater:true}
  rule fires    → repeaters.tls_preset = NULL      ← the send still presented chrome
  rule misses   → repeaters.tls_preset = 'chrome'
```

So `repeater send` on that saved session dials a different handshake from the one that
produced the response saved beside it, and the tool result denies an override it applied.
`h2_fields`/`h2_body` ride along now for the same reason: dropping them would turn a
field-native plan into a byte plan whose `requests` is only the synthetic scope line.

### 2. `wss://` failed through an exception type the WS rescues did not catch

`WsEngine`'s two transport rescues caught `IO::Error` alone. Crystal raises
`OpenSSL::SSL::Error`, which is not one, so a bad record mac unwound past both of them and
out of `exchange` into `send`'s rescue — the one whose comment reads "reaching here means the
handshake failed". It had not. Against a TLS origin that answered the 101, echoed a frame and
then wrote a bogus TLS record:

```
before  {"upgraded":false,"messages":[],"error":"SSL_read: … bad record mac"}
after   {"upgraded":true,"messages":[…out "first", in "echo:first"…],"error":null,
         "note":"stopped after 1 of 2 message(s): the connection failed (SSL_read: …)"}
```

The identical event on a `ws://` socket was always a note with the transcript intact, so one
protocol's findings were being deleted by the other's exception type. Both hierarchies now,
and no more: a parse bug raising `IndexError` has to stay loud rather than come back as an
exchange that merely lost its socket.

### 3. The editor kept a Content-Length rule the wire did not

`RepeaterView#plain_numeric_header?` refuses to rewrite a deliberately malformed length and
its comment states the rule as "the test on screen must be the test on the wire".
`FlowRequest.resync_content_length` rewrote it anyway, so the pane went on showing
`Content-Length: 0abc` while the socket got `Content-Length: 2` — and since a malformed
length is a desync primitive, the repair also defused the probe. One predicate now, read by
both, and while it was being written down two more shapes turned out to need it:

* a DUPLICATE Content-Length. `5`/`7` over a 2-byte body came back `2`/`7` — the operator's
  CL.CL probe replaced by a different one. Refused whole, like the CL+TE pair beside it.
* an obs-fold continuation line. The matcher `lstrip`s so a bail-out cannot be dodged by
  indenting — right for a refusal, destructive for a rewrite, which replaces the whole line:
  `X-Foo: bar\r\n Content-Length: 5` came back unindented, as a second real header.

`Minimize`'s body-param candidate gate follows, because its premise was "auto_cl ⇒ resolve
re-lengths the body" and that had just stopped being true: every variant would have gone out
one param shorter under an unchanged, unparseable length, the origin mis-framing all of them
identically, so `unchanged?` would say "identical" and the minimizer strip the lot.

### 4. MCP `send_websocket` wiped a good stored handshake, and `ok?` alone was the other half

It wrote the session's last response unconditionally, where `gori run repeater send` and the
TUI both write only on success and say why. A failed re-send therefore replaced a stored 101
with an empty head — `length(response_head)` 129 → 0, taking the TUI tab's handshake card and
`repeater send --diff`'s baseline with it.

Fixing it to `ok?` would have been the mistake in the other direction: a 403 at an origin that
used to upgrade IS the news, and `WsEngine.send` keeps that real response head. All three
surfaces now key on `Result#answered?` — the origin answered, whatever it answered.

### 5. Three `repeater` subcommands discarded positional arguments in silence

`create`, `list` and `h2` installed no `unknown_args` handler at all, and `OptionParser`'s
default one says nothing:

```
$ gori run repeater create -t http://h -f req.txt extra.txt
Repeater session #8 created successfully.        ← extra.txt never mentioned
```

Same class as the twelve sites #882 swept, one step further down: there the first token is
kept, here every one of them is. `Run.parse_no_positionals` installs the handler and runs the
guard, so a call site cannot get the `before + after` half wrong; a source-scan spec keeps
both repeater files honest.

### 6. Minimize's send count

One too high on a capped run (`CappedBackend` refuses *before* it charges), and four of the
seven notes never carried the count at all — which the CLI had been papering over by
appending it, so the other three read `… (11 sends) · 11 sends`.

### Still open, deliberately out of scope

31 more `OptionParser` blocks under `src/gori/cli/run/` have no `unknown_args` handler, and
they are not all reads: `gori run project scope add -p zzz.test STRAY` adds the rule and says
nothing about `STRAY`. The regression gate here is scoped to the two repeater files rather
than made repo-wide, so it is a green gate over fixed ground instead of a red one standing in
for a sweep nobody has done. Worth its own pass.

### Verification

`crystal build --no-codegen src/main.cr`, `crystal spec`, `scripts/bench_check.sh` (49
harnesses), `scripts/seed_demo.cr`, `crystal tool format --check`. Both new regression specs
were checked against the un-fixed code and fail there.
