### PR TITLE
feat(verb): guard chord collisions at boot and model delete severity

### DIFF
--- a/spec/tui/space_menu_spec.cr
+++ b/spec/tui/space_menu_spec.cr
@@ -549,7 +549,7 @@ describe Gori::Tui::SpaceMenu do
     # Nothing clipped: the first and last entries of the LAST band are both on screen,
     # which is only possible once a second column exists.
     backend.contains?("Open flow detail").should be_true # first band (VIEW)
-    backend.contains?("Clear history").should be_true    # last band (DANGER)
+    backend.contains?("Clear history").should be_true    # last band (WIPE)
     backend.contains?("▼").should be_false               # …and no scrolling was needed
 
     # Every band header that renders has at least one of its entries on the SAME row or

--- a/spec/verb/registry_spec.cr
+++ b/spec/verb/registry_spec.cr
@@ -1903,6 +1903,72 @@ describe Gori::Verb do
         reg.register(Definition.new("dup", "B", "", Gori::Verb::Scope::Global) { |_| nil })
       end
     end
+
+    describe "#validate_chords!" do
+      it "passes on the shipped registry (the guarantee itself)" do
+        Gori::Verbs.registry.validate_chords! # raises on any violation
+      end
+
+      it "raises on two verbs claiming the same chord in the same scope" do
+        reg = Registry.new
+        reg.register(Definition.new("a", "A", "d", Gori::Verb::Scope::Body, [Chord.new("g")]) { |_| nil })
+        reg.register(Definition.new("b", "B", "d", Gori::Verb::Scope::Body, [Chord.new("g")]) { |_| nil })
+        expect_raises(Gori::Error, /chord collision.*'g'.*a.*b.*Body/) do
+          reg.validate_chords!
+        end
+      end
+
+      it "allows the SAME chord in DIFFERENT scopes (deliberate shadowing)" do
+        reg = Registry.new
+        reg.register(Definition.new("a", "A", "d", Gori::Verb::Scope::Body, [Chord.new("g")]) { |_| nil })
+        reg.register(Definition.new("b", "B", "d", Gori::Verb::Scope::Sitemap, [Chord.new("g")]) { |_| nil })
+        reg.validate_chords! # must not raise — lookup resolves the scope before Global
+      end
+
+      it "does NOT skip hidden verbs — a collision on a hidden nav primitive still raises" do
+        reg = Registry.new
+        reg.register(Definition.new("nav", "Nav", "d", Gori::Verb::Scope::Body,
+          [Chord.new("down")], hidden: true) { |_| nil })
+        reg.register(Definition.new("other", "Other", "d", Gori::Verb::Scope::Body,
+          [Chord.new("down")]) { |_| nil })
+        expect_raises(Gori::Error, /chord collision.*'down'/) do
+          reg.validate_chords!
+        end
+      end
+
+      it "catches a collision that only exists on a NON-native OS profile" do
+        # The verb's base chords are collision-free, but a Windows override makes two
+        # verbs land on the same chord — a check that read only `verb.chords` would miss it.
+        reg = Registry.new
+        reg.register(Definition.new("a", "A", "d", Gori::Verb::Scope::Body, [Chord.new("g")]) { |_| nil })
+        reg.register(Definition.new("b", "B", "d", Gori::Verb::Scope::Body, [Chord.new("h")]) { |_| nil })
+        win = Gori::Verb::OsProfile::Os::Windows
+        original = Gori::Verb::OsProfile::OVERRIDES[win]
+        begin
+          Gori::Verb::OsProfile::OVERRIDES[win] = {"b" => [Chord.new("g")]}
+          expect_raises(Gori::Error, /chord collision.*'g'.*Windows/) do
+            reg.validate_chords!
+          end
+        ensure
+          Gori::Verb::OsProfile::OVERRIDES[win] = original
+        end
+      end
+
+      it "rejects a dead capital-letter chord (never fires — normalised to shift+lowercase)" do
+        reg = Registry.new
+        reg.register(Definition.new("cap", "Cap", "d", Gori::Verb::Scope::Body, [Chord.new("X")]) { |_| nil })
+        expect_raises(Gori::Error, /dead capital chord.*'X'.*cap/) do
+          reg.validate_chords!
+        end
+      end
+
+      it "accepts the correct spelling of a capital chord (shift + lowercase)" do
+        reg = Registry.new
+        reg.register(Definition.new("cap", "Cap", "d", Gori::Verb::Scope::Body,
+          [Chord.new("x", shift: true)]) { |_| nil })
+        reg.validate_chords! # shift-x fires; must not raise
+      end
+    end
   end
 
   describe "handler execution" do

--- a/spec/verbs/activity_spec.cr
+++ b/spec/verbs/activity_spec.cr
@@ -38,12 +38,14 @@ describe "Gori::Verbs.register_activity" do
     r["activity.clear"].chords.should_not contain(shift_chord('C'))
     r["activity.clear"].chords.should_not contain(Gori::Verb::Chord.new("x"))
     r["activity.clear"].menu_key.should eq('X')
-    r["activity.clear"].group.should eq(:danger)
+    r["activity.clear"].group.should eq(:wipe)
   end
 
   # One chord, four scopes — History, Probe, Authorize and this pane all spell the wipe the
   # same way, and all four hang the space menu off `X`. Read from the registry rather than
-  # restated per file, so a fifth clear-all verb that picks its own letter fails HERE.
+  # restated per file, so a fifth clear-all verb that picks its own letter fails HERE. The
+  # `:wipe` band (distinct from a selection-delete's `:danger`) is what makes that same
+  # convention legible straight off the registry — see registry_sweep_spec's chord rule.
   it "spells the wipe the way every other clear-all verb does" do
     {"history.clear"   => Gori::Verb::Scope::Body,
      "probe.clear"     => Gori::Verb::Scope::Probe,
@@ -53,7 +55,7 @@ describe "Gori::Verbs.register_activity" do
       r[id].scope.should eq(scope), id
       r[id].chords.should eq([shift_chord('X')]), id
       r[id].menu_key.should eq('X'), id
-      r[id].group.should eq(:danger), id
+      r[id].group.should eq(:wipe), id
       # The letter under the shift is free in each of those scopes — that is the property that
       # made ⇧X the right key, and it is the one a later bare-`x` binding would quietly break.
       r.select { |v| v.scope == scope && v.chords.includes?(Gori::Verb::Chord.new("x")) }

--- a/spec/verbs/registry_sweep_spec.cr
+++ b/spec/verbs/registry_sweep_spec.cr
@@ -1,6 +1,11 @@
 require "../spec_helper"
 require "../support/fake_context"
 
+# A chord that fires on a single unmodified keypress (a lone letter / named key).
+private def bare_chord?(chord : Gori::Verb::Chord) : Bool
+  !chord.ctrl && !chord.alt && !chord.shift
+end
+
 # Whole-registry invariants over EVERY verb file under src/gori/verbs/, not just one.
 # Kept out of the per-file specs on purpose: a failure here names the offending verb id,
 # and filing it under any single register_* group would send the reader to the wrong file.
@@ -48,6 +53,48 @@ describe "Gori::Verbs.registry (every verb)" do
       v.id.should_not be_empty
       v.title.should_not be_empty
       v.description.should_not be_empty
+    end
+  end
+
+  # The ⇧X convention (#899) modelled as a group: a store-emptying verb is :wipe, a
+  # selection-delete is :danger. The one part of the policy that is genuinely checkable
+  # from the registry alone: a WIPE verb's chord, if it has one, must be MODIFIED —
+  # never a bare unmodified letter — so "empty the whole tab" can't ride a single tap.
+  # Selection-deletes (:danger) on a bare `d` stay legal; that is the established shape.
+  # (Confirm-gating is NOT checkable here — the @host.confirm call lives in the
+  # controller, not the registry — so it stays a documented convention, not a spec.)
+  #
+  # This goes by Verb::Definition#group (a hand-assigned semantic band), never by an id
+  # regex: the eighteen *.clear-selection and five *.mark-clear verbs are :none and drop
+  # out on their own, which is the point — a name match would mislabel every one of them.
+  it "gives every :wipe verb a modified chord (or none)" do
+    wipes = r.select(&.group.==(:wipe))
+    wipes.should_not be_empty # would pass vacuously if the band ever emptied
+    wipes.each do |v|
+      v.chords.each do |c|
+        bare_chord?(c).should be_false # e.g. shift-x, ctrl-…, never a lone letter
+      end
+    end
+  end
+
+  it "flags a bare-chord :wipe verb (proves the guard bites)" do
+    reg = Gori::Verb::Registry.new
+    reg.register(Gori::Verb::Definition.new(
+      "demo.wipe", "Wipe", "x", Gori::Verb::Scope::Body,
+      [Gori::Verb::Chord.new("z")], group: :wipe) { |_| nil })
+    offenders = reg.select(&.group.==(:wipe)).select { |v| v.chords.any? { |c| bare_chord?(c) } }
+    offenders.map(&.id).should eq(["demo.wipe"])
+  end
+
+  it "keeps sibling deletes in the same severity band (probe.delete ⇔ probe.delete-selected)" do
+    # The list-scope and detail-scope forms of one delete are the same action; they must
+    # not drift apart the way they had (:danger vs :none) before #899's convention landed.
+    r["probe.delete"].group.should eq(r["probe.delete-selected"].group)
+  end
+
+  it "tags the four ⇧X store-wipes as :wipe, so the convention reads off the registry" do
+    %w[history.clear probe.clear authorize.clear activity.clear].each do |id|
+      r[id].group.should eq(:wipe)
     end
   end
 end

--- a/src/gori/tui/space_menu.cr
+++ b/src/gori/tui/space_menu.cr
@@ -58,11 +58,12 @@ module Gori::Tui
     } of Symbol => String
 
     # The semantic bands a bucket is subdivided into, in RENDER ORDER — read top-to-
-    # bottom / left-to-right, so the order is the reading order and :danger lands last
-    # (a destructive key is never the neighbour of the key above it by accident).
+    # bottom / left-to-right, so the order is the reading order and the destructive
+    # bands land last, in severity order (a destructive key is never the neighbour of
+    # the key above it by accident, and the widest blast radius sits at the very end).
     # A verb's Verb::Definition#group picks its band; :none-tagged verbs are not
     # subdivided at all (see #split_semantic).
-    GROUP_ORDER = [:view, :send, :triage, :copy, :scope, :danger]
+    GROUP_ORDER = [:view, :send, :triage, :copy, :scope, :danger, :wipe]
 
     GROUP_LABELS = {
       :view   => "VIEW",   # inspect / filter / display toggles — changes what you SEE
@@ -70,7 +71,8 @@ module Gori::Tui
       :triage => "TRIAGE", # mark, tag, file, link, promote — engagement bookkeeping
       :copy   => "COPY",   # copy out (clipboard / copy-as)
       :scope  => "SCOPE",  # scope lens + scope membership
-      :danger => "DANGER", # deletes and clears
+      :danger => "DANGER", # permanently deletes the SELECTED item(s) — a flow, a rule, a var
+      :wipe   => "WIPE",   # empties the whole tab/project store — the ⇧X verbs (#899)
     } of Symbol => String
 
     # Below this many interior rows a column is too stubby to be worth splitting into,

--- a/src/gori/verb.cr
+++ b/src/gori/verb.cr
@@ -140,8 +140,14 @@ module Gori
       # exactly as they do today (one flat group).
       getter section : Symbol
       # The SEMANTIC band this verb sits in within whatever section shows it —
-      # :view / :send / :triage / :copy / :scope / :danger (see
-      # Tui::SpaceMenu::GROUP_LABELS). Orthogonal to `section`, which is a FOCUS-AREA
+      # :view / :send / :triage / :copy / :scope / :danger / :wipe (see
+      # Tui::SpaceMenu::GROUP_LABELS). The last two are a SEVERITY axis for verbs that
+      # permanently destroy stored data: :danger deletes the SELECTED item(s) and may
+      # ride a bare letter (the established `d`), while :wipe empties a whole
+      # tab/project store and must answer a MODIFIED chord — ⇧X across the app (#899),
+      # never a bare letter (registry_sweep_spec enforces the chord rule). Verbs that
+      # only clear a text selection, marks, or scratch editor state are NOT destructive
+      # and stay out of both. Orthogonal to `section`, which is a FOCUS-AREA
       # axis: `section` answers "which pane is focused" (and a section's verbs only
       # appear when that pane IS focused), while `group` answers "what kind of action
       # is this" and never gates visibility. The single-region scopes — History's Body

--- a/src/gori/verb/registry.cr
+++ b/src/gori/verb/registry.cr
@@ -63,6 +63,47 @@ module Gori
         end
       end
 
+      # Fail fast on a same-scope CHORD collision, the keybinding sibling of
+      # #validate_menu_keys!. Keymap.build is a plain hash assignment per scope, so a
+      # second verb claiming a chord SILENTLY SHADOWS the first — the shadowed binding
+      # has no other symptom (Verb::Conflicts only ever checks a USER rebind from the
+      # hotkey editor; nothing ran against the shipped defaults). Three deliberate
+      # divergences from the menu-key sweep:
+      #   • HIDDEN verbs are included. A hidden verb has no menu row but absolutely has
+      #     chords (body.up/body.down own the arrow keys); skipping them would blind
+      #     the check to the nav primitives.
+      #   • All three OS profiles are swept via Keymap.effective_chords, because
+      #     OsProfile.overrides_for SUBSTITUTES chords per verb — a collision can exist
+      #     on a profile this binary wasn't built for.
+      #   • Conflicts.detect is NOT reused: that path answers "is this one proposed
+      #     user chord free?" and its allowances belong to the editor. This is a strict
+      #     boot-time sweep over defaults. Cross-scope reuse stays legal here too
+      #     (lookup resolves the active scope before the Global fallback, and gori
+      #     ships such shadows deliberately — see Conflicts' comment).
+      # Also rejects a DEAD capital-letter chord: Keybind.from_event normalises a typed
+      # capital to shift+lowercase, so Chord.new("X") can never fire — a warning half a
+      # dozen verb-file comments have been standing in for until now.
+      def validate_chords! : Nil
+        OsProfile::Os.each do |os|
+          seen = Hash(Scope, Hash(Chord, String)).new { |h, k| h[k] = {} of Chord => String }
+          each do |v|
+            Keymap.effective_chords(v, os).each do |chord|
+              if chord.key.size == 1 && chord.key[0].ascii_uppercase?
+                raise Gori::Error.new(
+                  "dead capital chord: '#{chord.label}' on #{v.id} in #{v.scope} can never fire " \
+                  "(Keybind.from_event normalises a typed capital to shift+lowercase — " \
+                  "spell it Chord.new(#{chord.key.downcase.inspect}, shift: true))")
+              end
+              if prior = seen[v.scope][chord]?
+                raise Gori::Error.new(
+                  "chord collision: '#{chord.label}' claimed by both #{prior} and #{v.id} in #{v.scope} (#{os} profile)")
+              end
+              seen[v.scope][chord] = v.id
+            end
+          end
+        end
+      end
+
       # Raise on the first key collision among `verbs` (one displayable view's worth).
       private def check_menu_keys!(scope : Scope, section : Symbol, verbs : Array(Definition)) : Nil
         seen = {} of Char => String

--- a/src/gori/verbs/activity.cr
+++ b/src/gori/verbs/activity.cr
@@ -78,7 +78,7 @@ module Gori
         # typed capital to shift+lowercase, so the capital spelling never fires (the same note
         # `comparer.cr`, `authorize.cr`, `core.cr`, `diff.cr` and `issues.cr` all carry).
         Verb::Scope::ProjectActivity, [Verb::Chord.new("x", shift: true)],
-        mnemonic: 'X', group: :danger) { |ctx| ctx.activity_clear; nil }
+        mnemonic: 'X', group: :wipe) { |ctx| ctx.activity_clear; nil }
 
       r.register Verb::Definition.new(
         "activity.refresh", "Refresh feed",

--- a/src/gori/verbs/authorize.cr
+++ b/src/gori/verbs/authorize.cr
@@ -79,7 +79,7 @@ module Gori
       r.register Verb::Definition.new(
         "authorize.clear", "Clear", "Empty the request queue and its results",
         Verb::Scope::Authorize, [Verb::Chord.new("x", shift: true)],
-        available: queued, mnemonic: 'X', group: :danger) { |ctx| ctx.authorize_clear; nil }
+        available: queued, mnemonic: 'X', group: :wipe) { |ctx| ctx.authorize_clear; nil }
 
       register_send_to_authorize(r)
     end

--- a/src/gori/verbs/colormarker.cr
+++ b/src/gori/verbs/colormarker.cr
@@ -31,7 +31,8 @@ module Gori
         Verb::Scope::Colormarker, [Verb::Chord.new("x")], available: on_rule, mnemonic: 'x', section: :rules) { |ctx| ctx.colormarker_toggle; nil }
       r.register Verb::Definition.new(
         "colormarker.delete", "Delete rule", "Delete the selected rule (confirms first)",
-        Verb::Scope::Colormarker, [Verb::Chord.new("d")], available: on_rule, mnemonic: 'd', section: :rules) { |ctx| ctx.colormarker_delete; nil }
+        Verb::Scope::Colormarker, [Verb::Chord.new("d")], available: on_rule, mnemonic: 'd', section: :rules,
+        group: :danger) { |ctx| ctx.colormarker_delete; nil }
       # "Move up/down" reads like cosmetics on the Rewriter, where rules compose and order is a
       # tiebreak. Here the FIRST enabled match paints the row and the rest are never consulted,
       # so a move changes which rule wins — the descriptions say so.
@@ -79,7 +80,8 @@ module Gori
         Verb::Scope::Colormarker, available: on_color, mnemonic: 'e', section: :colors) { |ctx| ctx.colormarker_color_edit; nil }
       r.register Verb::Definition.new(
         "colormarker.color-delete", "Delete colour", "Delete the selected custom colour (confirms first)",
-        Verb::Scope::Colormarker, available: on_color, mnemonic: 'd', section: :colors) { |ctx| ctx.colormarker_color_delete; nil }
+        Verb::Scope::Colormarker, available: on_color, mnemonic: 'd', section: :colors,
+        group: :danger) { |ctx| ctx.colormarker_color_delete; nil }
     end
   end
 end

--- a/src/gori/verbs/core.cr
+++ b/src/gori/verbs/core.cr
@@ -178,7 +178,8 @@ module Gori
         Verb::Scope::Project, [Verb::Chord.new("e")], available: scope_rule) { |ctx| ctx.scope_edit_rule; nil }
       r.register Verb::Definition.new(
         "scope.delete-rule", "Delete scope rule", "Remove the selected scope rule",
-        Verb::Scope::Project, [Verb::Chord.new("d")], available: scope_rule) { |ctx| ctx.scope_delete_rule; nil }
+        Verb::Scope::Project, [Verb::Chord.new("d")], available: scope_rule,
+        group: :danger) { |ctx| ctx.scope_delete_rule; nil }
 
       # The single smart Copy (see repeater.copy in verbs/history.cr) — copy-all is gone.
       # Was `hidden: true` (the menu only ever showed "Copy description"); now that

--- a/src/gori/verbs/env.cr
+++ b/src/gori/verbs/env.cr
@@ -23,7 +23,7 @@ module Gori
 
       r.register Verb::Definition.new(
         "env.delete-var", "Delete env var", "Remove the selected environment variable",
-        Verb::Scope::Env, [Verb::Chord.new("d")], available: have_var) { |ctx| ctx.env_delete_var; nil }
+        Verb::Scope::Env, [Verb::Chord.new("d")], available: have_var, group: :danger) { |ctx| ctx.env_delete_var; nil }
 
       r.register Verb::Definition.new(
         "env.edit-prefix", "Change prefix", "Edit the token prefix used for $KEY substitution (applies globally)",

--- a/src/gori/verbs/history.cr
+++ b/src/gori/verbs/history.cr
@@ -198,7 +198,7 @@ module Gori
       r.register Verb::Definition.new(
         "history.clear", "Clear history", "Delete ALL History flows for this project (asks first)",
         Verb::Scope::Body, [Verb::Chord.new("x", shift: true)],
-        available: in_history, mnemonic: 'X', group: :danger) { |ctx| ctx.history_clear; nil }
+        available: in_history, mnemonic: 'X', group: :wipe) { |ctx| ctx.history_clear; nil }
 
       # --- repeater workbench (request editing is inline; these power the palette
       # and show their key hints — actual keys are handled directly by the TUI) ---
@@ -837,6 +837,7 @@ module Gori
       register_activity(r)
       register_read_edit(r)
       r.validate_menu_keys! # fail fast if any scope has a colliding space-menu key
+      r.validate_chords!    # …and on a same-scope chord collision or dead capital, on every OS profile
       r
     end
   end

--- a/src/gori/verbs/host_overrides.cr
+++ b/src/gori/verbs/host_overrides.cr
@@ -20,7 +20,7 @@ module Gori
 
       r.register Verb::Definition.new(
         "hostoverride.delete-entry", "Delete host override", "Remove the selected host override",
-        Verb::Scope::HostOverrides, [Verb::Chord.new("d")], available: have_entry) { |ctx| ctx.hostov_delete_entry; nil }
+        Verb::Scope::HostOverrides, [Verb::Chord.new("d")], available: have_entry, group: :danger) { |ctx| ctx.hostov_delete_entry; nil }
     end
   end
 end

--- a/src/gori/verbs/issues.cr
+++ b/src/gori/verbs/issues.cr
@@ -44,7 +44,7 @@ module Gori
       r.register Verb::Definition.new(
         "issues.delete", "Delete issue", "Delete the selected issue (or every marked one)",
         Verb::Scope::Issues, [Verb::Chord.new("d")],
-        available: issues_targets) { |ctx| ctx.issues_delete; nil }
+        available: issues_targets, group: :danger) { |ctx| ctx.issues_delete; nil }
 
       # Severity/status from the LIST, so re-triaging a set is one pass: mark five, pick
       # "False positive" once. Same ExecContext methods as the detail-scope pair below —
@@ -178,7 +178,7 @@ module Gori
 
       r.register Verb::Definition.new(
         "issue.delete", "Delete issue", "Delete this issue", Verb::Scope::IssuesDetail,
-        [Verb::Chord.new("d")]) { |ctx| ctx.issues_delete; nil }
+        [Verb::Chord.new("d")], group: :danger) { |ctx| ctx.issues_delete; nil }
 
       r.register Verb::Definition.new(
         "issue.status-up", "Advance status", "Cycle triage status forward (open→confirmed→fp→resolved)",

--- a/src/gori/verbs/notes.cr
+++ b/src/gori/verbs/notes.cr
@@ -53,7 +53,7 @@ module Gori
 
       r.register Verb::Definition.new(
         "notes.clear", "Clear note", "Clear the current note's text",
-        Verb::Scope::Notes, available: in_notes, mnemonic: 'c') { |ctx| ctx.notes_clear; nil }
+        Verb::Scope::Notes, available: in_notes, mnemonic: 'c', group: :danger) { |ctx| ctx.notes_clear; nil }
 
       # Export the note as Markdown. Mnemonic 'E', not 'e' or 'x': 'e' is Edit-in-$EDITOR
       # and 'x' is read_edit.cr's Select line, both already in this scope. A capital follows

--- a/src/gori/verbs/oast.cr
+++ b/src/gori/verbs/oast.cr
@@ -76,7 +76,7 @@ module Gori
 
       r.register Verb::Definition.new(
         "oast.delete-provider", "Delete provider", "Delete the selected provider (keeps its callback history)",
-        Verb::Scope::OastProviders, [] of Verb::Chord, mnemonic: 'd') { |ctx| ctx.oast_delete_provider; nil }
+        Verb::Scope::OastProviders, [] of Verb::Chord, mnemonic: 'd', group: :danger) { |ctx| ctx.oast_delete_provider; nil }
 
       # --- cross-tab: insert / copy a fresh OAST payload (gated on an active listener) ---
       insert_avail = ->(tab : Symbol) {

--- a/src/gori/verbs/probe.cr
+++ b/src/gori/verbs/probe.cr
@@ -110,7 +110,7 @@ module Gori
       r.register Verb::Definition.new(
         "probe.clear", "Clear issues", "Delete all Probe issues for this project", Verb::Scope::Probe,
         [Verb::Chord.new("x", shift: true)],
-        mnemonic: 'X', group: :danger) { |ctx| ctx.probe_clear; nil }
+        mnemonic: 'X', group: :wipe) { |ctx| ctx.probe_clear; nil }
 
       r.register Verb::Definition.new(
         "probe.leave", "Back to menu", "Return focus to the tab menu", Verb::Scope::Probe,
@@ -158,7 +158,7 @@ module Gori
 
       r.register Verb::Definition.new(
         "probe.delete", "Delete issue", "Delete this issue", Verb::Scope::ProbeDetail,
-        [Verb::Chord.new("d")]) { |ctx| ctx.probe_delete; nil }
+        [Verb::Chord.new("d")], group: :danger) { |ctx| ctx.probe_delete; nil }
 
       # --- Rules sub-tab (Verb::Scope::ProbeRules) ---
       # Nav (↑/↓, j/k) + Esc→strip are controller-claimed; these are the actions. edit/delete are
@@ -182,7 +182,8 @@ module Gori
         mnemonic: 'e', available: probe_custom) { |ctx| ctx.probe_rule_edit; nil }
       r.register Verb::Definition.new(
         "probe-rules.delete", "Delete custom rule", "Delete the selected custom rule",
-        Verb::Scope::ProbeRules, [Verb::Chord.new("d")], available: probe_custom) { |ctx| ctx.probe_rule_delete; nil }
+        Verb::Scope::ProbeRules, [Verb::Chord.new("d")], available: probe_custom,
+        group: :danger) { |ctx| ctx.probe_rule_delete; nil }
     end
   end
 end

--- a/src/gori/verbs/rewriter.cr
+++ b/src/gori/verbs/rewriter.cr
@@ -49,7 +49,8 @@ module Gori
         Verb::Scope::Rewriter, available: has_rule, mnemonic: 'x', section: :rules) { |ctx| ctx.rewriter_toggle; nil }
       r.register Verb::Definition.new(
         "rewriter.delete", "Delete rule", "Delete the selected rule (confirms first)",
-        Verb::Scope::Rewriter, [Verb::Chord.new("d")], available: has_rule, mnemonic: 'd', section: :rules) { |ctx| ctx.rewriter_delete; nil }
+        Verb::Scope::Rewriter, [Verb::Chord.new("d")], available: has_rule, mnemonic: 'd', section: :rules,
+        group: :danger) { |ctx| ctx.rewriter_delete; nil }
       r.register Verb::Definition.new(
         "rewriter.move-up", "Move up", "Move the selected rule earlier in apply order",
         Verb::Scope::Rewriter, [Verb::Chord.new("k", shift: true)], available: has_rule, mnemonic: 'u', section: :rules) { |ctx| ctx.rewriter_move(-1); nil }


### PR DESCRIPTION
Two related pieces of keybinding hygiene, one PR.

## Part 1 — `Registry#validate_chords!`

`validate_menu_keys!` has raised at boot on a space-menu key collision since it landed; chords had no equivalent. `Keymap.build` is a plain per-scope hash assignment (`by_scope[scope][chord] = verb.id`), so a second verb claiming a chord in the same scope **silently shadows** the first with no error anywhere. `Verb::Conflicts.detect` exists but is wired only to the hotkey editor — it validates *user* rebinds at runtime and has never run against the shipped defaults.

The new `validate_chords!` is called from `Gori::Verbs.registry`, right after `validate_menu_keys!`. It:

- **includes hidden verbs** — `body.up`/`body.down` are hidden and own the arrow keys; skipping them (as the menu-key sweep does, because a hidden verb has no menu row) would blind the check to the nav primitives;
- **sweeps all three OS profiles** through `Keymap.effective_chords(verb, os)`, because `OsProfile.overrides_for` substitutes chords per verb — a collision can exist only on a profile this binary was not built for;
- stays **strict within a scope** while leaving cross-scope reuse legal (lookup resolves the active scope before the Global fallback, and gori ships such shadows deliberately). It does **not** reuse `Conflicts.detect`: that answers "is this one proposed user chord free?" and its allowances belong to the editor;
- **rejects a dead capital-letter chord** — `Chord.new("X")` can never fire because `Keybind.from_event` normalises a typed capital to shift+lowercase. At least six verb files carry a hand-written comment warning about this; the check is what those comments were standing in for.

**Baseline reproduced on `b88c2363`: 513 verbs, 316 declared chords, 33 scopes, 0 same-scope collisions and 0 dead capitals on Darwin/Linux/Windows.** The check goes green the moment it is added — no live binding bug was found.

## Part 2 — severity axis for destructive verbs

The #899 ⇧X rollout produced a convention nothing in the code stated: a store-wipe and a selection-delete both wore `group: :danger`, which is why the ⇧X decision had to be re-derived from a commit message (`0edc3c5b`) and six file comments.

**Chosen model: a new band `:wipe`, distinct from `:danger`** — picked over a `Definition#destroys` field because `group` already drives the palette's colour-coded sigil and the space-menu section, so severity now reads off the same axis the menu already renders. A separate field would have left `group` still conflating the two. `:wipe` renders after `:danger` in `GROUP_ORDER` (widest blast radius last).

### Severity table

| verb | scope | chord | before | after |
|---|---|---|---|---|
| `history.clear` | Body | ⇧X | `:danger` | **`:wipe`** |
| `probe.clear` | Probe | ⇧X | `:danger` | **`:wipe`** |
| `authorize.clear` | Authorize | ⇧X | `:danger` | **`:wipe`** |
| `activity.clear` | ProjectActivity | ⇧X | `:danger` | **`:wipe`** |
| `scope.delete-rule` | Project | `d` | `:none` | **`:danger`** |
| `issues.delete` | Issues | `d` | `:none` | **`:danger`** |
| `issue.delete` | IssuesDetail | `d` | `:none` | **`:danger`** |
| `probe.delete` | ProbeDetail | `d` | `:none` | **`:danger`** |
| `probe-rules.delete` | ProbeRules | `d` | `:none` | **`:danger`** |
| `rewriter.delete` | Rewriter | `d` | `:none` | **`:danger`** |
| `colormarker.delete` | Colormarker | `d` | `:none` | **`:danger`** |
| `colormarker.color-delete` | Colormarker | — | `:none` | **`:danger`** |
| `hostoverride.delete-entry` | HostOverrides | `d` | `:none` | **`:danger`** |
| `env.delete-var` | Env | `d` | `:none` | **`:danger`** |
| `oast.delete-provider` | OastProviders | — | `:none` | **`:danger`** |
| `notes.clear` | Notes | — | `:none` | **`:danger`** |

Reasons: the four ⇧X verbs empty a whole tab/project store, so they move to `:wipe`. The eleven `none → danger` verbs permanently delete stored data and were untagged. `probe.delete` (detail scope) was `:none` while its list-scope twin `probe.delete-selected` was already `:danger` — that was drift, not a decision; they now agree.

Regroupings were verified by **what the handler does**, never by an id regex: the 18 `*.clear-selection` and 5 `*.mark-clear`/`clear-marks` verbs clear a text selection or drop marks, and the workbench `decoder.clear`/`jwt.clear`/`cookie.clear` reset scratch editor state — none touch stored data, so all stay `:none`.

### Specs

- `registry_spec` covers the four `validate_chords!` failure modes (same-scope collision, hidden-verb collision, a collision that exists only on a non-native OS profile, dead capital) plus the two must-pass cases (cross-scope reuse, correctly-spelled `shift`+lowercase capital).
- `registry_sweep_spec` encodes the one policy that is **genuinely checkable from the registry alone**: a `:wipe` verb's chord, if it has one, must be modified — with a companion test that plants a bare-chord `:wipe` verb to prove the guard bites, plus the `probe.delete` ⇔ `probe.delete-selected` sibling-agreement and the four-⇧X lock.

**Confirm-gating is not asserted.** The confirmation lives in the controller (`@host.confirm(...)`), not the registry, so it cannot be statically checked here; it stays a documented convention rather than a spec that reads as though it verified the real thing.

## Verification

`crystal tool format --check`, `crystal build --no-codegen src/main.cr`, `crystal spec` (12170 examples, 0 failures), `./scripts/bench_check.sh` (49 harnesses), and `crystal build --no-codegen scripts/seed_demo.cr` all pass. Two pre-existing `activity_spec` assertions that pinned the ⇧X verbs to `:danger` were updated to `:wipe`. ameba reports nothing new on changed lines. Guard-removal was verified for each new spec (neutering `validate_chords!` fails the four negative cases; breaking the bare-chord helper fails the "proves the guard bites" test).