### PR TITLE
fix(tui): wire hjkl into the Repeater's request/target/response read caret

### DIFF
--- a/src/gori/tui/controllers/repeater_controller.cr
+++ b/src/gori/tui/controllers/repeater_controller.cr
@@ -2535,18 +2535,18 @@ module Gori::Tui
       c = ev.char || key.to_char
       selecting = ev.shift?
       case
-      when key.enter?     then view.enter_request_insert!
-      when c == 'i'       then view.enter_request_insert!
-      when word_step?(ev)                  then view.request_read_move(0, key.left? ? -1 : 1, selecting: selecting)
-      when key.up?, key.lower_k?           then view.at_top? ? view.focus_first : view.request_read_move(-1, 0, selecting: selecting)
-      when key.down?, key.lower_j?         then view.request_read_move(1, 0, selecting: selecting)
-      when key.left?, key.lower_h?         then view.request_read_move(0, -1, selecting: selecting)
-      when key.right?, key.lower_l?        then view.request_read_move(0, 1, selecting: selecting)
-      when key.page_up?   then view.request_read_page(-1, selecting: selecting)
-      when key.page_down? then view.request_read_page(1, selecting: selecting)
-      when key.home?      then view.edit_home(selecting)
-      when key.end?       then view.edit_end(selecting)
-      when c == 'x'       then view.pane_select_line
+      when key.enter?               then view.enter_request_insert!
+      when c == 'i'                 then view.enter_request_insert!
+      when word_step?(ev)           then view.request_read_move(0, key.left? ? -1 : 1, selecting: selecting)
+      when key.up?, key.lower_k?    then view.at_top? ? view.focus_first : view.request_read_move(-1, 0, selecting: selecting)
+      when key.down?, key.lower_j?  then view.request_read_move(1, 0, selecting: selecting)
+      when key.left?, key.lower_h?  then view.request_read_move(0, -1, selecting: selecting)
+      when key.right?, key.lower_l? then view.request_read_move(0, 1, selecting: selecting)
+      when key.page_up?             then view.request_read_page(-1, selecting: selecting)
+      when key.page_down?           then view.request_read_page(1, selecting: selecting)
+      when key.home?                then view.edit_home(selecting)
+      when key.end?                 then view.edit_end(selecting)
+      when c == 'x'                 then view.pane_select_line
       when c && !ev.ctrl? && !ev.alt? && !c.control?
         return false # y copy, Global c/i/s, …
       end
@@ -2565,9 +2565,9 @@ module Gori::Tui
       when key.down?, key.lower_j?  then view.pane_advance(1)
       when key.left?, key.lower_h?  then view.target_read_move(-1, selecting: selecting)
       when key.right?, key.lower_l? then view.target_read_move(1, selecting: selecting)
-      when key.home?  then view.target_home(selecting)
-      when key.end?   then view.target_end(selecting)
-      when c == 'x'   then view.pane_select_line
+      when key.home?                then view.target_home(selecting)
+      when key.end?                 then view.target_end(selecting)
+      when c == 'x'                 then view.pane_select_line
       when c && !ev.ctrl? && !ev.alt? && !c.control?
         return false
       end
@@ -2622,7 +2622,7 @@ module Gori::Tui
       # was transcript-specific: `resp_drawn_source` reports a decoration offset of 0 for a
       # transcript (only DIFF has one), so the caret columns are the row's own columns.
       case
-      when key.enter?              then repeater_send
+      when key.enter?               then repeater_send
       when key.up?, key.lower_k?    then view.at_top? ? view.focus_first : resp_nav_step(view, -1, 0, selecting, nav)
       when key.down?, key.lower_j?  then resp_nav_step(view, 1, 0, selecting, nav)
       when key.left?, key.lower_h?  then resp_nav_step(view, 0, -1, selecting, nav)

--- a/src/gori/tui/controllers/repeater_controller.cr
+++ b/src/gori/tui/controllers/repeater_controller.cr
@@ -2537,11 +2537,11 @@ module Gori::Tui
       case
       when key.enter?     then view.enter_request_insert!
       when c == 'i'       then view.enter_request_insert!
-      when word_step?(ev) then view.request_read_move(0, key.left? ? -1 : 1, selecting: selecting)
-      when key.up?        then view.at_top? ? view.focus_first : view.request_read_move(-1, 0, selecting: selecting)
-      when key.down?      then view.request_read_move(1, 0, selecting: selecting)
-      when key.left?      then view.request_read_move(0, -1, selecting: selecting)
-      when key.right?     then view.request_read_move(0, 1, selecting: selecting)
+      when word_step?(ev)                  then view.request_read_move(0, key.left? ? -1 : 1, selecting: selecting)
+      when key.up?, key.lower_k?           then view.at_top? ? view.focus_first : view.request_read_move(-1, 0, selecting: selecting)
+      when key.down?, key.lower_j?         then view.request_read_move(1, 0, selecting: selecting)
+      when key.left?, key.lower_h?         then view.request_read_move(0, -1, selecting: selecting)
+      when key.right?, key.lower_l?        then view.request_read_move(0, 1, selecting: selecting)
       when key.page_up?   then view.request_read_page(-1, selecting: selecting)
       when key.page_down? then view.request_read_page(1, selecting: selecting)
       when key.home?      then view.edit_home(selecting)
@@ -2559,12 +2559,12 @@ module Gori::Tui
       c = ev.char || key.to_char
       selecting = ev.shift?
       case
-      when key.enter? then view.enter_target_insert!
-      when c == 'i'   then view.enter_target_insert!
-      when key.up?    then @host.request_focus(subtab_strip_shown? ? :subtabs : :menu)
-      when key.down?  then view.pane_advance(1)
-      when key.left?  then view.target_read_move(-1, selecting: selecting)
-      when key.right? then view.target_read_move(1, selecting: selecting)
+      when key.enter?               then view.enter_target_insert!
+      when c == 'i'                 then view.enter_target_insert!
+      when key.up?, key.lower_k?    then @host.request_focus(subtab_strip_shown? ? :subtabs : :menu)
+      when key.down?, key.lower_j?  then view.pane_advance(1)
+      when key.left?, key.lower_h?  then view.target_read_move(-1, selecting: selecting)
+      when key.right?, key.lower_l? then view.target_read_move(1, selecting: selecting)
       when key.home?  then view.target_home(selecting)
       when key.end?   then view.target_end(selecting)
       when c == 'x'   then view.pane_select_line
@@ -2623,10 +2623,10 @@ module Gori::Tui
       # transcript (only DIFF has one), so the caret columns are the row's own columns.
       case
       when key.enter?              then repeater_send
-      when key.up?, key.lower_k?   then view.at_top? ? view.focus_first : resp_nav_step(view, -1, 0, selecting, nav)
-      when key.down?, key.lower_j? then resp_nav_step(view, 1, 0, selecting, nav)
-      when key.left?               then resp_nav_step(view, 0, -1, selecting, nav)
-      when key.right?              then resp_nav_step(view, 0, 1, selecting, nav)
+      when key.up?, key.lower_k?    then view.at_top? ? view.focus_first : resp_nav_step(view, -1, 0, selecting, nav)
+      when key.down?, key.lower_j?  then resp_nav_step(view, 1, 0, selecting, nav)
+      when key.left?, key.lower_h?  then resp_nav_step(view, 0, -1, selecting, nav)
+      when key.right?, key.lower_l? then resp_nav_step(view, 0, 1, selecting, nav)
         # Page/line-edge keys, ⇧ extending — the set every other read pane in the tree has
         # (`ReadPane#motion_key`, `HistoryView#detail_line_edge`/`#detail_page_rows`, and the
         # request editor beside this one). They sat in NO arm before, so the trailing `true`


### PR DESCRIPTION
## Summary
- Arrow keys already moved the caret in every Repeater READ pane; `h`/`j`/`k`/`l` did nothing there, unlike History's equivalent read handlers, which already alias both.
- The request pane and target pane had no vim-key support at all; the response pane only had `j`/`k` wired from an earlier "j/k parity" pass, missing `h`/`l`.
- None of `h`/`j`/`k`/`l` carry a bare-key verb chord in the Repeater scope (their `mnemonic` only fires inside the space menu), so aliasing them onto arrow-key caret movement doesn't shadow any existing shortcut.

## Test plan
- [x] `crystal build src/main.cr --no-codegen -o /dev/null` compiles clean
- [x] `crystal spec spec/tui/repeater_view_spec.cr spec/tui/target_row_select_spec.cr spec/tui/repeater_ws_editor_parity_spec.cr spec/tui/repeater_decode_spec.cr spec/tui/read_chrome_badge_parity_spec.cr` — 233 examples, 0 failures
- [x] Remaining `spec/tui/repeater_*` suite — 116 examples, 0 failures