### PR TITLE
feat(repeater): tab numbers, reorder and bulk management from MCP

### DIFF
--- a/docs/content/guide/mcp.ko.md
+++ b/docs/content/guide/mcp.ko.md
@@ -127,7 +127,7 @@ Codex와 Grok은 `[mcp_servers.gori]` 테이블이 있는 TOML을, Hermes는 `mc
 | `preview_color_rule` | 어떤 색상 조건이 최근 플로우 몇 개에 **매칭**되는지, 그리고 앞서 해소되는 규칙들을 셈한 뒤 실제로 몇 개를 **칠하는지** |
 | `grpc_schema` | 이 프로젝트가 캡처된 gRPC를 어떤 `.proto` 스키마로 렌더하는지, 각 조각이 어디서 왔는지(디스크립터 셋 파일 또는 리플렉션 페치). 아무것도 보내지 않습니다 |
 | `list_rules` | 프로젝트에 적용되는 Match & Replace 규칙을 적용 순서로 나열. 전역 규칙이 먼저, 그다음이 프로젝트 규칙(`scope`로 한쪽만 조회) |
-| `list_env` | `$KEY` 치환에 쓰이는 프로젝트 env 토큰(값은 가려짐) |
+| `list_env` | `$KEY` 치환에 쓰이는 프로젝트 env 토큰(값은 가려짐). 행마다 `length`와, 값이 스킴으로 시작할 때 `scheme`도 싣는다 — 헤더를 `Bearer $KEY`로 써야 하는지 그냥 `$KEY`로 써야 하는지, 값 없이 판단할 수 있을 만큼 |
 | `list_host_overrides` | 이 프로젝트에 적용 중인 호스트 → IP 다이얼 맵 |
 | `list_session_slots` | 프로젝트의 [세션 슬롯](/ko/guide/authorize/#session-slots-one-list-two-readers) — 이름 붙은 신원 각각이 헤더 오버레이 하나와 그 값을 묶어 주는 extract 규칙들로 이루어집니다 — 그리고 어느 쪽이 ACTIVE인지(헤더 값은 가려짐) |
 | `list_oast_providers` | 설정된 OAST 프로바이더와 현재 활성 프로바이더 |
@@ -140,7 +140,7 @@ Codex와 Grok은 `[mcp_servers.gori]` 테이블이 있는 TOML을, Hermes는 `mc
 | `discover_status` / `discover_results` | Discover 실행의 진행 상황과 결과 |
 | `project_info` | 플로우 / 이슈 개수, 데이터베이스, 워크스페이스 바인딩, 선택 출처 |
 | `get_current_context` | 사용자가 지금 TUI에서 보고 있는 것 |
-| `get_repeater_context` | Repeater 워크벤치 상태와 저장된 세션 |
+| `get_repeater_context` | Repeater 워크벤치 상태와 저장된 세션. 세션마다 id를 **둘 다** 싣는다 — 모든 repeater 툴이 받는 `db_id`, 그리고 TUI가 서브탭 칩에 그리는 1-based 번호 `tui_index`(`6:POST /api`) — 그래서 에이전트와 사용자가 같은 탭을 같은 이름으로 부른다. `filter`는 TUI의 `/`와 같은 서브탭 문법(`tag:` `name:` `host:` `method:` `status:`, `-`는 부정, 맨 단어는 검색)이고 `query`와 AND로 묶인다. `include_content`는 요청 헤드와 함께, 자격증명 헤더마다 비밀값 없이 배선만 밝히는 `env_headers` 모양(`Authorization: Bearer $AUTH`)을 준다. `include_response_body`는 저장된 마지막 응답 본문을 인라인한다 |
 | `ql_reference` | 쿼리 언어 레퍼런스 |
 | `ql_explain` | 쿼리를 실행하지 않고 진단. 요청을 쓰기 전에 필터를 점검할 때 사용 |
 
@@ -150,7 +150,10 @@ Codex와 Grok은 `[mcp_servers.gori]` 테이블이 있는 TOML을, Hermes는 `mc
 |------|---------|
 | `send_request` | HTTP 요청 전송 / 재전송(액티브; 기본적으로 History에 기록, `$KEY` 환경 토큰을 확장, 명시적으로 요청하지 않는 한 민감한 응답 헤더 값을 가림). `reframe_grpc: true`는 실제 전송되는 본문에 맞춰 단항 gRPC 메시지의 5바이트 길이 접두사를 다시 계산합니다 — 기본값은 꺼짐이므로 편집된 메시지도 캡처 당시의 접두사 그대로 나갑니다 |
 | `send_websocket` | 저장된 WebSocket Repeater 세션을 실행하고 응답을 수집 |
-| `create_repeater` / `update_repeater` / `delete_repeater` | Repeater 세션 관리 |
+| `create_repeater` / `update_repeater` / `delete_repeater` | Repeater 세션 하나를 관리. 모든 응답이 `id` 옆에 `tui_index`를 싣고, 삭제는 없앤 탭 번호(`was_tui_index`)를 밝힌 뒤 나머지를 다시 번호 매긴다 |
+| `create_repeaters` | 캡처된 flow 여러 개에서 탭을 하나씩 시드 — OpenAPI 임포트의 두 번째 단계(아래 참고). 첫 세션을 만들기 전에 모든 flow의 존재를 확인한다 |
+| `delete_repeaters` / `update_repeaters` | 일괄 닫기, 일괄 재라벨(태그와 이름 접사만 — 요청 바이트를 쓰는 건 `update_repeater`다). 둘 다 필터가 아니라 명시적 id만 받는다: 먼저 `get_repeater_context{filter}`로 좁혀서, 읽은 집합과 작용한 집합이 같게. 삭제는 `confirm:true`가 필요하고, 모르는 id 하나면 호출 전체를 거절한다 |
+| `move_repeater` | 서브탭 스트립을 재배치 — 절대 탭 번호는 `to_index`, 한 칸 이동은 `direction`. 열려 있는 TUI가 알아서 새 순서를 반영한다 |
 | `minimize_repeater` | Repeater 요청을 같은 응답이 재현되는 최소 형태로 줄임 |
 | `create_issue` / `update_issue` / `delete_issue` | 이슈 기록, 갱신, 삭제 |
 | `add_link` / `remove_link` | 이슈나 노트의 증거 포인터 연결 / 해제 |
@@ -189,6 +192,18 @@ Codex와 Grok은 `[mcp_servers.gori]` 테이블이 있는 TOML을, Hermes는 `mc
 | `intercept_toggle` / `intercept_set_filter` / `intercept_set_direction` | 캐치 활성화 및 해제, 조건 쿼리 설정, 홀드할 방향 선택 |
 
 > 액션 도구는 안전을 위해 상한이 있습니다: fuzz, mine, sequence, discover, authorize 작업은 총 요청 수, 동시성, 저장 결과 수가 제한됩니다. authorize의 상한은 `플로우 × 아이덴티티`를 세며, 상한을 넘는 선택은 잘라서 실행하는 대신 시작 전에 거부됩니다. 잘린 실행은 보내지도 않은 플로우를 "enforced"로 보고하게 되기 때문입니다. `create_rule`로 생성된 규칙은 `gori run`과 새로 열린 TUI에 적용됩니다. 이미 실행 중인 TUI는 규칙을 다시 로드한 뒤에만 적용합니다.
+
+## 스펙에서 Repeater 탭으로 {#from-a-spec-to-repeater-tabs}
+
+`import_flows`는 OpenAPI/Swagger(JSON·YAML)를 읽고 `servers[0].url`을 각 오퍼레이션 경로와 합쳐 준다. 베이스 경로를 손으로 붙일 일이 없다는 뜻이고, 스펙에서 탭 한 줄까지는 호출 세 번이다.
+
+```
+import_flows{kind: "oas", path: "openapi.yaml"}
+list_history{query: "src:import"}          → flow id들
+create_repeaters{flow_ids: [...], name_prefix: "oas: ", tags: "spec"}
+```
+
+`create_repeaters`는 첫 세션을 만들기 전에 모든 flow의 존재를 확인하고, `create_repeater{flow_id}` 하나가 쓰는 것과 같은 경로로 각각을 시드한 뒤, 준 순서대로 덧붙인다. 순서는 `move_repeater`로 바꾸고, 정리는 `delete_repeaters`로 한다.
 
 ## 라이브 인터셉트 {#live-intercept}
 

--- a/docs/content/guide/mcp.md
+++ b/docs/content/guide/mcp.md
@@ -127,7 +127,7 @@ Every flag you pass alongside `--install-*` is written into the installed comman
 | `preview_color_rule` | How many recent flows a colour condition would MATCH, and how many it would actually PAINT once the rules resolving ahead of it are counted |
 | `grpc_schema` | What `.proto` schema this project renders captured gRPC through, and where each piece came from — a descriptor-set file or a reflection fetch. Sends nothing |
 | `list_rules` | List the Match & Replace rules applied to the project in apply order — global rules first, then the project's own (`scope` filters to one) |
-| `list_env` | Project env tokens available to `$KEY` substitution (values redacted) |
+| `list_env` | Project env tokens available to `$KEY` substitution (values redacted). Each row also carries `length` and, when the value already begins with one, `scheme` — enough to tell whether a header should read `Bearer $KEY` or just `$KEY`, without the value |
 | `list_host_overrides` | The host to IP dial map in force for this project |
 | `list_session_slots` | The project's [session slots](/guide/authorize/#session-slots-one-list-two-readers) — named identities, each a header overlay plus the extract rules whose bound values belong to it — and which one is ACTIVE (header values redacted) |
 | `list_oast_providers` | Configured OAST providers and which one is active |
@@ -140,7 +140,7 @@ Every flag you pass alongside `--install-*` is written into the installed comman
 | `discover_status` / `discover_results` | Progress and findings of a Discover run |
 | `project_info` | Flow / issue counts, database, workspace binding, and selection source |
 | `get_current_context` | What the user is viewing in the TUI right now |
-| `get_repeater_context` | Repeater workbench state and saved sessions |
+| `get_repeater_context` | Repeater workbench state and saved sessions. Every session reports **both** ids — `db_id`, which every repeater tool takes, and `tui_index`, the 1-based number the TUI paints on its sub-tab chip (`6:POST /api`) — so an agent and the operator name the same tab. `filter` takes the same sub-tab language the TUI's `/` does (`tag:` `name:` `host:` `method:` `status:`, `-` negates, bare words search), ANDed with `query`. `include_content` adds the request head and, per credential header, an `env_headers` shape (`Authorization: Bearer $AUTH`) that names the wiring without the secret; `include_response_body` inlines the stored last response body |
 | `list_fuzz_runs` / `get_fuzz_run` | List and inspect permanent Fuzzer result sets. Metrics use a scalar-only projection, including `result_index`, so retained BLOBs are not loaded. `include_content:true` returns at most 25 rows from SQLite-capped prefixes: `max_head_bytes` (default 16 KiB, max 64 KiB) bounds heads and `max_body_bytes` (default 2 KiB, max 64 KiB) bounds decoded bodies/raw samples. Full source sizes plus head/source/decode truncation flags say what was omitted; `include_sensitive:true` opts into exact capped prefixes, never uncapped bytes. Run metadata labels pre-current snapshots as `legacy:true` |
 | `ql_reference` | The query-language reference |
 | `ql_explain` | Diagnose a query without running it, to check a filter before spending requests on it |
@@ -151,7 +151,10 @@ Every flag you pass alongside `--install-*` is written into the installed comman
 | ------ | --------- |
 | `send_request` | Send / resend an HTTP request (active; records History by default, expands `$KEY` env tokens, and redacts sensitive response-header values unless explicitly requested). `reframe_grpc: true` recomputes a unary gRPC message's 5-byte length prefix over the body actually sent — off by default, so an edited message ships with the prefix it was captured with |
 | `send_websocket` | Execute a saved WebSocket Repeater session and collect the replies |
-| `create_repeater` / `update_repeater` / `delete_repeater` | Manage Repeater sessions |
+| `create_repeater` / `update_repeater` / `delete_repeater` | Manage one Repeater session. Every reply carries `tui_index` beside `id`; a delete names the tab it destroyed (`was_tui_index`) and renumbers the rest |
+| `create_repeaters` | Seed a tab from each of several captured flows — the second hop of an OpenAPI import (see below). Checks every flow exists before creating the first session |
+| `delete_repeaters` / `update_repeaters` | Bulk close, and bulk re-label (tags and name affixes only — `update_repeater` is the one that writes request bytes). Both take explicit ids, never a filter: narrow with `get_repeater_context{filter}` first, so the set you read is the set acted on. Delete needs `confirm:true`, and an unknown id refuses the whole call |
+| `move_repeater` | Rearrange the sub-tab strip — `to_index` for an absolute tab number, `direction` for a one-step nudge. An open TUI picks the new order up on its own |
 | `minimize_repeater` | Shrink a Repeater request to the smallest form that still reproduces the response |
 | `create_issue` / `update_issue` / `delete_issue` | Record, update, and remove issues |
 | `add_link` / `remove_link` | Attach or detach an issue's / note's evidence pointer |
@@ -191,6 +194,18 @@ Every flag you pass alongside `--install-*` is written into the installed comman
 | `intercept_toggle` / `intercept_set_filter` / `intercept_set_direction` | Arm or disarm the catch, set its condition query, and choose which leg it holds |
 
 > Action tools are capped for safety: fuzz, mine, sequence, discover, and authorize jobs are limited in total requests, concurrency, and stored results. An authorize run's cap counts `flows × identities`, and a selection over it is refused up front rather than truncated into a run that would report "enforced" for flows it never sent. A rule created via `create_rule` is picked up by `gori run` and newly opened TUIs; an already-running TUI applies it only after its rules reload.
+
+## From a Spec to Repeater Tabs
+
+`import_flows` reads OpenAPI/Swagger (JSON or YAML) and joins `servers[0].url` with each operation path, so the base-path assembly is already done. Getting from a spec to a strip of tabs is three calls:
+
+```
+import_flows{kind: "oas", path: "openapi.yaml"}
+list_history{query: "src:import"}          → the flow ids
+create_repeaters{flow_ids: [...], name_prefix: "oas: ", tags: "spec"}
+```
+
+`create_repeaters` checks every flow exists before it creates the first session, seeds each one through the same path a single `create_repeater{flow_id}` uses, and appends them in the order given. Rearrange afterwards with `move_repeater`, and prune with `delete_repeaters`.
 
 ## Live Intercept
 

--- a/spec/mcp/repeater_bulk_spec.cr
+++ b/spec/mcp/repeater_bulk_spec.cr
@@ -1,0 +1,383 @@
+require "../spec_helper"
+
+# The tab-number / database-id split (#904), the reorder that `position` had no writer for,
+# and the bulk tools. Everything here goes through `Tools#call`, because the argument
+# validation and the per-id reporting are the point — a handler called directly would skip
+# `unknown_args` and the schema the reply is supposed to match.
+
+private def with_store(&)
+  path = File.tempname("gori-repeaterbulk", ".db")
+  store = Gori::Store.open(path)
+  prev_env = Gori::Settings.project_env_vars
+  begin
+    yield store
+  ensure
+    Gori::Settings.project_env_vars = prev_env
+    Gori::Env.bump_highlight_rev
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+private def tools(store)
+  Gori::MCP::Tools.new(store, allow_actions: true, verify_upstream: false)
+end
+
+private def call_json(store, name, args : String) : JSON::Any
+  r = tools(store).call(name, JSON.parse(args))
+  fail "#{name} errored: #{r.text}" if r.is_error
+  JSON.parse(r.text)
+end
+
+private def call_err(store, name, args : String) : Gori::MCP::Tools::Result
+  r = tools(store).call(name, JSON.parse(args))
+  fail "#{name} unexpectedly succeeded: #{r.text}" unless r.is_error
+  r
+end
+
+private def seed_flow(store, method : String, path : String) : Int64
+  store.insert_flow(Gori::Store::CapturedRequest.new(
+    created_at: 1_i64, scheme: "https", host: "api.test", port: 443,
+    method: method, target: path, http_version: "HTTP/1.1",
+    head: "#{method} #{path} HTTP/1.1\r\nHost: api.test\r\n\r\n".to_slice,
+    body: nil, source: Gori::FlowSource::Kind::Import))
+end
+
+# Three saved sessions, tab 1..3, named a/b/c.
+private def seed_three(store) : Array(Int64)
+  %w[a b c].map do |n|
+    call_json(store, "create_repeater",
+      %({"target":"https://#{n}.test","request":"GET /#{n} HTTP/1.1\\r\\nHost: #{n}.test\\r\\n\\r\\n","name":#{n.to_json}}))["id"].as_i64
+  end
+end
+
+describe "MCP repeater tab numbers" do
+  it "reports tui_index beside db_id, in the order the TUI paints the strip" do
+    with_store do |store|
+      ids = seed_three(store)
+      sessions = call_json(store, "get_repeater_context", "{}")["sessions"].as_a
+      sessions.map { |s| s["db_id"].as_i64 }.should eq(ids)
+      sessions.map { |s| s["tui_index"].as_i }.should eq([1, 2, 3])
+    end
+  end
+
+  it "numbers a session the same way RepeaterController#subtab_labels does" do
+    with_store do |store|
+      seed_three(store)
+      rows = store.repeaters_meta
+      # `subtab_labels` is `map_with_index { |tab, i| "#{i + 1}:…" }` over a list sorted by
+      # {position, id} — pinned here so the MCP projection and the chip cannot drift.
+      expected = rows.map_with_index { |r, i| {r.id, i + 1} }
+      call_json(store, "get_repeater_context", "{}")["sessions"].as_a
+        .map { |s| {s["db_id"].as_i64, s["tui_index"].as_i} }.should eq(expected)
+    end
+  end
+
+  it "keeps the numbers ABSOLUTE when a filter narrows the listing" do
+    with_store do |store|
+      ids = seed_three(store)
+      call_json(store, "update_repeaters", %({"ids":[#{ids[1]}],"tags_add":"idor"}))
+      got = call_json(store, "get_repeater_context", %({"filter":"tag:idor"}))
+      got["sessions"].as_a.size.should eq(1)
+      # Tab 2, not tab 1: the TUI's own filtered strip reads with gaps, and renumbering here
+      # would make an agent name a different chip than the operator sees.
+      got["sessions"][0]["tui_index"].as_i.should eq(2)
+    end
+  end
+
+  it "reports the number a session HAD when it is deleted, and that the rest shifted" do
+    with_store do |store|
+      ids = seed_three(store)
+      j = call_json(store, "delete_repeater", %({"id":#{ids[1]}}))
+      j["id"].as_i64.should eq(ids[1])
+      j["name"].as_s.should eq("b")
+      j["was_tui_index"].as_i.should eq(2)
+      j["note"].as_s.should contain("shifted down")
+      j["remaining"].as_i.should eq(2)
+      # And the survivors are renumbered densely, so tab 2 is now `c`.
+      store.repeaters.map(&.position).should eq([0, 1])
+    end
+  end
+
+  it "does not renumber-note a delete that took the LAST tab" do
+    with_store do |store|
+      ids = seed_three(store)
+      j = call_json(store, "delete_repeater", %({"id":#{ids[2]}}))
+      j["was_tui_index"].as_i.should eq(3)
+      j["note"]?.should be_nil
+    end
+  end
+
+  it "carries tui_index on create and update" do
+    with_store do |store|
+      seed_three(store)
+      created = call_json(store, "create_repeater",
+        %({"target":"https://d.test","request":"GET /d HTTP/1.1\\r\\n\\r\\n"}))
+      created["tui_index"].as_i.should eq(4)
+      call_json(store, "update_repeater", %({"id":#{created["id"]},"name":"dee"}))["tui_index"].as_i.should eq(4)
+    end
+  end
+
+  it "appends at the end even when the stored positions are sparse" do
+    with_store do |store|
+      first = seed_three(store)[0]
+      # The shape a legacy project is in: positions {0, 1, 9}.
+      store.set_repeater_positions([first])
+      store.insert_repeater("https://z.test", "GET /z HTTP/1.1\r\n\r\n".to_slice, false, true, nil, 9)
+      j = call_json(store, "create_repeater",
+        %({"target":"https://new.test","request":"GET /new HTTP/1.1\\r\\n\\r\\n"}))
+      store.repeaters.last.id.should eq(j["id"].as_i64)
+    end
+  end
+end
+
+describe "MCP move_repeater" do
+  it "moves a session to an absolute tab number and returns the resulting order" do
+    with_store do |store|
+      ids = seed_three(store)
+      j = call_json(store, "move_repeater", %({"id":#{ids[2]},"to_index":1}))
+      j["from_index"].as_i.should eq(3)
+      j["to_index"].as_i.should eq(1)
+      j["moved"].as_bool.should be_true
+      j["order"].as_a.map { |r| r["id"].as_i64 }.should eq([ids[2], ids[0], ids[1]])
+      j["order"].as_a.map { |r| r["tui_index"].as_i }.should eq([1, 2, 3])
+      store.repeaters.map(&.id).should eq([ids[2], ids[0], ids[1]])
+    end
+  end
+
+  it "nudges one place with direction" do
+    with_store do |store|
+      ids = seed_three(store)
+      call_json(store, "move_repeater", %({"id":#{ids[0]},"direction":"down"}))
+      store.repeaters.map(&.id).should eq([ids[1], ids[0], ids[2]])
+      call_json(store, "move_repeater", %({"id":#{ids[0]},"direction":"up"}))
+      store.repeaters.map(&.id).should eq([ids[0], ids[1], ids[2]])
+    end
+  end
+
+  it "reports a no-op placement as a success, not a failure" do
+    with_store do |store|
+      ids = seed_three(store)
+      j = call_json(store, "move_repeater", %({"id":#{ids[1]},"to_index":2}))
+      j["moved"].as_bool.should be_false
+      store.repeaters.map(&.id).should eq(ids)
+    end
+  end
+
+  it "REFUSES an out-of-range to_index rather than clamping it" do
+    with_store do |store|
+      ids = seed_three(store)
+      r = call_err(store, "move_repeater", %({"id":#{ids[0]},"to_index":9}))
+      r.text.should contain("outside this workbench")
+      r.text.should contain("1-3")
+      store.repeaters.map(&.id).should eq(ids) # nothing moved
+    end
+  end
+
+  it "refuses to_index and direction together" do
+    with_store do |store|
+      ids = seed_three(store)
+      call_err(store, "move_repeater", %({"id":#{ids[0]},"to_index":2,"direction":"down"}))
+        .text.should contain("not both")
+    end
+  end
+
+  it "refuses a nudge past the end, naming where it already is" do
+    with_store do |store|
+      ids = seed_three(store)
+      call_err(store, "move_repeater", %({"id":#{ids[2]},"direction":"down"}))
+        .text.should contain("already at the end")
+    end
+  end
+
+  it "refuses an unknown direction by naming the accepted values" do
+    with_store do |store|
+      ids = seed_three(store)
+      call_err(store, "move_repeater", %({"id":#{ids[0]},"direction":"sideways"}))
+        .text.should contain("up|down")
+    end
+  end
+
+  it "reports NOT_FOUND for an id that is not a session" do
+    with_store do |store|
+      seed_three(store)
+      call_err(store, "move_repeater", %({"id":9999,"to_index":1})).error_code.should eq("NOT_FOUND")
+    end
+  end
+end
+
+describe "MCP delete_repeaters" do
+  it "refuses without confirm, naming the count, and deletes NOTHING" do
+    with_store do |store|
+      ids = seed_three(store)
+      r = call_err(store, "delete_repeaters", %({"ids":[#{ids[0]},#{ids[1]}]}))
+      r.error_code.should eq("CONFIRM_REQUIRED")
+      r.text.should contain("2 repeater sessions")
+      store.repeaters.size.should eq(3)
+    end
+  end
+
+  it "refuses the WHOLE call when any id is unknown, with zero writes" do
+    with_store do |store|
+      ids = seed_three(store)
+      r = call_err(store, "delete_repeaters", %({"ids":[#{ids[0]},4242],"confirm":true}))
+      r.error_code.should eq("NOT_FOUND")
+      r.text.should contain("4242")
+      store.repeaters.size.should eq(3)
+    end
+  end
+
+  it "deletes the named set, reports each tab's old number, and renumbers the rest" do
+    with_store do |store|
+      ids = seed_three(store)
+      j = call_json(store, "delete_repeaters", %({"ids":[#{ids[0]},#{ids[2]}],"confirm":true}))
+      j["deleted_count"].as_i.should eq(2)
+      j["deleted"].as_a.map { |d| d["was_tui_index"].as_i }.should eq([1, 3])
+      j["deleted"].as_a.map { |d| d["name"].as_s }.should eq(%w[a c])
+      j["remaining"].as_i.should eq(1)
+      j["order"].as_a.map { |r| r["tui_index"].as_i }.should eq([1])
+      store.repeaters.map(&.id).should eq([ids[1]])
+      store.repeaters.map(&.position).should eq([0])
+    end
+  end
+
+  it "accepts a comma list and a bare id, and collapses a repeated id" do
+    with_store do |store|
+      ids = seed_three(store)
+      call_json(store, "delete_repeaters", %({"ids":"#{ids[0]},#{ids[0]}","confirm":true}))["deleted_count"].as_i.should eq(1)
+      call_json(store, "delete_repeaters", %({"ids":#{ids[1]},"confirm":true}))["deleted_count"].as_i.should eq(1)
+      store.repeaters.map(&.id).should eq([ids[2]])
+    end
+  end
+
+  it "names a non-integer entry instead of dropping it" do
+    with_store do |store|
+      seed_three(store)
+      call_err(store, "delete_repeaters", %({"ids":["1","nope"],"confirm":true}))
+        .text.should contain("nope")
+      store.repeaters.size.should eq(3)
+    end
+  end
+
+  it "refuses an empty ids list" do
+    with_store do |store|
+      seed_three(store)
+      call_err(store, "delete_repeaters", %({"ids":[],"confirm":true})).error_code.should eq("INVALID_ARGUMENT")
+    end
+  end
+end
+
+describe "MCP update_repeaters" do
+  it "adds tags to several sessions, keeping the ones they already had" do
+    with_store do |store|
+      ids = seed_three(store)
+      call_json(store, "update_repeater", %({"id":#{ids[0]},"tags":"auth"}))
+      j = call_json(store, "update_repeaters", %({"ids":[#{ids[0]},#{ids[1]}],"tags_add":"idor,#done"}))
+      j["updated_count"].as_i.should eq(2)
+      store.repeaters_mcp.find!(&.id.==(ids[0])).tags.should eq("auth idor done")
+      store.repeaters_mcp.find!(&.id.==(ids[1])).tags.should eq("idor done")
+      store.repeaters_mcp.find!(&.id.==(ids[2])).tags.should be_nil
+    end
+  end
+
+  it "removes tags case-insensitively and clears the column when none are left" do
+    with_store do |store|
+      ids = seed_three(store)
+      call_json(store, "update_repeaters", %({"ids":[#{ids[0]}],"tags_set":"IDOR auth"}))
+      call_json(store, "update_repeaters", %({"ids":[#{ids[0]}],"tags_remove":"idor"}))
+      store.repeaters_mcp.find!(&.id.==(ids[0])).tags.should eq("auth")
+      call_json(store, "update_repeaters", %({"ids":[#{ids[0]}],"tags_remove":"AUTH"}))
+      store.repeaters_mcp.find!(&.id.==(ids[0])).tags.should be_nil
+    end
+  end
+
+  it "refuses tags_set together with tags_add" do
+    with_store do |store|
+      ids = seed_three(store)
+      call_err(store, "update_repeaters", %({"ids":[#{ids[0]}],"tags_set":"x","tags_add":"y"}))
+        .text.should contain("not both")
+    end
+  end
+
+  it "refuses a call that would change nothing" do
+    with_store do |store|
+      ids = seed_three(store)
+      call_err(store, "update_repeaters", %({"ids":[#{ids[0]}]})).text.should contain("nothing to change")
+    end
+  end
+
+  it "affixes a stored name" do
+    with_store do |store|
+      ids = seed_three(store)
+      j = call_json(store, "update_repeaters", %({"ids":[#{ids[0]}],"name_prefix":"[P1] ","name_suffix":" ✓"}))
+      j["updated"][0]["name"].as_s.should eq("[P1] a ✓")
+      j["updated"][0]["name_materialised"]?.should be_nil
+      store.get_repeater(ids[0]).not_nil!.name.should eq("[P1] a ✓")
+    end
+  end
+
+  it "NAMES the sessions whose derived label it had to materialise" do
+    with_store do |store|
+      id = call_json(store, "create_repeater",
+        %({"target":"https://n.test","request":"POST /pay HTTP/1.1\\r\\nHost: n.test\\r\\n\\r\\n"}))["id"].as_i64
+      j = call_json(store, "update_repeaters", %({"ids":[#{id}],"name_prefix":"[P1] "}))
+      j["updated"][0]["name"].as_s.should eq("[P1] POST /pay")
+      j["updated"][0]["name_materialised"].as_bool.should be_true
+      j["name_materialised_note"].as_s.should contain("no longer follows the request")
+    end
+  end
+
+  it "refuses the whole call when any id is unknown" do
+    with_store do |store|
+      ids = seed_three(store)
+      r = call_err(store, "update_repeaters", %({"ids":[#{ids[0]},777],"tags_add":"x"}))
+      r.error_code.should eq("NOT_FOUND")
+      store.repeaters_mcp.find!(&.id.==(ids[0])).tags.should be_nil
+    end
+  end
+end
+
+describe "MCP create_repeaters" do
+  it "seeds one tab per flow, in the order given, with a prefix and shared tags" do
+    with_store do |store|
+      f1 = seed_flow(store, "GET", "/one")
+      f2 = seed_flow(store, "POST", "/two")
+      j = call_json(store, "create_repeaters",
+        %({"flow_ids":[#{f2},#{f1}],"name_prefix":"oas: ","tags":"spec"}))
+      j["created_count"].as_i.should eq(2)
+      j["created"].as_a.map { |c| c["flow_id"].as_i64 }.should eq([f2, f1])
+      j["created"].as_a.map { |c| c["tui_index"].as_i }.should eq([1, 2])
+      j["created"].as_a.map { |c| c["name"].as_s }.should eq(["oas: POST /two", "oas: GET /one"])
+      store.repeaters_mcp.map(&.tags).should eq(["spec", "spec"])
+      store.repeaters_mcp.map(&.flow_id).should eq([f2, f1])
+    end
+  end
+
+  it "refuses the WHOLE call when any flow is unknown, creating nothing" do
+    with_store do |store|
+      f1 = seed_flow(store, "GET", "/one")
+      r = call_err(store, "create_repeaters", %({"flow_ids":[#{f1},31337]}))
+      r.error_code.should eq("NOT_FOUND")
+      r.text.should contain("31337")
+      store.repeaters.should be_empty
+    end
+  end
+
+  it "appends after the sessions already in the workbench" do
+    with_store do |store|
+      existing = seed_three(store)
+      f1 = seed_flow(store, "GET", "/one")
+      j = call_json(store, "create_repeaters", %({"flow_ids":[#{f1}]}))
+      j["created"][0]["tui_index"].as_i.should eq(4)
+      store.repeaters.map(&.id).should eq(existing + [j["created"][0]["id"].as_i64])
+    end
+  end
+
+  it "refuses an empty flow_ids list" do
+    with_store do |store|
+      call_err(store, "create_repeaters", %({"flow_ids":[]})).error_code.should eq("INVALID_ARGUMENT")
+    end
+  end
+end

--- a/spec/mcp/repeater_env_headers_spec.cr
+++ b/spec/mcp/repeater_env_headers_spec.cr
@@ -1,0 +1,194 @@
+require "../spec_helper"
+
+# `env_headers` and the inlined last response body on `get_repeater_context` (#904).
+#
+# `redact_head` cannot tell `Authorization: Bearer $AUTH` from `Authorization: Bearer <token>`
+# — both are blanked — so the operator could not confirm which env key a saved request was
+# wired to without asking for the secret. These pin the shape projection: a reference and a
+# scheme survive, everything else collapses.
+
+private def with_store(&)
+  path = File.tempname("gori-envheaders", ".db")
+  store = Gori::Store.open(path)
+  prev_env = Gori::Settings.project_env_vars
+  begin
+    yield store
+  ensure
+    Gori::Settings.project_env_vars = prev_env
+    Gori::Env.bump_highlight_rev
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+private def tools(store)
+  Gori::MCP::Tools.new(store, allow_actions: true, verify_upstream: false)
+end
+
+private def call_json(store, name, args : String) : JSON::Any
+  r = tools(store).call(name, JSON.parse(args))
+  fail "#{name} errored: #{r.text}" if r.is_error
+  JSON.parse(r.text)
+end
+
+private def seeded_500(store) : Int64
+  id = store.insert_repeater("https://api.test", "GET /a HTTP/1.1\r\nHost: h\r\n\r\n".to_slice,
+    false, true, nil, 0)
+  store.update_repeater_response(id,
+    "HTTP/1.1 500 Internal Server Error\r\nContent-Type: application/json\r\n\r\n".to_slice,
+    %({"error":"boom"}).to_slice, nil, 42_i64)
+  id
+end
+
+private def shapes_for(store, request : String) : Hash(String, String)
+  id = store.insert_repeater("https://api.test", request.to_slice, false, true, nil, 0)
+  got = call_json(store, "get_repeater_context", %({"id":#{id},"include_content":true}))
+  h = {} of String => String
+  got["sessions"][0]["env_headers"]?.try(&.as_a.each { |e| h[e["name"].as_s] = e["shape"].as_s })
+  h
+end
+
+describe "MCP repeater env_headers" do
+  it "keeps an env reference and its scheme readable" do
+    with_store do |store|
+      shapes_for(store, "GET /a HTTP/1.1\r\nHost: h\r\nAuthorization: Bearer $AUTH\r\n\r\n")
+        .should eq({"Authorization" => "Bearer $AUTH"})
+    end
+  end
+
+  it "collapses a literal credential to the scheme alone" do
+    with_store do |store|
+      shapes_for(store, "GET /a HTTP/1.1\r\nHost: h\r\nAuthorization: Bearer eyJhbGciOi.J9.sig\r\n\r\n")
+        .should eq({"Authorization" => "Bearer …"})
+    end
+  end
+
+  it "collapses a bare token that carries no scheme at all" do
+    with_store do |store|
+      shapes_for(store, "GET /a HTTP/1.1\r\nHost: h\r\nX-Api-Key: abcdef0123456789\r\n\r\n")
+        .should eq({"X-Api-Key" => "…"})
+    end
+  end
+
+  it "keeps cookie NAMES and only the values that are references" do
+    with_store do |store|
+      shapes_for(store, "GET /a HTTP/1.1\r\nHost: h\r\nCookie: _test=$TEST; sid=abc123; csrf=$CSRF\r\n\r\n")
+        .should eq({"Cookie" => "_test=$TEST; sid=…; csrf=$CSRF"})
+    end
+  end
+
+  it "does not treat the $$ escape as a reference" do
+    with_store do |store|
+      shapes_for(store, "GET /a HTTP/1.1\r\nHost: h\r\nAuthorization: Bearer $$NOTAREF\r\n\r\n")
+        .should eq({"Authorization" => "Bearer …"})
+    end
+  end
+
+  it "names a LIVE value that matches a registered env var, rather than printing it" do
+    with_store do |store|
+      call_json(store, "set_env_var", %({"key":"AUTH","value":"s3cr3t-token-value"}))
+      shapes_for(store, "GET /a HTTP/1.1\r\nHost: h\r\nAuthorization: Bearer s3cr3t-token-value\r\n\r\n")
+        .should eq({"Authorization" => "Bearer $AUTH"})
+    end
+  end
+
+  it "reports nothing for a request with no credential header" do
+    with_store do |store|
+      shapes_for(store, "GET /a HTTP/1.1\r\nHost: h\r\nAccept: */*\r\n\r\n").should be_empty
+    end
+  end
+
+  it "never emits env_headers without include_content" do
+    with_store do |store|
+      id = store.insert_repeater("https://api.test",
+        "GET /a HTTP/1.1\r\nHost: h\r\nAuthorization: Bearer $AUTH\r\n\r\n".to_slice, false, true, nil, 0)
+      call_json(store, "get_repeater_context", %({"id":#{id}}))["sessions"][0]["env_headers"]?.should be_nil
+    end
+  end
+
+  it "leaves the redacted request head itself unchanged" do
+    with_store do |store|
+      id = store.insert_repeater("https://api.test",
+        "GET /a HTTP/1.1\r\nHost: h\r\nAuthorization: Bearer $AUTH\r\n\r\n".to_slice, false, true, nil, 0)
+      got = call_json(store, "get_repeater_context", %({"id":#{id},"include_content":true}))
+      got["sessions"][0]["request"].as_s.should contain("[REDACTED]")
+      got["sessions"][0]["request"].as_s.should_not contain("$AUTH")
+    end
+  end
+end
+
+describe "MCP list_env value shape" do
+  it "reports length and the scheme a value already carries, never the value" do
+    with_store do |store|
+      call_json(store, "set_env_var", %({"key":"AUTH","value":"Bearer eyJhbGciOiJ9"}))
+      call_json(store, "set_env_var", %({"key":"RAW","value":"eyJhbGciOiJ9"}))
+      rows = call_json(store, "list_env", "{}").as_a
+      auth = rows.find! { |r| r["key"].as_s == "AUTH" }
+      raw = rows.find! { |r| r["key"].as_s == "RAW" }
+      auth["value"].as_s.should eq("[REDACTED]")
+      auth["scheme"].as_s.should eq("Bearer")
+      auth["length"].as_i.should eq(19)
+      raw["scheme"]?.should be_nil
+      raw["length"].as_i.should eq(12)
+      rows.to_json.should_not contain("eyJhbGciOiJ9")
+    end
+  end
+end
+
+describe "MCP repeater last_response_body" do
+  it "is absent unless asked for, so a listing never pulls body BLOBs by default" do
+    with_store do |store|
+      id = seeded_500(store)
+      got = call_json(store, "get_repeater_context", %({"id":#{id},"include_content":true}))
+      got["sessions"][0]["last_response_head"].as_s.should contain("500")
+      got["sessions"][0]["last_response_body"]?.should be_nil
+    end
+  end
+
+  it "inlines the stored body when include_response_body is set" do
+    with_store do |store|
+      id = seeded_500(store)
+      s = call_json(store, "get_repeater_context",
+        %({"id":#{id},"include_response_body":true}))["sessions"][0]
+      s["last_response_body"].as_s.should eq(%({"error":"boom"}))
+      s["last_response_body_representation"].as_s.should eq("raw")
+    end
+  end
+
+  it "caps the body and names the cursor that serves the rest" do
+    with_store do |store|
+      id = store.insert_repeater("https://api.test", "GET /a HTTP/1.1\r\n\r\n".to_slice, false, true, nil, 0)
+      store.update_repeater_response(id, "HTTP/1.1 200 OK\r\n\r\n".to_slice, ("x" * 5000).to_slice, nil, 1_i64)
+      s = call_json(store, "get_repeater_context",
+        %({"id":#{id},"include_response_body":true,"max_body_bytes":100}))["sessions"][0]
+      s["last_response_body"].as_s.size.should eq(100)
+      s["last_response_body_truncated"].as_bool.should be_true
+      s["last_response_body_total_bytes"].as_i.should eq(5000)
+      s["last_response_body_read_more"].as_s.should contain("get_response_body_chunk")
+    end
+  end
+
+  it "distinguishes a session with no stored body from one that was omitted" do
+    with_store do |store|
+      id = store.insert_repeater("https://api.test", "GET /a HTTP/1.1\r\n\r\n".to_slice, false, true, nil, 0)
+      call_json(store, "get_repeater_context",
+        %({"id":#{id},"include_response_body":true}))["sessions"][0]["last_response_body_absent"].as_bool.should be_true
+    end
+  end
+
+  it "hydrates a bounded head of a wide page and NAMES what it skipped" do
+    with_store do |store|
+      12.times do |i|
+        rid = store.insert_repeater("https://api.test/#{i}", "GET /#{i} HTTP/1.1\r\n\r\n".to_slice,
+          false, true, nil, i)
+        store.update_repeater_response(rid, "HTTP/1.1 200 OK\r\n\r\n".to_slice, "body".to_slice, nil, 1_i64)
+      end
+      got = call_json(store, "get_repeater_context", %({"include_response_body":true}))
+      got["sessions"].as_a.count { |s| s["last_response_body"]? }.should eq(10)
+      got["response_bodies_omitted"].as_i.should eq(2)
+      got["response_bodies_omitted_note"].as_s.should contain("narrow")
+    end
+  end
+end

--- a/spec/mcp/repeater_filter_spec.cr
+++ b/spec/mcp/repeater_filter_spec.cr
@@ -1,0 +1,129 @@
+require "../spec_helper"
+
+# `get_repeater_context{filter}` — the TUI's own sub-tab filter language, answered headlessly
+# over stored rows. The point of the shared grammar is that ONE session cannot be described
+# differently by the operator's `/` and an agent's `filter`, so the projections are pinned
+# against each other here rather than only against literals.
+
+private def with_store(&)
+  path = File.tempname("gori-repfilter", ".db")
+  store = Gori::Store.open(path)
+  begin
+    yield store
+  ensure
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+private def tools(store)
+  Gori::MCP::Tools.new(store, allow_actions: true, verify_upstream: false)
+end
+
+private def call_json(store, name, args : String) : JSON::Any
+  r = tools(store).call(name, JSON.parse(args))
+  fail "#{name} errored: #{r.text}" if r.is_error
+  JSON.parse(r.text)
+end
+
+private def names(store, args : String) : Array(String)
+  call_json(store, "get_repeater_context", args)["sessions"].as_a.map { |s| s["name"]?.try(&.as_s) || "" }
+end
+
+private def seed(store) : Nil
+  a = store.insert_repeater("https://api.test/v1", "GET /v1/users HTTP/1.1\r\nHost: api.test\r\n\r\n".to_slice,
+    false, true, nil, 0)
+  store.set_repeater_name(a, "users")
+  store.set_repeater_tags(a, "idor auth")
+  store.update_repeater_response(a, "HTTP/1.1 200 OK\r\n\r\n".to_slice, "{}".to_slice, nil, 12_i64)
+
+  b = store.insert_repeater("https://shop.test/cart", "POST /cart HTTP/1.1\r\nHost: shop.test\r\n\r\n".to_slice,
+    false, true, nil, 1)
+  store.set_repeater_name(b, "cart")
+  store.set_repeater_tags(b, "idor")
+  store.update_repeater_response(b, "HTTP/1.1 403 Forbidden\r\n\r\n".to_slice, nil, nil, 9_i64)
+
+  c = store.insert_repeater("https://shop.test/admin", "DELETE /admin HTTP/1.1\r\nHost: shop.test\r\n\r\n".to_slice,
+    false, true, nil, 2)
+  store.set_repeater_name(c, "admin")
+  store.update_repeater_response(c, Bytes.empty, nil, "connection refused", 3_i64)
+
+  d = store.insert_repeater("https://shop.test/new", "GET /new HTTP/1.1\r\nHost: shop.test\r\n\r\n".to_slice,
+    false, true, nil, 3)
+  store.set_repeater_name(d, "unsent")
+end
+
+describe "MCP get_repeater_context filter" do
+  it "filters by tag" do
+    with_store do |store|
+      seed(store)
+      names(store, %({"filter":"tag:idor"})).should eq(%w[users cart])
+      names(store, %({"filter":"-tag:idor"})).should eq(%w[admin unsent])
+    end
+  end
+
+  it "filters by host and method" do
+    with_store do |store|
+      seed(store)
+      names(store, %({"filter":"host:shop.test"})).should eq(%w[cart admin unsent])
+      names(store, %({"filter":"method:get"})).should eq(%w[users unsent])
+      names(store, %({"filter":"host:shop.test method:get"})).should eq(%w[unsent])
+    end
+  end
+
+  it "filters by the last send's status, by prefix" do
+    with_store do |store|
+      seed(store)
+      names(store, %({"filter":"status:200"})).should eq(%w[users])
+      names(store, %({"filter":"status:4"})).should eq(%w[cart])
+      names(store, %({"filter":"status:error"})).should eq(%w[admin])
+      names(store, %({"filter":"status:unsent"})).should eq(%w[unsent])
+    end
+  end
+
+  it "ANDs filter with query rather than replacing it" do
+    with_store do |store|
+      seed(store)
+      names(store, %({"query":"shop.test","filter":"tag:idor"})).should eq(%w[cart])
+    end
+  end
+
+  it "matches nothing — and says so — for a term no session has" do
+    with_store do |store|
+      seed(store)
+      names(store, %({"filter":"tag:nosuchtag"})).should be_empty
+    end
+  end
+
+  it "reports a filter that produced no usable term instead of quietly returning everything" do
+    with_store do |store|
+      seed(store)
+      got = call_json(store, "get_repeater_context", %({"filter":"()"}))
+      got["sessions"].as_a.size.should eq(4)
+      got["filter_ignored"].as_bool.should be_true
+      got["filter_ignored_note"].as_s.should contain("narrowed nothing")
+    end
+  end
+
+  it "agrees with the projection the TUI's own strip filters on" do
+    with_store do |store|
+      seed(store)
+      rows = store.repeaters_mcp
+      f = Gori::Repeater::SubtabFilter.parse("host:shop.test -tag:idor")
+      expected = rows.select { |r| f.matches?(Gori::Repeater::SubtabFilter::Subject.from_row(r)) }.map(&.name)
+      names(store, %({"filter":"host:shop.test -tag:idor"})).should eq(expected)
+    end
+  end
+
+  it "survives a session whose request bytes are not valid UTF-8" do
+    with_store do |store|
+      seed(store)
+      bad = store.insert_repeater("https://bin.test", Bytes[0x47, 0x45, 0x54, 0x20, 0xff, 0x0d, 0x0a, 0x0d, 0x0a],
+        false, true, nil, 9)
+      store.set_repeater_name(bad, "binary")
+      names(store, %({"filter":"host:bin"})).should eq(%w[binary])
+    end
+  end
+end

--- a/spec/store/repeaters_spec.cr
+++ b/spec/store/repeaters_spec.cr
@@ -72,6 +72,49 @@ describe "Gori::Store repeater tabs (v9)" do
     end
   end
 
+  it "renumbers the workbench densely in the given order" do
+    with_store do |store|
+      a = store.insert_repeater("https://a.test", "a".to_slice, false, true, nil, 0)
+      b = store.insert_repeater("https://b.test", "b".to_slice, false, true, nil, 1)
+      c = store.insert_repeater("https://c.test", "c".to_slice, false, true, nil, 2)
+
+      store.set_repeater_positions([c, a, b]).should be_true
+      store.repeaters.map(&.id).should eq([c, a, b])
+      store.repeaters.map(&.position).should eq([0, 1, 2])
+    end
+  end
+
+  it "repairs a sparse, COLLIDING position space (the shape a close used to leave)" do
+    with_store do |store|
+      # Positions {0, 5, 5}: what the workbench looked like after closes, because
+      # `insert_repeater`'s callers passed the row COUNT and nothing renumbered.
+      a = store.insert_repeater("https://a.test", "a".to_slice, false, true, nil, 0)
+      b = store.insert_repeater("https://b.test", "b".to_slice, false, true, nil, 5)
+      c = store.insert_repeater("https://c.test", "c".to_slice, false, true, nil, 5)
+
+      store.set_repeater_positions(store.repeaters.map(&.id))
+      store.repeaters.map(&.position).should eq([0, 1, 2])
+      store.repeaters.map(&.id).should eq([a, b, c])
+    end
+  end
+
+  it "appends past the HIGHEST position in use, not the row count" do
+    with_store do |store|
+      # A sparse space is exactly where `repeaters_meta.size` put a new tab in the MIDDLE.
+      store.insert_repeater("https://a.test", "a".to_slice, false, true, nil, 0)
+      store.insert_repeater("https://b.test", "b".to_slice, false, true, nil, 9)
+      store.next_repeater_position.should eq(10)
+
+      last = store.insert_repeater("https://c.test", "c".to_slice, false, true, nil,
+        store.next_repeater_position)
+      store.repeaters.last.id.should eq(last)
+    end
+  end
+
+  it "starts from 0 on an empty workbench" do
+    with_store { |store| store.next_repeater_position.should eq(0) }
+  end
+
   it "starts a fresh tab with no persisted response (V11 columns NULL)" do
     with_store do |store|
       id = store.insert_repeater("https://a.test", "GET / HTTP/1.1\r\n\r\n".to_slice, false, true, nil, 0)

--- a/spec/tui/repeater_status_token_spec.cr
+++ b/spec/tui/repeater_status_token_spec.cr
@@ -1,0 +1,53 @@
+require "../spec_helper"
+
+include Gori::Tui
+
+# `RepeaterView#status_token` — the LIVE half of the sub-tab filter's `status:` field.
+#
+# The stored-row half (`SubtabFilter::Subject.from_row`, which MCP's `get_repeater_context
+# {filter}` reads) is covered in spec/mcp/repeater_filter_spec.cr. Both must spell one
+# session the same way, or the operator's `/` and an agent's `filter` would answer
+# differently about the same tab — which is why both go through `Subject.status_token`.
+describe "RepeaterView#status_token" do
+  it "reads unsent before anything has been sent" do
+    RepeaterView.new.status_token.should eq("unsent")
+  end
+
+  it "reads the status code of a restored response" do
+    view = RepeaterView.new
+    view.restore("https://h.test", "GET / HTTP/1.1\r\n\r\n", false, true,
+      response_head: "HTTP/1.1 403 Forbidden\r\n\r\n".to_slice)
+    view.status_token.should eq("403")
+  end
+
+  it "reads error when the send itself failed, even with a head from an earlier send" do
+    view = RepeaterView.new
+    view.restore("https://h.test", "GET / HTTP/1.1\r\n\r\n", false, true,
+      response_head: "HTTP/1.1 200 OK\r\n\r\n".to_slice,
+      response_error: "connection refused")
+    view.status_token.should eq("error")
+  end
+
+  it "agrees with the stored-row projection for the same session" do
+    path = File.tempname("gori-rvstatus", ".db")
+    store = Gori::Store.open(path)
+    begin
+      id = store.insert_repeater("https://h.test", "GET / HTTP/1.1\r\n\r\n".to_slice, false, true, nil, 0)
+      store.update_repeater_response(id, "HTTP/1.1 502 Bad Gateway\r\n\r\n".to_slice, nil, nil, 5_i64)
+      row = store.repeaters.first
+
+      view = RepeaterView.new
+      view.restore(row.target, String.new(row.request), row.http2?, row.auto_content_length?,
+        response_head: row.response_head, response_body: row.response_body,
+        response_error: row.response_error, response_duration_us: row.response_duration_us)
+
+      view.status_token.should eq(Gori::Repeater::SubtabFilter::Subject.from_row(row).status)
+      view.status_token.should eq("502")
+    ensure
+      store.close
+      File.delete?(path)
+      File.delete?("#{path}-wal")
+      File.delete?("#{path}-shm")
+    end
+  end
+end

--- a/src/gori/cli/run.cr
+++ b/src/gori/cli/run.cr
@@ -188,6 +188,8 @@ module Gori
         {"show <id>", "Print a flow's request/response (text, json, raw bytes, HAR, curl/python/fetch/go/httpie, or a CSRF PoC)"},
         {"repeater", "Re-send a captured flow; list/create/send (replay, incl. WebSocket) repeater sessions"},
         {"repeater minimize", "Strip noise from a saved request, keeping the response the same"},
+        {"repeater move", "Rearrange the sub-tab strip: move a session to a tab number (--to N) or one place (--up/--down)"},
+        {"repeater delete", "Delete saved repeater sessions by id (needs --yes)"},
         {"compare <a> <b>", "Diff two flows' request or response (unified diff)"},
         {"diff", "Retest report: diff two projects at endpoint scale (--from/--to, text/json/md)"},
         {"intercept", "Inspect/drive a live TUI's paused intercept queue (list, forward, drop, edit, …)"},

--- a/src/gori/cli/run/repeater.cr
+++ b/src/gori/cli/run/repeater.cr
@@ -13,6 +13,11 @@ module Gori
                         "client's hello, not a byte-exact JA3 match — `gori settings tls-fingerprint " \
                         "HOST --preset NAME` prints what actually goes out. Empty value = no override"
 
+      # `gori run repeater [list|create|send|minimize|h2|move|delete] …`, or a bare flow id /
+      # `--flow` for the one-shot resend.
+      #
+      # Matched on argv[0] only, so a subcommand name is never confused with the flow id the
+      # bare form takes.
       private def self.cmd_repeater(args : Array(String)) : Nil
         sub = args.first?
         if sub == "list"
@@ -29,6 +34,12 @@ module Gori
           return
         elsif sub == "h2"
           cmd_repeater_h2fields(args[1..])
+          return
+        elsif sub == "move"
+          cmd_repeater_move(args[1..])
+          return
+        elsif sub == "delete"
+          cmd_repeater_delete(args[1..])
           return
         end
 
@@ -177,9 +188,13 @@ module Gori
           if format == :json
             puts(JSON.build do |j|
               j.array do
-                repeaters.each do |r|
+                repeaters.each_with_index do |r, i|
                   j.object do
                     j.field "id", r.id
+                    # Both numbers, named. `position` is the ordering COLUMN; `tui_index` is
+                    # what the TUI paints on the sub-tab chip, which is the number the
+                    # operator reads and the one MCP's repeater replies carry.
+                    j.field "tui_index", i + 1
                     j.field "position", r.position
                     j.field "name", r.name || "Untitled"
                     j.field "tags", r.tags
@@ -201,7 +216,11 @@ module Gori
             if repeaters.empty?
               puts "No repeater sessions in the workbench."
             else
-              repeaters.each do |r|
+              # The chip number leads the line, so `6` here and `6:` on the TUI strip are the
+              # same tab — the mapping #904 was filed about. The database id follows it,
+              # because that is what every command and every MCP tool actually takes.
+              width = repeaters.size.to_s.size
+              repeaters.each_with_index do |r, i|
                 name = r.name || "Untitled"
                 h2 = r.http2? ? "H2" : "H1"
                 # The fingerprint is APPENDED, and only when set, so a workbench with no
@@ -210,10 +229,176 @@ module Gori
                 # that a stored preset is visible ("`repeater list` and the TUI chip both name
                 # a browser") — a claim that was not true of this listing.
                 tls = r.tls_preset.try { |t| "  tls:#{t}" } || ""
-                puts "##{r.id}  [#{h2}]  #{name.ljust(20)}  → #{r.target}#{tls}"
+                puts "#{(i + 1).to_s.rjust(width)}  ##{r.id}  [#{h2}]  #{name.ljust(20)}  → #{r.target}#{tls}"
               end
             end
           end
+        ensure
+          store.close
+        end
+      end
+
+      # `gori run repeater move <id> --to N | --up | --down` — rearrange the sub-tab strip.
+      #
+      # `--to` takes the 1-based TAB NUMBER, the same one `repeater list` prints and the TUI
+      # paints on the chip; `<id>` is the database id, as everywhere else on this surface.
+      # That split is deliberate: a destination that is stale merely misplaces this session,
+      # while a stale SELECTOR would act on a different one.
+      #
+      # An open TUI picks the new order up on its own — its reconcile poll re-sorts by
+      # {position, id} whenever a peer commits.
+      private def self.cmd_repeater_move(args : Array(String)) : Nil
+        db_path : String? = nil
+        project_name : String? = nil
+        to : Int32? = nil
+        dir = 0
+        format = :text
+        positional = [] of String
+
+        parser = OptionParser.new do |p|
+          p.banner = "Usage: gori run repeater move <repeater-id> (--to N | --up | --down)"
+          p.on("--to=N", "Move to this 1-based tab number (the number `repeater list` prints)") do |v|
+            to = v.to_i32? || abort("gori run repeater move: invalid --to '#{v}' (expected a 1-based tab number)")
+          end
+          p.on("--up", "Move one place toward tab 1") { dir = -1 }
+          p.on("--down", "Move one place toward the end") { dir = 1 }
+          p.on("--project=NAME", "Project to act on (default: most-recently-active)") { |v| project_name = v }
+          p.on("--db=PATH", "Explicit SQLite db file") { |v| db_path = v }
+          p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
+          p.on("-h", "--help", "Show this help") { puts p; exit 0 }
+          p.invalid_option { |f| abort "gori run repeater move: unknown option: #{f}\n#{p}" }
+          p.missing_option { |f| abort "gori run repeater move: missing value for #{f}" }
+          # Through the helper IN the sink, not twenty lines below it: a bare
+          # `positional = before + after` here reads fine and drops every token after the
+          # first, which is the shape `list_leftovers_spec`'s source gate exists to catch.
+          p.unknown_args do |before, after|
+            positional = one_positional_list(before, after, "gori run repeater move", "<repeater-id>")
+          end
+        end
+        parser.parse(args)
+
+        id_s = positional.first? || abort("gori run repeater move: <repeater-id> is required\n#{parser}")
+        id = id_s.to_i64? || abort("gori run repeater move: invalid repeater id '#{id_s}'")
+
+        # Two answers to one question. Choosing one silently is how a tab lands somewhere
+        # nobody asked for — the same refusal MCP's `move_repeater` makes.
+        abort "gori run repeater move: pass --to or --up/--down, not both" if to && dir != 0
+        abort "gori run repeater move: pass one of --to N, --up or --down\n#{parser}" if to.nil? && dir == 0
+
+        store = open_store(resolve_read_project(project_name, db_path))
+        begin
+          rows = store.repeaters_meta
+          from = rows.index { |r| r.id == id }
+          abort "gori run repeater move: no repeater session ##{id} (see `gori run repeater list`)" unless from
+          from += 1
+
+          target =
+            if t = to
+              # REFUSED, not clamped: a clamp would move the session somewhere other than
+              # where the command named and still exit 0.
+              abort "gori run repeater move: --to #{t} is outside this workbench (1-#{rows.size})" unless 1 <= t <= rows.size
+              t
+            else
+              t2 = from + dir
+              abort "gori run repeater move: session ##{id} is already at the #{dir < 0 ? "start" : "end"} " \
+                    "of the workbench (tab #{from} of #{rows.size})" unless 1 <= t2 <= rows.size
+              t2
+            end
+
+          moved = target != from
+          if moved
+            ids = rows.map(&.id)
+            ids.delete_at(from - 1)
+            ids.insert(target - 1, id)
+            abort "gori run repeater move: NOT moved (project busy or unwritable); the order is unchanged" unless store.set_repeater_positions(ids)
+          end
+
+          if format == :json
+            puts({"id" => id, "from_index" => from, "to_index" => target, "moved" => moved}.to_json)
+          elsif moved
+            puts "Repeater session ##{id} moved from tab #{from} to tab #{target}."
+          else
+            puts "Repeater session ##{id} is already tab #{target}."
+          end
+        ensure
+          store.close
+        end
+      end
+
+      # `gori run repeater delete <id> [<id>…] --yes` — close saved sessions headlessly.
+      #
+      # `--yes` is required because there is no undo: a session's request bytes, its stored
+      # WebSocket frames and any issue link pointing at it go with it. Unknown ids refuse the
+      # WHOLE command before the first delete, so a typo cannot destroy the eight that did
+      # exist and report the ninth as skipped.
+      private def self.cmd_repeater_delete(args : Array(String)) : Nil
+        db_path : String? = nil
+        project_name : String? = nil
+        yes = false
+        format = :text
+        positional = [] of String
+
+        parser = OptionParser.new do |p|
+          p.banner = "Usage: gori run repeater delete <repeater-id> [<repeater-id>…] --yes"
+          p.on("-y", "--yes", "Confirm the deletion (required)") { yes = true }
+          p.on("--project=NAME", "Project to act on (default: most-recently-active)") { |v| project_name = v }
+          p.on("--db=PATH", "Explicit SQLite db file") { |v| db_path = v }
+          p.on("--format=FMT", "Output: text (default) | json") { |v| format = parse_format(v, [:text, :json]) }
+          p.on("-h", "--help", "Show this help") { puts p; exit 0 }
+          p.invalid_option { |f| abort "gori run repeater delete: unknown option: #{f}\n#{p}" }
+          p.missing_option { |f| abort "gori run repeater delete: missing value for #{f}" }
+          p.unknown_args { |before, after| positional = before + after }
+        end
+        parser.parse(args)
+
+        abort "gori run repeater delete: at least one <repeater-id> is required\n#{parser}" if positional.empty?
+        ids = positional.map do |tok|
+          tok.to_i64? || abort("gori run repeater delete: invalid repeater id '#{tok}'")
+        end
+        ids = ids.uniq
+
+        store = open_store(resolve_read_project(project_name, db_path))
+        begin
+          rows = store.repeaters_mcp
+          by_id = rows.index_by(&.id)
+          missing = ids.reject { |i| by_id.has_key?(i) }
+          abort "gori run repeater delete: no repeater session #{missing.join(", ")} — nothing was deleted " \
+                "(see `gori run repeater list`)" unless missing.empty?
+
+          unless yes
+            abort "gori run repeater delete: refusing to delete #{ids.size} session#{ids.size == 1 ? "" : "s"} " \
+                  "without --yes; this cannot be undone"
+          end
+
+          # The tab number each id HAS, taken once before the first delete — every later tab
+          # shifts down, so a number read mid-batch would be relative to a different strip.
+          tab_of = {} of Int64 => Int32
+          rows.each_with_index { |r, i| tab_of[r.id] = i + 1 }
+
+          deleted = [] of {Int64, String, Int32}
+          failed = [] of Int64
+          ids.each do |i|
+            was = tab_of[i]
+            if store.delete_repeater(i)
+              deleted << {i, by_id[i].name || "Untitled", was}
+            else
+              failed << i
+            end
+          end
+          gone = deleted.map { |(i, _, _)| i }.to_set
+          store.set_repeater_positions(rows.reject { |r| gone.includes?(r.id) }.map(&.id))
+
+          if format == :json
+            puts({
+              "deleted"   => deleted.map { |(i, n, was)| {"id" => i, "name" => n, "was_tui_index" => was} },
+              "failed"    => failed,
+              "remaining" => rows.size - deleted.size,
+            }.to_json)
+          else
+            deleted.each { |(i, n, was)| puts "Deleted repeater session ##{i} (tab #{was}, #{n})." }
+            STDERR.puts "NOT deleted (project busy or unwritable): #{failed.join(", ")}" unless failed.empty?
+          end
+          exit 1 unless failed.empty?
         ensure
           store.close
         end
@@ -383,7 +568,7 @@ module Gori
           end
           tls_preset = Settings.tls_preset_normalize(tls_preset)
 
-          pos = store.repeaters_meta.size
+          pos = store.next_repeater_position
 
           # The REQUEST, the TARGET and the SNI are all stored as authored. Same seam and same
           # reason as `MCP::Tools#stored_request`: `mask_secrets` here rewrote an author's live

--- a/src/gori/mcp/serialize.cr
+++ b/src/gori/mcp/serialize.cr
@@ -36,6 +36,122 @@ module Gori
         SENSITIVE_HEADERS.includes?(name.strip.downcase)
       end
 
+      # The auth schemes a credential header may carry in FRONT of its secret. Kept verbatim
+      # by `env_header_shapes`, because "is the scheme already inside `$AUTH`, or do I write
+      # `Bearer $AUTH`?" is precisely the question that projection exists to answer — and a
+      # scheme keyword is a registered IANA name, not a secret.
+      AUTH_SCHEMES = {"bearer", "basic", "digest", "token", "apikey", "negotiate", "ntlm",
+                      "hoba", "mutual", "vapid", "scram-sha-1", "scram-sha-256",
+                      "aws4-hmac-sha256"}
+
+      # `{name, shape}` for every sensitive header in a request head: the header's value with
+      # everything that is NOT an env reference, a cookie name or an auth scheme collapsed to
+      # `…`.
+      #
+      # It exists because `redact_head` cannot tell the two apart. A repeater row stores what
+      # the author typed (see `MCP::Tools#stored_request`), so a session wired to an env var
+      # holds the literal bytes `Authorization: Bearer $AUTH` — and `redact_head` blanks that
+      # to `[REDACTED]` exactly as it blanks a live token. The operator then cannot confirm
+      # which key is wired into a request without asking for `include_sensitive`, i.e. without
+      # asking for the secret. This is the additive answer:
+      #
+      #     Authorization: Bearer $AUTH     ← env-bound, and readable
+      #     Authorization: Bearer …         ← a literal credential, and still withheld
+      #     Cookie: _test=$TEST; sid=…
+      #
+      # Nothing here weakens `redact_head`; the redacted head is still what `request` carries.
+      # Three classes of byte survive, and only three: an env token (a REFERENCE, whose name
+      # `list_env` already publishes), a cookie NAME (an identifier every response and every
+      # script already sees), and a scheme keyword. Every other run becomes `…`, including a
+      # value gori simply does not recognise.
+      #
+      # `Env.mask_secrets` runs first, so a session that stored a LIVE value whose bytes match
+      # a registered var reads back as that var's name — the same projection `create_repeater`
+      # already applies to `summary`/`target`, and it is reported there by `secrets_masked`.
+      def self.env_header_shapes(head : String) : Array({String, String})
+        # `shapes`, not `out`: `out` is a Crystal keyword (C-binding out-parameters), so
+        # `return out unless …` parses as one and fails to compile.
+        shapes = [] of {String, String}
+        return shapes unless head.includes?(':')
+        head.scrub.each_line.each_with_index do |raw, i|
+          line = raw.chomp
+          break if line.empty? # end of the head; the body is not header-shaped
+          next if i.zero?      # the request line
+          colon = line.index(':')
+          next unless colon
+          name = line[0...colon]
+          next unless sensitive_header?(name)
+          value = line[(colon + 1)..].strip
+          next if value.empty?
+          masked = Env.mask_secrets(value)
+          shape = cookie_header?(name) ? cookie_shape(masked) : scheme_shape(masked)
+          shapes << {name.strip, shape}
+        end
+        shapes
+      end
+
+      private def self.cookie_header?(name : String) : Bool
+        n = name.strip.downcase
+        n == "cookie" || n == "set-cookie"
+      end
+
+      # Is the WHOLE string one env token? Asked through `Env.token_regions`, the one scanner
+      # that owns the `$NAME` grammar (and the `$$` escape) — a second regex here would be a
+      # second answer to "is this a reference", and the wrong answer prints a secret.
+      private def self.env_token?(s : String) : Bool
+        regions = Env.token_regions(s)
+        regions.size == 1 && regions[0][0] == 0 && regions[0][1] == s.size
+      end
+
+      # A whitespace-delimited credential header: keep scheme keywords and env references,
+      # collapse every other run.
+      private def self.scheme_shape(value : String) : String
+        parts = value.split(/\s+/).reject(&.empty?)
+        return "…" if parts.empty?
+        kept = parts.map do |tok|
+          if env_token?(tok) || AUTH_SCHEMES.includes?(tok.downcase)
+            tok
+          else
+            "…"
+          end
+        end
+        collapse(kept).join(' ')
+      end
+
+      # A cookie header: `name=value` pairs. The NAME is kept (identifiers, not secrets, and
+      # naming which cookie is wired is the whole point); the value only when it is entirely
+      # an env reference.
+      private def self.cookie_shape(value : String) : String
+        pairs = value.split(';').map(&.strip).reject(&.empty?)
+        return "…" if pairs.empty?
+        pairs.map { |pair|
+          eq = pair.index('=')
+          next "…" unless eq
+          key = pair[0...eq]
+          val = pair[(eq + 1)..]
+          next "…" unless cookie_name?(key)
+          "#{key}=#{env_token?(val) ? val : "…"}"
+        }.join("; ")
+      end
+
+      # RFC 6265 cookie-name shape, length-capped. A name that is not token-shaped is not the
+      # identifier this projection assumes it is, so it is withheld with its value.
+      private def self.cookie_name?(key : String) : Bool
+        return false if key.empty? || key.size > 64
+        key.each_char.all? { |c| c.ascii_alphanumeric? || "!#$%&'*+-.^_`|~".includes?(c) }
+      end
+
+      # Runs of `…` become one `…`: three unrecognised tokens in a row are one unreadable
+      # value, and printing `… … …` would suggest a structure the reader cannot check.
+      private def self.collapse(parts : Array(String)) : Array(String)
+        kept = [] of String
+        parts.each do |p|
+          next if p == "…" && kept.last? == "…"
+          kept << p
+        end
+        kept
+      end
+
       # Every string that ORIGINATED OUTSIDE gori — a captured request target/host, a
       # response header, a regex-extracted fuzz capture, a crawled URL — must pass through
       # here before it reaches JSON::Builder. The stdio JSON-RPC transport carries UTF-8

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -135,6 +135,11 @@ module Gori
         "create_extract_rule", "update_extract_rule", "delete_extract_rule", "set_extract_rule_enabled",
         "create_note", "update_note", "delete_note",
         "create_repeater", "update_repeater", "delete_repeater",
+        # The bulk siblings and the reorder. `move_repeater` is here for the same reason
+        # `move_color_rule` is: order is what the operator navigates by, so an agent that
+        # rearranges the strip has changed something the human will notice and should be able
+        # to trace.
+        "move_repeater", "create_repeaters", "delete_repeaters", "update_repeaters",
         "oast_start", "oast_stop", "oast_resume", "oast_release",
         "add_scope_rule", "delete_scope_rule", "set_scope_enabled", "set_sandbox",
         "set_env_var", "delete_env_var",
@@ -234,6 +239,15 @@ module Gori
       DISCOVER_MAX_DEPTH       =          12
 
       MCP_REPEATER_REQUEST_MAX = 16 * 1024
+
+      # Caps for `get_repeater_context{include_response_body}`. Same numbers `list_fuzz_runs`
+      # uses for its own inlined bodies, so a caller does not have to learn two budgets.
+      # `MCP_REPEATER_BODY_ROWS` bounds how many rows of one page get a BLOB read at all —
+      # `repeaters_mcp` leaves `response_body` out on purpose, and a 500-row listing that
+      # hydrated every one of them would be the `get_flow`-vs-`flow_row` mistake at scale.
+      MCP_REPEATER_BODY_DEFAULT = 2 * 1024
+      MCP_REPEATER_BODY_MAX     = 64 * 1024
+      MCP_REPEATER_BODY_ROWS    = 10
 
       # Ceiling on concurrently-live OAST listening sessions (each holds an Oast::Http
       # socket until oast_stop). Bounds the leak from an agent that starts sessions and
@@ -1096,6 +1110,10 @@ module Gori
         when "create_repeater"           then gated { create_repeater(h) }
         when "update_repeater"           then gated { update_repeater(h) }
         when "delete_repeater"           then gated { delete_repeater(h) }
+        when "move_repeater"             then gated { move_repeater(h) }
+        when "create_repeaters"          then gated { create_repeaters(h) }
+        when "delete_repeaters"          then gated { delete_repeaters(h) }
+        when "update_repeaters"          then gated { update_repeaters(h) }
         when "create_issue"              then gated { create_issue(h) }
         when "update_issue"              then gated { update_issue(h) }
         when "probe_dismiss"             then gated { probe_dismiss(h) }
@@ -1575,6 +1593,42 @@ module Gori
         # caller who wrote a number that it passed an object.
         arr = raw.as_a? || return [str_entry(raw, key)]
         arr.map { |v| str_entry(v, key) }
+      end
+
+      # A list-of-IDS argument, in the shapes a caller reaches for: a real array of integers,
+      # a JSON-encoded array, a bare id, or a comma list. Built on `str_list`, so the leniency
+      # about the CONTAINER is the same one every other list argument here gives.
+      #
+      # Strict about the ENTRIES, though: a non-integer is NAMED and raises rather than being
+      # dropped. Silently skipping one would act on a smaller selection than the caller asked
+      # for and report it as complete — which, on the tools that take this, is a delete.
+      # Callers rescue `Gori::Error` and return the message as INVALID_ARGUMENT.
+      #
+      # Duplicates are collapsed, order preserved: a caller that names one id twice means one
+      # object, and leaving the repeat in would double every per-id line of the report.
+      private def id_list_arg(h, key : String) : Array(Int64)
+        ids = [] of Int64
+        seen = Set(Int64).new
+        str_list(h, key).each do |entry|
+          entry.split(',').each do |tok|
+            t = tok.strip
+            next if t.empty?
+            id = t.to_i64? || raise Gori::Error.new(
+              "invalid #{key.inspect} entry #{t.inspect} (expected an integer id)")
+            next if seen.includes?(id)
+            seen << id
+            ids << id
+          end
+        end
+        ids
+      end
+
+      # The schema for an `id_list_arg` property: the `oneOf` that advertises all three
+      # accepted shapes. One builder, so a second list-of-ids argument cannot advertise a
+      # different grammar from the one `id_list_arg` actually reads.
+      private def id_list_prop(description : String) : JSON::Any
+        JSON.parse(%({"description":#{description.to_json},"oneOf":) +
+                   %([{"type":"array","items":{"type":"integer"}},{"type":"integer"},{"type":"string"}]}))
       end
 
       # A `*_base64` argument decoded into the exact bytes it names, as a String (Crystal

--- a/src/gori/mcp/tools/authorize.cr
+++ b/src/gori/mcp/tools/authorize.cr
@@ -559,21 +559,11 @@ module Gori
         end
       end
 
-      # The flow ids to replay, in the order given. Accepts a real array, a JSON-encoded array
-      # (LLM clients stringify), a bare id, and a comma list — the shapes a caller reaches for
-      # — but a non-integer entry is NAMED rather than dropped: silently skipping one would
-      # replay a smaller selection than the one asked for and report it as complete.
+      # The flow ids to replay, in the order given — through the shared `id_list_arg`, which
+      # is this reader lifted into `tools.cr` so the repeater bulk tools cannot grow a second
+      # grammar for the same shape.
       private def authorize_flow_ids(h) : Array(Int64)
-        ids = [] of Int64
-        str_list(h, "flow_ids").each do |entry|
-          entry.split(',').each do |tok|
-            t = tok.strip
-            next if t.empty?
-            ids << (t.to_i64? || raise Gori::Error.new(
-              "invalid 'flow_ids' entry #{t.inspect} (expected an integer flow id)"))
-          end
-        end
-        ids
+        id_list_arg(h, "flow_ids")
       end
 
       # The explicit identity set as the JSON text `Authorize.parse_json` reads — the SAME
@@ -686,15 +676,12 @@ module Gori
         end
       end
 
-      # The `flow_ids` schema. An array of integers is the shape to reach for; a single id and
-      # a comma-list string are accepted because a caller with one flow writes one flow (the
-      # same leniency `str_list` gives every other list argument on this surface).
+      # The `flow_ids` schema, through the shared `id_list_prop` — the same `oneOf` every
+      # list-of-ids argument advertises, kept beside the reader that honours it.
       private def authorize_flow_ids_prop : JSON::Any
-        desc = "captured flow ids to replay, in the order given (ids come from list_history). " \
-               "An array of integers, a single integer, or a comma list. Combined with 'query' " \
-               "when both are passed; at least one of the two is required."
-        JSON.parse(%({"description":#{desc.to_json},"oneOf":) +
-                   %([{"type":"array","items":{"type":"integer"}},{"type":"integer"},{"type":"string"}]}))
+        id_list_prop("captured flow ids to replay, in the order given (ids come from list_history). " \
+                     "An array of integers, a single integer, or a comma list. Combined with 'query' " \
+                     "when both are passed; at least one of the two is required.")
       end
 
       # The `identities` schema: an array of identity objects, or the same array as a JSON

--- a/src/gori/mcp/tools/context.cr
+++ b/src/gori/mcp/tools/context.cr
@@ -135,6 +135,36 @@ module Gori
         end)
       end
 
+      # `query` (substring) and `filter` (the sub-tab language) applied together — both must
+      # match, the way `list_history{view}` ANDs with its own `query` rather than replacing it.
+      private def repeater_narrow(rows : Array(Store::RepeaterRecord), rx : Regex?,
+                                  filter : Repeater::SubtabFilter?) : Array(Store::RepeaterRecord)
+        if rx
+          rows = rows.select do |r|
+            # scrub: target/name/request can be invalid UTF-8 (seeded from a captured request
+            # without scrubbing); an unscrubbed matches? raises and fails the WHOLE response
+            # whenever a query meets any such repeater. Scrub is lossless for a filter match.
+            r.target.scrub.matches?(rx) ||
+              r.name.try(&.scrub.matches?(rx)) ||
+              String.new(r.request).scrub.matches?(rx)
+          end
+        end
+        return rows unless (f = filter) && !f.empty?
+        rows.select { |r| f.matches?(Repeater::SubtabFilter::Subject.from_row(r)) }
+      end
+
+      # The `filter` argument, compiled by the ONE matcher the TUI's `/` uses, or the Result
+      # that refuses it. An unparseable filter is REPORTED — a listing that answered "no such
+      # sessions" for a syntax error would read as a finding about the workbench.
+      private def repeater_filter_arg(text : String) : Repeater::SubtabFilter | Result
+        Repeater::SubtabFilter.parse(text)
+      rescue ex
+        err("invalid 'filter': #{ex.message}. Fields are " \
+            "#{Repeater::SubtabFilter::FIELDS.map { |x| "#{x}:" }.join(" ")}; " \
+            "a bare word searches name/summary/target/tags",
+          "QUERY_SYNTAX", field: "filter")
+      end
+
       private def get_repeater_context(h) : Result
         ui = parse_ui_state
         repeater_id = int(h, "id")
@@ -147,26 +177,34 @@ module Gori
         offset = clamp_nonneg(req_off)
         query_str = str(h, "query").try(&.strip)
         query_rx = query_str.try { |q| q.empty? ? nil : Regex.new(Regex.escape(q), Regex::Options::IGNORE_CASE) }
+        include_response_body = bool_arg(h, "include_response_body", false)
+        req_body_cap = optional_int_arg(h, "max_body_bytes")
+        body_cap = clamp(req_body_cap, MCP_REPEATER_BODY_DEFAULT, MCP_REPEATER_BODY_MAX)
 
-        all_repeaters = store.repeaters_mcp
+        # The sub-tab filter the operator types into the TUI's `/`, over the SAME grammar
+        # (`tag:` `name:` `host:`/`target:` `method:`/`verb:` `status:`, `-` to negate, bare
+        # words as free text). ANDed with `query` rather than replacing it, the way
+        # `list_history{view}` is ANDed with its own — two narrowings are two narrowings.
+        filter_str = str(h, "filter").try(&.strip).presence
+        filter = filter_str.try { |f| repeater_filter_arg(f) }
+        return filter if filter.is_a?(Result)
+
+        ordered = store.repeaters_mcp
+        # The chip number is a rank in the WHOLE workbench, so it is taken here — before the
+        # id lookup, the query and the filter each narrow the list. Deriving it from the
+        # returned page instead would renumber the tabs a filter happened to keep, which is
+        # exactly what the TUI's own strip refuses to do (`Chrome.chip_zones`: a filtered
+        # strip reads 2, 5, 7).
+        tui_index = {} of Int64 => Int32
+        ordered.each_with_index { |r, i| tui_index[r.id] = i + 1 }
+
+        all_repeaters = ordered
         if repeater_id && !all_repeaters.any? { |r| r.id == repeater_id }
           return not_found("no repeater with id #{repeater_id}")
         end
         all_repeaters = all_repeaters.select { |r| r.id == repeater_id } if repeater_id
 
-        filtered_repeaters = if rx = query_rx
-                               all_repeaters.select do |r|
-                                 # scrub: target/name/request can be invalid UTF-8 (seeded from a
-                                 # captured request without scrubbing); an unscrubbed matches? raises
-                                 # and fails the WHOLE list_repeaters response whenever a query filter
-                                 # meets any such repeater. Scrub is lossless for a filter match.
-                                 r.target.scrub.matches?(rx) ||
-                                   r.name.try(&.scrub.matches?(rx)) ||
-                                   String.new(r.request).scrub.matches?(rx)
-                               end
-                             else
-                               all_repeaters
-                             end
+        filtered_repeaters = repeater_narrow(all_repeaters, query_rx, filter)
 
         total_count = filtered_repeaters.size
         paginated_repeaters = if offset >= filtered_repeaters.size
@@ -174,6 +212,16 @@ module Gori
                               else
                                 filtered_repeaters[offset, Math.min(limit, filtered_repeaters.size - offset)]
                               end
+
+        # Response bodies are the one field on this tool that costs a BLOB read per row
+        # (`repeaters_mcp` deliberately leaves `response_body` out), so they are hydrated for
+        # a bounded head of the page and the shortfall is NAMED. Silently dropping them for
+        # rows 11+ would read as "those tabs have no body".
+        body_ids = if include_response_body
+                     paginated_repeaters.first(MCP_REPEATER_BODY_ROWS).map(&.id).to_set
+                   else
+                     Set(Int64).new
+                   end
 
         Result.new(JSON.build do |j|
           j.object do
@@ -207,11 +255,28 @@ module Gori
             j.field "offset", offset
             j.field "limit", limit
             emit_clamp(j, req_off, offset, req_lim, limit)
+            # A filter string whose every term was dropped narrows NOTHING, and a listing that
+            # answered "here is everything" while the caller believed it had filtered is the
+            # shape `ql_explain` was fixed for. Named, not silently applied.
+            if (f = filter) && f.empty? && (fs = filter_str) && !fs.empty?
+              j.field "filter_ignored", true
+              j.field "filter_ignored_note",
+                "filter #{fs.inspect} produced no usable term, so it narrowed nothing — these are ALL " \
+                "the project's sessions. Fields are #{Repeater::SubtabFilter::FIELDS.map { |x| "#{x}:" }.join(" ")}"
+            end
+            if include_response_body && paginated_repeaters.size > body_ids.size
+              j.field "response_bodies_omitted", paginated_repeaters.size - body_ids.size
+              j.field "response_bodies_omitted_note",
+                "last_response_body is hydrated for the first #{MCP_REPEATER_BODY_ROWS} rows of a page only " \
+                "(each is a separate BLOB read) — narrow with id/filter, or page, to read the rest"
+            end
             j.field "has_more", offset + paginated_repeaters.size < total_count
             j.field "sessions" do
               j.array do
                 paginated_repeaters.each do |r|
-                  emit_repeater_session(j, r, include_content, include_sensitive)
+                  emit_repeater_session(j, r, include_content, include_sensitive,
+                    tui_index: tui_index[r.id]?,
+                    response_body_cap: body_ids.includes?(r.id) ? body_cap : nil)
                 end
               end
             end
@@ -231,9 +296,17 @@ module Gori
 
       private def emit_repeater_session(j : JSON::Builder, r : Store::RepeaterRecord,
                                         include_content : Bool = false,
-                                        include_sensitive : Bool = false) : Nil
+                                        include_sensitive : Bool = false,
+                                        tui_index : Int32? = nil,
+                                        response_body_cap : Int32? = nil) : Nil
         j.object do
           j.field "db_id", r.id
+          # The number the operator reads off the sub-tab chip ("6:POST /api"), beside the id
+          # every tool here takes. Both, always, because holding one and needing the other is
+          # the round trip this field exists to remove — and because acting on the wrong tab
+          # is how an audit trail gets polluted. `position` below is the ORDERING COLUMN, not
+          # a rank: it is what sorts the strip, not what the chip says.
+          j.field "tui_index", tui_index if tui_index
           j.field "position", r.position
           # target/name/tags/sni are seeded from a captured request without scrubbing, so
           # they can carry invalid UTF-8 into the JSON-RPC line (see Serialize.text).
@@ -254,6 +327,20 @@ module Gori
             emit_capped_text(j, "request", Serialize.redact_head(String.new(r.request), include_sensitive),
               raw: r.request, include_sensitive: include_sensitive,
               read_more: %(get_response_body_chunk(repeater_id: #{r.id}, part: "request", offset: …)))
+            # What the credential headers are WIRED to, with the credentials still withheld —
+            # `redact_head` above blanks `Authorization: Bearer $AUTH` and a live token
+            # identically, so without this the operator cannot confirm an env binding without
+            # asking for the secret. See `Serialize.env_header_shapes`.
+            shapes = Serialize.env_header_shapes(r_request_text)
+            unless shapes.empty?
+              j.field("env_headers") do
+                j.array do
+                  shapes.each do |(name, shape)|
+                    j.object { j.field "name", name; j.field "shape", shape }
+                  end
+                end
+              end
+            end
           end
 
           if Repeater::WsEngine.upgrade_request?(r_request_text)
@@ -314,6 +401,44 @@ module Gori
               Serialize.emit_head_base64(j, "last_response_head", head, include_sensitive)
             end
           end
+          emit_repeater_response_body(j, r, head, response_body_cap, include_sensitive) if response_body_cap
+        end
+      end
+
+      # The stored last response BODY, capped and decoded — so "why did tab 6 answer 500?" is
+      # one call instead of three.
+      #
+      # Its own BLOB read (`get_repeater_full`), because `repeaters_mcp` leaves `response_body`
+      # out on purpose and a listing must not start pulling megabytes; the caller decides which
+      # rows get one and the tool names the ones it skipped.
+      #
+      # Decoded like `get_response_body_chunk`, through the same `ContentDecode` and reported
+      # with the same `representation`/`decode_note` words, so the inline preview and the paged
+      # read describe the same bytes the same way.
+      private def emit_repeater_response_body(j : JSON::Builder, r : Store::RepeaterRecord,
+                                              head : Bytes?, cap : Int32,
+                                              include_sensitive : Bool) : Nil
+        full = store.get_repeater_full(r.id)
+        body = full.try(&.response_body)
+        # Distinguishes "never sent / no body" from "omitted": the caller ASKED for a body
+        # here, so silence would be the only reading left and it is the wrong one.
+        return j.field "last_response_body_absent", true if body.nil? || body.empty?
+
+        decoded, note = Proxy::Codec::ContentDecode.decode(head, body)
+        bytes = decoded || body
+        text = String.new(bytes)
+        emit_capped_text(j, "last_response_body", text,
+          raw: bytes, include_sensitive: include_sensitive,
+          read_more: %(get_response_body_chunk(repeater_id: #{r.id}, part: "response", offset: …)),
+          cap: cap)
+        j.field "last_response_body_representation", decoded ? "decoded" : "raw"
+        j.field "last_response_body_decode_note", note if note
+        # `emit_capped_text` names a cursor only when it CUT. A body that fits but is not
+        # UTF-8 was still altered — scrubbed — and the caller needs the same pointer to read
+        # the bytes as bytes.
+        unless text.valid_encoding? || text.bytesize > cap
+          j.field "last_response_body_read_more",
+            %(get_response_body_chunk(repeater_id: #{r.id}, part: "response", offset: …))
         end
       end
 
@@ -334,12 +459,13 @@ module Gori
       # same silence in a different shape.
       private def emit_capped_text(j : JSON::Builder, field : String, text : String, *,
                                    raw : Bytes? = nil, include_sensitive : Bool = false,
-                                   read_more : String? = nil) : Nil
-        cut = text.bytesize > MCP_REPEATER_REQUEST_MAX
+                                   read_more : String? = nil,
+                                   cap : Int32 = MCP_REPEATER_REQUEST_MAX) : Nil
+        cut = text.bytesize > cap
         # Compare and cut by BYTES (the cap is a byte budget), then scrub — a slice
         # through a multi-byte UTF-8 sequence would otherwise emit invalid UTF-8 into
         # the JSON-RPC stream, which must be well-formed UTF-8 over the stdio transport.
-        j.field field, cut ? text.byte_slice(0, MCP_REPEATER_REQUEST_MAX).scrub : text.scrub
+        j.field field, cut ? text.byte_slice(0, cap).scrub : text.scrub
         if cut
           j.field "#{field}_truncated", true
           j.field "#{field}_total_bytes", text.bytesize
@@ -419,13 +545,19 @@ module Gori
           "The Repeater workbench state. Defaults to metadata only so request headers, WebSocket " \
           "payloads, response headers, and the live TUI editor snapshot are not copied into the " \
           "model context. Set include_content=true only when those bytes are necessary. Supports " \
-          "single-id lookup, pagination, and query filtering." do |s|
-          s.field "id", intprop("return one repeater database id")
+          "single-id lookup, pagination, and filtering. Every session reports BOTH ids: 'db_id', " \
+          "which every repeater tool takes, and 'tui_index', the 1-based number the TUI paints on " \
+          "its sub-tab chip — the number the operator says out loud. tui_index shifts whenever a " \
+          "session is created, deleted or moved, so read it fresh; db_id is the durable address." do |s|
+          s.field "id", intprop("return one repeater DATABASE id (not a tui_index)")
           s.field "limit", intprop("max rows to return (default 50, max 500)")
           s.field "offset", intprop("start row (default 0)")
-          s.field "query", strprop("filter repeaters by name or target URL (case-insensitive substring match)")
-          s.field "include_content", boolprop("include request text, WebSocket payloads, response head, and live TUI repeater snapshot (default false; may expose secrets)")
+          s.field "query", strprop("case-insensitive SUBSTRING match over a session's name, target URL and stored request bytes. For a field query (tags, host, method, last status) use 'filter' — both may be passed and both must match")
+          s.field "filter", strprop("the same sub-tab filter language the TUI's `/` takes, matched in memory: #{Repeater::SubtabFilter::FIELDS.map { |f| "#{f}:" }.join(" ")}, `-` before a term negates it, and a bare word searches name/summary/target/tags. `status:` is the LAST send's outcome as one token — a code (`status:404`, and `status:4` matches every 4xx by prefix), `status:error`, or `status:unsent`. ANDed with 'query' when both are given")
+          s.field "include_content", boolprop("include request text, WebSocket payloads, response head, the env-binding shape of each credential header, and the live TUI repeater snapshot (default false; may expose secrets)")
           s.field "include_sensitive", boolprop("with include_content, return Authorization/Cookie/Set-Cookie/API-key header values instead of [REDACTED] (default false)")
+          s.field "include_response_body", boolprop("also inline each session's stored last response BODY, decoded and capped (default false). Its own BLOB read per row, so it is hydrated for the first #{MCP_REPEATER_BODY_ROWS} rows of a page and the rest are reported as omitted — pass 'id' or narrow with 'filter' to read one. Page past the cap with get_response_body_chunk")
+          s.field "max_body_bytes", intprop("cap for each inlined response body (default #{MCP_REPEATER_BODY_DEFAULT}, max #{MCP_REPEATER_BODY_MAX})")
         end
       end
     end

--- a/src/gori/mcp/tools/env.cr
+++ b/src/gori/mcp/tools/env.cr
@@ -18,10 +18,34 @@ module Gori
               j.object do
                 j.field "key", key
                 j.field "value", include_sensitive ? val : "[REDACTED]"
+                # Two facts about the value that are not the value.
+                #
+                # `[REDACTED]` alone leaves one question a caller cannot answer without asking
+                # for the secret: does `$AUTH` already CARRY its scheme, or does the header
+                # have to read `Bearer $AUTH`? Getting that wrong sends `Bearer Bearer …` or a
+                # bare token, and both look like an auth bug at the target rather than a
+                # spelling mistake here.
+                #
+                # `scheme` is a registered IANA keyword, `length` is a size. Deliberately NOT
+                # `Bindings.mask_preview`, which shows first-4/last-4 — right for the TUI's own
+                # binding rows, but this contract has always been "no value bytes", and a
+                # preview would weaken it for every caller that never asked.
+                j.field "length", val.bytesize
+                env_value_scheme(val).try { |sc| j.field "scheme", sc }
               end
             end
           end
         end)
+      end
+
+      # The auth scheme an env value already carries, if any — the leading token, when it is
+      # one of the schemes a credential header uses and something follows it. Read off the
+      # shared `Serialize::AUTH_SCHEMES`, the same list `env_header_shapes` keeps verbatim, so
+      # the two answers about one value cannot drift.
+      private def env_value_scheme(value : String) : String?
+        head, sep, rest = value.strip.partition(' ')
+        return nil if sep.empty? || rest.strip.empty?
+        Serialize::AUTH_SCHEMES.includes?(head.downcase) ? head : nil
       end
 
       private def set_env_var(h) : Result
@@ -61,7 +85,11 @@ module Gori
         tool j, "list_env",
           "List the project's env vars (used for $KEY substitution in outbound requests — see " \
           "send_request/send_websocket). Values are [REDACTED] by default (a project env var is " \
-          "exactly the kind of place a credential/token lives); pass include_sensitive:true to see them." do |s|
+          "exactly the kind of place a credential/token lives); pass include_sensitive:true to see them. " \
+          "Each row also carries 'length' and, when the value already begins with one, 'scheme' " \
+          "(Bearer/Basic/…) — enough to tell whether a header should read \"Bearer $KEY\" or just " \
+          "\"$KEY\", without the value. To see which key a saved request is actually wired to, read " \
+          "get_repeater_context{include_content:true}'s env_headers." do |s|
           s.field "include_sensitive", boolprop("return actual values instead of [REDACTED] (default false)")
         end
 

--- a/src/gori/mcp/tools/minimize.cr
+++ b/src/gori/mcp/tools/minimize.cr
@@ -134,6 +134,9 @@ module Gori
         Result.new(JSON.build do |j|
           j.object do
             j.field "repeater_id", id
+            # The number the operator reads off the sub-tab chip, beside the id this tool
+            # takes — the same pair every repeater reply carries (see `repeater_tui_index`).
+            repeater_tui_index(id).try { |n| j.field "tui_index", n }
             j.field "aborted", report.aborted
             j.field "note", report.note
             j.field "sends", report.sends

--- a/src/gori/mcp/tools/repeater.cr
+++ b/src/gori/mcp/tools/repeater.cr
@@ -102,6 +102,137 @@ module Gori
           .sort!
       end
 
+      # The 1-based number the TUI paints on a Repeater sub-tab chip ("6:POST /api").
+      #
+      # Derived from the SAME order the TUI builds its strip in — `ORDER BY position, id`
+      # (`Store#repeaters_meta`; `RepeaterController#reconcile` re-sorts to exactly that on
+      # every peer commit, and `#subtab_labels` is `map_with_index { |tab, i| "#{i + 1}:…" }`)
+      # — so an agent and the operator can name the same tab. Every repeater reply carries it
+      # because that mapping was otherwise something a caller had to keep re-deriving, and
+      # acting on the wrong tab is how an audit trail gets polluted.
+      #
+      # It is a RANK, not an address, and no tool here accepts it as a selector. It shifts on
+      # every create, delete and move; `repeaters.id` is itself REUSED after a top-of-space
+      # delete (`Store#delete_repeater` documents why that matters), so a caller acting on a
+      # remembered number could reach a session it never read. `id` stays the only address.
+      #
+      # Unsaved and ephemeral sub-tabs (a gRPC or split-decode duplicate, `db_id == nil`) have
+      # no row at all; `reconcile` sorts them after every saved one, so they never shift these.
+      private def repeater_tui_index(id : Int64, ordered : Array(Store::RepeaterRecord)) : Int32?
+        i = ordered.index { |r| r.id == id }
+        i ? i + 1 : nil
+      end
+
+      # The same, for a caller with no ordered list already in hand. `repeaters_meta` carries
+      # no response BLOBs, which is what makes this cheap enough to put on every reply.
+      private def repeater_tui_index(id : Int64) : Int32?
+        repeater_tui_index(id, store.repeaters_meta)
+      end
+
+      # A `tags` argument, normalised through the ONE grammar that owns it
+      # (`Repeater::Tags`, which the TUI's `t` editor and the sub-tab filter both read): split
+      # on whitespace/commas, leading `#` stripped, deduped case-insensitively, space-joined.
+      # `nil` when the argument clears the column — an explicit blank, or a value that held no
+      # token at all (`"#"`, `","`), which must not be stored as a tag nothing can match.
+      #
+      # Masked on the way in, unlike `target`/`sni`: a tag is a TUI caption and never reaches a
+      # socket, so masking it costs nothing and keeps a secret out of a string the strip paints
+      # (see `wire_field` for the fields where that reasoning does NOT hold).
+      private def repeater_tags_arg(h, key : String = "tags") : String?
+        raw = str(h, key)
+        return nil unless raw
+        Repeater::Tags.serialize(Repeater::Tags.parse(Env.mask_secrets(raw)))
+      end
+
+      # Everything a captured flow contributes to a new Repeater session.
+      #
+      # Extracted because `create_repeaters` seeds the SAME way per flow, and a second copy of
+      # this block is the shape that has already cost this file twice: `create_repeater` once
+      # hand-assembled head+body and so skipped all three jobs `FlowRequest.build` exists for
+      # (below), and `Repeater::Plan#with_requests` once dropped `tls_preset` on a copy — a
+      # forgotten field in a copy-constructor reports one thing and sends another.
+      #
+      # `nil` fields mean "the flow contributed nothing here", never "false": `http2` is a real
+      # three-state at the call site (absent = inherit from the seed), and folding it in here
+      # would flatten that.
+      private record FlowSeed,
+        target : String,
+        request : String,
+        http2 : Bool,
+        rewrote_request_line : Bool = false,
+        ws_messages : Array(Store::WsOutMessage)? = nil,
+        notice_rows_dropped : Int32 = 0,
+        ws_h2_frames_unseeded : Int32 = 0
+
+      # Seed through `FlowRequest.build`, exactly as `gori run repeater create --flow` and
+      # `send_request{flow_id}` do. Hand-assembling head+body here skipped all three things
+      # that function exists for:
+      #   * `resync_truncated_head` — a capture cut at CAPTURE_MAX keeps its original
+      #     `Transfer-Encoding: chunked` over a body with no terminating 0-chunk (or a
+      #     Content-Length promising bytes that no longer exist), so the send blocked for
+      #     the full 30 s io_timeout and put a partial chunked stream on the wire. That
+      #     function's stated reason for existing is "so the repeater terminates instead
+      #     of hanging"; this was the one caller that did not get it.
+      #   * `origin_form_bytes` — every plain-HTTP flow gori captures has an ABSOLUTE-form
+      #     request line (that is how a proxy client writes it), which was then sent
+      #     verbatim to an origin that expects origin-form.
+      #   * `build_target` — this was a third hand-rolled copy of the authority formula,
+      #     without the ws/wss default-port fold or IPv6 re-bracketing the shared one has.
+      #
+      # `origin_form_bytes` is also the one of the three that is not always housekeeping:
+      # on a flow gori recorded from a DIRECT send the absolute-form line is the routing /
+      # cache-poisoning / SSRF payload, and baking the rewrite in here made the loss
+      # PERMANENT — the stored session no longer holds the line, so not even
+      # `send_repeater --verbatim` can recover it. `keep_request_line` turns it off and
+      # `request_line_rewritten` reports it when it fires, matching
+      # `gori run repeater --keep-request-line` and `send_request`.
+      #
+      # `built.sni` is deliberately NOT seeded: `gori run repeater create --flow` takes SNI
+      # from the operator's flag alone, and this tool is its MCP twin.
+      private def seed_from_flow(flow, flow_id : Int64, keep_request_line : Bool,
+                                 seed_ws_messages : Bool) : FlowSeed
+        built = Repeater::FlowRequest.build(flow, rewrite_absolute_form: !keep_request_line)
+        target = built.target
+        request = String.new(built.bytes)
+
+        # The gate is `WsEngine.upgrade_request?` and not `row.status == 101` (#742). A seed
+        # has to produce a session `send_websocket` can actually run, and `WsEngine` opens a
+        # socket exactly one way: an HTTP/1.1 `Upgrade:` handshake answered 101. The status
+        # was that handshake's, standing in for the handshake itself — so a WebSocket
+        # captured over RFC 8441 extended CONNECT (#733: `CONNECT`, answered `200`) took the
+        # ordinary-HTTP path and its frames went nowhere, unmentioned.
+        if Proxy::WS.upgrade_request?(String.new(flow.request_head)) && seed_ws_messages
+          # Opcode and raw bytes, both kept. The `&& m.text?` filter dropped every captured
+          # BINARY out-frame with no warning at all (the CLI at least printed one), and the
+          # `.scrub` rewrote an invalid-UTF-8 TEXT payload to U+FFFD before it was stored —
+          # so a §8.1/§5.6 test case could not be seeded into a repeater from MCP.
+          # A `[gori]` advisory row is a diagnostic about the socket, not traffic it
+          # carried; seeding one would replay gori's own sentence as a client frame. The
+          # count rides back to the agent — a seed quietly holding fewer frames than the
+          # capture is as wrong as one holding an extra. See `CLI::Run.ws_seed_rows`.
+          rows, dropped = CLI::Run.ws_seed_rows(store.ws_messages(flow_id))
+          msgs = rows.map { |m| Store::WsOutMessage.new(m.opcode, m.payload, CLI::Run.seed_shape(m.shape)) }
+          return FlowSeed.new(target, request, built.http2, built.rewrote_request_line,
+            ws_messages: msgs, notice_rows_dropped: dropped)
+        elsif flow.websocket? && seed_ws_messages
+          # A WebSocket gori captured over HTTP/2 (RFC 8441 extended CONNECT). The session
+          # is still created — the CONNECT request is a real h2 request and `send_request`
+          # will send it — but the frames are NOT seeded, because there is no h2 WebSocket
+          # send path to replay them over: `WsEngine` writes an h1 upgrade, and the
+          # `ws_http_only` seam moves a session between the WS engine and a plain send of
+          # the same handshake bytes, never onto a different WebSocket transport.
+          #
+          # Fabricating an h1 handshake to make the seed dial would put a request the client
+          # never sent into the operator's session under the flow's provenance. So the agent
+          # is TOLD, in the reply that would otherwise have looked like an ordinary success.
+          # `get_flow` returns the transcript, which is where it is readable.
+          return FlowSeed.new(target, request, built.http2, built.rewrote_request_line,
+            ws_h2_frames_unseeded: store.count_ws_messages(flow_id))
+        end
+
+        FlowSeed.new(target, request, built.http2, built.rewrote_request_line)
+      end
+
       private def create_repeater(h) : Result
         issue_id = int(h, "issue_id")
         return Result.new(id_error(h, "issue_id"), is_error: true) if issue_id.nil? && present?(h, "issue_id")
@@ -144,75 +275,20 @@ module Gori
           flow = store.get_flow(flow_id)
           return not_found("no flow with id #{flow_id}") unless flow
 
-          # Seed through `FlowRequest.build`, exactly as `gori run repeater create --flow` and
-          # `send_request{flow_id}` do. Hand-assembling head+body here skipped all three things
-          # that function exists for:
-          #   * `resync_truncated_head` — a capture cut at CAPTURE_MAX keeps its original
-          #     `Transfer-Encoding: chunked` over a body with no terminating 0-chunk (or a
-          #     Content-Length promising bytes that no longer exist), so the send blocked for
-          #     the full 30 s io_timeout and put a partial chunked stream on the wire. That
-          #     function's stated reason for existing is "so the repeater terminates instead
-          #     of hanging"; this was the one caller that did not get it.
-          #   * `origin_form_bytes` — every plain-HTTP flow gori captures has an ABSOLUTE-form
-          #     request line (that is how a proxy client writes it), which was then sent
-          #     verbatim to an origin that expects origin-form.
-          #   * `build_target` — this was a third hand-rolled copy of the authority formula,
-          #     without the ws/wss default-port fold or IPv6 re-bracketing the shared one has.
-          #
-          # `origin_form_bytes` is also the one of the three that is not always housekeeping:
-          # on a flow gori recorded from a DIRECT send the absolute-form line is the routing /
-          # cache-poisoning / SSRF payload, and baking the rewrite in here made the loss
-          # PERMANENT — the stored session no longer holds the line, so not even
-          # `send_repeater --verbatim` can recover it. `keep_request_line` turns it off and
-          # `request_line_rewritten` reports it when it fires, matching
-          # `gori run repeater --keep-request-line` and `send_request`.
-          built = Repeater::FlowRequest.build(flow, rewrite_absolute_form: !keep_request_line)
-
-          target = built.target if target.nil? || target.empty?
+          seed = seed_from_flow(flow, flow_id, keep_request_line,
+            seed_ws_messages: !present?(h, "ws_out_messages"))
+          target = seed.target if target.nil? || target.empty?
           if request.nil? || request.empty?
-            request = String.new(built.bytes)
+            request = seed.request
             # Only when the SEEDED bytes are the ones being stored: an explicit `request`
             # argument was never rewritten.
-            rewrote_request_line = built.rewrote_request_line
+            rewrote_request_line = seed.rewrote_request_line
           end
-          http2 = built.http2 if http2_val.nil?
-          # `built.sni` is deliberately NOT seeded here: `gori run repeater create --flow`
-          # takes SNI from the operator's flag alone, and this tool is its MCP twin.
-
-          # The gate is `WsEngine.upgrade_request?` and not `row.status == 101` (#742). A seed
-          # has to produce a session `send_websocket` can actually run, and `WsEngine` opens a
-          # socket exactly one way: an HTTP/1.1 `Upgrade:` handshake answered 101. The status
-          # was that handshake's, standing in for the handshake itself — so a WebSocket
-          # captured over RFC 8441 extended CONNECT (#733: `CONNECT`, answered `200`) took the
-          # ordinary-HTTP path and its frames went nowhere, unmentioned.
-          if Proxy::WS.upgrade_request?(String.new(flow.request_head)) && !present?(h, "ws_out_messages")
-            # Opcode and raw bytes, both kept. The `&& m.text?` filter dropped every captured
-            # BINARY out-frame with no warning at all (the CLI at least printed one), and the
-            # `.scrub` rewrote an invalid-UTF-8 TEXT payload to U+FFFD before it was stored —
-            # so a §8.1/§5.6 test case could not be seeded into a repeater from MCP.
-            # A `[gori]` advisory row is a diagnostic about the socket, not traffic it
-            # carried; seeding one would replay gori's own sentence as a client frame. The
-            # count rides back to the agent — a seed quietly holding fewer frames than the
-            # capture is as wrong as one holding an extra. See `CLI::Run.ws_seed_rows`.
-            rows, notice_rows_dropped = CLI::Run.ws_seed_rows(store.ws_messages(flow_id))
-            ws_messages_override = rows
-              .map { |m| Store::WsOutMessage.new(m.opcode, m.payload, CLI::Run.seed_shape(m.shape)) }
-          elsif flow.websocket? && !present?(h, "ws_out_messages")
-            # A WebSocket gori captured over HTTP/2 (RFC 8441 extended CONNECT). The session
-            # is still created — the CONNECT request is a real h2 request and `send_request`
-            # will send it — but the frames are NOT seeded, because there is no h2 WebSocket
-            # send path to replay them over: `WsEngine` writes an h1 upgrade, and the
-            # `ws_http_only` seam moves a session between the WS engine and a plain send of
-            # the same handshake bytes, never onto a different WebSocket transport.
-            #
-            # Fabricating an h1 handshake to make the seed dial would put a request the client
-            # never sent into the operator's session under the flow's provenance. So the agent
-            # is TOLD, in the reply that would otherwise have looked like an ordinary success.
-            # `get_flow` returns the transcript, which is where it is readable.
-            ws_h2_frames_unseeded = store.count_ws_messages(flow_id)
-          end
+          http2 = seed.http2 if http2_val.nil?
+          ws_messages_override = seed.ws_messages
+          notice_rows_dropped = seed.notice_rows_dropped
+          ws_h2_frames_unseeded = seed.ws_h2_frames_unseeded
         end
-
         return Result.new("missing required 'target'", is_error: true) if target.nil? || target.empty?
         return Result.new("missing required 'request'", is_error: true) if request.nil? || request.empty?
 
@@ -221,7 +297,7 @@ module Gori
         position = int(h, "position")
         if position.nil?
           return Result.new(id_error(h, "position"), is_error: true) if present?(h, "position") # present but non-integer
-          position = store.repeaters_meta.size.to_i64
+          position = store.next_repeater_position.to_i64
         elsif position < Int32::MIN || position > Int32::MAX
           return Result.new("'position' out of range", is_error: true)
         end
@@ -235,6 +311,11 @@ module Gori
         # nothing and keeps a secret out of a string the TUI paints. `target` and `sni` do
         # reach one, and are stored as authored — see `wire_field`.
         name = str(h, "name").try { |n| Env.mask_secrets(n) }
+        # Same standing as `name`, and readable here for the same reason the flags above are:
+        # `update_repeater` has always taken `tags` and this tool did not, so a session created
+        # from MCP could only be grouped by a second call — and `create_repeaters` needs one
+        # spelling to hand every row it seeds.
+        tags = present?(h, "tags") ? repeater_tags_arg(h) : nil
 
         # WebSocket mode check — on the bytes that will be STORED and sent, not a projection.
         is_ws = Repeater::WsEngine.upgrade_request?(request)
@@ -287,6 +368,15 @@ module Gori
           end
         end
 
+        # Its own batch after the name, like `update_repeater`'s: each write commits or rolls
+        # back alone, so the refusal has to name which half landed rather than report a partial
+        # create as one outcome.
+        if tags
+          unless store.set_repeater_tags(id, tags)
+            return busy("repeater ##{id} exists (with any issue link and name this call made), but its TAGS were NOT saved (store busy or unwritable); set them with update_repeater")
+          end
+        end
+
         # WebSocket messages handling
         ws_count = ws_messages.try(&.size)
         if (messages = ws_messages) && !messages.empty?
@@ -309,7 +399,12 @@ module Gori
             j.field "name", name || ""
             j.field "target", masked_target
             j.field "summary", summary
+            j.field "tags", tags if tags
             j.field "position", position
+            # The chip number the operator will see for this session — read AFTER the insert,
+            # because `position` is a sort key and not a rank: a caller that passed
+            # `position: 0` gets tab 1, whatever the column says.
+            repeater_tui_index(id).try { |n| j.field "tui_index", n }
             # Only when it FIRED, and it is worth more here than on `send_request`: the stored
             # session no longer carries the absolute-form line, so this is the only record
             # that it was ever there.
@@ -560,8 +655,8 @@ module Gori
         # Tags are the TUI's subtab labels (the `t` key) — the grouping a human uses to keep a
         # long session navigable. An explicit blank clears them.
         if present?(h, "tags")
-          tags = str(h, "tags").try { |t| Env.mask_secrets(t).strip }
-          unless store.set_repeater_tags(id, tags.presence)
+          tags = repeater_tags_arg(h)
+          unless store.set_repeater_tags(id, tags)
             return busy("request updated, but the TAGS were NOT saved (store busy or unwritable) — the row keeps its previous tags, and any ws frames in this call were not attempted; retry")
           end
         end
@@ -590,6 +685,7 @@ module Gori
             j.field "target", masked_target
             j.field "summary", summary
             j.field "position", existing.position
+            repeater_tui_index(id).try { |n| j.field "tui_index", n }
             j.field "ws_out_message_count", ws_count if ws_count
             emit_secrets_masked(j, request, masked_request, target, masked_target)
             # `flow_id` is unchanged by this write, and it is not a label: the TUI turns it
@@ -616,11 +712,461 @@ module Gori
         id = int(h, "id")
         return Result.new("missing or invalid required 'id'", is_error: true) unless id
 
+        ordered = store.repeaters_meta
         existing = store.get_repeater(id)
         return not_found("no repeater with id #{id}") unless existing
 
+        # Read BEFORE the delete — it is the number the tab HAD, and it is the whole point of
+        # echoing it: a caller that acted on "tab 6" needs the reply to name the object that
+        # was actually destroyed, not `{"success":true}` and a re-listing to find out.
+        was = repeater_tui_index(id, ordered)
+
         return busy("repeater NOT deleted (store busy or unwritable); it is unchanged") unless store.delete_repeater(id)
-        Result.new(JSON.build { |j| j.object { j.field "success", true } })
+
+        # Renumber the survivors densely. `position` had no writer other than the insert, so a
+        # close used to leave a gap that the next `create_repeater` collided with; now that
+        # there is one, the workbench is repaired on the way out of every delete.
+        rest = ordered.reject { |r| r.id == id }
+        store.set_repeater_positions(rest.map(&.id))
+
+        Result.new(JSON.build do |j|
+          j.object do
+            j.field "success", true
+            j.field "id", id
+            j.field "name", existing.name || ""
+            if n = was
+              j.field "was_tui_index", n
+              # Only when something moved. A caller holding numbers from an earlier listing has
+              # to be told they are stale — that is the failure mode this echo exists to close,
+              # and staying silent would leave it believing tab 7 is still tab 7.
+              j.field "note", "tab #{n} is gone; every session after it shifted down by one — " \
+                              "re-read tui_index from get_repeater_context before naming a tab again" if rest.size >= n
+            end
+            j.field "remaining", rest.size
+          end
+        end)
+      end
+
+      # How many sessions one bulk call may create. A `flow_ids` list is the OpenAPI-import
+      # path's second hop, so it is legitimately long — but each seed reads a whole flow
+      # (`get_flow` materialises both BLOBs) and stores its request bytes, so an unbounded list
+      # is an unbounded read. Refused up front and named, never truncated: a caller that asked
+      # for 400 tabs and got 100 without a word would believe its workbench is complete.
+      MCP_REPEATER_BULK_MAX = 100
+
+      # The 1-based tab order, as the reply's `order` field: what every session's number IS
+      # after the write this call just made. Emitted by the tools that CHANGE the order, so a
+      # caller never has to re-list to learn the numbers it must use next.
+      private def emit_repeater_order(j : JSON::Builder, rows : Array(Store::RepeaterRecord)) : Nil
+        j.field("order") do
+          j.array do
+            rows.each_with_index do |r, i|
+              j.object do
+                j.field "id", r.id
+                j.field "tui_index", i + 1
+                j.field "name", r.name || ""
+              end
+            end
+          end
+        end
+      end
+
+      # A session's tag column with `add` folded in and `remove` taken out.
+      #
+      # Removal first, so `{tags_add: "x", tags_remove: "x"}` ends with the tag rather than
+      # depending on which line ran last; and the result is re-parsed rather than concatenated,
+      # so the case-insensitive de-duplication is `Repeater::Tags`' and not a second copy of it
+      # written here.
+      private def repeater_tags_edited(current : String?, add : Array(String),
+                                       remove : Array(String)) : String?
+        drop = remove.map(&.downcase).to_set
+        kept = Repeater::Tags.parse(current).reject { |t| drop.includes?(t.downcase) }
+        Repeater::Tags.serialize(Repeater::Tags.parse((kept + add).join(' ')))
+      end
+
+      # The label the TUI derives for a session with no stored name: "METHOD /path" off the
+      # first non-blank request line. Through `SubtabFilter::Subject`, which is where that
+      # derivation lives for the headless surfaces — a second copy here would be a second
+      # answer to "what is this tab called".
+      private def repeater_derived_name(r : Store::RepeaterRecord) : String
+        Repeater::SubtabFilter::Subject.summary_of(String.new(r.request))
+      end
+
+      # The ids named in `key`, refused as a set when any of them is unknown.
+      # Returns the ordered rows to act on, or the Result that refuses.
+      #
+      # Refusal comes BEFORE any write, and it NAMES the missing ids. Deleting the eight that
+      # exist and reporting the ninth as skipped is a partial operation dressed as one outcome,
+      # and on this tool the partial half is irreversible.
+      private def repeater_bulk_selection(h, key : String) : {Array(Store::RepeaterRecord), Array(Store::RepeaterRecord)} | Result
+        ids = id_list_arg(h, key)
+        if ids.empty?
+          return err("missing required #{key.inspect} — pass the database ids to act on " \
+                     "(get_repeater_context lists them beside each tab's tui_index)",
+            "INVALID_ARGUMENT", field: key)
+        end
+        if ids.size > MCP_REPEATER_BULK_MAX
+          return err("#{ids.size} ids is over the #{MCP_REPEATER_BULK_MAX}-session cap for one bulk call — " \
+                     "split it, so a short result is never mistaken for a complete one",
+            "INVALID_ARGUMENT", field: key)
+        end
+        rows = store.repeaters_mcp
+        by_id = rows.index_by(&.id)
+        missing = ids.reject { |i| by_id.has_key?(i) }
+        unless missing.empty?
+          return err("no repeater with id #{missing.join(", ")} — NOTHING was changed. " \
+                     "Ids are per-project and are REUSED after a session is deleted, so re-read them " \
+                     "from get_repeater_context rather than replaying a remembered list",
+            "NOT_FOUND", field: key,
+            details: JSON.parse({"missing" => missing}.to_json))
+        end
+        {ids.map { |i| by_id[i] }, rows}
+      end
+
+      # Move one session to another place in the sub-tab strip.
+      #
+      # `to_index` is the 1-based chip number — the number a human says out loud — and it is
+      # the one place on this surface where an index is accepted at all. That is deliberate and
+      # narrow: it is a DESTINATION, not a selector. A stale `to_index` puts the tab somewhere
+      # else; a stale index in `id`'s place would act on a different session entirely, which is
+      # why `id` stays a database id everywhere (see `repeater_tui_index`).
+      private def move_repeater(h) : Result
+        id = int(h, "id")
+        return Result.new(id_error(h, "id"), is_error: true) unless id
+
+        rows = store.repeaters_mcp
+        from = repeater_tui_index(id, rows)
+        return not_found("no repeater with id #{id}") unless from
+
+        has_to = present?(h, "to_index")
+        dir_s = str(h, "direction").try(&.strip.downcase).presence
+
+        if has_to && dir_s
+          return err("pass 'to_index' or 'direction', not both — they are two answers to one question " \
+                     "and choosing one silently is how a tab lands somewhere nobody asked for",
+            "INVALID_ARGUMENT", field: "to_index")
+        end
+
+        target =
+          if has_to
+            to = int(h, "to_index")
+            return Result.new(id_error(h, "to_index"), is_error: true) unless to
+            # REFUSED, not clamped. A clamp would move the tab somewhere other than where the
+            # call named, report success, and leave the caller's model of the strip wrong.
+            unless 1 <= to <= rows.size
+              return err("'to_index' #{to} is outside this workbench — tab numbers are 1-based and there " \
+                         "#{rows.size == 1 ? "is 1 session" : "are #{rows.size} sessions"} (1-#{rows.size})",
+                "INVALID_ARGUMENT", field: "to_index")
+            end
+            to.to_i32
+          elsif dir_s
+            step = case dir_s
+                   when "up"   then -1
+                   when "down" then 1
+                   else             return err("invalid 'direction' (expected #{MOVE_DIRS.join("|")})",
+                     "INVALID_ARGUMENT", field: "direction")
+                   end
+            t = from + step
+            if t < 1 || t > rows.size
+              return err("repeater #{id} is already at the #{step < 0 ? "start" : "end"} of the workbench " \
+                         "(tab #{from} of #{rows.size})", "INVALID_ARGUMENT", field: "direction")
+            end
+            t
+          else
+            return err("pass one of 'to_index' (the 1-based tab number to move it to) or " \
+                       "'direction' (#{MOVE_DIRS.join("|")})", "INVALID_ARGUMENT", field: "to_index")
+          end
+
+        moved = target != from
+        if moved
+          ids = rows.map(&.id)
+          ids.delete_at(from - 1)
+          ids.insert(target - 1, id)
+          unless store.set_repeater_positions(ids)
+            return busy("repeater NOT moved (store busy or unwritable) — the workbench order is unchanged")
+          end
+          rows = store.repeaters_mcp
+        end
+
+        Result.new(JSON.build do |j|
+          j.object do
+            j.field "id", id
+            j.field "name", rows.find { |r| r.id == id }.try(&.name) || ""
+            j.field "from_index", from
+            j.field "to_index", target
+            # A no-op placement is a SUCCESS, not an error: a caller declaring an order one
+            # call at a time will land on this for every tab already in place, and refusing
+            # would turn "already correct" into a failure to handle.
+            j.field "moved", moved
+            emit_repeater_order(j, rows)
+          end
+        end)
+      end
+
+      # Seed a Repeater tab from each of several captured flows — the last hop of the
+      # OpenAPI/HAR path. `import_flows{kind:"oas"}` already parses the spec AND joins
+      # `servers[0].url` with each operation path, so the base-path assembly a caller would
+      # otherwise do by hand is work the importer has already done; what was missing was a way
+      # to turn the resulting flows into tabs without one call each.
+      #
+      # Every flow is checked to EXIST before the first insert (`flow_row`, the row-only probe
+      # — `get_flow` materialises both BLOBs and is read one flow at a time inside the loop, so
+      # a long list never holds every response in memory at once).
+      private def create_repeaters(h) : Result
+        flow_ids = id_list_arg(h, "flow_ids")
+        if flow_ids.empty?
+          return err("missing required 'flow_ids' — pass the captured flow ids to seed from " \
+                     "(list_history returns them; after import_flows, filter with query \"src:import\")",
+            "INVALID_ARGUMENT", field: "flow_ids")
+        end
+        if flow_ids.size > MCP_REPEATER_BULK_MAX
+          return err("#{flow_ids.size} flows is over the #{MCP_REPEATER_BULK_MAX}-session cap for one bulk call — " \
+                     "split it, so a short result is never mistaken for a complete one",
+            "INVALID_ARGUMENT", field: "flow_ids")
+        end
+        missing = flow_ids.reject { |fid| store.flow_row(fid) }
+        unless missing.empty?
+          return err("no flow with id #{missing.join(", ")} — NOTHING was created. Check list_history " \
+                     "(a pruned or cleared flow is gone, and its id can come back on a different flow)",
+            "NOT_FOUND", field: "flow_ids",
+            details: JSON.parse({"missing" => missing}.to_json))
+        end
+
+        keep_request_line = bool_arg(h, "keep_request_line", false)
+        name_prefix = str(h, "name_prefix").try { |v| Env.mask_secrets(v) }
+        tags = present?(h, "tags") ? repeater_tags_arg(h) : nil
+
+        created = [] of {Int64, Int64, String?, Bool, Int32, Int32}
+        failed = [] of {Int64, String}
+        pos = store.next_repeater_position
+
+        flow_ids.each do |fid|
+          flow = store.get_flow(fid)
+          # It existed a moment ago; a peer can still delete between the sweep and here. Named
+          # rather than silently short, like every other per-id outcome in this reply.
+          next failed << {fid, "flow disappeared before it could be seeded"} unless flow
+
+          seed = seed_from_flow(flow, fid, keep_request_line, seed_ws_messages: true)
+          id = store.insert_repeater(
+            target: wire_field(seed.target),
+            request: stored_request(seed.request),
+            http2: seed.http2,
+            auto_cl: true,
+            flow_id: fid,
+            position: pos
+          )
+          next failed << {fid, "store busy or unwritable"} if id == 0
+          pos += 1
+
+          # Named off the bytes just stored, not off a re-read of the row: the round trip
+          # would answer the same thing and cost a query, and it would have to assert the row
+          # it just inserted is there.
+          name = name_prefix.try { |pre| "#{pre}#{Repeater::SubtabFilter::Subject.summary_of(seed.request)}" }
+          store.set_repeater_name(id, name) if name
+          store.set_repeater_tags(id, tags) if tags
+          if (msgs = seed.ws_messages) && !msgs.empty?
+            store.update_repeater_ws_messages(id, msgs)
+          end
+          created << {fid, id, name, seed.rewrote_request_line,
+                      seed.notice_rows_dropped, seed.ws_h2_frames_unseeded}
+        end
+
+        rows = store.repeaters_mcp
+        Result.new(JSON.build do |j|
+          j.object do
+            j.field "created_count", created.size
+            j.field("created") do
+              j.array do
+                created.each do |(fid, id, name, rewrote, dropped, unseeded)|
+                  j.object do
+                    j.field "flow_id", fid
+                    j.field "id", id
+                    j.field "name", name || ""
+                    repeater_tui_index(id, rows).try { |n| j.field "tui_index", n }
+                    j.field "request_line_rewritten", true if rewrote
+                    j.field "ws_notice_rows_dropped", dropped if dropped > 0
+                    j.field "ws_frames_not_seeded", unseeded if unseeded > 0
+                  end
+                end
+              end
+            end
+            unless failed.empty?
+              j.field("failed") do
+                j.array do
+                  failed.each { |(fid, why)| j.object { j.field "flow_id", fid; j.field "reason", why } }
+                end
+              end
+              j.field "note", "#{failed.size} of #{flow_ids.size} flows produced no session — the ones " \
+                              "listed under created DID commit, so retry only the failed ids"
+            end
+            j.field "tags", tags if tags
+          end
+        end)
+      rescue ex : Gori::Error
+        Result.new(ex.message || "invalid repeater arguments", is_error: true)
+      end
+
+      # Delete several sessions by database id.
+      #
+      # `ids` only — never a filter. The set a caller SAW and the set this destroys are then
+      # the same set, which a filter evaluated here could not promise: it would match whatever
+      # the workbench holds now, and a session created since the listing would be deleted
+      # without ever having been read. Narrow the listing (`get_repeater_context{filter}`),
+      # then pass the ids it returned.
+      private def delete_repeaters(h) : Result
+        sel = repeater_bulk_selection(h, "ids")
+        return sel if sel.is_a?(Result)
+        targets, rows = sel
+
+        unless bool_arg(h, "confirm", false)
+          n = targets.size
+          return err("refusing to delete #{n} repeater session#{n == 1 ? "" : "s"} without confirm:true — " \
+                     "this cannot be undone: a session's request bytes, its stored WebSocket frames and any " \
+                     "issue link pointing at it go with it",
+            "CONFIRM_REQUIRED", field: "confirm",
+            details: JSON.parse({"repeaters" => n, "ids" => targets.map(&.id)}.to_json))
+        end
+
+        deleted = [] of {Int64, String?, Int32?}
+        failed = [] of Int64
+        targets.each do |r|
+          was = repeater_tui_index(r.id, rows)
+          if store.delete_repeater(r.id)
+            deleted << {r.id, r.name, was}
+          else
+            failed << r.id
+          end
+        end
+
+        gone = deleted.map { |(id, _, _)| id }.to_set
+        survivors = rows.reject { |r| gone.includes?(r.id) }
+        # Renumber once, after the whole batch: renumbering per delete would make every
+        # `was_tui_index` above relative to a different strip.
+        store.set_repeater_positions(survivors.map(&.id))
+        survivors = store.repeaters_mcp
+
+        Result.new(JSON.build do |j|
+          j.object do
+            j.field "deleted_count", deleted.size
+            j.field("deleted") do
+              j.array do
+                deleted.each do |(id, name, was)|
+                  j.object do
+                    j.field "id", id
+                    j.field "name", name || ""
+                    j.field "was_tui_index", was if was
+                  end
+                end
+              end
+            end
+            unless failed.empty?
+              j.field "failed" { j.array { failed.each { |id| j.number id } } }
+              j.field "note", "#{failed.size} session#{failed.size == 1 ? "" : "s"} could NOT be deleted " \
+                              "(store busy or unwritable) and #{failed.size == 1 ? "is" : "are"} unchanged; " \
+                              "the ones under deleted are gone — retry only the failed ids"
+            end
+            j.field "remaining", survivors.size
+            emit_repeater_order(j, survivors)
+          end
+        end)
+      rescue ex : Gori::Error
+        Result.new(ex.message || "invalid repeater arguments", is_error: true)
+      end
+
+      # Re-label several sessions at once: tags and name affixes, nothing else.
+      #
+      # LABELS ONLY, by design. `update_repeater` is the one that writes request bytes, target,
+      # transport flags and WebSocket frames — a bulk tool that could reach those would let one
+      # call change what many sessions PUT ON THE WIRE, and no per-id report makes that
+      # reviewable. Everything this writes is a caption the strip paints.
+      private def update_repeaters(h) : Result
+        sel = repeater_bulk_selection(h, "ids")
+        return sel if sel.is_a?(Result)
+        targets, _rows = sel
+
+        has_set = present?(h, "tags_set")
+        set_tags = has_set ? repeater_tags_arg(h, "tags_set") : nil
+        add = Repeater::Tags.parse(str(h, "tags_add").try { |t| Env.mask_secrets(t) })
+        remove = Repeater::Tags.parse(str(h, "tags_remove").try { |t| Env.mask_secrets(t) })
+        if has_set && !(add.empty? && remove.empty?)
+          return err("pass 'tags_set' or 'tags_add'/'tags_remove', not both — one replaces the tag set " \
+                     "and the others edit it, and applying both in some order is a rule nobody could predict",
+            "INVALID_ARGUMENT", field: "tags_set")
+        end
+        prefix = str(h, "name_prefix").try { |v| Env.mask_secrets(v) }
+        suffix = str(h, "name_suffix").try { |v| Env.mask_secrets(v) }
+        renaming = !(prefix.nil? && suffix.nil?)
+
+        unless has_set || renaming || !add.empty? || !remove.empty?
+          return err("nothing to change — pass at least one of tags_set, tags_add, tags_remove, " \
+                     "name_prefix, name_suffix",
+            "INVALID_ARGUMENT", field: "tags_add")
+        end
+
+        updated = [] of {Int64, String?, String?, Bool}
+        failed = [] of {Int64, String}
+
+        targets.each do |r|
+          new_tags = if has_set
+                       set_tags
+                     elsif add.empty? && remove.empty?
+                       r.tags
+                     else
+                       repeater_tags_edited(r.tags, add, remove)
+                     end
+
+          # A row with no stored name shows a label DERIVED from its request line. Affixing to
+          # that materialises it as a stored name, which is a real change — the caption stops
+          # tracking the request — so those ids are named in the reply rather than left to be
+          # noticed later.
+          materialised = renaming && r.name.nil?
+          new_name = renaming ? "#{prefix}#{r.name || repeater_derived_name(r)}#{suffix}" : r.name
+
+          if new_tags != r.tags && !store.set_repeater_tags(r.id, new_tags)
+            next failed << {r.id, "tags not saved (store busy or unwritable); the session is unchanged"}
+          end
+          if renaming && !store.set_repeater_name(r.id, new_name)
+            next failed << {r.id, "name not saved (store busy or unwritable); any tag change in this call DID commit"}
+          end
+          updated << {r.id, new_name, new_tags, materialised}
+        end
+
+        rows = store.repeaters_mcp
+        Result.new(JSON.build do |j|
+          j.object do
+            j.field "updated_count", updated.size
+            j.field("updated") do
+              j.array do
+                updated.each do |(id, name, tags, materialised)|
+                  j.object do
+                    j.field "id", id
+                    repeater_tui_index(id, rows).try { |n| j.field "tui_index", n }
+                    j.field "name", name || ""
+                    j.field "tags", tags || ""
+                    j.field "name_materialised", true if materialised
+                  end
+                end
+              end
+            end
+            if (mats = updated.count { |(_, _, _, m)| m }) > 0
+              j.field "name_materialised_note",
+                "#{mats} session#{mats == 1 ? "" : "s"} had no stored name, so the affix was applied to the " \
+                "label gori derives from the request line and that label is now STORED — it no longer " \
+                "follows the request if you edit it"
+            end
+            unless failed.empty?
+              j.field("failed") do
+                j.array do
+                  failed.each { |(id, why)| j.object { j.field "id", id; j.field "reason", why } }
+                end
+              end
+              j.field "note", "#{failed.size} of #{targets.size} sessions were not updated — the ones under " \
+                              "updated DID commit, so retry only the failed ids"
+            end
+          end
+        end)
+      rescue ex : Gori::Error
+        Result.new(ex.message || "invalid repeater arguments", is_error: true)
       end
 
       # The tools/list schemas for the Repeater tools, kept beside the handlers that
@@ -630,7 +1176,12 @@ module Gori
       private def list_repeater_tools(j : JSON::Builder) : Nil
         return unless @allow_actions
 
-        tool j, "create_repeater", "Create a new repeater tab/session in the database. Provide either ('target' and 'request') OR ('flow_id') OR ('issue_id')." do |s|
+        tool j, "create_repeater",
+          "Create a new repeater tab/session in the database. Provide either ('target' and 'request') " \
+          "OR ('flow_id') OR ('issue_id'). The reply carries both 'id' (the durable database id, " \
+          "which every tool here takes) and 'tui_index' (the 1-based number the TUI paints on the " \
+          "sub-tab chip, which is what the operator says out loud). To seed many tabs from one " \
+          "import, use create_repeaters." do |s|
           s.field "target", strprop("absolute target URL (scheme+host+optional port), e.g. https://api.example.com")
           s.field "request", strprop("verbatim raw HTTP request bytes/text")
           s.field "request_base64", strprop("the raw HTTP request as base64 — the byte-exact form; use it when the request carries an octet a JSON string cannot (0x00, 0x80-0xFF, invalid UTF-8, a binary body). Overrides 'request'")
@@ -642,14 +1193,18 @@ module Gori
           s.field "position", intprop("tab position order index (optional, defaults to appending at end)")
           s.field "sni", strprop("optional TLS Server Name Indication override")
           s.field "name", strprop("optional custom name for the repeater tab")
+          s.field "tags", strprop("free-text tags for grouping tabs (the TUI subtab label). Space- or comma-separated, a leading # optional; stored deduped and space-joined. Filter on them with get_repeater_context{filter:\"tag:idor\"}")
           s.field "ws_out_messages", ws_out_messages_prop
           s.field "ws_keep_key", boolprop("WebSocket: send this session's own Sec-WebSocket-Key instead of a fresh one (default false)")
           s.field "tls_preset", strprop("TLS fingerprint this session presents: shape the ClientHello like #{Settings::TLS_PRESET_NAMES.join(" | ")} instead of gori's own, without touching the settings.json outbound_tls table. Stored on the session, so `send_request{repeater_id}`, `gori run repeater send` and a reopened TUI tab all present it. Two sessions on ONE host with different values dial two separate SSL contexts — that A/B is what it is for. The destination's client certificate, protocol range and permissive flag still apply. An APPROXIMATION of that client's hello, not a byte-exact JA3 match. https targets only")
           s.field "ws_http_only", boolprop("WebSocket: treat this session as plain HTTP — `gori run repeater send` and the TUI send the upgrade handshake as an ordinary request and read the 101 as a response, instead of performing the framed exchange. The bytes are unchanged and the session's messages are kept (default false)")
         end
 
-        tool j, "update_repeater", "Update an existing repeater tab's properties by database id." do |s|
-          s.field "id", intprop("repeater database id"), required: true
+        tool j, "update_repeater",
+          "Update an existing repeater tab's properties by database id — including the request " \
+          "bytes, target and transport flags. To re-label several tabs at once (tags and name " \
+          "affixes only) use update_repeaters." do |s|
+          s.field "id", intprop("repeater DATABASE id — not the number on the TUI sub-tab chip. get_repeater_context returns both, as 'db_id' and 'tui_index'"), required: true
           s.field "target", strprop("absolute target URL")
           s.field "request", strprop("verbatim raw HTTP request")
           s.field "request_base64", strprop("the raw HTTP request as base64 — the byte-exact form (see create_repeater). Overrides 'request'")
@@ -664,8 +1219,58 @@ module Gori
           s.field "ws_http_only", boolprop("WebSocket: treat this session as plain HTTP — the handshake is sent as an ordinary request and the 101 read as a response. The bytes are unchanged and the session's messages are kept")
         end
 
-        tool j, "delete_repeater", "Delete a repeater tab by database id." do |s|
-          s.field "id", intprop("repeater database id"), required: true
+        tool j, "delete_repeater",
+          "Delete a repeater tab by database id. The reply names what was destroyed — its id, " \
+          "name and the 'was_tui_index' it had — because every later tab shifts down by one, so " \
+          "tab numbers read before this call are stale afterwards. The remaining sessions are " \
+          "renumbered densely." do |s|
+          s.field "id", intprop("repeater DATABASE id — not the number on the TUI sub-tab chip"), required: true
+        end
+
+        tool j, "move_repeater",
+          "Move a repeater session to another place in the TUI's sub-tab strip — the order the " \
+          "operator sees, and the order a reopened TUI restores. Pass exactly one of 'to_index' " \
+          "(absolute placement) or 'direction' (a one-step nudge). The reply returns the full " \
+          "resulting order with each session's new tui_index, so there is no need to re-list." do |s|
+          s.field "id", intprop("repeater DATABASE id of the session to move"), required: true
+          s.field "to_index", intprop("the 1-based tab number to move it to (1 = first chip). This is the one argument on this surface that takes a tab NUMBER, and only because it is a destination: getting it wrong misplaces this session, it cannot act on a different one. Out of range is refused, never clamped")
+          s.field "direction", enumprop("move one place: up toward tab 1, down toward the end. Refused when the session is already at that end", MOVE_DIRS)
+        end
+
+        tool j, "create_repeaters",
+          "Seed a Repeater tab from each of several captured flows — the second hop of an " \
+          "OpenAPI/HAR import. import_flows already parses the spec and joins servers[0].url " \
+          "with each operation path, so the recipe is: import_flows{kind:\"oas\"} then " \
+          "list_history{query:\"src:import\"} to collect the ids, then this. Every flow is " \
+          "checked to exist before the first session is created; tabs append in the order given. " \
+          "For one tab, or for a tab from raw request bytes, use create_repeater." do |s|
+          s.field "flow_ids", id_list_prop("captured flow ids to seed from, in the order the tabs should appear (ids come from list_history). An array of integers, a single integer, or a comma list. At most #{MCP_REPEATER_BULK_MAX} per call"), required: true
+          s.field "name_prefix", strprop("prepend this to each new tab's name; the rest of the name is the label gori derives from the request line (\"METHOD /path\"). Omit to leave the tabs deriving their own labels")
+          s.field "tags", strprop("tags to place on every session created by this call (space- or comma-separated, leading # optional)")
+          s.field "keep_request_line", boolprop("store each captured request line as-is instead of rewriting an absolute-form line (GET http://h/p) to origin-form (GET /p). Default false; see create_repeater for why this is permanent once stored")
+        end
+
+        tool j, "delete_repeaters",
+          "Delete several repeater sessions by database id. Requires confirm:true — without it " \
+          "the call is refused and reports how many it would have destroyed. This takes ids and " \
+          "never a filter: narrow the listing with get_repeater_context{filter} first and pass " \
+          "the ids it returned, so the set you read and the set destroyed are the same set. If " \
+          "any id is unknown the whole call is refused and nothing is deleted. Cannot be undone." do |s|
+          s.field "ids", id_list_prop("repeater DATABASE ids to delete (get_repeater_context returns them as 'db_id'). An array of integers, a single integer, or a comma list. At most #{MCP_REPEATER_BULK_MAX} per call"), required: true
+          s.field "confirm", boolprop("must be true to actually delete; anything else refuses and reports the count"), required: true
+        end
+
+        tool j, "update_repeaters",
+          "Re-label several repeater sessions at once: tags and name affixes, nothing else. It " \
+          "never touches request bytes, target, transport flags or WebSocket frames — " \
+          "update_repeater is the tool that writes those. If any id is unknown the whole call is " \
+          "refused and nothing is changed." do |s|
+          s.field "ids", id_list_prop("repeater DATABASE ids to re-label. An array of integers, a single integer, or a comma list. At most #{MCP_REPEATER_BULK_MAX} per call"), required: true
+          s.field "tags_set", strprop("replace each session's tags with these (space- or comma-separated; an empty string clears them). Mutually exclusive with tags_add/tags_remove")
+          s.field "tags_add", strprop("add these tags to each session, keeping the ones it already has (deduped case-insensitively)")
+          s.field "tags_remove", strprop("remove these tags from each session; tags it does not have are ignored")
+          s.field "name_prefix", strprop("prepend this to each session's name. A session with no stored name has one derived from its request line — affixing materialises that label as a stored name, and the reply names the sessions where that happened")
+          s.field "name_suffix", strprop("append this to each session's name (same materialising note as name_prefix)")
         end
       end
     end

--- a/src/gori/mcp/tools/send.cr
+++ b/src/gori/mcp/tools/send.cr
@@ -525,7 +525,7 @@ module Gori
           http2: http2,
           auto_cl: auto_cl,
           flow_id: flow_id,
-          position: store.repeaters_meta.size.to_i32,
+          position: store.next_repeater_position,
           # The SNI the send actually used, so re-sending the saved row reproduces the same
           # ClientHello. Through the effective value above, not a hard-coded nil / arg-only
           # read that silently dropped the source's SNI.
@@ -749,7 +749,12 @@ module Gori
                 "flow_id takes precedence; #{ignored.join(", ")} #{ignored.size == 1 ? "was" : "were"} ignored"
             end
             j.field "recorded_flow_id", recorded_flow_id
-            j.field "saved_repeater_id", repeater_id if repeater_id && repeater_id > 0
+            if repeater_id && repeater_id > 0
+              j.field "saved_repeater_id", repeater_id
+              # Where the new tab landed in the strip, so `save_as_repeater` does not have to
+              # be followed by a listing to find out what the operator will call it.
+              repeater_tui_index(repeater_id).try { |n| j.field "saved_repeater_tui_index", n }
+            end
             unless result.ok?
               kind = network_error_kind(result.error)
               # `Serialize.text`: a send failure quotes bytes the ORIGIN chose (a malformed
@@ -940,6 +945,7 @@ module Gori
           j.object do
             emit_scope(j, sc)
             j.field "repeater_id", repeater_id
+            repeater_tui_index(repeater_id).try { |n| j.field "tui_index", n }
             j.field "upgraded", result.upgraded?
             j.field "duration_us", result.duration_us
             j.field "close_code", result.close_code if result.close_code

--- a/src/gori/repeater/subtab_filter.cr
+++ b/src/gori/repeater/subtab_filter.cr
@@ -1,5 +1,7 @@
 require "uri"
 require "../filter_ast"
+require "../store"
+require "../proxy/codec/http1"
 
 module Gori
   module Repeater
@@ -45,19 +47,98 @@ module Gori
     class SubtabFilter
       # Completable field names (canonical forms shown in the filter guidance row).
       # Aliases host/target and method/verb share value pools below.
-      FIELDS = %w[tag name host target method verb]
+      FIELDS = %w[tag name host target method verb status]
+
+      # The non-numeric `status:` values, so the completion pool can offer them beside the
+      # codes actually present. Words, never digits, so neither can shadow a real code.
+      STATUS_WORDS = %w[error unsent]
 
       # Common HTTP methods suggested even when no open session uses them yet.
       METHODS = %w[GET POST PUT PATCH DELETE HEAD OPTIONS CONNECT TRACE]
 
       # The searchable projection of one Repeater session. Kept free of TUI types so the
       # matcher is pure + unit-testable; the controller builds these from its views.
+      # `status` is the last send's outcome as ONE lowercase token: the status code
+      # ("404"), `error` when the send itself failed, or `unsent` when this session has
+      # never been sent. A String rather than an `Int32?` because those are three answers to
+      # one question the operator asks in one field — `status:4` for every 4xx, and matching
+      # by PREFIX (below) is what makes that spelling work. A nil would have needed its own
+      # word anyway, and the two words cannot collide with a code.
       record Subject,
         name : String?,
         summary : String,
         target : String,
         method : String,
-        tags : Array(String)
+        tags : Array(String),
+        status : String = "" do
+        # The projection of a PERSISTED row, for the headless surfaces (MCP `get_repeater_context`).
+        #
+        # The TUI builds its subjects from the live `RepeaterView` instead, because a dirty
+        # editor's bytes are not the row's — but both must reach the SAME shape or the
+        # operator's `/` filter and an agent's `filter` argument would answer differently
+        # about one session. Everything here is derived exactly as `RepeaterView` derives it:
+        # `summary`/`request_method` off the first non-blank request line, `tags` through
+        # `Tags.parse`, `status` off the stored response head.
+        def self.from_row(r : Store::RepeaterRecord) : Subject
+          request = String.new(r.request)
+          new(name: r.name, summary: summary_of(request), target: r.target,
+            method: method_of(request), tags: Tags.parse(r.tags),
+            status: Subject.row_status(r))
+        end
+
+        # "METHOD /path" off the first non-blank request line — the label `RepeaterView#summary`
+        # derives for a tab with no stored name, and therefore the label the strip paints.
+        # Public because a caller holding request BYTES and no row yet needs the same answer
+        # (`create_repeaters` naming a session it is about to insert); a second derivation
+        # there would be a second answer to "what is this tab called".
+        def self.summary_of(request : String) : String
+          line = first_nonblank_line(request)
+          parts = line.split(' ')
+          s = "#{parts[0]?} #{parts[1]?}".strip
+          s.empty? ? line : s
+        end
+
+        # The leading METHOD token, for `method:`.
+        def self.method_of(request : String) : String
+          first_nonblank_line(request).split(' ').first? || ""
+        end
+
+        # `scrub`, because a repeater request is seeded from a capture without one and
+        # `split`/`downcase` on invalid UTF-8 raises — which would fail the WHOLE listing
+        # over one bad row. Lossless for a filter match.
+        def self.first_nonblank_line(request : String) : String
+          request.scrub.each_line.find { |l| !l.strip.empty? }.try(&.strip) || ""
+        end
+
+        # The ONE spelling of the `status:` token, from the two facts every surface has: the
+        # send's error (if any) and the response HEAD bytes.
+        #
+        # The head, and not a parsed status object, is what both callers can actually supply.
+        # `RepeaterView#restore` rebuilds its `Repeater::Result` with `response: nil` on
+        # purpose — the parsed `RawResponse` is not persisted — so a live view asked for
+        # `result.response.try(&.status)` answers `unsent` for a session that plainly shows a
+        # 403 in its response pane. Reading the head is the one question both a reopened tab
+        # and a stored row can answer, so it is the only one this asks.
+        #
+        # `error` beats a head: a session that answered 200 and was then re-sent into a
+        # connection refusal keeps the old head (`update_repeater_response` writes both), and
+        # the news is the failure.
+        def self.status_token(error : String?, head : Bytes?) : String
+          return "error" if error && !error.empty?
+          return "unsent" if head.nil? || head.empty?
+          begin
+            Proxy::Codec::Http1.parse_response_head(head).status.to_s
+          rescue
+            # Bytes we hold and cannot read. NOT "unsent" — something answered — and not a
+            # code, because there is none to name.
+            "error"
+          end
+        end
+
+        protected def self.row_status(r : Store::RepeaterRecord) : String
+          status_token(r.response_error, r.response_head)
+        end
+      end
 
       private record Term, kind : Symbol, text : String, negate : Bool
 
@@ -155,6 +236,7 @@ module Gori
           when "name"           then return Term.new(:name, value, negate)
           when "host", "target" then return Term.new(:target, value, negate)
           when "method", "verb" then return Term.new(:method, value, negate)
+          when "status"         then return Term.new(:status, value, negate)
           end
         end
         # Unrecognised prefix or bare token → free text (name/summary/target/tags).
@@ -178,6 +260,12 @@ module Gori
           seen = Set(String).new(from_sess.map(&.downcase))
           static = METHODS.select { |m| m.downcase.starts_with?(p) && !seen.includes?(m.downcase) }
           from_sess + static
+        when "status"
+          # Codes actually present first, then the two words for gaps — the same
+          # observed-then-static shape `method` uses.
+          from_sess = collect_prefix(p, subjects.map(&.status).reject(&.empty?))
+          seen = Set(String).new(from_sess)
+          from_sess + STATUS_WORDS.select { |w| w.starts_with?(p) && !seen.includes?(w) }
         else
           [] of String
         end
@@ -208,6 +296,10 @@ module Gori
               when :name   then (s.name || "").downcase.includes?(t.text)
               when :target then s.target.downcase.includes?(t.text)
               when :method then s.method.downcase.includes?(t.text)
+                # PREFIX, not substring: `status:4` has to mean "every 4xx", and `includes?`
+                # would also hand it 204 and 400-through-a-404. The one field here whose
+                # values have positional meaning.
+              when :status then s.status.starts_with?(t.text)
               else              free_text(t.text, s)
               end
         t.negate ? !hit : hit

--- a/src/gori/store/repeater_sessions.cr
+++ b/src/gori/store/repeater_sessions.cr
@@ -114,6 +114,19 @@ module Gori
       list
     end
 
+    # The position a NEW tab appends at: one past the highest in use — the same
+    # `COALESCE(MAX(position), -1) + 1` every other ordered table here computes
+    # (`color_rules`, `match_rules`, `display_columns`).
+    #
+    # Every caller used to pass the row COUNT instead, which is the same number only while
+    # the space is dense — and it was not, because nothing renumbered after a close. A
+    # workbench left holding positions {0, 5, 9} handed the next tab position 3, dropping it
+    # into the MIDDLE of a strip the operator had arranged. `set_repeater_positions` keeps the
+    # space dense from here on; this makes an already-sparse project append correctly too.
+    def next_repeater_position : Int32
+      @db.scalar("SELECT COALESCE(MAX(position), -1) + 1 FROM repeaters").as(Int64).to_i32
+    end
+
     # Returns the new row id (or 0 if the store is closing — the caller normalizes
     # 0 → nil so a later update never targets a bogus row).
     def insert_repeater(target : String, request : Bytes, http2 : Bool,
@@ -161,6 +174,36 @@ module Gori
     def set_repeater_tags(id : Int64, tags : String?) : Bool
       exec_task_ok ->(c : DB::Connection) {
         c.exec("UPDATE repeaters SET tags = ?, updated_at = ? WHERE id = ?", tags, now_us, id)
+        nil
+      }
+    end
+
+    # Renumber the workbench DENSELY, in the given order: `ids[0]` becomes position 0 and so
+    # on. The only writer of `position` other than `insert_repeater`.
+    #
+    # ONE batch, deliberately. A half-applied reorder is a scrambled strip and nothing else
+    # would repair it — `position` had no UPDATE at all until this method, so a partial write
+    # would be the workbench's permanent order.
+    #
+    # Renumbering rather than shifting one row is also a REPAIR. `insert_repeater`'s callers
+    # pass the row COUNT as the new position, so closing a tab left a gap and the next insert
+    # landed on a value a live row already held; `ORDER BY position, id` then broke the tie by
+    # id, which SQLite REUSES (see `delete_repeater`). The strip stayed deterministic, but the
+    # column stopped meaning "rank". Every caller here hands the full ordered id list, so it
+    # does.
+    #
+    # Ids not present in `repeaters` are simply not matched by their UPDATE — the caller
+    # decides whether an unknown id is an error, because a reorder and a post-delete
+    # renumbering want opposite answers.
+    #
+    # Returns whether the write committed (false = store busy/locked/closing), like the two
+    # label writes above.
+    def set_repeater_positions(ids : Array(Int64)) : Bool
+      exec_task_ok ->(c : DB::Connection) {
+        ts = now_us
+        ids.each_with_index do |id, i|
+          c.exec("UPDATE repeaters SET position = ?, updated_at = ? WHERE id = ?", i, ts, id)
+        end
         nil
       }
     end

--- a/src/gori/tui/controllers/repeater_controller.cr
+++ b/src/gori/tui/controllers/repeater_controller.cr
@@ -161,7 +161,7 @@ module Gori::Tui
     end
 
     def filter_fields : Array(String)
-      %w[tag name host method]
+      %w[tag name host method status]
     end
 
     # The filter bar occupies a body row whenever the strip is up (from the first session),
@@ -172,7 +172,8 @@ module Gori::Tui
 
     # The searchable projection of a session for the in-memory matcher (TUI-free).
     private def filter_subject(v : RepeaterView) : Repeater::SubtabFilter::Subject
-      Repeater::SubtabFilter::Subject.new(v.name, v.summary(200), v.target, v.request_method, v.tags)
+      Repeater::SubtabFilter::Subject.new(v.name, v.summary(200), v.target, v.request_method,
+        v.tags, v.status_token)
     end
 
     # One Subject per open session, in chip order (the base's filter projection hook).

--- a/src/gori/tui/repeater_view/session.cr
+++ b/src/gori/tui/repeater_view/session.cr
@@ -101,6 +101,19 @@ class Gori::Tui::RepeaterView
     (@editor.first_nonblank_line || "").strip.split(' ').first? || ""
   end
 
+  # The last send's outcome as the sub-tab filter's `status:` token — the LIVE one, off
+  # `@result`, which is the response this session is showing. Read through
+  # `SubtabFilter::Subject.status_token` so this and the stored-row projection
+  # (`Subject.from_row`, used headlessly by MCP) cannot spell the same session differently.
+  def status_token : String
+    res = @result
+    return "unsent" unless res
+    # `res.head`, NOT `res.response.try(&.status)`: `restore` rebuilds the Result with
+    # `response: nil` (the parsed RawResponse is not persisted), so reading the parsed object
+    # answered "unsent" for a reopened tab that was plainly showing a 403.
+    Repeater::SubtabFilter::Subject.status_token(res.error, res.head)
+  end
+
   # Replace the request body (e.g. from the external editor); marks dirty so the
   # tab persists + the cross-session reconcile won't clobber it.
   def replace_request(text : String) : Nil


### PR DESCRIPTION
Closes #904.

## What the exploration changed about the plan

Four of the six reported pain points turned out not to need new machinery — they needed a fact the codebase already holds to reach the surface asking for it. Worth stating up front, because it is most of why this diff is the size it is:

- **`import_flows{kind:"oas"}` already parses OpenAPI/Swagger and joins `servers[0].url` with each operation path** (`import/oas.cr:62-86`). The manual base-path assembly the report describes was work the importer had already done. The missing piece was the last hop, flows → tabs. No new parser.
- **`Repeater::SubtabFilter` already exists** — the `tag:` / `name:` / `host:` / `method:` grammar the operator types into the TUI's `/`. It was TUI-only; MCP now compiles the same one.
- Repeaters already store `name`, `tags` and `response_body`. There is **no** `status` column and **no** "closed" concept — closing a tab *is* a delete — so `status:` is derived from the response head, and "delete closed items" has no referent to build against.

## Two things that were actually broken

**The chip number is an array index.** `RepeaterController#subtab_labels` is `map_with_index { |tab, i| "#{i + 1}:…" }` — not the row id, not `position`. And it stays **absolute** under the tag filter (`chrome.cr:524`: a filtered strip reads `2, 5, 7`). So `tui_index` has to be taken from the full ordered list, before any narrowing; deriving it from a returned page would renumber exactly what the TUI refuses to renumber.

**`repeaters.position` had no writer other than `insert_repeater`** — no `UPDATE … SET position` anywhere in the tree, so nothing on any surface could reorder the strip. Worse, all three insert callers passed the row **count** as the new position, so closing a tab left a gap the next insert collided with; `ORDER BY position, id` broke the tie by id, which SQLite reuses. The column had quietly stopped meaning "rank".

## Commit 1 — a writable tab order, and `status:`

- `Store#set_repeater_positions` renumbers densely in **one batch** (a half-applied reorder is a scrambled strip and nothing else would repair it). Renumbering rather than shifting one row also repairs an already-sparse space.
- `Store#next_repeater_position` — `COALESCE(MAX(position), -1) + 1`, the same expression `color_rules` / `match_rules` / `display_columns` already use.
- `status:` on the sub-tab filter: a code (`status:4` matches every 4xx by prefix), `error`, or `unsent`.
- CLI: `gori run repeater move <id> --to N | --up | --down` and `gori run repeater delete <id> [<id>…] --yes`. `repeater list` leads each line with the chip number and adds `tui_index` to the JSON row.

**The TUI needed no change to benefit** — its reconcile poll already re-sorts by `{position, id}` on a peer commit, so an MCP reorder shows up in a running TUI immediately (verified below).

**A real bug this surfaced.** Reading `status:` off `Result#response.try(&.status)` made the live view answer `unsent` for a reopened tab plainly showing a 403: `RepeaterView#restore` rebuilds its `Repeater::Result` with `response: nil`, because the parsed `RawResponse` is not persisted. The head bytes are the only input **both** readers can answer from, so both go through one `Subject.status_token(error, head)`. Caught by a spec that pins the two projections against each other rather than against literals.

## Commit 2 — the MCP surface

**Tab number ↔ database id.** Every repeater reply now carries `tui_index` beside `id`: create, update, delete, `get_repeater_context` sessions, `send_request` (both `repeater_id` and `save_as_repeater`), `send_websocket`, `minimize_repeater`. `delete_repeater` names what it destroyed (`id`, `name`, `was_tui_index`) and says the rest shifted.

It is **report-only**. No tool takes it as a selector: it moves on every create, delete and move, and `repeaters.id` is itself reused after a top-of-space delete (`Store#delete_repeater` already documents why that matters), so a caller acting on a remembered *number* could reach a session it never read. The one exception is `move_repeater{to_index}`, which is a **destination** — a stale one misplaces a tab, it cannot act on a different one.

**Reorder and bulk.**

| Tool | Notes |
| --- | --- |
| `move_repeater{id, to_index \| direction}` | Absolute placement or a one-step nudge. Out of range is **refused, not clamped**. The reply returns the full resulting order, so there is nothing to re-list |
| `create_repeaters{flow_ids, name_prefix, tags}` | One tab per captured flow, through the same seed path `create_repeater{flow_id}` uses — **extracted** to `seed_from_flow`, not copied |
| `delete_repeaters` / `update_repeaters` | Bulk close, and bulk re-label (tags and name affixes **only**; `update_repeater` stays the one that writes request bytes) |
| `get_repeater_context{filter}` | The TUI's own sub-tab language, ANDed with `query` |

Both bulk tools take **explicit ids and never a filter**. A filter evaluated inside the tool cannot promise that the set the caller *read* is the set acted on — it would match whatever the workbench holds now, and a session created since the listing would be deleted without ever having been read. Narrow with `get_repeater_context{filter}`, pass the ids it returned. An unknown id refuses the whole call with **zero writes**; delete additionally needs `confirm:true`.

`update_repeaters` is labels-only by design: a bulk tool that could reach request bytes would let one call change what many sessions put **on the wire**, and no per-id report makes that reviewable.

**OpenAPI → tabs**, now three calls, documented in the guide:

```
import_flows{kind: "oas", path: "openapi.yaml"}
list_history{query: "src:import"}          → the flow ids
create_repeaters{flow_ids: [...], name_prefix: "oas: ", tags: "spec"}
```

**Response body.** `get_repeater_context{include_response_body}` inlines the stored last response, decoded and capped through the same `ContentDecode` and the same `representation` / `decode_note` words `get_response_body_chunk` uses. It is its own BLOB read per row (`repeaters_mcp` leaves the body out on purpose), so it is hydrated for a bounded head of a page and the rest are **named**, not dropped.

**What a credential header is wired to.** A repeater row stores the author's bytes verbatim, so an env-bound session literally holds `Authorization: Bearer $AUTH` — and `redact_head` blanks that exactly as it blanks a live token. The operator could not confirm the binding without asking for the secret. `Serialize.env_header_shapes` adds a shape beside the redacted head; three classes of byte survive and only three — an env reference (through `Env.token_regions`, `$$` escape included), a cookie **name**, and an auth scheme keyword:

```
Authorization: Bearer $AUTH        ← env-bound, readable
Authorization: Bearer …            ← a literal credential, still withheld
Cookie: _test=$TEST; sid=…
```

Nothing about the existing redaction changes. `list_env` rows gain `length` and `scheme` for the same question one level up — whether a header should read `Bearer $KEY` or just `$KEY` — and still carry no value bytes. Deliberately **not** `Bindings.mask_preview` (first-4/last-4): right for the TUI's own binding rows, but this contract has always been "no value bytes", and a preview would weaken it for every caller that never asked.

Also lifts `authorize`'s id-array reader into a shared `id_list_arg` / `id_list_prop`, so the bulk tools cannot grow a second grammar for the same shape.

## Test plan

- [x] `crystal spec` — **12,260 examples, 0 failures** (63 new)
- [x] `crystal build --no-codegen src/main.cr` and `scripts/seed_demo.cr`
- [x] `./scripts/bench_check.sh` — 49 harnesses build
- [x] `crystal tool format --check` on every touched file
- [x] ameba diffed against a `git worktree add --detach HEAD` baseline: two new `not_nil!` removed; `get_repeater_context` complexity brought back 34 → 27
- [x] **Commit 1 builds and passes its specs standalone**, verified in a detached worktree
- [x] **Three-surface dogfood**: seeded a project, drove `./bin/gori mcp` over stdio, ran the CLI, and opened the TUI in tmux. `repeater list`, MCP `tui_index` and the TUI chips agreed exactly (`1:… 2:admin 3:… 4:…`), and `move_repeater{id:3, to_index:4}` **reordered the running TUI live**.
- [x] Dogfooded the OpenAPI recipe end to end against a real spec: 3 operations imported with `/v2` joined, then seeded as 3 named/tagged tabs.

## Not in scope

- **#906** — a separate issue that says so itself.
- A TUI chord to drag sub-tabs. `move_repeater` makes the strip reorderable and the TUI follows it live, but a keybinding is its own UX change and #683 already owns multi-select there.
- A soft-close / archive state. "Delete closed items" has no referent today — close *is* delete — and inventing a lifecycle is a data-model change, not a usability fix.
- **`repeaters.id` is `INTEGER PRIMARY KEY` without AUTOINCREMENT, so ids are reused after a top-of-space delete.** Real, and the reason `tui_index` stays report-only, but changing it is a migration and its own argument. Flagging it rather than folding it in.

---

## 요약 (KO)

#904의 여섯 항목 중 넷은 새 기능이 아니라 **이미 있는 사실을 필요한 표면에 노출**하는 일이었습니다. `import_flows{kind:"oas"}`는 이미 OpenAPI를 파싱하고 `servers[0].url`을 합치고 있었고, TUI의 `/` 서브탭 필터 문법도 이미 존재했습니다.

실제로 깨져 있던 것은 둘입니다. **칩 번호는 배열 인덱스**(`i + 1`)라 db id도 `position`도 아니고, 태그 필터를 걸어도 절대값을 유지합니다. 그리고 **`position`에는 insert 말고 쓰는 곳이 없었고**, 세 호출자가 전부 행 개수를 새 position으로 넘겨서 탭을 닫으면 다음 insert가 살아있는 행과 충돌했습니다 — 컬럼이 조용히 "순위"이기를 그만둔 상태였습니다.

- **커밋 1**: `set_repeater_positions`(한 배치 조밀 재번호, 기존 sparse 공간도 복구) + `next_repeater_position`, 서브탭 필터 `status:`, CLI `repeater move`/`delete`와 `list`의 탭 번호. TUI는 코드 변경이 필요 없습니다 — reconcile이 이미 `{position, id}`로 재정렬합니다.
- **커밋 2**: 모든 repeater 응답의 `tui_index`(**보고 전용** — id가 재사용되므로 선택자로는 받지 않음), `move_repeater` / `create_repeaters` / `delete_repeaters` / `update_repeaters`, `get_repeater_context`의 `filter`·`include_response_body`, `env_headers`, `list_env`의 `length`/`scheme`.

파괴적 벌크는 필터가 아니라 **명시적 id만** 받습니다. 툴 안에서 평가하는 필터는 "읽은 집합 == 작용한 집합"을 약속할 수 없기 때문입니다.

작업 중 실제 버그 하나를 잡았습니다: `restore`가 `Repeater::Result`를 `response: nil`로 재구성해서, 라이브 뷰가 403을 표시하면서도 `status:`에는 `unsent`로 답했습니다. 두 리더가 답할 수 있는 유일한 입력인 head 바이트로 통일했습니다.
