### PR TITLE
test(miner,fuzz): root-cause two specs that fail on their own schedule

### DIFF
--- a/spec/fuzz/conn_pool_spec.cr
+++ b/spec/fuzz/conn_pool_spec.cr
@@ -113,9 +113,19 @@ private class PoisonOrigin
       tail = req.target.lchop("/f/")
       ident = "ID:#{tail}"
       if tail == @poison_tail
-        # framed body is 4 bytes; a WHOLE extra response is glued on behind it
+        # framed body is 4 bytes; a WHOLE extra response is glued on behind it.
+        #
+        # ONE write, not two. `TCPSocket#sync` is true by default, so `conn << resp << ghost`
+        # is two `write` syscalls and therefore two segments — the residue then arrives after
+        # the response instead of with it, and whether it has landed by the time
+        # `checkout_state` looks is a race this spec loses roughly one full-suite run in three
+        # (it never loses it alone, which is what made it read as a mystery). A real
+        # out-of-process origin whose body over-ran its Content-Length puts the leftover in
+        # the same send as the response, which is the case under test; residue still in
+        # flight is the other one, and `recycle`'s early retire is explicitly best-effort
+        # about it.
         ghost = "HTTP/1.1 200 OK\r\nContent-Length: 9\r\n\r\nID:GHOST!"
-        conn << "HTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\nPOIS" << ghost
+        conn << "HTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\nPOIS#{ghost}"
         conn.flush
       else
         conn << "HTTP/1.1 200 OK\r\nContent-Length: #{ident.bytesize}\r\n\r\n" << ident

--- a/spec/miner/baseline_spec.cr
+++ b/spec/miner/baseline_spec.cr
@@ -112,9 +112,19 @@ private class WidthAwareBackend < F::Backend
   # `jitter` is a rotating element — bytes that move on every response and belong to no
   # parameter. `bytes_only` reacts to the parameters in LENGTH alone (names run together on one
   # line), which is a JSON API naming back the keys it did not recognise.
+  #
+  # The churn is drawn from a SEEDED generator, one per backend, so a run reproduces. It used to
+  # come off the global `Random`, and that made the reference guard's own spec fail about one
+  # run in twelve: `settle` estimates this page's churn from exactly two controls (`p` and
+  # `twin`) and widens the band to twice what they disagreed by, so two draws that land close
+  # together leave a band too narrow to absorb a third sample, and a page that only churns gets
+  # locked in as an anchor. That is a real property of a two-sample estimate — `injected_bands`
+  # says as much where it only ever WIDENS — and not something a spec can assert away; what a
+  # spec can do is name the sequence it exercises instead of drawing a new one each run.
   def initialize(@refuse_over : Int32 = 1024, @react : Bool = true,
-                 @jitter : Int32 = 0, @bytes_only : Bool = false)
+                 @jitter : Int32 = 0, @bytes_only : Bool = false, seed : UInt64 = 0x5eed_u64)
     @origin = F::Origin.new("http", "h", 80)
+    @churn = Random.new(seed)
   end
 
   def send(bytes : Bytes) : Gori::Repeater::Result
@@ -125,7 +135,7 @@ private class WidthAwareBackend < F::Backend
     end
     body = String.build do |io|
       io << "BASELINE BODY\n"
-      io << ("x" * Random.rand(@jitter)) << "\n" if @jitter > 0
+      io << ("x" * @churn.rand(@jitter)) << "\n" if @jitter > 0
       if @bytes_only
         io << "unknown:" << (0...n).join(",") { |i| "k#{i}" } << "\n"
       elsif @react


### PR DESCRIPTION
Two specs that fail on a schedule nobody controls, found while merging the five dogfooding PRs
(#911–#915): each one turned a merge red on a branch that touches neither subsystem, and the
first thing anyone does with a red gate is re-audit the innocent diff. Both are harness defects,
both root-caused, neither hides a product claim.

## 1. `spec/miner/baseline_spec.cr` drew its churn from the global `Random`

`WidthAwareBackend`'s rotating element was `Random.rand(@jitter)`, so
`does NOT lock onto a page whose only reaction is its own churn` failed **1 run in 12** locally
— measured on the exact tree CI had just failed on:

```
$ for i in $(seq 1 12); do crystal spec spec/miner/baseline_spec.cr; done
run 5 FAILED    # 1 / 12
```

The mechanism is not luck about an unrelated number, it is luck about the thing under test.
`Baseline#settle` estimates this page's churn from exactly two controls — `p` and its `twin` —
and `injected_bands` widens the band to twice what those two disagreed by. Two draws that land
close together leave a band too narrow to absorb a third sample, `reacts?` answers true, and the
churning page becomes the anchor for the whole run. That is a property of a two-sample estimate,
which `injected_bands` already states where it says it only ever WIDENS; a spec cannot assert it
away.

What a spec can do is name the sequence it exercises instead of drawing a new one every run. The
backend now owns a seeded `Random`. After: **15/15 green**.

## 2. `spec/fuzz/conn_pool_spec.cr` sent the residue in a second write

`retires a socket the origin left residue on` failed about **one full-suite run in three** and
**never once on its own** — including 25 consecutive isolated runs under eight spinning CPU hogs.
That split is what kept it reading as a mystery, and the spec's own comment had already written
it off as scheduler interleaving.

It is not the scheduler. `TCPSocket#sync` is `true` by default:

```crystal
$ crystal eval '...' # both ends
server: conn.sync = true
client: sync = true
```

so `conn << response << ghost` is **two `write` syscalls and two segments**. The leftover
therefore arrives *after* the response rather than *with* it, and whether it has landed by the
time `ConnPool.checkout_state` reads `@in_buffer_rem` is a race. The `conn.flush` on the next
line is a no-op that made it look like one send.

The comment above that line already named the case under test — "a real out-of-process origin
sends the residue with the response" — so the harness now does exactly that, in one write.

This does not weaken the assertion. Detecting residue that **has arrived** is the product's
contract, and it is what the spec pins; residue still in flight is the other case, which
`recycle`'s early retire is explicitly best-effort about (`client_conn.cr`, "the origin can be a
peer whose write races our park"). The checkout-time check that this spec exercises is the one
documented as reliable *because* the bytes are on the wire by then — which, after this change,
they deterministically are.

## Still open, and deliberately not fixed here

`spec/proxy/server_spec.cr:1005` (`never parks the upstream after answering the expectation with
a final status (#728)`) failed once in the three full-suite runs used to validate the above. It
predates this branch and #913 did not touch it — that PR only appended new examples to the file.

I am not guessing at it: the run's `tail` clipped the expected/got before I could read which
branch it took, and without that value there is no way to tell a spurious `-1` from a real `>0`.
The prime suspect is the origin leg's `conn.read_timeout = 2.seconds`, whose `rescue` maps a
timeout to `-1`, the same value that means "parked for reuse" — a load-sensitive threshold
standing in for a correctness signal. Whoever picks it up should capture the failing value first;
if it is `-1`, the timeout is a liveness bound and can be made generous without weakening
anything.

## Gates

`crystal spec` 12337 examples 0 failures (run B; run A carried only the `server_spec` flake
above), `crystal tool format --check src spec bench scripts`, `scripts/bench_check.sh` (49
harnesses). No `CHANGELOG.md` entry: spec-only, per the house rule.
