### PR TITLE
refactor(tui): i18n pre-work — cell-measured labels, toast kinds, coded choices

### DIFF
--- a/spec/tui/runner_status_spec.cr
+++ b/spec/tui/runner_status_spec.cr
@@ -1,0 +1,32 @@
+require "../spec_helper"
+
+include Gori::Tui
+
+# The status strip's spinner / ✓ / ✗ rides the KIND a producer passed to `status(message, kind)`,
+# not a prefix of the message text (see `Runner#format_status_message`). `Runner.new` owns a
+# terminal, so the rule is pinned through the pure class method the instance defers to.
+describe "Runner.decorate_status" do
+  spinner = "⣾"
+
+  it "decorates the message the kind was set with" do
+    Runner.decorate_status("fuzzer error: boom", {"fuzzer error: boom", :error}, spinner).should eq("✗ fuzzer error: boom")
+    Runner.decorate_status("sent → 200 in 12ms", {"sent → 200 in 12ms", :done}, spinner).should eq("✓ sent → 200 in 12ms")
+    Runner.decorate_status("stopping…", {"stopping…", :busy}, spinner).should eq("⣾ stopping…")
+  end
+
+  it "leaves a toast that never named a kind plain, even after a kinded one" do
+    # 239 sites write `@toast = …` directly. The kind is keyed to its own message, so the
+    # next plain toast does not inherit the previous glyph.
+    kinded = {"fuzzer error: boom", :error}
+    Runner.decorate_status("screen refreshed", kinded, spinner).should eq("screen refreshed")
+    Runner.decorate_status("screen refreshed", nil, spinner).should eq("screen refreshed")
+  end
+
+  it "does not depend on the wording — a translated error still earns its mark" do
+    Runner.decorate_status("퍼저 오류: boom", {"퍼저 오류: boom", :error}, spinner).should eq("✗ 퍼저 오류: boom")
+  end
+
+  it "treats an unknown kind as plain rather than raising on the render path" do
+    Runner.decorate_status("x", {"x", :sparkly}, spinner).should eq("x")
+  end
+end

--- a/spec/tui/settings_view_spec.cr
+++ b/spec/tui/settings_view_spec.cr
@@ -685,4 +685,52 @@ describe SettingsView do
       FileUtils.rm_rf(dir)
     end
   end
+
+  # A choice field's `@values` entry is the STORED code and the row draws `choice_labels[code]`.
+  # The four `*_from_label` helpers this replaced parsed the DISPLAYED string back into the
+  # setting, so rewording (or translating) a label silently saved the default instead.
+  it "draws a choice's label while saving its stored code" do
+    dir = File.tempname("gori-settings-choice-labels")
+    Dir.mkdir_p(dir)
+    prev_home = ENV["GORI_HOME"]?
+    prev = {Gori::Settings.command_modifier, Gori::Settings.history_list_order,
+            Gori::Settings.sitemap_expand_depth, Gori::Settings.terminal_title}
+    begin
+      ENV["GORI_HOME"] = dir
+      Gori::Settings.command_modifier = "alt"
+      Gori::Settings.history_list_order = "oldest"
+      Gori::Settings.sitemap_expand_depth = -1
+      Gori::Settings.terminal_title = "project"
+      box = Rect.new(0, 0, 120, 40)
+
+      v = SettingsView.new
+      v.reload(:keys)
+      backend = MemoryBackend.new(120, 40)
+      v.render(Screen.new(backend), box)
+      backend.contains?("◉ Option (⌥)").should be_true # the label…
+      backend.contains?("◉ alt").should be_false       # …never the code
+      v.save.should eq("settings saved")
+      Gori::Settings.command_modifier.should eq("alt") # a round-trip through the label lost this once
+
+      v.reload(:layout)
+      backend = MemoryBackend.new(120, 40)
+      v.render(Screen.new(backend), box)
+      backend.contains?("◉ oldest first").should be_true
+      backend.contains?("◉ all").should be_true # depth -1 shows as "all"
+      v.save.should eq("settings saved")
+      Gori::Settings.history_list_order.should eq("oldest")
+      Gori::Settings.sitemap_expand_depth.should eq(-1)
+
+      v.reload(:display)
+      backend = MemoryBackend.new(120, 40)
+      v.render(Screen.new(backend), box)
+      backend.contains?("◉ project + tab").should be_true
+      v.save.should eq("settings saved")
+      Gori::Settings.terminal_title.should eq("project")
+    ensure
+      Gori::Settings.command_modifier, Gori::Settings.history_list_order, Gori::Settings.sitemap_expand_depth, Gori::Settings.terminal_title = prev
+      prev_home ? (ENV["GORI_HOME"] = prev_home) : ENV.delete("GORI_HOME")
+      FileUtils.rm_rf(dir)
+    end
+  end
 end

--- a/spec/tui/toast_wording_spec.cr
+++ b/spec/tui/toast_wording_spec.cr
@@ -86,31 +86,34 @@ describe "status-strip wording" do
   end
 end
 
-# `Runner#format_status_message` prefixes the strip with a spinner / ✓ / ✗ by MATCHING THE
-# MESSAGE TEXT. That makes it the one place where renaming a toast silently changes how it
-# looks — and it did: `fuzz error:` became `fuzzer error:` for the sake of one noun per engine,
-# and the ✗ simply stopped appearing. Nothing failed; the mark was gone.
-describe "status glyph prefixes" do
-  it "cover every engine's error toast" do
+# The strip's spinner / ✓ / ✗ used to come from MATCHING THE MESSAGE TEXT against English
+# prefixes, which made `format_status_message` the one place where renaming a toast silently
+# changed how it looked — and it did: `fuzz error:` became `fuzzer error:` for the sake of one
+# noun per engine, and the ✗ simply stopped appearing. The glyph now rides a KIND passed with
+# the toast (`status(message, :error)`), so the wording — or the language it is drawn in — is
+# free to change. What this guards is the other direction: an engine error toast that forgot
+# to say it is one.
+describe "status glyph kinds" do
+  it "mark every engine's error toast as :error" do
     root = File.join(__DIR__, "..", "..", "src", "gori", "tui")
     # Only what reaches the STRIP. The same `<x> error:` shape is also used for text drawn
     # INTO a pane — `config error:` in the Fuzzer/Miner config bodies, `upstream error:` in a
     # History detail line, `wordlist error:` as a returned string — and those are not status
     # messages, so no glyph applies to them.
     emitted = [] of String
+    unmarked = [] of String
     Dir.glob(File.join(root, "**", "*.cr")).sort.each do |path|
-      File.read(path).lines.each do |line|
+      File.read(path).lines.each_with_index do |line, i|
         next unless line.matches?(/(status\(|@toast =|toast\()/)
+        next unless line.matches?(/"([a-z]+ error): #\{/)
         line.scan(/"([a-z]+ error): #\{/) { |m| emitted << m[1] }
+        unmarked << "#{File.basename(path)}:#{i + 1}" unless line.includes?(", :error)")
       end
     end
     emitted.uniq.sort.should eq(["discover error", "fuzzer error", "miner error",
                                  "probe error", "repeater error", "sequencer error"])
-    # Every one of them must be in the table that earns the ✗.
-    runner = File.read(File.join(root, "runner.cr"))
-    table = runner[/ERROR_PREFIXES = \[(.*?)\]/m]?.should_not be_nil
-    emitted.uniq.each do |prefix|
-      runner.should contain(%("#{prefix}:"))
-    end
+    unmarked.should be_empty
+    # …and the text-matching table is gone for good, not merely bypassed.
+    File.read(File.join(root, "runner.cr")).should_not contain("ERROR_PREFIXES")
   end
 end

--- a/spec/tui/tutorial_companion_spec.cr
+++ b/spec/tui/tutorial_companion_spec.cr
@@ -365,3 +365,16 @@ describe "Gori::Tui::Tutorial.prose_gaps" do
     end
   end
 end
+
+# The practice palette's "Go to …" rows act on the tab index they CARRY, not on their label:
+# `run_overlay_selection` used to `case` on the English text, so rewording a row (or drawing
+# it in another language) turned the switch into a silent no-op.
+describe "Gori::Tui::Tutorial::PALETTE_ROWS" do
+  it "carry the fake tab each navigating row switches to" do
+    rows = Gori::Tui::Tutorial::PALETTE_ROWS
+    rows.select { |(_, label, _)| label.starts_with?("Go to") || label == "Open Help" }
+      .map { |(_, _, tab)| tab }.should eq([4, 2, 6])
+    rows.reject { |(_, label, _)| label.starts_with?("Go to") || label == "Open Help" }
+      .all? { |(_, _, tab)| tab.nil? }.should be_true
+  end
+end

--- a/spec/tui/wide_label_geometry_spec.cr
+++ b/spec/tui/wide_label_geometry_spec.cr
@@ -1,0 +1,65 @@
+require "../spec_helper"
+require "../support/memory_backend"
+
+include Gori::Tui
+
+# Label geometry measured in CELLS, not characters.
+#
+# Every one of these helpers used `String#size` to place the thing drawn after a label, size
+# the card around it, or hit-test it. That is exact for ASCII and half the truth for Hangul
+# (two cells per syllable), so a Korean label overlapped its value, a Korean button was
+# clickable across half its band, and a centred footer sat a quarter-width to the right.
+# `Screen#text` already advanced by display width — these are the arithmetic sites that had
+# to agree with it before any label can be drawn in Korean.
+describe "wide-label geometry" do
+  it "sizes confirm buttons by display width and hit-tests across every cell" do
+    dlg = ConfirmDialog.new("DELETE", "Delete this?", confirm_label: "삭제", cancel_label: "취소")
+    box = dlg.overlay_box(Rect.new(0, 0, 80, 24))
+    confirm_rect, cancel_rect = dlg.button_rects(box)
+    confirm_rect.w.should eq(Screen.draw_width(" 삭제 ")) # 6 cells — `size` said 4
+    cancel_rect.x.should eq(confirm_rect.right + 4)
+    dlg.button_at(box, confirm_rect.right - 1, confirm_rect.y).should eq(:confirm)
+    dlg.button_at(box, cancel_rect.right - 1, cancel_rect.y).should eq(:cancel)
+    dlg.button_at(box, confirm_rect.right, confirm_rect.y).should be_nil # the gap
+  end
+
+  it "hit-tests a right-chained badge over the cells its Hangul name occupies" do
+    badges = [{:send, "^R", "전송"}] of {Symbol, String, String}
+    w = Screen.draw_width(" ^R:전송 ") # 9 cells
+    Frame.right_badge_edge(20, 0, badges).should eq(20 - w)
+    Frame.right_badge_hit(20 - w, 0, 0, 20, 0, badges).should eq(:send)
+    Frame.right_badge_hit(19, 0, 0, 20, 0, badges).should eq(:send)
+    Frame.right_badge_hit(20 - w - 1, 0, 0, 20, 0, badges).should be_nil
+  end
+
+  it "walks a left-to-right chip run by display width" do
+    chips = [{:diff, " d:차이 "}, {:hex, " ^X:hex "}] of {Symbol, String}
+    first = Screen.draw_width(" d:차이 ") # 8 cells
+    Frame.left_chip_hit(10 + first - 1, 0, 0, 10, chips).should eq(:diff)
+    Frame.left_chip_hit(10 + first, 0, 0, 10, chips).should be_nil # the 1-col gap
+    Frame.left_chip_hit(10 + first + 1, 0, 0, 10, chips).should eq(:hex)
+  end
+
+  it "starts the status hint one cell past a Hangul focus badge" do
+    rect = Rect.new(0, 23, 80, 1)
+    backend = MemoryBackend.new(80, 24)
+    Chrome.render_status(Screen.new(backend), rect, focus: "본문", hints: "hints here")
+    row = backend.row(rect.y)
+    row[1].should eq('본')
+    row[3].should eq('문')
+    hint_x = Screen.draw_width(" 본문 ") + 1
+    row[hint_x, 10].should eq("hints here")
+  end
+
+  it "widens the hidden-tab dropdown to a Hangul label's cells" do
+    menu = MoreMenu.new([{:history, "히스토리"}, {:notes, "Notes"}])
+    box = menu.overlay_box(Rect.new(70, 0, 10, 1), Rect.new(0, 1, 80, 20)).not_nil!
+    box.w.should eq(Screen.draw_width("히스토리") + 4)
+  end
+
+  it "pads a protobuf preview by cells, so a Hangul value keeps its column" do
+    ProtobufTree.cut("한글", 6).should eq("한글  ")
+    ProtobufTree.cut("한글테스트", 6).should eq("한글… ")
+    Screen.draw_width(ProtobufTree.cut("한글테스트", 6)).should eq(6)
+  end
+end

--- a/src/gori/tui/chrome.cr
+++ b/src/gori/tui/chrome.cr
@@ -707,7 +707,7 @@ module Gori::Tui
     # Shared by render_status and status_bar_chip_at, so the two cannot disagree about the
     # run's left edge — and with it about which cells a chip occupies.
     private def self.status_hint_x(rect : Rect, focus : String) : Int32
-      rect.x + " #{focus} ".size + 1
+      rect.x + Screen.draw_width(" #{focus} ") + 1
     end
 
     # Hit-test the status row's chips. Mirrors top_bar_chip_at, and for the same reason the

--- a/src/gori/tui/confirm_dialog.cr
+++ b/src/gori/tui/confirm_dialog.cr
@@ -186,7 +186,7 @@ module Gori::Tui
       # phantom box (e.g. firing the destructive button on an undrawn modal).
       return Rect.new(area.x, area.y, 0, 0) if area.w < 18 || area.h < MIN_H
       lines = display_lines(area)
-      content = {longest(lines), @heading.size + 2, button_row_width}.max
+      content = {longest(lines), Screen.draw_width(@heading) + 2, button_row_width}.max
       # The roomy height, capped by what there IS. The card used to demand its full height and
       # draw nothing at all below it — on an 80×12 terminal (body 6 rows) `⇧X Clear history`
       # armed a modal that showed no heading, no count and no warning, and `y` still wiped the
@@ -281,7 +281,7 @@ module Gori::Tui
     end
 
     private def btn_width(label : String) : Int32
-      label.size + 2
+      Screen.draw_width(label) + 2
     end
 
     private def render_buttons(screen : Screen, box : Rect) : Nil
@@ -316,14 +316,15 @@ module Gori::Tui
     private def render_button(screen : Screen, x : Int32, y : Int32, label : String,
                               selected : Bool, danger : Bool) : Int32
       text = " #{label} "
+      tw = Screen.draw_width(text)
       if selected
         bg = danger ? Theme.red : Theme.accent_bg
-        screen.fill(Rect.new(x, y, text.size, 1), bg)
+        screen.fill(Rect.new(x, y, tw, 1), bg)
         screen.text(x, y, text, Theme.text_bright, bg, attr: Attribute::Bold)
       else
         screen.text(x, y, text, danger ? Theme.red : Theme.muted, Theme.panel)
       end
-      x + text.size
+      x + tw
     end
   end
 end

--- a/src/gori/tui/controllers/discover_controller.cr
+++ b/src/gori/tui/controllers/discover_controller.cr
@@ -191,7 +191,7 @@ module Gori::Tui
         return
       end
       run.request_stop
-      @host.status("stopping #{run.label(40)}…")
+      @host.status("stopping #{run.label(40)}…", :busy)
     end
 
     # Remove the selected run's row — the manual half of retention, since the list is append-
@@ -452,7 +452,7 @@ module Gori::Tui
         msg = "Discover: #{ev.message} on #{run.target}"
         log_event(run, :error, msg)
         push_notification(run, :error, msg)
-        @host.status("discover error: #{ev.message}")
+        @host.status("discover error: #{ev.message}", :error)
       end
     end
 

--- a/src/gori/tui/controllers/fuzzer_controller.cr
+++ b/src/gori/tui/controllers/fuzzer_controller.cr
@@ -1142,7 +1142,7 @@ module Gori::Tui
         # feed (the AI firehose logs freely; only the human center suppresses it).
         @host.jobs.finish(v.job_id, :error, ev.message)
         log_event(v, :error, "Fuzzer: #{ev.message} on #{v.summary}")
-        @host.status("fuzzer error: #{ev.message}")
+        @host.status("fuzzer error: #{ev.message}", :error)
       end
     end
 
@@ -1188,7 +1188,7 @@ module Gori::Tui
       msg = "Fuzzer: #{n} hit#{n == 1 ? "" : "s"} / #{v.result_count} sent#{wire} on #{v.summary}#{ending}"
       log_event(v, level, msg)
       @host.notifications.push(level, msg, goto_for(v), source: "fuzzer")
-      @host.status(msg) if Settings.notify_toast?
+      @host.status(msg, :done) if Settings.notify_toast?
     end
 
     # #124: append every fuzz completion/error to the store event feed UNCONDITIONALLY
@@ -1280,7 +1280,7 @@ module Gori::Tui
         return
       end
       if v.running?
-        @host.status("fuzz running — ^X to stop")
+        @host.status("fuzz running — ^X to stop", :busy)
         return
       end
       # Flush any trailing Done/Error from a just-finished run before we rebind
@@ -1298,7 +1298,7 @@ module Gori::Tui
       total = begin
         engine.total
       rescue ex
-        @host.status("fuzz: #{ex.message}")
+        @host.status("fuzz: #{ex.message}", :error)
         return
       end
       if total.nil? || total > CONFIRM_THRESHOLD
@@ -1391,7 +1391,7 @@ module Gori::Tui
         end_worker(v)
       end
       archive = spool_run ? "" : " · complete archive unavailable"
-      @host.status("fuzzing #{v.target_origin} — ^X stop#{archive}#{framing_note(v)}")
+      @host.status("fuzzing #{v.target_origin} — ^X stop#{archive}#{framing_note(v)}", :busy)
     end
 
     # How this run frames its body, for the run-start line — the way `gori run fuzz` prints it
@@ -1416,7 +1416,7 @@ module Gori::Tui
     def fuzz_stop : Nil
       return unless (v = current_view) && v.running?
       v.request_stop
-      @host.status("stopping…")
+      @host.status("stopping…", :busy)
     end
 
     def results_saveable? : Bool

--- a/src/gori/tui/controllers/miner_controller.cr
+++ b/src/gori/tui/controllers/miner_controller.cr
@@ -627,7 +627,7 @@ module Gori::Tui
     def mine_stop : Nil
       return unless (v = current_view) && v.running?
       v.request_stop
-      @host.status("stopping…")
+      @host.status("stopping…", :busy)
     end
 
     # --- async (run loop) ---
@@ -669,7 +669,7 @@ module Gori::Tui
         msg = "Miner: #{ev.message} on #{v.summary}"
         log_event(v, :error, msg)
         push_mine_notification(v, :error, msg)
-        @host.status("miner error: #{ev.message}") if v.config.notify.posts_notification?(0, error: true)
+        @host.status("miner error: #{ev.message}", :error) if v.config.notify.posts_notification?(0, error: true)
       end
     end
 

--- a/src/gori/tui/controllers/probe_controller.cr
+++ b/src/gori/tui/controllers/probe_controller.cr
@@ -337,7 +337,7 @@ module Gori::Tui
           # into the notification center (#127). Still logged to the #124 event feed
           # (the AI firehose logs freely; only the human center suppresses it).
           @host.session.store.insert_event("probe", "error", "error", "Probe: #{ev.message}", goto_tab: "probe")
-          @host.status("probe error: #{ev.message}")
+          @host.status("probe error: #{ev.message}", :error)
         when Probe::CompleteEvent
           # A manual "Run active scan" in Always mode came back clean — the analyzer only emits
           # this when the operator asked to be told either way, so it always posts to the tray.

--- a/src/gori/tui/controllers/repeater_controller.cr
+++ b/src/gori/tui/controllers/repeater_controller.cr
@@ -1224,7 +1224,11 @@ module Gori::Tui
           probe_scan_repeater(id, result.head, result.body, result.duration_us, tab.flow_id, view)
         end
         note = record_note ? " · #{record_note}" : ""
-        @host.status(result.ok? ? "sent → #{result.response.try(&.status)} in #{result.duration_us // 1000}ms#{result.incomplete? ? " (incomplete)" : ""}#{evidence_literal_note(view)}#{note}" : "repeater error: #{result.error}#{note}")
+        if result.ok?
+          @host.status("sent → #{result.response.try(&.status)} in #{result.duration_us // 1000}ms#{result.incomplete? ? " (incomplete)" : ""}#{evidence_literal_note(view)}#{note}", :done)
+        else
+          @host.status("repeater error: #{result.error}#{note}", :error)
+        end
         applied = true
       end
       while pair = nonblocking_ws_result
@@ -1241,11 +1245,11 @@ module Gori::Tui
         end
         if result.ok?
           recv = result.messages.count(&.direction.==("in"))
-          @host.status("ws sent: #{recv} received#{result.close_code ? " · closed #{result.close_code}" : ""}")
+          @host.status("ws sent: #{recv} received#{result.close_code ? " · closed #{result.close_code}" : ""}", :done)
           # Feed the handshake + captured frames into Probe (WS payload secrets, tech).
           probe_scan_ws_repeater(id, result, tab.flow_id, view) if id
         else
-          @host.status("ws repeater error: #{result.error}")
+          @host.status("ws repeater error: #{result.error}", :error)
         end
         applied = true
       end
@@ -1828,7 +1832,7 @@ module Gori::Tui
       end
       view.inflight = true
       sni = plan.sni # custom TLS SNI host (nil → present the dialed host)
-      @host.status("sending#{sending_as} → #{plan.host}:#{plan.port}#{sni ? " (SNI #{sni})" : ""}…")
+      @host.status("sending#{sending_as} → #{plan.host}:#{plan.port}#{sni ? " (SNI #{sni})" : ""}…", :busy)
       # The bytes the socket gets, taken ONCE and sent as-is. `view.request_bytes` above is the
       # assembled DRAFT; this is the message, with the send seam's two passes applied (the
       # `$NAME` binding pass and the active session slot's header overlay). The History
@@ -2005,7 +2009,7 @@ module Gori::Tui
       # WebSocket sends are not written to History, and the CLI draws the same line
       # (`--record-history is HTTP-only`): a socket's evidence is its frame transcript, which
       # the repeater session already keeps, and a flow row would hold a handshake and nothing else.
-      @host.status("ws sending → #{plan.host}:#{plan.port} (#{messages.size} msg#{messages.size == 1 ? "" : "s"})…#{unrecorded_note("WebSocket")}")
+      @host.status("ws sending → #{plan.host}:#{plan.port} (#{messages.size} msg#{messages.size == 1 ? "" : "s"})…#{unrecorded_note("WebSocket")}", :busy)
       spawn(name: "gori-ws-repeater") do
         result = plan.send_ws(messages, Repeater::WsEngine::DEFAULT_IDLE, keep_key)
         select

--- a/src/gori/tui/controllers/sequencer_controller.cr
+++ b/src/gori/tui/controllers/sequencer_controller.cr
@@ -727,7 +727,7 @@ module Gori::Tui
     def sequence_stop : Nil
       return unless (v = current_view) && v.running?
       v.request_stop
-      @host.status("stopping…")
+      @host.status("stopping…", :busy)
     end
 
     # --- async (run loop) ---
@@ -774,7 +774,7 @@ module Gori::Tui
         msg = "Sequencer: #{ev.message} on #{v.summary}"
         log_event(v, :error, msg)
         push_notification(v, :error, msg)
-        @host.status("sequencer error: #{ev.message}") if v.config.notify.posts_notification?(0, error: true)
+        @host.status("sequencer error: #{ev.message}", :error) if v.config.notify.posts_notification?(0, error: true)
       end
     end
 

--- a/src/gori/tui/copy_picker.cr
+++ b/src/gori/tui/copy_picker.cr
@@ -136,7 +136,7 @@ module Gori::Tui
 
     # Widest row (label + size hint), driving the card width.
     private def content_w : Int32
-      @options.max_of { |o| o.label.size + Fmt.size(o.text.bytesize.to_i64).size + 4 }
+      @options.max_of { |o| Screen.draw_width(o.label) + Fmt.size(o.text.bytesize.to_i64).size + 4 }
     end
   end
 end

--- a/src/gori/tui/frame.cr
+++ b/src/gori/tui/frame.cr
@@ -326,7 +326,7 @@ module Gori::Tui
     def self.toggle_badge(screen : Screen, right_edge : Int32, y : Int32, min_x : Int32,
                           chord : String, name : String, on : Bool) : Int32
       text = " #{chord}:#{name} "
-      x = right_edge - text.size
+      x = right_edge - Screen.draw_width(text)
       return right_edge if x < min_x
       screen.text(x, y, text, on ? Theme.text_bright : Theme.muted, on ? Theme.accent_bg : Theme.bg)
       x
@@ -343,7 +343,7 @@ module Gori::Tui
                          chord : String, name : String, fg : Color, bg : Color,
                          attr : Attribute = Attribute::None) : Int32
       text = " #{chord}:#{name} "
-      x = right_edge - text.size
+      x = right_edge - Screen.draw_width(text)
       return right_edge if x < min_x
       screen.text(x, y, text, fg, bg, attr)
       x
@@ -365,7 +365,7 @@ module Gori::Tui
     def self.mode_badge(screen : Screen, right_edge : Int32, y : Int32, min_x : Int32,
                         insert : Bool) : Int32
       text = mode_badge_label(insert)
-      x = right_edge - text.size
+      x = right_edge - Screen.draw_width(text)
       return right_edge if x < min_x
       if insert
         screen.text(x, y, text, Theme.text_bright, Theme.accent_bg)
@@ -394,16 +394,16 @@ module Gori::Tui
                             min_x : Int32, insert : Bool) : Bool
       return false if my != y
       text = mode_badge_label(insert)
-      x = right_edge - text.size
+      x = right_edge - Screen.draw_width(text)
       return false if x < min_x
-      mx >= x && mx < x + text.size
+      mx >= x && mx < x + Screen.draw_width(text)
     end
 
     # Left edge after a `mode_badge` — the right_edge for whatever chains further left of it.
     # Mirrors `mode_badge`'s own return, unchanged edge and all, so a hit-test can follow the
     # chain past the mode chip the way the Repeater's ` ^K:MARK ` is drawn past it.
     def self.mode_badge_edge(right_edge : Int32, min_x : Int32, insert : Bool) : Int32
-      x = right_edge - mode_badge_label(insert).size
+      x = right_edge - Screen.draw_width(mode_badge_label(insert))
       x < min_x ? right_edge : x
     end
 
@@ -415,7 +415,7 @@ module Gori::Tui
       edge = right_edge
       badges.each do |(_, chord, name)|
         text = " #{chord}:#{name} "
-        x = edge - text.size
+        x = edge - Screen.draw_width(text)
         next if x < min_x # `next`, not `break` — see right_badge_hit
         edge = x
       end
@@ -433,7 +433,7 @@ module Gori::Tui
     def self.action_badge(screen : Screen, right_edge : Int32, y : Int32, min_x : Int32,
                           chord : String, name : String, ready : Bool) : Int32
       text = " #{chord}:#{name} "
-      x = right_edge - text.size
+      x = right_edge - Screen.draw_width(text)
       return right_edge if x < min_x
       if ready
         screen.text(x, y, text, Theme.ink_on(Theme.focus_gold), Theme.focus_gold, Attribute::Bold)
@@ -459,8 +459,8 @@ module Gori::Tui
       x = start_x
       chips.each do |(id, label)|
         break if limit && x + Screen.draw_width(label) > limit
-        return id if mx >= x && mx < x + label.size
-        x += label.size + 1
+        return id if mx >= x && mx < x + Screen.draw_width(label)
+        x += Screen.draw_width(label) + 1
       end
       nil
     end
@@ -483,9 +483,9 @@ module Gori::Tui
       edge = right_edge
       badges.each do |(id, chord, name)|
         text = " #{chord}:#{name} "
-        x = edge - text.size
+        x = edge - Screen.draw_width(text)
         next if x < min_x
-        return id if mx >= x && mx < x + text.size
+        return id if mx >= x && mx < x + Screen.draw_width(text)
         edge = x
       end
       nil

--- a/src/gori/tui/help_view.cr
+++ b/src/gori/tui/help_view.cr
@@ -711,7 +711,7 @@ module Gori::Tui
     # Horizontally center `text` on row `y` within `rect` (mirrors ProjectPicker).
     private def centered(screen : Screen, rect : Rect, y : Int32, text : String, fg : Color,
                          attr : Attribute = Attribute::None) : Nil
-      x = rect.x + {(rect.w - text.size) // 2, 0}.max
+      x = rect.x + {(rect.w - Screen.draw_width(text)) // 2, 0}.max
       screen.text(x, y, text, fg, Theme.bg, attr: attr)
     end
   end

--- a/src/gori/tui/more_menu.cr
+++ b/src/gori/tui/more_menu.cr
@@ -41,7 +41,7 @@ module Gori::Tui
     # there's nothing to show or it can't fit.
     def overlay_box(anchor : Rect, body : Rect) : Rect?
       return nil if @items.empty? || body.empty?
-      label_w = @items.max_of { |(_, l)| l.size }
+      label_w = @items.max_of { |(_, l)| Screen.draw_width(l) }
       w = {label_w + 4, body.w}.min     # left border + ▎ + label + right border
       h = {@items.size + 2, body.h}.min # top border + rows + bottom border
       return nil if w < 8 || h < 3

--- a/src/gori/tui/overlay.cr
+++ b/src/gori/tui/overlay.cr
@@ -187,8 +187,7 @@ module Gori::Tui
     def draw_field(screen : Screen, box : Rect, py : Int32, bg : Color, fg : Color,
                    sel : Bool, label : String, field : TextField) : Nil
       x = box.x + 3
-      screen.text(x, py, label, Theme.muted, bg)
-      vx = x + label.size + 1
+      vx = screen.text(x, py, label, Theme.muted, bg) + 1
       vw = {box.right - 2 - vx, 3}.max
       val = field.value
       pre = field.preedit

--- a/src/gori/tui/preferences_view.cr
+++ b/src/gori/tui/preferences_view.cr
@@ -416,8 +416,8 @@ module Gori::Tui
       # outline, the strip above this one when it has the keys — so spending it on a static
       # section heading makes two different things look like the same thing. The Probe rules
       # list already headed its sections in accent; this is the other half of that pair.
-      screen.text(content.x, y, title.upcase, Theme.accent, Theme.panel, Attribute::Bold, width: content.w)
-      screen.text(content.x + title.size + 1, y, "● unsaved", Theme.yellow, Theme.panel, width: {content.right - content.x - title.size - 1, 1}.max) if dirty
+      tw = screen.text(content.x, y, title.upcase, Theme.accent, Theme.panel, Attribute::Bold, width: content.w) - content.x
+      screen.text(content.x + tw + 1, y, "● unsaved", Theme.yellow, Theme.panel, width: {content.right - content.x - tw - 1, 1}.max) if dirty
     end
 
     private def draw_opener(screen : Screen, content : Rect, sec : SettingsCatalog::Section, y : Int32, focused : Bool) : Nil
@@ -436,7 +436,7 @@ module Gori::Tui
       # the screen, not at the card, so the row overwrote the right border and lost the cue
       # entirely. A 43-character :action label does that under ~61 columns, well above the
       # `box.w < 24` render guard.
-      cx = {content.right - cue.size, lx + 1}.max
+      cx = {content.right - Screen.draw_width(cue), lx + 1}.max
       screen.text(lx, y, label, focused ? Theme.text_bright : Theme.text, bg, width: {cx - lx - 1, 1}.max)
       # Theme row: preview the CURRENT theme inline — its name + a swatch of its palette —
       # so you see what's selected without opening the card. Both are extras: on a card too
@@ -444,7 +444,7 @@ module Gori::Tui
       # or the cue.
       if sec.sym == :theme
         name = Theme.canonical(Settings.theme)
-        name_x = lx + label.size + 2
+        name_x = lx + Screen.draw_width(label) + 2
         sx = cx - 1 - SWATCH_W
         if sx >= name_x
           screen.text(name_x, y, name, focused ? Theme.text_bright : Theme.muted, bg, width: {sx - name_x - 1, 1}.max)

--- a/src/gori/tui/project_picker.cr
+++ b/src/gori/tui/project_picker.cr
@@ -1801,11 +1801,11 @@ module Gori::Tui
 
     private def render_busy(screen : Screen, w : Int32, h : Int32) : Nil
       msg = BUSY_LABELS[@mode]? || " Working … "
-      bw = {msg.size + 4, 22}.max
+      bw = {Screen.draw_width(msg) + 4, 22}.max
       bh = 3
       box = Rect.new({(w - bw) // 2, 0}.max, {(h - bh) // 2, 0}.max, bw, bh)
       Frame.card(screen, box, border: Theme.border_focus)
-      screen.text(box.x + (box.w - msg.size) // 2, box.y + 1, msg, Theme.text_bright, Theme.panel, Attribute::Bold)
+      screen.text(box.x + (box.w - Screen.draw_width(msg)) // 2, box.y + 1, msg, Theme.text_bright, Theme.panel, Attribute::Bold)
     end
 
     private def render_rename(screen : Screen, cx : Int32, cw : Int32, w : Int32, h : Int32) : Nil
@@ -1903,7 +1903,7 @@ module Gori::Tui
     # x=0 and run off the right edge into the hint row.
     private def centered(screen : Screen, y : Int32, text : String, fg : Color, w : Int32,
                          attr : Attribute = Attribute::None, width : Int32? = nil) : Nil
-      screen.text({(w - text.size) // 2, 0}.max, y, text, fg, Theme.bg, attr: attr, width: width)
+      screen.text({(w - Screen.draw_width(text)) // 2, 0}.max, y, text, fg, Theme.bg, attr: attr, width: width)
     end
 
     # Draw BRAND_ART as one centered block: every line starts at the same left

--- a/src/gori/tui/protobuf_tree.cr
+++ b/src/gori/tui/protobuf_tree.cr
@@ -388,7 +388,8 @@ module Gori::Tui
           used += gw
         end
       end
-      "#{cut}…".ljust(width)
+      clipped = "#{cut}…"
+      "#{clipped}#{" " * {width - Screen.draw_width(clipped), 0}.max}"
     end
 
     private def self.hex(data : Bytes) : String

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -287,6 +287,9 @@ module Gori::Tui
       # placement also writes to it, so the two are resolved by recency rather than by a
       # fixed precedence — see #companion_notice for why a fixed one is wrong.
       @toast_at = nil.as(Time::Instant?)
+      # The last toast set WITH a kind (see `status(message, kind)`), paired with its text so
+      # the glyph only ever decorates that message.
+      @toast_kinded = nil.as({String, Symbol}?)
       @outcome = :running # :running | :quit | :back
       # {configured port, port we actually got} when the bind fell back at startup because the
       # configured one was taken; nil when the proxy got what it asked for. A RUNTIME note the
@@ -2162,29 +2165,28 @@ module Gori::Tui
       end
     end
 
-    # Glyph prefixes for the status strip, matched against the message TEXT. That coupling is
-    # the thing to know about this method: it is the one place where changing a toast's wording
-    # silently changes its appearance. `fuzz error:` was renamed `fuzzer error:` (one noun per
-    # engine, across both its channels) and the ✗ quietly stopped appearing — nothing failed,
-    # the mark was simply gone. `ERROR_PREFIXES` now carries every engine so the next one
-    # inherits the mark instead of needing a line here.
-    ERROR_PREFIXES = [
-      "repeater error:", "ws repeater error:", "fuzz:",
-      "fuzzer error:", "discover error:", "miner error:", "sequencer error:", "probe error:",
-    ]
-    BUSY_PREFIXES = ["sending →", "ws sending →", "fuzzing ", "fuzz running", "stopping"]
-    DONE_PREFIXES = ["sent →", "ws sent:", "Fuzzer:"]
-
+    # The status strip's glyph — spinner / ✓ / ✗ — comes from the KIND the producer passed to
+    # `status(message, kind)`, never from the message text. This used to match English
+    # prefixes (`"fuzzer error:"`, `"sent →"`) against the toast, and it was the one place
+    # where rewording a toast silently changed its appearance: `fuzz error:` became `fuzzer
+    # error:` and the ✗ just stopped appearing. A kind survives a reword, and survives the
+    # message being drawn in another language. The kind is keyed to the message it was set
+    # with, so any of the raw `@toast = …` writes that never name a kind draw plain.
     private def format_status_message(message : String?) : String?
       return nil unless message
-      if BUSY_PREFIXES.any? { |p| message.starts_with?(p) }
-        "#{SPINNER[@spinner_frame % SPINNER.size]} #{message}"
-      elsif DONE_PREFIXES.any? { |p| message.starts_with?(p) }
-        "✓ #{message}"
-      elsif ERROR_PREFIXES.any? { |p| message.starts_with?(p) }
-        "✗ #{message}"
-      else
-        message
+      Runner.decorate_status(message, @toast_kinded, SPINNER[@spinner_frame % SPINNER.size].to_s)
+    end
+
+    # The strip line for `message`: led by `spinner` / ✓ / ✗ when `kinded` names this same
+    # message, verbatim otherwise. Class-level and pure so the rule is spec-able — `Runner.new`
+    # owns a terminal and appears nowhere under spec/.
+    def self.decorate_status(message : String, kinded : {String, Symbol}?, spinner : String) : String
+      kind = kinded && kinded[0] == message ? kinded[1] : :plain
+      case kind
+      when :busy  then "#{spinner} #{message}"
+      when :done  then "✓ #{message}"
+      when :error then "✗ #{message}"
+      else             message
       end
     end
 
@@ -2866,6 +2868,13 @@ module Gori::Tui
     def status(message : String) : Nil
       @toast = message
       @toast_at = Time.instant
+    end
+
+    # A toast with a status-strip glyph: `:busy` (spinner), `:done` (✓) or `:error` (✗). See
+    # `format_status_message` for why the glyph is a kind and not a prefix of the text.
+    def status(message : String, kind : Symbol) : Nil
+      @toast_kinded = {message, kind}
+      status(message)
     end
 
     def open_palette : Nil

--- a/src/gori/tui/send_picker.cr
+++ b/src/gori/tui/send_picker.cr
@@ -122,7 +122,7 @@ module Gori::Tui
         screen.cell(box.x + 1, ry, active ? '▎' : ' ', Theme.accent, bg)
         screen.text(box.x + 3, ry, d.key.to_s, Theme.accent, bg, Attribute::Bold)
         screen.text(box.x + 6, ry, d.label, active ? Theme.text_bright : Theme.text, bg, Attribute::Bold)
-        screen.text(box.right - d.hint.size - 2, ry, d.hint, Theme.muted, bg)
+        screen.text(box.right - Screen.draw_width(d.hint) - 2, ry, d.hint, Theme.muted, bg)
       end
     end
 
@@ -134,8 +134,8 @@ module Gori::Tui
 
     # Widest row (label + hint) and the sized title, driving the card width.
     private def content_w : Int32
-      rows = @destinations.max_of { |d| d.label.size + d.hint.size + 4 }
-      {rows, card_title.size}.max
+      rows = @destinations.max_of { |d| Screen.draw_width(d.label) + Screen.draw_width(d.hint) + 4 }
+      {rows, Screen.draw_width(card_title)}.max
     end
   end
 end

--- a/src/gori/tui/settings_view.cr
+++ b/src/gori/tui/settings_view.cr
@@ -935,7 +935,7 @@ module Gori::Tui
     # `rect` (block == viewport, no extra clipping). Shared by the overlay and the tab.
     def render_fields_into(screen : Screen, rect : Rect, focused_idx : Int32, viewport : Rect = rect) : Nil
       flds = fields
-      label_w = flds.max_of(&.label.size)
+      label_w = flds.max_of { |f| Screen.draw_width(f.label) }
       flds.each_with_index do |field, i|
         ry = rect.y + i
         next if ry < viewport.y

--- a/src/gori/tui/settings_view.cr
+++ b/src/gori/tui/settings_view.cr
@@ -24,10 +24,17 @@ module Gori::Tui
     # `readonly` is a DISPLAY row: it shows a live summary of something configured elsewhere and
     # swallows every edit. It exists so a table that lives only in settings.json is still
     # discoverable from the UI, without pretending to be editable here.
+    #
+    # `choices` are the STORED codes, in cycle order, and `@values` holds one of them verbatim.
+    # `choice_labels` is what the row draws for a code (absent = the code itself) and is read
+    # in exactly one place, `render_field_value`. Nothing parses a label back: the four
+    # `*_from_label` helpers this replaced turned a displayed string into a setting, so the
+    # day a label was reworded (or translated) the save silently fell back to the default.
     record Field, label : String, hint : String, bool : Bool = false, choices : Array(String)? = nil,
-      opener : Symbol? = nil, readonly : Bool = false
+      opener : Symbol? = nil, readonly : Bool = false, choice_labels : Hash(String, String)? = nil
 
-    PROXY_PROTOCOL_CHOICES = ["None", "HTTP", "SOCKS5", "SOCKS5H"]
+    PROXY_PROTOCOL_CHOICES = ["none", "http", "socks5", "socks5h"]
+    PROXY_PROTOCOL_LABELS  = {"none" => "None", "http" => "HTTP", "socks5" => "SOCKS5", "socks5h" => "SOCKS5H"}
     NETWORK_PROXY_PROTOCOL = 2
     NETWORK_PROXY_HOST     = 3
     NETWORK_PROXY_PORT     = 4
@@ -36,7 +43,7 @@ module Gori::Tui
       Field.new("Bind IP", "global default listen address — projects may pin their own"),
       Field.new("Bind Port", "global default port (0-65535) — project overrides win when set"),
       Field.new("Proxy protocol", "None = direct · SOCKS5 resolves names locally · SOCKS5H resolves at the proxy — ←/→ cycles",
-        choices: PROXY_PROTOCOL_CHOICES),
+        choices: PROXY_PROTOCOL_CHOICES, choice_labels: PROXY_PROTOCOL_LABELS),
       Field.new("Proxy host", "upstream proxy hostname or IP — disabled when protocol is None"),
       Field.new("Proxy port", "upstream proxy port (1-65535) — disabled when protocol is None"),
       Field.new("Verify upstream TLS", "check the upstream server's certificate — off accepts any cert (MITM/testing); ←/→/space toggles", bool: true),
@@ -56,9 +63,10 @@ module Gori::Tui
         readonly: true),
       Field.new("Hostname overrides", "↵ to edit the global IP→host map (a /etc/hosts for this proxy)", opener: :hosts),
     ]
-    # Command-modifier labels. The stored values are "ctrl"/"alt" (Settings.command_modifier);
-    # these are what the row shows — see #modifier_label / #modifier_from_label.
-    COMMAND_MODIFIER_CHOICES = ["Ctrl", "Option (⌥)"]
+    # Command modifier: the stored values ARE the choices (Settings.command_modifier); the
+    # labels are what the row shows for each.
+    COMMAND_MODIFIER_CHOICES = ["ctrl", "alt"]
+    COMMAND_MODIFIER_LABELS  = {"ctrl" => "Ctrl", "alt" => "Option (⌥)"}
 
     EDITOR_FIELDS = [
       Field.new("External editor", "e.g. vim · code --wait — blank = $VISUAL/$EDITOR/vi"),
@@ -71,7 +79,7 @@ module Gori::Tui
     # "which binding" read as the pair they are.
     KEYS_FIELDS = [
       Field.new("Command modifier", "which modifier fronts gori's built-in shortcuts (^P ^N ^W ^G ^F ^B ^E ^, ^1-9) — Option ADDS ⌥ as an alias, Ctrl keeps working; for terminals/multiplexers that swallow the Ctrl form (tmux's ^B, Ctrl+digit). macOS Terminal/iTerm must be set to send Option as Meta. ←/→ cycles",
-        choices: COMMAND_MODIFIER_CHOICES),
+        choices: COMMAND_MODIFIER_CHOICES, choice_labels: COMMAND_MODIFIER_LABELS),
     ]
     # The THEME section is special: a single field whose value is the selected theme
     # name, but rendered as a vertical, scrollable list (built-ins + user themes) rather
@@ -81,8 +89,10 @@ module Gori::Tui
       Field.new("Theme", "TUI colour theme — ↑/↓ select, ↵ applies", choices: Theme.available),
     ]
     # Layout: vertical list of per-area prefs (extend by appending fields + Settings keys).
-    LAYOUT_DEPTH_CHOICES = ["all", "0", "1", "2", "3"]
-    LAYOUT_ORDER_CHOICES = ["newest first", "oldest first"]
+    LAYOUT_DEPTH_CHOICES = ["-1", "0", "1", "2", "3"] # Settings.sitemap_expand_depth, -1 = all
+    LAYOUT_DEPTH_LABELS  = {"-1" => "all"}
+    LAYOUT_ORDER_CHOICES = ["newest", "oldest"]
+    LAYOUT_ORDER_LABELS  = {"newest" => "newest first", "oldest" => "oldest first"}
     LAYOUT_FIELDS        = [
       Field.new("History Req/Res preview",
         "list page: bottom pane shows selected flow request + response — ←/→/space toggles",
@@ -95,10 +105,10 @@ module Gori::Tui
         bool: true),
       Field.new("History list order",
         "newest first (default, live tail at top) or oldest first — ←/→ cycles",
-        choices: LAYOUT_ORDER_CHOICES),
+        choices: LAYOUT_ORDER_CHOICES, choice_labels: LAYOUT_ORDER_LABELS),
       Field.new("Sitemap expand depth",
         "how deep the tree opens after reload — ←/→ cycles (all = fully expanded)",
-        choices: LAYOUT_DEPTH_CHOICES),
+        choices: LAYOUT_DEPTH_CHOICES, choice_labels: LAYOUT_DEPTH_LABELS),
     ]
     # Statusline: an opt-in bottom row that runs a command and shows its output.
     STATUSLINE_FIELDS = [
@@ -115,8 +125,10 @@ module Gori::Tui
     # Display: message-body + chrome prefs (three choice fields, three bools, a text cap).
     DISPLAY_PANE_CHOICES = ["request", "response"]
     DISPLAY_TIME_CHOICES = ["absolute", "relative"]
-    # Kept short: all three render inline on one row inside the settings box.
-    DISPLAY_TITLE_CHOICES = ["project + tab", "tab", "off"]
+    # Kept short: all three render inline on one row inside the settings box. "project" is
+    # stored (Settings.terminal_title) and shown as "project + tab" since the title carries both.
+    DISPLAY_TITLE_CHOICES = ["project", "tab", "off"]
+    DISPLAY_TITLE_LABELS  = {"project" => "project + tab"}
     DISPLAY_FIELDS        = [
       Field.new("Default detail pane",
         "which pane a freshly-opened History flow shows first — ←/→ cycles",
@@ -137,7 +149,7 @@ module Gori::Tui
         bool: true),
       Field.new("Terminal title",
         "what gori writes into the terminal window title — off leaves it to your shell/tmux — ←/→ cycles",
-        choices: DISPLAY_TITLE_CHOICES),
+        choices: DISPLAY_TITLE_CHOICES, choice_labels: DISPLAY_TITLE_LABELS),
     ]
     # Companion: Miss Ring, the mascot in the body's bottom-right corner.
     COMPANION_MOTION_CHOICES    = ["lively", "calm", "still"]
@@ -265,14 +277,14 @@ module Gori::Tui
                   Settings::DEFAULT_MOUSE ? "on" : "off",
                   Settings::DEFAULT_PRETTY_BODIES ? "on" : "off",
                 ]
-                when :keys  then [modifier_label(Settings::DEFAULT_COMMAND_MODIFIER)]
+                when :keys  then [Settings::DEFAULT_COMMAND_MODIFIER]
                 when :theme then [Theme.canonical(Settings::DEFAULT_THEME)]
                 when :layout then [
                   Settings::DEFAULT_HISTORY_PREVIEW ? "on" : "off",
                   Settings::DEFAULT_PROBE_PREVIEW ? "on" : "off",
                   Settings::DEFAULT_ISSUES_PREVIEW ? "on" : "off",
-                  order_label(Settings::DEFAULT_HISTORY_LIST_ORDER),
-                  depth_label(Settings::DEFAULT_SITEMAP_EXPAND_DEPTH),
+                  Settings::DEFAULT_HISTORY_LIST_ORDER,
+                  Settings::DEFAULT_SITEMAP_EXPAND_DEPTH.to_s,
                 ]
                 when :statusline then [
                   Settings::DEFAULT_STATUSLINE_ENABLED ? "on" : "off",
@@ -287,7 +299,7 @@ module Gori::Tui
                   Settings::DEFAULT_WRAP_LINES ? "on" : "off",
                   Settings::DEFAULT_PREVIEW_BODY_KIB.to_s,
                   Settings::DEFAULT_RESOURCE_METER ? "on" : "off",
-                  title_label(Settings::DEFAULT_TERMINAL_TITLE),
+                  Settings::DEFAULT_TERMINAL_TITLE,
                 ]
                 when :companion then [
                   Settings::DEFAULT_COMPANION ? "on" : "off",
@@ -308,7 +320,7 @@ module Gori::Tui
                   Settings::DEFAULT_REPEATER_RECORD_HISTORY ? "on" : "off",
                 ]
                 else [Settings::DEFAULT_BIND_HOST, Settings::DEFAULT_BIND_PORT.to_s,
-                      proxy_protocol_label("none"), "", "",
+                      "none", "", "",
                       Settings::DEFAULT_VERIFY_UPSTREAM ? "on" : "off",
                       Settings::DEFAULT_SERVE_LANDING ? "on" : "off",
                       Settings::DEFAULT_CONNECT_TIMEOUT_SECS.to_s,
@@ -356,23 +368,10 @@ module Gori::Tui
 
     private def upstream_proxy_field_values(raw : String) : {String, String, String}
       if fields = Settings.upstream_proxy_fields(raw)
-        {proxy_protocol_label(fields[0]), fields[1], fields[2]}
+        {PROXY_PROTOCOL_CHOICES.includes?(fields[0]) ? fields[0] : "none", fields[1], fields[2]}
       else
         {"Invalid · #{raw}", "", ""}
       end
-    end
-
-    private def proxy_protocol_label(kind : String) : String
-      case kind
-      when "http"    then "HTTP"
-      when "socks5"  then "SOCKS5"
-      when "socks5h" then "SOCKS5H"
-      else                "None"
-      end
-    end
-
-    private def proxy_protocol_kind(label : String) : String
-      label.downcase
     end
 
     # The EDITOR row values, read from the live Settings — same reason as #network_values:
@@ -389,17 +388,7 @@ module Gori::Tui
 
     # The KEYS row values (one row today — the command modifier).
     private def keys_values : Array(String)
-      [modifier_label(Settings.command_modifier)]
-    end
-
-    # "ctrl"/"alt" ↔ the row's display labels (unknown → the Ctrl default, matching
-    # Settings.normalize_command_modifier).
-    private def modifier_label(value : String) : String
-      value == "alt" ? COMMAND_MODIFIER_CHOICES[1] : COMMAND_MODIFIER_CHOICES[0]
-    end
-
-    private def modifier_from_label(label : String) : String
-      label == COMMAND_MODIFIER_CHOICES[1] ? "alt" : "ctrl"
+      [Settings.command_modifier]
     end
 
     # The GENERAL row values, read from the live Settings — one helper for the load and the
@@ -447,8 +436,8 @@ module Gori::Tui
         Settings.history_preview ? "on" : "off",
         Settings.probe_preview ? "on" : "off",
         Settings.issues_preview ? "on" : "off",
-        order_label(Settings.history_list_order),
-        depth_label(Settings.sitemap_expand_depth),
+        Settings.history_list_order,
+        Settings.sitemap_expand_depth.to_s,
       ]
     end
 
@@ -461,22 +450,6 @@ module Gori::Tui
       ]
     end
 
-    private def depth_label(d : Int32) : String
-      d < 0 ? "all" : d.to_s
-    end
-
-    private def depth_from_label(s : String) : Int32
-      s == "all" ? -1 : (s.to_i? || Settings::DEFAULT_SITEMAP_EXPAND_DEPTH)
-    end
-
-    private def order_label(order : String) : String
-      order == "oldest" ? "oldest first" : "newest first"
-    end
-
-    private def order_from_label(s : String) : String
-      s.starts_with?("oldest") ? "oldest" : "newest"
-    end
-
     private def display_values : Array(String)
       [
         Settings.default_detail_pane,
@@ -485,7 +458,7 @@ module Gori::Tui
         Settings.wrap_lines? ? "on" : "off",
         Settings.preview_body_kib.to_s,
         Settings.resource_meter? ? "on" : "off",
-        title_label(Settings.terminal_title),
+        Settings.terminal_title,
       ]
     end
 
@@ -498,16 +471,6 @@ module Gori::Tui
         Settings.companion_motion,
         Settings.companion_notices? ? "on" : "off",
       ]
-    end
-
-    # "tab"/"off" label as themselves; only the default mode reads differently in the UI
-    # ("project" stored, "project + tab" shown) since the title carries both.
-    private def title_label(mode : String) : String
-      mode == "project" ? "project + tab" : mode
-    end
-
-    private def title_from_label(s : String) : String
-      DISPLAY_TITLE_CHOICES.includes?(s) && s != "project + tab" ? s : "project"
     end
 
     # ↑/↓: move between fields — except in the THEME section, whose single field IS a
@@ -608,7 +571,7 @@ module Gori::Tui
       return false unless @section == :network
       return false unless index == NETWORK_PROXY_HOST || index == NETWORK_PROXY_PORT
       protocol = @values[NETWORK_PROXY_PROTOCOL]
-      protocol == "None" || protocol.starts_with?("Invalid ·")
+      protocol == "none" || protocol.starts_with?("Invalid ·")
     end
 
     # The sub-overlay the focused action row opens (↵), or nil for an ordinary field. The
@@ -659,10 +622,10 @@ module Gori::Tui
       @values[NETWORK_PROXY_PORT] = proxy_default_port(current)
     end
 
-    private def proxy_default_port(label : String) : String
-      case label
-      when "HTTP"              then Settings::DEFAULT_HTTP_PROXY_PORT.to_s
-      when "SOCKS5", "SOCKS5H" then Settings::DEFAULT_SOCKS_PORT.to_s
+    private def proxy_default_port(kind : String) : String
+      case kind
+      when "http"              then Settings::DEFAULT_HTTP_PROXY_PORT.to_s
+      when "socks5", "socks5h" then Settings::DEFAULT_SOCKS_PORT.to_s
       else                          ""
       end
     end
@@ -689,7 +652,7 @@ module Gori::Tui
         return persist
       end
       if @section == :keys
-        Settings.command_modifier = Settings.normalize_command_modifier(modifier_from_label(@values[0]))
+        Settings.command_modifier = Settings.normalize_command_modifier(@values[0])
         @values = keys_values
         return persist
       end
@@ -697,8 +660,8 @@ module Gori::Tui
         Settings.history_preview = @values[0] == "on"
         Settings.probe_preview = @values[1] == "on"
         Settings.issues_preview = @values[2] == "on"
-        Settings.history_list_order = Settings.normalize_history_list_order(order_from_label(@values[3]))
-        Settings.sitemap_expand_depth = Settings.normalize_sitemap_depth(depth_from_label(@values[4]))
+        Settings.history_list_order = Settings.normalize_history_list_order(@values[3])
+        Settings.sitemap_expand_depth = Settings.normalize_sitemap_depth(@values[4].to_i? || Settings::DEFAULT_SITEMAP_EXPAND_DEPTH)
         @values = layout_values
         return persist
       end
@@ -733,7 +696,7 @@ module Gori::Tui
         Settings.wrap_lines = @values[3] == "on"
         Settings.preview_body_kib = kib
         Settings.resource_meter = @values[5] == "on"
-        Settings.terminal_title = title_from_label(@values[6])
+        Settings.terminal_title = Settings.normalize_terminal_title(@values[6])
         @values = display_values
         return persist
       end
@@ -784,7 +747,7 @@ module Gori::Tui
         up = @network_upstream_raw
       else
         up, proxy_error = Settings.build_upstream_proxy(
-          proxy_protocol_kind(@values[NETWORK_PROXY_PROTOCOL]),
+          @values[NETWORK_PROXY_PROTOCOL],
           @values[NETWORK_PROXY_HOST], @values[NETWORK_PROXY_PORT])
         if proxy_error
           @status = "invalid upstream proxy"
@@ -973,9 +936,9 @@ module Gori::Tui
         choices.each do |opt|
           break if left <= 0
           on = opt == value
-          seg = "#{on ? '◉' : '◯'} #{opt}"
+          seg = "#{on ? '◉' : '◯'} #{field.choice_labels.try(&.[opt]?) || opt}"
           screen.text(cx, ry, seg, on ? Theme.text_bright : Theme.muted, bg, width: left)
-          adv = seg.size + 2
+          adv = Screen.draw_width(seg) + 2
           cx += adv
           left -= adv
         end

--- a/src/gori/tui/setup_wizard.cr
+++ b/src/gori/tui/setup_wizard.cr
@@ -665,13 +665,13 @@ module Gori::Tui
         # answers are still in hand. Keep SAVE_FAILED_SHORT's tail in step with the string
         # `finish` builds; that is the only one that reaches here (`skip`'s never renders,
         # see there).
-        err = SAVE_FAILED_SHORT if err.size > w
-        screen.text({(w - err.size) // 2, 0}.max, h - 1, err, Theme.red, Theme.bg)
+        err = SAVE_FAILED_SHORT if Screen.draw_width(err) > w
+        screen.text({(w - Screen.draw_width(err)) // 2, 0}.max, h - 1, err, Theme.red, Theme.bg)
         return
       end
       hints = footer_hints
-      hint = hints.find { |s| s.size <= w } || hints.last
-      screen.text({(w - hint.size) // 2, 0}.max, h - 1, hint, Theme.muted, Theme.bg)
+      hint = hints.find { |s| Screen.draw_width(s) <= w } || hints.last
+      screen.text({(w - Screen.draw_width(hint)) // 2, 0}.max, h - 1, hint, Theme.muted, Theme.bg)
     end
 
     # This step's key hints, widest first; `render_footer` takes the first that fits.
@@ -882,7 +882,7 @@ module Gori::Tui
       screen.text(ix, y, "You're all set!", Theme.text_bright, Theme.panel, width: {box.w - 6, 1}.max)
       y += 2
       recap_labels = ["Proxy (global)", "Theme", "Miss Ring", "Shortcuts"]
-      vx = ix + recap_labels.max_of(&.size) + 2 # +2 = min visible gap before the value column
+      vx = ix + recap_labels.max_of { |l| Screen.draw_width(l) } + 2 # +2 = min visible gap before the value column
       recap(screen, box, ix, vx, y, "Proxy (global)", "#{effective_ip}:#{@port.strip}"); y += 1
       recap(screen, box, ix, vx, y, "Theme", @theme_name); y += 1
       recap(screen, box, ix, vx, y, "Miss Ring", @companion_enabled ? "on · #{@companion_motion}" : "off"); y += 1

--- a/src/gori/tui/space_menu.cr
+++ b/src/gori/tui/space_menu.cr
@@ -176,8 +176,8 @@ module Gori::Tui
       # Widest of the entry titles AND the group headers ("─ LABEL ─", 4 chars of
       # chrome around the label) — a grouped view with a long section label (e.g.
       # SECTION_LABELS additions) must still fit inside the box the entries sized.
-      entry_w = @entries.empty? ? 0 : @entries.max_of { |v| menu_title(v, ctx).size + chord_hint_w(v) }
-      header_w = @groups.empty? ? 0 : @groups.max_of { |g| g.label.size + 4 }
+      entry_w = @entries.empty? ? 0 : @entries.max_of { |v| Screen.draw_width(menu_title(v, ctx)) + chord_hint_w(v) }
+      header_w = @groups.empty? ? 0 : @groups.max_of { |g| Screen.draw_width(g.label) + 4 }
       @title_w = {entry_w, header_w}.max
     end
 

--- a/src/gori/tui/tab_controller.cr
+++ b/src/gori/tui/tab_controller.cr
@@ -89,6 +89,15 @@ module Gori::Tui
     abstract def active_tab : Symbol # read the active tab (Repeater reconcile gates on it)
     abstract def focus : Symbol      # read the focus model (:menu | :subtabs | :body)
 
+    # A toast WITH a status-strip glyph: `:busy` (spinner), `:done` (✓) or `:error` (✗) — see
+    # `Runner#format_status_message` for why the glyph is a kind on the call and not a prefix
+    # of the text. CONCRETE with a plain-toast fallback for the same reason `subtab_find_focused?`
+    # below is: the spec doubles that `include Host` should not each have to restate it.
+    # Runner overrides it.
+    def status(message : String, kind : Symbol) : Nil
+      status(message)
+    end
+
     # The strip's ⌕ affordance is the current stop — one step LEFT of the first chip, inside
     # `:subtabs` focus. CONCRETE, not abstract: nine spec files `include Host` to drive a
     # controller, and `false` is the right answer for every one of them. Runner overrides.

--- a/src/gori/tui/tutorial.cr
+++ b/src/gori/tui/tutorial.cr
@@ -1211,7 +1211,7 @@ module Gori::Tui
     private def render_footer(screen : Screen, w : Int32, h : Int32) : Nil
       hint = footer_hint
       hy = h - 2
-      screen.text({(w - hint.size) // 2, 0}.max, hy, hint, Theme.muted, Theme.bg)
+      screen.text({(w - Screen.draw_width(hint)) // 2, 0}.max, hy, hint, Theme.muted, Theme.bg)
 
       by = h - 1
       prev_l = prev_btn_label
@@ -1505,7 +1505,7 @@ module Gori::Tui
       render_request_pane(screen, pane, true, insert: insert, typed: typed, flow: 0)
 
       kh = insert ? "INS · type · esc → READ" : "READ · i or ↵ → INS"
-      screen.text(shell.x + {(shell.w - kh.size) // 2, 0}.max, shell.bottom - 1, kh, Theme.muted, Theme.bg)
+      screen.text(shell.x + {(shell.w - Screen.draw_width(kh)) // 2, 0}.max, shell.bottom - 1, kh, Theme.muted, Theme.bg)
     end
 
     private def render_practice(screen : Screen, box : Rect) : Nil
@@ -1635,7 +1635,7 @@ module Gori::Tui
 
       unless keyhint.empty?
         kh = " #{keyhint} "
-        screen.text(rect.x + {(rect.w - kh.size) // 2, 0}.max, rect.y + 1, kh,
+        screen.text(rect.x + {(rect.w - Screen.draw_width(kh)) // 2, 0}.max, rect.y + 1, kh,
           Theme.ink_on(Theme.accent), Theme.accent, attr: Attribute::Bold)
       end
     end
@@ -1646,8 +1646,9 @@ module Gori::Tui
       cx = x
       TABS.each_with_index do |name, i|
         label = " #{name} "
-        break if cx + label.size > x + w
-        @tab_hits << {Rect.new(cx, y, label.size, 1), i}
+        lw = Screen.draw_width(label)
+        break if cx + lw > x + w
+        @tab_hits << {Rect.new(cx, y, lw, 1), i}
         if i == active
           bg = focused ? Theme.focus_gold : Theme.accent_bg
           fg = focused ? Theme.ink_on(Theme.focus_gold) : Theme.text_bright

--- a/src/gori/tui/tutorial.cr
+++ b/src/gori/tui/tutorial.cr
@@ -71,13 +71,16 @@ module Gori::Tui
     # did before she existed — see #companion_band.
     COMPANION_BAND = Companion::GUTTER + Mascot::W + 1
 
-    # Fake palette rows used by the palette lesson + practice overlay.
+    # Fake palette rows used by the palette lesson + practice overlay: sigil, label, and the
+    # fake tab index the row switches to (nil = the row only closes the palette). The action
+    # rides its own slot so the label is free to be reworded or translated without the
+    # practice step's "Go to …" quietly turning into a no-op.
     PALETTE_ROWS = [
-      {"»", "Go to Repeater"},
-      {"≡", "Settings: Theme"},
-      {"×", "Quit gori"},
-      {"→", "Go to History"},
-      {"?", "Open Help"},
+      {"»", "Go to Repeater", 4},
+      {"≡", "Settings: Theme", nil},
+      {"×", "Quit gori", nil},
+      {"→", "Go to History", 2},
+      {"?", "Open Help", 6},
     ]
 
     # Fake space-menu rows (mnemonic key + label).
@@ -678,10 +681,10 @@ module Gori::Tui
       end
     end
 
-    private def filtered_palette : Array({String, String})
+    private def filtered_palette : Array({String, String, Int32?})
       q = @pal_query.downcase
       return PALETTE_ROWS if q.empty?
-      PALETTE_ROWS.select { |(_, label)| label.downcase.includes?(q) }
+      PALETTE_ROWS.select { |(_, label, _)| label.downcase.includes?(q) }
     end
 
     private def run_overlay_selection : Nil
@@ -689,10 +692,9 @@ module Gori::Tui
         rows = filtered_palette
         if row = rows[@pal_sel]?
           # Mirror a couple of real "Go to …" actions so the palette feels alive.
-          case row[1]
-          when "Go to Repeater" then @p_tab = 4; mark_switch
-          when "Go to History"  then @p_tab = 2; mark_switch
-          when "Open Help"      then @p_tab = 6; mark_switch
+          if tab = row[2]
+            @p_tab = tab
+            mark_switch
           end
         end
       end


### PR DESCRIPTION
Pre-work for the TUI i18n series (English + 한국어, per-area language). Behaviour-preserving on its own; every change here is something that would have broken the moment a label stopped being ASCII or English.

**Why each piece**

- **Label geometry in cells, not characters.** ~20 sites placed what follows a label with `String#size` (overlay field values, space-menu width, confirm buttons, the status badge, badge/chip hit-tests, the hidden-tab dropdown, the settings label column, centred footers). Exact for ASCII, half the truth for Hangul — a Korean label overlapped its value and a Korean button was clickable across half its band. Everything now measures with `Screen.draw_width` or uses what `screen.text` returns, the measure `#text` already advances by. `ProtobufTree.cut` padded by characters too, which mis-aligned CJK *response data* today.
- **A toast's glyph rides a kind, not its English prefix.** `format_status_message` matched `"fuzzer error:"`, `"sent →"` … against the text to choose ✓/✗/spinner, so rewording a toast silently changed its look (the `fuzz error:` → `fuzzer error:` rename lost its ✗), and the HTTP send's `sending as X →` never matched at all. Producers now pass `status(message, :busy | :done | :error)`; the kind is keyed to its own message so the 239 raw `@toast =` writes stay plain. The prefix tables are deleted and the wording guard checks every engine error toast names its kind.
- **Settings choices store codes and draw labels.** Choice fields kept their *displayed* labels as values and four helpers parsed them back on save, so rewording "newest first" or "Option (⌥)" would have quietly saved the default. `choices` are now the stored codes; `Field#choice_labels` maps a code to what the row draws, in the one place that draws it.
- **The tour's palette rows act on a tab index, not their label.** `run_overlay_selection` matched the practice palette's row text.

**Verified**: `just test` (12,360 examples), `just benchmark-check`, format check on touched files. New specs: `wide_label_geometry_spec` (Hangul fixtures against each fixed helper), `runner_status_spec`, a settings round-trip that draws labels while saving codes, and a guard that the tour rows carry their tab.
