### PR TITLE
fix(tui,probe,export): four defects from the 2026-09-02 merge review

### DIFF
--- a/spec/export/escape_spec.cr
+++ b/spec/export/escape_spec.cr
@@ -49,5 +49,32 @@ describe Gori::Export::Escape do
     it "encodes from byte 0 when there is no scheme://authority to skip" do
       Gori::Export::Escape.percent_encode_non_ascii("/안").should eq("/%EC%95%88")
     end
+
+    # A raw C0 control or DEL in the target is a byte no client carries literally: curl rejects
+    # the URL (`(3) URL rejected`, exit 3, nothing sent) and Go's net/url panics. The
+    # Repeater/Fuzzer store exactly such bytes with auto-encode off, so the export has to spell
+    # them or the "runnable" script does not run.
+    it "percent-encodes C0 control bytes and DEL in the target, two hex digits each" do
+      io = IO::Memory.new
+      io << "https://h.test/a"
+      io.write_byte(0x7f_u8) # DEL
+      io << "b"
+      io.write_byte(0x01_u8) # SOH — one hex digit, must pad to %01, not %1
+      io << "?q="
+      io.write_byte(0x09_u8) # TAB
+      Gori::Export::Escape.percent_encode_non_ascii(String.new(io.to_slice))
+        .should eq("https://h.test/a%7Fb%01?q=%09")
+    end
+
+    # The authority is the part left raw (a client IDNA-encodes it), so a control byte there is
+    # NOT touched here — the neighbouring serializers refuse the whole command instead.
+    it "leaves a control byte in the authority raw for the caller to refuse" do
+      io = IO::Memory.new
+      io << "https://h"
+      io.write_byte(0x01_u8)
+      io << ".test/p"
+      url = String.new(io.to_slice)
+      Gori::Export::Escape.percent_encode_non_ascii(url).should be(url)
+    end
   end
 end

--- a/spec/probe/passive/cleartext_credentials_spec.cr
+++ b/spec/probe/passive/cleartext_credentials_spec.cr
@@ -74,9 +74,18 @@ describe Gori::Probe::Passive::CleartextCredentials do
   it "does not flag UI state carried under a password-ish name" do
     with_store do |store|
       dets(store, req_body: "showPassword=false&password=").should be_empty
-      # JSON booleans are unquoted, so the quoted-string requirement is the screen there.
+      # An unquoted JSON boolean never matches the "…" value pattern to begin with.
       dets(store, req_content_type: "application/json",
         req_body: %({"showPassword":false})).should be_empty
+      # A boolean a serialiser wrote as a QUOTED string is screened by NON_SECRET_VALUES, the
+      # same as the form-encoded path — otherwise `"showPassword":"false"` reads as a High
+      # cleartext password.
+      dets(store, req_content_type: "application/json",
+        req_body: %({"showPassword":"false"})).should be_empty
+      # …but a real quoted secret under the very same key is still flagged (the screen is the
+      # value, not the name).
+      dets(store, req_content_type: "application/json",
+        req_body: %({"showPassword":"hunter2"})).any?(&.code.== "cleartext_credentials").should be_true
     end
   end
 

--- a/spec/tui/wide_label_geometry_spec.cr
+++ b/spec/tui/wide_label_geometry_spec.cr
@@ -40,6 +40,21 @@ describe "wide-label geometry" do
     Frame.left_chip_hit(10 + first + 1, 0, 0, 10, chips).should eq(:hex)
   end
 
+  it "advances tour tab chips and their hit rects by cell width, not char count" do
+    # Each Hangul syllable is 2 cells but 1 char, so a char-measured advance drifts one cell per
+    # syllable: the chips after a Korean tab name would draw and hit-test off their labels.
+    rects = Tutorial.tab_chip_rects(["AB", "탭", "C"], 0, 0, 100)
+    rects.map(&.last).should eq([0, 1, 2])
+    rects[0][0].x.should eq(0)
+    rects[1][0].x.should eq(5)  # after " AB " (4 cells) + a 1-col gap
+    rects[1][0].w.should eq(4)  # " 탭 " is 4 cells — String#size said 3
+    rects[2][0].x.should eq(10) # 5 + 4 cells + 1 gap: the wide char advanced by cells, not chars
+  end
+
+  it "stops the tour tab run before the first chip that would overflow the width" do
+    Tutorial.tab_chip_rects(["AB", "CD"], 0, 0, 8).map(&.last).should eq([0])
+  end
+
   it "starts the status hint one cell past a Hangul focus badge" do
     rect = Rect.new(0, 23, 80, 1)
     backend = MemoryBackend.new(80, 24)

--- a/src/gori/export/escape.cr
+++ b/src/gori/export/escape.cr
@@ -62,12 +62,32 @@ module Gori
       def self.percent_encode_non_ascii(url : String) : String
         bytes = url.to_slice
         from = path_offset(url)
-        return url if bytes[from..].all? { |b| b < 0x80 }
+        return url if bytes[from..].none? { |b| opaque_target_byte?(b) }
         String.build do |io|
           bytes.each_with_index do |b, i|
-            b < 0x80 || i < from ? io.write_byte(b) : io << "%" << b.to_s(16).upcase
+            if i < from || !opaque_target_byte?(b)
+              io.write_byte(b)
+            else
+              io << "%" << b.to_s(16).rjust(2, '0').upcase
+            end
           end
         end
+      end
+
+      # A byte the request-target cannot carry literally, so `percent_encode_non_ascii` spells it
+      # `%NN`: every non-ASCII byte (which each generated client would otherwise re-encode its own
+      # way) plus the C0 controls (0x01–0x1f) and DEL. A raw control byte in a captured path is not
+      # a hypothetical — the Repeater and Fuzzer store whatever a target sent with `auto_encode`
+      # off — and left literal it made curl reject the URL (`(3) URL rejected`, exit 3, nothing
+      # sent) and Go's `net/url` panic, so the "runnable" export was a script that did not run.
+      # `rjust(2, '0')` because a control byte is one hex digit (`0x01` → `%01`, never `%1`).
+      #
+      # NUL (0x00) is deliberately NOT in this set: a shell argv is NUL-terminated, so no exporter
+      # can carry one at all, and `%00` would be a DIFFERENT resource than the raw NUL the capture
+      # holds. The shell serializers refuse the whole command for it instead (see curl's
+      # `nul_url_note`) — leaving it raw here is what lets that refusal still see it.
+      private def self.opaque_target_byte?(b : UInt8) : Bool
+        (0x01 <= b && b < 0x20) || b == 0x7f || b >= 0x80
       end
 
       # A whole `"…"` literal holding a URL, for the three serializers that hand one to a client

--- a/src/gori/probe/passive/cleartext_credentials.cr
+++ b/src/gori/probe/passive/cleartext_credentials.cr
@@ -41,10 +41,12 @@ module Gori
         # a password-ish name is otherwise a guaranteed High.
         NON_SECRET_VALUES = Set{"true", "false", "0", "1", "on", "off", "yes", "no", "null", "undefined"}
 
-        # A JSON member whose NAME ends in a password token and whose value is a non-empty STRING.
-        # JSON booleans are unquoted, so requiring the quoted form is already the `showPassword:
-        # false` screen the form-encoded path has to make explicitly.
-        JSON_PASSWORD = /"[A-Za-z0-9_.\[\]-]*(?:password|passwd|pwd)"\s*:\s*"(?:[^"\\]|\\.)+"/i
+        # A JSON member whose NAME ends in a password token, capturing the name and its non-empty
+        # STRING value. An unquoted boolean (`"showPassword": false`) never matches the `"…"`
+        # value; a value that IS a quoted boolean-ish token (`"false"`, `"off"` — a boolean a JS
+        # serialiser wrote as a string) is screened by `NON_SECRET_VALUES` in `json_password`, the
+        # same UI-state screen the form-encoded path applies to its value.
+        JSON_PASSWORD = /"([A-Za-z0-9_.\[\]-]*(?:password|passwd|pwd))"\s*:\s*"((?:[^"\\]|\\.)+)"/i
 
         # `<input … type=password>`. The negative lookbehind is the same one the neighbouring HTML
         # scans use: without it a `data-type="password"` attribute matches, because `\b` treats the
@@ -116,10 +118,11 @@ module Gori
 
         private def json_password(body : String) : String?
           m = JSON_PASSWORD.match(body) || return nil
-          # The member name, quotes stripped — the evidence is the field, never the value.
-          quoted = m[0]
-          close = quoted.index('"', 1) || return "password"
-          safe_name(quoted[1...close])
+          # A quoted boolean-ish value (`"showPassword":"false"`) is UI state, not a transmitted
+          # secret — the same screen `form_password` applies to its value. The evidence is the
+          # member NAME (capture 1), never the value.
+          return nil if NON_SECRET_VALUES.includes?(m[2].downcase)
+          safe_name(m[1])
         end
 
         # A parameter name reads as a credential once punctuation and case are dropped, so

--- a/src/gori/tui/project_picker.cr
+++ b/src/gori/tui/project_picker.cr
@@ -556,13 +556,18 @@ module Gori::Tui
     private def handle_confirm(ev : Termisu::Event::Key) : Project | Symbol?
       @preedit = ""
       dlg = @confirm
-      key = ev.key
-      case
-      when key.escape?, key.n?, ev.ctrl_c?                then cancel_confirm
-      when ConfirmDialog.affirmative?(ev)                 then commit_confirmed
-      when key.left?, key.right?, key.tab?, key.back_tab? then dlg.try(&.move)
-      when key.enter?
-        dlg.try(&.confirm_selected?) ? commit_confirmed : cancel_confirm
+      return nil if dlg.nil?
+      # ctrl-c is the picker's global abort; ConfirmDialog does not answer it. Everything else —
+      # the y/⇧Y with its ctrl-guard, the arrow/tab button moves, ↵-on-the-selection AND the
+      # `drawn?` gate that refuses to COMMIT a card a short window is hiding — is
+      # ConfirmDialog#handle_key's own ladder. Delegate to it rather than re-spelling it here: the
+      # gate (#912) lived only in handle_key, and this second copy of the ladder never got it, so
+      # a resize below MIN_H after arming let `y` run `rm_rf` on a project with nothing on screen.
+      # One ladder, both call sites — the way `affirmative?` is already shared.
+      return cancel_confirm if ev.ctrl_c?
+      case dlg.handle_key(ev)
+      when :commit then commit_confirmed
+      when :cancel then cancel_confirm
       end
       nil
     end

--- a/src/gori/tui/tutorial.cr
+++ b/src/gori/tui/tutorial.cr
@@ -1642,23 +1642,35 @@ module Gori::Tui
       end
     end
 
+    # The hit rect and index of each mock tab chip, laid left to right and measured in terminal
+    # CELLS. The advance to the next chip is the same `draw_width` the rect and the overflow test
+    # use, so a wide-glyph tab name (the point of the i18n pre-work) pushes the run and its click
+    # targets by the same amount instead of drifting one cell per wide char. Stops before the
+    # first chip that would overflow `w`.
+    def self.tab_chip_rects(labels : Array(String), x : Int32, y : Int32, w : Int32) : Array({Rect, Int32})
+      hits = [] of {Rect, Int32}
+      cx = x
+      labels.each_with_index do |name, i|
+        lw = Screen.draw_width(" #{name} ")
+        break if cx + lw > x + w
+        hits << {Rect.new(cx, y, lw, 1), i}
+        cx += lw + 1
+      end
+      hits
+    end
+
     private def render_tab_bar(screen : Screen, x : Int32, y : Int32, w : Int32,
                                active : Int32, focused : Bool) : Nil
-      @tab_hits = [] of {Rect, Int32}
-      cx = x
-      TABS.each_with_index do |name, i|
-        label = " #{name} "
-        lw = Screen.draw_width(label)
-        break if cx + lw > x + w
-        @tab_hits << {Rect.new(cx, y, lw, 1), i}
+      @tab_hits = Tutorial.tab_chip_rects(TABS, x, y, w)
+      @tab_hits.each do |(rect, i)|
+        label = " #{TABS[i]} "
         if i == active
           bg = focused ? Theme.focus_gold : Theme.accent_bg
           fg = focused ? Theme.ink_on(Theme.focus_gold) : Theme.text_bright
-          screen.text(cx, y, label, fg, bg, attr: Attribute::Bold)
+          screen.text(rect.x, y, label, fg, bg, attr: Attribute::Bold)
         else
-          screen.text(cx, y, label, Theme.muted, Theme.bg)
+          screen.text(rect.x, y, label, Theme.muted, Theme.bg)
         end
-        cx += label.size + 1
       end
     end
 


### PR DESCRIPTION
Fixes four defects found reviewing today's merges (#909–#921). Each is a small, self-contained correctness fix with a regression test. Full suite green: 12407 examples, 0 failures.

## Fixes

**`fix(tui)` — project picker confirm ladder ran rm_rf on an unseen card.** The `drawn?` gate #912 added lives only in `ConfirmDialog#handle_key`. ProjectPicker drives the same card through its own `handle_confirm` ladder, which never consulted `drawn?` — so arming a project delete, resizing below `MIN_H`, then pressing `y` ran `rm_rf` on the project directory with nothing on screen (the exact resize-after-arm case #912 targeted). Delegates `handle_confirm` to `handle_key` so the gate can't live in one ladder and be forgotten in the other.

**`fix(tui)` — tour tab bar mixed width measures (from #921).** `render_tab_bar` measured hit rects and the overflow break in cells (`Screen.draw_width`) but advanced the draw cursor by chars (`String#size`). A wide-glyph tab name — the point of the i18n pre-work — draws each chip to its right one cell short per wide char. Extracted a pure `Tutorial.tab_chip_rects`; pinned with a Hangul tab name.

**`fix(probe)` — cleartext-credentials JSON false positive (from #920).** The form-encoded path screens UI state (`showPassword=false`) against `NON_SECRET_VALUES`; the JSON path did not, so `{"showPassword":"false"}` (a boolean serialized as a quoted string) was reported High "password over cleartext HTTP". Screens the captured JSON value the same way; a real quoted secret still flags.

**`fix(export)` — control bytes made curl/Go exports non-runnable (from #914).** `percent_encode_non_ascii` encoded only bytes `>= 0x80`, leaving C0 controls and DEL literal. A captured path can hold a raw `0x01`/`0x09`/`0x7f` (Repeater/Fuzzer with auto-encode off), which made the curl export exit 3 and the Go export panic in `net/url`. Encodes `0x01–0x1f` and `0x7f` too. NUL stays out on purpose: no shell argv can carry one and `%00` would be a different resource, so the shell serializers keep refusing the whole command for it.

## Deliberately not in this PR

Findings from the same review left for a follow-up, to keep this set tight and low-risk:

- **export target divergence for ASCII (MEDIUM):** different clients normalize `[]{}()\` their own way; worst case `/c\d` becomes `/c/d` under fetch. Fixing it changes the wire for all clients and touches the "reproduce the capture" stance — wants its own discussion.
- **authorize redirect denial (LOW):** a `302 → /login` baseline is not caught by `denied?` (status `>= 400` only); #915 covers 4xx denials, pinned by spec.
- **interim-1xx head not recorded (LOW):** #913 left same-shape siblings in `client_conn.cr` / `repeater/engine.cr`.
- Minor: import `synthesized_length` on a foreign HAR, Go bare-`%` panic, `extract.cr` `to_i?` over-decoding, MCP refusal-message wording.

## Verification

- `crystal build --no-codegen src/main.cr` — pass
- `crystal spec` — 12407 examples, 0 failures, 0 errors, 0 pending
- `crystal tool format --check` on changed files — pass