### PR TITLE
fix(mcp): three defects an agent reads as facts — a phantom tag, a fake stop, a silent clamp

### DIFF
--- a/spec/mcp/authorize_spec.cr
+++ b/spec/mcp/authorize_spec.cr
@@ -259,7 +259,15 @@ describe "MCP authorize tools" do
         row["bypass_count"].as_i.should eq(0)
 
         stop = call_json(tools, "authorize_stop", %({"job_id":#{job_id.to_json}}))
-        stop["status"].as_s.should eq("stopping")
+        # No phantom "stopping". This used to assert that literal unconditionally, which the
+        # very next comment shows was unpinnable: a one-request run may already have finished
+        # before the stop landed, and the old hard-coded reply claimed "stopping" for a job
+        # that was `done`. The reply now carries the status the job is ACTUALLY in, plus the
+        # flag saying a stop was asked for — the same contract stop_job has always had.
+        stop["stop_requested"].as_bool.should be_true
+        stop["status"].as_s.should_not eq("stopping")
+        ["running", "done", "stopped"].should contain(stop["status"].as_s)
+        stop["stopped"].as_bool.should eq(stop["status"].as_s != "running")
         final = drain_job(tools, job_id)
         # A one-request run may well have finished before the stop landed; either terminal
         # state is correct, and neither may be :running.

--- a/spec/mcp/job_stop_status_spec.cr
+++ b/spec/mcp/job_stop_status_spec.cr
@@ -1,0 +1,164 @@
+require "../spec_helper"
+require "socket"
+
+# Two contracts the async job tools owe an agent.
+#
+# 1. A `*_stop` reply must say what state the job is ACTUALLY in. The five per-kind stop
+#    tools used to hard-code `status: "stopping"` without reading the job back, so a run that
+#    had already reached `done` / `budget_exhausted` answered "stopping" — a state it is not
+#    in and will never enter. An agent reads that as "I aborted a run that was in flight" and
+#    reports a complete run as cancelled. `stop_job` always re-read the status; all six now
+#    share `stop_and_report` / `emit_stop_result`.
+#
+# 2. A clamped `limit`/`offset` must be reported. `emit_clamp` is the shared pagination
+#    contract; six object-returning paginated tools skipped it and did not even echo `limit`,
+#    so an agent that computed `limit` down to 0 got one row back and no signal.
+
+private def with_store(&)
+  path = File.tempname("gori-mcp-jobstop", ".db")
+  store = Gori::Store.open(path)
+  begin
+    yield store
+  ensure
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+private def start_origin : Int32
+  origin = TCPServer.new("127.0.0.1", 0)
+  port = origin.local_address.port
+  spawn do
+    while conn = origin.accept?
+      Gori::Proxy::Codec::Http1.read_head(conn)
+      body = "ok"
+      conn << "HTTP/1.1 200 OK\r\nContent-Length: #{body.bytesize}\r\nConnection: close\r\n\r\n" << body
+      conn.flush
+      conn.close
+    end
+  end
+  port
+end
+
+private def call_json(tools : Gori::MCP::Tools, name : String, args : String) : JSON::Any
+  r = tools.call(name, JSON.parse(args))
+  fail "tool #{name} errored: #{r.text}" if r.is_error
+  JSON.parse(r.text)
+end
+
+# Poll `<kind>_status` until the job leaves `running`, and return its terminal status.
+private def wait_terminal(tools, kind : String, job_id : String) : String
+  400.times do
+    sleep 0.02.seconds
+    status = call_json(tools, "#{kind}_status", {job_id: job_id}.to_json)["status"].as_s
+    return status unless status == "running"
+  end
+  fail "#{kind} job #{job_id} did not reach a terminal state"
+end
+
+private def start_fuzz(tools, port : Int32) : String
+  call_json(tools, "fuzz_start", {
+    template:       "GET /f?q=§FUZZ§ HTTP/1.1\r\nHost: 127.0.0.1:#{port}\r\n\r\n",
+    url:            "http://127.0.0.1:#{port}",
+    payloads:       [{list: ["a", "b", "c"]}],
+    save_results:   true,
+    allow_unscoped: true,
+  }.to_json)["job_id"].as_s
+end
+
+describe "MCP per-kind job stop" do
+  it "reports the job's real terminal status instead of a hard-coded \"stopping\"" do
+    with_store do |store|
+      port = start_origin
+      tools = Gori::MCP::Tools.new(store, allow_actions: true, verify_upstream: false)
+      job_id = start_fuzz(tools, port)
+      terminal = wait_terminal(tools, "fuzz", job_id)
+      terminal.should eq("done")
+
+      stop = call_json(tools, "fuzz_stop", {job_id: job_id}.to_json)
+      stop["status"].as_s.should eq(terminal)
+      stop["status"].as_s.should_not eq("stopping")
+      stop["stopped"].as_bool.should be_true
+      stop["stop_requested"].as_bool.should be_true
+      stop["job_id"].as_s.should eq(job_id)
+    end
+  end
+
+  it "answers a finished job the same way the unified stop_job does" do
+    with_store do |store|
+      port = start_origin
+      tools = Gori::MCP::Tools.new(store, allow_actions: true, verify_upstream: false)
+      a = start_fuzz(tools, port)
+      b = start_fuzz(tools, port)
+      wait_terminal(tools, "fuzz", a)
+      wait_terminal(tools, "fuzz", b)
+
+      per_kind = call_json(tools, "fuzz_stop", {job_id: a}.to_json)
+      unified = call_json(tools, "stop_job", {job_id: b}.to_json)
+      %w(status stopped stop_requested).each do |field|
+        per_kind[field].should eq(unified[field])
+      end
+    end
+  end
+
+  it "sequence_stop reports its real status too (the same shared emitter)" do
+    with_store do |store|
+      port = start_origin
+      tools = Gori::MCP::Tools.new(store, allow_actions: true, verify_upstream: false)
+      job_id = call_json(tools, "sequence_start", {
+        template:       "GET /t HTTP/1.1\r\nHost: 127.0.0.1:#{port}\r\n\r\n",
+        url:            "http://127.0.0.1:#{port}",
+        regex:          "(ok)",
+        count:          2,
+        allow_unscoped: true,
+      }.to_json)["job_id"].as_s
+      terminal = wait_terminal(tools, "sequence", job_id)
+
+      stop = call_json(tools, "sequence_stop", {job_id: job_id}.to_json)
+      stop["status"].as_s.should eq(terminal)
+      stop["status"].as_s.should_not eq("stopping")
+    end
+  end
+end
+
+describe "MCP job-results pagination clamp" do
+  it "reports a clamped limit on fuzz_results, list_fuzz_runs and get_fuzz_run" do
+    with_store do |store|
+      port = start_origin
+      tools = Gori::MCP::Tools.new(store, allow_actions: true, verify_upstream: false)
+      job_id = start_fuzz(tools, port)
+      wait_terminal(tools, "fuzz", job_id)
+      run_id = call_json(tools, "fuzz_results", {job_id: job_id}.to_json)["run_id"].as_i64
+
+      {
+        "fuzz_results"   => {job_id: job_id, limit: -1, offset: -1}.to_json,
+        "list_fuzz_runs" => {limit: -1, offset: -1}.to_json,
+        "get_fuzz_run"   => {run_id: run_id, limit: -1, offset: -1}.to_json,
+      }.each do |tool, args|
+        res = call_json(tools, tool, args)
+        res["limit"].as_i.should eq(1)
+        res["requested_limit"].as_i.should eq(-1)
+        res["requested_offset"].as_i.should eq(-1)
+        res["pagination_warning"].as_s.should contain("clamped")
+      end
+    end
+  end
+
+  it "stays quiet when the pagination arguments were honoured" do
+    with_store do |store|
+      port = start_origin
+      tools = Gori::MCP::Tools.new(store, allow_actions: true, verify_upstream: false)
+      job_id = start_fuzz(tools, port)
+      wait_terminal(tools, "fuzz", job_id)
+
+      res = call_json(tools, "fuzz_results", {job_id: job_id, limit: 2, offset: 1}.to_json)
+      res["limit"].as_i.should eq(2)
+      res["offset"].as_i.should eq(1)
+      res.as_h.has_key?("requested_limit").should be_false
+      res.as_h.has_key?("requested_offset").should be_false
+      res.as_h.has_key?("pagination_warning").should be_false
+    end
+  end
+end

--- a/spec/mcp/sitemap_fold_tag_spec.cr
+++ b/spec/mcp/sitemap_fold_tag_spec.cr
@@ -1,0 +1,103 @@
+require "../spec_helper"
+
+# A tag pinned on a path whose captures all carry a query string is invisible BY DESIGN:
+# `Sitemap.fold_queries_node!` builds a synthetic `grouped` fold node for the path, and
+# `Sitemap.stamp_tags!` refuses to stamp a tag on a grouped node "because the tag key is the
+# path WITH the query". The TUI tree and `gori run sitemap` both honour that.
+#
+# MCP's `list_sitemap` did not: it stamped `tags[{host, path}]` onto its already-FOLDED rows,
+# so `set_sitemap_tag` answered `matches_endpoint:false` with "this tag will not show in
+# list_sitemap or the TUI" and then list_sitemap showed it — the two MCP tools contradicting
+# each other, and `set_sitemap_tag`'s own schema ("that folded row is synthetic … it holds no
+# tag of its own").
+
+private def with_store(&)
+  path = File.tempname("gori-mcp-smtag", ".db")
+  store = Gori::Store.open(path)
+  begin
+    yield store
+  ensure
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+private def call_json(tools : Gori::MCP::Tools, name : String, args : String) : JSON::Any
+  r = tools.call(name, JSON.parse(args))
+  fail "tool #{name} errored: #{r.text}" if r.is_error
+  JSON.parse(r.text)
+end
+
+private def seed(store, target : String) : Int64
+  id = store.insert_flow(Gori::Store::CapturedRequest.new(
+    created_at: 1_i64, scheme: "http", host: "acme.test", port: 80,
+    method: "GET", target: target, http_version: "HTTP/1.1",
+    head: "GET #{target} HTTP/1.1\r\nHost: acme.test\r\n\r\n".to_slice,
+    source: Gori::FlowSource::Kind::Proxy))
+  store.update_response(Gori::Store::CapturedResponse.new(
+    flow_id: id, status: 200, head: "HTTP/1.1 200 OK\r\n\r\n".to_slice))
+  id
+end
+
+private def row_for(res : JSON::Any, target : String) : JSON::Any
+  res.as_a.find { |r| r["target"].as_s == target }.not_nil!
+end
+
+describe "MCP list_sitemap tag stamping" do
+  it "does not stamp a path tag on a folded row, matching the tree model" do
+    with_store do |store|
+      seed(store, "/search?q=1")
+      tools = Gori::MCP::Tools.new(store, allow_actions: true, verify_upstream: false)
+      call_json(tools, "set_sitemap_tag", %({"host":"acme.test","path":"/search","tag":"look-here"}))
+
+      row = row_for(call_json(tools, "list_sitemap", "{}"), "/search")
+      row["query_variants"].as_i.should eq(1)
+      row.as_h.has_key?("tag").should be_false
+    end
+  end
+
+  it "keeps set_sitemap_tag's invisibility warning honest about list_sitemap" do
+    with_store do |store|
+      seed(store, "/search?q=1")
+      tools = Gori::MCP::Tools.new(store, allow_actions: true, verify_upstream: false)
+
+      set = call_json(tools, "set_sitemap_tag", %({"host":"acme.test","path":"/search","tag":"look-here"}))
+      set["matches_endpoint"].as_bool.should be_false
+      set["warning"].as_s.should contain("will not show in list_sitemap")
+
+      # The warning said list_sitemap will not show it. It must not.
+      row_for(call_json(tools, "list_sitemap", "{}"), "/search").as_h.has_key?("tag").should be_false
+    end
+  end
+
+  it "still stamps a tag on an UNFOLDED row" do
+    with_store do |store|
+      seed(store, "/plain")
+      tools = Gori::MCP::Tools.new(store, allow_actions: true, verify_upstream: false)
+      call_json(tools, "set_sitemap_tag", %({"host":"acme.test","path":"/plain","tag":"plain-tag"}))
+
+      row = row_for(call_json(tools, "list_sitemap", "{}"), "/plain")
+      row["query_variants"]?.try(&.as_i).should be_nil
+      row["tag"].as_s.should eq("plain-tag")
+    end
+  end
+
+  it "reports a tag pinned on a variant through variant_tags, and through fold_query:false" do
+    with_store do |store|
+      seed(store, "/search?q=1")
+      tools = Gori::MCP::Tools.new(store, allow_actions: true, verify_upstream: false)
+      set = call_json(tools, "set_sitemap_tag", %({"host":"acme.test","path":"/search?q=1","tag":"variant-tag"}))
+      set["matches_endpoint"].as_bool.should be_true
+
+      folded = row_for(call_json(tools, "list_sitemap", "{}"), "/search")
+      folded.as_h.has_key?("tag").should be_false
+      folded["variant_tags"].as_a.map { |t| {t["path"].as_s, t["tag"].as_s} }
+        .should eq([{"/search?q=1", "variant-tag"}])
+
+      row_for(call_json(tools, "list_sitemap", %({"fold_query":false})), "/search?q=1")["tag"]
+        .as_s.should eq("variant-tag")
+    end
+  end
+end

--- a/src/gori/mcp/tools/authorize.cr
+++ b/src/gori/mcp/tools/authorize.cr
@@ -198,8 +198,10 @@ module Gori
       private def authorize_results(h) : Result
         ajob = lookup_authorize_job(h)
         return ajob if ajob.is_a?(Result)
-        offset = clamp_nonneg(optional_int_arg(h, "offset"))
-        limit = clamp(optional_int_arg(h, "limit"), 50, 500)
+        req_off = optional_int_arg(h, "offset")
+        req_lim = optional_int_arg(h, "limit")
+        offset = clamp_nonneg(req_off)
+        limit = clamp(req_lim, 50, 500)
         page = ajob.results[offset, limit]? || [] of Authorize::Target
         Result.new(JSON.build do |j|
           j.object do
@@ -215,6 +217,8 @@ module Gori
             j.field "returned", page.size
             j.field "offset", offset
             j.field "total_available", ajob.results.size
+            j.field "limit", limit
+            emit_clamp(j, req_off, offset, req_lim, limit)
             j.field "page_complete", offset + page.size >= ajob.results.size
             j.field "has_more", offset + page.size < ajob.results.size
             j.field "job_complete", ajob.status != :running
@@ -231,7 +235,7 @@ module Gori
         ajob = lookup_authorize_job(h)
         return ajob if ajob.is_a?(Result)
         ajob.stop
-        Result.new(JSON.build { |j| j.object { j.field "job_id", ajob.id; j.field "status", "stopping" } })
+        stop_and_report(ajob)
       end
 
       private def lookup_authorize_job(h) : AuthorizeJob | Result

--- a/src/gori/mcp/tools/discover.cr
+++ b/src/gori/mcp/tools/discover.cr
@@ -319,8 +319,10 @@ module Gori
       private def discover_results(h) : Result
         djob = lookup_discover_job(h)
         return djob if djob.is_a?(Result)
-        offset = clamp_nonneg(optional_int_arg(h, "offset"))
-        limit = clamp(optional_int_arg(h, "limit"), 100, 1000)
+        req_off = optional_int_arg(h, "offset")
+        req_lim = optional_int_arg(h, "limit")
+        offset = clamp_nonneg(req_off)
+        limit = clamp(req_lim, 100, 1000)
         page = djob.results[offset, limit]? || [] of Discover::Finding
         Result.new(JSON.build do |j|
           j.object do
@@ -328,6 +330,8 @@ module Gori
             j.field "returned", page.size
             j.field "offset", offset
             j.field "total_available", djob.results.size
+            j.field "limit", limit
+            emit_clamp(j, req_off, offset, req_lim, limit)
             j.field "job_complete", djob.status != :running
             # `has_more` is about this PAGE. A budget-capped run has no more stored findings
             # and still is not an exhaustive answer — that is what incomplete_reason says.
@@ -356,7 +360,7 @@ module Gori
         djob = lookup_discover_job(h)
         return djob if djob.is_a?(Result)
         djob.stop
-        Result.new(JSON.build { |j| j.object { j.field "job_id", djob.id; j.field "status", "stopping" } })
+        stop_and_report(djob)
       end
 
       private def lookup_discover_job(h) : DiscoverJob | Result

--- a/src/gori/mcp/tools/fuzz.cr
+++ b/src/gori/mcp/tools/fuzz.cr
@@ -431,8 +431,10 @@ module Gori
         matched_only = bool_arg(h, "matched_only", false)
         picked = (0...rows.size).to_a
         picked.select! { |i| rows[i].matched? } if matched_only
-        offset = clamp_nonneg(optional_int_arg(h, "offset"))
-        limit = clamp(optional_int_arg(h, "limit"), 100, 1000)
+        req_off = optional_int_arg(h, "offset")
+        req_lim = optional_int_arg(h, "limit")
+        offset = clamp_nonneg(req_off)
+        limit = clamp(req_lim, 100, 1000)
         last = offset < picked.size ? Math.min(offset + limit, picked.size) : offset
         returned = last - offset
         Result.new(JSON.build do |j|
@@ -441,6 +443,8 @@ module Gori
             j.field "returned", returned
             j.field "offset", offset
             j.field "total_available", picked.size
+            j.field "limit", limit
+            emit_clamp(j, req_off, offset, req_lim, limit)
             j.field "matched_only", matched_only
             # What the filter is selecting FROM, so a caller that passed matched_only can see
             # how many non-matching rows the run kept rather than having to page twice to
@@ -463,7 +467,7 @@ module Gori
         fjob = lookup_fuzz_job(h)
         return fjob if fjob.is_a?(Result)
         fjob.stop
-        Result.new(JSON.build { |j| j.object { j.field "job_id", fjob.id; j.field "status", "stopping" } })
+        stop_and_report(fjob)
       end
 
       # The job for `job_id`, or an error Result the caller returns as-is.

--- a/src/gori/mcp/tools/fuzz_runs.cr
+++ b/src/gori/mcp/tools/fuzz_runs.cr
@@ -8,8 +8,10 @@ module Gori
       # Permanent saved-run readers remain available in --read-only mode. Only deletion is an
       # action; live fuzz_start/status/results keep their existing action gate.
       private def list_fuzz_runs(h) : Result
-        offset = clamp_nonneg(optional_int_arg(h, "offset"))
-        limit = clamp(optional_int_arg(h, "limit"), 50, 200)
+        req_off = optional_int_arg(h, "offset")
+        req_lim = optional_int_arg(h, "limit")
+        offset = clamp_nonneg(req_off)
+        limit = clamp(req_lim, 50, 200)
         session_id = optional_int_arg(h, "session_id")
         return err("session_id must be positive", "INVALID_ARGUMENT", field: "session_id") if session_id && session_id <= 0
 
@@ -27,6 +29,8 @@ module Gori
             end
             j.field "returned", runs.size
             j.field "offset", offset
+            j.field "limit", limit
+            emit_clamp(j, req_off, offset, req_lim, limit)
             j.field "total_available", total
             j.field "has_more", offset.to_i64 + runs.size < total
           end
@@ -59,10 +63,12 @@ module Gori
           return saved_fuzz_result_detail(run, row)
         end
 
-        offset = clamp_nonneg(optional_int_arg(h, "offset"))
+        req_off = optional_int_arg(h, "offset")
+        req_lim = optional_int_arg(h, "limit")
+        offset = clamp_nonneg(req_off)
         # Content rows retain multiple request/response BLOBs and are deliberately capped at
         # 25 per response. Metrics can page farther, but still use the scalar Store projection.
-        limit = clamp(optional_int_arg(h, "limit"), include_content ? 25 : 100,
+        limit = clamp(req_lim, include_content ? 25 : 100,
           include_content ? 25 : 1000)
         matched_only = bool_arg(h, "matched_only", false)
         total = store.fuzz_result_count(run_id, matched_only)
@@ -91,6 +97,8 @@ module Gori
             j.field "offset", offset
             j.field "total_available", total
             j.field "matched_only", matched_only
+            j.field "limit", limit
+            emit_clamp(j, req_off, offset, req_lim, limit)
             j.field "has_more", offset.to_i64 + returned < total
           end
         end)

--- a/src/gori/mcp/tools/jobs.cr
+++ b/src/gori/mcp/tools/jobs.cr
@@ -135,10 +135,31 @@ module Gori
             sleep 20.milliseconds
           end
         end
+        emit_stop_result(job, waited_out)
+      end
+
+      # `job.stop` plus the honest answer, for the five per-kind stop tools
+      # (fuzz_stop / mine_stop / discover_stop / sequence_stop / authorize_stop).
+      #
+      # Each of those used to hard-code `status: "stopping"` without ever reading the job
+      # back — a state a run that had already reached `done` / `budget_exhausted`, or that an
+      # earlier call stopped, is not in and will never enter. An agent reads that as "I
+      # aborted a run that was in flight" and reports a COMPLETE run as cancelled, or its
+      # results as partial. `stop_job` has always re-read the status; this is the same read,
+      # so all six stop surfaces now answer the same way.
+      private def stop_and_report(job : FuzzJob | MineJob | DiscoverJob | SequenceJob | AuthorizeJob) : Result
+        job.stop
+        emit_stop_result(job)
+      end
+
+      # The stop reply itself, shared by `stop_job` (which may have waited first) and the
+      # five per-kind tools. Read AFTER the stop and any wait, never assumed.
+      private def emit_stop_result(job : FuzzJob | MineJob | DiscoverJob | SequenceJob | AuthorizeJob,
+                                   waited_out : Bool = false) : Result
         status, stopped_at = job_status_and_end(job)
         Result.new(JSON.build do |j|
           j.object do
-            j.field "job_id", id
+            j.field "job_id", job.id
             j.field "status", status
             j.field "stop_requested", true
             j.field "stopped", status != "running"

--- a/src/gori/mcp/tools/mine.cr
+++ b/src/gori/mcp/tools/mine.cr
@@ -151,8 +151,10 @@ module Gori
       private def mine_results(h) : Result
         mjob = lookup_mine_job(h)
         return mjob if mjob.is_a?(Result)
-        offset = clamp_nonneg(optional_int_arg(h, "offset"))
-        limit = clamp(optional_int_arg(h, "limit"), 100, 1000)
+        req_off = optional_int_arg(h, "offset")
+        req_lim = optional_int_arg(h, "limit")
+        offset = clamp_nonneg(req_off)
+        limit = clamp(req_lim, 100, 1000)
         page = mjob.results[offset, limit]? || [] of Miner::Finding
         Result.new(JSON.build do |j|
           j.object do
@@ -160,6 +162,8 @@ module Gori
             j.field "returned", page.size
             j.field "offset", offset
             j.field "total_available", mjob.results.size
+            j.field "limit", limit
+            emit_clamp(j, req_off, offset, req_lim, limit)
             j.field "job_complete", mjob.status != :running
             j.field "page_complete", offset + page.size >= mjob.results.size
             j.field "has_more", offset + page.size < mjob.results.size
@@ -173,7 +177,7 @@ module Gori
         mjob = lookup_mine_job(h)
         return mjob if mjob.is_a?(Result)
         mjob.stop
-        Result.new(JSON.build { |j| j.object { j.field "job_id", mjob.id; j.field "status", "stopping" } })
+        stop_and_report(mjob)
       end
 
       private def lookup_mine_job(h) : MineJob | Result

--- a/src/gori/mcp/tools/sequence.cr
+++ b/src/gori/mcp/tools/sequence.cr
@@ -134,7 +134,7 @@ module Gori
         sjob = lookup_sequence_job(h)
         return sjob if sjob.is_a?(Result)
         sjob.stop
-        Result.new(JSON.build { |j| j.object { j.field "job_id", sjob.id; j.field "status", "stopping" } })
+        stop_and_report(sjob)
       end
 
       private def lookup_sequence_job(h) : SequenceJob | Result

--- a/src/gori/mcp/tools/sitemap.cr
+++ b/src/gori/mcp/tools/sitemap.cr
@@ -53,11 +53,15 @@ module Gori
                 j.field "last_seen_iso", Serialize.unix_micros_iso(e.last_seen)
                 # The operator's free-text memo for this endpoint, when one is pinned. The key
                 # is the tree's node path, which includes any query string.
-                # On a folded row this is the tag on the PATH, if one is pinned there: the
-                # tags on its variants are keyed by the path WITH the query, exactly as a
-                # `{uuid}` fold's children keep their own. list_sitemap_tags (or
-                # fold_query:false) is where those show.
-                if tag = tags[{e.host, sitemap_tag_path(e.target)}]?
+                # NOT on a folded row, which is synthetic: `Sitemap.stamp_tags!` bars a tag on
+                # a `grouped` node ("the tag key is the path WITH the query", fold_queries_node!),
+                # so the TUI tree and `gori run sitemap` both leave it bare — and this stamped
+                # one anyway, which made set_sitemap_tag's "will not show in list_sitemap or
+                # the TUI" warning a lie about half of itself. The tags on a fold's variants
+                # are keyed by the path WITH the query and ride `variant_tags` above, exactly
+                # as a `{uuid}` fold's children keep their own; list_sitemap_tags (or
+                # fold_query:false) is where the rest show.
+                if e.query_variants == 0 && (tag = tags[{e.host, sitemap_tag_path(e.target)}]?)
                   j.field "tag", Serialize.text(tag)
                 end
               end


### PR DESCRIPTION
Found by driving `gori mcp` over stdio against a local echo origin (~160 tools, ~130 calls). Each defect makes a tool **state something that is not true** — on this transport that is worse than an error, because an agent has no way to notice.

## 1. `list_sitemap` stamped a path tag onto a folded row

The shared tree model forbids it. `Sitemap.fold_queries_node!` builds a synthetic `grouped` node for the path, and `Sitemap.stamp_tags!` refuses to tag a grouped node — *"because the tag key is the path WITH the query"* (`src/gori/sitemap.cr:519-521`, `:285`). The TUI tree and `gori run sitemap` both honour that.

MCP's `list_sitemap` did not, so the two MCP tools contradicted each other:

```
send_request{url:"http://127.0.0.1:18080/search?q=1"}
set_sitemap_tag{host:"127.0.0.1", path:"/search", tag:"look-here"}
  -> matches_endpoint:false
     "no captured endpoint … this tag will not show in list_sitemap or the TUI"
list_sitemap{}
  -> [{"target":"/search","query_variants":1,"tag":"look-here"}]   <-- it DID show
```

`set_sitemap_tag`'s own schema already states the contract the code broke: *"that folded row is synthetic … it holds no tag of its own."* The warning was right; `list_sitemap` was the outlier, so that is the side that moved. The fold's variants keep their tags and still surface through `variant_tags` and `fold_query:false`.

## 2. The five per-kind `*_stop` tools faked `"stopping"`

`fuzz_stop` / `mine_stop` / `discover_stop` / `sequence_stop` / `authorize_stop` each hard-coded the status and never read the job back, so a run already at `done` or `budget_exhausted` answered with a state it is not in and will never enter:

```
fuzz_status -> "done", job_complete:true, ended_at set
fuzz_stop   -> {"status":"stopping"}                                  <-- false
stop_job    -> {"status":"done","stopped":true,"stopped_at":…}        <-- correct
```

An agent reads "stopping" as *"I aborted a run that was in flight"* and reports a complete run as cancelled, or its results as partial. The correct implementation already lived next door in the unified `stop_job` (`jobs.cr`), which has always re-read the status — the classic "fixed at the one generic site, left at the five specific ones". All six now share `stop_and_report` / `emit_stop_result`, so the per-kind replies also carry `stopped` / `stop_requested` / `stopped_at`.

Reproduced on all five against a terminal-state job before the fix.

## 3. `emit_clamp` reached 3 of 9 paginated tools

`emit_clamp` is the shared pagination contract ("*Surface a silently-clamped pagination value … Shared by the object-returning list tools*"). It had three callers. The other six — `fuzz_results`, `list_fuzz_runs`, `get_fuzz_run`, `mine_results`, `discover_results`, `authorize_results` — clamped `limit`/`offset` and did not even echo `limit` back, so the coercion was undetectable from the reply. An agent computing `limit = total - seen` down to 0 got one row and no signal.

(`get_response_body_chunk` was already fine — it carries its own equivalent `requested_offset` / `offset_out_of_range` / `warning` contract. `list_history` returns a bare array and cannot carry the fields.)

## Verification

- End-to-end over stdio against the rebuilt binary: the folded row loses its tag while the unfolded row and the variant keep theirs; all five stop tools echo the status their own `*_status` reports; all six paginated tools report the clamp **and stay quiet when the arguments were honoured** (no false positives).
- **Revert-proof**: each fix reverted independently makes its own spec fail — the sitemap guard (2 failures), the stop-status read (3 failures), the six `emit_clamp` calls (2 failures). A spec that still passed with the source reverted would prove nothing.
- `spec/mcp/authorize_spec.cr:262` asserted the old `"stopping"` literal unconditionally. Its own next comment — *"a one-request run may well have finished before the stop landed"* — describes exactly the bug, so the assertion passed even in that race. Updated to pin the honest contract instead.
- Full suite: **12460 examples, 0 failures**. `crystal tool format --check` clean.