### PR TITLE
fix(fuzz,cli,mcp,tui): twenty-two defects a Fuzzer audit found

### DIFF
--- a/spec/fuzz/engine_stop_and_hops_spec.cr
+++ b/spec/fuzz/engine_stop_and_hops_spec.cr
@@ -1,0 +1,213 @@
+require "../spec_helper"
+
+private alias F = Gori::Fuzz
+
+# A backend that fails every send with a network-shaped error — the retry loop's input.
+private class FailingBackend < F::Backend
+  getter sent = 0
+
+  def initialize(@origin : F::Origin)
+  end
+
+  def origin : F::Origin
+    @origin
+  end
+
+  def send(bytes : Bytes) : Gori::Repeater::Result
+    @sent += 1
+    Gori::Repeater::Result.new(Bytes.new(0), nil, nil, 0_i64, "connection refused")
+  end
+end
+
+# Answers the n-th send with a 302 to `locs[n]` while there is one, then 200. `h2` is what
+# `Backend#http2?` reports, so a spec can see what the engine writes on an h2 hop.
+private class HopBackend < F::Backend
+  getter sent = [] of String
+  # Runs after each reply is built — a spec stops the engine from inside a send with it.
+  property on_send : Proc(Int32, Nil)? = nil
+
+  def initialize(@origin : F::Origin, @locs : Array(String?), @h2 : Bool = false)
+  end
+
+  def origin : F::Origin
+    @origin
+  end
+
+  def http2? : Bool
+    @h2
+  end
+
+  def send(bytes : Bytes) : Gori::Repeater::Result
+    @sent << String.new(bytes)
+    loc = @locs[@sent.size - 1]?
+    head = if loc
+             "HTTP/1.1 302 Found\r\nLocation: #{loc}\r\nContent-Length: 0\r\n\r\n"
+           else
+             "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n"
+           end.to_slice
+    @on_send.try(&.call(@sent.size))
+    Gori::Repeater::Result.new(head, Bytes.new(0), Gori::Proxy::Codec::Http1.parse_response_head(head), 1_i64)
+  end
+end
+
+private def one_payload(tpl : String, cfg : F::Config) : F::Generator
+  F::Generator.new(F::Template.parse(tpl), [F::PayloadSet.new(F::InlineList.new(["1"]))], cfg)
+end
+
+private def follow(origin : F::Origin, locs : Array(String?) | Array(String), h2 : Bool = false,
+                   tpl : String = "GET /dir/start?q=§a§ HTTP/1.1\r\nHost: h\r\n\r\n") : Array(String)
+  cfg = F::Config.new(concurrency: 1, follow_redirects: true, max_redirects: 5)
+  be = HopBackend.new(origin, locs.map(&.as(String?)), h2)
+  F::Engine.new(one_payload(tpl, cfg), F::Matcher.new, be, cfg).run { }
+  be.sent
+end
+
+private def request_lines(sent : Array(String)) : Array(String)
+  sent.map { |r| r.lines.first }
+end
+
+describe "Fuzz::Engine — a stop stops" do
+  it "does not re-send a failed payload after stop, even with --retries pending" do
+    cfg = F::Config.new(concurrency: 1, retries: 5, retry_pause: 60.milliseconds)
+    be = FailingBackend.new(F::Origin.new("http", "h", 80))
+    engine = F::Engine.new(one_payload("GET /?q=§a§ HTTP/1.1\r\nHost: h\r\n\r\n", cfg), F::Matcher.new, be, cfg)
+    results = [] of F::Result
+    done = Channel(Nil).new(1)
+    spawn do
+      engine.run { |ev| results << ev.result if ev.is_a?(F::ResultEvent) }
+      done.send(nil)
+    end
+    sleep 20.milliseconds # inside the first retry pause
+    engine.stop
+    done.receive
+    be.sent.should eq(1) # the attempt that was in flight; none of the five retries
+    results.size.should eq(1)
+    results[0].error.should eq("connection refused")
+    results[0].resent_count.should eq(0) # no re-send happened, so none is claimed
+  end
+
+  it "does not follow a redirect hop after stop — the 3xx in hand is the row" do
+    cfg = F::Config.new(concurrency: 1, follow_redirects: true, max_redirects: 5)
+    be = HopBackend.new(F::Origin.new("http", "h", 80), ["/a", "/b", "/c"] of String?)
+    engine = F::Engine.new(one_payload("GET /start?q=§a§ HTTP/1.1\r\nHost: h\r\n\r\n", cfg), F::Matcher.new, be, cfg)
+    # The stop lands while the payload's own send is in flight (its 302 is being answered).
+    be.on_send = ->(n : Int32) { engine.stop if n == 1 }
+    results = [] of F::Result
+    engine.run { |ev| results << ev.result if ev.is_a?(F::ResultEvent) }
+    be.sent.size.should eq(1) # the payload; not one hop of the three on offer
+    results.size.should eq(1)
+    results[0].status.should eq(302)
+    results[0].error.should be_nil # nothing failed — the chain was not started
+  end
+end
+
+describe "Fuzz::Engine#follow_redirects — resolving the Location" do
+  it "follows a RELATIVE reference against the request that was answered" do
+    sent = follow(F::Origin.new("http", "h", 80), ["next?x=1", "?y=2", "../up", "sub/leaf", nil])
+    request_lines(sent).should eq([
+      "GET /dir/start?q=1 HTTP/1.1",
+      "GET /dir/next?x=1 HTTP/1.1", # relative to /dir/
+      "GET /dir/next?y=2 HTTP/1.1", # query-only: same path, new query
+      "GET /up HTTP/1.1",           # dot-segment climbs out of /dir/
+      "GET /sub/leaf HTTP/1.1",     # …and the next hop resolves against /up
+    ])
+  end
+
+  it "treats scheme and host case-insensitively on an absolute-form Location" do
+    sent = follow(F::Origin.new("http", "h", 80), ["HTTP://H/abs", nil])
+    request_lines(sent).should eq(["GET /dir/start?q=1 HTTP/1.1", "GET /abs HTTP/1.1"])
+  end
+
+  it "still refuses a cross-origin, cross-scheme, or unsafe Location" do
+    follow(F::Origin.new("http", "h", 80), ["http://other/x"]).size.should eq(1)
+    follow(F::Origin.new("http", "h", 80), ["https://h/x"]).size.should eq(1)
+    follow(F::Origin.new("http", "h", 80), ["//other/x"]).size.should eq(1)
+    follow(F::Origin.new("http", "h", 80), ["/a b"]).size.should eq(1)
+    follow(F::Origin.new("http", "h", 80), ["a b"]).size.should eq(1)
+  end
+
+  it "brackets an IPv6 literal in the hop's Host header" do
+    sent = follow(F::Origin.new("http", "::1", 8080), ["/x", nil])
+    sent[1].should contain("Host: [::1]:8080\r\n")
+    sent = follow(F::Origin.new("https", "::1", 443), ["/x", nil])
+    sent[1].should contain("Host: [::1]\r\n") # default port omitted
+  end
+
+  it "writes no Connection: close on an h2 hop (a connection-specific field h2 forbids)" do
+    h1 = follow(F::Origin.new("https", "h", 443), ["/x", nil], h2: false)
+    h1[1].should contain("Connection: close\r\n")
+    h2 = follow(F::Origin.new("https", "h", 443), ["/x", nil], h2: true)
+    h2[1].should_not contain("Connection")
+    h2[1].should eq("GET /x HTTP/1.1\r\nHost: h\r\n\r\n")
+  end
+end
+
+# A hop that FAILED: the row keeps the payload's own 3xx and notes the hop on `error`.
+private class RefusedHopBackend < F::Backend
+  def initialize(@origin : F::Origin)
+    @n = 0
+  end
+
+  def origin : F::Origin
+    @origin
+  end
+
+  def send(bytes : Bytes) : Gori::Repeater::Result
+    @n += 1
+    if @n == 1
+      head = "HTTP/1.1 302 Found\r\nLocation: /next\r\nContent-Length: 2\r\n\r\n".to_slice
+      Gori::Repeater::Result.new(head, "ok".to_slice, Gori::Proxy::Codec::Http1.parse_response_head(head), 1_i64)
+    else
+      Gori::Repeater::Result.new(Bytes.new(0), nil, nil, 0_i64, "connection refused")
+    end
+  end
+end
+
+describe "Fuzz::Matcher — a row whose redirect hop was refused" do
+  it "is still matched on the payload's own response" do
+    cfg = F::Config.new(concurrency: 1, follow_redirects: true)
+    matcher = F::Matcher.new
+    matcher.match_status = "302"
+    be = RefusedHopBackend.new(F::Origin.new("http", "h", 80))
+    results = [] of F::Result
+    F::Engine.new(one_payload("GET /start?q=§a§ HTTP/1.1\r\nHost: h\r\n\r\n", cfg), matcher, be, cfg).run do |ev|
+      results << ev.result if ev.is_a?(F::ResultEvent)
+    end
+    results.size.should eq(1)
+    r = results[0]
+    r.status.should eq(302)
+    r.error.not_nil!.should start_with(F::REDIRECT_HOP_REFUSED)
+    r.matched?.should be_true # the 302 IS the open-redirect finding
+  end
+
+  it "is still not matched when the row itself is a failed send" do
+    m = F::Matcher.new
+    m.match_status = "302"
+    dead = Gori::Repeater::Result.new(Bytes.new(0), nil, nil, 0_i64, "#{F::REDIRECT_HOP_REFUSED}x")
+    job = F::Job.new(0_i64, ["1"], nil, Bytes.new(0))
+    m.build(job, dead).matched?.should be_false # no response to match on
+  end
+end
+
+# `baseline_request` raising is the one way `run_race` can fail before its first dial.
+private class ExplodingGenerator < F::Generator
+  def baseline_request : Bytes
+    raise Gori::Error.new("chain exploded")
+  end
+end
+
+describe "Fuzz::Engine#run_race — a raise before the release" do
+  it "reports an ErrorEvent, then Done, instead of a silent empty run" do
+    cfg = F::Config.new(concurrency: 1, race_count: 2)
+    tpl = F::Template.parse("GET /race HTTP/1.1\r\nHost: h\r\n\r\n")
+    gen = ExplodingGenerator.new(tpl, [] of F::PayloadSet, cfg)
+    be = FailingBackend.new(F::Origin.new("http", "h", 80))
+    events = [] of F::Event
+    F::Engine.new(gen, F::Matcher.new, be, cfg).run { |ev| events << ev }
+    errors = events.select(F::ErrorEvent)
+    errors.size.should eq(1)
+    errors[0].message.should eq("chain exploded")
+    events.last.should be_a(F::DoneEvent)
+    be.sent.should eq(0)
+  end
+end

--- a/spec/fuzz/matcher_spec_error_spec.cr
+++ b/spec/fuzz/matcher_spec_error_spec.cr
@@ -1,0 +1,46 @@
+require "../spec_helper"
+
+private alias F = Gori::Fuzz
+
+describe "Fuzz::Matcher#spec_error" do
+  it "is nil for every valid spelling of a numeric and a status spec" do
+    m = F::Matcher.new
+    m.match_status = "200, 2xx, >=400, <500, 301-302, =404"
+    m.filter_status = "5xx"
+    m.match_size = ">100, 1-5, =7, <=9, 42"
+    m.match_time = ">=5000"
+    m.filter_grpc = "7, 1-16, >0"
+    m.match_words = ""       # blank = unconstrained, not an error
+    m.filter_lines = "  ,  " # only empty terms = unconstrained
+    m.spec_error.should be_nil
+  end
+
+  it "names the first term that can never fire, and which dimension it is on" do
+    m = F::Matcher.new
+    m.match_size = "1500,1O00"
+    m.spec_error.not_nil!.should contain("match size spec")
+    m.spec_error.not_nil!.should contain("\"1O00\"")
+
+    m = F::Matcher.new
+    m.filter_status = "2OO"
+    m.spec_error.not_nil!.should contain("filter status spec")
+    m.spec_error.not_nil!.should contain("2xx") # the remedy names the class form
+
+    m = F::Matcher.new
+    m.match_time = ">= fast"
+    m.spec_error.not_nil!.should contain("match time spec")
+
+    m = F::Matcher.new
+    m.match_status = ">=abc"
+    m.spec_error.should_not be_nil
+  end
+
+  it "validates exactly what the compiled predicate would refuse to match" do
+    F::Predicate.invalid_num_term("1O00").should eq("1O00")
+    F::Predicate.invalid_num_term(">=x").should eq(">=x")
+    F::Predicate.invalid_num_term("100-200,>5").should be_nil
+    F::Predicate.invalid_status_term("2OO").should eq("2OO")
+    F::Predicate.invalid_status_term("2xx,>=4xx,404,200-299").should be_nil
+    F::Predicate.invalid_status_term("6xx").should eq("6xx") # no such class
+  end
+end

--- a/spec/mcp/fuzz_spec.cr
+++ b/spec/mcp/fuzz_spec.cr
@@ -929,10 +929,74 @@ describe "MCP fuzz tools" do
         status["incomplete_reason"].as_s.should eq("budget_exhausted")
         status["sent"].as_i.should be < 5
         status["candidates_remaining"].as_i.should be > 0
+        # The unit the verdict was decided on, so `budget_exhausted` under `sent < cap` is
+        # arithmetic an agent can do rather than a riddle: requests ≥ the cap, always.
+        status["requests"].as_i.should eq(2)
         done = true
         break
       end
       done.should be_true
+    end
+  end
+
+  it "refuses a match/filter term that can never fire, before any send" do
+    with_store do |store|
+      tools = Gori::MCP::Tools.new(store, allow_actions: true, verify_upstream: false)
+      base = {"template" => "GET /?q=§x§ HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n",
+              "url" => "http://127.0.0.1:9", "payloads" => %([{"list":["a"]}]), "allow_unscoped" => true}
+      text, err = call_raw(tools, "fuzz_start", base.merge({"match" => {"size" => "1O00"}}).to_json)
+      err.should be_true
+      text.should contain("1O00")
+      text, err = call_raw(tools, "fuzz_start", base.merge({"filter" => {"status" => "2OO"}}).to_json)
+      err.should be_true
+      text.should contain("2OO")
+      # …and the lenient-but-valid forms still pass the parse (the origin is dead, so the
+      # refusal — if any — would come from the send, not the spec).
+      start = call_json(tools, "fuzz_start", base.merge({"match" => {"status" => "2xx,>=500,301-302", "size" => ">100,1-5"}}).to_json)
+      start["job_id"].as_s.should start_with("fz_")
+    end
+  end
+
+  it "reads a JSON null container argument as absent, and refuses race_warmup without race_count" do
+    with_store do |store|
+      tools = Gori::MCP::Tools.new(store, allow_actions: true, verify_upstream: false)
+      base = {"template" => "GET /?q=§x§ HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n",
+              "url" => "http://127.0.0.1:9", "payloads" => %([{"list":["a"]}]), "allow_unscoped" => true}
+      start = call_json(tools, "fuzz_start",
+        base.merge({"messages" => nil, "match" => nil, "filter" => nil, "marks" => nil, "processors" => nil}).to_json)
+      start["job_id"].as_s.should start_with("fz_")
+      text, err = call_raw(tools, "fuzz_start", base.merge({"race_warmup" => "GET / HTTP/1.1\r\n\r\n"}).to_json)
+      err.should be_true
+      text.should contain("race_count")
+    end
+  end
+
+  it "treats sni:\"\" and timeout_ms:0 as absent rather than as an empty name and a 1 ms deadline" do
+    port = start_origin
+    with_store do |store|
+      tools = Gori::MCP::Tools.new(store, allow_actions: true, verify_upstream: false)
+      start = call_json(tools, "fuzz_start",
+        {"template" => "GET /?q=§x§ HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n",
+         "url" => "http://127.0.0.1:#{port}", "payloads" => %([{"list":["a","b"]}]),
+         "sni" => "", "timeout_ms" => 0, "save_results" => true, "allow_unscoped" => true}.to_json)
+      status = wait_fuzz_done(tools, start["job_id"].as_s)
+      status["status"].as_s.should eq("done")
+      status["errors"].as_i.should eq(0) # a 1 ms deadline would have timed both out
+      store.get_fuzz_run(start["run_id"].as_i64).not_nil!.sni.should be_nil
+    end
+  end
+
+  it "records no tls_preset on a plaintext run's saved row, matching what fuzz_start reports" do
+    port = start_origin
+    with_store do |store|
+      tools = Gori::MCP::Tools.new(store, allow_actions: true, verify_upstream: false)
+      start = call_json(tools, "fuzz_start",
+        {"template" => "GET /?q=§x§ HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n",
+         "url" => "http://127.0.0.1:#{port}", "payloads" => %([{"list":["a"]}]),
+         "tls_preset" => "chrome", "save_results" => true, "allow_unscoped" => true}.to_json)
+      start["tls_preset"]?.try(&.raw).should be_nil
+      wait_fuzz_done(tools, start["job_id"].as_s)
+      store.get_fuzz_run(start["run_id"].as_i64).not_nil!.tls_preset.should be_nil
     end
   end
 

--- a/spec/tui/fuzz_set_overlay_spec.cr
+++ b/spec/tui/fuzz_set_overlay_spec.cr
@@ -17,7 +17,7 @@ private def ctrl_d : Termisu::Event::Key
 end
 
 describe Gori::Tui::FuzzSetOverlay do
-  it "List: multi-line values build a comma-joined spec (newline = a new value)" do
+  it "List: multi-line values build a newline-joined spec (newline = a new value)" do
     ov = FuzzSetOverlay.for_list
     ov.handle_key(okey(Termisu::Input::Key::Down)) # Type row → the values editor
     otype(ov, "admin")
@@ -25,7 +25,20 @@ describe Gori::Tui::FuzzSetOverlay do
     otype(ov, "root")
     spec = ov.build_spec.not_nil!
     spec.kind.should eq(:list)
-    spec.value.should eq("admin,root")
+    spec.value.should eq("admin\nroot\n")
+    Gori::Tui::SetSpec.list_values(spec.value).should eq(["admin", "root"])
+    spec.display.should eq("admin,root")
+  end
+
+  it "List: a comma inside a value is payload text, not a separator" do
+    ov = FuzzSetOverlay.for_list
+    otype(ov, %({"id":1,"role":"admin"}))
+    ov.handle_key(okey(Termisu::Input::Key::Enter))
+    otype(ov, "' OR 1=1,--")
+    spec = ov.build_spec.not_nil!
+    Gori::Tui::SetSpec.list_values(spec.value).should eq([%({"id":1,"role":"admin"}), "' OR 1=1,--"])
+    # …and reopening the set shows the same two lines, not four.
+    FuzzSetOverlay.editing(spec, 0).build_spec.not_nil!.value.should eq(spec.value)
   end
 
   it "List: typing on the Type row (before any nav) drops into the values editor" do
@@ -34,7 +47,7 @@ describe Gori::Tui::FuzzSetOverlay do
     otype(ov, "admin")
     ov.handle_key(okey(Termisu::Input::Key::Enter))
     otype(ov, "root")
-    ov.build_spec.not_nil!.value.should eq("admin,root")
+    ov.build_spec.not_nil!.value.should eq("admin\nroot\n")
   end
 
   it "Numbers: bounds above Int32::MAX survive build_spec (Int64 range)" do
@@ -46,10 +59,11 @@ describe Gori::Tui::FuzzSetOverlay do
     ov.build_spec.not_nil!.value.should eq("3000000000-100:1")
   end
 
-  it "seeds an existing List set (comma → lines) and round-trips back to commas" do
+  it "seeds a LEGACY comma-joined List set (a session saved before the newline grammar)" do
     ov = FuzzSetOverlay.editing(Gori::Tui::SetSpec.new(:list, "a,b,c"), 0)
     ov.edit_index.should eq(0)
-    ov.build_spec.not_nil!.value.should eq("a,b,c")
+    Gori::Tui::SetSpec.list_values("a,b,c").should eq(["a", "b", "c"])
+    ov.build_spec.not_nil!.value.should eq("a\nb\nc\n") # re-saved under the current grammar
   end
 
   it "esc returns :commit; a blank List yields nil so @sets stays unchanged" do
@@ -183,7 +197,7 @@ describe Gori::Tui::FuzzSetOverlay do
     h.commits.should eq(0)
     h.type("b").should eq(:open)
     h.press(Termisu::Input::Key::Escape).should eq(:closed)
-    applied.map(&.try(&.value)).should eq(["a,b"])
+    applied.map(&.try(&.value)).should eq(["a\nb\n"])
   end
 
   it "↵ on the last FIELD row applies (Numbers: From/To/Step)" do
@@ -270,7 +284,7 @@ describe Gori::Tui::FuzzSetOverlay do
     h.type("x")                        # non-empty, so the editor renders instead of the placeholder
     h.preedit("한")
     h.rendered?("한").should be_true
-    ov.build_spec.not_nil!.value.should eq("x") # composing text is not in the buffer yet
+    ov.build_spec.not_nil!.value.should eq("x\n") # composing text is not in the buffer yet
   end
 
   # `Overlay#handle_click` places the caret in whichever listed field the press landed in —

--- a/spec/tui/fuzzer_result_window_spec.cr
+++ b/spec/tui/fuzzer_result_window_spec.cr
@@ -46,6 +46,9 @@ describe Gori::Tui::FuzzerResultWindow do
     kept.request.should be_nil
     kept.head.should be_nil
     kept.body.should be_nil
+    # The bytes are in the archive, not absent: the projection mark is what tells the detail
+    # panes so, and it used to be set only when the SECOND cap tripped as well.
+    window.projected?(9_i64).should be_true
     kept.wire.should be_nil
   end
 

--- a/spec/tui/fuzzer_view_refusals_spec.cr
+++ b/spec/tui/fuzzer_view_refusals_spec.cr
@@ -1,0 +1,85 @@
+require "../spec_helper"
+require "../support/memory_backend"
+
+include Gori::Tui
+
+# `build_engine` refusals that used to be silent fallbacks: a match spec that can never fire
+# ran the sweep as `N sent · 0 hit`; a numeric Advanced field that did not parse ran with the
+# default while the row kept showing what was typed.
+
+private def fuzzer_with(snap_edit : AdvancedSnapshot -> AdvancedSnapshot) : FuzzerView
+  view = FuzzerView.new
+  view.load_request("http://127.0.0.1:9", "GET /?x=§1§ HTTP/1.1\r\nHost: h\r\n\r\n", false, "")
+  view.apply_set(nil, Gori::Tui::SetSpec.list(["a"]))
+  view.apply_advanced(snap_edit.call(view.advanced_snapshot))
+  view
+end
+
+private def with_scope(&)
+  path = File.tempname("gori-fuzz-refusals", ".db")
+  store = Gori::Store.open(path)
+  begin
+    yield Gori::Scope.load(store)
+  ensure
+    store.close
+    File.delete?(path)
+  end
+end
+
+private def refusal(view : FuzzerView) : String?
+  with_scope do |scope|
+    engine, err = view.build_engine(false, scope, nil)
+    engine.should be_nil
+    return err
+  end
+end
+
+describe "FuzzerView#build_engine refusals" do
+  it "refuses a match/filter spec that can never fire, naming the term" do
+    err = refusal(fuzzer_with(->(s : AdvancedSnapshot) { s.copy_with(m_status: "2OO") }))
+    err.not_nil!.should contain("2OO")
+    err = refusal(fuzzer_with(->(s : AdvancedSnapshot) { s.copy_with(f_size: ">1O0") }))
+    err.not_nil!.should contain("1O0")
+  end
+
+  it "refuses a numeric Advanced field that does not parse instead of running the default" do
+    refusal(fuzzer_with(->(s : AdvancedSnapshot) { s.copy_with(timeout: "1.5") })).not_nil!.should contain("Timeout")
+    refusal(fuzzer_with(->(s : AdvancedSnapshot) { s.copy_with(conc: "50x") })).not_nil!.should contain("Concurrency")
+    refusal(fuzzer_with(->(s : AdvancedSnapshot) { s.copy_with(retries: "3 x") })).not_nil!.should contain("Retries")
+  end
+
+  it "still builds on blank numeric fields (blank = default / off) and valid specs" do
+    view = fuzzer_with(->(s : AdvancedSnapshot) { s.copy_with(timeout: "", rate: "", m_status: "2xx,>=500", m_size: ">10") })
+    with_scope do |scope|
+      engine, err = view.build_engine(false, scope, nil)
+      err.should be_nil
+      engine.should_not be_nil
+    end
+  end
+
+  it "runs a List set whose value carries a comma as ONE payload" do
+    view = FuzzerView.new
+    view.load_request("http://127.0.0.1:9", "GET /?x=§1§ HTTP/1.1\r\nHost: h\r\n\r\n", false, "")
+    view.apply_set(nil, Gori::Tui::SetSpec.list([%({"id":1,"role":"admin"})]))
+    with_scope do |scope|
+      engine, err = view.build_engine(false, scope, nil)
+      err.should be_nil
+      engine.not_nil!.total.should eq(1)
+    end
+  end
+
+  it "clears the timeout on a peer sync whose config carries none" do
+    view = FuzzerView.new
+    view.load_request("http://127.0.0.1:9", "GET /?x=§1§ HTTP/1.1\r\nHost: h\r\n\r\n", false, "")
+    view.apply_advanced(view.advanced_snapshot.copy_with(timeout: "7"))
+    view.apply_set(nil, Gori::Tui::SetSpec.list(["a"]))
+    with_scope { |scope| view.build_engine(false, scope, nil) } # commits the buffers
+    view.config.timeout.should eq(7.seconds)
+    peer = view.config_json.gsub(/"timeout_s":7/, %("timeout_s":null))
+    peer.should contain(%("timeout_s":null))
+    view.apply_peer_session(Gori::Store::FuzzSessionRecord.new(
+      id: 1, target: view.target, template: view.template_text, http2: false, sni: nil,
+      config: peer, flow_id: nil, position: 0, name: nil))
+    view.config.timeout.should be_nil
+  end
+end

--- a/src/gori/cli/run/fuzz.cr
+++ b/src/gori/cli/run/fuzz.cr
@@ -267,6 +267,19 @@ module Gori
 
         # Every refusal below fires BEFORE anything dials. A refusal that arrives after the
         # traffic is not a refusal — the argument `fuzz_preflight`'s own comment makes.
+        #
+        # `--race-warmup` is read by `Engine#run_race` and by nothing else. Without `--race` the
+        # file was validated, read, handed to `Config#race_warmup` and never sent — the "knob
+        # that silently did nothing" shape every other refusal here exists to close.
+        if race_warmup_file && !race
+          abort "gori run fuzz: --race-warmup applies to a --race run (add --race N, or drop the warm-up)"
+        end
+        # A match/filter spec that can never fire (`--ms 1O00`, `--mc 2OO`) used to run the
+        # whole sweep and report `0 matched` — indistinguishable from "nothing there". See
+        # `Fuzz::Matcher#spec_error`.
+        if spec_err = matcher.spec_error
+          abort "gori run fuzz: #{spec_err}"
+        end
         unless websocket
           if !ws_overrides.empty?
             abort "gori run fuzz: --message / --message-frame describe a WebSocket exchange, but " \
@@ -858,7 +871,13 @@ module Gori
         # failure) is a failure, not a clean "no matches" — so a scripted caller can tell the two
         # apart even without --fail-if-no-matches. The errored rows are now shown too (below),
         # matching the TUI which renders every result. (#410)
-        exit 1 if matched == 0 && errored > 0
+        #
+        # EVERY send, and the comment above has always said so — the test was `errored > 0`, so
+        # one reset connection in a 500-payload sweep of clean 404s exited 1 and a scripted
+        # `gori run fuzz … || die` failed a healthy run. `errored` counts the rows with an error
+        # and no match; with `matched == 0` that is every error row, so "every send errored" is
+        # `errored >= sent` (the Done progress is the run's own count of completed payloads).
+        exit 1 if matched == 0 && errored > 0 && (p = last_progress) && p.sent > 0 && errored.to_i64 >= p.sent
       end
 
       private def self.fuzz_saved_mode(mode : Fuzz::Mode, requested_race : Int32?,

--- a/src/gori/cli/run/fuzz_args.cr
+++ b/src/gori/cli/run/fuzz_args.cr
@@ -19,7 +19,12 @@ module Gori
         abort "gori run fuzz: invalid --numbers '#{v}' (use FROM-TO[:STEP])" unless from && to
         step = step_part.empty? ? 1_i64 : (step_part.to_i64? || abort("gori run fuzz: invalid --numbers step '#{step_part}'"))
         abort "gori run fuzz: --numbers step must not be 0" if step == 0
-        Fuzz::NumberRange.new(from, to, step)
+        range = Fuzz::NumberRange.new(from, to, step)
+        # `10-1` (a typo for `1-10`) is an EMPTY range: the run printed `· 0 requests ·`, sent
+        # nothing and exited 0 as `done`. A descending range is spelled with a negative step
+        # (`10-1:-1`), which this leaves alone.
+        abort "gori run fuzz: --numbers '#{v}' is empty — FROM is past TO for step #{step} (a descending range is FROM-TO:-STEP)" if range.size == 0
+        range
       end
 
       # `--preset NAME` or `--preset NAME:FILE` (a user file merged into the built-in set,
@@ -39,6 +44,9 @@ module Gori
         max = max_s.empty? ? min : max_s.to_i?
         abort "gori run fuzz: invalid --brute lengths '#{lens}' (use MIN-MAX)" unless min && max
         abort "gori run fuzz: --brute MIN (#{min}) is greater than MAX (#{max})" if min > max
+        # `BruteForce` floors MIN at 1 silently; `abc:0-2` then sent 12 payloads under a banner
+        # that counted them, minus the empty string the operator asked for. Refused by name.
+        abort "gori run fuzz: --brute MIN must be at least 1 (got #{min}); use --null-payloads for an empty payload" if min < 1
         Fuzz::BruteForce.new(charset, min, max)
       end
 

--- a/src/gori/fuzz/engine.cr
+++ b/src/gori/fuzz/engine.cr
@@ -88,6 +88,17 @@ module Gori::Fuzz
       false
     end
 
+    # Whether this backend speaks HTTP/2 to the origin. Read by `Engine#redirect_request`,
+    # which WRITES a request of its own for every hop it follows: on h1 that hop carries
+    # `Connection: close` so the keep-alive pool gives it its own socket, and on h2 that same
+    # line is a connection-specific field RFC 9113 §8.2.2 tells a server to treat as MALFORMED
+    # — so every hop of an h2 sweep was refused (or reset) by a conforming origin, for a
+    # header the operator never wrote. Delegated by the wrappers, as `evidence?` is, because
+    # the wrapper is what the engine holds.
+    def http2? : Bool
+      false
+    end
+
     # Sends this backend REFUSED before the socket — Sandbox, an explicit exclude rule, or
     # a session binding nothing has bound yet. Zero for a backend with no gate.
     #
@@ -502,6 +513,10 @@ module Gori::Fuzz
       @pool.try(&.close_all)
     end
 
+    def http2? : Bool
+      @http2
+    end
+
     def extra_requests : Int64
       (@pool.try(&.stale_retries) || 0_i64) + @race_warmups
     end
@@ -728,6 +743,10 @@ module Gori::Fuzz
       @inner.evidence?
     end
 
+    def http2? : Bool
+      @inner.http2?
+    end
+
     def send(bytes : Bytes) : Repeater::Result
       send(bytes, nil)
     end
@@ -810,6 +829,10 @@ module Gori::Fuzz
     # Delegated, as on `CappedBackend` — see `Backend#evidence?`.
     def evidence? : Bool
       @inner.evidence?
+    end
+
+    def http2? : Bool
+      @inner.http2?
     end
 
     def send(bytes : Bytes) : Repeater::Result
@@ -1161,6 +1184,12 @@ module Gori::Fuzz
         end
         record_result(@matcher.build(jobs[i], raw))
       end
+    rescue ex
+      # The same channel `dispatch_loop` and `worker_loop` use: a raise here — `baseline_request`
+      # forking an `exec:` chain that fails, a backend double that throws — used to leave the
+      # fiber to the runtime's default handler and the consumer with a `Done` carrying `0 sent`
+      # and no word about why, i.e. a race that silently did not run.
+      @events.send(ErrorEvent.new(ex.message || "fuzz race error"))
     ensure
       @backend.close rescue nil
       @events.send(DoneEvent.new(snapshot, @state == State::Stopped))
@@ -1238,13 +1267,24 @@ module Gori::Fuzz
         # Don't burn retries/sleep on a permanent max-requests stop — further send()s
         # are also refused. Real network errors still retry as configured; each retry means the
         # previous attempt was a failed send, tallied via `resent_count` (see `worker_loop`).
-        if retryable?(raw) && attempts < @config.retries
-          attempts += 1
-          resent_count += 1
+        #
+        # And not after a STOP. `worker_loop` drains the queue without sending once the
+        # operator stops the run, and the documented promise is "in-flight requests finish" —
+        # a retry is a NEW request, so with `--retries 5 --retry-pause 1s` each busy worker kept
+        # the origin under fire for five more sends and five more seconds after the stop (P5:
+        # a stop stops). The attempt that already failed is reported as it stands.
+        if retryable?(raw) && attempts < @config.retries && @state != State::Stopped
           sleep @config.retry_pause
-          next
+          # Re-read AFTER the pause: that is where a stop lands on a run whose retries are
+          # paced. Counted only when the re-send actually happens, so `resent_count` stays
+          # "attempts that were superseded" and not "pauses that were slept".
+          unless @state == State::Stopped
+            attempts += 1
+            resent_count += 1
+            next
+          end
         end
-        raw = follow_redirects(raw) if @config.follow_redirects? && raw.error.nil?
+        raw = follow_redirects(raw, job.bytes) if @config.follow_redirects? && raw.error.nil?
         return @matcher.build(job, raw, resent_count: resent_count)
       end
     end
@@ -1268,11 +1308,15 @@ module Gori::Fuzz
           @blocked_reason ||= raw.error
           return @matcher.build(job, raw, resent_count: resent_count).with_ws(ws)
         end
-        if retryable?(raw) && attempts < @config.retries
-          attempts += 1
-          resent_count += 1
+        # `@state` guard for the reason `run_one` gives: a retry is a new session, not an
+        # in-flight one, and a stop must not open five more.
+        if retryable?(raw) && attempts < @config.retries && @state != State::Stopped
           sleep @config.retry_pause
-          next
+          unless @state == State::Stopped
+            attempts += 1
+            resent_count += 1
+            next
+          end
         end
         return @matcher.build(job, raw, resent_count: resent_count).with_ws(ws)
       end
@@ -1302,9 +1346,15 @@ module Gori::Fuzz
     # Follow up to max_redirects SAME-ORIGIN redirects (relative, or absolute to the
     # same scheme/host/port), re-issuing a GET. Cross-origin redirects are left as the
     # final 3xx (no implicit off-target sends).
-    private def follow_redirects(raw : Repeater::Result) : Repeater::Result
+    #
+    # `request` is the bytes the payload went out as: a `Location` is a URI-REFERENCE (RFC
+    # 7231 §7.1.2), and `next?page=2`, `?page=2` or `../login` resolve against the request
+    # that was answered — which is the one fact only the caller holds. Each followed hop then
+    # becomes the base for the next, exactly as a browser walks the chain.
+    private def follow_redirects(raw : Repeater::Result, request : Bytes) : Repeater::Result
       current = raw
       total_us = raw.duration_us
+      base = Gori::Outbound.request_target(request)
       # A keep-alive re-send ANYWHERE in the chain has to reach the row: the collapsed Result
       # below keeps the last hop's fields, so without this an original request that was
       # re-sent and then redirected would report as a single clean send.
@@ -1320,12 +1370,16 @@ module Gori::Fuzz
       hop_error : String? = nil
       hops = 0
       while hops < @config.max_redirects
+        # A hop is a NEW request, not an in-flight one — same rule as the retry loop in
+        # `run_one`: after a stop the payload's own answer (the 3xx in `current`) is the row.
+        break if @state == State::Stopped
         resp = current.response
         break unless resp && (300..399).includes?(resp.status)
         loc = resp.headers.get?("location")
         break unless loc
-        nxt = redirect_request(loc)
-        break unless nxt
+        nxt, path = redirect_request(loc, base)
+        break unless nxt && path
+        base = path
         # WHOLE-message verbatim, and not `nil` and not the job's spans. `Sender#send`'s
         # 1-argument overload means "no exclusions", i.e. substitute every `$NAME` an extract
         # rule has bound — and `nxt` is assembled below from a `Location` the ORIGIN chose. A
@@ -1356,7 +1410,7 @@ module Gori::Fuzz
         # reason rather than replacing the response with it. Prefixed so no surface reads it as
         # the PAYLOAD's own failure — it is a note about a hop gori chose to follow.
         if err = hop.error
-          hop_error = "redirect hop refused: #{err}"
+          hop_error = "#{REDIRECT_HOP_REFUSED}#{err}"
           break
         end
         current = hop
@@ -1372,9 +1426,11 @@ module Gori::Fuzz
         delivered: current.delivered?, timed_out: current.timed_out?, retried: retried) : current
     end
 
-    private def redirect_request(loc : String) : Bytes?
+    # The next hop's request bytes and its request-target, or `{nil, nil}` when the
+    # `Location` is not one this run may follow. `base` is the request-target the 3xx answered.
+    private def redirect_request(loc : String, base : String) : {Bytes?, String?}
       o = @backend.origin
-      path = resolve_redirect_path(loc, o)
+      path = resolve_redirect_path(loc, o, base)
       # The `Location` is chosen by whatever host answered, and the next line splices it
       # straight into a request line — so it gets the same rule as any other remote-chosen
       # request-line token (#397). Checked HERE rather than inside resolve_redirect_path
@@ -1393,32 +1449,60 @@ module Gori::Fuzz
       # know whether the origin meant a literal space or a broken link, and refusing leaves
       # the run reporting the 3xx it actually got. That matches the existing treatment of a
       # cross-origin Location — the chain stops, the 3xx is the result.
-      return nil unless path && Proxy::Codec::Http1.request_token_safe?(path)
-      default = o.scheme == "https" ? 443 : 80
-      host = o.port == default ? o.host : "#{o.host}:#{o.port}"
-      "GET #{path} HTTP/1.1\r\nHost: #{host}\r\nConnection: close\r\n\r\n".to_slice
+      return {nil, nil} unless path && Proxy::Codec::Http1.request_token_safe?(path)
+      # `FlowRequest.authority` is the one spelling of a `Host:` value gori writes: an IPv6
+      # literal bracketed (`Host: ::1:8080` is not a host and a port, it is a parse error), the
+      # port dropped when it is the scheme default.
+      host = Repeater::FlowRequest.authority(o.scheme, o.host, o.port)
+      # `Connection: close` is an h1 instruction — it hands the hop its own socket instead of
+      # the keep-alive pool's parked one. On h2 it is a connection-specific field a conforming
+      # server MUST reject (RFC 9113 §8.2.2), and it went out on every hop of an h2 sweep; the
+      # hop rides the h2 pool like any other request there. See `Backend#http2?`.
+      conn = @backend.http2? ? "" : "Connection: close\r\n"
+      {"GET #{path} HTTP/1.1\r\nHost: #{host}\r\n#{conn}\r\n".to_slice, path}
     end
 
-    # The same-origin path to follow a Location to, or nil for cross-origin / unparsable.
-    private def resolve_redirect_path(loc : String, o : Origin) : String?
+    # The same-origin request-target to follow a Location to, or nil for cross-origin /
+    # unparsable. `base` is the request-target the 3xx answered, which a RELATIVE reference
+    # resolves against (`next`, `?page=2`, `../login` — all legal per RFC 7231 §7.1.2, and all
+    # of them used to be dropped on the floor as "unparsable", so the sweep reported the 3xx
+    # and the operator read "followed nothing" as "nothing to follow").
+    private def resolve_redirect_path(loc : String, o : Origin, base : String) : String?
       # `//host/x` is a network-path reference (RFC 3986 §4.2) — it names ANOTHER authority, and
-      # is the canonical open-redirect answer. It starts with `/`, so the next line used to hand
-      # it back as a same-origin path and the follower asked the ORIGIN for the literal
-      # `//evil.test/x`, burning a hop and replacing the 302 the operator was hunting with that
-      # path's 404. Resolved against the origin's scheme rather than refused outright, so the
-      # absolute-form branch below decides: a cross-origin authority is dropped there like any
-      # other, while a same-origin `//host:port/next` is still followed, as this method promises.
+      # is the canonical open-redirect answer. Resolved against the origin's scheme so the
+      # same-origin check below decides: a cross-origin authority is dropped like any other,
+      # while a same-origin `//host:port/next` is still followed, as this method promises.
       loc = "#{o.scheme}:#{loc}" if loc.starts_with?("//")
       return loc if loc.starts_with?('/')
-      return nil unless loc.starts_with?("http://") || loc.starts_with?("https://")
-      uri = URI.parse(loc) rescue nil
-      return nil unless uri && uri.host == o.host
-      sc = uri.scheme || "http"
+      uri = (redirect_base(o, base).resolve(loc) rescue nil)
+      return nil unless uri
+      # Scheme and host are case-insensitive (RFC 3986 §3.1, §3.2.2); `Location: HTTP://Host/`
+      # is the same origin. `parse_target`'s bracket rule for an IPv6 literal, in reverse.
+      sc = (uri.scheme || o.scheme).downcase
+      host = (uri.host || "")
+      host = host[1..-2] if host.starts_with?('[') && host.ends_with?(']')
+      return nil unless host.downcase == o.host.downcase
       pt = uri.port || (sc == "https" ? 443 : 80)
       return nil unless sc == o.scheme && pt == o.port
       p = uri.path
       p = "/" if p.empty?
       uri.query ? "#{p}?#{uri.query}" : p
+    end
+
+    # The absolute URI the last request went to, for `URI#resolve`. An origin-form target
+    # hangs off the dial origin; an absolute-form one already is a URI; anything else (`*`,
+    # a garbled line) resolves from the root, which is the least surprising base there is.
+    private def redirect_base(o : Origin, target : String) : URI
+      authority = Repeater::FlowRequest.authority(o.scheme, o.host, o.port)
+      root = "#{o.scheme}://#{authority}/"
+      abs = if target.starts_with?('/')
+              "#{o.scheme}://#{authority}#{target}"
+            elsif target.includes?("://")
+              target
+            else
+              root
+            end
+      (URI.parse(abs) rescue nil) || URI.parse(root)
     end
 
     # ── lifecycle (pause / wake) ─────────────────────────────────────────────────

--- a/src/gori/fuzz/matcher.cr
+++ b/src/gori/fuzz/matcher.cr
@@ -499,8 +499,16 @@ module Gori::Fuzz
     # no status and an empty body, so a `--mc`/`--ms`/`--mr` alongside `--mt` fails it on its
     # own terms — "slow AND 200" cannot be satisfied by a response that never came, and it
     # should not be.
+    #
+    # And a row whose `error` is a REDIRECT HOP's failure. `Engine#follow_redirects` keeps the
+    # payload's own 3xx as the response and notes the hop it could not follow on `error` —
+    # the status, head and body are all real, so `--mc 302` / `--mr` must see them. Until
+    # this branch the note made the row ineligible, and an open-redirect finding whose hop
+    # the scope gate refused was reported `302 · error` and NOT matched: the same finding the
+    # collapse fix went to the trouble of preserving, thrown away one seam later.
     private def eligible?(raw : Repeater::Result) : Bool
       return true if raw.error.nil?
+      return true if raw.response && raw.error.try(&.starts_with?(REDIRECT_HOP_REFUSED))
       raw.timed_out? && !@match_time_c.nil?
     end
 
@@ -540,6 +548,34 @@ module Gori::Fuzz
 
     private def near?(value : Int64, sampled : Int64, tolerance : Int64) : Bool
       (value - sampled).abs <= tolerance
+    end
+
+    # The first match/filter spec this matcher holds that can NEVER fire, named — or nil when
+    # every set spec parses. A surface asks this ONCE, after its own parse and before the
+    # first dial, and refuses the run with it.
+    #
+    # The compiled forms are deliberately lenient: `classify_num` turns `1O00` (a letter O)
+    # into `NumKind::Never` and `compile_status` delegates `2OO` to `status_match?`, which
+    # answers false for it — so a typo did not raise, it ran the whole sweep and reported
+    # `0 matched`, byte-identical to "nothing there". A predicate that cannot be satisfied is
+    # not a strict predicate, it is a silent one, and the surfaces own the refusal because
+    # only they know the flag (`--ms`) or key (`match.size`) to name.
+    def spec_error : String?
+      {
+        {"status", @match_status, "match"}, {"status", @filter_status, "filter"},
+        {"grpc", @match_grpc, "match"}, {"grpc", @filter_grpc, "filter"},
+        {"size", @match_size, "match"}, {"size", @filter_size, "filter"},
+        {"words", @match_words, "match"}, {"words", @filter_words, "filter"},
+        {"lines", @match_lines, "match"}, {"lines", @filter_lines, "filter"},
+        {"time", @match_time, "match"}, {"time", @filter_time, "filter"},
+      }.each do |(dim, spec, which)|
+        next if spec.nil? || spec.blank?
+        bad = dim == "status" ? Predicate.invalid_status_term(spec) : Predicate.invalid_num_term(spec)
+        next unless bad
+        forms = dim == "status" ? "a status, a class (2xx), a range (200-299) or a comparator (>=400)" : "a number, a range (100-200) or a comparator (>=100)"
+        return "#{which} #{dim} spec #{spec.inspect}: #{bad.inspect} is not #{forms}"
+      end
+      nil
     end
 
     # Whether a TIMED-OUT send is a result this matcher can report rather than a failure —
@@ -780,6 +816,30 @@ module Gori::Fuzz
         else
           StatusTerm.delegate(t)
         end
+      end
+    end
+
+    # The first term of a numeric spec that can never match, or nil. The complement of
+    # `compile_num`'s leniency — see `Matcher#spec_error`.
+    def self.invalid_num_term(spec : String) : String?
+      terms(spec).find { |t| classify_num(t).kind.never? }
+    end
+
+    # The first term of a status spec that can never match, or nil: a range parses, a class
+    # is `Nxx`, and anything else must be an integer after an optional comparator — the exact
+    # grammar `InterceptFilter.status_match?` evaluates.
+    def self.invalid_status_term(spec : String) : String?
+      terms(spec).find do |t|
+        next false if parse_range(t)
+        rest = t
+        {">=", "<=", ">", "<", "="}.each do |op|
+          if t.starts_with?(op)
+            rest = t[op.size..]
+            break
+          end
+        end
+        # `[1-5]xx` — a class no HTTP status can belong to (`6xx`) is as unsatisfiable as a typo.
+        !(rest.matches?(/\A[1-5]xx\z/) || rest.to_i?)
       end
     end
 

--- a/src/gori/fuzz/types.cr
+++ b/src/gori/fuzz/types.cr
@@ -331,6 +331,14 @@ module Gori
       ws_notes : Int64 = 0_i64,
       ws_note_reason : String? = nil
 
+    # The prefix `Engine#follow_redirects` puts on a row's `error` when a hop it CHOSE to follow
+    # failed — the gate refused the origin's `Location`, or the hop's socket died — while the
+    # payload's own answer (the 3xx) is kept as the row's response. One spelling, shared with
+    # `Matcher#eligible?`: that row still HAS a status, a head and a body, so it stays matchable
+    # on them (`--mc 302` is exactly how an open-redirect sweep names its finding), which a
+    # plain "error ⇒ nothing arrived" reading would have thrown away a second time.
+    REDIRECT_HOP_REFUSED = "redirect hop refused: "
+
     # One durable verdict across CLI and TUI. `max_requests` is a wire-attempt budget,
     # so exhausting it before every payload completes is a partial run rather than `done`.
     def self.terminal_status(progress : Progress, stopped : Bool, max_requests : Int64?,

--- a/src/gori/mcp/tools.cr
+++ b/src/gori/mcp/tools.cr
@@ -525,6 +525,8 @@ module Gori
         # before checking every candidate is not read as an exhaustive "0 matches".
         property status : Symbol = :running
         property sent = 0_i64
+        # Requests on the wire (`Fuzz::Progress#requests`): the `max_requests` unit.
+        property requests = 0_i64
         property matched = 0_i64
         property errors = 0_i64
         # Refused before the socket — see `Fuzz::Backend#blocked`. Tracked separately from
@@ -1372,8 +1374,12 @@ module Gori
         end
       end
 
+      # `0` (and below) is "no override" — the engine default — as `rate: 0` is "unlimited" on
+      # this same tool and `--timeout 0` is refused on the CLI. It used to clamp UP to 1 ms, so
+      # a caller writing the conventional zero got every send timed out and a `done` verdict
+      # about a test they never asked for.
       private def fuzz_timeout(h) : Time::Span?
-        optional_int_arg(h, "timeout_ms").try(&.clamp(1_i64, 600_000_i64).milliseconds)
+        optional_int_arg(h, "timeout_ms").try { |ms| ms <= 0 ? nil : ms.clamp(1_i64, 600_000_i64).milliseconds }
       end
 
       private def clamp_nonneg(n : Int64?) : Int32

--- a/src/gori/mcp/tools/fuzz.cr
+++ b/src/gori/mcp/tools/fuzz.cr
@@ -34,11 +34,16 @@ module Gori
           effective_max_requests, Time.utc.to_unix_ms)
         fjob = FuzzJob.new(id, total, engine, fuzz_record_policy(h), origin, http2, audit, @db_path)
         fjob.websocket = !ws_frames.nil?
+        # https only: a plaintext sweep sends no ClientHello, and naming a preset on one would
+        # tell an agent its A/B happened when nothing about the handshake changed. Settled
+        # BEFORE the saved-run row below reads it, so `get_fuzz_run` cannot report the preset
+        # `fuzz_start`/`fuzz_status` withhold for the same run.
+        fjob.tls_preset = tls_preset if origin.scheme == "https"
         if save_results
           fjob.persistence = Fuzz::Persistence.new(store,
             Fuzz::SavedRunMeta.new(nil, audit.target, mode_label, total,
               created_at: audit.started_at_ms * 1000_i64, http2: http2,
-              sni: effective_sni, tls_preset: tls_preset, websocket: fjob.websocket?,
+              sni: effective_sni, tls_preset: fjob.tls_preset, websocket: fjob.websocket?,
               surface: "mcp", source_ref: id))
         end
         # Re-read rather than plumbed back out of `build_fuzz_job`: it is a REPORTING input
@@ -46,9 +51,6 @@ module Gori
         # `fuzz_config` applies, so a second accessor on the plan would only be a second place
         # for the two to disagree.
         fjob.reframe_grpc = bool_arg(h, "reframe_grpc", false)
-        # https only: a plaintext sweep sends no ClientHello, and naming a preset on one would
-        # tell an agent its A/B happened when nothing about the handshake changed.
-        fjob.tls_preset = tls_preset if origin.scheme == "https"
         evict_finished_jobs(@jobs)
         @jobs[id] = fjob
         warn = budget_warning(total, optional_int_arg(h, "max_requests"))
@@ -281,6 +283,7 @@ module Gori
 
       private def apply_fuzz_progress(fjob : FuzzJob, p : Fuzz::Progress) : Nil
         fjob.sent = p.sent
+        fjob.requests = p.requests
         fjob.matched = p.matched
         fjob.errors = p.errors
         fjob.blocked = p.blocked
@@ -348,6 +351,12 @@ module Gori
             j.field "status", fjob.status.to_s
             j.field "total", fjob.total
             j.field "sent", fjob.sent
+            # REQUESTS on the wire — retries and redirect hops each cost one here and none in
+            # `sent` — and the unit `max_requests` is enforced against. It is what turns a
+            # `budget_exhausted` verdict on `sent: 4` under `max_requests: 10` from a riddle
+            # into arithmetic; the CLI prints it and the TUI reads it, and this was the one
+            # surface that dropped it. See `Fuzz::Progress#requests`.
+            j.field "requests", fjob.requests
             j.field "candidates_remaining", (t = fjob.total) ? {0_i64, t - fjob.sent}.max : nil
             j.field "matched", fjob.matched
             j.field "errors", fjob.errors
@@ -514,9 +523,19 @@ module Gori
           end
           use_h2 = false
         end
-        effective_sni = str(h, "sni") || src_sni
+        # `.presence`: a schema-filling client sends `""` for every declared property (see
+        # `describes?`), and a bare `str` read it as an explicit override — winning over the
+        # seed session's stored SNI AND reaching the dial as an empty name, which OpenSSL
+        # treats as "send no SNI extension, check no hostname". `send_request`/`discover`
+        # already read theirs this way.
+        effective_sni = str(h, "sni").presence || src_sni
         config = fuzz_config(h, mode, src_tls_preset)
         matcher = fuzz_matcher(h)
+        # A `match`/`filter` term that can never fire (`size: "1O00"`, `status: "2OO"`) used to
+        # run the whole sweep and report `matched: 0` — the "nothing there" an agent acts on.
+        if spec_err = matcher.spec_error
+          raise FuzzArgError.new(spec_err)
+        end
         if save_results
           config.keep_bodies = :all
           matcher.keep_bodies = :all
@@ -716,7 +735,9 @@ module Gori
       # what they mean there. Re-deriving them would reintroduce the defect that comment records
       # (a PING sent as TEXT, a CLOSE as BINARY, with `isError:false`).
       private def fuzz_ws_messages(h, text : String) : Array(Fuzz::WsMessageSource)?
-        given = h["messages"]?
+        # A JSON `null` is ABSENT, as every scalar reader on this surface already holds
+        # (`str`, `present?`, `optional_int_arg`): a `JSON::Any` wrapping nil is truthy.
+        given = h["messages"]?.try { |v| v.raw.nil? ? nil : v }
         upgrade = Gori::Proxy::WS.upgrade_request?(text)
         http_only = bool_arg(h, "ws_http_only", false)
         # An explicit `messages` that cannot be sent is REFUSED, never dropped. Returning nil
@@ -814,7 +835,7 @@ module Gori
 
       private def string_array_arg(h, key : String) : Array(String)
         raw = h[key]?
-        return [] of String unless raw
+        return [] of String unless raw && !raw.raw.nil?
         arr =
           if a = raw.as_a?
             a
@@ -832,7 +853,7 @@ module Gori
       # shared `processors` pipeline — pairing them here too would build the sets twice.
       private def fuzz_sources(h) : Array(Fuzz::PayloadSource)
         raw = h["payloads"]?
-        return [] of Fuzz::PayloadSource unless raw
+        return [] of Fuzz::PayloadSource unless raw && !raw.raw.nil?
         arr =
           if a = raw.as_a?
             a
@@ -856,7 +877,7 @@ module Gori
       # (LLM clients vary in whether they send a real array or a JSON string).
       private def fuzz_processors(h) : Array(Fuzz::Processor)
         raw = h["processors"]?
-        return [] of Fuzz::Processor unless raw
+        return [] of Fuzz::Processor unless raw && !raw.raw.nil?
         arr =
           if a = raw.as_a?
             a
@@ -1114,7 +1135,7 @@ module Gori
       private alias FuzzConds = NamedTuple(status: String?, grpc: String?, size: String?, words: String?, lines: String?, time: String?, header: String?, regex: String?)
 
       private def fuzz_conditions(raw : JSON::Any?, which : String) : FuzzConds?
-        return nil unless raw
+        return nil unless raw && !raw.raw.nil?
         obj =
           if h = raw.as_h?
             h
@@ -1219,6 +1240,12 @@ module Gori
         # itself both clamp at (`Fuzz::Engine::MAX_RACE_SIZE`).
         optional_int_arg(h, "race_count").try { |v| cfg.race_count = v.clamp(1_i64, Fuzz::Engine::MAX_RACE_SIZE.to_i64).to_i }
         cfg.race_warmup = fuzz_race_warmup(h)
+        # Read by `Engine#run_race` and by nothing else: without `race_count` the bytes were
+        # accepted, echoed nowhere and never sent. Refused, as `gori run fuzz` refuses the
+        # same pair, rather than left as a knob that silently did nothing.
+        if cfg.race_warmup && cfg.race_count.nil?
+          raise FuzzArgError.new("'race_warmup' applies to a race_count run — pass race_count, or drop the warm-up")
+        end
         cfg
       end
 

--- a/src/gori/mcp/tools/jobs.cr
+++ b/src/gori/mcp/tools/jobs.cr
@@ -17,6 +17,7 @@ module Gori
                     j.field "kind", "fuzz"
                     j.field "status", f.status.to_s
                     j.field "sent", f.sent
+                    j.field "requests", f.requests
                     j.field "total", f.total
                     j.field "matched", f.matched
                     j.field "target", Serialize.text(f.audit.target)

--- a/src/gori/tui/controllers/fuzzer_controller.cr
+++ b/src/gori/tui/controllers/fuzzer_controller.cr
@@ -1137,7 +1137,11 @@ module Gori::Tui
         spool_run = @spool_runs[v]?
         archive_ready = !!spool_run && !spool_run.failed? && spool_run.finished?
         v.finish_run(terminal, archive_ready: archive_ready)
-        finish_job(v, ev, terminal)
+        # A view being CLOSED (`close_at`, `stop_all`) drains its own Done while it is still
+        # in `@fuzzers`; its job was already finished `:stopped` by the close, and a "Fuzzer:
+        # N hits (stopped)" toast with a jump to a session that no longer exists is not a
+        # completion — it is the close, reported a second time as a result.
+        finish_job(v, ev, terminal) unless @cancelled_views.includes?(v)
       when Fuzz::ErrorEvent
         # Generation/worker errors can be followed by many queued Result events and then Done.
         # Keep the view running (and therefore unsaveable) until that terminal event drains.
@@ -1272,7 +1276,7 @@ module Gori::Tui
     # Focus a fuzz sub-tab by persisted id (notification "jump to result").
     def reveal_session(id : Int64) : Nil
       if idx = @fuzzers.index { |t| t.db_id == id }
-        select_subtab(idx, save: false)
+        select_subtab(idx) # saving the tab it leaves, as every other switch does
         @host.focus_body
       end
     end
@@ -1760,6 +1764,10 @@ module Gori::Tui
     end
 
     private def open_session(view : FuzzerView, flow_id : Int64?) : Nil
+      # The OUTGOING tab first. `goto_tab` below flushes "the current fuzz tab", and by then
+      # that is the new one — so a dirty session the operator left with ^N / Duplicate / a
+      # notification jump was never written and vanished at quit.
+      save_current
       tab = FuzzerTab.new(view, flow_id, persist_new(view, flow_id))
       @fuzzers << tab
       # A session created in this controller lifetime has no prior saved run to restore.
@@ -1892,7 +1900,16 @@ module Gori::Tui
 
     # --- persistence ---
     def save_current : Nil
-      return unless tab = current_tab_obj
+      current_tab_obj.try { |tab| save_tab(tab) }
+    end
+
+    # EVERY dirty tab, for the exits that close the whole Runner (quit, leave project): only
+    # the current tab used to be flushed there, so an edit left on any other sub-tab was lost.
+    def save_all : Nil
+      @fuzzers.each { |tab| save_tab(tab) }
+    end
+
+    private def save_tab(tab : FuzzerTab) : Nil
       return unless (id = tab.db_id) && tab.view.dirty?
       v = tab.view
       cfg = v.config_json

--- a/src/gori/tui/fuzz_set_overlay.cr
+++ b/src/gori/tui/fuzz_set_overlay.cr
@@ -14,7 +14,29 @@ module Gori::Tui
   # brute="charset:min-max"). Shared by FuzzerView (@sets, persistence, engine
   # assembly) and FuzzSetOverlay (the editor that produces one). Hoisted to module
   # scope so the overlay can build one without depending on FuzzerView.
-  record SetSpec, kind : Symbol, value : String
+  record SetSpec, kind : Symbol, value : String do
+    # A `:list` value is NEWLINE-separated with a trailing newline — the overlay's own grammar
+    # ("one value per line") — because a comma is ordinary payload text: `{"id":1,"role":"x"}`
+    # or `' OR 1=1,--` stored comma-joined came back as two payloads, and the run count said
+    # so while the operator read it as one. The trailing newline is the format marker: a value
+    # with no newline at all is a session saved under the old comma grammar and is still
+    # split on `,`, so nothing already on disk changes meaning.
+    LIST_SEP = '\n'
+
+    def self.list(values : Array(String)) : SetSpec
+      new(:list, values.join(LIST_SEP) + LIST_SEP)
+    end
+
+    def self.list_values(value : String) : Array(String)
+      return value.split(',') unless value.includes?(LIST_SEP)
+      value.chomp(LIST_SEP).split(LIST_SEP)
+    end
+
+    # ONE line, for a set row and a signature. The stored form of a list carries newlines.
+    def display : String
+      kind == :list ? SetSpec.list_values(value).join(',') : value
+    end
+  end
 
   # The full-area popup for adding or editing ONE payload set. Replaces the cramped
   # in-pane draft fields: every payload type gets its own vertically-stacked, labeled
@@ -71,7 +93,7 @@ module Gori::Tui
       case spec.kind
       when :list
         @ptype = :list
-        @values.set_text(spec.value.split(',').map(&.strip).reject(&.empty?).join('\n'))
+        @values.set_text(SetSpec.list_values(spec.value).map(&.strip).reject(&.empty?).join('\n'))
       when :numbers
         @ptype = :numbers
         range, _, step = spec.value.partition(':')
@@ -328,7 +350,7 @@ module Gori::Tui
       case @ptype
       when :list
         vals = list_values
-        vals.empty? ? nil : SetSpec.new(:list, vals.join(","))
+        vals.empty? ? nil : SetSpec.list(vals)
       when :numbers
         SetSpec.new(:numbers, "#{num64(:from)}-#{num64(:to)}:#{num64(:step, 1_i64)}")
       when :wordlist

--- a/src/gori/tui/fuzzer_result_window.cr
+++ b/src/gori/tui/fuzzer_result_window.cr
@@ -27,13 +27,16 @@ module Gori::Tui
       charge = self.class.result_bytes(result)
       projected = false
       if charge > @byte_cap
+        # Projected from HERE on, not only past the second cap: `metrics_only` already dropped
+        # the request/head/body this row holds in the archive, and a row it sufficed for was
+        # left unmarked — so the detail panes said "not retained" about bytes the spool has.
+        projected = true
         result = self.class.metrics_only(result)
         charge = self.class.result_bytes(result)
         if charge > @byte_cap
           result = self.class.bounded_metrics(result,
             {@byte_cap - Fuzz::Persistence::ROW_METADATA_BYTES, SCALAR_PREVIEW_BYTES}.min)
           charge = self.class.result_bytes(result)
-          projected = true
         end
       end
       @rows << result

--- a/src/gori/tui/fuzzer_view.cr
+++ b/src/gori/tui/fuzzer_view.cr
@@ -1323,7 +1323,7 @@ module Gori::Tui
       # The RAW field row, not the parsed list: this runs on the render fiber every frame and
       # `grpc_field_specs` allocates, while the string it splits is the thing that actually
       # changes. (`position_count` is memoized on the editor revision for the same reason.)
-      sig = "#{@config.mode}|#{position_count}|#{@s_grpc_fields}|#{@sets.map { |s| "#{s.kind}:#{s.value}" }.join("~")}"
+      sig = "#{@config.mode}|#{position_count}|#{@s_grpc_fields}|#{@sets.map { |s| "#{s.kind}:#{s.display}" }.join("~")}"
       return @run_count_cache if sig == @run_count_sig
       @run_count_sig = sig
       @run_count_cache = compute_run_count
@@ -1427,6 +1427,24 @@ module Gori::Tui
       nil
     end
 
+    # The first Advanced numeric buffer that is non-blank and does not parse, named — the
+    # twin of `regex_error`. `commit_buffers` deliberately reads a blank as "default / off",
+    # and that is the ONLY silent fallback it may keep: text that is not a number is a typo,
+    # and the row kept displaying it while the run used something else.
+    private def buffer_error : String?
+      {
+        {"Concurrency", @s_conc, "a whole number"}, {"Rate", @s_rate, "requests per second"},
+        {"Timeout", @s_timeout, "whole seconds"}, {"Retries", @s_retries, "a whole number"},
+        {"Max requests", @s_max_req, "a whole number"}, {"Race", @s_race, "a whole number"},
+      }.each do |(name, buf, form)|
+        v = buf.strip
+        next if v.empty?
+        ok = name == "Rate" ? !v.to_f?.nil? : !v.to_i64?.nil?
+        return "invalid #{name}: #{v} (#{form})" unless ok
+      end
+      nil
+    end
+
     # --- engine assembly -----------------------------------------------------
     # Build an engine ready to run, or {nil, error}. `scope` becomes the interactive
     # `Gori::Outbound` decision the sender dials through: no up-front allowlist gate (the
@@ -1441,6 +1459,17 @@ module Gori::Tui
       commit_buffers
       if err = regex_error
         return {nil, err} # don't silently run match-everything on a bad pattern
+      end
+      # A numeric field the commit above fell back from (`Timeout 1.5` → no timeout,
+      # `Concurrency 50x` → 20) kept SHOWING the typed text while the run used the default.
+      if err = buffer_error
+        return {nil, err}
+      end
+      # A status/size/… spec that can never fire (`2OO`, `>1O0`) ran the whole sweep as
+      # `N sent · 0 hit`, byte-identical to "nothing there" — the CLI and MCP refuse the same
+      # typo up front through this one validator. See `Fuzz::Matcher#spec_error`.
+      if err = @matcher.spec_error
+        return {nil, err}
       end
       # `wire_text`, NOT `text` — the same distinction the Repeater's send path draws
       # (`RepeaterView#expanded_editor_bytes`) and for the same reason. `text` is the LF
@@ -1660,7 +1689,7 @@ module Gori::Tui
 
     private def build_source(s : SetSpec) : Fuzz::PayloadSource
       case s.kind
-      when :list    then Fuzz::InlineList.new(s.value.split(','))
+      when :list    then Fuzz::InlineList.new(SetSpec.list_values(s.value))
       when :file    then Fuzz::WordlistFile.new(s.value)
       when :preset  then Fuzz::PresetSource.new(s.value)
       when :null    then Fuzz::NullPayloads.new(s.value.to_i? || 1)
@@ -2434,7 +2463,9 @@ module Gori::Tui
       obj["concurrency"]?.try(&.as_i?).try { |n| @config.concurrency = n }
       @config.rps = obj["rps"]?.try(&.as_f?)
       @config.throttle_ms = obj["throttle_ms"]?.try(&.as_i?)
-      obj["timeout_s"]?.try(&.as_i?).try { |s| @config.timeout = s.seconds }
+      # Assigned, not guarded: `config_json` writes the key as `null` when there is no
+      # timeout, and a guarded read kept the stale one when the peer had CLEARED it.
+      @config.timeout = obj["timeout_s"]?.try(&.as_i?).try(&.seconds)
       obj["retries"]?.try(&.as_i?).try { |n| @config.retries = n }
       @config.max_requests = obj["max_requests"]?.try(&.as_i64?)
       @config.race_count = obj["race_count"]?.try(&.as_i?)
@@ -2924,7 +2955,7 @@ module Gori::Tui
       bg = sel ? (focused ? Theme.accent_bg : Theme.selection_dim) : Theme.bg
       screen.fill(Rect.new(inner.x, y, inner.w, 1), bg) if sel
       fg = sel ? Theme.text_bright : Theme.text
-      label = "#{i + 1} #{s.kind} #{s.value}"
+      label = "#{i + 1} #{s.kind} #{s.display}"
       unless pp
         screen.text(inner.x + 1, y, label, fg, bg, width: {inner.w - 2, 1}.max)
         return

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -2864,7 +2864,7 @@ module Gori::Tui
       notes_controller.save_notes
       project_controller.commit
       repeater_controller.save_current_repeater
-      fuzzer_controller.save_current
+      fuzzer_controller.save_all # every dirty sub-tab, not only the one in front
       miner_controller.save_current
       sequencer_controller.save_current
       issues_controller.commit
@@ -4283,6 +4283,12 @@ module Gori::Tui
 
     def open_fuzz_advanced_editor : Nil
       return unless v = fuzzer_controller.current_view
+      # `Config` is shared by reference with the live engine (`Fuzz::PlanOptions#config`),
+      # which reads `retries`, `follow_redirects?`, `max_requests` and the Content-Length knobs
+      # PER REQUEST — so a mid-run edit changed the rest of the sweep while the reconstruction
+      # of its rows kept the policy the run started with. The Sets editor is different: sets
+      # are read once at build time.
+      return status("fuzz running — ^X to stop before editing Advanced", :busy) if v.running?
       ov = FuzzAdvancedOverlay.new(v.advanced_snapshot)
       ov.on_commit = -> {
         fuzzer_controller.apply_fuzz_advanced(ov.snapshot)


### PR DESCRIPTION
A full audit of the Fuzzer — engine, CLI, MCP tools and the TUI tab — and the fixes for what it found. 4309 specs pass; format check clean.

## Engine (`src/gori/fuzz`)
- A stop stops: `--retries` re-sends and redirect hops re-read the state, so a busy worker no longer keeps the origin under fire after ^X.
- `follow_redirects` resolves a **relative** `Location` (`next?x=1`, `?p=2`, `../up`) against the answered request instead of dropping it; scheme/host compare case-insensitively; an IPv6 `Host:` is bracketed; an h2 hop carries no `Connection: close` (RFC 9113 §8.2.2 has a server reject it) via a new `Backend#http2?` seam.
- A row whose hop was refused keeps its 3xx **and is matchable on it** (`--mc 302` is the open-redirect finding).
- `run_race` reports a pre-release raise as an ErrorEvent instead of a silent `0 sent · done`.
- `Matcher#spec_error`: a match/filter term that can never fire (`--ms 1O00`, `--mc 2OO`) is refused before the first dial on every surface; it used to run the whole sweep as `0 matched`.

## CLI
- Exit 1 fires when **every** send errored (as the docs say), not when any did.
- `--race-warmup` without `--race`, an empty `--numbers 10-1`, and `--brute abc:0-N` are refused by name instead of silently ignored / clamped / run as `0 requests`.

## MCP
- `sni: ""` no longer overrides the seed's SNI and dials with an empty name (no SNI, no hostname check).
- `timeout_ms: 0` is "default", not a 1 ms deadline.
- `fuzz_status` / `list_jobs` emit `requests` (the `budget_exhausted` unit).
- A plaintext run's saved row no longer records the `tls_preset` the live echo withholds.
- JSON `null` container arguments read as absent; `race_warmup` without `race_count` is refused.

## TUI
- A List set is stored newline-separated — a comma is payload text (`{"id":1,"role":"admin"}` went out as two payloads). Legacy comma values still read.
- Switching sub-tab saves the tab it leaves; quit saves every dirty tab.
- The Advanced overlay is refused while a run is live (its Config is shared by reference with the engine); an unparsable numeric field is refused rather than silently defaulted.
- Closing a running session no longer toasts a completion with a jump to the deleted session.
- A metrics-only row carries its projection mark; a peer sync can clear the timeout.

New specs: `spec/fuzz/engine_stop_and_hops_spec.cr`, `spec/fuzz/matcher_spec_error_spec.cr`, `spec/tui/fuzzer_view_refusals_spec.cr`.
