### PR TITLE
fix(tui): a failing render shows a reduced frame instead of ending the session, and four more regex sites take wire bytes

### DIFF
--- a/spec/tui/authorize_identity_overlay_spec.cr
+++ b/spec/tui/authorize_identity_overlay_spec.cr
@@ -269,3 +269,32 @@ describe AuthorizeIdentitiesOverlay do
     b.contains?("a adds one").should be_true
   end
 end
+
+# The cursor has to survive the row under it being deleted: a stale `@selected` past the end
+# is the TUI's systemic crash shape (an IndexError on the next paint, three of them and the
+# tick breaker ends the session).
+describe AuthorizeIdentitiesOverlay, "cursor after a delete" do
+  private_ids2 = [
+    Identity.as_captured,
+    Identity.new("admin", set_headers: [{"Cookie", "s=A"}]),
+    Identity.new("guest", set_headers: [{"Cookie", "s=G"}]),
+  ]
+
+  it "keeps the selection on a real row when the LAST row is deleted, and still paints" do
+    ov = AuthorizeIdentitiesOverlay.new(private_ids2, 2) # cursor on the last row
+    ov.on_change = ->(_l : Array(Identity)) { true }
+    ov.handle_key(okey(Termisu::Input::Key::LowerD, 'd'))
+    ov.identities.size.should eq(2)
+    ov.selected.should eq(1)
+    render(ov)
+    ov.handle_key(okey(Termisu::Input::Key::LowerD, 'd'))
+    ov.identities.size.should eq(1)
+    ov.selected.should eq(0)
+    render(ov)
+    # the last identity is refused, not deleted — and the cursor stays where it can paint
+    ov.handle_key(okey(Termisu::Input::Key::LowerD, 'd'))
+    ov.identities.size.should eq(1)
+    ov.selected.should eq(0)
+    render(ov)
+  end
+end

--- a/spec/tui/contract_invalid_utf8_spec.cr
+++ b/spec/tui/contract_invalid_utf8_spec.cr
@@ -1,0 +1,71 @@
+require "../support/tui_contract"
+require "../support/overlay_harness"
+
+include Gori::Tui
+
+# CONTRACT: text that is not valid UTF-8 never takes the frame down.
+#
+# A captured method, host or path is wire bytes (`String.new(bytes)`, no scrub), and so is a
+# saved stub body or an MCP client's self-reported name. PCRE2 raises `ArgumentError: Regex
+# match error: UTF-8 error` on such a subject, and a raise on the RENDER path is the worst
+# kind: the same frame is asked for again on the next tick, so it repeats until the tick
+# breaker ends the session (`Runner#absorb_tick_error`). The 2026-08-15 crash audit found
+# nine of these; this states the rule once for every controller, and pins the four sites a
+# later review found still running a regex over untrusted text without a guard.
+private def bad(prefix : String) : String
+  String.new(prefix.to_slice + Bytes[0xff, 0xfe, 0x20, 0x41])
+end
+
+private def seed_invalid_flow(store : Gori::Store) : Int64
+  method = bad("GET")
+  host = bad("acme.test")
+  target = bad("/p")
+  id = store.insert_flow(Gori::Store::CapturedRequest.new(
+    created_at: 1_i64, scheme: "https", host: host, port: 443,
+    method: method, target: target, http_version: "HTTP/1.1",
+    head: "#{method} #{target} HTTP/1.1\r\nHost: #{host}\r\n\r\n".to_slice, body: nil,
+    source: Gori::FlowSource::Kind::Proxy))
+  store.update_response(Gori::Store::CapturedResponse.new(
+    flow_id: id, status: 200, head: "HTTP/1.1 200 OK\r\nX-Note: #{bad("v")}\r\n\r\n".to_slice,
+    body: bad("{\"a\":1}").to_slice, content_type: "application/json"))
+  id
+end
+
+describe "TUI contract — invalid UTF-8 never raises on the render path" do
+  it "every controller renders and hints over a flow whose identity fields are wire bytes" do
+    TuiContract.with_session("utf8-contract") do |session|
+      seed_invalid_flow(session.store)
+      failed = [] of String
+      TuiContract.each_controller(session) do |controller, _host|
+        controller.on_enter
+        TuiContract.render(controller)
+        controller.body_hint(:body)
+      rescue ex
+        failed << "#{controller.class}: #{ex.class}: #{ex.message}"
+      end
+      failed.should be_empty
+    end
+  end
+
+  it "the agents chip strips controls from a client name that is not UTF-8" do
+    # `scrub` marks the bad bytes as U+FFFD — a visible "something was here", which is the
+    # right answer for a name shown on a chip; only the C0 control still gets stripped.
+    AgentsOverlay.safe_client(bad("claude\u0001")).should eq("claude\uFFFD\uFFFD A")
+  end
+
+  it "the activity feed folds a message that is not UTF-8 onto one line" do
+    ProjectView.act_one_line(bad("a\n\nb")).should_not contain("\n")
+  end
+
+  it "a hint template that is not UTF-8 is returned as written" do
+    tpl = bad("{fuzz.run} run ")
+    Gori::Hotkeys.expand(Gori::Verbs.registry, tpl).should eq(tpl)
+  end
+
+  it "the library picker draws a saved spec that is not UTF-8" do
+    rows = [LibraryPicker::Row.new(0, "peel", bad("base64-decode\n> gunzip"))]
+    h = OverlayHarness.new(LibraryPicker.new("LOAD CHAIN", rows, "chain"))
+    h.render
+    h.rendered?("peel").should be_true
+  end
+end

--- a/spec/tui/tick_breaker_spec.cr
+++ b/spec/tui/tick_breaker_spec.cr
@@ -1,0 +1,46 @@
+require "../spec_helper"
+
+include Gori::Tui
+
+# The run loop's tick-error breaker, pinned through the class the loop defers the tally to
+# (`Runner.new` owns a terminal, so `absorb_tick_error` itself cannot run under spec). The
+# policy of which raises count lives in the Runner; the arithmetic is here.
+describe TickBreaker do
+  it "trips on the limit-th strike inside the window, and not before" do
+    b = TickBreaker.new(3, 10.seconds)
+    t0 = Time.instant
+    b.record(t0).should eq(1)
+    b.tripped?(t0).should be_false
+    b.record(t0 + 1.second).should eq(2)
+    b.tripped?(t0 + 1.second).should be_false
+    b.record(t0 + 2.seconds).should eq(3)
+    b.tripped?(t0 + 2.seconds).should be_true
+  end
+
+  it "forgets strikes older than the window, so a raise every few minutes never accumulates" do
+    b = TickBreaker.new(3, 10.seconds)
+    t0 = Time.instant
+    b.record(t0)
+    b.record(t0 + 1.second)
+    # 11s later the first two are outside the window: this is strike ONE of a new run.
+    b.record(t0 + 12.seconds).should eq(1)
+    b.tripped?(t0 + 12.seconds).should be_false
+  end
+
+  it "reads the window at the moment it is asked, not at the last strike" do
+    b = TickBreaker.new(2, 10.seconds)
+    t0 = Time.instant
+    b.record(t0)
+    b.record(t0 + 1.second)
+    b.tripped?(t0 + 1.second).should be_true
+    b.tripped?(t0 + 30.seconds).should be_false # both have aged out
+  end
+
+  it "resets" do
+    b = TickBreaker.new(1, 10.seconds)
+    b.record(Time.instant)
+    b.tripped?.should be_true
+    b.reset
+    b.tripped?.should be_false
+  end
+end

--- a/src/gori/hotkeys.cr
+++ b/src/gori/hotkeys.cr
@@ -263,7 +263,7 @@ module Gori
     def self.expand(registry : Verb::Registry, template : String,
                     overrides : Hash(String, Array(Verb::Chord)) = rebindable_overrides(registry),
                     profile : String = Settings.keymap_os) : String
-      return template unless template.includes?('{')
+      return template unless template.valid_encoding? && template.includes?('{')
       template.gsub(VERB_TOKEN_RE) do |token|
         id = $1
         if chord = binding_for(registry, id, overrides, profile) || default_for(registry, id, profile)

--- a/src/gori/tui.cr
+++ b/src/gori/tui.cr
@@ -95,6 +95,7 @@ require "./tui/input_idle_backoff_patch" # carried termisu patch — see the fil
 require "./tui/geometry"
 require "./tui/theme"
 require "./tui/screen"
+require "./tui/tick_breaker"
 require "./tui/frame"
 require "./tui/brand"
 require "./tui/highlight"

--- a/src/gori/tui/agents_overlay.cr
+++ b/src/gori/tui/agents_overlay.cr
@@ -58,7 +58,7 @@ module Gori::Tui
 
     def self.safe_client(name : String?) : String?
       return nil unless name
-      cleaned = name.gsub(/\p{C}/, "").gsub(/\s+/, " ").strip
+      cleaned = name.scrub.gsub(/\p{C}/, "").gsub(/\s+/, " ").strip
       return nil if cleaned.empty?
       Screen.fit(cleaned, CLIENT_MAX_CELLS)
     end

--- a/src/gori/tui/controllers/statusline_controller.cr
+++ b/src/gori/tui/controllers/statusline_controller.cr
@@ -126,7 +126,7 @@ module Gori::Tui
         break if room <= 0
         mem.write(room >= n ? chunk : chunk[0, room])
       end
-      String.new(mem.to_slice)
+      String.new(mem.to_slice).scrub
     end
 
     # First line of `s`, without a trailing CR (the statusline is one row). `s` is

--- a/src/gori/tui/library_picker.cr
+++ b/src/gori/tui/library_picker.cr
@@ -193,7 +193,7 @@ module Gori::Tui
     # A saved spec can carry newlines (a short-circuit stub body); collapse so one entry is
     # always exactly one row and can never push the rows below it out of alignment.
     private def oneline(s : String) : String
-      s.gsub(/[\r\n\t]+/, " ")
+      s.scrub.gsub(/[\r\n\t]+/, " ")
     end
   end
 end

--- a/src/gori/tui/project_view.cr
+++ b/src/gori/tui/project_view.cr
@@ -3032,7 +3032,7 @@ module Gori::Tui
     # Feed messages are prose and some are written across several source lines; a newline drawn
     # into a row would leave a hole in the list. The band below shows the whole thing.
     def self.act_one_line(message : String) : String
-      message.gsub(/\s+/, " ").strip
+      message.scrub.gsub(/\s+/, " ").strip
     end
 
     # The three-state filter bar, the grammar the OAST callbacks list already uses: the input

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -304,9 +304,14 @@ module Gori::Tui
       @body_h = 24                  # last body rect height (captured at render); drives PageUp/Down step size
       @title_text = nil.as(String?) # last string emitted as the terminal-window title (memo; see sync_terminal_title)
       @title_written = false        # have we ever written a title? gates the neutral restore on leave when the pref is "off"
-      # Timestamps of raises absorbed by the run loop, trimmed to TICK_ERROR_WINDOW — the
-      # circuit breaker behind `absorb_tick_error`.
-      @tick_errors = [] of Time::Instant
+      # The circuit breaker behind `absorb_tick_error`: strikes inside TICK_ERROR_WINDOW.
+      @breaker = TickBreaker.new(TICK_ERROR_LIMIT, TICK_ERROR_WINDOW)
+      # The exception a full render last raised, while the reduced frame stands in for it —
+      # nil once a key asks for the real frame again. See `absorb_tick_error`.
+      @safe_frame = nil.as(Exception?)
+      # A frame owed to the operator by something that could not set the tick's own `dirty`
+      # (the error path runs in the tick's rescue, after that local has gone out of scope).
+      @render_pending = false
 
       # Per-tab controllers (strangler-fig: tabs migrate into this registry one at a
       # time; an unmigrated tab is absent and still runs through the case ladders
@@ -507,6 +512,7 @@ module Gori::Tui
           # Wrapped in place rather than extracted so the `last_*` cursors above survive the
           # error: a recovered tick carries on from where it was instead of re-running every
           # poll and reload from scratch.
+          phase = :input # which half of the tick a raise came from — see `absorb_tick_error`
           begin
             ev = @term.poll_event(50)
             dirty = false
@@ -699,13 +705,20 @@ module Gori::Tui
               last_ui_ident = ident
               last_ui_write = now
             end
+            # A frame the error path owes (its toast, or the reduced frame) — that path runs in
+            # the rescue below, after this tick's `dirty` is gone, so it leaves a note instead.
+            if @render_pending
+              @render_pending = false
+              dirty = true
+            end
+            phase = :render
             render if dirty
           rescue ex : Gori::Error
             # gori's own errors keep their designed exit: `CLI.run` rescues these and aborts
             # with the operator-facing message, which is a deliberate answer, not a crash.
             raise ex
           rescue ex
-            raise ex unless absorb_tick_error(ex)
+            raise ex unless absorb_tick_error(ex, phase)
           end
           break unless @outcome == :running
         end
@@ -728,7 +741,12 @@ module Gori::Tui
         # "𝓰𝓸𝓻𝓲 - acme - Notes" mustn't linger. The shell's prompt overwrites it again after
         # quit. Skipped when we never wrote a title (pref "off"), so gori leaves the
         # terminal's own title alone end to end.
-        @term.title = "𝓰𝓸𝓻𝓲" if @title_written
+        # `rescue`d: on a tty that has gone away this write is the second raise in the same
+        # unwind, and it would replace the one that says why the session ended.
+        begin
+          @term.title = "𝓰𝓸𝓻𝓲" if @title_written
+        rescue IO::Error
+        end
       end
       @outcome
     end
@@ -778,20 +796,41 @@ module Gori::Tui
     #
     # The trace goes to <GORI_HOME>/gori.log, which `App#run_tui` binds before entering the
     # alt screen, so logging here cannot garble the display it is reporting about.
-    private def absorb_tick_error(ex : Exception) : Bool
+    #
+    # `phase` is which half of the tick raised. A raise from the INPUT half (a key handler, a
+    # channel drain, a timer) is one hostile event going past: it counts as a strike, the
+    # toast says so, and the next frame draws as usual. A raise from the RENDER half is a
+    # different animal — the same frame is asked for again 50ms later, so with a deterministic
+    # bug three strikes were ~150ms, and the recovery toast was drawn by the very render that
+    # kept failing: the operator saw a backtrace, never the toast. So a full render's failure
+    # does not strike. It puts the REDUCED frame up instead (`render_safe_frame`: chrome and
+    # status row, the error where the body was), which stays until a key asks for the real
+    # frame again — every retry is the operator's, not the clock's, and the tab bar still works
+    # so they can leave the tab that cannot draw. Only the reduced frame failing too (the
+    # chrome itself is broken, nothing left to fall back to) strikes like an input raise.
+    private def absorb_tick_error(ex : Exception, phase : Symbol) : Bool
       now = Time.instant
-      @tick_errors.reject! { |t| now - t > TICK_ERROR_WINDOW }
-      @tick_errors << now
-      ::Log.error(exception: ex) { "TUI tick raised (#{@tick_errors.size}/#{TICK_ERROR_LIMIT} in #{TICK_ERROR_WINDOW})" }
-      return false if @tick_errors.size >= TICK_ERROR_LIMIT
+      # The frame that raised is half-drawn, so force a full repaint rather than a cell diff
+      # against a screen state no complete render ever produced. And ask for that frame: this
+      # runs in the tick's rescue, where the tick's own `dirty` is out of reach.
+      @resized = true
+      @render_pending = true
+      if phase == :render && @safe_frame.nil?
+        ::Log.error(exception: ex) { "TUI render raised — showing the reduced frame" }
+        @safe_frame = ex
+        status("#{@active_tab} failed to draw — any key retries · details in gori.log (#{ex.class}: #{ex.message})", :error)
+        return true
+      end
+      count = @breaker.record(now)
+      ::Log.error(exception: ex) { "TUI #{phase} tick raised (#{count}/#{TICK_ERROR_LIMIT} in #{TICK_ERROR_WINDOW})" }
+      return false if @breaker.tripped?(now)
       # `status`, not a bare `@toast =`: `status_line` only prefers a toast over the
       # companion's bubble when `@toast_at` is fresher than `@companion.bubble_at`, so
       # assigning the message without its timestamp lost the race to any bubble Miss Ring
       # happened to be holding — and the breaker's one operator-visible signal never showed.
-      status("recovered from an internal error — details in gori.log (#{ex.class}: #{ex.message})")
-      # The frame that raised is half-drawn, so force a full repaint rather than a cell diff
-      # against a screen state no complete render ever produced.
-      @resized = true
+      # `:error`, so it reaches the notification centre as well (#960): the toast is gone on
+      # the next keypress, and this is the one message an operator should be able to re-read.
+      status("recovered from an internal error — details in gori.log (#{ex.class}: #{ex.message})", :error)
       true
     end
 
@@ -1109,6 +1148,11 @@ module Gori::Tui
     @paste_stall = PasteStall.new
 
     private def handle(ev : Termisu::Event::Any) : Nil
+      # A key retires the reduced frame (see `absorb_tick_error`): the next render is the
+      # real one, and if it fails again the reduced frame simply comes back. Keys only —
+      # xterm mode 1002 reports pointer motion continuously, and a drag would otherwise retry
+      # (and log) the broken render at the mouse's rate.
+      @safe_frame = nil if ev.is_a?(Termisu::Event::Key)
       # A PasteStart arriving while a paste is ALREADY open means the previous one was abandoned
       # (its marker lost) and a new one is beginning. Close the old one first, or there is no
       # start transition for the new one and it silently inherits the abandoned paste's
@@ -2341,6 +2385,10 @@ module Gori::Tui
       end
 
       layout = Layout.compute(w, h, statusline_active?)
+      if failed = @safe_frame
+        render_safe_frame(screen, layout, failed)
+        return
+      end
       Chrome.render_top_bar(screen, layout.topbar, project: @session.project.name,
         listen: listen_chip_label,
         scope: scope_label, probe: probe_label, rules: rules_label, intercept: intercept_label,
@@ -2391,6 +2439,54 @@ module Gori::Tui
       flush_screen
     end
 
+    # The frame drawn while a full render is failing (see `absorb_tick_error`): the top bar,
+    # the tab menu and the status row exactly as `render` draws them, and the error where the
+    # body would be. Nothing pane-owned is asked to draw — the body, the companion, overlays,
+    # the prompts and the controllers' hint strips are all suspects — so this frame can only
+    # fail if the chrome itself is broken. The tab menu is kept LIVE (focus, active tab) so
+    # 1-9 / ←→ still read as what they do: the way out of a tab that cannot draw.
+    private def render_safe_frame(screen : Screen, layout : Layout, ex : Exception) : Nil
+      Chrome.render_top_bar(screen, layout.topbar, project: @session.project.name,
+        listen: listen_chip_label,
+        scope: scope_label, probe: probe_label, rules: rules_label, intercept: intercept_label,
+        sandbox: sandbox_label,
+        unread: @notifications.unread, capturing: @session.capturing?,
+        write_failures: @session.store.write_failures, bypass: Settings.passthrough_count,
+        listeners: listener_chip_count, listener_errors: @session.listener_errors.size,
+        authorize: authorize_chip_label, session: session_slot_chip, agents: agent_chip)
+      Chrome.render_rule(screen, layout.rule)
+      vis_tabs, hid_tabs = Chrome.split_tabs(Settings.tab_prefs, force: @active_tab)
+      Chrome.render_menu(screen, layout.menu, active_tab: @active_tab,
+        focused: @focus == :menu && !@menu_more,
+        tabs: vis_tabs, intercept_count: @session.interceptor.pending_count,
+        hidden_count: hid_tabs.size, more_focused: @focus == :menu && @menu_more,
+        numbered: Settings.tab_numbers?)
+      body = layout.body
+      # A message may carry wire bytes or newlines (an IndexError's does not, a parser's may):
+      # one line, valid UTF-8, or the frame meant to report the crash would be the next one.
+      detail = "#{ex.class}: #{ex.message}".scrub.gsub(/\s+/, " ")
+      lines = [
+        "the #{@active_tab} tab failed to draw",
+        detail,
+        "",
+        "any key retries · 1-9 or ←/→ switch tab · the trace is in gori.log",
+      ]
+      y = body.y + {(body.h - lines.size) // 2, 0}.max
+      lines.each_with_index do |line, i|
+        break if y + i >= body.bottom
+        color = i == 0 ? Theme.red : (i == 1 ? Theme.text : Theme.muted)
+        screen.text(body.x + 2, y + i, line, color, Theme.bg, width: {body.w - 4, 0}.max)
+      end
+      Chrome.render_status(screen, layout.status, focus: focus_label,
+        hints: Hotkeys.retag(status_line || SAFE_FRAME_HINT),
+        activity: activity_chip, resource: @resource.label, time: clock_label,
+        companion: nil)
+      @term.hide_cursor
+      flush_screen
+    end
+
+    SAFE_FRAME_HINT = "any key retries · 1-9 switch tab · ^D quit"
+
     # The space menu (bottom-right popup) + the copy-as picker (centered) + the
     # bottom-anchored input prompts, all drawn last and orthogonal to @overlay so
     # they float over whatever's underneath (a tab body or the History detail).
@@ -2412,6 +2508,14 @@ module Gori::Tui
       # forces a full repaint since the diff would otherwise leave stale cells.
       @backend.flush(sync: @resized)
       @resized = false
+    rescue ex : IO::Error
+      # The tty went away (the terminal closed, the ssh session dropped). Absorbing this
+      # would spend the tick breaker on three writes to a dead fd and then end the process
+      # with a backtrace; a `Gori::Error` takes the designed exit instead — `run`'s ensure
+      # unwinds, `CLI.run` prints the one line. Narrow on purpose: only the flush is inside,
+      # so a `File::Error` (also an `IO::Error`) from a pane's own file write elsewhere in the
+      # tick is still that pane's to report, not a "terminal closed".
+      raise Gori::Error.new("terminal closed: #{ex.message}")
     end
 
     private def scope_label : String

--- a/src/gori/tui/tabs_overlay.cr
+++ b/src/gori/tui/tabs_overlay.cr
@@ -127,7 +127,8 @@ module Gori::Tui
     # Flip show/hide of the selected tab. Refuses (false) to hide the last visible one
     # so the bar can never go empty; the caller toasts the refusal.
     def toggle_selected : Bool
-      sym, label, vis = @items[@selected]
+      return false unless item = @items[@selected]?
+      sym, label, vis = item
       return false if vis && visible_count <= 1
       @items[@selected] = {sym, label, !vis}
       true

--- a/src/gori/tui/tick_breaker.cr
+++ b/src/gori/tui/tick_breaker.cr
@@ -1,0 +1,34 @@
+module Gori::Tui
+  # The run loop's tick-error circuit breaker, as arithmetic: `limit` raises recorded inside
+  # `window` and the breaker is tripped. `Runner#absorb_tick_error` owns the policy of WHICH
+  # raises count (an input-phase raise does; a full render's first failure does not — it is
+  # answered with the reduced frame instead); this class only keeps the tally. Pure and
+  # Runner-free for the same reason `Runner.decorate_status` is: `Runner.new` owns a terminal
+  # and appears nowhere under spec/, so the rule has to live where a spec can reach it.
+  class TickBreaker
+    getter limit : Int32
+    getter window : Time::Span
+
+    def initialize(@limit : Int32, @window : Time::Span)
+      @stamps = [] of Time::Instant
+    end
+
+    # Record one strike at `now` and return how many are inside the window, this one
+    # included. Strikes older than the window are forgotten first, so a raise every few
+    # minutes never accumulates into a trip.
+    def record(now : Time::Instant = Time.instant) : Int32
+      @stamps.reject! { |t| now - t > @window }
+      @stamps << now
+      @stamps.size
+    end
+
+    # Whether the strikes still inside the window at `now` have reached the limit.
+    def tripped?(now : Time::Instant = Time.instant) : Bool
+      @stamps.count { |t| now - t <= @window } >= @limit
+    end
+
+    def reset : Nil
+      @stamps.clear
+    end
+  end
+end


### PR DESCRIPTION
Track A of a three-PR TUI pass (stability → performance → usability). Three audits found what the recent contract passes (#956–#969) left behind; this PR is the stability half.

## What changed

- **Reduced frame on a render failure.** The tick breaker absorbed a raise and re-asked for the same frame 50 ms later, so a deterministic render bug hit the three-strike limit in ~150 ms and the recovery toast was drawn by the failing render itself. A full render's failure no longer strikes: the next frame is the chrome plus the error where the body was, until a key retries. The tab bar stays live so the operator can leave the tab that cannot draw. Only the reduced frame failing too strikes. The tally lives in `TickBreaker` (pure, spec'd).
- **Dead tty is a designed exit.** `flush_screen`'s `IO::Error` becomes a `Gori::Error` (one line, no backtrace), narrowed to the flush so a pane's `File::Error` is still its own.
- **Absorb toasts are `:error`** so they reach the notification centre.
- **Four UTF-8 guards** on render-path regexes over untrusted text (agents chip client name, library picker stub body, activity feed message, `Hotkeys.expand` template) plus a scrub of statusline script stdout. New contract spec renders every controller over a flow whose method/host/path are wire bytes.
- `TabsOverlay#toggle_selected` guard; identities-card cursor spec.

Reviewed and unchanged: History detail caches and the Comparer word cache already funnel every content swap through a clear.

## Verification

- `just test-tui`: 3965 examples, 0 failures
- `just lint-gate main`: no changed file gained findings
- `crystal tool format --check` on the changed files
- The reduced frame itself needs a tty; the breaker arithmetic and the guards are spec'd.
