### PR TITLE
perf(tui): one grid write per filled row, one downcase per searched line, and memos for what a frame rebuilt unchanged

### DIFF
--- a/bench/fill_span_bench.cr
+++ b/bench/fill_span_bench.cr
@@ -1,0 +1,53 @@
+# `Screen#fill` micro-benchmark. Every frame starts with a full-screen fill (`Runner#render`)
+# and ~150 more sites fill a card or a selected row, so the fill is the frame's largest fixed
+# cost. It used to go through `Screen#cell` → `Backend#put` per cell (bounds checks, the ASCII
+# intern, `accepted_width`, a `cont?` fetch, a `GridCell.new`); `Backend#fill_span` writes one
+# known-width-1 blank straight into the grid instead, and handles the wide-glyph edge cases
+# only at the two ends of the span. This drives the production `TermisuBackend` against a
+# recording terminal double so the measured path is the real one.
+#
+# Build: crystal build bench/fill_span_bench.cr -o bin/fill_span_bench --release
+# Run:   bin/fill_span_bench
+require "benchmark"
+require "../src/gori"
+
+include Gori::Tui
+
+# The duck-typed terminal `TermisuBackend` is generic over: records nothing, so the cost
+# measured is the grid write, not the terminal.
+class SinkTerm
+  def initialize(@w : Int32, @h : Int32)
+  end
+
+  def set_cell(x : Int32, y : Int32, g : String, *, fg : Color, bg : Color, attr : Attribute) : Bool
+    true
+  end
+
+  def render : Nil
+  end
+
+  def sync : Nil
+  end
+
+  def size : {Int32, Int32}
+    {@w, @h}
+  end
+end
+
+W = 200
+H =  50
+backend = TermisuBackend.new(SinkTerm.new(W, H))
+screen = Screen.new(backend)
+full = Rect.new(0, 0, W, H)
+row = Rect.new(2, 10, W - 4, 1)
+
+puts "full-screen fill #{W}x#{H} (the top of every frame), and one selected-row band:"
+Benchmark.ips do |x|
+  x.report("fill full screen via fill_span") { screen.fill(full, Theme.bg) }
+  x.report("fill full screen cell by cell") do
+    (full.y...full.bottom).each do |yy|
+      (full.x...full.right).each { |xx| screen.cell(xx, yy, ' ', Theme.text, Theme.bg) }
+    end
+  end
+  x.report("fill one row band via fill_span") { screen.fill(row, Theme.accent_bg) }
+end

--- a/bench/history_row_draw_bench.cr
+++ b/bench/history_row_draw_bench.cr
@@ -1,0 +1,68 @@
+# History LIST paint benchmark — the row loop in `HistoryView#render_list`, the busiest
+# list in gori. `history_filter_bench` measures the QUERY; this measures what happens
+# per frame AFTER the rows are in memory: per row a timestamp formatted, a Content-Type
+# folded to its short label, a method colour, an absolute-form target sliced — all from
+# fields that do not change between frames, now memoized on those fields. Three list
+# heights, so the per-row cost is visible next to the fixed cost of the frame.
+#
+# Build: crystal build bench/history_row_draw_bench.cr -o bin/history_row_draw_bench --release
+# Run:   bin/history_row_draw_bench
+require "benchmark"
+require "file_utils"
+require "../src/gori"
+
+include Gori::Tui
+
+# Records nothing: the subject is the row loop, not cell storage.
+class SinkBackend < Backend
+  def initialize(@w : Int32, @h : Int32)
+  end
+
+  def put(x : Int32, y : Int32, grapheme : Char | String, fg : Color, bg : Color, attr : Attribute) : Nil
+  end
+
+  def size : {Int32, Int32}
+    {@w, @h}
+  end
+end
+
+ROWS  = 400
+TYPES = ["application/json; charset=utf-8", "text/html; charset=utf-8", "image/png",
+         "application/javascript", "text/plain", "application/x-www-form-urlencoded",
+         "application/vnd.api+json", "image/svg+xml"]
+
+path = File.tempname("gori-row-draw", ".db")
+store = Gori::Store.open(path)
+begin
+  ROWS.times do |i|
+    method = i % 4 == 0 ? "POST" : "GET"
+    target = i % 3 == 0 ? "http://acme.test/api/v1/items/#{i}?page=#{i % 7}" : "/api/v1/items/#{i}?page=#{i % 7}"
+    id = store.insert_flow(Gori::Store::CapturedRequest.new(
+      created_at: 1_700_000_000_000_000_i64 + i * 1_000_000, scheme: "https", host: "acme.test", port: 443,
+      method: method, target: target, http_version: "HTTP/1.1",
+      head: "#{method} #{target} HTTP/1.1\r\nHost: acme.test\r\n\r\n".to_slice, body: nil,
+      source: Gori::FlowSource::Kind::Proxy))
+    store.update_response(Gori::Store::CapturedResponse.new(
+      flow_id: id, status: 200, head: "HTTP/1.1 200 OK\r\n\r\n".to_slice,
+      body: "{}".to_slice, content_type: TYPES[i % TYPES.size]))
+  end
+  view = HistoryView.new
+  view.reload(store)
+  Gori::Settings.history_time_format = "absolute"
+
+  {20, 50, 100}.each do |h|
+    w = 200
+    screen = Screen.new(SinkBackend.new(w, h + 4))
+    rect = Rect.new(0, 0, w, h + 4)
+    puts
+    puts "render_list over #{ROWS} rows, #{w}x#{h + 4} pane (~#{h} drawn rows):"
+    Benchmark.ips do |x|
+      x.report("render_list, absolute time") { view.render_list(screen, rect, true) }
+    end
+  end
+ensure
+  store.close
+  File.delete?(path)
+  File.delete?("#{path}-wal")
+  File.delete?("#{path}-shm")
+end

--- a/bench/mark_search_bench.cr
+++ b/bench/mark_search_bench.cr
@@ -94,3 +94,24 @@ puts "no-match scan (one byte_index pass, no cursor built — should be flat per
   ms = timed(REPS) { Wrap.mark_search(screen, 0, 0, text, 0, text.size, "zzz", W) }
   printf("  %-9d %8.3f ms  %8.4f ms/100k\n", n, ms, ms / (n / 100_000.0))
 end
+
+# A VIEWPORT of wrapped rows over one long line, the shape every read pane draws when a
+# minified body is on screen with a live ^F. `mark_search` needs the downcased line to match
+# in; without `lower:` each drawn row downcases the whole logical line again, so the pane paid
+# for one `downcase` of an 800k line PER ROW per frame. `ReadPane` hoists it beside the line
+# it caches per logical line; the History detail and the Repeater response panes do the same
+# now, and this is the difference that hoist buys.
+ROWS_PER_FRAME = 40
+
+puts
+puts "one wrapped 800k-char line, #{ROWS_PER_FRAME} drawn rows per frame, query 'ab'"
+big = "ab" * 400_000
+lower = big.downcase
+Benchmark.ips do |x|
+  x.report("downcase per row (no lower:)") do
+    ROWS_PER_FRAME.times { |i| Wrap.mark_search(screen, 0, 0, big, i * W, (i + 1) * W, "ab", W) }
+  end
+  x.report("downcase once per line (lower:)") do
+    ROWS_PER_FRAME.times { |i| Wrap.mark_search(screen, 0, 0, big, i * W, (i + 1) * W, "ab", W, lower: lower) }
+  end
+end

--- a/spec/hotkeys_spec.cr
+++ b/spec/hotkeys_spec.cr
@@ -288,3 +288,37 @@ describe Gori::Hotkeys do
     end
   end
 end
+
+# `expand` runs per frame and is memoized on the keymap revision; the memo must turn over
+# the moment a binding changes, or a rebind would keep advertising the old chord until the
+# process restarted.
+describe "Gori::Hotkeys.expand memo" do
+  it "re-expands after Settings.keymap_overrides changes" do
+    reg = Gori::Verbs.registry
+    prev = Gori::Settings.keymap_overrides
+    begin
+      Gori::Settings.keymap_overrides = {} of String => Array(String)
+      Gori::Hotkeys.expand(reg, "{fuzz.run} run").should eq("^R run")
+      Gori::Settings.keymap_overrides = {"fuzz.run" => ["ctrl-s"]}
+      Gori::Hotkeys.expand(reg, "{fuzz.run} run").should eq("^S run")
+      Gori::Settings.keymap_overrides = {} of String => Array(String)
+      Gori::Hotkeys.expand(reg, "{fuzz.run} run").should eq("^R run")
+    ensure
+      Gori::Settings.keymap_overrides = prev
+    end
+  end
+
+  it "bumps the keymap revision on every keymap setter" do
+    r0 = Gori::Settings.keymap_revision
+    os, mod = Gori::Settings.keymap_os, Gori::Settings.command_modifier
+    begin
+      Gori::Settings.keymap_os = os
+      Gori::Settings.command_modifier = mod
+      Gori::Settings.keymap_overrides = Gori::Settings.keymap_overrides
+    ensure
+      Gori::Settings.keymap_os = os
+      Gori::Settings.command_modifier = mod
+    end
+    (Gori::Settings.keymap_revision - r0).should be >= 3_u32
+  end
+end

--- a/spec/tui/chrome_tabs_spec.cr
+++ b/spec/tui/chrome_tabs_spec.cr
@@ -190,3 +190,22 @@ describe "Chrome.split_tabs" do
     end
   end
 end
+
+# `split_tabs` is called once per frame and memoized on (prefs, force). The memo has to
+# answer a CHANGED layout with a fresh reconcile, including an in-place edit of the very
+# array it was handed — the tabs overlay mutates `Settings.tab_prefs` entries in place.
+describe "Chrome.split_tabs memo" do
+  it "returns the same visible strip for the same inputs and a new one after a prefs edit" do
+    prefs = [{"history", true}, {"project", true}, {"miner", false}]
+    vis1, hid1 = Chrome.split_tabs(prefs, force: :history)
+    vis1.map(&.first).should contain(:project)
+    hid1.map(&.first).should contain(:miner)
+    prefs[1] = {"project", false} # in place, the shape the overlay writes
+    vis2, hid2 = Chrome.split_tabs(prefs, force: :history)
+    vis2.map(&.first).should_not contain(:project)
+    hid2.map(&.first).should contain(:project)
+    # a different `force` with the same prefs is a different answer too
+    vis3, _ = Chrome.split_tabs(prefs, force: :project)
+    vis3.map(&.first).should contain(:project)
+  end
+end

--- a/spec/tui/screen_backend_spec.cr
+++ b/spec/tui/screen_backend_spec.cr
@@ -262,5 +262,48 @@ module Gori::Tui
       fake.syncs.should be > 0
       Gori::Tui.buffers_identical(eager.buffer, fake.buffer, 30, 8).should be_nil
     end
+
+    # `fill_span` is the bulk path `Screen#fill` takes now; it must leave the grid exactly as
+    # the per-cell path did, and the only place the two can disagree is a wide glyph the span
+    # touches: its lead just outside the span's left edge, its continuation just past the
+    # right edge, or both halves inside. Each is drawn, then filled over, then compared
+    # against eager forwarding of the same sequence.
+    it "fills over a wide glyph at either edge and inside a span identically to eager" do
+      w, h = 20, 4
+      fake = FakeTerm.new(w, h)
+      eager = EagerRefBackend.new(w, h)
+      buffered = TermisuBackend.new(fake)
+      bscreen = Screen.new(buffered)
+      escreen = Screen.new(eager)
+      [bscreen, escreen].each do |sc|
+        sc.fill(Rect.new(0, 0, w, h), Theme.bg)
+        sc.text(4, 0, "中", Theme.text)                 # lead at 4, continuation at 5
+        sc.fill(Rect.new(5, 0, 6, 1), Theme.accent_bg) # span starts ON the continuation → lead orphaned
+        sc.text(4, 1, "中", Theme.text)
+        sc.fill(Rect.new(0, 1, 5, 1), Theme.accent_bg) # span ends ON the lead → continuation orphaned
+        sc.text(4, 2, "中文", Theme.text)
+        sc.fill(Rect.new(2, 2, 8, 1), Theme.accent_bg) # both halves inside
+        sc.text(w - 2, 3, "中", Theme.text)
+        sc.fill(Rect.new(w - 4, 3, 40, 1), Theme.accent_bg) # clipped at the right edge
+        sc.fill(Rect.new(-3, 3, 5, 1), Theme.selection_dim) # clipped at the left edge
+      end
+      buffered.flush
+      Gori::Tui.buffers_identical(eager.buffer, fake.buffer, w, h).should be_nil
+    end
+
+    it "clips a fill that leaves the screen entirely without writing anything" do
+      w, h = 10, 3
+      fake = FakeTerm.new(w, h)
+      buffered = TermisuBackend.new(fake)
+      screen = Screen.new(buffered)
+      screen.fill(Rect.new(0, 0, w, h), Theme.bg)
+      buffered.flush
+      fake.reset_counts
+      screen.fill(Rect.new(w, 0, 5, h), Theme.accent_bg)  # off the right
+      screen.fill(Rect.new(0, h, w, 2), Theme.accent_bg)  # off the bottom
+      screen.fill(Rect.new(-5, 0, 5, h), Theme.accent_bg) # off the left
+      buffered.flush
+      fake.set_calls.should eq(0)
+    end
   end
 end

--- a/src/gori/hotkeys.cr
+++ b/src/gori/hotkeys.cr
@@ -94,9 +94,29 @@ module Gori
     # through THIS set (not raw chord_overrides), so its column can never advertise a chord
     # dispatch would drop — build_keymap and the palette must agree, so they share this one
     # filter rather than duplicating it.
+    #
+    # Memoized on the keymap revision and the registry: `expand` defaults to this and runs per
+    # FRAME (the status strip, every controller's `keys`), and rebuilding it meant parsing
+    # every override label into a Chord and two Hash builds twenty times a second.
     def self.rebindable_overrides(registry : Verb::Registry) : Hash(String, Array(Verb::Chord))
-      chord_overrides.select { |id, _| (v = registry[id]?) && rebindable?(v) }
+      key = {registry.object_id, Settings.keymap_revision}
+      if (memo = @@overrides_memo) && memo[0] == key
+        return memo[1]
+      end
+      out = chord_overrides.select { |id, _| (v = registry[id]?) && rebindable?(v) }
+      @@overrides_memo = {key, out}
+      out
     end
+
+    @@overrides_memo : {Tuple(UInt64, UInt32), Hash(String, Array(Verb::Chord))}? = nil
+
+    # Expanded hint strips, keyed on the template and everything a token can resolve
+    # through (keymap revision, registry, profile). Templates are literals — the same ~60
+    # strings frame after frame — so this is small and hits almost always; the cap is for a
+    # `body_hint` that interpolates a count into its template and would otherwise grow it
+    # one entry per distinct count.
+    EXPAND_MEMO_CAP = 512
+    @@expand_memo = {} of Tuple(String, UInt64, UInt32, String) => String
 
     # The persisted user overrides, parsed from Settings' label strings into Chords. A
     # reserved/unparseable chord is DROPPED here too (not just refused by the editor) so a
@@ -261,9 +281,25 @@ module Gori
     # verb with no default at all is left as written — visibly wrong rather than silently
     # blank, which is what `spec/hotkeys_spec.cr` / the Help spec check for.
     def self.expand(registry : Verb::Registry, template : String,
-                    overrides : Hash(String, Array(Verb::Chord)) = rebindable_overrides(registry),
+                    overrides : Hash(String, Array(Verb::Chord))? = nil,
                     profile : String = Settings.keymap_os) : String
       return template unless template.valid_encoding? && template.includes?('{')
+      # Only the DEFAULT overrides are memoizable: a caller handing in its own working set
+      # (the hotkey editor previewing an unsaved rebind) is asking about a keymap that has no
+      # revision yet.
+      if overrides
+        return expand_uncached(registry, template, overrides, profile)
+      end
+      key = {template, registry.object_id, Settings.keymap_revision, profile}
+      if hit = @@expand_memo[key]?
+        return hit
+      end
+      @@expand_memo.clear if @@expand_memo.size >= EXPAND_MEMO_CAP
+      @@expand_memo[key] = expand_uncached(registry, template, rebindable_overrides(registry), profile)
+    end
+
+    private def self.expand_uncached(registry : Verb::Registry, template : String,
+                                     overrides : Hash(String, Array(Verb::Chord)), profile : String) : String
       template.gsub(VERB_TOKEN_RE) do |token|
         id = $1
         if chord = binding_for(registry, id, overrides, profile) || default_for(registry, id, profile)

--- a/src/gori/settings/keymap.cr
+++ b/src/gori/settings/keymap.cr
@@ -20,9 +20,29 @@ module Gori::Settings
   # "auto" tracks the build's platform; "darwin"/"linux"/"windows" force one.
   # `keymap_overrides` is SPARSE: verb-id → chord-label strings ("ctrl-p", "shift-s").
   # An empty list = explicit unbind; an absent id = use the profile default.
-  class_property keymap_os : String = DEFAULT_KEYMAP_OS
-  class_property keymap_overrides : Hash(String, Array(String)) = {} of String => Array(String)
-  class_property command_modifier : String = DEFAULT_COMMAND_MODIFIER
+  class_getter keymap_os : String = DEFAULT_KEYMAP_OS
+  class_getter keymap_overrides : Hash(String, Array(String)) = {} of String => Array(String)
+  class_getter command_modifier : String = DEFAULT_COMMAND_MODIFIER
+
+  # Bumped by every setter above, so a memo built from the three (the parsed overrides,
+  # an expanded hint strip — `Hotkeys.expand` runs per frame) can tell "same keymap" from
+  # "same values" without comparing the Hash. The `Theme.revision` shape.
+  class_getter keymap_revision : UInt32 = 0_u32
+
+  def self.keymap_os=(v : String) : String
+    @@keymap_revision &+= 1
+    @@keymap_os = v
+  end
+
+  def self.keymap_overrides=(v : Hash(String, Array(String))) : Hash(String, Array(String))
+    @@keymap_revision &+= 1
+    @@keymap_overrides = v
+  end
+
+  def self.command_modifier=(v : String) : String
+    @@keymap_revision &+= 1
+    @@command_modifier = v
+  end
 
   # Tolerant hotkey parse: a non-object (or absent) node keeps current values. `os`
   # is normalized (unknown → "auto"); `bindings` is a sparse verb-id → chord-label

--- a/src/gori/tui/chrome.cr
+++ b/src/gori/tui/chrome.cr
@@ -139,13 +139,26 @@ module Gori::Tui
     # both every frame (the menu strip + the ⋯ hidden count); calling visible_tabs and
     # hidden_tabs separately rebuilt reconcile's catalog hashes twice per frame for the same
     # output. Pure function of prefs, so folding the two into one pass is byte-identical.
+    #
+    # Memoized on its two inputs: this runs once per FRAME (`Runner#render`), and `reconcile`
+    # is three catalog Hashes, a quadratic insert walk and four array passes for an answer
+    # that changes only when the operator edits the tab layout or switches tab. A tuple
+    # equality over ≤25 small entries is what the hit costs; the prefs are copied into the
+    # memo so a later in-place edit of the live array cannot make a stale hit look fresh.
     def self.split_tabs(prefs : Array({String, Bool}), force : Symbol? = nil) : {Array({Symbol, String}), Array({Symbol, String})}
+      if (memo = @@split_memo) && memo[1] == force && memo[0] == prefs
+        return memo[2]
+      end
       ann = reconcile(prefs)
       vis = ann.select { |(_, _, v)| v }.map { |(s, l, _)| {s, l} }
       append_forced(ann, vis, force)
       hidden = ann.reject { |(s, _, v)| v || s == force }.map { |(s, l, _)| {s, l} }
-      {vis, hidden}
+      out = {vis, hidden}
+      @@split_memo = {prefs.dup, force, out}
+      out
     end
+
+    @@split_memo : {Array({String, Bool}), Symbol?, {Array({Symbol, String}), Array({Symbol, String})}}? = nil
 
     # The "more" affordance label — a ⋯ ellipsis plus the hidden-tab count, so the bar
     # reads "there are N tabs tucked away here" at a glance.

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -204,6 +204,17 @@ module Gori::Tui
       # reloads, re-sorts and re-filters constantly, so an index-keyed memo would retarget.
       # Dropped wholesale whenever the engine's revision moves — see `color_for`.
       @color_memo = {} of Int64 => Store::ColorRule?
+      # The three per-row strings the list builds from a row's own fields, memoized on those
+      # fields: a timestamp is parsed, localised and strftime'd, a Content-Type is split,
+      # stripped and downcased twice, and an absolute-form target is sliced — per row, per
+      # frame, for values that do not change between frames. Keyed on the VALUE (created_at,
+      # the header, the flow id for a target that is immutable per flow), never on the row
+      # object, so a row whose response lands later (its Content-Type goes from nil to a
+      # value) reads the new answer. Cleared on size like `@color_memo`; `@mime_memo` is
+      # bounded by the number of distinct Content-Types and capped for a hostile origin.
+      @time_memo = {} of Int64 => String
+      @mime_memo = {} of String => String
+      @path_memo = {} of Int64 => String
       @color_rev = 0_u64
       @detail = nil.as(Store::FlowDetail?)
       @detail_ws = nil.as(Array(Store::WsMessage)?)
@@ -2693,7 +2704,7 @@ module Gori::Tui
         if sw > 0 && (m = mark) && m.style.strip?
           screen.cell(strip_x, y, '█', Theme.mark_color(m.color), bg)
         end
-        screen.text(time_x, y, fmt_time(row.created_at), Theme.muted, bg)
+        screen.text(time_x, y, fmt_time_memo(row.created_at), Theme.muted, bg)
         # METHOD is a FIXED 8-column cell (method_x .. proto_x), so it needs its own clamp —
         # without a `width:` the limit is the whole SCREEN. RFC 9110 permits any token here and
         # the parser caps nothing, so a long method (`VERSION-CONTROL`, a smuggled
@@ -2723,7 +2734,7 @@ module Gori::Tui
         proto_color = stub ? Theme.yellow : (kind.http? ? Theme.muted : Theme.accent)
         screen.text(proto_x, y, proto_label, proto_color, bg)
         screen.text(host_x, y, row.host, fg, bg, width: host_w) if host_w > 0
-        screen.text(path_x, y, Url.origin_path(row.target), fg, bg, width: path_w) if path_w > 0
+        screen.text(path_x, y, origin_path_memo(row), fg, bg, width: path_w) if path_w > 0
         # Failed flows store status 0 — FlowStatus shows the STATE (ERR/ABT) instead of
         # a cryptic "0" indistinguishable from a still-pending "···".
         status, scolor = FlowStatus.cell(row)
@@ -2745,7 +2756,7 @@ module Gori::Tui
           screen.text(src_x, y, src.try(&.label) || "—",
             src.nil? || src.proxy? ? Theme.muted : Theme.accent, bg, width: 5)
         end
-        screen.text(type_x, y, fmt_mime(row.content_type), Theme.muted, bg, width: 6) if show_type
+        screen.text(type_x, y, fmt_mime_memo(row.content_type), Theme.muted, bg, width: 6) if show_type
         screen.text(size_x, y, fmt_size(row.response_size), Theme.muted, bg, width: 6) if show_size
         screen.text(dur_x, y, fmt_dur(row.duration_us), Theme.muted, bg, width: 6) if show_dur
         render_columns_row(screen, cols_x, y, shown_cols, row, fg, bg)
@@ -2950,6 +2961,27 @@ module Gori::Tui
       t = Time.unix(created_at // 1_000_000)
       return fmt_time_relative(t) if Settings.history_time_format == "relative"
       t.to_local.to_s("%m-%d %H:%M:%S")
+    end
+
+    # `fmt_time` through the memo — for the ABSOLUTE format only. A relative age is a
+    # function of now and has to be recomputed each frame (it is `Fmt.ago`, cheap).
+    private def fmt_time_memo(created_at : Int64) : String
+      return fmt_time(created_at) if Settings.history_time_format == "relative"
+      @time_memo.fetch(created_at) { @time_memo[created_at] = fmt_time(created_at) }
+    end
+
+    MIME_MEMO_CAP = 256
+
+    private def fmt_mime_memo(ct : String?) : String
+      return "—" unless ct
+      @mime_memo.fetch(ct) do
+        @mime_memo.clear if @mime_memo.size >= MIME_MEMO_CAP
+        @mime_memo[ct] = fmt_mime(ct)
+      end
+    end
+
+    private def origin_path_memo(row : Store::FlowRow) : String
+      @path_memo.fetch(row.id) { @path_memo[row.id] = Url.origin_path(row.target) }
     end
 
     # Compact relative age from now: "3s" / "5m" / "2h" / "1d". This said it "mirrors
@@ -3265,6 +3297,11 @@ module Gori::Tui
       # describes both and the colours cannot land a column off the glyphs.
       rows = detail_rows(cw, body.h, total, ->(i : Int32) { detail_line_text(dv, i) })
       xs = detail_xscroll
+      # The search band scans a DOWNCASED copy of the whole logical line, and under wrap one
+      # minified body line can fill the viewport — so the copy is made once per logical line
+      # here, not once per drawn row (the `ReadPane` hoist; `mark_search`'s `lower:`).
+      searching = !@search_hl.empty?
+      lower = Wrap::LowerMemo.new
       rows.each_with_index do |vr, i|
         li = vr.li
         y = body.y + i
@@ -3272,13 +3309,13 @@ module Gori::Tui
         shown = Highlight.slice_chars(styled_detail_line(dv, li), vr.a, vr.b)
         shown = Highlight.slice_left(shown, xs) if xs > 0
         Highlight.draw(screen, body.x + gw, y, shown, width: cw)
-        need_plain = (focused && detail_navigable? && (li == @detail_read.cy || sel_spans)) || !@search_hl.empty?
+        need_plain = (focused && detail_navigable? && (li == @detail_read.cy || sel_spans)) || searching
         plain = need_plain ? detail_line_text(dv, li) : nil
         paint_detail_line_chrome(screen, body.x + gw, y, li, plain, focused, sel_spans, vr.a, vr.b) if plain
         # The plain-text line feeds ONLY the search overlay, so skip it when no query is
         # active (else every frame builds/scans discarded strings per row).
-        if (text = plain) && !@search_hl.empty?
-          Wrap.mark_search(screen, body.x + gw, y, text, vr.a, vr.b, @search_hl, body.x + gw + cw, xoff: xs)
+        if (text = plain) && searching
+          Wrap.mark_search(screen, body.x + gw, y, text, vr.a, vr.b, @search_hl, body.x + gw + cw, xoff: xs, lower: lower.for(li, text))
         end
       end
       # The detail body scrolls (`@detail_scroll`) and had no gauge, while the Repeater's
@@ -3312,6 +3349,8 @@ module Gori::Tui
                   end
       rows = detail_rows(cw, body.h, total, ->(i : Int32) { lines[i] })
       xs = detail_xscroll
+      searching = !@search_hl.empty?
+      lower = Wrap::LowerMemo.new
       rows.each_with_index do |vr, i|
         y = body.y + i
         line = lines[vr.li]
@@ -3323,7 +3362,8 @@ module Gori::Tui
         styled = Highlight.slice_left(styled, xs) if xs > 0
         Highlight.draw(screen, body.x + gw, y, styled, width: cw)
         paint_detail_line_chrome(screen, body.x + gw, y, vr.li, line, focused, sel_spans, vr.a, vr.b)
-        Wrap.mark_search(screen, body.x + gw, y, line, vr.a, vr.b, @search_hl, body.x + gw + cw, xoff: xs) unless @search_hl.empty?
+        next unless searching
+        Wrap.mark_search(screen, body.x + gw, y, line, vr.a, vr.b, @search_hl, body.x + gw + cw, xoff: xs, lower: lower.for(vr.li, line))
       end
     end
 
@@ -3677,6 +3717,8 @@ module Gori::Tui
       # otherwise accumulate an entry per flow ever seen. Cleared rather than pruned per dropped
       # id: it refills from a screenful of rows on the next frame.
       @color_memo.clear if @color_memo.size > @max_rows
+      @time_memo.clear if @time_memo.size > @max_rows
+      @path_memo.clear if @path_memo.size > @max_rows
     end
 
     # The detail content as a windowed view (request/response head + body with HTTP

--- a/src/gori/tui/repeater_view/render_response.cr
+++ b/src/gori/tui/repeater_view/render_response.cr
@@ -122,6 +122,10 @@ class Gori::Tui::RepeaterView
     # (it is 7 rows showing a 4-5 line head — there is nothing to scroll to).
     rows = active ? resp_rows(cw, body.h, total, line_text) : resp_static_rows(cw, body.h, total, line_text)
     xs = active ? resp_xscroll : 0
+    # The search band's downcased copy of the logical line, made once per line rather than
+    # once per drawn row (a wrapped line can fill the pane) — the `ReadPane` hoist.
+    searching = !@search_hl.empty?
+    lower = Wrap::LowerMemo.new
     rows.each_with_index do |vr, i|
       y = body.y + i
       draw_resp_gutter(screen, body.x, y, gw, vr, lit)
@@ -134,7 +138,8 @@ class Gori::Tui::RepeaterView
       text = line_text.call(vr.li)
       paint_resp_line_chrome(screen, body.x + gw, y, vr.li, text, lit, sel_spans, vr.a, vr.b,
         clip_x: body.x + gw, clip_w: cw)
-      Wrap.mark_search(screen, body.x + gw, y, text, vr.a, vr.b, @search_hl, body.x + gw + cw, xoff: xs) unless @search_hl.empty?
+      next unless searching
+      Wrap.mark_search(screen, body.x + gw, y, text, vr.a, vr.b, @search_hl, body.x + gw + cw, xoff: xs, lower: lower.for(vr.li, text))
     end
     Frame.scroll_gauge(screen, body, total, @scroll, lit) if active
   end
@@ -210,6 +215,8 @@ class Gori::Tui::RepeaterView
     line_text = ->(i : Int32) { lines[i][0] }
     rows = active ? resp_rows(cw, body.h, lines.size, line_text) : resp_static_rows(cw, body.h, lines.size, line_text)
     xs = active ? resp_xscroll : 0
+    searching = !@search_hl.empty?
+    lower = Wrap::LowerMemo.new
     rows.each_with_index do |vr, i|
       text, color = lines[vr.li]
       y = body.y + i
@@ -220,7 +227,8 @@ class Gori::Tui::RepeaterView
       next unless active
       paint_resp_line_chrome(screen, body.x + gw, y, vr.li, text, lit, sel_spans, vr.a, vr.b,
         clip_x: body.x + gw, clip_w: cw)
-      Wrap.mark_search(screen, body.x + gw, y, text, vr.a, vr.b, @search_hl, body.x + gw + cw, xoff: xs) unless @search_hl.empty?
+      next unless searching
+      Wrap.mark_search(screen, body.x + gw, y, text, vr.a, vr.b, @search_hl, body.x + gw + cw, xoff: xs, lower: lower.for(vr.li, text))
     end
     Frame.scroll_gauge(screen, body, lines.size, @scroll, lit) if active
   end
@@ -239,6 +247,8 @@ class Gori::Tui::RepeaterView
     # RAW line and the wrap of the revealed line are the same break — no second layout.
     rows = resp_rows(cw, rect.h, total, ->(i : Int32) { lines[i] })
     xs = resp_xscroll
+    searching = !@search_hl.empty?
+    lower = Wrap::LowerMemo.new
     rows.each_with_index do |vr, i|
       y = rect.y + i
       line = lines[vr.li]
@@ -251,7 +261,8 @@ class Gori::Tui::RepeaterView
       Highlight.draw(screen, rect.x + gw, y, styled, width: cw)
       paint_resp_line_chrome(screen, rect.x + gw, y, vr.li, line, focused, sel_spans, vr.a, vr.b,
         clip_x: rect.x + gw, clip_w: cw)
-      Wrap.mark_search(screen, rect.x + gw, y, line, vr.a, vr.b, @search_hl, rect.x + gw + cw, xoff: xs) unless @search_hl.empty?
+      next unless searching
+      Wrap.mark_search(screen, rect.x + gw, y, line, vr.a, vr.b, @search_hl, rect.x + gw + cw, xoff: xs, lower: lower.for(vr.li, line))
     end
   end
 
@@ -297,10 +308,12 @@ class Gori::Tui::RepeaterView
     # describes both and the colours cannot land a column off the glyphs.
     rows = resp_rows(cw, rect.h, total, ->(i : Int32) { resp_line_text(rv, i) })
     xs = resp_xscroll
+    searching = !@search_hl.empty?
+    lower = Wrap::LowerMemo.new
     rows.each_with_index do |vr, i|
       li = vr.li
       y = rect.y + i
-      need_plain = (focused && resp_navigable? && (li == @resp_cursor.cy || sel_spans)) || !@search_hl.empty?
+      need_plain = (focused && resp_navigable? && (li == @resp_cursor.cy || sel_spans)) || searching
       text = need_plain ? resp_line_text(rv, li) : nil
       draw_resp_gutter(screen, rect.x, y, gw, vr, focused)
       shown = Highlight.slice_chars(styled_resp_line(rv, li), vr.a, vr.b)
@@ -308,8 +321,8 @@ class Gori::Tui::RepeaterView
       Highlight.draw(screen, rect.x + gw, y, shown, width: cw)
       paint_resp_line_chrome(screen, rect.x + gw, y, li, text, focused, sel_spans, vr.a, vr.b,
         clip_x: rect.x + gw, clip_w: cw) if text
-      if (t = text) && !@search_hl.empty?
-        Wrap.mark_search(screen, rect.x + gw, y, t, vr.a, vr.b, @search_hl, rect.x + gw + cw, xoff: xs)
+      if (t = text) && searching
+        Wrap.mark_search(screen, rect.x + gw, y, t, vr.a, vr.b, @search_hl, rect.x + gw + cw, xoff: xs, lower: lower.for(li, t))
       end
     end
   end
@@ -393,6 +406,8 @@ class Gori::Tui::RepeaterView
     _, decorated, _ = resp_drawn_source
     rows = resp_rows(cw, rect.h, data.size, decorated)
     xs = resp_xscroll
+    searching = !@search_hl.empty?
+    lower = Wrap::LowerMemo.new
     rows.each_with_index do |vr, i|
       d = data[vr.li]
       y = rect.y + i
@@ -416,7 +431,8 @@ class Gori::Tui::RepeaterView
         clip_x: rect.x + gw, clip_w: cw)
       # Mark only the line text, so the highlights match what response_search_lines
       # counts (d.text) rather than the diff decoration.
-      Wrap.mark_search(screen, tx, y, d.text, ts, te, @search_hl, rect.x + gw + cw, xoff: xs) unless @search_hl.empty?
+      next unless searching
+      Wrap.mark_search(screen, tx, y, d.text, ts, te, @search_hl, rect.x + gw + cw, xoff: xs, lower: lower.for(vr.li, d.text))
     end
   end
 end

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -299,11 +299,12 @@ module Gori::Tui
       # was the bug; see `Runner.port_fallback`) — read only by `apply_settings`, to tell "the
       # operator moved the pin" apart from "the environment moved us".
       @bind_fallback = nil.as(Tuple(Int32, Int32)?)
-      @quit_armed = false           # first ^D/^C arms quit; second confirms (avoids accidental exit)
-      @resized = false              # set on a Resize event → next frame full-repaints
-      @body_h = 24                  # last body rect height (captured at render); drives PageUp/Down step size
-      @title_text = nil.as(String?) # last string emitted as the terminal-window title (memo; see sync_terminal_title)
-      @title_written = false        # have we ever written a title? gates the neutral restore on leave when the pref is "off"
+      @quit_armed = false                                 # first ^D/^C arms quit; second confirms (avoids accidental exit)
+      @resized = false                                    # set on a Resize event → next frame full-repaints
+      @body_h = 24                                        # last body rect height (captured at render); drives PageUp/Down step size
+      @title_text = nil.as(String?)                       # last string emitted as the terminal-window title (memo; see sync_terminal_title)
+      @title_key = nil.as(Tuple(String, Symbol, String)?) # the inputs that title was built from
+      @title_written = false                              # have we ever written a title? gates the neutral restore on leave when the pref is "off"
       # The circuit breaker behind `absorb_tick_error`: strikes inside TICK_ERROR_WINDOW.
       @breaker = TickBreaker.new(TICK_ERROR_LIMIT, TICK_ERROR_WINDOW)
       # The exception a full render last raised, while the reduced frame stands in for it —
@@ -494,7 +495,7 @@ module Gori::Tui
       last_dv_poll = Time.instant
       last_probe_gen = @session.store.probe_generation # committed probe_issues mutations
       last_spin = Time.instant                         # advances the background-job spinner frame
-      last_clock = clock_label                         # top-bar wall clock; re-render only when the minute rolls over
+      last_clock = clock_minute                        # status-row wall clock; re-render only when the minute rolls over
       last_ui_ident = nil.as(UiIdentity?)              # last-written ui-state identity (see UI_STATE_THROTTLE)
       last_ui_write = Time.instant
       last_pub_rev = -1                                                     # #123: last interceptor revision mirrored to the store (-1 = publish on first tick)
@@ -673,7 +674,7 @@ module Gori::Tui
             dirty = true if sitemap_controller.flush_query_reload_if_due(now)
             # Tick the top-bar clock: dirty only when the displayed minute changes, so the
             # idle loop wakes once a minute to repaint rather than every second.
-            if (clock = clock_label) != last_clock
+            if (clock = clock_minute) != last_clock
               last_clock = clock
               dirty = true
             end
@@ -2351,8 +2352,15 @@ module Gori::Tui
     # Switching to "off" mid-session is the one exception: a title we put there would
     # otherwise freeze on whatever tab was active, so we release it to the neutral "𝓰𝓸𝓻𝓲"
     # once and go quiet from there.
+    #
+    # The three inputs are compared BEFORE the title is built: this runs at the top of every
+    # render, and building it is two interpolations plus `title_safe`'s per-char walk over the
+    # project name, all to be compared against the same string and dropped.
     private def sync_terminal_title : Nil
-      title = case Settings.terminal_title
+      key = {Settings.terminal_title, @active_tab, @session.project.name}
+      return if @title_key == key
+      @title_key = key
+      title = case key[0]
               when "off" then @title_text.nil? ? return : "𝓰𝓸𝓻𝓲"
               when "tab" then "𝓰𝓸𝓻𝓲 - #{Chrome.tab_label(@active_tab)}"
               else            "𝓰𝓸𝓻𝓲 - #{title_safe(@session.project.name)} - #{Chrome.tab_label(@active_tab)}"
@@ -2560,6 +2568,14 @@ module Gori::Tui
     # lowercase "pm" and `%P` the uppercase "PM" (GNU date has them the other way round).
     private def clock_label : String
       Time.local.to_s("%I:%M %P")
+    end
+
+    # The clock as the loop compares it — a tuple, so the 20-a-second check is two integer
+    # compares rather than a strftime and a String it throws away (the same reason
+    # `ui_state_identity` is a tuple and not the JSON it stands for).
+    private def clock_minute : {Int32, Int32}
+      t = Time.local
+      {t.hour, t.minute}
     end
 
     private def rules_label : String

--- a/src/gori/tui/screen.cr
+++ b/src/gori/tui/screen.cr
@@ -22,6 +22,15 @@ module Gori::Tui
     # ioctl). No-op for recording backends, which size themselves at construction.
     def resize(w : Int32, h : Int32) : Nil
     end
+
+    # Blank `w` cells from (x, y) in `bg` — what `Screen#fill` does per row, and the first
+    # thing every frame does to the whole screen. The default is the per-cell path, so a
+    # recording backend needs nothing; `TermisuBackend` overrides it with a grid write that
+    # skips the glyph work a blank never needs (see there). Same contract as `put` for the
+    # trailing half of a wide glyph the span lands on: the orphaned lead is cleared.
+    def fill_span(x : Int32, y : Int32, w : Int32, fg : Color, bg : Color) : Nil
+      w.times { |i| put(x + i, y, ' ', fg, bg, Attribute::None) }
+    end
   end
 
   # The production backend for a real terminal. Rather than forwarding every `put`
@@ -111,6 +120,37 @@ module Gori::Tui
       end
     end
 
+    # The bulk form of `put` for a run of blanks. `Screen#fill` paints the WHOLE screen this
+    # way at the top of every frame (10 000 cells at 200×50) and ~150 more sites fill a card
+    # or a selected row, so the per-cell path — `Screen#cell`'s bounds check and ASCII intern,
+    # then `put`'s bounds check, `accepted_width` (a slice fetch), a `cont?` fetch and a
+    # `GridCell.new` — was the frame's single largest fixed cost, spent on cells that are all
+    # the same known-width-1 blank. One struct, written straight into the grid.
+    #
+    # The wide-glyph rule is `put`'s, applied only where it can matter: a continuation cell at
+    # the span's FIRST column means its lead sits just outside on the left and is orphaned
+    # (cleared, as termisu clears it); a continuation just PAST the span means its lead was
+    # inside and has just been overwritten, so it is cleared too. A continuation INSIDE the
+    # span is simply overwritten along with its lead.
+    def fill_span(x : Int32, y : Int32, w : Int32, fg : Color, bg : Color) : Nil
+      return unless y >= 0 && y < @h
+      if x < 0
+        w += x
+        x = 0
+      end
+      w = @w - x if x + w > @w
+      return if w <= 0
+      blank = GridCell.new(" ", fg, bg, Attribute::None)
+      idx = y * @w + x
+      @back.unsafe_put(idx - 1, GridCell.blank) if x > 0 && @back.unsafe_fetch(idx).cont?
+      stop = idx + w
+      while idx < stop
+        @back.unsafe_put(idx, blank)
+        idx += 1
+      end
+      @back.unsafe_put(stop, GridCell.blank) if x + w < @w && @back.unsafe_fetch(stop).cont?
+    end
+
     # The column width termisu will render `g` at (1 or 2), or 0 if termisu's set_cell would
     # REJECT it — mirroring its guards so our grid only ever holds cells termisu accepts. A
     # single byte is width-1 EXCEPT a C0 control / DEL, which termisu rejects (buffer's
@@ -141,16 +181,25 @@ module Gori::Tui
       full = @full || sync
       i = 0
       n = @back.size
+      # (x, y) are carried rather than derived: `i % @w` and `i // @w` are two integer
+      # divisions per forwarded cell, and a `sync` forwards every cell on the screen.
+      x = 0
+      y = 0
       while i < n
         b = @back.unsafe_fetch(i)
         if full || b != @front.unsafe_fetch(i)
           # Advance @front only when the cell was actually accepted (or is a continuation
           # termisu builds from its lead). If termisu rejects a write it leaves the cell
           # unchanged, so caching it as sent would make the diff skip the still-wrong cell.
-          accepted = b.cont? || @term.set_cell(i % @w, i // @w, b.grapheme, fg: b.fg, bg: b.bg, attr: b.attr)
+          accepted = b.cont? || @term.set_cell(x, y, b.grapheme, fg: b.fg, bg: b.bg, attr: b.attr)
           @front.unsafe_put(i, b) if accepted
         end
         i += 1
+        x += 1
+        if x == @w
+          x = 0
+          y += 1
+        end
       end
       @full = false
       sync ? @term.sync : @term.render
@@ -504,10 +553,17 @@ module Gori::Tui
       cur_x
     end
 
+    # Clipped here, once per rect, so the backend's span write never has to. `Theme.text` as
+    # the fg is what the per-cell path always wrote (the diff compares fg too, so a blank
+    # with a different fg would count as a changed cell every frame).
     def fill(rect : Rect, bg : Color) : Nil
-      (rect.y...rect.bottom).each do |yy|
-        (rect.x...rect.right).each { |xx| cell(xx, yy, ' ', Theme.text, bg) }
-      end
+      x0 = {rect.x, 0}.max
+      x1 = {rect.right, @width}.min
+      return if x1 <= x0
+      y0 = {rect.y, 0}.max
+      y1 = {rect.bottom, @height}.min
+      fg = Theme.text
+      (y0...y1).each { |yy| @backend.fill_span(x0, yy, x1 - x0, fg, bg) }
     end
 
     def hline(x : Int32, y : Int32, w : Int32, ch : Char = '─',

--- a/src/gori/tui/theme.cr
+++ b/src/gori/tui/theme.cr
@@ -1232,9 +1232,16 @@ module Gori::Tui
       luma(text_bright) > luma(bg) ? bg : text_bright
     end
 
+    # Called once per History row per frame. The captured spelling is upper-case in all but
+    # a hostile request, so the common case is matched as written and `upcase` (an
+    # allocation per row per frame) is paid only by a method that missed.
     def self.method_color(method : String) : Color
+      case method
+      when "GET", "HEAD", "QUERY" then return green # QUERY is safe + idempotent like GET (RFC 10008)
+      when "POST", "PUT", "PATCH", "DELETE" then return yellow
+      end
       case method.upcase
-      when "GET", "HEAD", "QUERY"           then green # QUERY is safe + idempotent like GET (RFC 10008)
+      when "GET", "HEAD", "QUERY"           then green
       when "POST", "PUT", "PATCH", "DELETE" then yellow
       else                                       muted
       end

--- a/src/gori/tui/wrap.cr
+++ b/src/gori/tui/wrap.cr
@@ -327,6 +327,27 @@ module Gori::Tui
     # the Decoder OUTPUT that line can be a multi-MB minified body. A caller drawing one row
     # at a time hoists it beside the line itself and hands it in; anything else omits it and
     # gets exactly the old behaviour.
+    # The downcased copy `mark_search` scans, made once per LOGICAL line across a row loop.
+    # Under wrap one minified body line can fill the viewport, and a loop that downcased the
+    # line per DRAWN row paid for a copy of it forty times a frame; `ReadPane` hoisted the
+    # copy beside its cached line, and this is that hoist as an object so the seven other
+    # row loops (History detail, Repeater response) carry one line instead of a state pair.
+    class LowerMemo
+      def initialize
+        @li = -1
+        @lower = ""
+      end
+
+      # `text`'s downcase, reused while `li` is the line it was made from.
+      def for(li : Int32, text : String) : String
+        if li != @li
+          @li = li
+          @lower = text.downcase
+        end
+        @lower
+      end
+    end
+
     def self.mark_search(screen : Screen, x : Int32, y : Int32, line : String,
                          a : Int32, b : Int32, query : String, max_x : Int32,
                          conceal : Array({Int32, Int32})? = nil, xoff : Int32 = 0,


### PR DESCRIPTION
Track B of the three-PR TUI pass (stability #975 → **performance** → usability). The pipeline was already diffed and dirty-flag driven, so these are the narrow per-frame costs an audit found still being paid on every tick.

## Commits

- **Fill a row in one grid write** — `Backend#fill_span` replaces the per-cell `cell`→`put` path for `Screen#fill` (every frame starts with a full-screen fill; ~150 more sites fill cards and selected rows). Wide-glyph orphan rule applied only at the span's two edges. The flush loop carries (x, y) instead of dividing per cell. Bench (`fill_span_bench`, 200×50 full fill): 60.1 µs → 16.6 µs.
- **Downcase a searched line once per line** — seven `Wrap.mark_search` call sites (History detail ×2, Repeater response ×5) downcased the whole logical line per DRAWN row; under wrap a minified body line fills the viewport. `Wrap::LowerMemo` is `ReadPane`'s hoist as an object. Bench (`mark_search_bench`, 800k-char line, 40 rows): 30.5 MB/frame → 45 kB/frame.
- **History row memos** — `fmt_time`, `fmt_mime`, `Url.origin_path` memoized on the value they derive from (never the row object, so a response landing later reads the new Content-Type); relative time bypasses the memo. `Theme.method_color` matches the upper-case spelling before paying `upcase`. New `history_row_draw_bench`.
- **`Hotkeys.expand` on a keymap revision** — the three keymap setters bump `Settings.keymap_revision`; parsed overrides and expanded hint strips are memoized on it (it ran per frame, re-parsing every override label). A caller passing its own working overrides stays uncached.
- **`Chrome.split_tabs` memo** on (prefs, force) — the reconcile ran per frame.
- **Clock and title compared before formatting** — the tick compared a strftime'd string 20×/s; the title was rebuilt every render.

## Verification

- `just test-tui`: 3958 examples, 0 failures; `just test-changed main`: 635 examples, 0 failures
- `just lint-gate main`: no changed file gained findings
- `just benchmark-check` type-checks the three new/extended benches
