### PR TITLE
feat(tui): the last panes join the list, mouse and text-input contracts; the Sitemap filter and file imports leave the tick

### DIFF
--- a/spec/import/chunking_spec.cr
+++ b/spec/import/chunking_spec.cr
@@ -67,3 +67,33 @@ describe "Import::Result shortfall" do
     Gori::Import::Result.new(count: 4).short?.should be_false
   end
 end
+
+# The TUI runs an import as a background job (`Runner#apply_import`): between chunks the
+# worker polls `cancelled` and reports `progress`, so a palette cancel stops after the chunk
+# being written and the activity chip can show a count. Neither changes the numbers that
+# come back — a cancelled import is a short one, and the caller says so.
+describe "Import.insert_all cancel + progress" do
+  it "reports the running count after every chunk" do
+    chunk_store do |store|
+      n = Gori::Import::IMPORT_CHUNK + 3
+      seen = [] of {Int32, Int32}
+      Gori::Import.insert_all(store, (0...n).map { |i| pair(i) },
+        progress: ->(done : Int32, total : Int32) { seen << {done, total} })
+      seen.should eq([{Gori::Import::IMPORT_CHUNK, n}, {n, n}])
+    end
+  end
+
+  it "stops after the chunk in flight once cancelled, keeping what was written" do
+    chunk_store do |store|
+      n = Gori::Import::IMPORT_CHUNK * 3
+      chunks = 0
+      cancelled = false
+      committed, attempted = Gori::Import.insert_all(store, (0...n).map { |i| pair(i) },
+        cancelled: -> { cancelled },
+        progress: ->(_done : Int32, _total : Int32) { chunks += 1; cancelled = chunks >= 1 })
+      committed.should eq(Gori::Import::IMPORT_CHUNK) # one chunk landed, the flag stopped the second
+      attempted.should eq(n)
+      store.count.should eq(Gori::Import::IMPORT_CHUNK.to_i64)
+    end
+  end
+end

--- a/spec/support/fake_context.cr
+++ b/spec/support/fake_context.cr
@@ -251,9 +251,9 @@ class FakeExecContext < Gori::Verb::ExecContext
   property miner_detail_read : Bool = false      # settable so the Miner FINDING read-pane gate can be exercised
   property sequencer_analysis : Bool = false     # settable so the Sequencer ANALYSIS read-pane gate can be exercised
   property probe_detail_read : Bool = false      # settable so the Probe AFFECTED-URLS read-pane gate can be exercised
-  property sequencer_samples : Bool = false      # the Sequencer SAMPLES row-copy gate
-  property miner_results : Bool = false          # the Miner FINDINGS row-copy gate
-  property probe_issue : Bool = false            # the Probe issue-list row-copy gate
+  property? sequencer_samples : Bool = false     # the Sequencer SAMPLES row-copy gate
+  property? miner_results : Bool = false         # the Miner FINDINGS row-copy gate
+  property? probe_issue : Bool = false           # the Probe issue-list row-copy gate
   property oast_detail : Bool = false            # settable so the OAST callback-detail read-pane gate can be exercised
 
   def rewriter_rule_selected? : Bool
@@ -348,6 +348,10 @@ class FakeExecContext < Gori::Verb::ExecContext
 
   def probe_issue_selected? : Bool
     @probe_issue
+  end
+
+  def import_running? : Bool
+    false
   end
 
   def rewriter_global_rule_selected? : Bool

--- a/spec/support/fake_context.cr
+++ b/spec/support/fake_context.cr
@@ -251,6 +251,9 @@ class FakeExecContext < Gori::Verb::ExecContext
   property miner_detail_read : Bool = false      # settable so the Miner FINDING read-pane gate can be exercised
   property sequencer_analysis : Bool = false     # settable so the Sequencer ANALYSIS read-pane gate can be exercised
   property probe_detail_read : Bool = false      # settable so the Probe AFFECTED-URLS read-pane gate can be exercised
+  property sequencer_samples : Bool = false      # the Sequencer SAMPLES row-copy gate
+  property miner_results : Bool = false          # the Miner FINDINGS row-copy gate
+  property probe_issue : Bool = false            # the Probe issue-list row-copy gate
   property oast_detail : Bool = false            # settable so the OAST callback-detail read-pane gate can be exercised
 
   def rewriter_rule_selected? : Bool
@@ -333,6 +336,18 @@ class FakeExecContext < Gori::Verb::ExecContext
 
   def miner_detail_readable? : Bool
     @miner_detail_read
+  end
+
+  def sequencer_samples_readable? : Bool
+    @sequencer_samples
+  end
+
+  def miner_results_readable? : Bool
+    @miner_results
+  end
+
+  def probe_issue_selected? : Bool
+    @probe_issue
   end
 
   def rewriter_global_rule_selected? : Bool

--- a/spec/tui/authorize_view_spec.cr
+++ b/spec/tui/authorize_view_spec.cr
@@ -595,3 +595,36 @@ describe AuthorizeView do
     render(v)
   end
 end
+
+# The request list up top and the detail below are two mouse targets, hit-tested against
+# the geometry the LAST frame drew (the `OastController#callback_row_at` rule: invert the
+# window, never move it). The only list-bearing tab that took no click at all until now.
+describe AuthorizeView, "mouse geometry" do
+  it "maps a click to the visible row under it, and the pane below to the detail" do
+    v = AuthorizeView.new
+    v.add(flow("GET", "/one"))
+    v.add(flow("GET", "/two"))
+    v.add(flow("GET", "/three"))
+    v.list_row_at(5, 2).should be_nil # nothing drawn yet — no frame, no rows
+    render(v, 120, 30)
+    # row 0 is the header line, row 1 the column header, rows from 2
+    v.list_row_at(5, 2).should eq(0)
+    v.list_row_at(5, 4).should eq(2)
+    v.list_row_at(5, 5).should be_nil # past the three rows
+    v.list_contains?(5, 3).should be_true
+    v.detail_contains?(5, 20).should be_true
+    v.detail_contains?(5, 3).should be_false
+    v.select_row(2)
+    v.selected_entry.not_nil!.host_path.should contain("/three")
+  end
+
+  it "forgets last frame's rows when a frame draws no list" do
+    v = AuthorizeView.new
+    v.add(flow("GET", "/one"))
+    render(v, 120, 30)
+    v.list_row_at(5, 2).should eq(0)
+    v.clear
+    render(v, 120, 30)
+    v.list_row_at(5, 2).should be_nil
+  end
+end

--- a/spec/tui/library_overlays_spec.cr
+++ b/spec/tui/library_overlays_spec.cr
@@ -285,3 +285,38 @@ describe Gori::Tui::LibraryPicker do
     h.rendered?("200 OK X: 1").should be_true
   end
 end
+
+# The filter is a `TextField` now: the caret moves, and a motion does not reset the cursor.
+describe Gori::Tui::LibraryPicker, "filter caret" do
+  private_rows2 = [
+    LibraryPicker::Row.new(0, "peel", "base64-decode > gunzip"),
+    LibraryPicker::Row.new(1, "hash", "sha256"),
+    LibraryPicker::Row.new(2, "urlx", "url-decode > url-decode"),
+  ]
+
+  # Home/End are the LIST's here (`page_key` runs first — #958), so the caret walks with ←/→
+  # and the word motions.
+  it "inserts at the caret after a word-left, and matches on the assembled query" do
+    lp = LibraryPicker.new("LOAD CHAIN", private_rows2, "chain")
+    h = OverlayHarness.new(lp)
+    h.type("zip")
+    lp.entry_count.should eq(1)
+    h.press(Termisu::Input::Key::Left, ctrl: true)
+    h.type("gun")
+    lp.query.should eq("gunzip")
+    lp.entry_count.should eq(1)
+    h.press(Termisu::Input::Key::Right, ctrl: true)
+    h.press(Termisu::Input::Key::Backspace)
+    lp.query.should eq("gunzi")
+  end
+
+  it "keeps the cursor row across a bare caret motion" do
+    lp = LibraryPicker.new("LOAD CHAIN", private_rows2, "chain")
+    h = OverlayHarness.new(lp)
+    h.press(Termisu::Input::Key::Down)
+    h.press(Termisu::Input::Key::Down)
+    lp.selected_index.should eq(2)
+    h.press(Termisu::Input::Key::Left)
+    lp.selected_index.should eq(2)
+  end
+end

--- a/spec/tui/overlay_list_contract_spec.cr
+++ b/spec/tui/overlay_list_contract_spec.cr
@@ -1,0 +1,77 @@
+require "../spec_helper"
+require "../support/memory_backend"
+require "../support/overlay_harness"
+
+include Gori::Tui
+
+# `Overlay#page_key` — PgUp/PgDn/Home/End over a list CARD, one page being the rows the last
+# frame drew. `PickerOverlay` had this for the pickers (#958); the list cards each hand-rolled
+# ↑/↓ and walked a 100-entry ring one row at a time. The two cards below stand for the nine
+# that take the arm now (notifications, agents, listeners, passthrough, tabs, columns, hosts,
+# env, hotkeys): one whose window is derived from a scrolling ring, one whose list is fixed.
+
+private def notes(n : Int32) : Notifications
+  s = Notifications.new
+  n.times { |i| s.push(:info, "note #{i}", Jobs::Goto.new(:history, i.to_i64)) }
+  s
+end
+
+describe "Overlay#page_key on the list cards" do
+  it "pages the notification centre by the rows it drew, and jumps to the ends" do
+    ov = NotificationsOverlay.new(notes(60))
+    h = OverlayHarness.new(ov, area: Rect.new(0, 0, 100, 20))
+    h.render # the page is measured off a frame
+    first = ov.selected_note.not_nil!.message
+    h.press(Termisu::Input::Key::PageDown)
+    paged = ov.selected_note.not_nil!.message
+    paged.should_not eq(first)
+    h.press(Termisu::Input::Key::End)
+    last = ov.selected_note.not_nil!.message
+    last.should_not eq(paged)
+    h.press(Termisu::Input::Key::Home)
+    ov.selected_note.not_nil!.message.should eq(first)
+    h.press(Termisu::Input::Key::PageUp) # at the top already: inert, never raises
+    ov.selected_note.not_nil!.message.should eq(first)
+  end
+
+  it "jumps the tab editor to its ends" do
+    ov = TabsOverlay.new
+    h = OverlayHarness.new(ov)
+    h.render
+    h.press(Termisu::Input::Key::End)
+    ov.selected.should eq(ov.entry_count - 1)
+    h.press(Termisu::Input::Key::Home)
+    ov.selected.should eq(0)
+    h.press(Termisu::Input::Key::PageDown)
+    ov.selected.should be > 0
+  end
+
+  it "is inert on a card that reports no rows" do
+    ov = TabsOverlay.new
+    ov.page_key(Termisu::Event::Key.new(Termisu::Input::Key::LowerJ, Termisu::Input::Modifier::None, 'j')).should be_false
+  end
+end
+
+describe "NotificationsOverlay `y`" do
+  it "copies the selected note and says so in the hint until the next key" do
+    ov = NotificationsOverlay.new(notes(3))
+    h = OverlayHarness.new(ov)
+    h.render
+    h.press(Termisu::Input::Key::LowerY, 'y')
+    ov.hint.should start_with("copied ")
+    h.press(Termisu::Input::Key::Down)
+    ov.hint.should_not start_with("copied ")
+    ov.hint.should contain("y copy")
+  end
+end
+
+describe "Overlay.too_small" do
+  it "draws the one line inside the area, and nothing on an empty area" do
+    be = MemoryBackend.new(80, 3)
+    Overlay.too_small(Screen.new(be), Rect.new(0, 0, 80, 3), "the card needs a larger window")
+    be.contains?("the card needs a larger window · esc to close").should be_true
+    be2 = MemoryBackend.new(40, 3)
+    Overlay.too_small(Screen.new(be2), Rect.new(0, 0, 0, 0), "x")
+    be2.contains?("x").should be_false
+  end
+end

--- a/spec/tui/palette_spec.cr
+++ b/spec/tui/palette_spec.cr
@@ -211,3 +211,22 @@ describe Gori::Tui::PaletteState do
     backend.contains?("▸ Toggle capture").should be_true # the Action sigil precedes the title
   end
 end
+
+# The palette's query has a caret now: `edit` takes the motions the `/` bars have.
+describe Gori::Tui::PaletteState, "caret" do
+  it "moves by word and inserts at the caret" do
+    ctx = FakeExecContext.new
+    palette = PaletteState.new(Gori::Verbs.registry)
+    palette.reset(ctx)
+    "quit now".each_char { |c| palette.append(c, ctx) }
+    palette.edit(Termisu::Event::Key.new(Termisu::Input::Key::Left, Termisu::Input::Modifier::Ctrl), ctx).should be_true
+    palette.append('x', ctx)
+    palette.query.should eq("quit xnow")
+    palette.edit(Termisu::Event::Key.new(Termisu::Input::Key::Home), ctx).should be_true
+    palette.backspace(ctx) # at 0: nothing to delete, nothing raised
+    palette.query.should eq("quit xnow")
+    palette.edit(Termisu::Event::Key.new(Termisu::Input::Key::Delete), ctx).should be_true
+    palette.query.should eq("uit xnow")
+    palette.edit(Termisu::Event::Key.new(Termisu::Input::Key::LowerJ, Termisu::Input::Modifier::None, 'j'), ctx).should be_false
+  end
+end

--- a/spec/tui/sitemap_async_filter_spec.cr
+++ b/spec/tui/sitemap_async_filter_spec.cr
@@ -1,0 +1,75 @@
+require "../support/tui_contract"
+
+include Gori::Tui
+
+# The Sitemap `/` bar's reload runs its store reads on a worker fiber (`QueryControl`, the
+# History #967 shape): typing never waits behind the DISTINCT scan over the flow table, a
+# superseded read is cancelled and its answer dropped, and the tree is rebuilt on the main
+# fiber from what the worker brought back.
+private def seed(store : Gori::Store, host : String, target : String) : Nil
+  id = store.insert_flow(Gori::Store::CapturedRequest.new(
+    created_at: 1_i64, scheme: "https", host: host, port: 443,
+    method: "GET", target: target, http_version: "HTTP/1.1",
+    head: "GET #{target} HTTP/1.1\r\nHost: #{host}\r\n\r\n".to_slice, body: nil,
+    source: Gori::FlowSource::Kind::Proxy))
+  store.update_response(Gori::Store::CapturedResponse.new(
+    flow_id: id, status: 200, head: "HTTP/1.1 200 OK\r\n\r\n".to_slice))
+end
+
+# Spin the tick's drain until the worker's answer lands (bounded, so a wedge fails loudly).
+private def settle(controller : SitemapController) : Nil
+  200.times do
+    return if controller.drain_search
+    sleep 5.milliseconds
+  end
+  fail "the sitemap worker never answered"
+end
+
+describe SitemapController, "async `/` filter" do
+  it "reads on a worker and lands the filtered tree on drain" do
+    TuiContract.with_session("sitemap-async") do |session|
+      seed(session.store, "acme.test", "/api/one")
+      seed(session.store, "other.test", "/api/two")
+      host = TuiContract::Host.new(session)
+      controller = SitemapController.new(host)
+      host.tab = :sitemap
+      controller.reload
+      TuiContract.render(controller).contains?("other.test").should be_true
+
+      controller.sitemap_query
+      "host:acme".each_char { |c| controller.handle_query_key(TuiContract.plain(c)) }
+      # The debounce has not elapsed: nothing flushed, the old tree stands.
+      controller.flush_query_reload_if_due(Time.instant).should be_false
+      controller.flush_query_reload_if_due(Time.instant + 1.second).should be_true
+      controller.view.searching?.should be_true
+      settle(controller)
+      controller.view.searching?.should be_false
+      be = TuiContract.render(controller)
+      be.contains?("acme.test").should be_true
+      be.contains?("other.test").should be_false
+    end
+  end
+
+  it "drops a superseded read's answer — a synchronous reload after it wins" do
+    TuiContract.with_session("sitemap-async-2") do |session|
+      seed(session.store, "acme.test", "/api/one")
+      seed(session.store, "other.test", "/api/two")
+      host = TuiContract::Host.new(session)
+      controller = SitemapController.new(host)
+      host.tab = :sitemap
+      controller.sitemap_query
+      "host:acme".each_char { |c| controller.handle_query_key(TuiContract.plain(c)) }
+      controller.flush_query_reload_if_due(Time.instant + 1.second).should be_true
+      # Esc clears the filter and reloads in place; the in-flight `host:acme` read must not
+      # land on top of the full tree afterwards.
+      controller.handle_query_key(TuiContract.key(Termisu::Input::Key::Escape))
+      controller.view.searching?.should be_false
+      200.times do
+        break if controller.drain_search
+        sleep 5.milliseconds
+      end
+      be = TuiContract.render(controller)
+      be.contains?("other.test").should be_true
+    end
+  end
+end

--- a/spec/verb/registry_spec.cr
+++ b/spec/verb/registry_spec.cr
@@ -1744,6 +1744,14 @@ private class FakeContext < ExecContext
   def import_wsdl : Nil
     @calls << :import_wsdl
   end
+
+  def import_running? : Bool
+    false
+  end
+
+  def import_cancel : Nil
+    @calls << :import_cancel
+  end
 end
 
 describe Gori::Verb do

--- a/spec/verb/registry_spec.cr
+++ b/spec/verb/registry_spec.cr
@@ -1589,6 +1589,18 @@ private class FakeContext < ExecContext
     false
   end
 
+  def sequencer_samples_readable? : Bool
+    false
+  end
+
+  def miner_results_readable? : Bool
+    false
+  end
+
+  def probe_issue_selected? : Bool
+    false
+  end
+
   def rewriter_scope_toggle : Nil
   end
 

--- a/src/gori/import.cr
+++ b/src/gori/import.cr
@@ -123,9 +123,16 @@ module Gori
     # printing a smaller success. Whole-file atomicity was not protecting much: nothing
     # deduplicates on re-import, so a failed all-or-nothing import meant starting over anyway,
     # and 80% of a 200 MB HAR plus an honest message beats losing all of it.
-    def self.insert_all(store : Store, pairs : Array(Builder::FlowPair)) : {Int32, Int32}
+    #
+    # `cancelled` is polled between chunks (the TUI's import job sets it from the palette;
+    # what is committed stays) and `progress` is told the running count after each — both
+    # optional, and neither changes the count that comes back: a cancelled import is a
+    # short one, and the caller says so.
+    def self.insert_all(store : Store, pairs : Array(Builder::FlowPair), *,
+                        cancelled : (-> Bool)? = nil, progress : (Int32, Int32 ->)? = nil) : {Int32, Int32}
       committed = 0
       pairs.each_slice(IMPORT_CHUNK) do |slice|
+        break if cancelled.try(&.call)
         # `_ids`, not the counting form: a flow's WebSocket transcript is stored against the
         # flow id, which does not exist until this write commits.
         ids = store.insert_import_batch_ids(slice.map { |pair| {pair.request, pair.response} })
@@ -137,6 +144,7 @@ module Gori
           msgs = slice[i].ws_messages
           store.insert_ws_messages(id, msgs) unless msgs.empty?
         end
+        progress.try(&.call(committed, pairs.size))
         # A short answer means the batch rolled back or the store is closing; stop rather than
         # push more work at a store that just refused some.
         break if ids.size < slice.size
@@ -148,7 +156,8 @@ module Gori
     # stamped `source: import` and `source_ref: <basename>`, so a History row can say WHICH file
     # it came out of — the provenance question an operator actually asks of an imported row.
     def self.import_file(store : Store, kind : Symbol, path : String,
-                         surface : FlowSource::Surface? = nil) : Result
+                         surface : FlowSource::Surface? = nil, *,
+                         cancelled : (-> Bool)? = nil, progress : (Int32, Int32 ->)? = nil) : Result
       expanded = Path[path].expand(home: true).to_s
       raise Gori::Error.new("file not found: #{expanded}") unless File.exists?(expanded)
       raise Gori::Error.new("not a file: #{expanded}") unless File.file?(expanded)
@@ -178,7 +187,7 @@ module Gori
         end
         raise Gori::Error.new("no flows found in #{expanded}")
       end
-      committed, attempted = insert_all(store, parsed.flows)
+      committed, attempted = insert_all(store, parsed.flows, cancelled: cancelled, progress: progress)
       Result.new(committed, parsed.skipped, attempted)
     end
   end

--- a/src/gori/settings/discover.cr
+++ b/src/gori/settings/discover.cr
@@ -50,7 +50,7 @@ module Gori::Settings
   # Persist the Discover overlay's last confirmed choices (called when a run starts).
   def self.save_discover_prefs(containment : String, max_depth : Int32, concurrency : Int32,
                                spider : Bool, bruteforce : Bool, extensions : Bool,
-                               keep_alive : Bool) : Nil
+                               keep_alive : Bool) : Bool
     self.discover_containment = containment
     self.discover_max_depth = max_depth
     self.discover_concurrency = concurrency

--- a/src/gori/settings/miner.cr
+++ b/src/gori/settings/miner.cr
@@ -43,7 +43,7 @@ module Gori::Settings
 
   # Persist the overlay's last confirmed choices (called when mining starts).
   def self.save_mine_prefs(locations : Array(String), concurrency : Int32, notify : String,
-                           keep_alive : Bool = true) : Nil
+                           keep_alive : Bool = true) : Bool
     self.mine_locations = locations.map(&.downcase.strip).reject(&.empty?)
     self.mine_concurrency = concurrency
     self.mine_notify = notify

--- a/src/gori/settings/probe.cr
+++ b/src/gori/settings/probe.cr
@@ -11,7 +11,7 @@ module Gori::Settings
   class_property probe_active_notify : String = DEFAULT_PROBE_ACTIVE_NOTIFY
 
   # Persist the "Run active scan" popup's last notification choice.
-  def self.save_probe_active_notify(notify : String) : Nil
+  def self.save_probe_active_notify(notify : String) : Bool
     self.probe_active_notify = notify
     save
   end

--- a/src/gori/store/reads.cr
+++ b/src/gori/store/reads.cr
@@ -745,19 +745,25 @@ module Gori
       [] of SitemapEntry
     end
 
+    #
+    # `control` makes the read cooperative (`controlled_query`): the Sitemap's `/` bar runs
+    # this on a worker fiber, and the DISTINCT scan over the flow table is the two thirds of
+    # a reload that scales with retention rather than with the capped tree. A cancelled read
+    # raises `QueryCancelled` past the rescue below — cancellation is never an empty tree.
     def sitemap_entries(filter : QL::Filter = QL::EMPTY, limit : Int32 = SITEMAP_MAX, *,
-                        raise_on_error : Bool = false) : Array({String, String, String})
+                        raise_on_error : Bool = false, control : QueryControl? = nil) : Array({String, String, String})
       rows = [] of {String, String, String}
       args = filter.args.dup
       args << limit
       # `method` is SELECTed, so it must ORDER too, or the LIMIT cut between two rows that
       # differ only by method is arbitrary — and with no cursor here the loser is unreachable.
-      @db.query("SELECT DISTINCT host, method, target FROM flows WHERE #{filter.sql} " \
-                "ORDER BY host, target, method LIMIT ?",
-        args: args) do |rs|
+      controlled_query("SELECT DISTINCT host, method, target FROM flows WHERE #{filter.sql} " \
+                       "ORDER BY host, target, method LIMIT ?", args, control) do |rs|
         rs.each { rows << {rs.read(String), rs.read(String), rs.read(String)} }
       end
       rows
+    rescue ex : QueryCancelled
+      raise ex
     rescue ex
       # The Sitemap's `/` filter feeds user QL here; a malformed FTS phrase or a query
       # too complex for SQLite raises. The live TUI must never crash (degrade to no

--- a/src/gori/tui/agents_overlay.cr
+++ b/src/gori/tui/agents_overlay.cr
@@ -109,6 +109,8 @@ module Gori::Tui
         move(-1)
       elsif k.down?
         move(1)
+      elsif page_key(ev)
+        # PgUp/PgDn/Home/End — the list contract, `Overlay#page_key`
       elsif ev.ctrl? || ev.alt?
         # a chord is not a mnemonic
       elsif k.lower_k?
@@ -133,6 +135,10 @@ module Gori::Tui
       :stay
     end
 
+    def entry_count : Int32
+      @rows.size
+    end
+
     def move(d : Int32) : Nil
       @selected = (@selected + d).clamp(0, {@rows.size - 1, 0}.max)
     end
@@ -155,7 +161,7 @@ module Gori::Tui
     def render(screen : Screen, area : Rect) : Nil
       box = overlay_box(area)
       unless box
-        screen.text(area.x + 1, area.y, "agent list needs a larger window · esc to close", Theme.muted, Theme.bg) unless area.empty?
+        Overlay.too_small(screen, area, "agent list needs a larger window")
         return
       end
       Frame.card(screen, box, "AGENTS", border: Theme.border_focus)
@@ -163,6 +169,7 @@ module Gori::Tui
       Frame.border_meta(screen, box, "AGENTS", meta, bg: Theme.panel)
 
       cap = list_capacity(box)
+      @list_last_h = cap
       return if cap <= 0
       start = list_window(cap)
       if @rows.empty?

--- a/src/gori/tui/authorize_identities_overlay.cr
+++ b/src/gori/tui/authorize_identities_overlay.cr
@@ -181,7 +181,7 @@ module Gori::Tui
     def render(screen : Screen, area : Rect) : Nil
       box = overlay_box(area)
       unless box
-        screen.text(area.x + 1, area.y, "identities need a larger window · esc to close", Theme.muted, Theme.bg) unless area.empty?
+        Overlay.too_small(screen, area, "identities need a larger window")
         return
       end
       Frame.card(screen, box, "IDENTITIES", border: Theme.border_focus)

--- a/src/gori/tui/authorize_identity_overlay.cr
+++ b/src/gori/tui/authorize_identity_overlay.cr
@@ -261,7 +261,7 @@ module Gori::Tui
     def render(screen : Screen, area : Rect) : Nil
       box = overlay_box(area)
       unless box
-        screen.text(area.x + 1, area.y, "identity form needs a larger window · esc to close", Theme.muted, Theme.bg) unless area.empty?
+        Overlay.too_small(screen, area, "identity form needs a larger window")
         return
       end
       # `card_title`, never a local called `title`: Crystal has no `override`, so a local of

--- a/src/gori/tui/authorize_view.cr
+++ b/src/gori/tui/authorize_view.cr
@@ -508,6 +508,10 @@ module Gori::Tui
     # ── render ────────────────────────────────────────────────────────────────
 
     def render(screen : Screen, rect : Rect, focused : Bool) : Nil
+      # Published for the hit-tests below; cleared first so a frame that draws no list (empty,
+      # nothing matching) cannot leave last frame's rows clickable.
+      @list_rows_rect = Rect.new(0, 0, 0, 0)
+      @detail_rect = Rect.new(0, 0, 0, 0)
       return render_empty(screen, rect) if @entries.empty?
       clamp_trial
       y = render_header(screen, rect, rect.y)
@@ -533,7 +537,44 @@ module Gori::Tui
       render_list(screen, rect, y, list_bottom, focused)
       divider_y = list_bottom
       render_divider(screen, rect, divider_y)
+      @detail_rect = Rect.new(rect.x, divider_y + 1, rect.w, {rect.bottom - divider_y - 1, 0}.max)
       render_detail(screen, rect.x, divider_y + 1, rect.right, rect.bottom, focused)
+    end
+
+    # --- mouse hit-tests, against the geometry the LAST frame drew --------------------
+
+    @list_rows_rect = Rect.new(0, 0, 0, 0)
+    @detail_rect = Rect.new(0, 0, 0, 0)
+
+    # The VISIBLE index of the request row under (mx, my), or nil off the list. The window is
+    # the one `render_list` drew (`@list_scroll`), never re-derived here — a hit-test must
+    # invert the window, not move it (the `OastController#callback_row_at` rule).
+    def list_row_at(mx : Int32, my : Int32) : Int32?
+      r = @list_rows_rect
+      return nil if r.empty? || !r.contains?(mx, my)
+      i = @list_scroll + (my - r.y)
+      i >= 0 && i < visible.size ? i : nil
+    end
+
+    def list_contains?(mx : Int32, my : Int32) : Bool
+      r = @list_rows_rect
+      !r.empty? && r.contains?(mx, my)
+    end
+
+    def detail_contains?(mx : Int32, my : Int32) : Bool
+      r = @detail_rect
+      !r.empty? && r.contains?(mx, my)
+    end
+
+    # Put the cursor on visible row `i` — a click. Same resets as `move_row`: the identity
+    # sub-cursor and the detail scroll belong to the request they were made on.
+    def select_row(i : Int32) : Nil
+      n = visible.size
+      return if n == 0
+      @sel = i.clamp(0, n - 1)
+      @tsel = 0
+      @trial_scroll = 0
+      @detail_scroll = 0
     end
 
     # The shared onboarding card (figure + card, degrading to lines on a short pane), the same
@@ -572,6 +613,7 @@ module Gori::Tui
       vis = visible
       @list_scroll = Viewport.scroll_to_show(@sel, @list_scroll, rows, vis.size)
       top = y
+      @list_rows_rect = Rect.new(rect.x, top, rect.w, rows)
       rows.times do |n|
         i = @list_scroll + n
         break unless (src = vis[i]?) && (e = @entries[src]?)

--- a/src/gori/tui/browser_picker.cr
+++ b/src/gori/tui/browser_picker.cr
@@ -107,7 +107,7 @@ module Gori::Tui
     def render(screen : Screen, area : Rect) : Nil
       box = overlay_box(area)
       unless box
-        screen.text(area.x + 1, area.y, "browser picker needs a larger window · esc to close", Theme.muted, Theme.bg) unless area.empty?
+        Overlay.too_small(screen, area, "browser picker needs a larger window")
         return
       end
       w = box.w

--- a/src/gori/tui/ca_import_overlay.cr
+++ b/src/gori/tui/ca_import_overlay.cr
@@ -132,7 +132,7 @@ module Gori::Tui
     def render(screen : Screen, area : Rect) : Nil
       box = overlay_box(area)
       unless box
-        screen.text(area.x + 1, area.y, "CA import needs a larger window · esc to close", Theme.muted, Theme.bg) unless area.empty?
+        Overlay.too_small(screen, area, "CA import needs a larger window")
         return
       end
       Frame.card(screen, box, "IMPORT CA · cert + key PEM", bg: Theme.bg, border: Theme.border_focus)

--- a/src/gori/tui/choice_picker.cr
+++ b/src/gori/tui/choice_picker.cr
@@ -181,7 +181,7 @@ module Gori::Tui
     def render(screen : Screen, area : Rect) : Nil
       box = overlay_box(area)
       unless box
-        screen.text(area.x + 1, area.y, "picker needs a larger window · esc to close", Theme.muted, Theme.bg) unless area.empty?
+        Overlay.too_small(screen, area, "picker needs a larger window")
         return
       end
       Frame.card(screen, box, @title, border: Theme.border_focus)

--- a/src/gori/tui/colormarker_rule_overlay.cr
+++ b/src/gori/tui/colormarker_rule_overlay.cr
@@ -321,7 +321,7 @@ module Gori::Tui
     def render(screen : Screen, area : Rect) : Nil
       box = overlay_box(area)
       unless box
-        screen.text(area.x + 1, area.y, "colormarker-rule form needs a larger window · esc to close", Theme.muted, Theme.bg) unless area.empty?
+        Overlay.too_small(screen, area, "colormarker-rule form needs a larger window")
         return
       end
       Frame.card(screen, box, editing? ? "EDIT COLOUR RULE" : "ADD COLOUR RULE", border: Theme.border_focus)

--- a/src/gori/tui/column_overlay.cr
+++ b/src/gori/tui/column_overlay.cr
@@ -269,7 +269,7 @@ module Gori::Tui
     def render(screen : Screen, area : Rect) : Nil
       box = overlay_box(area)
       unless box
-        screen.text(area.x + 1, area.y, "column form needs a larger window · esc to close", Theme.muted, Theme.bg) unless area.empty?
+        Overlay.too_small(screen, area, "column form needs a larger window")
         return
       end
       Frame.card(screen, box, editing? ? "EDIT COLUMN" : "ADD COLUMN", border: Theme.border_focus)

--- a/src/gori/tui/columns_overlay.cr
+++ b/src/gori/tui/columns_overlay.cr
@@ -71,6 +71,7 @@ module Gori::Tui
       case
       when k.up?, k.lower_k?   then move(-1)
       when k.down?, k.lower_j? then move(1)
+      when page_key(ev)        then nil # PgUp/PgDn/Home/End — the list contract, `Overlay#page_key`
       when k.lower_a?
         # Refused HERE and not only at the store: the ceiling is about the ROW being readable,
         # which is a fact about this card's own list, and a form the operator fills in only to
@@ -90,6 +91,14 @@ module Gori::Tui
       when k.lower_d? then delete_selected
       end
       :stay
+    end
+
+    def entry_count : Int32
+      @columns.size
+    end
+
+    def set_selected(idx : Int32) : Nil
+      @selected = idx.clamp(0, {@columns.size - 1, 0}.max)
     end
 
     def move(d : Int32) : Nil
@@ -177,7 +186,7 @@ module Gori::Tui
     def render(screen : Screen, area : Rect) : Nil
       box = overlay_box(area)
       unless box
-        screen.text(area.x + 1, area.y, "columns need a larger window · esc to close", Theme.muted, Theme.bg) unless area.empty?
+        Overlay.too_small(screen, area, "columns need a larger window")
         return
       end
       Frame.card(screen, box, title, border: Theme.border_focus)

--- a/src/gori/tui/compact_overlay.cr
+++ b/src/gori/tui/compact_overlay.cr
@@ -129,7 +129,7 @@ module Gori::Tui
     def render(screen : Screen, area : Rect) : Nil
       box = overlay_box(area)
       unless box
-        screen.text(area.x + 1, area.y, "compress needs a larger window · esc to close", Theme.muted, Theme.bg) unless area.empty?
+        Overlay.too_small(screen, area, "compress needs a larger window")
         return
       end
       Frame.card(screen, box, "COMPRESS PROJECT", border: Theme.border_focus)

--- a/src/gori/tui/controllers/authorize_controller.cr
+++ b/src/gori/tui/controllers/authorize_controller.cr
@@ -914,6 +914,27 @@ module Gori::Tui
       true
     end
 
+    # The list up top and the detail below are two scroll targets, and the notch goes to the
+    # one UNDER THE POINTER (the #956 contract every other split tab keeps): over the request
+    # rows it moves the cursor, anywhere else it scrolls the detail as it always did.
+    def handle_wheel_at(step : Int32, mx : Int32, my : Int32, rect : Rect) : Bool
+      if @view.list_contains?(mx, my)
+        @view.move_row(step)
+        return true
+      end
+      handle_wheel(step)
+    end
+
+    # A click on a request row selects it (the detail below follows); the filter bar takes a
+    # click as `/`. The only list-bearing tab that took no click at all until now.
+    def handle_click(rect : Rect, mx : Int32, my : Int32) : Bool
+      @host.focus_body
+      if i = @view.list_row_at(mx, my)
+        @view.select_row(i)
+      end
+      true
+    end
+
     # --- the request-list `/` filter (a text sub-mode the shell claims ahead of the focus ring) ---
     def querying? : Bool
       @view.filter_editing?

--- a/src/gori/tui/controllers/colormarker_controller.cr
+++ b/src/gori/tui/controllers/colormarker_controller.cr
@@ -317,6 +317,21 @@ module Gori::Tui
       true
     end
 
+    # RULES and COLOURS sit side by side, so the notch goes to the pane under the pointer,
+    # not the focused one (#956); off both panes it falls back to the focused pane.
+    def handle_wheel_at(step : Int32, mx : Int32, my : Int32, rect : Rect) : Bool
+      inner = BodyChrome.frame_inner(rect)
+      rules_r, colors_r = @view.pane_rects(inner)
+      if !colors_r.empty? && colors_r.contains?(mx, my)
+        move_color_sel(step)
+      elsif !rules_r.empty? && rules_r.contains?(mx, my)
+        move_sel(step)
+      else
+        return handle_wheel(step)
+      end
+      true
+    end
+
     # --- policy actions (also the ExecContext verbs) ---
 
     def colormarker_add : Nil

--- a/src/gori/tui/controllers/miner_controller.cr
+++ b/src/gori/tui/controllers/miner_controller.cr
@@ -284,6 +284,20 @@ module Gori::Tui
       true
     end
 
+    # A double-click on a FINDINGS row runs ↵ on it (#969's contract): select, then open the
+    # detail, whichever pane held focus before. False off the list, so the plain click stands.
+    def handle_double_click(rect : Rect, mx : Int32, my : Int32) : Bool
+      body = body_rect_below_filter(rect)
+      return false unless v = current_view
+      return false unless v.pane_at(body, mx, my) == :results
+      return false unless row = v.results_row_at(body, mx, my)
+      @host.focus_body
+      v.focus_pane(:results)
+      v.select_result_row(row)
+      v.open_detail
+      true
+    end
+
     # Select the row under the cursor (grabbing focus from another pane on the first click),
     # or — a second click on the already-selected row while FINDINGS already holds focus —
     # open its detail, so the mouse matches ↵. History, Issues, Probe, OAST and the Fuzzer
@@ -316,6 +330,10 @@ module Gori::Tui
       current_view.try { |v| v.focus == :detail } || false
     end
 
+    def miner_results_readable? : Bool
+      current_view.try { |v| v.focus == :results && !v.selected_finding.nil? } || false
+    end
+
     def miner_selection_active? : Bool
       current_view.try(&.detail_selection?) || false
     end
@@ -336,6 +354,11 @@ module Gori::Tui
     # parameter's evidence is what goes into a report, and it had no copy at all.
     def miner_copy : Nil
       v = current_view
+      # The FINDINGS list: the finding as one line — name, where it was found, the evidence.
+      if v && v.focus == :results
+        f = v.selected_finding || return
+        return copy_text("#{f.name} · #{f.location.label} · #{f.evidence.label}", "finding")
+      end
       return unless v && v.focus == :detail
       sel = v.detail_selection?
       text = sel ? v.detail_copy_text : v.detail_copy_all

--- a/src/gori/tui/controllers/oast_controller.cr
+++ b/src/gori/tui/controllers/oast_controller.cr
@@ -1317,16 +1317,11 @@ module Gori::Tui
       # payload bar (2 rows) — no row action; body is the filter + table card below
       body = Rect.new(content.x, content.y + 2, content.w, content.h - 2)
       return if body.h < 1
-      table = if body.h >= 2
-                if my == body.y
-                  start_cb_filter unless @filter_editing
-                  return
-                end
-                Rect.new(body.x, body.y + 1, body.w, body.h - 1)
-              else
-                body
-              end
-      return unless idx = callback_row_at(table, mx, my)
+      if body.h >= 2 && my == body.y
+        start_cb_filter unless @filter_editing
+        return
+      end
+      return unless (table = callbacks_table(content)) && (idx = callback_row_at(table, mx, my))
       @filter_editing = false # a row click commits the filter, like History's list click
       if idx == @cb_sel
         @cb_detail = true
@@ -1335,6 +1330,31 @@ module Gori::Tui
         @cb_sel = idx
         sync_scroll
       end
+    end
+
+    # The CALLBACKS table card's rect inside `content` — under the two-row payload bar and
+    # the filter row — or nil when the pane is too short for one. The single derivation the
+    # click, the double-click and the filter-row test share.
+    private def callbacks_table(content : Rect) : Rect?
+      return nil if content.h < 2
+      body = Rect.new(content.x, content.y + 2, content.w, content.h - 2)
+      return nil if body.h < 1
+      body.h >= 2 ? Rect.new(body.x, body.y + 1, body.w, body.h - 1) : body
+    end
+
+    # A double-click on a callback row runs ↵ on it (#969's contract): select and open the
+    # detail in one gesture, where the click's select-then-open needs two.
+    def handle_double_click(rect : Rect, mx : Int32, my : Int32) : Bool
+      return false unless callbacks_sub? && !@cb_detail
+      content = BodyChrome.content_rect(rect, strip: true)
+      return false unless (table = callbacks_table(content)) && (idx = callback_row_at(table, mx, my))
+      @host.focus_body
+      @filter_editing = false
+      @cb_sel = idx
+      sync_scroll
+      @cb_detail = true
+      @cb_pane.reset
+      true
     end
 
     # Hit-test a click against the CALLBACKS table card (mirrors render_callback_table).

--- a/src/gori/tui/controllers/probe_controller.cr
+++ b/src/gori/tui/controllers/probe_controller.cr
@@ -721,6 +721,19 @@ module Gori::Tui
       @probe.detail_clear_selection
     end
 
+    def probe_issue_selected? : Bool
+      !rules_tab? && !@probe.detail_open? && !@probe.selected_issue.nil?
+    end
+
+    # `y` wherever the tab is: the detail's URLs when the detail is open, else the issue row
+    # under the cursor as a report line with its affected URLs beneath (#964's shape).
+    def probe_copy : Nil
+      return probe_detail_copy if probe_detail_readable?
+      return unless (issue = @probe.selected_issue) && probe_issue_selected?
+      head = "[#{issue.severity}] #{issue.title} · #{issue.host}"
+      copy_text(issue.affected.empty? ? head : "#{head}\n#{issue.affected.join('\n')}", "issue")
+    end
+
     # `y`: the selected URLs, or every affected URL when nothing is selected. This list IS the
     # finding's evidence, and it had no copy at all.
     def probe_detail_copy : Nil

--- a/src/gori/tui/controllers/rewriter_controller.cr
+++ b/src/gori/tui/controllers/rewriter_controller.cr
@@ -794,6 +794,25 @@ module Gori::Tui
       true
     end
 
+    # On the RULES sub-tab the list and the two previews share the body, so the notch goes to
+    # the pane under the pointer (#956); the other sub-tabs are one list and take the plain
+    # wheel.
+    def handle_wheel_at(step : Int32, mx : Int32, my : Int32, rect : Rect) : Bool
+      return handle_wheel(step) unless @sub == :rules
+      inner = BodyChrome.frame_inner(rect)
+      pin = @view.preview_input_body(inner)
+      pout = @view.preview_output_body(inner)
+      if !pin.empty? && pin.contains?(mx, my)
+        @preview_input.scroll_view(step)
+      elsif !pout.empty? && pout.contains?(mx, my)
+        sync_preview_out
+        @out.scroll_view(step)
+      else
+        move_sel(step)
+      end
+      true
+    end
+
     def set_preedit(text : String) : Bool
       return false unless @focus == :preview_in
       @preview_input.set_preedit(text)

--- a/src/gori/tui/controllers/sequencer_controller.cr
+++ b/src/gori/tui/controllers/sequencer_controller.cr
@@ -278,6 +278,21 @@ module Gori::Tui
       true
     end
 
+    # A double-click on a SAMPLES row runs ↵ on it (#969's contract): select, then open the
+    # detail. False off the list — the ANALYSIS rows are two columns with no word to select,
+    # so there the plain click stands.
+    def handle_double_click(rect : Rect, mx : Int32, my : Int32) : Bool
+      body = body_rect_below_filter(rect)
+      return false unless v = current_view
+      return false unless v.pane_at(body, mx, my) == :samples
+      return false unless row = v.samples_row_at(body, mx, my)
+      @host.focus_body
+      v.focus_pane(:samples)
+      v.select_sample_row(row)
+      v.open_detail
+      true
+    end
+
     # Select the row under the cursor, or — a second click on the already-selected row while
     # SAMPLES already holds focus — open its detail, so the mouse matches ↵. The same
     # select-then-open every other list in the tree uses; this one took no row click at all.
@@ -316,6 +331,10 @@ module Gori::Tui
       current_view.try { |v| v.focus == :analysis || v.focus == :detail } || false
     end
 
+    def sequencer_samples_readable? : Bool
+      current_view.try { |v| v.focus == :samples && !v.selected_sample.nil? } || false
+    end
+
     def sequencer_selection_active? : Bool
       v = current_view
       return false unless v
@@ -338,10 +357,17 @@ module Gori::Tui
       v.focus == :detail ? v.detail_clear_selection : v.analysis_clear_selection
     end
 
+    # The SAMPLES list's `y`: the token under the cursor, which is what an operator quotes.
+    private def copy_sample(v : SequencerView) : Nil
+      sample = v.selected_sample || return
+      copy_text(sample.token || "", "sample ##{sample.index}")
+    end
+
     # `y`: the selected report rows, or the whole entropy report when nothing is selected. The
     # report is the finding — a randomness verdict you cannot paste into an issue is half a tool.
     def sequencer_copy : Nil
       v = current_view
+      return copy_sample(v) if v && v.focus == :samples
       return unless v && (v.focus == :analysis || v.focus == :detail)
       detail = v.focus == :detail
       sel = detail ? v.detail_selection? : v.analysis_selection?

--- a/src/gori/tui/controllers/sitemap_controller.cr
+++ b/src/gori/tui/controllers/sitemap_controller.cr
@@ -14,6 +14,13 @@ module Gori::Tui
       @sitemap = SitemapView.new
       @sitemap.set_scope(@host.session.scope) # honour the lens + show its chip on the bar
       @query_reload_at = nil.as(Time::Instant?)
+      # The `/` bar's reload off the main fiber (the History #967 shape): one running read
+      # and one replaceable request. A superseded read is cancelled and its answer dropped
+      # by generation, so a fast typist never sees an older query's tree land last.
+      @search_generation = 0_i64
+      @search_control = nil.as(Store::QueryControl?)
+      @search_pending = nil.as({Store, SitemapView::ReloadPlan, Int64}?)
+      @search_results = Channel({Int64, SitemapView::ReloadPlan, {Array({String, String, String}), Hash({String, String}, String)}?}).new(1)
     end
 
     def view : SitemapView
@@ -193,8 +200,72 @@ module Gori::Tui
     # Re-derive the tree from the store under the current scope filter + `/` query
     # (both held by the view). Public so the scope-lens toggle (a cross-tab action
     # mediated by the shell) can refresh it.
+    # A synchronous reload (tab entry, an external change, an import) supersedes any read the
+    # bar has in flight — its answer would otherwise land AFTER this one, showing an older
+    # query's tree.
     def reload : Nil
+      invalidate_search
+      @sitemap.searching = false
       @sitemap.reload(@host.session.store)
+    end
+
+    private def invalidate_search : Nil
+      @search_generation += 1
+      @search_control.try(&.cancel)
+      @search_pending = nil
+    end
+
+    # The debounced flush: compile the query here, read on a worker, build on return.
+    private def request_reload(store : Store) : Nil
+      invalidate_search
+      unless plan = @sitemap.prepare_reload
+        @sitemap.searching = false # an invalid residual settled the tree by itself
+        return
+      end
+      @sitemap.searching = true
+      @search_pending = {store, plan, @search_generation}
+      start_search
+    end
+
+    private def start_search : Nil
+      return if @search_control
+      return unless pending = @search_pending
+      @search_pending = nil
+      store, plan, generation = pending
+      control = Store::QueryControl.new
+      @search_control = control
+      results = @search_results
+      view = @sitemap
+      spawn(name: "gori-sitemap-search") do
+        result = nil.as({Array({String, String, String}), Hash({String, String}, String)}?)
+        begin
+          control.check!
+          result = view.fetch_reload(store, plan, control)
+        rescue Store::QueryCancelled
+          # Superseded/closed is not a failed query and never means an empty tree.
+        rescue ex
+          ::Log.warn { "sitemap worker failed: #{ex.message}" }
+        ensure
+          results.send({generation, plan, result})
+        end
+      end
+    end
+
+    # Called each run-loop tick: land a finished read. True when it did (→ a frame).
+    def drain_search : Bool
+      select
+      when done = @search_results.receive
+        @search_control = nil
+        generation, plan, result = done
+        if generation == @search_generation
+          @sitemap.searching = false
+          @sitemap.apply_reload(result[0], result[1], plan) if result
+        end
+        start_search
+        true
+      else
+        false
+      end
     end
 
     # --- QL filter bar (a text sub-mode; the shell claims it before the focus ring) ---
@@ -258,6 +329,8 @@ module Gori::Tui
       return @sitemap.popup_close if @sitemap.popup_open?
       @query_reload_at = nil
       @sitemap.cancel_query
+      invalidate_search
+      @sitemap.searching = false
       @sitemap.reload(store)
     end
 
@@ -279,7 +352,7 @@ module Gori::Tui
     private def flush_query_reload : Nil
       return unless @query_reload_at
       @query_reload_at = nil
-      @sitemap.reload(@host.session.store)
+      request_reload(@host.session.store)
     end
 
     # `/` — focus the QL filter bar (verb-dispatched).

--- a/src/gori/tui/copy_picker.cr
+++ b/src/gori/tui/copy_picker.cr
@@ -113,7 +113,7 @@ module Gori::Tui
     def render(screen : Screen, area : Rect) : Nil
       box = overlay_box(area)
       unless box
-        screen.text(area.x + 1, area.y, "picker needs a larger window · esc to close", Theme.muted, Theme.bg) unless area.empty?
+        Overlay.too_small(screen, area, "picker needs a larger window")
         return
       end
       Frame.card(screen, box, @title, border: Theme.border_focus)

--- a/src/gori/tui/custom_color_overlay.cr
+++ b/src/gori/tui/custom_color_overlay.cr
@@ -147,7 +147,7 @@ module Gori::Tui
     def render(screen : Screen, area : Rect) : Nil
       box = overlay_box(area)
       unless box
-        screen.text(area.x + 1, area.y, "custom-colour form needs a larger window · esc to close", Theme.muted, Theme.bg) unless area.empty?
+        Overlay.too_small(screen, area, "custom-colour form needs a larger window")
         return
       end
       Frame.card(screen, box, editing? ? "EDIT CUSTOM COLOUR" : "ADD CUSTOM COLOUR", border: Theme.border_focus)

--- a/src/gori/tui/custom_rule_overlay.cr
+++ b/src/gori/tui/custom_rule_overlay.cr
@@ -243,7 +243,7 @@ module Gori::Tui
     def render(screen : Screen, area : Rect) : Nil
       box = overlay_box(area)
       unless box
-        screen.text(area.x + 1, area.y, "custom-rule form needs a larger window · esc to close", Theme.muted, Theme.bg) unless area.empty?
+        Overlay.too_small(screen, area, "custom-rule form needs a larger window")
         return
       end
       title = editing? ? "EDIT CUSTOM RULE" : "ADD CUSTOM RULE"

--- a/src/gori/tui/cvss_calculator_overlay.cr
+++ b/src/gori/tui/cvss_calculator_overlay.cr
@@ -495,7 +495,7 @@ module Gori::Tui
     def render(screen : Screen, area : Rect) : Nil
       box = overlay_box(area)
       unless box
-        screen.text(area.x + 1, area.y, "cvss form needs a larger window · esc to close", Theme.muted, Theme.bg) unless area.empty?
+        Overlay.too_small(screen, area, "cvss form needs a larger window")
         return
       end
       Frame.card(screen, box, "CVSS v#{spec.label}", border: Theme.border_focus)

--- a/src/gori/tui/discover_config_overlay.cr
+++ b/src/gori/tui/discover_config_overlay.cr
@@ -87,7 +87,7 @@ module Gori::Tui
     end
 
     # Remember the last confirmed overlay for the next Sitemap/History discovery.
-    def save_prefs : Nil
+    def save_prefs : Bool
       Settings.save_discover_prefs(CONTAINMENTS[@contain_idx].label, DEPTHS[@depth_idx],
         CONCS[@conc_idx], @spider, @bruteforce, @ext, @keep_alive)
     end
@@ -212,7 +212,7 @@ module Gori::Tui
     def render(screen : Screen, area : Rect) : Nil
       box = overlay_box(area)
       unless box
-        screen.text(area.x + 1, area.y, "config needs a larger window · esc to close", Theme.muted, Theme.bg) unless area.empty?
+        Overlay.too_small(screen, area, "config needs a larger window")
         return
       end
       Frame.card(screen, box, "DISCOVER", border: Theme.border_focus)

--- a/src/gori/tui/env_overlay.cr
+++ b/src/gori/tui/env_overlay.cr
@@ -85,6 +85,8 @@ module Gori::Tui
         select_move(-1)
       elsif key.down? || key.lower_j?
         select_move(1)
+      elsif page_key(ev)
+        # PgUp/PgDn/Home/End — the list contract, `Overlay#page_key`
       elsif key.enter?
         edit_start
       else
@@ -236,6 +238,10 @@ module Gori::Tui
       @selected = (@selected + d).clamp(0, {@items.size - 1, 0}.max)
     end
 
+    def entry_count : Int32
+      @items.size
+    end
+
     def set_selected(idx : Int32) : Nil
       @selected = idx.clamp(0, {@items.size - 1, 0}.max)
     end
@@ -357,7 +363,7 @@ module Gori::Tui
     def render(screen : Screen, area : Rect) : Nil
       box = overlay_box(area)
       unless box
-        screen.text(area.x + 1, area.y, "env editor needs a larger window · esc to close", Theme.muted, Theme.bg) unless area.empty?
+        Overlay.too_small(screen, area, "env editor needs a larger window")
         return
       end
       Frame.card(screen, box, "ENVIRONMENT", border: Theme.border_focus)
@@ -372,6 +378,7 @@ module Gori::Tui
       screen.text(box.x + 3, box.y + 2, "KEY VALUE · e.g. HOST api.example.com", Theme.muted, Theme.panel, width: {box.w - 5, 1}.max)
 
       cap = list_capacity(box)
+      @list_last_h = cap
       y = box.y + 3
       rows = cap
       if @adding

--- a/src/gori/tui/extract_rule_overlay.cr
+++ b/src/gori/tui/extract_rule_overlay.cr
@@ -265,7 +265,7 @@ module Gori::Tui
     def render(screen : Screen, area : Rect) : Nil
       box = overlay_box(area)
       unless box
-        screen.text(area.x + 1, area.y, "extract-rule form needs a larger window · esc to close", Theme.muted, Theme.bg) unless area.empty?
+        Overlay.too_small(screen, area, "extract-rule form needs a larger window")
         return
       end
       Frame.card(screen, box, editing? ? "EDIT EXTRACT RULE" : "ADD EXTRACT RULE", border: Theme.border_focus)

--- a/src/gori/tui/flow_picker.cr
+++ b/src/gori/tui/flow_picker.cr
@@ -57,7 +57,7 @@ module Gori::Tui
     # Recompute the visible rows from the precomputed haystacks: every whitespace-
     # separated term must appear (case-insensitive). Resets the cursor to the top.
     protected def refilter : Nil
-      terms = @query.downcase.split
+      terms = query.downcase.split
       @filtered = terms.empty? ? @rows : @indexed.select { |(_, hay)| terms.all? { |t| hay.includes?(t) } }.map(&.first)
       @selected = 0
       @scroll = 0
@@ -91,7 +91,7 @@ module Gori::Tui
     def render(screen : Screen, area : Rect) : Nil
       box = overlay_box(area)
       unless box
-        screen.text(area.x + 1, area.y, "flow picker needs a larger window · esc to close", Theme.muted, Theme.bg) unless area.empty?
+        Overlay.too_small(screen, area, "flow picker needs a larger window")
         return
       end
       Frame.card(screen, box, "PICK FLOW #{@target.to_s.upcase}", border: Theme.border_focus)

--- a/src/gori/tui/fuzz_advanced_overlay.cr
+++ b/src/gori/tui/fuzz_advanced_overlay.cr
@@ -277,7 +277,7 @@ module Gori::Tui
     def render(screen : Screen, area : Rect) : Nil
       box = overlay_box(area)
       unless box
-        screen.text(area.x + 1, area.y, "advanced editor needs a larger window · esc to close", Theme.muted, Theme.bg) unless area.empty?
+        Overlay.too_small(screen, area, "advanced editor needs a larger window")
         return
       end
       Frame.card(screen, box, "ADVANCED", bg: Theme.bg, border: Theme.border_focus)

--- a/src/gori/tui/fuzz_set_overlay.cr
+++ b/src/gori/tui/fuzz_set_overlay.cr
@@ -426,7 +426,7 @@ module Gori::Tui
     def render(screen : Screen, area : Rect) : Nil
       box = overlay_box(area)
       unless box
-        screen.text(area.x + 1, area.y, "payload set editor needs a larger window · esc to close", Theme.muted, Theme.bg) unless area.empty?
+        Overlay.too_small(screen, area, "payload set editor needs a larger window")
         return
       end
       # Not `title` — that is now the Overlay chrome method, and a local of the same name

--- a/src/gori/tui/help_popup_overlay.cr
+++ b/src/gori/tui/help_popup_overlay.cr
@@ -84,6 +84,7 @@ module Gori::Tui
     def initialize(@title : String, @all : Array(HelpView::Row), @key_w : Int32, @scroll : Int32)
       @rows = @all
       @query = ""
+      @qcx = 0
       @preedit = "" # live IME composition on the filter (e.g. Hangul jamo)
       @searching = false
       @search_origin_scroll = @scroll
@@ -124,6 +125,7 @@ module Gori::Tui
         return :cancel unless @searching
         cancel_search
       when handle_navigation_key(k)
+      when search_edit(ev)
       when k.backspace?
         backspace if @searching
       else
@@ -161,6 +163,7 @@ module Gori::Tui
       @search_origin_scroll = @scroll
       @searching = true
       @query = ""
+      @qcx = 0
       @preedit = ""
       @rows = @all
     end
@@ -168,6 +171,7 @@ module Gori::Tui
     private def cancel_search : Nil
       @searching = false
       @query = ""
+      @qcx = 0
       @preedit = ""
       @rows = @all
       @scroll = @search_origin_scroll
@@ -184,16 +188,37 @@ module Gori::Tui
       return unless @searching
       return if ch.control?
       @preedit = "" # a committed char ends any in-progress composition
-      @query += ch
+      @query = @query[0, @qcx] + ch + @query[@qcx..]
+      @qcx += 1
       refilter
     end
 
     def backspace : Nil
       return unless @searching
-      return if @query.empty?
+      return if @qcx == 0
       @preedit = ""
-      @query = @query[0, @query.size - 1]
+      @query = @query[0, @qcx - 1] + @query[@qcx..]
+      @qcx -= 1
       refilter
+    end
+
+    # The caret's other moves while searching — ⌃/⌥←→ by word, Delete, ⌥⌫ (`LineEdit`; Home
+    # and End stay the list's, taken by `handle_navigation_key` first) and the bare ←/→.
+    private def search_edit(ev : Termisu::Event::Key) : Bool
+      return false unless @searching
+      key = ev.key
+      if act = LineEdit.action(ev)
+        @query, @qcx = LineEdit.apply(act, @query, @qcx)
+        @preedit = ""
+        refilter if LineEdit.mutating?(act)
+      elsif key.left?
+        @qcx = {@qcx - 1, 0}.max
+      elsif key.right?
+        @qcx = {@qcx + 1, @query.size}.min
+      else
+        return false
+      end
+      true
     end
 
     # Substring, case-insensitive, over both columns — NOT the fuzzy subsequence the palette
@@ -274,7 +299,7 @@ module Gori::Tui
         # drew (the QL card opens with `?` straight off a filter bar), or it blinks on through
         # the "larger window" message.
         screen.desired_cursor = nil
-        screen.text(area.x + 1, area.y, "#{@title.downcase} needs a larger window · esc to close", Theme.muted, Theme.bg) unless area.empty?
+        Overlay.too_small(screen, area, "#{@title.downcase} needs a larger window")
         return
       end
       Frame.card(screen, box, @title, border: Theme.border_focus)
@@ -314,7 +339,7 @@ module Gori::Tui
     private def render_filter(screen : Screen, box : Rect) : Nil
       if @searching
         px = screen.text(box.x + 2, box.y + 1, "search: ", Theme.muted, Theme.panel)
-        screen.input_line(px, box.y + 1, @query, @query.size, @preedit, Theme.text_bright,
+        screen.input_line(px, box.y + 1, @query, @qcx, @preedit, Theme.text_bright,
           Theme.panel, width: {box.right - 2 - px, 1}.max)
       else
         screen.text(box.x + 2, box.y + 1, "/ search", Theme.muted, Theme.panel, width: {box.w - 4, 1}.max)

--- a/src/gori/tui/hosts_overlay.cr
+++ b/src/gori/tui/hosts_overlay.cr
@@ -86,6 +86,8 @@ module Gori::Tui
         select_move(-1)
       elsif key.down? || key.lower_j?
         select_move(1)
+      elsif page_key(ev)
+        # PgUp/PgDn/Home/End — the list contract, `Overlay#page_key`
       elsif key.enter?
         edit_start
       else
@@ -210,6 +212,10 @@ module Gori::Tui
       @selected = (@selected + d).clamp(0, {@items.size - 1, 0}.max)
     end
 
+    def entry_count : Int32
+      @items.size
+    end
+
     def set_selected(idx : Int32) : Nil
       @selected = idx.clamp(0, {@items.size - 1, 0}.max)
     end
@@ -323,7 +329,7 @@ module Gori::Tui
     def render(screen : Screen, area : Rect) : Nil
       box = overlay_box(area)
       unless box
-        screen.text(area.x + 1, area.y, "hostname editor needs a larger window · esc to close", Theme.muted, Theme.bg) unless area.empty?
+        Overlay.too_small(screen, area, "hostname editor needs a larger window")
         return
       end
       Frame.card(screen, box, "HOSTNAME OVERRIDES", border: Theme.border_focus)
@@ -336,6 +342,7 @@ module Gori::Tui
       screen.text(box.x + 3, box.y + 1, "IP HOSTNAME · e.g. 10.0.0.1 example.com", Theme.muted, Theme.panel, width: {box.w - 5, 1}.max)
 
       cap = list_capacity(box)
+      @list_last_h = cap
       y = box.y + 2
       rows = cap
       if @adding

--- a/src/gori/tui/hotkeys_overlay.cr
+++ b/src/gori/tui/hotkeys_overlay.cr
@@ -51,6 +51,7 @@ module Gori::Tui
       @mode = :browse
       @visible = [] of Int32
       @search_query = ""
+      @search_qcx = 0
       @search_preedit = ""
       @search_origin = 0
       @feedback = nil.as(String?)
@@ -68,6 +69,7 @@ module Gori::Tui
       @mode = :browse
       @visible = (0...@rows.size).to_a
       @search_query = ""
+      @search_qcx = 0
       @search_preedit = ""
       @search_origin = @selected
       @feedback = nil
@@ -160,6 +162,8 @@ module Gori::Tui
         select_move(-1)
       elsif key.down?
         select_move(1)
+      elsif page_key(ev)
+        # PgUp/PgDn/Home/End — the list contract, `Overlay#page_key`
       elsif key.left?
         cycle_profile(-1)
       elsif key.right?
@@ -187,6 +191,7 @@ module Gori::Tui
         select_move(-1)
       elsif key.down?
         select_move(1)
+      elsif search_edit(ev)
       elsif key.backspace?
         search_backspace
       elsif c = bare_char(ev)
@@ -229,6 +234,7 @@ module Gori::Tui
       @search_origin = @selected
       @mode = :search
       @search_query = ""
+      @search_qcx = 0
       @search_preedit = ""
       @visible = (0...@rows.size).to_a
       @feedback = nil
@@ -247,6 +253,7 @@ module Gori::Tui
     private def finish_search : Nil
       @mode = :browse
       @search_query = ""
+      @search_qcx = 0
       @search_preedit = ""
       @visible = (0...@rows.size).to_a
     end
@@ -254,15 +261,36 @@ module Gori::Tui
     private def search_insert(ch : Char) : Nil
       return if ch.control?
       @search_preedit = ""
-      @search_query += ch
+      @search_query = @search_query[0, @search_qcx] + ch + @search_query[@search_qcx..]
+      @search_qcx += 1
       refilter
     end
 
     private def search_backspace : Nil
-      return if @search_query.empty?
+      return if @search_qcx == 0
       @search_preedit = ""
-      @search_query = @search_query[0, @search_query.size - 1]
+      @search_query = @search_query[0, @search_qcx - 1] + @search_query[@search_qcx..]
+      @search_qcx -= 1
       refilter
+    end
+
+    # The caret's other moves — ⌃/⌥←→ by word, Home/End, Delete, ⌥⌫ (`LineEdit`) and the
+    # bare ←/→, which the search row has no other use for (browse mode's ←/→ cycle the
+    # profile, and that is a different ladder).
+    private def search_edit(ev : Termisu::Event::Key) : Bool
+      key = ev.key
+      if act = LineEdit.action(ev)
+        @search_query, @search_qcx = LineEdit.apply(act, @search_query, @search_qcx)
+        @search_preedit = ""
+        refilter if LineEdit.mutating?(act)
+      elsif key.left?
+        @search_qcx = {@search_qcx - 1, 0}.max
+      elsif key.right?
+        @search_qcx = {@search_qcx + 1, @search_query.size}.min
+      else
+        return false
+      end
+      true
     end
 
     # Match only text the row visibly presents: its scope heading, action title and current
@@ -360,6 +388,10 @@ module Gori::Tui
     end
 
     # Click target: snap to the row, or the nearest binding when a header is hit.
+    def entry_count : Int32
+      @visible.size
+    end
+
     def set_selected(idx : Int32) : Nil
       idx = idx.clamp(0, {@rows.size - 1, 0}.max)
       return if @rows.empty?
@@ -473,7 +505,7 @@ module Gori::Tui
         # No card, but the overlay still owns the screen: clear the caret the pane underneath
         # drew, or it blinks on through the "larger window" message.
         screen.desired_cursor = nil
-        screen.text(area.x + 1, area.y, "hotkeys editor needs a larger window · esc to close", Theme.muted, Theme.bg) unless area.empty?
+        Overlay.too_small(screen, area, "hotkeys editor needs a larger window")
         return
       end
       Frame.card(screen, box, "HOTKEYS", border: Theme.border_focus)
@@ -484,6 +516,7 @@ module Gori::Tui
 
       top = box.y + 3
       cap = list_capacity(box)
+      @list_last_h = cap
       start = list_window(cap)
       if @visible.empty?
         screen.text(box.x + 3, top, "no hotkeys match", Theme.muted, Theme.panel)
@@ -516,7 +549,7 @@ module Gori::Tui
         return
       end
       px = screen.text(box.x + 2, box.y + 1, "search: ", Theme.muted, Theme.panel)
-      screen.input_line(px, box.y + 1, @search_query, @search_query.size, @search_preedit,
+      screen.input_line(px, box.y + 1, @search_query, @search_qcx, @search_preedit,
         Theme.text_bright, Theme.panel, width: {box.right - 2 - px, 1}.max)
     end
 

--- a/src/gori/tui/issue_form.cr
+++ b/src/gori/tui/issue_form.cr
@@ -274,7 +274,7 @@ module Gori::Tui
 
     def render(screen : Screen, area : Rect) : Nil
       box = overlay_box(area)
-      return unless box
+      return render_too_small(screen, area, "the issue form needs a larger window") unless box
       w = box.w
       on_title = @sel == ROW_TITLE
       on_cvss = @sel == ROW_CVSS

--- a/src/gori/tui/jobs.cr
+++ b/src/gori/tui/jobs.cr
@@ -36,7 +36,7 @@ module Gori::Tui
 
     # Per-kind gerund for the activity chip when exactly one kind is active. A Hash (not
     # a case) keeps activity_label flat; unknown kinds fall back to "jobs".
-    KIND_LABELS = {:miner => "mining", :scan => "scanning", :fuzz => "fuzzing", :discover => "discovering", :minimize => "minimizing", :sequence => "sequencing", :oast => "listening", :authorize => "authorizing", :fuzz_save => "saving results", :fuzz_load => "loading results"}
+    KIND_LABELS = {:miner => "mining", :scan => "scanning", :fuzz => "fuzzing", :discover => "discovering", :minimize => "minimizing", :sequence => "sequencing", :oast => "listening", :authorize => "authorizing", :fuzz_save => "saving results", :fuzz_load => "loading results", :import => "importing"}
 
     CAP = 50 # cap finished jobs kept (running ones are never pruned)
 

--- a/src/gori/tui/library_picker.cr
+++ b/src/gori/tui/library_picker.cr
@@ -123,7 +123,7 @@ module Gori::Tui
     end
 
     protected def refilter : Nil
-      terms = @query.downcase.split
+      terms = query.downcase.split
       @filtered = terms.empty? ? @rows : @indexed.select { |(_, hay)| terms.all? { |t| hay.includes?(t) } }.map(&.first)
       @selected = 0
       @scroll = 0
@@ -151,7 +151,7 @@ module Gori::Tui
     def render(screen : Screen, area : Rect) : Nil
       box = overlay_box(area)
       unless box
-        screen.text(area.x + 1, area.y, "picker needs a larger window · esc to close", Theme.muted, Theme.bg) unless area.empty?
+        Overlay.too_small(screen, area, "picker needs a larger window")
         return
       end
       Frame.card(screen, box, @title, border: Theme.border_focus)

--- a/src/gori/tui/link_picker.cr
+++ b/src/gori/tui/link_picker.cr
@@ -82,12 +82,6 @@ module Gori::Tui
       @filtered[i]?
     end
 
-    # What has been typed into the filter. The Runner seeds a new issue's title with it
-    # (type the title, ↵ on `+ New issue…`, and the form is already filled in).
-    def query : String
-      @query
-    end
-
     # --- Overlay contract (see overlay.cr) ---
     def key : OverlayKind
       OverlayKind::LinkPick
@@ -102,7 +96,7 @@ module Gori::Tui
     end
 
     protected def refilter : Nil
-      terms = @query.downcase.split
+      terms = query.downcase.split
       @filtered = terms.empty? ? @rows : @indexed.select { |(_, hay)| terms.all? { |t| hay.includes?(t) } }.map(&.first)
       # Keep the create rows at the top; land on the first match when any, else on
       # `+ New issue…` — a query with no hits is the create case.
@@ -134,7 +128,7 @@ module Gori::Tui
 
     def render(screen : Screen, area : Rect) : Nil
       box = overlay_box(area)
-      return unless box
+      return render_too_small(screen, area, "the link picker needs a larger window") unless box
       Frame.card(screen, box, title, border: Theme.border_focus)
       list_top = render_filter(screen, box, CARD_HINT)
       list_h = list_height(box)

--- a/src/gori/tui/links_overlay.cr
+++ b/src/gori/tui/links_overlay.cr
@@ -171,7 +171,7 @@ module Gori::Tui
     def render(screen : Screen, area : Rect) : Nil
       box = overlay_box(area)
       unless box
-        screen.text(area.x + 1, area.y, "links overlay needs a larger window · esc to close", Theme.muted, Theme.bg) unless area.empty?
+        Overlay.too_small(screen, area, "links overlay needs a larger window")
         return
       end
       Frame.card(screen, box, title, border: Theme.border_focus)

--- a/src/gori/tui/listeners_overlay.cr
+++ b/src/gori/tui/listeners_overlay.cr
@@ -98,6 +98,8 @@ module Gori::Tui
         move(-1)
       elsif k.down?
         move(1)
+      elsif page_key(ev)
+        # PgUp/PgDn/Home/End — the list contract, `Overlay#page_key`
       elsif ev.ctrl? || ev.alt?
         # A chord is not a mnemonic. Claimed and dropped rather than fallen through: this
         # overlay returns :stay for everything, so the chord was consumed either way — the
@@ -127,6 +129,10 @@ module Gori::Tui
       :stay
     end
 
+    def entry_count : Int32
+      @rows.size
+    end
+
     def move(d : Int32) : Nil
       @selected = (@selected + d).clamp(0, {@rows.size - 1, 0}.max)
     end
@@ -150,7 +156,7 @@ module Gori::Tui
     def render(screen : Screen, area : Rect) : Nil
       box = overlay_box(area)
       unless box
-        screen.text(area.x + 1, area.y, "listener list needs a larger window · esc to close", Theme.muted, Theme.bg) unless area.empty?
+        Overlay.too_small(screen, area, "listener list needs a larger window")
         return
       end
       Frame.card(screen, box, "LISTENERS", border: Theme.border_focus)
@@ -158,6 +164,7 @@ module Gori::Tui
       Frame.border_meta(screen, box, "LISTENERS", meta, bg: Theme.panel)
 
       cap = list_capacity(box)
+      @list_last_h = cap
       return if cap <= 0
       start = list_window(cap)
       if @rows.empty?

--- a/src/gori/tui/mine_config_overlay.cr
+++ b/src/gori/tui/mine_config_overlay.cr
@@ -55,7 +55,7 @@ module Gori::Tui
     end
 
     # Remember the last confirmed overlay for the next History/Repeater mine.
-    def save_prefs : Nil
+    def save_prefs : Bool
       locs = @seed.applicable.select { |l| @checked[l]? }.map(&.label)
       notify = NOTIFY_CHOICES[@notify_idx].token
       Settings.save_mine_prefs(locs, CONC_CHOICES[@conc_idx], notify, @keep_alive)
@@ -232,7 +232,7 @@ module Gori::Tui
     def render(screen : Screen, area : Rect) : Nil
       box = overlay_box(area)
       unless box
-        screen.text(area.x + 1, area.y, "config needs a larger window · esc to close", Theme.muted, Theme.bg) unless area.empty?
+        Overlay.too_small(screen, area, "config needs a larger window")
         return
       end
       Frame.card(screen, box, "MINE PARAMETERS", border: Theme.border_focus)

--- a/src/gori/tui/notifications_overlay.cr
+++ b/src/gori/tui/notifications_overlay.cr
@@ -90,24 +90,33 @@ module Gori::Tui
     end
 
     def hint : String
-      "↑/↓ select · ↵ open · c clear · esc close"
+      if flash = @flash
+        return "#{flash} · ↑/↓ select · ↵ open · esc close"
+      end
+      "↑/↓ select · ↵ open · y copy · c clear · esc close"
     end
+
+    # The copy verdict, shown in the hint until the next key: this card has no host to toast
+    # through, and the centre exists to keep the one message an operator cannot afford to
+    # lose — being unable to put it on the clipboard was the gap.
+    @flash : String? = nil
 
     # Formerly Runner#handle_notifications_key. ↵ commits (the open-site's closure jumps
     # to the selected note's result); `c` empties the store in place and stays open.
     def handle_key(ev : Termisu::Event::Key) : Symbol
       k = ev.key
       c = ev.char
+      @flash = nil
       if ev.ctrl? && k.lower_p?
         @on_palette.try(&.call)
       elsif k.escape?
         return :cancel
-      elsif k.up?
-        move(-1)
-      elsif k.down?
-        move(1)
+      elsif nav_key(ev)
+        # ↑/↓, PgUp/PgDn/Home/End
       elsif k.enter?
         return :commit
+      elsif c == 'y' && !ev.ctrl? && !ev.alt?
+        copy_selected
       elsif c == 'c' && !ev.ctrl? && !ev.alt?
         # Guarded, and not merely for tidiness. `Event::Key#char` is `@char || key.to_char`,
         # so `^C` reports 'c' — and this branch WIPES the whole store. It used to be
@@ -155,6 +164,29 @@ module Gori::Tui
       @anchor = list[@selected]?.try(&.id)
     end
 
+    # ↑/↓ and the four page keys (`Overlay#page_key`) as one arm of `handle_key`.
+    private def nav_key(ev : Termisu::Event::Key) : Bool
+      key = ev.key
+      if key.up?
+        move(-1)
+      elsif key.down?
+        move(1)
+      else
+        return page_key(ev)
+      end
+      true
+    end
+
+    private def copy_selected : Nil
+      unless note = selected_note
+        @flash = "nothing to copy"
+        return
+      end
+      text = note.message
+      written = Clipboard.copy(text)
+      @flash = "copied #{written}b#{Clipboard.note(written, text)}"
+    end
+
     def selected_note : Notifications::Note?
       list = notes
       list[index_in(list)]?
@@ -173,7 +205,7 @@ module Gori::Tui
     def render(screen : Screen, area : Rect) : Nil
       box = overlay_box(area)
       unless box
-        screen.text(area.x + 1, area.y, "notifications need a larger window · esc to close", Theme.muted, Theme.bg) unless area.empty?
+        Overlay.too_small(screen, area, "notifications need a larger window")
         return
       end
       # ONE reversed copy per frame, and one resolved cursor: `notes` allocates, draw_row
@@ -185,6 +217,7 @@ module Gori::Tui
       Frame.border_meta(screen, box, "NOTIFICATIONS", meta, bg: Theme.panel)
 
       cap = list_capacity(box)
+      @list_last_h = cap
       if list.empty?
         screen.text(box.x + 3, box.y + 2, "(no notifications yet)", Theme.muted, Theme.panel) if cap > 0
         return

--- a/src/gori/tui/oast_provider_overlay.cr
+++ b/src/gori/tui/oast_provider_overlay.cr
@@ -223,7 +223,7 @@ module Gori::Tui
     def render(screen : Screen, area : Rect) : Nil
       box = overlay_box(area)
       unless box
-        screen.text(area.x + 1, area.y, "provider form needs a larger window · esc to close", Theme.muted, Theme.bg) unless area.empty?
+        Overlay.too_small(screen, area, "provider form needs a larger window")
         return
       end
       title = editing? ? "EDIT OAST PROVIDER" : "ADD OAST PROVIDER"

--- a/src/gori/tui/oast_provider_picker.cr
+++ b/src/gori/tui/oast_provider_picker.cr
@@ -110,7 +110,7 @@ module Gori::Tui
     def render(screen : Screen, area : Rect) : Nil
       box = overlay_box(area)
       unless box
-        screen.text(area.x + 1, area.y, "picker needs a larger window · esc to close", Theme.muted, Theme.bg) unless area.empty?
+        Overlay.too_small(screen, area, "picker needs a larger window")
         return
       end
       Frame.card(screen, box, title, border: Theme.border_focus)

--- a/src/gori/tui/oast_session_picker.cr
+++ b/src/gori/tui/oast_session_picker.cr
@@ -133,7 +133,7 @@ module Gori::Tui
     def render(screen : Screen, area : Rect) : Nil
       box = overlay_box(area)
       unless box
-        screen.text(area.x + 1, area.y, "picker needs a larger window · esc to close", Theme.muted, Theme.bg) unless area.empty?
+        Overlay.too_small(screen, area, "picker needs a larger window")
         return
       end
       Frame.card(screen, box, title, border: Theme.border_focus)

--- a/src/gori/tui/overlay.cr
+++ b/src/gori/tui/overlay.cr
@@ -353,6 +353,53 @@ module Gori::Tui
     def move(step : Int32) : Nil
     end
 
+    # --- the list-card contract: PgUp/PgDn/Home/End over whatever rows a card draws --------
+    #
+    # `PickerOverlay` had this for the five pickers (#958); the nine list CARDS — notifications,
+    # agents, listeners, passthrough, tabs, columns, hosts, env, hotkeys — each hand-rolled
+    # ↑/↓ and walked a 100-entry ring one row at a time. A card takes part by answering
+    # `entry_count`, keeping `set_selected`, recording the rows its last frame drew in
+    # `@list_last_h`, and taking `page_key(ev)` as one arm of its key ladder.
+
+    @list_last_h = 0 # rows the last frame drew — the PgUp/PgDn step
+
+    # Navigable rows. Zero (the default) leaves `page_key` inert.
+    def entry_count : Int32
+      0
+    end
+
+    # Put the cursor on row `idx` (clamped). Default no-op; list cards override it.
+    def set_selected(idx : Int32) : Nil
+    end
+
+    # PgUp/PgDn/Home/End over the list, one page being the rows the last frame drew. True
+    # when `ev` was one of the four, so a key ladder can take it as one arm.
+    def page_key(ev : Termisu::Event::Key) : Bool
+      key = ev.key
+      case
+      when key.page_up?   then move(-{@list_last_h, 1}.max)
+      when key.page_down? then move({@list_last_h, 1}.max)
+      when key.home?      then set_selected(0)
+      when key.end?       then set_selected(entry_count - 1)
+      else                     return false
+      end
+      true
+    end
+
+    # The one line a card draws when `area` cannot hold it: "<what> · esc to close" (or the
+    # `closing` a card with unsaved edits prefers, e.g. "esc saves & closes"). Forty-odd cards
+    # each spelled this out; the wording stays theirs, the paint and the empty-area guard are
+    # here. Class-level so a card that is not an `Overlay` (the confirm dialog, the settings
+    # view) draws the same line.
+    def self.too_small(screen : Screen, area : Rect, what : String, closing : String = "esc to close") : Nil
+      return if area.empty?
+      screen.text(area.x + 1, area.y, "#{what} · #{closing}", Theme.muted, Theme.bg, width: {area.w - 1, 0}.max)
+    end
+
+    def render_too_small(screen : Screen, area : Rect, what : String, closing : String = "esc to close") : Nil
+      Overlay.too_small(screen, area, what, closing)
+    end
+
     # A scroll-wheel notch over the modal (already ±3-scaled). Defaults to a field move, so
     # form overlays get wheel scrolling for free by overriding `move`.
     def handle_wheel(step : Int32) : Nil

--- a/src/gori/tui/palette.cr
+++ b/src/gori/tui/palette.cr
@@ -19,6 +19,7 @@ module Gori::Tui
 
     def initialize(@registry : Verb::Registry)
       @query = ""
+      @qcx = 0 # caret into @query
       @results = [] of Verb::Definition
       @selected = 0
       @preedit = ""
@@ -27,23 +28,53 @@ module Gori::Tui
 
     def reset(ctx : Verb::ExecContext) : Nil
       @query = ""
+      @qcx = 0
       @selected = 0
       @preedit = ""
       refresh(ctx)
     end
 
     def append(ch : Char, ctx : Verb::ExecContext) : Nil
-      @query += ch
+      @query = @query[0, @qcx] + ch + @query[@qcx..]
+      @qcx += 1
       @selected = 0
       @preedit = ""
       refresh(ctx)
     end
 
     def backspace(ctx : Verb::ExecContext) : Nil
-      return if @query.empty?
-      @query = @query[0, @query.size - 1]
+      return if @qcx == 0
+      @query = @query[0, @qcx - 1] + @query[@qcx..]
+      @qcx -= 1
       @selected = 0
       refresh(ctx)
+    end
+
+    # ↑/↓ over the results, and the caret edits beyond a character at a time — ⌃/⌥←→ by
+    # word, Home/End, Delete, ⌥⌫ (`LineEdit`, the `/` bars' keymap) and the bare ←/→. True
+    # when `ev` was one of them; the list is re-scored only when the text changed, so a
+    # motion keeps the cursor row.
+    def edit(ev : Termisu::Event::Key, ctx : Verb::ExecContext) : Bool
+      key = ev.key
+      if key.up?
+        move(-1)
+      elsif key.down?
+        move(1)
+      elsif act = LineEdit.action(ev)
+        @query, @qcx = LineEdit.apply(act, @query, @qcx)
+        @preedit = ""
+        if LineEdit.mutating?(act)
+          @selected = 0
+          refresh(ctx)
+        end
+      elsif key.left?
+        @qcx = {@qcx - 1, 0}.max
+      elsif key.right?
+        @qcx = {@qcx + 1, @query.size}.min
+      else
+        return false
+      end
+      true
     end
 
     # IME composing text, drawn (underlined) at the caret without touching the
@@ -81,7 +112,7 @@ module Gori::Tui
     def render(screen : Screen, area : Rect) : Nil
       box = overlay_box(area)
       if box.empty?
-        screen.text(area.x + 1, area.y, "command palette needs a larger window · esc to close", Theme.muted, Theme.bg) unless area.empty?
+        Overlay.too_small(screen, area, "command palette needs a larger window")
         return
       end
       w = box.w
@@ -89,7 +120,7 @@ module Gori::Tui
 
       # query line (caret always at end; preedit shown underlined there)
       screen.text(box.x + 2, box.y + 1, "›", Theme.accent, Theme.panel)
-      screen.input_line(box.x + 4, box.y + 1, @query, @query.size, @preedit, Theme.text_bright, Theme.panel, width: w - 6)
+      screen.input_line(box.x + 4, box.y + 1, @query, @qcx, @preedit, Theme.text_bright, Theme.panel, width: w - 6)
 
       Frame.tee_divider(screen, box, box.y + 2)
 

--- a/src/gori/tui/passthrough_overlay.cr
+++ b/src/gori/tui/passthrough_overlay.cr
@@ -86,6 +86,8 @@ module Gori::Tui
         move(-1)
       elsif k.down?
         move(1)
+      elsif page_key(ev)
+        # PgUp/PgDn/Home/End — the list contract, `Overlay#page_key`
       elsif ev.ctrl? || ev.alt?
         # A chord is not a mnemonic. Claimed and dropped rather than fallen through: this
         # overlay returns :stay for everything, so the chord was consumed either way — the
@@ -115,6 +117,10 @@ module Gori::Tui
       :stay
     end
 
+    def entry_count : Int32
+      @hosts.size
+    end
+
     def move(d : Int32) : Nil
       @selected = (@selected + d).clamp(0, {@hosts.size - 1, 0}.max)
     end
@@ -138,7 +144,7 @@ module Gori::Tui
     def render(screen : Screen, area : Rect) : Nil
       box = overlay_box(area)
       unless box
-        screen.text(area.x + 1, area.y, "passthrough list needs a larger window · esc to close", Theme.muted, Theme.bg) unless area.empty?
+        Overlay.too_small(screen, area, "passthrough list needs a larger window")
         return
       end
       Frame.card(screen, box, "TLS PASSTHROUGH", border: Theme.border_focus)
@@ -146,6 +152,7 @@ module Gori::Tui
       Frame.border_meta(screen, box, "TLS PASSTHROUGH", meta, bg: Theme.panel)
 
       cap = list_capacity(box)
+      @list_last_h = cap
       return if cap <= 0
       start = list_window(cap)
       if @hosts.empty?

--- a/src/gori/tui/picker_overlay.cr
+++ b/src/gori/tui/picker_overlay.cr
@@ -1,4 +1,5 @@
 require "./screen"
+require "./text_field"
 require "./theme"
 require "./frame"
 require "./overlay"
@@ -30,22 +31,9 @@ module Gori::Tui
       @selected = (@selected + step).clamp(0, n - 1)
     end
 
-    @list_last_h = 0 # rows the last frame drew — the PgUp/PgDn step
-
-    # PgUp/PgDn/Home/End over the list, one page being the rows the last frame drew. Every
-    # picker walked its rows one at a time — a 500-flow FlowPicker had no other gait. True
-    # when `ev` was one of the four, so a subclass's key ladder can take it as one arm.
-    def page_key(ev : Termisu::Event::Key) : Bool
-      key = ev.key
-      case
-      when key.page_up?   then move(-{@list_last_h, 1}.max)
-      when key.page_down? then move({@list_last_h, 1}.max)
-      when key.home?      then set_selected(0)
-      when key.end?       then set_selected(entry_count - 1)
-      else                     return false
-      end
-      true
-    end
+    # PgUp/PgDn/Home/End ride `Overlay#page_key` (it was born here for the pickers — a
+    # 500-flow FlowPicker had no other gait than one row at a time — and moved up to the
+    # base once the list cards needed the same four keys).
 
     def set_selected(idx : Int32) : Nil
       n = entry_count
@@ -82,24 +70,30 @@ module Gori::Tui
     # row +1 and the divider row +2.
     LIST_OFFSET = 3
 
-    @query = ""
-    @preedit = "" # live IME composition (e.g. Hangul jamo) shown under the filter caret
+    # The filter is a `TextField` (the `RowFilter` shape), so the bar answers every key a
+    # card's field does — ⌃/⌥←→ by word, Home/End, Delete, ⌥⌫, ^Z — where it used to be
+    # append-and-trailing-backspace with no caret at all. Live IME composition rides the
+    # field's own preedit.
+    @field = TextField.new
+
+    # What has been typed into the filter.
+    def query : String
+      @field.value
+    end
 
     def set_preedit(text : String) : Nil
-      @preedit = text
+      @field.set_preedit(text)
     end
 
     def query_char(ch : Char) : Nil
       return if ch.control?
-      @preedit = "" # a committed char ends any in-progress composition
-      @query += ch
+      @field.insert(ch) # a committed char ends any in-progress composition
       refilter
     end
 
     def backspace : Nil
-      return if @query.empty?
-      @preedit = ""
-      @query = @query[0, @query.size - 1]
+      return if @field.value.empty?
+      @field.backspace
       refilter
     end
 
@@ -108,21 +102,19 @@ module Gori::Tui
     def handle_key(ev : Termisu::Event::Key) : Symbol
       key = ev.key
       case
-      when key.escape?    then return :cancel
-      when key.up?        then move(-1)
-      when key.down?      then move(1)
-      when page_key(ev)   then nil
-      when key.enter?     then return :commit
-      when key.backspace? then backspace
+      when key.escape?  then return :cancel
+      when key.up?      then move(-1)
+      when key.down?    then move(1)
+      when page_key(ev) then nil
+      when key.enter?   then return :commit
       else
-        # `Event::Key#char` falls back to `key.to_char`, so a Ctrl/Alt chord still carries
-        # its plain letter ('p' for ^P) — query_char's `ch.control?` guard never sees a C0
-        # byte to drop. Without the modifier check every chord an operator presses over an
-        # open picker (^P for the palette, ^C/^D to leave — quit_chord_claimed? yields both
-        # to a modal) would silently type into the filter instead. Same guard every other
-        # ev.char consumer in the TUI carries.
-        if (c = ev.char) && !ev.ctrl? && !ev.alt?
-          query_char(c)
+        # The field refuses a Ctrl/Alt chord itself (`TextField#handle_edit_key` — the
+        # `Event::Key#char` fallback would otherwise type 'p' for ^P into the filter), and
+        # ⇥, which a picker has no use for. Refilter only when the TEXT changed: a caret
+        # motion must not reset the cursor to the top of the list.
+        before = @field.value
+        if @field.handle_edit_key(ev) && @field.value != before
+          refilter
         end
       end
       :stay
@@ -131,13 +123,13 @@ module Gori::Tui
     # Draw the filter bar + divider and return the list's first row. `idle_hint` shows
     # while nothing has been typed, so the card explains itself before it filters.
     private def render_filter(screen : Screen, box : Rect, idle_hint : String) : Int32
-      if @query.empty? && @preedit.empty?
+      if @field.value.empty? && @field.preedit.empty?
         screen.text(box.x + 2, box.y + 1, idle_hint, Theme.muted, Theme.panel, width: box.w - 4)
       else
         # input_line shows committed text + IME preedit (underline) + a caret, and syncs
         # the terminal cursor so Hangul/CJK composition renders where the user is typing.
         px = screen.text(box.x + 2, box.y + 1, "filter: ", Theme.muted, Theme.panel)
-        screen.input_line(px, box.y + 1, @query, @query.size, @preedit, Theme.text_bright,
+        screen.input_line(px, box.y + 1, @field.value, @field.caret, @field.preedit, Theme.text_bright,
           Theme.panel, width: {box.right - 1 - px, 1}.max)
       end
       Frame.tee_divider(screen, box, box.y + 2)

--- a/src/gori/tui/probe_active_overlay.cr
+++ b/src/gori/tui/probe_active_overlay.cr
@@ -259,7 +259,7 @@ module Gori::Tui
     def render(screen : Screen, area : Rect) : Nil
       box = overlay_box(area)
       unless box
-        screen.text(area.x + 1, area.y, "window too small · esc to close", Theme.muted, Theme.bg) unless area.empty?
+        Overlay.too_small(screen, area, "window too small")
         return
       end
       Frame.card(screen, box, "RUN ACTIVE SCAN", border: Theme.border_focus)

--- a/src/gori/tui/probe_view.cr
+++ b/src/gori/tui/probe_view.cr
@@ -191,6 +191,11 @@ module Gori::Tui
       @preview_focus = :list
     end
 
+    # The issue under the cursor, or nil on an empty (or fully filtered) list.
+    def selected_issue : Store::ProbeIssue?
+      @issues[@selected]?
+    end
+
     def selected_index : Int32
       @selected
     end

--- a/src/gori/tui/rewriter_rule_overlay.cr
+++ b/src/gori/tui/rewriter_rule_overlay.cr
@@ -414,7 +414,7 @@ module Gori::Tui
     def render(screen : Screen, area : Rect) : Nil
       box = overlay_box(area)
       unless box
-        screen.text(area.x + 1, area.y, "rewriter-rule form needs a larger window · esc to close", Theme.muted, Theme.bg) unless area.empty?
+        Overlay.too_small(screen, area, "rewriter-rule form needs a larger window")
         return
       end
       title = editing? ? "EDIT REWRITER RULE" : "ADD REWRITER RULE"

--- a/src/gori/tui/rewriter_stub_overlay.cr
+++ b/src/gori/tui/rewriter_stub_overlay.cr
@@ -135,7 +135,7 @@ module Gori::Tui
         # says: esc here returns :commit (see handle_key), and this line is the only thing on
         # screen when the card cannot be drawn. Telling an operator "close" about a key that
         # keeps their unsaved response is the one place the wording has to be exact.
-        screen.text(area.x + 1, area.y, "stub editor needs a larger window · esc saves & closes", Theme.muted, Theme.bg) unless area.empty?
+        Overlay.too_small(screen, area, "stub editor needs a larger window", closing: "esc saves & closes")
         return
       end
       # bg: Theme.bg (not the card default panel) so the embedded editor, which paints on

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -5128,7 +5128,7 @@ module Gori::Tui
       when :comparer  then comparer_controller.comparer_copy
       when :intercept then intercept_controller.intercept_preview_copy
       when :oast      then oast_controller.oast_detail_copy
-      when :probe     then probe_controller.probe_detail_copy
+      when :probe     then probe_controller.probe_copy
       when :sequencer then sequencer_controller.sequencer_copy
       when :miner     then miner_controller.miner_copy
         # List-row copies (#C12): the row under the cursor — or every marked row — as text.

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -188,16 +188,19 @@ module Gori::Tui
       # ↑/↓ keep stepping in BOTH modes — that's why Tab, not an arrow, is the toggle.
       @search_open = false
       @search_buffer = ""
+      @search_cx = 0 # caret into @search_buffer (the prompts edit through `prompt_edit`)
       @search_preedit = ""
       @search_target = :none
       @search_hits = [] of Int32
       @search_idx = 0
       @search_replace = false
       @search_replace_buffer = ""
+      @search_replace_cx = 0
       # The sub-tab rename prompt (Repeater + Fuzzer + Decoder + Miner) — orthogonal to
       # @overlay (floats over the bottom status row, like ^G/^F).
       @rename_open = false
       @rename_buffer = ""
+      @rename_cx = 0
       @rename_preedit = ""
       # The target is held by VIEW identity (not a positional index): the cross-session
       # reconcile can reorder/remove repeater tabs while the prompt is open, so the
@@ -207,6 +210,7 @@ module Gori::Tui
       # space-separated tags. Held by VIEW identity for the same reconcile-race reason.
       @tag_edit_open = false
       @tag_buffer = ""
+      @tag_cx = 0
       @tag_preedit = ""
       @tag_views = [] of RepeaterView # the sub-tabs the prompt will tag (marks, else the active one)
       # Whitespace reveal (·→␍␊) toggle for the req/res views — global view pref,
@@ -2189,10 +2193,7 @@ module Gori::Tui
           close_overlay
           @toast = verb.call(self) || @toast
         end
-      elsif key.up?
-        @palette.move(-1)
-      elsif key.down?
-        @palette.move(1)
+      elsif @palette.edit(ev, self) # ↑/↓, ⌃/⌥←→, Home/End, Delete, ⌥⌫, ←/→ — before ⌫ and the printables
       elsif key.backspace?
         @palette.backspace(self)
       elsif c && !ev.ctrl? && !ev.alt?
@@ -3519,16 +3520,13 @@ module Gori::Tui
 
     private def handle_rename_key(ev : Termisu::Event::Key) : Nil
       key = ev.key
-      c = ev.char || key.to_char
       if key.escape?
         close_rename
       elsif key.enter?
         apply_rename(@rename_buffer)
         close_rename
-      elsif key.backspace?
-        @rename_buffer = @rename_buffer[0, {@rename_buffer.size - 1, 0}.max]
-      elsif c && !ev.ctrl? && !ev.alt?
-        @rename_buffer += c
+      elsif edited = prompt_edit(ev, @rename_buffer, @rename_cx)
+        @rename_buffer, @rename_cx = edited
         @rename_preedit = "" # commit any IME preedit
       end
     end
@@ -3565,6 +3563,7 @@ module Gori::Tui
       return unless view
       @rename_view = view
       @rename_buffer = view.name || ""
+      @rename_cx = @rename_buffer.size
       @rename_preedit = ""
       @rename_open = true
     end
@@ -3600,7 +3599,7 @@ module Gori::Tui
       hint = "↵ save · esc cancel · empty: auto"
       x = rect.x + prefix.size
       iw = {rect.right - x - hint.size - 2, 4}.max
-      screen.input_line(x, rect.y, @rename_buffer, @rename_buffer.size, @rename_preedit, Theme.text_bright, Theme.panel, width: iw)
+      screen.input_line(x, rect.y, @rename_buffer, @rename_cx, @rename_preedit, Theme.text_bright, Theme.panel, width: iw)
       screen.text({rect.right - hint.size - 1, x + iw}.max, rect.y, hint, Theme.muted, Theme.panel)
     end
 
@@ -3622,6 +3621,7 @@ module Gori::Tui
       targets = repeater_controller.target_views
       @tag_views = targets.empty? ? [view] : targets
       @tag_buffer = view.tags.join(" ")
+      @tag_cx = @tag_buffer.size
       @tag_preedit = ""
       @tag_edit_open = true
     end
@@ -3634,16 +3634,13 @@ module Gori::Tui
 
     private def handle_tag_edit_key(ev : Termisu::Event::Key) : Nil
       key = ev.key
-      c = ev.char || key.to_char
       if key.escape?
         close_tag_edit
       elsif key.enter?
         apply_tag_edit(@tag_buffer)
         close_tag_edit
-      elsif key.backspace?
-        @tag_buffer = @tag_buffer[0, {@tag_buffer.size - 1, 0}.max]
-      elsif c && !ev.ctrl? && !ev.alt?
-        @tag_buffer += c
+      elsif edited = prompt_edit(ev, @tag_buffer, @tag_cx)
+        @tag_buffer, @tag_cx = edited
         @tag_preedit = "" # commit any IME preedit
       end
     end
@@ -3668,7 +3665,7 @@ module Gori::Tui
       hint = "↵ save · esc cancel · #tags space-separated"
       x = rect.x + prefix.size
       iw = {rect.right - x - hint.size - 2, 4}.max
-      screen.input_line(x, rect.y, @tag_buffer, @tag_buffer.size, @tag_preedit, Theme.text_bright, Theme.panel, width: iw)
+      screen.input_line(x, rect.y, @tag_buffer, @tag_cx, @tag_preedit, Theme.text_bright, Theme.panel, width: iw)
       screen.text({rect.right - hint.size - 1, x + iw}.max, rect.y, hint, Theme.muted, Theme.panel)
     end
 
@@ -3738,7 +3735,7 @@ module Gori::Tui
       suffix = hint_with_count(replace_target? ? "↵/↑↓ step · tab replace · esc done" : "↵/↑↓ step · esc done")
       sx = {rect.right - suffix.size, x}.max
       iw = {sx - x - 1, 0}.max
-      screen.input_line(x, rect.y, @search_buffer, @search_buffer.size, @search_preedit, Theme.text_bright, Theme.panel, width: iw)
+      screen.input_line(x, rect.y, @search_buffer, @search_cx, @search_preedit, Theme.text_bright, Theme.panel, width: iw)
       screen.text(sx, rect.y, suffix, no_matches? ? Theme.yellow : Theme.muted, Theme.panel)
     end
 
@@ -3761,7 +3758,7 @@ module Gori::Tui
       # Bottom row: the focused field — input_line syncs the hardware cursor here.
       rsuffix = "↵ replace all · esc done"
       rsx = {rect.right - rsuffix.size, x}.max
-      screen.input_line(x, rect.y, @search_replace_buffer, @search_replace_buffer.size, @search_preedit, Theme.text_bright, Theme.panel, width: {rsx - x - 1, 0}.max)
+      screen.input_line(x, rect.y, @search_replace_buffer, @search_replace_cx, @search_preedit, Theme.text_bright, Theme.panel, width: {rsx - x - 1, 0}.max)
       screen.text(rsx, rect.y, rsuffix, Theme.muted, Theme.panel)
     end
 
@@ -4242,7 +4239,7 @@ module Gori::Tui
         return false
       end
       notify = ov.notify_mode
-      Settings.save_probe_active_notify(notify.token)
+      status("notify choice applied — could not save to #{Settings.path}", :error) unless Settings.save_probe_active_notify(notify.token)
       # One run per flow (already background), so each target keeps its own scope decision at
       # the Outbound chokepoint — the batch changed the count, not the gate.
       ov.details.each do |d|
@@ -4414,7 +4411,7 @@ module Gori::Tui
       # its header names the flow count, so N sessions are never a surprise (P4).
       ov.on_commit = -> {
         if ov.any_checked?
-          ov.save_prefs
+          status("mine prefs applied — could not save to #{Settings.path}", :error) unless ov.save_prefs
           miner_controller.start_session(ov.seed, ov.build_config)
           started = 1
           ov.extra_seeds.each do |s|
@@ -4494,7 +4491,7 @@ module Gori::Tui
         @toast = "enable spider or bruteforce"
         return false
       end
-      ov.save_prefs
+      status("discover prefs applied — could not save to #{Settings.path}", :error) unless ov.save_prefs
       discover_controller.start_session(ov.selected_target, ov.build_config)
       switch_tab(:target)
       target_controller.select_discover

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -676,6 +676,7 @@ module Gori::Tui
             # Debounced QL filter: fire the deferred search once typing has paused.
             dirty = true if history_controller.flush_query_reload_if_due(now)
             dirty = true if sitemap_controller.flush_query_reload_if_due(now)
+            dirty = true if sitemap_controller.drain_search
             # Tick the top-bar clock: dirty only when the displayed minute changes, so the
             # idle loop wakes once a minute to repaint rather than every second.
             if (clock = clock_minute) != last_clock

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -211,6 +211,11 @@ module Gori::Tui
       @tag_edit_open = false
       @tag_buffer = ""
       @tag_cx = 0
+      # A running import: its job id, the worker's events (drained on the tick), and the
+      # cancel flag the worker polls between chunks. See `apply_import`.
+      @import_job = nil.as(Int32?)
+      @import_cancel = false
+      @import_events = Channel(ImportEvent).new(16)
       @tag_preedit = ""
       @tag_views = [] of RepeaterView # the sub-tabs the prompt will tag (marks, else the active one)
       # Whitespace reveal (·→␍␊) toggle for the req/res views — global view pref,
@@ -677,6 +682,7 @@ module Gori::Tui
             dirty = true if history_controller.flush_query_reload_if_due(now)
             dirty = true if sitemap_controller.flush_query_reload_if_due(now)
             dirty = true if sitemap_controller.drain_search
+            dirty = true if drain_import_events
             # Tick the top-bar clock: dirty only when the displayed minute changes, so the
             # idle loop wakes once a minute to repaint rather than every second.
             if (clock = clock_minute) != last_clock
@@ -741,6 +747,7 @@ module Gori::Tui
         #
         # Wind down the statusline worker fiber so it doesn't outlive this project's Runner.
         @statusline.stop
+        @import_cancel = true
         history_controller.cancel_searches
         # Drop the per-tab window title back to a neutral "𝓰𝓸𝓻𝓲" on leave — the shared term
         # outlives this Runner (project picker + the next session reuse it), so a stale
@@ -2904,6 +2911,7 @@ module Gori::Tui
     # listed: the ones that call `@host.jobs.start` are discover / fuzzer / miner /
     # sequencer / repeater(minimize) / oast / authorize.
     private def stop_all_jobs : Nil
+      @import_cancel = true # the worker stops after its chunk; the store outlives this tick
       discover_controller.stop_all
       fuzzer_controller.stop_all
       miner_controller.stop_all
@@ -3691,17 +3699,84 @@ module Gori::Tui
       true
     end
 
+    # What the import worker reports back, drained on the tick (`drain_import_events`).
+    private record ImportProgress, job : Int32, done : Int32, total : Int32
+    private record ImportDone, job : Int32, label : String, path : String, result : Import::Result?, error : String?
+    private alias ImportEvent = ImportProgress | ImportDone
+
+    # The import runs as a background JOB — on the activity chip, with progress, and with a
+    # palette cancel — instead of on the tick, where a large file froze every key and every
+    # frame until it was done. The shape is `FuzzerController#fuzz_save_results`: the worker
+    # fiber writes to the store and sends events; the shell applies them on its own fiber.
+    #
+    # HONEST LIMIT: only the INSERT phase yields (per 2000-row chunk, and the store write
+    # itself does) and cancels. The PARSE — `File.read` + `JSON.parse` of the whole file for a
+    # HAR — is one synchronous call on a single-threaded scheduler, so a very large file still
+    # holds the frame while it is parsed; a streaming reader is the follow-up that removes it.
     private def apply_import(kind : Symbol, label : String, path : String) : Nil
-      result = Import.import_file(@session.store, kind, path, Gori::FlowSource::Surface::Tui)
+      if @import_job
+        @toast = "an import is already running — cancel it from the palette (Import: cancel) or wait"
+        return
+      end
+      job = @jobs.start(:import, "import #{label} · #{File.basename(path)}")
+      @import_job = job
+      @import_cancel = false
+      store = @session.store
+      events = @import_events
+      status("importing #{label} — parsing #{File.basename(path)}…", :busy)
+      spawn(name: "gori-import") do
+        begin
+          result = Import.import_file(store, kind, path, Gori::FlowSource::Surface::Tui,
+            cancelled: -> { @import_cancel },
+            progress: ->(done : Int32, total : Int32) { events.send(ImportProgress.new(job, done, total)) })
+          events.send(ImportDone.new(job, label, path, result, nil))
+        rescue ex
+          events.send(ImportDone.new(job, label, path, nil, ex.message || ex.class.name))
+        end
+      end
+    end
+
+    # Land the import worker's events. True when anything arrived (→ a frame).
+    private def drain_import_events : Bool
+      any = false
+      loop do
+        select
+        when ev = @import_events.receive
+          any = true
+          case ev
+          in ImportProgress
+            @jobs.progress(ev.job, ev.done, ev.total, "#{ev.done}/#{ev.total} flows")
+          in ImportDone
+            finish_import(ev)
+          end
+        else
+          break
+        end
+      end
+      any
+    end
+
+    private def finish_import(ev : ImportDone) : Nil
+      @import_job = nil
+      if error = ev.error
+        @jobs.finish(ev.job, :error, error)
+        status("import failed: #{error}", :error)
+        return
+      end
+      result = ev.result || return
       sitemap_controller.reload
-      msg = "imported #{result.count} flow#{result.count == 1 ? "" : "s"} from #{label} · #{path}"
+      count = result.count
+      msg = if @import_cancel
+              "import cancelled — #{count} flow#{count == 1 ? "" : "s"} from #{ev.label} were written before the stop"
+            else
+              "imported #{count} flow#{count == 1 ? "" : "s"} from #{ev.label} · #{ev.path}"
+            end
       msg += " (#{result.skipped} entries skipped)" if result.skipped > 0
       # The import is chunked, so a partial write is possible — say so rather than letting a
       # short count read as a successful import of a smaller file (see Import::Result).
-      result.shortfall_note.try { |note| msg += " — #{note}" }
-      @toast = msg
-    rescue ex
-      @toast = "import failed: #{ex.message}"
+      result.shortfall_note.try { |note| msg += " — #{note}" } unless @import_cancel
+      @jobs.finish(ev.job, @import_cancel ? :stopped : :done, "#{count} flows")
+      status(msg, :done)
     end
 
     # --- Export path popup (Notes → Export note, Issues → Export issues) -----
@@ -5311,6 +5386,16 @@ module Gori::Tui
 
     def import_burp : Nil
       open_import(:burp)
+    end
+
+    def import_running? : Bool
+      !@import_job.nil?
+    end
+
+    def import_cancel : Nil
+      return @toast = "no import is running" unless @import_job
+      @import_cancel = true
+      status("cancelling the import after its current chunk…", :busy)
     end
 
     def import_wsdl : Nil

--- a/src/gori/tui/runner/miner.cr
+++ b/src/gori/tui/runner/miner.cr
@@ -75,4 +75,8 @@ class Gori::Tui::Runner < Gori::Verb::ExecContext
   def miner_detail_readable? : Bool
     miner_controller.miner_detail_readable?
   end
+
+  def miner_results_readable? : Bool
+    miner_controller.miner_results_readable?
+  end
 end

--- a/src/gori/tui/runner/probe.cr
+++ b/src/gori/tui/runner/probe.cr
@@ -194,4 +194,8 @@ class Gori::Tui::Runner < Gori::Verb::ExecContext
   def probe_detail_readable? : Bool
     probe_controller.probe_detail_readable?
   end
+
+  def probe_issue_selected? : Bool
+    probe_controller.probe_issue_selected?
+  end
 end

--- a/src/gori/tui/runner/search.cr
+++ b/src/gori/tui/runner/search.cr
@@ -11,6 +11,29 @@ class Gori::Tui::Runner < Gori::Verb::ExecContext
     @tabs[@active_tab]?.try(&.goto_symbol)
   end
 
+  # One keystroke over a bottom prompt's `{text, caret}`: the answer, or nil when `ev` is not
+  # an edit — so a prompt's own arms (esc, ↵, ↑/↓ stepping) run first and this takes the rest.
+  # `LineEdit` carries the motions the `/` bars gained (⌃/⌥←→ by word, Home/End, Delete,
+  # ⌥⌫); ←/→ and ⌫ are the bare forms, and a printable lands AT the caret. The ^F, rename
+  # and tag prompts all typed append-only before this — strictly less than the bars beside
+  # them, on the most-typed prompt in the app.
+  private def prompt_edit(ev : Termisu::Event::Key, text : String, cx : Int32) : {String, Int32}?
+    key = ev.key
+    cx = cx.clamp(0, text.size)
+    if key.backspace?
+      return {text, cx} if cx == 0
+      {text[0, cx - 1] + text[cx..], cx - 1}
+    elsif act = LineEdit.action(ev) # before the bare arrows: a modified arrow is a different request
+      LineEdit.apply(act, text, cx)
+    elsif key.left?
+      {text, {cx - 1, 0}.max}
+    elsif key.right?
+      {text, {cx + 1, text.size}.min}
+    elsif (c = ev.char || key.to_char) && !c.control? && !ev.ctrl? && !ev.alt? # control? drops Tab/\n etc. (Space stays)
+      {text[0, cx] + c + text[cx..], cx + 1}
+    end
+  end
+
   # The ^G "go to line" prompt: digits only; Enter jumps the captured target, Esc
   # cancels. A modal mini-input (mirrors handle_palette_key) drawn over the status.
   private def handle_goto_key(ev : Termisu::Event::Key) : Nil
@@ -89,7 +112,6 @@ class Gori::Tui::Runner < Gori::Verb::ExecContext
   # every match (behind a confirm) instead of stepping. ↑/↓ step in both modes.
   private def handle_search_key(ev : Termisu::Event::Key) : Nil
     key = ev.key
-    c = ev.char || key.to_char
     if key.escape?
       close_search
     elsif key.tab? || key.back_tab?
@@ -100,24 +122,16 @@ class Gori::Tui::Runner < Gori::Verb::ExecContext
       search_step(1)
     elsif key.up?
       search_step(-1)
-    elsif key.backspace?
-      if @search_replace
-        @search_replace_buffer = @search_replace_buffer[0, {@search_replace_buffer.size - 1, 0}.max]
+    elsif @search_replace
+      if edited = prompt_edit(ev, @search_replace_buffer, @search_replace_cx)
+        @search_replace_buffer, @search_replace_cx = edited
         @search_preedit = ""
-      else
-        @search_buffer = @search_buffer[0, {@search_buffer.size - 1, 0}.max]
-        @search_preedit = ""
-        search_refresh
       end
-    elsif c && !c.control? && !ev.ctrl? && !ev.alt? # control? drops Tab/\n etc. (Space stays)
-      if @search_replace
-        @search_replace_buffer += c
-        @search_preedit = ""
-      else
-        @search_buffer += c
-        @search_preedit = ""
-        search_refresh
-      end
+    elsif edited = prompt_edit(ev, @search_buffer, @search_cx)
+      changed = edited[0] != @search_buffer
+      @search_buffer, @search_cx = edited
+      @search_preedit = ""
+      search_refresh if changed # a caret motion keeps the hits (and the match the operator is on)
     end
   end
 
@@ -234,11 +248,13 @@ class Gori::Tui::Runner < Gori::Verb::ExecContext
   private def open_search(target : Symbol) : Nil
     @search_target = target
     @search_buffer = ""
+    @search_cx = 0
     @search_preedit = ""
     @search_hits = [] of Int32
     @search_idx = 0
     @search_replace = false
     @search_replace_buffer = ""
+    @search_replace_cx = 0
     @search_open = true
   end
 

--- a/src/gori/tui/runner/sequencer.cr
+++ b/src/gori/tui/runner/sequencer.cr
@@ -74,4 +74,8 @@ class Gori::Tui::Runner < Gori::Verb::ExecContext
   def sequencer_analysis_readable? : Bool
     sequencer_controller.sequencer_analysis_readable?
   end
+
+  def sequencer_samples_readable? : Bool
+    sequencer_controller.sequencer_samples_readable?
+  end
 end

--- a/src/gori/tui/scope_rule_overlay.cr
+++ b/src/gori/tui/scope_rule_overlay.cr
@@ -173,7 +173,7 @@ module Gori::Tui
     def render(screen : Screen, area : Rect) : Nil
       box = overlay_box(area)
       unless box
-        screen.text(area.x + 1, area.y, "scope form needs a larger window · esc to close", Theme.muted, Theme.bg) unless area.empty?
+        Overlay.too_small(screen, area, "scope form needs a larger window")
         return
       end
       title = editing? ? "EDIT SCOPE RULE" : "ADD SCOPE RULE"

--- a/src/gori/tui/send_picker.cr
+++ b/src/gori/tui/send_picker.cr
@@ -106,7 +106,7 @@ module Gori::Tui
     def render(screen : Screen, area : Rect) : Nil
       box = overlay_box(area)
       unless box
-        screen.text(area.x + 1, area.y, "picker needs a larger window · esc to close", Theme.muted, Theme.bg) unless area.empty?
+        Overlay.too_small(screen, area, "picker needs a larger window")
         return
       end
       Frame.card(screen, box, card_title, border: Theme.border_focus)

--- a/src/gori/tui/sequence_config_overlay.cr
+++ b/src/gori/tui/sequence_config_overlay.cr
@@ -269,7 +269,7 @@ module Gori::Tui
     def render(screen : Screen, area : Rect) : Nil
       box = overlay_box(area)
       unless box
-        screen.text(area.x + 1, area.y, "config needs a larger window · esc to close", Theme.muted, Theme.bg) unless area.empty?
+        Overlay.too_small(screen, area, "config needs a larger window")
         return
       end
       Frame.card(screen, box, "SEND TO SEQUENCER", border: Theme.border_focus)

--- a/src/gori/tui/sitemap_view.cr
+++ b/src/gori/tui/sitemap_view.cr
@@ -146,10 +146,24 @@ module Gori::Tui
     # rather than the capped tree, so the number to watch is retention: at the 100k default it
     # is what is quoted here. Re-measure before assuming it still holds if that default moves.
     def reload(store : Store) : Nil
-      prev_sel = selection_anchor
-      prev_scroll = @scroll
-      prev_expand = collect_expand_state
+      plan = prepare_reload || return
+      entries, tags = fetch_reload(store, plan)
+      apply_reload(entries, tags, plan)
+    end
 
+    # The store half of a reload, as three steps, so the `/` bar can run the middle one on a
+    # worker fiber (`SitemapController#request_reload`, the History #967 shape): `prepare`
+    # compiles the query on the main fiber and answers nil when it already settled the tree
+    # (an invalid residual); `fetch` is the two reads and touches no view state; `apply`
+    # builds the tree from what came back. `reload` is the three in a row, for every caller
+    # that is not typing.
+    record ReloadPlan, positives : Array(String), negatives : Array(String), combined : QL::Filter
+
+    # Whether a worker fetch is in flight — the empty-tree note says so instead of "no
+    # endpoints match" while the previous tree stays up.
+    property? searching : Bool = false
+
+    def prepare_reload : ReloadPlan?
       # `tag:`/`-tag:` are Sitemap-local (the shared QL has no tag column): split them
       # out, hand the residual to QL.parse, and apply the tag filter to the built tree.
       positives, negatives, residual = split_tag_terms(@query)
@@ -175,10 +189,22 @@ module Gori::Tui
         @loaded = true
         return
       end
-      combined = QL.and(@scope.try(&.filter) || QL::EMPTY, residual_filter)
-      @hosts = Sitemap.build(store.sitemap_entries(combined))
-      Sitemap.stamp_tags!(@hosts, store.sitemap_tags)
-      filter_by_tags(positives, negatives)
+      ReloadPlan.new(positives, negatives, QL.and(@scope.try(&.filter) || QL::EMPTY, residual_filter))
+    end
+
+    # Reads only — safe off the main fiber. `control` lets the caller cancel a superseded read.
+    def fetch_reload(store : Store, plan : ReloadPlan,
+                     control : Store::QueryControl? = nil) : {Array({String, String, String}), Hash({String, String}, String)}
+      {store.sitemap_entries(plan.combined, control: control), store.sitemap_tags}
+    end
+
+    def apply_reload(entries : Array({String, String, String}), tags : Hash({String, String}, String), plan : ReloadPlan) : Nil
+      prev_sel = selection_anchor
+      prev_scroll = @scroll
+      prev_expand = collect_expand_state
+      @hosts = Sitemap.build(entries)
+      Sitemap.stamp_tags!(@hosts, tags)
+      filter_by_tags(plan.positives, plan.negatives)
       if @grouping
         # Opaque ids first, then numeric runs — the two passes partition the children.
         @hosts.each { |h| Sitemap.fold_templates!(h) }
@@ -970,7 +996,9 @@ module Gori::Tui
         # A recovery hint mirrors Issues/Probe. The QL-clear cue only applies to a
         # real `/` query — a Scope-lens-only empty set isn't cleared with esc//.
         msg, hint =
-          if !@query.blank?
+          if @searching
+            {"searching…", nil}
+          elsif !@query.blank?
             # An INVALID QL residual (all terms bad, or a broken regex) reads as "no
             # endpoints match" unless we say why — @query_note distinguishes it.
             {@query_note || "no endpoints match", querying? ? "esc clears the filter" : "/ to edit the filter"}

--- a/src/gori/tui/subtab_picker.cr
+++ b/src/gori/tui/subtab_picker.cr
@@ -69,7 +69,7 @@ module Gori::Tui
     # substring arm still runs, so "8080" keeps matching a port in a request line.
     # Resets the cursor to the top.
     protected def refilter : Nil
-      terms = @query.downcase.split.map { |t| {t, (m = t.match(/\A(\d+):?\z/)) ? m[1] : nil} }
+      terms = query.downcase.split.map { |t| {t, (m = t.match(/\A(\d+):?\z/)) ? m[1] : nil} }
       @filtered = terms.empty? ? @rows : @indexed.select { |(_, hay, num)| terms.all? { |(t, n)| hay.includes?(t) || n == num } }.map(&.first)
       @selected = 0
       @scroll = 0
@@ -99,7 +99,7 @@ module Gori::Tui
     def render(screen : Screen, area : Rect) : Nil
       box = overlay_box(area)
       unless box
-        screen.text(area.x + 1, area.y, "picker needs a larger window · esc to close", Theme.muted, Theme.bg) unless area.empty?
+        Overlay.too_small(screen, area, "picker needs a larger window")
         return
       end
       Frame.card(screen, box, @title, border: Theme.border_focus)

--- a/src/gori/tui/tabs_overlay.cr
+++ b/src/gori/tui/tabs_overlay.cr
@@ -22,6 +22,8 @@ module Gori::Tui
     property on_reset : Proc(Nil)?
     property on_toast : Proc(String, Nil)?
 
+    getter selected : Int32
+
     def initialize
       @items = [] of {Symbol, String, Bool}
       @selected = 0
@@ -51,10 +53,8 @@ module Gori::Tui
         return :cancel # discard the working copy
       elsif key.enter?
         return :commit
-      elsif key.up?
-        ev.shift? ? move_selected(-1) : select_move(-1)
-      elsif key.down?
-        ev.shift? ? move_selected(1) : select_move(1)
+      elsif nav_key(ev)
+        # ↑/↓ (⇧ reorders), PgUp/PgDn/Home/End
       elsif (c = ev.char) && !ev.ctrl? && !ev.alt?
         # Guarded, and not for tidiness: `Event::Key#char` is `@char || key.to_char`, so ^R
         # reports 'r' and lands on the reset arm below — the shell's pre-filter claims only
@@ -93,6 +93,20 @@ module Gori::Tui
     end
 
     # ↑/↓ and the scroll wheel share the selection move (Overlay#handle_wheel calls this).
+    # ↑/↓ move the selection (⇧ moves the ROW), and the four page keys ride the list
+    # contract (`Overlay#page_key`). One arm of `handle_key`, so that ladder stays readable.
+    private def nav_key(ev : Termisu::Event::Key) : Bool
+      key = ev.key
+      if key.up?
+        ev.shift? ? move_selected(-1) : select_move(-1)
+      elsif key.down?
+        ev.shift? ? move_selected(1) : select_move(1)
+      else
+        return page_key(ev)
+      end
+      true
+    end
+
     def move(step : Int32) : Nil
       select_move(step)
     end
@@ -114,6 +128,10 @@ module Gori::Tui
 
     def select_move(d : Int32) : Nil
       @selected = (@selected + d).clamp(0, {@items.size - 1, 0}.max)
+    end
+
+    def entry_count : Int32
+      @items.size
     end
 
     def set_selected(idx : Int32) : Nil
@@ -178,7 +196,7 @@ module Gori::Tui
       unless box
         # Too small to draw the editor — show a one-line hint so the (still input-capturing)
         # :tabs modal is never fully invisible; esc closes it.
-        screen.text(area.x + 1, area.y, "tab editor needs a larger window · esc to close", Theme.muted, Theme.bg) unless area.empty?
+        Overlay.too_small(screen, area, "tab editor needs a larger window")
         return
       end
       Frame.card(screen, box, "TAB BAR", border: Theme.border_focus)
@@ -187,6 +205,7 @@ module Gori::Tui
 
       list_top = box.y + 2
       cap = list_capacity(box)
+      @list_last_h = cap
       start = list_window(cap)
       cap.times do |row|
         i = start + row

--- a/src/gori/verb/context.cr
+++ b/src/gori/verb/context.cr
@@ -188,6 +188,9 @@ module Gori
       abstract def import_insomnia : Nil
       abstract def import_burp : Nil
       abstract def import_wsdl : Nil
+      # Whether an import job is running, and the request to stop it after its current chunk.
+      abstract def import_running? : Bool
+      abstract def import_cancel : Nil
     end
   end
 end

--- a/src/gori/verb/context/miner.cr
+++ b/src/gori/verb/context/miner.cr
@@ -14,5 +14,8 @@ abstract class Gori::Verb::ExecContext
   # The FINDING pane holds focus — the gate for its row select / copy verbs. A mined parameter's
   # fields are what go into a report, and the pane had no copy at all.
   abstract def miner_detail_readable? : Bool
+
+  # The FINDINGS list holds focus and a finding is under the cursor — the row-copy gate.
+  abstract def miner_results_readable? : Bool
   abstract def mine_filter : Nil # open the FINDINGS `/` filter bar
 end

--- a/src/gori/verb/context/probe.cr
+++ b/src/gori/verb/context/probe.cr
@@ -33,4 +33,7 @@ abstract class Gori::Verb::ExecContext
   abstract def probe_active_from_repeater : Nil # active-scan the current Repeater session's last send
   # A Probe issue's detail is open — the gate for the AFFECTED URLS list's read verbs.
   abstract def probe_detail_readable? : Bool
+
+  # The issue LIST is in front (no detail open) and an issue is under the cursor.
+  abstract def probe_issue_selected? : Bool
 end

--- a/src/gori/verb/context/sequencer.cr
+++ b/src/gori/verb/context/sequencer.cr
@@ -18,4 +18,7 @@ abstract class Gori::Verb::ExecContext
   # The ANALYSIS report holds focus — the gate for its row select / copy verbs. The report IS the
   # randomness finding, so being unable to paste it was half a tool.
   abstract def sequencer_analysis_readable? : Bool
+
+  # The SAMPLES list holds focus and a sample is under the cursor — the row-copy gate.
+  abstract def sequencer_samples_readable? : Bool
 end

--- a/src/gori/verbs/import.cr
+++ b/src/gori/verbs/import.cr
@@ -24,6 +24,12 @@ module Gori
       r.register Verb::Definition.new(
         "import.wsdl", "Import: WSDL", "Import SOAP request templates from a WSDL 1.1 service description",
         Verb::Scope::Global, category: Verb::Category::Action) { |ctx| ctx.import_wsdl; nil }
+      # Listed only while an import runs (`available:`), which is also the only time it means
+      # anything. Stops after the chunk being written; what is committed stays.
+      r.register Verb::Definition.new(
+        "import.cancel", "Import: cancel", "Stop the running import after its current chunk (the flows already written stay)",
+        Verb::Scope::Global, available: ->(ctx : Verb::ExecContext) { ctx.import_running? },
+        category: Verb::Category::Action) { |ctx| ctx.import_cancel; nil }
     end
   end
 end

--- a/src/gori/verbs/probe.cr
+++ b/src/gori/verbs/probe.cr
@@ -27,6 +27,13 @@ module Gori
         "probe.filter", "Filter issues", "Filter the list (severity:/status:/category:/host:/code:/free text)",
         Verb::Scope::Probe, [Verb::Chord.new("/")], group: :view) { |ctx| ctx.probe_query; nil }
 
+      # `y` on the LIST (#964's shape): the issue as a report line with its affected URLs
+      # under it. The detail scope's own `y` copies the selected affected URLs.
+      r.register Verb::Definition.new(
+        "probe.copy-issue", "Copy issue", "Copy the selected issue (severity, title, host) and its affected URLs",
+        Verb::Scope::Probe, [Verb::Chord.new("y")],
+        available: ->(ctx : Verb::ExecContext) { ctx.probe_issue_selected? }, mnemonic: 'y') { |ctx| ctx.read_copy; nil }
+
       # Probe-local `m` (mode cycle). Global Match & Replace is palette-only by default,
       # so this no longer needs to shadow a Global bare letter.
       r.register Verb::Definition.new(

--- a/src/gori/verbs/read_edit.cr
+++ b/src/gori/verbs/read_edit.cr
@@ -247,6 +247,9 @@ module Gori
       # `SequencerView#analysis_plain` for the projection a copy produces). `x`/`v`/`S`/`y` are all
       # free in this scope; `r`/`s`/`c` are the run/stop/configure trio.
       in_seq_analysis = ->(ctx : Verb::ExecContext) { ctx.current_tab == :sequencer && ctx.sequencer_analysis_readable? }
+      # `y` reaches the SAMPLES list too (#964's shape): the sample's token, where the report
+      # panes copy their rows.
+      in_seq_copy = ->(ctx : Verb::ExecContext) { ctx.current_tab == :sequencer && (ctx.sequencer_analysis_readable? || ctx.sequencer_samples_readable?) }
       r.register Verb::Definition.new(
         "sequence.select-line", "Select row", "Select the analysis row under the cursor",
         Verb::Scope::Sequencer, [Verb::Chord.new("x")],
@@ -260,12 +263,14 @@ module Gori
       r.register Verb::Definition.new(
         "sequence.copy", "Copy", "Copy the selected analysis rows, or the whole entropy report if nothing is selected",
         Verb::Scope::Sequencer, [Verb::Chord.new("y")],
-        available: in_seq_analysis, mnemonic: 'y') { |ctx| ctx.read_copy; nil }
+        available: in_seq_copy, mnemonic: 'y') { |ctx| ctx.read_copy; nil }
 
       # The Miner's FINDING pane. Whole ROWS (label + value in two columns — see
       # `MinerView#detail_plain`). `x`/`v`/`S`/`y` are free in this scope; `r`/`s`/`p` are run,
       # stop and send-to-repeater.
       in_miner_detail = ->(ctx : Verb::ExecContext) { ctx.current_tab == :miner && ctx.miner_detail_readable? }
+      # `y` reaches the FINDINGS list too (#964's shape): the finding as one line.
+      in_miner_copy = ->(ctx : Verb::ExecContext) { ctx.current_tab == :miner && (ctx.miner_detail_readable? || ctx.miner_results_readable?) }
       r.register Verb::Definition.new(
         "mine.select-line", "Select row", "Select the finding row under the cursor",
         Verb::Scope::Miner, [Verb::Chord.new("x")],
@@ -279,7 +284,7 @@ module Gori
       r.register Verb::Definition.new(
         "mine.copy", "Copy", "Copy the selected finding rows, or the whole finding if nothing is selected",
         Verb::Scope::Miner, [Verb::Chord.new("y")],
-        available: in_miner_detail, mnemonic: 'y') { |ctx| ctx.read_copy; nil }
+        available: in_miner_copy, mnemonic: 'y') { |ctx| ctx.read_copy; nil }
 
       in_detail_nav = ->(ctx : Verb::ExecContext) { ctx.detail_navigable? }
       r.register Verb::Definition.new(


### PR DESCRIPTION
Track C of the three-PR TUI pass (stability #975 → performance #976 → **usability**). The recent contract passes (#956 list navigation, #958 pickers, #962 `/` bars, #964 `y`, #969 double-click) each left a few panes behind; this closes those gaps and moves the two remaining synchronous operations off the tick.

## Commits

- **Authorize takes the mouse; wheel under the pointer on Colormarker and Rewriter.** Authorize was the only list-bearing tab with no click, and its wheel scrolled the detail wherever the pointer was. Rects are published by the frame that drew them (the `callback_row_at` rule).
- **PgUp/PgDn/Home/End and `y` on the list cards; one "needs a larger window" line.** `Overlay#page_key` lifted from `PickerOverlay` to the nine list cards; the notification centre can finally copy the message it was built to keep; `Overlay.too_small` replaces 41 hand-spelled lines and covers the issue form and link picker, which drew nothing when short.
- **A caret for ^F, rename, tag and the picker filters; three pref savers report a failed write.** `Runner#prompt_edit` routes the bottom prompts through `LineEdit`; `FilterPickerOverlay` holds a `TextField`; palette/Help/hotkey search gain a caret. `save_discover_prefs`/`save_mine_prefs`/`save_probe_active_notify` return `Settings.save`'s Bool and the shell toasts like its sibling savers.
- **Double-click on Miner, Sequencer and OAST rows; `y` on the Probe, Sequencer and Miner lists.** Three new ExecContext predicates gate the list copies; `probe.copy-issue` is a new list-scope verb (the detail scope's `y` copies URLs).
- **Sitemap `/` reads on a worker fiber.** `SitemapView#reload` split into prepare/fetch/apply; the controller runs the fetch with a `Store::QueryControl` (the History #967 shape) with generations so a superseded read is dropped; `Store#sitemap_entries` takes the control and re-raises a cancellation past its degrade-to-empty rescue.
- **File import as a background job.** On the activity chip with a per-chunk count, `Import: cancel` in the palette while it runs, stop on leave/quit. **Honest limit:** only the insert phase yields and cancels; the parse (`File.read` + `JSON.parse`) is one synchronous call on a single-threaded scheduler, so a very large file still holds the frame while parsed. A streaming reader is the follow-up.

## Reviewed and left alone

- Overlay hint literals → keymap tokens: the overlays dispatch letters literally (`key.lower_a?`), so a token would lie after a rebind.
- OAST `handle_wheel_at`: its panes are mode-exclusive. Comparer/Help double-click: no ↵ on diff rows, Help takes no click.
- The three small `*_export_to` synchronous writes.

## Verification

- `just test-tui`: 3967 examples, 0 failures; `just test-changed main`: 12954 examples, 0 failures; `just test-store`, `just test-mcp`, `just test-verb`, `just test-import` green
- `just lint-gate main`: no changed file gained findings
- `crystal tool format --check src spec bench scripts` clean
