### PR TITLE
feat(import): read a HAR as a stream, so a large file no longer holds the frame while it is parsed

### DIFF
--- a/spec/import/chunking_spec.cr
+++ b/spec/import/chunking_spec.cr
@@ -76,9 +76,9 @@ describe "Import.insert_all cancel + progress" do
   it "reports the running count after every chunk" do
     chunk_store do |store|
       n = Gori::Import::IMPORT_CHUNK + 3
-      seen = [] of {Int32, Int32}
+      seen = [] of {Int32, Int32?}
       Gori::Import.insert_all(store, (0...n).map { |i| pair(i) },
-        progress: ->(done : Int32, total : Int32) { seen << {done, total} })
+        progress: ->(done : Int32, total : Int32?) { seen << {done, total} })
       seen.should eq([{Gori::Import::IMPORT_CHUNK, n}, {n, n}])
     end
   end
@@ -90,7 +90,7 @@ describe "Import.insert_all cancel + progress" do
       cancelled = false
       committed, attempted = Gori::Import.insert_all(store, (0...n).map { |i| pair(i) },
         cancelled: -> { cancelled },
-        progress: ->(_done : Int32, _total : Int32) { chunks += 1; cancelled = chunks >= 1 })
+        progress: ->(_done : Int32, _total : Int32?) { chunks += 1; cancelled = chunks >= 1 })
       committed.should eq(Gori::Import::IMPORT_CHUNK) # one chunk landed, the flag stopped the second
       attempted.should eq(n)
       store.count.should eq(Gori::Import::IMPORT_CHUNK.to_i64)

--- a/spec/import/har_stream_spec.cr
+++ b/spec/import/har_stream_spec.cr
@@ -1,0 +1,150 @@
+require "../spec_helper"
+
+# `Har.each_flow` walks a HAR's entries off the file one at a time (`JSON::PullParser`), so a
+# browser-session HAR of hundreds of MB is never in memory as one tree and a TUI import
+# keeps drawing while it runs. `parse_file` is the same walk plus an array, so what these pin
+# is the walk: the shape errors the whole-file parse raised, found where the pull parser
+# meets them; keys around `entries` skipped; a stop where the caller asks for one; and the
+# streamed `import_file`, which writes a chunk at a time and says so when the file breaks
+# after entries it already wrote.
+private def har_entry(i : Int32) : String
+  %({"startedDateTime":"2026-06-01T12:00:00.000Z","time":1,"request":{"method":"GET","url":"https://s.test/p/#{i}","httpVersion":"HTTP/1.1","headers":[]},"response":{"status":200,"statusText":"OK","httpVersion":"HTTP/1.1","headers":[],"content":{"mimeType":"text/plain","text":"ok"}}})
+end
+
+private def with_har(body : String, &)
+  path = File.tempname("gori-har-stream", ".har")
+  File.write(path, body)
+  begin
+    yield path
+  ensure
+    File.delete?(path)
+  end
+end
+
+private def stream_store(&)
+  path = File.tempname("gori-har-stream", ".db")
+  store = Gori::Store.open(path)
+  begin
+    yield store
+  ensure
+    store.close
+    File.delete?(path)
+    File.delete?("#{path}-wal")
+    File.delete?("#{path}-shm")
+  end
+end
+
+describe "Import::Har.each_flow" do
+  it "yields every entry in order, skipping the keys around `entries` and counting malformed ones" do
+    body = %({"log":{"version":"1.2","creator":{"name":"x","version":"1"},"pages":[{"id":"p"}],"entries":[#{har_entry(1)},{"request":{"method":"GET","url":""}},#{har_entry(2)}],"comment":"tail"},"extra":[1,2,{"a":null}]})
+    with_har(body) do |path|
+      seen = [] of String
+      skipped = Gori::Import::Har.each_flow(path) { |pair| seen << pair.request.target }
+      seen.should eq(["/p/1", "/p/2"])
+      skipped.should eq(1)
+      whole = Gori::Import::Har.parse_file(path)
+      whole.flows.map(&.request.target).should eq(seen)
+      whole.skipped.should eq(1)
+    end
+  end
+
+  it "raises the same shape errors the whole-file parse did, where it meets them" do
+    with_har("[1, 2]") do |path|
+      expect_raises(Gori::Error, /not a JSON object/) { Gori::Import::Har.each_flow(path) { } }
+    end
+    with_har(%({"version": "1.2"})) do |path|
+      expect_raises(Gori::Error, /missing log object/) { Gori::Import::Har.each_flow(path) { } }
+    end
+    with_har(%({"log": []})) do |path|
+      expect_raises(Gori::Error, /missing log object/) { Gori::Import::Har.each_flow(path) { } }
+    end
+    with_har(%({"log": {"version": "1.2"}})) do |path|
+      expect_raises(Gori::Error, /has no entries/) { Gori::Import::Har.each_flow(path) { } }
+    end
+    with_har(%({"log": {"entries": {}}})) do |path|
+      expect_raises(Gori::Error, /has no entries/) { Gori::Import::Har.each_flow(path) { } }
+    end
+    with_har("not json {{{") do |path|
+      expect_raises(Gori::Error, /not valid JSON/) { Gori::Import::Har.each_flow(path) { } }
+    end
+  end
+
+  it "stops where the caller cancels, without reading the rest of the file" do
+    body = %({"log":{"entries":[#{har_entry(1)},#{har_entry(2)},#{har_entry(3)}]}})
+    with_har(body) do |path|
+      seen = 0
+      stop = false
+      Gori::Import::Har.each_flow(path, cancelled: -> { stop }) do |_pair|
+        seen += 1
+        stop = true
+      end
+      seen.should eq(1)
+    end
+  end
+end
+
+describe "Import.import_file streams a HAR" do
+  it "writes a chunk at a time and reports a running count with no total" do
+    n = Gori::Import::IMPORT_CHUNK + 5
+    body = String.build do |io|
+      io << %({"log":{"entries":[)
+      n.times { |i| io << "," if i > 0; io << har_entry(i) }
+      io << "]}}"
+    end
+    with_har(body) do |path|
+      stream_store do |store|
+        seen = [] of {Int32, Int32?}
+        result = Gori::Import.import_file(store, :har, path,
+          progress: ->(done : Int32, total : Int32?) { seen << {done, total} })
+        result.count.should eq(n)
+        result.attempted.should eq(n)
+        result.short?.should be_false
+        seen.should eq([{Gori::Import::IMPORT_CHUNK, nil}, {n, nil}])
+        store.count.should eq(n.to_i64)
+      end
+    end
+  end
+
+  it "names the flows it wrote when the file turns out to be invalid JSON after them" do
+    n = Gori::Import::IMPORT_CHUNK + 1
+    body = String.build do |io|
+      io << %({"log":{"entries":[)
+      n.times { |i| io << "," if i > 0; io << har_entry(i) }
+      io << %(, {"request": {"method": "GET" "url": "broken"}}]}}) # a missing comma
+    end
+    with_har(body) do |path|
+      stream_store do |store|
+        ex = expect_raises(Gori::Error, /not valid JSON/) { Gori::Import.import_file(store, :har, path) }
+        ex.message.not_nil!.should contain("#{Gori::Import::IMPORT_CHUNK} flows from the entries before it were written")
+        store.count.should eq(Gori::Import::IMPORT_CHUNK.to_i64)
+      end
+    end
+  end
+
+  it "stops after the chunk in flight once cancelled, and reports a short import" do
+    n = Gori::Import::IMPORT_CHUNK * 2 + 1
+    body = String.build do |io|
+      io << %({"log":{"entries":[)
+      n.times { |i| io << "," if i > 0; io << har_entry(i) }
+      io << "]}}"
+    end
+    with_har(body) do |path|
+      stream_store do |store|
+        stop = false
+        result = Gori::Import.import_file(store, :har, path,
+          cancelled: -> { stop },
+          progress: ->(_done : Int32, _total : Int32?) { stop = true })
+        result.count.should eq(Gori::Import::IMPORT_CHUNK)
+        store.count.should eq(Gori::Import::IMPORT_CHUNK.to_i64)
+      end
+    end
+  end
+
+  it "still reports an all-malformed file with its count" do
+    with_har(%({"log":{"entries":[{"request":{"method":"GET","url":""}},{"request":{"method":"GET","url":""}}]}})) do |path|
+      stream_store do |store|
+        expect_raises(Gori::Error, /all 2 entries were skipped as malformed/) { Gori::Import.import_file(store, :har, path) }
+      end
+    end
+  end
+end

--- a/src/gori/import.cr
+++ b/src/gori/import.cr
@@ -129,27 +129,83 @@ module Gori
     # optional, and neither changes the count that comes back: a cancelled import is a
     # short one, and the caller says so.
     def self.insert_all(store : Store, pairs : Array(Builder::FlowPair), *,
-                        cancelled : (-> Bool)? = nil, progress : (Int32, Int32 ->)? = nil) : {Int32, Int32}
+                        cancelled : (-> Bool)? = nil, progress : (Int32, Int32? ->)? = nil) : {Int32, Int32}
       committed = 0
       pairs.each_slice(IMPORT_CHUNK) do |slice|
         break if cancelled.try(&.call)
-        # `_ids`, not the counting form: a flow's WebSocket transcript is stored against the
-        # flow id, which does not exist until this write commits.
-        ids = store.insert_import_batch_ids(slice.map { |pair| {pair.request, pair.response} })
-        committed += ids.size
-        # Ids come back in PAIR ORDER, which is what makes the index the pairing. A short
-        # answer is a rolled-back batch, and walking the ids we actually got is then exactly
-        # right: the pairs past the end have no flow to hang messages on.
-        ids.each_with_index do |id, i|
-          msgs = slice[i].ws_messages
-          store.insert_ws_messages(id, msgs) unless msgs.empty?
-        end
+        landed = insert_chunk(store, slice)
+        committed += landed
         progress.try(&.call(committed, pairs.size))
         # A short answer means the batch rolled back or the store is closing; stop rather than
         # push more work at a store that just refused some.
-        break if ids.size < slice.size
+        break if landed < slice.size
       end
       {committed, pairs.size}
+    end
+
+    # One chunk, one transaction: the flows, then each flow's WebSocket transcript against the
+    # id it just got. Returns how many of `slice` committed.
+    def self.insert_chunk(store : Store, slice : Array(Builder::FlowPair)) : Int32
+      # `_ids`, not the counting form: a flow's WebSocket transcript is stored against the
+      # flow id, which does not exist until this write commits.
+      ids = store.insert_import_batch_ids(slice.map { |pair| {pair.request, pair.response} })
+      # Ids come back in PAIR ORDER, which is what makes the index the pairing. A short
+      # answer is a rolled-back batch, and walking the ids we actually got is then exactly
+      # right: the pairs past the end have no flow to hang messages on.
+      ids.each_with_index do |id, i|
+        msgs = slice[i].ws_messages
+        store.insert_ws_messages(id, msgs) unless msgs.empty?
+      end
+      ids.size
+    end
+
+    # A HAR is imported as it is READ: `Har.each_flow` walks the entries off the file one at a
+    # time and this writes them a chunk at a time, so neither the parsed tree nor the flow
+    # pairs of a 200 MB file are ever all in memory, and the fiber yields on the way (the
+    # walk paces itself; the store write does). The other formats are small by nature and
+    # keep the parse-then-insert shape.
+    #
+    # `progress` gets a nil total — a stream does not know its length. A file that turns out
+    # to be invalid JSON PAST some entries has already had those written; the error says so,
+    # because "not valid JSON" alone reads as "nothing happened".
+    private def self.import_har_stream(store : Store, path : String, prov : Provenance,
+                                       cancelled : (-> Bool)?, progress : (Int32, Int32? ->)?) : Result
+      committed = 0
+      attempted = 0
+      chunk = [] of Builder::FlowPair
+      refused = false
+      flush = -> {
+        return if chunk.empty? || refused
+        attempted += chunk.size
+        landed = insert_chunk(store, chunk)
+        committed += landed
+        refused = landed < chunk.size # the store rolled back / is closing: stop pushing
+        chunk.clear
+        progress.try(&.call(committed, nil))
+      }
+      skipped = begin
+        Har.each_flow(path, prov, cancelled: -> { refused || (cancelled.try(&.call) || false) }) do |pair|
+          chunk << pair
+          flush.call if chunk.size >= IMPORT_CHUNK
+        end
+      rescue ex : Gori::Error
+        raise ex if committed == 0
+        raise Gori::Error.new("#{ex.message} — #{committed} flows from the entries before it were written")
+      end
+      flush.call
+      raise_nothing_landed(path, skipped) if attempted == 0 && !cancelled.try(&.call)
+      Result.new(committed, skipped, attempted)
+    end
+
+    # Preserve WHY nothing landed: if every entry was skipped as malformed, say so (with the
+    # count) instead of the generic "no flows found", which hid the real reason and threw
+    # away the skipped tally.
+    private def self.raise_nothing_landed(path : String, skipped : Int32) : NoReturn
+      if skipped > 0
+        noun = skipped == 1 ? "entry was" : "entries were"
+        raise Gori::Error.new("no flows imported from #{path} — all #{skipped} #{noun} skipped as malformed")
+      end
+      raise Gori::Error.new("no flows found in #{path}")
     end
 
     # `surface` is which of gori's three faces asked for this import. Every imported flow is
@@ -157,12 +213,19 @@ module Gori
     # it came out of — the provenance question an operator actually asks of an imported row.
     def self.import_file(store : Store, kind : Symbol, path : String,
                          surface : FlowSource::Surface? = nil, *,
-                         cancelled : (-> Bool)? = nil, progress : (Int32, Int32 ->)? = nil) : Result
+                         cancelled : (-> Bool)? = nil, progress : (Int32, Int32? ->)? = nil) : Result
       expanded = Path[path].expand(home: true).to_s
       raise Gori::Error.new("file not found: #{expanded}") unless File.exists?(expanded)
       raise Gori::Error.new("not a file: #{expanded}") unless File.file?(expanded)
       prov = Provenance.new(surface, File.basename(expanded))
 
+      if kind == :har
+        begin
+          return import_har_stream(store, expanded, prov, cancelled, progress)
+        rescue ex : File::Error
+          raise Gori::Error.new("cannot read #{expanded}: #{ex.message}")
+        end
+      end
       parsed = begin
         case kind
         when :har      then from_har(expanded, prov)
@@ -177,16 +240,7 @@ module Gori
       rescue ex : File::Error
         raise Gori::Error.new("cannot read #{expanded}: #{ex.message}")
       end
-      if parsed.flows.empty?
-        # Preserve WHY nothing landed: if every entry was skipped as malformed, say so
-        # (with the count) instead of the generic "no flows found", which hid the real
-        # reason and threw away the skipped tally.
-        if parsed.skipped > 0
-          noun = parsed.skipped == 1 ? "entry was" : "entries were"
-          raise Gori::Error.new("no flows imported from #{expanded} — all #{parsed.skipped} #{noun} skipped as malformed")
-        end
-        raise Gori::Error.new("no flows found in #{expanded}")
-      end
+      raise_nothing_landed(expanded, parsed.skipped) if parsed.flows.empty?
       committed, attempted = insert_all(store, parsed.flows, cancelled: cancelled, progress: progress)
       Result.new(committed, parsed.skipped, attempted)
     end

--- a/src/gori/import/har.cr
+++ b/src/gori/import/har.cr
@@ -8,45 +8,122 @@ require "../proxy/h2/head_codec" # PROTOCOL_MARKER — the `:protocol` line Expo
 module Gori
   module Import
     module Har
+      # The whole file as one `ParseResult` — the CLI, MCP and the specs read it this way.
+      # Built on `each_flow`, so there is one parser; what this adds is the array.
+      #
+      # No raise on an empty result, deliberately. `Import.import_file` owns that message and
+      # says WHY nothing landed — "all N entries were skipped as malformed" — which is the
+      # whole reason `ParseResult` carries a tally. Raising here first made that branch dead
+      # for HAR, the format it matters most for: an operator with a 4000-entry file got "no
+      # valid HAR entries in <path>" and no count, while the same all-malformed OpenAPI spec
+      # got the tally. Every other parser already returns and lets `import_file` speak.
       def self.parse_file(path : String, prov : Provenance = Provenance.none) : ParseResult
-        raw = File.read(path)
-        doc = begin
-          JSON.parse(raw)
-        rescue ex : JSON::ParseException
-          raise Gori::Error.new("HAR file is not valid JSON: #{ex.message}")
-        end
-        # A valid-JSON-but-wrong-shape file (a top-level array, a scalar, a `log` that
-        # isn't an object) must yield a clean Gori::Error, not the raw Exception that
-        # JSON::Any#[](String) throws on a non-Hash — cmd_import only rescues Gori::Error.
-        doc_h = doc.as_h? || raise Gori::Error.new("HAR file is not a JSON object")
-        log = doc_h["log"]?.try(&.as_h?)
-        raise Gori::Error.new("HAR file missing log object") unless log
-        entries = log["entries"]?.try(&.as_a?)
-        raise Gori::Error.new("HAR file has no entries") unless entries
         flows = [] of Builder::FlowPair
+        skipped = each_flow(path, prov) { |flow| flows << flow }
+        ParseResult.new(flows, skipped)
+      end
+
+      # How long the walk runs before it hands the fiber back. A HAR is the one import that
+      # gets big (a browser session is hundreds of MB), and `File.read` + `JSON.parse` of the
+      # whole thing was one synchronous call: the TUI froze for as long as it took. Same slice
+      # `Store::QueryControl` uses for a cooperative read.
+      PACE_SLICE = 4.milliseconds
+
+      # Walk the file's entries ONE AT A TIME — `JSON::PullParser` over the open file, each
+      # entry materialised as its own `JSON::Any` and handed to the same `entry_to_flow` the
+      # whole-file parse always used — so a 200 MB HAR is never in memory as one tree, and the
+      # fiber yields every `PACE_SLICE` so a render loop keeps drawing while it runs. Yields
+      # each flow; returns the number of entries SKIPPED as malformed (a bad body encoding, a
+      # bad date, an unexpected shape — one entry must never abort the file).
+      #
+      # `cancelled` is polled per entry: true stops the walk where it is (the rest of the file
+      # is not read), which is the palette cancel of a running TUI import.
+      #
+      # The shape errors (`not a JSON object`, `missing log object`, `has no entries`) are the
+      # same `Gori::Error`s the whole-file parse raised, found where the pull parser meets
+      # them. INVALID JSON is found where it lies, too — which for a file that breaks after
+      # its 3000th entry is AFTER those entries were yielded; `Import.import_file` says so.
+      # The walk's way out on a cancel. It leaves the parser mid-array by design (nothing past
+      # the stop is read), so the loops above it must not resume — they unwind on this.
+      private class Stopped < Exception
+        getter skipped : Int32
+
+        def initialize(@skipped : Int32)
+          super("HAR walk stopped")
+        end
+      end
+
+      def self.each_flow(path : String, prov : Provenance = Provenance.none,
+                         cancelled : (-> Bool)? = nil, &block : Builder::FlowPair ->) : Int32
+        File.open(path) do |file|
+          pull = JSON::PullParser.new(file)
+          raise Gori::Error.new("HAR file is not a JSON object") unless pull.kind.begin_object?
+          pull.read_begin_object
+          skipped = nil.as(Int32?)
+          while !pull.kind.end_object?
+            if pull.read_object_key == "log"
+              skipped = walk_log(pull, prov, cancelled, block)
+            else
+              pull.skip
+            end
+          end
+          pull.read_end_object
+          skipped || raise Gori::Error.new("HAR file missing log object")
+        end
+      rescue ex : Stopped
+        ex.skipped
+      rescue ex : JSON::ParseException
+        raise Gori::Error.new("HAR file is not valid JSON: #{ex.message}")
+      end
+
+      # The `log` object: its `entries` array is walked, everything else (version, creator,
+      # pages, comment) skipped without being built. Returns the skipped-entry count.
+      private def self.walk_log(pull : JSON::PullParser, prov : Provenance,
+                                cancelled : (-> Bool)?, block : Builder::FlowPair ->) : Int32
+        raise Gori::Error.new("HAR file missing log object") unless pull.kind.begin_object?
+        pull.read_begin_object
+        skipped = nil.as(Int32?)
+        while !pull.kind.end_object?
+          if pull.read_object_key == "entries"
+            skipped = walk_entries(pull, prov, cancelled, block)
+          else
+            pull.skip
+          end
+        end
+        pull.read_end_object
+        skipped || raise Gori::Error.new("HAR file has no entries")
+      end
+
+      # The `entries` array, one entry at a time. A cancel unwinds through `Stopped` with the
+      # parser still inside the array: the caller is stopping, and nothing past it is read.
+      private def self.walk_entries(pull : JSON::PullParser, prov : Provenance,
+                                    cancelled : (-> Bool)?, block : Builder::FlowPair ->) : Int32
+        raise Gori::Error.new("HAR file has no entries") unless pull.kind.begin_array?
+        pull.read_begin_array
         skipped = 0
-        entries.each do |e|
-          # A single malformed entry (invalid base64 body, bad date, unexpected JSON
-          # shape) must SKIP, not abort the whole import — entry_to_flow can raise
-          # (Base64::Error, type casts), which previously discarded every valid entry.
+        last_pause = Time.instant
+        while !pull.kind.end_array?
+          raise Stopped.new(skipped) if cancelled.try(&.call)
+          # The entry as its own tree, straight off the parser. OUTSIDE the rescue below on
+          # purpose: a JSON error here is the FILE being malformed, and swallowing it as one
+          # skipped entry would leave the parser where it stopped and this loop spinning on it.
+          entry = JSON::Any.new(pull)
+          # A single malformed entry (invalid base64 body, bad date, unexpected JSON shape)
+          # must SKIP, not abort the whole import — entry_to_flow can raise (Base64::Error,
+          # type casts), which previously discarded every valid entry.
           flow = begin
-            entry_to_flow(e, prov)
+            entry_to_flow(entry, prov)
           rescue
             nil
           end
-          if flow
-            flows << flow
-          else
-            skipped += 1
+          flow ? block.call(flow) : (skipped += 1)
+          if Time.instant - last_pause >= PACE_SLICE
+            Fiber.yield
+            last_pause = Time.instant
           end
         end
-        # No raise on an empty result, deliberately. `Import.import_file` owns that message and
-        # says WHY nothing landed — "all N entries were skipped as malformed" — which is the
-        # whole reason `ParseResult` carries a tally. Raising here first made that branch dead
-        # for HAR, the format it matters most for: an operator with a 4000-entry file got "no
-        # valid HAR entries in <path>" and no count, while the same all-malformed OpenAPI spec
-        # got the tally. Every other parser already returns and lets `import_file` speak.
-        ParseResult.new(flows, skipped)
+        pull.read_end_array
+        skipped
       end
 
       private def self.entry_to_flow(entry : JSON::Any, prov : Provenance) : Builder::FlowPair?

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -3700,7 +3700,7 @@ module Gori::Tui
     end
 
     # What the import worker reports back, drained on the tick (`drain_import_events`).
-    private record ImportProgress, job : Int32, done : Int32, total : Int32
+    private record ImportProgress, job : Int32, done : Int32, total : Int32?
     private record ImportDone, job : Int32, label : String, path : String, result : Import::Result?, error : String?
     private alias ImportEvent = ImportProgress | ImportDone
 
@@ -3709,10 +3709,10 @@ module Gori::Tui
     # frame until it was done. The shape is `FuzzerController#fuzz_save_results`: the worker
     # fiber writes to the store and sends events; the shell applies them on its own fiber.
     #
-    # HONEST LIMIT: only the INSERT phase yields (per 2000-row chunk, and the store write
-    # itself does) and cancels. The PARSE — `File.read` + `JSON.parse` of the whole file for a
-    # HAR — is one synchronous call on a single-threaded scheduler, so a very large file still
-    # holds the frame while it is parsed; a streaming reader is the follow-up that removes it.
+    # A HAR — the one import that gets big — is read and written as a stream (`Har.each_flow`
+    # paces itself, and `Import.import_har_stream` writes a chunk at a time), so the frame keeps
+    # drawing for the whole of it and the count on the chip is live. The other formats are
+    # small by nature and still parse in one call before their chunks go in.
     private def apply_import(kind : Symbol, label : String, path : String) : Nil
       if @import_job
         @toast = "an import is already running — cancel it from the palette (Import: cancel) or wait"
@@ -3723,12 +3723,12 @@ module Gori::Tui
       @import_cancel = false
       store = @session.store
       events = @import_events
-      status("importing #{label} — parsing #{File.basename(path)}…", :busy)
+      status("importing #{label} — #{File.basename(path)}…", :busy)
       spawn(name: "gori-import") do
         begin
           result = Import.import_file(store, kind, path, Gori::FlowSource::Surface::Tui,
             cancelled: -> { @import_cancel },
-            progress: ->(done : Int32, total : Int32) { events.send(ImportProgress.new(job, done, total)) })
+            progress: ->(done : Int32, total : Int32?) { events.send(ImportProgress.new(job, done, total)) })
           events.send(ImportDone.new(job, label, path, result, nil))
         rescue ex
           events.send(ImportDone.new(job, label, path, nil, ex.message || ex.class.name))
@@ -3745,7 +3745,7 @@ module Gori::Tui
           any = true
           case ev
           in ImportProgress
-            @jobs.progress(ev.job, ev.done, ev.total, "#{ev.done}/#{ev.total} flows")
+            @jobs.progress(ev.job, ev.done, ev.total, Runner.import_progress_note(ev.done, ev.total))
           in ImportDone
             finish_import(ev)
           end
@@ -3754,6 +3754,11 @@ module Gori::Tui
         end
       end
       any
+    end
+
+    # The activity note: "1200/5000 flows" when the total is known, "1200 flows" for a stream.
+    def self.import_progress_note(done : Int32, total : Int32?) : String
+      total ? "#{done}/#{total} flows" : "#{done} flows"
     end
 
     private def finish_import(ev : ImportDone) : Nil


### PR DESCRIPTION
Follow-up to #977, which ran a file import as a background job but named an honest limit: the parse was still `File.read` + `JSON.parse` of the whole file, one synchronous call, so a browser-session HAR of hundreds of MB froze the TUI for as long as it took to parse. This removes that limit for HAR, the one import that gets big.

## What changed

- **`Har.each_flow`** walks the entries off the open file one at a time with `JSON::PullParser`. Each entry is built as its own `JSON::Any` and handed to the same `entry_to_flow` as before; `version`/`creator`/`pages` are skipped without being built; the walk yields the fiber every 4 ms (the `QueryControl` slice). `parse_file` is the same walk plus an array — one parser, CLI/MCP/specs unchanged. A cancel unwinds the walk where it is.
- **`Import.import_file` streams a HAR**: `import_har_stream` writes a chunk (2000) at a time as entries arrive, so neither the parsed tree nor the flow pairs are ever all in memory. Progress carries no total (a stream has none); the TUI's activity note reads "N flows".
- **Honest on a broken file**: invalid JSON found past entries that were already written raises "not valid JSON … — 2000 flows from the entries before it were written" instead of reading as "nothing happened". The shape errors (`not a JSON object`, `missing log object`, `has no entries`) are unchanged.
- Other formats are small by nature and keep parse-then-insert.

## Numbers (release build, 50k entries / 17 MB)

| | ms |
|---|---|
| `JSON.parse` of the whole file (tree only, no flows built) | 114 |
| `Har.each_flow` (entries walked, flows built, fiber yielding) | 293 |

The walk is not faster than the tree parse — it builds the flows and yields — but it never holds the frame, and the memory high-water mark is one entry plus one chunk instead of the whole file twice.

## Verification

- `just test-import`: 212 examples (new `spec/import/har_stream_spec.cr` pins the walk, the shape errors, cancel, the streamed import, and the written-before-the-break message)
- `just test-changed origin/main`: 216; `just test-tui`: 3982 — all green
- `just lint-gate origin/main` clean; `crystal tool format --check` clean
