### PR TITLE
chore(deps): cvss.cr 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - MCP: `gori mcp --install-pi` configures Pi in `~/.pi/agent/mcp.json`, honoring `PI_CODING_AGENT_DIR`; requires a Pi MCP adapter (#992)
 - Docs: an accuracy pass over the English and Korean guides — corrected keys (deleting marked flows, Sitemap tagging), the rule host-scope and colour-rule condition semantics, per-field `Alt-Svc` stripping, undocumented `gori run` flags and MCP tool gating, and restored dropped Korean paragraphs.
 - TUI/CLI/MCP: every place gori names the scope-lens key now says `s` — the two `--in-scope` help lines, the History and Probe empty-state hints, the colour-rule advice note and the MCP scope arguments still named `⇧S`, the twin key removed when the lens became the Global `s` (#959)
+- Issues: CVSS v2.0 vectors written in the parenthesised form NVD's v2 calculator renders — `(AV:N/AC:L/Au:N/C:P/I:P/A:P)` — are accepted and scored instead of refused (cvss.cr 0.3.0, #994)
 
 ## v0.5.0
 

--- a/nix/shards.nix
+++ b/nix/shards.nix
@@ -6,8 +6,8 @@
   };
   "cvss" = {
     url = "https://github.com/hahwul/cvss.cr.git";
-    rev = "v0.2.0";
-    sha256 = "16fm9c7l0g3jgk9r8kjcaw5c197w36d0irl6iixmqpaavnqjsgvk";
+    rev = "v0.3.0";
+    sha256 = "016aky70cspqavviq38haxjkfy4p4yxa68m8k3070ml42p57s561";
   };
   "db" = {
     url = "https://github.com/crystal-lang/crystal-db.git";

--- a/shard.lock
+++ b/shard.lock
@@ -6,7 +6,7 @@ shards:
 
   cvss:
     git: https://github.com/hahwul/cvss.cr.git
-    version: 0.2.0
+    version: 0.3.0
 
   db:
     git: https://github.com/crystal-lang/crystal-db.git

--- a/shard.yml
+++ b/shard.yml
@@ -33,7 +33,7 @@ dependencies:
     version: ~> 0.2
   cvss:
     github: hahwul/cvss.cr
-    version: ~> 0.2
+    version: ~> 0.3
 
 development_dependencies:
   ameba:

--- a/spec/cvss_spec.cr
+++ b/spec/cvss_spec.cr
@@ -27,6 +27,19 @@ describe Gori::Cvss do
     sev.should eq(Gori::Store::Severity::High)
   end
 
+  # NVD's v2 calculator renders its vector wrapped in parentheses, so that is the form an
+  # operator copying a score out of a CVE record has on the clipboard. gori refused it until
+  # cvss.cr 0.3.0; the parentheses are notation, not part of the vector, and the canonical
+  # form gori stores drops them.
+  it "resolves a parenthesised CVSS v2.0 vector into the bare canonical vector" do
+    res = Gori::Cvss.resolve("(AV:N/AC:L/Au:N/C:P/I:P/A:P)")
+    res.should_not be_nil
+    score, sev, canonical = res.not_nil!
+    score.should eq(7.5)
+    sev.should eq(Gori::Store::Severity::High)
+    canonical.should eq("AV:N/AC:L/Au:N/C:P/I:P/A:P")
+  end
+
   it "resolves numeric scores across severity bands" do
     Gori::Cvss.severity_for("0.0").should eq(Gori::Store::Severity::Info)
     Gori::Cvss.severity_for("0").should eq(Gori::Store::Severity::Info)


### PR DESCRIPTION
Bumps `cvss` to `~> 0.3`, relocks, and regenerates `nix/shards.nix` (`just nix-shards` — otherwise the flake keeps building v0.2.0 and nothing says so).

## What actually changes for gori

Upstream's changelog lists eight changes. Exactly one reaches us, because the two entry points `Gori::Cvss` calls — `::CVSS.parse?` and `::CVSS::Severity.from_score` — filter the rest out:

| upstream change | reaches gori? |
| --- | --- |
| parenthesised v2.0 vectors misrouted to the v1.0 parser | **yes** — the only one |
| prefix-less v3.x/v4.0 reported as itself | no — an error-*message* fix; `parse?` swallows it and returns nil either way |
| `Severity.from_score` raises on NaN | no — `Cvss.read` checks `score.finite?` before calling |
| `from_json` finds `vectorString` anywhere / `from_json_all` / `from_json?` | no — we do not call them |
| `metric_code?`, v4 `temporal_score`/`temporal_severity` | no — new API, uncalled |
| `CVSS:` prefix accepted in any case | no — already covered by our `parse?(s) \|\| parse?(s.upcase)` retry |

So the user-visible delta is one line: `(AV:N/AC:L/Au:N/C:P/I:P/A:P)` — the parenthesised form **NVD's v2 calculator renders**, and therefore the form an operator copying out of a CVE record has on the clipboard — used to fail as a v1.0 vector. `Cvss.valid?` was false for it, so the Issue form and every other write path refused the paste. It now resolves to 7.5 / High, canonicalised with the parentheses stripped (`AV:N/AC:L/Au:N/C:P/I:P/A:P`), which is what lands in the column.

## How that was established

By A/B, not by reading the changelog. v0.2.0 cloned at its tag, one probe body run twice — once against `cvss020/src/cvss`, once against the new `lib/` — over a corpus of v1..v4 vectors, temporal/environmental metrics, mixed-case spellings, an unknown metric key, an unknown version, parenthesised v2, and out-of-range / non-numeric / `NaN` / empty scores.

Two lines differ, both the parenthesised form, both `nil` → scored. Every other line is byte-identical: the bump neither adds nor regresses anything else. Three of the table rows above are "no" *because* the sweep said so — reading the changelog alone would have put wrong claims in the release note.

`spec/cvss_spec.cr` gains one example pinning the newly-accepted form, including the paren-stripped canonical string, since that string is what exports and `cvss:` queries key on.

## Verification

- `crystal build --no-codegen src/main.cr` and `scripts/seed_demo.cr`
- `crystal spec` — 13168 examples, 0 failures
- `scripts/bench_check.sh` — 56 harnesses
- `crystal tool format --check src spec bench scripts`, `just nix-shards-check`, `just lint-gate` (no changed file gained findings)
- `nix build .#gori` — rebuilds `crystal-lib` on the new pin and produces a running `gori 0.5.0`; the regenerated sha256 matches an independent `nix-prefetch-git` of `refs/tags/v0.3.0`

`git diff shard.lock` moved only the `cvss` entry — no incidental relock of the other five shards.
