### PR TITLE
perf(store,ql): answer a literal REGEXP with a byte search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- History: `body~`, `header:` and index-free `body:` no longer run the regex engine over every stored byte. A literal needle is answered by a byte search instead, allocating nothing (`body~` across 500k flows: 4.1s → 0.25s, 688MB → ~1KB; `header:` 199ms → 120ms), and a real regex stops paying to validate each body twice (2-4x, whether the capture holds text or compressed bytes). A `body:`/`header:` needle under three characters also folds case the same way a longer one does now, so it can no longer match fewer rows than the longer needle containing it.
 - OAST: `gori run oast listen --save` and MCP `oast_start{persist:true}` keep the registration as a project session, so a headless or agent-driven listener lands in `oast list` / `list_oast_sessions`, is re-openable with `resume`, and — the reason it matters — gives the blind `ssrf_oast` / `xxe_oast` / `cmd_injection_oast` rules a session to mint payloads against. Only the TUI could write one before, so those rules ran inert everywhere else
 - MCP: `probe_scan{active:true}` reports an `out_of_band` block when an enabled out-of-band rule had no OAST session to plant against, instead of returning an empty `issues` array that reads as "no blind vulnerability" — the notice `gori run probe` already printed
 - OAST: a listener that has stopped REACHING its provider (a rotated api key, an expired webhook token) draws "not answering" instead of a green ●listening and raises a notification, rather than looking busy while every planted payload calls home to nobody

--- a/spec/ql_spec.cr
+++ b/spec/ql_spec.cr
@@ -129,11 +129,15 @@ describe Gori::QL do
     Gori::QL.analyze("body:\u0001").clean?.should be_false
   end
 
-  it "falls back to a byte-wise blob scan for a body: value below the 3-char trigram floor" do
-    f = Gori::QL.parse("body:ab")
-    f.sql.should contain("COALESCE(instr(request_body, CAST(? AS BLOB)), 0) > 0")
-    f.sql.should contain("COALESCE(instr(response_body, CAST(? AS BLOB)), 0) > 0")
-    f.args.should eq(["ab", "ab", "aB", "aB", "Ab", "Ab", "AB", "AB"]) # every case spelling
+  it "compiles a body: value below the 3-char trigram floor like any other literal needle" do
+    # Only the INDEX has a length floor; the term itself does not change shape, so a short
+    # needle takes the very clause an index-free longer one takes — one NUL-transparent,
+    # NULL-guarded REGEXP per body column. It used to be an `instr` per ASCII case
+    # permutation per column (eight full-BLOB scans for two characters), which also folded
+    # case by a different rule at 1-2 characters than at 3.
+    short = Gori::QL.parse("body:ab")
+    short.sql.should eq(Gori::QL.parse("body:abc", fts: false).sql)
+    short.args.should eq(["(?i)ab", "(?i)ab"])
   end
 
   # The <3-char fallback used `CAST(request_body AS TEXT)`, which SQLite truncates at the first
@@ -227,12 +231,11 @@ describe Gori::QL do
     f.args.should eq(["(?i)Set\\-Cookie", "(?i)Set\\-Cookie"])
   end
 
-  it "compiles a short header: needle via byte-wise instr (NUL-transparent)" do
+  it "compiles a short header: needle exactly like a long one" do
+    # `header:` has no index to fall off, so it never had a reason for a second spelling.
     f = Gori::QL.parse("header:ab")
-    # case permutations of "ab" → ab/aB/Ab/AB, each against request + response head
-    f.sql.includes?("instr(request_head").should be_true
-    f.sql.includes?("instr(response_head").should be_true
-    f.args.size.should eq(8)
+    f.sql.should eq(Gori::QL.parse("header:abc").sql)
+    f.args.should eq(["(?i)ab", "(?i)ab"])
   end
 
   it "matches header: past an embedded NUL in the stored head bytes" do

--- a/spec/ql_spec.cr
+++ b/spec/ql_spec.cr
@@ -143,8 +143,8 @@ describe Gori::QL do
   # The <3-char fallback used `CAST(request_body AS TEXT)`, which SQLite truncates at the first
   # NUL — so a needle sitting AFTER a NUL byte was invisible, a monotonicity violation (a
   # shorter needle matching fewer rows) that cannot be explained to an operator. This is a tool
-  # whose targets deliberately put NULs in bodies, so the short path is now byte-wise `instr`,
-  # which is NUL-transparent. Asserted against a real store because the bug lived in SQLite's
+  # whose targets deliberately put NULs in bodies, so the short path scans the raw bytes
+  # through SafeRegexp, which is NUL-transparent. Asserted against a real store because the bug lived in SQLite's
   # cast, not in the SQL text. (The FTS >=3-char path's handling of a NUL is the trigram
   # tokenizer's, which varies by SQLite build, so it is deliberately not pinned here — this
   # test targets the blob fallback that the fix actually changed.)
@@ -168,9 +168,10 @@ describe Gori::QL do
       store.search(Gori::QL.parse("body:nu"), 50).map(&.id).should eq([buried]) # still case-insensitive
       store.search(Gori::QL.parse("body:zz"), 50).map(&.id).should be_empty
 
-      # `-body:x` (negation) must KEEP a bodyless flow, not drop it. `instr(NULL,…)` is NULL and
-      # `NOT (NULL > 0)` is NULL, which SQLite excludes — so an un-COALESCE'd instr silently
-      # narrowed the negated form. `buried` has `NU`, `bodyless` has no body at all.
+      # `-body:x` (negation) must KEEP a bodyless flow, not drop it. An unguarded predicate
+      # over a NULL body yields NULL, and `NOT NULL` is NULL, which SQLite's three-valued
+      # logic EXCLUDES — a silent narrow of the negated form, which the clause's own
+      # `IS NOT NULL` guard is there to stop. `buried` has `NU`, `bodyless` has no body.
       bodyless = store.insert_flow(Gori::Store::CapturedRequest.new(
         created_at: 3_i64, scheme: "http", host: "acme.test", port: 80,
         method: "GET", target: "/none", http_version: "HTTP/1.1",
@@ -239,7 +240,7 @@ describe Gori::QL do
   end
 
   it "matches header: past an embedded NUL in the stored head bytes" do
-    # CAST AS TEXT LIKE stopped at the first NUL; the REGEXP/instr path must not.
+    # CAST AS TEXT LIKE stopped at the first NUL; the SafeRegexp path must not.
     with_store do |store|
       head = "HTTP/1.1 200 OK\r\nX-Trace: a\u0000b\r\nSet-Cookie: sid=1\r\n\r\n".to_slice
       id = store.insert_flow(Gori::Store::CapturedRequest.new(
@@ -640,7 +641,7 @@ describe "Gori::Store#search (QL)" do
       ids.call("resp.body:secrettoken").should eq([resp_side])
       ids.call("res.body:secrettoken").should eq([resp_side]) # `res.` is a synonym of `resp.`
 
-      # a short needle takes the byte-wise `instr` path instead of the index — same scoping
+      # a short needle scans the stored bytes instead of the index — same scoping
       ids.call("req.body:se").should eq([req_side])
       ids.call("resp.body:se").should eq([resp_side])
 

--- a/spec/store/safe_regexp_spec.cr
+++ b/spec/store/safe_regexp_spec.cr
@@ -1,0 +1,130 @@
+require "../spec_helper"
+
+# `SafeRegexp` answers a literal pattern with a byte search instead of PCRE2 (see the
+# file for why — it is 10x, and QL compiles every `header:` and index-free `body:` to
+# one). These examples pin the thing that makes that safe: the fast path must never be a
+# SECOND definition of what matches. Every one of them asserts the answer the PCRE2 path
+# gives, so a divergence fails here rather than silently narrowing a search.
+private def old_answer(pattern : String, hay : Bytes) : Bool
+  # What the callback did before the fast path existed: scrub, then PCRE2.
+  Regex.new(pattern).matches?(String.new(hay).scrub)
+rescue
+  false
+end
+
+private def fast_answer(pattern : String, hay : Bytes) : Bool?
+  lit = Gori::SafeRegexp.literal(pattern)
+  return nil unless lit
+  Gori::SafeRegexp.literal_match?(hay.to_unsafe, hay.size, lit)
+end
+
+private def agree(pattern : String, hay : String | Bytes) : Nil
+  bytes = hay.is_a?(String) ? hay.to_slice : hay
+  got = fast_answer(pattern, bytes)
+  return if got.nil? # deliberately deferred to PCRE2 — that IS the agreement
+  got.should eq(old_answer(pattern, bytes))
+end
+
+describe Gori::SafeRegexp do
+  describe "literal extraction" do
+    it "takes the shapes QL compiles `:` and a literal `~` into" do
+      # `header:`/`body:` (>=3 chars) => `(?i)<Regex.escape(needle)>`; `body~admin` is bare.
+      Gori::SafeRegexp.literal("(?i)#{Regex.escape("Set-Cookie")}").should_not be_nil
+      Gori::SafeRegexp.literal("admin").should_not be_nil
+      Gori::SafeRegexp.literal(Regex.escape("/api/v1?x=1")).should_not be_nil
+    end
+
+    it "declines anything that is not a plain ASCII literal" do
+      # A metacharacter, a class escape, and a backslash with nothing behind it: all real
+      # regexes (or errors), and PCRE2 owns every one of them.
+      Gori::SafeRegexp.literal("secret[a-z]+").should be_nil
+      Gori::SafeRegexp.literal("secret\\d").should be_nil
+      Gori::SafeRegexp.literal("a|b").should be_nil
+      Gori::SafeRegexp.literal("^host").should be_nil
+      Gori::SafeRegexp.literal("trailing\\").should be_nil
+      # Non-ASCII: `(?i)` over these is Unicode's fold table, not `| 0x20`.
+      Gori::SafeRegexp.literal("(?i)café").should be_nil
+      Gori::SafeRegexp.literal("(?i)漢字").should be_nil
+      # Empty (and `(?i)` alone) is a match-all; PCRE2 should say so, not a byte search.
+      Gori::SafeRegexp.literal("").should be_nil
+      Gori::SafeRegexp.literal("(?i)").should be_nil
+    end
+  end
+
+  describe "agreement with the PCRE2 path" do
+    it "matches case-sensitively when the pattern carries no (?i)" do
+      agree("SeCrEt", "a SeCrEt token")
+      agree("SeCrEt", "a secret token")
+      agree("secret", "a SeCrEt token")
+      fast_answer("SeCrEt", "a SeCrEt token".to_slice).should be_true
+      fast_answer("SeCrEt", "a secret token".to_slice).should be_false
+    end
+
+    it "folds ASCII case behind (?i)" do
+      %w[secret SECRET SeCrEt].each { |hay| agree("(?i)secret", "x #{hay} y") }
+      fast_answer("(?i)secret", "a SECRET token".to_slice).should be_true
+      fast_answer("(?i)secret", "a sekret token".to_slice).should be_false
+    end
+
+    it "reads past a NUL and over invalid UTF-8, like the byte-length haystack promises" do
+      # The `body~ABC` case ql_spec pins end-to-end, at the callback's own level.
+      hay = Bytes[0xFF, 0xFE, 0x00, 0x41, 0x42, 0x43]
+      fast_answer("ABC", hay).should be_true
+      agree("ABC", hay)
+      agree("(?i)abc", hay)
+    end
+
+    it "defers to PCRE2 for the two codepoints (?i) folds onto an ASCII letter" do
+      # U+017F 'ſ' folds to `s` and U+212A 'K' to `k` — the ENTIRE set (enumerated over the
+      # codepoint space, see FOLD_ESCAPES). An ASCII byte fold cannot see them, so a MISS on
+      # a needle carrying s/k is handed back as nil whenever the haystack could hold one,
+      # and PCRE2 gives the real answer.
+      fast_answer("(?i)sql", "a \u{017F}ql injection".to_slice).should be_nil
+      fast_answer("(?i)kelvin", "a \u{212A}elvin reading".to_slice).should be_nil
+      # A HIT never needs the deferral: ASCII folding is a subset of PCRE2's.
+      fast_answer("(?i)sql", "a SQL injection".to_slice).should be_true
+      # Nor does a miss with no lead byte in sight, or a needle without s/k.
+      fast_answer("(?i)sql", "nothing here".to_slice).should be_false
+      fast_answer("(?i)admin", "a \u{017F}ql injection".to_slice).should be_false
+      # Case-SENSITIVE needles never fold at all, so `ſ` is irrelevant to them.
+      fast_answer("sql", "a \u{017F}ql injection".to_slice).should be_false
+    end
+  end
+
+  describe "through the query, where the answer has to hold end to end" do
+    it "keeps `(?i)` finding ſ and K that no ASCII fold could" do
+      with_store do |store|
+        body = ->(text : String) do
+          Gori::Store::CapturedRequest.new(
+            created_at: 1_i64, scheme: "http", host: "h.test", port: 80,
+            method: "POST", target: "/", http_version: "HTTP/1.1",
+            head: "POST / HTTP/1.1\r\nHost: h.test\r\n\r\n".to_slice,
+            body: text.to_slice, source: Gori::FlowSource::Kind::Proxy)
+        end
+        long_s = store.insert_flow(body.call("a \u{017F}ql injection"))
+        plain = store.insert_flow(body.call("a sql injection"))
+        upper = store.insert_flow(body.call("A SQL INJECTION"))
+        kelvin = store.insert_flow(body.call("5 \u{212A} units"))
+
+        ids = ->(query : String, fts : Bool) do
+          store.search(Gori::QL.parse(query, fts: fts), 50, raise_on_error: true).map(&.id).sort!
+        end
+        # `body:` without the FTS index is `body~` with an escaped needle (body_literal_cond),
+        # the fast path's biggest caller — and it must still reach the ſ row.
+        ids.call("body:sql", false).should eq([long_s, plain, upper].sort)
+        ids.call("body:units", false).should eq([kelvin])
+        ids.call("body~(?i)sql", true).should eq([long_s, plain, upper].sort)
+        # `~` is case-sensitive, so these two split the rows byte-exactly.
+        ids.call("body~sql", true).should eq([plain])
+        ids.call("body~SQL", true).should eq([upper])
+
+        # And the needle's LENGTH no longer changes the fold rule. A 1-2 char `body:` used
+        # to be `instr` over ASCII case permutations, so `body:s` byte-matched s/S only
+        # while `body:sql` (a `(?i)` REGEXP) also reached ſ — a shorter needle matching
+        # FEWER rows than a longer one. Both spellings are the same clause now.
+        ids.call("body:s", true).should contain(long_s)
+        ids.call("body:sq", true).should eq(ids.call("body:sql", false))
+      end
+    end
+  end
+end

--- a/spec/store/safe_regexp_spec.cr
+++ b/spec/store/safe_regexp_spec.cr
@@ -26,6 +26,26 @@ private def agree(pattern : String, hay : String | Bytes) : Nil
 end
 
 describe Gori::SafeRegexp do
+  describe "the assumption the whole fast path rests on" do
+    it "finds exactly two non-ASCII codepoints that (?i) folds onto an ASCII letter" do
+      # FOLD_ESCAPES is a property of the LINKED PCRE2's caseless tables, not of gori, and
+      # Unicode has added caseless sets before. If a future PCRE2 folds a third codepoint onto
+      # an ASCII letter, `literal_match?` would answer a confident `false` for a row PCRE2
+      # matches — the silent narrow this module exists to prevent — with nothing to catch it.
+      # So re-run the enumeration the constant's comment describes, rather than trusting it.
+      any_letter = Regex.new("^(?i)[a-z]$")
+      folded = [] of Int32
+      (0x80..0x10FFFF).each do |cp|
+        next if 0xD800 <= cp <= 0xDFFF # lone surrogates are not scalar values
+        folded << cp if any_letter.matches?(cp.unsafe_chr.to_s)
+      end
+      folded.should eq([0x017F, 0x212A])
+      # …and that they are spelled the way the search looks for them.
+      0x017F.unsafe_chr.to_s.to_slice.should eq(Gori::SafeRegexp::LONG_S)
+      0x212A.unsafe_chr.to_s.to_slice.should eq(Gori::SafeRegexp::KELVIN)
+    end
+  end
+
   describe "literal extraction" do
     it "takes the shapes QL compiles `:` and a literal `~` into" do
       # `header:`/`body:` (>=3 chars) => `(?i)<Regex.escape(needle)>`; `body~admin` is bare.
@@ -88,6 +108,74 @@ describe Gori::SafeRegexp do
       fast_answer("(?i)admin", "a \u{017F}ql injection".to_slice).should be_false
       # Case-SENSITIVE needles never fold at all, so `ſ` is irrelevant to them.
       fast_answer("sql", "a \u{017F}ql injection".to_slice).should be_false
+    end
+
+    it "hands a haystack that outruns the work budget back to PCRE2" do
+      # The skip table narrows the quadratic case but does not remove it: a needle whose
+      # SUFFIX is the haystack's one repeated byte walks a position at a time and compares
+      # the whole needle at each. The budget catches that and defers rather than grinding —
+      # a captured body is the attacker's to shape, so this is a bound, not a nicety.
+      repeated = Bytes.new(70_000, 'a'.ord.to_u8)
+      fast_answer("b" + "a" * 64, repeated).should be_nil
+      # The mirror shape (the repeated byte is the needle's PREFIX) is exactly what testing
+      # the LAST position first fixes, so it stays inside the budget and answers.
+      fast_answer("a" * 64 + "b", repeated).should be_false
+      # And an ordinary needle over the same body never comes close to the budget.
+      fast_answer("absentneedle", repeated).should be_false
+      fast_answer("a" * 64, repeated).should be_true
+    end
+  end
+
+  describe "the PCRE2 path the literal search hands back to" do
+    # Everything above is about patterns the byte search ANSWERS. These drive the other
+    # branch — a real regex over a haystack PCRE2 rejects — through the actual SQLite
+    # callback, which nothing else in the suite does: the literal specs never reach the
+    # rescue chain, and every failure mode of that chain is a silent `false`.
+    it "matches a non-literal pattern over an invalid-UTF-8 body, past a NUL" do
+      with_store do |store|
+        binary = store.insert_flow(Gori::Store::CapturedRequest.new(
+          created_at: 1_i64, scheme: "http", host: "bin.test", port: 80,
+          method: "POST", target: "/", http_version: "HTTP/1.1",
+          head: "POST / HTTP/1.1\r\nHost: bin.test\r\n\r\n".to_slice,
+          # invalid UTF-8, then a NUL, then the text a regex has to still reach
+          body: Bytes[0xFF, 0xFE, 0x00, 0x41, 0x42, 0x43, 0x31, 0x32],
+          source: Gori::FlowSource::Kind::Proxy))
+        text = store.insert_flow(Gori::Store::CapturedRequest.new(
+          created_at: 2_i64, scheme: "http", host: "txt.test", port: 80,
+          method: "POST", target: "/", http_version: "HTTP/1.1",
+          head: "POST / HTTP/1.1\r\nHost: txt.test\r\n\r\n".to_slice,
+          body: "plain ABC99 body".to_slice, source: Gori::FlowSource::Kind::Proxy))
+        ids = ->(q : String) { store.search(Gori::QL.parse(q), 50, raise_on_error: true).map(&.id).sort! }
+        # `\\d` makes these regexes, so `extract_literal` declines and PCRE2 answers.
+        ids.call("body~ABC\\d+").should eq([binary, text].sort)
+        ids.call("body~ABC9\\d").should eq([text])
+        ids.call("body~ZZZ\\d").should be_empty
+        # A pattern that cannot compile is a never-match, not a raise out of the callback.
+        ids.call("body~[").should be_empty
+      end
+    end
+
+    it "gives the same answer whichever validation route the sampler picked" do
+      # The two routes (let PCRE2 reject an invalid subject, or scrub before matching) are a
+      # cost choice, never a meaning choice. Drive enough rows to flip the sampler and assert
+      # the query still answers identically.
+      with_store do |store|
+        wanted = [] of Int64
+        600.times do |i|
+          body = i % 3 == 0 ? "plain ABC#{i} text".to_slice : Bytes[0xFF, 0xFE, 0x00, 0x41, 0x42, 0x43, 0x37]
+          id = store.insert_flow(Gori::Store::CapturedRequest.new(
+            created_at: i.to_i64 + 1, scheme: "http", host: "h.test", port: 80,
+            method: "POST", target: "/#{i}", http_version: "HTTP/1.1",
+            head: "POST /#{i} HTTP/1.1\r\nHost: h.test\r\n\r\n".to_slice,
+            body: body, source: Gori::FlowSource::Kind::Proxy))
+          wanted << id
+        end
+        query = -> { store.search(Gori::QL.parse("body~ABC\\d+"), 1000, raise_on_error: true).map(&.id).sort! }
+        first = query.call
+        first.should eq(wanted.sort)
+        # The second run is the one that reads whatever the first run's sample decided.
+        query.call.should eq(first)
+      end
     end
   end
 

--- a/src/gori/ql.cr
+++ b/src/gori/ql.cr
@@ -859,7 +859,9 @@ module Gori
     # quotes doubled) so arbitrary characters can't form FTS operator syntax. A
     # bodyless flow has an empty FTS row, so it never matches and `-body:x`
     # correctly KEEPS it. The trigram index needs >=3 characters, so shorter
-    # values fall back to the NULL-safe BLOB LIKE scan.
+    # values take the index-free spelling below instead — the same NUL-transparent,
+    # NULL-guarded literal REGEXP `fts:`-off `body:` takes, so the needle's LENGTH never
+    # changes what `body:` means.
     # The body columns a `side` selects — both, or one. Named because `body_cond`,
     # `body_literal_cond` and `body_regex_cond` each build their own clause and must not be able
     # to disagree about what `resp.` means.

--- a/src/gori/ql.cr
+++ b/src/gori/ql.cr
@@ -897,35 +897,20 @@ module Gori
       # Dropping the term is what `body:` (genuinely empty) already does; this makes the two
       # spellings agree.
       return nil if value.empty?
-      if value.size < 3
-        # BYTE-wise, not `CAST(... AS TEXT)`: SQLite truncates a BLOB→TEXT cast at the first
-        # NUL, so the LIKE fallback stopped scanning there and a body of
-        # `head\0NULNEEDLE tail` was invisible to `body:nu` while `body:NULNEEDLE` (the FTS
-        # path, >=3 chars) found it. A SHORTER needle matching FEWER rows is a monotonicity
-        # violation that cannot be explained to an operator, and this is a tool whose targets
-        # deliberately put NULs in bodies. `instr` over the raw BLOB is NUL-transparent.
-        #
-        # `instr` is case-SENSITIVE while `body:` promises case-insensitive substring matching,
-        # so match every case permutation of the needle instead — at most four, since this
-        # branch only runs for one or two characters.
-        # `COALESCE`-wrapped, and that is load-bearing: a NULL body (a bodyless GET, or any
-        # response-less/in-flight flow — the common case) makes `instr(NULL, …)` NULL, and
-        # `NOT (NULL > 0)` is NULL, which SQLite's three-valued logic then EXCLUDES — so a bare
-        # `instr` made `-body:x` silently drop every bodyless flow (a silent NARROW, the mirror
-        # of the broaden this path guards against). `COALESCE(…, 0) > 0` is FALSE for a NULL
-        # body, so the positive term still skips it and `NOT FALSE` keeps it under negation.
-        conds = [] of String
-        params = [] of DB::Any
-        cols = body_columns(side)
-        case_permutations(value).each do |v|
-          cols.each do |col|
-            conds << "COALESCE(instr(#{body_col(col, body_max)}, CAST(? AS BLOB)), 0) > 0"
-            params << v
-          end
-        end
-        return {"(#{conds.join(" OR ")})", params}
-      end
-      return body_literal_cond(value, body_max, side) unless fts
+      # Under the trigram minimum the FTS index cannot answer — but the term is still a
+      # literal substring search, and `body_literal_cond` IS that search: NUL-transparent
+      # (SafeRegexp reads the haystack by its true byte length, so a body of
+      # `head\0NULNEEDLE tail` is not invisible to `body:nu` the way a BLOB→TEXT `LIKE`
+      # made it) and NULL-guarded, so `-body:x` still keeps a bodyless flow.
+      #
+      # This used to be spelled as `instr` over every ASCII case permutation of the needle,
+      # because `instr` is case-SENSITIVE and `body:` promises case-insensitive matching.
+      # That cost up to four permutations x two body columns = EIGHT full-BLOB scans per row
+      # where one now suffices, and it folded case by a DIFFERENT rule than every longer
+      # needle used — `body:s` and `body:sql` disagreeing about `ſ` for no reason an operator
+      # could see. One spelling for every needle length, and the shorter needle can no longer
+      # match fewer rows than the longer one.
+      return body_literal_cond(value, body_max, side) if value.size < 3 || !fts
       phrase = %("#{value.gsub('"', "\"\"")}") # quoted phrase → contiguous substring match
       # An FTS5 COLUMN FILTER (`resp : "phrase"`) narrows the match to one indexed column. The
       # column name is this module's own constant, never user input — the value stays inside the
@@ -951,16 +936,6 @@ module Gori
       # can never carry a NUL of its own. `(?i)` because `body:` promises case-insensitive
       # matching where `body~` is case-SENSITIVE by default.
       body_regex_cond("(?i)#{Regex.escape(value)}", body_max, side)
-    end
-
-    # Every upper/lower spelling of a one- or two-character needle, so a byte-wise `instr`
-    # can stand in for a case-insensitive LIKE. Bounded at 4 by `body_cond`'s `size < 3`
-    # guard; a character with no case (a digit, a symbol, most CJK) contributes one variant.
-    private def self.case_permutations(value : String) : Array(String)
-      value.each_char.reduce([""]) do |acc, ch|
-        forms = [ch.downcase, ch.upcase].uniq!
-        acc.flat_map { |prefix| forms.map { |f| prefix + f } }
-      end.uniq!
     end
 
     # Split a leading comparison operator (<= >= < > =, default =) off a value. Shared
@@ -1073,24 +1048,14 @@ module Gori
     # first NUL, so a head that stored an embedded NUL (header-injection / smuggling
     # cases — the codec keeps the octets, P7) made every header after the NUL invisible
     # to `header:` while `header~` (SafeRegexp over the full blob) still found it. Same
-    # trap `body_cond` already routed around. `instr` is case-SENSITIVE, so OR every case
-    # permutation of a short needle; longer needles go through a case-insensitive literal
-    # REGEXP, which SafeRegexp already makes NUL-transparent.
+    # trap `body_cond` already routed around, and the same way: ONE case-insensitive
+    # literal REGEXP, which SafeRegexp makes both NUL-transparent and (for a literal)
+    # allocation-free. A short needle used to take an `instr` per ASCII case permutation
+    # per head column instead — more scans, and a different fold rule at 1-2 characters
+    # than at 3, which `body_cond` explains at more length.
     private def self.header_cond(value : String, side : Symbol? = nil) : {String, Array(DB::Any)}?
       value = value.chars.reject(&.control?).join
       return nil if value.empty?
-      if value.size < 3
-        conds = [] of String
-        params = [] of DB::Any
-        cols = head_columns(side)
-        case_permutations(value).each do |v|
-          cols.each do |col|
-            conds << "COALESCE(instr(#{col}, CAST(? AS BLOB)), 0) > 0"
-            params << v
-          end
-        end
-        return {"(#{conds.join(" OR ")})", params}
-      end
       pat = "(?i)#{Regex.escape(value)}"
       return {"0", [] of DB::Any} unless valid_regex?(pat)
       header_regex_cond(pat, side)

--- a/src/gori/store/safe_regexp.cr
+++ b/src/gori/store/safe_regexp.cr
@@ -26,10 +26,13 @@ module Gori
   # We re-register `regexp` on every pooled connection with a version that scrubs the
   # haystack to valid UTF-8 (invalid sequences → U+FFFD) and rescues any residual error,
   # so a regex scan can never crash and a binary body simply fails to match a text
-  # pattern. Unlike the upstream function (which reads the haystack via `value_text`, a
+  # pattern. The scrub sits on the ERROR path, not in front of every row: PCRE2 does that
+  # same UTF-8 validation itself, so scrubbing up front paid for it twice (see `FN`).
+  # Unlike the upstream function (which reads the haystack via `value_text`, a
   # NUL-terminated pointer, and so silently stops scanning at the first embedded NUL),
   # we read the FULL byte length via `value_bytes` so content past a NUL — common in a
-  # body that mixes binary and text — is still matched.
+  # body that mixes binary and text — is still matched. A pattern that is a plain literal
+  # skips PCRE2 altogether (see the literal fast path below) — the same answer, ~10x.
   module SafeRegexp
     # SQLite fires this scalar callback once per row. A query's WHERE clause holds a
     # small FIXED set of regex patterns — one per `~` term / regex scope rule — constant
@@ -60,21 +63,212 @@ module Gori
       rx
     end
 
+    # --- literal fast path ------------------------------------------------------
+    #
+    # Most patterns reaching this callback are not regexes at all. QL compiles EVERY
+    # `header:` and every index-free `body:` to `(?i)<Regex.escape(needle)>` (see
+    # ql.cr's `header_cond` / `body_literal_cond`), and a hand-written `body~admin` is
+    # a bare literal too. Handing those to PCRE2 pays for three passes over the body
+    # that a byte search does not need — the `String` copy, `scrub`'s UTF-8 validation,
+    # and PCRE2's own UTF-8 validation — before the match even starts. Over 100k flows
+    # with 1KB bodies (bench/history_filter_bench), `body~absentneedle` spent 876ms in
+    # this callback: 81ms copying, 370ms scrubbing, the rest matching. The byte search
+    # answers the same query in 108ms.
+    #
+    # `nil` from `extract_literal` means "not a literal" — the pattern goes to PCRE2
+    # unchanged. This is an OPTIMISATION, never a second definition of what matches:
+    # every case it declines falls through, and the cases it takes are argued below to
+    # give the identical answer.
+    record Literal,
+      # The literal bytes, ASCII-only (a non-ASCII byte makes `(?i)` Unicode's business,
+      # not ours, so `extract_literal` refuses those patterns outright).
+      needle : Bytes,
+      # `(?i)` was on the front: compare ASCII letters case-insensitively.
+      fold : Bool,
+      # UTF-8 LEAD bytes of the non-ASCII codepoints PCRE2 would also fold onto a letter
+      # this needle carries — see `literal_match?`. Empty unless `fold`.
+      fold_leads : Bytes
+
+    # The two non-ASCII codepoints PCRE2's `(?i)` folds onto an ASCII letter, under the
+    # UTF|UCP options Crystal compiles every Regex with. NOT assumed — enumerated by
+    # matching `(?i)<letter>` against every codepoint in the space; these two are the
+    # entire set, so an ASCII-only fold is exact for any needle without `s`/`k`.
+    FOLD_ESCAPES = {'s' => 0xC5_u8, 'k' => 0xE2_u8} # U+017F 'ſ' = C5 BF, U+212A 'K' = E2 84 AA
+
+    # Unescaped, these end the literal — the pattern is a real regex and PCRE2 owns it.
+    # `-`, `=`, `!`, `<`, `>`, `:`, `#` and space are NOT here on purpose: `Regex.escape`
+    # backslashes them, but none is a metacharacter outside a character class (and `#`/
+    # space would need EXTENDED, which Crystal does not set), so they stay literal
+    # whether or not the escape survived.
+    META = ".*+?()[]{}|^$"
+
+    @@literals = {} of String => Literal?
+
+    # :nodoc: — internal (called from FN, which needs an explicit receiver)
+    def self.literal(pattern : String) : Literal?
+      return @@literals[pattern] if @@literals.has_key?(pattern)
+      lit = extract_literal(pattern)
+      # Bounded for the reason `@@cache` is, and cleared with it in mind: a scan uses a
+      # handful of patterns, so this can never evict one mid-scan.
+      @@literals.clear if @@literals.size >= CACHE_MAX
+      @@literals[pattern] = lit
+      lit
+    end
+
+    # `(?i)` on the very front — the only inline flag QL emits, and the only one this path
+    # reads. Any other group disqualifies the pattern at its `(` below.
+    private def self.fold_prefix?(src : Bytes) : Bool
+      src.size >= 4 && src[0] === '(' && src[1] === '?' && src[2] === 'i' && src[3] === ')'
+    end
+
+    # One literal byte of `src` at `i` and where the next one starts — or nil when what is
+    # there is not a literal at all, which disqualifies the whole pattern.
+    private def self.literal_byte_at(src : Bytes, i : Int32) : {UInt8, Int32}?
+      b = src[i]
+      # A non-ASCII byte is only ever part of a multi-byte codepoint, and folding those is
+      # Unicode's table, not `| 0x20`. Refuse the pattern rather than guess.
+      return nil if b >= 0x80
+      if b === '\\'
+        i += 1
+        return nil if i >= src.size # trailing backslash: let PCRE2 report it
+        b = src[i]
+        # `\d`, `\w`, `\b`, `\1`, `\n` … are classes, anchors and escapes — not the
+        # character itself. Only a backslashed PUNCTUATION byte is a plain literal.
+        return nil if b >= 0x80 || b.unsafe_chr.ascii_alphanumeric?
+      elsif META.byte_index(b)
+        return nil
+      end
+      {b, i + 1}
+    end
+
+    private def self.extract_literal(pattern : String) : Literal?
+      src = pattern.to_slice
+      fold = fold_prefix?(src)
+      i = fold ? 4 : 0
+      # NOT named `out`: `out` is a Crystal keyword and `out[0, n]` fails to parse.
+      buf = Bytes.new(src.size - i)
+      n = 0
+      leads = Set(UInt8).new
+      while i < src.size
+        b, i = literal_byte_at(src, i) || return nil
+        if fold && (lead = FOLD_ESCAPES[b.unsafe_chr.downcase]?)
+          leads << lead
+        end
+        buf[n] = b
+        n += 1
+      end
+      return nil if n == 0 # `` or `(?i)`: a match-all, which PCRE2 should answer
+      ordered = leads.to_a
+      Literal.new(buf[0, n], fold, Bytes.new(ordered.size) { |k| ordered[k] })
+    end
+
+    # `true` / `false`, or `nil` when an ASCII fold cannot answer and PCRE2 must.
+    #
+    # A HIT is always final: ASCII case folding is a strict subset of PCRE2's, so
+    # anything this finds, `(?i)` finds too. A MISS is final unless the needle carries an
+    # `s` or a `k` AND the haystack could hold the one non-ASCII codepoint PCRE2 folds
+    # onto it (`ſ` / `K`) — which the presence of that codepoint's UTF-8 lead byte
+    # settles, since neither can occur without it. Case-SENSITIVE needles skip all of
+    # this: byte equality is exactly what PCRE2 would do.
+    #
+    # Reads the haystack by pointer + true length, never through a `String`: that is the
+    # whole point (no copy, no `scrub`), and it keeps the NUL-transparency the callback
+    # has promised since it started reading `value_bytes` instead of `value_text`.
+    def self.literal_match?(hay : Pointer(UInt8), len : Int32, lit : Literal) : Bool?
+      needle = lit.needle
+      n = needle.size
+      # A needle longer than the haystack cannot match even under folding, so this needs no
+      # deferral either: `ſ`/`K` make a MATCHED REGION longer than the needle, never shorter.
+      return false if n > len
+      i = 0
+      limit = len - n
+      while i <= limit
+        return true if matches_at?(hay + i, needle, lit.fold)
+        i += 1
+      end
+      return false if lit.fold_leads.empty?
+      # Only now, and only for the miss, is the haystack worth a second look.
+      lit.fold_leads.each do |lead|
+        return nil if find_byte(hay, len, lead)
+      end
+      false
+    end
+
+    private def self.matches_at?(at : Pointer(UInt8), needle : Bytes, fold : Bool) : Bool
+      j = 0
+      while j < needle.size
+        b = at[j]
+        want = needle[j]
+        unless b == want || (fold && (b | 0x20_u8) == (want | 0x20_u8) && want.unsafe_chr.ascii_letter?)
+          return false
+        end
+        j += 1
+      end
+      true
+    end
+
+    private def self.find_byte(hay : Pointer(UInt8), len : Int32, byte : UInt8) : Bool
+      i = 0
+      while i < len
+        return true if hay[i] == byte
+        i += 1
+      end
+      false
+    end
+
+    # The pattern arrives as raw SQLite bytes on EVERY row, so `String.new` on it is an
+    # allocation per row — 6.4MB of garbage for one 100k-row `header:` scan, every byte of
+    # it another copy of the same eleven. A scan's patterns are a small fixed set (the
+    # reason `@@cache` exists at all), so keep the ones already interned and hand back the
+    # SAME String when the bytes match; only a pattern this scan has not seen allocates.
+    # Bounded and cleared like the caches it feeds, and a byte compare against a handful of
+    # short patterns costs far less than the allocation it replaces.
+    @@known = [] of String
+
+    # :nodoc: — internal (called from FN, which needs an explicit receiver)
+    def self.intern(ptr : Pointer(UInt8), len : Int32) : String
+      @@known.each do |known|
+        return known if known.bytesize == len && known.to_unsafe.memcmp(ptr, len) == 0
+      end
+      @@known.clear if @@known.size >= CACHE_MAX
+      pattern = String.new(ptr, len)
+      @@known << pattern
+      pattern
+    end
+
     # Closure-free proc (no captured locals) so it is valid as a C callback, matching
     # the driver's own FuncCallback signature: (context, argc, argv) ordered args.
     FN = ->(context : LibSQLite3::SQLite3Context, _argc : Int32, argv : LibSQLite3::SQLite3Value*) do
       args = Slice.new(argv, 2)
-      pattern = String.new(LibSQLite3.value_text(args[0]))
+      pattern = SafeRegexp.intern(LibSQLite3.value_text(args[0]), LibSQLite3.value_bytes(args[0]))
       # value_text first (forces the text representation + keeps the pointer valid),
       # then value_bytes for its true length — so an embedded NUL doesn't truncate.
       hay_ptr = LibSQLite3.value_text(args[1])
       hay_len = LibSQLite3.value_bytes(args[1])
-      text = hay_ptr.null? || hay_len <= 0 ? "" : String.new(hay_ptr, hay_len).scrub
+      empty = hay_ptr.null? || hay_len <= 0
       matched =
-        begin
-          SafeRegexp.compile(pattern).matches?(text)
-        rescue
-          false
+        if !empty && (lit = SafeRegexp.literal(pattern)) &&
+           !(answer = SafeRegexp.literal_match?(hay_ptr, hay_len, lit)).nil?
+          answer
+        else
+          text = empty ? "" : String.new(hay_ptr, hay_len)
+          begin
+            # NOT `.scrub` first. PCRE2 validates the subject itself under the UTF option
+            # Crystal compiles with, so scrubbing up front paid for that pass TWICE — and
+            # the second one is the expensive one here (370ms of the 876ms above). Let the
+            # engine reject the invalid haystack instead, and scrub only that row: a
+            # capture holds far more valid-UTF-8 bodies than binary ones, and the ones it
+            # does hold still get the identical answer, one rescue later.
+            SafeRegexp.compile(pattern).matches?(text)
+          rescue
+            begin
+              # Scrubbed => valid by construction, so PCRE2's check is pure overhead now.
+              SafeRegexp.compile(pattern).matches_at_byte_index?(
+                text.scrub, 0, Regex::MatchOptions::NO_UTF_CHECK)
+            rescue
+              false
+            end
+          end
         end
       LibSQLite3.result_int(context, matched ? 1 : 0)
       nil

--- a/src/gori/store/safe_regexp.cr
+++ b/src/gori/store/safe_regexp.cr
@@ -66,52 +66,65 @@ module Gori
     # --- literal fast path ------------------------------------------------------
     #
     # Most patterns reaching this callback are not regexes at all. QL compiles EVERY
-    # `header:` and every index-free `body:` to `(?i)<Regex.escape(needle)>` (see
-    # ql.cr's `header_cond` / `body_literal_cond`), and a hand-written `body~admin` is
-    # a bare literal too. Handing those to PCRE2 pays for three passes over the body
-    # that a byte search does not need — the `String` copy, `scrub`'s UTF-8 validation,
-    # and PCRE2's own UTF-8 validation — before the match even starts. Over 100k flows
-    # with 1KB bodies (bench/history_filter_bench), `body~absentneedle` spent 876ms in
-    # this callback: 81ms copying, 370ms scrubbing, the rest matching. The byte search
-    # answers the same query in 108ms.
+    # `header:` and every index-free `body:` to `(?i)<Regex.escape(needle)>` (see ql.cr's
+    # `header_cond` / `body_literal_cond`), and a hand-written `body~admin` is a bare literal
+    # too. Handing those to PCRE2 pays for a `String` copy of the whole body and a UTF-8
+    # validation pass before the match even starts; a byte search off the SQLite pointer pays
+    # for neither. Over 100k flows with 1KB bodies (bench/history_filter_bench),
+    # `body~absentneedle` went from 798ms to 40ms and from 137MB of garbage to none.
     #
     # `nil` from `extract_literal` means "not a literal" — the pattern goes to PCRE2
-    # unchanged. This is an OPTIMISATION, never a second definition of what matches:
-    # every case it declines falls through, and the cases it takes are argued below to
-    # give the identical answer.
+    # unchanged. This is an OPTIMISATION, never a second definition of what matches: every
+    # case it declines falls through, and the cases it takes are argued below to give the
+    # identical answer.
     record Literal,
-      # The literal bytes, ASCII-only (a non-ASCII byte makes `(?i)` Unicode's business,
-      # not ours, so `extract_literal` refuses those patterns outright).
+      # The literal bytes, ASCII-only (a non-ASCII byte makes `(?i)` Unicode's business, not
+      # ours, so `extract_literal` refuses those patterns outright). EMPTY marks the sentinel
+      # below; a real literal always has at least one byte.
       needle : Bytes,
       # `(?i)` was on the front: compare ASCII letters case-insensitively.
       fold : Bool,
-      # UTF-8 LEAD bytes of the non-ASCII codepoints PCRE2 would also fold onto a letter
-      # this needle carries — see `literal_match?`. Empty unless `fold`.
-      fold_leads : Bytes
+      # The needle carries a letter PCRE2 would ALSO fold a non-ASCII codepoint onto, so a
+      # miss is not final until that codepoint is ruled out of the haystack — see
+      # `literal_match?`. Both false unless `fold`.
+      long_s : Bool,
+      kelvin : Bool,
+      # Boyer-Moore-Horspool bad-character table: with the needle laid over the haystack, how
+      # far the scan may jump when the byte under the needle's LAST position is `b`. A byte
+      # the needle does not carry jumps the whole needle. Empty for a one-byte needle, which
+      # never consults it. Built once per pattern.
+      skip : Array(Int32)
+
+    # A pattern PCRE2 must own is CACHED as this rather than as `nil`, so the per-row lookup
+    # is one hash instead of `has_key?` + `[]`.
+    NOT_LITERAL = Literal.new(Bytes.empty, false, false, false, [] of Int32)
 
     # The two non-ASCII codepoints PCRE2's `(?i)` folds onto an ASCII letter, under the
-    # UTF|UCP options Crystal compiles every Regex with. NOT assumed — enumerated by
-    # matching `(?i)<letter>` against every codepoint in the space; these two are the
-    # entire set, so an ASCII-only fold is exact for any needle without `s`/`k`.
-    FOLD_ESCAPES = {'s' => 0xC5_u8, 'k' => 0xE2_u8} # U+017F 'ſ' = C5 BF, U+212A 'K' = E2 84 AA
+    # UTF|UCP options Crystal compiles every Regex with. NOT assumed — enumerated by matching
+    # `(?i)<letter>` against every codepoint in the space, and `spec/store/safe_regexp_spec.cr`
+    # re-runs that enumeration so a PCRE2 upgrade that widened the set could not pass silently.
+    LONG_S = Bytes[0xC5, 0xBF]       # U+017F ſ, which `(?i)s` matches
+    KELVIN = Bytes[0xE2, 0x84, 0xAA] # U+212A K, which `(?i)k` matches
 
     # Unescaped, these end the literal — the pattern is a real regex and PCRE2 owns it.
     # `-`, `=`, `!`, `<`, `>`, `:`, `#` and space are NOT here on purpose: `Regex.escape`
-    # backslashes them, but none is a metacharacter outside a character class (and `#`/
-    # space would need EXTENDED, which Crystal does not set), so they stay literal
-    # whether or not the escape survived.
+    # backslashes them, but none is a metacharacter outside a character class (and `#`/space
+    # would need EXTENDED, which Crystal does not set), so they stay literal whether or not
+    # the escape survived.
     META = ".*+?()[]{}|^$"
 
-    @@literals = {} of String => Literal?
+    @@literals = {} of String => Literal
 
     # :nodoc: — internal (called from FN, which needs an explicit receiver)
     def self.literal(pattern : String) : Literal?
-      return @@literals[pattern] if @@literals.has_key?(pattern)
+      if hit = @@literals[pattern]?
+        return hit.needle.empty? ? nil : hit
+      end
       lit = extract_literal(pattern)
       # Bounded for the reason `@@cache` is, and cleared with it in mind: a scan uses a
       # handful of patterns, so this can never evict one mid-scan.
       @@literals.clear if @@literals.size >= CACHE_MAX
-      @@literals[pattern] = lit
+      @@literals[pattern] = lit || NOT_LITERAL
       lit
     end
 
@@ -148,92 +161,194 @@ module Gori
       # NOT named `out`: `out` is a Crystal keyword and `out[0, n]` fails to parse.
       buf = Bytes.new(src.size - i)
       n = 0
-      leads = Set(UInt8).new
+      long_s = false
+      kelvin = false
       while i < src.size
         b, i = literal_byte_at(src, i) || return nil
-        if fold && (lead = FOLD_ESCAPES[b.unsafe_chr.downcase]?)
-          leads << lead
-        end
+        long_s = true if fold && (b === 's' || b === 'S')
+        kelvin = true if fold && (b === 'k' || b === 'K')
         buf[n] = b
         n += 1
       end
       return nil if n == 0 # `` or `(?i)`: a match-all, which PCRE2 should answer
-      ordered = leads.to_a
-      Literal.new(buf[0, n], fold, Bytes.new(ordered.size) { |k| ordered[k] })
+      Literal.new(buf[0, n], fold, long_s, kelvin, skip_table(buf, n, fold))
     end
 
-    # `true` / `false`, or `nil` when an ASCII fold cannot answer and PCRE2 must.
+    private def self.skip_table(buf : Bytes, n : Int32, fold : Bool) : Array(Int32)
+      return [] of Int32 if n == 1 # `contains_byte?` handles those and never reads the table
+      skip = Array(Int32).new(256, n)
+      (0...n - 1).each do |j|
+        b = buf[j]
+        skip[b] = n - 1 - j
+        # A folded needle has to be skippable by EITHER spelling of its letters, or the table
+        # would jump past a match the comparison would have found.
+        skip[b ^ 0x20_u8] = n - 1 - j if fold && b.unsafe_chr.ascii_letter?
+      end
+      skip
+    end
+
+    # `true` / `false`, or `nil` when this cannot answer and PCRE2 must.
     #
-    # A HIT is always final: ASCII case folding is a strict subset of PCRE2's, so
-    # anything this finds, `(?i)` finds too. A MISS is final unless the needle carries an
-    # `s` or a `k` AND the haystack could hold the one non-ASCII codepoint PCRE2 folds
-    # onto it (`ſ` / `K`) — which the presence of that codepoint's UTF-8 lead byte
-    # settles, since neither can occur without it. Case-SENSITIVE needles skip all of
-    # this: byte equality is exactly what PCRE2 would do.
+    # A HIT is always final: ASCII case folding is a strict subset of PCRE2's, so anything
+    # this finds, `(?i)` finds too. A MISS is final unless the needle carries an `s` or a `k`
+    # AND the haystack actually holds `ſ` / `K` — the two codepoints PCRE2 folds onto those
+    # letters. That is tested as the full UTF-8 SEQUENCE, not the lead byte: 0xE2 leads every
+    # codepoint from U+2000 to U+2FFF, so an em dash or a curly quote — never mind a
+    # compressed body, where it appears with probability ~0.98 per KB — would have deferred
+    # every `(?i)` needle containing a `k`, which is most of them. Case-SENSITIVE needles skip
+    # all of this: byte equality is exactly what PCRE2 would do.
     #
-    # Reads the haystack by pointer + true length, never through a `String`: that is the
-    # whole point (no copy, no `scrub`), and it keeps the NUL-transparency the callback
-    # has promised since it started reading `value_bytes` instead of `value_text`.
+    # Reads the haystack by pointer + true length, never through a `String`: that is the whole
+    # point (no copy, no `scrub`), and it keeps the NUL-transparency the callback has promised
+    # since it started reading `value_bytes` instead of `value_text`.
     def self.literal_match?(hay : Pointer(UInt8), len : Int32, lit : Literal) : Bool?
-      needle = lit.needle
-      n = needle.size
+      m = lit.needle.size
       # A needle longer than the haystack cannot match even under folding, so this needs no
       # deferral either: `ſ`/`K` make a MATCHED REGION longer than the needle, never shorter.
-      return false if n > len
+      return false if m > len
+      hit = m == 1 ? contains_byte?(hay, len, lit.needle[0], lit.fold) : horspool?(hay, len, lit)
+      return hit unless hit == false
+      return false unless lit.long_s || lit.kelvin
+      # Only now, and only for the miss, is the haystack worth a second look — and one pass
+      # answers for both codepoints.
+      contains_fold_escape?(hay, len, lit) ? nil : false
+    end
+
+    # Horspool, and comparing from the END of the needle is the load-bearing half of it. The
+    # obvious forward scan is fast on real traffic but quadratic on a body of one repeated
+    # byte — a needle whose PREFIX is that byte measured 1.1ms per 64KB body against PCRE2's
+    # 0.22ms, and a captured body is the ATTACKER's to shape. Testing the last position first
+    # is the same "required last code unit" trick that keeps PCRE2 fast there, and it costs
+    # nothing on the ordinary path: 64KB of JSON, absent needle, 6us here against PCRE2's
+    # 234us.
+    #
+    # The skip table narrows the quadratic case rather than removing it (a needle whose SUFFIX
+    # is the repeated byte still walks one position at a time, comparing the whole needle at
+    # each), so the scan carries a work budget and returns `nil` — hand the row to PCRE2 —
+    # rather than grinding. Four passes over the haystack is far more than any realistic
+    # needle spends, and it bounds the worst case at roughly 1.5x what PCRE2 alone would have
+    # cost instead of 8x.
+    private def self.horspool?(hay : Pointer(UInt8), len : Int32, lit : Literal) : Bool?
+      needle = lit.needle
+      m = needle.size
+      skip = lit.skip.to_unsafe # bounds-checked `Array#[]` in this loop is per haystack byte
+      budget = 4_i64 * len + 16
       i = 0
-      limit = len - n
+      limit = len - m
       while i <= limit
-        return true if matches_at?(hay + i, needle, lit.fold)
-        i += 1
-      end
-      return false if lit.fold_leads.empty?
-      # Only now, and only for the miss, is the haystack worth a second look.
-      lit.fold_leads.each do |lead|
-        return nil if find_byte(hay, len, lead)
+        j = m - 1
+        while j >= 0 && byte_eq?(hay[i + j], needle[j], lit.fold)
+          j -= 1
+        end
+        return true if j < 0
+        budget -= m - j
+        return nil if budget < 0
+        i += skip[hay[i + m - 1]]
       end
       false
     end
 
-    private def self.matches_at?(at : Pointer(UInt8), needle : Bytes, fold : Bool) : Bool
-      j = 0
-      while j < needle.size
-        b = at[j]
-        want = needle[j]
-        unless b == want || (fold && (b | 0x20_u8) == (want | 0x20_u8) && want.unsafe_chr.ascii_letter?)
-          return false
-        end
-        j += 1
-      end
-      true
-    end
-
-    private def self.find_byte(hay : Pointer(UInt8), len : Int32, byte : UInt8) : Bool
+    # One byte, which is linear by construction — no table to consult and no budget to keep.
+    # Kept off the general loop because the bookkeeping for both dominated it there: `body:z`
+    # over 100k 1KB bodies went 39ms -> 117ms when a one-byte needle walked the same path.
+    private def self.contains_byte?(hay : Pointer(UInt8), len : Int32, want : UInt8,
+                                    fold : Bool) : Bool
       i = 0
       while i < len
-        return true if hay[i] == byte
+        return true if byte_eq?(hay[i], want, fold)
         i += 1
       end
       false
+    end
+
+    # Does the haystack hold a codepoint PCRE2 would fold onto a letter this needle carries?
+    # ONE pass for both — a needle with an `s` AND a `k` used to walk the body twice more
+    # after the search that missed.
+    private def self.contains_fold_escape?(hay : Pointer(UInt8), len : Int32,
+                                           lit : Literal) : Bool
+      i = 0
+      while i < len
+        b = hay[i]
+        if lit.long_s && b == LONG_S[0]
+          return true if i + 1 < len && hay[i + 1] == LONG_S[1]
+        elsif lit.kelvin && b == KELVIN[0]
+          return true if i + 2 < len && hay[i + 1] == KELVIN[1] && hay[i + 2] == KELVIN[2]
+        end
+        i += 1
+      end
+      false
+    end
+
+    # `want` is a needle byte, so the letter test is on IT: for a letter, `| 0x20` maps both
+    # spellings onto the lowercase one, and the only bytes that land in `a`-`z` that way are
+    # themselves letters — no non-letter can alias into a match.
+    private def self.byte_eq?(got : UInt8, want : UInt8, fold : Bool) : Bool
+      got == want || (fold && (got | 0x20_u8) == (want | 0x20_u8) && want.unsafe_chr.ascii_letter?)
+    end
+
+    # --- the PCRE2 path, for everything the literal search declined --------------
+    #
+    # Whether to `scrub` before matching, rather than letting PCRE2 reject an invalid subject.
+    # Both routes give the IDENTICAL answer; this only picks the cheaper one for the corpus in
+    # hand, and they are far apart in both directions. Per 1KB body, measured: PCRE2 validates
+    # the subject itself at 0.26us, so scrubbing up front pays for that pass twice and costs
+    # 4.7us on a VALID body against 0.29us — but a body PCRE2 REJECTS unwinds a Crystal
+    # exception at 11.3us against the 6.5us scrubbing it would have cost. Break-even is around
+    # two invalid bodies in five, and a capture holds whatever the target served: mostly text
+    # from an API, mostly compressed bytes from a site. So sample the recent rows rather than
+    # assume either shape. `scrub` returns the string ITSELF when it was already valid, which
+    # is how the scrub-first route keeps feeding the sample that may switch it back off.
+    SAMPLE_ROWS = 512
+    @@rows_seen = 0
+    @@rows_invalid = 0
+    @@scrub_first = false
+
+    # :nodoc: — internal (called from FN, which needs an explicit receiver)
+    def self.match_text(pattern : String, text : String) : Bool
+      rx = compile(pattern)
+      if @@scrub_first
+        scrubbed = text.scrub
+        note_subject(!scrubbed.same?(text))
+        # Scrubbed => valid by construction, so PCRE2's own check is pure overhead now.
+        rx.matches_at_byte_index?(scrubbed, 0, Regex::MatchOptions::NO_UTF_CHECK)
+      else
+        begin
+          matched = rx.matches?(text)
+          note_subject(false)
+          matched
+        rescue
+          note_subject(true)
+          rx.matches_at_byte_index?(text.scrub, 0, Regex::MatchOptions::NO_UTF_CHECK)
+        end
+      end
+    rescue
+      # A pattern that will not compile, or a residual engine error: never a raise out of a C
+      # callback, which would abort the whole query (see the module comment).
+      false
+    end
+
+    private def self.note_subject(invalid : Bool) : Nil
+      @@rows_seen += 1
+      @@rows_invalid += 1 if invalid
+      return if @@rows_seen < SAMPLE_ROWS
+      @@scrub_first = @@rows_invalid * 5 > @@rows_seen * 2 # more than two in five
+      @@rows_seen = 0
+      @@rows_invalid = 0
     end
 
     # The pattern arrives as raw SQLite bytes on EVERY row, so `String.new` on it is an
-    # allocation per row — 6.4MB of garbage for one 100k-row `header:` scan, every byte of
-    # it another copy of the same eleven. A scan's patterns are a small fixed set (the
-    # reason `@@cache` exists at all), so keep the ones already interned and hand back the
-    # SAME String when the bytes match; only a pattern this scan has not seen allocates.
-    # Bounded and cleared like the caches it feeds, and a byte compare against a handful of
-    # short patterns costs far less than the allocation it replaces.
-    @@known = [] of String
+    # allocation per row — 64MB of garbage for one 500k-row `header:` scan, every byte of it
+    # another copy of the same eleven. Both clauses of a `body:`/`header:` term bind the same
+    # value, so a single remembered pattern covers the whole scan; a query with two `~` terms
+    # alternates and simply allocates, exactly as it did before this existed.
+    @@last_pattern : String? = nil
 
     # :nodoc: — internal (called from FN, which needs an explicit receiver)
     def self.intern(ptr : Pointer(UInt8), len : Int32) : String
-      @@known.each do |known|
-        return known if known.bytesize == len && known.to_unsafe.memcmp(ptr, len) == 0
+      if last = @@last_pattern
+        return last if last.bytesize == len && last.to_unsafe.memcmp(ptr, len) == 0
       end
-      @@known.clear if @@known.size >= CACHE_MAX
-      pattern = String.new(ptr, len)
-      @@known << pattern
-      pattern
+      @@last_pattern = String.new(ptr, len)
     end
 
     # Closure-free proc (no captured locals) so it is valid as a C callback, matching
@@ -251,24 +366,7 @@ module Gori
            !(answer = SafeRegexp.literal_match?(hay_ptr, hay_len, lit)).nil?
           answer
         else
-          text = empty ? "" : String.new(hay_ptr, hay_len)
-          begin
-            # NOT `.scrub` first. PCRE2 validates the subject itself under the UTF option
-            # Crystal compiles with, so scrubbing up front paid for that pass TWICE — and
-            # the second one is the expensive one here (370ms of the 876ms above). Let the
-            # engine reject the invalid haystack instead, and scrub only that row: a
-            # capture holds far more valid-UTF-8 bodies than binary ones, and the ones it
-            # does hold still get the identical answer, one rescue later.
-            SafeRegexp.compile(pattern).matches?(text)
-          rescue
-            begin
-              # Scrubbed => valid by construction, so PCRE2's check is pure overhead now.
-              SafeRegexp.compile(pattern).matches_at_byte_index?(
-                text.scrub, 0, Regex::MatchOptions::NO_UTF_CHECK)
-            rescue
-              false
-            end
-          end
+          SafeRegexp.match_text(pattern, empty ? "" : String.new(hay_ptr, hay_len))
         end
       LibSQLite3.result_int(context, matched ? 1 : 0)
       nil

--- a/src/gori/store/schema.cr
+++ b/src/gori/store/schema.cr
@@ -71,7 +71,8 @@ module Gori
         # are bounded by retention.
         #
         # trigram tokenizer => case-insensitive SUBSTRING matching (like a body: LIKE), just
-        # indexed. Query terms must be >=3 chars (QL falls back to a BLOB LIKE scan below that).
+        # indexed. Query terms must be >=3 chars; below that QL scans the stored bytes with
+        # the same literal REGEXP its index-free `body:` uses (see ql.cr's `body_cond`).
         #
         # CONTENTLESS (content='') because we already store the raw bodies in
         # flows.{request,response}_body — the default FTS5 shadow %_content copy would be pure


### PR DESCRIPTION
`body~`, `header:` and index-free `body:` all end up in the SQLite `REGEXP` callback, once per row per column, and it was the most expensive thing History could be asked to do — 798ms and 137MB of garbage for `body~absentneedle` over 100k flows with 1KB bodies, against ≤31ms for every other query in `bench/history_filter_bench`. At 500k it was 4.1s and 688MB.

Decomposing the callback with parallel UDF variants over one fixture put the cost somewhere other than where it looked. Of the 876ms measured inside it the `String` copy was 81ms and the match 437ms — but `.scrub` was 370ms, and it was buying nothing: PCRE2 validates the subject itself under the UTF option Crystal compiles every Regex with. And most patterns arriving there are not regexes at all: QL compiles every `header:` and every index-free `body:` to `(?i)<escaped needle>`, and a hand-written `body~admin` is a literal too.

So a literal pattern is matched by a byte search straight off the SQLite pointer — no copy, no scrub, no engine — and a real regex stops validating each body twice.

## What keeps it honest

The fast path can never be a second definition of what matches, so it declines everything it cannot argue. A metacharacter, a class escape or a non-ASCII byte hands the pattern back to PCRE2 untouched. Case-sensitive needles are byte equality, which is exactly what PCRE2 would do. For `(?i)` the ASCII fold is a strict subset of PCRE2's, so a hit is always final; a miss is final too, except that PCRE2's UCP folding also maps `ſ` (U+017F) onto `s` and `K` (U+212A) onto `k` — **those two only, enumerated over the whole codepoint space rather than assumed, and a spec re-runs that enumeration** so a PCRE2 upgrade that widened the set cannot pass silently. A miss on a needle carrying `s` or `k` is handed back as "no answer" when the haystack actually holds that codepoint, and PCRE2 decides. `body:sql` still finds a body holding `ſql`.

Comparing from the **end** of the needle is load-bearing: the obvious forward scan is quadratic on a body of one repeated byte, and a captured body is the attacker's to shape. A work budget bounds what is left of that case by handing the row to PCRE2 rather than grinding.

## Also, one spelling instead of two

A `body:`/`header:` needle under three characters used to compile to an `instr` per ASCII case permutation per column — up to eight full-BLOB scans per row — and it folded case by a different rule than any longer needle, so `body:s` and `body:sql` disagreed about `ſ`: a shorter needle matching *fewer* rows than a longer one. Both lengths take the same NUL-transparent, NULL-guarded clause now, and `case_permutations` is gone.

## Measured

100k flows / 1KB bodies, against `main` (500k in brackets):

| query | before | after |
|---|---|---|
| `body~absentneedle` | 798ms · 137.6MB | **38ms · 656B** |
| | [4130ms · 688MB] | [**250ms · ~1KB**] |
| `header:missing` | 30.8ms · 12.8MB | **16ms · 592B** |
| | [199ms · 64MB] | [**120ms · 592B**] |
| `body:zz` | 123ms | **53ms** |
| `body:z` | 62.9ms | **38ms** |

The non-literal PCRE2 path, `body~secret\d+` over 20k 1KB bodies, against `main`:

| corpus | before | after |
|---|---|---|
| all valid UTF-8 | 4.36µs/row | **1.20µs/row** |
| half binary | 9.51µs/row | **5.21µs/row** |
| all binary | 13.86µs/row | **6.97µs/row** |

Which of the two equivalent validation routes runs is decided by sampling the last 512 rows, because the break-even between them is around two invalid bodies in five and a capture holds whatever the target served.

FTS, `host:`, `path:` and free-text are untouched. The History row paint was never the bottleneck — 19–60µs per frame against a 16ms budget.

## Verification

- `crystal spec`: 13,180 examples, 0 failures. `ameba_gate`, `bench_check`, `crystal build --no-codegen` all clean.
- `spec/store/safe_regexp_spec.cr` (new) asserts the answer the PCRE2 path gives for every case the byte search takes, including the two folds it defers for, the work budget, and a non-literal regex over an invalid-UTF-8 body driven through the real callback.
- A differential fuzz over randomised patterns and haystacks (invalid UTF-8, NULs, `ſ`, `K`, em dashes, CJK) found no disagreement in ~79k cases the fast path accepted.

## Known gap, not addressed here

`InterceptFilter#body:` still folds ASCII-only, so the live-message surface answers a `body:` needle carrying `s` differently from the same query over captured flows. That predates this work for needles of three characters or more; this change extends it to short needles by making the SQL side consistent with itself, and closing it belongs with that surface.