### PR TITLE
perf(miner): find JSON injection spans by one canary scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Docs: an accuracy pass over the English and Korean guides — corrected keys (deleting marked flows, Sitemap tagging), the rule host-scope and colour-rule condition semantics, per-field `Alt-Svc` stripping, undocumented `gori run` flags and MCP tool gating, and restored dropped Korean paragraphs.
 - TUI/CLI/MCP: every place gori names the scope-lens key now says `s` — the two `--in-scope` help lines, the History and Probe empty-state hints, the colour-rule advice note and the MCP scope arguments still named `⇧S`, the twin key removed when the lens became the Global `s` (#959)
 - Issues: CVSS v2.0 vectors written in the parenthesised form NVD's v2 calculator renders — `(AV:N/AC:L/Au:N/C:P/I:P/A:P)` — are accepted and scored instead of refused (cvss.cr 0.3.0, #994)
+- Miner: building a JSON probe no longer scans the whole body once per candidate name to locate the injected spans — a nested body was spending ~80x the reserialization itself there (a 256-name bucket over a 32-node body: ~117ms → ~1ms per probe). The injected canary values are unique, so one scan of the body finds them all; the output bytes are unchanged
 
 ## v0.5.0
 

--- a/bench/miner_inject_bench.cr
+++ b/bench/miner_inject_bench.cr
@@ -5,6 +5,14 @@
 # 128 (Query/Form/Multipart), 256 (Json) and 64 (Headers/Cookies), and this runs on the
 # orchestrator fiber ahead of the send.
 #
+# The JSON row uses `apply_with_spans` — the entry the ENGINE actually calls, which also returns
+# the injected byte spans the send seam protects from `$NAME` expansion. The other locations
+# splice at a known offset, but JSON is RESERIALIZED (`any.to_json`), so the spans can only be
+# found by searching the new body; that search was O(body) per candidate and, on a nested body,
+# cost ~80× the reserialization itself until the canary-scan fast path replaced it. It is here
+# so that regression cannot come back invisibly — and with CANARY values (`Canary.fresh`, what
+# the engine injects), so the fast path is the one measured.
+#
 # Build: crystal build bench/miner_inject_bench.cr -o bin/miner_inject_bench --release
 # Run:   bin/miner_inject_bench
 require "benchmark"
@@ -14,6 +22,7 @@ module Gori
 end
 
 require "../src/gori/miner/inject"
+require "../src/gori/miner/types" # Canary — the JSON row injects real canary values
 
 include Gori::Miner
 
@@ -21,8 +30,15 @@ def params(k : Int32) : Array({String, String})
   Array({String, String}).new(k) { |i| {"candidate_param_#{i}", "canary#{i}zz"} }
 end
 
-P128 = params(128)
-P64  = params(64)
+# Candidate names paired with real canary values (`Canary.fresh`), as the engine injects them —
+# the shape `Inject.json_spans`' fast path keys on.
+def canary_params(k : Int32) : Array({String, String})
+  Array({String, String}).new(k) { |i| {"candidate_param_#{i}", Canary.fresh} }
+end
+
+P128  = params(128)
+P64   = params(64)
+JP256 = canary_params(256)
 
 # A realistic seed request with a normal header block.
 HEAD_LINES = [
@@ -47,21 +63,35 @@ def request_with(first : String, body : String, ct : String?) : Bytes
 end
 
 FORM_BODY = String.build { |io| 30.times { |i| io << "&" if i > 0; io << "field" << i << "=value" << i } }
+# A nested JSON body: candidate keys are injected into EVERY object node, so the injected count
+# — and the span-search cost — scale with the node count, not just the bucket size.
+JSON_BODY = String.build do |io|
+  io << %({"user":{"id":123,"name":"alice","prefs":{"theme":"dark","lang":"en"}},"items":[)
+  32.times { |i| io << "," if i > 0; io << %({"sku":"ABC#{i}","qty":#{i},"meta":{"a":1,"b":2}}) }
+  io << "]}"
+end
 
 GET_REQ  = request_with("GET /api/v1/search?q=widgets&page=2 HTTP/1.1", "", nil)
 FORM_REQ = request_with("POST /api/v1/submit HTTP/1.1", FORM_BODY, "application/x-www-form-urlencoded")
+JSON_REQ = request_with("POST /api/v1/submit HTTP/1.1", JSON_BODY, "application/json")
+# Injected once for the header line — the benchmark loop below re-runs the full inject+scan.
+JSON_PROBE = Inject.apply_with_spans(JSON_REQ, Gori::Miner::Location::Json, JP256)
 
 puts "Miner::Inject.apply — one probe request per bucket:"
 puts "  GET  seed: #{GET_REQ.size} bytes; FORM seed: #{FORM_REQ.size} bytes (body #{FORM_BODY.bytesize})"
-puts "  bucket sizes: headers/cookies 64, query/form 128"
+puts "  JSON seed: #{JSON_REQ.size} bytes (body #{JSON_BODY.bytesize}, #{Inject.json_object_node_count(JSON_BODY.to_slice, Inject::MAX_JSON_NODES)} object nodes)"
+puts "  bucket sizes: headers/cookies 64, query/form 128, json 256"
 puts "  outputs: headers=#{Inject.apply(GET_REQ, Gori::Miner::Location::Headers, P64).size}" \
      " cookies=#{Inject.apply(GET_REQ, Gori::Miner::Location::Cookies, P64).size}" \
      " query=#{Inject.apply(GET_REQ, Gori::Miner::Location::Query, P128).size}" \
-     " form=#{Inject.apply(FORM_REQ, Gori::Miner::Location::Form, P128).size}"
+     " form=#{Inject.apply(FORM_REQ, Gori::Miner::Location::Form, P128).size}" \
+     " json=#{JSON_PROBE[0].size} (#{JSON_PROBE[1].size} spans)"
 
 Benchmark.ips do |x|
   x.report("Headers  x64 ") { Inject.apply(GET_REQ, Gori::Miner::Location::Headers, P64) }
   x.report("Cookies  x64 ") { Inject.apply(GET_REQ, Gori::Miner::Location::Cookies, P64) }
   x.report("Query    x128") { Inject.apply(GET_REQ, Gori::Miner::Location::Query, P128) }
   x.report("Form     x128") { Inject.apply(FORM_REQ, Gori::Miner::Location::Form, P128) }
+  # The engine's real JSON entry: reserialize + locate the injected spans (canary fast path).
+  x.report("Json+spans x256") { Inject.apply_with_spans(JSON_REQ, Gori::Miner::Location::Json, JP256) }
 end

--- a/spec/miner/inject_spec.cr
+++ b/spec/miner/inject_spec.cr
@@ -350,6 +350,51 @@ describe Gori::Miner::Inject do
       spans.each { |(a, b)| String.new(bytes[a, b - a]).should eq("\"pMINE\":\"vCANARY\"") }
     end
 
+    # The CANARY fast path (`Inject.json_spans_by_canary`): the engine injects real canaries, so
+    # the spans are found by scanning the body for canary tokens rather than the whole fragment.
+    # The slow path above uses non-canary `vCANARY`; this covers the road the engine takes.
+    it "json: real canary values still yield exactly the per-node fragment spans" do
+      c1 = M::Canary.fresh
+      c2 = M::Canary.fresh
+      base = "POST /a HTTP/1.1\r\nHost: h\r\nContent-Type: application/json\r\nContent-Length: 19\r\n\r\n{\"a\":{\"b\":1},\"c\":2}"
+      # A `$`-carrying candidate name is exactly what the spans protect from binding expansion.
+      bytes, spans = M::Inject.apply_with_spans(req(base), M::Location::Json, [{"p$NAME", c1}, {"q", c2}])
+      # 2 candidates × 2 object nodes (root + nested {"b":1}) = 4 spans.
+      spans.size.should eq(4)
+      covered = spans.map { |(a, b)| String.new(bytes[a, b - a]) }
+      covered.count("\"p$NAME\":\"#{c1}\"").should eq(2)
+      covered.count("\"q\":\"#{c2}\"").should eq(2)
+      # The `$`-carrying candidate is inside a span, so a send seam leaves it literal.
+      covered.all? { |s| !s.includes?("$NAME") || s == "\"p$NAME\":\"#{c1}\"" }.should be_true
+    end
+
+    # The by-canary scan finds a fragment by its canary tail, so a canary-shaped token that is
+    # ALREADY in the body — or one that happens to equal an injected value — must not become a
+    # phantom span. The full-fragment verify is what keeps that honest.
+    it "json: a canary-shaped token in the seed body is not mistaken for an injected span" do
+      c = M::Canary.fresh
+      # The seed already carries the very value we inject, as a pre-existing field's value.
+      body = "{\"seed\":\"#{c}\"}"
+      base = "POST /a HTTP/1.1\r\nHost: h\r\nContent-Type: application/json\r\nContent-Length: #{body.bytesize}\r\n\r\n#{body}"
+      bytes, spans = M::Inject.apply_with_spans(req(base), M::Location::Json, [{"cand", c}])
+      spans.size.should eq(1) # only the injected "cand":"<c>", not the seed's "seed":"<c>"
+      String.new(bytes[spans[0][0], spans[0][1] - spans[0][0]]).should eq("\"cand\":\"#{c}\"")
+    end
+
+    # A malformed (non-parsing) body takes the byte-splice road, and one ENDING in a bare
+    # canary-shaped token that also equals the injected value put that token at the very end of
+    # the body — one byte short of the fragment's closing quote. The by-canary scan must not read
+    # past the body there (it would raise IndexError); it skips it, exactly as the fragment
+    # search does. `--flow` mines captured bodies, so an adversarial capture can reach this.
+    it "json: a trailing canary-shaped token in a malformed body does not read past the body" do
+      c = M::Canary.fresh
+      body = "{\"x\":1 #{c}" # no closing brace → splice road; body ends in a bare canary token
+      base = "POST /a HTTP/1.1\r\nHost: h\r\nContent-Type: application/json\r\nContent-Length: #{body.bytesize}\r\n\r\n#{body}"
+      bytes, spans = M::Inject.apply_with_spans(req(base), M::Location::Json, [{"cand", c}])
+      spans.size.should eq(1) # only the spliced "cand":"<c>", not the trailing bare token
+      String.new(bytes[spans[0][0], spans[0][1] - spans[0][0]]).should eq("\"cand\":\"#{c}\"")
+    end
+
     it "multipart: spans cover the injected part (name and value), seed part excluded" do
       base = "POST /a HTTP/1.1\r\nHost: h\r\nContent-Type: multipart/form-data; boundary=BB\r\nContent-Length: 40\r\n\r\n--BB\r\nContent-Disposition: form-data; name=\"seedm\"\r\n\r\nSEEDVAL\r\n--BB--\r\n"
       bytes, spans = M::Inject.apply_with_spans(req(base), M::Location::Multipart, [{"pMINE", "vCANARY"}])

--- a/src/gori/miner/fingerprint.cr
+++ b/src/gori/miner/fingerprint.cr
@@ -41,38 +41,13 @@ module Gori::Miner
       Probe.new(metrics, found)
     end
 
-    # Collect every `gq`+8-lower-hex token (Canary.fresh's exact shape, LEN=10) present in
-    # `bytes` into `into`. A verbatim canary occurrence lands at its own start offset, so the
-    # set holds exactly the tokens the old per-canary `includes?` would have matched — same
-    # reflected set, same echo-control result. No canary can be a substring of another (fixed
-    # length), and no lower-hex byte is `g` (0x67), so tokens never overlap.
+    # Collect every canary token present in `bytes` into `into`. A verbatim canary occurrence
+    # lands at its own start offset, so the set holds exactly the tokens the old per-canary
+    # `includes?` would have matched — same reflected set, same echo-control result. The scan
+    # (and the `gq`+8-lower-hex shape it recognises) is `Canary.each_token`, shared with
+    # `Inject`'s JSON span finder so the two cannot disagree about what a canary looks like.
     private def self.scan_canaries(bytes : Bytes, into : Set(String)) : Nil
-      return if bytes.size < Canary::LEN
-      last = bytes.size - Canary::LEN
-      i = 0
-      while i <= last
-        # `Slice(UInt8)#index` is memchr, so the bytes BETWEEN candidate starts are skipped by
-        # libc a word at a time instead of one comparison each in Crystal. Every response body
-        # of the run is walked here, and a `g` is ~2% of ordinary text — so 98% of the walk was
-        # a loop doing nothing but failing its first test.
-        break unless found = bytes.index(0x67_u8, i)
-        break if found > last
-        i = found
-        if bytes.unsafe_fetch(i + 1) == 0x71_u8 && canary_tail?(bytes, i + 2)
-          into << String.new(bytes[i, Canary::LEN])
-        end
-        i += 1
-      end
-    end
-
-    # The 8 bytes after `gq` are all lower-hex (0-9 a-f). `from` + 8 is in bounds by the
-    # `i <= last` invariant in scan_canaries, so unsafe_fetch is safe.
-    private def self.canary_tail?(bytes : Bytes, from : Int32) : Bool
-      8.times do |k|
-        b = bytes.unsafe_fetch(from + k)
-        return false unless (b >= 0x30_u8 && b <= 0x39_u8) || (b >= 0x61_u8 && b <= 0x66_u8)
-      end
-      true
+      Canary.each_token(bytes) { |i| into << String.new(bytes[i, Canary::LEN]) }
     end
 
     # Word count over decoded bytes, allocation-free (whitespace transitions) — lifted

--- a/src/gori/miner/inject.cr
+++ b/src/gori/miner/inject.cr
@@ -363,14 +363,87 @@ module Gori::Miner
       io.write(new_body)
       out = io.to_slice
 
-      # A JSON candidate is reserialized (`any.to_json`) or textually spliced, so its final
-      # position is only known after the fact: locate every injected `"name":"value"` fragment
-      # in the new body (the SAME spelling both paths emit — `n.to_json`/`v.to_json`, no space,
-      # Crystal-compact). A name is injected into every object node, so a fragment can recur;
-      # each occurrence is a span. Values are canaries here (unique), so a fragment cannot
-      # collide with pre-existing body content, and merge_spans folds any incidental overlap so
-      # the list stays sorted+disjoint for `Env.expand_bindings`' cursor.
       body_off = head.size + eol.bytesize * 2
+      {out, merge_spans(json_spans(new_body, body_off, params))}
+    end
+
+    # Byte spans of every injected `"name":"value"` fragment in the reserialized body.
+    #
+    # A JSON candidate is reserialized (`any.to_json`) or textually spliced, so its final
+    # position is only known after the fact — and a name is injected into EVERY object node, so
+    # each fragment can recur, each occurrence its own span. The SAME spelling both inject paths
+    # emit (`n.to_json`/`v.to_json`, no space, Crystal-compact) is what is searched for.
+    #
+    # Two roads to the identical span set. The general one (`json_spans_by_fragment`) searches
+    # the whole body for each fragment, which is O(body) PER candidate: measured, a 128-name
+    # bucket over a 32-node body spent ~29 ms here, ~80× the ~370 µs the reserialization itself
+    # costs — the span scan, not the JSON work, was the JSON location's real per-probe cost. The
+    # fast one exploits what the miner ALWAYS injects: DISTINCT canary values (`Canary.fresh`).
+    # Every fragment ends in its canary, and a canary appears nowhere else, so ONE
+    # memchr-accelerated scan of the body for canary tokens — the same scan `Fingerprint` runs —
+    # locates all of them at once, O(body) for the whole bucket. It falls back to the general
+    # search the moment a value is not a distinct canary (the specs, any hand-driven
+    # `apply_with_spans`), so the answer is byte-identical either way.
+    #
+    # Returns spans in whatever order each road emits them; `inject_json` runs `merge_spans` on
+    # the result to give `Env.expand_bindings`' single-cursor walk the sorted+disjoint list it
+    # requires.
+    private def self.json_spans(new_body : Bytes, body_off : Int32,
+                                params : Array({String, String})) : Array({Int32, Int32})
+      if by_canary = canary_fragments(params)
+        json_spans_by_canary(new_body, body_off, by_canary)
+      else
+        json_spans_by_fragment(new_body, body_off, params)
+      end
+    end
+
+    # `{canary => its full "name":"value" fragment}`, or nil the moment a value is not a
+    # DISTINCT canary — the signal to take the general span search instead. A canary
+    # (`Canary.shaped?`: `gq` + 8 lower-hex) needs no JSON escaping, so the fragment's tail is
+    # exactly `"` + canary + `"` and the canary's byte offset inside the fragment is fixed at
+    # `frag.size - Canary::LEN - 1`. A repeated value would make one canary map to two fragments,
+    # which the by-canary scan cannot disambiguate, so that too falls back.
+    private def self.canary_fragments(params : Array({String, String})) : Hash(String, Bytes)?
+      map = Hash(String, Bytes).new(initial_capacity: params.size)
+      params.each do |(n, v)|
+        return nil unless Canary.shaped?(v)
+        return nil if map.has_key?(v)
+        map[v] = "#{n.to_json}:#{v.to_json}".to_slice
+      end
+      map
+    end
+
+    # Locate injected fragments by scanning ONCE for their canary tails (`Canary.each_token`, the
+    # same memchr scan `Fingerprint` runs). A body position holding a canary is the tail of
+    # exactly one fragment; its start is a fixed offset back, and the full-fragment VERIFY keeps a
+    # stray canary-shaped token in PRE-EXISTING body content — or one that happens to also equal
+    # an injected value — from ever becoming a span (the general search would not have matched
+    # there either).
+    private def self.json_spans_by_canary(new_body : Bytes, body_off : Int32,
+                                          by_canary : Hash(String, Bytes)) : Array({Int32, Int32})
+      spans = [] of {Int32, Int32}
+      Canary.each_token(new_body) do |i|
+        # `each_token` already validated the shape, so the map lookup only has to reject a token
+        # that is not one of THIS bucket's injected values.
+        next unless frag = by_canary[String.new(new_body[i, Canary::LEN])]?
+        # `start >= 0` AND `start + frag.size <= size`: a canary at the very END of the body (a
+        # bare canary-shaped token in a malformed, non-parsing body — the `splice_json_object`
+        # road — that also equals an injected value) leaves no room for the fragment's closing
+        # quote, so the slice read would run past the body. The general search never matches
+        # there either, so skipping keeps the two roads identical.
+        start = i - (frag.size - Canary::LEN - 1)
+        if start >= 0 && start + frag.size <= new_body.size && new_body[start, frag.size] == frag
+          spans << {body_off + start, body_off + start + frag.size}
+        end
+      end
+      spans
+    end
+
+    # The general span search: O(body) per candidate. Correct for ANY value (the specs' plain
+    # `"v"`, a hand-driven `apply_with_spans`), and the fallback when the fast canary scan cannot
+    # apply. Returns spans grouped by candidate, not ordered — `json_spans`' caller merges them.
+    private def self.json_spans_by_fragment(new_body : Bytes, body_off : Int32,
+                                            params : Array({String, String})) : Array({Int32, Int32})
       spans = [] of {Int32, Int32}
       params.each do |(n, v)|
         frag = "#{n.to_json}:#{v.to_json}".to_slice
@@ -380,7 +453,7 @@ module Gori::Miner
           from = idx + frag.size
         end
       end
-      {out, merge_spans(spans)}
+      spans
     end
 
     # The new JSON body for `body`, or nil when this location has nothing to inject into.

--- a/src/gori/miner/types.cr
+++ b/src/gori/miner/types.cr
@@ -166,6 +166,51 @@ module Gori
         "gq#{Random::Secure.hex(4)}"
       end
 
+      # ── recognising a canary in captured bytes ──────────────────────────────────────
+      # The token SHAPE is a correctness-linked invariant, not a cosmetic one: `Fingerprint`
+      # decides reflection by whether a canary appears in the response, and `Inject` locates the
+      # JSON spans a send seam must protect by the same tokens. If those two ever disagreed about
+      # what a canary looks like, one would mint what the other cannot find. So the shape lives
+      # HERE, beside `fresh` that mints it, and both scanners call it — no second definition to
+      # drift from this one.
+
+      # The 8 bytes at `from` are all lower-hex (0-9 a-f) — a `gq`+8-hex canary's tail. `from`+8
+      # must be in bounds; every caller holds `i <= size - LEN`.
+      def self.hex_tail?(bytes : Bytes, from : Int32) : Bool
+        i = 0
+        while i < LEN - 2
+          b = bytes.unsafe_fetch(from + i)
+          return false unless (b >= 0x30_u8 && b <= 0x39_u8) || (b >= 0x61_u8 && b <= 0x66_u8)
+          i += 1
+        end
+        true
+      end
+
+      # Is `s` exactly a canary — `gq` + 8 lower-hex, `LEN` bytes and no more?
+      def self.shaped?(s : String) : Bool
+        return false unless s.bytesize == LEN
+        b = s.to_slice
+        b.unsafe_fetch(0) == 0x67_u8 && b.unsafe_fetch(1) == 0x71_u8 && hex_tail?(b, 2)
+      end
+
+      # Yield the start offset of every `gq`+8-hex canary token in `bytes`. `Slice(UInt8)#index`
+      # is memchr, so the bytes BETWEEN candidate `g`s are skipped by libc a word at a time
+      # rather than one Crystal comparison each — a `g` is ~2% of ordinary text, so the walk that
+      # matters is the memchr, not this loop. No canary is a substring of another (fixed length)
+      # and no lower-hex byte is `g`, so tokens never overlap and each start is yielded once.
+      def self.each_token(bytes : Bytes, & : Int32 ->) : Nil
+        return if bytes.size < LEN
+        last = bytes.size - LEN
+        i = 0
+        while i <= last
+          break unless found = bytes.index(0x67_u8, i)
+          break if found > last
+          i = found
+          yield i if bytes.unsafe_fetch(i + 1) == 0x71_u8 && hex_tail?(bytes, i + 2)
+          i += 1
+        end
+      end
+
       # `n` canaries from ONE CSPRNG draw. `fresh` costs a `getrandom` syscall per call, and
       # the miner mints one canary per candidate NAME — a bucket is 64 by default and up to
       # 1024 (`Config#bucket`), so a single bucket send was up to 1024 syscalls before a byte


### PR DESCRIPTION
## What

Building a JSON probe re-searched the whole reserialized body **once per candidate name** to locate the injected `"name":"value"` spans (the send seam protects those from `$NAME` expansion) — O(body × N). On a nested body that dwarfed the reserialization itself: a 256-name bucket over a 32-node body spent **~117ms per probe** there, ~80× the ~370µs `any.to_json` costs. `bench/miner_inject_bench.cr` never saw this because it used `Inject.apply` (which discards spans) and skipped JSON entirely.

## Fix

The miner always injects **distinct canary values**, and every fragment ends in its canary, so one memchr-accelerated scan of the body for canary tokens locates all of them at once — O(body) for the whole bucket. A full-fragment verify plus a `start >= 0 && start + frag.size <= size` bounds guard keep it **byte-identical** to the general search, which stays as the fallback for any non-canary value (the specs, a hand-driven `apply_with_spans`).

- **~117ms → ~1ms per probe**, output bytes unchanged.
- The canary token shape + its memchr scan are a correctness-linked invariant shared by Fingerprint (reflection) and Inject (span protection), so they move onto `Canary` (`shaped?` / `each_token`) — one definition both call, no drift.
- The inject bench now measures the JSON `apply_with_spans` path the engine actually takes.

## Verification

- **5000 randomized differential cases** (nested bodies, pre-existing canary-shaped tokens, `$`-carrying names, canary + non-canary values) — fast path byte-identical to the general search.
- New regression specs: multi-node canary spans, a seed body's canary-shaped token not mistaken for an injected span, and a malformed trailing-token OOB guard (a bug the fast path would otherwise crash on).
- `crystal spec spec/miner/` (241) + probe specs green; reflect bench unregressed (23µs); `crystal build --no-codegen src/main.cr`, `scripts/bench_check.sh`, `crystal tool format --check` and ameba all clean.