### PR TITLE
fix(jwt): stop the JSON decode from hiding a malformed token as a clean JWS

### DIFF
--- a/spec/cli/run/jwt_spec.cr
+++ b/spec/cli/run/jwt_spec.cr
@@ -29,6 +29,40 @@ describe "gori run jwt" do
     j["header"]["typ"].as_s.should eq("JWT")
     j["payload"]["sub"].as_s.should eq("1")
     j["signed"].as_bool.should be_true
+    # A plain 3-part token carries no extra-segment fields — the shape stays clean.
+    j["extra_segments"]?.should be_nil
+    j["note"]?.should be_nil
+  end
+
+  it "decode_json surfaces segments smuggled after a JWS instead of dropping them" do
+    # The text decoder WARNS on a >3-segment token (decoder_spec, fix #22) and `verify`
+    # REFUSES it, but `decode_json` used to report a clean {type:JWS, signed:true} and drop
+    # parts[3..] on the floor — so `gori run jwt --format json` / MCP `jwt_decode` hid data
+    # smuggled after a valid-looking JWS prefix. It now rides in `extra_segments` + `note`,
+    # keyed on presence the way a JWE is keyed on `type`.
+    smuggled = "#{jwt}.SMUGGLED"
+    j = JSON.parse(Gori::Jwt.decode_json(smuggled))
+    j["type"].as_s.should eq("JWS")
+    j["extra_segments"].as_a.map(&.as_s).should eq(["SMUGGLED"])
+    j["note"].as_s.should contain("4 dot-separated segments")
+
+    # A five-part blob that is not a decodable JWE (no `enc`) surfaces both extras too, and
+    # is NOT reported as a JWE (that discrimination lives in Jwe.parse).
+    five = "#{jwt}.extra.more"
+    j5 = JSON.parse(Gori::Jwt.decode_json(five))
+    j5["type"].as_s.should eq("JWS")
+    j5["extra_segments"].as_a.map(&.as_s).should eq(["extra", "more"])
+  end
+
+  it "decode_json flags an under-segmented blob instead of reporting a clean JWS" do
+    # The other end of the same divergence: a single dotted-less segment is "not a decodable
+    # JWT" to `verify` and the text decoder, but decode_json used to report a success-shaped
+    # {type:JWS, payload:null, signed:false}. It now carries a `note` (no extra_segments).
+    j = JSON.parse(Gori::Jwt.decode_json("eyJhbGciOiJIUzI1NiJ9"))
+    j["type"].as_s.should eq("JWS")
+    j["signed"].as_bool.should be_false
+    j["note"].as_s.should contain("not a decodable token")
+    j["extra_segments"]?.should be_nil
   end
 
   it "verify_json is {alg, verified, reason} with reason null on the plain answers" do

--- a/src/gori/jwt/present.cr
+++ b/src/gori/jwt/present.cr
@@ -27,6 +27,27 @@ module Gori
           sig = parts[2]?
           j.field "signature", (sig || "")
           j.field "signed", !(sig.nil? || sig.empty?)
+          # `note` (and, for a long token, `extra_segments`) rides on exactly the malformed
+          # shapes the sibling surfaces refuse, so the JSON projection can't quietly disagree
+          # with them — the divergence this file's header comment warns against. The ordinary
+          # 2/3-segment JWS carries neither field, so its shape is unchanged and a consumer
+          # keys on `note`/`extra_segments` presence the way it keys on `type` for a JWE.
+          if parts.size < 2
+            # A single dotted-less blob is not a JWS at all — `verify` calls it "not a
+            # decodable JWT" and the text decoder raises "need 2-3 dot-separated parts", while
+            # this used to report a clean {type:JWS, payload:null, signed:false} for junk.
+            j.field "note", "only #{parts.size} segment — a JWS needs at least header.payload " \
+                            "(2 or 3 dot-separated parts); not a decodable token"
+          elsif parts.size > 3
+            # Anything past three segments is smuggled/obfuscated data riding after a
+            # valid-looking JWS prefix (a JWE, at five, was already returned above). `parts[3..]`
+            # would otherwise be dropped on the floor and the token reported as a clean signed
+            # JWS — what the text decoder WARNS on (fix #22) and `verify` REFUSES.
+            extra = parts[3..]
+            j.field "extra_segments" { j.array { extra.each { |seg| j.string seg } } }
+            j.field "note", "#{parts.size} dot-separated segments — a JWS has 3 and a JWE 5; " \
+                            "#{extra.size} segment(s) beyond header.payload.signature shown raw, not decoded"
+          end
         end
       end
     end

--- a/src/gori/mcp/tools/decode.cr
+++ b/src/gori/mcp/tools/decode.cr
@@ -265,7 +265,10 @@ module Gori
           "signature, signed}. An ENCRYPTED five-part token (JWE) returns {type:\"JWE\", alg, enc, " \
           "kid, header, payload:null, encrypted:true, encrypted_key, iv, ciphertext, tag} — gori " \
           "reads the JWE protected header and does NOT decrypt, so the claims are not available " \
-          "at any surface and `payload` is null rather than absent. Branch on `type`." do |s|
+          "at any surface and `payload` is null rather than absent. Branch on `type`. A " \
+          "malformed token stays type JWS but also carries a `note`: one segment (not a " \
+          "decodable token) or, past three, `extra_segments` too — the raw trailing segments " \
+          "of data smuggled after a JWS prefix, which `jwt_verify` refuses." do |s|
           s.field "token", strprop("the JWT: a JWS (header.payload[.signature]) or a JWE (header.encrypted_key.iv.ciphertext.tag)"), required: true
         end
 


### PR DESCRIPTION
## What

Audited the whole JWT feature (engine, CLI, MCP, TUI, passive probe) and found one real defect: a **surface-parity gap** in `Jwt.decode_json`, the shared emitter behind `gori run jwt --format json` and MCP `jwt_decode`.

`decode_json` read `parts[2]` as the signature and dropped everything past it, so a token with data smuggled after a valid JWS prefix (`header.payload.sig.SMUGGLED`) came back as a clean `{"type":"JWS","signed":true}` with the 4th segment gone. Meanwhile:

- the **text** decoder (`Decoder::Codecs.jwt_decode`, used by the TUI DECODED pane and `gori run jwt`) already **WARNS** on >3 segments (fix #22), and
- `jwt_verify` already **REFUSES** the token.

Only the JSON projection quietly disagreed — the exact "which surface speaks" divergence `present.cr`'s own header comment (*"the two surfaces can never diverge — the DecodedView lesson"*) warns against. A scripted/agent consumer of the JSON saw smuggled data as a legitimate signed token.

## Change

`decode_json` now surfaces the malformation on the JSON side too:

- **> 3 segments**: the raw trailing segments ride in a new `extra_segments` array plus an explanatory `note`.
- **< 2 segments** (the other end of the same gap — a single dotted-less blob that `verify`/the text decoder call *"not a decodable JWT"* but this reported as a success-shaped JWS): a `note`.

Both fields are present **only** on the malformed shapes, so the ordinary 2/3-segment JWS is byte-for-byte unchanged, and a consumer keys on their presence the way it already keys on `type` for a JWE.

`signed` is deliberately left reflecting *"a non-empty signature segment is present"* — its documented meaning. Decode does no verification (that is `jwt_verify`'s job; a 3-part token with a garbage signature also reports `signed:true`), so overloading it to mean "well-formed" would give it two meanings depending on segment count. The `extra_segments`/`note` are the malformation signal.

The MCP `jwt_decode` schema docstring documents the new fields.

## Testing

- New regression specs in `spec/cli/run/jwt_spec.cr` for both the >3 and <2 cases, plus an assertion that a plain 3-part token stays clean.
- `crystal spec` for all JWT-related specs: **268 examples, 0 failures**.
- `crystal build --no-codegen src/main.cr` clean; `crystal tool format --check` clean.
- The two ameba cyclomatic-complexity warnings on `decode.cr` are pre-existing on `main` (methods untouched by this change).

Reviewed via `/code-review` (xhigh); its findings on `signed` semantics and note-wording centralization were considered and declined with the reasoning above.