### PR TITLE
fix(oast): arm the live probe out-of-band minter when a listener starts

### DIFF
--- a/spec/tui/oast_arms_probe_oob_spec.cr
+++ b/spec/tui/oast_arms_probe_oob_spec.cr
@@ -1,0 +1,244 @@
+require "../spec_helper"
+require "file_utils"
+
+include Gori::Tui
+
+# Starting an OAST listener has to ARM the live probe analyzer's out-of-band minter.
+#
+# `Probe::Analyzer#@oob` — the minter the blind SSRF/XXE/command-injection rules plant against —
+# is resolved once at construction and otherwise ONLY by `reload_rule_config` (a Rules-tab edit
+# / factory reset). The OAST tab was the surface that creates the session those rules mint
+# against, and it never touched the analyzer: a project opened with no session left `@oob` nil,
+# so a listener could be live in the OAST tab while an active probe scan planted nothing and its
+# empty result read as "no blind vulnerability" when it meant "never looked". `apply_registration`
+# now calls `Analyzer#rearm_out_of_band`, so both a fresh register and a resume arm the rules
+# without a restart.
+#
+# The assertion reads `session.probe.@oob` directly, the same ivar seam the sibling OAST specs
+# use for `@reg_events` / `@oast_events` — a StoreMinter is non-nil exactly when the analyzer can
+# mint, which is the whole of what the wiring changed.
+
+# The narrow shell facade a controller reaches the world through. Inert except `session`, `jobs`
+# and `notifications` — the members `apply_registration` and its drain touch.
+private class FakeHost
+  include Gori::Tui::Host
+
+  def initialize(@session : Gori::Session)
+    @jobs = Gori::Tui::Jobs.new
+    @notifications = Gori::Tui::Notifications.new
+  end
+
+  def session : Gori::Session
+    @session
+  end
+
+  def jobs : Gori::Tui::Jobs
+    @jobs
+  end
+
+  def notifications : Gori::Tui::Notifications
+    @notifications
+  end
+
+  def status(message : String) : Nil
+  end
+
+  def request_overlay(kind : Symbol) : Nil
+  end
+
+  def request_focus(pane : Symbol) : Nil
+  end
+
+  def focus_body : Nil
+  end
+
+  def resolve_subtab_focus : Nil
+  end
+
+  def switch_tab(tab : Symbol) : Nil
+  end
+
+  def goto_tab(tab : Symbol) : Nil
+  end
+
+  def open_palette : Nil
+  end
+
+  def open_help_query(surface : Symbol) : Nil
+  end
+
+  def open_space_menu : Nil
+  end
+
+  def open_fuzz_set_editor(edit_index : Int32?) : Nil
+  end
+
+  def open_fuzz_advanced_editor : Nil
+  end
+
+  def open_authorize_identities : Nil
+  end
+
+  def reconfigure_sequence : Nil
+  end
+
+  def open_scope_rule_editor(edit_id : Int64?, kind : String, match_type : String, pattern : String) : Nil
+  end
+
+  def open_custom_rule_editor(rule : Gori::Probe::CustomRule?) : Nil
+  end
+
+  def open_rewriter_preset_picker : Nil
+  end
+
+  def open_rewriter_rule_editor(rule : Gori::Store::MatchRule?) : Nil
+  end
+
+  def open_colormarker_rule_editor(rule : Gori::Store::ColorRule?) : Nil
+  end
+
+  def open_colormarker_color_editor(color : Gori::Settings::ColormarkerColor?) : Nil
+  end
+
+  def open_extract_rule_editor(rule : Gori::Store::ExtractRule?) : Nil
+  end
+
+  def open_chain_save : Nil
+  end
+
+  def open_chain_load : Nil
+  end
+
+  def open_oast_provider_editor(provider : Gori::Oast::ProviderConfig?) : Nil
+  end
+
+  def confirm(title : String, message : String, *, confirm_label : String, danger : Bool,
+              return_to : Symbol = :none, &action : -> Nil) : Nil
+    action.call
+  end
+
+  def overlay : Symbol
+    :none
+  end
+
+  def active_tab : Symbol
+    :oast
+  end
+
+  def focus : Symbol
+    :body
+  end
+
+  def reveal? : Bool
+    false
+  end
+
+  def toggle_reveal : Nil
+  end
+
+  def pretty? : Bool
+    false
+  end
+
+  def toggle_pretty : Nil
+  end
+
+  def toggle_scope_lens : Nil
+  end
+
+  def toggle_sandbox : Nil
+  end
+
+  def apply_project_network(bind_host : String, bind_port : Int32, upstream : String,
+                            connect_secs : Int32, io_secs : Int32, capture_mib : Int32) : String
+    ""
+  end
+
+  def apply_project_protos(spec : String) : String
+    ""
+  end
+end
+
+# A Provider that never dials a socket: register would be a network call the fixture must not
+# make, and apply_registration only ever calls generate_payload/deregister on a fresh RegOk.
+private class ArmStubProvider < Gori::Oast::Provider
+  def initialize
+    super(Gori::Oast::ProviderKind::Interactsh, "https://oast.test", nil)
+  end
+
+  def register(http : Gori::Oast::Http) : Gori::Oast::Session
+    raise "not used"
+  end
+
+  def generate_payload(session : Gori::Oast::Session) : String
+    "#{session.correlation_id}.oast.test"
+  end
+
+  def poll(http : Gori::Oast::Http, session : Gori::Oast::Session) : Array(Gori::Oast::Interaction)
+    [] of Gori::Oast::Interaction
+  end
+end
+
+private ARM_CA_ROOT = File.tempname("gori-oast-arm-ca")
+Spec.after_suite { FileUtils.rm_rf(ARM_CA_ROOT) }
+
+# A real Session with one enabled project provider and NO oast_sessions row, so the analyzer is
+# built with a nil out-of-band minter (the project-opened-with-no-session case).
+private def with_arm_controller(&)
+  saved = Gori::Settings.oast_providers
+  Gori::Settings.oast_providers = [] of Gori::Settings::OastProvider
+  root = File.tempname("gori-oast-arm")
+  Dir.mkdir_p(root)
+  project = Gori::ProjectRegistry.new(root).temp("oastarm")
+  session = Gori::Session.open(Gori::Config.new(listen: "127.0.0.1", port: 0),
+    Gori::Proxy::Tls::CertAuthority.load_or_create(ARM_CA_ROOT), Gori::Verbs.registry, project)
+  begin
+    pid = session.store.insert_oast_provider("prov", "interactsh", "https://oast.test", nil, true, 0)
+    host = FakeHost.new(session)
+    yield OastController.new(host), session, "p_#{pid}"
+  ensure
+    session.close
+    FileUtils.rm_rf(root) if Dir.exists?(root)
+    Gori::Settings.oast_providers = saved
+  end
+end
+
+private def reg_ok(key : String, corr : String) : OastController::RegOk
+  engine = Gori::Oast::Session.new(0_i64, Gori::Oast::ProviderKind::Interactsh,
+    "https://oast.test", corr, "sec", registered: true)
+  OastController::RegOk.new(engine, ArmStubProvider.new, key, nil, key, false)
+end
+
+describe Gori::Tui::OastController do
+  it "arms the probe analyzer's out-of-band minter when a listener registers" do
+    with_arm_controller do |c, session, key|
+      # A project opened with no session: the analyzer has nothing to mint against, so every
+      # out-of-band rule plans nothing.
+      session.probe.@oob.should be_nil
+      # A flow the passive pass already scanned. rearm must not re-run passive analysis over it
+      # (that path bumps hit_count for existing findings), so the id has to survive the register.
+      session.probe.@analyzed << 4242_i64
+
+      c.@reg_events.send(reg_ok(key, "c0rrelati0nid00001"))
+      c.drain_events
+
+      # The register inserted a session row AND re-resolved the minter, so the OOB rules can now
+      # plant against the live listener without a restart or a Rules-tab edit.
+      session.probe.@oob.should_not be_nil
+      # It re-armed the ACTIVE pipeline only — @analyzed is untouched, so no passive re-scan and
+      # no hit_count inflation on existing findings (that is why it is not `@analyzed.clear`).
+      session.probe.@analyzed.includes?(4242_i64).should be_true
+    end
+  end
+
+  it "does NOT arm when the provider vanished mid-flight (the discard path)" do
+    with_arm_controller do |c, session, _key|
+      session.probe.@oob.should be_nil
+      # A RegOk whose key names no current provider is discarded before any session row is
+      # written, so the minter stays nil — the rearm call sits past that early return.
+      c.@reg_events.send(reg_ok("p_999999", "c0rrelati0nid00002"))
+      c.drain_events
+      session.probe.@oob.should be_nil
+    end
+  end
+end

--- a/src/gori/probe/analyzer.cr
+++ b/src/gori/probe/analyzer.cr
@@ -115,11 +115,36 @@ module Gori
         @disabled, @disabled_degraded = load_disabled
         @warned_degraded = false unless @disabled_degraded # re-arm the warning if the store re-breaks
         @custom = load_custom
-        # Re-resolve the OAST minter too: starting a listener is exactly the kind of change that
-        # should arm the out-of-band rules without a restart, and this is the one place every
-        # surface already calls after touching probe config.
+        # Re-resolve the OAST minter too, so a Rules-tab edit picks up a listener started since
+        # construction. The OAST tab arms it directly through `rearm_out_of_band` (starting a
+        # listener is not a probe-config edit, so it does not route here).
         @oob = load_oob
         @analyzed.clear
+      end
+
+      # Re-resolve the OAST minter after a listener is registered or resumed, so the out-of-band
+      # rules can plant against it WITHOUT a restart or a Rules-tab edit. `@oob` is otherwise
+      # built once at construction and refreshed only by `reload_rule_config` (a Rules-tab edit /
+      # factory reset) — neither of which fires when the OAST tab starts a listener, so a project
+      # opened with no session left the blind SSRF/XXE/command-injection rules INERT with a live
+      # listener until gori restarted, and an active scan's empty result read as "no blind vuln"
+      # when it meant "never planted".
+      #
+      # `arm_active_backfill`, not `@analyzed.clear`: this re-arms the ACTIVE pipeline ONLY, the
+      # same mechanism `set_mode` uses to enter an actively-probing mode. Clearing @analyzed would
+      # additionally re-run PASSIVE analysis over recent flows, and `upsert_probe_issues` bumps
+      # `hit_count` for every existing (code, host) — so merely starting a listener would inflate
+      # the count of unrelated passive findings and repeat that I/O on every register. An OOB rule
+      # recorded NO @active_seen key while unarmed (its `dedup_key` returns nil with no minter), so
+      # a plain backfill re-enqueues and fires it while every already-planted non-OOB rule skips on
+      # its existing key. It arms only in an actively-probing mode; in Passive/Off there is nothing
+      # to plant yet, and the next set_mode into Active runs the same backfill against the minter
+      # this just resolved. Already-probed flows keep the payloads planted under the prior session
+      # (@active_seen has no session id) — a stop keeps those resolving, so it is a re-plant this
+      # deliberately does not force, not a coverage gap.
+      def rearm_out_of_band : Nil
+        @oob = load_oob
+        arm_active_backfill
       end
 
       # {the operator's disabled set, degraded}. `degraded` = the list could NOT be read (store

--- a/src/gori/tui/controllers/oast_controller.cr
+++ b/src/gori/tui/controllers/oast_controller.cr
@@ -1644,6 +1644,13 @@ module Gori::Tui
         # Mark the session live NOW so a probe scan in the ≤SESSION_HEARTBEAT window before the
         # first heartbeat still mints against it rather than an older polled session.
         @host.session.store.touch_oast_session(id)
+        # Arm the live probe analyzer's OAST minter against this session. It is resolved once at
+        # construction and otherwise only on a Rules-tab edit, so a project opened with no
+        # session left the out-of-band probe rules (blind SSRF/XXE/command-injection) INERT with
+        # a listener running here until a restart — the callbacks arrived nowhere and the active
+        # scan read clean. Both a fresh register and a resume land here, and this is past the
+        # discard early-return above, so a listener whose provider vanished mid-flight never arms.
+        @host.session.probe.rearm_out_of_band
         if reg.want_payload
           deliver_payload(reg.provider.generate_payload(reg.session))
         elsif reg.resumed


### PR DESCRIPTION
## What

Starting or resuming an OAST listener in the TUI now arms the live probe analyzer's out-of-band minter, so the blind SSRF / XXE / command-injection rules can plant against it — without a Rules-tab edit or a gori restart.

## The bug

`Probe::Analyzer#@oob` (the minter the out-of-band rules plant against) is resolved once at construction and otherwise only in `reload_rule_config` — a Rules-tab edit or factory reset. Neither fires when the OAST tab registers or resumes a listener.

So on a project **opened with no OAST session** (the common first-time case):

- the operator starts a listener in the OAST tab,
- switches probe to Active,
- but every out-of-band rule's `plan` sees `opts.oob == nil` and plants **nothing**,
- callbacks arrive nowhere, and the active scan's empty result reads as *"no blind vulnerability"* when it means *"never looked"*.

The rules only came alive after an unrelated Rules-tab edit or a restart. The author's own comment in `reload_rule_config` anticipated this arming, but the wiring from the OAST surface was missing.

Only the long-lived TUI analyzer caches the minter — CLI `gori run probe` and MCP `probe_scan` read the store fresh per scan and were never affected.

## The fix

`OastController#apply_registration` calls a new `Analyzer#rearm_out_of_band` once the session row is written and touched — placed **past the discard early-return**, so a listener whose provider vanished mid-flight never arms. Both a fresh register and a resume land here.

`rearm_out_of_band` re-resolves `@oob` and then runs `arm_active_backfill` — the same active-only re-arm `set_mode` already uses. An OOB rule recorded no `@active_seen` key while unarmed (its `dedup_key` returns nil with no minter), so a plain backfill fires it while every already-planted non-OOB rule skips on its existing key. It deliberately does **not** clear `@analyzed`: that would re-run passive analysis over recent flows and inflate `hit_count` on unrelated existing findings every time a listener starts.

## Tests

`spec/tui/oast_arms_probe_oob_spec.cr` drives the real registration path (a `RegOk` through `@reg_events` + `drain_events`) and asserts:

- the minter flips from nil to armed on register,
- a seeded `@analyzed` id survives (no passive re-scan / no `hit_count` inflation),
- the discard path leaves the minter nil.

Reverting the wiring, or swapping the mechanism back to `@analyzed.clear`, turns the spec red. Full suite green (13,645 examples, 0 failures); `crystal build --no-codegen`, `seed_demo` compile, and `bench_check.sh` all pass.