### PR TITLE
feat(tui): one contract for the History/Issues/Probe drill-in — breadcrumb, list rail, and a way back

### DIFF
--- a/spec/tui/drill_in_spec.cr
+++ b/spec/tui/drill_in_spec.cr
@@ -1,0 +1,131 @@
+require "../spec_helper"
+require "../support/memory_backend"
+
+include Gori::Tui
+
+private def rail_rows(n : Int32) : Array(DrillIn::RailRow)
+  (0...n).map { |i| DrillIn::RailRow.new("200", "GET api.test/v1/item/#{i}", "22:59:0#{i}") }
+end
+
+describe Gori::Tui::DrillIn do
+  describe ".rail_split" do
+    it "gives the rail its rows plus a divider and hands the rest to the detail" do
+      rail, detail = DrillIn.rail_split(Rect.new(2, 3, 80, 30))
+      rail.should_not be_nil
+      rail = rail.not_nil!
+      rail.y.should eq(3)
+      rail.h.should eq(DrillIn::RAIL_ROWS)
+      # One row between them: the divider the crumb rides.
+      detail.y.should eq(rail.bottom + 1)
+      detail.h.should eq(30 - DrillIn::RAIL_H)
+    end
+
+    it "drops the rail whole rather than squeezing the item you opened" do
+      # One row under the floor. The detail is what the drill-in is FOR; a four-line detail
+      # with context above it is worse than a full one with the crumb alone.
+      short = DrillIn::RAIL_H + DrillIn::MIN_DETAIL_H - 1
+      rail, detail = DrillIn.rail_split(Rect.new(0, 0, 80, short))
+      rail.should be_nil
+      detail.h.should eq(short) # byte-identical to the pre-rail drill-in
+    end
+
+    it "drops the rail when there is no neighbour to show" do
+      # A one-row list has nothing either side, so the rail would spend four rows redrawing
+      # the row the crumb already names.
+      rail, detail = DrillIn.rail_split(Rect.new(0, 0, 80, 40), 1)
+      rail.should be_nil
+      detail.h.should eq(40)
+    end
+  end
+
+  describe "the crumb row" do
+    it "is the rail's divider, which is also the detail's own top border" do
+      # This identity is what lets `Frame.crumb`'s default row be right in BOTH cases, so
+      # neither the render nor the hit-test needs a rail-aware branch.
+      inner = Rect.new(1, 5, 80, 40)
+      rail, detail = DrillIn.rail_split(inner)
+      (detail.y - 1).should eq(rail.not_nil!.bottom)
+
+      _, unrailed = DrillIn.rail_split(inner, 1)
+      (unrailed.y - 1).should eq(inner.y - 1)
+    end
+  end
+
+  describe ".window_start" do
+    it "centres the cursor and slides at both ends instead of padding blanks" do
+      DrillIn.window_start(10, 5).should eq(4) # centred
+      DrillIn.window_start(10, 0).should eq(0) # top: no row above to claim
+      DrillIn.window_start(10, 9).should eq(7) # bottom: the last three
+      DrillIn.window_start(2, 1).should eq(0)  # shorter than the window
+    end
+  end
+
+  describe ".render_rail" do
+    it "carries the list's own cursor treatment onto the open row" do
+      backend = MemoryBackend.new(80, 5)
+      screen = Screen.new(backend)
+      DrillIn.render_rail(screen, Rect.new(0, 0, 80, 3), rail_rows(3), 1)
+      # The gutter bar is what makes the rail read as the list rather than as a new widget.
+      backend.row(1).starts_with?("▎").should be_true
+      backend.row(0).starts_with?("▎").should be_false
+      backend.row(0).includes?("GET api.test/v1/item/0").should be_true
+      backend.row(2).includes?("GET api.test/v1/item/2").should be_true
+    end
+
+    it "never draws past its rect, however many rows it is handed" do
+      backend = MemoryBackend.new(80, 6)
+      screen = Screen.new(backend)
+      DrillIn.render_rail(screen, Rect.new(0, 0, 80, 2), rail_rows(5), 0)
+      backend.row(2).strip.should be_empty
+    end
+  end
+
+  describe ".rail_row_at" do
+    it "answers only for rows that were actually drawn" do
+      rail = Rect.new(0, 4, 80, DrillIn::RAIL_ROWS)
+      DrillIn.rail_row_at(rail, 10, 4, 3).should eq(0)
+      DrillIn.rail_row_at(rail, 10, 6, 3).should eq(2)
+      # Near the ends of a short list the window holds fewer rows than the rect has: a click
+      # on an undrawn row must miss, not select whatever index the arithmetic yields.
+      DrillIn.rail_row_at(rail, 10, 6, 2).should be_nil
+      DrillIn.rail_row_at(rail, 10, 7, 3).should be_nil # past the rail
+      DrillIn.rail_row_at(nil, 10, 4, 3).should be_nil  # no rail at this size
+    end
+  end
+end
+
+describe Gori::Tui::Frame::Crumb do
+  it "names where you are, which row of it, and what is open" do
+    Frame::Crumb.new("HISTORY", "GET api.test/v1/me", "12/123").text
+      .should eq(" ‹ HISTORY · 12/123 · GET api.test/v1/me ")
+  end
+
+  it "drops the position when the list behind is empty" do
+    Frame::Crumb.new("ISSUES", "Deployed .env readable").text
+      .should eq(" ‹ ISSUES · Deployed .env readable ")
+  end
+
+  describe ".crumb_rect" do
+    it "clips to the frame rather than overwriting its top-right corner" do
+      inner = Rect.new(1, 1, 30, 10)
+      crumb = Frame::Crumb.new("HISTORY", "GET a-very-long-host.example/some/deep/path", "9/99")
+      rect = Frame.crumb_rect(inner, crumb).not_nil!
+      rect.y.should eq(0)
+      rect.x.should eq(2)
+      (rect.right <= inner.right - 1).should be_true
+    end
+
+    it "declines rather than drawing a clipped crumb on a narrow pane" do
+      Frame.crumb_rect(Rect.new(0, 2, 8, 5), Frame::Crumb.new("PROBE", "x")).should be_nil
+    end
+
+    it "declines when the border row would be off-screen" do
+      Frame.crumb_rect(Rect.new(0, 0, 40, 5), Frame::Crumb.new("PROBE", "x")).should be_nil
+    end
+
+    it "rides an explicit row — the rail's divider — when given one" do
+      inner = Rect.new(1, 1, 40, 20)
+      Frame.crumb_rect(inner, Frame::Crumb.new("HISTORY", "GET /a"), 7).not_nil!.y.should eq(7)
+    end
+  end
+end

--- a/spec/tui/drill_in_spec.cr
+++ b/spec/tui/drill_in_spec.cr
@@ -10,7 +10,7 @@ end
 describe Gori::Tui::DrillIn do
   describe ".rail_split" do
     it "gives the rail its rows plus a divider and hands the rest to the detail" do
-      rail, detail = DrillIn.rail_split(Rect.new(2, 3, 80, 30))
+      rail, detail = DrillIn.rail_split(Rect.new(2, 3, 80, 30), 3)
       rail.should_not be_nil
       rail = rail.not_nil!
       rail.y.should eq(3)
@@ -24,7 +24,7 @@ describe Gori::Tui::DrillIn do
       # One row under the floor. The detail is what the drill-in is FOR; a four-line detail
       # with context above it is worse than a full one with the crumb alone.
       short = DrillIn::RAIL_H + DrillIn::MIN_DETAIL_H - 1
-      rail, detail = DrillIn.rail_split(Rect.new(0, 0, 80, short))
+      rail, detail = DrillIn.rail_split(Rect.new(0, 0, 80, short), 3)
       rail.should be_nil
       detail.h.should eq(short) # byte-identical to the pre-rail drill-in
     end
@@ -43,7 +43,7 @@ describe Gori::Tui::DrillIn do
       # This identity is what lets `Frame.crumb`'s default row be right in BOTH cases, so
       # neither the render nor the hit-test needs a rail-aware branch.
       inner = Rect.new(1, 5, 80, 40)
-      rail, detail = DrillIn.rail_split(inner)
+      rail, detail = DrillIn.rail_split(inner, 3)
       (detail.y - 1).should eq(rail.not_nil!.bottom)
 
       _, unrailed = DrillIn.rail_split(inner, 1)
@@ -78,9 +78,9 @@ describe Gori::Tui::DrillIn do
       DrillIn.render_rail(screen, Rect.new(0, 0, 80, 3), rail_rows(3), 1)
       # The key rides the cursor bar's own column, so "press this, land here" is one fact
       # rather than two the operator has to connect.
-      backend.row(0).starts_with?("⇧P").should be_true
+      backend.row(0).starts_with?("⇧N").should be_true
       backend.row(1).starts_with?("▎").should be_true
-      backend.row(2).starts_with?("⇧N").should be_true
+      backend.row(2).starts_with?("n").should be_true
     end
 
     it "labels only rows ONE press away, at either end of the list" do
@@ -90,7 +90,7 @@ describe Gori::Tui::DrillIn do
       # and the row two below must NOT wear ⇧N — one press does not reach it.
       DrillIn.render_rail(screen, Rect.new(0, 0, 80, 3), rail_rows(3), 0)
       backend.row(0).starts_with?("▎").should be_true
-      backend.row(1).starts_with?("⇧N").should be_true
+      backend.row(1).starts_with?("n").should be_true
       backend.row(2).strip.starts_with?("⇧").should be_false
     end
 
@@ -113,13 +113,10 @@ describe Gori::Tui::DrillIn do
   describe ".rail_row_at" do
     it "answers only for rows that were actually drawn" do
       rail = Rect.new(0, 4, 80, DrillIn::RAIL_ROWS)
-      DrillIn.rail_row_at(rail, 10, 4, 3).should eq(0)
-      DrillIn.rail_row_at(rail, 10, 6, 3).should eq(2)
-      # Near the ends of a short list the window holds fewer rows than the rect has: a click
-      # on an undrawn row must miss, not select whatever index the arithmetic yields.
-      DrillIn.rail_row_at(rail, 10, 6, 2).should be_nil
-      DrillIn.rail_row_at(rail, 10, 7, 3).should be_nil # past the rail
-      DrillIn.rail_row_at(nil, 10, 4, 3).should be_nil  # no rail at this size
+      DrillIn.rail_row_at(rail, 10, 4).should eq(0)
+      DrillIn.rail_row_at(rail, 10, 6).should eq(2)
+      DrillIn.rail_row_at(rail, 10, 7).should be_nil # past the rail
+      DrillIn.rail_row_at(nil, 10, 4).should be_nil  # no rail at this size
     end
   end
 end
@@ -157,12 +154,12 @@ describe Gori::Tui::Frame::Crumb do
       backend = MemoryBackend.new(80, 6)
       screen = Screen.new(backend)
       inner = Rect.new(1, 1, 78, 4)
-      Frame.crumb(screen, inner, Frame::Crumb.new("HISTORY", "GET /a", "4/120"), meta: "⇧N/⇧P")
+      Frame.crumb(screen, inner, Frame::Crumb.new("HISTORY", "GET /a", "4/120"), meta: "n/⇧N")
       row = backend.row(0)
       row.includes?("‹ HISTORY").should be_true
-      row.includes?("⇧N/⇧P").should be_true
+      row.includes?("n/⇧N").should be_true
       # Right-aligned, clear of the frame's top-right corner.
-      row.rstrip.ends_with?("⇧N/⇧P").should be_true
+      row.rstrip.ends_with?("n/⇧N").should be_true
     end
 
     it "drops the step keys rather than colliding with the crumb" do
@@ -170,13 +167,13 @@ describe Gori::Tui::Frame::Crumb do
       screen = Screen.new(backend)
       inner = Rect.new(1, 1, 38, 4)
       long = Frame::Crumb.new("HISTORY", "GET a-very-long-host.example/deep/path/here", "9/99")
-      Frame.crumb(screen, inner, long, meta: "⇧N/⇧P")
-      backend.row(0).includes?("⇧N/⇧P").should be_false
+      Frame.crumb(screen, inner, long, meta: "n/⇧N")
+      backend.row(0).includes?("n/⇧N").should be_false
     end
 
-    it "rides an explicit row — the rail's divider — when given one" do
+    it "rides the row above its interior, which is the rail's divider or the card's edge" do
       inner = Rect.new(1, 1, 40, 20)
-      Frame.crumb_rect(inner, Frame::Crumb.new("HISTORY", "GET /a"), 7).not_nil!.y.should eq(7)
+      Frame.crumb_rect(inner, Frame::Crumb.new("HISTORY", "GET /a")).not_nil!.y.should eq(0)
     end
   end
 end

--- a/spec/tui/drill_in_spec.cr
+++ b/spec/tui/drill_in_spec.cr
@@ -72,6 +72,36 @@ describe Gori::Tui::DrillIn do
       backend.row(2).includes?("GET api.test/v1/item/2").should be_true
     end
 
+    it "labels the immediate neighbours with the key that lands on them" do
+      backend = MemoryBackend.new(80, 5)
+      screen = Screen.new(backend)
+      DrillIn.render_rail(screen, Rect.new(0, 0, 80, 3), rail_rows(3), 1)
+      # The key rides the cursor bar's own column, so "press this, land here" is one fact
+      # rather than two the operator has to connect.
+      backend.row(0).starts_with?("⇧P").should be_true
+      backend.row(1).starts_with?("▎").should be_true
+      backend.row(2).starts_with?("⇧N").should be_true
+    end
+
+    it "labels only rows ONE press away, at either end of the list" do
+      backend = MemoryBackend.new(80, 5)
+      screen = Screen.new(backend)
+      # Cursor at the top of the list: the window cannot slide, so there is no previous row
+      # and the row two below must NOT wear ⇧N — one press does not reach it.
+      DrillIn.render_rail(screen, Rect.new(0, 0, 80, 3), rail_rows(3), 0)
+      backend.row(0).starts_with?("▎").should be_true
+      backend.row(1).starts_with?("⇧N").should be_true
+      backend.row(2).strip.starts_with?("⇧").should be_false
+    end
+
+    it "prints the labels it is given, so a rebind moves what the gutter says" do
+      backend = MemoryBackend.new(80, 5)
+      screen = Screen.new(backend)
+      DrillIn.render_rail(screen, Rect.new(0, 0, 80, 3), rail_rows(3), 1, next_key: "^J", prev_key: "^K")
+      backend.row(0).starts_with?("^K").should be_true
+      backend.row(2).starts_with?("^J").should be_true
+    end
+
     it "never draws past its rect, however many rows it is handed" do
       backend = MemoryBackend.new(80, 6)
       screen = Screen.new(backend)
@@ -121,6 +151,27 @@ describe Gori::Tui::Frame::Crumb do
 
     it "declines when the border row would be off-screen" do
       Frame.crumb_rect(Rect.new(0, 0, 40, 5), Frame::Crumb.new("PROBE", "x")).should be_nil
+    end
+
+    it "hangs the step keys off the same row, right-aligned" do
+      backend = MemoryBackend.new(80, 6)
+      screen = Screen.new(backend)
+      inner = Rect.new(1, 1, 78, 4)
+      Frame.crumb(screen, inner, Frame::Crumb.new("HISTORY", "GET /a", "4/120"), meta: "⇧N/⇧P")
+      row = backend.row(0)
+      row.includes?("‹ HISTORY").should be_true
+      row.includes?("⇧N/⇧P").should be_true
+      # Right-aligned, clear of the frame's top-right corner.
+      row.rstrip.ends_with?("⇧N/⇧P").should be_true
+    end
+
+    it "drops the step keys rather than colliding with the crumb" do
+      backend = MemoryBackend.new(40, 6)
+      screen = Screen.new(backend)
+      inner = Rect.new(1, 1, 38, 4)
+      long = Frame::Crumb.new("HISTORY", "GET a-very-long-host.example/deep/path/here", "9/99")
+      Frame.crumb(screen, inner, long, meta: "⇧N/⇧P")
+      backend.row(0).includes?("⇧N/⇧P").should be_false
     end
 
     it "rides an explicit row — the rail's divider — when given one" do

--- a/spec/tui/history_view_spec.cr
+++ b/spec/tui/history_view_spec.cr
@@ -1338,7 +1338,7 @@ describe Gori::Tui::HistoryView do
     end
   end
 
-  it "renders the '‹ list' back marker on the detail's top frame border (framed path)" do
+  it "renders the breadcrumb on the detail's top frame border (framed path)" do
     with_store do |store|
       add_flow(store, "GET", "/api", 200)
       view = HistoryView.new
@@ -1352,7 +1352,62 @@ describe Gori::Tui::HistoryView do
       BodyChrome.framed(screen, Rect.new(0, 0, 80, 16), true) do |inner|
         view.render_detail(screen, inner, focused: true)
       end
-      backend.row(0).includes?("‹ list").should be_true
+      row = backend.row(0)
+      # Names WHERE you are, WHICH row of it, and WHAT is open — the three facts the old
+      # ` ‹ list ` marker left off, and the reason the drill-in read as a different screen.
+      row.includes?("‹ HISTORY").should be_true
+      row.includes?("1/1").should be_true
+      row.includes?("GET").should be_true
+    end
+  end
+
+  it "puts the list rail over the detail and moves the crumb onto its divider" do
+    with_store do |store|
+      5.times { |i| add_flow(store, "GET", "/api/#{i}", 200) }
+      view = HistoryView.new
+      view.reload(store)
+      view.move(2) # land mid-list so the rail has a neighbour on either side
+      view.open_detail(store).should be_true
+
+      backend = MemoryBackend.new(90, 30)
+      screen = Screen.new(backend)
+      inner = uninitialized Rect
+      BodyChrome.framed(screen, Rect.new(0, 0, 90, 30), true) do |i|
+        inner = i
+        view.render_drill(screen, i, true, false)
+      end
+
+      # The rail sits at the top of the interior, with the open row wearing the list's own
+      # cursor gutter — that glyph is what makes it read as the list rather than a new widget.
+      rail = view.rail_rect(inner).not_nil!
+      backend.row(rail.y + 1).includes?("▎").should be_true
+      # …and the crumb rides the rail's DIVIDER, not the card's top border, so the two
+      # derivations (render + hit-test) cannot drift apart.
+      backend.row(rail.bottom).includes?("‹ HISTORY").should be_true
+      backend.row(0).includes?("‹ HISTORY").should be_false
+      # The hit-test rect is the one the detail was drawn into.
+      view.detail_body_rect(inner).y.should eq(rail.bottom + 1)
+    end
+  end
+
+  it "keeps the whole interior for the detail when the pane is too short for a rail" do
+    with_store do |store|
+      3.times { |i| add_flow(store, "GET", "/api/#{i}", 200) }
+      view = HistoryView.new
+      view.reload(store)
+      view.open_detail(store).should be_true
+
+      backend = MemoryBackend.new(80, 16)
+      screen = Screen.new(backend)
+      inner = uninitialized Rect
+      BodyChrome.framed(screen, Rect.new(0, 0, 80, 16), true) do |i|
+        inner = i
+        view.render_drill(screen, i, true, false)
+      end
+      view.rail_rect(inner).should be_nil
+      view.detail_body_rect(inner).should eq(inner)
+      # With no rail the crumb is the ONLY thing naming where you are, so it must still be up.
+      backend.row(0).includes?("‹ HISTORY").should be_true
     end
   end
 

--- a/spec/tui/history_view_spec.cr
+++ b/spec/tui/history_view_spec.cr
@@ -1390,6 +1390,45 @@ describe Gori::Tui::HistoryView do
     end
   end
 
+  it "anchors the rail and the crumb on the OPEN flow, not on the list cursor" do
+    with_store do |store|
+      3.times { |i| add_flow(store, "GET", "/api/#{i}", 200) }
+      view = HistoryView.new
+      view.reload(store)
+      view.move(2)
+      view.open_detail(store).should be_true
+      opened = view.detail_flow_id
+
+      # Live capture under follow (the default) snaps the LIST cursor to the newest row while
+      # the drill-in stays on its own flow — the divergence `history_target_flow_id` warns
+      # every detail verb about. Everything the drill-in draws has to follow the DETAIL.
+      view.select_row(0)
+      view.selected_index.should eq(0)
+      view.detail_flow_id.should eq(opened)
+      view.detail_row_index.should eq(2)
+      view.detail_crumb.not_nil!.pos.should eq("3/3")
+      # …including the band: the row it lands on is the one the crumb names, not the cursor's.
+      view.rail_rows[view.rail_cursor].text.should eq(view.detail_crumb.not_nil!.subject)
+    end
+  end
+
+  it "has no rail and no position when the open flow is not in the filtered list" do
+    with_store do |store|
+      add_flow(store, "GET", "/keep", 200)
+      other = add_flow(store, "GET", "/hidden", 200)
+      view = HistoryView.new
+      view.reload(store)
+      # A deep link (Issues/Sitemap/Discover/link jump) can open a flow the filter excludes;
+      # `open_detail_id` leaves @selected alone there, so there is no row to anchor on.
+      view.open_detail_id(other, store).should be_true
+      view.set_query("path:/keep")
+      view.reload(store)
+      view.detail_row_index.should be_nil
+      view.rail_count.should eq(0)
+      view.detail_crumb.not_nil!.pos.should be_nil
+    end
+  end
+
   it "keeps the whole interior for the detail when the pane is too short for a rail" do
     with_store do |store|
       3.times { |i| add_flow(store, "GET", "/api/#{i}", 200) }

--- a/spec/tui/issues_view_spec.cr
+++ b/spec/tui/issues_view_spec.cr
@@ -152,7 +152,7 @@ describe Gori::Tui::IssuesView do
     end
   end
 
-  it "renders the '‹ list' back marker on the detail's top frame border (framed path)" do
+  it "renders the breadcrumb on the detail's top frame border (framed path)" do
     with_store do |store|
       store.insert_issue("SQL injection", Gori::Store::Severity::Critical, "acme.test", nil)
       view = IssuesView.new
@@ -164,7 +164,10 @@ describe Gori::Tui::IssuesView do
       BodyChrome.framed(screen, Rect.new(0, 0, 80, 16), true) do |inner|
         view.render(screen, inner, focused: true)
       end
-      backend.row(0).includes?("‹ list").should be_true
+      row = backend.row(0)
+      row.includes?("‹ ISSUES").should be_true
+      row.includes?("1/1").should be_true
+      row.includes?("SQL injection").should be_true
     end
   end
 

--- a/spec/tui/probe_view_spec.cr
+++ b/spec/tui/probe_view_spec.cr
@@ -100,7 +100,7 @@ describe Gori::Tui::ProbeView do
     end
   end
 
-  it "renders the '‹ list' back marker on the detail's top frame border (framed path)" do
+  it "renders the breadcrumb on the detail's top frame border (framed path)" do
     view_store do |store|
       seed(store, "missing_hsts", "a.test")
       view = Gori::Tui::ProbeView.new
@@ -112,7 +112,9 @@ describe Gori::Tui::ProbeView do
       Gori::Tui::BodyChrome.framed(screen, Gori::Tui::Rect.new(0, 0, 80, 16), true) do |inner|
         view.render(screen, inner)
       end
-      backend.row(0).includes?("‹ list").should be_true
+      row = backend.row(0)
+      row.includes?("‹ PROBE").should be_true
+      row.includes?("1/1").should be_true
     end
   end
 

--- a/spec/verb/registry_spec.cr
+++ b/spec/verb/registry_spec.cr
@@ -112,6 +112,10 @@ private class FakeContext < ExecContext
     @calls << :close_detail
   end
 
+  def detail_step_item(delta : Int32) : Nil
+    @calls << :detail_step_item
+  end
+
   def toggle_follow : Nil
     @calls << :toggle_follow
   end
@@ -868,6 +872,10 @@ private class FakeContext < ExecContext
     @calls << :issue_close
   end
 
+  def issue_step_item(delta : Int32) : Nil
+    @calls << :issue_step_item
+  end
+
   def issues_delete : Nil
     @calls << :issues_delete
   end
@@ -1007,6 +1015,10 @@ private class FakeContext < ExecContext
 
   def probe_close : Nil
     @calls << :probe_close
+  end
+
+  def probe_step_item(delta : Int32) : Nil
+    @calls << :probe_step_item
   end
 
   def probe_query : Nil

--- a/src/gori/tui/controllers/history_controller.cr
+++ b/src/gori/tui/controllers/history_controller.cr
@@ -101,6 +101,7 @@ module Gori::Tui
         # while the active chip lights a gold pill (strip_focused).
         strip_here = body_focused && @history.detail_strip_focus?
         body_here = body_focused && !@history.detail_strip_focus?
+        @history.step_keys = step_key_labels
         BodyChrome.framed(screen, rect, body_here) { |inner| @history.render_drill(screen, inner, body_here, strip_here) }
       else
         # The list's user-defined columns (#819) read flow bytes for the rows they are about to
@@ -113,6 +114,15 @@ module Gori::Tui
             listen: {proxy.host, proxy.port}, capturing: @host.session.capturing?)
         end
       end
+    end
+
+    # The effective chords for the item step, read from the keymap so the rail's gutter and
+    # the crumb's chip move when they are rebound. Each half comes from its OWN verb: a
+    # derived label (⇧ + whatever `next` is bound to) lies the moment only one is rebound.
+    private def step_key_labels : {String, String}
+      reg = @host.session.registry
+      {Hotkeys.binding_label(reg, "detail.next-item", DrillIn::NEXT_KEY),
+       Hotkeys.binding_label(reg, "detail.prev-item", DrillIn::PREV_KEY)}
     end
 
     # Called after settings:layout save so the preview cache matches the new pref.
@@ -489,12 +499,13 @@ module Gori::Tui
         # does not from the body, where the caret owns it — so the body's line says `esc`
         # alone. Naming a key that does nothing from where you are is the defect the old
         # ` ‹ list ` border chip had.
+        nx, pv = step_key_labels
         if @history.detail_strip_focus?
-          return "←/→ panes · ↓/↵ enter · ⇧N/⇧P flow · ↑/← list · ↹ pane · space cmds · esc back"
+          return "←/→ panes · ↓/↵ enter · #{nx}/#{pv} flow · ↑/← list · ↹ pane · space cmds · esc back"
         end
         nav = @history.detail_navigable? ? "↑/↓ move · ←/→ caret" : "↑/↓ scroll"
         dy = Hotkeys.binding_label(reg, "detail.copy", "y")
-        return "#{nav} · ⇧arrows select · #{dy} copy · ⇧N/⇧P flow · ↑ strip · ↹ pane · space cmds · esc back"
+        return "#{nav} · ⇧arrows select · #{dy} copy · #{nx}/#{pv} flow · ↑ strip · ↹ pane · space cmds · esc back"
       end
       return "type query · ↹ complete · ↵ apply · esc clear" if @history.querying?
       # #898 gave this list `d` and `⇧X` and named neither here. `⇧X` is the one that goes in:

--- a/src/gori/tui/controllers/history_controller.cr
+++ b/src/gori/tui/controllers/history_controller.cr
@@ -180,7 +180,7 @@ module Gori::Tui
       # The crumb's `‹` — a real button now. First arm, because it rides a row nothing else
       # in the drill-in claims (the frame's top edge, or the rail's divider), and because
       # "leave" must win over any pane hit-test a stray column might also match.
-      if (c = @history.detail_crumb) && Frame.crumb_rect(inner, c).try(&.contains?(mx, my))
+      if (c = @history.detail_crumb) && Frame.crumb_hit_rect(inner, c).try(&.contains?(mx, my))
         @host.focus_body
         close_detail
         return
@@ -188,9 +188,9 @@ module Gori::Tui
       # A rail row: open THAT flow, staying in the drill-in. The rail shows the list, so a
       # click on it means what a click on the list means — with the one difference that you
       # are already inside an item, so it opens rather than merely selecting.
-      if i = DrillIn.rail_row_at(rail, mx, my, @history.rail_window[0].size)
+      if i = DrillIn.rail_row_at(rail, mx, my)
         @host.focus_body
-        detail_step_item(i - @history.rail_window[1])
+        detail_step_item(i - @history.rail_cursor)
         return
       end
       if pane = @history.detail_pane_at(inner, mx, my)
@@ -413,7 +413,7 @@ module Gori::Tui
     # register comment above the pane verbs ("neither ever closes the detail") documented
     # the divergence rather than resolving it.
     private def detail_pane_back : Nil
-      close_detail unless @history.detail_pane_advance(-1)
+      move_detail_pane(-1)
     end
 
     # BODY level: caret move + shift-selection (all four directions, incl. horizontal
@@ -717,7 +717,7 @@ module Gori::Tui
       @history.close_detail
     end
 
-    # ⇧N/⇧P inside the drill-in: open the next/previous flow of the list behind WITHOUT
+    # `n`/`⇧N` inside the drill-in: open the next/previous flow of the list behind WITHOUT
     # going back to it.
     #
     # The drill-in had no way to step, so reading twenty rows meant `esc ↓ ↵` twenty times.
@@ -730,16 +730,24 @@ module Gori::Tui
     # same flow and throw away its scroll position.
     def detail_step_item(delta : Int32) : Nil
       return unless @host.overlay == :detail
+      # Anchored on the flow the detail HAS OPEN, not on the list cursor: live capture
+      # advances the cursor under follow while the drill-in stays put, so stepping from
+      # `selected_index` walks away from whatever the tail happens to be showing.
+      here = @history.detail_row_index || return
+      target = here + delta
+      # Clamp and bail BEFORE touching the list: `select_row` re-seeds the ⇧-range mark
+      # anchor and drops the preview even when the index does not move, so a ⇧N at the end
+      # of the list would silently destroy a mark range the operator had built.
+      return if target < 0 || target >= @history.row_count
       pane = @history.detail_pane
-      before = @history.selected_index
-      # `select_row`, not `move`: `move` routes to the REQ/RES preview whenever that pane
-      # holds focus, and the preview's focus survives opening the detail (it is not drawn
-      # there, so nothing resets it). A step would then scroll a pane nobody can see and
-      # read as a dead key.
-      @history.select_row(before + delta)
-      return if @history.selected_index == before
+      strip = @history.detail_strip_focus?
+      @history.select_row(target)
       open_detail
       @history.set_detail_pane_public(pane)
+      # …and the LEVEL, not just the pane. `open_detail_id` lands every open on the chip
+      # strip, so a step out of a response body used to put ↑/↓ back on pane-switching — and
+      # the very next ↑ leaves the drill-in entirely.
+      @history.set_detail_focus(strip ? :strip : :body)
     end
 
     def toggle_follow : Nil
@@ -1078,8 +1086,13 @@ module Gori::Tui
     # the STRIP level above does for the same keys: `handle_detail_strip_key` claims ←/h first,
     # so this verb only fires under a rebinding, and a rebound ← must not close the detail
     # when the stock one does not. esc/q are the way out.
+    # ←/→ between the detail's panes, and at the FIRST pane ← leaves for the list. Both the
+    # keymap verb (`detail.prev-pane`) and the chip strip's literal ← arm come through here,
+    # so a rebound prev-pane behaves like the arrow instead of clamping dead — the very key
+    # this contract exists to remove.
     def move_detail_pane(dir : Int32) : Nil
-      @history.detail_pane_advance(dir)
+      return if @history.detail_pane_advance(dir)
+      close_detail if dir < 0
     end
 
     def toggle_detail_hex : Nil

--- a/src/gori/tui/controllers/history_controller.cr
+++ b/src/gori/tui/controllers/history_controller.cr
@@ -101,7 +101,7 @@ module Gori::Tui
         # while the active chip lights a gold pill (strip_focused).
         strip_here = body_focused && @history.detail_strip_focus?
         body_here = body_focused && !@history.detail_strip_focus?
-        BodyChrome.framed(screen, rect, body_here) { |inner| @history.render_detail(screen, inner, focused: body_here, strip_focused: strip_here) }
+        BodyChrome.framed(screen, rect, body_here) { |inner| @history.render_drill(screen, inner, body_here, strip_here) }
       else
         # The list's user-defined columns (#819) read flow bytes for the rows they are about to
         # draw, and the list holds no store of its own — same seam, and same reason, as the
@@ -155,14 +155,34 @@ module Gori::Tui
     # read cursor pins it to the first text row, which is what an upward drag means.
     private def detail_text_rect(rect : Rect) : Rect?
       # The view owns the derivation: it is the side that also draws the footer strip under
-      # the text, and the strip's height is what this rect must stop above.
-      @history.detail_text_rect(rect.inset(1, 1))
+      # the text, and the strip's height is what this rect must stop above. `detail_body_rect`
+      # is the other half — the text sits under the LIST RAIL when one fits, so an `inset`
+      # alone would hit-test three rows above where the body was drawn.
+      @history.detail_text_rect(@history.detail_body_rect(rect.inset(1, 1)))
     end
 
     # A click inside the detail drill-in: the pane chips, then the mode chips (both on the
     # strip rows), then the text. Lifted out of `handle_click`, which carries the LIST arm as
     # well and was over ameba's complexity ceiling with a third condition on this ladder.
     private def click_detail(rect : Rect, inner : Rect, mx : Int32, my : Int32) : Nil
+      rail = @history.rail_rect(inner)
+      inner = @history.detail_body_rect(inner)
+      # The crumb's `‹` — a real button now. First arm, because it rides a row nothing else
+      # in the drill-in claims (the frame's top edge, or the rail's divider), and because
+      # "leave" must win over any pane hit-test a stray column might also match.
+      if (c = @history.detail_crumb) && Frame.crumb_rect(inner, c).try(&.contains?(mx, my))
+        @host.focus_body
+        close_detail
+        return
+      end
+      # A rail row: open THAT flow, staying in the drill-in. The rail shows the list, so a
+      # click on it means what a click on the list means — with the one difference that you
+      # are already inside an item, so it opens rather than merely selecting.
+      if i = DrillIn.rail_row_at(rail, mx, my, @history.rail_window[0].size)
+        @host.focus_body
+        detail_step_item(i - @history.rail_window[1])
+        return
+      end
       if pane = @history.detail_pane_at(inner, mx, my)
         @history.set_detail_pane_public(pane)
         @history.set_detail_focus(:strip) # a chip click parks focus on the strip
@@ -355,21 +375,35 @@ module Gori::Tui
       @history.detail_strip_focus? ? handle_detail_strip_key(ev) : handle_detail_body_key(ev)
     end
 
-    # STRIP level: the chip row acts as a focusable sub-tab strip. ←/→ switch panes
-    # (clamped at both ends — no auto-close), ↓/↵/j descend into the body, ↑/k pop out
-    # (close detail → the tab bar). esc/Tab/toggles fall through (return false).
+    # STRIP level: the chip row acts as a focusable sub-tab strip. → switches panes, ←
+    # walks back and LEAVES at the first one, ↓/↵/j descend into the body, ↑/k pop out to
+    # the list. esc/Tab/toggles fall through (return false).
+    #
+    # ↑ used to close the detail AND jump to the TAB BAR, skipping the list the drill-in
+    # came from — two levels on one press, from a strip whose own ←/→ are tab-switch keys
+    # one level up. It copied `handle_subtabs_key`, which is right for a strip that IS a
+    # sibling of the tab bar and wrong for one nested under a list.
     private def handle_detail_strip_key(ev : Termisu::Event::Key) : Bool
       return false if ev.ctrl? || ev.alt?
       key = ev.key
       case
-      when key.left?, key.lower_h?             then @history.detail_pane_advance(-1)
+      when key.left?, key.lower_h?             then detail_pane_back
       when key.right?, key.lower_l?            then @history.detail_pane_advance(1)
       when key.down?, key.lower_j?, key.enter? then @history.set_detail_focus(:body)
-      when key.up?, key.lower_k?               then close_detail; @host.request_focus(:menu)
+      when key.up?, key.lower_k?               then close_detail
       else
         return false
       end
       true
+    end
+
+    # ← on the chip strip: walk back a pane, and at the FIRST pane leave for the list.
+    # It used to clamp and do nothing there — a dead key under a border that said `‹ list`,
+    # while Issues and Probe both closed on ←. One arrow, three tabs, three meanings; the
+    # register comment above the pane verbs ("neither ever closes the detail") documented
+    # the divergence rather than resolving it.
+    private def detail_pane_back : Nil
+      close_detail unless @history.detail_pane_advance(-1)
     end
 
     # BODY level: caret move + shift-selection (all four directions, incl. horizontal
@@ -450,12 +484,17 @@ module Gori::Tui
       filter = Hotkeys.binding_label(reg, "history.query", "/")
       intercept = Hotkeys.binding_label(reg, "intercept.toggle", "i")
       if @host.overlay == :detail
+        # Each level names the key that leaves FROM HERE, and only that key. ← really does
+        # go back from the strip (it walks panes and then leaves at the first one) and really
+        # does not from the body, where the caret owns it — so the body's line says `esc`
+        # alone. Naming a key that does nothing from where you are is the defect the old
+        # ` ‹ list ` border chip had.
         if @history.detail_strip_focus?
-          return "←/→ panes · ↓/↵ enter · ↑ tabs · ↹ pane · space cmds · esc back"
+          return "←/→ panes · ↓/↵ enter · ⇧N/⇧P flow · ↑/← list · ↹ pane · space cmds · esc back"
         end
         nav = @history.detail_navigable? ? "↑/↓ move · ←/→ caret" : "↑/↓ scroll"
         dy = Hotkeys.binding_label(reg, "detail.copy", "y")
-        return "#{nav} · ⇧arrows select · #{dy} copy · ↑ strip · ↹ pane · space cmds · esc back"
+        return "#{nav} · ⇧arrows select · #{dy} copy · ⇧N/⇧P flow · ↑ strip · ↹ pane · space cmds · esc back"
       end
       return "type query · ↹ complete · ↵ apply · esc clear" if @history.querying?
       # #898 gave this list `d` and `⇧X` and named neither here. `⇧X` is the one that goes in:
@@ -665,6 +704,31 @@ module Gori::Tui
     def close_detail : Nil
       @host.request_overlay(:none)
       @history.close_detail
+    end
+
+    # ⇧N/⇧P inside the drill-in: open the next/previous flow of the list behind WITHOUT
+    # going back to it.
+    #
+    # The drill-in had no way to step, so reading twenty rows meant `esc ↓ ↵` twenty times.
+    # That is most of what "going back is inconvenient" was measuring: not the cost of one
+    # exit, but paying a full exit and re-entry for every row. The crumb's `12/123` is this
+    # verb's affordance — a position readout is what makes "there is a next one" visible.
+    #
+    # Carries the pane you were reading (`open_detail` resets it), and does nothing at the
+    # ends of the list: `move` clamps, so a step that changed no row must not re-open the
+    # same flow and throw away its scroll position.
+    def detail_step_item(delta : Int32) : Nil
+      return unless @host.overlay == :detail
+      pane = @history.detail_pane
+      before = @history.selected_index
+      # `select_row`, not `move`: `move` routes to the REQ/RES preview whenever that pane
+      # holds focus, and the preview's focus survives opening the detail (it is not drawn
+      # there, so nothing resets it). A step would then scroll a pane nobody can see and
+      # read as a dead key.
+      @history.select_row(before + delta)
+      return if @history.selected_index == before
+      open_detail
+      @history.set_detail_pane_public(pane)
     end
 
     def toggle_follow : Nil

--- a/src/gori/tui/controllers/issues_controller.cr
+++ b/src/gori/tui/controllers/issues_controller.cr
@@ -82,7 +82,11 @@ module Gori::Tui
     end
 
     def body_badge : Symbol
-      @issues.notes_insert_mode? ? :editor : :body
+      # INS wins over the drill-in: what the keys under your fingers DO outranks where you
+      # are, and it is also what `body_editor?` (paste routing, the copy verbs' INS gate)
+      # reads this for.
+      return :editor if @issues.notes_insert_mode?
+      @issues.detail_open? ? :detail : :body
     end
 
     def body_hint(focus : Symbol) : String
@@ -100,12 +104,12 @@ module Gori::Tui
         if @issues.notes_insert_mode?
           "type to edit · ⇧arrows select · ^Y copy · esc save · ^W discard"
         elsif @issues.notes_focused?
-          "↑/↓ move · ⇧arrows select · #{y} copy · i/↵ edit · space cmds · ↹/←/esc related"
+          "↑/↓ move · ⇧arrows select · #{y} copy · i/↵ edit · ⇧N/⇧P issue · space cmds · ↹/←/esc related"
         else
           # `↹/↓ notes`, and `i edit` rather than the old `i/↵ notes`: ↵ in this pane opens
           # the selected RELATED item (`issue.open-link`), so naming it as the way into the
           # notes editor was wrong about one of the two keys it listed.
-          keys("↑/↓ links · ↵ open · ↹/↓ notes · i edit · {issue.open-flow} flow · {issue.repeater-flow} repeater · space cmds · ←/esc back")
+          keys("↑/↓ links · ↵ open · ↹/↓ notes · i edit · ⇧N/⇧P issue · {issue.open-flow} flow · {issue.repeater-flow} repeater · space cmds · ←/esc back")
         end
       elsif @issues.querying?
         "type to filter · ↹ complete · ↓ list · ? reference · ↵ apply · esc clear"
@@ -149,9 +153,17 @@ module Gori::Tui
     # Measured with `Frame.card`'s own refusal (`render_related_card` / `render_notes_card`
     # return on the same test), so this cannot drift from what was painted.
     private def detail_card_lit?(rect : Rect) : Bool
-      inner = BodyChrome.frame_inner(rect)
+      inner = detail_inner(rect)
       card = @issues.notes_focused? ? @issues.notes_card_rect(inner) : @issues.links_card_rect(inner)
       card.h >= 2 && card.w >= 2
+    end
+
+    # The DETAIL's rect inside the drill-in. `frame_inner` alone stopped being the answer
+    # once the list rail could sit above it, and every detail hit-test in this file measures
+    # against THIS — a card drawn under the rail and clicked as though it were not there is a
+    # dead row, which is the failure `detail_split`'s own comment exists to prevent.
+    private def detail_inner(rect : Rect) : Rect
+      @issues.detail_body_rect(BodyChrome.frame_inner(rect))
     end
 
     # --- mouse drag + double-click (see TabController#supports_drag?) ---
@@ -175,12 +187,12 @@ module Gori::Tui
 
     def handle_drag(rect : Rect, mx : Int32, my : Int32) : Nil
       return unless supports_drag?
-      @issues.notes_drag_to_cursor(rect.inset(1, 1), mx, my)
+      @issues.notes_drag_to_cursor(detail_inner(rect), mx, my)
     end
 
     def handle_double_click(rect : Rect, mx : Int32, my : Int32) : Bool
       return false unless @issues.detail_open?
-      inner = rect.inset(1, 1)
+      inner = detail_inner(rect)
       return double_click_related(inner, mx, my) if @issues.links_card_rect(inner).contains?(mx, my)
       # The NOTES BODY, and only it. `notes_select_word` forces INSERT and hit-tests nothing,
       # so a pair of presses on the meta block up top (title, chips, timestamps, evidence)
@@ -257,6 +269,25 @@ module Gori::Tui
       # The detail is a body pane like any other, and this branch never took focus: with the
       # tab bar focused, a click placed the notes caret and then sent the typing to the bar.
       @host.focus_body
+      rail = @issues.rail_rect(inner)
+      inner = @issues.detail_body_rect(inner)
+      # A rail row: open THAT issue, staying in the drill-in. The rail shows the list, so a
+      # click on it means what a click on the list means.
+      if i = DrillIn.rail_row_at(rail, mx, my, @issues.rail_window[0].size)
+        issue_step_item(i - @issues.rail_window[1])
+        return true
+      end
+      # The crumb's `‹` — a real button now. Ahead of every pane hit-test, because it rides a
+      # row nothing else in the drill-in claims (the frame's top edge, or the rail's divider)
+      # and because "leave" must win over any stray column that also matches.
+      if (c = @issues.detail_crumb) && Frame.crumb_rect(inner, c).try(&.contains?(mx, my))
+        # Persist first, and stay when that write is refused — leaving by pointer means what
+        # `esc` means (`leave_notes_editor`). Without it this one gesture would be the only
+        # way out of the detail that silently drops an unsaved writeup, which is exactly the
+        # text a conflict refusal has just told the operator to look at.
+        issue_close if leave_notes_editor
+        return true
+      end
       card = @issues.notes_card_rect(inner)
       # NOR/INS chip on the NOTES card border toggles insert. `↵` on the way IN, and on the way
       # out the `^W`-less half of `esc`: it drops to READ without saving, which is what makes
@@ -326,7 +357,7 @@ module Gori::Tui
         # Pointer-aware inside the detail too: RELATED scrolls under the pointer while the
         # NOTES editor keeps the keyboard, and vice versa. Off both cards (the meta block up
         # top) the focused pane still moves, which is what `handle_wheel` answers.
-        inner = rect.inset(1, 1)
+        inner = detail_inner(rect)
         return (@issues.scroll_links_wheel(step); true) if @issues.links_card_rect(inner).contains?(mx, my)
         return (@issues.notes_scroll_wheel(step); true) if @issues.notes_card_rect(inner).contains?(mx, my)
         return handle_wheel(step)
@@ -679,6 +710,25 @@ module Gori::Tui
 
     def issue_close : Nil
       @issues.close_detail
+    end
+
+    # ⇧N/⇧P inside the drill-in: open the next/previous issue WITHOUT going back to the list.
+    # See HistoryController#detail_step_item for why the step exists at all.
+    #
+    # Saves the notes buffer first, exactly as leaving by pointer or `esc` does, and ABORTS
+    # when that write is refused — a conflict keeps INS on with the typed text still on
+    # screen, and stepping off it would drop the paragraph the operator was just warned
+    # about. Same rule the sub-tab strip follows: save the outgoing one FIRST.
+    def issue_step_item(delta : Int32) : Nil
+      return unless @issues.detail_open?
+      return unless leave_notes_editor
+      before = @issues.selected_index
+      # `select_index`, not `move`: `move` routes to the PREVIEW pane whenever that side holds
+      # focus, and its focus survives opening the detail (the preview is not drawn there, so
+      # nothing resets it). A step would then scroll a pane nobody can see.
+      @issues.select_index(before + delta)
+      return if @issues.selected_index == before
+      issues_open
     end
 
     # --- marks (multi-select) -------------------------------------------------

--- a/src/gori/tui/controllers/issues_controller.cr
+++ b/src/gori/tui/controllers/issues_controller.cr
@@ -104,12 +104,12 @@ module Gori::Tui
         if @issues.notes_insert_mode?
           "type to edit · ⇧arrows select · ^Y copy · esc save · ^W discard"
         elsif @issues.notes_focused?
-          "↑/↓ move · ⇧arrows select · #{y} copy · i/↵ edit · ⇧N/⇧P issue · space cmds · ↹/←/esc related"
+          "↑/↓ move · ⇧arrows select · #{y} copy · i/↵ edit · #{step_key_labels.join("/")} issue · space cmds · ↹/←/esc related"
         else
           # `↹/↓ notes`, and `i edit` rather than the old `i/↵ notes`: ↵ in this pane opens
           # the selected RELATED item (`issue.open-link`), so naming it as the way into the
           # notes editor was wrong about one of the two keys it listed.
-          keys("↑/↓ links · ↵ open · ↹/↓ notes · i edit · ⇧N/⇧P issue · {issue.open-flow} flow · {issue.repeater-flow} repeater · space cmds · ←/esc back")
+          keys("↑/↓ links · ↵ open · ↹/↓ notes · i edit · {issue.next-item}/{issue.prev-item} issue · {issue.open-flow} flow · {issue.repeater-flow} repeater · space cmds · ←/esc back")
         end
       elsif @issues.querying?
         "type to filter · ↹ complete · ↓ list · ? reference · ↵ apply · esc clear"
@@ -138,8 +138,17 @@ module Gori::Tui
       # focused" and left the card that actually owns the keyboard with nothing to distinguish
       # it. The LIST page is the other case — neither the list nor its preview draws a card of
       # its own, so the shell outline IS the list's border and keeps the gold.
+      @issues.step_keys = step_key_labels if @issues.detail_open?
       shell = BodyChrome.shell_focused(focus, multi_pane: @issues.detail_open? && detail_card_lit?(rect))
       BodyChrome.framed(screen, rect, shell) { |inner| @issues.render(screen, inner, focused: focused) }
+    end
+
+    # The effective chords for the item step — see HistoryController#step_key_labels for why
+    # each half is read from its own verb rather than derived from the other.
+    private def step_key_labels : {String, String}
+      reg = @host.session.registry
+      {Hotkeys.binding_label(reg, "issue.next-item", DrillIn::NEXT_KEY),
+       Hotkeys.binding_label(reg, "issue.prev-item", DrillIn::PREV_KEY)}
     end
 
     # Is the card that OWNS the keyboard actually on screen to light? Handing the shell frame

--- a/src/gori/tui/controllers/issues_controller.cr
+++ b/src/gori/tui/controllers/issues_controller.cr
@@ -93,7 +93,6 @@ module Gori::Tui
       reg = @host.session.registry
       filt = Hotkeys.binding_label(reg, "issues.filter", "/")
       nnew = Hotkeys.binding_label(reg, "issues.new", "n")
-      y = Hotkeys.binding_label(reg, "issue.copy", "y")
       # Named in every state the chord can FIRE from, which is every list state — `command_scope`
       # answers Scope::Issues for the marks state and both preview focuses too, and only an open
       # detail (or the `/` bar, which claims every key) leaves it. Naming it in the default branch
@@ -104,7 +103,7 @@ module Gori::Tui
         if @issues.notes_insert_mode?
           "type to edit · ⇧arrows select · ^Y copy · esc save · ^W discard"
         elsif @issues.notes_focused?
-          "↑/↓ move · ⇧arrows select · #{y} copy · i/↵ edit · #{step_key_labels.join("/")} issue · space cmds · ↹/←/esc related"
+          keys("↑/↓ move · ⇧arrows select · {issue.copy} copy · i/↵ edit · {issue.next-item}/{issue.prev-item} issue · space cmds · ↹/←/esc related")
         else
           # `↹/↓ notes`, and `i edit` rather than the old `i/↵ notes`: ↵ in this pane opens
           # the selected RELATED item (`issue.open-link`), so naming it as the way into the
@@ -282,14 +281,14 @@ module Gori::Tui
       inner = @issues.detail_body_rect(inner)
       # A rail row: open THAT issue, staying in the drill-in. The rail shows the list, so a
       # click on it means what a click on the list means.
-      if i = DrillIn.rail_row_at(rail, mx, my, @issues.rail_window[0].size)
-        issue_step_item(i - @issues.rail_window[1])
+      if i = DrillIn.rail_row_at(rail, mx, my)
+        issue_step_item(i - @issues.rail_cursor)
         return true
       end
       # The crumb's `‹` — a real button now. Ahead of every pane hit-test, because it rides a
       # row nothing else in the drill-in claims (the frame's top edge, or the rail's divider)
       # and because "leave" must win over any stray column that also matches.
-      if (c = @issues.detail_crumb) && Frame.crumb_rect(inner, c).try(&.contains?(mx, my))
+      if (c = @issues.detail_crumb) && Frame.crumb_hit_rect(inner, c).try(&.contains?(mx, my))
         # Persist first, and stay when that write is refused — leaving by pointer means what
         # `esc` means (`leave_notes_editor`). Without it this one gesture would be the only
         # way out of the detail that silently drops an unsaved writeup, which is exactly the
@@ -721,7 +720,7 @@ module Gori::Tui
       @issues.close_detail
     end
 
-    # ⇧N/⇧P inside the drill-in: open the next/previous issue WITHOUT going back to the list.
+    # `n`/`⇧N` inside the drill-in: open the next/previous issue WITHOUT going back to the list.
     # See HistoryController#detail_step_item for why the step exists at all.
     #
     # Saves the notes buffer first, exactly as leaving by pointer or `esc` does, and ABORTS
@@ -731,13 +730,22 @@ module Gori::Tui
     def issue_step_item(delta : Int32) : Nil
       return unless @issues.detail_open?
       return unless leave_notes_editor
-      before = @issues.selected_index
+      # Anchored on the issue the detail HAS OPEN, and clamped BEFORE the list is touched:
+      # `select_index` re-seeds the ⇧-range mark anchor even when the index does not move,
+      # so a step at either end would quietly destroy a range the operator had built.
+      here = @issues.detail_row_index || return
+      target = here + delta
+      return if target < 0 || target >= @issues.row_count
+      notes = @issues.notes_focused?
       # `select_index`, not `move`: `move` routes to the PREVIEW pane whenever that side holds
       # focus, and its focus survives opening the detail (the preview is not drawn there, so
       # nothing resets it). A step would then scroll a pane nobody can see.
-      @issues.select_index(before + delta)
-      return if @issues.selected_index == before
+      @issues.select_index(target)
       issues_open
+      # The LEVEL survives the step, as the pane does on History: `open_detail` lands every
+      # open on RELATED, which is right for a fresh drill-in and wrong for a step taken while
+      # reading the notes.
+      @issues.focus_notes! if notes
     end
 
     # --- marks (multi-select) -------------------------------------------------

--- a/src/gori/tui/controllers/probe_controller.cr
+++ b/src/gori/tui/controllers/probe_controller.cr
@@ -122,7 +122,9 @@ module Gori::Tui
     end
 
     def body_badge : Symbol
-      :body # read-only/navigable list + detail (no inline text editor)
+      # No inline text editor anywhere in this tab, so the only split is list vs drill-in.
+      # `rules_tab?` has no detail of its own — its editor is a modal.
+      !rules_tab? && @probe.detail_open? ? :detail : :body
     end
 
     def body_hint(focus : Symbol) : String
@@ -157,12 +159,12 @@ module Gori::Tui
         # rather than URLs, so naming "↑/↓ URL" over it would be the confident lie this line
         # exists to avoid.
         if @probe.desc_focused?
-          keys("↑/↓ read · ⇧arrows select · {probe.copy} copy · ↹ urls · space cmds · ←/esc back")
+          keys("↑/↓ read · ⇧arrows select · {probe.copy} copy · ⇧N/⇧P finding · ↹ urls · space cmds · ←/esc back")
         else
           # `↵ open` and `o flow` are two different destinations and both belong here — the
           # caret's own affected URL, and the issue's sample evidence. The Issues detail names
           # the same pair for the same reason (`↵ open` over its related links, `o flow`).
-          keys("↑/↓ URL · ↵ open · ⇧arrows select · {probe.copy} copy · {probe.open-flow} flow · {probe.repeater-flow} repeater · ↹ description · space cmds · ←/esc back")
+          keys("↑/↓ URL · ↵ open · ⇧arrows select · {probe.copy} copy · ⇧N/⇧P finding · {probe.open-flow} flow · {probe.repeater-flow} repeater · ↹ description · space cmds · ←/esc back")
         end
       elsif @probe.querying?
         "type to filter · ↹ complete · ↓ list · ? reference · ↵ apply · esc clear"
@@ -210,9 +212,25 @@ module Gori::Tui
         return true
       end
       if @probe.detail_open?
+        rail = @probe.rail_rect(content)
+        body = @probe.detail_body_rect(content)
+        # A rail row: open THAT finding, staying in the drill-in. The rail shows the list, so
+        # a click on it means what a click on the list means.
+        if i = DrillIn.rail_row_at(rail, mx, my, @probe.rail_window[0].size)
+          @host.focus_body
+          probe_step_item(i - @probe.rail_window[1])
+          return true
+        end
+        # The crumb's `‹` — a real button now. Ahead of the pane hit-test, because it rides a
+        # row nothing else in the drill-in claims (the frame's top edge, or the rail's
+        # divider) and because "leave" must win over any stray column that also matches.
+        if (c = @probe.detail_crumb) && Frame.crumb_rect(body, c).try(&.contains?(mx, my))
+          probe_close
+          return true
+        end
         # The AFFECTED URLS list takes a caret from the pointer; the rest of the card is chrome.
         @host.focus_body
-        @probe.detail_click(content, mx, my)
+        @probe.detail_click(body, mx, my)
         return true
       end
       @host.focus_body
@@ -485,6 +503,19 @@ module Gori::Tui
 
     def probe_close : Nil
       @probe.close_detail
+    end
+
+    # ⇧N/⇧P inside the drill-in: open the next/previous finding WITHOUT going back to the
+    # list. See HistoryController#detail_step_item for why the step exists at all. Nothing to
+    # persist here — this detail is read-only.
+    def probe_step_item(delta : Int32) : Nil
+      return unless @probe.detail_open?
+      before = @probe.selected_index
+      # `select_index`, not `move`: `move` routes to the PREVIEW pane whenever that side holds
+      # focus, and its focus survives opening the detail. A step would scroll a hidden pane.
+      @probe.select_index(before + delta)
+      return if @probe.selected_index == before
+      probe_open
     end
 
     def probe_query : Nil
@@ -807,9 +838,16 @@ module Gori::Tui
       !rules_tab? && @probe.detail_open?
     end
 
+    # The DETAIL's rect inside the drill-in. `content_rect` alone stopped being the answer
+    # once the list rail could sit above it, and every detail hit-test here measures against
+    # THIS — a pane drawn under the rail and clicked as though it were not there is dead.
+    private def detail_inner(rect : Rect) : Rect
+      @probe.detail_body_rect(BodyChrome.content_rect(rect, strip: true))
+    end
+
     def handle_drag(rect : Rect, mx : Int32, my : Int32) : Nil
       return unless supports_drag?
-      @probe.detail_click(BodyChrome.content_rect(rect, strip: true), mx, my, selecting: true)
+      @probe.detail_click(detail_inner(rect), mx, my, selecting: true)
     end
 
     # RULES: a pair on a row opens its editor — what ↵ / `e` (`probe-rules.edit`) do, and the
@@ -828,7 +866,7 @@ module Gori::Tui
         return true
       end
       return false unless supports_drag?
-      @probe.detail_select_word(content, mx, my)
+      @probe.detail_select_word(detail_inner(rect), mx, my)
     end
 
     # --- READ-pane delegators (the detail's read verbs + the Runner's read_* ladders) ---

--- a/src/gori/tui/controllers/probe_controller.cr
+++ b/src/gori/tui/controllers/probe_controller.cr
@@ -159,12 +159,12 @@ module Gori::Tui
         # rather than URLs, so naming "↑/↓ URL" over it would be the confident lie this line
         # exists to avoid.
         if @probe.desc_focused?
-          keys("↑/↓ read · ⇧arrows select · {probe.copy} copy · ⇧N/⇧P finding · ↹ urls · space cmds · ←/esc back")
+          keys("↑/↓ read · ⇧arrows select · {probe.copy} copy · {probe.next-item}/{probe.prev-item} finding · ↹ urls · space cmds · ←/esc back")
         else
           # `↵ open` and `o flow` are two different destinations and both belong here — the
           # caret's own affected URL, and the issue's sample evidence. The Issues detail names
           # the same pair for the same reason (`↵ open` over its related links, `o flow`).
-          keys("↑/↓ URL · ↵ open · ⇧arrows select · {probe.copy} copy · ⇧N/⇧P finding · {probe.open-flow} flow · {probe.repeater-flow} repeater · ↹ description · space cmds · ←/esc back")
+          keys("↑/↓ URL · ↵ open · ⇧arrows select · {probe.copy} copy · {probe.next-item}/{probe.prev-item} finding · {probe.open-flow} flow · {probe.repeater-flow} repeater · ↹ description · space cmds · ←/esc back")
         end
       elsif @probe.querying?
         "type to filter · ↹ complete · ↓ list · ? reference · ↵ apply · esc clear"
@@ -181,6 +181,7 @@ module Gori::Tui
 
     def render_body(screen : Screen, rect : Rect, focus : Symbol) : Nil
       focused = focus == :body
+      @probe.step_keys = step_key_labels if @probe.detail_open?
       shell = BodyChrome.shell_focused(focus, multi_pane: false)
       @subtab_start = BodyChrome.framed_body(screen, rect, shell, focus == :subtabs, SUBTABS, @sub_idx, @subtab_start,
         find: subtab_find_shown?, find_lit: @host.subtab_find_focused?, marked: marked_chip_set) do |content|
@@ -192,6 +193,14 @@ module Gori::Tui
             listen: {proxy.host, proxy.port}, capturing: @host.session.capturing?)
         end
       end
+    end
+
+    # The effective chords for the item step — see HistoryController#step_key_labels for why
+    # each half is read from its own verb rather than derived from the other.
+    private def step_key_labels : {String, String}
+      reg = @host.session.registry
+      {Hotkeys.binding_label(reg, "probe.next-item", DrillIn::NEXT_KEY),
+       Hotkeys.binding_label(reg, "probe.prev-item", DrillIn::PREV_KEY)}
     end
 
     def handle_click(rect : Rect, mx : Int32, my : Int32) : Bool

--- a/src/gori/tui/controllers/probe_controller.cr
+++ b/src/gori/tui/controllers/probe_controller.cr
@@ -225,15 +225,19 @@ module Gori::Tui
         body = @probe.detail_body_rect(content)
         # A rail row: open THAT finding, staying in the drill-in. The rail shows the list, so
         # a click on it means what a click on the list means.
-        if i = DrillIn.rail_row_at(rail, mx, my, @probe.rail_window[0].size)
+        if i = DrillIn.rail_row_at(rail, mx, my)
           @host.focus_body
-          probe_step_item(i - @probe.rail_window[1])
+          probe_step_item(i - @probe.rail_cursor)
           return true
         end
         # The crumb's `‹` — a real button now. Ahead of the pane hit-test, because it rides a
         # row nothing else in the drill-in claims (the frame's top edge, or the rail's
         # divider) and because "leave" must win over any stray column that also matches.
-        if (c = @probe.detail_crumb) && Frame.crumb_rect(body, c).try(&.contains?(mx, my))
+        if (c = @probe.detail_crumb) && Frame.crumb_hit_rect(body, c).try(&.contains?(mx, my))
+          # Focus first, like the rail branch above and like History's and Issues' crumbs:
+          # with the tab bar holding the keyboard, returning to the list without taking it
+          # left ↑/↓ switching TABS over a list that looked focused.
+          @host.focus_body
           probe_close
           return true
         end
@@ -514,17 +518,22 @@ module Gori::Tui
       @probe.close_detail
     end
 
-    # ⇧N/⇧P inside the drill-in: open the next/previous finding WITHOUT going back to the
+    # `n`/`⇧N` inside the drill-in: open the next/previous finding WITHOUT going back to the
     # list. See HistoryController#detail_step_item for why the step exists at all. Nothing to
     # persist here — this detail is read-only.
     def probe_step_item(delta : Int32) : Nil
       return unless @probe.detail_open?
-      before = @probe.selected_index
+      # Anchored on the finding the detail HAS OPEN, and clamped BEFORE the list is touched —
+      # see IssuesController#issue_step_item for both.
+      here = @probe.detail_row_index || return
+      target = here + delta
+      return if target < 0 || target >= @probe.row_count
+      desc = @probe.desc_focused?
       # `select_index`, not `move`: `move` routes to the PREVIEW pane whenever that side holds
       # focus, and its focus survives opening the detail. A step would scroll a hidden pane.
-      @probe.select_index(before + delta)
-      return if @probe.selected_index == before
+      @probe.select_index(target)
       probe_open
+      @probe.focus_desc! if desc
     end
 
     def probe_query : Nil

--- a/src/gori/tui/drill_in.cr
+++ b/src/gori/tui/drill_in.cr
@@ -43,6 +43,14 @@ module Gori::Tui
     # rail: on a short terminal the crumb is the ONLY thing saying where you are.
     MIN_DETAIL_H = 12
 
+    # Default labels for the two chords that step the drill-in through the list. Literals,
+    # because the rail renders with no registry in reach — the fallback every registry-less
+    # render in this codebase keeps. A controller that HAS the registry pushes the effective
+    # labels down instead (see the `step_keys` setter on each view), so a rebind moves what
+    # the gutter prints.
+    NEXT_KEY = "⇧N"
+    PREV_KEY = "⇧P"
+
     # One rail row, in the three parts every one of these lists happens to have: a short
     # coloured lead (status code / severity), the identity, and a muted tail (host, type).
     # A view maps its own row onto this; nothing else about its list renderer is involved.
@@ -84,7 +92,8 @@ module Gori::Tui
     # holds focus — the rail is a readout, not a pane you can move into, so it never takes
     # the gold border, only the band.
     def self.render_rail(screen : Screen, rect : Rect, rows : Array(RailRow), cursor : Int32,
-                         focused : Bool = true) : Nil
+                         focused : Bool = true, next_key : String = NEXT_KEY,
+                         prev_key : String = PREV_KEY) : Nil
       return if rect.empty? || rows.empty?
       # Leads share one column so the identities start at the same x — an unaligned status
       # code reads as three ragged rows rather than as a list.
@@ -92,7 +101,14 @@ module Gori::Tui
       rows.each_with_index do |row, i|
         y = rect.y + i
         break if y >= rect.bottom
-        draw_row(screen, rect, y, row, lead_w, here: i == cursor, focused: focused)
+        # Only the IMMEDIATE neighbours carry a key: the label says "one press lands here",
+        # and a row two steps away wearing the same label would be a lie. At the ends of the
+        # list the window slides and the cursor is not centred, so one side simply has none.
+        step = case i - cursor
+               when -1 then prev_key
+               when  1 then next_key
+               end
+        draw_row(screen, rect, y, row, lead_w, step: step, here: i == cursor, focused: focused)
       end
     end
 
@@ -100,13 +116,22 @@ module Gori::Tui
     # this codebase splits its row draw: the loop is about WHICH rows, the row is about what
     # a row looks like, and only the second one grows.
     private def self.draw_row(screen : Screen, rect : Rect, y : Int32, row : RailRow,
-                              lead_w : Int32, *, here : Bool, focused : Bool) : Nil
+                              lead_w : Int32, *, step : String?, here : Bool, focused : Bool) : Nil
       bg = here ? (focused ? Theme.accent_bg : Theme.selection_dim) : Theme.bg
       if here
         screen.fill(Rect.new(rect.x, y, rect.w, 1), bg)
         screen.cell(rect.x, y, '▎', Theme.accent, bg)
+      elsif step
+        # The step key rides the CURSOR'S OWN COLUMN, so the key and the row it moves to line
+        # up instead of being two facts the operator has to connect — the position readout in
+        # the crumb says a next one exists, this says which press gets there. Muted, because
+        # the cursor bar has to stay the brightest thing in the gutter.
+        screen.text(rect.x, y, step, Theme.muted, bg, width: 2)
       end
-      x = rect.x + 2
+      # 3, not 2: the gutter holds either the cursor bar (1 cell) or a step key (2), and a
+      # 2-cell gutter left `⇧P` flush against the status code — `⇧P200`, the same fusing the
+      # History list's METHOD/PROTO columns buy a blank column to avoid.
+      x = rect.x + 3
       if lead_w > 0
         screen.text(x, y, row.lead, row.lead_color || Theme.muted, bg, width: lead_w)
         x += lead_w + 1

--- a/src/gori/tui/drill_in.cr
+++ b/src/gori/tui/drill_in.cr
@@ -1,0 +1,137 @@
+require "./screen"
+require "./theme"
+require "./frame"
+
+module Gori::Tui
+  # The list RAIL a drill-in keeps above itself — the three rows of context (previous,
+  # current, next) that stop an opened item from reading as a different screen.
+  #
+  # Shared by the three tabs that replace their body with one item's detail (History,
+  # Issues, Probe), the same three that already share `PreviewSplit`. Before it, opening a
+  # row swapped the whole tab body: the card lost its title, the tab bar rendered exactly as
+  # it does over the list, and nothing on screen said which list was behind — so the way
+  # back was something you had to remember rather than see.
+  #
+  # The rail is deliberately NOT a re-render of each tab's list. Those renderers draw a
+  # filter bar, a column header and a divider before their first data row (four rows of
+  # chrome to show three rows of content), and their column geometry is derived per frame
+  # from the full pane width. A rail built from `RailRow` costs one row per item, reads the
+  # same left-to-right, and — the part that matters — carries the list's own cursor
+  # treatment: the `▎` gutter and the accent band, so the eye maps it to the list it came
+  # from rather than to a new widget.
+  #
+  # AXIS, which is the load-bearing choice: the rail is HORIZONTAL (rows above), not a
+  # column beside. gori's lists are wide tables and its details are read by width, so a
+  # left-hand peek would shrink the thing you opened and turn the list into a truncated
+  # shape that no longer looks like the list. Rows are the cheap axis here — the same one
+  # `PreviewSplit` already took, and the one every HTTP proxy's master/detail uses.
+  module DrillIn
+    # Rows of list context: the item before, the item itself, the item after. Three is the
+    # fewest that can show a NEIGHBOUR ON EITHER SIDE, which is what makes ⇧N/⇧P legible as
+    # "there is more this way" rather than as a key you have to be told about.
+    RAIL_ROWS = 3
+
+    # What the rail costs the detail: its rows plus the divider that anchors it.
+    RAIL_H = RAIL_ROWS + 1
+
+    # Interior rows the DETAIL must keep for the rail to be affordable. Under this the rail
+    # is dropped whole rather than squeezed — the item is what the drill-in is FOR, and a
+    # detail reduced to four lines is worse than one with no context above it. `Layout` admits
+    # a 40×8 terminal, where the body interior is three rows and there is no choice to make.
+    #
+    # This is also why the crumb (Frame::Crumb) had to land first and cannot depend on the
+    # rail: on a short terminal the crumb is the ONLY thing saying where you are.
+    MIN_DETAIL_H = 12
+
+    # One rail row, in the three parts every one of these lists happens to have: a short
+    # coloured lead (status code / severity), the identity, and a muted tail (host, type).
+    # A view maps its own row onto this; nothing else about its list renderer is involved.
+    record RailRow, lead : String, text : String, tail : String? = nil, lead_color : Color? = nil
+
+    # Split a drill-in's framed interior into {rail, detail}. `rail` is nil when the pane is
+    # too short to keep both, and then `detail` is the whole interior — byte-identical to
+    # what the drill-in drew before the rail existed.
+    #
+    # ONE derivation: the render calls it, and so does every hit-test, because a body drawn
+    # against one rect and clicked against another is a dead row.
+    #
+    # `count` is how many rows of context there actually ARE. One is not context — a
+    # single-row list has no neighbour either side, so the rail would spend four rows to
+    # redraw the row the crumb already names.
+    def self.rail_split(inner : Rect, count : Int32 = RAIL_ROWS) : {Rect?, Rect}
+      return {nil, inner} if count <= 1 || inner.h < RAIL_H + MIN_DETAIL_H
+      rail = Rect.new(inner.x, inner.y, inner.w, RAIL_ROWS)
+      detail = Rect.new(inner.x, inner.y + RAIL_H, inner.w, inner.h - RAIL_H)
+      # The divider between them IS `detail.y - 1`, which is where `Frame.crumb` puts itself
+      # by default — so the crumb rides the rail's divider with a rail and the card's own top
+      # border without one, and neither the drill-in's render nor its hit-test has to know
+      # which case it is in.
+      {rail, detail}
+    end
+
+    # First index of the window a rail of `size` rows shows around `cursor`. Slides at the
+    # ends instead of leaving blank rows: near the top of a list the cursor simply is not in
+    # the middle, and padding it there would claim neighbours that do not exist.
+    def self.window_start(total : Int32, cursor : Int32, size : Int32 = RAIL_ROWS) : Int32
+      return 0 if total <= size
+      (cursor - size // 2).clamp(0, total - size)
+    end
+
+    # Draw the rail. `cursor` is the index WITHIN `rows` of the open item, so a view hands
+    # over its window and does not have to think about the slide above.
+    #
+    # `focused` gilds the open row the way the list's own cursor row is gilded when the body
+    # holds focus — the rail is a readout, not a pane you can move into, so it never takes
+    # the gold border, only the band.
+    def self.render_rail(screen : Screen, rect : Rect, rows : Array(RailRow), cursor : Int32,
+                         focused : Bool = true) : Nil
+      return if rect.empty? || rows.empty?
+      # Leads share one column so the identities start at the same x — an unaligned status
+      # code reads as three ragged rows rather than as a list.
+      lead_w = rows.max_of { |r| Screen.draw_width(r.lead) }
+      rows.each_with_index do |row, i|
+        y = rect.y + i
+        break if y >= rect.bottom
+        draw_row(screen, rect, y, row, lead_w, here: i == cursor, focused: focused)
+      end
+    end
+
+    # One rail row. Split out of `render_rail` for the same reason every other renderer in
+    # this codebase splits its row draw: the loop is about WHICH rows, the row is about what
+    # a row looks like, and only the second one grows.
+    private def self.draw_row(screen : Screen, rect : Rect, y : Int32, row : RailRow,
+                              lead_w : Int32, *, here : Bool, focused : Bool) : Nil
+      bg = here ? (focused ? Theme.accent_bg : Theme.selection_dim) : Theme.bg
+      if here
+        screen.fill(Rect.new(rect.x, y, rect.w, 1), bg)
+        screen.cell(rect.x, y, '▎', Theme.accent, bg)
+      end
+      x = rect.x + 2
+      if lead_w > 0
+        screen.text(x, y, row.lead, row.lead_color || Theme.muted, bg, width: lead_w)
+        x += lead_w + 1
+      end
+      fg = here ? Theme.text_bright : Theme.text
+      # The tail is granted only what is left once the identity has room to be a name rather
+      # than an ellipsis; below that it drops whole, like every other cluster here that
+      # competes with a path for a narrow pane.
+      if (tail = row.tail) && rect.right - x > 24
+        tw = {Screen.draw_width(tail), (rect.right - x) // 3}.min
+        screen.text(x, y, row.text, fg, bg, width: {rect.right - x - tw - 1, 0}.max)
+        screen.text(rect.right - tw, y, tail, Theme.muted, bg, width: tw)
+      else
+        screen.text(x, y, row.text, fg, bg, width: {rect.right - x, 0}.max)
+      end
+    end
+
+    # Which rail row (0-based within the drawn window) the pointer is over, or nil. Read off
+    # the same `rail_split` rect the render used, so a click cannot land on a row that was
+    # never drawn.
+    def self.rail_row_at(rail : Rect?, mx : Int32, my : Int32, count : Int32) : Int32?
+      r = rail || return nil
+      return nil unless r.contains?(mx, my)
+      i = my - r.y
+      i < count ? i : nil
+    end
+  end
+end

--- a/src/gori/tui/drill_in.cr
+++ b/src/gori/tui/drill_in.cr
@@ -27,11 +27,12 @@ module Gori::Tui
   # `PreviewSplit` already took, and the one every HTTP proxy's master/detail uses.
   module DrillIn
     # Rows of list context: the item before, the item itself, the item after. Three is the
-    # fewest that can show a NEIGHBOUR ON EITHER SIDE, which is what makes ⇧N/⇧P legible as
+    # fewest that can show a NEIGHBOUR ON EITHER SIDE, which is what makes the step keys legible as
     # "there is more this way" rather than as a key you have to be told about.
     RAIL_ROWS = 3
 
-    # What the rail costs the detail: its rows plus the divider that anchors it.
+    # What a FULL rail costs the detail: its rows plus the divider that anchors it. The real
+    # cost is `{count, RAIL_ROWS}.min + 1` — see `rail_split`, which sizes to the window.
     RAIL_H = RAIL_ROWS + 1
 
     # Interior rows the DETAIL must keep for the rail to be affordable. Under this the rail
@@ -43,13 +44,19 @@ module Gori::Tui
     # rail: on a short terminal the crumb is the ONLY thing saying where you are.
     MIN_DETAIL_H = 12
 
-    # Default labels for the two chords that step the drill-in through the list. Literals,
+    # Default labels for the two chords that step the drill-in through the list — `n` forward
+    # and `⇧N` back, which is what `comparer.next-change` / `comparer.prev-change` already
+    # mean one tab over (and what vim and less mean everywhere). The first spelling here was
+    # ⇧N/⇧P, which made ⇧N move FORWARD in a drill-in and BACKWARD in the Comparer; the boot
+    # gate cannot see that, because `Registry#validate_chords!` builds its seen-set per Scope.
+    #
+    # Literals,
     # because the rail renders with no registry in reach — the fallback every registry-less
     # render in this codebase keeps. A controller that HAS the registry pushes the effective
     # labels down instead (see the `step_keys` setter on each view), so a rebind moves what
     # the gutter prints.
-    NEXT_KEY = "⇧N"
-    PREV_KEY = "⇧P"
+    NEXT_KEY = "n"
+    PREV_KEY = "⇧N"
 
     # One rail row, in the three parts every one of these lists happens to have: a short
     # coloured lead (status code / severity), the identity, and a muted tail (host, type).
@@ -57,23 +64,25 @@ module Gori::Tui
     record RailRow, lead : String, text : String, tail : String? = nil, lead_color : Color? = nil
 
     # Split a drill-in's framed interior into {rail, detail}. `rail` is nil when the pane is
-    # too short to keep both, and then `detail` is the whole interior — byte-identical to
-    # what the drill-in drew before the rail existed.
+    # too short to keep both or there is no context to show, and then `detail` is the whole
+    # interior — byte-identical to what the drill-in drew before the rail existed.
     #
     # ONE derivation: the render calls it, and so does every hit-test, because a body drawn
     # against one rect and clicked against another is a dead row.
     #
-    # `count` is how many rows of context there actually ARE. One is not context — a
-    # single-row list has no neighbour either side, so the rail would spend four rows to
-    # redraw the row the crumb already names.
-    def self.rail_split(inner : Rect, count : Int32 = RAIL_ROWS) : {Rect?, Rect}
-      return {nil, inner} if count <= 1 || inner.h < RAIL_H + MIN_DETAIL_H
-      rail = Rect.new(inner.x, inner.y, inner.w, RAIL_ROWS)
-      detail = Rect.new(inner.x, inner.y + RAIL_H, inner.w, inner.h - RAIL_H)
+    # `count` is how many rows of context there actually ARE, and it SIZES the rail as well
+    # as gating it. A fixed RAIL_ROWS-tall rail on a two-item list left an undrawn row
+    # between the last entry and the divider, and forced every hit-test to carry `count` a
+    # second time just to reject clicks on it.
+    def self.rail_split(inner : Rect, count : Int32) : {Rect?, Rect}
+      h = {count, RAIL_ROWS}.min
+      return {nil, inner} if count <= 1 || inner.h < h + 1 + MIN_DETAIL_H
+      rail = Rect.new(inner.x, inner.y, inner.w, h)
       # The divider between them IS `detail.y - 1`, which is where `Frame.crumb` puts itself
-      # by default — so the crumb rides the rail's divider with a rail and the card's own top
-      # border without one, and neither the drill-in's render nor its hit-test has to know
-      # which case it is in.
+      # — so the crumb rides the rail's divider with a rail and the card's own top border
+      # without one, and neither the drill-in's render nor its hit-test has to know which
+      # case it is in.
+      detail = Rect.new(inner.x, inner.y + h + 1, inner.w, inner.h - h - 1)
       {rail, detail}
     end
 
@@ -150,13 +159,72 @@ module Gori::Tui
     end
 
     # Which rail row (0-based within the drawn window) the pointer is over, or nil. Read off
-    # the same `rail_split` rect the render used, so a click cannot land on a row that was
-    # never drawn.
-    def self.rail_row_at(rail : Rect?, mx : Int32, my : Int32, count : Int32) : Int32?
+    # the same `rail_split` rect the render used — and that rect is exactly as tall as the
+    # window has rows, so every row inside it was drawn.
+    def self.rail_row_at(rail : Rect?, mx : Int32, my : Int32) : Int32?
       r = rail || return nil
-      return nil unless r.contains?(mx, my)
-      i = my - r.y
-      i < count ? i : nil
+      r.contains?(mx, my) ? my - r.y : nil
+    end
+
+    # The half of the drill-in every one of the three tabs implements identically: the
+    # split's two rects, the rail draw, and the step-key labels the controller pushes down.
+    # Included by HistoryView, IssuesView and ProbeView, the same three that already share
+    # `PreviewSplit` — and for the same reason. Three copies of this had already drifted
+    # apart on the day they were written (one gilded the rail's divider and two did not).
+    #
+    # The includer supplies `rail_count`, `rail_window` and `detail_crumb`; everything below
+    # is derived, so a fourth drill-in gets the whole contract by including this.
+    module Host
+      # The effective labels for the item-step chords, pushed down each frame by the
+      # controller — the side that can read the keymap. Literal defaults so a registry-less
+      # render (every view spec) still prints something, which is the fallback convention
+      # every such render in this codebase keeps.
+      property step_keys : {String, String} = {DrillIn::NEXT_KEY, DrillIn::PREV_KEY}
+
+      # How many rows the rail would draw — answered WITHOUT building them. Every geometry
+      # caller needs only this, and `rail_window` allocates a record and a string per row:
+      # a single click used to rebuild it four times, and a drag once per motion event.
+      abstract def rail_count : Int32
+
+      # The rows themselves, and — separately, so a caller that only needs the index pays
+      # nothing — where the OPEN row sits within them. A click on rail row `i` steps by
+      # `i - rail_cursor`.
+      abstract def rail_rows : Array(RailRow)
+      abstract def rail_cursor : Int32
+
+      abstract def detail_crumb : Frame::Crumb?
+
+      # The RAIL's rect, or nil when it is not shown.
+      def rail_rect(inner : Rect) : Rect?
+        DrillIn.rail_split(inner, rail_count)[0]
+      end
+
+      # The DETAIL's rect inside the drill-in. `inset` alone stopped being the answer once
+      # the rail could sit above it, and every hit-test measures against this.
+      def detail_body_rect(inner : Rect) : Rect
+        DrillIn.rail_split(inner, rail_count)[1]
+      end
+
+      # Draw the rail and its divider; answer {detail rect, crumb meta}.
+      #
+      # `focused` is the frame's own state (it colours the divider, so the line matches the
+      # border it meets); `active` is "the drill-in has the keyboard at all", which is what
+      # lights the open row's band — on History those differ, because the chip strip holds
+      # focus without the body frame gilding.
+      def render_rail_chrome(screen : Screen, inner : Rect, focused : Bool,
+                             active : Bool = focused) : {Rect, String?}
+        rail, body = DrillIn.rail_split(inner, rail_count)
+        unless rail
+          # No rail to hang the step keys off, so they ride the crumb's row instead — the
+          # affordance must not depend on the terminal being tall enough. Nothing to step
+          # to on a single-row list, and then neither surface offers them.
+          return {body, rail_count <= 1 ? nil : "#{@step_keys[0]}/#{@step_keys[1]}"}
+        end
+        DrillIn.render_rail(screen, rail, rail_rows, rail_cursor, focused: active,
+          next_key: @step_keys[0], prev_key: @step_keys[1])
+        Frame.inner_divider(screen, inner, rail.bottom, border: Frame.pane_border(focused))
+        {body, nil}
+      end
     end
   end
 end

--- a/src/gori/tui/frame.cr
+++ b/src/gori/tui/frame.cr
@@ -48,22 +48,64 @@ module Gori::Tui
       end
     end
 
-    # A "‹ list" back affordance riding the top-left border of a detail drill-in, where
-    # `inner` is the framed interior (the frame sits one column outside it, as produced
-    # by BodyChrome.framed / rect.inset(1, 1)). Advertises that ←/esc return to the list
-    # behind the detail — the whole point being discoverability, since users miss the
-    # status-bar "esc back". Rides the border at Frame.card's title column so it reads as
-    # a control on the frame; call it AFTER the frame so it overwrites the hairline cleanly.
-    def self.list_back_hint(screen : Screen, inner : Rect, bg : Color = Theme.bg) : Nil
-      y = inner.y - 1
-      # ` ‹ list ` is 8 cells from inner.x + 1; require inner.w > 8 so its trailing cell
-      # stays left of the frame's top-right ╮ (at inner.x + inner.w) — never clobber it.
-      return if y < 0 || inner.w <= 8
-      screen.text(inner.x + 1, y, " ‹ list ", Theme.accent, bg, Attribute::Bold)
+    # The breadcrumb a detail drill-in rides on its top-left border, where `Frame.card`
+    # would put a title: ` ‹ HISTORY · 12/123 · GET api.demo.test/v1/me `. `inner` is the
+    # framed interior (the frame sits one column outside it, as produced by
+    # BodyChrome.framed / rect.inset(1, 1)).
+    #
+    # It replaces a bare ` ‹ list `, which named neither WHERE you were nor WHAT you had
+    # opened — the drill-in's whole identity problem. Once the detail replaces the tab body
+    # the card loses its title and the tab bar renders exactly as it does over the list, so
+    # nothing on screen said "this is one row of History". The old hint also advertised a
+    # control that did not exist: no tab hit-tested those cells, and in History `←` did not
+    # even close (it walked panes and clamped), so the one glyph pointing the way out named
+    # a key that did nothing there.
+    #
+    # `pos` is the cursor's place in the list behind ("12/123"). It is also the affordance
+    # for the ⇧J/⇧K item step — without a visible position, stepping is a key nobody finds.
+    record Crumb, tab : String, subject : String, pos : String? = nil do
+      # The full run, padded the way every other border decoration in this module pads
+      # itself. ONE derivation, read by the draw AND by the click hit-test, so the `‹`
+      # cannot be drawn in cells the pointer misses.
+      def text : String
+        parts = [@tab]
+        if pos = @pos
+          parts << pos
+        end
+        parts << @subject unless @subject.empty?
+        " ‹ #{parts.join(" · ")} "
+      end
+    end
+
+    # Where the crumb lands: the border row above `inner`, or `row` for a drill-in that sits
+    # under a rail and rides that divider instead. nil when there is no room — the same
+    # refusal the old hint made, so a narrow pane simply has no crumb rather than a clipped
+    # one that overwrites the frame's top-right ╮ (at inner.x + inner.w).
+    def self.crumb_rect(inner : Rect, crumb : Crumb, row : Int32? = nil) : Rect?
+      y = row || (inner.y - 1)
+      return nil if y < 0 || inner.w <= 8
+      w = {Screen.draw_width(crumb.text), inner.w - 2}.min
+      return nil if w < 6
+      Rect.new(inner.x + 1, y, w, 1)
+    end
+
+    # Draws it. Call AFTER the frame, like every border decoration here — it overwrites the
+    # hairline. The `‹` is accent-bold because it IS the button (its hit-test is
+    # `crumb_rect`, the very rect this draws into); the tab name is bright so the eye lands
+    # on "which list is behind this"; the rest stays muted so the subject does not compete
+    # with the content underneath.
+    def self.crumb(screen : Screen, inner : Rect, crumb : Crumb, row : Int32? = nil,
+                   bg : Color = Theme.bg) : Nil
+      r = crumb_rect(inner, crumb, row) || return
+      screen.text(r.x, r.y, crumb.text, Theme.muted, bg, width: r.w)
+      return if r.w < 5
+      screen.text(r.x + 1, r.y, "‹", Theme.accent, bg, Attribute::Bold)
+      screen.text(r.x + 3, r.y, crumb.tab, Theme.text_bright, bg, Attribute::Bold,
+        width: {r.w - 3, 0}.max)
     end
 
     # A short right-aligned annotation riding a card's TOP border, right of the title —
-    # "2/2 enabled", "lens:off · 3", "4 entries". Rides the hairline the way `list_back_hint`
+    # "2/2 enabled", "lens:off · 3", "4 entries". Rides the hairline the way `crumb`
     # does, so it costs no interior row.
     #
     # Every card that wanted one used to hand-roll this, and the copies had drifted into

--- a/src/gori/tui/frame.cr
+++ b/src/gori/tui/frame.cr
@@ -62,7 +62,7 @@ module Gori::Tui
     # a key that did nothing there.
     #
     # `pos` is the cursor's place in the list behind ("12/123"). It is also the affordance
-    # for the ⇧J/⇧K item step — without a visible position, stepping is a key nobody finds.
+    # for the item step — without a visible position, stepping is a key nobody finds.
     record Crumb, tab : String, subject : String, pos : String? = nil do
       # The full run, padded the way every other border decoration in this module pads
       # itself. ONE derivation, read by the draw AND by the click hit-test, so the `‹`
@@ -77,37 +77,49 @@ module Gori::Tui
       end
     end
 
-    # Where the crumb lands: the border row above `inner`, or `row` for a drill-in that sits
-    # under a rail and rides that divider instead. nil when there is no room — the same
-    # refusal the old hint made, so a narrow pane simply has no crumb rather than a clipped
-    # one that overwrites the frame's top-right ╮ (at inner.x + inner.w).
-    def self.crumb_rect(inner : Rect, crumb : Crumb, row : Int32? = nil) : Rect?
-      y = row || (inner.y - 1)
+    # Where the crumb lands: the border row above `inner`. nil when there is no room — so a
+    # narrow pane simply has no crumb rather than a clipped one that overwrites the frame's
+    # top-right ╮ (at inner.x + inner.w).
+    #
+    # There is no `row` parameter and there must not be: the crumb rides `inner.y - 1`, which
+    # IS the list rail's divider when a rail is up and the card's own top border when it is
+    # not (see DrillIn.rail_split), so no caller has to be rail-aware to place it.
+    def self.crumb_rect(inner : Rect, crumb : Crumb) : Rect?
+      y = inner.y - 1
       return nil if y < 0 || inner.w <= 8
       w = {Screen.draw_width(crumb.text), inner.w - 2}.min
       return nil if w < 6
       Rect.new(inner.x + 1, y, w, 1)
     end
 
+    # The CLICKABLE run within that: ` ‹ TAB `, and not the position or the subject after it.
+    #
+    # The hit rect used to be the whole crumb — 45-60 columns of muted label — so a click
+    # anywhere on the path text left the drill-in, while the only part drawn as a control was
+    # the accent `‹` and the bright tab name. A button you cannot see is as wrong as a label
+    # that acts like one; this is the run that LOOKS pressable, so it is the run that is.
+    def self.crumb_hit_rect(inner : Rect, crumb : Crumb) : Rect?
+      r = crumb_rect(inner, crumb) || return nil
+      Rect.new(r.x, r.y, {Screen.draw_width(crumb.tab) + 4, r.w}.min, 1)
+    end
+
     # Draws it. Call AFTER the frame, like every border decoration here — it overwrites the
     # hairline. The `‹` is accent-bold because it IS the button (its hit-test is
-    # `crumb_rect`, the very rect this draws into); the tab name is bright so the eye lands
-    # on "which list is behind this"; the rest stays muted so the subject does not compete
-    # with the content underneath.
+    # `crumb_hit_rect`, the run this draws bright); the rest stays muted so the subject does
+    # not compete with the content underneath.
+    #
     # `meta` rides the same row, right-aligned: the keys that CHANGE the position the crumb
     # just printed. It is what the drill-in shows when there is no list rail to hang those
     # keys off (the rail prints them in its own gutter, beside the row each one lands on), so
     # the affordance does not depend on the terminal being tall enough for a rail. Dropped
     # whole when it would collide with the crumb, like every other border decoration here.
-    def self.crumb(screen : Screen, inner : Rect, crumb : Crumb, row : Int32? = nil,
-                   bg : Color = Theme.bg, meta : String? = nil) : Nil
-      r = crumb_rect(inner, crumb, row) || return
+    def self.crumb(screen : Screen, inner : Rect, crumb : Crumb, bg : Color = Theme.bg,
+                   meta : String? = nil) : Nil
+      r = crumb_rect(inner, crumb) || return
       screen.text(r.x, r.y, crumb.text, Theme.muted, bg, width: r.w)
-      if r.w >= 5
-        screen.text(r.x + 1, r.y, "‹", Theme.accent, bg, Attribute::Bold)
-        screen.text(r.x + 3, r.y, crumb.tab, Theme.text_bright, bg, Attribute::Bold,
-          width: {r.w - 3, 0}.max)
-      end
+      screen.text(r.x + 1, r.y, "‹", Theme.accent, bg, Attribute::Bold)
+      screen.text(r.x + 3, r.y, crumb.tab, Theme.text_bright, bg, Attribute::Bold,
+        width: {r.w - 3, 0}.max)
       return unless meta && !meta.empty?
       mx = inner.right - 1 - Screen.draw_width(meta) - 2
       return if mx <= r.right

--- a/src/gori/tui/frame.cr
+++ b/src/gori/tui/frame.cr
@@ -94,14 +94,24 @@ module Gori::Tui
     # `crumb_rect`, the very rect this draws into); the tab name is bright so the eye lands
     # on "which list is behind this"; the rest stays muted so the subject does not compete
     # with the content underneath.
+    # `meta` rides the same row, right-aligned: the keys that CHANGE the position the crumb
+    # just printed. It is what the drill-in shows when there is no list rail to hang those
+    # keys off (the rail prints them in its own gutter, beside the row each one lands on), so
+    # the affordance does not depend on the terminal being tall enough for a rail. Dropped
+    # whole when it would collide with the crumb, like every other border decoration here.
     def self.crumb(screen : Screen, inner : Rect, crumb : Crumb, row : Int32? = nil,
-                   bg : Color = Theme.bg) : Nil
+                   bg : Color = Theme.bg, meta : String? = nil) : Nil
       r = crumb_rect(inner, crumb, row) || return
       screen.text(r.x, r.y, crumb.text, Theme.muted, bg, width: r.w)
-      return if r.w < 5
-      screen.text(r.x + 1, r.y, "‹", Theme.accent, bg, Attribute::Bold)
-      screen.text(r.x + 3, r.y, crumb.tab, Theme.text_bright, bg, Attribute::Bold,
-        width: {r.w - 3, 0}.max)
+      if r.w >= 5
+        screen.text(r.x + 1, r.y, "‹", Theme.accent, bg, Attribute::Bold)
+        screen.text(r.x + 3, r.y, crumb.tab, Theme.text_bright, bg, Attribute::Bold,
+          width: {r.w - 3, 0}.max)
+      end
+      return unless meta && !meta.empty?
+      mx = inner.right - 1 - Screen.draw_width(meta) - 2
+      return if mx <= r.right
+      screen.text(mx, r.y, " #{meta} ", Theme.muted, bg)
     end
 
     # A short right-aligned annotation riding a card's TOP border, right of the title —

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -35,7 +35,8 @@ module Gori::Tui
   # (no queue/ranking, P8). A QL bar (`/`) filters the list; analysis is by query
   # (pull), with field/value suggestions while typing. Also owns the detail view.
   class HistoryView
-    include QueryBarEdit # ⌃/⌥←→ word motion, Home/End, Delete, ⌥⌫ on the `/` bar
+    include QueryBarEdit  # ⌃/⌥←→ word motion, Home/End, Delete, ⌥⌫ on the `/` bar
+    include DrillIn::Host # the rail/detail split, its render, and the step-key labels
 
     # After a `LineEdit` edit: the dropdown follows the token now under the caret.
     def query_edited : Nil
@@ -1084,56 +1085,62 @@ module Gori::Tui
       @detail.try(&.row.id)
     end
 
-    # The rail's window of list context around the open flow — see DrillIn. Maps the list
-    # row onto the shared three-part shape; nothing of the list RENDERER is involved, which
-    # is what keeps a 200-line column layout out of a three-row readout.
-    def rail_window : {Array(DrillIn::RailRow), Int32}
-      return {[] of DrillIn::RailRow, 0} if @rows.empty?
-      start = DrillIn.window_start(@rows.size, @selected)
-      slice = @rows[start, {DrillIn::RAIL_ROWS, @rows.size - start}.min]
-      rows = slice.map do |r|
+    # The row the drill-in actually has OPEN, as an index into the filtered list — not the
+    # cursor. Live capture advances the cursor (`@selected = 0` under follow, which is the
+    # default) while the detail stays on its own flow, and `history_target_flow_id` already
+    # carries that warning for every detail verb: a rail keyed off `@selected` would band a
+    # row that is not open, print someone else's position, and step from the tail.
+    #
+    # nil when the open flow is not in the list at all — a deep link from Issues, Sitemap,
+    # Discover or a link jump can open a flow the current filter excludes — and then there is
+    # no rail, no position and nothing to step through.
+    def detail_row_index : Int32?
+      id = detail_flow_id || return nil
+      @rows.index { |r| r.id == id }
+    end
+
+    # Rows in the filtered list — the bound the item step clamps against.
+    def row_count : Int32
+      @rows.size
+    end
+
+    # See DrillIn::Host.
+    def rail_count : Int32
+      detail_row_index ? {DrillIn::RAIL_ROWS, @rows.size}.min : 0
+    end
+
+    # First index of the window the rail shows. Private: everything outside reads
+    # `rail_rows`/`rail_cursor`, which are derived from it.
+    private def rail_start : Int32
+      here = detail_row_index || return 0
+      DrillIn.window_start(@rows.size, here)
+    end
+
+    # See DrillIn::Host.
+    def rail_cursor : Int32
+      (detail_row_index || 0) - rail_start
+    end
+
+    # The rail's window of list context around the open flow — see DrillIn. Maps the list row
+    # onto the shared three-part shape; nothing of the list RENDERER is involved, which is
+    # what keeps a 200-line column layout out of a three-row readout.
+    def rail_rows : Array(DrillIn::RailRow)
+      n = rail_count
+      return [] of DrillIn::RailRow if n == 0
+      start = rail_start
+      @rows[start, n].map do |r|
         status, scolor = FlowStatus.cell(r)
         DrillIn::RailRow.new(status, "#{r.method} #{r.host}#{origin_path_memo(r)}",
           fmt_time_memo(r.created_at), scolor)
       end
-      {rows, @selected - start}
     end
 
     # The drill-in as a whole: the list rail (when it fits) over the flow detail. ONE entry
     # point, so the controller cannot draw the rail and then hit-test as though it were not
-    # there. The crumb needs no rail-awareness — it rides `body.y - 1`, which IS the rail's
-    # divider when there is one and the card's own top border when there is not.
-    # The effective labels for the item-step chords, pushed down each frame by the controller
-    # — the side that can read the keymap. Literal defaults so a registry-less render (every
-    # view spec) still prints something, which is the fallback convention every such render
-    # in this codebase keeps.
-    property step_keys : {String, String} = {DrillIn::NEXT_KEY, DrillIn::PREV_KEY}
-
+    # there.
     def render_drill(screen : Screen, inner : Rect, focused : Bool, strip_focused : Bool) : Nil
-      rows, cur = rail_window
-      rail, body = DrillIn.rail_split(inner, rows.size)
-      if rail
-        DrillIn.render_rail(screen, rail, rows, cur, focused: focused || strip_focused,
-          next_key: @step_keys[0], prev_key: @step_keys[1])
-        Frame.inner_divider(screen, inner, rail.bottom, border: Frame.pane_border(focused))
-      end
-      # The keys go on the crumb's row only when there is no rail to hang them off — with one
-      # up, the gutter already names them BESIDE the row each lands on, which says more than
-      # a chip can. Suppressed on a single-row list, where neither key has anywhere to go.
-      meta = rail || rows.size <= 1 ? nil : "#{@step_keys[0]}/#{@step_keys[1]}"
+      body, meta = render_rail_chrome(screen, inner, focused, active: focused || strip_focused)
       render_detail(screen, body, focused: focused, strip_focused: strip_focused, step_meta: meta)
-    end
-
-    # The DETAIL's rect inside the drill-in. `inset` alone stopped being the answer once the
-    # rail could sit above it, and every hit-test measures against this.
-    def detail_body_rect(inner : Rect) : Rect
-      DrillIn.rail_split(inner, rail_window[0].size)[1]
-    end
-
-    # The RAIL's rect, or nil when it is not shown. The twin of `detail_body_rect`, so the
-    # two sides of one split are read from one derivation rather than recomputed per caller.
-    def rail_rect(inner : Rect) : Rect?
-      DrillIn.rail_split(inner, rail_window[0].size)[0]
     end
 
     # The drill-in's breadcrumb. ONE derivation, read by `render_detail` AND by
@@ -1141,12 +1148,12 @@ module Gori::Tui
     # one rect and hit-tested against another is a dead button (which is what the old
     # ` ‹ list ` was in all three tabs).
     #
-    # `pos` counts the FILTERED list, not the store: it names the row the cursor is on in
-    # what is actually on screen behind, which is what ⇧N/⇧P steps through.
+    # `pos` counts the FILTERED list and names the OPEN flow's place in it, which is what
+    # the step chords move through.
     def detail_crumb : Frame::Crumb?
       d = @detail || return nil
       row = d.row
-      pos = @rows.empty? ? nil : "#{@selected + 1}/#{@rows.size}"
+      pos = detail_row_index.try { |i| "#{i + 1}/#{@rows.size}" }
       Frame::Crumb.new("HISTORY", "#{row.method} #{row.host}#{origin_path_memo(row)}", pos)
     end
 
@@ -2522,7 +2529,7 @@ module Gori::Tui
       set_detail_pane(pane) if detail_panes.includes?(pane)
     end
 
-    # Which pane is on screen. Read by the ⇧N/⇧P item step so it can carry the pane you are
+    # Which pane is on screen. Read by the item step so it can carry the pane you are
     # reading into the next flow — comparing one pane across rows is what stepping is FOR,
     # and `open_detail_id` resets to `initial_detail_pane` on every open. `set_detail_pane_public`
     # is the other half: it declines a pane the new flow does not offer, so a step off a JWT

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -1103,14 +1103,25 @@ module Gori::Tui
     # point, so the controller cannot draw the rail and then hit-test as though it were not
     # there. The crumb needs no rail-awareness — it rides `body.y - 1`, which IS the rail's
     # divider when there is one and the card's own top border when there is not.
+    # The effective labels for the item-step chords, pushed down each frame by the controller
+    # — the side that can read the keymap. Literal defaults so a registry-less render (every
+    # view spec) still prints something, which is the fallback convention every such render
+    # in this codebase keeps.
+    property step_keys : {String, String} = {DrillIn::NEXT_KEY, DrillIn::PREV_KEY}
+
     def render_drill(screen : Screen, inner : Rect, focused : Bool, strip_focused : Bool) : Nil
       rows, cur = rail_window
       rail, body = DrillIn.rail_split(inner, rows.size)
       if rail
-        DrillIn.render_rail(screen, rail, rows, cur, focused: focused || strip_focused)
+        DrillIn.render_rail(screen, rail, rows, cur, focused: focused || strip_focused,
+          next_key: @step_keys[0], prev_key: @step_keys[1])
         Frame.inner_divider(screen, inner, rail.bottom, border: Frame.pane_border(focused))
       end
-      render_detail(screen, body, focused: focused, strip_focused: strip_focused)
+      # The keys go on the crumb's row only when there is no rail to hang them off — with one
+      # up, the gutter already names them BESIDE the row each lands on, which says more than
+      # a chip can. Suppressed on a single-row list, where neither key has anywhere to go.
+      meta = rail || rows.size <= 1 ? nil : "#{@step_keys[0]}/#{@step_keys[1]}"
+      render_detail(screen, body, focused: focused, strip_focused: strip_focused, step_meta: meta)
     end
 
     # The DETAIL's rect inside the drill-in. `inset` alone stopped being the answer once the
@@ -3241,7 +3252,8 @@ module Gori::Tui
       end
     end
 
-    def render_detail(screen : Screen, rect : Rect, focused : Bool = true, strip_focused : Bool = false) : Nil
+    def render_detail(screen : Screen, rect : Rect, focused : Bool = true, strip_focused : Bool = false,
+                      step_meta : String? = nil) : Nil
       return if rect.empty?
       detail = @detail
       unless detail
@@ -3251,7 +3263,7 @@ module Gori::Tui
       # Back-to-list breadcrumb on the top border: which list, which row of it, and what is
       # open. See Frame::Crumb — the `‹` is a button, hit-tested off the same rect.
       if c = detail_crumb
-        Frame.crumb(screen, rect, c)
+        Frame.crumb(screen, rect, c, meta: step_meta)
       end
       # Pane strip: show ALL panes as chips with the active one highlighted, so it's
       # obvious there's more behind (←/→ walk `detail_panes`, in that order).

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -1,6 +1,7 @@
 require "./screen"
 require "./theme"
 require "./frame"
+require "./drill_in"
 require "./query_suggest"
 require "./suggest_popup"
 require "./traffic_empty_state"
@@ -1081,6 +1082,61 @@ module Gori::Tui
     # The flow id currently open in the detail overlay (nil when the list is showing).
     def detail_flow_id : Int64?
       @detail.try(&.row.id)
+    end
+
+    # The rail's window of list context around the open flow — see DrillIn. Maps the list
+    # row onto the shared three-part shape; nothing of the list RENDERER is involved, which
+    # is what keeps a 200-line column layout out of a three-row readout.
+    def rail_window : {Array(DrillIn::RailRow), Int32}
+      return {[] of DrillIn::RailRow, 0} if @rows.empty?
+      start = DrillIn.window_start(@rows.size, @selected)
+      slice = @rows[start, {DrillIn::RAIL_ROWS, @rows.size - start}.min]
+      rows = slice.map do |r|
+        status, scolor = FlowStatus.cell(r)
+        DrillIn::RailRow.new(status, "#{r.method} #{r.host}#{origin_path_memo(r)}",
+          fmt_time_memo(r.created_at), scolor)
+      end
+      {rows, @selected - start}
+    end
+
+    # The drill-in as a whole: the list rail (when it fits) over the flow detail. ONE entry
+    # point, so the controller cannot draw the rail and then hit-test as though it were not
+    # there. The crumb needs no rail-awareness — it rides `body.y - 1`, which IS the rail's
+    # divider when there is one and the card's own top border when there is not.
+    def render_drill(screen : Screen, inner : Rect, focused : Bool, strip_focused : Bool) : Nil
+      rows, cur = rail_window
+      rail, body = DrillIn.rail_split(inner, rows.size)
+      if rail
+        DrillIn.render_rail(screen, rail, rows, cur, focused: focused || strip_focused)
+        Frame.inner_divider(screen, inner, rail.bottom, border: Frame.pane_border(focused))
+      end
+      render_detail(screen, body, focused: focused, strip_focused: strip_focused)
+    end
+
+    # The DETAIL's rect inside the drill-in. `inset` alone stopped being the answer once the
+    # rail could sit above it, and every hit-test measures against this.
+    def detail_body_rect(inner : Rect) : Rect
+      DrillIn.rail_split(inner, rail_window[0].size)[1]
+    end
+
+    # The RAIL's rect, or nil when it is not shown. The twin of `detail_body_rect`, so the
+    # two sides of one split are read from one derivation rather than recomputed per caller.
+    def rail_rect(inner : Rect) : Rect?
+      DrillIn.rail_split(inner, rail_window[0].size)[0]
+    end
+
+    # The drill-in's breadcrumb. ONE derivation, read by `render_detail` AND by
+    # HistoryController's click hit-test — the `‹` is a control, and a control drawn from
+    # one rect and hit-tested against another is a dead button (which is what the old
+    # ` ‹ list ` was in all three tabs).
+    #
+    # `pos` counts the FILTERED list, not the store: it names the row the cursor is on in
+    # what is actually on screen behind, which is what ⇧N/⇧P steps through.
+    def detail_crumb : Frame::Crumb?
+      d = @detail || return nil
+      row = d.row
+      pos = @rows.empty? ? nil : "#{@selected + 1}/#{@rows.size}"
+      Frame::Crumb.new("HISTORY", "#{row.method} #{row.host}#{origin_path_memo(row)}", pos)
     end
 
     def selected_id : Int64?
@@ -2455,6 +2511,15 @@ module Gori::Tui
       set_detail_pane(pane) if detail_panes.includes?(pane)
     end
 
+    # Which pane is on screen. Read by the ⇧N/⇧P item step so it can carry the pane you are
+    # reading into the next flow — comparing one pane across rows is what stepping is FOR,
+    # and `open_detail_id` resets to `initial_detail_pane` on every open. `set_detail_pane_public`
+    # is the other half: it declines a pane the new flow does not offer, so a step off a JWT
+    # request onto one without a token lands on that flow's opening pane rather than nothing.
+    def detail_pane : Symbol
+      @detail_pane
+    end
+
     # Two-level detail focus: the chip row (:strip) vs the caret/text body (:body).
     # ←/→ switch panes at the strip level and move the caret at the body level; the
     # split is invisible to the verb layer (current_scope keys off @overlay only).
@@ -3183,8 +3248,11 @@ module Gori::Tui
         screen.text(rect.x + 1, rect.y, "no flow selected", Theme.muted)
         return
       end
-      # Back-to-list affordance on the top border (← past REQUEST / esc → the list).
-      Frame.list_back_hint(screen, rect)
+      # Back-to-list breadcrumb on the top border: which list, which row of it, and what is
+      # open. See Frame::Crumb — the `‹` is a button, hit-tested off the same rect.
+      if c = detail_crumb
+        Frame.crumb(screen, rect, c)
+      end
       # Pane strip: show ALL panes as chips with the active one highlighted, so it's
       # obvious there's more behind (←/→ walk `detail_panes`, in that order).
       x = render_detail_chips(screen, rect, strip_focused)

--- a/src/gori/tui/issues_view.cr
+++ b/src/gori/tui/issues_view.cr
@@ -251,14 +251,24 @@ module Gori::Tui
     # The drill-in as a whole: the list rail (when it fits) over the issue detail. ONE entry
     # point — see HistoryView#render_drill, which this mirrors. The crumb needs no
     # rail-awareness: it rides `body.y - 1`, the rail's divider or the card's top border.
+    # The effective labels for the item-step chords, pushed down each frame by the controller
+    # — the side that can read the keymap. Literal defaults so a registry-less render (every
+    # view spec) still prints something, which is the fallback convention every such render
+    # in this codebase keeps.
+    property step_keys : {String, String} = {DrillIn::NEXT_KEY, DrillIn::PREV_KEY}
+
     private def render_drill(screen : Screen, rect : Rect, focused : Bool) : Nil
       rows, cur = rail_window
       rail, body = DrillIn.rail_split(rect, rows.size)
       if rail
-        DrillIn.render_rail(screen, rail, rows, cur, focused: focused)
+        DrillIn.render_rail(screen, rail, rows, cur, focused: focused,
+          next_key: @step_keys[0], prev_key: @step_keys[1])
         Frame.inner_divider(screen, rect, rail.bottom)
       end
-      render_detail(screen, body, focused)
+      # See HistoryView#render_drill: the chip is the no-rail fallback, and a single-row list
+      # gets neither (there is nowhere to step).
+      meta = rail || rows.size <= 1 ? nil : "#{@step_keys[0]}/#{@step_keys[1]}"
+      render_detail(screen, body, focused, step_meta: meta)
     end
 
     # The DETAIL's rect inside the drill-in — what every detail hit-test measures against
@@ -1307,12 +1317,13 @@ module Gori::Tui
       hidden > 0 ? "#{@marks.size} marked ·#{hidden} hidden" : "#{@marks.size} marked"
     end
 
-    private def render_detail(screen : Screen, rect : Rect, focused : Bool) : Nil
+    private def render_detail(screen : Screen, rect : Rect, focused : Bool,
+                              step_meta : String? = nil) : Nil
       issue = @detail.not_nil!
       # Back-to-list breadcrumb on the top border: which list, which row of it, and what is
       # open. See Frame::Crumb — the `‹` is a button, hit-tested off the same rect.
       if c = detail_crumb
-        Frame.crumb(screen, rect, c)
+        Frame.crumb(screen, rect, c, meta: step_meta)
       end
       w = {rect.w - 2, 0}.max
 

--- a/src/gori/tui/issues_view.cr
+++ b/src/gori/tui/issues_view.cr
@@ -29,6 +29,7 @@ module Gori::Tui
     include PreviewSplit
     include PreviewPane
     include IssuePresentation
+    include DrillIn::Host # the rail/detail split, its render, and the step-key labels
 
     # The `/` bar's own label, hoisted out of `render_filter_bar` because the dropdown
     # anchors to the column the query text starts in and must not re-measure it.
@@ -235,57 +236,62 @@ module Gori::Tui
     # The drill-in's breadcrumb. ONE derivation, read by `render_detail` AND by
     # IssuesController's click hit-test — the `‹` is a control, and a control drawn from one
     # rect and hit-tested against another is a dead button (which is what ` ‹ list ` was).
-    # `pos` counts the FILTERED list behind, which is what ⇧N/⇧P steps through.
-    # The rail's window of list context around the open issue — see DrillIn.
-    def rail_window : {Array(DrillIn::RailRow), Int32}
-      return {[] of DrillIn::RailRow, 0} if @issues.empty?
-      start = DrillIn.window_start(@issues.size, @selected)
-      slice = @issues[start, {DrillIn::RAIL_ROWS, @issues.size - start}.min]
-      rows = slice.map do |i|
-        DrillIn::RailRow.new(severity_badge(i.severity), i.title,
-          i.host.try(&.presence), severity_color(i.severity))
-      end
-      {rows, @selected - start}
+    # `pos` counts the FILTERED list behind, which is what the step chords move through.
+    # The row the drill-in actually has OPEN, as an index into the filtered list — not the
+    # cursor. The two are the same at open time and a reload re-anchors the cursor by id, but
+    # keying the rail off the OPEN item is the only spelling that cannot band a row the detail
+    # is not showing (see HistoryView#detail_row_index, where live capture makes them diverge
+    # every few seconds).
+    def detail_row_index : Int32?
+      d = @detail || return nil
+      @issues.index { |i| i.id == d.id }
     end
 
-    # The drill-in as a whole: the list rail (when it fits) over the issue detail. ONE entry
-    # point — see HistoryView#render_drill, which this mirrors. The crumb needs no
-    # rail-awareness: it rides `body.y - 1`, the rail's divider or the card's top border.
-    # The effective labels for the item-step chords, pushed down each frame by the controller
-    # — the side that can read the keymap. Literal defaults so a registry-less render (every
-    # view spec) still prints something, which is the fallback convention every such render
-    # in this codebase keeps.
-    property step_keys : {String, String} = {DrillIn::NEXT_KEY, DrillIn::PREV_KEY}
+    # Rows in the filtered list — the bound the item step clamps against.
+    def row_count : Int32
+      @issues.size
+    end
 
-    private def render_drill(screen : Screen, rect : Rect, focused : Bool) : Nil
-      rows, cur = rail_window
-      rail, body = DrillIn.rail_split(rect, rows.size)
-      if rail
-        DrillIn.render_rail(screen, rail, rows, cur, focused: focused,
-          next_key: @step_keys[0], prev_key: @step_keys[1])
-        Frame.inner_divider(screen, rect, rail.bottom)
+    # See DrillIn::Host.
+    def rail_count : Int32
+      detail_row_index ? {DrillIn::RAIL_ROWS, @issues.size}.min : 0
+    end
+
+    # First index of the window the rail shows. Private: everything outside reads
+    # `rail_rows`/`rail_cursor`, which are derived from it.
+    private def rail_start : Int32
+      here = detail_row_index || return 0
+      DrillIn.window_start(@issues.size, here)
+    end
+
+    # See DrillIn::Host.
+    def rail_cursor : Int32
+      (detail_row_index || 0) - rail_start
+    end
+
+    # The rail's window of list context around the open item — see DrillIn.
+    def rail_rows : Array(DrillIn::RailRow)
+      n = rail_count
+      return [] of DrillIn::RailRow if n == 0
+      @issues[rail_start, n].map do |i|
+        DrillIn::RailRow.new(severity_badge(i.severity), i.title, i.host.try(&.presence),
+          severity_color(i.severity))
       end
-      # See HistoryView#render_drill: the chip is the no-rail fallback, and a single-row list
-      # gets neither (there is nowhere to step).
-      meta = rail || rows.size <= 1 ? nil : "#{@step_keys[0]}/#{@step_keys[1]}"
+    end
+
+    # The drill-in as a whole: the list rail (when it fits) over the item detail. ONE entry
+    # point — see HistoryView#render_drill, which this mirrors.
+    private def render_drill(screen : Screen, rect : Rect, focused : Bool) : Nil
+      body, meta = render_rail_chrome(screen, rect, focused)
       render_detail(screen, body, focused, step_meta: meta)
     end
 
-    # The DETAIL's rect inside the drill-in — what every detail hit-test measures against
-    # (`detail_split` and the four card rects below all take THIS, not the framed interior).
-    def detail_body_rect(rect : Rect) : Rect
-      DrillIn.rail_split(rect, rail_window[0].size)[1]
-    end
-
-    # The RAIL's rect, or nil when it is not shown. The twin of `detail_body_rect`, so the
-    # two sides of one split are read from one derivation rather than recomputed per caller.
-    def rail_rect(rect : Rect) : Rect?
-      DrillIn.rail_split(rect, rail_window[0].size)[0]
-    end
-
+    # The drill-in's breadcrumb. ONE derivation, read by `render_detail` AND by the
+    # controller's click hit-test — the `‹` is a control, and a control drawn from one rect
+    # and hit-tested against another is a dead button (which is what ` ‹ list ` was).
     def detail_crumb : Frame::Crumb?
       issue = @detail || return nil
-      pos = @issues.empty? ? nil : "#{@selected + 1}/#{@issues.size}"
+      pos = detail_row_index.try { |i| "#{i + 1}/#{@issues.size}" }
       Frame::Crumb.new("ISSUES", issue.title, pos)
     end
 

--- a/src/gori/tui/issues_view.cr
+++ b/src/gori/tui/issues_view.cr
@@ -1,6 +1,7 @@
 require "./screen"
 require "./theme"
 require "./frame"
+require "./drill_in"
 require "./traffic_empty_state"
 require "./text_area"
 require "./input_mode"
@@ -229,6 +230,53 @@ module Gori::Tui
 
     def detail_open? : Bool
       !@detail.nil?
+    end
+
+    # The drill-in's breadcrumb. ONE derivation, read by `render_detail` AND by
+    # IssuesController's click hit-test — the `‹` is a control, and a control drawn from one
+    # rect and hit-tested against another is a dead button (which is what ` ‹ list ` was).
+    # `pos` counts the FILTERED list behind, which is what ⇧N/⇧P steps through.
+    # The rail's window of list context around the open issue — see DrillIn.
+    def rail_window : {Array(DrillIn::RailRow), Int32}
+      return {[] of DrillIn::RailRow, 0} if @issues.empty?
+      start = DrillIn.window_start(@issues.size, @selected)
+      slice = @issues[start, {DrillIn::RAIL_ROWS, @issues.size - start}.min]
+      rows = slice.map do |i|
+        DrillIn::RailRow.new(severity_badge(i.severity), i.title,
+          i.host.try(&.presence), severity_color(i.severity))
+      end
+      {rows, @selected - start}
+    end
+
+    # The drill-in as a whole: the list rail (when it fits) over the issue detail. ONE entry
+    # point — see HistoryView#render_drill, which this mirrors. The crumb needs no
+    # rail-awareness: it rides `body.y - 1`, the rail's divider or the card's top border.
+    private def render_drill(screen : Screen, rect : Rect, focused : Bool) : Nil
+      rows, cur = rail_window
+      rail, body = DrillIn.rail_split(rect, rows.size)
+      if rail
+        DrillIn.render_rail(screen, rail, rows, cur, focused: focused)
+        Frame.inner_divider(screen, rect, rail.bottom)
+      end
+      render_detail(screen, body, focused)
+    end
+
+    # The DETAIL's rect inside the drill-in — what every detail hit-test measures against
+    # (`detail_split` and the four card rects below all take THIS, not the framed interior).
+    def detail_body_rect(rect : Rect) : Rect
+      DrillIn.rail_split(rect, rail_window[0].size)[1]
+    end
+
+    # The RAIL's rect, or nil when it is not shown. The twin of `detail_body_rect`, so the
+    # two sides of one split are read from one derivation rather than recomputed per caller.
+    def rail_rect(rect : Rect) : Rect?
+      DrillIn.rail_split(rect, rail_window[0].size)[0]
+    end
+
+    def detail_crumb : Frame::Crumb?
+      issue = @detail || return nil
+      pos = @issues.empty? ? nil : "#{@selected + 1}/#{@issues.size}"
+      Frame::Crumb.new("ISSUES", issue.title, pos)
     end
 
     getter notes_mode : InputMode
@@ -978,7 +1026,7 @@ module Gori::Tui
     def render(screen : Screen, rect : Rect, focused : Bool = true) : Nil
       return if rect.empty?
       if @detail
-        render_detail(screen, rect, focused)
+        render_drill(screen, rect, focused)
       else
         list_rect, preview_rect = list_split(rect)
         # No preview pane at this size (or after a resize down) ⇒ snap focus back to the list,
@@ -1261,8 +1309,11 @@ module Gori::Tui
 
     private def render_detail(screen : Screen, rect : Rect, focused : Bool) : Nil
       issue = @detail.not_nil!
-      # Back-to-list affordance on the top border (←/esc → the issue list).
-      Frame.list_back_hint(screen, rect)
+      # Back-to-list breadcrumb on the top border: which list, which row of it, and what is
+      # open. See Frame::Crumb — the `‹` is a button, hit-tested off the same rect.
+      if c = detail_crumb
+        Frame.crumb(screen, rect, c)
+      end
       w = {rect.w - 2, 0}.max
 
       # y0 — title row: a severity-coloured bullet + the bright title; #id at the right.

--- a/src/gori/tui/probe_view.cr
+++ b/src/gori/tui/probe_view.cr
@@ -1,6 +1,7 @@
 require "./screen"
 require "./theme"
 require "./frame"
+require "./drill_in"
 require "./read_pane"
 require "./traffic_empty_state"
 require "../settings"
@@ -243,6 +244,49 @@ module Gori::Tui
 
     def detail_open? : Bool
       !@detail.nil?
+    end
+
+    # The drill-in's breadcrumb — the twin of IssuesView#detail_crumb, and read the same two
+    # ways (render + the `‹` hit-test). `pos` counts the FILTERED list behind.
+    # The rail's window of list context around the open finding — see DrillIn.
+    def rail_window : {Array(DrillIn::RailRow), Int32}
+      return {[] of DrillIn::RailRow, 0} if @issues.empty?
+      start = DrillIn.window_start(@issues.size, @selected)
+      slice = @issues[start, {DrillIn::RAIL_ROWS, @issues.size - start}.min]
+      rows = slice.map do |i|
+        DrillIn::RailRow.new(severity_badge(i.severity), i.title, i.host.presence,
+          severity_color(i.severity))
+      end
+      {rows, @selected - start}
+    end
+
+    # The drill-in as a whole: the list rail (when it fits) over the finding detail. ONE
+    # entry point — see HistoryView#render_drill, which this mirrors.
+    private def render_drill(screen : Screen, rect : Rect, focused : Bool) : Nil
+      rows, cur = rail_window
+      rail, body = DrillIn.rail_split(rect, rows.size)
+      if rail
+        DrillIn.render_rail(screen, rail, rows, cur, focused: focused)
+        Frame.inner_divider(screen, rect, rail.bottom)
+      end
+      render_detail(screen, body, focused)
+    end
+
+    # The DETAIL's rect inside the drill-in — what every detail hit-test measures against.
+    def detail_body_rect(rect : Rect) : Rect
+      DrillIn.rail_split(rect, rail_window[0].size)[1]
+    end
+
+    # The RAIL's rect, or nil when it is not shown. The twin of `detail_body_rect`, so the
+    # two sides of one split are read from one derivation rather than recomputed per caller.
+    def rail_rect(rect : Rect) : Rect?
+      DrillIn.rail_split(rect, rail_window[0].size)[0]
+    end
+
+    def detail_crumb : Frame::Crumb?
+      issue = @detail || return nil
+      pos = @issues.empty? ? nil : "#{@selected + 1}/#{@issues.size}"
+      Frame::Crumb.new("PROBE", issue.title, pos)
     end
 
     # No issues at all (the raw list) — gates "clear all".
@@ -800,7 +844,7 @@ module Gori::Tui
                listen : {String, Int32}? = nil, capturing : Bool = true) : Nil
       return if rect.empty?
       if @detail
-        render_detail(screen, rect, focused)
+        render_drill(screen, rect, focused)
       else
         list_rect, preview_rect = list_split(rect)
         # No preview pane at this size (or after a resize down) ⇒ snap focus back to the list,
@@ -1103,8 +1147,11 @@ module Gori::Tui
 
     private def render_detail(screen : Screen, rect : Rect, focused : Bool) : Nil
       issue = @detail || return
-      # Back-to-list affordance on the top border (←/esc → the issue list).
-      Frame.list_back_hint(screen, rect)
+      # Back-to-list breadcrumb on the top border: which list, which row of it, and what is
+      # open. See Frame::Crumb — the `‹` is a button, hit-tested off the same rect.
+      if c = detail_crumb
+        Frame.crumb(screen, rect, c)
+      end
       w = {rect.w - 2, 0}.max
       code_label = "##{issue.code}"
       screen.text(rect.right - code_label.size - 1, rect.y, code_label, Theme.muted)

--- a/src/gori/tui/probe_view.cr
+++ b/src/gori/tui/probe_view.cr
@@ -29,6 +29,7 @@ module Gori::Tui
     include PreviewSplit
     include PreviewPane
     include IssuePresentation
+    include DrillIn::Host # the rail/detail split, its render, and the step-key labels
 
     # See `IssuesView::QUERY_PREFIX` / `FILTER_HINT` / `QUERY_HINT` — the sibling bar over the
     # sibling backend, and the same two reasons: the dropdown anchors to the column the query
@@ -248,54 +249,56 @@ module Gori::Tui
 
     # The drill-in's breadcrumb — the twin of IssuesView#detail_crumb, and read the same two
     # ways (render + the `‹` hit-test). `pos` counts the FILTERED list behind.
-    # The rail's window of list context around the open finding — see DrillIn.
-    def rail_window : {Array(DrillIn::RailRow), Int32}
-      return {[] of DrillIn::RailRow, 0} if @issues.empty?
-      start = DrillIn.window_start(@issues.size, @selected)
-      slice = @issues[start, {DrillIn::RAIL_ROWS, @issues.size - start}.min]
-      rows = slice.map do |i|
+    # The row the drill-in actually has OPEN, as an index into the filtered list — not the
+    # cursor. The two are the same at open time and a reload re-anchors the cursor by id, but
+    # keying the rail off the OPEN item is the only spelling that cannot band a row the detail
+    # is not showing (see HistoryView#detail_row_index, where live capture makes them diverge
+    # every few seconds).
+    def detail_row_index : Int32?
+      d = @detail || return nil
+      @issues.index { |i| i.id == d.id }
+    end
+
+    # See DrillIn::Host.
+    def rail_count : Int32
+      detail_row_index ? {DrillIn::RAIL_ROWS, @issues.size}.min : 0
+    end
+
+    # First index of the window the rail shows. Private: everything outside reads
+    # `rail_rows`/`rail_cursor`, which are derived from it.
+    private def rail_start : Int32
+      here = detail_row_index || return 0
+      DrillIn.window_start(@issues.size, here)
+    end
+
+    # See DrillIn::Host.
+    def rail_cursor : Int32
+      (detail_row_index || 0) - rail_start
+    end
+
+    # The rail's window of list context around the open item — see DrillIn.
+    def rail_rows : Array(DrillIn::RailRow)
+      n = rail_count
+      return [] of DrillIn::RailRow if n == 0
+      @issues[rail_start, n].map do |i|
         DrillIn::RailRow.new(severity_badge(i.severity), i.title, i.host.presence,
           severity_color(i.severity))
       end
-      {rows, @selected - start}
     end
 
-    # The drill-in as a whole: the list rail (when it fits) over the finding detail. ONE
-    # entry point — see HistoryView#render_drill, which this mirrors.
-    # The effective labels for the item-step chords, pushed down each frame by the controller
-    # — the side that can read the keymap. Literal defaults so a registry-less render (every
-    # view spec) still prints something, which is the fallback convention every such render
-    # in this codebase keeps.
-    property step_keys : {String, String} = {DrillIn::NEXT_KEY, DrillIn::PREV_KEY}
-
+    # The drill-in as a whole: the list rail (when it fits) over the item detail. ONE entry
+    # point — see HistoryView#render_drill, which this mirrors.
     private def render_drill(screen : Screen, rect : Rect, focused : Bool) : Nil
-      rows, cur = rail_window
-      rail, body = DrillIn.rail_split(rect, rows.size)
-      if rail
-        DrillIn.render_rail(screen, rail, rows, cur, focused: focused,
-          next_key: @step_keys[0], prev_key: @step_keys[1])
-        Frame.inner_divider(screen, rect, rail.bottom)
-      end
-      # See HistoryView#render_drill: the chip is the no-rail fallback, and a single-row list
-      # gets neither (there is nowhere to step).
-      meta = rail || rows.size <= 1 ? nil : "#{@step_keys[0]}/#{@step_keys[1]}"
+      body, meta = render_rail_chrome(screen, rect, focused)
       render_detail(screen, body, focused, step_meta: meta)
     end
 
-    # The DETAIL's rect inside the drill-in — what every detail hit-test measures against.
-    def detail_body_rect(rect : Rect) : Rect
-      DrillIn.rail_split(rect, rail_window[0].size)[1]
-    end
-
-    # The RAIL's rect, or nil when it is not shown. The twin of `detail_body_rect`, so the
-    # two sides of one split are read from one derivation rather than recomputed per caller.
-    def rail_rect(rect : Rect) : Rect?
-      DrillIn.rail_split(rect, rail_window[0].size)[0]
-    end
-
+    # The drill-in's breadcrumb. ONE derivation, read by `render_detail` AND by the
+    # controller's click hit-test — the `‹` is a control, and a control drawn from one rect
+    # and hit-tested against another is a dead button (which is what ` ‹ list ` was).
     def detail_crumb : Frame::Crumb?
       issue = @detail || return nil
-      pos = @issues.empty? ? nil : "#{@selected + 1}/#{@issues.size}"
+      pos = detail_row_index.try { |i| "#{i + 1}/#{@issues.size}" }
       Frame::Crumb.new("PROBE", issue.title, pos)
     end
 

--- a/src/gori/tui/probe_view.cr
+++ b/src/gori/tui/probe_view.cr
@@ -262,14 +262,24 @@ module Gori::Tui
 
     # The drill-in as a whole: the list rail (when it fits) over the finding detail. ONE
     # entry point — see HistoryView#render_drill, which this mirrors.
+    # The effective labels for the item-step chords, pushed down each frame by the controller
+    # — the side that can read the keymap. Literal defaults so a registry-less render (every
+    # view spec) still prints something, which is the fallback convention every such render
+    # in this codebase keeps.
+    property step_keys : {String, String} = {DrillIn::NEXT_KEY, DrillIn::PREV_KEY}
+
     private def render_drill(screen : Screen, rect : Rect, focused : Bool) : Nil
       rows, cur = rail_window
       rail, body = DrillIn.rail_split(rect, rows.size)
       if rail
-        DrillIn.render_rail(screen, rail, rows, cur, focused: focused)
+        DrillIn.render_rail(screen, rail, rows, cur, focused: focused,
+          next_key: @step_keys[0], prev_key: @step_keys[1])
         Frame.inner_divider(screen, rect, rail.bottom)
       end
-      render_detail(screen, body, focused)
+      # See HistoryView#render_drill: the chip is the no-rail fallback, and a single-row list
+      # gets neither (there is nowhere to step).
+      meta = rail || rows.size <= 1 ? nil : "#{@step_keys[0]}/#{@step_keys[1]}"
+      render_detail(screen, body, focused, step_meta: meta)
     end
 
     # The DETAIL's rect inside the drill-in — what every detail hit-test measures against.
@@ -1145,12 +1155,13 @@ module Gori::Tui
         Probe::Filter::FIELD_HELP_PROC)
     end
 
-    private def render_detail(screen : Screen, rect : Rect, focused : Bool) : Nil
+    private def render_detail(screen : Screen, rect : Rect, focused : Bool,
+                              step_meta : String? = nil) : Nil
       issue = @detail || return
       # Back-to-list breadcrumb on the top border: which list, which row of it, and what is
       # open. See Frame::Crumb — the `‹` is a button, hit-tested off the same rect.
       if c = detail_crumb
-        Frame.crumb(screen, rect, c)
+        Frame.crumb(screen, rect, c, meta: step_meta)
       end
       w = {rect.w - 2, 0}.max
       code_label = "##{issue.code}"

--- a/src/gori/tui/runner.cr
+++ b/src/gori/tui/runner.cr
@@ -2657,7 +2657,15 @@ module Gori::Tui
         case @focus
         when :menu    then "TABS"
         when :subtabs then "SUBTABS"
-        else               body_editor? ? "EDITOR" : "BODY"
+        else
+          # The controller names its own body state (TabController#body_badge) — the same
+          # answer `body_editor?` reads, asked one level wider so a view-owned drill-in can
+          # say DETAIL too. History's arrives above, off `@overlay`.
+          case @tabs[@active_tab]?.try(&.body_badge)
+          when :editor then "EDITOR"
+          when :detail then "DETAIL"
+          else              "BODY"
+          end
         end
       end
     end

--- a/src/gori/tui/runner/history.cr
+++ b/src/gori/tui/runner/history.cr
@@ -31,6 +31,13 @@ class Gori::Tui::Runner < Gori::Verb::ExecContext
     history_controller.close_detail
   end
 
+  # ⇧N/⇧P in the drill-in — the next/previous flow, in place. `@detail_pin` is deliberately
+  # NOT set: unlike `close_detail`, this stays in the detail, and the pin exists for verbs
+  # that leave it and then resolve a target.
+  def detail_step_item(delta : Int32) : Nil
+    history_controller.detail_step_item(delta)
+  end
+
   def toggle_follow : Nil
     history_controller.toggle_follow
   end

--- a/src/gori/tui/runner/history.cr
+++ b/src/gori/tui/runner/history.cr
@@ -31,7 +31,7 @@ class Gori::Tui::Runner < Gori::Verb::ExecContext
     history_controller.close_detail
   end
 
-  # ⇧N/⇧P in the drill-in — the next/previous flow, in place. `@detail_pin` is deliberately
+  # `n`/`⇧N` in the drill-in — the next/previous flow, in place. `@detail_pin` is deliberately
   # NOT set: unlike `close_detail`, this stays in the detail, and the pin exists for verbs
   # that leave it and then resolve a target.
   def detail_step_item(delta : Int32) : Nil

--- a/src/gori/tui/runner/issues.cr
+++ b/src/gori/tui/runner/issues.cr
@@ -44,6 +44,11 @@ class Gori::Tui::Runner < Gori::Verb::ExecContext
     issues_controller.issue_close
   end
 
+  # ⇧N/⇧P in the drill-in — the next/previous issue, in place.
+  def issue_step_item(delta : Int32) : Nil
+    issues_controller.issue_step_item(delta)
+  end
+
   def issues_delete : Nil
     issues_controller.issues_delete
   end

--- a/src/gori/tui/runner/issues.cr
+++ b/src/gori/tui/runner/issues.cr
@@ -44,7 +44,7 @@ class Gori::Tui::Runner < Gori::Verb::ExecContext
     issues_controller.issue_close
   end
 
-  # ⇧N/⇧P in the drill-in — the next/previous issue, in place.
+  # `n`/`⇧N` in the drill-in — the next/previous issue, in place.
   def issue_step_item(delta : Int32) : Nil
     issues_controller.issue_step_item(delta)
   end

--- a/src/gori/tui/runner/mouse.cr
+++ b/src/gori/tui/runner/mouse.cr
@@ -331,6 +331,13 @@ class Gori::Tui::Runner < Gori::Verb::ExecContext
   private def click_subtab_strip(body : Rect, mx : Int32, my : Int32) : Bool
     sub_rect = BodyChrome.strip_rect(body, strip: subtabs_shown?, strip_divider: subtab_strip_divider?)
     return false unless sub_rect && sub_rect.contains?(mx, my)
+    # The strip owns its CHIP row; the hairline under it is the body's top boundary, and
+    # `BodyChrome.tab_row`'s own comment already says hit-tests ignore the divider. Swallowing
+    # that row (this method consumes anything inside sub_rect) made every control a tab draws
+    # there dead — a drill-in's `‹` back button rides exactly that hairline whenever no list
+    # rail is up, so on Probe it silently worked or did not depending on how many findings
+    # the filter left.
+    return false unless my == BodyChrome.tab_row(sub_rect).y
     icon, chips = subtab_strip_split(sub_rect)
     if icon.try(&.contains?(mx, my))
       open_subtab_find_from_click

--- a/src/gori/tui/runner/probe.cr
+++ b/src/gori/tui/runner/probe.cr
@@ -13,6 +13,11 @@ class Gori::Tui::Runner < Gori::Verb::ExecContext
     probe_controller.probe_close
   end
 
+  # ⇧N/⇧P in the drill-in — the next/previous finding, in place.
+  def probe_step_item(delta : Int32) : Nil
+    probe_controller.probe_step_item(delta)
+  end
+
   def probe_query : Nil
     probe_controller.view.start_query
   end

--- a/src/gori/tui/runner/probe.cr
+++ b/src/gori/tui/runner/probe.cr
@@ -13,7 +13,7 @@ class Gori::Tui::Runner < Gori::Verb::ExecContext
     probe_controller.probe_close
   end
 
-  # ⇧N/⇧P in the drill-in — the next/previous finding, in place.
+  # `n`/`⇧N` in the drill-in — the next/previous finding, in place.
   def probe_step_item(delta : Int32) : Nil
     probe_controller.probe_step_item(delta)
   end

--- a/src/gori/tui/tab_controller.cr
+++ b/src/gori/tui/tab_controller.cr
@@ -1183,7 +1183,15 @@ module Gori::Tui
     end
 
     # --- status bar ---
-    def body_badge : Symbol # :editor (captures text) | :body (navigable/read-only)
+    # :editor (captures text) | :detail (an ITEM is open over this tab's list) | :body
+    # (navigable/read-only).
+    #
+    # `:detail` exists because the badge was the one always-visible slot that could say "you
+    # are a level down", and it said so on exactly one of the three tabs that have the level:
+    # History's drill-in lives in the shell (`@overlay == :detail`) so `focus_label` saw it,
+    # while Issues' and Probe's live in their views, and both read `BODY` — the same state,
+    # two different words, on adjacent tabs.
+    def body_badge : Symbol
       :body
     end
 

--- a/src/gori/verb/context/history.cr
+++ b/src/gori/verb/context/history.cr
@@ -5,6 +5,8 @@ abstract class Gori::Verb::ExecContext
   abstract def move_selection(delta : Int32) : Nil
   abstract def open_detail : Nil
   abstract def close_detail : Nil
+  # ⇧N/⇧P inside the drill-in — open the next/previous flow without returning to the list.
+  abstract def detail_step_item(delta : Int32) : Nil
   abstract def toggle_follow : Nil
   abstract def selected_flow_id : Int64?
 

--- a/src/gori/verb/context/history.cr
+++ b/src/gori/verb/context/history.cr
@@ -5,7 +5,7 @@ abstract class Gori::Verb::ExecContext
   abstract def move_selection(delta : Int32) : Nil
   abstract def open_detail : Nil
   abstract def close_detail : Nil
-  # ⇧N/⇧P inside the drill-in — open the next/previous flow without returning to the list.
+  # `n`/`⇧N` inside the drill-in — open the next/previous flow without returning to the list.
   abstract def detail_step_item(delta : Int32) : Nil
   abstract def toggle_follow : Nil
   abstract def selected_flow_id : Int64?

--- a/src/gori/verb/context/issues.cr
+++ b/src/gori/verb/context/issues.cr
@@ -8,7 +8,7 @@ abstract class Gori::Verb::ExecContext
   abstract def issues_move(delta : Int32) : Nil
   abstract def issues_open : Nil
   abstract def issue_close : Nil
-  # ⇧N/⇧P inside the drill-in — open the next/previous issue without returning to the list.
+  # `n`/`⇧N` inside the drill-in — open the next/previous issue without returning to the list.
   abstract def issue_step_item(delta : Int32) : Nil
   abstract def issues_delete : Nil
   # ⇧X — delete EVERY issue in the project (after a confirm). The whole-tab wipe the

--- a/src/gori/verb/context/issues.cr
+++ b/src/gori/verb/context/issues.cr
@@ -8,6 +8,8 @@ abstract class Gori::Verb::ExecContext
   abstract def issues_move(delta : Int32) : Nil
   abstract def issues_open : Nil
   abstract def issue_close : Nil
+  # ⇧N/⇧P inside the drill-in — open the next/previous issue without returning to the list.
+  abstract def issue_step_item(delta : Int32) : Nil
   abstract def issues_delete : Nil
   # ⇧X — delete EVERY issue in the project (after a confirm). The whole-tab wipe the
   # clear-all family shares (#899); `issues_delete` is the selection-delete beside it.

--- a/src/gori/verb/context/probe.cr
+++ b/src/gori/verb/context/probe.cr
@@ -12,7 +12,7 @@ abstract class Gori::Verb::ExecContext
   abstract def probe_move(delta : Int32) : Nil
   abstract def probe_open : Nil  # open the selected issue's detail
   abstract def probe_close : Nil # back to the list
-  # ⇧N/⇧P inside the drill-in — open the next/previous finding without returning to the list.
+  # `n`/`⇧N` inside the drill-in — open the next/previous finding without returning to the list.
   abstract def probe_step_item(delta : Int32) : Nil
   abstract def probe_query : Nil         # focus the `/` filter bar
   abstract def probe_set_mode : Nil      # open the OFF/Passive/Active picker

--- a/src/gori/verb/context/probe.cr
+++ b/src/gori/verb/context/probe.cr
@@ -10,8 +10,10 @@ abstract class Gori::Verb::ExecContext
 
   # probe (passive/active scan issues — grouped by code+host)
   abstract def probe_move(delta : Int32) : Nil
-  abstract def probe_open : Nil          # open the selected issue's detail
-  abstract def probe_close : Nil         # back to the list
+  abstract def probe_open : Nil  # open the selected issue's detail
+  abstract def probe_close : Nil # back to the list
+  # ⇧N/⇧P inside the drill-in — open the next/previous finding without returning to the list.
+  abstract def probe_step_item(delta : Int32) : Nil
   abstract def probe_query : Nil         # focus the `/` filter bar
   abstract def probe_set_mode : Nil      # open the OFF/Passive/Active picker
   abstract def probe_clear : Nil         # delete all issues (after a confirm)

--- a/src/gori/verbs/history.cr
+++ b/src/gori/verbs/history.cr
@@ -480,25 +480,29 @@ module Gori
         "detail.toggle-pane", "Switch pane (cycle)", "Cycle REQ → RES → FRAMES",
         Verb::Scope::HistoryDetail, [Verb::Chord.new("tab")], hidden: true) { |ctx| ctx.toggle_detail_pane; nil }
 
-      # ⇧N/⇧P: the next/previous FLOW, without leaving the drill-in. Hidden like the other
-      # nav verbs here (←/→/⇥) — the crumb's `12/123` is the affordance and the status hint
-      # names the keys.
+      # `n` / `⇧N`: the next/previous FLOW, without leaving the drill-in. Hidden like the
+      # other nav verbs here (←/→/⇥) — the rail's gutter names them beside the row each one
+      # lands on, and the status hint names them too.
       #
-      # NOT ⇧J/⇧K, the obvious spelling: `handle_detail_body_select` claims every ⇧ + h/j/k/l
-      # for the text selection this pane has always had, and a controller claim runs BEFORE
-      # this keymap — so those two would have been dead here and live on the chip strip, which
-      # is the position-dependent trap the ← fix exists to remove.
+      # This pair, and not ⇧J/⇧K or ⇧N/⇧P. ⇧J/⇧K is claimed a level below: the detail body's
+      # `handle_detail_body_select` takes every ⇧ + h/j/k/l for its text selection, and a
+      # controller claim runs BEFORE this keymap, so those two would be dead in the body and
+      # live on the chip strip — the position-dependent trap the ← fix exists to remove.
+      # ⇧N/⇧P collided in meaning instead of in scope: `comparer.prev-change` is ⇧N one tab
+      # over, so ⇧N would have moved forward here and backward there, and `validate_chords!`
+      # cannot see it (its seen-set is per Scope). `n` forward / `⇧N` back is what the
+      # Comparer, vim and less all already mean.
       #
       # Spelled `Chord.new("n", shift: true)`, never `Chord.new("N")`: `Keybind.from_event`
       # normalises a capital to shift + lowercase, so the latter never fires.
       r.register Verb::Definition.new(
         "detail.next-item", "Next flow", "Open the next flow in the list without leaving the detail",
-        Verb::Scope::HistoryDetail, [Verb::Chord.new("n", shift: true)],
+        Verb::Scope::HistoryDetail, [Verb::Chord.new("n")],
         hidden: true) { |ctx| ctx.detail_step_item(1); nil }
 
       r.register Verb::Definition.new(
         "detail.prev-item", "Previous flow", "Open the previous flow in the list without leaving the detail",
-        Verb::Scope::HistoryDetail, [Verb::Chord.new("p", shift: true)],
+        Verb::Scope::HistoryDetail, [Verb::Chord.new("n", shift: true)],
         hidden: true) { |ctx| ctx.detail_step_item(-1); nil }
 
       # The view-toggles are NON-hidden so they front the detail's "space" action menu

--- a/src/gori/verbs/history.cr
+++ b/src/gori/verbs/history.cr
@@ -443,8 +443,11 @@ module Gori
         available: in_repeater, mnemonic: 'p', section: :response) { |ctx| ctx.toggle_pretty; nil }
 
       # --- detail view ---
-      # esc/q always leave. ← walks back through the panes (FRAMES→RES→REQ) and → forward
-      # (REQ→RES→FRAMES); both clamp at the ends, so neither ever closes the detail.
+      # esc/q always leave. → walks forward through the panes (REQ→RES→FRAMES) and clamps at
+      # the end; ← walks back and, at the FIRST pane, leaves for the list — which is what
+      # Issues and Probe have always done with ←, and what the border crumb has always
+      # implied. It used to clamp there instead, so one arrow meant three things across the
+      # three tabs that have a drill-in, and the only one that pointed at a way out was dead.
       r.register Verb::Definition.new(
         "detail.close", "Close detail", "Return to the History list", Verb::Scope::HistoryDetail,
         [Verb::Chord.new("escape"), Verb::Chord.new("q")],
@@ -456,7 +459,7 @@ module Gori
         hidden: true) { |ctx| ctx.move_detail_pane(1); nil }
 
       r.register Verb::Definition.new(
-        "detail.prev-pane", "Previous pane ←", "Move to the previous detail pane (FRAMES → RES → REQ)",
+        "detail.prev-pane", "Previous pane ←", "Previous detail pane (FRAMES → RES → REQ); at REQ, back to the list",
         Verb::Scope::HistoryDetail, [Verb::Chord.new("left"), Verb::Chord.new("h")],
         hidden: true) { |ctx| ctx.move_detail_pane(-1); nil }
 
@@ -476,6 +479,27 @@ module Gori
       r.register Verb::Definition.new(
         "detail.toggle-pane", "Switch pane (cycle)", "Cycle REQ → RES → FRAMES",
         Verb::Scope::HistoryDetail, [Verb::Chord.new("tab")], hidden: true) { |ctx| ctx.toggle_detail_pane; nil }
+
+      # ⇧N/⇧P: the next/previous FLOW, without leaving the drill-in. Hidden like the other
+      # nav verbs here (←/→/⇥) — the crumb's `12/123` is the affordance and the status hint
+      # names the keys.
+      #
+      # NOT ⇧J/⇧K, the obvious spelling: `handle_detail_body_select` claims every ⇧ + h/j/k/l
+      # for the text selection this pane has always had, and a controller claim runs BEFORE
+      # this keymap — so those two would have been dead here and live on the chip strip, which
+      # is the position-dependent trap the ← fix exists to remove.
+      #
+      # Spelled `Chord.new("n", shift: true)`, never `Chord.new("N")`: `Keybind.from_event`
+      # normalises a capital to shift + lowercase, so the latter never fires.
+      r.register Verb::Definition.new(
+        "detail.next-item", "Next flow", "Open the next flow in the list without leaving the detail",
+        Verb::Scope::HistoryDetail, [Verb::Chord.new("n", shift: true)],
+        hidden: true) { |ctx| ctx.detail_step_item(1); nil }
+
+      r.register Verb::Definition.new(
+        "detail.prev-item", "Previous flow", "Open the previous flow in the list without leaving the detail",
+        Verb::Scope::HistoryDetail, [Verb::Chord.new("p", shift: true)],
+        hidden: true) { |ctx| ctx.detail_step_item(-1); nil }
 
       # The view-toggles are NON-hidden so they front the detail's "space" action menu
       # (the palette stays Global-only, so un-hiding doesn't leak there). ws/pretty take

--- a/src/gori/verbs/issues.cr
+++ b/src/gori/verbs/issues.cr
@@ -165,17 +165,17 @@ module Gori
         "issue.close", "Back to list", "Return to the issues list", Verb::Scope::IssuesDetail,
         [Verb::Chord.new("escape"), Verb::Chord.new("left"), Verb::Chord.new("h")], hidden: true) { |ctx| ctx.issue_close; nil }
 
-      # ⇧N/⇧P: the next/previous ISSUE, without leaving the drill-in. Same spelling as
+      # n/⇧N: the next/previous ISSUE, without leaving the drill-in. Same spelling as
       # History's and Probe's pair — one control, three tabs (see verbs/history.cr for why
       # it is not ⇧J/⇧K).
       r.register Verb::Definition.new(
         "issue.next-item", "Next issue", "Open the next issue in the list without leaving the detail",
-        Verb::Scope::IssuesDetail, [Verb::Chord.new("n", shift: true)],
+        Verb::Scope::IssuesDetail, [Verb::Chord.new("n")],
         hidden: true) { |ctx| ctx.issue_step_item(1); nil }
 
       r.register Verb::Definition.new(
         "issue.prev-item", "Previous issue", "Open the previous issue in the list without leaving the detail",
-        Verb::Scope::IssuesDetail, [Verb::Chord.new("p", shift: true)],
+        Verb::Scope::IssuesDetail, [Verb::Chord.new("n", shift: true)],
         hidden: true) { |ctx| ctx.issue_step_item(-1); nil }
 
       # Severity/status edits live on the Space menu (a colour picker) so arrows

--- a/src/gori/verbs/issues.cr
+++ b/src/gori/verbs/issues.cr
@@ -165,6 +165,19 @@ module Gori
         "issue.close", "Back to list", "Return to the issues list", Verb::Scope::IssuesDetail,
         [Verb::Chord.new("escape"), Verb::Chord.new("left"), Verb::Chord.new("h")], hidden: true) { |ctx| ctx.issue_close; nil }
 
+      # ⇧N/⇧P: the next/previous ISSUE, without leaving the drill-in. Same spelling as
+      # History's and Probe's pair — one control, three tabs (see verbs/history.cr for why
+      # it is not ⇧J/⇧K).
+      r.register Verb::Definition.new(
+        "issue.next-item", "Next issue", "Open the next issue in the list without leaving the detail",
+        Verb::Scope::IssuesDetail, [Verb::Chord.new("n", shift: true)],
+        hidden: true) { |ctx| ctx.issue_step_item(1); nil }
+
+      r.register Verb::Definition.new(
+        "issue.prev-item", "Previous issue", "Open the previous issue in the list without leaving the detail",
+        Verb::Scope::IssuesDetail, [Verb::Chord.new("p", shift: true)],
+        hidden: true) { |ctx| ctx.issue_step_item(-1); nil }
+
       # Severity/status edits live on the Space menu (a colour picker) so arrows
       # never change them by accident. The bracket/brace chords stay as hidden
       # power-shortcuts (one-step cycling); the pickers are the discoverable path.

--- a/src/gori/verbs/probe.cr
+++ b/src/gori/verbs/probe.cr
@@ -128,16 +128,16 @@ module Gori
         "probe.close", "Back to list", "Return to the issue list", Verb::Scope::ProbeDetail,
         [Verb::Chord.new("escape"), Verb::Chord.new("left"), Verb::Chord.new("h")], hidden: true) { |ctx| ctx.probe_close; nil }
 
-      # ⇧N/⇧P: the next/previous FINDING, without leaving the drill-in. Same spelling as
-      # History's and Issues' pair (see verbs/history.cr for why it is not ⇧J/⇧K).
+      # n/⇧N: the next/previous FINDING, without leaving the drill-in. Same spelling as
+      # History's and Issues' pair (see verbs/history.cr for the spelling).
       r.register Verb::Definition.new(
         "probe.next-item", "Next finding", "Open the next finding in the list without leaving the detail",
-        Verb::Scope::ProbeDetail, [Verb::Chord.new("n", shift: true)],
+        Verb::Scope::ProbeDetail, [Verb::Chord.new("n")],
         hidden: true) { |ctx| ctx.probe_step_item(1); nil }
 
       r.register Verb::Definition.new(
         "probe.prev-item", "Previous finding", "Open the previous finding in the list without leaving the detail",
-        Verb::Scope::ProbeDetail, [Verb::Chord.new("p", shift: true)],
+        Verb::Scope::ProbeDetail, [Verb::Chord.new("n", shift: true)],
         hidden: true) { |ctx| ctx.probe_step_item(-1); nil }
 
       # ↵ over the AFFECTED URLS list: the caret's OWN url, which is not what `o` opens — that

--- a/src/gori/verbs/probe.cr
+++ b/src/gori/verbs/probe.cr
@@ -128,6 +128,18 @@ module Gori
         "probe.close", "Back to list", "Return to the issue list", Verb::Scope::ProbeDetail,
         [Verb::Chord.new("escape"), Verb::Chord.new("left"), Verb::Chord.new("h")], hidden: true) { |ctx| ctx.probe_close; nil }
 
+      # ⇧N/⇧P: the next/previous FINDING, without leaving the drill-in. Same spelling as
+      # History's and Issues' pair (see verbs/history.cr for why it is not ⇧J/⇧K).
+      r.register Verb::Definition.new(
+        "probe.next-item", "Next finding", "Open the next finding in the list without leaving the detail",
+        Verb::Scope::ProbeDetail, [Verb::Chord.new("n", shift: true)],
+        hidden: true) { |ctx| ctx.probe_step_item(1); nil }
+
+      r.register Verb::Definition.new(
+        "probe.prev-item", "Previous finding", "Open the previous finding in the list without leaving the detail",
+        Verb::Scope::ProbeDetail, [Verb::Chord.new("p", shift: true)],
+        hidden: true) { |ctx| ctx.probe_step_item(-1); nil }
+
       # ↵ over the AFFECTED URLS list: the caret's OWN url, which is not what `o` opens — that
       # is the group's one sample flow, so before this every other row of a group of up to 50
       # was a dead line in the pane listing it. The Issues detail's related-links list has


### PR DESCRIPTION
Opening a row in History, Issues or Probe replaced the whole tab body, and nothing on screen said which list was behind it. The card lost its title to a bare ` ‹ list ` marker, the tab bar rendered exactly as it does over the list, and getting back meant remembering a key rather than seeing one — `←` meant three different things across the three tabs that have the level.

## What changed

**A breadcrumb instead of ` ‹ list `.** `Frame::Crumb` prints ` ‹ HISTORY · 12/123 · GET host/path ` on the drill-in's top edge: where you are, which row of it, and what is open. The `‹` is a real button now — no tab hit-tested those cells before, so the one glyph pointing at the way out did nothing when pressed.

**One way back.**

- History's `←` walks back through the panes and *leaves* at the first one, which is what Issues and Probe have always done and what the border has always implied. It used to clamp there and do nothing.
- History's `↑` on the chip strip returns to the **list**. It used to close the detail *and* jump to the tab bar — two levels on one press, from a strip whose own `←`/`→` switch tabs one level up.
- The focus badge says `DETAIL` on all three. It came from the shell's `@overlay`, which only History sets, so the one always-visible slot that could say "you are a level down" read `BODY` on the other two.

**`n` / `⇧N` step to the next/previous item without leaving.** Reading twenty rows used to mean `esc ↓ ↵` twenty times, which is most of what "going back is inconvenient" was measuring.

**A list rail keeps the parent on screen.** `DrillIn` draws three rows of the list above the detail — previous, current, next — with the list's own `▎` gutter, and each row is clickable. The gutter that carries the cursor bar carries `⇧N` above and `n` below, so "press this, land here" is one fact rather than two. Only the immediate neighbours are labelled; at the ends of the list the window cannot slide, and a row two presses away wearing the label would be a lie.

The rail is dropped whole below 16 interior rows or on a single-row list, and then the step keys ride the crumb's own row instead — the affordance never depends on the terminal being tall enough. That is also why the crumb landed first: on a short terminal it is the only thing naming where you are.

Rows, not a left-hand column: gori's lists are wide tables and its details are read by width, so the cheap axis is the one `PreviewSplit` already took.

## Review fixes (third commit)

- The rail, the crumb's position and the step keyed off `@selected`. `@follow` is on by default, so every captured flow snaps the cursor to the newest row while the detail stays put — the divergence `history_target_flow_id` already warns every detail verb about. All three derive from the OPEN item now, and answer "no rail, no position" when a deep link opened a flow the filter excludes.
- Probe's crumb was dead whenever no rail was up: it rides the sub-tab strip's hairline there, and `click_subtab_strip` consumed anything inside `sub_rect`. The strip owns its chip row — `BodyChrome.tab_row`'s own comment already said hit-tests ignore the divider.
- `n`/`⇧N` rather than `⇧N`/`⇧P`: `comparer.prev-change` is `⇧N` one tab over, so `⇧N` would have meant forward here and backward there, and `validate_chords!` cannot see it (its seen-set is per Scope).
- The step carries the focus level as well as the pane, and clamps before touching the list — `select_row` re-seeds the ⇧-range mark anchor even when the index does not move.
- `detail.prev-pane` promised "at REQ, back to the list" but still clamped; both paths share `move_detail_pane` now.
- The crumb's hit rect was the whole 45–60 column label; it is the ` ‹ TAB ` run that is actually drawn as a control.
- `DrillIn::Host` holds the split, the rail draw and the step-key labels the three views were each copying — the copies had already diverged.

## Verification

`crystal spec spec/tui spec/verb spec/verbs` — 4,401 examples, 0 failures · `scripts/ameba_gate.sh origin/main` — no changed file gained findings · `./scripts/bench_check.sh` — 57 harnesses build · rebased onto `main` and rebuilt (CI never builds the merge result).

Driven by hand under tmux on all three tabs: the step chords, `←`/`↑`/`esc` exits, crumb and rail-row clicks, the list ends, the no-rail fallback at 130×22, and the crumb clipping at 46×14.
