### PR TITLE
fix(tui): the ⇧X confirm promised a frozen-evidence deletion it never performs

### DIFF
--- a/spec/tui/issues_clear_spec.cr
+++ b/spec/tui/issues_clear_spec.cr
@@ -43,6 +43,19 @@ private def seed_issue(store : Gori::Store, title : String,
   id
 end
 
+private def seed_frozen(store : Gori::Store, issue_id : Int64, target : String) : Int64
+  fid = store.insert_flow(Gori::Store::CapturedRequest.new(
+    created_at: 1_000_i64, scheme: "https", host: "acme.test", port: 443,
+    method: "GET", target: target, http_version: "HTTP/1.1",
+    head: "GET #{target} HTTP/1.1\r\nHost: acme.test\r\n\r\n".to_slice, body: nil,
+    source: Gori::FlowSource::Kind::Proxy))
+  store.update_response(Gori::Store::CapturedResponse.new(
+    fid, 500, "HTTP/1.1 500 Boom\r\n\r\n".to_slice, "stack".to_slice, duration_us: 9_i64))
+  eid, status = store.freeze_evidence(issue_id, Gori::Evidence.from_flow(store.get_flow(fid).not_nil!))
+  status.ok?.should be_true
+  eid
+end
+
 describe "IssuesController#issues_clear" do
   it "empties the project past a danger confirm that names the total" do
     with_issues_tab do |ctl, host, store|
@@ -111,6 +124,56 @@ describe "IssuesController#issues_clear" do
       # A fresh issue is handed that same rowid — and inherits nothing.
       again = seed_issue(store, "next one")
       store.list_links(Gori::Store::LinkOwnerKind::Issue, again).should be_empty
+    end
+  end
+
+  # The dialog used to say the frozen evidence "goes too". It does not: `clear_issues` drops
+  # `evidence_issue_links` and leaves every `issue_evidence` row standing (#1039), so the
+  # confirm has to make the same promise the per-issue delete already makes — the memberships
+  # go, the archived bytes stay, orphaned, in the Evidence tab.
+  it "promises the frozen copies survive the wipe, and they do" do
+    with_issues_tab do |ctl, host, store|
+      a = seed_issue(store, "sqli")
+      b = seed_issue(store, "xss")
+      seed_frozen(store, a, "/one")
+      seed_frozen(store, b, "/two")
+      store.count_evidence_links.should eq(2)
+      ctl.view.reload(store)
+
+      ctl.issues_clear
+      _, message = host.confirms.first
+      message.should contain("2 frozen evidence links are removed")
+      message.should contain("the archived copies stay in the Evidence tab")
+      message.should_not contain("frozen evidence go")
+      message.should contain("This can't be undone.")
+
+      # …and the store agrees with the sentence: memberships gone, copies still there.
+      store.count_evidence_links.should eq(0)
+      store.count_evidence.should eq(2)
+    end
+  end
+
+  # Singular, and nothing at all when the project has no frozen copies: a line about zero
+  # links in a modal is noise the operator has to read past to reach "can't be undone".
+  it "leaves the frozen line out entirely when there is no frozen evidence" do
+    with_issues_tab do |ctl, host, store|
+      seed_issue(store, "finding")
+      ctl.view.reload(store)
+
+      ctl.issues_clear
+      _, message = host.confirms.first
+      message.should_not contain("frozen")
+    end
+  end
+
+  it "says it in the singular for one link" do
+    with_issues_tab do |ctl, host, store|
+      seed_frozen(store, seed_issue(store, "sqli"), "/one")
+      ctl.view.reload(store)
+
+      ctl.issues_clear
+      _, message = host.confirms.first
+      message.should contain("1 frozen evidence link is removed; the archived copy stays in the Evidence tab")
     end
   end
 

--- a/src/gori/store/issue_evidence.cr
+++ b/src/gori/store/issue_evidence.cr
@@ -198,6 +198,14 @@ module Gori
       @db.scalar("SELECT COUNT(*) FROM issue_evidence").as(Int64).to_i
     end
 
+    # Every issue↔evidence membership in the project — the number the Issues tab's ⇧X confirm
+    # names, since `clear_issues` drops the whole table unqualified. Links, not copies: one
+    # snapshot shared by two issues loses two memberships and still keeps its bytes. One
+    # COUNT over an index-covered table, so the confirm costs a single query at press time.
+    def count_evidence_links : Int32
+      @db.scalar("SELECT COUNT(*) FROM evidence_issue_links").as(Int64).to_i
+    end
+
     private EVIDENCE_META_COLS = "id, COALESCE((SELECT group_concat(issue_id, ',') FROM " \
                                  "(SELECT issue_id FROM evidence_issue_links WHERE evidence_id = issue_evidence.id ORDER BY issue_id)), ''), " \
                                  "created_at, source_kind, source_id, method, url, protocol, " \

--- a/src/gori/tui/controllers/issues_controller.cr
+++ b/src/gori/tui/controllers/issues_controller.cr
@@ -1073,9 +1073,16 @@ module Gori::Tui
     def issues_clear : Nil
       n = @host.session.store.count_issues
       return @host.status("issues: nothing to clear") if n <= 0
+      # Same split the per-issue delete confirm spells out, project-wide: `clear_issues` drops
+      # `evidence_issue_links` unqualified and leaves every `issue_evidence` row standing
+      # (#1039). Saying "frozen evidence goes too" claimed a byte deletion this wipe does not
+      # do — and the copies it names outlive it, orphaned but visible in the Evidence tab.
+      frozen = @host.session.store.count_evidence_links
+      frozen_note = frozen > 0 ? "\n#{frozen} frozen evidence link#{frozen == 1 ? " is" : "s are"} removed; " \
+                                 "the archived cop#{frozen == 1 ? "y stays" : "ies stay"} in the Evidence tab." : ""
       @host.confirm("CLEAR ISSUES",
         "Delete ALL #{n} issue#{n == 1 ? "" : "s"} for this project?\n" \
-        "Their notes, CVSS scores, evidence links and frozen evidence go too.\nThis can't be undone.",
+        "Their notes, CVSS scores and related links go too.#{frozen_note}\nThis can't be undone.",
         confirm_label: "clear", danger: true) do
         ok = @issues.clear(@host.session.store)
         @host.status(ok ? "issues cleared" : "issues NOT cleared (project busy) — every issue is still there")


### PR DESCRIPTION
## What the dialog claimed

The Issues tab's ⇧X (`IssuesController#issues_clear`) confirm read:

> Delete ALL 3 issues for this project?
> Their notes, CVSS scores, evidence links and **frozen evidence go too.**
> This can't be undone.

## What the store does

`Store#clear_issues` (`src/gori/store/issues.cr`) drops `entity_links`, `evidence_issue_links`, the retest rows and `issues` — and deliberately leaves every `issue_evidence` row standing. That is the #1039 contract, and the method's own comment says so: the immutable copies are project-wide and survive as orphans in the Evidence tab, visible and deletable there.

So the one sentence in the whole app that an operator reads immediately before wiping a project's findings claimed a byte deletion that never happens. The per-issue delete confirm a few lines above already had it right ("N frozen evidence links are removed; the archived copies stay.") — the whole-tab wipe was the outlier.

## The fix

- `Store#count_evidence_links` — one `COUNT(*)` over `evidence_issue_links`, read at press time like the issue total beside it, so the gate and the prompt cannot disagree after a peer write.
- The confirm now mirrors the per-issue wording: *"Their notes, CVSS scores and related links go too. / N frozen evidence links are removed; the archived copies stay in the Evidence tab. / This can't be undone."* Singular/plural handled the same way the delete confirm handles it, and the frozen line is omitted entirely when the project holds none — a "0 links" line in a modal is just something to read past.
- `evidence links` in the old second line was ambiguous between the RELATED card's live links and the frozen ones; it is now `related links`, which is what `entity_links WHERE owner_kind = 'issue'` actually holds.

No store behaviour changed. `IssuesView#clear` needed no change (it just calls the store), and the docs (`docs/content/guide/scanning.md` / `.ko.md`) were already accurate — they say notes, CVSS and evidence links, never that the frozen copies are deleted — so they are untouched.

## Verification

- `spec/tui/issues_clear_spec.cr` — three new examples: the plural sentence plus a store assertion that the memberships are gone (`count_evidence_links == 0`) while both archived copies remain (`count_evidence == 2`), the singular form, and no frozen line at all when there is no frozen evidence. The existing example asserting the prompt names `notes` still passes. 9 examples, 0 failures.
- `crystal spec spec/store/issue_evidence_spec.cr spec/tui/issues_view_spec.cr spec/tui/issues_frozen_related_spec.cr spec/store/issue_retest_spec.cr` — 58 examples, 0 failures.
- `crystal tool format --check src spec` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)