### PR TITLE
TUI: style a line once per logical line, and stop re-formatting settled row cells

### DIFF
--- a/bench/history_row_draw_bench.cr
+++ b/bench/history_row_draw_bench.cr
@@ -42,9 +42,15 @@ begin
       method: method, target: target, http_version: "HTTP/1.1",
       head: "#{method} #{target} HTTP/1.1\r\nHost: acme.test\r\n\r\n".to_slice, body: nil,
       source: Gori::FlowSource::Kind::Proxy))
+    # Sizes and durations VARY per row on purpose: they are the two cells whose formatter
+    # divides, rounds and interpolates, and a fixture where every row carried the same
+    # response would let one memo entry stand in for four hundred. These are still stable
+    # per row ACROSS frames — which is the property the memo actually trades on.
     store.update_response(Gori::Store::CapturedResponse.new(
-      flow_id: id, status: 200, head: "HTTP/1.1 200 OK\r\n\r\n".to_slice,
-      body: "{}".to_slice, content_type: TYPES[i % TYPES.size]))
+      flow_id: id, status: 200 + (i % 5) * 100, head: "HTTP/1.1 200 OK\r\n\r\n".to_slice,
+      body: "{}".to_slice, content_type: TYPES[i % TYPES.size],
+      body_size: (37_i64 + i * 911) % 4_000_000,
+      duration_us: (1_200_i64 + i * 7_919) % 90_000_000))
   end
   view = HistoryView.new
   view.reload(store)

--- a/bench/read_pane_frame_bench.cr
+++ b/bench/read_pane_frame_bench.cr
@@ -36,8 +36,10 @@ end
 W = 100
 H =  40
 
-# The Intercept preview's exact wiring: a windowed message, plain text bridged through
-# `Highlight.plain`, colour through `line_at`.
+# The Intercept preview's exact wiring: a windowed message, colour through `line_at` and
+# plain text through `plain_at` — which is the pane's other half of the same story. It used
+# to bridge the text through `Highlight.plain(line_at(i))`, i.e. tokenise the line and then
+# discard every colour, so each drawn logical line was styled TWICE a frame.
 def wrapped_pane(body : String) : {ReadPane, Highlight::Windowed}
   lines = ("POST /api/v1/submit HTTP/1.1\r\nHost: api.example.com\r\n" \
            "Content-Type: application/json\r\n\r\n#{body}").split('\n').map(&.rstrip('\r'))

--- a/bench/read_pane_frame_bench.cr
+++ b/bench/read_pane_frame_bench.cr
@@ -1,0 +1,72 @@
+# ReadPane per-frame cost with a STYLED provider — the Intercept detail preview, the
+# Rewriter/OAST output panes, the Probe description pane. Every one of them wraps, and a
+# wrapped logical line becomes N visual rows.
+#
+# `render` already materialises the PLAIN line once per logical line (`cached_li`) for
+# exactly that reason. The `styled_at` provider had no such guard, so it ran once per DRAWN
+# ROW — and it is the more expensive of the two providers, since it tokenises the line
+# rather than just slicing it. One JSON body line wide enough to fill the viewport was
+# therefore tokenised ~`rect.h` times per frame. `TextArea#styled_line` carries the same
+# memo for the same reason; this is the pane that lacked it.
+#
+# Two shapes, so the fix is visible where it bites and provably neutral where it doesn't:
+#   * WRAPPED long lines  — one logical line per several visual rows (the regression case)
+#   * WRAPPED short lines — one logical line per visual row (the memo must not cost anything)
+#
+# Build: crystal build bench/read_pane_frame_bench.cr -o bin/read_pane_frame_bench --release
+# Run:   bin/read_pane_frame_bench
+require "benchmark"
+require "../src/gori"
+
+include Gori::Tui
+
+# Records nothing: the subject is the row loop and its providers, not cell storage.
+class SinkBackend < Backend
+  def initialize(@w : Int32, @h : Int32)
+  end
+
+  def put(x : Int32, y : Int32, grapheme : Char | String, fg : Color, bg : Color, attr : Attribute) : Nil
+  end
+
+  def size : {Int32, Int32}
+    {@w, @h}
+  end
+end
+
+W = 100
+H =  40
+
+# The Intercept preview's exact wiring: a windowed message, plain text bridged through
+# `Highlight.plain`, colour through `line_at`.
+def wrapped_pane(body : String) : {ReadPane, Highlight::Windowed}
+  lines = ("POST /api/v1/submit HTTP/1.1\r\nHost: api.example.com\r\n" \
+           "Content-Type: application/json\r\n\r\n#{body}").split('\n').map(&.rstrip('\r'))
+  win = Highlight.from_lines_windowed(lines, true)
+  pane = ReadPane.new(wrap: true)
+  pane.source(win.total, ->(i : Int32) { win.plain_at(i) })
+  {pane, win}
+end
+
+# LONG lines: each logical line is ~6 visual rows at W=100, so the viewport holds ~7 of them.
+long_body = (0...60).map do |i|
+  %({"id": #{1000 + i}, "name": "Alice Example #{i}", "email": "a#{i}@example.com", ) +
+    %("active": true, "score": -12.5e3, "tags": ["alpha", "beta"], "note": "an ordinary value here"})
+end.join("\n")
+
+# SHORT lines: one logical line per visual row — nothing to reuse, so this is the memo's cost.
+short_body = (0...200).map { |i| %({"id": #{1000 + i}, "ok": true}) }.join("\n")
+
+{ {"wrapped, long lines (~6 rows/line)", long_body},
+ {"wrapped, short lines (1 row/line)", short_body} }.each do |(label, body)|
+  pane, win = wrapped_pane(body)
+  screen = Screen.new(SinkBackend.new(W, H))
+  rect = Rect.new(0, 0, W, H)
+  styled = ->(i : Int32) { win.line_at(i) }
+  pane.render(screen, rect, true, styled_at: styled) # warm
+
+  puts
+  puts "ReadPane#render #{W}x#{H} — #{label}:"
+  Benchmark.ips do |x|
+    x.report("render (styled)") { pane.render(screen, rect, true, styled_at: styled) }
+  end
+end

--- a/spec/tui/highlight_spec.cr
+++ b/spec/tui/highlight_spec.cr
@@ -809,6 +809,28 @@ describe "Highlight.from_lines_windowed vs from_lines" do
     end
   end
 
+  # `plain_at` is the text seam for a pane whose only source is styled (ReadPane's caret,
+  # selection, search and copy). It must equal the concatenation `line_at` would have given —
+  # WITHOUT styling the line — including under the env overlay, which only splits spans.
+  fixtures.each do |name, (src, request)|
+    it "plain_at equals plain(line_at) on #{name}" do
+      literal = Set{"VER"}
+      win = Highlight.from_lines_windowed(src, request, env_tokens: request, literal: literal)
+      (0...win.total).each do |i|
+        win.plain_at(i).should eq(Highlight.plain(win.line_at(i))), "line #{i} of #{name}"
+      end
+    end
+  end
+
+  it "plain_at equals plain(line_at) on a byte-backed body, CR and scrub included" do
+    head = "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n".to_slice
+    body = ("{\"a\": 1}\r\n{\"b\": \"café\"}\n" + String.new(Bytes[0xff_u8, 0x0a_u8])).to_slice
+    win = Highlight.message_windowed(head, body, request: false)
+    (0...win.total).each do |i|
+      win.plain_at(i).should eq(Highlight.plain(win.line_at(i))), "line #{i}"
+    end
+  end
+
   it "leaves the env overlay OFF for the read-only windowed callers" do
     # `env_tokens` is opt-in rather than derived from `request`, so Intercept's held-bytes
     # view keeps rendering exactly as it did before the editor started sharing this path.

--- a/spec/tui/history_view_spec.cr
+++ b/spec/tui/history_view_spec.cr
@@ -240,6 +240,48 @@ describe Gori::Tui::HistoryView do
     end
   end
 
+  # SIZE and DUR are memoized on their VALUE, like TIME and TYPE beside them — the reason the
+  # key is the value and never the row is that a captured flow is drawn PENDING first and
+  # settles later. A row-keyed memo would keep painting "—" for a response that has landed.
+  it "re-reads SIZE and DUR once a pending row's response lands" do
+    prev = Gori::Settings.history_preview
+    begin
+      Gori::Settings.history_preview = false
+      with_store do |store|
+        id = store.insert_flow(Gori::Store::CapturedRequest.new(
+          created_at: 1_i64, scheme: "http", host: "h.test", port: 80,
+          method: "GET", target: "/settling", http_version: "HTTP/1.1",
+          head: "GET /settling HTTP/1.1\r\nHost: h.test\r\n\r\n".to_slice,
+          source: Gori::FlowSource::Kind::Proxy))
+        view = HistoryView.new
+        view.reload(store)
+
+        draw = -> do
+          backend = MemoryBackend.new(120, 12)
+          view.render_list(Screen.new(backend), Rect.new(0, 0, 120, 12))
+          (0...12).map { |y| backend.row(y) }.join("\n")
+        end
+
+        # Pending: no response, so both cells are the em dash.
+        pending = draw.call
+        pending.should contain("—")
+        pending.should_not contain("3.5KB")
+
+        store.update_response(Gori::Store::CapturedResponse.new(
+          flow_id: id, status: 200, head: "HTTP/1.1 200 OK\r\n\r\n".to_slice,
+          body: "x".to_slice, content_type: "text/plain",
+          body_size: 3_600_i64, duration_us: 42_000_i64))
+        view.reload(store)
+
+        settled = draw.call
+        settled.should contain("3.5KB")
+        settled.should contain("42ms")
+      end
+    ensure
+      Gori::Settings.history_preview = prev
+    end
+  end
+
   it "loads a preview detail for the selected flow" do
     prev = Gori::Settings.history_preview
     begin

--- a/spec/tui/history_view_spec.cr
+++ b/spec/tui/history_view_spec.cr
@@ -262,9 +262,11 @@ describe Gori::Tui::HistoryView do
           (0...12).map { |y| backend.row(y) }.join("\n")
         end
 
-        # Pending: no response, so both cells are the em dash.
+        # Pending: no response, so both cells read whatever `Fmt` spells a missing value as —
+        # asked rather than written out, so this cannot pin a second spelling of that
+        # convention next to the one `Fmt` owns.
         pending = draw.call
-        pending.should contain("—")
+        pending.should contain(Fmt.size(nil))
         pending.should_not contain("3.5KB")
 
         store.update_response(Gori::Store::CapturedResponse.new(

--- a/spec/tui/read_pane_wrap_spec.cr
+++ b/spec/tui/read_pane_wrap_spec.cr
@@ -284,6 +284,24 @@ describe "Gori::Tui::ReadPane soft wrap" do
     b.fg_at(9, 1).should eq(Theme.text)
   end
 
+  # `styled_at` is resolved ONCE PER LOGICAL LINE, not once per drawn row — the same rule the
+  # plain `line_at` has always had, and the more important of the two since styling tokenises
+  # the line where materialising it only slices. A 4 KB JSON line filling a wrapped Intercept
+  # preview was being re-tokenised once per visual row, every frame.
+  it "resolves styled_at once per logical line however many rows it wraps to" do
+    text = "z" * 200 # 5 visual rows at w=40
+    pane = Gori::Tui::ReadPane.new(wrap: true)
+    pane.source(2, ->(_i : Int32) { text })
+    calls = [] of Int32
+    styled = ->(i : Int32) do
+      calls << i
+      Highlight::Line{Highlight::Span.new(text, Theme.text)}
+    end
+    render_wrapped(pane, w: 40, h: 8, styled_at: styled)
+    # 8 rows drawn: 5 from line 0 and 3 from line 1 — two resolutions, not eight.
+    calls.should eq([0, 1])
+  end
+
   # A single grapheme cluster wider than the pane still gets a row of its own — `Wrap.layout`
   # places a cluster whole or moves it whole, so it can never be cut in half.
   it "keeps a wide cluster whole across the break" do

--- a/src/gori/tui/highlight.cr
+++ b/src/gori/tui/highlight.cr
@@ -142,6 +142,19 @@ module Gori::Tui
         line = i < head.size ? head[i] : Highlight.body_styled(body[i - head.size], kind)
         env_tokens ? Highlight.with_env_tokens(line, literal) : line
       end
+
+      # The line's own characters, colour dropped — WITHOUT styling it. A body line is already
+      # a String in `body`, so `Highlight.plain(line_at(i))` was tokenising it and then throwing
+      # every span colour away; the head is pre-styled, so there it is only the join.
+      # Mirrors `HistoryView::DetailView#line_text`, and is exact for the same reason: spans
+      # partition the line in order and carry no inserted padding, and the `env_tokens` overlay
+      # only SPLITS spans — so the concatenation is the source line either way.
+      #
+      # The seam a pane needs when its only source is styled but it addresses text: ReadPane's
+      # caret, selection, search and copy all read this, once per drawn logical line.
+      def plain_at(i : Int32) : String
+        i < head.size ? Highlight.plain(head[i]) : body[i - head.size]
+      end
     end
 
     # Wrap an already-styled array so a caller that must style eagerly (markdown, whose

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -3194,9 +3194,11 @@ module Gori::Tui
     # Through the memo, like the timestamp and the MIME label beside it: the value is a
     # frozen field of a settled flow, so this is the same String every frame it is drawn.
     # `nil` short-circuits rather than taking a key, so the pending rows of a live capture
-    # never fill the map with one entry for "no response yet".
+    # never fill the map with one entry for "no response yet" — but it still asks `Fmt`
+    # what a missing value reads as, because `Fmt` is where that convention lives and the
+    # Repeater and Fuzzer rows that call it directly have to keep agreeing with this one.
     private def fmt_size(bytes : Int64?) : String
-      return "—" unless bytes
+      return Fmt.size(nil) unless bytes
       @size_memo.fetch(bytes) do
         @size_memo.clear if @size_memo.size >= @max_rows
         @size_memo[bytes] = Fmt.size(bytes)
@@ -3206,7 +3208,7 @@ module Gori::Tui
     # Compact request→response latency (ms/s/m/h), bounded to ≤6 cols. "—" until the
     # response lands; a minute/hour tier keeps very slow flows from overflowing.
     private def fmt_dur(us : Int64?) : String
-      return "—" unless us
+      return Fmt.dur(nil) unless us
       @dur_memo.fetch(us) do
         @dur_memo.clear if @dur_memo.size >= @max_rows
         @dur_memo[us] = Fmt.dur(us)

--- a/src/gori/tui/history_view.cr
+++ b/src/gori/tui/history_view.cr
@@ -218,6 +218,13 @@ module Gori::Tui
       @time_memo = {} of Int64 => String
       @mime_memo = {} of String => String
       @path_memo = {} of Int64 => String
+      # SIZE and DUR join them on the same argument, and they are the two that cost the most:
+      # `Fmt.size`/`Fmt.dur` pick a unit, divide into a Float64, round and interpolate — two
+      # fresh Strings per row per frame, which on a 50-row list was 42% of everything the row
+      # loop allocated. Keyed on the VALUE for the same reason the three above are: a pending
+      # row draws `—` and reads the real answer the moment its response lands.
+      @size_memo = {} of Int64 => String
+      @dur_memo = {} of Int64 => String
       @color_rev = 0_u64
       @detail = nil.as(Store::FlowDetail?)
       # How many FROZEN copies of the open flow exist (#1038) — the detail's marker, which
@@ -3183,14 +3190,27 @@ module Gori::Tui
     # lands. The unit is picked from the ROUNDED magnitude so a value just under a
     # boundary (e.g. 1023.6 KB) rolls up to the next unit ("1.0MB") instead of the
     # misleading "1024KB".
+    #
+    # Through the memo, like the timestamp and the MIME label beside it: the value is a
+    # frozen field of a settled flow, so this is the same String every frame it is drawn.
+    # `nil` short-circuits rather than taking a key, so the pending rows of a live capture
+    # never fill the map with one entry for "no response yet".
     private def fmt_size(bytes : Int64?) : String
-      Fmt.size(bytes)
+      return "—" unless bytes
+      @size_memo.fetch(bytes) do
+        @size_memo.clear if @size_memo.size >= @max_rows
+        @size_memo[bytes] = Fmt.size(bytes)
+      end
     end
 
     # Compact request→response latency (ms/s/m/h), bounded to ≤6 cols. "—" until the
     # response lands; a minute/hour tier keeps very slow flows from overflowing.
     private def fmt_dur(us : Int64?) : String
-      Fmt.dur(us)
+      return "—" unless us
+      @dur_memo.fetch(us) do
+        @dur_memo.clear if @dur_memo.size >= @max_rows
+        @dur_memo[us] = Fmt.dur(us)
+      end
     end
 
     # Compact response MIME — the useful subtype (json/html/png/js…), params dropped.

--- a/src/gori/tui/intercept_view.cr
+++ b/src/gori/tui/intercept_view.cr
@@ -1336,7 +1336,7 @@ module Gori::Tui
 
     private def sync_preview(it : Interceptor::Item) : Nil
       win = detail_window_for(it)
-      @preview.source(win.total, ->(i : Int32) { Highlight.plain(win.line_at(i)) })
+      @preview.source(win.total, ->(i : Int32) { win.plain_at(i) })
     end
 
     # Scroll the read-only preview so a held body taller than the pane is fully readable WITHOUT

--- a/src/gori/tui/read_pane.cr
+++ b/src/gori/tui/read_pane.cr
@@ -486,13 +486,21 @@ module Gori::Tui
       # downcased copy of the WHOLE logical line, so computing it inside the row loop would
       # downcase a viewport-filling line once per drawn row. Built only while a query is live.
       cached_lower = ""
+      # …and the STYLED line, which had been left out of that rule even though it is the more
+      # expensive of the two providers: `styled_at` tokenises the line where `line_at` only
+      # materialises it, and `draw_row` was calling it once per DRAWN ROW. A wrapped 4 KB JSON
+      # line filling the viewport was therefore re-tokenised ~`rect.h` times per frame — the
+      # exact multiplication `TextArea#styled_line` already memoises away for its own draw.
+      # Only the per-row SLICE of it is row-specific, and that stays in `draw_row`.
+      cached_styled = nil.as(Highlight::Line?)
       rows.each_with_index do |vr, i|
         if vr.li != cached_li
           cached_li = vr.li
           cached_line = @line_at.call(vr.li)
           cached_lower = @search_hl.empty? ? "" : cached_line.downcase
+          cached_styled = styled_at.try(&.call(vr.li))
         end
-        draw_row(screen, rect, rect.y + i, vr, cached_line, gw, cw, focused, styled_at, fg, bg)
+        draw_row(screen, rect, rect.y + i, vr, cached_line, gw, cw, focused, cached_styled, fg, bg)
         # Between the text and the chrome ON PURPOSE: the band goes OVER the drawn glyphs (it
         # is what makes a match findable at a glance) and UNDER the caret/selection, so the
         # match the ^F prompt just jumped to still shows where the cursor sits inside it.
@@ -538,11 +546,13 @@ module Gori::Tui
       @xscroll = @xscroll.clamp(0, {widest - cw, 0}.max)
     end
 
-    # One drawn row: its gutter cell and its slice of `plain`, coloured through `styled_at` when
-    # the caller supplied one. The chrome (band + caret) goes over the top of it separately.
+    # One drawn row: its gutter cell and its slice of `plain`, coloured through `styled` when
+    # the caller supplied a `styled_at` provider. `styled` is the WHOLE logical line, already
+    # resolved once by the caller (see the memo in `render`) — this only slices it to the row.
+    # The chrome (band + caret) goes over the top of it separately.
     private def draw_row(screen : Screen, rect : Rect, y : Int32, vr : Wrap::Row, plain : String,
                          gw : Int32, cw : Int32, focused : Bool,
-                         styled_at : (Int32 -> Highlight::Line)?, fg : Color, bg : Color) : Nil
+                         styled : Highlight::Line?, fg : Color, bg : Color) : Nil
       if gw > 0
         # The line number rides the FIRST visual row of a logical line and nothing else (Burp
         # style). A continuation row gets a blank of the same width rather than no write at all,
@@ -554,8 +564,7 @@ module Gori::Tui
         end
       end
       whole = vr.a == 0 && vr.b >= plain.size
-      if styled_at
-        sl = styled_at.call(vr.li)
+      if sl = styled
         # Char offsets, not columns: `Wrap::Layout` decided the break by walking clusters and
         # handed back char indices, so slicing by column here would re-derive it with a second
         # measure — and the colours would land off the glyphs they belong to.


### PR DESCRIPTION
Three per-frame costs in the TUI render path, each one measured before and after. All
behavior-preserving — no intentional behavior change.

The common shape: **work the frame does once per DRAWN ROW that it only needs once per
LOGICAL LINE, or once per FRAME that it only needs once per VALUE.** Two of the three are
that; the third is a pane that got its plain text by styling the line and throwing the
colours away.

## 1. `ReadPane` resolved `styled_at` once per drawn row

`ReadPane#render` already materialised the plain line once per LOGICAL line (`cached_li`),
with a comment saying why: a wrapped line can fill the whole viewport. The `styled_at`
provider was left out of that rule even though it is the more expensive of the two — it
tokenises the line where the plain one only slices it — so `draw_row` called it once per
VISUAL row. A wrapped 4 KB JSON line filling the pane was re-tokenised ~`rect.h` times a
frame. `TextArea#styled_line` carries exactly this memo for exactly this reason; the pane
lacked it.

Only the per-row *slice* is row-specific, and that stays in `draw_row`.

## 2. `Intercept` preview got its plain text by styling the line

```crystal
@preview.source(win.total, ->(i : Int32) { Highlight.plain(win.line_at(i)) })
```

`Windowed#line_at` tokenises the line into styled spans; `Highlight.plain` then joins them
back and drops every colour. But a body line is *already a String* in `Windowed#body` — the
tokenising was pure waste, and it ran alongside the styled call for the same line, so each
drawn logical line was styled twice per frame.

New `Windowed#plain_at(i)`: the body line straight out of `BodyLines`, the head line joined
from its pre-styled spans. Exact for the same reason `HistoryView::DetailView#line_text` is
— spans partition the line in order with no inserted padding, and the `env_tokens` overlay
only *splits* spans. Pinned by a spec that asserts `plain_at(i) == plain(line_at(i))` across
every `from_lines_windowed` fixture plus a byte-backed body with CR and invalid UTF-8.

### Measured — `bench/read_pane_frame_bench.cr` (new harness, 100×40, `SinkBackend`)

The harness drives the Intercept preview's exact wiring. Two shapes, so the fix is visible
where it bites and provably neutral where it cannot help.

| case | before | after 1 only | after 1+2 |
| --- | --- | --- | --- |
| wrapped, long lines (~6 rows/line) | 103.41 µs / 273 kB | 76.16 µs / 209 kB | **49.96 µs / 134 kB** |
| wrapped, short lines (1 row/line) | 32.61 µs / 72.4 kB | 31.82 µs / 72.4 kB | **15.86 µs / 33.0 kB** |

2.07× and 2.06×, allocation roughly halved in both. The short-line row is the control for
change 1: one logical line per visual row means there is nothing to reuse, and the memo
costs nothing there (31.82 vs 32.61 is inside the noise band).

## 3. History list re-formatted SIZE and DUR every frame

`@time_memo` / `@mime_memo` / `@path_memo` already memoise the three per-row strings the row
loop builds from a row's own fields. SIZE and DUR were not among them, and they are the two
that cost the most: `Fmt.size` / `Fmt.dur` pick a unit, divide into a `Float64`, round and
interpolate — two fresh Strings per row per frame, for values frozen the moment the response
lands.

Keyed on the VALUE, not the row, for the same reason the existing three are: a captured flow
is drawn PENDING first and settles later, and a row-keyed memo would keep painting `—` for a
response that has arrived. Self-capping at `@max_rows`, like `@mime_memo`. A spec renders a
pending row, lands its response, and asserts the cells change.

### Measured — `bench/history_row_draw_bench.cr`

The fixture gave every one of its 400 rows the same 2-byte response and no duration, so one
memo entry stood in for four hundred and `Fmt.dur` never left its `nil` early return. Sizes
and durations now vary per row — still stable per row ACROSS frames, which is the property
the memo actually trades on. Both columns below are that fixture.

| drawn rows | before | after |
| --- | --- | --- |
| 20 | 18.35 µs / 12.2 kB | **14.42 µs / 6.95 kB** |
| 50 | 29.62 µs / 23.1 kB | **21.09 µs / 10.4 kB** |
| 100 | 49.06 µs / 41.3 kB | **33.49 µs / 16.0 kB** |

−29 % to −32 % time, −55 % to −61 % allocation.

## Measured and rejected

- **`ReadPane`'s plain provider, unwrapped.** Each visible logical line is materialised
  THREE times per frame: `visible_rows` (for `line(li).size`), `clamp_xscroll`, then the draw
  loop. Measured on a 40-row pane with a string-building provider (the Comparer / Miner /
  Sequencer shape): **8.40 µs / 6.31 kB per frame**, of which a frame-scoped memo would
  recover about two thirds — ~4 kB a frame on three mid-traffic panes. Below the bar for the
  arm/disarm machinery it needs, since `line` is also called off the render path (caret,
  copy, search) where a stale entry would be wrong. Left as-is; the count is here for
  whoever measures it next.

- **Interning the status code in `FlowStatus.cell`.** `row.status.try(&.to_s)` allocates per
  row per frame: **0.77 µs / 1.56 kB per 50 rows** measured. That is 15 % of what the History
  row loop still allocates after change 3, and `FlowStatus` is shared with the Comparer's
  flow picker and headers — not worth the churn in a shared module for that slice.

- **A row-text memo for `FuzzerView#render_result_row`** (~12 Strings per row per frame).
  `fuzz_view_frame_bench` reports 225 µs / 193 kB for an idle 160×48 frame, but ~118 µs and
  ~120 kB of that is the harness: `MemoryBackend#put` takes a `Char` on `Backend#fill_span`'s
  default per-cell path and allocates a String for every cell, so a full-card fill alone is
  ~7 700 of them (confirmed against `companion_draw_bench`, which prices a 116×28 fill at
  50.6 µs / 50.8 kB through the same backend). Production's `TermisuBackend` overrides
  `fill_span` with a grid write and allocates nothing there. The real per-row figure did not
  justify a run-generation-keyed cache inside a width-sensitive layout function.

- **`real_frame_bench` / `buffered_frame_bench` reporting ~416 kB and ~360 kB per frame.**
  That is a bench-only path: both drive `Windowed#line_at` directly with no styled-line
  cache, and in production every windowed pane already has one (`@detail_styled_cache`,
  `@resp_styled_cache`, `@preview_*_styled_cache`, `FuzzerView`'s `@detail_styled_cache`).
  Decomposed it anyway — `line_at` is 114.55 µs / 283 kB per 50 lines against
  `Highlight.draw`'s 17.33 µs / 0 B — which is what pointed at the two panes above that
  genuinely had no memo. Nothing to fix in the frame benches themselves.

## Self-review

`/code-review high` found no correctness bug and two low-severity nits, both taken in the
second commit:

- `fmt_size` / `fmt_dur` had begun spelling the missing-value sentinel themselves
  (`return "—" unless bytes`) beside the `Fmt` that owns that convention and that the
  Repeater and Fuzzer rows still call directly. They ask `Fmt.size(nil)` / `Fmt.dur(nil)`
  now, and the spec asserts against `Fmt.size(nil)` rather than the glyph.
- The new harness's comment still described the pre-commit wiring
  (`Highlight.plain(line_at(i))`) over a line that now calls `plain_at`.

It also built a throwaway harness to check the invariant the whole change rests on —
`Highlight.plain(body_styled(raw, kind)) == raw` across every kind and 35 adversarial lines
(unterminated JSON strings, trailing backslash, unclosed tags, control bytes, ZWJ clusters,
a 70 KB line crossing `MAX_HL_LINE`) — and confirmed `slice_chars` / `slice_left` /
`Highlight.draw` are non-mutating, so one memoized `Line` shared across the visual rows of a
wrapped logical line cannot be corrupted by row 1 before row 2 reads it.

## Verification

`just check`, `just lint-gate`, `just benchmark-check` green; `just test` 14 286 examples,
0 failures. No CHANGELOG entry: nothing here is user-visible beyond being faster.
