### PR TITLE
perf(probe): validate before scrubbing, and lex each script once

### DIFF
--- a/bench/probe_passive_bench.cr
+++ b/bench/probe_passive_bench.cr
@@ -148,12 +148,13 @@ BIG_HTML_FLOW = flow("GET", "/docs", "text/html; charset=utf-8",
 # A BINARY asset — an image, the single most common response shape in a real browse after the
 # document itself, and the one none of the fixtures above covers. It is deliberately NOT valid
 # UTF-8, which is the whole point: `Context#body_text` has to repair the bytes before any rule
-# hands them to PCRE, and repairing invalid bytes EXPANDS them (each becomes a 3-byte U+FFFD),
-# so a 64 KiB BODY_CAP prefix of binary becomes a ~180 KiB string that every body-scanning rule
-# then walks. Nothing in the BODY can produce a detection (the two the fixture reports are
-# header-only: the nginx `Server:` fingerprint and missing HSTS), so the body scan is pure
-# overhead on the fiber the passive scan shares with the proxy — and it is invisible in any
-# all-text fixture.
+# hands them to PCRE, and repairing invalid bytes EXPANDS them (each becomes a 3-byte U+FFFD).
+# Half this generator's bytes happen to be ASCII and pass through, so the 64 KiB BODY_CAP prefix
+# scrubs to 102,612 bytes — a 1.57× blow-up here, and up to 3× on a body with no ASCII at all.
+# (The fixture is 180 KiB so the cap really bites; only its first 64 KiB is ever scanned.)
+# Nothing in the BODY can produce a detection — the two the fixture reports are header-only, the
+# nginx `Server:` fingerprint and missing HSTS — so the body scan is pure overhead on the fiber
+# the passive scan shares with the proxy, and it is invisible in any all-text fixture.
 BIN_BODY = Bytes.new(180 * 1024) { |i| ((i.to_u64 &* 2654435761_u64) >> 13).to_u8! }
 
 BIN_RESP_HEAD = ("HTTP/1.1 200 OK\r\nContent-Type: image/png\r\n" \

--- a/bench/probe_passive_bench.cr
+++ b/bench/probe_passive_bench.cr
@@ -145,6 +145,24 @@ BIG_HTML_FLOW = flow("GET", "/docs", "text/html; charset=utf-8",
   ("GET /docs HTTP/1.1\r\nHost: app.example.com\r\n\r\n").to_slice, nil,
   HTML_RESP_HEAD, BIG_HTML_BODY)
 
+# A BINARY asset — an image, the single most common response shape in a real browse after the
+# document itself, and the one none of the fixtures above covers. It is deliberately NOT valid
+# UTF-8, which is the whole point: `Context#body_text` has to repair the bytes before any rule
+# hands them to PCRE, and repairing invalid bytes EXPANDS them (each becomes a 3-byte U+FFFD),
+# so a 64 KiB BODY_CAP prefix of binary becomes a ~180 KiB string that every body-scanning rule
+# then walks. Nothing in the BODY can produce a detection (the two the fixture reports are
+# header-only: the nginx `Server:` fingerprint and missing HSTS), so the body scan is pure
+# overhead on the fiber the passive scan shares with the proxy — and it is invisible in any
+# all-text fixture.
+BIN_BODY = Bytes.new(180 * 1024) { |i| ((i.to_u64 &* 2654435761_u64) >> 13).to_u8! }
+
+BIN_RESP_HEAD = ("HTTP/1.1 200 OK\r\nContent-Type: image/png\r\n" \
+                 "Server: nginx/1.24.0\r\nCache-Control: max-age=31536000\r\n\r\n").to_slice
+
+BIN_FLOW = flow("GET", "/static/hero.png", "image/png",
+  ("GET /static/hero.png HTTP/1.1\r\nHost: app.example.com\r\n\r\n").to_slice, nil,
+  BIN_RESP_HEAD, BIN_BODY)
+
 JS_RESP_HEAD = ("HTTP/1.1 200 OK\r\nContent-Type: application/javascript\r\n" \
                 "Server: nginx/1.24.0\r\nCache-Control: max-age=31536000\r\n\r\n").to_slice
 
@@ -160,15 +178,18 @@ puts "Probe passive scan — full Passive.analyze per flow:"
 puts "  JSON POST body: #{JSON_BODY.size} bytes; HTML document: #{HTML_BODY.size} bytes"
 puts "  JS bundle: #{JS_BODY.size} bytes (at the CLIENT_BODY_CAP ceiling)"
 puts "  JS bundle + non-ASCII regex literal: #{JS_I18N_BODY.size} bytes"
+puts "  binary asset: #{BIN_BODY.size} bytes (invalid UTF-8 by construction)"
 puts "  (detections: json=#{Gori::Probe::Passive.analyze(JSON_FLOW).size}" \
      " html=#{Gori::Probe::Passive.analyze(HTML_FLOW).size}" \
      " js=#{Gori::Probe::Passive.analyze(JS_FLOW).size}" \
-     " js_i18n=#{Gori::Probe::Passive.analyze(JS_I18N_FLOW).size})"
+     " js_i18n=#{Gori::Probe::Passive.analyze(JS_I18N_FLOW).size}" \
+     " binary=#{Gori::Probe::Passive.analyze(BIN_FLOW).size})"
 
 Benchmark.ips do |x|
   x.report("JSON API POST flow ") { Gori::Probe::Passive.analyze(JSON_FLOW) }
   x.report("HTML document flow ") { Gori::Probe::Passive.analyze(HTML_FLOW) }
   x.report("HTML doc, 200 KiB  ") { Gori::Probe::Passive.analyze(BIG_HTML_FLOW) }
+  x.report("binary asset 180 KiB") { Gori::Probe::Passive.analyze(BIN_FLOW) }
   x.report("JS bundle flow     ") { Gori::Probe::Passive.analyze(JS_FLOW) }
   # Must stay in the SAME order of magnitude as the plain JS bundle. A large gap here means the
   # non-ASCII slow path is back.

--- a/spec/probe/passive/context_spec.cr
+++ b/spec/probe/passive/context_spec.cr
@@ -1,0 +1,83 @@
+require "../../spec_helper"
+
+# Context is the per-flow parse/decode cache every passive rule reads from. It needs no Store:
+# a FlowDetail is a plain record, so these build one directly. What is pinned here is the two
+# properties the rules depend on and that an optimisation of this file could silently break —
+# the body text handed to PCRE is always valid UTF-8, and the two client-script views agree
+# with the lexer whichever one a rule asks for first.
+
+private alias Passive = Gori::Probe::Passive
+
+private def ctx_for(body : Bytes?, content_type : String?, resp_head : String) : Passive::Context
+  row = Gori::Store::FlowRow.new(
+    1_i64, 1_i64, "https", "GET", "app.example", 443, "/",
+    200, (body.try(&.size) || 0).to_i64, Gori::Store::FlowState::Complete,
+    content_type: content_type)
+  detail = Gori::Store::FlowDetail.new(
+    row, "HTTP/1.1", "GET / HTTP/1.1\r\nHost: app.example\r\n\r\n".to_slice, nil,
+    resp_head.to_slice, body)
+  Passive::Context.new(detail)
+end
+
+private HTML_HEAD = "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n"
+private PNG_HEAD  = "HTTP/1.1 200 OK\r\nContent-Type: image/png\r\n\r\n"
+
+private DOC = <<-HTML
+  <!doctype html><html><body><script>
+  var s = "keep //me"; /* drop me */ el.innerHTML = location.hash; // drop me too
+  </script></body></html>
+  HTML
+
+describe Gori::Probe::Passive::Context do
+  describe "#body_text" do
+    # The repair moved from a bare `String#scrub` to `Utf8.text`, which asks the cheap
+    # `valid_encoding?` question first and only scrubs what actually needs it. Every rule then
+    # hands this string to PCRE2, which RAISES on invalid UTF-8 rather than failing to match —
+    # so "always valid" is a correctness property, not a nicety.
+    it "repairs a body that is not valid UTF-8" do
+      ctx = ctx_for(Bytes[0x41, 0xff, 0xfe, 0x42], "image/png", PNG_HEAD)
+      text = ctx.body_text.not_nil!
+      text.valid_encoding?.should be_true
+      text.should eq(String.new(Bytes[0x41, 0xff, 0xfe, 0x42]).scrub)
+    end
+
+    it "hands back a valid body unchanged" do
+      ctx = ctx_for("héllo = 1".to_slice, "text/plain", HTML_HEAD)
+      ctx.body_text.should eq("héllo = 1")
+    end
+
+    it "is nil when there is no body" do
+      ctx_for(nil, "text/html", HTML_HEAD).body_text.should be_nil
+    end
+  end
+
+  # Both views come from ONE lex per fragment (JsScan.strip_both), filled by whichever getter is
+  # asked first. A rule order that happens to ask for the comments-only view first must see the
+  # same thing as one that asks for the stripped view first.
+  describe "client script views" do
+    it "matches the lexer when client_code is asked for first" do
+      ctx = ctx_for(DOC.to_slice, "text/html", HTML_HEAD)
+      ctx.client_code.should eq(ctx.client_scripts.map { |s| Passive::JsScan.strip(s) })
+      ctx.client_scripts_nocomment.should eq(ctx.client_scripts.map { |s| Passive::JsScan.strip_comments(s) })
+    end
+
+    it "matches the lexer when client_scripts_nocomment is asked for first" do
+      ctx = ctx_for(DOC.to_slice, "text/html", HTML_HEAD)
+      ctx.client_scripts_nocomment.should eq(ctx.client_scripts.map { |s| Passive::JsScan.strip_comments(s) })
+      ctx.client_code.should eq(ctx.client_scripts.map { |s| Passive::JsScan.strip(s) })
+    end
+
+    it "keeps the two views distinct — strings survive only in the comments-only one" do
+      ctx = ctx_for(DOC.to_slice, "text/html", HTML_HEAD)
+      ctx.client_code.first.includes?("keep //me").should be_false
+      ctx.client_scripts_nocomment.first.includes?("keep //me").should be_true
+      ctx.client_scripts_nocomment.first.includes?("drop me").should be_false
+    end
+
+    it "memoises both as empty for a response with no script" do
+      ctx = ctx_for("image bytes".to_slice, "image/png", PNG_HEAD)
+      ctx.client_code.should be_empty
+      ctx.client_scripts_nocomment.should be_empty
+    end
+  end
+end

--- a/spec/probe/passive/js_scan_spec.cr
+++ b/spec/probe/passive/js_scan_spec.cr
@@ -58,6 +58,51 @@ describe Gori::Probe::Passive::JsScan do
     end
   end
 
+  # `strip` and `strip_comments` are two VIEWS of one walk (`strip_both`): the lexer consumes a
+  # script exactly once and emits the strings-blanked projection into one builder and the
+  # comments-only projection into the other. So the property to pin is that the fused walk still
+  # produces what two separate walks produced — a token consumed on one side but not the other
+  # would desync the two views' offsets, and DOM-XSS's window arithmetic is measured against
+  # those offsets.
+  describe ".strip_both" do
+    # Every token kind in one fragment: a line comment, a block comment, an escaped quote, a URL
+    # literal whose `//` must NOT read as a comment, and a template with a nested interpolation.
+    fragment = %(a = "x//y"; /* c */ b = 'it\\'s'; t = `p ${loc + "q"} s`; // tail\nz = 1;)
+
+    it "blanks string contents on one side and keeps them on the other" do
+      code, kept = JsScan.strip_both(fragment)
+      # The strings-blanked view: delimiters kept, contents gone, `${…}` still readable as code.
+      code.includes?("x//y").should be_false
+      code.includes?("loc + ").should be_true
+      # The comments-only view: string contents survive, comments do not.
+      kept.includes?("x//y").should be_true
+      kept.includes?("/* c */").should be_false
+      kept.includes?("// tail").should be_false
+      # Both are offset-preserving, which is the whole contract.
+      code.size.should eq(fragment.size)
+      kept.size.should eq(fragment.size)
+    end
+
+    it "returns exactly what the two separate entry points return" do
+      JsScan.strip_both(fragment).should eq({JsScan.strip(fragment), JsScan.strip_comments(fragment)})
+    end
+
+    it "agrees with the separate entry points over randomised token soup" do
+      # Bare delimiters, escapes and interpolation openers in every order — the shapes that
+      # expose a desync, which hand-written samples reliably miss.
+      alphabet = ['a', '/', '*', '\'', '"', '`', '$', '{', '}', '\\', '\n', ';', 'é']
+      rng = Random.new(20_260_912)
+      2_000.times do
+        src = String.build { |io| (rng.rand(1..40)).times { io << alphabet[rng.rand(alphabet.size)] } }
+        JsScan.strip_both(src).should eq({JsScan.strip(src), JsScan.strip_comments(src)})
+      end
+    end
+
+    it "handles an empty script without lexing it" do
+      JsScan.strip_both("").should eq({"", ""})
+    end
+  end
+
   # source_in_window works on BYTE offsets: char-index slicing was O(1) only while the script
   # stayed all-ASCII, and one non-ASCII byte turned every window slice into a walk from the
   # start of the string (measured 9ms -> 1765ms per flow). The pairs must be identical either

--- a/spec/probe/passive_exposure_spec.cr
+++ b/spec/probe/passive_exposure_spec.cr
@@ -5,6 +5,22 @@ describe Gori::Probe::Passive::ExposedConfig do
   private_plain = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\n"
   private_html = "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n"
 
+  # `head_of` bounds the scan to the opening SCAN_PREFIX bytes, and the cut can land in the
+  # middle of a multi-byte character. PCRE2 RAISES on invalid UTF-8 rather than failing to
+  # match, and Passive.analyze catches a rule's raise per rule — so a broken cut would not
+  # crash, it would silently drop this rule's findings on every large page with any non-ASCII
+  # content. The repair behind the cut changed spelling (`String#scrub` → `Utf8.text`, which
+  # validates before repairing), so pin that the scan still sees a clean prefix and still
+  # reports the signature sitting inside it.
+  it "scans a prefix whose cut lands mid-codepoint" do
+    with_store do |store|
+      body = "[core]\n\trepositoryformatversion = 0\n" + ("가" * 20_000)
+      body.bytesize.should be > Gori::Probe::Passive::ExposedConfig::SCAN_PREFIX
+      dets = probe_analyze(store, resp_head: private_plain, content_type: "text/plain", body: body)
+      dets.find(&.code.==("exposed_config")).not_nil!.evidence.should eq(".git/config")
+    end
+  end
+
   it "flags a served .git/config" do
     with_store do |store|
       body = "[core]\n\trepositoryformatversion = 0\n\tbare = false\n[remote \"origin\"]\n\turl = git@github.com:acme/app.git\n"

--- a/src/gori/probe/active/graphql_introspection.cr
+++ b/src/gori/probe/active/graphql_introspection.cr
@@ -1,4 +1,5 @@
 require "json"
+require "../../utf8"
 require "./types"
 require "../../ascii_bytes"
 require "../../miner/inject"
@@ -93,7 +94,9 @@ module Gori
           decoded, _ = Proxy::Codec::ContentDecode.decode(result.head, result.body, BODY_CAP)
           bytes = decoded || result.body
           return false if bytes.nil? || bytes.empty?
-          INTROSPECTION_RESULT.matches?(String.new(bytes[0, {bytes.size, BODY_CAP}.min]).scrub)
+          # `Utf8.text` rather than `String#scrub` — same repair, but a valid body (which a JSON
+          # introspection result always is) skips the character walk. See `Gori::Utf8`.
+          INTROSPECTION_RESULT.matches?(Utf8.text(bytes[0, {bytes.size, BODY_CAP}.min]))
         end
 
         # The shared gate both `plan` and `dedup_key` funnel through, returning {probe_method,
@@ -147,7 +150,10 @@ module Gori
           end
           return false unless AsciiBytes.contains_ci?(capped, QUERY_KEY)
           q = begin
-            JSON.parse(String.new(capped).scrub).as_h?.try(&.["query"]?).try(&.as_s?)
+            # Twin of the same gate in `Passive::Tech`, down to the `Utf8.text` spelling: the
+            # prefilter above has already decided this body is worth parsing, so the repair only
+            # has to not cost a full character walk on the valid bodies that reach it.
+            JSON.parse(Utf8.text(capped)).as_h?.try(&.["query"]?).try(&.as_s?)
           rescue JSON::ParseException
             nil
           end

--- a/src/gori/probe/passive/context.cr
+++ b/src/gori/probe/passive/context.cr
@@ -1,4 +1,5 @@
 require "../../store"
+require "../../utf8"
 require "../../proxy/codec/http1"
 require "../../proxy/codec/content_decode"
 require "./cache_control"
@@ -169,11 +170,19 @@ module Gori
         # Decoded, capped, scrubbed response body text — computed once and shared by the rules
         # that scan the body. nil when there is no body. Slices the shared `decoded_body` buffer
         # to its first BODY_CAP bytes.
+        #
+        # Every text getter here repairs through `Utf8.text`, not a bare `String#scrub`: scrub
+        # walks the body a CHARACTER at a time and returns `self` when there was nothing to fix,
+        # so a valid body — nearly all of them — pays a full decode to be told so, while
+        # `valid_encoding?` answers the same question with a byte DFA. Measured over this file's
+        # own worst case (bench/probe_passive_bench's 256 KiB JS bundle): 0.90ms → 0.10ms, and
+        # 0.69ms → 0.08ms over the 200 KiB HTML page. The repair itself is unchanged — an
+        # invalid body still ends up scrubbed, at ~5% for the second walk. See `Gori::Utf8`.
         def body_text : String?
           return @body_text if @body_text_done
           @body_text_done = true
           bytes = decoded_body
-          @body_text = (bytes && !bytes.empty?) ? String.new(bytes[0, {bytes.size, BODY_CAP}.min]).scrub : nil
+          @body_text = (bytes && !bytes.empty?) ? Utf8.text(bytes[0, {bytes.size, BODY_CAP}.min]) : nil
         end
 
         # Decoded, larger-capped (CLIENT_BODY_CAP), scrubbed body — computed once and shared by
@@ -184,7 +193,7 @@ module Gori
           @client_body_text_done = true
           return @client_body_text = nil unless html? || js?
           bytes = decoded_body
-          @client_body_text = (bytes && !bytes.empty?) ? String.new(bytes[0, {bytes.size, CLIENT_BODY_CAP}.min]).scrub : nil
+          @client_body_text = (bytes && !bytes.empty?) ? Utf8.text(bytes[0, {bytes.size, CLIENT_BODY_CAP}.min]) : nil
         end
 
         # RAW executable JS fragments (inline <script> bodies for HTML, whole body for JS),
@@ -198,7 +207,11 @@ module Gori
         # so the DOM-XSS source->sink correlation never matches a sink or source that lived in a
         # string or comment. Memoised so the lex runs at most once per flow.
         def client_code : Array(String)
-          @client_code ||= client_scripts.map { |s| JsScan.strip(s) }
+          if c = @client_code
+            return c
+          end
+          build_client_views
+          @client_code || [] of String
         end
 
         # The fragments with ONLY comments blanked (string/template CONTENTS kept). The
@@ -206,7 +219,32 @@ module Gori
         # "message"/"__proto__" inside a live string is still seen, but the same keyword in a
         # commented-out example/debug line no longer false-matches. Memoised per flow.
         def client_scripts_nocomment : Array(String)
-          @client_scripts_nocomment ||= client_scripts.map { |s| JsScan.strip_comments(s) }
+          if c = @client_scripts_nocomment
+            return c
+          end
+          build_client_views
+          @client_scripts_nocomment || [] of String
+        end
+
+        # Both client views from ONE lex of each fragment (`JsScan.strip_both`), because on an
+        # HTML or JS flow both are live: DomXss/DomClobbering read client_code, PostMessage/
+        # PrototypePollution read client_scripts_nocomment. Two `map`s meant two full walks of
+        # the same scripts (bench/probe_passive_bench's 256 KiB bundle: 1.75ms for the pair,
+        # 2.92ms for its non-ASCII variant — see `JsScan.strip_both` for what fusing them buys).
+        # Whichever getter is asked first fills both, so the memos still make this at most once
+        # per flow; an operator who has disabled one of the two rule pairs pays the other view's
+        # emission (~8% of one walk), not a second walk.
+        private def build_client_views : Nil
+          scripts = client_scripts
+          code = Array(String).new(scripts.size)
+          kept = Array(String).new(scripts.size)
+          scripts.each do |s|
+            stripped, nocomment = JsScan.strip_both(s)
+            code << stripped
+            kept << nocomment
+          end
+          @client_code = code
+          @client_scripts_nocomment = kept
         end
 
         # --- region text for user-defined custom match rules ---------------------------------
@@ -225,7 +263,7 @@ module Gori
 
         # Raw request head (request line + headers) as scrubbed text.
         def request_head_text : String
-          @req_head_text ||= String.new(@detail.request_head).scrub
+          @req_head_text ||= Utf8.text(@detail.request_head)
         end
 
         # Decoded, capped, scrubbed request body text (nil when there is no body). A request body
@@ -238,7 +276,7 @@ module Gori
           if body && !body.empty?
             decoded, _ = Proxy::Codec::ContentDecode.decode(@detail.request_head, body, BODY_CAP)
             bytes = decoded || body
-            @req_body_text = String.new(bytes[0, {bytes.size, BODY_CAP}.min]).scrub
+            @req_body_text = Utf8.text(bytes[0, {bytes.size, BODY_CAP}.min])
           end
           @req_body_text
         end
@@ -247,7 +285,7 @@ module Gori
         def response_head_text : String?
           return @resp_head_text if @resp_head_text_done
           @resp_head_text_done = true
-          @resp_head_text = @detail.response_head.try { |h| String.new(h).scrub }
+          @resp_head_text = @detail.response_head.try { |h| Utf8.text(h) }
         end
 
         # The "whole" region — head and body joined — memoized like every other region getter.

--- a/src/gori/probe/passive/exposed_config.cr
+++ b/src/gori/probe/passive/exposed_config.cr
@@ -1,4 +1,5 @@
 require "./rule"
+require "../../utf8"
 
 module Gori
   module Probe
@@ -115,12 +116,19 @@ module Gori
           acc << det(ctx, ".env file", Store::Severity::High)
         end
 
-        # The first SCAN_PREFIX bytes, scrubbed. The cut can land mid-codepoint, and PCRE RAISES
+        # The first SCAN_PREFIX bytes, repaired. The cut can land mid-codepoint, and PCRE RAISES
         # on invalid UTF-8 — which here would take out the whole flow's detections, not just
-        # this rule's — so the slice is scrubbed before any pattern sees it.
+        # this rule's — so the slice is validated before any pattern sees it.
+        #
+        # Through `Utf8.text`, not a bare `scrub`: the source is `body_text`, which is already
+        # valid, so the ONLY way this slice can be broken is a cut landing mid-codepoint — i.e.
+        # essentially never, while the scrub walked all 16 KiB a character at a time to find that
+        # out. That mattered most on a body this rule cannot possibly hit: an image response's
+        # `body_text` is 64 KiB of binary already expanded to U+FFFD, and this one call was 139µs
+        # of the 625µs that response costs the passive fiber. Same repair either way.
         private def head_of(text : String) : String
           return text if text.bytesize <= SCAN_PREFIX
-          String.new(text.to_slice[0, SCAN_PREFIX]).scrub
+          Utf8.text(text.to_slice[0, SCAN_PREFIX])
         end
 
         # One code for the whole family: these are the same finding ("a server-side artifact is

--- a/src/gori/probe/passive/exposed_config.cr
+++ b/src/gori/probe/passive/exposed_config.cr
@@ -117,15 +117,17 @@ module Gori
         end
 
         # The first SCAN_PREFIX bytes, repaired. The cut can land mid-codepoint, and PCRE RAISES
-        # on invalid UTF-8 — which here would take out the whole flow's detections, not just
-        # this rule's — so the slice is validated before any pattern sees it.
+        # on invalid UTF-8 rather than failing to match — `Passive.analyze` rescues per rule, so
+        # that would not lose the flow's other findings, but it would silently cost this rule
+        # every finding on every large page carrying any non-ASCII byte. So the slice is
+        # validated before any pattern sees it.
         #
         # Through `Utf8.text`, not a bare `scrub`: the source is `body_text`, which is already
         # valid, so the ONLY way this slice can be broken is a cut landing mid-codepoint — i.e.
         # essentially never, while the scrub walked all 16 KiB a character at a time to find that
         # out. That mattered most on a body this rule cannot possibly hit: an image response's
-        # `body_text` is 64 KiB of binary already expanded to U+FFFD, and this one call was 139µs
-        # of the 625µs that response costs the passive fiber. Same repair either way.
+        # `body_text` is a binary BODY_CAP prefix already expanded to U+FFFD, and this one call
+        # was 139µs of the 625µs that response cost the passive fiber. Same repair either way.
         private def head_of(text : String) : String
           return text if text.bytesize <= SCAN_PREFIX
           Utf8.text(text.to_slice[0, SCAN_PREFIX])

--- a/src/gori/probe/passive/js_scan.cr
+++ b/src/gori/probe/passive/js_scan.cr
@@ -172,6 +172,30 @@ module Gori
           out
         end
 
+        # The two output sides of one lex pass, so the lexers below never spell a nil test.
+        # A nil side is one this call is not building (`strip` builds only `code`,
+        # `strip_comments` only `kept`); `strip_both` builds both.
+        #
+        # `String::Builder`, not `IO`: a concrete receiver keeps `<<` a direct call on the hot
+        # per-char path instead of a virtual dispatch. Every emission goes through `<<` (same
+        # char to both) or `push` (one char each, different) — never a multi-char write — so
+        # "one consumed char emits exactly one char per side", the invariant every offset in
+        # this file rests on, is visible in the shape rather than argued about.
+        private struct Sink
+          def initialize(@code : String::Builder?, @kept : String::Builder?)
+          end
+
+          def <<(ch : Char) : Nil
+            @code.try &.<<(ch)
+            @kept.try &.<<(ch)
+          end
+
+          def push(code_ch : Char, kept_ch : Char) : Nil
+            @code.try &.<<(code_ch)
+            @kept.try &.<<(kept_ch)
+          end
+        end
+
         # Blank // line comments, /* */ block comments, and '…' / "…" / `…` string literals,
         # replacing their CONTENTS with spaces so byte/char offsets are preserved. A single
         # conservative left-to-right pass. Regex literals are intentionally left intact:
@@ -179,36 +203,78 @@ module Gori
         # tokens. Every consumed char emits exactly one char, so indices stay aligned.
         def self.strip(js : String) : String
           return js if js.empty?
+          String.build(js.bytesize) { |io| lex(js, Sink.new(io, nil)) }
+        end
+
+        # Blank ONLY // and /* */ comments, keeping string/template CONTENTS intact (offsets
+        # preserved). For the string-literal-keyed rules (postMessage "message"/"*", prototype
+        # pollution "__proto__") that need those literals visible but must NOT match keywords
+        # inside commented-out example/debug code. Strings are copied verbatim so an embedded
+        # `//` or `/*` (e.g. in a URL literal) is not mistaken for a comment.
+        def self.strip_comments(js : String) : String
+          return js if js.empty?
+          String.build(js.bytesize) { |io| lex(js, Sink.new(nil, io)) }
+        end
+
+        # BOTH projections of one script from ONE pass: `{strip(js), strip_comments(js)}`.
+        #
+        # The two differ only in what they EMIT for a string literal's contents — they consume
+        # the script identically, token for token and index for index (an escape pair, a `${…}`
+        # interpolation and a closing quote are found at the same offsets whether the contents
+        # are blanked or copied). So a Context that needs both — every HTML or JS flow does, one
+        # for the DOM-XSS/clobbering rules and one for the postMessage/prototype-pollution rules
+        # — was lexing the same bytes twice. Fusing saves the walk, not the emission (each side
+        # still writes its own char), so the pair costs ~1.7 walks instead of 2: measured over
+        # the 256 KiB bundle in bench/probe_passive_bench, 1.75ms → 1.47ms. It pays far better on
+        # the non-ASCII variant of the same bundle, where `scan_source` falls back to
+        # `String#chars`: 2.92ms → 2.05ms, and one ~1 MiB `Array(Char)` built instead of two.
+        #
+        # Not a third lexer: `lex` below is the only one, and `strip`/`strip_comments` are it
+        # with the other side's builder left nil. Keeping one walk is the point — a copy of this
+        # control flow that drifted would desync the two views' offsets, which is the exact
+        # failure `lex_string` is written the way it is to prevent.
+        def self.strip_both(js : String) : {String, String}
+          return {js, js} if js.empty?
+          code = String::Builder.new(js.bytesize)
+          kept = String::Builder.new(js.bytesize)
+          lex(js, Sink.new(code, kept))
+          {code.to_s, kept.to_s}
+        end
+
+        # Opens a string / template literal. One home so the three places that ask — the top-level
+        # dispatch, a nested literal inside a `${…}`, and the closing-delimiter test — cannot
+        # drift apart on which quotes count.
+        private def self.quote?(ch : Char) : Bool
+          ch == '\'' || ch == '"' || ch == '`'
+        end
+
+        # The single left-to-right lexer behind all three entry points above.
+        private def self.lex(js : String, out_to : Sink) : Nil
           scan_source(js) do |chars, n|
-            String.build(js.bytesize) do |io|
-              i = 0
-              while i < n
-                # The token dispatch is spelled out here rather than delegated to
-                # `blank_token_at` (which `emit_interpolation` still uses), and the shape mirrors
-                # `strip_comments`' loop deliberately. That helper returns `Int32?` — nil meaning
-                # "no token starts here" — so the OVERWHELMINGLY common case, an ordinary code
-                # character, paid a nilable-union result on every char of the script. Deciding it
-                # from the char in the loop keeps this hot path on a plain Int32; the branch order
-                # (comment, then string) is the helper's, so what gets blanked is unchanged.
-                c = chars[i]
-                i = if c == '/' && i + 1 < n && chars[i + 1] == '/'
-                      blank_line_comment(chars, i, n, io)
-                    elsif c == '/' && i + 1 < n && chars[i + 1] == '*'
-                      blank_block_comment(chars, i, n, io)
-                    elsif c == '\'' || c == '"' || c == '`'
-                      blank_string(chars, i, n, io, 0)
-                    else
-                      io << c
-                      i + 1
-                    end
-              end
+            i = 0
+            while i < n
+              # The token dispatch is spelled out here rather than delegated to a nilable-result
+              # helper: the OVERWHELMINGLY common case is an ordinary code character, and deciding
+              # it from the char in the loop keeps this hot path on a plain Int32. The branch
+              # order (comment, then string) is what both projections have always used.
+              c = chars[i]
+              i = if c == '/' && i + 1 < n && chars[i + 1] == '/'
+                    blank_line_comment(chars, i, n, out_to)
+                  elsif c == '/' && i + 1 < n && chars[i + 1] == '*'
+                    blank_block_comment(chars, i, n, out_to)
+                  elsif quote?(c)
+                    lex_string(chars, i, n, out_to, 0)
+                  else
+                    out_to << c
+                    i + 1
+                  end
             end
           end
         end
 
         # Yields the random-access char source for `js` plus its length: a zero-allocation
-        # AsciiChars view when the script is all-ASCII, else the `Array(Char)` the lexers have
-        # always used. Both satisfy the same `size`/`[]` shape, so the lexers below are compiled
+        # AsciiChars view when the script is all-ASCII, else the `Array(Char)` the lexer has
+        # always used. Both satisfy the same `size`/`[]` shape, so the lexer below is compiled
         # for each and neither is special-cased. `ascii_only?` is a single byte pass, far cheaper
         # than the array it avoids.
         private def self.scan_source(js : String, &)
@@ -221,136 +287,106 @@ module Gori
           end
         end
 
-        # Template-literal nesting recurses one frame per level (blank_string →
-        # emit_interpolation → blank_token_at → …, and the copy_* mirror of it), and the depth is
-        # ATTACKER-CONTROLLED: it is just response-body text. The recursion happens on the way IN,
-        # so no closing delimiters are needed — an unterminated "`${" costs 3 bytes per level, and
-        # CLIENT_BODY_CAP / 3 = 87381 levels lands past the ~87k frames an 8 MiB fiber stack holds.
-        # A Crystal stack overflow is a FATAL SIGNAL, not a rescuable exception, so Analyzer's
-        # per-flow `rescue` cannot contain it: one 256 KiB response body took the whole process
-        # down (proxy capture, TUI, CLI and MCP alike). The body cap is not a defense here — it
-        # sits on the wrong side of the limit — so the lexers cap the nesting themselves.
+        # Template-literal nesting recurses one frame per level (lex_string → lex_interpolation
+        # → lex_string → …), and the depth is ATTACKER-CONTROLLED: it is just response-body text.
+        # The recursion happens on the way IN, so no closing delimiters are needed — an
+        # unterminated "`${" costs 3 bytes per level, and CLIENT_BODY_CAP / 3 = 87381 levels
+        # lands past the ~87k frames an 8 MiB fiber stack holds. A Crystal stack overflow is a
+        # FATAL SIGNAL, not a rescuable exception, so Analyzer's per-flow `rescue` cannot contain
+        # it: one 256 KiB response body took the whole process down (proxy capture, TUI, CLI and
+        # MCP alike). The body cap is not a defense here — it sits on the wrong side of the limit
+        # — so the lexer caps the nesting itself.
         #
         # 64 is far past anything real: minifiers do not add template nesting and hand-written
         # code does not go beyond a handful of levels. Past it we blank the rest of the FRAGMENT
         # (see blank_rest) rather than stop descending in place — declining to recurse would let a
         # nested backtick close the enclosing template early and re-lex the remainder, the exact
-        # desync copy_string exists to prevent. Blanking is offset-preserving and cannot desync;
+        # desync lex_string exists to prevent. Blanking is offset-preserving and cannot desync;
         # the cost is that content past 64 levels of nesting is not analyzed, which is the safe
         # direction (a missed lead, never a false one).
         MAX_INTERP_DEPTH = 64
 
         # Blank every remaining char of the fragment (one space each, offsets preserved) and
-        # return the end index, so the caller's `while i < n` loop terminates immediately.
-        private def self.blank_rest(chars, i : Int32, n : Int32, io : IO) : Int32
+        # return the end index, so the caller's `while i < n` loop terminates immediately. Both
+        # projections blank here — past the depth cap neither view is trustworthy.
+        private def self.blank_rest(chars, i : Int32, n : Int32, out_to : Sink) : Int32
           while i < n
-            io << ' '
+            out_to << ' '
             i += 1
           end
           n
         end
 
         # If chars[i] starts a // or /* */ comment, blank it (→ spaces, offsets preserved) and
-        # return the index just past it; else nil. Shared by the string- and comment-strip lexers.
-        # No `depth`: a comment never recurses.
-        private def self.blank_comment_at(chars, i : Int32, n : Int32, io : IO) : Int32?
+        # return the index just past it; else nil. A comment is blanked in BOTH projections —
+        # that is the one thing they agree on — and never recurses, so there is no `depth`.
+        private def self.lex_comment_at(chars, i : Int32, n : Int32, out_to : Sink) : Int32?
           c = chars[i]
           if c == '/' && i + 1 < n && chars[i + 1] == '/'
-            blank_line_comment(chars, i, n, io)
+            blank_line_comment(chars, i, n, out_to)
           elsif c == '/' && i + 1 < n && chars[i + 1] == '*'
-            blank_block_comment(chars, i, n, io)
+            blank_block_comment(chars, i, n, out_to)
           end
         end
 
-        # If chars[i] starts a // comment, /* */ comment, or a '…'/"…"/`…` string, blank it
-        # (contents → spaces, offsets preserved) and return the index just past it; else nil.
-        # Shared by strip and emit_interpolation so the token lexing lives in one place.
-        # `depth` is the template-interpolation nesting level (see MAX_INTERP_DEPTH).
-        private def self.blank_token_at(chars, i : Int32, n : Int32, io : IO, depth : Int32) : Int32?
-          if j = blank_comment_at(chars, i, n, io)
-            j
-          else
-            c = chars[i]
-            (c == '\'' || c == '"' || c == '`') ? blank_string(chars, i, n, io, depth) : nil
-          end
-        end
-
-        # Blank ONLY // and /* */ comments, keeping string/template CONTENTS intact (offsets
-        # preserved). For the string-literal-keyed rules (postMessage "message"/"*", prototype
-        # pollution "__proto__") that need those literals visible but must NOT match keywords
-        # inside commented-out example/debug code. Strings are copied verbatim so an embedded
-        # `//` or `/*` (e.g. in a URL literal) is not mistaken for a comment.
-        def self.strip_comments(js : String) : String
-          return js if js.empty?
-          scan_source(js) do |chars, n|
-            String.build(js.bytesize) do |io|
-              i = 0
-              while i < n
-                c = chars[i]
-                i = if c == '/' && i + 1 < n && chars[i + 1] == '/'
-                      blank_line_comment(chars, i, n, io)
-                    elsif c == '/' && i + 1 < n && chars[i + 1] == '*'
-                      blank_block_comment(chars, i, n, io)
-                    elsif c == '\'' || c == '"' || c == '`'
-                      copy_string(chars, i, n, io, 0)
-                    else
-                      io << c
-                      i + 1
-                    end
-              end
-            end
-          end
-        end
-
-        # Copy a '…'/"…"/`…` literal verbatim (contents kept), consuming it so an embedded
-        # // or /* inside the string is not treated as a comment. Honors \\ escapes. For a
-        # template literal, a ${…} interpolation is CODE, not string content — it is consumed
-        # via copy_interpolation so a NESTED template's backtick inside ${…} is not mistaken
-        # for this template's closing delimiter (which would terminate early and re-lex the
-        # real remainder, blanking a URL's // as a comment).
-        private def self.copy_string(chars, i : Int32, n : Int32, io : IO, depth : Int32) : Int32
+        # Consume a '…' / "…" / `…` literal, honoring \\ escapes: its CONTENTS are blanked into
+        # the `code` side (delimiters kept) and copied verbatim into the `kept` side. Consuming
+        # it in one pass is what stops an embedded `//` or `/*` inside the string from being read
+        # as a comment. For a template literal a `${…}` interpolation is CODE, not string
+        # content, so it is handed to lex_interpolation — which also keeps a NESTED template's
+        # backtick from being mistaken for this template's closing delimiter (that would
+        # terminate early and re-lex the real remainder, blanking a URL's // as a comment).
+        private def self.lex_string(chars, i : Int32, n : Int32, out_to : Sink, depth : Int32) : Int32
           quote = chars[i]
-          io << quote
+          out_to << quote # opening delimiter kept on both sides
           i += 1
           while i < n
             ch = chars[i]
             if ch == '\\' && i + 1 < n
-              io << ch << chars[i + 1]
+              out_to.push(' ', ch) # escaped pair: blanked as two spaces, kept verbatim
+              out_to.push(' ', chars[i + 1])
               i += 2
-              next
+            elsif quote == '`' && ch == '$' && i + 1 < n && chars[i + 1] == '{'
+              i = lex_interpolation(chars, i, n, out_to, depth)
+            elsif ch == quote
+              out_to << ch # closing delimiter kept on both sides
+              i += 1
+              break
+            else
+              out_to.push(' ', ch) # content blanked (incl. newlines inside a template), or kept
+              i += 1
             end
-            if quote == '`' && ch == '$' && i + 1 < n && chars[i + 1] == '{'
-              i = copy_interpolation(chars, i, n, io, depth)
-              next
-            end
-            io << ch
-            i += 1
-            break if ch == quote
           end
           i
         end
 
-        # Consume a template ${…} interpolation for the comment-only strip: blank real code
-        # comments inside it, but COPY string literals verbatim (so their contents stay for the
-        # string-key rules), tracking brace depth to find the matching `}`. Recurses through
-        # copy_string for nested strings/templates. `i` points at `$`. Offset-preserving.
-        private def self.copy_interpolation(chars, i : Int32, n : Int32, io : IO, depth : Int32) : Int32
-          return blank_rest(chars, i, n, io) if depth >= MAX_INTERP_DEPTH
-          io << '$' << '{'
+        # Consume a template-literal `${…}` interpolation, tracking brace depth to find the
+        # matching `}`. Its expression is CODE, so both projections keep it visible — the `code`
+        # side so a source/sink keyword inside it survives (otherwise `innerHTML = `${location
+        # .hash}`` loses its source and DOM-XSS misses it), the `kept` side because it was never
+        # string content. They differ only on the delimiters: `code` blanks the `${` and the
+        # matching `}` so source_in_window's /[;{}\n]/ statement-boundary scan does not truncate
+        # the window at the interpolation, while `kept` copies them. Nested strings and comments
+        # recurse through lex_string / lex_comment_at, so each side gets its own treatment there
+        # too. `i` points at `$`.
+        private def self.lex_interpolation(chars, i : Int32, n : Int32, out_to : Sink, depth : Int32) : Int32
+          return blank_rest(chars, i, n, out_to) if depth >= MAX_INTERP_DEPTH
+          out_to.push(' ', '$') # blank the '${' delimiter on the code side (offset-preserved)
+          out_to.push(' ', '{')
           i += 2
           braces = 1
           while i < n && braces > 0
             ch = chars[i]
             if ch == '{' || ch == '}'
               braces += ch == '{' ? 1 : -1
-              io << ch
+              out_to.push(ch == '}' && braces == 0 ? ' ' : ch, ch) # blank the OUTER closing '}'
               i += 1
-            elsif j = blank_comment_at(chars, i, n, io) # real code comment inside ${…} → blank
+            elsif j = lex_comment_at(chars, i, n, out_to)
               i = j
-            elsif ch == '\'' || ch == '"' || ch == '`'
-              i = copy_string(chars, i, n, io, depth + 1) # string content kept
+            elsif quote?(ch)
+              i = lex_string(chars, i, n, out_to, depth + 1)
             else
-              io << ch
+              out_to << ch
               i += 1
             end
           end
@@ -358,86 +394,30 @@ module Gori
         end
 
         # Blank a // comment through end-of-line (the terminating newline is left to the caller).
-        private def self.blank_line_comment(chars, i : Int32, n : Int32, io : IO) : Int32
-          io << "  "
+        private def self.blank_line_comment(chars, i : Int32, n : Int32, out_to : Sink) : Int32
+          out_to << ' '
+          out_to << ' '
           i += 2
           while i < n && chars[i] != '\n'
-            io << ' '
+            out_to << ' '
             i += 1
           end
           i
         end
 
         # Blank a /* … */ comment, delimiters included.
-        private def self.blank_block_comment(chars, i : Int32, n : Int32, io : IO) : Int32
-          io << "  "
+        private def self.blank_block_comment(chars, i : Int32, n : Int32, out_to : Sink) : Int32
+          out_to << ' '
+          out_to << ' '
           i += 2
           while i < n && !(chars[i] == '*' && i + 1 < n && chars[i + 1] == '/')
-            io << ' '
+            out_to << ' '
             i += 1
           end
           if i < n
-            io << "  "
+            out_to << ' '
+            out_to << ' '
             i += 2
-          end
-          i
-        end
-
-        # Blank a '…' / "…" / `…` literal's CONTENTS (delimiters kept), honoring \\ escapes.
-        # For a template literal a `${…}` interpolation is CODE, not string content, so its
-        # expression is emitted (via emit_interpolation) instead of blanked — otherwise the
-        # common template-literal sink shape (innerHTML = `${location.hash}`) would lose its
-        # source and DOM-XSS would miss it.
-        private def self.blank_string(chars, i : Int32, n : Int32, io : IO, depth : Int32) : Int32
-          quote = chars[i]
-          io << quote # opening delimiter kept
-          i += 1
-          while i < n
-            ch = chars[i]
-            if ch == '\\' && i + 1 < n
-              io << "  " # escaped pair, length preserved
-              i += 2
-              next
-            end
-            if ch == quote
-              io << ch # closing delimiter kept
-              i += 1
-              break
-            end
-            if quote == '`' && ch == '$' && i + 1 < n && chars[i + 1] == '{'
-              i = emit_interpolation(chars, i, n, io, depth) # ${…} expression kept as code
-              next
-            end
-            io << ' ' # content blanked (incl. newlines inside a template)
-            i += 1
-          end
-          i
-        end
-
-        # Emit a template-literal `${…}` interpolation as CODE: keep the expression visible so
-        # source/sink keywords inside it survive, but blank nested strings/comments (so their
-        # CONTENTS can't false-match) and track brace depth to find the matching `}`. Every
-        # consumed char emits exactly one char, so offsets stay aligned. `i` points at `$`.
-        private def self.emit_interpolation(chars, i : Int32, n : Int32, io : IO, depth : Int32) : Int32
-          return blank_rest(chars, i, n, io) if depth >= MAX_INTERP_DEPTH
-          io << "  " # blank the '${' delimiter (2 spaces, offset-preserved): keeps the inner
-          #            expression as code but removes the '{' so source_in_window's /[;{}\n]/
-          #            statement-boundary scan doesn't truncate the window at the interpolation
-          #            (else `innerHTML = `${location.hash}`` loses its source and DOM-XSS misses it)
-          i += 2
-          braces = 1
-          while i < n && braces > 0
-            ch = chars[i]
-            if ch == '{' || ch == '}'
-              braces += ch == '{' ? 1 : -1
-              io << (ch == '}' && braces == 0 ? ' ' : ch) # blank the OUTER closing '}'; keep inner braces
-              i += 1
-            elsif j = blank_token_at(chars, i, n, io, depth + 1) # nested string/comment (recurses for a nested template)
-              i = j
-            else
-              io << ch
-              i += 1
-            end
           end
           i
         end

--- a/src/gori/probe/passive/sourcemap.cr
+++ b/src/gori/probe/passive/sourcemap.cr
@@ -1,4 +1,5 @@
 require "./rule"
+require "../../utf8"
 require "../../proxy/codec/content_decode"
 
 module Gori
@@ -83,7 +84,13 @@ module Gori
           decoded, _ = Proxy::Codec::ContentDecode.decode(ctx.detail.response_head, body, TAIL_DECODE_CAP)
           bytes = decoded || body
           return nil if bytes.size <= Context::CLIENT_BODY_CAP
-          String.new(bytes[(bytes.size - TAIL_WINDOW)..]).scrub
+          # `Utf8.text`, not `String#scrub`: this runs on every capped JS response on the fiber
+          # the passive scan shares with the proxy, so ask `valid_encoding?` and repair only what
+          # needs it — 70.6µs → 8.4µs over a 16 KiB valid slice. A tail cut at a fixed byte offset
+          # CAN land mid-codepoint, and that case walks twice (validate, then scrub) for ~5% over
+          # the old spelling; a minified bundle's last 16 KiB is ASCII far more often than not,
+          # so the trade is the same one `Gori::Utf8` argues for everywhere else.
+          Utf8.text(bytes[(bytes.size - TAIL_WINDOW)..])
         end
 
         # The reference is server-controlled text landing in stored evidence + the TUI: keep it

--- a/src/gori/probe/passive/tech.cr
+++ b/src/gori/probe/passive/tech.cr
@@ -1,5 +1,6 @@
 require "json"
 require "./rule"
+require "../../utf8"
 require "../../ascii_bytes"
 require "../../proxy/h2/grpc"
 require "../../sse"
@@ -167,7 +168,7 @@ module Gori
           # (scrub cannot create or destroy an ASCII `"query"`), and the as_h?/as_s? guards below
           # still decide the outcome — so no detection is lost.
           return false unless AsciiBytes.contains_ci?(capped, QUERY_KEY)
-          text = String.new(capped).scrub
+          text = Utf8.text(capped)
           q = begin
             JSON.parse(text).as_h?.try(&.["query"]?).try(&.as_s?)
           rescue JSON::ParseException

--- a/src/gori/probe/passive/ws_payloads.cr
+++ b/src/gori/probe/passive/ws_payloads.cr
@@ -1,3 +1,4 @@
+require "../../utf8"
 require "./rule"
 require "./secrets"
 
@@ -55,11 +56,13 @@ module Gori
 
         # Scannable text for one frame, capped at MSG_CAP.
         #
-        # A TEXT frame is declared UTF-8, so `scrub` is the right repair and keeps the payload
-        # readable. A BINARY frame is not, and scrub is the wrong tool for it twice over: it
-        # EXPANDS each invalid byte to a 3-byte U+FFFD, so a 64 KiB frame would allocate ~192 KiB
-        # per message on the fiber the passive scan shares with the proxy, and it would do that
-        # for every frame of a chatty socket.
+        # A TEXT frame is declared UTF-8, so a scrub is the right repair and keeps the payload
+        # readable — through `Utf8.text`, which asks `valid_encoding?` first and only scrubs a
+        # frame that is really broken, so a chatty socket's valid frames skip the character walk.
+        # A BINARY frame is not, and scrub is the wrong tool for it twice over: it EXPANDS each
+        # invalid byte to a 3-byte U+FFFD, so a 64 KiB frame would allocate ~192 KiB per message
+        # on the fiber the passive scan shares with the proxy, and it would do that for every
+        # frame of a chatty socket.
         #
         # The projection below is size-preserving, always valid UTF-8, and LOSSLESS for the shapes
         # this rule matches: every pattern is pure ASCII, and mapping a non-ASCII byte to a space
@@ -68,7 +71,7 @@ module Gori
         private def payload_text(payload : Bytes, text_frame : Bool) : String?
           return nil if payload.empty?
           bytes = payload[0, {payload.size, MSG_CAP}.min]
-          return String.new(bytes).scrub if text_frame
+          return Utf8.text(bytes) if text_frame
           # Mapped over a byte slice rather than char-by-char into a String::Builder: the result is
           # ASCII by construction, so `String.new` on it is valid UTF-8 without a second pass, and
           # this skips one virtual IO dispatch per byte (a 64 KiB frame is 65_536 of them).


### PR DESCRIPTION
Two allocation/pass-count wins on the passive probe path — the scan the proxy's own
fiber runs for every captured flow — plus a third, smaller one in the same family. No
behaviour change: every projection is byte-identical to what it was, and the full suite
(14291 examples) is green.

## What I measured

`bench/probe_passive_bench.cr`, `--release`, three alternating before/after runs of the
same binary pair (baseline built by reverting `src/` and rebuilding the same bench file,
so the new fixture is present on both sides). Medians:

| flow shape | before | after | |
| --- | --- | --- | --- |
| JSON API POST, 27 KiB request body | 55.3 µs | 54.0 µs | unchanged (no response body to decode) |
| HTML document, 30 KiB | 969 µs | 769 µs | **1.26×** |
| HTML document, 200 KiB | 2.65 ms | 1.82 ms | **1.46×** |
| binary asset, 180 KiB (new fixture) | 573 µs | 560 µs | 1.02× |
| JS bundle, 256 KiB | 6.72 ms | 5.69 ms | **1.18×** |
| JS bundle + non-ASCII regex literal | 8.05 ms | 6.29 ms | **1.28×**, 3.06 MB/op → **2.06 MB/op** |

## 1. `String#scrub` → `Gori::Utf8.text` on the body getters

`Gori::Utf8` already exists and already carries this measurement (`src/gori/utf8.cr`):
`scrub` walks the string a CHARACTER at a time through a `Char::Reader` and returns
`self` when there was nothing to fix, so a valid body — nearly all of them — pays a full
decode to be told so. `valid_encoding?` answers the same question with a byte DFA.

`Probe::Passive::Context` still carried the slow spelling on all five of its text
getters, as did `Tech`'s GraphQL body read, `WsPayloads`' per-frame text, and
`ExposedConfig#head_of`. Isolated, on a fresh String (what the real path builds):

| subject | `String.new(b).scrub` | `Utf8.text(b)` |
| --- | --- | --- |
| 256 KiB JS bundle | 0.896 ms | 0.097 ms |
| 200 KiB HTML page | 0.692 ms | 0.075 ms |
| 30 KiB HTML page | 0.094 ms | 0.012 ms |
| 256 KiB + one invalid byte | 1.044 ms | 1.101 ms |

Same repair either way: `Utf8.subject` scrubs when the answer is "invalid", so an
actually-broken body ends up at the same string, ~5% slower for the second walk. That is
the trade `Gori::Utf8`'s own comment argues for, at roughly one body in a run.

## 2. `JsScan.strip` + `strip_comments` → one walk (`strip_both`)

Every HTML or JS flow materialises BOTH client views: `client_code` (strings and
comments blanked) for DomXss/DomClobbering, `client_scripts_nocomment` (comments only)
for PostMessage/PrototypePollution. They are two projections of the same lex — they
consume a script identically, token for token and index for index, and differ only in
what they emit for a string literal's contents — so the second `map` was re-walking the
same bytes.

`strip`/`strip_comments`/`strip_both` are now one lexer (`lex`) with a `Sink` holding
the two builders; a nil side is one this call is not building. No second copy of the
control flow, because a copy that drifted would desync the two views' offsets, which is
what `source_in_window`'s window arithmetic is measured against.

Fusing saves the walk, not the emission (each side still writes its own char), so the
pair costs ~1.7 walks instead of 2:

| script | two walks | fused |
| --- | --- | --- |
| 256 KiB bundle | 1.75 ms | 1.47 ms |
| same + one non-ASCII regex literal | 2.92 ms | 2.05 ms |

The non-ASCII case pays much better because `scan_source` falls back to `String#chars`
there: one ~1 MiB `Array(Char)` is now built instead of two, which is the whole 1 MB/op
drop in the table above.

**Equivalence check.** Beyond the specs, I ran a differential fuzz against the lexer as
it stands on `main` (compiled in beside the new one, module-renamed): 600 000 random
strings over `a / * ' " \` $ { } \\ \n ; = é` (lengths 1–48), plus 100-level template
nesting past `MAX_INTERP_DEPTH` and the three bench fixtures — **0 mismatches** on both
projections. The harness was scratch and is not in the diff; the property it pins lives
in `spec/probe/passive/js_scan_spec.cr` as a seeded 2 000-case version.

Call sites swept: `Context`'s five text getters, `Tech`'s GraphQL body read, `WsPayloads`'
per-frame text, `ExposedConfig#head_of`, `SourceMap#tail_text` (an 8 KiB tail on every capped
JS response — 70.6 µs → 8.4 µs over a 16 KiB valid slice), and both of
`Active::GraphqlIntrospection`'s, which are byte-for-byte twins of the `Tech` one. The last
three came out of the self-review, which caught the sweep as incomplete.

## 3. `ExposedConfig#head_of`

Same swap, called out separately because it is where the cost is most absurd: it slices
the first 16 KiB off `body_text`, which is ALREADY valid, so the only way the slice can
be broken is a cut landing mid-codepoint — and the scrub walked all 16 KiB a character
at a time to find that out. On a CSS response that halved the rule (89 µs → 44 µs). New
spec pins that a prefix cut mid-codepoint still scans and still reports.

## New fixture: a binary asset

`bench/probe_passive_bench.cr` had no binary-body shape, and an image is the most common
response in a real browse after the document. It is deliberately not valid UTF-8, which
is the point: `body_text` has to repair the bytes, and repairing them EXPANDS each into a
3-byte U+FFFD, so a 64 KiB `BODY_CAP` prefix of binary becomes a ~180 KiB string that
every body-scanning rule then walks. That shape is invisible in an all-text fixture.

The fixture is mostly a **measurement of what this PR does not fix**: 573 µs → 560 µs.
See "not done" below.

## Self-review

`/code-review high` found no correctness bugs. It independently re-ran the equivalence
check — 320 000 adversarial inputs through both lexers plus the `MAX_INTERP_DEPTH`
boundary cases, and 1 000 000 random byte sequences confirming `valid_encoding?` and
`scrub`'s identity agree on every UTF-8 divergence class (overlong, CESU-8 surrogate,
`F5`, truncated) — and raised three low-severity notes, all fixed in the second commit:

1. The `head_of` comment claimed a PCRE raise there would lose the whole flow's
   detections. Not true since `Passive.analyze` gained per-rule containment, and this
   PR's own new spec said the opposite. Comment corrected.
2. The sweep was incomplete: `sourcemap.cr` and both `graphql_introspection.cr` sites.
   Converted.
3. The new fixture's comment said a 64 KiB binary prefix scrubs to ~180 KiB. Measured,
   it is 102 612 bytes — half this generator's bytes are ASCII and pass through
   unexpanded, so it is 1.57×, not 3×. (180 KiB is the fixture's total size, of which
   only the first 64 KiB is ever scanned.) Arithmetic corrected.

## Candidates measured and rejected

**`Regex.union` over the `body_leaks` pattern loop.** `body_leaks` is ~50% of an
ordinary texty flow's scan (384 µs of 784 µs on the 30 KiB page; 896 µs of 1.82 ms on the
200 KiB one), and it is 40 separate PCRE passes over `body_text` — 16 error signatures,
23 secret shapes, JWT. The file's existing comment says a union measured ~5× slower; I
re-measured rather than trust it, and it is worse than that here: over the 64 KiB
`bightml` prefix, 41 separate `matches?` cost 721 µs and one union cost 6 325 µs (8.8×).
The comment stands. Loop kept.

**A multi-needle prefilter in front of those 40 passes.** Each pass is already at PCRE2's
floor — a plain `/ZZZQQQWWW/` and `/\bAKIA[0-9A-Z]{16}\b/` and `/AccountKey=/` all cost
18.3–18.5 µs over the same 64 KiB, i.e. ~1 byte/cycle regardless of anchor — so the only
lever left is scanning the body ONCE. That needs a required-literal per pattern (an
Aho-Corasick or n-gram screen), which re-derives each regex's semantics in a second
place: widen a pattern, forget its needle, and the rule goes silently dead. That is
exactly the silent-failure shape `SOLO_SOURCES` in `js_scan.cr` is derived rather than
hardcoded to avoid, and a security scanner is the worst place to take it. Not attempted.

**A size-preserving projection for invalid bodies** (non-ASCII byte → space, the shape
`WsPayloads#payload_text` already uses for BINARY frames) would cut the binary-asset flow
by roughly the 3× expansion. It is a real behaviour change, though — `\S`, `\s` and `\b`
all read U+FFFD and a space differently, and `ExposedConfig::DOTENV`'s `=\s*\S` is one of
several patterns that would flip — and the helper lives in `src/gori/utf8.cr`, outside
this branch's file boundary. Left alone; the new fixture is there so the cost is at
least visible.

## Handed to another group

Nothing outside `src/gori/probe/**` was touched. The one thing I would raise: the
analyzer feeds EVERY captured flow to `Passive.analyze` with no content-type filter
(`src/gori/probe/analyzer.cr#scan_detail`), so an image or font response costs ~560 µs and
277 kB on the fiber the proxy shares. Whether asset responses should reach the passive
scan at all is a probe-policy question, not a `passive/` one.
